### PR TITLE
[sival,tests] Remove fpga_cw310 from clkmgr_external_clk_src_for_sw_s…

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -642,16 +642,10 @@ opentitan_test(
     srcs = ["clkmgr_external_clk_src_for_sw_slow_test.c"],
     cw310 = new_cw310_params(
         otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_dev_manuf_personalized",
-        # TODO(lowrisc/opentitan#12486): [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
+        # TODO(lowrisc/opentitan#19620): fpga doesn't support lowering main clk frequency
         tags = ["broken"],
     ),
     exec_env = {
-        # Exclude fpga_cw310_rom_with_fake_keys because they are signed with
-        # RMA keys, while we need DEV, and the infrastructure doesn't allow
-        # changing the key for a single environment.
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },


### PR DESCRIPTION
…low_test

The fpga doesn't support lowering the main clock frequency.

Fixes #19620