### PR TITLE
[RV_DM]rv_dm_stress_all_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -45,6 +45,7 @@ filesets:
       - seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_stress_all_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_stress_all_vseq.sv
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_stress_all_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_stress_all_vseq)
+
+  `uvm_object_new
+
+  constraint num_trans_c {
+    num_trans inside {[5:9]};
+  }
+
+  task body();
+    string seq_names[] = {
+                          "rv_dm_mem_tl_access_resuming_vseq",
+                          "rv_dm_halt_resume_whereto_vseq",
+                          "rv_dm_cmderr_busy_vseq",
+                          "rv_dm_smoke_vseq",
+                          "rv_dm_ndmreset_req_vseq",
+                          "rv_dm_mem_tl_access_halted_vseq",
+                          "rv_dm_cmderr_not_supported_vseq",
+                          "rv_dm_hart_unavail_vseq",
+                          "rv_dm_jtag_dtm_hard_reset_vseq",
+                          "rv_dm_jtag_dmi_dm_inactive_vseq",
+                          "rv_dm_jtag_dtm_idle_hint_vseq",
+                          "rv_dm_jtag_dmi_debug_disabled_vseq"
+                          };
+    for (int i = 1; i <= num_trans; i++) begin
+      uvm_sequence    seq;
+      rv_dm_base_vseq rv_dm_vseq;
+      uint            seq_idx = $urandom_range(0, seq_names.size - 1);
+
+      seq = create_seq_by_name(seq_names[seq_idx]);
+      `downcast(rv_dm_vseq, seq)
+
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
+      // as upper seq may drive reset.
+      if (do_apply_reset) rv_dm_vseq.do_apply_reset = $urandom_range(0, 1);
+      else                rv_dm_vseq.do_apply_reset = 0;
+
+      rv_dm_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(rv_dm_vseq)
+      rv_dm_vseq.start(p_sequencer);
+     end
+   endtask
+
+endclass : rv_dm_stress_all_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -23,3 +23,4 @@
 `include "rv_dm_jtag_dmi_dm_inactive_vseq.sv"
 `include "rv_dm_jtag_dmi_debug_disabled_vseq.sv"
 `include "rv_dm_jtag_dtm_hard_reset_vseq.sv"
+`include "rv_dm_stress_all_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -250,6 +250,10 @@
       uvm_test_seq: rv_dm_jtag_dtm_hard_reset_vseq
       reseed: 2
     }
+    {
+      name: rv_dm_stress_all
+      uvm_test_seq: rv_dm_stress_all_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
Combine sequences in one test and run as many of them as possible in parallel.This commit remove a sequence called "common_vseq". As it was failing in regression.