### PR TITLE
[sival,uart] Add uart_smoketest for uart_line_loopback test point

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -102,7 +102,8 @@
       stage: V3
       si_stage: SV3
       features: ["UART.LINE_LOOPBACK"]
-      tests: []
+      tests: ["uart_smoketest"]
+	  bazel: ["//sw/device/tests:uart_smoketest"]
     },
     {
       name: chip_sw_uart_system_loopback


### PR DESCRIPTION
The smoketest enables the loopback before transmitting data and checking the received data matches.

I believe this fulfils the test point:

* Here's the code for `uart_smoketest`:

  https://github.com/lowRISC/opentitan/blob/master/sw/device/tests/uart_smoketest.c#L36

* Here's the test point description:

  > Verify UART line loopback feature.                                                                                                                                      
  >
  > Configure the UART to enable RX, TX and line loopback. Send it some data and check that
  > bits appear on its TX side.