### PR TITLE
[crypto] Fix a broken "failure" branch in P-256 and P-384.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/ecdh_p256.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p256.c
@@ -20,7 +20,8 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, y);     // The public key y-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh,
                          d0);  // The private key scalar d (share 0).
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh,
-                         d1);  // The private key scalar d (share 1).
+                         d1);             // The private key scalar d (share 1).
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, ok);  // Public key validity.
 
 static const otbn_app_t kOtbnAppEcdh = OTBN_APP_T_INIT(p256_ecdh);
 static const otbn_addr_t kOtbnVarEcdhMode = OTBN_ADDR_T_INIT(p256_ecdh, mode);
@@ -28,6 +29,7 @@ static const otbn_addr_t kOtbnVarEcdhX = OTBN_ADDR_T_INIT(p256_ecdh, x);
 static const otbn_addr_t kOtbnVarEcdhY = OTBN_ADDR_T_INIT(p256_ecdh, y);
 static const otbn_addr_t kOtbnVarEcdhD0 = OTBN_ADDR_T_INIT(p256_ecdh, d0);
 static const otbn_addr_t kOtbnVarEcdhD1 = OTBN_ADDR_T_INIT(p256_ecdh, d1);
+static const otbn_addr_t kOtbnVarEcdhOk = OTBN_ADDR_T_INIT(p256_ecdh, ok);
 
 enum {
   /*
@@ -111,6 +113,14 @@ status_t ecdh_p256_shared_key_start(const p256_masked_scalar_t *private_key,
 status_t ecdh_p256_shared_key_finalize(ecdh_p256_shared_key_t *shared_key) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read the code indicating if the public key is valid.
+  uint32_t ok;
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarEcdhOk, &ok));
+  if (launder32(ok) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
   // Read the shares of the key from OTBN dmem (at vars x and y).
   HARDENED_TRY(

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p256.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p256.c
@@ -25,6 +25,7 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa,
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa,
                          d1);  // The private key scalar d (share 1).
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);  // Verification result.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, ok);   // Status code.
 
 static const otbn_app_t kOtbnAppEcdsa = OTBN_APP_T_INIT(p256_ecdsa);
 static const otbn_addr_t kOtbnVarEcdsaMode = OTBN_ADDR_T_INIT(p256_ecdsa, mode);
@@ -36,6 +37,7 @@ static const otbn_addr_t kOtbnVarEcdsaY = OTBN_ADDR_T_INIT(p256_ecdsa, y);
 static const otbn_addr_t kOtbnVarEcdsaD0 = OTBN_ADDR_T_INIT(p256_ecdsa, d0);
 static const otbn_addr_t kOtbnVarEcdsaD1 = OTBN_ADDR_T_INIT(p256_ecdsa, d1);
 static const otbn_addr_t kOtbnVarEcdsaXr = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
+static const otbn_addr_t kOtbnVarEcdsaOk = OTBN_ADDR_T_INIT(p256_ecdsa, ok);
 
 enum {
   /*
@@ -243,6 +245,15 @@ status_t ecdsa_p256_verify_finalize(const ecdsa_p256_signature_t *signature,
                                     hardened_bool_t *result) {
   // Spin here waiting for OTBN to complete.
   HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read the status code out of DMEM (false if basic checks on the validity of
+  // the signature and public key failed).
+  uint32_t ok;
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarEcdsaOk, &ok));
+  if (launder32(ok) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
 
   // Read x_r (recovered R) out of OTBN dmem.
   uint32_t x_r[kP256ScalarWords];

--- a/sw/otbn/crypto/p256_ecdh.s
+++ b/sw/otbn/crypto/p256_ecdh.s
@@ -30,6 +30,14 @@
 .equ MODE_KEYPAIR_FROM_SEED, 0x29f
 .equ MODE_SHARED_KEY_FROM_SEED, 0x74b
 
+/**
+ * Hardened boolean values.
+ *
+ * Should match the values in `hardened_asm.h`.
+ */
+.equ HARDENED_BOOL_TRUE, 0x739
+.equ HARDENED_BOOL_FALSE, 0x1d4
+
 .section .text.start
 start:
   /* Init all-zero register. */
@@ -95,6 +103,10 @@ keypair_random:
  * shared key is expressed in boolean shares x0, x1 such that the key is (x0 ^
  * x1).
  *
+ * If `ok` is false, the public key is invalid and the shared key is
+ * meaningless. The value will be either HARDENED_BOOL_TRUE or
+ * HARDENED_BOOL_FALSE.
+ *
  * This routine runs in constant time.
  *
  * @param[in]       w31: all-zero
@@ -102,14 +114,18 @@ keypair_random:
  * @param[in]  dmem[k1]: Second share of secret key.
  * @param[in]   dmem[x]: Public key (Q) x-coordinate.
  * @param[in]   dmem[y]: Public key (Q) y-coordinate.
+ * @param[out] dmem[ok]: Whether the public key is valid.
  * @param[out]  dmem[x]: x0, first share of shared key.
  * @param[out]  dmem[y]: x1, second share of shared key.
  */
 shared_key:
-  /* Validate the public key. Halts the program if the key is invalid and jumps
-     back here if it's OK. */
-  jal      x0, check_public_key_valid
-  _pk_valid:
+  /* Validate the public key (ends the program on failure). */
+  jal      x1, p256_check_public_key
+
+  /* If we got here the basic validity checks passed, so set `ok` to true. */
+  la       x2, ok
+  addi     x3, x0, HARDENED_BOOL_TRUE
+  sw       x3, 0(x2)
 
   /* Generate boolean-masked shared key (d*Q).x.
        dmem[x] <= x0
@@ -153,11 +169,16 @@ keypair_from_seed:
  * shared key is expressed in boolean shares x0, x1 such that the key is (x0 ^
  * x1).
  *
+ * If `ok` is false, the public key is invalid and the shared key is
+ * meaningless. The value will be either HARDENED_BOOL_TRUE or
+ * HARDENED_BOOL_FALSE.
+ *
  * This routine runs in constant time.
  *
  * @param[in]       w31: all-zero
  * @param[in]   dmem[x]: Public key (Q) x-coordinate.
  * @param[in]   dmem[y]: Public key (Q) y-coordinate.
+ * @param[out] dmem[ok]: Whether the public key is valid.
  * @param[out]  dmem[x]: x0, first share of shared key.
  * @param[out]  dmem[y]: x1, second share of shared key.
  */
@@ -216,94 +237,18 @@ secret_key_from_seed:
 
   ret
 
-/**
- * Check if a provided public key is valid.
- *
- * For a given public key (x, y), check that:
- * - x and y are both fully reduced mod p
- * - (x, y) is on the P-256 curve.
- *
- * Note that, because the point is in affine form, it is not possible that (x,
- * y) is the point at infinity. In some other forms such as projective
- * coordinates, we would need to check for this also.
- *
- * This routine raises a software error and halts operation if the public key
- * is invalid.
- *
- * @param[in] dmem[x]: Public key x-coordinate.
- * @param[in] dmem[y]: Public key y-coordinate.
- */
-check_public_key_valid:
-  /* Init all-zero register. */
-  bn.xor   w31, w31, w31
-
-  /* Load domain parameter p.
-       w29 <= dmem[p256_p] = p */
-  li        x2, 29
-  la        x3, p256_p
-  bn.lid    x2, 0(x3)
-
-  /* Load public key x-coordinate.
-       w2 <= dmem[x] = x */
-  li        x2, 2
-  la        x3, x
-  bn.lid    x2, 0(x3)
-
-  /* Compare x to p.
-       FG0.C <= (x < p) */
-  bn.cmp    w2, w29
-
-  /* Trigger a fault if FG0.C is false. */
-  csrrs     x2, FG0, x0
-  andi      x2, x2, 1
-  bne       x2, x0, _x_valid
-  unimp
-
-  _x_valid:
-
-  /* Load public key y-coordinate.
-       w2 <= dmem[y] = y */
-  li        x2, 2
-  la        x3, y
-  bn.lid    x2, 0(x3)
-
-  /* Compare y to p.
-       FG0.C <= (y < p) */
-  bn.cmp    w2, w29
-
-  /* Trigger a fault if FG0.C is false. */
-  csrrs     x2, FG0, x0
-  andi      x2, x2, 1
-  bne       x2, x0, _y_valid
-  unimp
-
-  _y_valid:
-
-  /* Compute both sides of the Weierstrauss equation.
-       w18 <= (x^3 + ax + b) mod p
-       w19 <= (y^2) mod p */
-  jal      x1, p256_isoncurve
-
-  /* Compare the two sides of the equation.
-       FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
-  bn.cmp    w18, w19
-
-  /* Trigger a fault if FG0.Z is false; otherwise jump back to the single call
-     site. */
-  csrrs     x2, FG0, x0
-  srli      x2, x2, 3
-  andi      x2, x2, 1
-  bne       x2, x0, _pk_valid
-  unimp
-  unimp
-  unimp
-
 .bss
 
 /* Operational mode. */
 .globl mode
 .balign 4
 mode:
+  .zero 4
+
+/* Success code for basic validity checks on the public key. */
+.globl ok
+.balign 4
+ok:
   .zero 4
 
 /* Public key (Q) x-coordinate. */

--- a/sw/otbn/crypto/p256_ecdsa.s
+++ b/sw/otbn/crypto/p256_ecdsa.s
@@ -103,17 +103,26 @@ ecdsa_sign:
 /**
  * Verify a signature.
  *
+ * The result of the verification is returned in two variables: `ok`
+ * indicates whether the signature passed basic validity checks, and `x_r`
+ * indicates the recovered value. A signature passes verification only if BOTH:
+ * - `ok` is true, and
+ * - `x_r` is equal to the original `r` value.
+ *
+ * If `ok` is false, the value in `x_r` is meaningless; callers
+ * should check both.
+ *
  * @param[in]  dmem[msg]: message to be verified (256 bits)
  * @param[in]  dmem[r]:   r component of signature (256 bits)
  * @param[in]  dmem[s]:   s component of signature (256 bits)
  * @param[in]  dmem[x]:   affine x-coordinate of public key (256 bits)
  * @param[in]  dmem[y]:   affine y-coordinate of public key (256 bits)
+ * @param[out] dmem[ok]:  success/failure of basic checks (32 bits)
  * @param[out] dmem[x_r]: dmem buffer for reduced affine x_r-coordinate (x_1)
  */
 ecdsa_verify:
-  /* Validate the public key (jumps back here if successful). */
-  jal      x0, check_public_key_valid
-  _pk_valid:
+  /* Validate the public key (ends the program on failure). */
+  jal      x1, p256_check_public_key
 
   /* Verify the signature (compute x_r). */
   jal      x1, p256_verify
@@ -195,94 +204,18 @@ secret_key_from_seed:
 
   ret
 
-/**
- * Check if a provided public key is valid.
- *
- * For a given public key (x, y), check that:
- * - x and y are both fully reduced mod p
- * - (x, y) is on the P-256 curve.
- *
- * Note that, because the point is in affine form, it is not possible that (x,
- * y) is the point at infinity. In some other forms such as projective
- * coordinates, we would need to check for this also.
- *
- * This routine raises a software error and halts operation if the public key
- * is invalid.
- *
- * @param[in] dmem[x]: Public key x-coordinate.
- * @param[in] dmem[y]: Public key y-coordinate.
- */
-check_public_key_valid:
-  /* Init all-zero register. */
-  bn.xor   w31, w31, w31
-
-  /* Load domain parameter p.
-       w29 <= dmem[p256_p] = p */
-  li        x2, 29
-  la        x3, p256_p
-  bn.lid    x2, 0(x3)
-
-  /* Load public key x-coordinate.
-       w2 <= dmem[x] = x */
-  li        x2, 2
-  la        x3, x
-  bn.lid    x2, 0(x3)
-
-  /* Compare x to p.
-       FG0.C <= (x < p) */
-  bn.cmp    w2, w29
-
-  /* Trigger a fault if FG0.C is false. */
-  csrrs     x2, FG0, x0
-  andi      x2, x2, 1
-  bne       x2, x0, _x_valid
-  unimp
-
-  _x_valid:
-
-  /* Load public key y-coordinate.
-       w2 <= dmem[y] = y */
-  li        x2, 2
-  la        x3, y
-  bn.lid    x2, 0(x3)
-
-  /* Compare y to p.
-       FG0.C <= (y < p) */
-  bn.cmp    w2, w29
-
-  /* Trigger a fault if FG0.C is false. */
-  csrrs     x2, FG0, x0
-  andi      x2, x2, 1
-  bne       x2, x0, _y_valid
-  unimp
-
-  _y_valid:
-
-  /* Compute both sides of the Weierstrauss equation.
-       w18 <= (x^3 + ax + b) mod p
-       w19 <= (y^2) mod p */
-  jal      x1, p256_isoncurve
-
-  /* Compare the two sides of the equation.
-       FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
-  bn.cmp    w18, w19
-
-  /* Trigger a fault if FG0.Z is false; otherwise jump back to the single call
-     site. */
-  csrrs     x2, FG0, x0
-  srli      x2, x2, 3
-  andi      x2, x2, 1
-  bne       x2, x0, _pk_valid
-  unimp
-  unimp
-  unimp
-
 .bss
 
 /* Operation mode. */
 .globl mode
 .balign 4
 mode:
+  .zero 4
+
+/* Success code for basic validity checks on the public key and signature. */
+.globl ok
+.balign 4
+ok:
   .zero 4
 
 /* Message digest. */

--- a/sw/otbn/crypto/p256_isoncurve.s
+++ b/sw/otbn/crypto/p256_isoncurve.s
@@ -3,6 +3,16 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 .globl p256_isoncurve
+.globl p256_check_public_key
+.globl p256_invalid_input
+
+/**
+ * Hardened boolean values.
+ *
+ * Should match the values in `hardened_asm.h`.
+ */
+.equ HARDENED_BOOL_TRUE, 0x739
+.equ HARDENED_BOOL_FALSE, 0x1d4
 
 /**
  * Checks if a point is a valid curve point on curve P-256 (secp256r1)
@@ -84,3 +94,120 @@ p256_isoncurve:
   jal       x1, mul_modp
 
   ret
+
+/**
+ * Check if a provided public key is valid.
+ *
+ * For a given public key (x, y), check that:
+ * - x and y are both fully reduced mod p
+ * - (x, y) is on the P-256 curve.
+ *
+ * Note that, because the point is in affine form, it is not possible that (x,
+ * y) is the point at infinity. In some other forms such as projective
+ * coordinates, we would need to check for this also.
+ *
+ * This routine sets `ok` to false if the check fails and immediately exits the
+ * program. If the check succeeds, `ok` is unmodified.
+ *
+ * @param[in] dmem[x]: Public key x-coordinate.
+ * @param[in] dmem[y]: Public key y-coordinate.
+ * @param[out] dmem[ok]: success/failure of basic checks (32 bits)
+ *
+ * clobbered registers: x2, x3, x19, x20, w0, w2, w19 to w29
+ * clobbered flag groups: FG0
+ */
+p256_check_public_key:
+  /* Init all-zero register. */
+  bn.xor   w31, w31, w31
+
+  /* Load domain parameter p.
+       w29 <= dmem[p256_p] = p */
+  li        x2, 29
+  la        x3, p256_p
+  bn.lid    x2, 0(x3)
+
+  /* Load public key x-coordinate.
+       w2 <= dmem[x] = x */
+  li        x2, 2
+  la        x3, x
+  bn.lid    x2, 0(x3)
+
+  /* Compare x to p.
+       FG0.C <= (x < p) */
+  bn.cmp    w2, w29
+
+  /* Fail if FG0.C is false. */
+  csrrs     x2, FG0, x0
+  andi      x2, x2, 1
+  bne       x2, x0, _x_valid
+  jal       x0, p256_invalid_input
+  unimp
+
+  _x_valid:
+
+  /* Load public key y-coordinate.
+       w2 <= dmem[y] = y */
+  li        x2, 2
+  la        x3, y
+  bn.lid    x2, 0(x3)
+
+  /* Compare y to p.
+       FG0.C <= (y < p) */
+  bn.cmp    w2, w29
+
+  /* Fail if FG0.C is false. */
+  csrrs     x2, FG0, x0
+  andi      x2, x2, 1
+  bne       x2, x0, _y_valid
+  jal       x0, p256_invalid_input
+  unimp
+
+  _y_valid:
+
+  /* Compute both sides of the Weierstrauss equation.
+       w18 <= (x^3 + ax + b) mod p
+       w19 <= (y^2) mod p */
+  jal      x1, p256_isoncurve
+
+  /* Compare the two sides of the equation.
+       FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
+  bn.cmp    w18, w19
+
+  /* Fail if FG0.Z is false; otherwise return. */
+  csrrs     x2, FG0, x0
+  andi      x2, x2, 8
+  bne       x2, x0, _xy_on_curve
+  jal       x0, p256_invalid_input
+
+  /* Extra unimps in case an attacker tries to skip the jump. */
+  unimp
+  unimp
+  unimp
+
+  _xy_on_curve:
+  ret
+
+/**
+ * Failure cases for basic validity checks jump here.
+ *
+ * This routine sets `ok` to false if the check fails.
+ *
+ * @param[out] dmem[ok] Set to HARDENED_BOOL_FALSE.
+ */
+p256_invalid_input:
+  /* Set the `ok` code to false. */
+  la       x2, ok
+  addi     x3, x0, HARDENED_BOOL_FALSE
+  sw       x3, 0(x2)
+
+  /* End the program. */
+  ecall
+
+.section .bss
+
+/* Success code for basic validity checks on the public key and signature.
+   Used for verify. Should be HARDENED_BOOL_TRUE or HARDENED_BOOL_FALSE. */
+.balign 4
+.weak ok
+ok:
+  .zero 4

--- a/sw/otbn/crypto/p256_verify.s
+++ b/sw/otbn/crypto/p256_verify.s
@@ -234,7 +234,6 @@ p256_verify:
   bn.wsrw   MOD, w0
   bn.subm   w24, w19, w31
 
-  fail:
   /* store affine x-coordinate in dmem: dmem[x_r] = w24 = x_r */
   la        x17, x_r
   li        x2, 24
@@ -377,6 +376,14 @@ mod_inv_var:
   bn.addm   w1, w2, w31
 
   ret
+
+/**
+ * Failure cases jump here.
+ */
+fail:
+  unimp
+  unimp
+  unimp
 
 .section .bss
 

--- a/sw/otbn/crypto/p384_verify.s
+++ b/sw/otbn/crypto/p384_verify.s
@@ -396,8 +396,6 @@ p384_verify:
   bn.sel    w4, w16, w4, C
   bn.sel    w5, w17, w5, C
 
-  fail:
-
   /* store affine x-coordinate in dmem: dmem[dptr_rnd] <= x1 = [w5,w4] */
   li        x2, 4
   la        x3, dptr_rnd
@@ -406,6 +404,14 @@ p384_verify:
   bn.sid    x2++, 32(x3)
 
   ret
+
+/**
+ * Failure cases jump here.
+ */
+fail:
+  unimp
+  unimp
+  unimp
 
 
 /* pointers and scratchpad memory */

--- a/sw/otbn/crypto/tests/BUILD
+++ b/sw/otbn/crypto/tests/BUILD
@@ -300,6 +300,7 @@ otbn_sim_test(
     exp = "p256_ecdsa_verify_test.exp",
     deps = [
         "//sw/otbn/crypto:p256_base",
+        "//sw/otbn/crypto:p256_isoncurve",
         "//sw/otbn/crypto:p256_verify",
     ],
 )

--- a/sw/otbn/crypto/tests/p256_ecdsa_verify_test.exp
+++ b/sw/otbn/crypto/tests/p256_ecdsa_verify_test.exp
@@ -1,2 +1,3 @@
-# Expected values (w0=x_r == R):
+# Expected values (w0=x_r == R, x2 = HARDENED_BOOL_TRUE):
+x2 = 0x739
 w0 = 0x815215ad7dd27f336b35843cbe064de299504edd0c7d87dd1147ea5680a9674a

--- a/sw/otbn/crypto/tests/p256_ecdsa_verify_test.s
+++ b/sw/otbn/crypto/tests/p256_ecdsa_verify_test.s
@@ -20,10 +20,12 @@ ecdsa_verify_test:
   /* call ECDSA signature verification subroutine in P-256 lib */
   jal      x1, p256_verify
 
-  /* load signature to wregs for comparison with reference */
+  /* load results to wregs for comparison with reference */
   li        x2, 0
   la        x3, x_r
   bn.lid    x2, 0(x3)
+  la        x3, ok
+  lw        x2, 0(x3)
 
   ecall
 


### PR DESCRIPTION
Fixes a bug in P-256 and P-384 found by @RyanTorok via the Wycheproof tests that would have caused the implementation to accept invalid signatures with r=0. Thanks Ryan! :clap: 

Previously, the "fail" jump point for certain paths (e.g. r and s out of range in the signature) copied all-zero values into `x_r` and expected the comparison with `r` to fail. But that doesn't work if `r` is zero; as far as I can tell from a quick sift through the code history, the code originally didn't check the range of `r` and likely expected this to happen on the Ibex side. However, when I went through and implemented the Ibex side, I didn't realize this, and I added the checks for the range of `r` on the OTBN side, jumping to "fail" without inspecting the logic carefully enough and thereby introducing the bug.

For P-256, I've changed the logic to:
- separate the public key check into a shared function between ECDSA/ECDH (it was a lot of duplicated code)
- use a new `ok` return value to indicate if the input was valid or not

For P-384, I've just changed the `fail` directive to point to some `unimps`, because I don't want to conflict with https://github.com/lowRISC/opentitan/pull/21067. But once it's merged I think it should probably do the same thing as P-256.