### PR TITLE
[dv,chip_level] Clean up apply_reset

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -35,40 +35,32 @@ class chip_base_vseq #(
     super.post_start();
   endtask
 
+  // At chip level the only external reset is POR. All others are internally generated, or
+  // are triggered by specific pin actions. The important observation is that we DO NOT
+  // handle resets like it is done for IP blocks, where each invididual reset is triggered
+  // by the environment.
   virtual task apply_reset(string kind = "HARD");
     callback_vseq.pre_apply_reset();
-    // Note: The JTAG reset does not have a dedicated pad and is muxed with other chip IOs.
-    // These IOs have pad attributes that are driven from registers, and as long as
-    // the reset line of those registers is X, the registers and hence the pad outputs
-    // will also be X. This causes the JTAG reset to not properly propagate, and hence we
-    // have to assert the main reset before that (release can happen in a randomized way
-    // via the apply_reset task later on).
-    // assert_por_reset();
-    void'($value$plusargs("skip_por_n_during_first_pwrup=%0b", skip_por_n_during_first_pwrup));
-    if (!(skip_por_n_during_first_pwrup && is_first_pwrup)) begin
-      `uvm_info(`gfn, "Asserting POR_N", UVM_LOW)
-      cfg.chip_vif.por_n_if.drive(0);
-      #10us;  // TODO: revisit this.
-      cfg.chip_vif.por_n_if.drive(1);
-      `uvm_info(`gfn, "POR_N complete", UVM_LOW)
+    if (kind == "HARD") begin
+      if (!is_first_pwrup) begin
+        assert_por_reset(.delay(0));
+      end
+      // Note: The JTAG reset does not have a dedicated pad and is muxed with other chip IOs.
+      // These IOs have pad attributes that are driven from registers, and as long as
+      // the reset line of those registers is X, the registers and hence the pad outputs
+      // will also be X. This causes the JTAG reset to not properly propagate, and hence we
+      // have to assert the main reset before that (release can happen in a randomized way
+      // via the apply_reset task later on).
+
+      // Should this be reset for any reset_kind?
+      cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n();
+      if (jtag_dmi_ral != null) jtag_dmi_ral.reset(kind);
     end
-    // TODO: Cannot assert different types of resets in parallel; due to randomization
-    // resets de-assert at different times. If the main rst_n de-asserts before others,
-    // the CPU starts executing right away which can cause breakages.
-    cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.do_trst_n();
-    super.apply_reset(kind);
-    if (jtag_dmi_ral != null) jtag_dmi_ral.reset(kind);
     callback_vseq.post_apply_reset();
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
-    cfg.chip_vif.por_n_if.drive(0);
-    // At least 6 AON clock cycles.
-    // TODO: Tentatively this is set to 100us. Fetch the individual clock freqs from AST via
-    // chip_vif.
-    reset_duration_ps = max2(reset_duration_ps, 100_000_000 /* 100us */);
-    super.apply_resets_concurrently(reset_duration_ps);
-    cfg.chip_vif.por_n_if.drive(1);
+    apply_reset("HARD");
   endtask
 
   chip_callback_vseq callback_vseq;
@@ -380,7 +372,10 @@ class chip_base_vseq #(
   // POR_N needs to stay asserted for at least 6 AON clock cycles.
   task assert_por_reset(int delay = 0);
     repeat (delay) @cfg.chip_vif.pwrmgr_low_power_if.fast_cb;
+    `uvm_info(`gfn, "Asserting POR_N", UVM_LOW)
     cfg.chip_vif.por_n_if.drive(0);
+    // For reset we need the aon clock to be running, so it is okay to wait a few cycles
+    // before de-asserting .
     repeat (6) @cfg.chip_vif.pwrmgr_low_power_if.cb;
     cfg.clk_rst_vif.wait_clks(10);
     cfg.chip_vif.por_n_if.drive(1);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -10,9 +10,8 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   }
   `uvm_object_new
 
-  virtual task post_apply_reset(string reset_kind = "HARD");
-    super.post_apply_reset(reset_kind);
-
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
     for (int ram_idx = 0; ram_idx < cfg.num_ram_ret_tiles; ram_idx++) begin
       cfg.mem_bkdr_util_h[chip_mem_e'(RamRet0 + ram_idx)].randomize_mem();
     end

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -40,22 +40,8 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
 
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset(kind);
-    `DV_SPINWAIT(cfg.chip_vif.cpu_clk_rst_if.wait_for_reset();)
-  endtask
-
-  virtual task post_apply_reset(string reset_kind = "HARD");
-    super.post_apply_reset(reset_kind);
-    // Wait until rom_ctrl and lc_ctrl have finished to ensure stub_cpu
-    // does not conflict with any background power-up activity
-
-    // Add extra guard for closed source env.
-    // Closed source has long reset period (> 1ms).
-    // If `wait_rom_check_done()` is called during the reset period,
-    // this task pass without checking and causes false failure.
-    // wait for aon clock to make sure reset is de-asserted.
-    @cfg.chip_vif.aon_clk_por_rst_if.cb;
-    `uvm_info(`gfn, "Wait for ROM check to complete", UVM_MEDIUM)
-    wait_rom_check_done();
+    // The test body cannot start before all is ready for the CPU to run.
+    `DV_WAIT(cfg.chip_vif.pwrmgr_fast_pwr_state_active)
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");


### PR DESCRIPTION
Change apply_reset to just do a POR, plus some jtag resets that have independent pins. Remove the apply_resets_concurrently, and rely on POR only, since the chip should internally create the derived resets.

Addresses #19445