### PR TITLE
[crypto] Trial division for RSA key generation.

### DIFF
--- a/sw/otbn/crypto/rsa_keygen.s
+++ b/sw/otbn/crypto/rsa_keygen.s
@@ -11,6 +11,7 @@
 .globl check_p
 .globl check_q
 .globl modinv_f4
+.globl relprime_small_primes
 
 /**
  * Generate a random RSA key pair.
@@ -1003,8 +1004,7 @@ check_p:
   /* Get the FG0.Z flag into a register.
        x2 <= (CSRs[FG0] >> 3) & 1 = FG0.Z */
   csrrs    x2, FG0, x0
-  srli     x2, x2, 3
-  andi     x2, x2, 1
+  andi     x2, x2, 8
 
   /* If the flag is set, then the check failed and we can skip the remaining
      checks. */
@@ -1032,13 +1032,6 @@ check_p:
   la       x14, tmp_scratchpad
   li       x2, 256
   add      x15, x14, x2
-
-  /**
-   * TODO: add something like BoringSSL's is_obviously_composite to filter out
-   * numbers that are divisible by the first few hundred primes. This filters
-   * out 80-90% of composites without resorting to the very slow Miller-Rabin
-   * check.
-   */
 
   /* Calculate the number of Miller-Rabin rounds. The number of rounds is
      selected based on the bit-length according to FIPS 186-5, table B.1.
@@ -1212,58 +1205,37 @@ generate_prime_candidate:
   ret
 
 /**
- * Check if a large number is relatively prime to 65537 (aka F4).
+ * Partially reduce a value modulo m such that 2^32 mod m == 1.
  *
- * Returns a nonzero value if GCD(x,65537) == 1, and 0 otherwise
+ * Returns r such that r mod m = x mod m and r < 2^35.
  *
- * A naive implementation would simply check if GCD(x, F4) == 1, However, we
- * can simplify the check for relative primality using a few helpful facts
- * about F4 specifically:
- *   1. It is prime.
- *   2. It has the special form (2^16 + 1).
+ * Can be used to speed up modular reduction on certain numbers.
  *
- * Because F4 is prime, checking if a number x is relatively prime to F4 means
- * simply checking if x is a direct multiple of F4; if (x % F4) != 0, then x is
- * relatively prime to F4. This means that instead of computing GCD, we can use
- * basic modular arithmetic.
- *
- * Here, the special form of F4, fact (2), comes in handy. Note that 2^16 is
- * equivalent to -1 modulo F4. So if we express a number x in base-2^16, we can
- * simplify as
- * follows:
- *   x = x0 + 2^16 * x1 + 2^32 * x2 + 2^48 * x3 + ...
- *   x \equiv x0 + (-1) * x1 + (-1)^2 * x2 + (-1)^3 * x3 + ... (mod F4)
- *   x \equiv x0 - x1 + x2 - x3 + ... (mod F4)
- *
- * An additionally helpful observation based on fact (2) is that 2^32, 2^64,
- * and in general 2^(32*k) for any k are all 1 modulo F4. This includes 2^256,
- * so when we receive the input as a bignum in 256-bit limbs, we can simply
- * all the limbs together to get an equivalent number modulo F4:
+ * Because we know 2^32 mod m is 1, it follows that in general 2^(32*k) for any
+ * k are all 1 modulo m. This includes 2^256, so when we receive the input as
+ * a bignum in 256-bit limbs, we can simply all the limbs together to get an
+ * equivalent number modulo m:
  *  x = x[0] + 2^256 * x[1] + 2^512 * x[2] + ...
  *  x \equiv x[0] + x[1] + x[2] + ... (mod F4)
  *
  * From there, we can essentially use the same trick to bisect the number into
  * 128-bit, 64-bit, and 32-bit chunks and add these together to get an
- * equivalent number modulo F4. For the final 16-bit chunks, we need to
- * subtract because 2^16 mod F4 = -1 rather than 1.
+ * equivalent number modulo m. This operation is visually sort of like folding
+ * the number over itself repeatedly, which is where the function gets its
+ * name.
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
  * @param[in]  x16: dptr_x, pointer to first limb of x in dmem
  * @param[in]  x30: plen, number of 256-bit limbs for x
+ * @param[in]  w24: constant, 2^256 - 1
  * @param[in]  w31: all-zero
- * @param[out] w22: result, 0 only if x is not relatively prime to F4
+ * @param[out] w23: r, result
  *
  * clobbered registers: x2, w22, w23
  * clobbered flag groups: FG0
  */
-relprime_f4:
-  /* Load F4 into the modulus register for later.
-       MOD <= 2^16 + 1 */
-  bn.addi  w22, w31, 1
-  bn.add   w22, w22, w22 << 16
-  bn.wsrw  MOD, w22
-
+fold_bignum:
   /* Initialize constants for loop. */
   li      x22, 22
 
@@ -1295,8 +1267,7 @@ relprime_f4:
 
   /* Isolate the lower 128 bits of the sum.
        w22 <= w23[127:0] */
-  bn.rshi  w22, w23, w31 >> 128
-  bn.rshi  w22, w31, w22 >> 128
+  bn.and   w22, w23, w24 >> 128
 
   /* Add the two 128-bit halves of the sum, plus the carry from the last round
      of the sum computation. The sum is now up to 129 bits.
@@ -1305,8 +1276,7 @@ relprime_f4:
 
   /* Isolate the lower 64 bits of the sum.
        w22 <= w23[63:0] */
