### PR TITLE
[cryptotest] Updates to ECDSA test vector parsing

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -40,7 +40,7 @@ genrule(
         tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_ecdsa_parser",
     )
     for src_name, cryptotest_name in [
-        ("ecdsa_secp256k1_sha256_test.json", "wycheproof_ecdsa_p256_sha256"),
+        ("ecdsa_secp256r1_sha256_test.json", "wycheproof_ecdsa_p256_sha256"),
         ("ecdsa_secp384r1_sha384_test.json", "wycheproof_ecdsa_p384_sha384"),
     ]
 ]

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -41,6 +41,12 @@ genrule(
     )
     for src_name, cryptotest_name in [
         ("ecdsa_secp256r1_sha256_test.json", "wycheproof_ecdsa_p256_sha256"),
+        ("ecdsa_secp256r1_sha512_test.json", "wycheproof_ecdsa_p256_sha512"),
+        ("ecdsa_secp256r1_sha3_256_test.json", "wycheproof_ecdsa_p256_sha3_256"),
+        ("ecdsa_secp256r1_sha3_512_test.json", "wycheproof_ecdsa_p256_sha3_512"),
         ("ecdsa_secp384r1_sha384_test.json", "wycheproof_ecdsa_p384_sha384"),
+        ("ecdsa_secp384r1_sha512_test.json", "wycheproof_ecdsa_p384_sha512"),
+        ("ecdsa_secp384r1_sha3_384_test.json", "wycheproof_ecdsa_p384_sha3_384"),
+        ("ecdsa_secp384r1_sha3_512_test.json", "wycheproof_ecdsa_p384_sha3_512"),
     ]
 ]

