### PR TITLE
[doc] CIP interrupt doc updates

### DIFF
--- a/doc/contributing/hw/comportability/event_intr_type.svg
+++ b/doc/contributing/hw/comportability/event_intr_type.svg
@@ -1,0 +1,1933 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 697.82776 272.81125"
+   fill="none"
+   stroke="none"
+   stroke-linecap="square"
+   stroke-miterlimit="10"
+   id="svg143"
+   sodipodi:docname="event_intr_type.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   width="697.82776"
+   height="272.81125"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs143">
+    <marker
+       style="overflow:visible"
+       id="marker12_Fnone_S-000000"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="Triangle arrow"
+       markerWidth="1"
+       markerHeight="1"
+       viewBox="0 0 1 1"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid">
+      <path
+         transform="scale(0.5)"
+         style="fill:#000000;fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Triangle_Fnone_S-000000"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="Triangle arrow"
+       markerWidth="1"
+       markerHeight="1"
+       viewBox="0 0 1 1"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid">
+      <path
+         transform="scale(0.5)"
+         style="fill:#000000;fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path18" />
+    </marker>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <g
+         id="g145">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path144" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <g
+         id="g146">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path145" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <g
+         id="g148">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path147" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <g
+         id="g149">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path148" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <g
+         id="g150">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path149" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <g
+         id="g151">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path150" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <g
+         id="g152">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path151" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <g
+         id="g153">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path152" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <g
+         id="g154">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path153" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <g
+         id="g155">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path154" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <g
+         id="g156">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path155" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <g
+         id="g157">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path156" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <g
+         id="g158">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path157" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath158">
+      <g
+         id="g159">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path158" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath159">
+      <g
+         id="g160">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path159" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath160">
+      <g
+         id="g161">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path160" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath161">
+      <g
+         id="g162">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path161" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath162">
+      <g
+         id="g163">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path162" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath163">
+      <g
+         id="g164">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path163" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath164">
+      <g
+         id="g165">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path164" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath165">
+      <g
+         id="g166">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path165" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath166">
+      <g
+         id="g167">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path166" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath167">
+      <g
+         id="g168">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path167" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath168">
+      <g
+         id="g169">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path168" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath169">
+      <g
+         id="g170">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path169" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath170">
+      <g
+         id="g171">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path170" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath171">
+      <g
+         id="g172">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path171" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath172">
+      <g
+         id="g173">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path172" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath173">
+      <g
+         id="g174">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path173" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath174">
+      <g
+         id="g175">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path174" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath175">
+      <g
+         id="g176">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path175" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath176">
+      <g
+         id="g177">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path176" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath177">
+      <g
+         id="g178">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path177" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath178">
+      <g
+         id="g179">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path178" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath179">
+      <g
+         id="g180">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path179" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath180">
+      <g
+         id="g181">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path180" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath181">
+      <g
+         id="g182">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path181" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath182">
+      <g
+         id="g183">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path182" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath183">
+      <g
+         id="g184">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path183" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath184">
+      <g
+         id="g185">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path184" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath185">
+      <g
+         id="g186">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path185" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath186">
+      <g
+         id="g187">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path186" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath187">
+      <g
+         id="g188">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path187" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath188">
+      <g
+         id="g189">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path188" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath189">
+      <g
+         id="g190">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path189" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath190">
+      <g
+         id="g191">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path190" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath191">
+      <g
+         id="g192">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path191" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath192">
+      <g
+         id="g193">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path192" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath193">
+      <g
+         id="g194">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path193" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <g
+         id="g195">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path194" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath195">
+      <g
+         id="g196">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path195" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath196">
+      <g
+         id="g197">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path196" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath197">
+      <g
+         id="g198">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path197" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath198">
+      <g
+         id="g199">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path198" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath199">
+      <g
+         id="g200">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path199" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath200">
+      <g
+         id="g201">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path200" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath201">
+      <g
+         id="g202">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path201" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <g
+         id="g203">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path202" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath203">
+      <g
+         id="g204">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path203" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath204">
+      <g
+         id="g205">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path204" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath205">
+      <g
+         id="g206">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path205" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath206">
+      <g
+         id="g207">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path206" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath207">
+      <g
+         id="g208">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path207" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath208">
+      <g
+         id="g209">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path208" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath209">
+      <g
+         id="g210">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path209" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath210">
+      <g
+         id="g211">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path210" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath211">
+      <g
+         id="g212">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path211" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath212">
+      <g
+         id="g213">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path212" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath213">
+      <g
+         id="g214">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path213" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath214">
+      <g
+         id="g215">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path214" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath215">
+      <g
+         id="g216">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path215" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath216">
+      <g
+         id="g217">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path216" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath217">
+      <g
+         id="g218">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path217" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath218">
+      <g
+         id="g219">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path218" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath219">
+      <g
+         id="g220">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path219" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath220">
+      <g
+         id="g221">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path220" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath221">
+      <g
+         id="g222">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path221" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath222">
+      <g
+         id="g223">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path222" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath223">
+      <g
+         id="g224">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path223" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath224">
+      <g
+         id="g225">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path224" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath225">
+      <g
+         id="g226">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path225" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath226">
+      <g
+         id="g227">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path226" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath227">
+      <g
+         id="g228">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path227" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath228">
+      <g
+         id="g229">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path228" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath229">
+      <g
+         id="g230">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path229" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath230">
+      <g
+         id="g231">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path230" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath231">
+      <g
+         id="g232">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path231" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath232">
+      <g
+         id="g233">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path232" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath233">
+      <g
+         id="g234">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path233" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath234">
+      <g
+         id="g235">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path234" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath235">
+      <g
+         id="g236">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path235" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath236">
+      <g
+         id="g237">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path236" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath237">
+      <g
+         id="g238">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path237" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath238">
+      <g
+         id="g239">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path238" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath239">
+      <g
+         id="g240">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path239" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath240">
+      <g
+         id="g241">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path240" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath241">
+      <g
+         id="g242">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path241" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath242">
+      <g
+         id="g243">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path242" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath243">
+      <g
+         id="g244">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path243" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath244">
+      <g
+         id="g245">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path244" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath245">
+      <g
+         id="g246">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path245" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath246">
+      <g
+         id="g247">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path246" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath247">
+      <g
+         id="g248">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path247" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath248">
+      <g
+         id="g249">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path248" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath249">
+      <g
+         id="g250">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path249" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath250">
+      <g
+         id="g251">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path250" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath251">
+      <g
+         id="g252">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path251" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath252">
+      <g
+         id="g253">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path252" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath253">
+      <g
+         id="g254">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path253" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath254">
+      <g
+         id="g255">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path254" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath255">
+      <g
+         id="g256">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path255" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath256">
+      <g
+         id="g257">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path256" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath257">
+      <g
+         id="g258">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path257" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath258">
+      <g
+         id="g259">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path258" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath259">
+      <g
+         id="g260">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path259" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath260">
+      <g
+         id="g261">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path260" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath261">
+      <g
+         id="g262">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path261" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath262">
+      <g
+         id="g263">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path262" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath263">
+      <g
+         id="g264">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path263" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath264">
+      <g
+         id="g265">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path264" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath265">
+      <g
+         id="g266">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path265" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath266">
+      <g
+         id="g267">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path266" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath267">
+      <g
+         id="g268">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path267" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath268">
+      <g
+         id="g269">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path268" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath269">
+      <g
+         id="g270">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path269" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath270">
+      <g
+         id="g271">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path270" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath271">
+      <g
+         id="g272">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path271" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath272">
+      <g
+         id="g273">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path272" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath273">
+      <g
+         id="g274">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path273" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath274">
+      <g
+         id="g275">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path274" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath275">
+      <g
+         id="g276">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path275" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath276">
+      <g
+         id="g277">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path276" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath277">
+      <g
+         id="g278">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path277" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath278">
+      <g
+         id="g279">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path278" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath279">
+      <g
+         id="g280">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path279" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath280">
+      <g
+         id="g281">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path280" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath281">
+      <g
+         id="g282">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path281" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath282">
+      <g
+         id="g283">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path282" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath283">
+      <g
+         id="g284">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path283" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath284">
+      <g
+         id="g285">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path284" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath285">
+      <g
+         id="g286">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path285" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview143"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="2.2273514"
+     inkscape:cx="212.13536"
+     inkscape:cy="117.40402"
+     inkscape:window-width="1728"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg143">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="-9.3993349"
+       originy="-8.6661557"
+       spacingx="1100"
+       spacingy="621"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="true" />
+  </sodipodi:namedview>
+  <g
+     id="g1"
+     transform="matrix(1.0528699,0,0,1.0461242,-476.27321,-168.7913)"
+     style="stroke:#000000;stroke-width:0.967134;stroke-dasharray:none;stroke-opacity:1;fill:#c9daf8;fill-opacity:1">
+    <rect
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:0.967134;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="rect286"
+       width="82.097443"
+       height="85.569839"
+       x="455.87643"
+       y="336.07864"
+       rx="0"
+       ry="0" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:4.79226;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="path288"
+       inkscape:flatsided="false"
+       sodipodi:sides="3"
+       sodipodi:cx="365.09799"
+       sodipodi:cy="344.51163"
+       sodipodi:r1="44.331238"
+       sodipodi:r2="22.21102"
+       sodipodi:arg1="-2.0920243"
+       sodipodi:arg2="-1.0448267"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 343.02346,306.06721 33.22561,19.23549 33.18004,19.31403 -33.27124,19.15648 -33.31645,19.07774 0.0456,-38.39198 z"
+       inkscape:transform-center-x="-1.8025121"
+       inkscape:transform-center-y="-0.17577181"
+       transform="matrix(0.17240876,0,0,0.23622944,396.93803,320.38139)" />
+  </g>
+  <g
+     id="g2-7"
+     transform="matrix(1.0528699,0,0,1.0461242,-155.86873,-168.7913)"
+     style="stroke:#000000;stroke-width:0.967134;stroke-dasharray:none;stroke-opacity:1;fill:#c9daf8;fill-opacity:1">
+    <rect
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:0.967134;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="rect286-8"
+       width="82.097443"
+       height="85.569839"
+       x="455.87643"
+       y="336.07864"
+       rx="0"
+       ry="0" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:4.79226;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="path288-6"
+       inkscape:flatsided="false"
+       sodipodi:sides="3"
+       sodipodi:cx="365.09799"
+       sodipodi:cy="344.51163"
+       sodipodi:r1="44.331238"
+       sodipodi:r2="22.21102"
+       sodipodi:arg1="-2.0920243"
+       sodipodi:arg2="-1.0448267"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 343.02346,306.06721 33.22561,19.23549 33.18004,19.31403 -33.27124,19.15648 -33.31645,19.07774 0.0456,-38.39198 z"
+       inkscape:transform-center-x="-1.8025121"
+       inkscape:transform-center-y="-0.17577181"
+       transform="matrix(0.17240876,0,0,0.23622944,396.93803,320.38139)" />
+  </g>
+  <g
+     id="g2"
+     transform="matrix(1.0528699,0,0,1.0461242,-260.04639,-274.75988)"
+     style="stroke:#000000;stroke-width:0.967134;stroke-dasharray:none;stroke-opacity:1;fill:#c9daf8;fill-opacity:1">
+    <rect
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:0.967134;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="rect286-3"
+       width="82.097443"
+       height="85.569839"
+       x="455.87643"
+       y="336.07864"
+       rx="0"
+       ry="0" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:4.79226;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="path288-7"
+       inkscape:flatsided="false"
+       sodipodi:sides="3"
+       sodipodi:cx="365.09799"
+       sodipodi:cy="344.51163"
+       sodipodi:r1="44.331238"
+       sodipodi:r2="22.21102"
+       sodipodi:arg1="-2.0920243"
+       sodipodi:arg2="-1.0448267"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 343.02346,306.06721 33.22561,19.23549 33.18004,19.31403 -33.27124,19.15648 -33.31645,19.07774 0.0456,-38.39198 z"
+       inkscape:transform-center-x="-1.8025121"
+       inkscape:transform-center-y="-0.17577181"
+       transform="matrix(0.17240876,0,0,0.23622944,396.93803,320.38139)" />
+  </g>
+  <rect
+     style="fill:#ffffff;stroke:#000000;stroke-width:1.015;stroke-linejoin:miter;stroke-dasharray:4.06, 4.06;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect286-8-4"
+     width="38.545761"
+     height="39.945568"
+     x="539.68195"
+     y="94.992455"
+     rx="0"
+     ry="0" />
+  <path
+     sodipodi:type="star"
+     style="fill:#ffffff;stroke:#000000;stroke-width:10.7429;stroke-linejoin:miter;stroke-dasharray:85.9434, 10.7429;stroke-dashoffset:0;stroke-opacity:1"
+     id="path288-6-9"
+     inkscape:flatsided="false"
+     sodipodi:sides="3"
+     sodipodi:cx="365.09799"
+     sodipodi:cy="344.51163"
+     sodipodi:r1="44.331238"
+     sodipodi:r2="22.21102"
+     sodipodi:arg1="-2.0920243"
+     sodipodi:arg2="-1.0448267"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="m 343.02346,306.06721 33.22561,19.23549 33.18004,19.31403 -33.27124,19.15648 -33.31645,19.07774 0.0456,-38.39198 z"
+     inkscape:transform-center-x="-2.4647657"
+     inkscape:transform-center-y="-0.24035288"
+     transform="matrix(0.08094803,0,0,0.11027623,512.00965,87.664678)" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 53.693712,95.851609 76.110148,0"
+     id="path5"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 90.661794,197.74872 h 18.646996 v -80.90306 h 20.27886"
+     id="path6"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker12_Fnone_S-000000)"
+     d="m 181.07495,106.67815 19.7089,0 v 91.07057 l 63.43995,0 v -26.58989"
+     id="path10"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Triangle_Fnone_S-000000)"
+     d="M 173.33469,19.354653 H 264.2238 V 71.68842"
+     id="path13"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 305.63725,93.273916 H 446.13872"
+     id="path14"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 410.58604,197.74872 h 17.09264 V 117.5111 h 18.46004"
+     id="path15"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 501.86071,105.40969 h 37.26195"
+     id="path16"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 578.9485,105.40969 h 37.26194"
+     id="path16-0"
+     sodipodi:nodetypes="cc" />
+  <rect
+     style="fill:none;stroke:#000000;stroke-width:1.015;stroke-dasharray:none;stroke-opacity:1"
+     id="rect16"
+     width="52.696339"
+     height="22.238785"
+     x="21.288849"
+     y="212.73575" />
+  <rect
+     style="fill:none;stroke:#000000;stroke-width:1.015;stroke-dasharray:none;stroke-opacity:1"
+     id="rect16-2"
+     width="64.299225"
+     height="22.72224"
+     x="232.67262"
+     y="110.14322" />
+  <rect
+     style="fill:none;stroke:#000000;stroke-width:1.015;stroke-dasharray:none;stroke-opacity:1"
+     id="rect16-6"
+     width="77.352402"
+     height="23.689146"
+     x="328.98132"
+     y="213.66145" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 75.677255,0.5 h 79.769695 l 18.85466,18.854653 -18.49207,18.492071 H 75.677255 Z"
+     id="path17"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     stroke="#000000"
+     stroke-width="0.999999"
+     stroke-linejoin="round"
+     stroke-linecap="butt"
+     d="m 447.06312,76.812096 h 27.69007 v 0 c 15.29279,0 27.69007,12.397278 27.69007,27.690074 0,15.2928 -12.39728,27.69007 -27.69007,27.69007 h -27.69007 z"
+     fill-rule="evenodd"
+     id="path141"
+     clip-path="none"
+     style="display:inline" />
+  <path
+     style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+     d="M 8.6210972,100.04354 H 6.7622731 v -6.847745 q 0,-1.23921 -0.4700475,-1.84813 -0.4593639,-0.61962 -1.3246792,-0.61962 -0.3739007,0 -0.7050712,0.1068 -0.320487,0.0961 -0.6730219,0.35253 -0.3525363,0.24571 -0.7691686,0.67302 -0.4166336,0.42732 -0.9614607,1.0683 V 100.0435 H 0 V 84.948556 h 1.858824 v 4.369309 l -0.064091,1.6879 q 0.4379981,-0.52346 0.8546318,-0.876 0.4273159,-0.36321 0.8439482,-0.58755 0.4273158,-0.22435 0.8653153,-0.3205 0.4379981,-0.0961 0.9080456,-0.0961 1.6024345,0 2.4784321,0.98282 0.8759976,0.97215 0.8759976,2.9378 z M 21.964037,89.317905 20.404333,100.04354 h -2.254092 l -1.549019,-4.486825 -0.309804,-1.08965 -0.352536,1.15376 -1.484922,4.422715 H 12.263966 L 10.714945,89.317905 h 1.816093 l 0.897363,7.28574 0.192292,1.6238 0.459365,-1.42082 1.559704,-4.81799 h 1.335361 l 1.677215,4.75389 0.48073,1.42081 0.160244,-1.50628 0.833266,-7.33915 z M 34.377563,104.42353 H 22.348621 v -1.53833 h 12.028942 z m 5.362814,-13.567285 h -3.17282 v -1.53834 h 5.053011 v 9.17661 h 3.194185 v 1.549025 h -8.599732 v -1.549025 h 3.525356 z m 0.651657,-6.035842 q 0.309804,0 0.576876,0.11746 0.267073,0.106795 0.459365,0.309801 0.202974,0.202979 0.309803,0.470047 0.117516,0.25639 0.117516,0.56619 0,0.299121 -0.117516,0.566204 -0.106836,0.267069 -0.309803,0.470048 -0.192292,0.202965 -0.459365,0.320479 -0.267072,0.106796 -0.576876,0.106796 -0.309804,0 -0.576877,-0.106796 -0.267071,-0.11746 -0.470047,-0.320479 -0.192293,-0.202979 -0.309804,-0.470048 -0.106836,-0.267083 -0.106836,-0.566204 0,-0.3098 0.106836,-0.56619 0.117516,-0.267068 0.309804,-0.470047 0.202976,-0.202978 0.470047,-0.309801 0.267073,-0.11746 0.576877,-0.11746 z"
+     id="text2"
+     aria-label="hw_i" />
+  <path
+     style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+     d="m 92.402262,23.566762 q 0,0.566193 -0.192298,1.014874 -0.192286,0.448682 -0.523459,0.801218 -0.331174,0.341853 -0.769169,0.587559 -0.437996,0.245707 -0.940095,0.40595 -0.49142,0.160244 -1.014879,0.235024 -0.523458,0.07479 -1.025557,0.07479 -1.089649,0 -2.008385,-0.09614 -0.908043,-0.09614 -1.784048,-0.309804 V 24.57097 q 0.940095,0.267071 1.869511,0.40595 0.929415,0.138877 1.848138,0.138877 1.335372,0 1.976346,-0.363219 0.640973,-0.363218 0.640973,-1.03624 0,-0.288439 -0.106794,-0.512779 -0.09613,-0.235023 -0.363212,-0.438 -0.267083,-0.213657 -0.833273,-0.437997 -0.555511,-0.224342 -1.527658,-0.51278 -0.726436,-0.213657 -1.346038,-0.480731 -0.608921,-0.277755 -1.057609,-0.651656 -0.448676,-0.373902 -0.705065,-0.875998 -0.256389,-0.502097 -0.256389,-1.185802 0,-0.448681 0.202964,-0.982826 0.213658,-0.534145 0.715758,-0.993509 0.502099,-0.459366 1.356731,-0.758486 0.854632,-0.309804 2.13658,-0.309804 0.630294,0 1.399462,0.07479 0.769169,0.0641 1.602428,0.235024 v 1.65585 q -0.875991,-0.213659 -1.666532,-0.309806 -0.779847,-0.106834 -1.356731,-0.106834 -0.694385,0 -1.175111,0.106834 -0.470049,0.106836 -0.76917,0.299122 -0.288441,0.181611 -0.416636,0.437999 -0.128126,0.245706 -0.128126,0.534146 0,0.288437 0.106794,0.523461 0.117461,0.235023 0.416623,0.459365 0.309814,0.213658 0.854632,0.437998 0.544832,0.213658 1.420836,0.470047 0.950774,0.277756 1.602428,0.587561 0.651652,0.299121 1.05761,0.673021 0.405942,0.373903 0.576869,0.84395 0.181619,0.470047 0.181619,1.068289 z m 13.471128,-7.798516 -1.55971,10.725629 h -2.25408 l -1.54903,-4.486817 -0.3098,-1.089655 -0.352532,1.153753 -1.484926,4.422719 H 96.173321 L 94.624305,15.768246 h 1.816086 l 0.897363,7.285736 0.192299,1.623801 0.459354,-1.420826 1.55971,-4.817986 h 1.335363 l 1.67721,4.753889 0.48074,1.420826 0.16023,-1.506289 0.83327,-7.339151 z m 23.96174,-3.236917 -0.94009,13.962546 h -2.46775 l -1.73064,-4.967548 -0.48073,-1.591751 -0.50209,1.719946 -1.60243,4.839353 h -2.3823 l -0.96144,-13.962546 h 1.79472 l 0.54481,9.497095 0.16026,2.606628 0.67302,-2.211361 1.68789,-5.181204 h 1.314 l 1.94429,5.555105 0.65166,1.83746 0.0427,-1.922922 0.55551,-10.180801 z m 11.13157,13.962546 h -8.77066 v -1.730629 h 3.58947 V 14.571762 l -3.34376,1.816092 -0.6837,-1.581068 4.44409,-2.339556 h 1.64515 v 12.296016 h 3.11941 z m 12.00757,-0.523462 q -1.67721,0.694388 -3.51466,0.694388 -2.95916,0 -4.55092,-1.762678 -1.58107,-1.773361 -1.58107,-5.234619 0,-1.677215 0.438,-3.033944 0.438,-1.356727 1.24989,-2.296822 0.81191,-0.950778 1.96566,-1.463557 1.15376,-0.512779 2.58525,-0.512779 0.97215,0 1.80543,0.170927 0.83326,0.160244 1.60242,0.502096 v 1.869506 q -0.75848,-0.416632 -1.57039,-0.63029 -0.81189,-0.224341 -1.77335,-0.224341 -0.98282,0 -1.78405,0.373901 -0.79052,0.363219 -1.34603,1.068291 -0.55552,0.694387 -0.85463,1.709262 -0.29913,1.004193 -0.29913,2.296823 0,2.713456 1.10033,4.091551 1.10034,1.378092 3.22624,1.378092 0.89737,0 1.71994,-0.202974 0.82259,-0.213658 1.58107,-0.58756 z"
+     id="text2-9"
+     aria-label="sw W1C" />
+  <path
+     style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+     d="m 631.99976,102.04458 h -3.17284 v -1.53834 h 5.05302 v 9.17661 h 3.19418 v 1.54902 h -8.59972 v -1.54902 h 3.52536 z m 0.65165,-6.035842 q 0.3098,0 0.57687,0.11746 0.26708,0.106795 0.45937,0.309801 0.20298,0.202979 0.3098,0.470047 0.11746,0.25639 0.11746,0.56619 0,0.299121 -0.11746,0.566204 -0.10679,0.267069 -0.3098,0.470048 -0.19229,0.202965 -0.45937,0.320479 -0.26707,0.106796 -0.57687,0.106796 -0.3098,0 -0.57688,-0.106796 -0.26707,-0.11746 -0.47005,-0.320479 -0.19229,-0.202979 -0.3098,-0.470048 -0.10679,-0.267083 -0.10679,-0.566204 0,-0.3098 0.10679,-0.56619 0.11746,-0.267068 0.3098,-0.470047 0.20298,-0.202978 0.47005,-0.309801 0.26708,-0.11746 0.57688,-0.11746 z m 7.72374,4.497502 h 1.65584 l 0.0748,1.73064 q 0.47005,-0.55552 0.90805,-0.91874 0.43801,-0.37389 0.85464,-0.59824 0.42731,-0.22434 0.86532,-0.3098 0.43799,-0.0961 0.90804,-0.0961 1.65585,0 2.49979,0.98282 0.85463,0.97215 0.85463,2.9378 v 6.99729 h -1.85882 v -6.84773 q 0,-1.26058 -0.47005,-1.85882 -0.47003,-0.60893 -1.39945,-0.60893 -0.34186,0 -0.67304,0.10679 -0.32047,0.0961 -0.673,0.35253 -0.35255,0.24571 -0.76917,0.67303 -0.40595,0.42732 -0.91874,1.06829 v 7.1148 h -1.85882 z m 20.6714,10.57608 q -0.63028,0.16024 -1.30331,0.22433 -0.67302,0.0748 -1.36741,0.0748 -2.01906,0 -3.01258,-0.90804 -0.99351,-0.91874 -0.99351,-2.80961 v -5.59784 h -3.0019 v -1.55971 h 3.0019 v -2.948481 l 1.85883,-0.480727 v 3.429208 h 4.81798 v 1.55971 h -4.81798 v 5.44828 q 0,1.15375 0.60892,1.73063 0.61961,0.56619 1.81608,0.56619 0.51279,0 1.12173,-0.0748 0.60891,-0.0854 1.27125,-0.2564 z m 3.82448,-10.57608 h 1.69859 l 0.0534,1.97635 q 0.95077,-1.14308 1.86951,-1.65586 0.9294,-0.51278 1.8695,-0.51278 1.66653,0 2.52116,1.07897 0.86533,1.07897 0.80122,3.20487 h -1.88019 q 0.032,-1.41014 -0.41663,-2.04043 -0.438,-0.64098 -1.29264,-0.64098 -0.3739,0 -0.75848,0.13889 -0.37389,0.12813 -0.77985,0.42732 -0.39526,0.28842 -0.84395,0.74779 -0.44868,0.45937 -0.96146,1.11102 v 6.89047 h -1.88019 z m 21.91063,15.10562 h -12.02895 v -1.53833 h 12.02895 z m 11.0461,-9.82826 q 0,1.2499 -0.35253,2.29682 -0.35253,1.03625 -1.01488,1.78404 -0.66233,0.73713 -1.61312,1.15375 -0.95078,0.40595 -2.15793,0.40595 -1.15376,0 -2.07249,-0.35253 -0.90805,-0.36323 -1.54902,-1.0576 -0.6303,-0.69439 -0.97215,-1.71995 -0.33115,-1.02555 -0.33115,-2.36093 0,-1.24989 0.35252,-2.27546 0.35253,-1.03623 1.01489,-1.77335 0.66233,-0.74781 1.6131,-1.15375 0.95078,-0.41664 2.15795,-0.41664 1.15376,0 2.0618,0.36322 0.91873,0.35254 1.54902,1.04693 0.64097,0.6837 0.97214,1.70926 0.34185,1.02556 0.34185,2.35024 z m -1.90154,0.0854 q 0,-0.99351 -0.22436,-1.73064 -0.21366,-0.74779 -0.6196,-1.23921 -0.40595,-0.50209 -0.9935,-0.7478 -0.57689,-0.25639 -1.29265,-0.25639 -0.83325,0 -1.43149,0.33117 -0.58757,0.32048 -0.97215,0.86532 -0.37391,0.54483 -0.55552,1.27127 -0.17092,0.71574 -0.17092,1.50628 0,0.9935 0.21366,1.74131 0.22434,0.7478 0.63029,1.2499 0.40594,0.4914 0.98283,0.74779 0.57686,0.24571 1.3033,0.24571 0.83328,0 1.42084,-0.32047 0.59825,-0.33118 0.97214,-0.87601 0.38458,-0.54483 0.5555,-1.26058 0.18163,-0.72643 0.18163,-1.52765 z"
+     id="text2-1"
+     aria-label="intr_o" />
+  <path
+     style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+     d="m 34.805259,218.99343 h -4.13428 v 12.33875 h -1.922922 v -12.33875 h -4.134282 v -1.62381 h 10.191484 z m 11.003384,12.33875 h -7.937392 v -13.96256 h 7.937392 v 1.60244 h -6.035836 v 4.32658 h 5.800813 v 1.60242 h -5.800813 v 4.80732 h 6.035836 z m 12.595137,-3.78176 q 0,0.99352 -0.40595,1.74132 -0.40595,0.74781 -1.132387,1.24989 -0.726437,0.49142 -1.751995,0.73713 -1.014877,0.2457 -2.243409,0.2457 -0.55551,0 -1.111021,-0.0427 -0.544829,-0.0427 -1.057608,-0.1068 -0.502095,-0.0641 -0.950777,-0.14956 -0.448682,-0.0854 -0.8119,-0.18161 v -1.83745 q 0.801217,0.29911 1.794726,0.47003 1.004193,0.17094 2.275457,0.17094 0.918729,0 1.559702,-0.13888 0.651658,-0.14956 1.057608,-0.42732 0.416633,-0.28843 0.598243,-0.69438 0.192291,-0.40596 0.192291,-0.92942 0,-0.56618 -0.320487,-0.96146 -0.309804,-0.40595 -0.822583,-0.71574 -0.512779,-0.3205 -1.175119,-0.57689 -0.651656,-0.26706 -1.335361,-0.54483 -0.683705,-0.27775 -1.346045,-0.59824 -0.651657,-0.33116 -1.164437,-0.76917 -0.512778,-0.44867 -0.833265,-1.04692 -0.309803,-0.59824 -0.309803,-1.42082 0,-0.71575 0.29912,-1.41014 0.299121,-0.6944 0.929411,-1.22854 0.630292,-0.54483 1.613119,-0.876 0.993509,-0.33116 2.36092,-0.33116 0.352535,0 0.758486,0.032 0.416632,0.032 0.833266,0.0961 0.427315,0.0534 0.833265,0.12813 0.416633,0.0748 0.769169,0.16023 v 1.70927 q -0.822584,-0.23502 -1.645166,-0.35254 -0.822583,-0.12812 -1.591752,-0.12812 -1.634482,0 -2.403652,0.54483 -0.769168,0.54483 -0.769168,1.46355 0,0.56619 0.309803,0.97215 0.320487,0.40595 0.833267,0.72643 0.512778,0.32049 1.164436,0.58757 0.66234,0.25639 1.346045,0.53413 0.683706,0.27777 1.335362,0.60893 0.662339,0.33117 1.175118,0.79054 0.512779,0.44867 0.822584,1.05761 0.320487,0.60892 0.320487,1.44218 z m 12.488303,-8.55699 h -4.134278 v 12.33875 h -1.922922 v -12.33875 h -4.134281 v -1.62381 h 10.191481 z"
+     id="text2-5"
+     aria-label="TEST" />
+  <path
+     style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+     d="m 341.46773,232.54685 h -7.9374 v -13.96254 h 7.9374 v 1.60243 h -6.03584 v 4.32657 h 5.8008 v 1.60244 h -5.8008 v 4.8073 h 6.03584 z m 12.71264,0 h -2.47844 l -4.07018,-8.70656 -1.1751,-2.79891 v 7.04003 4.46544 h -1.77338 v -13.96254 h 2.44639 l 3.8779,8.2472 1.39946,3.19417 v -7.47802 -3.96335 h 1.77335 z m 13.1827,0 h -2.07249 l -0.97213,-3.04463 h -5.8115 l -0.98282,3.04463 h -1.97635 l 4.63638,-13.96254 h 2.60663 z m -3.58945,-4.74321 -2.36092,-7.46733 -2.36093,7.46733 z m 14.55009,0.5662 q 0,1.00419 -0.39526,1.78403 -0.38458,0.76918 -1.11102,1.30333 -0.71576,0.53413 -1.74131,0.8119 -1.01487,0.27775 -2.26477,0.27775 h -3.65355 v -13.96254 h 3.99539 q 4.66844,0 4.66844,3.39715 0,1.1324 -0.54483,1.9443 -0.53416,0.8119 -1.75199,1.20717 0.56618,0.10679 1.06828,0.36321 0.51278,0.25639 0.89736,0.66234 0.3846,0.40594 0.60893,0.96146 0.22433,0.5555 0.22433,1.2499 z m -2.47843,-6.13199 q 0,-0.42731 -0.12812,-0.80121 -0.12813,-0.38459 -0.44867,-0.65165 -0.3205,-0.27776 -0.86531,-0.438 -0.54484,-0.16025 -1.37812,-0.16025 h -1.96565 v 4.3693 h 1.90157 q 0.65165,0 1.17511,-0.13887 0.53415,-0.13888 0.90806,-0.42731 0.38458,-0.28845 0.58755,-0.71576 0.21365,-0.438 0.21365,-1.03625 z m 0.45937,6.19609 q 0,-0.53414 -0.22434,-0.96146 -0.22433,-0.42732 -0.65165,-0.71576 -0.42732,-0.29911 -1.04693,-0.45937 -0.60892,-0.16024 -1.37809,-0.16024 h -1.9443 v 4.80731 h 2.0084 q 1.63449,0 2.43569,-0.60892 0.80122,-0.60894 0.80122,-1.90156 z m 13.71684,4.11291 h -8.03354 v -13.96254 h 1.93361 v 12.33874 h 6.09993 z m 11.59094,0 h -7.93738 v -13.96254 h 7.93738 v 1.60243 h -6.03583 v 4.32657 h 5.80081 v 1.60244 h -5.80081 v 4.8073 h 6.03583 z"
+     id="text2-5-8"
+     aria-label="ENABLE" />
+  <path
+     style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+     d="m 245.33232,124.54762 q 0,0.99352 -0.40596,1.74131 -0.40594,0.74781 -1.13238,1.2499 -0.72643,0.49142 -1.75199,0.73713 -1.01488,0.24569 -2.24342,0.24569 -0.55551,0 -1.11102,-0.0427 -0.54483,-0.0427 -1.05761,-0.1068 -0.50208,-0.0641 -0.95077,-0.14956 -0.44868,-0.0854 -0.81191,-0.1816 v -1.83746 q 0.80123,0.29912 1.79473,0.47004 1.0042,0.17093 2.27545,0.17093 0.91874,0 1.55972,-0.13887 0.65165,-0.14958 1.05761,-0.42732 0.41662,-0.28844 0.59824,-0.69438 0.19228,-0.40597 0.19228,-0.92942 0,-0.56619 -0.32047,-0.96147 -0.30982,-0.40594 -0.8226,-0.71575 -0.51278,-0.32048 -1.17511,-0.57687 -0.65165,-0.26707 -1.33536,-0.54484 -0.6837,-0.27775 -1.34605,-0.59824 -0.65166,-0.33116 -1.16444,-0.76917 -0.51277,-0.44867 -0.83327,-1.04691 -0.3098,-0.59825 -0.3098,-1.42083 0,-0.71576 0.29912,-1.41014 0.29913,-0.6944 0.92942,-1.22853 0.63029,-0.54484 1.61312,-0.87601 0.99351,-0.33116 2.36092,-0.33116 0.35253,0 0.75848,0.032 0.41663,0.032 0.83327,0.0961 0.42731,0.0534 0.83327,0.12813 0.41662,0.0748 0.76917,0.16023 v 1.70926 q -0.8226,-0.23502 -1.64517,-0.35253 -0.82259,-0.12813 -1.59175,-0.12813 -1.63449,0 -2.40366,0.54484 -0.76916,0.54482 -0.76916,1.46354 0,0.5662 0.30979,0.97215 0.32049,0.40595 0.83327,0.72644 0.51277,0.32048 1.16445,0.58756 0.66233,0.25639 1.34604,0.53414 0.6837,0.27777 1.33535,0.60892 0.66235,0.33118 1.17513,0.79055 0.51277,0.44867 0.82258,1.0576 0.32049,0.60892 0.32049,1.44219 z m 12.48831,-8.55699 h -4.13429 v 12.33874 h -1.92293 v -12.33874 h -4.13428 v -1.62381 h 10.1915 z m 12.84083,12.33874 h -2.07248 l -0.97214,-3.04462 h -5.8115 l -0.98283,3.04462 h -1.97633 l 4.63637,-13.96255 h 2.60663 z m -3.58945,-4.74321 -2.36093,-7.46734 -2.36091,7.46734 z m 14.8065,-7.59553 h -4.13429 v 12.33874 h -1.92291 v -12.33874 h -4.13429 v -1.62381 h 10.19149 z m 11.00337,12.33874 h -7.93737 v -13.96255 h 7.93737 v 1.60244 h -6.03583 v 4.32657 h 5.80082 v 1.60243 h -5.80082 v 4.8073 h 6.03583 z"
+     id="text2-5-4"
+     aria-label="STATE" />
+  <path
+     style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+     d="m 259.05499,160.21204 q 0,0.2831 -0.0961,0.50744 -0.0961,0.22433 -0.26174,0.40061 -0.16558,0.17092 -0.38458,0.29377 -0.219,0.12279 -0.47005,0.20299 -0.24571,0.0801 -0.50743,0.11745 -0.26174,0.0373 -0.51278,0.0373 -0.54483,0 -1.0042,-0.0481 -0.45402,-0.0481 -0.89202,-0.1549 v -0.85463 q 0.47005,0.13359 0.93476,0.20298 0.4647,0.0695 0.92407,0.0695 0.66767,0 0.98816,-0.1816 0.32049,-0.18161 0.32049,-0.51813 0,-0.14422 -0.0535,-0.25639 -0.0481,-0.11746 -0.1816,-0.21899 -0.1336,-0.10679 -0.41665,-0.21901 -0.27774,-0.11212 -0.76381,-0.25639 -0.36323,-0.10679 -0.67303,-0.24036 -0.30447,-0.13887 -0.52881,-0.32582 -0.22433,-0.18695 -0.35253,-0.43801 -0.12812,-0.25104 -0.12812,-0.5929 0,-0.22434 0.10146,-0.4914 0.1068,-0.26708 0.35787,-0.49678 0.25105,-0.22966 0.67836,-0.37923 0.42732,-0.1549 1.0683,-0.1549 0.31514,0 0.69973,0.0373 0.38458,0.032 0.80122,0.11746 v 0.82793 q -0.43801,-0.1068 -0.83327,-0.1549 -0.38994,-0.0535 -0.67836,-0.0535 -0.3472,0 -0.58757,0.0535 -0.23503,0.0534 -0.38458,0.14955 -0.14423,0.0908 -0.20831,0.219 -0.0642,0.1228 -0.0642,0.26707 0,0.14422 0.0535,0.26174 0.0588,0.11746 0.20833,0.22968 0.1549,0.1068 0.42731,0.219 0.27242,0.10678 0.71042,0.23503 0.47537,0.13887 0.80121,0.29376 0.32583,0.14958 0.5288,0.33653 0.20298,0.18694 0.28843,0.42197 0.0908,0.23502 0.0908,0.53414 z m 6.29758,-1.50095 q 0,0.19763 -0.005,0.33118 -0.005,0.13346 -0.016,0.25104 h -3.76571 q 0,0.82258 0.45936,1.26592 0.45937,0.43799 1.32468,0.43799 0.23503,0 0.47005,-0.016 0.23503,-0.0213 0.45402,-0.0535 0.219,-0.032 0.41663,-0.0695 0.20298,-0.0427 0.37391,-0.0908 v 0.76384 q -0.37924,0.10679 -0.85998,0.17092 -0.47538,0.0695 -0.98816,0.0695 -0.68905,0 -1.1858,-0.18696 -0.49676,-0.18695 -0.81726,-0.53948 -0.31514,-0.35788 -0.47003,-0.87065 -0.14957,-0.51813 -0.14957,-1.16978 0,-0.5662 0.16026,-1.0683 0.16558,-0.50743 0.47537,-0.88668 0.31515,-0.38458 0.76917,-0.60892 0.45403,-0.22434 1.03091,-0.22434 0.56084,0 0.9935,0.17627 0.43266,0.17626 0.72644,0.50209 0.29913,0.3205 0.44869,0.78519 0.1549,0.45938 0.1549,1.03091 z m -0.9668,-0.13359 q 0.016,-0.35788 -0.0695,-0.65166 -0.0854,-0.29912 -0.26707,-0.51277 -0.17626,-0.21366 -0.44334,-0.33118 -0.26707,-0.12279 -0.6196,-0.12279 -0.30447,0 -0.55551,0.11746 -0.25106,0.11746 -0.43266,0.33116 -0.18161,0.21366 -0.29378,0.51277 -0.11212,0.29913 -0.13887,0.65701 z m 6.77295,3.02326 q -0.31515,0.0801 -0.65166,0.11213 -0.33652,0.0373 -0.6837,0.0373 -1.00953,0 -1.50628,-0.45403 -0.49677,-0.45935 -0.49677,-1.40478 v -2.79893 h -1.50094 v -0.77985 h 1.50094 v -1.47423 l 0.92942,-0.24037 v 1.7146 h 2.40899 v 0.77985 h -2.40899 v 2.72414 q 0,0.57688 0.30446,0.86531 0.3098,0.28311 0.90804,0.28311 0.25639,0 0.56086,-0.0375 0.30446,-0.0427 0.63563,-0.12813 z"
+     id="text2-54"
+     aria-label="set" />
+  <g
+     id="text2-54-8"
+     style="font-size:8px;font-family:consolas;-inkscape-font-specification:consolas;text-align:center;text-anchor:middle;stroke-width:0.731309"
+     aria-label="optional&#10;output&#10;flop"
+     transform="matrix(1.3674109,0,0,1.3674109,-69.600304,-58.964694)">
+    <path
+       style="fill:#000000;stroke-width:0.731309"
+       d="m 446.8522,148.44385 q 0,0.45703 -0.1289,0.83984 -0.12891,0.37891 -0.3711,0.65235 -0.24218,0.26953 -0.58984,0.42187 -0.34766,0.14844 -0.78906,0.14844 -0.42188,0 -0.75782,-0.12891 -0.33203,-0.13281 -0.5664,-0.38672 -0.23047,-0.2539 -0.35547,-0.6289 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45704 0.1289,-0.83204 0.12891,-0.3789 0.3711,-0.64843 0.24218,-0.27344 0.58984,-0.42188 0.34766,-0.15234 0.78906,-0.15234 0.42188,0 0.75391,0.13281 0.33594,0.12891 0.5664,0.38281 0.23438,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69531,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22656,-0.45313 -0.14844,-0.18359 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30469,0 -0.52344,0.1211 -0.21484,0.11718 -0.35547,0.3164 -0.13672,0.19922 -0.20312,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27343 0.23047,0.45703 0.14844,0.17969 0.35938,0.27344 0.21093,0.0898 0.47656,0.0898 0.30469,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14062,-0.19922 0.20312,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z m 5.03125,-0.0703 q 0,0.52343 -0.14844,0.91406 -0.14453,0.39062 -0.40234,0.64844 -0.25781,0.25781 -0.60938,0.38671 -0.35156,0.12891 -0.76171,0.12891 -0.1875,0 -0.375,-0.0195 -0.1836,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29296,-0.40234 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33593,0 0.58984,0.14062 0.25391,0.14063 0.42578,0.39844 0.17188,0.25391 0.25781,0.61719 0.0859,0.35937 0.0859,0.80469 z m -0.69531,0.0312 q 0,-0.3086 -0.0469,-0.56641 -0.043,-0.25781 -0.14062,-0.44141 -0.0977,-0.18359 -0.25,-0.28515 -0.15235,-0.10547 -0.36328,-0.10547 -0.12891,0 -0.26172,0.043 -0.13281,0.0391 -0.27735,0.13672 -0.14062,0.0937 -0.30078,0.2539 -0.15625,0.15625 -0.33593,0.39063 v 1.90234 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.37109 0.3125,-0.375 0.3125,-1.125 z m 4.90234,1.94531 q -0.23047,0.0586 -0.47656,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 h -1.09766 V 146.514 h 1.09766 v -1.07812 l 0.67968,-0.17579 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42188 0.22266,0.63281 0.22656,0.20703 0.66406,0.20703 0.1875,0 0.41016,-0.0273 0.22265,-0.0312 0.46484,-0.0937 z m 2.57422,-3.30469 h -1.16016 v -0.5625 h 1.84766 v 3.35547 h 1.16797 v 0.56641 h -3.14453 v -0.56641 h 1.28906 z m 0.23828,-2.20703 q 0.11328,0 0.21094,0.043 0.0977,0.0391 0.16797,0.11328 0.0742,0.0742 0.11328,0.17187 0.043,0.0937 0.043,0.20704 0,0.10937 -0.043,0.20703 -0.0391,0.0977 -0.11328,0.17187 -0.0703,0.0742 -0.16797,0.11719 -0.0977,0.0391 -0.21094,0.0391 -0.11328,0 -0.21094,-0.0391 -0.0976,-0.043 -0.17187,-0.11719 -0.0703,-0.0742 -0.11328,-0.17187 -0.0391,-0.0977 -0.0391,-0.20703 0,-0.11329 0.0391,-0.20704 0.043,-0.0977 0.11328,-0.17187 0.0742,-0.0742 0.17187,-0.11328 0.0977,-0.043 0.21094,-0.043 z m 6.23828,3.57422 q 0,0.45703 -0.1289,0.83984 -0.12891,0.37891 -0.3711,0.65235 -0.24218,0.26953 -0.58984,0.42187 -0.34766,0.14844 -0.78906,0.14844 -0.42188,0 -0.75782,-0.12891 -0.33203,-0.13281 -0.5664,-0.38672 -0.23047,-0.2539 -0.35547,-0.6289 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45704 0.1289,-0.83204 0.12891,-0.3789 0.3711,-0.64843 0.24218,-0.27344 0.58984,-0.42188 0.34766,-0.15234 0.78906,-0.15234 0.42188,0 0.75391,0.13281 0.33594,0.12891 0.5664,0.38281 0.23438,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69531,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22656,-0.45313 -0.14844,-0.18359 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30469,0 -0.52344,0.1211 -0.21484,0.11718 -0.35547,0.3164 -0.13672,0.19922 -0.20312,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27343 0.23047,0.45703 0.14844,0.17969 0.35938,0.27344 0.21093,0.0898 0.47656,0.0898 0.30469,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14062,-0.19922 0.20312,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z m 1.67969,-1.96094 h 0.60547 l 0.0273,0.63281 q 0.17188,-0.20312 0.33203,-0.33593 0.16016,-0.13672 0.3125,-0.21875 0.15625,-0.082 0.31641,-0.11329 0.16015,-0.0352 0.33203,-0.0352 0.60547,0 0.91406,0.35937 0.3125,0.35547 0.3125,1.07422 v 2.5586 h -0.67969 v -2.50391 q 0,-0.46094 -0.17187,-0.67969 -0.17188,-0.22265 -0.51172,-0.22265 -0.125,0 -0.24609,0.0391 -0.11719,0.0352 -0.2461,0.1289 -0.1289,0.0898 -0.28125,0.2461 -0.14843,0.15625 -0.33593,0.39062 v 2.60157 h -0.67969 z m 6.91797,3.92188 -0.0156,-0.52735 q -0.32031,0.31641 -0.65234,0.45703 -0.32813,0.14063 -0.69141,0.14063 -0.33594,0 -0.57422,-0.0859 -0.23828,-0.0859 -0.39453,-0.23437 -0.15234,-0.15235 -0.22656,-0.35547 -0.0703,-0.20313 -0.0703,-0.44141 0,-0.58984 0.4375,-0.92187 0.4414,-0.33594 1.30078,-0.33594 h 0.8125 v -0.34375 q 0,-0.34766 -0.22266,-0.55469 -0.22265,-0.21094 -0.67969,-0.21094 -0.33203,0 -0.65625,0.0742 -0.32031,0.0742 -0.66406,0.21094 v -0.61328 q 0.12891,-0.0469 0.28516,-0.0898 0.16015,-0.0469 0.33594,-0.082 0.17578,-0.0352 0.36718,-0.0547 0.19141,-0.0234 0.38672,-0.0234 0.35547,0 0.64063,0.0781 0.28515,0.0781 0.48047,0.23828 0.19921,0.16016 0.30468,0.40235 0.10547,0.24219 0.10547,0.57031 v 2.70313 z m -0.0742,-1.78516 h -0.86328 q -0.25391,0 -0.4375,0.0508 -0.1836,0.0508 -0.30078,0.14453 -0.11719,0.0937 -0.17579,0.22656 -0.0547,0.12891 -0.0547,0.29297 0,0.11328 0.0351,0.21875 0.0352,0.10157 0.11328,0.1836 0.0781,0.0781 0.20313,0.125 0.125,0.0469 0.30469,0.0469 0.23437,0 0.53515,-0.14062 0.30469,-0.14453 0.64063,-0.45313 z m 3.28906,-3.17578 H 474.403 v -0.5586 h 1.84766 v 4.95313 h 1.16797 v 0.56641 h -3.14453 v -0.56641 h 1.28906 z"
+       id="path7" />
+    <path
+       style="fill:#000000;stroke-width:0.731309"
+       d="m 451.25064,158.44385 q 0,0.45703 -0.12891,0.83984 -0.1289,0.37891 -0.37109,0.65235 -0.24219,0.26953 -0.58984,0.42187 -0.34766,0.14844 -0.78907,0.14844 -0.42187,0 -0.75781,-0.12891 -0.33203,-0.13281 -0.5664,-0.38672 -0.23047,-0.2539 -0.35547,-0.6289 -0.1211,-0.375 -0.1211,-0.86328 0,-0.45704 0.12891,-0.83204 0.12891,-0.3789 0.37109,-0.64843 0.24219,-0.27344 0.58985,-0.42188 0.34765,-0.15234 0.78906,-0.15234 0.42187,0 0.75391,0.13281 0.33593,0.12891 0.5664,0.38281 0.23438,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69531,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22657,-0.45313 -0.14843,-0.18359 -0.36328,-0.27344 -0.21093,-0.0937 -0.47265,-0.0937 -0.30469,0 -0.52344,0.1211 -0.21484,0.11718 -0.35547,0.3164 -0.13672,0.19922 -0.20312,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27343 0.23047,0.45703 0.14844,0.17969 0.35937,0.27344 0.21094,0.0898 0.47657,0.0898 0.30468,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14062,-0.19922 0.20312,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z m 4.83203,1.96094 h -0.60938 l -0.0234,-0.63282 q -0.17578,0.20313 -0.33594,0.33985 -0.15625,0.13281 -0.3125,0.21484 -0.15625,0.082 -0.31641,0.11328 -0.15625,0.0352 -0.33203,0.0352 -0.60547,0 -0.91406,-0.35547 -0.30859,-0.35547 -0.30859,-1.07422 v -2.5625 h 0.67968 v 2.50781 q 0,0.90235 0.67969,0.90235 0.125,0 0.24219,-0.0352 0.12109,-0.0391 0.25,-0.12891 0.13281,-0.0937 0.28125,-0.25 0.15234,-0.15625 0.33984,-0.39453 v -2.60156 h 0.67969 z m 4.40625,-0.0547 q -0.23047,0.0586 -0.47656,0.082 -0.2461,0.0273 -0.5,0.0273 -0.73828,0 -1.10157,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 h -1.09765 v -0.57031 h 1.09765 v -1.07812 l 0.67969,-0.17579 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42188 0.22266,0.63281 0.22656,0.20703 0.66406,0.20703 0.1875,0 0.41016,-0.0273 0.22265,-0.0312 0.46484,-0.0937 z m 4.58984,-1.97656 q 0,0.52343 -0.14843,0.91406 -0.14454,0.39062 -0.40235,0.64844 -0.25781,0.25781 -0.60937,0.38671 -0.35157,0.12891 -0.76172,0.12891 -0.1875,0 -0.375,-0.0195 -0.1836,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29297,-0.40234 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33594,0 0.58984,0.14062 0.25391,0.14063 0.42578,0.39844 0.17188,0.25391 0.25782,0.61719 0.0859,0.35937 0.0859,0.80469 z m -0.69531,0.0312 q 0,-0.3086 -0.0469,-0.56641 -0.043,-0.25781 -0.14063,-0.44141 -0.0977,-0.18359 -0.25,-0.28515 -0.15234,-0.10547 -0.36328,-0.10547 -0.12891,0 -0.26172,0.043 -0.13281,0.0391 -0.27734,0.13672 -0.14063,0.0937 -0.30078,0.2539 -0.15625,0.15625 -0.33594,0.39063 v 1.90234 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.37109 0.3125,-0.375 0.3125,-1.125 z m 4.89453,2 h -0.60937 l -0.0234,-0.63282 q -0.17578,0.20313 -0.33594,0.33985 -0.15625,0.13281 -0.3125,0.21484 -0.15625,0.082 -0.3164,0.11328 -0.15625,0.0352 -0.33204,0.0352 -0.60546,0 -0.91406,-0.35547 -0.30859,-0.35547 -0.30859,-1.07422 v -2.5625 h 0.67969 v 2.50781 q 0,0.90235 0.67968,0.90235 0.125,0 0.24219,-0.0352 0.12109,-0.0391 0.25,-0.12891 0.13281,-0.0937 0.28125,-0.25 0.15234,-0.15625 0.33984,-0.39453 v -2.60156 h 0.67969 z m 4.40625,-0.0547 q -0.23047,0.0586 -0.47656,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 h -1.09766 v -0.57031 h 1.09766 v -1.07812 l 0.67968,-0.17579 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42188 0.22266,0.63281 0.22656,0.20703 0.66406,0.20703 0.1875,0 0.41016,-0.0273 0.22265,-0.0312 0.46484,-0.0937 z"
+       id="path8" />
+    <path
+       style="fill:#000000;stroke-width:0.731309"
+       d="m 455.71548,165.54932 q -0.53515,-0.11328 -0.92187,-0.11328 -0.91797,0 -0.91797,0.96093 v 0.6875 h 1.71875 v 0.56641 h -1.71875 v 2.78516 h -0.69141 v -2.78516 h -1.26171 v -0.56641 h 1.26171 v -0.64843 q 0,-1.56641 1.63282,-1.56641 0.40625,0 0.89843,0.0937 z m -4.10546,0.96484 z m 6.35937,-1.03906 h -1.16016 v -0.5586 h 1.84766 v 4.95313 h 1.16797 v 0.56641 h -3.14453 v -0.56641 h 1.28906 z m 6.47656,2.96875 q 0,0.45703 -0.1289,0.83984 -0.12891,0.37891 -0.3711,0.65235 -0.24218,0.26953 -0.58984,0.42187 -0.34766,0.14844 -0.78906,0.14844 -0.42188,0 -0.75782,-0.12891 -0.33203,-0.13281 -0.5664,-0.38672 -0.23047,-0.2539 -0.35547,-0.6289 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45704 0.1289,-0.83204 0.12891,-0.3789 0.3711,-0.64843 0.24218,-0.27344 0.58984,-0.42188 0.34766,-0.15234 0.78906,-0.15234 0.42188,0 0.75391,0.13281 0.33594,0.12891 0.5664,0.38281 0.23438,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69531,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22656,-0.45313 -0.14844,-0.18359 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30469,0 -0.52344,0.1211 -0.21484,0.11718 -0.35547,0.3164 -0.13672,0.19922 -0.20312,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27343 0.23047,0.45703 0.14844,0.17969 0.35938,0.27344 0.21093,0.0898 0.47656,0.0898 0.30469,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14062,-0.19922 0.20312,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z m 5.03125,-0.0703 q 0,0.52343 -0.14844,0.91406 -0.14453,0.39062 -0.40234,0.64844 -0.25781,0.25781 -0.60938,0.38671 -0.35156,0.12891 -0.76171,0.12891 -0.1875,0 -0.375,-0.0195 -0.1836,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29296,-0.40234 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33593,0 0.58984,0.14062 0.25391,0.14063 0.42578,0.39844 0.17188,0.25391 0.25781,0.61719 0.0859,0.35937 0.0859,0.80469 z m -0.69531,0.0312 q 0,-0.3086 -0.0469,-0.56641 -0.043,-0.25781 -0.14062,-0.44141 -0.0977,-0.18359 -0.25,-0.28515 -0.15235,-0.10547 -0.36328,-0.10547 -0.12891,0 -0.26172,0.043 -0.13281,0.0391 -0.27735,0.13672 -0.14062,0.0937 -0.30078,0.2539 -0.15625,0.15625 -0.33593,0.39063 v 1.90234 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.37109 0.3125,-0.375 0.3125,-1.125 z"
+       id="path9" />
+  </g>
+  <path
+     style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+     d="m 253.89841,86.793497 q -0.36322,0.138874 -0.7478,0.202977 -0.37924,0.06946 -0.7852,0.06946 -1.27126,0 -1.96031,-0.689052 -0.6837,-0.689038 -0.6837,-2.013718 0,-0.635641 0.19763,-1.153752 0.19764,-0.518127 0.55551,-0.886684 0.35788,-0.368558 0.85463,-0.56619 0.49677,-0.202979 1.095,-0.202979 0.41663,0 0.77986,0.0588 0.36321,0.0588 0.69438,0.192285 v 0.886684 q -0.3472,-0.181606 -0.71041,-0.261722 -0.35788,-0.08547 -0.74246,-0.08547 -0.35788,0 -0.67836,0.138874 -0.31515,0.133459 -0.55551,0.389917 -0.24036,0.256389 -0.37925,0.624961 -0.13888,0.368558 -0.13888,0.83326 0,0.972147 0.47005,1.45822 0.4754,0.480727 1.314,0.480727 0.37923,0 0.73177,-0.08547 0.35788,-0.08547 0.68905,-0.25639 z m 3.67491,-6.585998 h -1.58641 v -0.763836 h 2.52651 v 6.772964 h 1.59709 v 0.774501 h -4.29986 v -0.774501 h 1.76267 z m 8.71725,3.819123 q 0,0.197646 -0.005,0.331174 -0.005,0.133596 -0.016,0.251057 h -3.76573 q 0,0.822579 0.45937,1.265921 0.45936,0.437995 1.32468,0.437995 0.23502,0 0.47005,-0.016 0.23501,-0.02133 0.45402,-0.05347 0.21899,-0.032 0.41664,-0.06946 0.20296,-0.04266 0.37389,-0.09079 v 0.763822 q -0.37924,0.106796 -0.85996,0.170927 -0.4754,0.06946 -0.98818,0.06946 -0.68905,0 -1.18581,-0.186952 -0.49675,-0.186952 -0.81723,-0.539485 -0.31515,-0.357879 -0.47004,-0.870657 -0.14958,-0.518127 -0.14958,-1.169779 0,-0.56619 0.16026,-1.06829 0.16557,-0.507446 0.47539,-0.886684 0.31513,-0.384584 0.76916,-0.608921 0.45402,-0.224339 1.0309,-0.224339 0.56085,0 0.9935,0.17626 0.43266,0.176273 0.72644,0.502099 0.29912,0.32048 0.44869,0.785195 0.1549,0.459368 0.1549,1.030892 z m -0.9668,-0.133459 q 0.016,-0.357879 -0.0695,-0.651653 -0.0854,-0.299122 -0.26707,-0.512779 -0.17627,-0.213658 -0.44334,-0.331174 -0.26708,-0.12293 -0.61961,-0.12293 -0.30446,0 -0.55551,0.117461 -0.25104,0.11746 -0.43265,0.331173 -0.18162,0.213658 -0.29379,0.51278 -0.11213,0.29912 -0.13887,0.656999 z m 5.89696,3.098033 -0.0214,-0.72109 q -0.43799,0.432662 -0.89201,0.624948 -0.44867,0.192299 -0.94544,0.192299 -0.45935,0 -0.78518,-0.117461 -0.32585,-0.117461 -0.5395,-0.320494 -0.20832,-0.20831 -0.3098,-0.486073 -0.0961,-0.277749 -0.0961,-0.603575 0,-0.806568 0.59824,-1.260589 0.60359,-0.459354 1.7787,-0.459354 h 1.11102 v -0.470048 q 0,-0.475394 -0.30447,-0.758489 -0.30445,-0.288442 -0.92939,-0.288442 -0.45402,0 -0.89737,0.101463 -0.43801,0.101462 -0.90806,0.288441 v -0.838606 q 0.17628,-0.06414 0.38994,-0.122793 0.219,-0.06414 0.45936,-0.112128 0.24037,-0.04813 0.50211,-0.0748 0.26171,-0.032 0.52878,-0.032 0.48608,0 0.87601,0.106795 0.38993,0.106795 0.657,0.325826 0.27242,0.219005 0.41664,0.550178 0.1442,0.33116 0.1442,0.779848 v 3.696276 z m -0.10146,-2.441033 h -1.18046 q -0.3472,0 -0.59825,0.06946 -0.25103,0.06946 -0.41129,0.197632 -0.16024,0.128126 -0.24036,0.309801 -0.0748,0.176272 -0.0748,0.400611 0,0.154899 0.0481,0.299121 0.0481,0.138874 0.1549,0.251042 0.1068,0.106795 0.27774,0.170927 0.17094,0.06413 0.41665,0.06413 0.32047,0 0.73178,-0.192299 0.41662,-0.197632 0.87599,-0.619601 z m 2.88972,-2.921774 h 0.8493 l 0.0266,0.98816 q 0.47538,-0.571523 0.93475,-0.827913 0.4647,-0.25639 0.93475,-0.25639 0.83327,0 1.26058,0.539485 0.43267,0.539484 0.40062,1.602427 h -0.94009 q 0.016,-0.705064 -0.20834,-1.020211 -0.21898,-0.320493 -0.6463,-0.320493 -0.18695,0 -0.37925,0.06946 -0.18694,0.06414 -0.38992,0.213657 -0.19763,0.144221 -0.42198,0.373906 -0.22433,0.229683 -0.48072,0.55551 v 3.445233 h -0.9401 z"
+     id="text2-54-4"
+     aria-label="clear" />
+  <rect
+     style="fill:#6f6f6f;stroke:none;stroke-width:1.015;stroke-dasharray:4.06, 4.06;fill-opacity:0.08994709"
+     id="rect17"
+     width="150"
+     height="58.5"
+     x="545.5"
+     y="212.5" />
+  <g
+     id="text2-54-8-5"
+     style="font-size:12.8119px;font-family:consolas;-inkscape-font-specification:consolas;text-align:center;text-anchor:middle;stroke-width:1.2655"
+     transform="scale(0.99918987,1.0008108)"
+     aria-label="prim_intr_hw #(&#10;  .IntrT (&quot;Event&quot;)&#10;)&#10;">
+    <path
+       style="fill:#000000"
+       d="m 561.318,225.38408 q 0,0.83828 -0.23772,1.46386 -0.23147,0.62558 -0.64435,1.03846 -0.41288,0.41289 -0.97591,0.61933 -0.56302,0.20644 -1.21988,0.20644 -0.30028,0 -0.60056,-0.0313 -0.29402,-0.0313 -0.60055,-0.10635 v 2.62744 h -1.08852 v -8.84571 h 0.96966 l 0.0688,1.05097 q 0.46919,-0.64435 1.00093,-0.90083 0.53174,-0.26275 1.15107,-0.26275 0.538,0 0.94463,0.22521 0.40662,0.22521 0.68188,0.63809 0.27525,0.40663 0.41288,0.98842 0.13763,0.57554 0.13763,1.2887 z m -1.11353,0.05 q 0,-0.49421 -0.0751,-0.9071 -0.0688,-0.41288 -0.22521,-0.7069 -0.1564,-0.29403 -0.40037,-0.45668 -0.24398,-0.16891 -0.5818,-0.16891 -0.20644,0 -0.41913,0.0688 -0.2127,0.0626 -0.44417,0.21895 -0.22521,0.15014 -0.48169,0.40663 -0.25024,0.25023 -0.538,0.62558 v 3.04658 q 0.30027,0.12512 0.63183,0.20019 0.33156,0.0688 0.65061,0.0688 0.88207,0 1.38253,-0.5943 0.50047,-0.60056 0.50047,-1.80167 z m 3.04658,-3.07786 h 0.99467 l 0.0313,1.15732 q 0.55677,-0.66937 1.09477,-0.96965 0.54425,-0.30028 1.09476,-0.30028 0.97591,0 1.47637,0.63184 0.50672,0.63184 0.46919,1.87674 h -1.10102 q 0.0188,-0.82577 -0.24398,-1.19486 -0.25649,-0.37535 -0.75695,-0.37535 -0.21896,0 -0.44417,0.0813 -0.21895,0.0751 -0.45667,0.25023 -0.23146,0.16891 -0.49421,0.43791 -0.26274,0.269 -0.56302,0.6506 v 4.035 h -1.10102 z m 8.92704,0.90083 h -1.85798 v -0.90083 h 2.959 v 5.37374 h 1.87049 v 0.90709 h -5.03593 v -0.90709 h 2.06442 z m 0.3816,-3.53453 q 0.18142,0 0.33782,0.0688 0.15639,0.0626 0.269,0.18142 0.11886,0.11886 0.18141,0.27526 0.0688,0.15014 0.0688,0.33156 0,0.17516 -0.0688,0.33155 -0.0626,0.1564 -0.18141,0.27526 -0.11261,0.11886 -0.269,0.18767 -0.1564,0.0626 -0.33782,0.0626 -0.18142,0 -0.33781,-0.0626 -0.1564,-0.0688 -0.27526,-0.18767 -0.1126,-0.11886 -0.18142,-0.27526 -0.0626,-0.15639 -0.0626,-0.33155 0,-0.18142 0.0626,-0.33156 0.0688,-0.1564 0.18142,-0.27526 0.11886,-0.11886 0.27526,-0.18142 0.15639,-0.0688 0.33781,-0.0688 z m 9.00211,8.91453 v -4.51044 q 0,-0.29402 -0.025,-0.4817 -0.0188,-0.18767 -0.0688,-0.29402 -0.0438,-0.1126 -0.11886,-0.1564 -0.0688,-0.0438 -0.17517,-0.0438 -0.12511,0 -0.23146,0.0751 -0.10635,0.0751 -0.23147,0.24398 -0.11886,0.16891 -0.269,0.45042 -0.14388,0.27525 -0.34407,0.68188 v 4.035 h -0.99467 v -4.39158 q 0,-0.34407 -0.025,-0.55677 -0.0188,-0.21269 -0.0688,-0.33155 -0.0438,-0.11886 -0.11886,-0.16266 -0.0751,-0.0438 -0.18142,-0.0438 -0.1126,0 -0.21269,0.0626 -0.1001,0.0626 -0.22521,0.22521 -0.11886,0.16265 -0.269,0.44416 -0.15014,0.28152 -0.35658,0.71942 v 4.035 h -1.00093 v -6.28083 h 0.83202 l 0.05,1.19486 q 0.16266,-0.35659 0.3128,-0.60682 0.15639,-0.25023 0.31904,-0.40037 0.16265,-0.15639 0.34407,-0.22521 0.18768,-0.0751 0.41288,-0.0751 0.50673,0 0.76947,0.33156 0.26274,0.33156 0.26274,1.02595 0.15014,-0.3253 0.29403,-0.57553 0.14388,-0.25649 0.30653,-0.4254 0.16891,-0.17516 0.36909,-0.26274 0.20019,-0.0938 0.46293,-0.0938 1.18235,0 1.18235,1.82044 v 4.573 z m 8.608,2.56488 h -7.04404 v -0.90083 h 7.04404 z m 3.14042,-7.94488 h -1.85798 v -0.90083 h 2.959 v 5.37374 h 1.87049 v 0.90709 h -5.03593 v -0.90709 h 2.06442 z m 0.3816,-3.53453 q 0.18142,0 0.33781,0.0688 0.1564,0.0626 0.269,0.18142 0.11887,0.11886 0.18142,0.27526 0.0688,0.15014 0.0688,0.33156 0,0.17516 -0.0688,0.33155 -0.0625,0.1564 -0.18142,0.27526 -0.1126,0.11886 -0.269,0.18767 -0.15639,0.0626 -0.33781,0.0626 -0.18142,0 -0.33781,-0.0626 -0.1564,-0.0688 -0.27526,-0.18767 -0.1126,-0.11886 -0.18142,-0.27526 -0.0625,-0.15639 -0.0625,-0.33155 0,-0.18142 0.0625,-0.33156 0.0688,-0.1564 0.18142,-0.27526 0.11886,-0.11886 0.27526,-0.18142 0.15639,-0.0688 0.33781,-0.0688 z m 4.52295,2.6337 h 0.96965 l 0.0438,1.01344 q 0.27526,-0.3253 0.53175,-0.538 0.25648,-0.21896 0.50046,-0.35033 0.25023,-0.13137 0.50672,-0.18142 0.25649,-0.0563 0.53174,-0.0563 0.96966,0 1.46386,0.57554 0.50047,0.56928 0.50047,1.72034 v 4.09756 h -1.08851 v -4.00997 q 0,-0.73819 -0.27526,-1.08852 -0.27525,-0.35658 -0.81951,-0.35658 -0.20018,0 -0.39411,0.0626 -0.18768,0.0563 -0.39412,0.20644 -0.20644,0.14389 -0.45042,0.39412 -0.23772,0.25023 -0.538,0.62558 v 4.16637 h -1.08851 z m 12.10499,6.19325 q -0.36909,0.0938 -0.76321,0.13137 -0.39411,0.0438 -0.80074,0.0438 -1.18235,0 -1.76414,-0.53174 -0.58179,-0.538 -0.58179,-1.64528 v -3.27805 H 604.652 v -0.91334 h 1.75788 v -1.72661 l 1.08851,-0.28151 v 2.00812 h 2.82137 v 0.91334 h -2.82137 v 3.19047 q 0,0.67563 0.35658,1.01344 0.36284,0.33156 1.06349,0.33156 0.30028,0 0.65686,-0.0438 0.35658,-0.05 0.74444,-0.15014 z m 2.23958,-6.19325 h 0.99468 l 0.0313,1.15732 q 0.55676,-0.66937 1.09476,-0.96965 0.54426,-0.30028 1.09477,-0.30028 0.97591,0 1.47637,0.63184 0.50672,0.63184 0.46919,1.87674 h -1.10103 q 0.0188,-0.82577 -0.24397,-1.19486 -0.25649,-0.37535 -0.75696,-0.37535 -0.21895,0 -0.44416,0.0813 -0.21895,0.0751 -0.45667,0.25023 -0.23147,0.16891 -0.49421,0.43791 -0.26274,0.269 -0.56302,0.6506 v 4.035 h -1.10103 z m 12.83067,8.84571 h -7.04404 v -0.90083 h 7.04404 z m 6.04937,-2.56488 h -1.08851 v -4.00997 q 0,-0.72568 -0.27525,-1.08226 -0.269,-0.36284 -0.77572,-0.36284 -0.21896,0 -0.41289,0.0626 -0.18767,0.0563 -0.39411,0.20644 -0.20645,0.14389 -0.45042,0.39412 -0.24398,0.25023 -0.56302,0.62558 v 4.16637 h -1.08852 v -8.83946 h 1.08852 v 2.55863 l -0.0375,0.98841 q 0.25649,-0.30653 0.50047,-0.51297 0.25023,-0.2127 0.4942,-0.34407 0.25024,-0.13137 0.50673,-0.18768 0.25648,-0.0563 0.53174,-0.0563 0.93837,0 1.45135,0.57554 0.51297,0.56928 0.51297,1.72034 z m 7.81351,-6.28083 -0.91335,6.28083 h -1.31998 l -0.90709,-2.62744 -0.18142,-0.63809 -0.20644,0.67562 -0.86956,2.58991 h -1.28244 l -0.90709,-6.28083 h 1.06348 l 0.52549,4.26646 0.11261,0.95088 0.269,-0.83202 0.91335,-2.82137 h 0.78197 l 0.98216,2.78383 0.28152,0.83203 0.0938,-0.88207 0.48796,-4.29774 z m 13.71274,3.98495 h -1.39505 l -0.23147,2.29588 h -0.92586 l 0.23147,-2.29588 h -1.59523 l -0.23147,2.29588 h -0.92586 l 0.23147,-2.29588 h -1.33249 v -0.81326 h 1.41381 l 0.22521,-2.18953 h -1.31997 v -0.81326 h 1.4013 l 0.2127,-2.06441 h 0.91334 l -0.20644,2.06441 h 1.60149 l 0.2127,-2.06441 h 0.92586 l -0.21896,2.06441 h 1.345 v 0.81326 h -1.42632 l -0.21895,2.18953 h 1.31372 z m -2.23333,-0.81326 0.21895,-2.18953 h -1.60148 l -0.21896,2.18953 z m 7.59455,5.73658 q -2.88393,-2.67123 -2.88393,-5.90548 0,-0.75696 0.15014,-1.50765 0.1564,-0.75696 0.49421,-1.51391 0.34407,-0.75695 0.90084,-1.51391 0.56302,-0.75695 1.36376,-1.50139 l 0.63184,0.64435 q -2.42726,2.39597 -2.42726,5.31118 0,1.45135 0.61307,2.79009 0.61307,1.33874 1.81419,2.52735 z"
+       id="path21" />
+    <path
+       style="fill:#000000"
+       d="m 572.50965,242.6814 q 0.21269,0 0.40037,0.0813 0.19393,0.0813 0.33155,0.22521 0.14389,0.14388 0.22521,0.33781 0.0813,0.18768 0.0813,0.40663 0,0.2127 -0.0813,0.40037 -0.0813,0.18768 -0.22521,0.33156 -0.13762,0.13763 -0.33155,0.21895 -0.18768,0.0813 -0.40037,0.0813 -0.21896,0 -0.40663,-0.0813 -0.18768,-0.0813 -0.33156,-0.21895 -0.13763,-0.14388 -0.21895,-0.33156 -0.0813,-0.18767 -0.0813,-0.40037 0,-0.21895 0.0813,-0.40663 0.0813,-0.19393 0.21895,-0.33781 0.14388,-0.14388 0.33156,-0.22521 0.18767,-0.0813 0.40663,-0.0813 z m 6.53106,-5.2674 h -1.883 v -0.93837 h 4.89205 v 0.93837 h -1.883 v 6.28709 h 1.883 v 0.95089 h -4.89205 v -0.95089 h 1.883 z m 5.08598,0.95714 h 0.96965 l 0.0438,1.01344 q 0.27525,-0.3253 0.53174,-0.538 0.25649,-0.21895 0.50047,-0.35032 0.25023,-0.13137 0.50672,-0.18142 0.25648,-0.0563 0.53174,-0.0563 0.96965,0 1.46386,0.57553 0.50046,0.56928 0.50046,1.72035 v 4.09756 h -1.08851 V 240.642 q 0,-0.73818 -0.27525,-1.08851 -0.27526,-0.35658 -0.81951,-0.35658 -0.20019,0 -0.39412,0.0626 -0.18767,0.0563 -0.39412,0.20644 -0.20644,0.14388 -0.45041,0.39411 -0.23773,0.25024 -0.538,0.62559 v 4.16637 h -1.08851 z m 12.10499,6.19325 q -0.36909,0.0938 -0.76321,0.13138 -0.39411,0.0438 -0.80074,0.0438 -1.18235,0 -1.76414,-0.53175 -0.58179,-0.538 -0.58179,-1.64528 v -3.27804 h -1.75788 v -0.91335 h 1.75788 v -1.7266 l 1.08851,-0.28151 v 2.00811 h 2.82137 v 0.91335 h -2.82137 v 3.19046 q 0,0.67563 0.35658,1.01344 0.36284,0.33156 1.06349,0.33156 0.30028,0 0.65686,-0.0438 0.35658,-0.05 0.74444,-0.15014 z m 2.23958,-6.19325 h 0.99467 l 0.0313,1.15733 q 0.55677,-0.66938 1.09477,-0.96965 0.54425,-0.30028 1.09477,-0.30028 0.9759,0 1.47637,0.63183 0.50672,0.63184 0.46918,1.87675 h -1.10102 q 0.0188,-0.82577 -0.24398,-1.19486 -0.25649,-0.37535 -0.75695,-0.37535 -0.21895,0 -0.44416,0.0813 -0.21896,0.0751 -0.45668,0.25024 -0.23146,0.1689 -0.49421,0.4379 -0.26274,0.269 -0.56302,0.65061 v 4.035 h -1.10102 z m 12.29266,-0.94463 h -2.42099 v 7.22547 h -1.12605 v -7.22547 h -2.421 v -0.95088 h 5.96804 z m 12.34272,9.85291 q -2.88393,-2.67124 -2.88393,-5.90549 0,-0.75695 0.15014,-1.50765 0.1564,-0.75695 0.49421,-1.51391 0.34407,-0.75695 0.90084,-1.5139 0.56302,-0.75696 1.36377,-1.5014 l 0.63183,0.64435 q -2.42725,2.39598 -2.42725,5.31119 0,1.45134 0.61307,2.79009 0.61307,1.33874 1.81418,2.52734 z m 5.27991,-11.46691 -0.17516,2.93398 h -1.02596 l -0.18142,-2.93398 z m 2.43351,0 -0.17516,2.93398 h -1.02596 l -0.18142,-2.93398 z m 7.51948,8.83947 h -4.64807 v -8.17635 h 4.64807 V 237.414 H 634.805 v 2.53361 h 3.39691 v 0.93837 H 634.805 v 2.81511 h 3.53454 z m 1.55144,-6.28084 h 1.23865 l 1.53893,4.15386 0.33156,1.01344 0.34407,-1.03846 1.52641,-4.12884 h 1.19486 l -2.46478,6.28084 h -1.25117 z M 652.828,241.18 q 0,0.23147 -0.006,0.38786 -0.006,0.1564 -0.0188,0.29402 h -4.41034 q 0,0.9634 0.538,1.48263 0.538,0.51298 1.55144,0.51298 0.27525,0 0.55051,-0.0188 0.27526,-0.025 0.53174,-0.0626 0.25649,-0.0375 0.48796,-0.0813 0.23772,-0.05 0.4379,-0.10635 v 0.89458 q -0.44416,0.12511 -1.00718,0.20018 -0.55677,0.0813 -1.15733,0.0813 -0.807,0 -1.38879,-0.21895 -0.58179,-0.21896 -0.95714,-0.63184 -0.36909,-0.41914 -0.55051,-1.0197 -0.17516,-0.60681 -0.17516,-1.37002 0,-0.66312 0.18767,-1.25116 0.19393,-0.5943 0.55677,-1.03847 0.36909,-0.45041 0.90084,-0.71316 0.53174,-0.26274 1.20737,-0.26274 0.65686,0 1.16358,0.20644 0.50672,0.20644 0.85079,0.58804 0.35033,0.37535 0.52549,0.91961 0.18142,0.538 0.18142,1.20737 z m -1.1323,-0.15639 q 0.0188,-0.41914 -0.0813,-0.76321 -0.10009,-0.35033 -0.31279,-0.60056 -0.20644,-0.25023 -0.51923,-0.38786 -0.31279,-0.14389 -0.72568,-0.14389 -0.35658,0 -0.6506,0.13763 -0.29402,0.13763 -0.50672,0.38786 -0.2127,0.25024 -0.34407,0.60056 -0.13137,0.35033 -0.16265,0.76947 z m 2.87141,-2.65247 h 0.96965 l 0.0438,1.01344 q 0.27525,-0.3253 0.53174,-0.538 0.25649,-0.21895 0.50047,-0.35032 0.25023,-0.13137 0.50672,-0.18142 0.25649,-0.0563 0.53174,-0.0563 0.96965,0 1.46386,0.57553 0.50047,0.56928 0.50047,1.72035 v 4.09756 h -1.08851 V 240.642 q 0,-0.73818 -0.27526,-1.08851 -0.27526,-0.35658 -0.81951,-0.35658 -0.20019,0 -0.39412,0.0626 -0.18767,0.0563 -0.39411,0.20644 -0.20645,0.14388 -0.45042,0.39411 -0.23772,0.25024 -0.538,0.62559 v 4.16637 h -1.08851 z m 12.10499,6.19325 q -0.36909,0.0938 -0.76321,0.13138 -0.39411,0.0438 -0.80074,0.0438 -1.18235,0 -1.76414,-0.53175 -0.58179,-0.538 -0.58179,-1.64528 v -3.27804 h -1.75788 v -0.91335 h 1.75788 v -1.7266 l 1.08851,-0.28151 v 2.00811 h 2.82137 v 0.91335 h -2.82137 v 3.19046 q 0,0.67563 0.35658,1.01344 0.36284,0.33156 1.06349,0.33156 0.30028,0 0.65686,-0.0438 0.35658,-0.05 0.74444,-0.15014 z m 3.9787,-8.75188 -0.17516,2.93398 h -1.02596 l -0.18141,-2.93398 z m 2.43351,0 -0.17516,2.93398 h -1.02596 l -0.18141,-2.93398 z m 3.89737,-0.47544 q 2.88393,2.67123 2.88393,5.94302 0,0.67563 -0.13763,1.40131 -0.13763,0.72567 -0.46918,1.48888 -0.33156,0.75695 -0.89458,1.53893 -0.55677,0.78197 -1.40756,1.57021 l -0.63184,-0.64435 q 1.21988,-1.20737 1.82044,-2.52109 0.60056,-1.31372 0.60056,-2.75256 0,-2.97777 -2.421,-5.35497 z"
+       id="path22" />
+    <path
+       style="fill:#000000"
+       d="m 557.23296,251.35195 q 2.88392,2.67123 2.88392,5.94302 0,0.67563 -0.13762,1.4013 -0.13763,0.72567 -0.46919,1.48888 -0.33156,0.75696 -0.89458,1.53893 -0.55677,0.78198 -1.40756,1.57021 l -0.63183,-0.64435 q 1.21988,-1.20737 1.82044,-2.52109 0.60055,-1.31372 0.60055,-2.75256 0,-2.97776 -2.42099,-5.35497 z"
+       id="path23" />
+  </g>
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 123.80796,82.116989 c 50.40691,-0.09951 57.53362,24.442131 57.53362,24.442131 0,0 -8.66763,24.41786 -57.53362,24.20936 9.78263,-14.89806 8.38512,-35.615688 0,-48.651491 z"
+     id="path2"
+     sodipodi:nodetypes="cccc" />
+</svg>

