### PR TITLE
[spi_device] Fix up synchronization of status bits

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -446,6 +446,22 @@
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
+        { bits: "0",
+          name: "FLASH_STATUS_FIFO_CLR",
+          swaccess: "rw1s",
+          hwaccess: "hrw",
+          desc: '''Set to clear the flash status FIFO.
+
+            When set to 1, resets the flash status FIFO used for synchronizing changes from firmware.
+            The reset should only be used when the upstream SPI host is known to be inactive.
+            This function is intended to allow restoring initial values when the upstream SPI host is reset.
+
+            This CSR automatically resets to 0.
+            '''
+          resval: "0",
+          tags: [// This CSR only briefly pulses to anything other than 0.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        },
         { bits: "5:4",
           name: "MODE",
           desc: "SPI Device flash operation mode.",

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -679,17 +679,24 @@
           swaccess: "rw0c"
           hwaccess: "hrw"
         } // f: busy
-        { bits: "23:1"
+        { bits: "1"
+          name: "wel"
+          desc: '''WEL signal is cleared when CSb is high. SW should read
+            back the register to confirm the value is cleared.
+
+            Bit 1 (WEL) is a SW modifiable and HW modifiable field.
+            HW updates the WEL field when `WRDI` or `WREN` command is received.
+          '''
+          swaccess: "rw0c"
+          hwaccess: "hrw"
+        } // f: busy
+        { bits: "23:2"
           name: "status"
           desc: '''Rest of the status register.
 
             Fields other than the bit 0 (BUSY) and bit 1 (WEL) fields are
             SW-maintained fields. HW just reads and returns to the host system.
 
-            Bit 1 (WEL) is a SW modifiable and HW modifiable field. HW updates
-            the WEL field when `WRDI` or `WREN` command is received.
-
-            - [ 1]\: WEL
             - [ 2]\: BP0
             - [ 3]\: BP1
             - [ 4]\: BP2
@@ -842,7 +849,19 @@
       fields: [
         { bits: "7:0"
           name: "data"
-          desc: "read data"
+          desc: "command opcode"
+        }
+        { bits: "13"
+          name: "busy"
+          desc: "State of BUSY bit at command time"
+        }
+        { bits: "14"
+          name: "wel"
+          desc: "State of WEL bit at command time"
+        }
+        { bits: "15"
+          name: "addr4b_mode"
+          desc: "1 if address mode at command time is 4 Bytes, else 3 Bytes"
         }
       ]
     } // R: UPLOAD_CMDFIFO

--- a/hw/ip/spi_device/doc/registers.md
+++ b/hw/ip/spi_device/doc/registers.md
@@ -345,13 +345,14 @@ completed.
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "busy", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "status", "bits": 23, "attr": ["rw"], "rotate": 0}, {"bits": 8}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "busy", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "wel", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "status", "bits": 22, "attr": ["rw"], "rotate": 0}, {"bits": 8}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                            |
 |:------:|:------:|:-------:|:--------------------------------|
 | 31:24  |        |         | Reserved                        |
-|  23:1  |   rw   |    x    | [status](#flash_status--status) |
+|  23:2  |   rw   |    x    | [status](#flash_status--status) |
+|   1    |  rw0c  |    x    | [wel](#flash_status--wel)       |
 |   0    |  rw0c  |    x    | [busy](#flash_status--busy)     |
 
 ### FLASH_STATUS . status
@@ -360,10 +361,6 @@ Rest of the status register.
 Fields other than the bit 0 (BUSY) and bit 1 (WEL) fields are
 SW-maintained fields. HW just reads and returns to the host system.
 
-Bit 1 (WEL) is a SW modifiable and HW modifiable field. HW updates
-the WEL field when `WRDI` or `WREN` command is received.
-
-- [ 1]\: WEL
 - [ 2]\: BP0
 - [ 3]\: BP1
 - [ 4]\: BP2
@@ -381,6 +378,13 @@ the WEL field when `WRDI` or `WREN` command is received.
 - [21]\: DRV0
 - [22]\: DRV1
 - [23]\: HOLD /RST
+
+### FLASH_STATUS . wel
+WEL signal is cleared when CSb is high. SW should read
+back the register to confirm the value is cleared.
+
+Bit 1 (WEL) is a SW modifiable and HW modifiable field.
+HW updates the WEL field when `WRDI` or `WREN` command is received.
 
 ### FLASH_STATUS . busy
 BUSY signal is cleared when CSb is high. SW should read
@@ -518,18 +522,22 @@ holds 256B of payload), the payload_start_idx is 2. SW should read from
 Command Fifo Read Port.
 - Offset: `0x44`
 - Reset default: `0x0`
-- Reset mask: `0xff`
+- Reset mask: `0xe0ff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "data", "bits": 8, "attr": ["ro"], "rotate": 0}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "data", "bits": 8, "attr": ["ro"], "rotate": 0}, {"bits": 5}, {"name": "busy", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "wel", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "addr4b_mode", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description   |
-|:------:|:------:|:-------:|:-------|:--------------|
-|  31:8  |        |         |        | Reserved      |
-|  7:0   |   ro   |    x    | data   | read data     |
+|  Bits  |  Type  |  Reset  | Name        | Description                                                |
+|:------:|:------:|:-------:|:------------|:-----------------------------------------------------------|
+| 31:16  |        |         |             | Reserved                                                   |
+|   15   |   ro   |    x    | addr4b_mode | 1 if address mode at command time is 4 Bytes, else 3 Bytes |
+|   14   |   ro   |    x    | wel         | State of WEL bit at command time                           |
+|   13   |   ro   |    x    | busy        | State of BUSY bit at command time                          |
+|  12:8  |        |         |             | Reserved                                                   |
+|  7:0   |   ro   |    x    | data        | command opcode                                             |
 
 ## UPLOAD_ADDRFIFO
 Address Fifo Read Port.

--- a/hw/ip/spi_device/doc/registers.md
+++ b/hw/ip/spi_device/doc/registers.md
@@ -169,19 +169,20 @@ Alert Test Register
 Control register
 - Offset: `0x10`
 - Reset default: `0x10`
-- Reset mask: `0x30`
+- Reset mask: `0x31`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"bits": 4}, {"name": "MODE", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "FLASH_STATUS_FIFO_CLR", "bits": 1, "attr": ["rw1s"], "rotate": -90}, {"bits": 3}, {"name": "MODE", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                   |
-|:------:|:------:|:-------:|:-----------------------|
-|  31:6  |        |         | Reserved               |
-|  5:4   |   rw   |   0x1   | [MODE](#control--mode) |
-|  3:0   |        |         | Reserved               |
+|  Bits  |  Type  |  Reset  | Name                                                     |
+|:------:|:------:|:-------:|:---------------------------------------------------------|
+|  31:6  |        |         | Reserved                                                 |
+|  5:4   |   rw   |   0x1   | [MODE](#control--mode)                                   |
+|  3:1   |        |         | Reserved                                                 |
+|   0    |  rw1s  |   0x0   | [FLASH_STATUS_FIFO_CLR](#control--flash_status_fifo_clr) |
 
 ### CONTROL . MODE
 SPI Device flash operation mode.
@@ -193,6 +194,15 @@ SPI Device flash operation mode.
 | 0x2     | passthrough | In passthrough mode, SPI Device IP forwards the incoming SPI flash traffics to the attached downstream flash device. HW may processes commands internally and returns data. SW may configure the device to drop inadmissable commands.                                     |
 
 Other values are reserved.
+
+### CONTROL . FLASH_STATUS_FIFO_CLR
+Set to clear the flash status FIFO.
+
+When set to 1, resets the flash status FIFO used for synchronizing changes from firmware.
+The reset should only be used when the upstream SPI host is known to be inactive.
+This function is intended to allow restoring initial values when the upstream SPI host is reset.
+
+This CSR automatically resets to 0.
 
 ## CFG
 Configuration Register

--- a/hw/ip/spi_device/doc/theory_of_operation.md
+++ b/hw/ip/spi_device/doc/theory_of_operation.md
@@ -93,6 +93,14 @@ SW sees the committed registers when reading the [`FLASH_STATUS`](registers.md#f
 
 The attached host system also reads back the committed registers via Read Status commands.
 This scheme is to guarantee the atomicity of the STATUS register.
+On every 8th SPI clock cycle, the SPI domain commits the latest resolved value to the committed registers.
+Each byte beat of the Read Status commands will return the latest committed value of the targeted register.
+A Read Status commands can thus repeatedly poll the BUSY bit and see updates in the same transaction.
+
+Again, note that the passthrough gate only updates after CSB makes a 0->1 transition, and it derives its value from the committed BUSY bit.
+After the BUSY bit is set, there must be at least one command before the gate will open again.
+Typically, a Read Status command follows any command that would set the BUSY bit, to check that the BUSY bit has cleared.
+This activity is sufficient to unblock passthrough for the next command.
 
 If the host sends the Write Status commands, the commands are not processed in this module.
 SW must configure the remaining command information entries to upload the Write Status commands to the FIFOs.

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -154,8 +154,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
                 check_read_cmd_data_for_non_read_buffer(item, downstream_item);
               end
               InternalProcessCfgCmd: begin
-                // wel is the first bit of `flash_status.status`
-                bit prev_wel = `gmv(ral.flash_status.status) & 1'b1;
+                bit prev_wel = `gmv(ral.flash_status.wel);
                 if (`GET_OPCODE_VALID_AND_MATCH(cmd_info_en4b, item.opcode)) begin
                   if (cfg.en_cov) begin
                     cov.spi_device_addr_4b_enter_exit_command_cg.sample(
@@ -1088,7 +1087,8 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
       "upload_cmdfifo": begin
         if (!write && channel == DataChannel) begin
           `DV_CHECK_GT(upload_cmd_q.size, 0)
-          `DV_CHECK_EQ(item.d_data, upload_cmd_q.pop_front())
+          // TODO: Check addr4b_mode, wel, and busy bits
+          `DV_CHECK_EQ(item.d_data[7:0], upload_cmd_q.pop_front())
           update_cmdfifo_status();
         end
       end

--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -91,6 +91,9 @@ waive -rules RESET_MUX -location {spi_device.sv} \
 waive -rules RESET_DRIVER -location {spi_device.sv} \
       -regexp {'tpm_rst_n' is driven} \
       -comment "Async reset generation is required here"
+waive -rules RESET_DRIVER -location {spid_status.sv} \
+      -regexp {'status_fifo_rst_n' is driven} \
+      -comment "Async reset generation is required here"
 
 # clock inverter and muxes
 waive -rules CLOCK_MUX -location {spi_device.sv} -regexp {Clock 'sck_n' is driven by a multiplexer here, used as a clock 'clk_(out|src)_i'} \

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -367,7 +367,7 @@ module spi_device
   assign hw2reg.status.csb.d     = sys_csb_syncd;
   assign hw2reg.status.tpm_csb.d = sys_tpm_csb_syncd;
 
-  assign spi_mode = spi_mode_e'(reg2hw.control.q);
+  assign spi_mode = spi_mode_e'(reg2hw.control.mode.q);
 
   prim_edge_detector #(
     .Width (2),
@@ -1121,6 +1121,11 @@ module spi_device
   assign sck_status_wr_set = (cmd_only_dp_sel == DpWrEn);
   assign sck_status_wr_clr = (cmd_only_dp_sel == DpWrDi);
 
+  logic flash_status_sync_fifo_clr;
+  assign flash_status_sync_fifo_clr = reg2hw.control.flash_status_fifo_clr.q;
+  assign hw2reg.control.flash_status_fifo_clr.d  = '0;
+  assign hw2reg.control.flash_status_fifo_clr.de = 1'b1;
+
   spid_status u_spid_status (
     .clk_i  (clk_spi_in_buf),
     .rst_ni (rst_spi_n),
@@ -1133,6 +1138,8 @@ module spi_device
     .sys_rst_ni (rst_ni),
 
     .sys_csb_deasserted_pulse_i (sys_csb_deasserted_pulse),
+
+    .sys_update_clr_i(flash_status_sync_fifo_clr),
 
     .sys_status_we_i (readstatus_qe),
     .sys_status_i    (readstatus_q),
@@ -1153,6 +1160,7 @@ module spi_device
     .inclk_we_set_i (sck_status_wr_set),
     .inclk_we_clr_i (sck_status_wr_clr),
 
+    .inclk_status_commit_i(s2p_data_valid),
     .csb_busy_broadcast_o (csb_status_busy_broadcast) // SCK domain
   );
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -161,9 +161,13 @@ package spi_device_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [22:0] q;
+      logic [21:0] q;
       logic        qe;
     } status;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } wel;
     struct packed {
       logic        q;
       logic        qe;
@@ -197,8 +201,22 @@ package spi_device_reg_pkg;
   } spi_device_reg2hw_mailbox_addr_reg_t;
 
   typedef struct packed {
-    logic [7:0]  q;
-    logic        re;
+    struct packed {
+      logic        q;
+      logic        re;
+    } addr4b_mode;
+    struct packed {
+      logic        q;
+      logic        re;
+    } wel;
+    struct packed {
+      logic        q;
+      logic        re;
+    } busy;
+    struct packed {
+      logic [7:0]  q;
+      logic        re;
+    } data;
   } spi_device_reg2hw_upload_cmdfifo_reg_t;
 
   typedef struct packed {
@@ -441,7 +459,10 @@ package spi_device_reg_pkg;
       logic        d;
     } busy;
     struct packed {
-      logic [22:0] d;
+      logic        d;
+    } wel;
+    struct packed {
+      logic [21:0] d;
     } status;
   } spi_device_hw2reg_flash_status_reg_t;
 
@@ -476,7 +497,18 @@ package spi_device_reg_pkg;
   } spi_device_hw2reg_upload_status2_reg_t;
 
   typedef struct packed {
-    logic [7:0]  d;
+    struct packed {
+      logic [7:0]  d;
+    } data;
+    struct packed {
+      logic        d;
+    } busy;
+    struct packed {
+      logic        d;
+    } wel;
+    struct packed {
+      logic        d;
+    } addr4b_mode;
   } spi_device_hw2reg_upload_cmdfifo_reg_t;
 
   typedef struct packed {
@@ -528,20 +560,20 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1509:1504]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1503:1498]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1497:1486]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1485:1484]
-    spi_device_reg2hw_control_reg_t control; // [1483:1481]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1480:1476]
-    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1475:1472]
-    spi_device_reg2hw_addr_mode_reg_t addr_mode; // [1471:1470]
-    spi_device_reg2hw_flash_status_reg_t flash_status; // [1469:1444]
-    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1443:1428]
-    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1427:1404]
-    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1403:1394]
-    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1393:1362]
-    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1361:1353]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1516:1511]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1510:1505]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1504:1493]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1492:1491]
+    spi_device_reg2hw_control_reg_t control; // [1490:1488]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1487:1483]
+    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1482:1479]
+    spi_device_reg2hw_addr_mode_reg_t addr_mode; // [1478:1477]
+    spi_device_reg2hw_flash_status_reg_t flash_status; // [1476:1450]
+    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1449:1434]
+    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1433:1410]
+    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1409:1400]
+    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1399:1368]
+    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1367:1353]
     spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1352:1320]
     spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1319:1064]
     spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [1063:1032]
@@ -569,15 +601,15 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [217:206]
-    spi_device_hw2reg_control_reg_t control; // [205:204]
-    spi_device_hw2reg_status_reg_t status; // [203:202]
-    spi_device_hw2reg_addr_mode_reg_t addr_mode; // [201:200]
-    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [199:168]
-    spi_device_hw2reg_flash_status_reg_t flash_status; // [167:144]
-    spi_device_hw2reg_upload_status_reg_t upload_status; // [143:128]
-    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [127:109]
-    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [108:101]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [220:209]
+    spi_device_hw2reg_control_reg_t control; // [208:207]
+    spi_device_hw2reg_status_reg_t status; // [206:205]
+    spi_device_hw2reg_addr_mode_reg_t addr_mode; // [204:203]
+    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [202:171]
+    spi_device_hw2reg_flash_status_reg_t flash_status; // [170:147]
+    spi_device_hw2reg_upload_status_reg_t upload_status; // [146:131]
+    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [130:112]
+    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [111:101]
     spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [100:69]
     spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [68:50]
     spi_device_hw2reg_tpm_status_reg_t tpm_status; // [49:40]
@@ -677,7 +709,7 @@ package spi_device_reg_pkg;
   parameter logic [31:0] SPI_DEVICE_ADDR_MODE_RESVAL = 32'h 0;
   parameter logic [31:0] SPI_DEVICE_LAST_READ_ADDR_RESVAL = 32'h 0;
   parameter logic [23:0] SPI_DEVICE_FLASH_STATUS_RESVAL = 24'h 0;
-  parameter logic [7:0] SPI_DEVICE_UPLOAD_CMDFIFO_RESVAL = 8'h 0;
+  parameter logic [15:0] SPI_DEVICE_UPLOAD_CMDFIFO_RESVAL = 16'h 0;
   parameter logic [31:0] SPI_DEVICE_UPLOAD_ADDRFIFO_RESVAL = 32'h 0;
   parameter logic [31:0] SPI_DEVICE_TPM_CMD_ADDR_RESVAL = 32'h 0;
   parameter logic [31:0] SPI_DEVICE_TPM_READ_FIFO_RESVAL = 32'h 0;
@@ -788,7 +820,7 @@ package spi_device_reg_pkg;
     4'b 1111, // index[14] SPI_DEVICE_MAILBOX_ADDR
     4'b 0011, // index[15] SPI_DEVICE_UPLOAD_STATUS
     4'b 0111, // index[16] SPI_DEVICE_UPLOAD_STATUS2
-    4'b 0001, // index[17] SPI_DEVICE_UPLOAD_CMDFIFO
+    4'b 0011, // index[17] SPI_DEVICE_UPLOAD_CMDFIFO
     4'b 1111, // index[18] SPI_DEVICE_UPLOAD_ADDRFIFO
     4'b 1111, // index[19] SPI_DEVICE_CMD_FILTER_0
     4'b 1111, // index[20] SPI_DEVICE_CMD_FILTER_1

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -111,7 +111,12 @@ package spi_device_reg_pkg;
   } spi_device_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
-    logic [1:0]  q;
+    struct packed {
+      logic [1:0]  q;
+    } mode;
+    struct packed {
+      logic        q;
+    } flash_status_fifo_clr;
   } spi_device_reg2hw_control_reg_t;
 
   typedef struct packed {
@@ -405,6 +410,13 @@ package spi_device_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
+      logic        de;
+    } flash_status_fifo_clr;
+  } spi_device_hw2reg_control_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
     } csb;
     struct packed {
       logic        d;
@@ -516,11 +528,11 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1508:1503]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1502:1497]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1496:1485]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1484:1483]
-    spi_device_reg2hw_control_reg_t control; // [1482:1481]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1509:1504]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1503:1498]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1497:1486]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1485:1484]
+    spi_device_reg2hw_control_reg_t control; // [1483:1481]
     spi_device_reg2hw_cfg_reg_t cfg; // [1480:1476]
     spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1475:1472]
     spi_device_reg2hw_addr_mode_reg_t addr_mode; // [1471:1470]
@@ -557,7 +569,8 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [215:204]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [217:206]
+    spi_device_hw2reg_control_reg_t control; // [205:204]
     spi_device_hw2reg_status_reg_t status; // [203:202]
     spi_device_hw2reg_addr_mode_reg_t addr_mode; // [201:200]
     spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [199:168]

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -12,7 +12,6 @@
 
 #define DIF_SPI_DEVICE_TPM_FIFO_DEPTH 16
 
-enum { kDifSpiDeviceFlashStatusWelBit = 1 };
 enum {
   kDifSpiDeviceEFlashLen =
       SPI_DEVICE_PARAM_SRAM_READ_BUFFER_DEPTH * sizeof(uint32_t),
@@ -767,7 +766,7 @@ dif_result_t dif_spi_device_clear_flash_busy_bit(dif_spi_device_handle_t *spi) {
   uint32_t reg_val = mmio_region_read32(spi->dev.base_addr,
                                         SPI_DEVICE_FLASH_STATUS_REG_OFFSET);
   reg_val =
-      bitfield_bit32_write(reg_val, kDifSpiDeviceFlashStatusWelBit, false);
+      bitfield_bit32_write(reg_val, SPI_DEVICE_FLASH_STATUS_WEL_BIT, false);
   reg_val =
       bitfield_bit32_write(reg_val, SPI_DEVICE_FLASH_STATUS_BUSY_BIT, false);
   mmio_region_write32(spi->dev.base_addr, SPI_DEVICE_FLASH_STATUS_REG_OFFSET,

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -631,7 +631,9 @@ rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {
     return kErrorSpiDevicePayloadOverflow;
   }
 
-  cmd->opcode = abs_mmio_read32(kBase + SPI_DEVICE_UPLOAD_CMDFIFO_REG_OFFSET);
+  reg = abs_mmio_read32(kBase + SPI_DEVICE_UPLOAD_CMDFIFO_REG_OFFSET);
+  cmd->opcode =
+      bitfield_field32_read(reg, SPI_DEVICE_UPLOAD_CMDFIFO_DATA_FIELD);
   cmd->address = kSpiDeviceNoAddress;
   reg = abs_mmio_read32(kBase + SPI_DEVICE_UPLOAD_STATUS_REG_OFFSET);
   if (bitfield_bit32_read(reg,

--- a/sw/host/tests/chip/spi_passthru/src/main.rs
+++ b/sw/host/tests/chip/spi_passthru/src/main.rs
@@ -117,8 +117,9 @@ fn test_read_status_extended(opts: &Opts, transport: &TransportWrapper) -> Resul
     let uart = transport.uart("console")?;
     let spi = transport.spi(&opts.spi)?;
 
+    // Note that the WIP and WEL bits cannot be written.
     let sr = StatusRegister {
-        status: 0x5A55AA,
+        status: 0x5A55A8,
         addr_4b: false,
     };
     sr.write(&*uart)?;


### PR DESCRIPTION
This PR builds on top of #21119 . Only the last two commits are new.

### Enable continuously polled status registers

Previously, the Read Status Register commands behaved differently from
the SPI flash convention, holding a fixed value for every word clocked
out of the same command + rotating through all three registers for each
command. Change the commands to only return the byte targeted by the
specific command, and update the status register value at every byte
beat (8th posedge of SCK).

This brings the SPI device flash behavior in line with the convention,
which is to allow hosts to poll the same register repeatedly and see
updated values as it goes along.

Disable the scoreboard's validation of Read Status commands for now. It
uses csr_rd() to determine the resolved value, but this is impossible.
The source of truth is in the SPI domain, and it updates at a much more
frequent interval than the core clock domain: The SPI domain updates for
every 8th posedge of SCK, whereas the core clock domain's view updates
only at every CSB de-assertion (delayed by synchronization to an async
domain).

In addition, add a CSR to permit resetting the async FIFO used to bring
software-originated status register changes into the SPI clock domain.

### Write mode and status bits alongside the command
Write some pertinent mode and status bits to the cmdfifo alongside the
command. The BUSY and WEL bits can be used to determine whether an
uploaded command should be accepted, and the address mode bit helps
determine whether an associated address in the addrfifo should be
interpreted as 3 bytes or 4 bytes.

Uploading these bits alongside the command byte avoids race conditions
with software checking their values after the transaction actually
occurs.

Make WEL an explicit field in the FLASH_STATUS CSR, and mark it as only
RW0C. Like the BUSY bit, software has no need to set this field to 1. It
should only clear it when it completes uploaded commands. Making it RW0C
eliminates the need for read-modify-write cycles just for checking
hardware-writable bits.

### Related issues
https://github.com/lowRISC/opentitan/issues/16411 is related, but this doesn't do enough to handle it. We would need to know if the address phase was cut short.

Resolves #20754