--- a/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
@@ -19,6 +19,14 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "vendor": {
+        "description": "test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "test_case_id",
+        "type": "integer"
+      },
       "algorithm": {
         "description": "Should be ecdsa",
         "type": "string",

--- a/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
@@ -45,7 +45,7 @@
       "hash_alg": {
         "description": "Hash algorithm",
         "type": "string",
-        "enum": ["sha-1", "sha-224", "sha-256", "sha-384", "sha-512"]
+        "enum": ["sha-1", "sha-224", "sha-256", "sha-384", "sha-512", "sha3-256", "sha3-384", "sha3-512"]
       },
       "message": {
         "description": "Message to be verified",

--- a/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/aes_block_schema.json",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json",
   "title": "Cryptotest ECDSA Signature Verification Test Vector",
   "description": "A list of testvectors for ECDSA Signature Verification testing",
   "$defs": {

--- a/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ecdsa_sig_ver_schema.json
@@ -53,19 +53,19 @@
       },
       "qx": {
         "description": "Qx",
-        "type": "integer"
+        "type": "string"
       },
       "qy": {
         "description": "Qy",
-        "type": "integer"
+        "type": "string"
       },
       "r": {
         "description": "r parameter",
-        "type": "integer"
+        "type": "string"
       },
       "s": {
         "description": "s parameter",
-        "type": "integer"
+        "type": "string"
       },
       "result": {
         "description": "Verification result",

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_ecdsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_ecdsa_parser.py
@@ -34,6 +34,8 @@ def parse_testcases(args) -> None:
             continue
         for test_vec in raw_testcases[section_name]:
             test_case = {
+                "vendor": "nist",
+                "test_case_id": test_count,
                 "algorithm": "ecdsa",
                 "operation": "verify",
                 "curve": EC_NAME_MAPPING[curve],

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_ecdsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_ecdsa_parser.py
@@ -2,19 +2,17 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-
 """Parser for converting NIST CAVP Digital Signatures test vectors to JSON.
 
 """
 # TODO: Add more detailed docstring
 
 import argparse
-import sys
 import json
+import sys
+
 import jsonschema
-
 from cryptotest_util import parse_rsp, str_to_byte_array
-
 
 # Mapping from the curve names used by NIST to those used by cryptotest
 EC_NAME_MAPPING = {
@@ -58,7 +56,8 @@ def parse_testcases(args) -> None:
             elif result_str == "F":
                 test_case["result"] = False
             else:
-                raise ValueError(f"Unknown verification result value: {result_str}")
+                raise ValueError(
+                    f"Unknown verification result value: {result_str}")
 
             test_cases.append(test_case)
 
@@ -74,21 +73,12 @@ def parse_testcases(args) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Parsing utility for NIST CAVP Digital Signatures test vectors.")
+        description=
+        "Parsing utility for NIST CAVP Digital Signatures test vectors.")
 
-    parser.add_argument(
-        "--src",
-        help="Source file to import."
-    )
-    parser.add_argument(
-        "--dst",
-        help="Destination of the output file."
-    )
-    parser.add_argument(
-        "--schema",
-        type = str,
-        help = "Test vector schema file"
-    )
+    parser.add_argument("--src", help="Source file to import.")
+    parser.add_argument("--dst", help="Destination of the output file.")
+    parser.add_argument("--schema", type=str, help="Test vector schema file")
     args = parser.parse_args()
     parse_testcases(args)
 

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_ecdsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_ecdsa_parser.py
@@ -17,7 +17,8 @@ from cryptotest_util import parse_rsp, str_to_byte_array
 # Mapping from the curve names used by NIST to those used by cryptotest
 EC_NAME_MAPPING = {
     "P-256": "p256",
-    "P-384": "p384",
+    # TODO (#21067) uncomment when cryptolib supports P-384
+    # "P-384": "p384",
 }
 
 

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_ecdsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_ecdsa_parser.py
@@ -5,15 +5,15 @@
 
 import argparse
 import json
-import jsonschema
 import logging
 import sys
 
+import jsonschema
 from Crypto.Util.asn1 import DerSequence
 
 # Mapping from the curve names used by Wycheproof to those used by cryptotest
 EC_NAME_MAPPING = {
-    "secp256k1": "p256",
+    "secp256r1": "p256",
     "secp384r1": "p384",
 }
 
@@ -31,7 +31,8 @@ def _parse_der_signature(der_str):
     # Some tests parse correctly as a DER sequence but produce extra values.
     # These tests should be reject for a bad DER-encoded signature
     if len(seq) != 2:
-        raise ValueError("Failed to parse DER-encoded signature into r and s values")
+        raise ValueError(
+            "Failed to parse DER-encoded signature into r and s values")
     return seq
 
 
@@ -62,10 +63,14 @@ def parse_test_vectors(raw_data):
             try:
                 signature_seq = _parse_der_signature(test["sig"])
             except ValueError:
-                logging.info(f"Skipped tcId {test['tcId']}: ValueError while parsing DER sequence.")
+                logging.info(
+                    f"Skipped tcId {test['tcId']}: ValueError while parsing DER sequence."
+                )
                 continue
             except IndexError:
-                logging.info(f"Skipped tcId {test['tcId']}: IndexError while parsing DER sequence.")
+                logging.info(
+                    f"Skipped tcId {test['tcId']}: IndexError while parsing DER sequence."
+                )
                 continue
 
             test_vec["r"], test_vec["s"] = signature_seq
@@ -88,23 +93,15 @@ def parse_test_vectors(raw_data):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--src',
-        metavar='FILE',
-        type=argparse.FileType('r'),
-        help='Read test vectors from this JSON file.'
-    )
-    parser.add_argument(
-        '--dst',
-        metavar='FILE',
-        type=argparse.FileType('w'),
-        help='Write output to this file.'
-    )
-    parser.add_argument(
-        "--schema",
-        type = str,
-        help = "Testvector schema file"
-    )
+    parser.add_argument('--src',
+                        metavar='FILE',
+                        type=argparse.FileType('r'),
+                        help='Read test vectors from this JSON file.')
+    parser.add_argument('--dst',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help='Write output to this file.')
+    parser.add_argument("--schema", type=str, help="Testvector schema file")
     args = parser.parse_args()
 
     testvecs = parse_test_vectors(json.load(args.src))

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_ecdsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_ecdsa_parser.py
@@ -47,6 +47,8 @@ def parse_test_vectors(raw_data):
         for test in group["tests"]:
             logging.debug(f"Parsing tcId {test['tcId']}")
             test_vec = {
+                "vendor": "wycheproof",
+                "test_case_id": test['tcId'],
                 "algorithm": "ecdsa",
                 "operation": "verify",
                 "curve": EC_NAME_MAPPING[key["curve"]],


### PR DESCRIPTION
This PR makes several minor changes to the ECDSA test vector parsing to facilitate testing. The test firmware and drivers are included in #20853.

Changes: 

1. Changed curve type tested for P-256/SHA-256 in wycheproof test vector parser (Koblitz curves (*k1) are currently unsupported, only NIST curves (*r1) are)
2. Included wycheproof test vectors for P-256 for SHA-512, SHA3-256, and SHA3-512
3. Corrected `$id` field in ECDSA test vector JSON schema to display the correct protocol name
4. Added `vendor` and `test_case_id` as new fields in the ECDSA JSON schema to allow better navigation of the test output for debugging
5. Added support for additional hash functions in JSON schema
6. Changed type of `qx`, `qy`, `r`, and `s` values for ECDSA test vectors from integers to hex strings, preventing `serde_json` from truncating the precision of the values to an `f64` in the Rust test driver.
7. Excluded a few tests in the wycheproof vectors that encode the signature `(r, s)` pair as a valid DER sequence but the values are too long for their respective curves. Cryptolib statically prevents passing a value too long because the `signature` argument to `otcrypto_ecdsa_verify` is internally cast to an `ecdsa_p256_signature_t`, which enforces the size.