-  bn.rshi  w22, w23, w31 >> 64
-  bn.rshi  w22, w31, w22 >> 192
+  bn.and   w22, w23, w24 >> 192
 
   /* Add the two halves of the sum (technically 64 and 65 bits). A carry was
      not possible in the previous addition since the value is too small. The
@@ -1316,29 +1286,76 @@ relprime_f4:
 
   /* Isolate the lower 32 bits of the sum.
        w22 <= w23[31:0] */
-  bn.rshi  w22, w23, w31 >> 32
-  bn.rshi  w22, w31, w22 >> 224
+  bn.and   w22, w23, w24 >> 224
 
   /* Add the two halves of the sum (technically 32 and 34 bits). A carry was
      not possible in the previous addition since the value is too small.
        w23 <= (w22 + (w23 >> 32)) */
   bn.add   w23, w22, w23 >> 32
 
-  /* Note: At this point, we're down to the last few terms:
-       x \equiv (w23[15:0] - w23[31:16] + w23[34:32]) mod F4 */
+  ret
+
+/**
+ * Check if a large number is relatively prime to 65537 (aka F4).
+ *
+ * Returns a nonzero value if GCD(x,65537) == 1, and 0 otherwise
+ *
+ * A naive implementation would simply check if GCD(x, F4) == 1, However, we
+ * can simplify the check for relative primality using a few helpful facts
+ * about F4 specifically:
+ *   1. It is prime.
+ *   2. It has the special form (2^16 + 1).
+ *
+ * Because F4 is prime, checking if a number x is relatively prime to F4 means
+ * simply checking if x is a direct multiple of F4; if (x % F4) != 0, then x is
+ * relatively prime to F4. This means that instead of computing GCD, we can use
+ * basic modular arithmetic.
+ *
+ * Here, the special form of F4, fact (2), comes in handy. Since 2^32 mod F4 =
+ * 1, we can use `fold_bignum` to bring the number down to 35 bits cheaply.
+ *
+ * Since 2^16 is equivalent to -1 modulo F4, we can express the resulting
+ * number in base-2^16 and simplify as follows:
+ *   x = x0 + 2^16 * x1 + 2^32 * x2
+ *   x \equiv x0 + (-1) * x1 + (-1)^2 * x2
+ *   x \equiv x0 - x1 + x2 (mod F4)
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  x16: dptr_x, pointer to first limb of x in dmem
+ * @param[in]  x30: n, number of 256-bit limbs for x
+ * @param[in]  w31: all-zero
+ * @param[out] w22: result, 0 only if x is not relatively prime to F4
+ *
+ * clobbered registers: x2, w22, w23
+ * clobbered flag groups: FG0
+ */
+relprime_f4:
+  /* Load F4 into the modulus register for later.
+       MOD <= 2^16 + 1 */
+  bn.addi  w22, w31, 1
+  bn.add   w22, w22, w22 << 16
+  bn.wsrw  MOD, w22
+
+  /* Generate a 256-bit mask.
+       w24 <= 2^256 - 1 */
+  bn.not   w24, w31
+
+  /* Fold the bignum to get a 35-bit number r such that r mod F4 = x mod F4.
+       w23 <= r */
+  jal      x1, fold_bignum
 
   /* Isolate the lower 16 bits of the 35-bit working sum.
        w22 <= w23[15:0] */
-  bn.rshi  w22, w23, w31 >> 16
-  bn.rshi  w22, w31, w22 >> 240
+  bn.and   w22, w23, w24 >> 240
 
   /* Add the lower 16 bits of the sum to the highest 3 bits to get a 17-bit
      result.
        w22 <= w22 + (w23 >> 32) */
   bn.add   w22, w22, w23 >> 32
 
-  /* The sum from the previous addition is < 2 * F4, so a modular addition with
-     zero is sufficient to fully reduce.
+  /* The sum from the previous addition is <= 2^16 - 1 + 2^3 - 1 < 2 * F4, so a
+     modular addition with zero is sufficient to fully reduce.
        w22 <= w22 mod F4 */
   bn.addm  w22, w22, w31
 
@@ -1350,6 +1367,155 @@ relprime_f4:
   /* Final subtraction modulo F4.
        w22 <= (w22 - w23) mod F4 = x mod F4 */
   bn.subm  w22, w22, w23
