### PR TITLE
[sca] Prepare SHA3 for pen. tests

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -100,7 +100,10 @@ cc_library(
 cc_library(
     name = "sha3_sca",
     srcs = ["sha3_sca.c"],
-    hdrs = ["sha3_sca.h"],
+    hdrs = [
+        "sha3_sca.h",
+        "status.h",
+    ],
     deps = [
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",

--- a/sw/device/tests/crypto/cryptotest/json/sha3_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/sha3_sca_commands.h
@@ -11,6 +11,7 @@ extern "C" {
 
 #define SHA3SCA_CMD_MAX_BATCH_DIGEST_BYTES 32
 #define SHA3SCA_CMD_MAX_DATA_BYTES 16
+#define SHA3SCA_CMD_MAX_FPGA_MODE_BYTES 1
 #define SHA3SCA_CMD_MAX_MASKS_OFF_BYTES 1
 #define SHA3SCA_CMD_MAX_LFSR_BYTES 4
 #define SHA3SCA_CMD_MAX_MSG_BYTES 16
@@ -38,6 +39,10 @@ UJSON_SERDE_STRUCT(CryptotestSha3ScaLfsr, cryptotest_sha3_sca_lfsr_t, SHA3_SCA_L
 #define SHA3_SCA_DATA(field, string) \
     field(data, uint8_t, SHA3SCA_CMD_MAX_DATA_BYTES)
 UJSON_SERDE_STRUCT(CryptotestSha3ScaData, cryptotest_sha3_sca_data_t, SHA3_SCA_DATA);
+
+#define SHA3_SCA_FPGA_MODE(field, string) \
+    field(fpga_mode, uint8_t)
+UJSON_SERDE_STRUCT(CryptotestSha3ScaFpgaMode, cryptotest_sha3_sca_fpga_mode_t, SHA3_SCA_FPGA_MODE);
 
 #define SHA3_SCA_MSG(field, string) \
     field(msg, uint8_t, SHA3SCA_CMD_MAX_MSG_BYTES) \


### PR DESCRIPTION
Currently, the SCA code for SHA3 uses features to improve SCA that are only available on the FPGA but not on the discrete chip.

This PR, similar to #20772, changes the sha3_sca code such that the code supports measurements on the FPGA and on the chip.

I've made the following experiments:

`fpga_mode=true` and `masks_off=true`:
![sha3_fpga_mode_true](https://github.com/lowRISC/opentitan/assets/5767400/1a7f38ca-ab10-4597-bc1b-7ad5695c02cb)

`fpga_mode=off` (new mode in this PR) and `masks_off=true`:
![sha3_fpga_mode_false](https://github.com/lowRISC/opentitan/assets/5767400/ce3cfab4-4130-4e5a-a9d1-06f140bc01bf)

As expected, the SCA relevant part is delayed and more noisy but we still can measure leakage. Note that I had to set `kIbexLoadHashMessageSleepCycles = 500` to get first order leakage.