--- a/doc/contributing/hw/comportability/ot_interrupt_arch.svg
+++ b/doc/contributing/hw/comportability/ot_interrupt_arch.svg
@@ -1,0 +1,1958 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 695.90118 237.99603"
+   fill="none"
+   stroke="none"
+   stroke-linecap="square"
+   stroke-miterlimit="10"
+   id="svg143"
+   sodipodi:docname="ot_interrupt_arch.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   width="695.90118"
+   height="237.99603"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs143">
+    <marker
+       style="overflow:visible"
+       id="ArrowWideRounded_Fnone_S-000000"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="Wide, rounded arrow"
+       markerWidth="1"
+       markerHeight="1"
+       viewBox="0 0 1 1"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round"
+         d="M 3,-3 0,0 3,3"
+         transform="rotate(180,0.125,0)"
+         sodipodi:nodetypes="ccc"
+         id="path1" />
+    </marker>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <g
+         id="g145">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path144" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <g
+         id="g146">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path145" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <g
+         id="g148">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path147" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <g
+         id="g149">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path148" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <g
+         id="g150">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path149" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <g
+         id="g151">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path150" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <g
+         id="g152">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path151" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <g
+         id="g153">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path152" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <g
+         id="g154">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path153" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <g
+         id="g155">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path154" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <g
+         id="g156">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path155" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <g
+         id="g157">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path156" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <g
+         id="g158">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path157" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath158">
+      <g
+         id="g159">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path158" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath159">
+      <g
+         id="g160">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path159" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath160">
+      <g
+         id="g161">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path160" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath161">
+      <g
+         id="g162">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path161" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath162">
+      <g
+         id="g163">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path162" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath163">
+      <g
+         id="g164">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path163" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath164">
+      <g
+         id="g165">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path164" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath165">
+      <g
+         id="g166">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path165" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath166">
+      <g
+         id="g167">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path166" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath167">
+      <g
+         id="g168">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path167" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath168">
+      <g
+         id="g169">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path168" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath169">
+      <g
+         id="g170">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path169" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath170">
+      <g
+         id="g171">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path170" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath171">
+      <g
+         id="g172">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path171" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath172">
+      <g
+         id="g173">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path172" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath173">
+      <g
+         id="g174">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path173" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath174">
+      <g
+         id="g175">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path174" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath175">
+      <g
+         id="g176">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path175" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath176">
+      <g
+         id="g177">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path176" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath177">
+      <g
+         id="g178">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path177" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath178">
+      <g
+         id="g179">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path178" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath179">
+      <g
+         id="g180">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path179" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath180">
+      <g
+         id="g181">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path180" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath181">
+      <g
+         id="g182">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path181" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath182">
+      <g
+         id="g183">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path182" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath183">
+      <g
+         id="g184">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path183" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath184">
+      <g
+         id="g185">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path184" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath185">
+      <g
+         id="g186">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path185" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath186">
+      <g
+         id="g187">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path186" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath187">
+      <g
+         id="g188">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path187" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath188">
+      <g
+         id="g189">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path188" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath189">
+      <g
+         id="g190">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path189" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath190">
+      <g
+         id="g191">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path190" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath191">
+      <g
+         id="g192">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path191" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath192">
+      <g
+         id="g193">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path192" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath193">
+      <g
+         id="g194">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path193" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <g
+         id="g195">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path194" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath195">
+      <g
+         id="g196">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path195" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath196">
+      <g
+         id="g197">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path196" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath197">
+      <g
+         id="g198">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path197" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath198">
+      <g
+         id="g199">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path198" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath199">
+      <g
+         id="g200">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path199" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath200">
+      <g
+         id="g201">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path200" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath201">
+      <g
+         id="g202">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path201" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <g
+         id="g203">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path202" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath203">
+      <g
+         id="g204">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path203" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath204">
+      <g
+         id="g205">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path204" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath205">
+      <g
+         id="g206">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path205" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath206">
+      <g
+         id="g207">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path206" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath207">
+      <g
+         id="g208">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path207" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath208">
+      <g
+         id="g209">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path208" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath209">
+      <g
+         id="g210">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path209" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath210">
+      <g
+         id="g211">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path210" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath211">
+      <g
+         id="g212">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path211" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath212">
+      <g
+         id="g213">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path212" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath213">
+      <g
+         id="g214">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path213" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath214">
+      <g
+         id="g215">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path214" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath215">
+      <g
+         id="g216">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path215" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath216">
+      <g
+         id="g217">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path216" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath217">
+      <g
+         id="g218">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path217" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath218">
+      <g
+         id="g219">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path218" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath219">
+      <g
+         id="g220">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path219" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath220">
+      <g
+         id="g221">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path220" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath221">
+      <g
+         id="g222">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path221" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath222">
+      <g
+         id="g223">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path222" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath223">
+      <g
+         id="g224">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path223" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath224">
+      <g
+         id="g225">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path224" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath225">
+      <g
+         id="g226">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path225" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath226">
+      <g
+         id="g227">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path226" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath227">
+      <g
+         id="g228">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path227" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath228">
+      <g
+         id="g229">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path228" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath229">
+      <g
+         id="g230">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path229" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath230">
+      <g
+         id="g231">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path230" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath231">
+      <g
+         id="g232">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path231" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath232">
+      <g
+         id="g233">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path232" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath233">
+      <g
+         id="g234">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path233" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath234">
+      <g
+         id="g235">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path234" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath235">
+      <g
+         id="g236">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path235" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath236">
+      <g
+         id="g237">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path236" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath237">
+      <g
+         id="g238">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path237" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath238">
+      <g
+         id="g239">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path238" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath239">
+      <g
+         id="g240">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path239" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath240">
+      <g
+         id="g241">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path240" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath241">
+      <g
+         id="g242">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path241" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath242">
+      <g
+         id="g243">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path242" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath243">
+      <g
+         id="g244">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path243" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath244">
+      <g
+         id="g245">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path244" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath245">
+      <g
+         id="g246">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path245" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath246">
+      <g
+         id="g247">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path246" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath247">
+      <g
+         id="g248">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path247" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath248">
+      <g
+         id="g249">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path248" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath249">
+      <g
+         id="g250">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path249" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath250">
+      <g
+         id="g251">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path250" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath251">
+      <g
+         id="g252">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path251" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath252">
+      <g
+         id="g253">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path252" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath253">
+      <g
+         id="g254">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path253" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath254">
+      <g
+         id="g255">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path254" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath255">
+      <g
+         id="g256">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path255" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath256">
+      <g
+         id="g257">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path256" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath257">
+      <g
+         id="g258">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path257" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath258">
+      <g
+         id="g259">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path258" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath259">
+      <g
+         id="g260">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path259" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath260">
+      <g
+         id="g261">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path260" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath261">
+      <g
+         id="g262">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path261" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath262">
+      <g
+         id="g263">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path262" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath263">
+      <g
+         id="g264">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path263" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath264">
+      <g
+         id="g265">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path264" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath265">
+      <g
+         id="g266">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path265" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath266">
+      <g
+         id="g267">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path266" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath267">
+      <g
+         id="g268">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path267" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath268">
+      <g
+         id="g269">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path268" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath269">
+      <g
+         id="g270">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path269" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath270">
+      <g
+         id="g271">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path270" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath271">
+      <g
+         id="g272">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path271" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath272">
+      <g
+         id="g273">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path272" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath273">
+      <g
+         id="g274">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path273" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath274">
+      <g
+         id="g275">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path274" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath275">
+      <g
+         id="g276">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path275" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath276">
+      <g
+         id="g277">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path276" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath277">
+      <g
+         id="g278">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path277" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath278">
+      <g
+         id="g279">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path278" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath279">
+      <g
+         id="g280">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path279" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath280">
+      <g
+         id="g281">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path280" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath281">
+      <g
+         id="g282">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path281" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath282">
+      <g
+         id="g283">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path282" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath283">
+      <g
+         id="g284">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path283" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath284">
+      <g
+         id="g285">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path284" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath285">
+      <g
+         id="g286">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path285" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview143"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="1.2186808"
+     inkscape:cx="341.3527"
+     inkscape:cy="102.9802"
+     inkscape:window-width="1728"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg143">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.99999999"
+       spacingy="0.99999999"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="true" />
+  </sodipodi:namedview>
+  <g
+     id="g2"
+     transform="matrix(1.3831018,0,0,1.5224314,-49.248677,-511.12423)"
+     style="fill:#dfa8b9;fill-opacity:1;stroke:#000000;stroke-width:0.699472;stroke-dasharray:none;stroke-opacity:1">
+    <rect
+       style="opacity:1;fill:#dfa8b9;fill-opacity:1;stroke:#000000;stroke-width:0.699472;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect286-3"
+       width="82.52655"
+       height="73.611923"
+       x="455.87643"
+       y="336.07864"
+       rx="0"
+       ry="0" />
+  </g>
+  <g
+     id="g2-9"
+     transform="matrix(1.3831018,0,0,1.5224314,-361.84075,-476.77444)"
+     style="fill:#dfa8b9;fill-opacity:1;stroke:#000000;stroke-width:0.699472;stroke-dasharray:none;stroke-opacity:1">
+    <rect
+       style="opacity:1;fill:#dfa8b9;fill-opacity:1;stroke:#000000;stroke-width:0.699472;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect286-3-1"
+       width="120.4314"
+       height="49.956024"
+       x="440.1424"
+       y="349.85626"
+       rx="0"
+       ry="0" />
+  </g>
+  <g
+     id="g2-9-2"
+     transform="matrix(1.3831018,0,0,1.5224314,-612.23472,-507.90397)"
+     style="fill:#dfa8b9;fill-opacity:1;stroke:#000000;stroke-width:0.699472;stroke-dasharray:none;stroke-opacity:1">
+    <rect
+       style="opacity:1;fill:#dfa8b9;fill-opacity:1;stroke:#000000;stroke-width:0.699472;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect286-3-1-7"
+       width="83.241745"
+       height="118.32418"
+       x="443.00314"
+       y="334.51889"
+       rx="0"
+       ry="0" />
+  </g>
+  <g
+     id="g7"
+     style="display:none;stroke-width:0.790202"
+     inkscape:label="text"
+     transform="matrix(1.264986,0,0,1.2660116,-107.59699,-29.537846)" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 247.10247,95.52113 H 115.34443"
+     id="path35" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 412.88811,69.004974 H 591.44766"
+     id="path36"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.40005951"
+     d="m 413.28377,93.14656 h 100.1104 v 144.84948"
+     id="path37"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.40005951"
+     d="m 413.67944,99.478779 h 91.40567 V 237.99604"
+     id="path38"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.40005951"
+     d="m 413.67944,106.60252 h 83.88795 v 131.39352"
+     id="path39"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.40005951"
+     d="m 413.28377,113.72627 h 75.57888 v 124.26977"
+     id="path40"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="opacity:0.219886;fill:none;stroke:#000000;stroke-width:9.3;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:9.3, 9.3;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 639.68197,154.83148 0.27978,71.13361"
+     id="path41"
+     sodipodi:nodetypes="cc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.015;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect41"
+     width="36.401619"
+     height="53.823849"
+     x="591.33514"
+     y="51.19561" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 627.86742,68.287714 h 18.04585"
+     id="path42" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#ArrowWideRounded_Fnone_S-000000)"
+     d="M 598.91011,126.21607 V 105.78722"
+     id="path43" />
+  <g
+     id="g46"
+     style="display:none;stroke-width:0.893451"
+     transform="matrix(1.1191232,0,0,1.1193886,-52.419547,-55.264796)">
+    <text
+       xml:space="preserve"
+       style="font-size:8px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas"
+       x="517.47266"
+       y="221.8418"
+       id="text63"
+       transform="matrix(0.89355667,0,0,0.89334481,46.839836,49.370519)"><tspan
+         sodipodi:role="line"
+         id="tspan63"
+         x="517.47266"
+         y="221.8418"
+         style="font-size:8px;fill:#000000">to other</tspan><tspan
+         sodipodi:role="line"
+         x="517.47266"
+         y="231.8418"
+         style="font-size:8px;fill:#000000"
+         id="tspan64">peripherals...</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:16px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       x="581.5"
+       y="66.692406"
+       id="text33"><tspan
+         sodipodi:role="line"
+         id="tspan33"
+         x="581.5"
+         y="66.692406"
+         style="stroke-width:0.893451">periph_a</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       x="625.75"
+       y="112.50781"
+       id="text33-0"><tspan
+         sodipodi:role="line"
+         id="tspan33-9"
+         x="625.75"
+         y="112.50781"
+         style="font-size:8px;stroke-width:0.893451">hw_i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       x="537.125"
+       y="107.56641"
+       id="text33-0-3"><tspan
+         sodipodi:role="line"
+         id="tspan33-9-6"
+         x="537.125"
+         y="107.56641"
+         style="font-size:8px;stroke-width:0.893451">intr_o</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:16px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;stroke-width:0.893451"
+       x="323.50134"
+       y="116.00694"
+       id="text34"><tspan
+         sodipodi:role="line"
+         id="tspan34"
+         x="323.50134"
+         y="116.00694"
+         style="fill:#000000;stroke-width:0.893451">plic</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:16px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;stroke-width:0.893451"
+       x="84.145706"
+       y="64.346718"
+       id="text35"><tspan
+         sodipodi:role="line"
+         id="tspan35"
+         x="84.145706"
+         y="64.346718"
+         style="fill:#000000;stroke-width:0.893451">cpu</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       x="577.32812"
+       y="110.31641"
+       id="text33-0-3-0"><tspan
+         sodipodi:role="line"
+         id="tspan33-9-6-6"
+         x="577.32812"
+         y="110.31641"
+         style="font-size:8px;stroke-width:0.893451">prim</tspan><tspan
+         sodipodi:role="line"
+         x="577.32812"
+         y="120.31641"
+         style="font-size:8px;stroke-width:0.893451"
+         id="tspan42">intr</tspan><tspan
+         sodipodi:role="line"
+         x="577.32812"
+         y="130.31641"
+         style="font-size:8px;stroke-width:0.893451"
+         id="tspan43">hw</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;text-align:center;text-anchor:middle;fill:#000000;stroke-width:0.893451"
+       x="582.46747"
+       y="168.88531"
+       id="text33-0-3-0-2"><tspan
+         sodipodi:role="line"
+         x="582.46747"
+         y="168.88531"
+         style="font-size:8px;text-align:center;text-anchor:middle;stroke-width:0.893451"
+         id="tspan43-8">IntrT</tspan><tspan
+         sodipodi:role="line"
+         x="582.46747"
+         y="178.88531"
+         style="font-size:8px;text-align:center;text-anchor:middle;stroke-width:0.893451"
+         id="tspan45">(Event/Status)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;stroke-width:0.893451"
+       x="176.77669"
+       y="130.81413"
+       id="text46"><tspan
+         sodipodi:role="line"
+         id="tspan46"
+         x="176.77669"
+         y="130.81413"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;font-family:consolas;-inkscape-font-specification:'consolas Italic';fill:#000000;stroke-width:0.893451">level-triggered</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;stroke-width:0.893451"
+       x="438.79111"
+       y="107.03949"
+       id="text46-7"><tspan
+         sodipodi:role="line"
+         id="tspan46-9"
+         x="438.79111"
+         y="107.03949"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;font-family:consolas;-inkscape-font-specification:'consolas Italic';fill:#000000;stroke-width:0.893451">level-triggered</tspan></text>
+  </g>
+  <g
+     id="g58"
+     transform="matrix(1.1191232,0,0,1.1193886,-52.419547,-55.264796)"
+     style="stroke-width:0.893451">
+    <g
+       id="text63-2"
+       style="font-size:8px;font-family:consolas;-inkscape-font-specification:consolas"
+       aria-label="to other&#10;peripherals...">
+      <path
+         style="fill:#000000"
+         d="m 515.00293,242.78072 q -0.23047,0.0586 -0.47656,0.082 -0.2461,0.0273 -0.5,0.0273 -0.73828,0 -1.10157,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 h -1.09765 v -0.57031 h 1.09765 v -1.07813 l 0.67969,-0.17578 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42187 0.22266,0.63281 0.22656,0.20703 0.66406,0.20703 0.1875,0 0.41016,-0.0273 0.22265,-0.0312 0.46484,-0.0937 z m 4.65234,-1.9375 q 0,0.45703 -0.1289,0.83984 -0.12891,0.37891 -0.3711,0.65234 -0.24218,0.26953 -0.58984,0.42188 -0.34766,0.14844 -0.78906,0.14844 -0.42188,0 -0.75782,-0.12891 -0.33203,-0.13281 -0.5664,-0.38672 -0.23047,-0.25391 -0.35547,-0.62891 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45703 0.1289,-0.83203 0.12891,-0.3789 0.3711,-0.64844 0.24218,-0.27343 0.58984,-0.42187 0.34766,-0.15234 0.78906,-0.15234 0.42188,0 0.75391,0.13281 0.33594,0.1289 0.5664,0.38281 0.23438,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69531,0.0312 q 0,-0.36329 -0.082,-0.63282 -0.0781,-0.27343 -0.22656,-0.45312 -0.14844,-0.1836 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30469,0 -0.52344,0.12109 -0.21484,0.11719 -0.35547,0.31641 -0.13672,0.19922 -0.20312,0.46484 -0.0625,0.26172 -0.0625,0.55079 0,0.36328 0.0781,0.63671 0.082,0.27344 0.23047,0.45704 0.14844,0.17968 0.35938,0.27343 0.21093,0.0899 0.47656,0.0899 0.30469,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14062,-0.19922 0.20312,-0.46094 0.0664,-0.26563 0.0664,-0.55859 z m 9.49219,-0.0312 q 0,0.45703 -0.12891,0.83984 -0.1289,0.37891 -0.37109,0.65234 -0.24219,0.26953 -0.58985,0.42188 -0.34765,0.14844 -0.78906,0.14844 -0.42187,0 -0.75781,-0.12891 -0.33203,-0.13281 -0.56641,-0.38672 -0.23047,-0.25391 -0.35547,-0.62891 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45703 0.12891,-0.83203 0.1289,-0.3789 0.37109,-0.64844 0.24219,-0.27343 0.58984,-0.42187 0.34766,-0.15234 0.78907,-0.15234 0.42187,0 0.7539,0.13281 0.33594,0.1289 0.56641,0.38281 0.23437,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69531,0.0312 q 0,-0.36329 -0.082,-0.63282 -0.0781,-0.27343 -0.22656,-0.45312 -0.14844,-0.1836 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30468,0 -0.52343,0.12109 -0.21485,0.11719 -0.35547,0.31641 -0.13672,0.19922 -0.20313,0.46484 -0.0625,0.26172 -0.0625,0.55079 0,0.36328 0.0781,0.63671 0.082,0.27344 0.23047,0.45704 0.14843,0.17968 0.35937,0.27343 0.21094,0.0899 0.47656,0.0899 0.30469,0 0.51954,-0.11719 0.21875,-0.12109 0.35546,-0.32031 0.14063,-0.19922 0.20313,-0.46094 0.0664,-0.26563 0.0664,-0.55859 z m 4.83984,1.90625 q -0.23047,0.0586 -0.47656,0.082 -0.2461,0.0273 -0.5,0.0273 -0.73828,0 -1.10157,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 h -1.09765 v -0.57031 h 1.09765 v -1.07813 l 0.67969,-0.17578 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42187 0.22266,0.63281 0.22656,0.20703 0.66406,0.20703 0.1875,0 0.41016,-0.0273 0.22265,-0.0312 0.46484,-0.0937 z m 4.39062,0.0547 h -0.67968 v -2.5039 q 0,-0.45313 -0.17188,-0.67578 -0.16797,-0.22657 -0.48437,-0.22657 -0.13672,0 -0.25782,0.0391 -0.11718,0.0351 -0.24609,0.1289 -0.12891,0.0899 -0.28125,0.2461 -0.15234,0.15625 -0.35156,0.39062 v 2.60156 h -0.67969 v -5.51953 h 0.67969 v 1.59766 l -0.0234,0.61719 q 0.16016,-0.19141 0.3125,-0.32032 0.15625,-0.13281 0.30859,-0.21484 0.15625,-0.082 0.31641,-0.11719 0.16016,-0.0351 0.33203,-0.0351 0.58594,0 0.90625,0.35937 0.32031,0.35547 0.32031,1.07422 z m 4.5586,-2.16797 q 0,0.14454 -0.004,0.24219 -0.004,0.0977 -0.0117,0.1836 h -2.7539 q 0,0.60156 0.33593,0.92578 0.33594,0.32031 0.96875,0.32031 0.17188,0 0.34375,-0.0117 0.17188,-0.0156 0.33204,-0.0391 0.16015,-0.0234 0.30468,-0.0508 0.14844,-0.0312 0.27344,-0.0664 v 0.55859 q -0.27734,0.0781 -0.62891,0.125 -0.34765,0.0508 -0.72265,0.0508 -0.50391,0 -0.86719,-0.13672 -0.36328,-0.13672 -0.59766,-0.39453 -0.23046,-0.26172 -0.34375,-0.63672 -0.10937,-0.37891 -0.10937,-0.85547 0,-0.41406 0.11719,-0.78125 0.12109,-0.3711 0.34765,-0.64844 0.23047,-0.28125 0.5625,-0.44531 0.33203,-0.16406 0.75391,-0.16406 0.41016,0 0.72656,0.1289 0.31641,0.12891 0.53125,0.36719 0.21875,0.23437 0.32813,0.57422 0.11328,0.33594 0.11328,0.7539 z m -0.70703,-0.0976 q 0.0117,-0.26172 -0.0508,-0.47656 -0.0625,-0.21875 -0.19532,-0.375 -0.1289,-0.15625 -0.32422,-0.24219 -0.19531,-0.0899 -0.45312,-0.0899 -0.22266,0 -0.40625,0.0859 -0.18359,0.0859 -0.31641,0.24219 -0.13281,0.15625 -0.21484,0.375 -0.082,0.21875 -0.10156,0.48047 z m 1.95312,-1.65625 h 0.6211 l 0.0195,0.72265 q 0.34765,-0.41796 0.68359,-0.60546 0.33984,-0.1875 0.68359,-0.1875 0.60938,0 0.92188,0.39453 0.31641,0.39453 0.29297,1.17187 h -0.6875 q 0.0117,-0.51562 -0.15235,-0.74609 -0.16015,-0.23438 -0.47265,-0.23438 -0.13672,0 -0.27735,0.0508 -0.13671,0.0469 -0.28515,0.15625 -0.14453,0.10547 -0.3086,0.27344 -0.16406,0.16797 -0.35156,0.40625 v 2.51953 h -0.6875 z"
+         id="path64" />
+      <path
+         style="fill:#000000"
+         d="m 515.19434,250.80415 q 0,0.52344 -0.14844,0.91407 -0.14453,0.39062 -0.40235,0.64843 -0.25781,0.25782 -0.60937,0.38672 -0.35156,0.12891 -0.76172,0.12891 -0.1875,0 -0.375,-0.0195 -0.18359,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29297,-0.40235 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33594,0 0.58984,0.14062 0.25391,0.14063 0.42579,0.39844 0.17187,0.2539 0.25781,0.61719 0.0859,0.35937 0.0859,0.80468 z m -0.69532,0.0312 q 0,-0.30859 -0.0469,-0.5664 -0.043,-0.25782 -0.14063,-0.44141 -0.0976,-0.18359 -0.25,-0.28516 -0.15234,-0.10546 -0.36328,-0.10546 -0.1289,0 -0.26172,0.043 -0.13281,0.0391 -0.27734,0.13672 -0.14063,0.0937 -0.30078,0.25391 -0.15625,0.15625 -0.33594,0.39062 v 1.90235 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.3711 0.3125,-0.375 0.3125,-1.125 z m 5.05469,-0.16797 q 0,0.14454 -0.004,0.24219 -0.004,0.0977 -0.0117,0.1836 h -2.75391 q 0,0.60156 0.33594,0.92578 0.33593,0.32031 0.96875,0.32031 0.17187,0 0.34375,-0.0117 0.17187,-0.0156 0.33203,-0.0391 0.16015,-0.0234 0.30469,-0.0508 0.14843,-0.0312 0.27343,-0.0664 v 0.55859 q -0.27734,0.0781 -0.6289,0.125 -0.34766,0.0508 -0.72266,0.0508 -0.50391,0 -0.86719,-0.13672 -0.36328,-0.13672 -0.59765,-0.39453 -0.23047,-0.26172 -0.34375,-0.63672 -0.10938,-0.37891 -0.10938,-0.85547 0,-0.41406 0.11719,-0.78125 0.12109,-0.3711 0.34766,-0.64844 0.23046,-0.28125 0.5625,-0.44531 0.33203,-0.16406 0.7539,-0.16406 0.41016,0 0.72656,0.1289 0.31641,0.12891 0.53125,0.36719 0.21875,0.23437 0.32813,0.57422 0.11328,0.33594 0.11328,0.7539 z m -0.70703,-0.0976 q 0.0117,-0.26172 -0.0508,-0.47656 -0.0625,-0.21875 -0.19531,-0.375 -0.12891,-0.15625 -0.32422,-0.24219 -0.19532,-0.0899 -0.45313,-0.0899 -0.22265,0 -0.40625,0.0859 -0.18359,0.0859 -0.3164,0.24219 -0.13282,0.15625 -0.21485,0.375 -0.082,0.21875 -0.10156,0.48047 z m 1.95312,-1.65625 h 0.6211 l 0.0195,0.72265 q 0.34766,-0.41796 0.68359,-0.60546 0.33985,-0.1875 0.6836,-0.1875 0.60937,0 0.92187,0.39453 0.31641,0.39453 0.29297,1.17187 h -0.6875 q 0.0117,-0.51562 -0.15234,-0.74609 -0.16016,-0.23438 -0.47266,-0.23438 -0.13672,0 -0.27734,0.0508 -0.13672,0.0469 -0.28516,0.15625 -0.14453,0.10547 -0.30859,0.27344 -0.16407,0.16797 -0.35157,0.40625 v 2.51953 h -0.6875 z m 5.57422,0.5625 h -1.16015 v -0.5625 h 1.84765 v 3.35547 h 1.16797 v 0.5664 h -3.14453 v -0.5664 h 1.28906 z m 0.23828,-2.20703 q 0.11329,0 0.21094,0.043 0.0977,0.0391 0.16797,0.11328 0.0742,0.0742 0.11328,0.17187 0.043,0.0937 0.043,0.20703 0,0.10938 -0.043,0.20703 -0.0391,0.0977 -0.11328,0.17188 -0.0703,0.0742 -0.16797,0.11719 -0.0977,0.0391 -0.21094,0.0391 -0.11328,0 -0.21093,-0.0391 -0.0977,-0.043 -0.17188,-0.11719 -0.0703,-0.0742 -0.11328,-0.17188 -0.0391,-0.0976 -0.0391,-0.20703 0,-0.11328 0.0391,-0.20703 0.043,-0.0976 0.11328,-0.17187 0.0742,-0.0742 0.17188,-0.11328 0.0976,-0.043 0.21093,-0.043 z m 6.17579,3.53515 q 0,0.52344 -0.14844,0.91407 -0.14453,0.39062 -0.40235,0.64843 -0.25781,0.25782 -0.60937,0.38672 -0.35156,0.12891 -0.76172,0.12891 -0.1875,0 -0.375,-0.0195 -0.18359,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29297,-0.40235 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33594,0 0.58984,0.14062 0.25391,0.14063 0.42579,0.39844 0.17187,0.2539 0.25781,0.61719 0.0859,0.35937 0.0859,0.80468 z m -0.69532,0.0312 q 0,-0.30859 -0.0469,-0.5664 -0.043,-0.25782 -0.14063,-0.44141 -0.0976,-0.18359 -0.25,-0.28516 -0.15234,-0.10546 -0.36328,-0.10546 -0.1289,0 -0.26172,0.043 -0.13281,0.0391 -0.27734,0.13672 -0.14063,0.0937 -0.30078,0.25391 -0.15625,0.15625 -0.33594,0.39062 v 1.90235 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.3711 0.3125,-0.375 0.3125,-1.125 z m 4.89453,2 h -0.67968 v -2.5039 q 0,-0.45313 -0.17188,-0.67578 -0.16797,-0.22657 -0.48437,-0.22657 -0.13672,0 -0.25782,0.0391 -0.11718,0.0351 -0.24609,0.1289 -0.12891,0.0899 -0.28125,0.2461 -0.15234,0.15625 -0.35156,0.39062 v 2.60156 h -0.67969 v -5.51953 h 0.67969 v 1.59766 l -0.0234,0.61719 q 0.16016,-0.19141 0.3125,-0.32032 0.15625,-0.13281 0.30859,-0.21484 0.15625,-0.082 0.31641,-0.11719 0.16016,-0.0351 0.33203,-0.0351 0.58594,0 0.90625,0.35937 0.32031,0.35547 0.32031,1.07422 z m 4.5586,-2.16797 q 0,0.14454 -0.004,0.24219 -0.004,0.0977 -0.0117,0.1836 h -2.7539 q 0,0.60156 0.33593,0.92578 0.33594,0.32031 0.96875,0.32031 0.17188,0 0.34375,-0.0117 0.17188,-0.0156 0.33204,-0.0391 0.16015,-0.0234 0.30468,-0.0508 0.14844,-0.0312 0.27344,-0.0664 v 0.55859 q -0.27734,0.0781 -0.62891,0.125 -0.34765,0.0508 -0.72265,0.0508 -0.50391,0 -0.86719,-0.13672 -0.36328,-0.13672 -0.59766,-0.39453 -0.23046,-0.26172 -0.34375,-0.63672 -0.10937,-0.37891 -0.10937,-0.85547 0,-0.41406 0.11719,-0.78125 0.12109,-0.3711 0.34765,-0.64844 0.23047,-0.28125 0.5625,-0.44531 0.33203,-0.16406 0.75391,-0.16406 0.41016,0 0.72656,0.1289 0.31641,0.12891 0.53125,0.36719 0.21875,0.23437 0.32813,0.57422 0.11328,0.33594 0.11328,0.7539 z m -0.70703,-0.0976 q 0.0117,-0.26172 -0.0508,-0.47656 -0.0625,-0.21875 -0.19532,-0.375 -0.1289,-0.15625 -0.32422,-0.24219 -0.19531,-0.0899 -0.45312,-0.0899 -0.22266,0 -0.40625,0.0859 -0.18359,0.0859 -0.31641,0.24219 -0.13281,0.15625 -0.21484,0.375 -0.082,0.21875 -0.10156,0.48047 z m 1.95312,-1.65625 h 0.6211 l 0.0195,0.72265 q 0.34765,-0.41796 0.68359,-0.60546 0.33984,-0.1875 0.68359,-0.1875 0.60938,0 0.92188,0.39453 0.31641,0.39453 0.29297,1.17187 h -0.6875 q 0.0117,-0.51562 -0.15235,-0.74609 -0.16015,-0.23438 -0.47265,-0.23438 -0.13672,0 -0.27735,0.0508 -0.13671,0.0469 -0.28515,0.15625 -0.14453,0.10547 -0.3086,0.27344 -0.16406,0.16797 -0.35156,0.40625 v 2.51953 h -0.6875 z m 6.75781,3.92187 -0.0156,-0.52734 q -0.32031,0.31641 -0.65234,0.45703 -0.32813,0.14063 -0.69141,0.14063 -0.33594,0 -0.57422,-0.0859 -0.23828,-0.0859 -0.39453,-0.23438 -0.15234,-0.15234 -0.22656,-0.35547 -0.0703,-0.20312 -0.0703,-0.4414 0,-0.58985 0.4375,-0.92188 0.44141,-0.33593 1.30079,-0.33593 h 0.8125 v -0.34375 q 0,-0.34766 -0.22266,-0.55469 -0.22266,-0.21094 -0.67969,-0.21094 -0.33203,0 -0.65625,0.0742 -0.32031,0.0742 -0.66406,0.21094 v -0.61328 q 0.12891,-0.0469 0.28516,-0.0899 0.16015,-0.0469 0.33593,-0.082 0.17578,-0.0352 0.36719,-0.0547 0.19141,-0.0234 0.38672,-0.0234 0.35547,0 0.64062,0.0781 0.28516,0.0781 0.48047,0.23828 0.19922,0.16016 0.30469,0.40235 0.10547,0.24218 0.10547,0.57031 v 2.70312 z m -0.0742,-1.78515 h -0.86329 q -0.2539,0 -0.4375,0.0508 -0.18359,0.0508 -0.30078,0.14453 -0.11718,0.0937 -0.17578,0.22656 -0.0547,0.12891 -0.0547,0.29297 0,0.11328 0.0352,0.21875 0.0352,0.10156 0.11328,0.18359 0.0781,0.0781 0.20313,0.125 0.125,0.0469 0.30468,0.0469 0.23438,0 0.53516,-0.14063 0.30469,-0.14453 0.64063,-0.45312 z m 3.28906,-3.17578 h -1.16016 v -0.5586 h 1.84766 v 4.95313 h 1.16797 v 0.5664 h -3.14453 v -0.5664 h 1.28906 z m 6.16797,3.89062 q 0,0.20703 -0.0703,0.37109 -0.0703,0.16407 -0.1914,0.29297 -0.1211,0.125 -0.28125,0.21485 -0.16016,0.0898 -0.34375,0.14843 -0.17969,0.0586 -0.3711,0.0859 -0.1914,0.0274 -0.375,0.0274 -0.39843,0 -0.73437,-0.0352 -0.33203,-0.0352 -0.65234,-0.11328 v -0.625 q 0.34375,0.0976 0.68359,0.14844 0.33984,0.0508 0.67578,0.0508 0.48828,0 0.72266,-0.13282 0.23437,-0.13281 0.23437,-0.3789 0,-0.10547 -0.0391,-0.1875 -0.0352,-0.0859 -0.13281,-0.16016 -0.0977,-0.0781 -0.30469,-0.16015 -0.20313,-0.082 -0.55859,-0.1875 -0.26563,-0.0781 -0.49219,-0.17579 -0.22266,-0.10156 -0.38672,-0.23828 -0.16406,-0.13672 -0.25781,-0.32031 -0.0937,-0.18359 -0.0937,-0.43359 0,-0.16407 0.0742,-0.35938 0.0781,-0.19531 0.26171,-0.36328 0.1836,-0.16797 0.4961,-0.27734 0.3125,-0.11328 0.78125,-0.11328 0.23047,0 0.51172,0.0273 0.28125,0.0234 0.58593,0.0859 v 0.60547 q -0.32031,-0.0781 -0.60937,-0.11329 -0.28516,-0.0391 -0.49609,-0.0391 -0.25391,0 -0.42969,0.0391 -0.17188,0.0391 -0.28125,0.10938 -0.10547,0.0664 -0.15235,0.16016 -0.0469,0.0898 -0.0469,0.19531 0,0.10547 0.0391,0.1914 0.043,0.0859 0.15235,0.16797 0.11328,0.0781 0.3125,0.16016 0.19921,0.0781 0.51953,0.17187 0.34765,0.10157 0.58593,0.21485 0.23829,0.10937 0.38672,0.24609 0.14844,0.13672 0.21094,0.3086 0.0664,0.17187 0.0664,0.39062 z m 2.83593,-0.16016 q 0.13282,0 0.25,0.0508 0.1211,0.0508 0.20704,0.14062 0.0898,0.0898 0.14062,0.21094 0.0508,0.11719 0.0508,0.2539 0,0.13282 -0.0508,0.25 -0.0508,0.11719 -0.14062,0.20704 -0.0859,0.0859 -0.20704,0.13671 -0.11718,0.0508 -0.25,0.0508 -0.13671,0 -0.2539,-0.0508 -0.11719,-0.0508 -0.20703,-0.13671 -0.0859,-0.0899 -0.13672,-0.20704 -0.0508,-0.11718 -0.0508,-0.25 0,-0.13671 0.0508,-0.2539 0.0508,-0.1211 0.13672,-0.21094 0.0898,-0.0898 0.20703,-0.14062 0.11719,-0.0508 0.2539,-0.0508 z m 4.39844,0 q 0.13281,0 0.25,0.0508 0.1211,0.0508 0.20703,0.14062 0.0899,0.0898 0.14063,0.21094 0.0508,0.11719 0.0508,0.2539 0,0.13282 -0.0508,0.25 -0.0508,0.11719 -0.14063,0.20704 -0.0859,0.0859 -0.20703,0.13671 -0.11719,0.0508 -0.25,0.0508 -0.13672,0 -0.2539,-0.0508 -0.11719,-0.0508 -0.20704,-0.13671 -0.0859,-0.0899 -0.13671,-0.20704 -0.0508,-0.11718 -0.0508,-0.25 0,-0.13671 0.0508,-0.2539 0.0508,-0.1211 0.13671,-0.21094 0.0898,-0.0898 0.20704,-0.14062 0.11718,-0.0508 0.2539,-0.0508 z m 4.39844,0 q 0.13281,0 0.25,0.0508 0.12109,0.0508 0.20703,0.14062 0.0898,0.0898 0.14063,0.21094 0.0508,0.11719 0.0508,0.2539 0,0.13282 -0.0508,0.25 -0.0508,0.11719 -0.14063,0.20704 -0.0859,0.0859 -0.20703,0.13671 -0.11719,0.0508 -0.25,0.0508 -0.13672,0 -0.25391,-0.0508 -0.11718,-0.0508 -0.20703,-0.13671 -0.0859,-0.0899 -0.13672,-0.20704 -0.0508,-0.11718 -0.0508,-0.25 0,-0.13671 0.0508,-0.2539 0.0508,-0.1211 0.13672,-0.21094 0.0898,-0.0898 0.20703,-0.14062 0.11719,-0.0508 0.25391,-0.0508 z"
+         id="path65" />
+    </g>
+    <path
+       d="m 589.45312,62.629906 q 0,1.046875 -0.29687,1.828125 -0.28906,0.78125 -0.80469,1.296875 -0.51562,0.515625 -1.21875,0.773437 -0.70312,0.257813 -1.52344,0.257813 -0.375,0 -0.75,-0.03906 -0.36718,-0.03906 -0.75,-0.132812 v 3.28125 H 582.75 V 58.848656 h 1.21094 l 0.0859,1.3125 q 0.58594,-0.804688 1.25,-1.125 0.66407,-0.328125 1.4375,-0.328125 0.67188,0 1.17969,0.28125 0.50781,0.28125 0.85156,0.796875 0.34375,0.507812 0.51563,1.234375 0.17187,0.71875 0.17187,1.609375 z m -1.39062,0.0625 q 0,-0.617188 -0.0937,-1.132813 -0.0859,-0.515625 -0.28125,-0.882812 -0.19531,-0.367188 -0.5,-0.570313 -0.30469,-0.210937 -0.72656,-0.210937 -0.25782,0 -0.52344,0.08594 -0.26563,0.07813 -0.55469,0.273438 -0.28125,0.1875 -0.60156,0.507812 -0.3125,0.3125 -0.67188,0.78125 v 3.804688 q 0.375,0.15625 0.78907,0.25 0.41406,0.08594 0.8125,0.08594 1.10156,0 1.72656,-0.742187 0.625,-0.75 0.625,-2.25 z m 10.10937,-0.335938 q 0,0.289063 -0.008,0.484375 -0.008,0.195313 -0.0234,0.367188 h -5.50781 q 0,1.203125 0.67188,1.851562 0.67187,0.640625 1.9375,0.640625 0.34375,0 0.6875,-0.02344 0.34375,-0.03125 0.66406,-0.07813 0.32031,-0.04687 0.60937,-0.101563 0.29688,-0.0625 0.54688,-0.132812 v 1.117187 q -0.55469,0.15625 -1.25781,0.25 -0.69532,0.101563 -1.44532,0.101563 -1.00781,0 -1.73437,-0.273438 -0.72656,-0.273437 -1.19531,-0.789062 -0.46094,-0.523438 -0.6875,-1.273438 -0.21875,-0.757812 -0.21875,-1.710937 0,-0.828125 0.23437,-1.5625 0.24219,-0.742188 0.69531,-1.296875 0.46094,-0.5625 1.125,-0.890625 0.66407,-0.328125 1.50782,-0.328125 0.82031,0 1.45312,0.257812 0.63281,0.257813 1.0625,0.734375 0.4375,0.46875 0.65625,1.148438 0.22656,0.671875 0.22656,1.507812 z m -1.41406,-0.195312 q 0.0234,-0.523438 -0.10156,-0.953125 -0.125,-0.4375 -0.39063,-0.75 -0.25781,-0.3125 -0.64843,-0.484375 -0.39063,-0.179688 -0.90625,-0.179688 -0.44532,0 -0.8125,0.171875 -0.36719,0.171875 -0.63282,0.484375 -0.26562,0.3125 -0.42968,0.75 -0.16407,0.4375 -0.20313,0.960938 z m 3.90625,-3.3125 h 1.24219 l 0.0391,1.445312 q 0.69531,-0.835937 1.36719,-1.210937 0.67969,-0.375 1.36719,-0.375 1.21875,0 1.84375,0.789062 0.63281,0.789063 0.58593,2.34375 h -1.375 q 0.0234,-1.03125 -0.30468,-1.492187 -0.32032,-0.46875 -0.94532,-0.46875 -0.27343,0 -0.55468,0.101562 -0.27344,0.09375 -0.57032,0.3125 -0.28906,0.210938 -0.61718,0.546875 -0.32813,0.335938 -0.70313,0.8125 v 5.039063 h -1.375 z m 11.14844,1.125 h -2.32031 v -1.125 h 3.69531 v 6.710937 h 2.33594 v 1.132813 h -6.28907 v -1.132813 h 2.57813 z m 0.47656,-4.414063 q 0.22656,0 0.42188,0.08594 0.19531,0.07813 0.33593,0.226562 0.14844,0.148438 0.22657,0.34375 0.0859,0.1875 0.0859,0.414063 0,0.21875 -0.0859,0.414062 -0.0781,0.195313 -0.22657,0.34375 -0.14062,0.148438 -0.33593,0.234375 -0.19532,0.07813 -0.42188,0.07813 -0.22656,0 -0.42187,-0.07813 -0.19532,-0.08594 -0.34375,-0.234375 -0.14063,-0.148437 -0.22657,-0.34375 -0.0781,-0.195312 -0.0781,-0.414062 0,-0.226563 0.0781,-0.414063 0.0859,-0.195312 0.22657,-0.34375 0.14843,-0.148437 0.34375,-0.226562 0.19531,-0.08594 0.42187,-0.08594 z m 12.35156,7.070313 q 0,1.046875 -0.29687,1.828125 -0.28906,0.78125 -0.80469,1.296875 -0.51562,0.515625 -1.21875,0.773437 -0.70312,0.257813 -1.52344,0.257813 -0.375,0 -0.75,-0.03906 -0.36718,-0.03906 -0.75,-0.132812 v 3.28125 H 617.9375 V 58.848656 h 1.21094 l 0.0859,1.3125 q 0.58594,-0.804688 1.25,-1.125 0.66407,-0.328125 1.4375,-0.328125 0.67188,0 1.17969,0.28125 0.50781,0.28125 0.85156,0.796875 0.34375,0.507812 0.51563,1.234375 0.17187,0.71875 0.17187,1.609375 z m -1.39062,0.0625 q 0,-0.617188 -0.0937,-1.132813 -0.0859,-0.515625 -0.28125,-0.882812 -0.19531,-0.367188 -0.5,-0.570313 -0.30469,-0.210937 -0.72656,-0.210937 -0.25782,0 -0.52344,0.08594 -0.26563,0.07813 -0.55469,0.273438 -0.28125,0.1875 -0.60156,0.507812 -0.3125,0.3125 -0.67188,0.78125 v 3.804688 q 0.375,0.15625 0.78907,0.25 0.41406,0.08594 0.8125,0.08594 1.10156,0 1.72656,-0.742187 0.625,-0.75 0.625,-2.25 z m 9.78906,4 h -1.35937 v -5.007813 q 0,-0.90625 -0.34375,-1.351562 -0.33594,-0.453125 -0.96875,-0.453125 -0.27344,0 -0.51563,0.07813 -0.23437,0.07031 -0.49219,0.257812 -0.25781,0.179688 -0.5625,0.492188 -0.30468,0.3125 -0.70312,0.78125 v 5.203125 h -1.35938 V 55.653343 h 1.35938 v 3.195313 l -0.0469,1.234375 q 0.32032,-0.382813 0.625,-0.640625 0.3125,-0.265625 0.61719,-0.429688 0.3125,-0.164062 0.63281,-0.234375 0.32032,-0.07031 0.66407,-0.07031 1.17187,0 1.8125,0.71875 0.64062,0.710937 0.64062,2.148437 z m 10.03906,3.203125 h -8.79687 v -1.125 h 8.79687 z m 6.28907,-3.203125 -0.0312,-1.054688 q -0.64063,0.632813 -1.30469,0.914063 -0.65625,0.28125 -1.38281,0.28125 -0.67188,0 -1.14844,-0.171875 -0.47656,-0.171875 -0.78906,-0.46875 -0.30469,-0.304688 -0.45313,-0.710938 -0.14062,-0.40625 -0.14062,-0.882812 0,-1.179688 0.875,-1.84375 0.88281,-0.671875 2.60156,-0.671875 h 1.625 v -0.6875 q 0,-0.695313 -0.44531,-1.109375 -0.44532,-0.421875 -1.35938,-0.421875 -0.66406,0 -1.3125,0.148437 -0.64062,0.148438 -1.32812,0.421875 v -1.226562 q 0.25781,-0.09375 0.57031,-0.179688 0.32031,-0.09375 0.67187,-0.164062 0.35157,-0.07031 0.73438,-0.109375 0.38281,-0.04687 0.77344,-0.04687 0.71093,0 1.28125,0.15625 0.57031,0.15625 0.96093,0.476562 0.39844,0.320313 0.60938,0.804688 0.21094,0.484375 0.21094,1.140625 v 5.40625 z m -0.14844,-3.570313 h -1.72656 q -0.50782,0 -0.875,0.101563 -0.36719,0.101562 -0.60157,0.289062 -0.23437,0.1875 -0.35156,0.453125 -0.10937,0.257813 -0.10937,0.585938 0,0.226562 0.0703,0.4375 0.0703,0.203125 0.22656,0.367187 0.15625,0.15625 0.40625,0.25 0.25,0.09375 0.60938,0.09375 0.46875,0 1.07031,-0.28125 0.60937,-0.289062 1.28125,-0.90625 z"
+       id="text47"
+       style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       aria-label="periph_a" />
+    <path
+       d="m 629.52734,112.50781 h -0.67968 v -2.5039 q 0,-0.45313 -0.17188,-0.67578 -0.16797,-0.22657 -0.48437,-0.22657 -0.13672,0 -0.25782,0.0391 -0.11718,0.0352 -0.24609,0.1289 -0.12891,0.0898 -0.28125,0.2461 -0.15234,0.15625 -0.35156,0.39062 v 2.60156 H 626.375 v -5.51953 h 0.67969 v 1.59766 l -0.0234,0.61719 q 0.16016,-0.19141 0.3125,-0.32032 0.15625,-0.13281 0.30859,-0.21484 0.15625,-0.082 0.31641,-0.11719 0.16016,-0.0352 0.33203,-0.0352 0.58594,0 0.90625,0.35937 0.32031,0.35547 0.32031,1.07422 z m 4.87891,-3.92187 -0.57031,3.92187 h -0.82422 l -0.56641,-1.64062 -0.11328,-0.39844 -0.12891,0.42188 -0.54296,1.61718 h -0.80079 l -0.5664,-3.92187 h 0.66406 l 0.32813,2.66406 0.0703,0.59375 0.16797,-0.51953 0.57031,-1.76172 h 0.48828 l 0.61328,1.73828 0.17578,0.51953 0.0586,-0.55078 0.30468,-2.68359 z m 4.53906,5.52344 h -4.39844 v -0.5625 h 4.39844 z m 1.96094,-4.96094 h -1.16016 v -0.5625 h 1.84766 v 3.35547 h 1.16797 v 0.5664 h -3.14453 v -0.5664 h 1.28906 z m 0.23828,-2.20703 q 0.11328,0 0.21094,0.043 0.0977,0.0391 0.16797,0.11328 0.0742,0.0742 0.11328,0.17187 0.043,0.0937 0.043,0.20703 0,0.10938 -0.043,0.20703 -0.0391,0.0977 -0.11328,0.17188 -0.0703,0.0742 -0.16797,0.11719 -0.0977,0.0391 -0.21094,0.0391 -0.11328,0 -0.21094,-0.0391 -0.0976,-0.043 -0.17187,-0.11719 -0.0703,-0.0742 -0.11328,-0.17188 -0.0391,-0.0977 -0.0391,-0.20703 0,-0.11328 0.0391,-0.20703 0.043,-0.0977 0.11328,-0.17187 0.0742,-0.0742 0.17187,-0.11328 0.0977,-0.043 0.21094,-0.043 z"
+       id="text48"
+       style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       aria-label="hw_i" />
+    <path
+       d="m 539.08594,104.20703 h -1.16016 v -0.5625 h 1.84766 V 107 h 1.16797 v 0.56641 h -3.14454 V 107 h 1.28907 z M 539.32422,102 q 0.11328,0 0.21094,0.043 0.0976,0.0391 0.16796,0.11328 0.0742,0.0742 0.11329,0.17188 0.043,0.0937 0.043,0.20703 0,0.10937 -0.043,0.20703 -0.0391,0.0977 -0.11329,0.17187 -0.0703,0.0742 -0.16796,0.11719 -0.0977,0.0391 -0.21094,0.0391 -0.11328,0 -0.21094,-0.0391 -0.0977,-0.043 -0.17187,-0.11719 -0.0703,-0.0742 -0.11329,-0.17187 -0.0391,-0.0977 -0.0391,-0.20703 0,-0.11328 0.0391,-0.20703 0.043,-0.0977 0.11329,-0.17188 0.0742,-0.0742 0.17187,-0.11328 0.0977,-0.043 0.21094,-0.043 z m 2.82422,1.64453 h 0.60547 l 0.0273,0.63281 q 0.17187,-0.20312 0.33203,-0.33593 0.16016,-0.13672 0.3125,-0.21875 0.15625,-0.082 0.31641,-0.11328 0.16015,-0.0352 0.33203,-0.0352 0.60547,0 0.91406,0.35937 0.3125,0.35547 0.3125,1.07422 v 2.5586 h -0.67969 v -2.50391 q 0,-0.46094 -0.17187,-0.67969 -0.17188,-0.22265 -0.51172,-0.22265 -0.125,0 -0.24609,0.0391 -0.11719,0.0352 -0.2461,0.12891 -0.1289,0.0898 -0.28125,0.24609 -0.14844,0.15625 -0.33594,0.39062 v 2.60157 h -0.67968 z m 7.55859,3.86719 q -0.23047,0.0586 -0.47656,0.082 -0.2461,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36329,-0.33593 -0.36329,-1.02734 v -2.04688 h -1.09765 v -0.57031 h 1.09765 v -1.07812 l 0.67969,-0.17578 v 1.2539 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42188 0.22266,0.63281 0.22656,0.20704 0.66406,0.20704 0.1875,0 0.41016,-0.0273 0.22265,-0.0312 0.46484,-0.0937 z m 1.39844,-3.86719 h 0.62109 l 0.0195,0.72266 q 0.34766,-0.41797 0.6836,-0.60547 0.33984,-0.1875 0.68359,-0.1875 0.60938,0 0.92188,0.39453 0.3164,0.39453 0.29296,1.17188 h -0.6875 q 0.0117,-0.51563 -0.15234,-0.7461 -0.16016,-0.23437 -0.47266,-0.23437 -0.13671,0 -0.27734,0.0508 -0.13672,0.0469 -0.28516,0.15625 -0.14453,0.10547 -0.30859,0.27344 -0.16406,0.16796 -0.35156,0.40625 v 2.51953 h -0.6875 z m 8.01172,5.52344 h -4.39844 v -0.5625 h 4.39844 z m 4.03906,-3.59375 q 0,0.45703 -0.12891,0.83984 -0.1289,0.37891 -0.37109,0.65235 -0.24219,0.26953 -0.58984,0.42187 -0.34766,0.14844 -0.78907,0.14844 -0.42187,0 -0.75781,-0.12891 -0.33203,-0.13281 -0.56641,-0.38672 -0.23046,-0.2539 -0.35546,-0.6289 -0.1211,-0.375 -0.1211,-0.86328 0,-0.45703 0.12891,-0.83203 0.1289,-0.37891 0.37109,-0.64844 0.24219,-0.27344 0.58985,-0.42188 0.34765,-0.15234 0.78906,-0.15234 0.42187,0 0.7539,0.13281 0.33594,0.12891 0.56641,0.38281 0.23438,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69531,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22657,-0.45313 -0.14843,-0.18359 -0.36328,-0.27344 -0.21094,-0.0937 -0.47265,-0.0937 -0.30469,0 -0.52344,0.1211 -0.21485,0.11719 -0.35547,0.3164 -0.13672,0.19922 -0.20313,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27344 0.23047,0.45703 0.14844,0.17969 0.35937,0.27344 0.21094,0.0898 0.47657,0.0898 0.30468,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14062,-0.19922 0.20312,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z"
+       id="text49"
+       style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       aria-label="intr_o" />
+    <path
+       style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       d="m 331.45447,111.94444 q 0,1.04688 -0.29688,1.82813 -0.28906,0.78125 -0.80468,1.29687 -0.51563,0.51563 -1.21875,0.77344 -0.70313,0.25781 -1.52344,0.25781 -0.375,0 -0.75,-0.0391 -0.36719,-0.0391 -0.75,-0.13281 v 3.28125 h -1.35938 v -11.04688 h 1.21094 l 0.0859,1.3125 q 0.58594,-0.80468 1.25,-1.125 0.66406,-0.32812 1.4375,-0.32812 0.67187,0 1.17969,0.28125 0.50781,0.28125 0.85156,0.79687 0.34375,0.50782 0.51562,1.23438 0.17188,0.71875 0.17188,1.60937 z m -1.39063,0.0625 q 0,-0.61718 -0.0937,-1.13281 -0.0859,-0.51562 -0.28125,-0.88281 -0.19531,-0.36719 -0.5,-0.57031 -0.30468,-0.21094 -0.72656,-0.21094 -0.25781,0 -0.52344,0.0859 -0.26562,0.0781 -0.55468,0.27343 -0.28125,0.1875 -0.60157,0.50782 -0.3125,0.3125 -0.67187,0.78125 v 3.80468 q 0.375,0.15625 0.78906,0.25 0.41406,0.0859 0.8125,0.0859 1.10156,0 1.72656,-0.74219 0.625,-0.75 0.625,-2.25 z m 6.15625,-5.92187 h -2.32031 v -1.11719 h 3.69531 v 9.90625 h 2.33594 v 1.13281 h -6.28906 v -1.13281 h 2.57812 z m 8.79688,3.20312 h -2.32031 v -1.125 h 3.69531 v 6.71094 h 2.33594 v 1.13281 h -6.28907 v -1.13281 h 2.57813 z m 0.47656,-4.41406 q 0.22656,0 0.42188,0.0859 0.19531,0.0781 0.33593,0.22656 0.14844,0.14844 0.22657,0.34375 0.0859,0.1875 0.0859,0.41406 0,0.21875 -0.0859,0.41407 -0.0781,0.19531 -0.22657,0.34375 -0.14062,0.14843 -0.33593,0.23437 -0.19532,0.0781 -0.42188,0.0781 -0.22656,0 -0.42187,-0.0781 -0.19532,-0.0859 -0.34375,-0.23437 -0.14063,-0.14844 -0.22657,-0.34375 -0.0781,-0.19532 -0.0781,-0.41407 0,-0.22656 0.0781,-0.41406 0.0859,-0.19531 0.22657,-0.34375 0.14843,-0.14844 0.34375,-0.22656 0.19531,-0.0859 0.42187,-0.0859 z m 11.74219,10.84375 q -0.53125,0.20313 -1.09375,0.29688 -0.55469,0.10156 -1.14844,0.10156 -1.85937,0 -2.86719,-1.00781 -1,-1.00782 -1,-2.94532 0,-0.92968 0.28907,-1.6875 0.28906,-0.75781 0.8125,-1.29687 0.52343,-0.53906 1.25,-0.82813 0.72656,-0.29687 1.60156,-0.29687 0.60937,0 1.14062,0.0859 0.53125,0.0859 1.01563,0.28125 v 1.29687 q -0.50781,-0.26562 -1.03906,-0.38281 -0.52344,-0.125 -1.08594,-0.125 -0.52344,0 -0.99219,0.20312 -0.46094,0.19532 -0.8125,0.57032 -0.35156,0.375 -0.55469,0.91406 -0.20312,0.53906 -0.20312,1.21875 0,1.42187 0.6875,2.13281 0.69531,0.70313 1.92187,0.70313 0.55469,0 1.07032,-0.125 0.52343,-0.125 1.00781,-0.375 z"
+       id="text50"
+       aria-label="plic" />
+    <path
+       style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       d="m 91.489456,64.057655 q -0.53125,0.203125 -1.09375,0.296875 -0.554687,0.101563 -1.148437,0.101563 -1.859375,0 -2.867188,-1.007813 -1,-1.007812 -1,-2.945312 0,-0.929688 0.289063,-1.6875 0.289062,-0.757813 0.8125,-1.296875 0.523437,-0.539063 1.25,-0.828125 0.726562,-0.296875 1.601562,-0.296875 0.609375,0 1.140625,0.08594 0.53125,0.08594 1.015625,0.28125 v 1.296875 q -0.507812,-0.265625 -1.039062,-0.382812 -0.523438,-0.125 -1.085938,-0.125 -0.523437,0 -0.992187,0.203125 -0.460938,0.195312 -0.8125,0.570312 -0.351563,0.375 -0.554688,0.914063 -0.203125,0.539062 -0.203125,1.21875 0,1.421875 0.6875,2.132812 0.695313,0.703125 1.921875,0.703125 0.554688,0 1.070313,-0.125 0.523437,-0.125 1.007812,-0.375 z m 9.406254,-3.773437 q 0,1.046875 -0.29688,1.828125 -0.28906,0.78125 -0.804686,1.296875 -0.515625,0.515625 -1.21875,0.773437 -0.703125,0.257813 -1.523438,0.257813 -0.375,0 -0.75,-0.03906 -0.367187,-0.03906 -0.75,-0.132812 v 3.28125 H 94.192581 V 56.502968 h 1.210938 l 0.08594,1.3125 q 0.585938,-0.804688 1.25,-1.125 0.664063,-0.328125 1.4375,-0.328125 0.671875,0 1.179688,0.28125 0.507812,0.28125 0.851563,0.796875 0.34375,0.507812 0.51562,1.234375 0.17188,0.71875 0.17188,1.609375 z m -1.390629,0.0625 q 0,-0.617188 -0.09375,-1.132813 -0.08594,-0.515625 -0.28125,-0.882812 -0.195312,-0.367188 -0.5,-0.570313 -0.304687,-0.210937 -0.726562,-0.210937 -0.257813,0 -0.523438,0.08594 -0.265625,0.07813 -0.554687,0.273438 -0.28125,0.1875 -0.601563,0.507812 -0.3125,0.3125 -0.671875,0.78125 v 3.804688 q 0.375,0.15625 0.789063,0.25 0.414062,0.08594 0.8125,0.08594 1.101562,0 1.726562,-0.742187 0.625,-0.75 0.625,-2.25 z m 9.789059,4 h -1.21875 l -0.0469,-1.265625 q -0.35156,0.40625 -0.67188,0.679687 -0.3125,0.265625 -0.625,0.429688 -0.3125,0.164062 -0.63281,0.226562 -0.3125,0.07031 -0.66406,0.07031 -1.21094,0 -1.82813,-0.710938 -0.61718,-0.710937 -0.61718,-2.148437 v -5.125 h 1.35937 v 5.015625 q 0,1.804687 1.35938,1.804687 0.25,0 0.48437,-0.07031 0.24219,-0.07813 0.5,-0.257813 0.26563,-0.1875 0.5625,-0.5 0.30469,-0.3125 0.67969,-0.789062 v -5.203125 h 1.35937 z"
+       id="text51"
+       aria-label="cpu" />
+    <g
+       id="text54"
+       style="font-size:8px;font-family:consolas;-inkscape-font-specification:consolas;fill:#000000;stroke-width:0.893451"
+       aria-label="prim&#10;intr&#10;hw">
+      <path
+         d="m 581.30469,108.28516 q 0,0.52343 -0.14844,0.91406 -0.14453,0.39062 -0.40234,0.64844 -0.25782,0.25781 -0.60938,0.38672 -0.35156,0.1289 -0.76172,0.1289 -0.1875,0 -0.375,-0.0195 -0.18359,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29297,-0.40234 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33594,0 0.58985,0.14062 0.2539,0.14063 0.42578,0.39844 0.17187,0.25391 0.25781,0.61719 0.0859,0.35937 0.0859,0.80469 z m -0.69532,0.0312 q 0,-0.3086 -0.0469,-0.56641 -0.043,-0.25781 -0.14063,-0.44141 -0.0977,-0.18359 -0.25,-0.28515 -0.15234,-0.10547 -0.36328,-0.10547 -0.1289,0 -0.26172,0.043 -0.13281,0.0391 -0.27734,0.13672 -0.14062,0.0937 -0.30078,0.2539 -0.15625,0.15625 -0.33594,0.39063 v 1.90234 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.37109 0.3125,-0.375 0.3125,-1.125 z m 1.90235,-1.92188 h 0.62109 l 0.0195,0.72266 q 0.34766,-0.41797 0.6836,-0.60547 0.33984,-0.1875 0.68359,-0.1875 0.60938,0 0.92188,0.39453 0.3164,0.39453 0.29296,1.17188 h -0.6875 q 0.0117,-0.51563 -0.15234,-0.7461 -0.16016,-0.23437 -0.47266,-0.23437 -0.13671,0 -0.27734,0.0508 -0.13672,0.0469 -0.28516,0.15625 -0.14453,0.10547 -0.30859,0.27344 -0.16406,0.16796 -0.35156,0.40625 v 2.51953 h -0.6875 z m 5.57422,0.5625 h -1.16016 v -0.5625 h 1.84766 V 109.75 h 1.16797 v 0.56641 h -3.14454 V 109.75 h 1.28907 z m 0.23828,-2.20703 q 0.11328,0 0.21094,0.043 0.0976,0.0391 0.16796,0.11328 0.0742,0.0742 0.11329,0.17188 0.043,0.0937 0.043,0.20703 0,0.10937 -0.043,0.20703 -0.0391,0.0977 -0.11329,0.17187 -0.0703,0.0742 -0.16796,0.11719 -0.0977,0.0391 -0.21094,0.0391 -0.11328,0 -0.21094,-0.0391 -0.0977,-0.043 -0.17187,-0.11719 -0.0703,-0.0742 -0.11329,-0.17187 -0.0391,-0.0977 -0.0391,-0.20703 0,-0.11328 0.0391,-0.20703 0.043,-0.0977 0.11329,-0.17188 0.0742,-0.0742 0.17187,-0.11328 0.0977,-0.043 0.21094,-0.043 z m 5.62109,5.56641 V 107.5 q 0,-0.18359 -0.0156,-0.30078 -0.0117,-0.11719 -0.043,-0.18359 -0.0273,-0.0703 -0.0742,-0.0977 -0.043,-0.0273 -0.10938,-0.0273 -0.0781,0 -0.14453,0.0469 -0.0664,0.0469 -0.14453,0.15234 -0.0742,0.10547 -0.16797,0.28125 -0.0898,0.17188 -0.21484,0.42579 v 2.51953 h -0.62109 v -2.74219 q 0,-0.21484 -0.0156,-0.34766 -0.0117,-0.13281 -0.043,-0.20703 -0.0273,-0.0742 -0.0742,-0.10156 -0.0469,-0.0273 -0.11328,-0.0273 -0.0703,0 -0.13281,0.0391 -0.0625,0.0391 -0.14063,0.14062 -0.0742,0.10157 -0.16796,0.27735 -0.0937,0.17578 -0.22266,0.44922 v 2.51953 h -0.625 v -3.92188 h 0.51953 l 0.0312,0.7461 q 0.10156,-0.22266 0.19531,-0.37891 0.0977,-0.15625 0.19922,-0.25 0.10156,-0.0977 0.21485,-0.14063 0.11718,-0.0469 0.25781,-0.0469 0.3164,0 0.48047,0.20703 0.16406,0.20703 0.16406,0.64063 0.0937,-0.20313 0.18359,-0.35938 0.0899,-0.16016 0.19141,-0.26562 0.10547,-0.10938 0.23047,-0.16407 0.125,-0.0586 0.28906,-0.0586 0.73828,0 0.73828,1.13672 v 2.85547 z"
+         id="path59"
+         style="stroke-width:0.893451" />
+      <path
+         d="m 579.28906,116.95703 h -1.16015 v -0.5625 h 1.84765 V 119.75 h 1.16797 v 0.56641 H 578 V 119.75 h 1.28906 z m 0.23828,-2.20703 q 0.11328,0 0.21094,0.043 0.0977,0.0391 0.16797,0.11328 0.0742,0.0742 0.11328,0.17188 0.043,0.0937 0.043,0.20703 0,0.10937 -0.043,0.20703 -0.0391,0.0977 -0.11328,0.17187 -0.0703,0.0742 -0.16797,0.11719 -0.0977,0.0391 -0.21094,0.0391 -0.11328,0 -0.21093,-0.0391 -0.0977,-0.043 -0.17188,-0.11719 -0.0703,-0.0742 -0.11328,-0.17187 -0.0391,-0.0977 -0.0391,-0.20703 0,-0.11328 0.0391,-0.20703 0.043,-0.0977 0.11328,-0.17188 0.0742,-0.0742 0.17188,-0.11328 0.0976,-0.043 0.21093,-0.043 z m 2.82422,1.64453 h 0.60547 l 0.0273,0.63281 q 0.17188,-0.20312 0.33204,-0.33593 0.16015,-0.13672 0.3125,-0.21875 0.15625,-0.082 0.3164,-0.11328 0.16016,-0.0352 0.33203,-0.0352 0.60547,0 0.91407,0.35937 0.3125,0.35547 0.3125,1.07422 v 2.5586 h -0.67969 v -2.50391 q 0,-0.46094 -0.17188,-0.67969 -0.17187,-0.22265 -0.51172,-0.22265 -0.125,0 -0.24609,0.0391 -0.11719,0.0352 -0.24609,0.12891 -0.12891,0.0898 -0.28125,0.24609 -0.14844,0.15625 -0.33594,0.39062 v 2.60157 h -0.67969 z m 7.5586,3.86719 q -0.23047,0.0586 -0.47657,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33593 -0.36328,-1.02734 v -2.04688 h -1.09766 v -0.57031 h 1.09766 v -1.07812 l 0.67969,-0.17578 v 1.2539 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42188 0.22265,0.63281 0.22657,0.20704 0.66407,0.20704 0.1875,0 0.41015,-0.0273 0.22266,-0.0312 0.46485,-0.0937 z m 1.39843,-3.86719 h 0.6211 l 0.0195,0.72266 q 0.34765,-0.41797 0.68359,-0.60547 0.33985,-0.1875 0.6836,-0.1875 0.60937,0 0.92187,0.39453 0.31641,0.39453 0.29297,1.17188 h -0.6875 q 0.0117,-0.51563 -0.15234,-0.7461 -0.16016,-0.23437 -0.47266,-0.23437 -0.13672,0 -0.27734,0.0508 -0.13672,0.0469 -0.28516,0.15625 -0.14453,0.10547 -0.30859,0.27344 -0.16407,0.16796 -0.35157,0.40625 v 2.51953 h -0.6875 z"
+         id="path60"
+         style="stroke-width:0.893451" />
+      <path
+         d="m 581.10547,130.31641 h -0.67969 v -2.50391 q 0,-0.45312 -0.17187,-0.67578 -0.16797,-0.22656 -0.48438,-0.22656 -0.13672,0 -0.25781,0.0391 -0.11719,0.0352 -0.2461,0.12891 -0.1289,0.0898 -0.28125,0.24609 -0.15234,0.15625 -0.35156,0.39062 v 2.60157 h -0.67969 v -5.51953 h 0.67969 v 1.59765 l -0.0234,0.61719 q 0.16016,-0.19141 0.3125,-0.32031 0.15625,-0.13282 0.3086,-0.21485 0.15625,-0.082 0.3164,-0.11718 0.16016,-0.0352 0.33204,-0.0352 0.58593,0 0.90625,0.35937 0.32031,0.35547 0.32031,1.07422 z m 4.8789,-3.92188 -0.57031,3.92188 h -0.82422 l -0.5664,-1.64063 -0.11328,-0.39844 -0.12891,0.42188 -0.54297,1.61719 h -0.80078 l -0.56641,-3.92188 h 0.66407 l 0.32812,2.66406 0.0703,0.59375 0.16797,-0.51953 0.57031,-1.76172 h 0.48829 l 0.61328,1.73828 0.17578,0.51954 0.0586,-0.55079 0.30469,-2.68359 z"
+         id="path61"
+         style="stroke-width:0.893451" />
+    </g>
+    <g
+       id="text56"
+       style="font-size:8px;font-family:consolas;-inkscape-font-specification:consolas;text-align:center;text-anchor:middle;fill:#000000;stroke-width:0.893451"
+       aria-label="IntrT&#10;(Event/Status)">
+      <path
+         d="m 573.31903,164.36578 h -1.17578 v -0.58593 h 3.05469 v 0.58593 h -1.17578 v 3.92578 h 1.17578 v 0.59375 h -3.05469 v -0.59375 h 1.17578 z m 3.17578,0.59766 h 0.60547 l 0.0273,0.63281 q 0.17188,-0.20312 0.33204,-0.33594 0.16015,-0.13671 0.3125,-0.21875 0.15625,-0.082 0.3164,-0.11328 0.16016,-0.0351 0.33203,-0.0351 0.60547,0 0.91407,0.35937 0.3125,0.35547 0.3125,1.07422 v 2.55859 h -0.67969 v -2.5039 q 0,-0.46094 -0.17188,-0.67969 -0.17187,-0.22266 -0.51172,-0.22266 -0.125,0 -0.24609,0.0391 -0.11719,0.0351 -0.24609,0.1289 -0.12891,0.0899 -0.28125,0.2461 -0.14844,0.15625 -0.33594,0.39062 v 2.60156 h -0.67969 z m 7.5586,3.86719 q -0.23047,0.0586 -0.47657,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 h -1.09766 v -0.57031 h 1.09766 v -1.07813 l 0.67969,-0.17578 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42187 0.22265,0.63281 0.22657,0.20703 0.66407,0.20703 0.1875,0 0.41015,-0.0273 0.22266,-0.0312 0.46485,-0.0937 z m 1.39843,-3.86719 h 0.6211 l 0.0195,0.72266 q 0.34765,-0.41797 0.68359,-0.60547 0.33985,-0.1875 0.6836,-0.1875 0.60937,0 0.92187,0.39453 0.31641,0.39453 0.29297,1.17187 h -0.6875 q 0.0117,-0.51562 -0.15234,-0.74609 -0.16016,-0.23438 -0.47266,-0.23438 -0.13672,0 -0.27734,0.0508 -0.13672,0.0469 -0.28516,0.15625 -0.14453,0.10546 -0.30859,0.27343 -0.16407,0.16797 -0.35157,0.40625 v 2.51953 h -0.6875 z m 7.67578,-0.58984 h -1.51171 v 4.51171 h -0.70313 v -4.51171 h -1.51172 v -0.59375 h 3.72656 z"
+         id="path62"
+         style="stroke-width:0.893451" />
+      <path
+         d="m 554.65106,180.52594 q -1.80078,-1.66797 -1.80078,-3.6875 0,-0.47266 0.0937,-0.94141 0.0977,-0.47265 0.30859,-0.94531 0.21485,-0.47266 0.5625,-0.94531 0.35157,-0.47266 0.85157,-0.9375 l 0.39453,0.40234 q -1.51563,1.4961 -1.51563,3.31641 0,0.90625 0.38282,1.74219 0.38281,0.83593 1.13281,1.57812 z m 5.11328,-1.64063 H 556.862 v -5.10546 h 2.90234 v 0.58593 h -2.20703 v 1.58203 h 2.1211 v 0.58594 h -2.1211 v 1.75781 h 2.20703 z m 0.96875,-3.92187 h 0.77344 l 0.96094,2.59375 0.20703,0.63281 0.21484,-0.64844 0.95313,-2.57812 h 0.74609 l -1.53906,3.92187 h -0.78125 z m 8.07813,1.75391 q 0,0.14453 -0.004,0.24218 -0.004,0.0977 -0.0117,0.1836 h -2.7539 q 0,0.60156 0.33593,0.92578 0.33594,0.32031 0.96875,0.32031 0.17188,0 0.34375,-0.0117 0.17188,-0.0156 0.33204,-0.0391 0.16015,-0.0234 0.30468,-0.0508 0.14844,-0.0312 0.27344,-0.0664 v 0.5586 q -0.27734,0.0781 -0.62891,0.125 -0.34765,0.0508 -0.72265,0.0508 -0.50391,0 -0.86719,-0.13672 -0.36328,-0.13672 -0.59766,-0.39453 -0.23046,-0.26172 -0.34375,-0.63672 -0.10937,-0.37891 -0.10937,-0.85547 0,-0.41406 0.11719,-0.78125 0.12109,-0.37109 0.34765,-0.64844 0.23047,-0.28125 0.5625,-0.44531 0.33203,-0.16406 0.75391,-0.16406 0.41016,0 0.72656,0.1289 0.31641,0.12891 0.53125,0.36719 0.21875,0.23438 0.32813,0.57422 0.11328,0.33594 0.11328,0.75391 z m -0.70703,-0.0977 q 0.0117,-0.26172 -0.0508,-0.47656 -0.0625,-0.21875 -0.19532,-0.375 -0.1289,-0.15625 -0.32422,-0.24219 -0.19531,-0.0898 -0.45312,-0.0898 -0.22266,0 -0.40625,0.0859 -0.18359,0.0859 -0.31641,0.24219 -0.13281,0.15625 -0.21484,0.375 -0.082,0.21875 -0.10156,0.48047 z m 1.79297,-1.65625 h 0.60546 l 0.0274,0.63281 q 0.17187,-0.20312 0.33203,-0.33594 0.16016,-0.13671 0.3125,-0.21875 0.15625,-0.082 0.31641,-0.11328 0.16015,-0.0351 0.33203,-0.0351 0.60547,0 0.91406,0.35937 0.3125,0.35547 0.3125,1.07422 v 2.55859 h -0.67969 v -2.5039 q 0,-0.46094 -0.17187,-0.67969 -0.17188,-0.22266 -0.51172,-0.22266 -0.125,0 -0.2461,0.0391 -0.11718,0.0351 -0.24609,0.1289 -0.12891,0.0899 -0.28125,0.2461 -0.14844,0.15625 -0.33594,0.39062 v 2.60156 h -0.67968 z m 7.55859,3.86719 q -0.23047,0.0586 -0.47656,0.082 -0.2461,0.0273 -0.5,0.0273 -0.73828,0 -1.10157,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 h -1.09765 v -0.57031 h 1.09765 v -1.07813 l 0.67969,-0.17578 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42187 0.22266,0.63281 0.22656,0.20703 0.66406,0.20703 0.1875,0 0.41016,-0.0273 0.22265,-0.0312 0.46484,-0.0937 z m 4.39062,-5.46485 -2.67968,6.35938 h -0.64844 l 2.67969,-6.35938 z m 4.51563,4.13672 q 0,0.36328 -0.14844,0.63672 -0.14844,0.27344 -0.41406,0.45703 -0.26563,0.17969 -0.64063,0.26953 -0.37109,0.0899 -0.82031,0.0899 -0.20312,0 -0.40625,-0.0156 -0.19922,-0.0156 -0.38672,-0.0391 -0.18359,-0.0234 -0.34765,-0.0547 -0.16407,-0.0312 -0.29688,-0.0664 v -0.67188 q 0.29297,0.10938 0.65625,0.17188 0.36719,0.0625 0.83203,0.0625 0.33594,0 0.57032,-0.0508 0.23828,-0.0547 0.38671,-0.15625 0.15235,-0.10546 0.21875,-0.2539 0.0703,-0.14844 0.0703,-0.33985 0,-0.20703 -0.11719,-0.35156 -0.11328,-0.14844 -0.30078,-0.26172 -0.1875,-0.11718 -0.42969,-0.21093 -0.23828,-0.0977 -0.48828,-0.19922 -0.25,-0.10157 -0.49219,-0.21875 -0.23828,-0.1211 -0.42578,-0.28125 -0.1875,-0.16407 -0.30469,-0.38282 -0.11328,-0.21875 -0.11328,-0.51953 0,-0.26172 0.10938,-0.51562 0.10937,-0.25391 0.33984,-0.44922 0.23047,-0.19922 0.58984,-0.32031 0.36329,-0.1211 0.86329,-0.1211 0.1289,0 0.27734,0.0117 0.15234,0.0117 0.30469,0.0352 0.15625,0.0195 0.30468,0.0469 0.15235,0.0274 0.28125,0.0586 v 0.625 q -0.30078,-0.0859 -0.60156,-0.12891 -0.30078,-0.0469 -0.58203,-0.0469 -0.59766,0 -0.87891,0.19921 -0.28125,0.19922 -0.28125,0.53516 0,0.20703 0.11329,0.35547 0.11718,0.14844 0.30468,0.26562 0.1875,0.11719 0.42578,0.21485 0.24219,0.0937 0.49219,0.19531 0.25,0.10156 0.48828,0.22266 0.24219,0.12109 0.42969,0.28906 0.1875,0.16406 0.30078,0.38672 0.11719,0.22265 0.11719,0.52734 z m 4.28906,1.32813 q -0.23047,0.0586 -0.47656,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 H 587.112 v -0.57031 h 1.09766 v -1.07813 l 0.67968,-0.17578 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42187 0.22266,0.63281 0.22656,0.20703 0.66406,0.20703 0.1875,0 0.41016,-0.0273 0.22265,-0.0312 0.46484,-0.0937 z m 3.75781,0.0547 -0.0156,-0.52734 q -0.32031,0.31641 -0.65234,0.45703 -0.32813,0.14063 -0.69141,0.14063 -0.33594,0 -0.57422,-0.0859 -0.23828,-0.0859 -0.39453,-0.23438 -0.15234,-0.15234 -0.22656,-0.35546 -0.0703,-0.20313 -0.0703,-0.44141 0,-0.58984 0.4375,-0.92188 0.44141,-0.33593 1.30079,-0.33593 h 0.8125 v -0.34375 q 0,-0.34766 -0.22266,-0.55469 -0.22266,-0.21094 -0.67969,-0.21094 -0.33203,0 -0.65625,0.0742 -0.32031,0.0742 -0.66406,0.21094 v -0.61328 q 0.12891,-0.0469 0.28516,-0.0899 0.16015,-0.0469 0.33593,-0.082 0.17578,-0.0351 0.36719,-0.0547 0.19141,-0.0234 0.38672,-0.0234 0.35547,0 0.64062,0.0781 0.28516,0.0781 0.48047,0.23828 0.19922,0.16016 0.30469,0.40235 0.10547,0.24218 0.10547,0.57031 v 2.70312 z m -0.0742,-1.78515 h -0.86329 q -0.2539,0 -0.4375,0.0508 -0.18359,0.0508 -0.30078,0.14453 -0.11718,0.0937 -0.17578,0.22656 -0.0547,0.12891 -0.0547,0.29297 0,0.11328 0.0352,0.21875 0.0352,0.10156 0.11328,0.1836 0.0781,0.0781 0.20313,0.125 0.125,0.0469 0.30468,0.0469 0.23438,0 0.53516,-0.14062 0.30469,-0.14454 0.64063,-0.45313 z m 5.11328,1.73047 q -0.23047,0.0586 -0.47657,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33594 -0.36328,-1.02734 v -2.04688 h -1.09766 v -0.57031 h 1.09766 v -1.07813 l 0.67969,-0.17578 v 1.25391 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42187 0.22265,0.63281 0.22657,0.20703 0.66407,0.20703 0.1875,0 0.41015,-0.0273 0.22266,-0.0312 0.46485,-0.0937 z m 4.39062,0.0547 h -0.60937 l -0.0234,-0.63281 q -0.17578,0.20313 -0.33594,0.33985 -0.15625,0.13281 -0.3125,0.21484 -0.15625,0.082 -0.3164,0.11328 -0.15625,0.0352 -0.33204,0.0352 -0.60546,0 -0.91406,-0.35547 -0.30859,-0.35547 -0.30859,-1.07422 v -2.5625 h 0.67969 v 2.50781 q 0,0.90235 0.67968,0.90235 0.125,0 0.24219,-0.0352 0.12109,-0.0391 0.25,-0.12891 0.13281,-0.0937 0.28125,-0.25 0.15234,-0.15625 0.33984,-0.39453 v -2.60156 h 0.67969 z m 4.35156,-1.07031 q 0,0.20703 -0.0703,0.3711 -0.0703,0.16406 -0.1914,0.29296 -0.1211,0.125 -0.28125,0.21485 -0.16016,0.0898 -0.34375,0.14844 -0.17969,0.0586 -0.3711,0.0859 -0.1914,0.0274 -0.375,0.0274 -0.39844,0 -0.73437,-0.0352 -0.33203,-0.0352 -0.65235,-0.11328 v -0.625 q 0.34375,0.0977 0.6836,0.14844 0.33984,0.0508 0.67578,0.0508 0.48828,0 0.72265,-0.13281 0.23438,-0.13282 0.23438,-0.37891 0,-0.10547 -0.0391,-0.1875 -0.0352,-0.0859 -0.13282,-0.16016 -0.0976,-0.0781 -0.30468,-0.16015 -0.20313,-0.082 -0.5586,-0.1875 -0.26562,-0.0781 -0.49218,-0.17578 -0.22266,-0.10157 -0.38672,-0.23829 -0.16407,-0.13671 -0.25782,-0.32031 -0.0937,-0.18359 -0.0937,-0.43359 0,-0.16406 0.0742,-0.35938 0.0781,-0.19531 0.26172,-0.36328 0.1836,-0.16797 0.4961,-0.27734 0.3125,-0.11328 0.78125,-0.11328 0.23046,0 0.51171,0.0273 0.28125,0.0234 0.58594,0.0859 v 0.60547 q -0.32031,-0.0781 -0.60937,-0.11328 -0.28516,-0.0391 -0.4961,-0.0391 -0.2539,0 -0.42968,0.0391 -0.17188,0.0391 -0.28125,0.10937 -0.10547,0.0664 -0.15235,0.16016 -0.0469,0.0898 -0.0469,0.19531 0,0.10547 0.0391,0.19141 0.043,0.0859 0.15234,0.16796 0.11328,0.0781 0.3125,0.16016 0.19922,0.0781 0.51953,0.17188 0.34766,0.10156 0.58594,0.21484 0.23828,0.10937 0.38672,0.24609 0.14844,0.13672 0.21094,0.3086 0.0664,0.17187 0.0664,0.39062 z m 2.09375,-4.74609 q 1.80079,1.66797 1.80079,3.71094 0,0.42187 -0.0859,0.875 -0.0859,0.45312 -0.29297,0.92968 -0.20703,0.47266 -0.55859,0.96094 -0.34766,0.48828 -0.87891,0.98047 l -0.39453,-0.40234 q 0.76172,-0.75391 1.13672,-1.57422 0.375,-0.82032 0.375,-1.71875 0,-1.85938 -1.51172,-3.34375 z"
+         id="path63"
+         style="stroke-width:0.893451" />
+    </g>
+    <path
+       style="-inkscape-font-specification:'consolas Italic';fill:#000000;stroke-width:0.893451"
+       d="m 180.32747,130.54851 q -0.375,0.15234 -0.75,0.23828 -0.37109,0.082 -0.76172,0.082 -0.36719,0 -0.60156,-0.0898 -0.23438,-0.0898 -0.35156,-0.29297 -0.11719,-0.20703 -0.1211,-0.53906 -0.004,-0.33204 0.0898,-0.8125 l 0.77734,-3.83985 h 0.69531 l -0.76562,3.83985 q -0.0703,0.34765 -0.0899,0.57031 -0.0156,0.22265 0.0274,0.35156 0.043,0.12891 0.14453,0.17969 0.10547,0.0508 0.27734,0.0508 0.28906,0 0.64063,-0.082 0.35547,-0.082 0.78906,-0.26172 z m 1.97656,-1.47656 q -0.0195,0.10156 -0.0312,0.1914 -0.008,0.0898 -0.008,0.17578 0,0.42578 0.25391,0.65235 0.2539,0.22656 0.78515,0.22656 0.34375,0 0.67969,-0.0508 0.33984,-0.0508 0.60547,-0.11719 v 0.55859 q -0.29297,0.0781 -0.66016,0.125 -0.36328,0.0508 -0.73828,0.0508 -0.82812,0 -1.22266,-0.36719 -0.39453,-0.3711 -0.39453,-1.07031 0,-0.53907 0.16797,-1.01563 0.16797,-0.47656 0.46485,-0.83203 0.29687,-0.35938 0.70312,-0.56641 0.41016,-0.21093 0.89063,-0.21093 0.33203,0 0.58984,0.0781 0.26172,0.0781 0.44141,0.21484 0.17968,0.13672 0.27343,0.32422 0.0937,0.1836 0.0937,0.39844 0,0.28125 -0.12109,0.50781 -0.11719,0.22657 -0.37891,0.39063 -0.25781,0.16015 -0.66797,0.25 -0.41015,0.0859 -0.99218,0.0859 z m 0.72656,-0.52344 q 0.4336,0 0.71485,-0.0508 0.28515,-0.0547 0.44922,-0.14453 0.16797,-0.0898 0.23437,-0.20704 0.0664,-0.11718 0.0664,-0.24218 0,-0.10938 -0.043,-0.20703 -0.043,-0.0977 -0.13672,-0.17188 -0.0898,-0.0742 -0.23047,-0.11719 -0.13672,-0.043 -0.32422,-0.043 -0.2539,0 -0.46484,0.0859 -0.20703,0.082 -0.375,0.23828 -0.16797,0.15235 -0.29688,0.3711 -0.1289,0.21875 -0.21875,0.48828 z m 3.1836,-1.65625 h 0.73437 l 0.4336,2.59375 0.0937,0.66406 q 0.34375,-0.3125 0.60156,-0.69141 0.26172,-0.3789 0.44531,-0.79687 0.1875,-0.42188 0.29688,-0.86719 0.10937,-0.44922 0.15234,-0.90234 h 0.76953 q -0.0625,0.54687 -0.24219,1.08984 -0.17968,0.54297 -0.45703,1.05078 -0.27343,0.50782 -0.64062,0.96094 -0.36328,0.45313 -0.79688,0.82031 h -0.65625 z m 4.88672,2.17969 q -0.0195,0.10156 -0.0312,0.1914 -0.008,0.0898 -0.008,0.17578 0,0.42578 0.25391,0.65235 0.25391,0.22656 0.78516,0.22656 0.34375,0 0.67968,-0.0508 0.33985,-0.0508 0.60547,-0.11719 v 0.55859 q -0.29297,0.0781 -0.66015,0.125 -0.36328,0.0508 -0.73828,0.0508 -0.82813,0 -1.22266,-0.36719 -0.39453,-0.3711 -0.39453,-1.07031 0,-0.53907 0.16797,-1.01563 0.16797,-0.47656 0.46484,-0.83203 0.29688,-0.35938 0.70313,-0.56641 0.41015,-0.21093 0.89062,-0.21093 0.33203,0 0.58984,0.0781 0.26172,0.0781 0.44141,0.21484 0.17969,0.13672 0.27344,0.32422 0.0937,0.1836 0.0937,0.39844 0,0.28125 -0.1211,0.50781 -0.11718,0.22657 -0.3789,0.39063 -0.25781,0.16015 -0.66797,0.25 -0.41016,0.0859 -0.99219,0.0859 z m 0.72656,-0.52344 q 0.43359,0 0.71484,-0.0508 0.28516,-0.0547 0.44922,-0.14453 0.16797,-0.0898 0.23438,-0.20704 0.0664,-0.11718 0.0664,-0.24218 0,-0.10938 -0.043,-0.20703 -0.043,-0.0977 -0.13671,-0.17188 -0.0898,-0.0742 -0.23047,-0.11719 -0.13672,-0.043 -0.32422,-0.043 -0.25391,0 -0.46485,0.0859 -0.20703,0.082 -0.375,0.23828 -0.16796,0.15235 -0.29687,0.3711 -0.12891,0.21875 -0.21875,0.48828 z m 6.09375,2 q -0.375,0.15234 -0.75,0.23828 -0.37109,0.082 -0.76172,0.082 -0.36719,0 -0.60156,-0.0898 -0.23438,-0.0898 -0.35156,-0.29297 -0.11719,-0.20703 -0.1211,-0.53906 -0.004,-0.33204 0.0898,-0.8125 l 0.77734,-3.83985 h 0.69531 l -0.76562,3.83985 q -0.0703,0.34765 -0.0899,0.57031 -0.0156,0.22265 0.0274,0.35156 0.043,0.12891 0.14453,0.17969 0.10547,0.0508 0.27734,0.0508 0.28906,0 0.64063,-0.082 0.35547,-0.082 0.78906,-0.26172 z m 4.17578,-1.54297 h -2.33594 l 0.12891,-0.64063 h 2.33594 z m 4.52734,1.75391 q -0.24609,0.0586 -0.48828,0.082 -0.23828,0.0273 -0.42578,0.0273 -0.39844,0 -0.68359,-0.0859 -0.28125,-0.0898 -0.44531,-0.28125 -0.16407,-0.1914 -0.20704,-0.49218 -0.0391,-0.30469 0.0508,-0.73829 l 0.35937,-1.80859 h -1.09766 l 0.11329,-0.57031 h 1.09375 l 0.21875,-1.07813 0.71875,-0.17578 -0.25782,1.25391 h 1.76172 l -0.11328,0.57031 h -1.75781 l -0.36719,1.83203 q -0.0547,0.26953 -0.043,0.46094 0.0117,0.1875 0.0937,0.30859 0.082,0.1211 0.23828,0.17578 0.15625,0.0547 0.39844,0.0547 0.14453,0 0.36328,-0.0273 0.21875,-0.0312 0.47656,-0.0937 z m 1.75,-2.06641 q 0.0156,-0.0742 0.0312,-0.19531 0.0195,-0.1211 0.043,-0.32422 0.0234,-0.20703 0.0586,-0.51563 0.0351,-0.3125 0.082,-0.76562 h 0.64062 l -0.0976,0.90625 q 0.13672,-0.19922 0.29687,-0.375 0.16016,-0.17969 0.35156,-0.3125 0.19141,-0.13281 0.41797,-0.21094 0.22657,-0.0781 0.4961,-0.0781 0.64453,0 0.89062,0.40234 0.2461,0.40234 0.0781,1.16406 H 210.972 q 0.0586,-0.26953 0.0586,-0.45703 0,-0.1875 -0.0547,-0.30078 -0.0508,-0.11719 -0.15625,-0.16797 -0.10157,-0.0547 -0.2461,-0.0547 -0.28125,0 -0.54687,0.17188 -0.26563,0.16797 -0.48828,0.44531 -0.21875,0.27344 -0.37891,0.61719 -0.15625,0.34375 -0.22656,0.6914 l -0.29688,1.48047 h -0.6875 z m 5.71094,-2.88672 q 0,-0.12109 0.043,-0.22266 0.043,-0.10156 0.11719,-0.17578 0.0781,-0.0742 0.17969,-0.11718 0.10156,-0.043 0.21875,-0.043 0.11328,0 0.20703,0.043 0.0937,0.0391 0.16015,0.10937 0.0703,0.0664 0.10547,0.16016 0.0391,0.0937 0.0391,0.19922 0,0.12109 -0.043,0.22265 -0.043,0.10156 -0.1211,0.17578 -0.0742,0.0742 -0.17578,0.11719 -0.10156,0.043 -0.21875,0.043 -0.11328,0 -0.21094,-0.0391 -0.0937,-0.043 -0.16015,-0.10938 -0.0664,-0.0703 -0.10547,-0.16406 -0.0352,-0.0937 -0.0352,-0.19922 z m 1.61328,4.76172 q -0.26953,0.14844 -0.57031,0.23437 -0.29687,0.082 -0.63672,0.082 -0.27734,0 -0.46484,-0.0781 -0.1875,-0.0781 -0.28906,-0.24609 -0.0977,-0.17188 -0.10938,-0.4375 -0.0117,-0.26563 0.0625,-0.64453 l 0.26563,-1.3125 q 0.0469,-0.22266 0.043,-0.3711 0,-0.15234 -0.0391,-0.24219 -0.0391,-0.0898 -0.11719,-0.125 -0.0742,-0.0391 -0.17578,-0.0391 -0.26562,0 -0.52343,0.10547 -0.25782,0.10156 -0.52344,0.25 v -0.60156 q 0.26953,-0.14844 0.5664,-0.23438 0.30079,-0.0859 0.64063,-0.0859 0.27734,0 0.46484,0.0781 0.1875,0.0781 0.28516,0.25 0.10156,0.16797 0.11328,0.43359 0.0117,0.26563 -0.0625,0.64454 l -0.26562,1.3125 q -0.043,0.22656 -0.043,0.375 0,0.14843 0.0391,0.23828 0.043,0.0898 0.11719,0.1289 0.0742,0.0352 0.17578,0.0352 0.26562,0 0.52344,-0.10156 0.25781,-0.10547 0.52343,-0.25 z m 3.32032,0.32422 q 0.0586,-0.25391 0.12109,-0.49219 0.0664,-0.23828 0.13281,-0.44922 -0.11719,0.21875 -0.27734,0.39453 -0.15625,0.17188 -0.33985,0.29297 -0.18359,0.11719 -0.39453,0.17969 -0.21093,0.0664 -0.43359,0.0664 -0.28125,0 -0.49219,-0.0937 -0.20703,-0.0937 -0.34375,-0.26563 -0.13672,-0.17578 -0.20312,-0.41797 -0.0664,-0.24219 -0.0664,-0.53906 0,-0.5625 0.14453,-1.05469 0.14844,-0.49609 0.4336,-0.86719 0.28515,-0.37109 0.70312,-0.58593 0.42188,-0.21485 0.96875,-0.21485 0.25391,0 0.48438,0.0352 0.23046,0.0312 0.4414,0.0937 l 0.61719,-0.15234 -0.83984,4.19921 q -0.0625,0.31641 -0.19532,0.57813 -0.1289,0.26172 -0.35156,0.45312 -0.22266,0.19141 -0.54687,0.29688 -0.32422,0.10547 -0.75,0.10547 -0.45704,0 -0.79297,-0.1211 -0.33594,-0.12109 -0.53125,-0.26171 l 0.34375,-0.5 q 0.22265,0.15234 0.47656,0.24609 0.25781,0.0937 0.5625,0.0937 0.30469,0 0.5,-0.0859 0.19531,-0.082 0.31641,-0.22265 0.125,-0.14063 0.19531,-0.32422 0.0703,-0.1836 0.11719,-0.38672 z m -1.60938,-1.39063 q 0,0.3711 0.12891,0.58203 0.1289,0.21094 0.41797,0.21094 0.16796,0 0.33593,-0.0781 0.16797,-0.0781 0.32422,-0.21485 0.16016,-0.13672 0.30469,-0.32031 0.14453,-0.18359 0.26172,-0.39062 0.11719,-0.21094 0.20312,-0.4336 0.0859,-0.22265 0.12891,-0.4414 l 0.16797,-0.84766 q -0.1836,-0.0781 -0.37891,-0.12109 -0.1914,-0.0469 -0.35547,-0.0469 -0.32031,0 -0.55859,0.10938 -0.23828,0.10937 -0.41016,0.28515 -0.17187,0.17578 -0.28125,0.40235 -0.10937,0.22265 -0.17578,0.45703 -0.0625,0.23437 -0.0898,0.45703 -0.0234,0.22265 -0.0234,0.39062 z m 6.00781,1.39063 q 0.0586,-0.25391 0.1211,-0.49219 0.0664,-0.23828 0.13281,-0.44922 -0.11719,0.21875 -0.27734,0.39453 -0.15625,0.17188 -0.33985,0.29297 -0.18359,0.11719 -0.39453,0.17969 -0.21094,0.0664 -0.43359,0.0664 -0.28125,0 -0.49219,-0.0937 -0.20703,-0.0937 -0.34375,-0.26563 -0.13672,-0.17578 -0.20313,-0.41797 -0.0664,-0.24219 -0.0664,-0.53906 0,-0.5625 0.14453,-1.05469 0.14844,-0.49609 0.43359,-0.86719 0.28516,-0.37109 0.70313,-0.58593 0.42187,-0.21485 0.96875,-0.21485 0.2539,0 0.48437,0.0352 0.23047,0.0312 0.44141,0.0937 l 0.61719,-0.15234 -0.83985,4.19921 q -0.0625,0.31641 -0.19531,0.57813 -0.12891,0.26172 -0.35156,0.45312 -0.22266,0.19141 -0.54688,0.29688 -0.32422,0.10547 -0.75,0.10547 -0.45703,0 -0.79297,-0.1211 -0.33593,-0.12109 -0.53125,-0.26171 l 0.34375,-0.5 q 0.22266,0.15234 0.47657,0.24609 0.25781,0.0937 0.5625,0.0937 0.30468,0 0.5,-0.0859 0.19531,-0.082 0.3164,-0.22265 0.125,-0.14063 0.19532,-0.32422 0.0703,-0.1836 0.11718,-0.38672 z m -1.60937,-1.39063 q 0,0.3711 0.1289,0.58203 0.12891,0.21094 0.41797,0.21094 0.16797,0 0.33594,-0.0781 0.16797,-0.0781 0.32422,-0.21485 0.16016,-0.13672 0.30469,-0.32031 0.14453,-0.18359 0.26172,-0.39062 0.11718,-0.21094 0.20312,-0.4336 0.0859,-0.22265 0.12891,-0.4414 l 0.16797,-0.84766 q -0.1836,-0.0781 -0.37891,-0.12109 -0.19141,-0.0469 -0.35547,-0.0469 -0.32031,0 -0.55859,0.10938 -0.23828,0.10937 -0.41016,0.28515 -0.17187,0.17578 -0.28125,0.40235 -0.10937,0.22265 -0.17578,0.45703 -0.0625,0.23437 -0.0898,0.45703 -0.0234,0.22265 -0.0234,0.39062 z m 4.48047,-0.42968 q -0.0195,0.10156 -0.0312,0.1914 -0.008,0.0898 -0.008,0.17578 0,0.42578 0.25391,0.65235 0.25391,0.22656 0.78516,0.22656 0.34375,0 0.67968,-0.0508 0.33985,-0.0508 0.60547,-0.11719 v 0.55859 q -0.29297,0.0781 -0.66015,0.125 -0.36328,0.0508 -0.73828,0.0508 -0.82813,0 -1.22266,-0.36719 -0.39453,-0.3711 -0.39453,-1.07031 0,-0.53907 0.16797,-1.01563 0.16797,-0.47656 0.46484,-0.83203 0.29688,-0.35938 0.70313,-0.56641 0.41015,-0.21093 0.89062,-0.21093 0.33203,0 0.58984,0.0781 0.26172,0.0781 0.44141,0.21484 0.17969,0.13672 0.27344,0.32422 0.0937,0.1836 0.0937,0.39844 0,0.28125 -0.1211,0.50781 -0.11718,0.22657 -0.3789,0.39063 -0.25781,0.16015 -0.66797,0.25 -0.41016,0.0859 -0.99219,0.0859 z m 0.72656,-0.52344 q 0.43359,0 0.71484,-0.0508 0.28516,-0.0547 0.44922,-0.14453 0.16797,-0.0898 0.23438,-0.20704 0.0664,-0.11718 0.0664,-0.24218 0,-0.10938 -0.043,-0.20703 -0.043,-0.0977 -0.13671,-0.17188 -0.0898,-0.0742 -0.23047,-0.11719 -0.13672,-0.043 -0.32422,-0.043 -0.25391,0 -0.46485,0.0859 -0.20703,0.082 -0.375,0.23828 -0.16796,0.15235 -0.29687,0.3711 -0.12891,0.21875 -0.21875,0.48828 z m 3.35156,0.14453 q 0.0156,-0.0742 0.0312,-0.19531 0.0195,-0.1211 0.043,-0.32422 0.0234,-0.20703 0.0586,-0.51563 0.0352,-0.3125 0.082,-0.76562 h 0.64062 l -0.0977,0.90625 q 0.13672,-0.19922 0.29688,-0.375 0.16016,-0.17969 0.35156,-0.3125 0.19141,-0.13281 0.41797,-0.21094 0.22656,-0.0781 0.49609,-0.0781 0.64454,0 0.89063,0.40234 0.24609,0.40234 0.0781,1.16406 h -0.6914 q 0.0586,-0.26953 0.0586,-0.45703 0,-0.1875 -0.0547,-0.30078 -0.0508,-0.11719 -0.15625,-0.16797 -0.10156,-0.0547 -0.24609,-0.0547 -0.28125,0 -0.54687,0.17188 -0.26563,0.16797 -0.48829,0.44531 -0.21875,0.27344 -0.3789,0.61719 -0.15625,0.34375 -0.22656,0.6914 l -0.29688,1.48047 h -0.6875 z m 4.71875,0.37891 q -0.0195,0.10156 -0.0312,0.1914 -0.008,0.0898 -0.008,0.17578 0,0.42578 0.25391,0.65235 0.2539,0.22656 0.78515,0.22656 0.34375,0 0.67969,-0.0508 0.33984,-0.0508 0.60547,-0.11719 v 0.55859 q -0.29297,0.0781 -0.66016,0.125 -0.36328,0.0508 -0.73828,0.0508 -0.82812,0 -1.22266,-0.36719 -0.39453,-0.3711 -0.39453,-1.07031 0,-0.53907 0.16797,-1.01563 0.16797,-0.47656 0.46485,-0.83203 0.29687,-0.35938 0.70312,-0.56641 0.41016,-0.21093 0.89063,-0.21093 0.33203,0 0.58984,0.0781 0.26172,0.0781 0.44141,0.21484 0.17968,0.13672 0.27343,0.32422 0.0937,0.1836 0.0937,0.39844 0,0.28125 -0.12109,0.50781 -0.11719,0.22657 -0.37891,0.39063 -0.25781,0.16015 -0.66797,0.25 -0.41015,0.0859 -0.99218,0.0859 z m 0.72656,-0.52344 q 0.4336,0 0.71485,-0.0508 0.28515,-0.0547 0.44922,-0.14453 0.16797,-0.0898 0.23437,-0.20704 0.0664,-0.11718 0.0664,-0.24218 0,-0.10938 -0.043,-0.20703 -0.043,-0.0977 -0.13672,-0.17188 -0.0898,-0.0742 -0.23047,-0.11719 -0.13672,-0.043 -0.32422,-0.043 -0.2539,0 -0.46484,0.0859 -0.20703,0.082 -0.375,0.23828 -0.16797,0.15235 -0.29688,0.3711 -0.1289,0.21875 -0.21875,0.48828 z m 5.15235,-1.70313 q 0.28125,0 0.47265,0.0234 0.19532,0.0234 0.36719,0.0742 l 0.32813,-1.64844 h 0.67968 l -0.74609,3.71875 q -0.0156,0.0742 -0.0352,0.19531 -0.0156,0.1211 -0.0391,0.32813 -0.0234,0.20312 -0.0586,0.51562 -0.0352,0.3086 -0.082,0.76172 h -0.64063 l 0.0977,-0.90234 q -0.26953,0.46875 -0.65625,0.72266 -0.38281,0.25 -0.83203,0.25 -0.28125,0 -0.49219,-0.0937 -0.20703,-0.0937 -0.34375,-0.26563 -0.13672,-0.17578 -0.20313,-0.41797 -0.0664,-0.24219 -0.0664,-0.53906 0,-0.5625 0.14453,-1.05469 0.14844,-0.49609 0.43359,-0.86719 0.28516,-0.37109 0.70313,-0.58593 0.42187,-0.21485 0.96875,-0.21485 z m -1.5625,2.65625 q 0,0.3711 0.1289,0.58203 0.12891,0.21094 0.41797,0.21094 0.16797,0 0.33594,-0.0781 0.16797,-0.0781 0.32813,-0.21485 0.16015,-0.13672 0.30078,-0.32031 0.14453,-0.1875 0.26172,-0.39844 0.12109,-0.21484 0.20703,-0.44531 0.0859,-0.23437 0.13281,-0.46484 l 0.16016,-0.80469 q -0.1836,-0.0781 -0.37891,-0.12109 -0.19141,-0.0469 -0.35547,-0.0469 -0.32031,0 -0.55859,0.10938 -0.23828,0.10937 -0.41016,0.28515 -0.17187,0.17578 -0.28125,0.40235 -0.10937,0.22265 -0.17578,0.45703 -0.0625,0.23437 -0.0898,0.45703 -0.0234,0.22265 -0.0234,0.39062 z"
+       id="text57"
+       aria-label="level-triggered" />
+    <path
+       style="-inkscape-font-specification:'consolas Italic';fill:#000000;stroke-width:0.893451"
+       d="m 442.34189,106.77386 q -0.375,0.15235 -0.75,0.23829 -0.3711,0.082 -0.76172,0.082 -0.36719,0 -0.60156,-0.0898 -0.23438,-0.0898 -0.35157,-0.29297 -0.11718,-0.20703 -0.12109,-0.53906 -0.004,-0.33203 0.0898,-0.8125 l 0.77735,-3.83984 h 0.69531 l -0.76562,3.83984 q -0.0703,0.34766 -0.0898,0.57031 -0.0156,0.22266 0.0273,0.35157 0.043,0.1289 0.14453,0.17968 0.10547,0.0508 0.27734,0.0508 0.28906,0 0.64063,-0.082 0.35546,-0.082 0.78906,-0.26171 z m 1.97656,-1.47656 q -0.0195,0.10156 -0.0312,0.19141 -0.008,0.0898 -0.008,0.17578 0,0.42578 0.2539,0.65234 0.25391,0.22657 0.78516,0.22657 0.34375,0 0.67969,-0.0508 0.33984,-0.0508 0.60547,-0.11718 v 0.55859 q -0.29297,0.0781 -0.66016,0.125 -0.36328,0.0508 -0.73828,0.0508 -0.82813,0 -1.22266,-0.36719 -0.39453,-0.37109 -0.39453,-1.07031 0,-0.53906 0.16797,-1.01562 0.16797,-0.47657 0.46484,-0.83203 0.29688,-0.35938 0.70313,-0.56641 0.41016,-0.21094 0.89062,-0.21094 0.33204,0 0.58985,0.0781 0.26172,0.0781 0.4414,0.21484 0.17969,0.13672 0.27344,0.32422 0.0937,0.18359 0.0937,0.39844 0,0.28125 -0.12109,0.50781 -0.11719,0.22656 -0.37891,0.39062 -0.25781,0.16016 -0.66797,0.25 -0.41015,0.0859 -0.99218,0.0859 z m 0.72656,-0.52344 q 0.4336,0 0.71485,-0.0508 0.28515,-0.0547 0.44922,-0.14453 0.16796,-0.0898 0.23437,-0.20703 0.0664,-0.11719 0.0664,-0.24219 0,-0.10937 -0.043,-0.20703 -0.043,-0.0977 -0.13672,-0.17187 -0.0898,-0.0742 -0.23047,-0.11719 -0.13672,-0.043 -0.32422,-0.043 -0.2539,0 -0.46484,0.0859 -0.20703,0.082 -0.375,0.23828 -0.16797,0.15234 -0.29688,0.37109 -0.1289,0.21875 -0.21875,0.48828 z m 3.1836,-1.65625 h 0.73437 l 0.4336,2.59375 0.0937,0.66407 q 0.34375,-0.3125 0.60156,-0.69141 0.26172,-0.37891 0.44531,-0.79687 0.1875,-0.42188 0.29688,-0.86719 0.10937,-0.44922 0.15234,-0.90235 h 0.76953 q -0.0625,0.54688 -0.24219,1.08985 -0.17968,0.54297 -0.45703,1.05078 -0.27344,0.50781 -0.64062,0.96094 -0.36328,0.45312 -0.79688,0.82031 h -0.65625 z m 4.88672,2.17969 q -0.0195,0.10156 -0.0312,0.19141 -0.008,0.0898 -0.008,0.17578 0,0.42578 0.25391,0.65234 0.25391,0.22657 0.78516,0.22657 0.34375,0 0.67968,-0.0508 0.33985,-0.0508 0.60547,-0.11718 v 0.55859 q -0.29297,0.0781 -0.66015,0.125 -0.36329,0.0508 -0.73829,0.0508 -0.82812,0 -1.22265,-0.36719 -0.39453,-0.37109 -0.39453,-1.07031 0,-0.53906 0.16797,-1.01562 0.16796,-0.47657 0.46484,-0.83203 0.29687,-0.35938 0.70312,-0.56641 0.41016,-0.21094 0.89063,-0.21094 0.33203,0 0.58984,0.0781 0.26172,0.0781 0.44141,0.21484 0.17969,0.13672 0.27344,0.32422 0.0937,0.18359 0.0937,0.39844 0,0.28125 -0.1211,0.50781 -0.11718,0.22656 -0.3789,0.39062 -0.25782,0.16016 -0.66797,0.25 -0.41016,0.0859 -0.99219,0.0859 z m 0.72656,-0.52344 q 0.43359,0 0.71484,-0.0508 0.28516,-0.0547 0.44922,-0.14453 0.16797,-0.0898 0.23438,-0.20703 0.0664,-0.11719 0.0664,-0.24219 0,-0.10937 -0.043,-0.20703 -0.043,-0.0977 -0.13672,-0.17187 -0.0898,-0.0742 -0.23046,-0.11719 -0.13672,-0.043 -0.32422,-0.043 -0.25391,0 -0.46485,0.0859 -0.20703,0.082 -0.375,0.23828 -0.16797,0.15234 -0.29687,0.37109 -0.12891,0.21875 -0.21875,0.48828 z m 6.09375,2 q -0.375,0.15235 -0.75,0.23829 -0.3711,0.082 -0.76172,0.082 -0.36719,0 -0.60156,-0.0898 -0.23438,-0.0898 -0.35157,-0.29297 -0.11718,-0.20703 -0.12109,-0.53906 -0.004,-0.33203 0.0898,-0.8125 l 0.77735,-3.83984 h 0.69531 l -0.76562,3.83984 q -0.0703,0.34766 -0.0898,0.57031 -0.0156,0.22266 0.0273,0.35157 0.043,0.1289 0.14453,0.17968 0.10547,0.0508 0.27734,0.0508 0.28906,0 0.64063,-0.082 0.35546,-0.082 0.78906,-0.26171 z m 4.17578,-1.54296 h -2.33594 l 0.12891,-0.64063 h 2.33594 z m 4.52734,1.7539 q -0.24609,0.0586 -0.48828,0.082 -0.23828,0.0273 -0.42578,0.0273 -0.39844,0 -0.68359,-0.0859 -0.28125,-0.0898 -0.44532,-0.28125 -0.16406,-0.19141 -0.20703,-0.49219 -0.0391,-0.30469 0.0508,-0.73828 l 0.35938,-1.80859 h -1.09766 l 0.11328,-0.57032 h 1.09375 l 0.21875,-1.07812 0.71875,-0.17578 -0.25781,1.2539 h 1.76172 l -0.11328,0.57032 h -1.75781 l -0.36719,1.83203 q -0.0547,0.26953 -0.043,0.46094 0.0117,0.1875 0.0937,0.30859 0.082,0.12109 0.23828,0.17578 0.15625,0.0547 0.39844,0.0547 0.14453,0 0.36328,-0.0273 0.21875,-0.0312 0.47656,-0.0937 z m 1.75,-2.0664 q 0.0156,-0.0742 0.0312,-0.19532 0.0195,-0.12109 0.043,-0.32422 0.0234,-0.20703 0.0586,-0.51562 0.0352,-0.3125 0.082,-0.76563 h 0.64062 l -0.0977,0.90625 q 0.13671,-0.19921 0.29687,-0.375 0.16016,-0.17968 0.35156,-0.3125 0.19141,-0.13281 0.41797,-0.21093 0.22656,-0.0781 0.4961,-0.0781 0.64453,0 0.89062,0.40235 0.24609,0.40234 0.0781,1.16406 h -0.69141 q 0.0586,-0.26953 0.0586,-0.45703 0,-0.1875 -0.0547,-0.30078 -0.0508,-0.11719 -0.15625,-0.16797 -0.10157,-0.0547 -0.2461,-0.0547 -0.28125,0 -0.54687,0.17187 -0.26563,0.16797 -0.48828,0.44532 -0.21875,0.27343 -0.37891,0.61718 -0.15625,0.34375 -0.22656,0.69141 l -0.29688,1.48047 h -0.6875 z m 5.71094,-2.88672 q 0,-0.1211 0.043,-0.22266 0.043,-0.10156 0.11719,-0.17578 0.0781,-0.0742 0.17968,-0.11719 0.10157,-0.043 0.21875,-0.043 0.11329,0 0.20704,0.043 0.0937,0.0391 0.16015,0.10938 0.0703,0.0664 0.10547,0.16015 0.0391,0.0937 0.0391,0.19922 0,0.1211 -0.043,0.22266 -0.043,0.10156 -0.12109,0.17578 -0.0742,0.0742 -0.17578,0.11719 -0.10156,0.043 -0.21875,0.043 -0.11328,0 -0.21094,-0.0391 -0.0937,-0.043 -0.16015,-0.10937 -0.0664,-0.0703 -0.10547,-0.16406 -0.0352,-0.0937 -0.0352,-0.19922 z m 1.61328,4.76172 q -0.26953,0.14843 -0.57031,0.23437 -0.29688,0.082 -0.63672,0.082 -0.27734,0 -0.46484,-0.0781 -0.1875,-0.0781 -0.28907,-0.2461 -0.0977,-0.17187 -0.10937,-0.4375 -0.0117,-0.26562 0.0625,-0.64453 l 0.26562,-1.3125 q 0.0469,-0.22265 0.043,-0.37109 0,-0.15235 -0.0391,-0.24219 -0.0391,-0.0898 -0.11719,-0.125 -0.0742,-0.0391 -0.17578,-0.0391 -0.26562,0 -0.52344,0.10547 -0.25781,0.10156 -0.52343,0.25 v -0.60157 q 0.26953,-0.14843 0.5664,-0.23437 0.30078,-0.0859 0.64063,-0.0859 0.27734,0 0.46484,0.0781 0.1875,0.0781 0.28516,0.25 0.10156,0.16797 0.11328,0.43359 0.0117,0.26563 -0.0625,0.64453 l -0.26563,1.3125 q -0.043,0.22656 -0.043,0.375 0,0.14844 0.0391,0.23828 0.043,0.0898 0.11719,0.12891 0.0742,0.0352 0.17578,0.0352 0.26562,0 0.52343,-0.10157 0.25782,-0.10547 0.52344,-0.25 z m 3.32031,0.32421 q 0.0586,-0.2539 0.1211,-0.49218 0.0664,-0.23828 0.13281,-0.44922 -0.11719,0.21875 -0.27734,0.39453 -0.15625,0.17187 -0.33985,0.29297 -0.18359,0.11719 -0.39453,0.17969 -0.21094,0.0664 -0.43359,0.0664 -0.28125,0 -0.49219,-0.0937 -0.20703,-0.0937 -0.34375,-0.26562 -0.13672,-0.17578 -0.20312,-0.41797 -0.0664,-0.24219 -0.0664,-0.53906 0,-0.5625 0.14453,-1.05469 0.14844,-0.4961 0.43359,-0.86719 0.28516,-0.37109 0.70313,-0.58594 0.42187,-0.21484 0.96875,-0.21484 0.25391,0 0.48437,0.0352 0.23047,0.0312 0.44141,0.0937 l 0.61719,-0.15235 -0.83985,4.19922 q -0.0625,0.31641 -0.19531,0.57813 -0.1289,0.26171 -0.35156,0.45312 -0.22266,0.19141 -0.54688,0.29688 -0.32421,0.10546 -0.75,0.10546 -0.45703,0 -0.79296,-0.12109 -0.33594,-0.12109 -0.53125,-0.26172 l 0.34375,-0.5 q 0.22265,0.15235 0.47656,0.2461 0.25781,0.0937 0.5625,0.0937 0.30469,0 0.5,-0.0859 0.19531,-0.082 0.3164,-0.22266 0.125,-0.14062 0.19532,-0.32422 0.0703,-0.18359 0.11718,-0.38672 z m -1.60937,-1.39062 q 0,0.37109 0.12891,0.58203 0.1289,0.21094 0.41796,0.21094 0.16797,0 0.33594,-0.0781 0.16797,-0.0781 0.32422,-0.21484 0.16016,-0.13672 0.30469,-0.32031 0.14453,-0.1836 0.26172,-0.39063 0.11718,-0.21094 0.20312,-0.43359 0.0859,-0.22266 0.12891,-0.44141 l 0.16797,-0.84765 q -0.1836,-0.0781 -0.37891,-0.1211 -0.19141,-0.0469 -0.35547,-0.0469 -0.32031,0 -0.55859,0.10937 -0.23828,0.10938 -0.41016,0.28516 -0.17187,0.17578 -0.28125,0.40234 -0.10937,0.22266 -0.17578,0.45703 -0.0625,0.23438 -0.0898,0.45703 -0.0234,0.22266 -0.0234,0.39063 z m 6.00781,1.39062 q 0.0586,-0.2539 0.1211,-0.49218 0.0664,-0.23828 0.13281,-0.44922 -0.11719,0.21875 -0.27735,0.39453 -0.15625,0.17187 -0.33984,0.29297 -0.18359,0.11719 -0.39453,0.17969 -0.21094,0.0664 -0.43359,0.0664 -0.28125,0 -0.49219,-0.0937 -0.20703,-0.0937 -0.34375,-0.26562 -0.13672,-0.17578 -0.20313,-0.41797 -0.0664,-0.24219 -0.0664,-0.53906 0,-0.5625 0.14453,-1.05469 0.14844,-0.4961 0.43359,-0.86719 0.28516,-0.37109 0.70313,-0.58594 0.42187,-0.21484 0.96875,-0.21484 0.2539,0 0.48437,0.0352 0.23047,0.0312 0.44141,0.0937 l 0.61719,-0.15235 -0.83985,4.19922 q -0.0625,0.31641 -0.19531,0.57813 -0.12891,0.26171 -0.35156,0.45312 -0.22266,0.19141 -0.54688,0.29688 -0.32422,0.10546 -0.75,0.10546 -0.45703,0 -0.79297,-0.12109 -0.33593,-0.12109 -0.53125,-0.26172 l 0.34375,-0.5 q 0.22266,0.15235 0.47657,0.2461 0.25781,0.0937 0.5625,0.0937 0.30468,0 0.5,-0.0859 0.19531,-0.082 0.3164,-0.22266 0.125,-0.14062 0.19531,-0.32422 0.0703,-0.18359 0.11719,-0.38672 z m -1.60937,-1.39062 q 0,0.37109 0.1289,0.58203 0.12891,0.21094 0.41797,0.21094 0.16797,0 0.33594,-0.0781 0.16797,-0.0781 0.32422,-0.21484 0.16015,-0.13672 0.30469,-0.32031 0.14453,-0.1836 0.26171,-0.39063 0.11719,-0.21094 0.20313,-0.43359 0.0859,-0.22266 0.12891,-0.44141 l 0.16796,-0.84765 q -0.18359,-0.0781 -0.3789,-0.1211 -0.19141,-0.0469 -0.35547,-0.0469 -0.32031,0 -0.55859,0.10937 -0.23829,0.10938 -0.41016,0.28516 -0.17188,0.17578 -0.28125,0.40234 -0.10938,0.22266 -0.17578,0.45703 -0.0625,0.23438 -0.0898,0.45703 -0.0234,0.22266 -0.0234,0.39063 z m 4.48047,-0.42969 q -0.0195,0.10156 -0.0312,0.19141 -0.008,0.0898 -0.008,0.17578 0,0.42578 0.25391,0.65234 0.25391,0.22657 0.78516,0.22657 0.34375,0 0.67968,-0.0508 0.33985,-0.0508 0.60547,-0.11718 v 0.55859 q -0.29297,0.0781 -0.66015,0.125 -0.36329,0.0508 -0.73829,0.0508 -0.82812,0 -1.22265,-0.36719 -0.39453,-0.37109 -0.39453,-1.07031 0,-0.53906 0.16797,-1.01562 0.16796,-0.47657 0.46484,-0.83203 0.29687,-0.35938 0.70312,-0.56641 0.41016,-0.21094 0.89063,-0.21094 0.33203,0 0.58984,0.0781 0.26172,0.0781 0.44141,0.21484 0.17969,0.13672 0.27344,0.32422 0.0937,0.18359 0.0937,0.39844 0,0.28125 -0.1211,0.50781 -0.11718,0.22656 -0.3789,0.39062 -0.25782,0.16016 -0.66797,0.25 -0.41016,0.0859 -0.99219,0.0859 z m 0.72656,-0.52344 q 0.43359,0 0.71484,-0.0508 0.28516,-0.0547 0.44922,-0.14453 0.16797,-0.0898 0.23438,-0.20703 0.0664,-0.11719 0.0664,-0.24219 0,-0.10937 -0.043,-0.20703 -0.043,-0.0977 -0.13672,-0.17187 -0.0898,-0.0742 -0.23046,-0.11719 -0.13672,-0.043 -0.32422,-0.043 -0.25391,0 -0.46485,0.0859 -0.20703,0.082 -0.375,0.23828 -0.16797,0.15234 -0.29687,0.37109 -0.12891,0.21875 -0.21875,0.48828 z m 3.35156,0.14454 q 0.0156,-0.0742 0.0312,-0.19532 0.0195,-0.12109 0.043,-0.32422 0.0234,-0.20703 0.0586,-0.51562 0.0352,-0.3125 0.082,-0.76563 h 0.64063 l -0.0977,0.90625 q 0.13672,-0.19921 0.29688,-0.375 0.16015,-0.17968 0.35156,-0.3125 0.19141,-0.13281 0.41797,-0.21093 0.22656,-0.0781 0.49609,-0.0781 0.64453,0 0.89063,0.40235 0.24609,0.40234 0.0781,1.16406 h -0.6914 q 0.0586,-0.26953 0.0586,-0.45703 0,-0.1875 -0.0547,-0.30078 -0.0508,-0.11719 -0.15625,-0.16797 -0.10156,-0.0547 -0.24609,-0.0547 -0.28125,0 -0.54688,0.17187 -0.26562,0.16797 -0.48828,0.44532 -0.21875,0.27343 -0.3789,0.61718 -0.15625,0.34375 -0.22657,0.69141 l -0.29687,1.48047 h -0.6875 z m 4.71875,0.3789 q -0.0195,0.10156 -0.0312,0.19141 -0.008,0.0898 -0.008,0.17578 0,0.42578 0.2539,0.65234 0.25391,0.22657 0.78516,0.22657 0.34375,0 0.67969,-0.0508 0.33984,-0.0508 0.60547,-0.11718 v 0.55859 q -0.29297,0.0781 -0.66016,0.125 -0.36328,0.0508 -0.73828,0.0508 -0.82813,0 -1.22266,-0.36719 -0.39453,-0.37109 -0.39453,-1.07031 0,-0.53906 0.16797,-1.01562 0.16797,-0.47657 0.46484,-0.83203 0.29688,-0.35938 0.70313,-0.56641 0.41016,-0.21094 0.89062,-0.21094 0.33204,0 0.58985,0.0781 0.26172,0.0781 0.4414,0.21484 0.17969,0.13672 0.27344,0.32422 0.0937,0.18359 0.0937,0.39844 0,0.28125 -0.12109,0.50781 -0.11719,0.22656 -0.37891,0.39062 -0.25781,0.16016 -0.66797,0.25 -0.41015,0.0859 -0.99218,0.0859 z m 0.72656,-0.52344 q 0.4336,0 0.71485,-0.0508 0.28515,-0.0547 0.44922,-0.14453 0.16796,-0.0898 0.23437,-0.20703 0.0664,-0.11719 0.0664,-0.24219 0,-0.10937 -0.043,-0.20703 -0.043,-0.0977 -0.13672,-0.17187 -0.0898,-0.0742 -0.23047,-0.11719 -0.13672,-0.043 -0.32422,-0.043 -0.2539,0 -0.46484,0.0859 -0.20703,0.082 -0.375,0.23828 -0.16797,0.15234 -0.29688,0.37109 -0.1289,0.21875 -0.21875,0.48828 z m 5.15235,-1.70312 q 0.28125,0 0.47265,0.0234 0.19532,0.0234 0.36719,0.0742 l 0.32813,-1.64844 h 0.67968 l -0.74609,3.71875 q -0.0156,0.0742 -0.0352,0.19531 -0.0156,0.12109 -0.0391,0.32813 -0.0234,0.20312 -0.0586,0.51562 -0.0352,0.30859 -0.082,0.76172 h -0.64063 l 0.0977,-0.90234 q -0.26953,0.46875 -0.65625,0.72265 -0.38282,0.25 -0.83203,0.25 -0.28125,0 -0.49219,-0.0937 -0.20703,-0.0937 -0.34375,-0.26562 -0.13672,-0.17578 -0.20313,-0.41797 -0.0664,-0.24219 -0.0664,-0.53906 0,-0.5625 0.14453,-1.05469 0.14844,-0.4961 0.43359,-0.86719 0.28516,-0.37109 0.70313,-0.58594 0.42187,-0.21484 0.96875,-0.21484 z m -1.5625,2.65625 q 0,0.37109 0.1289,0.58203 0.12891,0.21094 0.41797,0.21094 0.16797,0 0.33594,-0.0781 0.16797,-0.0781 0.32812,-0.21484 0.16016,-0.13672 0.30079,-0.32031 0.14453,-0.1875 0.26171,-0.39844 0.1211,-0.21484 0.20704,-0.44531 0.0859,-0.23438 0.13281,-0.46485 l 0.16015,-0.80468 q -0.18359,-0.0781 -0.3789,-0.1211 -0.19141,-0.0469 -0.35547,-0.0469 -0.32031,0 -0.55859,0.10937 -0.23829,0.10938 -0.41016,0.28516 -0.17188,0.17578 -0.28125,0.40234 -0.10938,0.22266 -0.17578,0.45703 -0.0625,0.23438 -0.0898,0.45703 -0.0234,0.22266 -0.0234,0.39063 z"
+       id="text58"
+       aria-label="level-triggered" />
+  </g>
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.40005951"
+     d="M 413.0514,71.602116 H 581.5591"
+     id="path36-3"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.40005951"
+     d="m 413.10688,74.166817 h 168.5077"
+     id="path36-3-7"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.40005951"
+     d="m 413.23379,76.88458 h 168.5077"
+     id="path36-3-7-5"
+     sodipodi:nodetypes="cc" />
+</svg>