+
+  ret
+
+/**
+ * Check if a large number is divisible by a few small primes.
+ *
+ * Returns 0 if x is divisible by a small prime, 2^256 - 1 otherwise.
+ *
+ * In this implementation we specifically check the primes 3, 8, and 17, since
+ * these values m have the property that (1 << 8) mod m is 1, so we can use
+ * `fold_bignum` to check them very quickly. We use `fold_bignum` to get a
+ * 35-bit result and then fold the number a few more times to get a 9-bit
+ * result.
+ *
+ * Testing 
+ *
+ * This routine is constant-time relative to x if x is not divisible by any
+ * small primes, but exits early if it finds that x is divisible by a small
+ * prime.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  x16: dptr_x, pointer to first limb of x in dmem
+ * @param[in]  x30: n, number of 256-bit limbs for x
+ * @param[in]  w31: all-zero
+ * @param[out] w22: result, 0 if x is divisible by a small prime
+ *
+ * clobbered registers: x2, w22, w23, w24, w25
+ * clobbered flag groups: FG0
+ */
+relprime_small_primes:
+  /* Generate a 256-bit mask.
+       w24 <= 2^256 - 1 */
+  bn.not   w24, w31
+
+  /* Fold the bignum to get a 35-bit number r such that r mod F4 = x mod F4.
+       w23 <= r */
+  jal      x1, fold_bignum
+
+  /* Isolate the lower 16 bits of the 35-bit working sum.
+       w22 <= w23[15:0] */
+  bn.and   w22, w23, w24 >> 240
+
+  /* Add the lower 16 bits to the higher 19 bits to get a 20-bit result.
+       w23 <= w22 + (w23 >> 16) */
+  bn.add   w23, w22, w23 >> 16
+
+  /* Isolate the lower 8 bits of the 20-bit working sum.
+       w22 <= w23[7:0] */
+  bn.and   w22, w23, w24 >> 248
+
+  /* Add the lower 8 bits to the higher 12 bits to get a 13-bit result.
+       w23 <= w22 + (w23 >> 8) */
+  bn.add   w23, w22, w23 >> 8
+
+  /* Isolate the lower 8 bits of the 13-bit working sum.
+       w22 <= w23[7:0] */
+  bn.and   w22, w23, w24 >> 248
+
+  /* Add the lower 8 bits to the higher 5 bits to get a 9-bit result.
+       w23 <= w22 + (w23 >> 8) */
+  bn.add   w23, w22, w23 >> 8
+
+  /* Check the residue modulo 3.
+       x2 <= if (w23 mod 3) == 0 then 8 else 0 */
+  bn.mov   w25, w23
+  bn.addi  w24, w31, 3
+  jal      x1, is_zero_mod_small_prime
+
+  /* If x2 != 0, exit early. */
+  bne      x2, x0, __relprime_small_primes_fail
+
+  /* Check the residue modulo 5.
+       x2 <= if (w23 mod 5) == 0 then 8 else 0 */
+  bn.mov   w25, w23
+  bn.addi  w24, w31, 5
+  jal      x1, is_zero_mod_small_prime
+
+  /* If x2 != 0, exit early. */
+  bne      x2, x0, __relprime_small_primes_fail
+
+  /* Check the residue modulo 17.
+       x2 <= if (w23 mod 17) == 0 then 8 else 0 */
+  bn.mov   w25, w23
+  bn.addi  w24, w31, 17
+  jal      x1, is_zero_mod_small_prime
+
+  /* If x2 != 0, exit early. */
+  bne      x2, x0, __relprime_small_primes_fail
+
+  /* No small prime divisors found; return 2^256 - 1. */
+  bn.not   w22, w31
+  ret
+
+__relprime_small_primes_fail:
+  /* Small prime divisor found; return 0. */
+  bn.sub   w22, w22, w22
+  ret
+
+/**
+ * Reduce a 9-bit number modulo a small number with conditional subtractions.
+ *
+ * Returns r = 8 if x mod m = 0, otherwise r = 0.
+ *
+ * Helper function for `relprime_small_primes`.
+ *
+ * This function runs in constant time.
+ *
+ * @param[in]  w23: x, input, x < 2^9.
+ * @param[in]  w24: m, modulus, 2 < m < 2^256.
+ * @param[in]  w31: all-zero
+ * @param[out] x2: result, 8 if x mod m = 0 and otherwise 0
+ *
+ * clobbered registers: x2, w24, w25
+ * clobbered flag groups: FG0
+ */
+is_zero_mod_small_prime:
+  /* Copy input. */
+  bn.mov  w25, w23
+
+  /* Since we know m is at least 2 bits, start with m << 7 as a value that will
+     definitely be greater than x / 2.
+       w24 <= m << 7 */
+  bn.rshi  w24, w24, w31 >> 249
+
+  /* Repeatedly reduce using conditional subtractions.
+
+     Loop invariant (i=7 to 0):
+       w24 = m << i
+       w25 < 2*(m << i)
+       w25 mod m = x mod m
+  */
+  loopi    8, 3
+    /* w22 <= w25 - w24 */
+    bn.sub   w22, w25, w24
+    /* Select the subtraction only if it did not underflow.
+         w25 <= FG0.C ? w25 : w22 */
+    bn.sel   w25, w25, w22, FG0.C
+    /* w24 <= w24 >> 1 */
+    bn.rshi  w24, w31, w24 >> 1
+
+  /* Check if w25 is 0.
+       FG0.Z <= w25 == 0 */
+  bn.cmp   w25, w31
+
+  /* Get the FG0.Z flag into a register and return.
+       x2 <= FG0 & 8 = FG0.Z << 3 */
+  csrrs    x2, 0x7c0, x0
+  andi     x2, x2, 8
 
   ret
 

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -789,11 +789,62 @@ otbn_sim_test(
 )
 
 otbn_sim_test(
+    name = "relprime_small_primes_multiple_of_7_test",
+    srcs = [
+        "relprime_small_primes_multiple_of_7_test.s",
+    ],
+    exp = "relprime_small_primes_multiple_of_7_test.exp",
+    deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
+        "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:rsa_keygen",
+    ],
+)
+
+otbn_sim_test(
+    name = "relprime_small_primes_multiple_of_11_test",
+    srcs = [
+        "relprime_small_primes_multiple_of_11_test.s",
+    ],
+    exp = "relprime_small_primes_multiple_of_11_test.exp",
+    deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
+        "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:rsa_keygen",
+    ],
+)
+
+otbn_sim_test(
     name = "relprime_small_primes_multiple_of_17_test",
     srcs = [
         "relprime_small_primes_multiple_of_17_test.s",
     ],
     exp = "relprime_small_primes_multiple_of_17_test.exp",
+    deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
+        "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:rsa_keygen",
+    ],
+)
+
+otbn_sim_test(
+    name = "relprime_small_primes_multiple_of_31_test",
+    srcs = [
+        "relprime_small_primes_multiple_of_31_test.s",
+    ],
+    exp = "relprime_small_primes_multiple_of_31_test.exp",
     deps = [
         "//sw/otbn/crypto:div",
         "//sw/otbn/crypto:gcd",

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -754,6 +754,74 @@ otbn_consttime_test(
     ],
 )
 
+otbn_sim_test(
+    name = "relprime_small_primes_multiple_of_3_test",
+    srcs = [
+        "relprime_small_primes_multiple_of_3_test.s",
+    ],
+    exp = "relprime_small_primes_multiple_of_3_test.exp",
+    deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
+        "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:rsa_keygen",
+    ],
+)
+
+otbn_sim_test(
+    name = "relprime_small_primes_multiple_of_5_test",
+    srcs = [
+        "relprime_small_primes_multiple_of_5_test.s",
+    ],
+    exp = "relprime_small_primes_multiple_of_5_test.exp",
+    deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
+        "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:rsa_keygen",
+    ],
+)
+
+otbn_sim_test(
+    name = "relprime_small_primes_multiple_of_17_test",
+    srcs = [
+        "relprime_small_primes_multiple_of_17_test.s",
+    ],
+    exp = "relprime_small_primes_multiple_of_17_test.exp",
+    deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
+        "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:rsa_keygen",
+    ],
+)
+
+otbn_sim_test(
+    name = "relprime_small_primes_negative_test",
+    srcs = [
+        "relprime_small_primes_negative_test.s",
+    ],
+    exp = "relprime_small_primes_negative_test.exp",
+    deps = [
+        "//sw/otbn/crypto:div",
+        "//sw/otbn/crypto:gcd",
+        "//sw/otbn/crypto:lcm",
+        "//sw/otbn/crypto:montmul",
+        "//sw/otbn/crypto:mul",
+        "//sw/otbn/crypto:primality",
+        "//sw/otbn/crypto:rsa_keygen",
+    ],
+)
+
 otbn_library(
     name = "rsa_keygen_checkpq_test_data",
     srcs = [

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_11_test.exp
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_11_test.exp
@@ -1,0 +1,2 @@
+# Expect 0 (check failed).
+w22 = 0

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_11_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_11_test.s
@@ -1,0 +1,68 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test to check an RSA keygen subroutine.
+ *
+ * The `relprime_small_primes` subroutine checks if a candidate prime is a
+ * multiple of a small prime. This test ensures that the check detects a
+ * multiple of 11.
+ */
+
+.section .text.start
+
+main:
+  /* Init all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Load the number of limbs for this test. */
+  li        x30, 4
+
+  /* w22 <= 0 if dmem[simple_positive_input] is NOT relatively prime to F4 */
+  la        x16, input
+  jal       x1, relprime_small_primes
+
+  ecall
+
+.data
+
+/**
+ * A 1024-bit value that is a multiple of 11 and NOT 3, 5, 7, 17, or 31.
+ *
+ * Full value for reference =
+ */
+.balign 32
+input:
+.word 0x0a9a411f
+.word 0xca52e7f3
+.word 0x2c301918
+.word 0x948c97b0
+.word 0x171f68fc
+.word 0xe36be04a
+.word 0x0a7ffbaa
+.word 0xf9cf072d
+.word 0x51b76bd5
+.word 0x19d0fec0
+.word 0x0771be64
+.word 0x49c95131
+.word 0x1ed7cd7a
+.word 0xda4a6077
+.word 0x11fa0022
+.word 0x66e409f1
+.word 0x95548bfd
+.word 0x7938113a
+.word 0x9296d0f5
+.word 0x1352294c
+.word 0x33eaf657
+.word 0x6c47a7dc
+.word 0xf57e2b6b
+.word 0xd1194a3e
+.word 0x84402e7e
+.word 0x87641b66
+.word 0x2c3c225e
+.word 0x5e27e299
+.word 0x5ee52414
+.word 0xab6816c2
+.word 0x0ea3266c
+.word 0x5f4b97ff

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_17_test.exp
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_17_test.exp
@@ -1,0 +1,2 @@
+# Expect 0 (check failed).
+w22 = 0

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_17_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_17_test.s
@@ -1,0 +1,69 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test to check an RSA keygen subroutine.
+ *
+ * The `relprime_small_primes` subroutine checks if a candidate prime is a
+ * multiple of a small prime. This test ensures that the check detects a
+ * multiple of 17.
+ */
+
+.section .text.start
+
+main:
+  /* Init all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Load the number of limbs for this test. */
+  li        x30, 4
+
+  /* w22 <= 0 if dmem[simple_positive_input] is NOT relatively prime to F4 */
+  la        x16, input
+  jal       x1, relprime_small_primes
+
+  ecall
+
+.data
+
+/**
+ * A 1024-bit value that is a multiple of 17 and NOT 3 or 5.
+ *
+ * Full value for reference =
+ * 0xfbe7d1a3a6642d2eb873e0b4c23eda03f9d299d8b5cbd03e735f18989c2f3e275e1d38306b2de24f70253a17b1197785e775bfbd717249031f4258944965eb3ff3078793cbff7898739b0062121017b7a328b77eddc338ec653f324f08771703909453a99c976fdc385d405480f795117ee9807fbe51cbe4b96770fb961719ba
+ */
+.balign 32
+input:
+.word 0x961719ba
+.word 0xb96770fb
+.word 0xbe51cbe4
+.word 0x7ee9807f
+.word 0x80f79511
+.word 0x385d4054
+.word 0x9c976fdc
+.word 0x909453a9
+.word 0x08771703
+.word 0x653f324f
+.word 0xddc338ec
+.word 0xa328b77e
+.word 0x121017b7
+.word 0x739b0062
+.word 0xcbff7898
+.word 0xf3078793
+.word 0x4965eb3f
+.word 0x1f425894
+.word 0x71724903
+.word 0xe775bfbd
+.word 0xb1197785
+.word 0x70253a17
+.word 0x6b2de24f
+.word 0x5e1d3830
+.word 0x9c2f3e27
+.word 0x735f1898
+.word 0xb5cbd03e
+.word 0xf9d299d8
+.word 0xc23eda03
+.word 0xb873e0b4
+.word 0xa6642d2e
+.word 0xfbe7d1a3

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_17_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_17_test.s
@@ -28,42 +28,42 @@ main:
 .data
 
 /**
- * A 1024-bit value that is a multiple of 17 and NOT 3 or 5.
+ * A 1024-bit value that is a multiple of 17 and NOT 3, 5, 11, 17, or 31.
  *
  * Full value for reference =
- * 0xfbe7d1a3a6642d2eb873e0b4c23eda03f9d299d8b5cbd03e735f18989c2f3e275e1d38306b2de24f70253a17b1197785e775bfbd717249031f4258944965eb3ff3078793cbff7898739b0062121017b7a328b77eddc338ec653f324f08771703909453a99c976fdc385d405480f795117ee9807fbe51cbe4b96770fb961719ba
+ * 0x5143649b8bf054404d0ebedfa7a956dabd297218a15c6410335f8fc10f679ea7b4c0c055a34801e48f9a22cc124580ae9de9fda12300eb6cc6a5ab1e9edb8ff24329ef86ec8833131fbfcbbf8e97f9ac5475dc577367b017cb30d1df1c4baa3c63be79499d79f3e1fda86b6ad1790701b6156e77604ad67d9a8e49e8a4c2a845
  */
 .balign 32
 input:
-.word 0x961719ba
-.word 0xb96770fb
-.word 0xbe51cbe4
-.word 0x7ee9807f
-.word 0x80f79511
-.word 0x385d4054
-.word 0x9c976fdc
-.word 0x909453a9
-.word 0x08771703
-.word 0x653f324f
-.word 0xddc338ec
-.word 0xa328b77e
-.word 0x121017b7
-.word 0x739b0062
-.word 0xcbff7898
-.word 0xf3078793
-.word 0x4965eb3f
-.word 0x1f425894
-.word 0x71724903
-.word 0xe775bfbd
-.word 0xb1197785
-.word 0x70253a17
-.word 0x6b2de24f
-.word 0x5e1d3830
-.word 0x9c2f3e27
-.word 0x735f1898
-.word 0xb5cbd03e
-.word 0xf9d299d8
-.word 0xc23eda03
-.word 0xb873e0b4
-.word 0xa6642d2e
-.word 0xfbe7d1a3
+.word 0xa4c2a845
+.word 0x9a8e49e8
+.word 0x604ad67d
+.word 0xb6156e77
+.word 0xd1790701
+.word 0xfda86b6a
+.word 0x9d79f3e1
+.word 0x63be7949
+.word 0x1c4baa3c
+.word 0xcb30d1df
+.word 0x7367b017
+.word 0x5475dc57
+.word 0x8e97f9ac
+.word 0x1fbfcbbf
+.word 0xec883313
+.word 0x4329ef86
+.word 0x9edb8ff2
+.word 0xc6a5ab1e
+.word 0x2300eb6c
+.word 0x9de9fda1
+.word 0x124580ae
+.word 0x8f9a22cc
+.word 0xa34801e4
+.word 0xb4c0c055
+.word 0x0f679ea7
+.word 0x335f8fc1
+.word 0xa15c6410
+.word 0xbd297218
+.word 0xa7a956da
+.word 0x4d0ebedf
+.word 0x8bf05440
+.word 0x5143649b

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_31_test.exp
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_31_test.exp
@@ -1,0 +1,2 @@
+# Expect 0 (check failed).
+w22 = 0

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_31_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_31_test.s
@@ -1,0 +1,69 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test to check an RSA keygen subroutine.
+ *
+ * The `relprime_small_primes` subroutine checks if a candidate prime is a
+ * multiple of a small prime. This test ensures that the check detects a
+ * multiple of 31.
+ */
+
+.section .text.start
+
+main:
+  /* Init all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Load the number of limbs for this test. */
+  li        x30, 4
+
+  /* w22 <= 0 if dmem[simple_positive_input] is NOT relatively prime to F4 */
+  la        x16, input
+  jal       x1, relprime_small_primes
+
+  ecall
+
+.data
+
+/**
+ * A 1024-bit value that is a multiple of 31 and NOT 3, 5, 7, 11, or 17.
+ *
+ * Full value for reference =
+ * 0xc6b202813cf17e3c55fefc6282020980fa205b3ccfb384f597e2c0749b1d5213c2ebbf45d5f239e911062650cd43d3c008183c6c2cf217ac48af2bcfeac39a280afd60eea8508324e97f40fa78d5d70a5b5fcb80c1e260feaa1f02f54c072a915d48a0d13a162f1e22f40b26c1eb29d4e7a44c48956c2daa5edfd222e7cf7221
+ */
+.balign 32
+input:
+.word 0xe7cf7221
+.word 0x5edfd222
+.word 0x956c2daa
+.word 0xe7a44c48
+.word 0xc1eb29d4
+.word 0x22f40b26
+.word 0x3a162f1e
+.word 0x5d48a0d1
+.word 0x4c072a91
+.word 0xaa1f02f5
+.word 0xc1e260fe
+.word 0x5b5fcb80
+.word 0x78d5d70a
+.word 0xe97f40fa
+.word 0xa8508324
+.word 0x0afd60ee
+.word 0xeac39a28
+.word 0x48af2bcf
+.word 0x2cf217ac
+.word 0x08183c6c
+.word 0xcd43d3c0
+.word 0x11062650
+.word 0xd5f239e9
+.word 0xc2ebbf45
+.word 0x9b1d5213
+.word 0x97e2c074
+.word 0xcfb384f5
+.word 0xfa205b3c
+.word 0x82020980
+.word 0x55fefc62
+.word 0x3cf17e3c
+.word 0xc6b20281

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_3_test.exp
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_3_test.exp
@@ -1,0 +1,2 @@
+# Expect 0 (check failed).
+w22 = 0

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_3_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_3_test.s
@@ -1,0 +1,69 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test to check an RSA keygen subroutine.
+ *
+ * The `relprime_small_primes` subroutine checks if a candidate prime is a
+ * multiple of a small prime. This test ensures that the check detects a
+ * multiple of 3.
+ */
+
+.section .text.start
+
+main:
+  /* Init all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Load the number of limbs for this test. */
+  li        x30, 4
+
+  /* w22 <= 0 if dmem[simple_positive_input] is NOT relatively prime to F4 */
+  la        x16, input
+  jal       x1, relprime_small_primes
+
+  ecall
+
+.data
+
+/**
+ * A 1024-bit value that is a multiple of 3 and NOT 5 or 17.
+ *
+ * Full value for reference =
+ * 0x859619e48009dbf121db2000c823862f3ac30d8806a7babf54e784b3a8e2a63c70cca37ce01839e3c6eb780ce56eed882cb9603835f194b2f93ec68a397229d0159827ceb0881ef9c54bc11956b19b9894b2f99373d4d7996bf59a4bcb592cc0933519023a53e46b311acf7565307ad9a419d45066edbfb174bbb8169d56b246
+ */
+.balign 32
+input:
+.word 0x9d56b246
+.word 0x74bbb816
+.word 0x66edbfb1
+.word 0xa419d450
+.word 0x65307ad9
+.word 0x311acf75
+.word 0x3a53e46b
+.word 0x93351902
+.word 0xcb592cc0
+.word 0x6bf59a4b
+.word 0x73d4d799
+.word 0x94b2f993
+.word 0x56b19b98
+.word 0xc54bc119
+.word 0xb0881ef9
+.word 0x159827ce
+.word 0x397229d0
+.word 0xf93ec68a
+.word 0x35f194b2
+.word 0x2cb96038
+.word 0xe56eed88
+.word 0xc6eb780c
+.word 0xe01839e3
+.word 0x70cca37c
+.word 0xa8e2a63c
+.word 0x54e784b3
+.word 0x06a7babf
+.word 0x3ac30d88
+.word 0xc823862f
+.word 0x21db2000
+.word 0x8009dbf1
+.word 0x859619e4

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_3_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_3_test.s
@@ -28,42 +28,42 @@ main:
 .data
 
 /**
- * A 1024-bit value that is a multiple of 3 and NOT 5 or 17.
+ * A 1024-bit value that is a multiple of 3 and NOT 5, 7, 11, 17, or 31.
  *
  * Full value for reference =
- * 0x859619e48009dbf121db2000c823862f3ac30d8806a7babf54e784b3a8e2a63c70cca37ce01839e3c6eb780ce56eed882cb9603835f194b2f93ec68a397229d0159827ceb0881ef9c54bc11956b19b9894b2f99373d4d7996bf59a4bcb592cc0933519023a53e46b311acf7565307ad9a419d45066edbfb174bbb8169d56b246
+ * 0xaf8f432e511b6294ef296e4c0c73fdad210a09a5355a5150cc190b64f9e384fbc3bff603b12bf716d6b7493876ea0aa119eb3cca8706f1cfde452289edf554350bfec6b4812f05bcfd3d799c703a901cf7bc99536b6d1c0df187a62eed3114384bba11b8132de7aed844a98ac7597ea336a01df3664d9ebf3126dc99a5896a45
  */
 .balign 32
 input:
-.word 0x9d56b246
-.word 0x74bbb816
-.word 0x66edbfb1
-.word 0xa419d450
-.word 0x65307ad9
-.word 0x311acf75
-.word 0x3a53e46b
-.word 0x93351902
-.word 0xcb592cc0
-.word 0x6bf59a4b
-.word 0x73d4d799
-.word 0x94b2f993
-.word 0x56b19b98
-.word 0xc54bc119
-.word 0xb0881ef9
-.word 0x159827ce
-.word 0x397229d0
-.word 0xf93ec68a
-.word 0x35f194b2
-.word 0x2cb96038
-.word 0xe56eed88
-.word 0xc6eb780c
-.word 0xe01839e3
-.word 0x70cca37c
-.word 0xa8e2a63c
-.word 0x54e784b3
-.word 0x06a7babf
-.word 0x3ac30d88
-.word 0xc823862f
-.word 0x21db2000
-.word 0x8009dbf1
-.word 0x859619e4
+.word 0xa5896a45
+.word 0x3126dc99
+.word 0x664d9ebf
+.word 0x36a01df3
+.word 0xc7597ea3
+.word 0xd844a98a
+.word 0x132de7ae
+.word 0x4bba11b8
+.word 0xed311438
+.word 0xf187a62e
+.word 0x6b6d1c0d
+.word 0xf7bc9953
+.word 0x703a901c
+.word 0xfd3d799c
+.word 0x812f05bc
+.word 0x0bfec6b4
+.word 0xedf55435
+.word 0xde452289
+.word 0x8706f1cf
+.word 0x19eb3cca
+.word 0x76ea0aa1
+.word 0xd6b74938
+.word 0xb12bf716
+.word 0xc3bff603
+.word 0xf9e384fb
+.word 0xcc190b64
+.word 0x355a5150
+.word 0x210a09a5
+.word 0x0c73fdad
+.word 0xef296e4c
+.word 0x511b6294
+.word 0xaf8f432e

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_5_test.exp
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_5_test.exp
@@ -1,0 +1,2 @@
+# Expect 0 (check failed).
+w22 = 0

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_5_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_5_test.s
@@ -1,0 +1,69 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test to check an RSA keygen subroutine.
+ *
+ * The `relprime_small_primes` subroutine checks if a candidate prime is a
+ * multiple of a small prime. This test ensures that the check detects a
+ * multiple of 5.
+ */
+
+.section .text.start
+
+main:
+  /* Init all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Load the number of limbs for this test. */
+  li        x30, 4
+
+  /* w22 <= 0 if dmem[simple_positive_input] is NOT relatively prime to F4 */
+  la        x16, input
+  jal       x1, relprime_small_primes
+
+  ecall
+
+.data
+
+/**
+ * A 1024-bit value that is a multiple of 5 and NOT 3 or 17.
+ *
+ * Full value for reference =
+ * 0x7dd35aeb866062ae017ae1f605b19b348668ad55367975302fa84bc99ef347339199cdb22e9bd1f4ef3340edc27e18b79ad3168f7bba3f36bd642650d1e0fc061f17fe99ba598320a03b3f503e63d9017b375642188965eda30f5d792390a6cc080768f3e1d07e76b992e92a1f7f383bb40ef314e55b90ec12e4323a97af0ac5
+ */
+.balign 32
+input:
+.word 0x97af0ac5
+.word 0x12e4323a
+.word 0xe55b90ec
+.word 0xb40ef314
+.word 0x1f7f383b
+.word 0xb992e92a
+.word 0xe1d07e76
+.word 0x080768f3
+.word 0x2390a6cc
+.word 0xa30f5d79
+.word 0x188965ed
+.word 0x7b375642
+.word 0x3e63d901
+.word 0xa03b3f50
+.word 0xba598320
+.word 0x1f17fe99
+.word 0xd1e0fc06
+.word 0xbd642650
+.word 0x7bba3f36
+.word 0x9ad3168f
+.word 0xc27e18b7
+.word 0xef3340ed
+.word 0x2e9bd1f4
+.word 0x9199cdb2
+.word 0x9ef34733
+.word 0x2fa84bc9
+.word 0x36797530
+.word 0x8668ad55
+.word 0x05b19b34
+.word 0x017ae1f6
+.word 0x866062ae
+.word 0x7dd35aeb

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_5_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_5_test.s
@@ -28,42 +28,42 @@ main:
 .data
 
 /**
- * A 1024-bit value that is a multiple of 5 and NOT 3 or 17.
+ * A 1024-bit value that is a multiple of 5 and NOT 3, 7, 11, 17, or 31.
  *
  * Full value for reference =
- * 0x7dd35aeb866062ae017ae1f605b19b348668ad55367975302fa84bc99ef347339199cdb22e9bd1f4ef3340edc27e18b79ad3168f7bba3f36bd642650d1e0fc061f17fe99ba598320a03b3f503e63d9017b375642188965eda30f5d792390a6cc080768f3e1d07e76b992e92a1f7f383bb40ef314e55b90ec12e4323a97af0ac5
+ * 0x95746f2e1cadd653af519d764878e64c332cc27a5ccd76c989ff609bdee59d4d487c89bb09057b968afd2fd69fe76d25b99c1399a7b8e7e5f9bb301f6d62651a62c9c3aea5ff9e44f2f7065b96b16fda5b776f60760644686798018c960f96eaf2fa5e0dd0cbc707c4a06380dccaeea77ac0775afa2eb98d0e560c47f2ddb2bd
  */
 .balign 32
 input:
-.word 0x97af0ac5
-.word 0x12e4323a
-.word 0xe55b90ec
-.word 0xb40ef314
-.word 0x1f7f383b
-.word 0xb992e92a
-.word 0xe1d07e76
-.word 0x080768f3
-.word 0x2390a6cc
-.word 0xa30f5d79
-.word 0x188965ed
-.word 0x7b375642
-.word 0x3e63d901
-.word 0xa03b3f50
-.word 0xba598320
-.word 0x1f17fe99
-.word 0xd1e0fc06
-.word 0xbd642650
-.word 0x7bba3f36
-.word 0x9ad3168f
-.word 0xc27e18b7
-.word 0xef3340ed
-.word 0x2e9bd1f4
-.word 0x9199cdb2
-.word 0x9ef34733
-.word 0x2fa84bc9
-.word 0x36797530
-.word 0x8668ad55
-.word 0x05b19b34
-.word 0x017ae1f6
-.word 0x866062ae
-.word 0x7dd35aeb
+.word 0x2e6f7495
+.word 0x53d6ad1c
+.word 0x769d51af
+.word 0x4ce67848
+.word 0x7ac22c33
+.word 0xc976cd5c
+.word 0x9b60ff89
+.word 0x4d9de5de
+.word 0xbb897c48
+.word 0x967b0509
+.word 0xd62ffd8a
+.word 0x256de79f
+.word 0x99139cb9
+.word 0xe5e7b8a7
+.word 0x1f30bbf9
+.word 0x1a65626d
+.word 0xaec3c962
+.word 0x449effa5
+.word 0x5b06f7f2
+.word 0xda6fb196
+.word 0x606f775b
+.word 0x68440676
+.word 0x8c019867
+.word 0xea960f96
+.word 0x0d5efaf2
+.word 0x07c7cbd0
+.word 0x8063a0c4
+.word 0xa7eecadc
+.word 0x5a77c07a
+.word 0x8db92efa
+.word 0x470c560e
+.word 0xbdb2ddf2

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_7_test.exp
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_7_test.exp
@@ -1,0 +1,2 @@
+# Expect 0 (check failed).
+w22 = 0

--- a/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_7_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_multiple_of_7_test.s
@@ -1,0 +1,69 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test to check an RSA keygen subroutine.
+ *
+ * The `relprime_small_primes` subroutine checks if a candidate prime is a
+ * multiple of a small prime. This test ensures that the check detects a
+ * multiple of 7.
+ */
+
+.section .text.start
+
+main:
+  /* Init all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Load the number of limbs for this test. */
+  li        x30, 4
+
+  /* w22 <= 0 if dmem[simple_positive_input] is NOT relatively prime to F4 */
+  la        x16, input
+  jal       x1, relprime_small_primes
+
+  ecall
+
+.data
+
+/**
+ * A 1024-bit value that is a multiple of 7 and NOT 3, 5, 11, 17, or 31.
+ *
+ * Full value for reference =
+ * 0x91986e138a0211deddc97f1f4284182b075166745a567a4866c7093a0e4ba084f82346b6572d6b3110ee488087c5b5385227e1671f48b4460afc72659e7e70521b347174161d184c63788c24b4b2e2db3fc1a6b56f86abfaeb7d19a2902a2223a2e51e15f5bc2b4a1f7ee67a1210881cb8b0c7a949efce5d4422e19865050a9f
+ */
+.balign 32
+input:
+.word 0x65050a9f
+.word 0x4422e198
+.word 0x49efce5d
+.word 0xb8b0c7a9
+.word 0x1210881c
+.word 0x1f7ee67a
+.word 0xf5bc2b4a
+.word 0xa2e51e15
+.word 0x902a2223
+.word 0xeb7d19a2
+.word 0x6f86abfa
+.word 0x3fc1a6b5
+.word 0xb4b2e2db
+.word 0x63788c24
+.word 0x161d184c
+.word 0x1b347174
+.word 0x9e7e7052
+.word 0x0afc7265
+.word 0x1f48b446
+.word 0x5227e167
+.word 0x87c5b538
+.word 0x10ee4880
+.word 0x572d6b31
+.word 0xf82346b6
+.word 0x0e4ba084
+.word 0x66c7093a
+.word 0x5a567a48
+.word 0x07516674
+.word 0x4284182b
+.word 0xddc97f1f
+.word 0x8a0211de
+.word 0x91986e13

--- a/sw/otbn/crypto/tests/relprime_small_primes_negative_test.exp
+++ b/sw/otbn/crypto/tests/relprime_small_primes_negative_test.exp
@@ -1,0 +1,2 @@
+# Expect 2^256 - 1 (check passed).
+w22 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/sw/otbn/crypto/tests/relprime_small_primes_negative_test.s
+++ b/sw/otbn/crypto/tests/relprime_small_primes_negative_test.s
@@ -1,0 +1,69 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Standalone test to check an RSA keygen subroutine.
+ *
+ * The `relprime_small_primes` subroutine checks if a candidate prime is a
+ * multiple of a small prime. This test ensures that the check does not think a
+ * prime number is divisible by small primes.
+ */
+
+.section .text.start
+
+main:
+  /* Init all-zero register. */
+  bn.xor    w31, w31, w31
+
+  /* Load the number of limbs for this test. */
+  li        x30, 4
+
+  /* w22 <= 0 if dmem[simple_positive_input] is NOT relatively prime to F4 */
+  la        x16, input
+  jal       x1, relprime_small_primes
+
+  ecall
+
+.data
+
+/**
+ * A 1024-bit value that is prime.
+ *
+ * Full value for reference =
+ * 0xde7d8c0eb2b3beca4db93f640590f62840bbe2435734ee154ef9dfd6eb5f8b9367a86989b88ee86dea529f5d1d62eb7fff904bd9a62d864a50aac31e5dec899a09255b18d8d61eca4b1bc038d3c655397cac166eb3ae6232e9dc11d31398fd4c0bb0af114cd5670c2c99f59cd6963500d0e9edcac0957b414a394ec915bd9377
+ */
+.balign 32
+input:
+.word 0x15bd9377
+.word 0x4a394ec9
+.word 0xc0957b41
+.word 0xd0e9edca
+.word 0xd6963500
+.word 0x2c99f59c
+.word 0x4cd5670c
+.word 0x0bb0af11
+.word 0x1398fd4c
+.word 0xe9dc11d3
+.word 0xb3ae6232
+.word 0x7cac166e
+.word 0xd3c65539
+.word 0x4b1bc038
+.word 0xd8d61eca
+.word 0x09255b18
+.word 0x5dec899a
+.word 0x50aac31e
+.word 0xa62d864a
+.word 0xff904bd9
+.word 0x1d62eb7f
+.word 0xea529f5d
+.word 0xb88ee86d
+.word 0x67a86989
+.word 0xeb5f8b93
+.word 0x4ef9dfd6
+.word 0x5734ee15
+.word 0x40bbe243
+.word 0x0590f628
+.word 0x4db93f64
+.word 0xb2b3beca
+.word 0xde7d8c0e


### PR DESCRIPTION
Filter out 62.1% of composite numbers by using arithmetic tricks specific to certain small primes. This should speed up RSA key generation by something close to 60% in expectation, because primality testing is the vast majority of the runtime and this lets us skip it in 60% of cases where it will eventually fail.