### PR TITLE
[cryptolib] Add unused result before status_t functions in P-256 headers

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/ecdh_p256.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p256.c
@@ -29,20 +29,36 @@ static const otbn_addr_t kOtbnVarEcdhY = OTBN_ADDR_T_INIT(p256_ecdh, y);
 static const otbn_addr_t kOtbnVarEcdhD0 = OTBN_ADDR_T_INIT(p256_ecdh, d0);
 static const otbn_addr_t kOtbnVarEcdhD1 = OTBN_ADDR_T_INIT(p256_ecdh, d1);
 
-// Mode is represented by a single word. See `p256_ecdh.s` for values.
-static const uint32_t kOtbnEcdhModeWords = 1;
-static const uint32_t kOtbnEcdhModeKeypairRandom = 0x3f1;
-static const uint32_t kOtbnEcdhModeSharedKey = 0x5ec;
-static const uint32_t kOtbnEcdhModeKeypairFromSeed = 0x29f;
-static const uint32_t kOtbnEcdhModeSharedKeyFromSeed = 0x74b;
+enum {
+  /*
+   * Mode is represented by a single word.
+   */
+  kOtbnEcdhModeWords = 1,
+  /*
+   * Mode to generate a new random keypair.
+   */
+  kOtbnEcdhModeKeypairRandom = 0x3f1,
+  /*
+   * Mode to generate a new shared key.
+   */
+  kOtbnEcdhModeSharedKey = 0x5ec,
+  /*
+   * Mode to generate a new sideloaded keypair.
+   */
+  kOtbnEcdhModeKeypairFromSeed = 0x29f,
+  /*
+   * Mode to generate a new sideloaded shared key.
+   */
+  kOtbnEcdhModeSharedKeyFromSeed = 0x74b,
+};
 
 status_t ecdh_p256_keypair_start(void) {
   // Load the ECDSA/P-256 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
 
   // Set mode so start() will jump into keygen.
-  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &kOtbnEcdhModeKeypairRandom,
-                               kOtbnVarEcdhMode));
+  uint32_t mode = kOtbnEcdhModeKeypairRandom;
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &mode, kOtbnVarEcdhMode));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -75,8 +91,8 @@ status_t ecdh_p256_shared_key_start(const p256_masked_scalar_t *private_key,
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
 
   // Set mode so start() will jump into shared-key generation.
-  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &kOtbnEcdhModeSharedKey,
-                               kOtbnVarEcdhMode));
+  uint32_t mode = kOtbnEcdhModeSharedKey;
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &mode, kOtbnVarEcdhMode));
 
   // Set the private key shares.
   HARDENED_TRY(
@@ -113,8 +129,8 @@ status_t ecdh_p256_sideload_keypair_start(void) {
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
 
   // Set mode so start() will jump into sideloaded keygen.
-  HARDENED_TRY(otbn_dmem_write(
-      kOtbnEcdhModeWords, &kOtbnEcdhModeKeypairFromSeed, kOtbnVarEcdhMode));
+  uint32_t mode = kOtbnEcdhModeKeypairFromSeed;
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &mode, kOtbnVarEcdhMode));
 
   // Start the OTBN routine.
   return otbn_execute();
