### PR TITLE
[spi_device] Fix address mode synchronization

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -513,23 +513,6 @@
           desc: "RX bit order on SDI. Module stores bitstream from MSB to LSB if value is 0.",
           resval: "0",
         },
-        { bits: "16"
-          name: "addr_4b_en"
-          swaccess: "rw"
-          hwaccess: "hrw" // Updated by EN4B/EX4B
-          desc: '''4B Address Mode enable.
-
-            This field configures the internal module to receive 32 bits of the
-            SPI commands. The affected commands are the SPI read commands
-            except QPI, and program commands. It is expected for SW to
-            configure this field at the configuration stage and leave the
-            updation to HW until next reset.
-
-            Even though Read SFDP command has address fields, the SFDP command
-            is not affected by this field. The command always parse 24 bits on
-            the SPI line 0 following the SPI command as the address field.
-            '''
-        }
         { bits: "24"
           name: "mailbox_en"
           desc: '''Mailbox enable.
@@ -588,6 +571,52 @@
         } // f: mailbox
       ]
     } // R: INTERCEPT_EN
+    { name: "ADDR_MODE"
+      desc: '''Flash address mode configuration
+
+        This register shows the current address mode and pending changes.
+        It is updated by the HW when the command phase completes.
+        '''
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwext: true
+      tags: [
+        // SW is not able to read back the ADDR_MODE register right after write.
+        // The pending field changes whenever the CSR is written, regardless of the value.
+        // So, the CSR is excluded from most automated CSR tests.
+        "excl:CsrNonInitTests:CsrExclWrite"
+      ]
+      fields: [
+        { bits: "0"
+          name: "addr_4b_en"
+          swaccess: "rw"
+          hwaccess: "hrw" // Updated by EN4B/EX4B
+          hwqe: true
+          desc: '''4B Address Mode enable.
+
+            This field configures the internal module to receive 32 bits of the SPI commands.
+            The affected commands are the SPI read commands except QPI, and program commands.
+            It is expected for SW to configure this field at the configuration stage and release control to HW until the next reset.
+
+            Even though Read SFDP command has address fields, the SFDP command is not affected by this field.
+            The command always parse 24 bits on the SPI line 0 following the SPI command as the address field.
+
+            This field has noteworthy read behavior.
+            If a software-initiated change is still `pending` the sync to the SPI domain, this bit will reflect the value to be sent.
+            Otherwise, this field will reflect the current value observed in the SPI domain.
+            '''
+        },
+        { bits: "31"
+          name: "pending"
+          desc: '''SW-originated change is pending.
+
+            This bit is 1 whenever the current value of addr_4b_en has yet to sync with the SPI domain.
+            If an EN4B or EX4B command arrives next, the current value in `addr_4b_en` will be ignored,
+            and the SPI flash command will take priority, with an update to `addr_4b_en` to match the command's result.
+            '''
+        }
+      ]
+    } // R: ADDR_MODE
     { name: "LAST_READ_ADDR"
       desc: '''Last Read Address
 
@@ -622,8 +651,7 @@
       hwqe: true
       tags: [
         // SW is not able to read back the STATUS register right after write.
-        // The read back value is committed value, which needs at least a SPI
-        // transaction.
+        // The read back value is the committed value, which needs at least a SPI transaction.
         // So excluded from CSR automation test.
         "excl:CsrNonInitTests:CsrExclWrite"
       ]

--- a/hw/ip/spi_device/doc/registers.md
+++ b/hw/ip/spi_device/doc/registers.md
@@ -13,56 +13,57 @@
 | spi_device.[`CFG`](#cfg)                                 | 0x14     |        4 | Configuration Register                          |
 | spi_device.[`STATUS`](#status)                           | 0x18     |        4 | SPI Device status register                      |
 | spi_device.[`INTERCEPT_EN`](#intercept_en)               | 0x1c     |        4 | Intercept Passthrough datapath.                 |
-| spi_device.[`LAST_READ_ADDR`](#last_read_addr)           | 0x20     |        4 | Last Read Address                               |
-| spi_device.[`FLASH_STATUS`](#flash_status)               | 0x24     |        4 | SPI Flash Status register.                      |
-| spi_device.[`JEDEC_CC`](#jedec_cc)                       | 0x28     |        4 | JEDEC Continuation Code configuration register. |
-| spi_device.[`JEDEC_ID`](#jedec_id)                       | 0x2c     |        4 | JEDEC ID register.                              |
-| spi_device.[`READ_THRESHOLD`](#read_threshold)           | 0x30     |        4 | Read Buffer threshold register.                 |
-| spi_device.[`MAILBOX_ADDR`](#mailbox_addr)               | 0x34     |        4 | Mailbox Base address register.                  |
-| spi_device.[`UPLOAD_STATUS`](#upload_status)             | 0x38     |        4 | Upload module status register.                  |
-| spi_device.[`UPLOAD_STATUS2`](#upload_status2)           | 0x3c     |        4 | Upload module status 2 register.                |
-| spi_device.[`UPLOAD_CMDFIFO`](#upload_cmdfifo)           | 0x40     |        4 | Command Fifo Read Port.                         |
-| spi_device.[`UPLOAD_ADDRFIFO`](#upload_addrfifo)         | 0x44     |        4 | Address Fifo Read Port.                         |
-| spi_device.[`CMD_FILTER_0`](#CMD_FILTER_0)               | 0x48     |        4 | Command Filter                                  |
-| spi_device.[`CMD_FILTER_1`](#CMD_FILTER_1)               | 0x4c     |        4 | Command Filter                                  |
-| spi_device.[`CMD_FILTER_2`](#CMD_FILTER_2)               | 0x50     |        4 | Command Filter                                  |
-| spi_device.[`CMD_FILTER_3`](#CMD_FILTER_3)               | 0x54     |        4 | Command Filter                                  |
-| spi_device.[`CMD_FILTER_4`](#CMD_FILTER_4)               | 0x58     |        4 | Command Filter                                  |
-| spi_device.[`CMD_FILTER_5`](#CMD_FILTER_5)               | 0x5c     |        4 | Command Filter                                  |
-| spi_device.[`CMD_FILTER_6`](#CMD_FILTER_6)               | 0x60     |        4 | Command Filter                                  |
-| spi_device.[`CMD_FILTER_7`](#CMD_FILTER_7)               | 0x64     |        4 | Command Filter                                  |
-| spi_device.[`ADDR_SWAP_MASK`](#addr_swap_mask)           | 0x68     |        4 | Address Swap Mask register.                     |
-| spi_device.[`ADDR_SWAP_DATA`](#addr_swap_data)           | 0x6c     |        4 | The address value for the address swap feature. |
-| spi_device.[`PAYLOAD_SWAP_MASK`](#payload_swap_mask)     | 0x70     |        4 | Write Data Swap in the passthrough mode.        |
-| spi_device.[`PAYLOAD_SWAP_DATA`](#payload_swap_data)     | 0x74     |        4 | Write Data Swap in the passthrough mode.        |
-| spi_device.[`CMD_INFO_0`](#cmd_info)                     | 0x78     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_1`](#cmd_info)                     | 0x7c     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_2`](#cmd_info)                     | 0x80     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_3`](#cmd_info)                     | 0x84     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_4`](#cmd_info)                     | 0x88     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_5`](#cmd_info)                     | 0x8c     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_6`](#cmd_info)                     | 0x90     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_7`](#cmd_info)                     | 0x94     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_8`](#cmd_info)                     | 0x98     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_9`](#cmd_info)                     | 0x9c     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_10`](#cmd_info)                    | 0xa0     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_11`](#cmd_info)                    | 0xa4     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_12`](#cmd_info)                    | 0xa8     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_13`](#cmd_info)                    | 0xac     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_14`](#cmd_info)                    | 0xb0     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_15`](#cmd_info)                    | 0xb4     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_16`](#cmd_info)                    | 0xb8     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_17`](#cmd_info)                    | 0xbc     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_18`](#cmd_info)                    | 0xc0     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_19`](#cmd_info)                    | 0xc4     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_20`](#cmd_info)                    | 0xc8     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_21`](#cmd_info)                    | 0xcc     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_22`](#cmd_info)                    | 0xd0     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_23`](#cmd_info)                    | 0xd4     |        4 | Command Info register.                          |
-| spi_device.[`CMD_INFO_EN4B`](#cmd_info_en4b)             | 0xd8     |        4 | Opcode for EN4B.                                |
-| spi_device.[`CMD_INFO_EX4B`](#cmd_info_ex4b)             | 0xdc     |        4 | Opcode for EX4B                                 |
-| spi_device.[`CMD_INFO_WREN`](#cmd_info_wren)             | 0xe0     |        4 | Opcode for Write Enable (WREN)                  |
-| spi_device.[`CMD_INFO_WRDI`](#cmd_info_wrdi)             | 0xe4     |        4 | Opcode for Write Disable (WRDI)                 |
+| spi_device.[`ADDR_MODE`](#addr_mode)                     | 0x20     |        4 | Flash address mode configuration                |
+| spi_device.[`LAST_READ_ADDR`](#last_read_addr)           | 0x24     |        4 | Last Read Address                               |
+| spi_device.[`FLASH_STATUS`](#flash_status)               | 0x28     |        4 | SPI Flash Status register.                      |
+| spi_device.[`JEDEC_CC`](#jedec_cc)                       | 0x2c     |        4 | JEDEC Continuation Code configuration register. |
+| spi_device.[`JEDEC_ID`](#jedec_id)                       | 0x30     |        4 | JEDEC ID register.                              |
+| spi_device.[`READ_THRESHOLD`](#read_threshold)           | 0x34     |        4 | Read Buffer threshold register.                 |
+| spi_device.[`MAILBOX_ADDR`](#mailbox_addr)               | 0x38     |        4 | Mailbox Base address register.                  |
+| spi_device.[`UPLOAD_STATUS`](#upload_status)             | 0x3c     |        4 | Upload module status register.                  |
+| spi_device.[`UPLOAD_STATUS2`](#upload_status2)           | 0x40     |        4 | Upload module status 2 register.                |
+| spi_device.[`UPLOAD_CMDFIFO`](#upload_cmdfifo)           | 0x44     |        4 | Command Fifo Read Port.                         |
+| spi_device.[`UPLOAD_ADDRFIFO`](#upload_addrfifo)         | 0x48     |        4 | Address Fifo Read Port.                         |
+| spi_device.[`CMD_FILTER_0`](#CMD_FILTER_0)               | 0x4c     |        4 | Command Filter                                  |
+| spi_device.[`CMD_FILTER_1`](#CMD_FILTER_1)               | 0x50     |        4 | Command Filter                                  |
+| spi_device.[`CMD_FILTER_2`](#CMD_FILTER_2)               | 0x54     |        4 | Command Filter                                  |
+| spi_device.[`CMD_FILTER_3`](#CMD_FILTER_3)               | 0x58     |        4 | Command Filter                                  |
+| spi_device.[`CMD_FILTER_4`](#CMD_FILTER_4)               | 0x5c     |        4 | Command Filter                                  |
+| spi_device.[`CMD_FILTER_5`](#CMD_FILTER_5)               | 0x60     |        4 | Command Filter                                  |
+| spi_device.[`CMD_FILTER_6`](#CMD_FILTER_6)               | 0x64     |        4 | Command Filter                                  |
+| spi_device.[`CMD_FILTER_7`](#CMD_FILTER_7)               | 0x68     |        4 | Command Filter                                  |
+| spi_device.[`ADDR_SWAP_MASK`](#addr_swap_mask)           | 0x6c     |        4 | Address Swap Mask register.                     |
+| spi_device.[`ADDR_SWAP_DATA`](#addr_swap_data)           | 0x70     |        4 | The address value for the address swap feature. |
+| spi_device.[`PAYLOAD_SWAP_MASK`](#payload_swap_mask)     | 0x74     |        4 | Write Data Swap in the passthrough mode.        |
+| spi_device.[`PAYLOAD_SWAP_DATA`](#payload_swap_data)     | 0x78     |        4 | Write Data Swap in the passthrough mode.        |
+| spi_device.[`CMD_INFO_0`](#cmd_info)                     | 0x7c     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_1`](#cmd_info)                     | 0x80     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_2`](#cmd_info)                     | 0x84     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_3`](#cmd_info)                     | 0x88     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_4`](#cmd_info)                     | 0x8c     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_5`](#cmd_info)                     | 0x90     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_6`](#cmd_info)                     | 0x94     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_7`](#cmd_info)                     | 0x98     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_8`](#cmd_info)                     | 0x9c     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_9`](#cmd_info)                     | 0xa0     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_10`](#cmd_info)                    | 0xa4     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_11`](#cmd_info)                    | 0xa8     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_12`](#cmd_info)                    | 0xac     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_13`](#cmd_info)                    | 0xb0     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_14`](#cmd_info)                    | 0xb4     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_15`](#cmd_info)                    | 0xb8     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_16`](#cmd_info)                    | 0xbc     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_17`](#cmd_info)                    | 0xc0     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_18`](#cmd_info)                    | 0xc4     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_19`](#cmd_info)                    | 0xc8     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_20`](#cmd_info)                    | 0xcc     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_21`](#cmd_info)                    | 0xd0     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_22`](#cmd_info)                    | 0xd4     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_23`](#cmd_info)                    | 0xd8     |        4 | Command Info register.                          |
+| spi_device.[`CMD_INFO_EN4B`](#cmd_info_en4b)             | 0xdc     |        4 | Opcode for EN4B.                                |
+| spi_device.[`CMD_INFO_EX4B`](#cmd_info_ex4b)             | 0xe0     |        4 | Opcode for EX4B                                 |
+| spi_device.[`CMD_INFO_WREN`](#cmd_info_wren)             | 0xe4     |        4 | Opcode for Write Enable (WREN)                  |
+| spi_device.[`CMD_INFO_WRDI`](#cmd_info_wrdi)             | 0xe8     |        4 | Opcode for Write Disable (WRDI)                 |
 | spi_device.[`TPM_CAP`](#tpm_cap)                         | 0x800    |        4 | TPM HWIP Capability register.                   |
 | spi_device.[`TPM_CFG`](#tpm_cfg)                         | 0x804    |        4 | TPM Configuration register.                     |
 | spi_device.[`TPM_STATUS`](#tpm_status)                   | 0x808    |        4 | TPM submodule state register.                   |
@@ -197,58 +198,23 @@ Other values are reserved.
 Configuration Register
 - Offset: `0x14`
 - Reset default: `0x0`
-- Reset mask: `0x101000f`
+- Reset mask: `0x100000f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "CPOL", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "CPHA", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "tx_order", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "rx_order", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 12}, {"name": "addr_4b_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 7}, {"name": "mailbox_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 7}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "CPOL", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "CPHA", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "tx_order", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "rx_order", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 20}, {"name": "mailbox_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 7}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                           |
-|:------:|:------:|:-------:|:-------------------------------|
-| 31:25  |        |         | Reserved                       |
-|   24   |   rw   |   0x0   | [mailbox_en](#cfg--mailbox_en) |
-| 23:17  |        |         | Reserved                       |
-|   16   |   rw   |   0x0   | [addr_4b_en](#cfg--addr_4b_en) |
-|  15:4  |        |         | Reserved                       |
-|   3    |   rw   |   0x0   | [rx_order](#cfg--rx_order)     |
-|   2    |   rw   |   0x0   | [tx_order](#cfg--tx_order)     |
-|   1    |   rw   |   0x0   | [CPHA](#cfg--cpha)             |
-|   0    |   rw   |   0x0   | [CPOL](#cfg--cpol)             |
-
-### CFG . mailbox_en
-Mailbox enable.
-
-If 1, in the flash and passthrough mode, the IP checks the incoming
-address and return from the internal Mailbox buffer if the address
-falls into the MAILBOX range
-(MAILBOX_ADDR:MAILBOX_ADDR+MAILBOX_SIZE)}.
-
-### CFG . addr_4b_en
-4B Address Mode enable.
-
-This field configures the internal module to receive 32 bits of the
-SPI commands. The affected commands are the SPI read commands
-except QPI, and program commands. It is expected for SW to
-configure this field at the configuration stage and leave the
-updation to HW until next reset.
-
-Even though Read SFDP command has address fields, the SFDP command
-is not affected by this field. The command always parse 24 bits on
-the SPI line 0 following the SPI command as the address field.
-
-### CFG . rx_order
-RX bit order on SDI. Module stores bitstream from MSB to LSB if value is 0.
-
-### CFG . tx_order
-TX bit order on SDO. 0 for MSB to LSB, 1 for LSB to MSB
-
-### CFG . CPHA
-Data phase. 0 for negative edge change, 1 for positive edge change
-
-### CFG . CPOL
-Clock polarity. 0 for normal SPI, 1 for negative edge latch
+|  Bits  |  Type  |  Reset  | Name       | Description                                                                                                                                                                                                                    |
+|:------:|:------:|:-------:|:-----------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:25  |        |         |            | Reserved                                                                                                                                                                                                                       |
+|   24   |   rw   |   0x0   | mailbox_en | Mailbox enable. If 1, in the flash and passthrough mode, the IP checks the incoming address and return from the internal Mailbox buffer if the address falls into the MAILBOX range (MAILBOX_ADDR:MAILBOX_ADDR+MAILBOX_SIZE)}. |
+|  23:4  |        |         |            | Reserved                                                                                                                                                                                                                       |
+|   3    |   rw   |   0x0   | rx_order   | RX bit order on SDI. Module stores bitstream from MSB to LSB if value is 0.                                                                                                                                                    |
+|   2    |   rw   |   0x0   | tx_order   | TX bit order on SDO. 0 for MSB to LSB, 1 for LSB to MSB                                                                                                                                                                        |
+|   1    |   rw   |   0x0   | CPHA       | Data phase. 0 for negative edge change, 1 for positive edge change                                                                                                                                                             |
+|   0    |   rw   |   0x0   | CPOL       | Clock polarity. 0 for normal SPI, 1 for negative edge latch                                                                                                                                                                    |
 
 ## STATUS
 SPI Device status register
@@ -290,12 +256,54 @@ Intercept Passthrough datapath.
 |   1    |   rw   |   0x0   | jedec  | If set, Read JEDEC ID is processed internally.                  |
 |   0    |   rw   |   0x0   | status | If set, Read Status is processed internally.                    |
 
+## ADDR_MODE
+Flash address mode configuration
+
+This register shows the current address mode and pending changes.
+It is updated by the HW when the command phase completes.
+- Offset: `0x20`
+- Reset default: `0x0`
+- Reset mask: `0x80000001`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "addr_4b_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 30}, {"name": "pending", "bits": 1, "attr": ["ro"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                                 |
+|:------:|:------:|:-------:|:-------------------------------------|
+|   31   |   ro   |    x    | [pending](#addr_mode--pending)       |
+|  30:1  |        |         | Reserved                             |
+|   0    |   rw   |    x    | [addr_4b_en](#addr_mode--addr_4b_en) |
+
+### ADDR_MODE . pending
+SW-originated change is pending.
+
+This bit is 1 whenever the current value of addr_4b_en has yet to sync with the SPI domain.
+If an EN4B or EX4B command arrives next, the current value in `addr_4b_en` will be ignored,
+and the SPI flash command will take priority, with an update to `addr_4b_en` to match the command's result.
+
+### ADDR_MODE . addr_4b_en
+4B Address Mode enable.
+
+This field configures the internal module to receive 32 bits of the SPI commands.
+The affected commands are the SPI read commands except QPI, and program commands.
+It is expected for SW to configure this field at the configuration stage and release control to HW until the next reset.
+
+Even though Read SFDP command has address fields, the SFDP command is not affected by this field.
+The command always parse 24 bits on the SPI line 0 following the SPI command as the address field.
+
+This field has noteworthy read behavior.
+If a software-initiated change is still `pending` the sync to the SPI domain, this bit will reflect the value to be sent.
+Otherwise, this field will reflect the current value observed in the SPI domain.
+
 ## LAST_READ_ADDR
 Last Read Address
 
 This register shows the last address accessed by the host system.
 It is updated by the HW when CSb is de-asserted.
-- Offset: `0x20`
+- Offset: `0x24`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -320,7 +328,7 @@ maintain this register value up to date.
 The HW latches the value when SPI Flash transaction begins. Any updates
 during the transaction will be updated after the transaction is
 completed.
-- Offset: `0x24`
+- Offset: `0x28`
 - Reset default: `0x0`
 - Reset mask: `0xffffff`
 
@@ -374,7 +382,7 @@ JEDEC Continuation Code configuration register.
 Read JEDEC ID must return the continuation code if the manufacturer ID
 is not shown in the first page of JEDEC table. This register controls
 the Continuation Code.
-- Offset: `0x28`
+- Offset: `0x2c`
 - Reset default: `0x7f`
 - Reset mask: `0xffff`
 
@@ -392,7 +400,7 @@ the Continuation Code.
 
 ## JEDEC_ID
 JEDEC ID register.
-- Offset: `0x2c`
+- Offset: `0x30`
 - Reset default: `0x0`
 - Reset mask: `0xffffff`
 
@@ -411,7 +419,7 @@ JEDEC ID register.
 ## READ_THRESHOLD
 Read Buffer threshold register.
 
-- Offset: `0x30`
+- Offset: `0x34`
 - Reset default: `0x0`
 - Reset mask: `0x3ff`
 
@@ -431,7 +439,7 @@ Mailbox Base address register.
 
 The mailbox size is fixed. In this version of IP, the size is 1kB.
 Lower 10 bits of the Mailbox address is tied to 0.
-- Offset: `0x34`
+- Offset: `0x38`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -447,7 +455,7 @@ Lower 10 bits of the Mailbox address is tied to 0.
 
 ## UPLOAD_STATUS
 Upload module status register.
-- Offset: `0x38`
+- Offset: `0x3c`
 - Reset default: `0x0`
 - Reset mask: `0x9f9f`
 
@@ -479,7 +487,7 @@ payload in a command, this field may not be 0. For example, if the
 system issues 258B payload, the payload_depth is 256 (as the IP only
 holds 256B of payload), the payload_start_idx is 2. SW should read from
 2 to 255 then 0 and 1.
-- Offset: `0x3c`
+- Offset: `0x40`
 - Reset default: `0x0`
 - Reset mask: `0xff01ff`
 
@@ -498,7 +506,7 @@ holds 256B of payload), the payload_start_idx is 2. SW should read from
 
 ## UPLOAD_CMDFIFO
 Command Fifo Read Port.
-- Offset: `0x40`
+- Offset: `0x44`
 - Reset default: `0x0`
 - Reset mask: `0xff`
 
@@ -515,7 +523,7 @@ Command Fifo Read Port.
 
 ## UPLOAD_ADDRFIFO
 Address Fifo Read Port.
-- Offset: `0x44`
+- Offset: `0x48`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -534,7 +542,7 @@ Command Filter
 
 If a bit in this CSR is 1, then corresponding SPI command w.r.t the
 bit position among 256 bit is dropped in SPI Passthrough mode.
-- Offset: `0x48`
+- Offset: `0x4c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -584,7 +592,7 @@ Command Filter
 
 If a bit in this CSR is 1, then corresponding SPI command w.r.t the
 bit position among 256 bit is dropped in SPI Passthrough mode.
-- Offset: `0x4c`
+- Offset: `0x50`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -634,7 +642,7 @@ Command Filter
 
 If a bit in this CSR is 1, then corresponding SPI command w.r.t the
 bit position among 256 bit is dropped in SPI Passthrough mode.
-- Offset: `0x50`
+- Offset: `0x54`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -684,7 +692,7 @@ Command Filter
 
 If a bit in this CSR is 1, then corresponding SPI command w.r.t the
 bit position among 256 bit is dropped in SPI Passthrough mode.
-- Offset: `0x54`
+- Offset: `0x58`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -734,7 +742,7 @@ Command Filter
 
 If a bit in this CSR is 1, then corresponding SPI command w.r.t the
 bit position among 256 bit is dropped in SPI Passthrough mode.
-- Offset: `0x58`
+- Offset: `0x5c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -784,7 +792,7 @@ Command Filter
 
 If a bit in this CSR is 1, then corresponding SPI command w.r.t the
 bit position among 256 bit is dropped in SPI Passthrough mode.
-- Offset: `0x5c`
+- Offset: `0x60`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -834,7 +842,7 @@ Command Filter
 
 If a bit in this CSR is 1, then corresponding SPI command w.r.t the
 bit position among 256 bit is dropped in SPI Passthrough mode.
-- Offset: `0x60`
+- Offset: `0x64`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -884,7 +892,7 @@ Command Filter
 
 If a bit in this CSR is 1, then corresponding SPI command w.r.t the
 bit position among 256 bit is dropped in SPI Passthrough mode.
-- Offset: `0x64`
+- Offset: `0x68`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -937,7 +945,7 @@ this register is set, the corresponding address bit in the SPI Read
 commands is replaced with the data from [`ADDR_SWAP_DATA.`](#addr_swap_data)
 
 If 3B address mode is active, upper 8bit [31:24] is ignored.
-- Offset: `0x68`
+- Offset: `0x6c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -953,7 +961,7 @@ If 3B address mode is active, upper 8bit [31:24] is ignored.
 
 ## ADDR_SWAP_DATA
 The address value for the address swap feature.
-- Offset: `0x6c`
+- Offset: `0x70`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -972,7 +980,7 @@ Write Data Swap in the passthrough mode.
 
 PAYLOAD_SWAP_MASK CSR provides the SW to change certain bits in the
 first 4 bytes of the write payload in the passthrough mode.
-- Offset: `0x70`
+- Offset: `0x74`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -996,7 +1004,7 @@ passthrough mode.
 The register should be written in Little-Endian order. [7:0] bits are
 processed in the first received payload byte. [31:24] bits for the 4th
 byte.
-- Offset: `0x74`
+- Offset: `0x78`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -1020,30 +1028,30 @@ Command Info register.
 
 | Name        | Offset   |
 |:------------|:---------|
-| CMD_INFO_0  | 0x78     |
-| CMD_INFO_1  | 0x7c     |
-| CMD_INFO_2  | 0x80     |
-| CMD_INFO_3  | 0x84     |
-| CMD_INFO_4  | 0x88     |
-| CMD_INFO_5  | 0x8c     |
-| CMD_INFO_6  | 0x90     |
-| CMD_INFO_7  | 0x94     |
-| CMD_INFO_8  | 0x98     |
-| CMD_INFO_9  | 0x9c     |
-| CMD_INFO_10 | 0xa0     |
-| CMD_INFO_11 | 0xa4     |
-| CMD_INFO_12 | 0xa8     |
-| CMD_INFO_13 | 0xac     |
-| CMD_INFO_14 | 0xb0     |
-| CMD_INFO_15 | 0xb4     |
-| CMD_INFO_16 | 0xb8     |
-| CMD_INFO_17 | 0xbc     |
-| CMD_INFO_18 | 0xc0     |
-| CMD_INFO_19 | 0xc4     |
-| CMD_INFO_20 | 0xc8     |
-| CMD_INFO_21 | 0xcc     |
-| CMD_INFO_22 | 0xd0     |
-| CMD_INFO_23 | 0xd4     |
+| CMD_INFO_0  | 0x7c     |
+| CMD_INFO_1  | 0x80     |
+| CMD_INFO_2  | 0x84     |
+| CMD_INFO_3  | 0x88     |
+| CMD_INFO_4  | 0x8c     |
+| CMD_INFO_5  | 0x90     |
+| CMD_INFO_6  | 0x94     |
+| CMD_INFO_7  | 0x98     |
+| CMD_INFO_8  | 0x9c     |
+| CMD_INFO_9  | 0xa0     |
+| CMD_INFO_10 | 0xa4     |
+| CMD_INFO_11 | 0xa8     |
+| CMD_INFO_12 | 0xac     |
+| CMD_INFO_13 | 0xb0     |
+| CMD_INFO_14 | 0xb4     |
+| CMD_INFO_15 | 0xb8     |
+| CMD_INFO_16 | 0xbc     |
+| CMD_INFO_17 | 0xc0     |
+| CMD_INFO_18 | 0xc4     |
+| CMD_INFO_19 | 0xc8     |
+| CMD_INFO_20 | 0xcc     |
+| CMD_INFO_21 | 0xd0     |
+| CMD_INFO_22 | 0xd4     |
+| CMD_INFO_23 | 0xd8     |
 
 
 ### Fields
@@ -1156,7 +1164,7 @@ Command Opcode
 Opcode for EN4B.
 
 If the register is active, it affects in flash / passthrough modes.
-- Offset: `0xd8`
+- Offset: `0xdc`
 - Reset default: `0x0`
 - Reset mask: `0x800000ff`
 
@@ -1174,7 +1182,7 @@ If the register is active, it affects in flash / passthrough modes.
 
 ## CMD_INFO_EX4B
 Opcode for EX4B
-- Offset: `0xdc`
+- Offset: `0xe0`
 - Reset default: `0x0`
 - Reset mask: `0x800000ff`
 
@@ -1192,7 +1200,7 @@ Opcode for EX4B
 
 ## CMD_INFO_WREN
 Opcode for Write Enable (WREN)
-- Offset: `0xe0`
+- Offset: `0xe4`
 - Reset default: `0x0`
 - Reset mask: `0x800000ff`
 
@@ -1210,7 +1218,7 @@ Opcode for Write Enable (WREN)
 
 ## CMD_INFO_WRDI
 Opcode for Write Disable (WRDI)
-- Offset: `0xe4`
+- Offset: `0xe8`
 - Reset default: `0x0`
 - Reset mask: `0x800000ff`
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -342,9 +342,10 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     ral.cfg.rx_order.set(cfg.spi_host_agent_cfg.device_bit_dir);
 
     if (cfg.do_addr_4b_cfg) begin
-      `DV_CHECK_RANDOMIZE_FATAL(ral.cfg.addr_4b_en)
-      cfg.spi_host_agent_cfg.flash_addr_4b_en = ral.cfg.addr_4b_en.get();
-      cfg.spi_device_agent_cfg.flash_addr_4b_en = ral.cfg.addr_4b_en.get();
+      `DV_CHECK_RANDOMIZE_FATAL(ral.addr_mode.addr_4b_en)
+      cfg.spi_host_agent_cfg.flash_addr_4b_en = ral.addr_mode.addr_4b_en.get();
+      cfg.spi_device_agent_cfg.flash_addr_4b_en = ral.addr_mode.addr_4b_en.get();
+      csr_update(.csr(ral.addr_mode));
       cfg.do_addr_4b_cfg = 0;
     end
 
@@ -523,7 +524,7 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
       @(posedge cfg.spi_host_agent_cfg.vif.csb[FW_FLASH_CSB_ID]);
       `uvm_info(`gfn, $sformatf("set addr_4b_en = %0b", value), UVM_MEDIUM)
       cfg.clk_rst_vif.wait_clks(3);
-      void'(ral.cfg.addr_4b_en.predict(.value(value)));
+      void'(ral.addr_mode.addr_4b_en.predict(.value(value)));
     end join_none
   endtask
 
@@ -744,14 +745,14 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
       // Wait for register to be free
       `DV_SPINWAIT(
         while(1) begin
-          if (ral.cfg.is_busy()) begin
+          if (ral.addr_mode.is_busy()) begin
             cfg.clk_rst_vif.wait_clks(1);
           end else begin
             break;
           end
         end)
       // Check the contents of addr4b_en
-      csr_rd_check(.ptr(ral.cfg.addr_4b_en),
+      csr_rd_check(.ptr(ral.addr_mode.addr_4b_en),
              .compare_value(cfg.spi_device_agent_cfg.flash_addr_4b_en));
       cfg.spi_cfg_sema.put();
   endtask

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -159,16 +159,16 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
                 if (`GET_OPCODE_VALID_AND_MATCH(cmd_info_en4b, item.opcode)) begin
                   if (cfg.en_cov) begin
                     cov.spi_device_addr_4b_enter_exit_command_cg.sample(
-                        .addr_4b_en(1), .prev_addr_4b_en(`gmv(ral.cfg.addr_4b_en)));
+                        .addr_4b_en(1), .prev_addr_4b_en(`gmv(ral.addr_mode.addr_4b_en)));
                   end
-                  void'(ral.cfg.addr_4b_en.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
+                  void'(ral.addr_mode.addr_4b_en.predict(.value(1), .kind(UVM_PREDICT_WRITE)));
                   `uvm_info(`gfn, "Enable 4b addr due to cmd EN4B", UVM_MEDIUM)
                 end else if (`GET_OPCODE_VALID_AND_MATCH(cmd_info_ex4b, item.opcode)) begin
                   if (cfg.en_cov) begin
                     cov.spi_device_addr_4b_enter_exit_command_cg.sample(
-                        .addr_4b_en(0), .prev_addr_4b_en(`gmv(ral.cfg.addr_4b_en)));
+                        .addr_4b_en(0), .prev_addr_4b_en(`gmv(ral.addr_mode.addr_4b_en)));
                   end
-                  void'(ral.cfg.addr_4b_en.predict(.value(0), .kind(UVM_PREDICT_WRITE)));
+                  void'(ral.addr_mode.addr_4b_en.predict(.value(0), .kind(UVM_PREDICT_WRITE)));
                   `uvm_info(`gfn, "Disable 4b addr due to cmd EX4B", UVM_MEDIUM)
                 end else if (`GET_OPCODE_VALID_AND_MATCH(cmd_info_wren, item.opcode)) begin
                   update_wel = 1;
@@ -987,9 +987,9 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
           tpm_hw_reg_pre_val_aa[csr.get_name] = `gmv(csr);
         end
       end
-      if (cfg.en_cov && csr.get_name == "cfg") begin
-        bit pre_addr4b = `gmv(ral.cfg.addr_4b_en);
-        bit cur_addr4b = get_field_val(ral.cfg.addr_4b_en, item.a_data);
+      if (cfg.en_cov && csr.get_name == "addr_mode") begin
+        bit pre_addr4b = `gmv(ral.addr_mode.addr_4b_en);
+        bit cur_addr4b = get_field_val(ral.addr_mode.addr_4b_en, item.a_data);
         // cover that the addr4b is updated by SW
         if (pre_addr4b != cur_addr4b) cov.sw_update_addr4b_cg.sample();
       end

--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -48,6 +48,10 @@ module spi_cmdparse
   output cmd_info_t              cmd_only_info_o,
   output logic [CmdInfoIdxW-1:0] cmd_only_info_idx_o,
 
+  // Synchronization pulse that indicates the 8th bit of the command is
+  // arriving. Originates from the SCK domain.
+  output logic                   cmd_sync_pulse_o,
+
   // CFG: Intercept
   input cfg_intercept_en_status_i,
   input cfg_intercept_en_jedec_i,
@@ -308,6 +312,7 @@ module spi_cmdparse
     sel_dp = DpNone;
     cmd_only_sel_dp = DpNone;
 
+    cmd_sync_pulse_o = 1'b0;
     latch_cmdinfo = 1'b 0;
 
     intercept_d = 1'b 0;
@@ -317,6 +322,7 @@ module spi_cmdparse
         if (module_active && data_valid_i && cmd_info_d.valid) begin
           // 8th bit is valid here
           latch_cmdinfo = 1'b 1;
+          cmd_sync_pulse_o = 1'b1;
 
           priority case (1'b 1)
             opcode_readstatus: begin
@@ -390,6 +396,7 @@ module spi_cmdparse
         else if (module_active && data_valid_i) begin
           // Could not find valid command information entry.
           st_d = StWait;
+          cmd_sync_pulse_o = 1'b1;
         end // if (module_active && data_valid_i)
       end
 

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -691,19 +691,22 @@ module spi_device
   );
 
   // CSb edge on the system clock
-  prim_edge_detector #(
-    .Width     (1    ),
-    .ResetValue(1'b 1),
-    .EnSync    (1'b 1)
-  ) u_csb_edge_sysclk (
+  spid_csb_sync u_spid_csb_sync (
     .clk_i,
     .rst_ni,
-    .d_i      (sys_csb      ),
-    .q_sync_o (sys_csb_syncd),
+    .sck_i                     (clk_spi_in_buf),
+    .sck_pulse_en_i            (1'b1),
+    .csb_i                     (clk_csb),
+    .csb_deasserted_pulse_o    (sys_csb_deasserted_pulse)
+  );
 
-    // sys_csb_assertion can be detected but no usage
-    .q_posedge_pulse_o (sys_csb_deasserted_pulse),
-    .q_negedge_pulse_o (                        )
+  prim_flop_2sync #(
+    .Width       (1)
+  ) u_sys_csb_syncd (
+    .clk_i,
+    .rst_ni,
+    .d_i       (sys_csb),
+    .q_o       (sys_csb_syncd)
   );
 
   // CSb edge on the SPI input clock
@@ -1224,7 +1227,6 @@ module spi_device
     .clk_csb_i (clk_csb),
 
     .sck_csb_asserted_pulse_i   (sck_csb_asserted_pulse),
-    .sys_csb_deasserted_pulse_i (sys_csb_deasserted_pulse),
 
     .sel_dp_i          (cmd_dp_sel),
     .cmd_only_sel_dp_i (cmd_only_dp_sel),

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -120,9 +120,6 @@ package spi_device_reg_pkg;
     } mailbox_en;
     struct packed {
       logic        q;
-    } addr_4b_en;
-    struct packed {
-      logic        q;
     } rx_order;
     struct packed {
       logic        q;
@@ -149,6 +146,13 @@ package spi_device_reg_pkg;
       logic        q;
     } status;
   } spi_device_reg2hw_intercept_en_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } addr_4b_en;
+  } spi_device_reg2hw_addr_mode_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -401,18 +405,20 @@ package spi_device_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
-      logic        de;
-    } addr_4b_en;
-  } spi_device_hw2reg_cfg_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic        d;
     } csb;
     struct packed {
       logic        d;
     } tpm_csb;
   } spi_device_hw2reg_status_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+    } addr_4b_en;
+    struct packed {
+      logic        d;
+    } pending;
+  } spi_device_hw2reg_addr_mode_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -510,13 +516,14 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1507:1502]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1501:1496]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1495:1484]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1483:1482]
-    spi_device_reg2hw_control_reg_t control; // [1481:1480]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1479:1474]
-    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1473:1470]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1508:1503]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1502:1497]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1496:1485]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1484:1483]
+    spi_device_reg2hw_control_reg_t control; // [1482:1481]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1480:1476]
+    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1475:1472]
+    spi_device_reg2hw_addr_mode_reg_t addr_mode; // [1471:1470]
     spi_device_reg2hw_flash_status_reg_t flash_status; // [1469:1444]
     spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1443:1428]
     spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1427:1404]
@@ -551,8 +558,8 @@ package spi_device_reg_pkg;
   // HW -> register type
   typedef struct packed {
     spi_device_hw2reg_intr_state_reg_t intr_state; // [215:204]
-    spi_device_hw2reg_cfg_reg_t cfg; // [203:202]
-    spi_device_hw2reg_status_reg_t status; // [201:200]
+    spi_device_hw2reg_status_reg_t status; // [203:202]
+    spi_device_hw2reg_addr_mode_reg_t addr_mode; // [201:200]
     spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [199:168]
     spi_device_hw2reg_flash_status_reg_t flash_status; // [167:144]
     spi_device_hw2reg_upload_status_reg_t upload_status; // [143:128]
@@ -574,56 +581,57 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_CFG_OFFSET = 13'h 14;
   parameter logic [BlockAw-1:0] SPI_DEVICE_STATUS_OFFSET = 13'h 18;
   parameter logic [BlockAw-1:0] SPI_DEVICE_INTERCEPT_EN_OFFSET = 13'h 1c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_LAST_READ_ADDR_OFFSET = 13'h 20;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_FLASH_STATUS_OFFSET = 13'h 24;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_CC_OFFSET = 13'h 28;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_ID_OFFSET = 13'h 2c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_READ_THRESHOLD_OFFSET = 13'h 30;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_MAILBOX_ADDR_OFFSET = 13'h 34;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 38;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS2_OFFSET = 13'h 3c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 40;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 44;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 48;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 4c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 50;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 54;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 58;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 5c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 60;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 64;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 68;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 6c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 70;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 74;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 78;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 7c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 80;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 84;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 88;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 8c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 90;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h 94;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h 98;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h 9c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h a0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h a4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h a8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h ac;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h b0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h b4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h b8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h bc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h c0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h c4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h c8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h cc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h d0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h d4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EN4B_OFFSET = 13'h d8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EX4B_OFFSET = 13'h dc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_WREN_OFFSET = 13'h e0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_WRDI_OFFSET = 13'h e4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_MODE_OFFSET = 13'h 20;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_LAST_READ_ADDR_OFFSET = 13'h 24;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_FLASH_STATUS_OFFSET = 13'h 28;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_CC_OFFSET = 13'h 2c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_ID_OFFSET = 13'h 30;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_READ_THRESHOLD_OFFSET = 13'h 34;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_MAILBOX_ADDR_OFFSET = 13'h 38;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 3c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS2_OFFSET = 13'h 40;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 44;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 48;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 4c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 50;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 54;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 58;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 5c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 60;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 64;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 68;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 6c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 70;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 74;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 78;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 7c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 80;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 84;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 88;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 8c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 90;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 94;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h 9c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h a0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h a4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h a8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h ac;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h b0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h b4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h b8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h bc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h c0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h c4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h c8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h cc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h d0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h d8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EN4B_OFFSET = 13'h dc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EX4B_OFFSET = 13'h e0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_WREN_OFFSET = 13'h e4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_WRDI_OFFSET = 13'h e8;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
@@ -653,6 +661,7 @@ package spi_device_reg_pkg;
   parameter logic [6:0] SPI_DEVICE_STATUS_RESVAL = 7'h 60;
   parameter logic [0:0] SPI_DEVICE_STATUS_CSB_RESVAL = 1'h 1;
   parameter logic [0:0] SPI_DEVICE_STATUS_TPM_CSB_RESVAL = 1'h 1;
+  parameter logic [31:0] SPI_DEVICE_ADDR_MODE_RESVAL = 32'h 0;
   parameter logic [31:0] SPI_DEVICE_LAST_READ_ADDR_RESVAL = 32'h 0;
   parameter logic [23:0] SPI_DEVICE_FLASH_STATUS_RESVAL = 24'h 0;
   parameter logic [7:0] SPI_DEVICE_UPLOAD_CMDFIFO_RESVAL = 8'h 0;
@@ -679,6 +688,7 @@ package spi_device_reg_pkg;
     SPI_DEVICE_CFG,
     SPI_DEVICE_STATUS,
     SPI_DEVICE_INTERCEPT_EN,
+    SPI_DEVICE_ADDR_MODE,
     SPI_DEVICE_LAST_READ_ADDR,
     SPI_DEVICE_FLASH_STATUS,
     SPI_DEVICE_JEDEC_CC,
@@ -747,7 +757,7 @@ package spi_device_reg_pkg;
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [73] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [74] = '{
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
@@ -756,71 +766,72 @@ package spi_device_reg_pkg;
     4'b 1111, // index[ 5] SPI_DEVICE_CFG
     4'b 0001, // index[ 6] SPI_DEVICE_STATUS
     4'b 0001, // index[ 7] SPI_DEVICE_INTERCEPT_EN
-    4'b 1111, // index[ 8] SPI_DEVICE_LAST_READ_ADDR
-    4'b 0111, // index[ 9] SPI_DEVICE_FLASH_STATUS
-    4'b 0011, // index[10] SPI_DEVICE_JEDEC_CC
-    4'b 0111, // index[11] SPI_DEVICE_JEDEC_ID
-    4'b 0011, // index[12] SPI_DEVICE_READ_THRESHOLD
-    4'b 1111, // index[13] SPI_DEVICE_MAILBOX_ADDR
-    4'b 0011, // index[14] SPI_DEVICE_UPLOAD_STATUS
-    4'b 0111, // index[15] SPI_DEVICE_UPLOAD_STATUS2
-    4'b 0001, // index[16] SPI_DEVICE_UPLOAD_CMDFIFO
-    4'b 1111, // index[17] SPI_DEVICE_UPLOAD_ADDRFIFO
-    4'b 1111, // index[18] SPI_DEVICE_CMD_FILTER_0
-    4'b 1111, // index[19] SPI_DEVICE_CMD_FILTER_1
-    4'b 1111, // index[20] SPI_DEVICE_CMD_FILTER_2
-    4'b 1111, // index[21] SPI_DEVICE_CMD_FILTER_3
-    4'b 1111, // index[22] SPI_DEVICE_CMD_FILTER_4
-    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_5
-    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_6
-    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_7
-    4'b 1111, // index[26] SPI_DEVICE_ADDR_SWAP_MASK
-    4'b 1111, // index[27] SPI_DEVICE_ADDR_SWAP_DATA
-    4'b 1111, // index[28] SPI_DEVICE_PAYLOAD_SWAP_MASK
-    4'b 1111, // index[29] SPI_DEVICE_PAYLOAD_SWAP_DATA
-    4'b 1111, // index[30] SPI_DEVICE_CMD_INFO_0
-    4'b 1111, // index[31] SPI_DEVICE_CMD_INFO_1
-    4'b 1111, // index[32] SPI_DEVICE_CMD_INFO_2
-    4'b 1111, // index[33] SPI_DEVICE_CMD_INFO_3
-    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_4
-    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_5
-    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_6
-    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_7
-    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_8
-    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_9
-    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_10
-    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_11
-    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_12
-    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_13
-    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_14
-    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_15
-    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_16
-    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_17
-    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_18
-    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_19
-    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_20
-    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_21
-    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_22
-    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_23
-    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_EN4B
-    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_EX4B
-    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_WREN
-    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_WRDI
-    4'b 0111, // index[58] SPI_DEVICE_TPM_CAP
-    4'b 0001, // index[59] SPI_DEVICE_TPM_CFG
-    4'b 0111, // index[60] SPI_DEVICE_TPM_STATUS
-    4'b 1111, // index[61] SPI_DEVICE_TPM_ACCESS_0
-    4'b 0001, // index[62] SPI_DEVICE_TPM_ACCESS_1
-    4'b 1111, // index[63] SPI_DEVICE_TPM_STS
-    4'b 1111, // index[64] SPI_DEVICE_TPM_INTF_CAPABILITY
-    4'b 1111, // index[65] SPI_DEVICE_TPM_INT_ENABLE
-    4'b 0001, // index[66] SPI_DEVICE_TPM_INT_VECTOR
-    4'b 1111, // index[67] SPI_DEVICE_TPM_INT_STATUS
-    4'b 1111, // index[68] SPI_DEVICE_TPM_DID_VID
-    4'b 0001, // index[69] SPI_DEVICE_TPM_RID
-    4'b 1111, // index[70] SPI_DEVICE_TPM_CMD_ADDR
-    4'b 1111, // index[71] SPI_DEVICE_TPM_READ_FIFO
-    4'b 0001  // index[72] SPI_DEVICE_TPM_WRITE_FIFO
+    4'b 1111, // index[ 8] SPI_DEVICE_ADDR_MODE
+    4'b 1111, // index[ 9] SPI_DEVICE_LAST_READ_ADDR
+    4'b 0111, // index[10] SPI_DEVICE_FLASH_STATUS
+    4'b 0011, // index[11] SPI_DEVICE_JEDEC_CC
+    4'b 0111, // index[12] SPI_DEVICE_JEDEC_ID
+    4'b 0011, // index[13] SPI_DEVICE_READ_THRESHOLD
+    4'b 1111, // index[14] SPI_DEVICE_MAILBOX_ADDR
+    4'b 0011, // index[15] SPI_DEVICE_UPLOAD_STATUS
+    4'b 0111, // index[16] SPI_DEVICE_UPLOAD_STATUS2
+    4'b 0001, // index[17] SPI_DEVICE_UPLOAD_CMDFIFO
+    4'b 1111, // index[18] SPI_DEVICE_UPLOAD_ADDRFIFO
+    4'b 1111, // index[19] SPI_DEVICE_CMD_FILTER_0
+    4'b 1111, // index[20] SPI_DEVICE_CMD_FILTER_1
+    4'b 1111, // index[21] SPI_DEVICE_CMD_FILTER_2
+    4'b 1111, // index[22] SPI_DEVICE_CMD_FILTER_3
+    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_4
+    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_5
+    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_6
+    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_7
+    4'b 1111, // index[27] SPI_DEVICE_ADDR_SWAP_MASK
+    4'b 1111, // index[28] SPI_DEVICE_ADDR_SWAP_DATA
+    4'b 1111, // index[29] SPI_DEVICE_PAYLOAD_SWAP_MASK
+    4'b 1111, // index[30] SPI_DEVICE_PAYLOAD_SWAP_DATA
+    4'b 1111, // index[31] SPI_DEVICE_CMD_INFO_0
+    4'b 1111, // index[32] SPI_DEVICE_CMD_INFO_1
+    4'b 1111, // index[33] SPI_DEVICE_CMD_INFO_2
+    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_3
+    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_4
+    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_5
+    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_6
+    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_7
+    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_8
+    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_9
+    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_10
+    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_11
+    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_12
+    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_13
+    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_14
+    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_15
+    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_16
+    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_17
+    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_18
+    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_19
+    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_20
+    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_21
+    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_22
+    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_23
+    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_EN4B
+    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_EX4B
+    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_WREN
+    4'b 1111, // index[58] SPI_DEVICE_CMD_INFO_WRDI
+    4'b 0111, // index[59] SPI_DEVICE_TPM_CAP
+    4'b 0001, // index[60] SPI_DEVICE_TPM_CFG
+    4'b 0111, // index[61] SPI_DEVICE_TPM_STATUS
+    4'b 1111, // index[62] SPI_DEVICE_TPM_ACCESS_0
+    4'b 0001, // index[63] SPI_DEVICE_TPM_ACCESS_1
+    4'b 1111, // index[64] SPI_DEVICE_TPM_STS
+    4'b 1111, // index[65] SPI_DEVICE_TPM_INTF_CAPABILITY
+    4'b 1111, // index[66] SPI_DEVICE_TPM_INT_ENABLE
+    4'b 0001, // index[67] SPI_DEVICE_TPM_INT_VECTOR
+    4'b 1111, // index[68] SPI_DEVICE_TPM_INT_STATUS
+    4'b 1111, // index[69] SPI_DEVICE_TPM_DID_VID
+    4'b 0001, // index[70] SPI_DEVICE_TPM_RID
+    4'b 1111, // index[71] SPI_DEVICE_TPM_CMD_ADDR
+    4'b 1111, // index[72] SPI_DEVICE_TPM_READ_FIFO
+    4'b 0001  // index[73] SPI_DEVICE_TPM_WRITE_FIFO
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -2245,6 +2245,8 @@ module spi_device_reg_top (
   logic addr_mode_qe;
   logic [1:0] addr_mode_flds_we;
   // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_addr_mode_flds_we;
+  assign unused_addr_mode_flds_we = ^(addr_mode_flds_we & 2'h2);
   assign addr_mode_qe = &(addr_mode_flds_we | 2'h2);
   //   F[addr_4b_en]: 0:0
   prim_subreg_ext #(

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -57,9 +57,9 @@ module spi_device_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [72:0] reg_we_check;
+  logic [73:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(73)
+    .OneHotWidth(74)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -219,8 +219,6 @@ module spi_device_reg_top (
   logic cfg_tx_order_wd;
   logic cfg_rx_order_qs;
   logic cfg_rx_order_wd;
-  logic cfg_addr_4b_en_qs;
-  logic cfg_addr_4b_en_wd;
   logic cfg_mailbox_en_qs;
   logic cfg_mailbox_en_wd;
   logic status_re;
@@ -235,6 +233,11 @@ module spi_device_reg_top (
   logic intercept_en_sfdp_wd;
   logic intercept_en_mbx_qs;
   logic intercept_en_mbx_wd;
+  logic addr_mode_re;
+  logic addr_mode_we;
+  logic addr_mode_addr_4b_en_qs;
+  logic addr_mode_addr_4b_en_wd;
+  logic addr_mode_pending_qs;
   logic last_read_addr_re;
   logic [31:0] last_read_addr_qs;
   logic flash_status_re;
@@ -2068,33 +2071,6 @@ module spi_device_reg_top (
     .qs     (cfg_rx_order_qs)
   );
 
-  //   F[addr_4b_en]: 16:16
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_cfg_addr_4b_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (cfg_we),
-    .wd     (cfg_addr_4b_en_wd),
-
-    // from internal hardware
-    .de     (hw2reg.cfg.addr_4b_en.de),
-    .d      (hw2reg.cfg.addr_4b_en.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.cfg.addr_4b_en.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (cfg_addr_4b_en_qs)
-  );
-
   //   F[mailbox_en]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -2262,6 +2238,43 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (intercept_en_mbx_qs)
+  );
+
+
+  // R[addr_mode]: V(True)
+  logic addr_mode_qe;
+  logic [1:0] addr_mode_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  assign addr_mode_qe = &(addr_mode_flds_we | 2'h2);
+  //   F[addr_4b_en]: 0:0
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_addr_mode_addr_4b_en (
+    .re     (addr_mode_re),
+    .we     (addr_mode_we),
+    .wd     (addr_mode_addr_4b_en_wd),
+    .d      (hw2reg.addr_mode.addr_4b_en.d),
+    .qre    (),
+    .qe     (addr_mode_flds_we[0]),
+    .q      (reg2hw.addr_mode.addr_4b_en.q),
+    .ds     (),
+    .qs     (addr_mode_addr_4b_en_qs)
+  );
+  assign reg2hw.addr_mode.addr_4b_en.qe = addr_mode_qe;
+
+  //   F[pending]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_addr_mode_pending (
+    .re     (addr_mode_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.addr_mode.pending.d),
+    .qre    (),
+    .qe     (addr_mode_flds_we[1]),
+    .q      (),
+    .ds     (),
+    .qs     (addr_mode_pending_qs)
   );
 
 
@@ -18551,7 +18564,7 @@ module spi_device_reg_top (
 
 
 
-  logic [72:0] addr_hit;
+  logic [73:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -18562,71 +18575,72 @@ module spi_device_reg_top (
     addr_hit[ 5] = (reg_addr == SPI_DEVICE_CFG_OFFSET);
     addr_hit[ 6] = (reg_addr == SPI_DEVICE_STATUS_OFFSET);
     addr_hit[ 7] = (reg_addr == SPI_DEVICE_INTERCEPT_EN_OFFSET);
-    addr_hit[ 8] = (reg_addr == SPI_DEVICE_LAST_READ_ADDR_OFFSET);
-    addr_hit[ 9] = (reg_addr == SPI_DEVICE_FLASH_STATUS_OFFSET);
-    addr_hit[10] = (reg_addr == SPI_DEVICE_JEDEC_CC_OFFSET);
-    addr_hit[11] = (reg_addr == SPI_DEVICE_JEDEC_ID_OFFSET);
-    addr_hit[12] = (reg_addr == SPI_DEVICE_READ_THRESHOLD_OFFSET);
-    addr_hit[13] = (reg_addr == SPI_DEVICE_MAILBOX_ADDR_OFFSET);
-    addr_hit[14] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
-    addr_hit[15] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS2_OFFSET);
-    addr_hit[16] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
-    addr_hit[17] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
-    addr_hit[18] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
-    addr_hit[19] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
-    addr_hit[20] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
-    addr_hit[21] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
-    addr_hit[22] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
-    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
-    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
-    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
-    addr_hit[26] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
-    addr_hit[27] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
-    addr_hit[28] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
-    addr_hit[29] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
-    addr_hit[30] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
-    addr_hit[31] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
-    addr_hit[32] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
-    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
-    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
-    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
-    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
-    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
-    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
-    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
-    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
-    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
-    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
-    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
-    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
-    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
-    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
-    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
-    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
-    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
-    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
-    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
-    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
-    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
-    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_EN4B_OFFSET);
-    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_EX4B_OFFSET);
-    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_WREN_OFFSET);
-    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_WRDI_OFFSET);
-    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
-    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
-    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
-    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
-    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
-    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
-    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
-    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
-    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
-    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
-    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
-    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
-    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
-    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
-    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
+    addr_hit[ 8] = (reg_addr == SPI_DEVICE_ADDR_MODE_OFFSET);
+    addr_hit[ 9] = (reg_addr == SPI_DEVICE_LAST_READ_ADDR_OFFSET);
+    addr_hit[10] = (reg_addr == SPI_DEVICE_FLASH_STATUS_OFFSET);
+    addr_hit[11] = (reg_addr == SPI_DEVICE_JEDEC_CC_OFFSET);
+    addr_hit[12] = (reg_addr == SPI_DEVICE_JEDEC_ID_OFFSET);
+    addr_hit[13] = (reg_addr == SPI_DEVICE_READ_THRESHOLD_OFFSET);
+    addr_hit[14] = (reg_addr == SPI_DEVICE_MAILBOX_ADDR_OFFSET);
+    addr_hit[15] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
+    addr_hit[16] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS2_OFFSET);
+    addr_hit[17] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
+    addr_hit[18] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
+    addr_hit[19] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
+    addr_hit[20] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
+    addr_hit[21] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
+    addr_hit[22] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
+    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
+    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
+    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
+    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
+    addr_hit[27] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
+    addr_hit[28] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
+    addr_hit[29] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
+    addr_hit[30] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
+    addr_hit[31] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
+    addr_hit[32] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
+    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
+    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
+    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
+    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
+    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
+    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
+    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
+    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
+    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
+    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
+    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
+    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
+    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
+    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
+    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
+    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
+    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
+    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
+    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
+    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
+    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
+    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_EN4B_OFFSET);
+    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_EX4B_OFFSET);
+    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_WREN_OFFSET);
+    addr_hit[58] = (reg_addr == SPI_DEVICE_CMD_INFO_WRDI_OFFSET);
+    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
+    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
+    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
+    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
+    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
+    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
+    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
+    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
+    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
+    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
+    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
+    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
+    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
+    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
+    addr_hit[73] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -18706,7 +18720,8 @@ module spi_device_reg_top (
                (addr_hit[69] & (|(SPI_DEVICE_PERMIT[69] & ~reg_be))) |
                (addr_hit[70] & (|(SPI_DEVICE_PERMIT[70] & ~reg_be))) |
                (addr_hit[71] & (|(SPI_DEVICE_PERMIT[71] & ~reg_be))) |
-               (addr_hit[72] & (|(SPI_DEVICE_PERMIT[72] & ~reg_be)))));
+               (addr_hit[72] & (|(SPI_DEVICE_PERMIT[72] & ~reg_be))) |
+               (addr_hit[73] & (|(SPI_DEVICE_PERMIT[73] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -18763,8 +18778,6 @@ module spi_device_reg_top (
 
   assign cfg_rx_order_wd = reg_wdata[3];
 
-  assign cfg_addr_4b_en_wd = reg_wdata[16];
-
   assign cfg_mailbox_en_wd = reg_wdata[24];
   assign status_re = addr_hit[6] & reg_re & !reg_error;
   assign intercept_en_we = addr_hit[7] & reg_we & !reg_error;
@@ -18776,32 +18789,36 @@ module spi_device_reg_top (
   assign intercept_en_sfdp_wd = reg_wdata[2];
 
   assign intercept_en_mbx_wd = reg_wdata[3];
-  assign last_read_addr_re = addr_hit[8] & reg_re & !reg_error;
-  assign flash_status_re = addr_hit[9] & reg_re & !reg_error;
-  assign flash_status_we = addr_hit[9] & reg_we & !reg_error;
+  assign addr_mode_re = addr_hit[8] & reg_re & !reg_error;
+  assign addr_mode_we = addr_hit[8] & reg_we & !reg_error;
+
+  assign addr_mode_addr_4b_en_wd = reg_wdata[0];
+  assign last_read_addr_re = addr_hit[9] & reg_re & !reg_error;
+  assign flash_status_re = addr_hit[10] & reg_re & !reg_error;
+  assign flash_status_we = addr_hit[10] & reg_we & !reg_error;
 
   assign flash_status_busy_wd = reg_wdata[0];
 
   assign flash_status_status_wd = reg_wdata[23:1];
-  assign jedec_cc_we = addr_hit[10] & reg_we & !reg_error;
+  assign jedec_cc_we = addr_hit[11] & reg_we & !reg_error;
 
   assign jedec_cc_cc_wd = reg_wdata[7:0];
 
   assign jedec_cc_num_cc_wd = reg_wdata[15:8];
-  assign jedec_id_we = addr_hit[11] & reg_we & !reg_error;
+  assign jedec_id_we = addr_hit[12] & reg_we & !reg_error;
 
   assign jedec_id_id_wd = reg_wdata[15:0];
 
   assign jedec_id_mf_wd = reg_wdata[23:16];
-  assign read_threshold_we = addr_hit[12] & reg_we & !reg_error;
+  assign read_threshold_we = addr_hit[13] & reg_we & !reg_error;
 
   assign read_threshold_wd = reg_wdata[9:0];
-  assign mailbox_addr_we = addr_hit[13] & reg_we & !reg_error;
+  assign mailbox_addr_we = addr_hit[14] & reg_we & !reg_error;
 
   assign mailbox_addr_wd = reg_wdata[31:0];
-  assign upload_cmdfifo_re = addr_hit[16] & reg_re & !reg_error;
-  assign upload_addrfifo_re = addr_hit[17] & reg_re & !reg_error;
-  assign cmd_filter_0_we = addr_hit[18] & reg_we & !reg_error;
+  assign upload_cmdfifo_re = addr_hit[17] & reg_re & !reg_error;
+  assign upload_addrfifo_re = addr_hit[18] & reg_re & !reg_error;
+  assign cmd_filter_0_we = addr_hit[19] & reg_we & !reg_error;
 
   assign cmd_filter_0_filter_0_wd = reg_wdata[0];
 
@@ -18866,7 +18883,7 @@ module spi_device_reg_top (
   assign cmd_filter_0_filter_30_wd = reg_wdata[30];
 
   assign cmd_filter_0_filter_31_wd = reg_wdata[31];
-  assign cmd_filter_1_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_1_we = addr_hit[20] & reg_we & !reg_error;
 
   assign cmd_filter_1_filter_32_wd = reg_wdata[0];
 
@@ -18931,7 +18948,7 @@ module spi_device_reg_top (
   assign cmd_filter_1_filter_62_wd = reg_wdata[30];
 
   assign cmd_filter_1_filter_63_wd = reg_wdata[31];
-  assign cmd_filter_2_we = addr_hit[20] & reg_we & !reg_error;
+  assign cmd_filter_2_we = addr_hit[21] & reg_we & !reg_error;
 
   assign cmd_filter_2_filter_64_wd = reg_wdata[0];
 
@@ -18996,7 +19013,7 @@ module spi_device_reg_top (
   assign cmd_filter_2_filter_94_wd = reg_wdata[30];
 
   assign cmd_filter_2_filter_95_wd = reg_wdata[31];
-  assign cmd_filter_3_we = addr_hit[21] & reg_we & !reg_error;
+  assign cmd_filter_3_we = addr_hit[22] & reg_we & !reg_error;
 
   assign cmd_filter_3_filter_96_wd = reg_wdata[0];
 
@@ -19061,7 +19078,7 @@ module spi_device_reg_top (
   assign cmd_filter_3_filter_126_wd = reg_wdata[30];
 
   assign cmd_filter_3_filter_127_wd = reg_wdata[31];
-  assign cmd_filter_4_we = addr_hit[22] & reg_we & !reg_error;
+  assign cmd_filter_4_we = addr_hit[23] & reg_we & !reg_error;
 
   assign cmd_filter_4_filter_128_wd = reg_wdata[0];
 
@@ -19126,7 +19143,7 @@ module spi_device_reg_top (
   assign cmd_filter_4_filter_158_wd = reg_wdata[30];
 
   assign cmd_filter_4_filter_159_wd = reg_wdata[31];
-  assign cmd_filter_5_we = addr_hit[23] & reg_we & !reg_error;
+  assign cmd_filter_5_we = addr_hit[24] & reg_we & !reg_error;
 
   assign cmd_filter_5_filter_160_wd = reg_wdata[0];
 
@@ -19191,7 +19208,7 @@ module spi_device_reg_top (
   assign cmd_filter_5_filter_190_wd = reg_wdata[30];
 
   assign cmd_filter_5_filter_191_wd = reg_wdata[31];
-  assign cmd_filter_6_we = addr_hit[24] & reg_we & !reg_error;
+  assign cmd_filter_6_we = addr_hit[25] & reg_we & !reg_error;
 
   assign cmd_filter_6_filter_192_wd = reg_wdata[0];
 
@@ -19256,7 +19273,7 @@ module spi_device_reg_top (
   assign cmd_filter_6_filter_222_wd = reg_wdata[30];
 
   assign cmd_filter_6_filter_223_wd = reg_wdata[31];
-  assign cmd_filter_7_we = addr_hit[25] & reg_we & !reg_error;
+  assign cmd_filter_7_we = addr_hit[26] & reg_we & !reg_error;
 
   assign cmd_filter_7_filter_224_wd = reg_wdata[0];
 
@@ -19321,19 +19338,19 @@ module spi_device_reg_top (
   assign cmd_filter_7_filter_254_wd = reg_wdata[30];
 
   assign cmd_filter_7_filter_255_wd = reg_wdata[31];
-  assign addr_swap_mask_we = addr_hit[26] & reg_we & !reg_error;
+  assign addr_swap_mask_we = addr_hit[27] & reg_we & !reg_error;
 
   assign addr_swap_mask_wd = reg_wdata[31:0];
-  assign addr_swap_data_we = addr_hit[27] & reg_we & !reg_error;
+  assign addr_swap_data_we = addr_hit[28] & reg_we & !reg_error;
 
   assign addr_swap_data_wd = reg_wdata[31:0];
-  assign payload_swap_mask_we = addr_hit[28] & reg_we & !reg_error;
+  assign payload_swap_mask_we = addr_hit[29] & reg_we & !reg_error;
 
   assign payload_swap_mask_wd = reg_wdata[31:0];
-  assign payload_swap_data_we = addr_hit[29] & reg_we & !reg_error;
+  assign payload_swap_data_we = addr_hit[30] & reg_we & !reg_error;
 
   assign payload_swap_data_wd = reg_wdata[31:0];
-  assign cmd_info_0_we = addr_hit[30] & reg_we & !reg_error;
+  assign cmd_info_0_we = addr_hit[31] & reg_we & !reg_error;
 
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
@@ -19358,7 +19375,7 @@ module spi_device_reg_top (
   assign cmd_info_0_busy_0_wd = reg_wdata[25];
 
   assign cmd_info_0_valid_0_wd = reg_wdata[31];
-  assign cmd_info_1_we = addr_hit[31] & reg_we & !reg_error;
+  assign cmd_info_1_we = addr_hit[32] & reg_we & !reg_error;
 
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
@@ -19383,7 +19400,7 @@ module spi_device_reg_top (
   assign cmd_info_1_busy_1_wd = reg_wdata[25];
 
   assign cmd_info_1_valid_1_wd = reg_wdata[31];
-  assign cmd_info_2_we = addr_hit[32] & reg_we & !reg_error;
+  assign cmd_info_2_we = addr_hit[33] & reg_we & !reg_error;
 
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
@@ -19408,7 +19425,7 @@ module spi_device_reg_top (
   assign cmd_info_2_busy_2_wd = reg_wdata[25];
 
   assign cmd_info_2_valid_2_wd = reg_wdata[31];
-  assign cmd_info_3_we = addr_hit[33] & reg_we & !reg_error;
+  assign cmd_info_3_we = addr_hit[34] & reg_we & !reg_error;
 
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
@@ -19433,7 +19450,7 @@ module spi_device_reg_top (
   assign cmd_info_3_busy_3_wd = reg_wdata[25];
 
   assign cmd_info_3_valid_3_wd = reg_wdata[31];
-  assign cmd_info_4_we = addr_hit[34] & reg_we & !reg_error;
+  assign cmd_info_4_we = addr_hit[35] & reg_we & !reg_error;
 
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
@@ -19458,7 +19475,7 @@ module spi_device_reg_top (
   assign cmd_info_4_busy_4_wd = reg_wdata[25];
 
   assign cmd_info_4_valid_4_wd = reg_wdata[31];
-  assign cmd_info_5_we = addr_hit[35] & reg_we & !reg_error;
+  assign cmd_info_5_we = addr_hit[36] & reg_we & !reg_error;
 
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
@@ -19483,7 +19500,7 @@ module spi_device_reg_top (
   assign cmd_info_5_busy_5_wd = reg_wdata[25];
 
   assign cmd_info_5_valid_5_wd = reg_wdata[31];
-  assign cmd_info_6_we = addr_hit[36] & reg_we & !reg_error;
+  assign cmd_info_6_we = addr_hit[37] & reg_we & !reg_error;
 
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
@@ -19508,7 +19525,7 @@ module spi_device_reg_top (
   assign cmd_info_6_busy_6_wd = reg_wdata[25];
 
   assign cmd_info_6_valid_6_wd = reg_wdata[31];
-  assign cmd_info_7_we = addr_hit[37] & reg_we & !reg_error;
+  assign cmd_info_7_we = addr_hit[38] & reg_we & !reg_error;
 
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
@@ -19533,7 +19550,7 @@ module spi_device_reg_top (
   assign cmd_info_7_busy_7_wd = reg_wdata[25];
 
   assign cmd_info_7_valid_7_wd = reg_wdata[31];
-  assign cmd_info_8_we = addr_hit[38] & reg_we & !reg_error;
+  assign cmd_info_8_we = addr_hit[39] & reg_we & !reg_error;
 
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
@@ -19558,7 +19575,7 @@ module spi_device_reg_top (
   assign cmd_info_8_busy_8_wd = reg_wdata[25];
 
   assign cmd_info_8_valid_8_wd = reg_wdata[31];
-  assign cmd_info_9_we = addr_hit[39] & reg_we & !reg_error;
+  assign cmd_info_9_we = addr_hit[40] & reg_we & !reg_error;
 
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
@@ -19583,7 +19600,7 @@ module spi_device_reg_top (
   assign cmd_info_9_busy_9_wd = reg_wdata[25];
 
   assign cmd_info_9_valid_9_wd = reg_wdata[31];
-  assign cmd_info_10_we = addr_hit[40] & reg_we & !reg_error;
+  assign cmd_info_10_we = addr_hit[41] & reg_we & !reg_error;
 
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
@@ -19608,7 +19625,7 @@ module spi_device_reg_top (
   assign cmd_info_10_busy_10_wd = reg_wdata[25];
 
   assign cmd_info_10_valid_10_wd = reg_wdata[31];
-  assign cmd_info_11_we = addr_hit[41] & reg_we & !reg_error;
+  assign cmd_info_11_we = addr_hit[42] & reg_we & !reg_error;
 
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
@@ -19633,7 +19650,7 @@ module spi_device_reg_top (
   assign cmd_info_11_busy_11_wd = reg_wdata[25];
 
   assign cmd_info_11_valid_11_wd = reg_wdata[31];
-  assign cmd_info_12_we = addr_hit[42] & reg_we & !reg_error;
+  assign cmd_info_12_we = addr_hit[43] & reg_we & !reg_error;
 
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
@@ -19658,7 +19675,7 @@ module spi_device_reg_top (
   assign cmd_info_12_busy_12_wd = reg_wdata[25];
 
   assign cmd_info_12_valid_12_wd = reg_wdata[31];
-  assign cmd_info_13_we = addr_hit[43] & reg_we & !reg_error;
+  assign cmd_info_13_we = addr_hit[44] & reg_we & !reg_error;
 
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
@@ -19683,7 +19700,7 @@ module spi_device_reg_top (
   assign cmd_info_13_busy_13_wd = reg_wdata[25];
 
   assign cmd_info_13_valid_13_wd = reg_wdata[31];
-  assign cmd_info_14_we = addr_hit[44] & reg_we & !reg_error;
+  assign cmd_info_14_we = addr_hit[45] & reg_we & !reg_error;
 
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
@@ -19708,7 +19725,7 @@ module spi_device_reg_top (
   assign cmd_info_14_busy_14_wd = reg_wdata[25];
 
   assign cmd_info_14_valid_14_wd = reg_wdata[31];
-  assign cmd_info_15_we = addr_hit[45] & reg_we & !reg_error;
+  assign cmd_info_15_we = addr_hit[46] & reg_we & !reg_error;
 
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
@@ -19733,7 +19750,7 @@ module spi_device_reg_top (
   assign cmd_info_15_busy_15_wd = reg_wdata[25];
 
   assign cmd_info_15_valid_15_wd = reg_wdata[31];
-  assign cmd_info_16_we = addr_hit[46] & reg_we & !reg_error;
+  assign cmd_info_16_we = addr_hit[47] & reg_we & !reg_error;
 
   assign cmd_info_16_opcode_16_wd = reg_wdata[7:0];
 
@@ -19758,7 +19775,7 @@ module spi_device_reg_top (
   assign cmd_info_16_busy_16_wd = reg_wdata[25];
 
   assign cmd_info_16_valid_16_wd = reg_wdata[31];
-  assign cmd_info_17_we = addr_hit[47] & reg_we & !reg_error;
+  assign cmd_info_17_we = addr_hit[48] & reg_we & !reg_error;
 
   assign cmd_info_17_opcode_17_wd = reg_wdata[7:0];
 
@@ -19783,7 +19800,7 @@ module spi_device_reg_top (
   assign cmd_info_17_busy_17_wd = reg_wdata[25];
 
   assign cmd_info_17_valid_17_wd = reg_wdata[31];
-  assign cmd_info_18_we = addr_hit[48] & reg_we & !reg_error;
+  assign cmd_info_18_we = addr_hit[49] & reg_we & !reg_error;
 
   assign cmd_info_18_opcode_18_wd = reg_wdata[7:0];
 
@@ -19808,7 +19825,7 @@ module spi_device_reg_top (
   assign cmd_info_18_busy_18_wd = reg_wdata[25];
 
   assign cmd_info_18_valid_18_wd = reg_wdata[31];
-  assign cmd_info_19_we = addr_hit[49] & reg_we & !reg_error;
+  assign cmd_info_19_we = addr_hit[50] & reg_we & !reg_error;
 
   assign cmd_info_19_opcode_19_wd = reg_wdata[7:0];
 
@@ -19833,7 +19850,7 @@ module spi_device_reg_top (
   assign cmd_info_19_busy_19_wd = reg_wdata[25];
 
   assign cmd_info_19_valid_19_wd = reg_wdata[31];
-  assign cmd_info_20_we = addr_hit[50] & reg_we & !reg_error;
+  assign cmd_info_20_we = addr_hit[51] & reg_we & !reg_error;
 
   assign cmd_info_20_opcode_20_wd = reg_wdata[7:0];
 
@@ -19858,7 +19875,7 @@ module spi_device_reg_top (
   assign cmd_info_20_busy_20_wd = reg_wdata[25];
 
   assign cmd_info_20_valid_20_wd = reg_wdata[31];
-  assign cmd_info_21_we = addr_hit[51] & reg_we & !reg_error;
+  assign cmd_info_21_we = addr_hit[52] & reg_we & !reg_error;
 
   assign cmd_info_21_opcode_21_wd = reg_wdata[7:0];
 
@@ -19883,7 +19900,7 @@ module spi_device_reg_top (
   assign cmd_info_21_busy_21_wd = reg_wdata[25];
 
   assign cmd_info_21_valid_21_wd = reg_wdata[31];
-  assign cmd_info_22_we = addr_hit[52] & reg_we & !reg_error;
+  assign cmd_info_22_we = addr_hit[53] & reg_we & !reg_error;
 
   assign cmd_info_22_opcode_22_wd = reg_wdata[7:0];
 
@@ -19908,7 +19925,7 @@ module spi_device_reg_top (
   assign cmd_info_22_busy_22_wd = reg_wdata[25];
 
   assign cmd_info_22_valid_22_wd = reg_wdata[31];
-  assign cmd_info_23_we = addr_hit[53] & reg_we & !reg_error;
+  assign cmd_info_23_we = addr_hit[54] & reg_we & !reg_error;
 
   assign cmd_info_23_opcode_23_wd = reg_wdata[7:0];
 
@@ -19933,27 +19950,27 @@ module spi_device_reg_top (
   assign cmd_info_23_busy_23_wd = reg_wdata[25];
 
   assign cmd_info_23_valid_23_wd = reg_wdata[31];
-  assign cmd_info_en4b_we = addr_hit[54] & reg_we & !reg_error;
+  assign cmd_info_en4b_we = addr_hit[55] & reg_we & !reg_error;
 
   assign cmd_info_en4b_opcode_wd = reg_wdata[7:0];
 
   assign cmd_info_en4b_valid_wd = reg_wdata[31];
-  assign cmd_info_ex4b_we = addr_hit[55] & reg_we & !reg_error;
+  assign cmd_info_ex4b_we = addr_hit[56] & reg_we & !reg_error;
 
   assign cmd_info_ex4b_opcode_wd = reg_wdata[7:0];
 
   assign cmd_info_ex4b_valid_wd = reg_wdata[31];
-  assign cmd_info_wren_we = addr_hit[56] & reg_we & !reg_error;
+  assign cmd_info_wren_we = addr_hit[57] & reg_we & !reg_error;
 
   assign cmd_info_wren_opcode_wd = reg_wdata[7:0];
 
   assign cmd_info_wren_valid_wd = reg_wdata[31];
-  assign cmd_info_wrdi_we = addr_hit[57] & reg_we & !reg_error;
+  assign cmd_info_wrdi_we = addr_hit[58] & reg_we & !reg_error;
 
   assign cmd_info_wrdi_opcode_wd = reg_wdata[7:0];
 
   assign cmd_info_wrdi_valid_wd = reg_wdata[31];
-  assign tpm_cfg_we = addr_hit[59] & reg_we & !reg_error;
+  assign tpm_cfg_we = addr_hit[60] & reg_we & !reg_error;
 
   assign tpm_cfg_en_wd = reg_wdata[0];
 
@@ -19964,7 +19981,7 @@ module spi_device_reg_top (
   assign tpm_cfg_tpm_reg_chk_dis_wd = reg_wdata[3];
 
   assign tpm_cfg_invalid_locality_wd = reg_wdata[4];
-  assign tpm_access_0_we = addr_hit[61] & reg_we & !reg_error;
+  assign tpm_access_0_we = addr_hit[62] & reg_we & !reg_error;
 
   assign tpm_access_0_access_0_wd = reg_wdata[7:0];
 
@@ -19973,37 +19990,37 @@ module spi_device_reg_top (
   assign tpm_access_0_access_2_wd = reg_wdata[23:16];
 
   assign tpm_access_0_access_3_wd = reg_wdata[31:24];
-  assign tpm_access_1_we = addr_hit[62] & reg_we & !reg_error;
+  assign tpm_access_1_we = addr_hit[63] & reg_we & !reg_error;
 
   assign tpm_access_1_wd = reg_wdata[7:0];
-  assign tpm_sts_we = addr_hit[63] & reg_we & !reg_error;
+  assign tpm_sts_we = addr_hit[64] & reg_we & !reg_error;
 
   assign tpm_sts_wd = reg_wdata[31:0];
-  assign tpm_intf_capability_we = addr_hit[64] & reg_we & !reg_error;
+  assign tpm_intf_capability_we = addr_hit[65] & reg_we & !reg_error;
 
   assign tpm_intf_capability_wd = reg_wdata[31:0];
-  assign tpm_int_enable_we = addr_hit[65] & reg_we & !reg_error;
+  assign tpm_int_enable_we = addr_hit[66] & reg_we & !reg_error;
 
   assign tpm_int_enable_wd = reg_wdata[31:0];
-  assign tpm_int_vector_we = addr_hit[66] & reg_we & !reg_error;
+  assign tpm_int_vector_we = addr_hit[67] & reg_we & !reg_error;
 
   assign tpm_int_vector_wd = reg_wdata[7:0];
-  assign tpm_int_status_we = addr_hit[67] & reg_we & !reg_error;
+  assign tpm_int_status_we = addr_hit[68] & reg_we & !reg_error;
 
   assign tpm_int_status_wd = reg_wdata[31:0];
-  assign tpm_did_vid_we = addr_hit[68] & reg_we & !reg_error;
+  assign tpm_did_vid_we = addr_hit[69] & reg_we & !reg_error;
 
   assign tpm_did_vid_vid_wd = reg_wdata[15:0];
 
   assign tpm_did_vid_did_wd = reg_wdata[31:16];
-  assign tpm_rid_we = addr_hit[69] & reg_we & !reg_error;
+  assign tpm_rid_we = addr_hit[70] & reg_we & !reg_error;
 
   assign tpm_rid_wd = reg_wdata[7:0];
-  assign tpm_cmd_addr_re = addr_hit[70] & reg_re & !reg_error;
-  assign tpm_read_fifo_we = addr_hit[71] & reg_we & !reg_error;
+  assign tpm_cmd_addr_re = addr_hit[71] & reg_re & !reg_error;
+  assign tpm_read_fifo_we = addr_hit[72] & reg_we & !reg_error;
 
   assign tpm_read_fifo_wd = reg_wdata[31:0];
-  assign tpm_write_fifo_re = addr_hit[72] & reg_re & !reg_error;
+  assign tpm_write_fifo_re = addr_hit[73] & reg_re & !reg_error;
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -20016,71 +20033,72 @@ module spi_device_reg_top (
     reg_we_check[5] = cfg_we;
     reg_we_check[6] = 1'b0;
     reg_we_check[7] = intercept_en_we;
-    reg_we_check[8] = 1'b0;
-    reg_we_check[9] = flash_status_we;
-    reg_we_check[10] = jedec_cc_we;
-    reg_we_check[11] = jedec_id_we;
-    reg_we_check[12] = read_threshold_we;
-    reg_we_check[13] = mailbox_addr_we;
-    reg_we_check[14] = 1'b0;
+    reg_we_check[8] = addr_mode_we;
+    reg_we_check[9] = 1'b0;
+    reg_we_check[10] = flash_status_we;
+    reg_we_check[11] = jedec_cc_we;
+    reg_we_check[12] = jedec_id_we;
+    reg_we_check[13] = read_threshold_we;
+    reg_we_check[14] = mailbox_addr_we;
     reg_we_check[15] = 1'b0;
     reg_we_check[16] = 1'b0;
     reg_we_check[17] = 1'b0;
-    reg_we_check[18] = cmd_filter_0_we;
-    reg_we_check[19] = cmd_filter_1_we;
-    reg_we_check[20] = cmd_filter_2_we;
-    reg_we_check[21] = cmd_filter_3_we;
-    reg_we_check[22] = cmd_filter_4_we;
-    reg_we_check[23] = cmd_filter_5_we;
-    reg_we_check[24] = cmd_filter_6_we;
-    reg_we_check[25] = cmd_filter_7_we;
-    reg_we_check[26] = addr_swap_mask_we;
-    reg_we_check[27] = addr_swap_data_we;
-    reg_we_check[28] = payload_swap_mask_we;
-    reg_we_check[29] = payload_swap_data_we;
-    reg_we_check[30] = cmd_info_0_we;
-    reg_we_check[31] = cmd_info_1_we;
-    reg_we_check[32] = cmd_info_2_we;
-    reg_we_check[33] = cmd_info_3_we;
-    reg_we_check[34] = cmd_info_4_we;
-    reg_we_check[35] = cmd_info_5_we;
-    reg_we_check[36] = cmd_info_6_we;
-    reg_we_check[37] = cmd_info_7_we;
-    reg_we_check[38] = cmd_info_8_we;
-    reg_we_check[39] = cmd_info_9_we;
-    reg_we_check[40] = cmd_info_10_we;
-    reg_we_check[41] = cmd_info_11_we;
-    reg_we_check[42] = cmd_info_12_we;
-    reg_we_check[43] = cmd_info_13_we;
-    reg_we_check[44] = cmd_info_14_we;
-    reg_we_check[45] = cmd_info_15_we;
-    reg_we_check[46] = cmd_info_16_we;
-    reg_we_check[47] = cmd_info_17_we;
-    reg_we_check[48] = cmd_info_18_we;
-    reg_we_check[49] = cmd_info_19_we;
-    reg_we_check[50] = cmd_info_20_we;
-    reg_we_check[51] = cmd_info_21_we;
-    reg_we_check[52] = cmd_info_22_we;
-    reg_we_check[53] = cmd_info_23_we;
-    reg_we_check[54] = cmd_info_en4b_we;
-    reg_we_check[55] = cmd_info_ex4b_we;
-    reg_we_check[56] = cmd_info_wren_we;
-    reg_we_check[57] = cmd_info_wrdi_we;
-    reg_we_check[58] = 1'b0;
-    reg_we_check[59] = tpm_cfg_we;
-    reg_we_check[60] = 1'b0;
-    reg_we_check[61] = tpm_access_0_we;
-    reg_we_check[62] = tpm_access_1_we;
-    reg_we_check[63] = tpm_sts_we;
-    reg_we_check[64] = tpm_intf_capability_we;
-    reg_we_check[65] = tpm_int_enable_we;
-    reg_we_check[66] = tpm_int_vector_we;
-    reg_we_check[67] = tpm_int_status_we;
-    reg_we_check[68] = tpm_did_vid_we;
-    reg_we_check[69] = tpm_rid_we;
-    reg_we_check[70] = 1'b0;
-    reg_we_check[71] = tpm_read_fifo_we;
-    reg_we_check[72] = 1'b0;
+    reg_we_check[18] = 1'b0;
+    reg_we_check[19] = cmd_filter_0_we;
+    reg_we_check[20] = cmd_filter_1_we;
+    reg_we_check[21] = cmd_filter_2_we;
+    reg_we_check[22] = cmd_filter_3_we;
+    reg_we_check[23] = cmd_filter_4_we;
+    reg_we_check[24] = cmd_filter_5_we;
+    reg_we_check[25] = cmd_filter_6_we;
+    reg_we_check[26] = cmd_filter_7_we;
+    reg_we_check[27] = addr_swap_mask_we;
+    reg_we_check[28] = addr_swap_data_we;
+    reg_we_check[29] = payload_swap_mask_we;
+    reg_we_check[30] = payload_swap_data_we;
+    reg_we_check[31] = cmd_info_0_we;
+    reg_we_check[32] = cmd_info_1_we;
+    reg_we_check[33] = cmd_info_2_we;
+    reg_we_check[34] = cmd_info_3_we;
+    reg_we_check[35] = cmd_info_4_we;
+    reg_we_check[36] = cmd_info_5_we;
+    reg_we_check[37] = cmd_info_6_we;
+    reg_we_check[38] = cmd_info_7_we;
+    reg_we_check[39] = cmd_info_8_we;
+    reg_we_check[40] = cmd_info_9_we;
+    reg_we_check[41] = cmd_info_10_we;
+    reg_we_check[42] = cmd_info_11_we;
+    reg_we_check[43] = cmd_info_12_we;
+    reg_we_check[44] = cmd_info_13_we;
+    reg_we_check[45] = cmd_info_14_we;
+    reg_we_check[46] = cmd_info_15_we;
+    reg_we_check[47] = cmd_info_16_we;
+    reg_we_check[48] = cmd_info_17_we;
+    reg_we_check[49] = cmd_info_18_we;
+    reg_we_check[50] = cmd_info_19_we;
+    reg_we_check[51] = cmd_info_20_we;
+    reg_we_check[52] = cmd_info_21_we;
+    reg_we_check[53] = cmd_info_22_we;
+    reg_we_check[54] = cmd_info_23_we;
+    reg_we_check[55] = cmd_info_en4b_we;
+    reg_we_check[56] = cmd_info_ex4b_we;
+    reg_we_check[57] = cmd_info_wren_we;
+    reg_we_check[58] = cmd_info_wrdi_we;
+    reg_we_check[59] = 1'b0;
+    reg_we_check[60] = tpm_cfg_we;
+    reg_we_check[61] = 1'b0;
+    reg_we_check[62] = tpm_access_0_we;
+    reg_we_check[63] = tpm_access_1_we;
+    reg_we_check[64] = tpm_sts_we;
+    reg_we_check[65] = tpm_intf_capability_we;
+    reg_we_check[66] = tpm_int_enable_we;
+    reg_we_check[67] = tpm_int_vector_we;
+    reg_we_check[68] = tpm_int_status_we;
+    reg_we_check[69] = tpm_did_vid_we;
+    reg_we_check[70] = tpm_rid_we;
+    reg_we_check[71] = 1'b0;
+    reg_we_check[72] = tpm_read_fifo_we;
+    reg_we_check[73] = 1'b0;
   end
 
   // Read data return
@@ -20127,7 +20145,6 @@ module spi_device_reg_top (
         reg_rdata_next[1] = cfg_cpha_qs;
         reg_rdata_next[2] = cfg_tx_order_qs;
         reg_rdata_next[3] = cfg_rx_order_qs;
-        reg_rdata_next[16] = cfg_addr_4b_en_qs;
         reg_rdata_next[24] = cfg_mailbox_en_qs;
       end
 
@@ -20144,53 +20161,58 @@ module spi_device_reg_top (
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[31:0] = last_read_addr_qs;
+        reg_rdata_next[0] = addr_mode_addr_4b_en_qs;
+        reg_rdata_next[31] = addr_mode_pending_qs;
       end
 
       addr_hit[9]: begin
+        reg_rdata_next[31:0] = last_read_addr_qs;
+      end
+
+      addr_hit[10]: begin
         reg_rdata_next[0] = flash_status_busy_qs;
         reg_rdata_next[23:1] = flash_status_status_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[11]: begin
         reg_rdata_next[7:0] = jedec_cc_cc_qs;
         reg_rdata_next[15:8] = jedec_cc_num_cc_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[12]: begin
         reg_rdata_next[15:0] = jedec_id_id_qs;
         reg_rdata_next[23:16] = jedec_id_mf_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[13]: begin
         reg_rdata_next[9:0] = read_threshold_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[14]: begin
         reg_rdata_next[31:0] = mailbox_addr_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[15]: begin
         reg_rdata_next[4:0] = upload_status_cmdfifo_depth_qs;
         reg_rdata_next[7] = upload_status_cmdfifo_notempty_qs;
         reg_rdata_next[12:8] = upload_status_addrfifo_depth_qs;
         reg_rdata_next[15] = upload_status_addrfifo_notempty_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[8:0] = upload_status2_payload_depth_qs;
         reg_rdata_next[23:16] = upload_status2_payload_start_idx_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[7:0] = upload_cmdfifo_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[31:0] = upload_addrfifo_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = cmd_filter_0_filter_0_qs;
         reg_rdata_next[1] = cmd_filter_0_filter_1_qs;
         reg_rdata_next[2] = cmd_filter_0_filter_2_qs;
@@ -20225,7 +20247,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_0_filter_31_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = cmd_filter_1_filter_32_qs;
         reg_rdata_next[1] = cmd_filter_1_filter_33_qs;
         reg_rdata_next[2] = cmd_filter_1_filter_34_qs;
@@ -20260,7 +20282,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_1_filter_63_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[0] = cmd_filter_2_filter_64_qs;
         reg_rdata_next[1] = cmd_filter_2_filter_65_qs;
         reg_rdata_next[2] = cmd_filter_2_filter_66_qs;
@@ -20295,7 +20317,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_2_filter_95_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[0] = cmd_filter_3_filter_96_qs;
         reg_rdata_next[1] = cmd_filter_3_filter_97_qs;
         reg_rdata_next[2] = cmd_filter_3_filter_98_qs;
@@ -20330,7 +20352,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_3_filter_127_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = cmd_filter_4_filter_128_qs;
         reg_rdata_next[1] = cmd_filter_4_filter_129_qs;
         reg_rdata_next[2] = cmd_filter_4_filter_130_qs;
@@ -20365,7 +20387,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_4_filter_159_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[0] = cmd_filter_5_filter_160_qs;
         reg_rdata_next[1] = cmd_filter_5_filter_161_qs;
         reg_rdata_next[2] = cmd_filter_5_filter_162_qs;
@@ -20400,7 +20422,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_5_filter_191_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = cmd_filter_6_filter_192_qs;
         reg_rdata_next[1] = cmd_filter_6_filter_193_qs;
         reg_rdata_next[2] = cmd_filter_6_filter_194_qs;
@@ -20435,7 +20457,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_6_filter_223_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = cmd_filter_7_filter_224_qs;
         reg_rdata_next[1] = cmd_filter_7_filter_225_qs;
         reg_rdata_next[2] = cmd_filter_7_filter_226_qs;
@@ -20470,23 +20492,23 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_7_filter_255_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[31:0] = addr_swap_mask_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[31:0] = addr_swap_data_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[31:0] = payload_swap_mask_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = payload_swap_data_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[7:0] = cmd_info_0_opcode_0_qs;
         reg_rdata_next[9:8] = cmd_info_0_addr_mode_0_qs;
         reg_rdata_next[10] = cmd_info_0_addr_swap_en_0_qs;
@@ -20501,7 +20523,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_0_valid_0_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[7:0] = cmd_info_1_opcode_1_qs;
         reg_rdata_next[9:8] = cmd_info_1_addr_mode_1_qs;
         reg_rdata_next[10] = cmd_info_1_addr_swap_en_1_qs;
@@ -20516,7 +20538,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_1_valid_1_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[7:0] = cmd_info_2_opcode_2_qs;
         reg_rdata_next[9:8] = cmd_info_2_addr_mode_2_qs;
         reg_rdata_next[10] = cmd_info_2_addr_swap_en_2_qs;
@@ -20531,7 +20553,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_2_valid_2_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[7:0] = cmd_info_3_opcode_3_qs;
         reg_rdata_next[9:8] = cmd_info_3_addr_mode_3_qs;
         reg_rdata_next[10] = cmd_info_3_addr_swap_en_3_qs;
@@ -20546,7 +20568,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_3_valid_3_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[7:0] = cmd_info_4_opcode_4_qs;
         reg_rdata_next[9:8] = cmd_info_4_addr_mode_4_qs;
         reg_rdata_next[10] = cmd_info_4_addr_swap_en_4_qs;
@@ -20561,7 +20583,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_4_valid_4_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[7:0] = cmd_info_5_opcode_5_qs;
         reg_rdata_next[9:8] = cmd_info_5_addr_mode_5_qs;
         reg_rdata_next[10] = cmd_info_5_addr_swap_en_5_qs;
@@ -20576,7 +20598,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_5_valid_5_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_6_opcode_6_qs;
         reg_rdata_next[9:8] = cmd_info_6_addr_mode_6_qs;
         reg_rdata_next[10] = cmd_info_6_addr_swap_en_6_qs;
@@ -20591,7 +20613,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_6_valid_6_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = cmd_info_7_opcode_7_qs;
         reg_rdata_next[9:8] = cmd_info_7_addr_mode_7_qs;
         reg_rdata_next[10] = cmd_info_7_addr_swap_en_7_qs;
@@ -20606,7 +20628,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_7_valid_7_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[7:0] = cmd_info_8_opcode_8_qs;
         reg_rdata_next[9:8] = cmd_info_8_addr_mode_8_qs;
         reg_rdata_next[10] = cmd_info_8_addr_swap_en_8_qs;
@@ -20621,7 +20643,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_8_valid_8_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[40]: begin
         reg_rdata_next[7:0] = cmd_info_9_opcode_9_qs;
         reg_rdata_next[9:8] = cmd_info_9_addr_mode_9_qs;
         reg_rdata_next[10] = cmd_info_9_addr_swap_en_9_qs;
@@ -20636,7 +20658,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_9_valid_9_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:0] = cmd_info_10_opcode_10_qs;
         reg_rdata_next[9:8] = cmd_info_10_addr_mode_10_qs;
         reg_rdata_next[10] = cmd_info_10_addr_swap_en_10_qs;
@@ -20651,7 +20673,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_10_valid_10_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[42]: begin
         reg_rdata_next[7:0] = cmd_info_11_opcode_11_qs;
         reg_rdata_next[9:8] = cmd_info_11_addr_mode_11_qs;
         reg_rdata_next[10] = cmd_info_11_addr_swap_en_11_qs;
@@ -20666,7 +20688,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_11_valid_11_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[43]: begin
         reg_rdata_next[7:0] = cmd_info_12_opcode_12_qs;
         reg_rdata_next[9:8] = cmd_info_12_addr_mode_12_qs;
         reg_rdata_next[10] = cmd_info_12_addr_swap_en_12_qs;
@@ -20681,7 +20703,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_12_valid_12_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[44]: begin
         reg_rdata_next[7:0] = cmd_info_13_opcode_13_qs;
         reg_rdata_next[9:8] = cmd_info_13_addr_mode_13_qs;
         reg_rdata_next[10] = cmd_info_13_addr_swap_en_13_qs;
@@ -20696,7 +20718,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_13_valid_13_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[45]: begin
         reg_rdata_next[7:0] = cmd_info_14_opcode_14_qs;
         reg_rdata_next[9:8] = cmd_info_14_addr_mode_14_qs;
         reg_rdata_next[10] = cmd_info_14_addr_swap_en_14_qs;
@@ -20711,7 +20733,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_14_valid_14_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[46]: begin
         reg_rdata_next[7:0] = cmd_info_15_opcode_15_qs;
         reg_rdata_next[9:8] = cmd_info_15_addr_mode_15_qs;
         reg_rdata_next[10] = cmd_info_15_addr_swap_en_15_qs;
@@ -20726,7 +20748,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_15_valid_15_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[47]: begin
         reg_rdata_next[7:0] = cmd_info_16_opcode_16_qs;
         reg_rdata_next[9:8] = cmd_info_16_addr_mode_16_qs;
         reg_rdata_next[10] = cmd_info_16_addr_swap_en_16_qs;
@@ -20741,7 +20763,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_16_valid_16_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[48]: begin
         reg_rdata_next[7:0] = cmd_info_17_opcode_17_qs;
         reg_rdata_next[9:8] = cmd_info_17_addr_mode_17_qs;
         reg_rdata_next[10] = cmd_info_17_addr_swap_en_17_qs;
@@ -20756,7 +20778,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_17_valid_17_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[49]: begin
         reg_rdata_next[7:0] = cmd_info_18_opcode_18_qs;
         reg_rdata_next[9:8] = cmd_info_18_addr_mode_18_qs;
         reg_rdata_next[10] = cmd_info_18_addr_swap_en_18_qs;
@@ -20771,7 +20793,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_18_valid_18_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[50]: begin
         reg_rdata_next[7:0] = cmd_info_19_opcode_19_qs;
         reg_rdata_next[9:8] = cmd_info_19_addr_mode_19_qs;
         reg_rdata_next[10] = cmd_info_19_addr_swap_en_19_qs;
@@ -20786,7 +20808,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_19_valid_19_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[51]: begin
         reg_rdata_next[7:0] = cmd_info_20_opcode_20_qs;
         reg_rdata_next[9:8] = cmd_info_20_addr_mode_20_qs;
         reg_rdata_next[10] = cmd_info_20_addr_swap_en_20_qs;
@@ -20801,7 +20823,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_20_valid_20_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[52]: begin
         reg_rdata_next[7:0] = cmd_info_21_opcode_21_qs;
         reg_rdata_next[9:8] = cmd_info_21_addr_mode_21_qs;
         reg_rdata_next[10] = cmd_info_21_addr_swap_en_21_qs;
@@ -20816,7 +20838,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_21_valid_21_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[53]: begin
         reg_rdata_next[7:0] = cmd_info_22_opcode_22_qs;
         reg_rdata_next[9:8] = cmd_info_22_addr_mode_22_qs;
         reg_rdata_next[10] = cmd_info_22_addr_swap_en_22_qs;
@@ -20831,7 +20853,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_22_valid_22_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[54]: begin
         reg_rdata_next[7:0] = cmd_info_23_opcode_23_qs;
         reg_rdata_next[9:8] = cmd_info_23_addr_mode_23_qs;
         reg_rdata_next[10] = cmd_info_23_addr_swap_en_23_qs;
@@ -20846,34 +20868,34 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_23_valid_23_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[55]: begin
         reg_rdata_next[7:0] = cmd_info_en4b_opcode_qs;
         reg_rdata_next[31] = cmd_info_en4b_valid_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[56]: begin
         reg_rdata_next[7:0] = cmd_info_ex4b_opcode_qs;
         reg_rdata_next[31] = cmd_info_ex4b_valid_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[57]: begin
         reg_rdata_next[7:0] = cmd_info_wren_opcode_qs;
         reg_rdata_next[31] = cmd_info_wren_valid_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[58]: begin
         reg_rdata_next[7:0] = cmd_info_wrdi_opcode_qs;
         reg_rdata_next[31] = cmd_info_wrdi_valid_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[59]: begin
         reg_rdata_next[7:0] = tpm_cap_rev_qs;
         reg_rdata_next[8] = tpm_cap_locality_qs;
         reg_rdata_next[18:16] = tpm_cap_max_wr_size_qs;
         reg_rdata_next[22:20] = tpm_cap_max_rd_size_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[60]: begin
         reg_rdata_next[0] = tpm_cfg_en_qs;
         reg_rdata_next[1] = tpm_cfg_tpm_mode_qs;
         reg_rdata_next[2] = tpm_cfg_hw_reg_dis_qs;
@@ -20881,61 +20903,61 @@ module spi_device_reg_top (
         reg_rdata_next[4] = tpm_cfg_invalid_locality_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[61]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[22:16] = tpm_status_wrfifo_depth_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[62]: begin
         reg_rdata_next[7:0] = tpm_access_0_access_0_qs;
         reg_rdata_next[15:8] = tpm_access_0_access_1_qs;
         reg_rdata_next[23:16] = tpm_access_0_access_2_qs;
         reg_rdata_next[31:24] = tpm_access_0_access_3_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[63]: begin
         reg_rdata_next[7:0] = tpm_access_1_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[64]: begin
         reg_rdata_next[31:0] = tpm_sts_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[65]: begin
         reg_rdata_next[31:0] = tpm_intf_capability_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[66]: begin
         reg_rdata_next[31:0] = tpm_int_enable_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[67]: begin
         reg_rdata_next[7:0] = tpm_int_vector_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[68]: begin
         reg_rdata_next[31:0] = tpm_int_status_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[69]: begin
         reg_rdata_next[15:0] = tpm_did_vid_vid_qs;
         reg_rdata_next[31:16] = tpm_did_vid_did_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[70]: begin
         reg_rdata_next[7:0] = tpm_rid_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[71]: begin
         reg_rdata_next[23:0] = tpm_cmd_addr_addr_qs;
         reg_rdata_next[31:24] = tpm_cmd_addr_cmd_qs;
       end
 
-      addr_hit[71]: begin
+      addr_hit[72]: begin
         reg_rdata_next[31:0] = '0;
       end
 
-      addr_hit[72]: begin
+      addr_hit[73]: begin
         reg_rdata_next[7:0] = tpm_write_fifo_qs;
       end
 

--- a/hw/ip/spi_device/rtl/spid_csb_sync.sv
+++ b/hw/ip/spi_device/rtl/spid_csb_sync.sv
@@ -1,0 +1,71 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// spid_csb_sync detects the deassertion edge (positive edge) of CSB for
+// spi_device. With a prim_edge_detector alone, CSB would have pulse width
+// requirements relative to clk_i, and these could be restrictive relative to
+// the downstream SPI flash.
+//
+// Instead, use a CSB-clocked toggle and detect the much slower-changing
+// toggles, making use of CSB's low duty cycle.
+//
+// In addition, this module filters CSB "cycles" without SPI clocks.
+// The sck_pulse_en_i input allows further filtering of CSB-triggered pulses.
+// For example, this can be used to trigger a pulse only when there is a new
+// uploaded command.
+
+module spid_csb_sync (
+  input clk_i,
+  input rst_ni,
+  input sck_i,
+  input sck_pulse_en_i,
+  input csb_i,
+  output csb_deasserted_pulse_o
+);
+
+  logic sck_toggle, csb_toggle, sys_toggle, sys_toggle_last;
+
+  // CSB and SCK have setup / hold relationships for SPI flash devices. Only
+  // change counts on CSB posedge if there is at least one SCK cycle.
+  always_ff @(posedge sck_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      sck_toggle <= 1'b0;
+    end else begin
+      if (sck_pulse_en_i) begin
+        sck_toggle <= ~csb_toggle;
+      end
+    end
+  end
+
+  // Signal CSB de-assertion with a change in count, but only do it if the
+  // change originated from the SCK domain.
+  always_ff @(posedge csb_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      csb_toggle <= 1'b0;
+    end else begin
+      csb_toggle <= sck_toggle;
+    end
+  end
+
+  // clk_i is asynchronous to CSB/SCK, so use a synchronizer.
+  prim_flop_2sync #(
+    .Width     (1)
+  ) u_count_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i       (csb_toggle),
+    .q_o       (sys_toggle)
+  );
+
+  // sys_toggle_last is used to generate the pulse on differences.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      sys_toggle_last <= 1'b0;
+    end else begin
+      sys_toggle_last <= sys_toggle;
+    end
+  end
+
+  assign csb_deasserted_pulse_o = (sys_toggle != sys_toggle_last);
+endmodule : spid_csb_sync

--- a/hw/ip/spi_device/rtl/spid_jedec.sv
+++ b/hw/ip/spi_device/rtl/spid_jedec.sv
@@ -14,7 +14,7 @@ module spid_jedec
 
   input clk_out_i, // Output clock (inverted SCK)
 
-  input inclk_csb_asserted_pulse_i,
+  input cmd_sync_pulse_i,
 
   input jedec_cfg_t sys_jedec_i, // from CSR
 
@@ -70,7 +70,7 @@ module spid_jedec
   // Jedec latch
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)                         jedec <= '{default: '0};
-    else if (inclk_csb_asserted_pulse_i) jedec <= sys_jedec_i;
+    else if (cmd_sync_pulse_i) jedec <= sys_jedec_i;
   end
 
   // If num_cc is non-zero, the logic shall return CC first

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -34,6 +34,7 @@ filesets:
       - rtl/spid_jedec.sv
       - rtl/spid_addr_4b.sv
       - rtl/spid_fifo2sram_adapter.sv
+      - rtl/spid_csb_sync.sv
       - rtl/spid_upload.sv
       - rtl/spi_tpm.sv
       - rtl/spi_s2p.sv

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -180,16 +180,16 @@ dif_result_t dif_spi_device_set_4b_address_mode(dif_spi_device_handle_t *spi,
   if (spi == NULL || !dif_is_valid_toggle(addr_4b)) {
     return kDifBadArg;
   }
-  uint32_t cfg_reg =
-      mmio_region_read32(spi->dev.base_addr, SPI_DEVICE_CFG_REG_OFFSET);
+  uint32_t cfg_reg = 0;
   if (addr_4b == kDifToggleEnabled) {
-    cfg_reg =
-        bitfield_bit32_write(cfg_reg, SPI_DEVICE_CFG_ADDR_4B_EN_BIT, true);
+    cfg_reg = bitfield_bit32_write(cfg_reg, SPI_DEVICE_ADDR_MODE_ADDR_4B_EN_BIT,
+                                   true);
   } else {
-    cfg_reg =
-        bitfield_bit32_write(cfg_reg, SPI_DEVICE_CFG_ADDR_4B_EN_BIT, false);
+    cfg_reg = bitfield_bit32_write(cfg_reg, SPI_DEVICE_ADDR_MODE_ADDR_4B_EN_BIT,
+                                   false);
   }
-  mmio_region_write32(spi->dev.base_addr, SPI_DEVICE_CFG_REG_OFFSET, cfg_reg);
+  mmio_region_write32(spi->dev.base_addr, SPI_DEVICE_ADDR_MODE_REG_OFFSET,
+                      cfg_reg);
   return kDifOk;
 }
 
@@ -199,8 +199,8 @@ dif_result_t dif_spi_device_get_4b_address_mode(dif_spi_device_handle_t *spi,
     return kDifBadArg;
   }
   uint32_t cfg_reg =
-      mmio_region_read32(spi->dev.base_addr, SPI_DEVICE_CFG_REG_OFFSET);
-  if (bitfield_bit32_read(cfg_reg, SPI_DEVICE_CFG_ADDR_4B_EN_BIT)) {
+      mmio_region_read32(spi->dev.base_addr, SPI_DEVICE_ADDR_MODE_REG_OFFSET);
+  if (bitfield_bit32_read(cfg_reg, SPI_DEVICE_ADDR_MODE_ADDR_4B_EN_BIT)) {
     *addr_4b = kDifToggleEnabled;
   } else {
     *addr_4b = kDifToggleDisabled;

--- a/sw/device/lib/dif/dif_spi_device_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_device_unittest.cc
@@ -281,41 +281,29 @@ TEST_F(FlashTest, MailboxConfigTest) {
 
 TEST_F(FlashTest, Addr4bConfig) {
   dif_toggle_t toggle;
-  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+  EXPECT_READ32(SPI_DEVICE_ADDR_MODE_REG_OFFSET,
                 {
-                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                    {SPI_DEVICE_ADDR_MODE_PENDING_BIT, 1},
                 });
   EXPECT_DIF_OK(dif_spi_device_get_4b_address_mode(&spi_, &toggle));
   EXPECT_EQ(toggle, kDifToggleDisabled);
 
-  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+  EXPECT_READ32(SPI_DEVICE_ADDR_MODE_REG_OFFSET,
                 {
-                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
-                    {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 1},
+                    {SPI_DEVICE_ADDR_MODE_PENDING_BIT, 1},
+                    {SPI_DEVICE_ADDR_MODE_ADDR_4B_EN_BIT, 1},
                 });
   EXPECT_DIF_OK(dif_spi_device_get_4b_address_mode(&spi_, &toggle));
   EXPECT_EQ(toggle, kDifToggleEnabled);
 
-  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
-                {
-                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
-                    {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 0},
-                });
-  EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+  EXPECT_WRITE32(SPI_DEVICE_ADDR_MODE_REG_OFFSET,
                  {
-                     {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
-                     {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 1},
+                     {SPI_DEVICE_ADDR_MODE_ADDR_4B_EN_BIT, 1},
                  });
   EXPECT_DIF_OK(dif_spi_device_set_4b_address_mode(&spi_, kDifToggleEnabled));
-  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
-                {
-                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
-                    {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 1},
-                });
-  EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+  EXPECT_WRITE32(SPI_DEVICE_ADDR_MODE_REG_OFFSET,
                  {
-                     {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
-                     {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 0},
+                     {SPI_DEVICE_ADDR_MODE_ADDR_4B_EN_BIT, 0},
                  });
   EXPECT_DIF_OK(dif_spi_device_set_4b_address_mode(&spi_, kDifToggleDisabled));
 }

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -502,9 +502,11 @@ void spi_device_init(void) {
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_CPHA_BIT, false);
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_TX_ORDER_BIT, false);
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_RX_ORDER_BIT, false);
-  reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_ADDR_4B_EN_BIT, false);
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_MAILBOX_EN_BIT, false);
   abs_mmio_write32(kBase + SPI_DEVICE_CFG_REG_OFFSET, reg);
+
+  reg = bitfield_bit32_write(0, SPI_DEVICE_ADDR_MODE_ADDR_4B_EN_BIT, false);
+  abs_mmio_write32(kBase + SPI_DEVICE_ADDR_MODE_REG_OFFSET, reg);
 
   // JEDEC manufacturer and device ID.
   // spi_device sends these in the following order: continuation codes,

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -39,10 +39,12 @@ TEST_F(InitTest, Init) {
                          {SPI_DEVICE_CFG_CPHA_BIT, 0},
                          {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
                          {SPI_DEVICE_CFG_RX_ORDER_BIT, 0},
-                         {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 0},
                          {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 0},
                      });
-
+  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_ADDR_MODE_REG_OFFSET,
+                     {
+                         {SPI_DEVICE_ADDR_MODE_ADDR_4B_EN_BIT, 0},
+                     });
   EXPECT_ABS_WRITE32(
       base_ + SPI_DEVICE_JEDEC_CC_REG_OFFSET,
       {

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -563,6 +563,7 @@ ${reg_hdr}
         flds_no_we |= (not f.swaccess.needs_we()) << f_idx
       if flds_no_we != 0:
         flds_we_masked = f"&({sr_name}_flds_we | {len(sr.fields)}'h{flds_no_we:x})"
+        unused_flds_we_masked = f"^({sr_name}_flds_we & {len(sr.fields)}'h{flds_no_we:x})"
       else:
         flds_we_masked = f"&{sr_name}_flds_we"
       f"" if flds_no_we != 0 else ""
@@ -570,6 +571,8 @@ ${reg_hdr}
         % if sr.hwext and flds_no_we != 2**len(sr.fields)-1:
           % if flds_no_we != 0:
   // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_${sr_name}_flds_we;
+  assign unused_${sr_name}_flds_we = ${unused_flds_we_masked};
           % endif
   assign ${sr_name}_qe = ${flds_we_masked};
         % elif flds_no_we != 2**len(sr.fields)-1:


### PR DESCRIPTION
### Relax stringent CSB pulse width requirements:
Add a new edge-to-toggle synchronizer + filter module for SPI to remove
the stringent CSB pulse width requirements that fell out of using
prim_edge_detector to detect CSB de-assertion.

spid_csb_sync produces a pulse in the sys_clk domain when a CSB-clocked
flop produces a value change, compared against the last seen value in
the sys_clk domain. The toggling flop input signal gets filtered based
on (1) whether any SPI clocks were observed and (2) whether the
toggle_en_i signal was asserted for one of those SPI clocks.

In addition to merely providing the notification that a transaction has
completed, this module is also used in the spid_upload module for
qualifying whether an uploaded command was written (for the interrupt
event).

### Harmonize address mode syncs to byte beats
Simplify address mode synchronization by using a common commit point at
the end of the command phase. Add a sync pulse for the address mode to
commit at the 8th posedge of the SPI clock. This allows enough time for
software-originated changes to cross into the SPI domain and be picked
up for the next command. In addition, there is no need to reset the
entire spi_device IP when changing address modes after a period of SPI
activity.

Harmonize address calculations to align with this commit point. The
passthrough and upload modules have slightly different mechanisms, but
they now use the address mode from this point. The passthrough module
uses the registered value, but the upload module uses the D side of that
flop instead. The upload module may need this information for some
future enhancements related to metadata committed to the command FIFO.

In addition, inform software when a software-originated address mode
change is still pending. This may occur if no transactions occurred
since the last software write. When a write is pending, the value shown
is the pending value, not the current committed one in hardware.
However, that pending value will be picked up in time for the next
command. If the desired value is different from the prior write,
software may overwrite, as long as the SPI host is known to be inactive.

### Related issues
Fixes #15543, https://github.com/lowRISC/opentitan/issues/15721