### PR TITLE
[sival,pwrmgr] Create dedicated test for wakeup 5

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1828,6 +1828,13 @@
       run_opts: ["+sw_test_timeout_ns=18_000_000", "+do_random=1"]
     }
     {
+      name: chip_sw_pwrmgr_sleep_wake_5_bug
+      uvm_test_seq: "chip_sw_base_vseq"
+      sw_images: ["//sw/device/tests:pwrmgr_sleep_wake_5_bug_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=18_000_000", "+do_random=1"]
+    }
+    {
       name: chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up
       uvm_test_seq: "chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up_vseq"
       sw_images: ["//sw/device/tests:pwrmgr_sensor_ctrl_deep_sleep_wake_up:1:new_rules"]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2671,6 +2671,53 @@ opentitan_test(
     ],
 )
 
+# This test reproduces a silicon failure, but passes in all other environments.
+# TODO(lowrisc/opentitan#20798)  Remove this test and extend
+# pwrmgr_random_sleep_all_wake_ups to cover all wakeups once this issue is
+# fixed.
+opentitan_test(
+    name = "pwrmgr_sleep_wake_5_bug_test",
+    srcs = ["pwrmgr_sleep_wake_5_bug_test.c"],
+    cw310 = new_cw310_params(
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:silicon_creator": None,
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
+        "//hw/top_earlgrey:sim_dv": None,
+    },
+    silicon = silicon_params(
+        tags = ["broken"],
+        test_cmd = """
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
+    ),
+    deps = [
+        "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:ret_sram_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/tests/sim_dv:pwrmgr_sleep_all_wake_ups_impl",
+    ],
+)
+
 opentitan_test(
     name = "pwrmgr_sensor_ctrl_deep_sleep_wake_up",
     srcs = ["pwrmgr_sensor_ctrl_deep_sleep_wake_up.c"],

--- a/sw/device/tests/pwrmgr_normal_sleep_por_reset_test.c
+++ b/sw/device/tests/pwrmgr_normal_sleep_por_reset_test.c
@@ -35,7 +35,7 @@ static dif_rstmgr_t rstmgr;
 /**
  * Initialize the peripherals used in this test.
  */
-void init_peripherals(void) {
+static void init_peripherals(void) {
   // Initialize pwrmgr.
   CHECK_DIF_OK(dif_pwrmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));

--- a/sw/device/tests/pwrmgr_sleep_disabled_test.c
+++ b/sw/device/tests/pwrmgr_sleep_disabled_test.c
@@ -28,7 +28,7 @@ static volatile top_earlgrey_plic_peripheral_t peripheral;
 static volatile bool interrupt_serviced;
 static volatile bool interrupt_failed;
 
-bool is_pwrmgr_irq_pending(void) {
+static bool is_pwrmgr_irq_pending(void) {
   bool status;
   CHECK_DIF_OK(dif_rv_plic_irq_is_pending(
       &plic, kTopEarlgreyPlicIrqIdPwrmgrAonWakeup, &status));

--- a/sw/device/tests/pwrmgr_sleep_wake_5_bug_test.c
+++ b/sw/device/tests/pwrmgr_sleep_wake_5_bug_test.c
@@ -19,24 +19,15 @@
 #include "sw/device/lib/testing/autogen/isr_testutils.h"
 
 /*
-  PWRMGR RANDOM SLEEP ALL WAKE UPS TEST
+  PWRMGR RANDOM SLEEP WAKE UP 5 TEST
 
   This test runs power manager wake up from normal or deep sleep mode by
   wake up inputs.
 
-  There are 6 wake up inputs.
-  0: sysrst_ctrl
-  1: adc_ctrl, only runnable in DV
-  2: pinmux
-  3: usb
-  4: aon_timer
+  It deals with wake up 5.
   5: sensor_ctrl
 
-  #1 is excluded in non-DV because it forces an internal signal.
-
-  There are 10 cases to be tested. For each wake up this tests normal and
-  deep sleep in succession; for example, case 2 is adc_ctrl normal sleep and
-  case 3 is adc_ctrl deep sleep.
+  For wake up 5 this tests normal and deep sleep in succession.
 
   This is tracked by a retention sram counter, given there are resets involved.
  */
@@ -78,7 +69,7 @@ bool test_main(void) {
   if (wakeup_reason.request_sources == 0) {
     // This is a POR. Prepare to start the test.
     CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_clear(&pwrmgr));
-    CHECK_STATUS_OK(ret_sram_testutils_counter_clear(kCounterCases));
+    CHECK_STATUS_OK(ret_sram_testutils_counter_set(kCounterCases, 10));
   } else if (wakeup_reason.types != kDifPwrmgrWakeupTypeRequest) {
     LOG_ERROR("Unexpected wakeup_reason.types 0x%x", wakeup_reason.types);
     return false;
@@ -99,17 +90,8 @@ bool test_main(void) {
         ret_sram_testutils_counter_get(kCounterCases, &wakeup_count));
 
     // Check if all wakeups are tested, or some need to be skipped.
-    // There is a bug in the last wakeup (5), so this test skips that
-    // and there is a separate test that triggers it.
-    // TODO(lowrisc/opentitan#20798) Enable all wakeups once this is addressed.
-    if (wakeup_count >= 2 * (PWRMGR_PARAM_NUM_WKUPS - 1)) {
+    if (wakeup_count >= 2 * PWRMGR_PARAM_NUM_WKUPS) {
       return true;
-    } else if (kDeviceType != kDeviceSimDV &&
-               wakeup_count == 2 * PWRMGR_PARAM_ADC_CTRL_AON_WKUP_REQ_IDX) {
-      // Skip both normal and deep sleep.
-      wakeup_count += 2;
-      CHECK_STATUS_OK(
-          ret_sram_testutils_counter_set(kCounterCases, wakeup_count));
     }
   }
   // All is well, get ready for the next unit, normal and deep sleep.
@@ -118,9 +100,17 @@ bool test_main(void) {
   deep_sleep = get_deep_sleep(wakeup_count);
   delay_n_clear(4);
   CHECK(!deep_sleep, "Should be normal sleep");
+  dif_pwrmgr_request_sources_t wake_req = ~0u;
+  CHECK_DIF_OK(dif_pwrmgr_get_current_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, &wake_req));
+  LOG_INFO("Wake_status 0x%x", wake_req);
   execute_test(wakeup_unit, deep_sleep);
   check_wakeup_reason(wakeup_unit);
   LOG_INFO("Woke up by source %d", wakeup_unit);
+  wake_req = ~0u;
+  CHECK_DIF_OK(dif_pwrmgr_get_current_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, &wake_req));
+  LOG_INFO("Wake_status 0x%x", wake_req);
   clear_wakeup(wakeup_unit);
   // Prepare deep sleep. The check is done above where a reset is handled.
   CHECK_STATUS_OK(ret_sram_testutils_counter_increment(kCounterCases));

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
@@ -242,11 +242,7 @@ void check_wakeup_reason(uint32_t wakeup_unit) {
       CHECK(has_wakeup, "Expected sysrst_ctrl wakeup to be set");
     } break;
     case PWRMGR_PARAM_ADC_CTRL_AON_WKUP_REQ_IDX: {
-      uint32_t irq_causes = 0;
       uint32_t filter_status = 0;
-      CHECK_DIF_OK(dif_adc_ctrl_irq_get_causes(&adc_ctrl, &irq_causes));
-      CHECK(irq_causes == (1 << kDifAdcCtrlFilter5),
-            "Expected bit %d set in irq causes", kDifAdcCtrlFilter5);
       CHECK_DIF_OK(dif_adc_ctrl_get_filter_status(&adc_ctrl, &filter_status));
       CHECK(filter_status == (1 << kDifAdcCtrlFilter5),
             "Expected bit %d set in irq causes", kDifAdcCtrlFilter5);
@@ -324,10 +320,6 @@ void clear_wakeup(uint32_t wakeup_unit) {
           &sensor_ctrl, kSensorCtrlEventIdx, kDifToggleDisabled));
       CHECK_DIF_OK(
           dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, kSensorCtrlEventIdx));
-      // For some reason bit 5 is also set. This is unexpected and needs
-      // clarification from the AST team.
-      // TODO(lowrisc/opentitan#20798) Update this once the issue is closed.
-      CHECK_DIF_OK(dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, 5));
       dif_toggle_t enable;
       CHECK_DIF_OK(dif_sensor_ctrl_get_ast_event_trigger(
           &sensor_ctrl, kSensorCtrlEventIdx, &enable));


### PR DESCRIPTION
Create test for wakeup reason 5, expected to fail due to #20798 from sw/device/tests/pwrmgr_random_sleep_all_wake_ups.c.

Skip wakeup reason 5 in pwrmgr_random_sleep_all_wake_ups, with a TODO referring to #20798.