### PR TITLE
[RV_DM]rv_dm_mem_tl_access_halted_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
@@ -17,6 +17,9 @@ class rv_dm_mem_tl_access_halted_vseq extends rv_dm_base_vseq;
 
   task body();
     uvm_reg_data_t r_data;
+    // Disable unavailable signal to make sure that hart should be in known state. if hart
+    // is unavailable then it could not halted.
+    cfg.rv_dm_vif.unavailable <= 0;
     repeat ($urandom_range(1, 10)) begin
       // Verify that writing to HALTED results in anyhalted and allhalted to be set.
       csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(1));


### PR DESCRIPTION
This commit contain changes in which we disable the unavailable signal to make sure that hart should be in known state. if hart will be unavailable it could not halted. I write unavailable signal outside repeat loop as it is not necessary to be in repeat loop.