--- a/doc/contributing/hw/comportability/status_intr_type.svg
+++ b/doc/contributing/hw/comportability/status_intr_type.svg
@@ -1,0 +1,1987 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 700 270"
+   fill="none"
+   stroke="none"
+   stroke-linecap="square"
+   stroke-miterlimit="10"
+   id="svg143"
+   sodipodi:docname="status_intr_type.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   width="700"
+   height="270"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs143">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <g
+         id="g145">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path144" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <g
+         id="g146">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path145" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <g
+         id="g148">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path147" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <g
+         id="g149">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path148" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <g
+         id="g150">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path149" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <g
+         id="g151">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path150" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <g
+         id="g152">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path151" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <g
+         id="g153">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path152" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <g
+         id="g154">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path153" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <g
+         id="g155">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path154" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <g
+         id="g156">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path155" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <g
+         id="g157">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path156" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <g
+         id="g158">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path157" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath158">
+      <g
+         id="g159">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path158" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath159">
+      <g
+         id="g160">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path159" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath160">
+      <g
+         id="g161">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path160" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath161">
+      <g
+         id="g162">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path161" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath162">
+      <g
+         id="g163">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path162" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath163">
+      <g
+         id="g164">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path163" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath164">
+      <g
+         id="g165">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path164" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath165">
+      <g
+         id="g166">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path165" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath166">
+      <g
+         id="g167">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path166" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath167">
+      <g
+         id="g168">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path167" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath168">
+      <g
+         id="g169">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path168" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath169">
+      <g
+         id="g170">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path169" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath170">
+      <g
+         id="g171">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path170" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath171">
+      <g
+         id="g172">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path171" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath172">
+      <g
+         id="g173">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path172" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath173">
+      <g
+         id="g174">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path173" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath174">
+      <g
+         id="g175">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path174" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath175">
+      <g
+         id="g176">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path175" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath176">
+      <g
+         id="g177">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path176" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath177">
+      <g
+         id="g178">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path177" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath178">
+      <g
+         id="g179">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path178" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath179">
+      <g
+         id="g180">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path179" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath180">
+      <g
+         id="g181">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path180" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath181">
+      <g
+         id="g182">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path181" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath182">
+      <g
+         id="g183">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path182" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath183">
+      <g
+         id="g184">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path183" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath184">
+      <g
+         id="g185">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path184" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath185">
+      <g
+         id="g186">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path185" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath186">
+      <g
+         id="g187">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path186" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath187">
+      <g
+         id="g188">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path187" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath188">
+      <g
+         id="g189">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path188" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath189">
+      <g
+         id="g190">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path189" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath190">
+      <g
+         id="g191">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path190" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath191">
+      <g
+         id="g192">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path191" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath192">
+      <g
+         id="g193">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path192" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath193">
+      <g
+         id="g194">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path193" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath194">
+      <g
+         id="g195">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path194" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath195">
+      <g
+         id="g196">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path195" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath196">
+      <g
+         id="g197">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path196" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath197">
+      <g
+         id="g198">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path197" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath198">
+      <g
+         id="g199">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path198" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath199">
+      <g
+         id="g200">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path199" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath200">
+      <g
+         id="g201">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path200" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath201">
+      <g
+         id="g202">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path201" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath202">
+      <g
+         id="g203">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path202" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath203">
+      <g
+         id="g204">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path203" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath204">
+      <g
+         id="g205">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path204" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath205">
+      <g
+         id="g206">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path205" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath206">
+      <g
+         id="g207">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path206" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath207">
+      <g
+         id="g208">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path207" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath208">
+      <g
+         id="g209">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path208" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath209">
+      <g
+         id="g210">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path209" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath210">
+      <g
+         id="g211">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path210" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath211">
+      <g
+         id="g212">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path211" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath212">
+      <g
+         id="g213">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path212" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath213">
+      <g
+         id="g214">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path213" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath214">
+      <g
+         id="g215">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path214" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath215">
+      <g
+         id="g216">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path215" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath216">
+      <g
+         id="g217">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path216" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath217">
+      <g
+         id="g218">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path217" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath218">
+      <g
+         id="g219">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path218" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath219">
+      <g
+         id="g220">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path219" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath220">
+      <g
+         id="g221">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path220" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath221">
+      <g
+         id="g222">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path221" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath222">
+      <g
+         id="g223">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path222" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath223">
+      <g
+         id="g224">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path223" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath224">
+      <g
+         id="g225">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path224" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath225">
+      <g
+         id="g226">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path225" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath226">
+      <g
+         id="g227">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path226" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath227">
+      <g
+         id="g228">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path227" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath228">
+      <g
+         id="g229">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path228" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath229">
+      <g
+         id="g230">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path229" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath230">
+      <g
+         id="g231">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path230" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath231">
+      <g
+         id="g232">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path231" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath232">
+      <g
+         id="g233">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path232" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath233">
+      <g
+         id="g234">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path233" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath234">
+      <g
+         id="g235">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path234" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath235">
+      <g
+         id="g236">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path235" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath236">
+      <g
+         id="g237">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path236" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath237">
+      <g
+         id="g238">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path237" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath238">
+      <g
+         id="g239">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path238" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath239">
+      <g
+         id="g240">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path239" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath240">
+      <g
+         id="g241">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path240" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath241">
+      <g
+         id="g242">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path241" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath242">
+      <g
+         id="g243">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path242" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath243">
+      <g
+         id="g244">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path243" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath244">
+      <g
+         id="g245">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path244" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath245">
+      <g
+         id="g246">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path245" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath246">
+      <g
+         id="g247">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path246" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath247">
+      <g
+         id="g248">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path247" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath248">
+      <g
+         id="g249">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path248" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath249">
+      <g
+         id="g250">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path249" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath250">
+      <g
+         id="g251">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path250" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath251">
+      <g
+         id="g252">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path251" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath252">
+      <g
+         id="g253">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path252" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath253">
+      <g
+         id="g254">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path253" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath254">
+      <g
+         id="g255">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path254" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath255">
+      <g
+         id="g256">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path255" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath256">
+      <g
+         id="g257">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path256" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath257">
+      <g
+         id="g258">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path257" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath258">
+      <g
+         id="g259">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path258" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath259">
+      <g
+         id="g260">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path259" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath260">
+      <g
+         id="g261">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path260" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath261">
+      <g
+         id="g262">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path261" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath262">
+      <g
+         id="g263">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path262" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath263">
+      <g
+         id="g264">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path263" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath264">
+      <g
+         id="g265">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path264" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath265">
+      <g
+         id="g266">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path265" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath266">
+      <g
+         id="g267">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path266" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath267">
+      <g
+         id="g268">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path267" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath268">
+      <g
+         id="g269">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path268" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath269">
+      <g
+         id="g270">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path269" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath270">
+      <g
+         id="g271">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path270" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath271">
+      <g
+         id="g272">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path271" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath272">
+      <g
+         id="g273">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path272" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath273">
+      <g
+         id="g274">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path273" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath274">
+      <g
+         id="g275">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path274" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath275">
+      <g
+         id="g276">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path275" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath276">
+      <g
+         id="g277">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path276" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath277">
+      <g
+         id="g278">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path277" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath278">
+      <g
+         id="g279">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path278" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath279">
+      <g
+         id="g280">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path279" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath280">
+      <g
+         id="g281">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path280" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath281">
+      <g
+         id="g282">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path281" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath282">
+      <g
+         id="g283">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path282" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath283">
+      <g
+         id="g284">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path283" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath284">
+      <g
+         id="g285">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path284" />
+      </g>
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath285">
+      <g
+         id="g286">
+        <path
+           d="M 0,0 H 1100 V 621 H 0 Z"
+           clip-rule="nonzero"
+           id="path285" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview143"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="4.0000002"
+     inkscape:cx="207.12499"
+     inkscape:cy="58.374997"
+     inkscape:window-width="1728"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg143" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="bg"
+     style="display:none">
+    <rect
+       style="opacity:1;fill:#ffffff;stroke:#1e1e5c;stroke-width:1.00157;stroke-dasharray:4.0063, 1.00157"
+       id="rect143"
+       width="686.21216"
+       height="257.0719"
+       x="6.8420901"
+       y="5.8641596"
+       rx="6.4447041"
+       ry="3.7994201"
+       sodipodi:insensitive="true" />
+  </g>
+  <path
+     stroke="#000000"
+     stroke-width="0.624357"
+     stroke-linejoin="round"
+     stroke-linecap="butt"
+     d="m 704,496.91577 h 16 v 0 c 8.83655,0 16,7.16345 16,16 0,8.83655 -7.16345,16 -16,16 h -16 z"
+     fill-rule="evenodd"
+     id="path141"
+     clip-path="none"
+     transform="matrix(1.6009978,0,0,1.6022959,-711.84017,-701.64009)" />
+  <g
+     id="g1"
+     transform="matrix(0.97400535,0,0,0.96854968,-438.46494,-143.11972)"
+     style="stroke:#000000;stroke-width:1.04502;stroke-dasharray:none;stroke-opacity:1;fill:#c9daf8;fill-opacity:1">
+    <rect
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:1.04502;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="rect286"
+       width="82.097443"
+       height="85.569839"
+       x="455.87643"
+       y="336.07864"
+       rx="0"
+       ry="0" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:5.17818;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="path288"
+       inkscape:flatsided="false"
+       sodipodi:sides="3"
+       sodipodi:cx="365.09799"
+       sodipodi:cy="344.51163"
+       sodipodi:r1="44.331238"
+       sodipodi:r2="22.21102"
+       sodipodi:arg1="-2.0920243"
+       sodipodi:arg2="-1.0448267"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 343.02346,306.06721 33.22561,19.23549 33.18004,19.31403 -33.27124,19.15648 -33.31645,19.07774 0.0456,-38.39198 z"
+       inkscape:transform-center-x="-1.8025121"
+       inkscape:transform-center-y="-0.17577181"
+       transform="matrix(0.17240876,0,0,0.23622944,396.93803,320.38139)" />
+  </g>
+  <g
+     id="g2-7"
+     transform="matrix(0.97400535,0,0,0.96854968,-142.06014,-143.11972)"
+     style="stroke:#000000;stroke-width:1.04502;stroke-dasharray:none;stroke-opacity:1;fill:#c9daf8;fill-opacity:1">
+    <rect
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:1.04502;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="rect286-8"
+       width="82.097443"
+       height="85.569839"
+       x="455.87643"
+       y="336.07864"
+       rx="0"
+       ry="0" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:#c9daf8;stroke:#000000;stroke-width:5.17818;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       id="path288-6"
+       inkscape:flatsided="false"
+       sodipodi:sides="3"
+       sodipodi:cx="365.09799"
+       sodipodi:cy="344.51163"
+       sodipodi:r1="44.331238"
+       sodipodi:r2="22.21102"
+       sodipodi:arg1="-2.0920243"
+       sodipodi:arg2="-1.0448267"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 343.02346,306.06721 33.22561,19.23549 33.18004,19.31403 -33.27124,19.15648 -33.31645,19.07774 0.0456,-38.39198 z"
+       inkscape:transform-center-x="-1.8025121"
+       inkscape:transform-center-y="-0.17577181"
+       transform="matrix(0.17240876,0,0,0.23622944,396.93803,320.38139)" />
+  </g>
+  <g
+     id="g2"
+     transform="matrix(0.97400535,0,0,0.96854968,-205.27848,-321.93851)"
+     style="fill:#c9daf8;fill-opacity:1;stroke:#000000;stroke-width:1.04502;stroke-dasharray:none;stroke-opacity:1">
+    <rect
+       style="opacity:1;fill:#c9daf8;fill-opacity:1;stroke:#000000;stroke-width:1.04502;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect286-3"
+       width="82.097443"
+       height="85.569839"
+       x="455.87643"
+       y="336.07864"
+       rx="0"
+       ry="0" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:#c9daf8;fill-opacity:1;stroke:#000000;stroke-width:5.17818;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="path288-7"
+       inkscape:flatsided="false"
+       sodipodi:sides="3"
+       sodipodi:cx="365.09799"
+       sodipodi:cy="344.51163"
+       sodipodi:r1="44.331238"
+       sodipodi:r2="22.21102"
+       sodipodi:arg1="-2.0920243"
+       sodipodi:arg2="-1.0448267"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 343.02346,306.06721 33.22561,19.23549 33.18004,19.31403 -33.27124,19.15648 -33.31645,19.07774 0.0456,-38.39198 z"
+       inkscape:transform-center-x="-1.8025121"
+       inkscape:transform-center-y="-0.17577181"
+       transform="matrix(0.17240876,0,0,0.23622944,396.93803,320.38139)" />
+  </g>
+  <rect
+     style="fill:#ffffff;stroke:#000000;stroke-width:1.015;stroke-linejoin:miter;stroke-dasharray:4.06, 4.06;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect286-8-4"
+     width="35.65852"
+     height="36.98344"
+     x="500.9436"
+     y="111.39822"
+     rx="0"
+     ry="0" />
+  <path
+     sodipodi:type="star"
+     style="fill:#ffffff;stroke:#000000;stroke-width:11.6081;stroke-linejoin:miter;stroke-dasharray:92.8645, 11.6081;stroke-dashoffset:0;stroke-opacity:1"
+     id="path288-6-9"
+     inkscape:flatsided="false"
+     sodipodi:sides="3"
+     sodipodi:cx="365.09799"
+     sodipodi:cy="344.51163"
+     sodipodi:r1="44.331238"
+     sodipodi:r2="22.21102"
+     sodipodi:arg1="-2.0920243"
+     sodipodi:arg2="-1.0448267"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="m 343.02346,306.06721 33.22561,19.23549 33.18004,19.31403 -33.27124,19.15648 -33.31645,19.07774 0.0456,-38.39198 z"
+     inkscape:transform-center-x="-2.2801569"
+     inkscape:transform-center-y="-0.22252603"
+     transform="matrix(0.07488467,0,0,0.10209878,475.34407,104.61384)" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 50.921296,102.72517 79.121484,0"
+     id="path5"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 86.004205,196.03886 h 27.923985 l 0,-74.62372 15.02602,-0.20074"
+     id="path6"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 381.96479,198.26117 h 15.81233 v -66.12605 h 17.07731"
+     id="path15"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 465.95537,121.04299 h 34.47087"
+     id="path16"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 537.26897,121.04299 h 34.47086"
+     id="path16-0"
+     sodipodi:nodetypes="cc" />
+  <rect
+     style="fill:none;stroke:#000000;stroke-width:1.015;stroke-dasharray:none;stroke-opacity:1"
+     id="rect16"
+     width="48.749161"
+     height="20.589687"
+     x="21.827579"
+     y="210.11551" />
+  <rect
+     style="fill:none;stroke:#000000;stroke-width:1.015;stroke-dasharray:none;stroke-opacity:1"
+     id="rect16-2"
+     width="59.482941"
+     height="21.037292"
+     x="248.52768"
+     y="34.422398" />
+  <rect
+     style="fill:none;stroke:#000000;stroke-width:1.015;stroke-dasharray:none;stroke-opacity:1"
+     id="rect16-6"
+     width="71.558388"
+     height="21.932495"
+     x="306.4726"
+     y="210.97256" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 181.33725,108.50969 233.85385,0"
+     id="path1"
+     sodipodi:nodetypes="cc" />
+  <rect
+     style="display:inline;stroke-width:1.015;fill:#6f6f6f;fill-opacity:0.0899471;stroke:none;stroke-dasharray:4.06, 4.06"
+     id="rect17"
+     width="150"
+     height="58.5"
+     x="545"
+     y="208" />
+  <path
+     style="display:inline;stroke-width:0.790202px;fill:none;stroke:#000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 253.30108,107.86373 V 39.963637 h 17.89108"
+     id="path3"
+     transform="matrix(1.264986,0,0,1.2660116,-104.29416,-28.009135)" />
+  <path
+     style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 123.85478,84.033447 c 50.40691,-0.0995 57.53362,24.442133 57.53362,24.442133 0,0 -8.66763,24.41786 -57.53362,24.20936 9.78263,-14.89806 8.38512,-35.615693 0,-48.651493 z"
+     id="path2"
+     sodipodi:nodetypes="cccc" />
+  <g
+     id="g7"
+     style="display:none;stroke-width:0.790202"
+     inkscape:label="text"
+     transform="matrix(1.264986,0,0,1.2660116,-104.29416,-28.009135)">
+    <text
+       xml:space="preserve"
+       style="font-size:16px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;stroke-width:0.790202"
+       x="542.0451"
+       y="121.99142"
+       id="text2-1"><tspan
+         sodipodi:role="line"
+         id="tspan2-4"
+         x="542.0451"
+         y="121.99142"
+         style="fill:#000000;stroke-width:0.790202">intr_o</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:20.248px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;display:inline;stroke-width:1"
+       x="0.55234647"
+       y="107.43295"
+       id="text2"
+       transform="matrix(0.79020232,0,0,0.79020232,82.446889,22.123917)"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         x="0.55234647"
+         y="107.43295"
+         style="fill:#000000;stroke-width:1">hw_i</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:16px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;stroke-width:0.790202"
+       x="101.46175"
+       y="201.69014"
+       id="text2-5"><tspan
+         sodipodi:role="line"
+         id="tspan2-6"
+         x="101.46175"
+         y="201.69014"
+         style="fill:#000000;stroke-width:0.790202">TEST</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:16px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;stroke-width:0.790202"
+       x="326.47681"
+       y="202.57845"
+       id="text2-5-8"><tspan
+         sodipodi:role="line"
+         id="tspan2-6-4"
+         x="326.47681"
+         y="202.57845"
+         style="fill:#000000;stroke-width:0.790202">ENABLE</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;text-align:center;text-anchor:middle;stroke-width:0.790202"
+       x="493.28738"
+       y="147.96117"
+       id="text2-54-8"><tspan
+         sodipodi:role="line"
+         x="493.28738"
+         y="147.96117"
+         style="font-size:8px;text-align:center;text-anchor:middle;fill:#000000;stroke-width:0.790202"
+         id="tspan18">optional</tspan><tspan
+         sodipodi:role="line"
+         x="493.28738"
+         y="157.96117"
+         style="font-size:8px;text-align:center;text-anchor:middle;fill:#000000;stroke-width:0.790202"
+         id="tspan19">output</tspan><tspan
+         sodipodi:role="line"
+         x="493.28738"
+         y="167.96117"
+         style="font-size:8px;text-align:center;text-anchor:middle;fill:#000000;stroke-width:0.790202"
+         id="tspan20">flop</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:20.248px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;display:inline;stroke-width:1"
+       x="249.9873"
+       y="51.239189"
+       id="text2-5-4"
+       transform="matrix(0.79020232,0,0,0.79020232,82.446889,22.123917)"><tspan
+         sodipodi:role="line"
+         id="tspan2-6-5"
+         x="249.9873"
+         y="51.239189"
+         style="fill:#000000;stroke-width:1">STATE</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:10.124px;line-height:1.25;font-family:consolas;-inkscape-font-specification:consolas;text-align:center;text-anchor:middle;display:inline;stroke-width:1"
+       x="516.54034"
+       y="199.30267"
+       id="text2-54-8-5"
+       transform="scale(0.99959487,1.0004053)"><tspan
+         sodipodi:role="line"
+         x="516.54034"
+         y="199.30267"
+         style="font-size:10.124px;text-align:start;text-anchor:start;fill:#000000;stroke-width:1"
+         id="tspan20-6">prim_intr_hw #(</tspan><tspan
+         sodipodi:role="line"
+         x="516.54034"
+         y="211.95767"
+         style="font-size:10.124px;text-align:start;text-anchor:start;fill:#000000;stroke-width:1"
+         id="tspan22">  .IntrT (&quot;Status&quot;)</tspan><tspan
+         sodipodi:role="line"
+         x="516.54034"
+         y="224.61267"
+         style="font-size:10.124px;text-align:start;text-anchor:start;fill:#000000;stroke-width:1"
+         id="tspan23">)</tspan><tspan
+         sodipodi:role="line"
+         x="516.54034"
+         y="237.26767"
+         style="font-size:10.124px;text-align:start;text-anchor:start;fill:#000000;stroke-width:1"
+         id="tspan24" /></text>
+  </g>
+  <g
+     id="g17"
+     inkscape:label="text_stroke"
+     style="stroke-width:0.790202"
+     transform="matrix(1.264986,0,0,1.2660116,-104.29416,-28.009135)">
+    <path
+       style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+       d="M 10.112803,107.43295 H 8.3925141 v -6.33738 q 0,-1.146863 -0.4350156,-1.710406 -0.4251289,-0.57343 -1.2259531,-0.57343 -0.3460351,0 -0.6525234,0.09887 -0.2966015,0.08898 -0.6228632,0.326261 Q 5.1298971,99.464258 4.7443151,99.859727 4.358733,100.2552 3.8545104,100.8484 v 6.58455 H 2.1342214 V 93.46302 h 1.720289 v 4.043668 l -0.05932,1.562101 Q 4.2005455,98.58434 4.5861276,98.258078 4.9815963,97.92193 5.3671783,97.714309 5.762647,97.506688 6.1680025,97.417707 q 0.4053554,-0.08898 0.8403711,-0.08898 1.4830077,0 2.2937186,0.909578 0.8107108,0.899691 0.8107108,2.718845 z m 12.348512,-9.926262 -1.443461,9.926262 h -2.086098 l -1.433574,-4.15242 -0.286715,-1.00844 -0.326261,1.06776 -1.374254,4.0931 H 13.484175 L 12.0506,97.506688 h 1.680743 l 0.830484,6.742742 0.177961,1.50278 0.425129,-1.31493 1.443461,-4.458913 h 1.235839 l 1.552215,4.399593 0.444902,1.31493 0.148301,-1.39403 0.771164,-6.792172 z M 33.949682,111.48651 H 22.817237 v -1.42369 h 11.132445 z m 4.963132,-12.556135 h -2.936355 v -1.423687 h 4.676418 v 8.492692 h 2.956128 v 1.43357 h -7.958808 v -1.43357 h 3.262617 z m 0.60309,-5.585996 q 0.286715,0 0.533883,0.108754 0.247168,0.09887 0.425129,0.286715 0.187847,0.187848 0.286714,0.435016 0.108754,0.237281 0.108754,0.523996 0,0.276828 -0.108754,0.523996 -0.09887,0.247168 -0.286714,0.435015 -0.177961,0.187848 -0.425129,0.296602 -0.247168,0.09887 -0.533883,0.09887 -0.286715,0 -0.533883,-0.09887 -0.247168,-0.108754 -0.435015,-0.296602 -0.177961,-0.187847 -0.286715,-0.435015 -0.09887,-0.247168 -0.09887,-0.523996 0,-0.286715 0.09887,-0.523996 0.108754,-0.247168 0.286715,-0.435016 0.187847,-0.187848 0.435015,-0.286715 0.247168,-0.108754 0.533883,-0.108754 z"
+       id="text3"
+       transform="matrix(0.79020232,0,0,0.79020232,82.446889,22.123917)"
+       aria-label="hw_i" />
+    <path
+       style="-inkscape-font-specification:consolas;fill:#000000;stroke-width:1"
+       d="m 259.84436,47.739291 q 0,0.919465 -0.37569,1.611535 -0.3757,0.69207 -1.04799,1.156746 -0.6723,0.454789 -1.62143,0.682184 -0.93923,0.227394 -2.07621,0.227394 -0.51411,0 -1.02822,-0.03955 -0.50422,-0.03955 -0.97878,-0.09887 -0.46468,-0.05932 -0.87992,-0.138414 -0.41524,-0.07909 -0.75139,-0.168074 v -1.700516 q 0.7415,0.276828 1.66097,0.435016 0.92935,0.158187 2.10587,0.158187 0.85026,0 1.44346,-0.128527 0.60309,-0.138414 0.97879,-0.395469 0.38558,-0.266941 0.55365,-0.642636 0.17796,-0.375696 0.17796,-0.860145 0,-0.523996 -0.2966,-0.889805 -0.28671,-0.375695 -0.76128,-0.66241 -0.47456,-0.296601 -1.08753,-0.533883 -0.60309,-0.247167 -1.23584,-0.504222 -0.63275,-0.257055 -1.24573,-0.553656 -0.60309,-0.306489 -1.07765,-0.711844 -0.47457,-0.415242 -0.77117,-0.968899 -0.28671,-0.553656 -0.28671,-1.314933 0,-0.66241 0.27683,-1.305047 0.27682,-0.642637 0.86014,-1.136972 0.58332,-0.504223 1.4929,-0.810711 0.91946,-0.306489 2.18496,-0.306489 0.32626,0 0.70196,0.02966 0.38558,0.02966 0.77116,0.08898 0.39547,0.04943 0.77116,0.118641 0.38559,0.06921 0.71185,0.1483 v 1.581875 q -0.76128,-0.217508 -1.52256,-0.326261 -0.76127,-0.118641 -1.47312,-0.118641 -1.51267,0 -2.22451,0.504223 -0.71184,0.504222 -0.71184,1.35448 0,0.523996 0.28671,0.899691 0.2966,0.375696 0.77117,0.672297 0.47456,0.296602 1.07765,0.54377 0.61298,0.237281 1.24573,0.494336 0.63275,0.257054 1.23584,0.563543 0.61297,0.306488 1.08753,0.731617 0.47457,0.415242 0.76128,0.978785 0.2966,0.563543 0.2966,1.334707 z m 11.55758,-7.919262 h -3.82616 v 11.41916 h -1.77961 v -11.41916 h -3.82616 v -1.502781 h 9.43193 z m 11.88383,11.41916 h -1.91802 l -0.89969,-2.817715 h -5.37838 l -0.90957,2.817715 h -1.82905 l 4.29084,-12.921941 h 2.41236 z m -3.32193,-4.389703 -2.18497,-6.910816 -2.18496,6.910816 z m 13.70299,-7.029457 h -3.82616 v 11.41916 h -1.77961 v -11.41916 h -3.82616 v -1.502781 h 9.43193 z m 10.18332,11.41916 h -7.34583 V 38.317248 h 7.34583 v 1.483008 h -5.586 v 4.004121 h 5.36849 v 1.483008 h -5.36849 v 4.449023 h 5.586 z"
+       id="text1"
+       transform="matrix(0.79020232,0,0,0.79020232,82.446889,22.123917)"
+       aria-label="STATE" />
+    <path
+       style="-inkscape-font-specification:consolas;fill:#000000"
+       d="m 545.96698,115.27267 h -2.32031 v -1.125 h 3.69531 v 6.71093 h 2.33594 v 1.13282 h -6.28907 v -1.13282 h 2.57813 z m 0.47656,-4.41407 q 0.22656,0 0.42188,0.0859 0.19531,0.0781 0.33593,0.22656 0.14844,0.14844 0.22657,0.34375 0.0859,0.1875 0.0859,0.41407 0,0.21875 -0.0859,0.41406 -0.0781,0.19531 -0.22657,0.34375 -0.14062,0.14844 -0.33593,0.23437 -0.19532,0.0781 -0.42188,0.0781 -0.22656,0 -0.42187,-0.0781 -0.19532,-0.0859 -0.34375,-0.23437 -0.14063,-0.14844 -0.22657,-0.34375 -0.0781,-0.19531 -0.0781,-0.41406 0,-0.22657 0.0781,-0.41407 0.0859,-0.19531 0.22657,-0.34375 0.14843,-0.14843 0.34375,-0.22656 0.19531,-0.0859 0.42187,-0.0859 z m 5.64844,3.28907 h 1.21094 l 0.0547,1.26562 q 0.34375,-0.40625 0.66407,-0.67187 0.32031,-0.27344 0.625,-0.4375 0.3125,-0.16407 0.63281,-0.22657 0.32031,-0.0703 0.66406,-0.0703 1.21094,0 1.82813,0.71875 0.625,0.71094 0.625,2.14844 v 5.11719 h -1.35938 v -5.00782 q 0,-0.92187 -0.34375,-1.35937 -0.34375,-0.44531 -1.02344,-0.44531 -0.25,0 -0.49218,0.0781 -0.23438,0.0703 -0.49219,0.25781 -0.25781,0.17969 -0.5625,0.49219 -0.29688,0.3125 -0.67188,0.78125 v 5.20313 h -1.35937 z m 15.11719,7.73437 q -0.46094,0.11719 -0.95313,0.16406 -0.49219,0.0547 -1,0.0547 -1.47656,0 -2.20312,-0.66406 -0.72657,-0.67188 -0.72657,-2.05469 v -4.09375 h -2.19531 v -1.14062 h 2.19531 v -2.15625 l 1.35938,-0.35157 v 2.50782 h 3.52344 v 1.14062 h -3.52344 v 3.98438 q 0,0.84375 0.44531,1.26562 0.45313,0.41406 1.32813,0.41406 0.375,0 0.82031,-0.0547 0.44531,-0.0625 0.92969,-0.1875 z m 2.79687,-7.73437 h 1.24219 l 0.0391,1.44531 q 0.69531,-0.83594 1.36719,-1.21094 0.67969,-0.375 1.36719,-0.375 1.21875,0 1.84375,0.78906 0.63281,0.78907 0.58593,2.34375 h -1.375 q 0.0234,-1.03125 -0.30468,-1.49218 -0.32032,-0.46875 -0.94532,-0.46875 -0.27343,0 -0.55468,0.10156 -0.27344,0.0937 -0.57032,0.3125 -0.28906,0.21094 -0.61718,0.54687 -0.32813,0.33594 -0.70313,0.8125 v 5.03907 h -1.375 z m 16.02344,11.04687 h -8.79688 v -1.125 h 8.79688 z m 8.07812,-7.1875 q 0,0.91406 -0.25781,1.67969 -0.25781,0.75781 -0.74219,1.30469 -0.48437,0.53906 -1.17968,0.84375 -0.69532,0.29687 -1.57813,0.29687 -0.84375,0 -1.51562,-0.25781 -0.66407,-0.26563 -1.13282,-0.77344 -0.46093,-0.50781 -0.71093,-1.25781 -0.24219,-0.75 -0.24219,-1.72656 0,-0.91407 0.25781,-1.66407 0.25781,-0.75781 0.74219,-1.29687 0.48437,-0.54688 1.17969,-0.84375 0.69531,-0.30469 1.57812,-0.30469 0.84375,0 1.50781,0.26563 0.67188,0.25781 1.13282,0.76562 0.46875,0.5 0.71093,1.25 0.25,0.75 0.25,1.71875 z m -1.39062,0.0625 q 0,-0.72656 -0.16406,-1.26562 -0.15625,-0.54688 -0.45313,-0.90625 -0.29687,-0.36719 -0.72656,-0.54688 -0.42188,-0.1875 -0.94531,-0.1875 -0.60938,0 -1.04688,0.24219 -0.42969,0.23437 -0.71094,0.63281 -0.27343,0.39844 -0.40625,0.92969 -0.125,0.52344 -0.125,1.10156 0,0.72656 0.15625,1.27344 0.16407,0.54687 0.46094,0.91406 0.29688,0.35938 0.71875,0.54688 0.42188,0.17968 0.95313,0.17968 0.60937,0 1.03906,-0.23437 0.4375,-0.24219 0.71094,-0.64063 0.28125,-0.39843 0.40625,-0.92187 0.13281,-0.53125 0.13281,-1.11719 z"
+       id="text11"
+       aria-label="intr_o" />
+    <path
+       style="-inkscape-font-specification:consolas;fill:#000000"
+       d="m 109.58675,192.6667 h -3.02344 v 9.02344 h -1.40625 v -9.02344 h -3.02344 v -1.1875 h 7.45313 z m 8.04687,9.02344 h -5.80469 V 191.4792 h 5.80469 v 1.17188 h -4.41406 v 3.16406 h 4.24219 v 1.17187 h -4.24219 v 3.51563 h 4.41406 z m 9.21094,-2.76563 q 0,0.72657 -0.29688,1.27344 -0.29687,0.54688 -0.82812,0.91406 -0.53125,0.35938 -1.28125,0.53907 -0.74219,0.17968 -1.64063,0.17968 -0.40625,0 -0.8125,-0.0312 -0.39843,-0.0312 -0.77343,-0.0781 -0.36719,-0.0469 -0.69532,-0.10938 -0.32812,-0.0625 -0.59375,-0.13281 v -1.34375 q 0.58594,0.21875 1.3125,0.34375 0.73438,0.125 1.66407,0.125 0.67187,0 1.14062,-0.10156 0.47656,-0.10938 0.77344,-0.3125 0.30469,-0.21094 0.4375,-0.50781 0.14062,-0.29688 0.14062,-0.67969 0,-0.41406 -0.23437,-0.70313 -0.22656,-0.29687 -0.60156,-0.52343 -0.375,-0.23438 -0.85938,-0.42188 -0.47656,-0.19531 -0.97656,-0.39844 -0.5,-0.20312 -0.98438,-0.4375 -0.47656,-0.24218 -0.85156,-0.5625 -0.375,-0.32812 -0.60937,-0.76562 -0.22657,-0.4375 -0.22657,-1.03906 0,-0.52344 0.21875,-1.03125 0.21875,-0.50782 0.67969,-0.89844 0.46094,-0.39844 1.17969,-0.64063 0.72656,-0.24218 1.72656,-0.24218 0.25781,0 0.55469,0.0234 0.30469,0.0234 0.60937,0.0703 0.3125,0.0391 0.60938,0.0937 0.30469,0.0547 0.5625,0.11718 v 1.25 q -0.60156,-0.17187 -1.20313,-0.25781 -0.60156,-0.0937 -1.16406,-0.0937 -1.19531,0 -1.75781,0.39844 -0.5625,0.39844 -0.5625,1.07031 0,0.41406 0.22656,0.71094 0.23438,0.29687 0.60938,0.53125 0.375,0.23437 0.85156,0.42969 0.48437,0.1875 0.98437,0.39062 0.5,0.20313 0.97657,0.44531 0.48437,0.24219 0.85937,0.57813 0.375,0.32812 0.60156,0.77344 0.23438,0.44531 0.23438,1.05468 z m 9.13281,-6.25781 h -3.02344 v 9.02344 h -1.40625 v -9.02344 h -3.02343 v -1.1875 h 7.45312 z"
+       id="text12"
+       aria-label="TEST" />
+    <path
+       style="-inkscape-font-specification:consolas;fill:#000000"
+       d="m 333.85181,202.57845 h -5.80469 v -10.21094 h 5.80469 v 1.17187 h -4.41407 v 3.16407 h 4.24219 v 1.17187 h -4.24219 v 3.51563 h 4.41407 z m 9.29687,0 h -1.8125 l -2.97656,-6.36719 -0.85938,-2.04688 v 5.14844 3.26563 h -1.29687 v -10.21094 h 1.78906 l 2.83594,6.03125 1.02344,2.33594 v -5.46875 -2.89844 h 1.29687 z m 9.64063,0 h -1.51563 l -0.71094,-2.22657 h -4.25 l -0.71875,2.22657 h -1.44531 l 3.39063,-10.21094 h 1.90625 z m -2.625,-3.46875 -1.72657,-5.46094 -1.72656,5.46094 z m 10.64062,0.41406 q 0,0.73437 -0.28906,1.30469 -0.28125,0.5625 -0.8125,0.95312 -0.52344,0.39063 -1.27344,0.59375 -0.74219,0.20313 -1.65625,0.20313 h -2.67187 v -10.21094 h 2.92187 q 3.41406,0 3.41406,2.48437 0,0.82813 -0.39843,1.42188 -0.39063,0.59375 -1.28125,0.88281 0.41406,0.0781 0.78125,0.26563 0.375,0.1875 0.65625,0.48437 0.28125,0.29688 0.44531,0.70313 0.16406,0.40625 0.16406,0.91406 z m -1.8125,-4.48438 q 0,-0.3125 -0.0937,-0.58593 -0.0937,-0.28125 -0.32812,-0.47657 -0.23438,-0.20312 -0.63282,-0.32031 -0.39843,-0.11719 -1.00781,-0.11719 h -1.4375 v 3.19532 h 1.39063 q 0.47656,0 0.85937,-0.10157 0.39063,-0.10156 0.66406,-0.3125 0.28125,-0.21093 0.42969,-0.52343 0.15625,-0.32032 0.15625,-0.75782 z m 0.33594,4.53125 q 0,-0.39062 -0.16406,-0.70312 -0.16407,-0.3125 -0.47657,-0.52344 -0.3125,-0.21875 -0.76562,-0.33594 -0.44531,-0.11718 -1.00781,-0.11718 h -1.42188 v 3.51562 h 1.46875 q 1.19531,0 1.78125,-0.44531 0.58594,-0.44531 0.58594,-1.39063 z m 10.03125,3.00782 h -5.875 v -10.21094 h 1.41406 v 9.02344 h 4.46094 z m 8.47656,0 h -5.80469 v -10.21094 h 5.80469 v 1.17187 h -4.41406 v 3.16407 h 4.24219 v 1.17187 h -4.24219 v 3.51563 h 4.41406 z"
+       id="text13"
+       aria-label="ENABLE" />
+    <g
+       id="text17"
+       style="font-size:8px;font-family:consolas;-inkscape-font-specification:consolas;text-align:center;text-anchor:middle"
+       aria-label="optional&#10;output&#10;flop">
+      <path
+         style="fill:#000000"
+         d="m 479.7327,145.96898 q 0,0.45703 -0.12891,0.83984 -0.12891,0.37891 -0.37109,0.65235 -0.24219,0.26953 -0.58985,0.42187 -0.34765,0.14844 -0.78906,0.14844 -0.42187,0 -0.75781,-0.12891 -0.33203,-0.13281 -0.56641,-0.38672 -0.23047,-0.2539 -0.35547,-0.6289 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45703 0.12891,-0.83203 0.1289,-0.37891 0.37109,-0.64844 0.24219,-0.27344 0.58984,-0.42188 0.34766,-0.15234 0.78907,-0.15234 0.42187,0 0.7539,0.13281 0.33594,0.12891 0.56641,0.38281 0.23437,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69532,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22656,-0.45313 -0.14844,-0.18359 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30468,0 -0.52343,0.1211 -0.21485,0.11719 -0.35547,0.3164 -0.13672,0.19922 -0.20313,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27344 0.23047,0.45703 0.14843,0.17969 0.35937,0.27344 0.21094,0.0898 0.47656,0.0898 0.30469,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14063,-0.19922 0.20313,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z m 5.03125,-0.0703 q 0,0.52343 -0.14843,0.91406 -0.14453,0.39062 -0.40235,0.64844 -0.25781,0.25781 -0.60937,0.38672 -0.35156,0.1289 -0.76172,0.1289 -0.1875,0 -0.375,-0.0195 -0.18359,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29297,-0.40234 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33594,0 0.58984,0.14062 0.25391,0.14063 0.42578,0.39844 0.17188,0.25391 0.25782,0.61719 0.0859,0.35937 0.0859,0.80469 z m -0.69531,0.0312 q 0,-0.3086 -0.0469,-0.56641 -0.043,-0.25781 -0.14063,-0.44141 -0.0976,-0.18359 -0.25,-0.28515 -0.15234,-0.10547 -0.36328,-0.10547 -0.12891,0 -0.26172,0.043 -0.13281,0.0391 -0.27734,0.13672 -0.14063,0.0937 -0.30078,0.2539 -0.15625,0.15625 -0.33594,0.39063 v 1.90234 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.37109 0.3125,-0.375 0.3125,-1.125 z m 4.90235,1.94531 q -0.23047,0.0586 -0.47657,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33593 -0.36328,-1.02734 v -2.04688 h -1.09766 v -0.57031 h 1.09766 v -1.07812 l 0.67969,-0.17578 v 1.2539 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42188 0.22265,0.63281 0.22657,0.20704 0.66407,0.20704 0.1875,0 0.41015,-0.0274 0.22266,-0.0312 0.46485,-0.0937 z m 2.57421,-3.30469 h -1.16015 v -0.5625 h 1.84765 v 3.35547 h 1.16797 v 0.56641 h -3.14453 v -0.56641 h 1.28906 z m 0.23829,-2.20703 q 0.11328,0 0.21093,0.043 0.0977,0.0391 0.16797,0.11328 0.0742,0.0742 0.11328,0.17188 0.043,0.0937 0.043,0.20703 0,0.10937 -0.043,0.20703 -0.0391,0.0976 -0.11328,0.17187 -0.0703,0.0742 -0.16797,0.11719 -0.0976,0.0391 -0.21093,0.0391 -0.11329,0 -0.21094,-0.0391 -0.0977,-0.043 -0.17188,-0.11719 -0.0703,-0.0742 -0.11328,-0.17187 -0.0391,-0.0977 -0.0391,-0.20703 0,-0.11328 0.0391,-0.20703 0.043,-0.0977 0.11328,-0.17188 0.0742,-0.0742 0.17188,-0.11328 0.0976,-0.043 0.21094,-0.043 z m 6.23828,3.57422 q 0,0.45703 -0.12891,0.83984 -0.12891,0.37891 -0.37109,0.65235 -0.24219,0.26953 -0.58985,0.42187 -0.34765,0.14844 -0.78906,0.14844 -0.42187,0 -0.75781,-0.12891 -0.33203,-0.13281 -0.56641,-0.38672 -0.23047,-0.2539 -0.35547,-0.6289 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45703 0.12891,-0.83203 0.1289,-0.37891 0.37109,-0.64844 0.24219,-0.27344 0.58984,-0.42188 0.34766,-0.15234 0.78907,-0.15234 0.42187,0 0.7539,0.13281 0.33594,0.12891 0.56641,0.38281 0.23437,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69532,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22656,-0.45313 -0.14844,-0.18359 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30468,0 -0.52343,0.1211 -0.21485,0.11719 -0.35547,0.3164 -0.13672,0.19922 -0.20313,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27344 0.23047,0.45703 0.14843,0.17969 0.35937,0.27344 0.21094,0.0898 0.47656,0.0898 0.30469,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14063,-0.19922 0.20313,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z m 1.67969,-1.96094 h 0.60547 l 0.0273,0.63281 q 0.17188,-0.20312 0.33204,-0.33593 0.16015,-0.13672 0.3125,-0.21875 0.15625,-0.082 0.3164,-0.11328 0.16016,-0.0352 0.33203,-0.0352 0.60547,0 0.91407,0.35937 0.3125,0.35547 0.3125,1.07422 v 2.5586 h -0.67969 v -2.50391 q 0,-0.46094 -0.17188,-0.67969 -0.17187,-0.22265 -0.51172,-0.22265 -0.125,0 -0.24609,0.0391 -0.11719,0.0352 -0.24609,0.12891 -0.12891,0.0898 -0.28125,0.24609 -0.14844,0.15625 -0.33594,0.39062 v 2.60157 h -0.67969 z m 6.91797,3.92188 -0.0156,-0.52735 q -0.32032,0.31641 -0.65235,0.45703 -0.32812,0.14063 -0.6914,0.14063 -0.33594,0 -0.57422,-0.0859 -0.23828,-0.0859 -0.39453,-0.23437 -0.15235,-0.15235 -0.22657,-0.35547 -0.0703,-0.20313 -0.0703,-0.44141 0,-0.58984 0.4375,-0.92187 0.44141,-0.33594 1.30078,-0.33594 h 0.8125 v -0.34375 q 0,-0.34766 -0.22265,-0.55469 -0.22266,-0.21094 -0.67969,-0.21094 -0.33203,0 -0.65625,0.0742 -0.32031,0.0742 -0.66406,0.21094 v -0.61328 q 0.1289,-0.0469 0.28515,-0.0898 0.16016,-0.0469 0.33594,-0.082 0.17578,-0.0351 0.36719,-0.0547 0.1914,-0.0234 0.38672,-0.0234 0.35546,0 0.64062,0.0781 0.28516,0.0781 0.48047,0.23829 0.19922,0.16015 0.30469,0.40234 0.10547,0.24219 0.10547,0.57031 v 2.70313 z m -0.0742,-1.78516 h -0.86328 q -0.25391,0 -0.4375,0.0508 -0.18359,0.0508 -0.30078,0.14453 -0.11719,0.0937 -0.17578,0.22657 -0.0547,0.1289 -0.0547,0.29296 0,0.11329 0.0352,0.21875 0.0351,0.10157 0.11328,0.1836 0.0781,0.0781 0.20312,0.125 0.125,0.0469 0.30469,0.0469 0.23438,0 0.53516,-0.14062 0.30468,-0.14453 0.64062,-0.45313 z m 3.28906,-3.17578 h -1.16015 v -0.55859 h 1.84765 v 4.95312 h 1.16797 v 0.56641 h -3.14453 v -0.56641 h 1.28906 z"
+         id="path28" />
+      <path
+         style="fill:#000000"
+         d="m 484.13113,155.96898 q 0,0.45703 -0.1289,0.83984 -0.12891,0.37891 -0.3711,0.65235 -0.24218,0.26953 -0.58984,0.42187 -0.34766,0.14844 -0.78906,0.14844 -0.42188,0 -0.75781,-0.12891 -0.33204,-0.13281 -0.56641,-0.38672 -0.23047,-0.2539 -0.35547,-0.6289 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45703 0.1289,-0.83203 0.12891,-0.37891 0.3711,-0.64844 0.24218,-0.27344 0.58984,-0.42188 0.34766,-0.15234 0.78906,-0.15234 0.42188,0 0.75391,0.13281 0.33594,0.12891 0.56641,0.38281 0.23437,0.25 0.35546,0.625 0.125,0.375 0.125,0.85938 z m -0.69531,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22656,-0.45313 -0.14844,-0.18359 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30469,0 -0.52344,0.1211 -0.21484,0.11719 -0.35547,0.3164 -0.13671,0.19922 -0.20312,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27344 0.23047,0.45703 0.14844,0.17969 0.35938,0.27344 0.21094,0.0898 0.47656,0.0898 0.30469,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14063,-0.19922 0.20313,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z m 4.83203,1.96094 h -0.60937 l -0.0234,-0.63282 q -0.17578,0.20313 -0.33594,0.33985 -0.15625,0.13281 -0.3125,0.21484 -0.15625,0.082 -0.3164,0.11328 -0.15625,0.0352 -0.33203,0.0352 -0.60547,0 -0.91407,-0.35547 -0.30859,-0.35547 -0.30859,-1.07422 v -2.5625 h 0.67969 v 2.50781 q 0,0.90235 0.67968,0.90235 0.125,0 0.24219,-0.0352 0.1211,-0.0391 0.25,-0.1289 0.13281,-0.0937 0.28125,-0.25 0.15235,-0.15625 0.33985,-0.39454 v -2.60156 h 0.67968 z m 4.40625,-0.0547 q -0.23047,0.0586 -0.47656,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33593 -0.36328,-1.02734 v -2.04688 h -1.09766 v -0.57031 h 1.09766 v -1.07812 l 0.67968,-0.17578 v 1.2539 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42188 0.22266,0.63281 0.22656,0.20704 0.66406,0.20704 0.1875,0 0.41016,-0.0274 0.22266,-0.0312 0.46484,-0.0937 z m 4.58985,-1.97656 q 0,0.52343 -0.14844,0.91406 -0.14453,0.39062 -0.40234,0.64844 -0.25782,0.25781 -0.60938,0.38672 -0.35156,0.1289 -0.76172,0.1289 -0.1875,0 -0.375,-0.0195 -0.18359,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29297,-0.40234 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33594,0 0.58985,0.14062 0.2539,0.14063 0.42578,0.39844 0.17187,0.25391 0.25781,0.61719 0.0859,0.35937 0.0859,0.80469 z m -0.69532,0.0312 q 0,-0.3086 -0.0469,-0.56641 -0.043,-0.25781 -0.14063,-0.44141 -0.0976,-0.18359 -0.25,-0.28515 -0.15234,-0.10547 -0.36328,-0.10547 -0.1289,0 -0.26172,0.043 -0.13281,0.0391 -0.27734,0.13672 -0.14062,0.0937 -0.30078,0.2539 -0.15625,0.15625 -0.33594,0.39063 v 1.90234 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.37109 0.3125,-0.375 0.3125,-1.125 z m 4.89454,2 h -0.60938 l -0.0234,-0.63282 q -0.17578,0.20313 -0.33593,0.33985 -0.15625,0.13281 -0.3125,0.21484 -0.15625,0.082 -0.31641,0.11328 -0.15625,0.0352 -0.33203,0.0352 -0.60547,0 -0.91406,-0.35547 -0.3086,-0.35547 -0.3086,-1.07422 v -2.5625 h 0.67969 v 2.50781 q 0,0.90235 0.67969,0.90235 0.125,0 0.24218,-0.0352 0.1211,-0.0391 0.25,-0.1289 0.13282,-0.0937 0.28125,-0.25 0.15235,-0.15625 0.33985,-0.39454 v -2.60156 h 0.67969 z m 4.40625,-0.0547 q -0.23047,0.0586 -0.47657,0.082 -0.24609,0.0273 -0.5,0.0273 -0.73828,0 -1.10156,-0.33203 -0.36328,-0.33593 -0.36328,-1.02734 v -2.04688 h -1.09766 v -0.57031 h 1.09766 v -1.07812 l 0.67969,-0.17578 v 1.2539 h 1.76172 v 0.57031 h -1.76172 v 1.99219 q 0,0.42188 0.22265,0.63281 0.22657,0.20704 0.66407,0.20704 0.1875,0 0.41015,-0.0274 0.22266,-0.0312 0.46485,-0.0937 z"
+         id="path29" />
+      <path
+         style="fill:#000000"
+         d="m 488.59598,163.07445 q -0.53516,-0.11328 -0.92188,-0.11328 -0.91797,0 -0.91797,0.96093 v 0.6875 h 1.71875 v 0.56641 h -1.71875 v 2.78516 h -0.6914 v -2.78516 h -1.26172 v -0.56641 h 1.26172 v -0.64843 q 0,-1.56641 1.63281,-1.56641 0.40625,0 0.89844,0.0937 z m -4.10547,0.96484 z m 6.35937,-1.03906 h -1.16015 v -0.55859 h 1.84765 v 4.95312 h 1.16797 v 0.56641 h -3.14453 v -0.56641 h 1.28906 z m 6.47657,2.96875 q 0,0.45703 -0.12891,0.83984 -0.12891,0.37891 -0.37109,0.65235 -0.24219,0.26953 -0.58985,0.42187 -0.34765,0.14844 -0.78906,0.14844 -0.42187,0 -0.75781,-0.12891 -0.33203,-0.13281 -0.56641,-0.38672 -0.23047,-0.2539 -0.35547,-0.6289 -0.12109,-0.375 -0.12109,-0.86328 0,-0.45703 0.12891,-0.83203 0.1289,-0.37891 0.37109,-0.64844 0.24219,-0.27344 0.58984,-0.42188 0.34766,-0.15234 0.78907,-0.15234 0.42187,0 0.7539,0.13281 0.33594,0.12891 0.56641,0.38281 0.23437,0.25 0.35547,0.625 0.125,0.375 0.125,0.85938 z m -0.69532,0.0312 q 0,-0.36328 -0.082,-0.63281 -0.0781,-0.27344 -0.22656,-0.45313 -0.14844,-0.18359 -0.36328,-0.27344 -0.21094,-0.0937 -0.47266,-0.0937 -0.30468,0 -0.52343,0.1211 -0.21485,0.11719 -0.35547,0.3164 -0.13672,0.19922 -0.20313,0.46485 -0.0625,0.26172 -0.0625,0.55078 0,0.36328 0.0781,0.63672 0.082,0.27344 0.23047,0.45703 0.14843,0.17969 0.35937,0.27344 0.21094,0.0898 0.47656,0.0898 0.30469,0 0.51953,-0.11719 0.21875,-0.12109 0.35547,-0.32031 0.14063,-0.19922 0.20313,-0.46094 0.0664,-0.26562 0.0664,-0.55859 z m 5.03125,-0.0703 q 0,0.52343 -0.14843,0.91406 -0.14453,0.39062 -0.40235,0.64844 -0.25781,0.25781 -0.60937,0.38672 -0.35156,0.1289 -0.76172,0.1289 -0.1875,0 -0.375,-0.0195 -0.18359,-0.0195 -0.375,-0.0664 v 1.64063 h -0.67969 v -5.52344 h 0.60547 l 0.043,0.65625 q 0.29297,-0.40234 0.625,-0.5625 0.33203,-0.16406 0.71875,-0.16406 0.33594,0 0.58984,0.14062 0.25391,0.14063 0.42578,0.39844 0.17188,0.25391 0.25782,0.61719 0.0859,0.35937 0.0859,0.80469 z m -0.69531,0.0312 q 0,-0.3086 -0.0469,-0.56641 -0.043,-0.25781 -0.14063,-0.44141 -0.0976,-0.18359 -0.25,-0.28515 -0.15234,-0.10547 -0.36328,-0.10547 -0.12891,0 -0.26172,0.043 -0.13281,0.0391 -0.27734,0.13672 -0.14063,0.0937 -0.30078,0.2539 -0.15625,0.15625 -0.33594,0.39063 v 1.90234 q 0.1875,0.0781 0.39453,0.125 0.20703,0.043 0.40625,0.043 0.55078,0 0.86328,-0.37109 0.3125,-0.375 0.3125,-1.125 z"
+         id="path30" />
+    </g>
+    <g
+       id="text28"
+       style="font-size:10.124px;font-family:consolas;-inkscape-font-specification:consolas;text-align:center;text-anchor:middle;stroke-width:1"
+       transform="scale(0.99959486,1.0004053)"
+       aria-label="prim_intr_hw #(&#10;  .IntrT (&quot;Status&quot;)&#10;)&#10;">
+      <path
+         style="fill:#000000"
+         d="m 521.57268,196.73213 q 0,0.66241 -0.18784,1.15674 -0.18291,0.49434 -0.50917,0.8206 -0.32626,0.32626 -0.77116,0.48939 -0.44491,0.16313 -0.96396,0.16313 -0.23728,0 -0.47456,-0.0247 -0.23234,-0.0247 -0.47456,-0.084 v 2.07621 h -0.86015 v -6.98991 h 0.76622 l 0.0544,0.83049 q 0.37075,-0.50917 0.79094,-0.71185 0.42018,-0.20762 0.90957,-0.20762 0.42513,0 0.74645,0.17796 0.32132,0.17796 0.53883,0.50422 0.21751,0.32132 0.32626,0.78105 0.10875,0.45479 0.10875,1.01834 z m -0.87991,0.0395 q 0,-0.39052 -0.0593,-0.71678 -0.0544,-0.32627 -0.17797,-0.5586 -0.12358,-0.23234 -0.31637,-0.36087 -0.19279,-0.13347 -0.45973,-0.13347 -0.16313,0 -0.33121,0.0544 -0.16807,0.0494 -0.35098,0.17302 -0.17796,0.11864 -0.38063,0.32131 -0.19774,0.19774 -0.42513,0.49434 v 2.40742 q 0.23728,0.0989 0.49928,0.15818 0.26199,0.0544 0.5141,0.0544 0.69702,0 1.09249,-0.46962 0.39547,-0.47456 0.39547,-1.42369 z m 2.40741,-2.43213 h 0.786 l 0.0247,0.91452 q 0.43996,-0.52894 0.86509,-0.76622 0.43007,-0.23728 0.86509,-0.23728 0.77116,0 1.16663,0.49928 0.40041,0.49928 0.37075,1.48301 h -0.87003 q 0.0148,-0.65253 -0.19279,-0.94418 -0.20268,-0.29661 -0.59815,-0.29661 -0.17301,0 -0.35097,0.0643 -0.17302,0.0593 -0.36087,0.19773 -0.1829,0.13347 -0.39052,0.34604 -0.20763,0.21256 -0.44491,0.51411 v 3.18846 h -0.87003 z m 7.05418,0.71184 h -1.46818 v -0.71184 h 2.33821 v 4.24635 h 1.47806 v 0.71678 h -3.9794 v -0.71678 h 1.63131 z m 0.30154,-2.79299 q 0.14336,0 0.26694,0.0544 0.12359,0.0494 0.21257,0.14336 0.0939,0.0939 0.14335,0.21751 0.0544,0.11864 0.0544,0.262 0,0.13841 -0.0544,0.26199 -0.0494,0.12359 -0.14335,0.21751 -0.089,0.0939 -0.21257,0.1483 -0.12358,0.0494 -0.26694,0.0494 -0.14336,0 -0.26694,-0.0494 -0.12358,-0.0544 -0.21751,-0.1483 -0.089,-0.0939 -0.14336,-0.21751 -0.0494,-0.12358 -0.0494,-0.26199 0,-0.14336 0.0494,-0.262 0.0544,-0.12359 0.14336,-0.21751 0.0939,-0.0939 0.21751,-0.14336 0.12358,-0.0544 0.26694,-0.0544 z m 7.11349,7.04428 v -3.56416 q 0,-0.23234 -0.0198,-0.38064 -0.0148,-0.1483 -0.0544,-0.23234 -0.0346,-0.089 -0.0939,-0.12358 -0.0544,-0.0346 -0.13841,-0.0346 -0.0989,0 -0.18291,0.0593 -0.084,0.0593 -0.1829,0.19279 -0.0939,0.13347 -0.21257,0.35592 -0.11369,0.21751 -0.27188,0.53883 v 3.18846 h -0.786 v -3.47023 q 0,-0.27189 -0.0198,-0.43996 -0.0148,-0.16808 -0.0544,-0.262 -0.0346,-0.0939 -0.0939,-0.12853 -0.0593,-0.0346 -0.14336,-0.0346 -0.089,0 -0.16807,0.0494 -0.0791,0.0494 -0.17796,0.17796 -0.0939,0.12853 -0.21257,0.35098 -0.11864,0.22245 -0.28177,0.56849 v 3.18846 h -0.79094 v -4.96313 h 0.65747 l 0.0396,0.94418 q 0.12853,-0.28177 0.24717,-0.4795 0.12358,-0.19774 0.25211,-0.31638 0.12852,-0.12358 0.27188,-0.17796 0.1483,-0.0593 0.32626,-0.0593 0.40042,0 0.60804,0.262 0.20762,0.262 0.20762,0.81071 0.11864,-0.25706 0.23234,-0.45479 0.11369,-0.20268 0.24222,-0.33615 0.13347,-0.13841 0.29166,-0.20762 0.15819,-0.0742 0.36581,-0.0742 0.93429,0 0.93429,1.43852 v 3.61359 z m 6.80207,2.02678 h -5.56623 v -0.71184 h 5.56623 z m 2.48156,-6.27807 h -1.46817 v -0.71184 h 2.33821 v 4.24635 h 1.47806 v 0.71678 h -3.9794 v -0.71678 h 1.6313 z m 0.30155,-2.79299 q 0.14336,0 0.26694,0.0544 0.12358,0.0494 0.21257,0.14336 0.0939,0.0939 0.14335,0.21751 0.0544,0.11864 0.0544,0.262 0,0.13841 -0.0544,0.26199 -0.0494,0.12359 -0.14335,0.21751 -0.089,0.0939 -0.21257,0.1483 -0.12358,0.0494 -0.26694,0.0494 -0.14336,0 -0.26694,-0.0494 -0.12359,-0.0544 -0.21751,-0.1483 -0.089,-0.0939 -0.14336,-0.21751 -0.0494,-0.12358 -0.0494,-0.26199 0,-0.14336 0.0494,-0.262 0.0544,-0.12359 0.14336,-0.21751 0.0939,-0.0939 0.21751,-0.14336 0.12358,-0.0544 0.26694,-0.0544 z m 3.57405,2.08115 h 0.76622 l 0.0346,0.80082 q 0.21751,-0.25705 0.42019,-0.42512 0.20267,-0.17302 0.39547,-0.27683 0.19773,-0.10381 0.40041,-0.14336 0.20268,-0.0445 0.42018,-0.0445 0.76622,0 1.15675,0.45479 0.39547,0.44984 0.39547,1.35942 v 3.2379 h -0.86015 v -3.16869 q 0,-0.58332 -0.2175,-0.86014 -0.21751,-0.28178 -0.64758,-0.28178 -0.15819,0 -0.31144,0.0494 -0.1483,0.0445 -0.31143,0.16313 -0.16313,0.1137 -0.35592,0.31143 -0.18785,0.19773 -0.42513,0.49434 v 3.29227 h -0.86014 z m 9.5654,4.89393 q -0.29166,0.0741 -0.60309,0.10381 -0.31143,0.0346 -0.63275,0.0346 -0.9343,0 -1.39403,-0.42019 -0.45973,-0.42512 -0.45973,-1.3001 v -2.59032 h -1.38909 v -0.72173 h 1.38909 v -1.36437 l 0.86014,-0.22245 v 1.58682 h 2.22946 v 0.72173 h -2.22946 v 2.52111 q 0,0.53389 0.28177,0.80083 0.28672,0.262 0.84038,0.262 0.23728,0 0.51905,-0.0346 0.28177,-0.0395 0.58826,-0.11864 z m 1.76972,-4.89393 h 0.78599 l 0.0247,0.91452 q 0.43996,-0.52894 0.86509,-0.76622 0.43007,-0.23728 0.86509,-0.23728 0.77116,0 1.16663,0.49928 0.40041,0.49928 0.37075,1.48301 h -0.87003 q 0.0148,-0.65253 -0.19279,-0.94418 -0.20268,-0.29661 -0.59815,-0.29661 -0.17301,0 -0.35098,0.0643 -0.17301,0.0593 -0.36086,0.19773 -0.1829,0.13347 -0.39053,0.34604 -0.20762,0.21256 -0.4449,0.51411 v 3.18846 h -0.87003 z m 10.13883,6.98991 h -5.56622 v -0.71184 h 5.56622 z m 4.78023,-2.02678 h -0.86014 v -3.16869 q 0,-0.57343 -0.21751,-0.8552 -0.21257,-0.28672 -0.61298,-0.28672 -0.17302,0 -0.32626,0.0494 -0.1483,0.0445 -0.31143,0.16313 -0.16313,0.1137 -0.35592,0.31143 -0.19279,0.19773 -0.44491,0.49434 v 3.29227 h -0.86014 v -6.98496 h 0.86014 v 2.02183 l -0.0297,0.78105 q 0.20268,-0.24222 0.39547,-0.40535 0.19774,-0.16808 0.39053,-0.27189 0.19773,-0.10381 0.40041,-0.1483 0.20268,-0.0445 0.42019,-0.0445 0.7415,0 1.14685,0.45479 0.40536,0.44984 0.40536,1.35942 z m 6.17426,-4.96313 -0.72173,4.96313 h -1.04305 l -0.71679,-2.07621 -0.14336,-0.50422 -0.16313,0.53388 -0.68712,2.04655 h -1.01339 l -0.71679,-4.96313 h 0.84037 l 0.41524,3.37137 0.089,0.75139 0.21257,-0.65746 0.72173,-2.22946 h 0.61792 l 0.77611,2.1998 0.22245,0.65746 0.0741,-0.69701 0.38558,-3.39609 z m 10.83584,3.14892 h -1.10237 l -0.18291,1.81421 h -0.73161 l 0.1829,-1.81421 h -1.26056 l -0.1829,1.81421 h -0.73162 l 0.18291,-1.81421 h -1.05294 v -0.64264 h 1.1172 l 0.17796,-1.73017 h -1.04305 v -0.64264 h 1.10732 l 0.16807,-1.63131 h 0.72173 l -0.16313,1.63131 h 1.2655 l 0.16807,-1.63131 h 0.73162 l -0.17302,1.63131 h 1.06283 v 0.64264 h -1.12709 l -0.17302,1.73017 h 1.03811 z m -1.76478,-0.64264 0.17302,-1.73017 h -1.2655 l -0.17302,1.73017 z m 6.00124,4.53306 q -2.27889,-2.11081 -2.27889,-4.66653 0,-0.59814 0.11864,-1.19135 0.12358,-0.59814 0.39052,-1.19629 0.27189,-0.59815 0.71185,-1.19629 0.4449,-0.59815 1.07765,-1.18641 l 0.49928,0.50917 q -1.91802,1.8933 -1.91802,4.19691 0,1.14686 0.48445,2.20474 0.48444,1.05788 1.43357,1.99711 z"
+         id="path31" />
+      <path
+         style="fill:#000000"
+         d="m 530.41635,210.40051 q 0.16808,0 0.31638,0.0643 0.15324,0.0643 0.262,0.17796 0.11369,0.1137 0.17796,0.26694 0.0643,0.1483 0.0643,0.32132 0,0.16807 -0.0643,0.31637 -0.0643,0.1483 -0.17796,0.262 -0.10876,0.10876 -0.262,0.17302 -0.1483,0.0643 -0.31638,0.0643 -0.17301,0 -0.32131,-0.0643 -0.14831,-0.0643 -0.262,-0.17302 -0.10876,-0.1137 -0.17302,-0.262 -0.0643,-0.1483 -0.0643,-0.31637 0,-0.17302 0.0643,-0.32132 0.0643,-0.15324 0.17302,-0.26694 0.11369,-0.1137 0.262,-0.17796 0.1483,-0.0643 0.32131,-0.0643 z m 5.16087,-4.1623 h -1.48795 v -0.74151 h 3.86571 v 0.74151 h -1.48795 v 4.96807 h 1.48795 v 0.75139 h -3.86571 v -0.75139 h 1.48795 z m 4.01895,0.75633 h 0.76622 l 0.0346,0.80082 q 0.2175,-0.25705 0.42018,-0.42512 0.20268,-0.17302 0.39547,-0.27683 0.19774,-0.10381 0.40041,-0.14336 0.20268,-0.0445 0.42019,-0.0445 0.76622,0 1.15674,0.45479 0.39547,0.44984 0.39547,1.35942 v 3.2379 h -0.86014 v -3.16869 q 0,-0.58332 -0.21751,-0.86014 -0.21751,-0.28178 -0.64758,-0.28178 -0.15819,0 -0.31143,0.0494 -0.1483,0.0445 -0.31143,0.16313 -0.16313,0.1137 -0.35592,0.31143 -0.18785,0.19773 -0.42513,0.49434 v 3.29227 h -0.86015 z m 9.5654,4.89393 q -0.29166,0.0741 -0.60309,0.10381 -0.31143,0.0346 -0.63275,0.0346 -0.93429,0 -1.39402,-0.42019 -0.45974,-0.42512 -0.45974,-1.3001 v -2.59032 h -1.38908 v -0.72173 h 1.38908 v -1.36437 l 0.86015,-0.22245 v 1.58682 h 2.22945 v 0.72173 h -2.22945 v 2.52111 q 0,0.53389 0.28177,0.80083 0.28671,0.262 0.84037,0.262 0.23728,0 0.51905,-0.0346 0.28177,-0.0395 0.58826,-0.11864 z m 1.76972,-4.89393 h 0.786 l 0.0247,0.91452 q 0.43995,-0.52894 0.86508,-0.76622 0.43008,-0.23728 0.86509,-0.23728 0.77117,0 1.16663,0.49928 0.40042,0.49928 0.37076,1.48301 h -0.87004 q 0.0148,-0.65253 -0.19279,-0.94418 -0.20267,-0.29661 -0.59814,-0.29661 -0.17302,0 -0.35098,0.0643 -0.17302,0.0593 -0.36087,0.19773 -0.1829,0.13347 -0.39052,0.34604 -0.20762,0.21256 -0.4449,0.51411 v 3.18846 h -0.87004 z m 9.71371,-0.74645 h -1.91308 v 5.70958 h -0.88981 v -5.70958 h -1.91308 v -0.75139 h 4.71597 z m 9.75325,7.78579 q -2.27889,-2.11081 -2.27889,-4.66653 0,-0.59814 0.11864,-1.19135 0.12358,-0.59814 0.39052,-1.19629 0.27189,-0.59815 0.71185,-1.19629 0.4449,-0.59815 1.07765,-1.18641 l 0.49928,0.50917 q -1.91803,1.8933 -1.91803,4.19691 0,1.14686 0.48445,2.20474 0.48445,1.05788 1.43358,1.99711 z m 4.17219,-9.06117 -0.13841,2.31843 h -0.81071 l -0.14336,-2.31843 z m 1.92297,0 -0.13842,2.31843 h -0.81071 l -0.14335,-2.31843 z m 6.20391,5.23501 q 0,0.45974 -0.18784,0.80577 -0.18785,0.34604 -0.524,0.57837 -0.33615,0.2274 -0.81071,0.3411 -0.46962,0.11369 -1.03811,0.11369 -0.25705,0 -0.51411,-0.0198 -0.25211,-0.0198 -0.48939,-0.0494 -0.23234,-0.0297 -0.43996,-0.0692 -0.20762,-0.0396 -0.37569,-0.084 v -0.85026 q 0.37075,0.13842 0.83048,0.21751 0.46468,0.0791 1.05294,0.0791 0.42513,0 0.72173,-0.0643 0.30154,-0.0692 0.48939,-0.19773 0.19279,-0.13347 0.27683,-0.32132 0.089,-0.18785 0.089,-0.43007 0,-0.262 -0.1483,-0.44491 -0.14336,-0.18784 -0.38064,-0.3312 -0.23728,-0.1483 -0.54377,-0.26694 -0.30154,-0.12359 -0.61792,-0.25211 -0.31637,-0.12853 -0.62286,-0.27683 -0.30155,-0.15325 -0.53883,-0.35592 -0.23728,-0.20762 -0.38558,-0.48445 -0.14336,-0.27683 -0.14336,-0.65747 0,-0.3312 0.13842,-0.65252 0.13841,-0.32132 0.43007,-0.56849 0.29166,-0.25211 0.74645,-0.40535 0.45973,-0.15325 1.09248,-0.15325 0.16313,0 0.35098,0.0148 0.19279,0.0148 0.38558,0.0445 0.19773,0.0247 0.38558,0.0593 0.19279,0.0346 0.35592,0.0742 v 0.79094 q -0.38064,-0.10875 -0.76128,-0.16313 -0.38063,-0.0593 -0.73656,-0.0593 -0.75633,0 -1.11225,0.25211 -0.35592,0.25211 -0.35592,0.67724 0,0.262 0.14335,0.44985 0.1483,0.18784 0.38559,0.33614 0.23728,0.14831 0.53882,0.27189 0.30649,0.11864 0.62287,0.24717 0.31637,0.12852 0.61792,0.28177 0.30648,0.15324 0.54376,0.36581 0.23729,0.20762 0.38064,0.48939 0.1483,0.28177 0.1483,0.66735 z m 5.42781,1.68075 q -0.29166,0.0741 -0.60309,0.10381 -0.31143,0.0346 -0.63275,0.0346 -0.9343,0 -1.39403,-0.42019 -0.45973,-0.42512 -0.45973,-1.3001 v -2.59032 h -1.38908 v -0.72173 h 1.38908 v -1.36437 l 0.86014,-0.22245 v 1.58682 h 2.22946 v 0.72173 h -2.22946 v 2.52111 q 0,0.53389 0.28178,0.80083 0.28671,0.262 0.84037,0.262 0.23728,0 0.51905,-0.0346 0.28177,-0.0395 0.58826,-0.11864 z m 4.75551,0.0692 -0.0198,-0.66735 q -0.40536,0.40041 -0.82554,0.57837 -0.41524,0.17796 -0.87498,0.17796 -0.42513,0 -0.72667,-0.10875 -0.30155,-0.10875 -0.49928,-0.2966 -0.19279,-0.19279 -0.28672,-0.44985 -0.089,-0.25705 -0.089,-0.5586 0,-0.74644 0.55366,-1.16663 0.5586,-0.42513 1.64614,-0.42513 h 1.02822 v -0.43501 q 0,-0.43996 -0.28177,-0.70196 -0.28178,-0.26694 -0.86015,-0.26694 -0.42018,0 -0.83048,0.0939 -0.40536,0.0939 -0.84037,0.26694 v -0.77611 q 0.16313,-0.0593 0.36086,-0.11369 0.20268,-0.0593 0.42513,-0.10381 0.22245,-0.0445 0.46468,-0.0692 0.24222,-0.0297 0.48939,-0.0297 0.44984,0 0.81071,0.0989 0.36086,0.0989 0.60803,0.30154 0.25211,0.20268 0.38558,0.50917 0.13348,0.30649 0.13348,0.72173 v 3.4208 z m -0.0939,-2.25911 h -1.09248 q -0.32132,0 -0.55366,0.0643 -0.23234,0.0643 -0.38064,0.18291 -0.1483,0.11864 -0.22245,0.28671 -0.0692,0.16313 -0.0692,0.37075 0,0.14336 0.0445,0.27683 0.0445,0.12853 0.14336,0.23234 0.0989,0.0989 0.25705,0.15819 0.15819,0.0593 0.38559,0.0593 0.2966,0 0.67724,-0.17796 0.38558,-0.18291 0.81071,-0.57343 z m 6.47086,2.18991 q -0.29166,0.0741 -0.60309,0.10381 -0.31144,0.0346 -0.63275,0.0346 -0.9343,0 -1.39403,-0.42019 -0.45973,-0.42512 -0.45973,-1.3001 v -2.59032 h -1.38909 v -0.72173 h 1.38909 v -1.36437 l 0.86014,-0.22245 v 1.58682 h 2.22946 v 0.72173 h -2.22946 v 2.52111 q 0,0.53389 0.28177,0.80083 0.28672,0.262 0.84037,0.262 0.23728,0 0.51906,-0.0346 0.28177,-0.0395 0.58826,-0.11864 z m 5.55633,0.0692 h -0.77116 l -0.0297,-0.80082 q -0.22245,0.25705 -0.42513,0.43007 -0.19774,0.16808 -0.39547,0.27189 -0.19773,0.10381 -0.40041,0.14335 -0.19774,0.0445 -0.42019,0.0445 -0.76622,0 -1.15674,-0.44984 -0.39053,-0.44985 -0.39053,-1.35943 v -3.24284 h 0.86015 v 3.17364 q 0,1.14191 0.86014,1.14191 0.15819,0 0.30649,-0.0445 0.15324,-0.0494 0.31637,-0.16313 0.16808,-0.11864 0.35593,-0.31637 0.19279,-0.19774 0.43007,-0.49928 v -3.29228 h 0.86014 z m 5.5069,-1.35448 q 0,0.262 -0.089,0.46962 -0.089,0.20762 -0.24222,0.37075 -0.15324,0.15819 -0.35592,0.27189 -0.20268,0.1137 -0.43502,0.18785 -0.22739,0.0742 -0.46962,0.10875 -0.24222,0.0346 -0.47456,0.0346 -0.50422,0 -0.92935,-0.0445 -0.42019,-0.0445 -0.82554,-0.14335 v -0.79094 q 0.43501,0.12358 0.86509,0.18785 0.43007,0.0643 0.8552,0.0643 0.61792,0 0.91452,-0.16807 0.2966,-0.16808 0.2966,-0.47951 0,-0.13347 -0.0494,-0.23728 -0.0445,-0.10876 -0.16808,-0.20268 -0.12358,-0.0989 -0.38558,-0.20268 -0.25705,-0.10381 -0.7069,-0.23728 -0.33615,-0.0989 -0.62286,-0.22245 -0.28177,-0.12853 -0.4894,-0.30154 -0.20762,-0.17302 -0.32626,-0.40536 -0.11864,-0.23234 -0.11864,-0.54871 0,-0.20762 0.0939,-0.45479 0.0989,-0.24717 0.3312,-0.45973 0.23234,-0.21257 0.62781,-0.35098 0.39547,-0.14336 0.98867,-0.14336 0.29166,0 0.64758,0.0346 0.35592,0.0297 0.7415,0.10876 v 0.76622 q -0.40535,-0.0989 -0.77116,-0.14336 -0.36087,-0.0494 -0.62781,-0.0494 -0.32132,0 -0.54377,0.0494 -0.2175,0.0494 -0.35592,0.13841 -0.13347,0.084 -0.19279,0.20268 -0.0593,0.1137 -0.0593,0.24717 0,0.13347 0.0494,0.24222 0.0544,0.10876 0.19279,0.21257 0.14336,0.0989 0.39547,0.20268 0.25211,0.0989 0.65747,0.2175 0.43996,0.12853 0.7415,0.27189 0.30155,0.13841 0.4894,0.31143 0.18784,0.17302 0.26694,0.39053 0.084,0.2175 0.084,0.49433 z m 3.21319,-5.63048 -0.13841,2.31843 h -0.81072 l -0.14335,-2.31843 z m 1.92297,0 -0.13842,2.31843 h -0.81071 l -0.14336,-2.31843 z m 3.07971,-0.3757 q 2.27889,2.11082 2.27889,4.69619 0,0.53389 -0.10876,1.10731 -0.10875,0.57343 -0.37075,1.17652 -0.262,0.59815 -0.7069,1.21607 -0.43996,0.61792 -1.11225,1.24078 l -0.49928,-0.50916 q 0.96395,-0.95407 1.43851,-1.99218 0.47457,-1.0381 0.47457,-2.17507 0,-2.35304 -1.91308,-4.23152 z"
+         id="path32" />
+      <path
+         style="fill:#000000"
+         d="m 518.34467,217.25201 q 2.27889,2.11081 2.27889,4.69619 0,0.53388 -0.10875,1.10731 -0.10876,0.57343 -0.37076,1.17652 -0.26199,0.59815 -0.7069,1.21607 -0.43996,0.61792 -1.11225,1.24078 l -0.49928,-0.50916 q 0.96395,-0.95407 1.43852,-1.99218 0.47456,-1.0381 0.47456,-2.17507 0,-2.35304 -1.91308,-4.23152 z"
+         id="path33" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
To go along with future interrupt type-alignment tasks, tighten-up the documentation of comportable interrupts, particularly around prim_intr_hw and the distinction between *Status* and *Event* type interrupts.

Add some new block diagrams to support these changes, mirroring the hardware implementations provided by 'prim_intr_hw'. Diagrams were taken from the original RFC which proposed the addition of the **Status**-type interrupt.

Update the existing wavejson waveforms to explicitly include the effects of enabling the output flop (which is the default, and currently the only behaviour used within the codebase).

---

I would particularly appreciate any feedback/suggestion for content in the final paragraph of the section (### CIP Interrupt Types), which (currently, only vaguely) describes how such a distinction can help to make the software handler ergonomic.

---

Some sample screenshots....

![image](https://github.com/lowRISC/opentitan/assets/102029880/ce7904f2-abd7-4977-889b-b454d7d1cc9e)

![image](https://github.com/lowRISC/opentitan/assets/102029880/85b09505-00b7-4d41-83a4-4463b8bc76e2)

![image](https://github.com/lowRISC/opentitan/assets/102029880/9bacba00-14ba-49b2-84ce-a639fb983dbc)
