### PR TITLE
[dv/csr_utils] Change `csr_peek` to function

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -383,10 +383,10 @@ package csr_utils_pkg;
 
   // backdoor read csr
   // uvm_reg::peek() returns a 2-state value, directly get data from hdl path
-  task automatic csr_peek(input uvm_object      ptr,
-                          output uvm_reg_data_t value,
-                          input uvm_check_e     check = default_csr_check,
-                          input bkdr_reg_path_e kind = BkdrRegPathRtl);
+  function automatic void csr_peek(input uvm_object      ptr,
+                                   output uvm_reg_data_t value,
+                                   input uvm_check_e     check = default_csr_check,
+                                   input bkdr_reg_path_e kind = BkdrRegPathRtl);
     string      msg_id = {csr_utils_pkg::msg_id, "::csr_peek"};
     csr_field_t csr_or_fld = decode_csr_or_field(ptr);
     uvm_reg     csr = csr_or_fld.csr;
@@ -411,7 +411,7 @@ package csr_utils_pkg;
 
     // if it's field, only return field value
     if (csr_or_fld.field != null) value = get_field_val(csr_or_fld.field, value);
-  endtask
+  endfunction
 
   task automatic csr_rd_check(input  uvm_object         ptr,
                               input  uvm_check_e        check = default_csr_check,


### PR DESCRIPTION
This procedure does not have to be a task because it does not control time.  Thus it can be a function, which is easier to use because it can be called from functions and not only from tasks -- and functions are easier to use because they can have a return value.

I ran this change through VCS and Xcelium as part of PR #21061 and did not notice any problems.