@@ -139,8 +155,8 @@ status_t ecdh_p256_sideload_shared_key_start(const p256_point_t *public_key) {
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
 
   // Set mode so start() will jump into shared-key generation.
-  HARDENED_TRY(otbn_dmem_write(
-      kOtbnEcdhModeWords, &kOtbnEcdhModeSharedKeyFromSeed, kOtbnVarEcdhMode));
+  uint32_t mode = kOtbnEcdhModeSharedKeyFromSeed;
+  HARDENED_TRY(otbn_dmem_write(kOtbnEcdhModeWords, &mode, kOtbnVarEcdhMode));
 
   // Set the public key x coordinate.
   HARDENED_TRY(otbn_dmem_write(kP256CoordWords, public_key->x, kOtbnVarEcdhX));

--- a/sw/device/lib/crypto/impl/ecc/ecdh_p256.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p256.h
@@ -33,6 +33,7 @@ typedef struct ecdh_p256_shared_key {
  *
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdh_p256_keypair_start(void);
 
 /**
@@ -44,6 +45,7 @@ status_t ecdh_p256_keypair_start(void);
  * @param[out] public_key Generated public key.
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdh_p256_keypair_finalize(p256_masked_scalar_t *private_key,
                                     p256_point_t *public_key);
 
@@ -56,6 +58,7 @@ status_t ecdh_p256_keypair_finalize(p256_masked_scalar_t *private_key,
  * @param public_key Public key (Q).
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdh_p256_shared_key_start(const p256_masked_scalar_t *private_key,
                                     const p256_point_t *public_key);
 
@@ -69,6 +72,7 @@ status_t ecdh_p256_shared_key_start(const p256_masked_scalar_t *private_key,
  * @param[out] shared_key Shared secret key (x-coordinate of d*Q).
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdh_p256_shared_key_finalize(ecdh_p256_shared_key_t *shared_key);
 
 /**
@@ -81,6 +85,7 @@ status_t ecdh_p256_shared_key_finalize(ecdh_p256_shared_key_t *shared_key);
  *
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdh_p256_sideload_keypair_start(void);
 
 /**
@@ -91,6 +96,7 @@ status_t ecdh_p256_sideload_keypair_start(void);
  * @param[out] public_key Generated public key.
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdh_p256_sideload_keypair_finalize(p256_point_t *public_key);
 
 /**
@@ -104,6 +110,7 @@ status_t ecdh_p256_sideload_keypair_finalize(p256_point_t *public_key);
  * @param public_key Public key (Q).
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdh_p256_sideload_shared_key_start(const p256_point_t *public_key);
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p256.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p256.h
@@ -33,6 +33,7 @@ typedef struct ecdsa_p256_signature_t {
  *
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_keygen_start(void);
 
 /**
@@ -43,6 +44,7 @@ status_t ecdsa_p256_keygen_start(void);
  *
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_sideload_keygen_start(void);
 
 /**
@@ -54,6 +56,7 @@ status_t ecdsa_p256_sideload_keygen_start(void);
  * @param[out] public_key Generated public key.
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_keygen_finalize(p256_masked_scalar_t *private_key,
                                     p256_point_t *public_key);
 
@@ -66,6 +69,7 @@ status_t ecdsa_p256_keygen_finalize(p256_masked_scalar_t *private_key,
  * @param[out] public_key Public key.
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_sideload_keygen_finalize(p256_point_t *public_key);
 
 /**
@@ -77,6 +81,7 @@ status_t ecdsa_p256_sideload_keygen_finalize(p256_point_t *public_key);
  * @param private_key Secret key to sign the message with.
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_sign_start(const uint32_t digest[kP256ScalarWords],
                                const p256_masked_scalar_t *private_key);
 
@@ -89,6 +94,7 @@ status_t ecdsa_p256_sign_start(const uint32_t digest[kP256ScalarWords],
  * @param digest Digest of the message to sign.
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_sideload_sign_start(
     const uint32_t digest[kP256ScalarWords]);
 
@@ -102,6 +108,7 @@ status_t ecdsa_p256_sideload_sign_start(
  * @param[out] result Buffer in which to store the generated signature.
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_sign_finalize(ecdsa_p256_signature_t *result);
 
 /**
@@ -116,6 +123,7 @@ status_t ecdsa_p256_sign_finalize(ecdsa_p256_signature_t *result);
  * @param public_key Key to check the signature against.
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_verify_start(const ecdsa_p256_signature_t *signature,
                                  const uint32_t digest[kP256ScalarWords],
                                  const p256_point_t *public_key);
@@ -140,6 +148,7 @@ status_t ecdsa_p256_verify_start(const ecdsa_p256_signature_t *signature,
  * otherwise)
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t ecdsa_p256_verify_finalize(const ecdsa_p256_signature_t *signature,
                                     hardened_bool_t *result);
 

--- a/sw/device/lib/crypto/impl/ecc/p256_common.h
+++ b/sw/device/lib/crypto/impl/ecc/p256_common.h
@@ -101,6 +101,7 @@ typedef struct p256_point {
  * @param share1_addr DMEM address of the second share.
  * @return Result of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,
                                   const otbn_addr_t share0_addr,
                                   const otbn_addr_t share1_addr);


### PR DESCRIPTION
This PR 
- adds the `OT_WARN_UNUSED_RESULT` macro before `status_t` functions of p256 files to protect against a caller forgetting to check and forward the error code.
- puts P-256 ECDH modes in an anonymous enum to match the other files.
- addresses issues which came up in the discussion of https://github.com/lowRISC/opentitan/pull/21067 .