### PR TITLE
[tock] Update our Tock dependencies.

### DIFF
--- a/sw/device/silicon_owner/tock/kernel/BUILD
+++ b/sw/device/silicon_owner/tock/kernel/BUILD
@@ -36,6 +36,7 @@ rust_binary(
         "src/io.rs",
         "src/main.rs",
         "src/otbn.rs",
+        "src/pinmux_layout.rs",
     ],
     rustc_flags = [
         "-g",

--- a/sw/device/silicon_owner/tock/kernel/src/io.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/io.rs
@@ -46,8 +46,11 @@ use kernel::hil::led;
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let first_led_pin = &mut earlgrey::gpio::GpioPin::new(
-        earlgrey::gpio::GPIO0_BASE,
-        earlgrey::gpio::PADCTRL_BASE,
+        earlgrey::gpio::GPIO_BASE,
+        earlgrey::pinmux::PadConfig::Output(
+            earlgrey::registers::top_earlgrey::MuxedPads::Ioa6,
+            earlgrey::registers::top_earlgrey::PinmuxOutsel::GpioGpio7,
+        ),
         earlgrey::gpio::pins::pin7,
     );
     first_led_pin.make_output();

--- a/sw/device/silicon_owner/tock/kernel/src/main.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/main.rs
@@ -16,11 +16,13 @@
 
 use crate::hil::symmetric_encryption::AES128_BLOCK_SIZE;
 use crate::otbn::OtbnComponent;
+use crate::pinmux_layout::BoardPinmuxLayout;
 use capsules_aes_gcm::aes_gcm;
 use capsules_core::virtualizers::virtual_aes_ccm;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use earlgrey::chip::EarlGreyDefaultPeripherals;
 use earlgrey::chip_config::EarlGreyConfig;
+use earlgrey::pinmux_config::EarlGreyPinmuxConfig;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
@@ -42,6 +44,7 @@ use rv32i::csr;
 
 pub mod io;
 mod otbn;
+mod pinmux_layout;
 #[cfg(test)]
 mod tests;
 
@@ -54,7 +57,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; 4] = [None
 
 // Test access to the peripherals
 #[cfg(test)]
-static mut PERIPHERALS: Option<&'static EarlGreyDefaultPeripherals<ChipConfig>> = None;
+static mut PERIPHERALS: Option<&'static EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>> = None;
 // Test access to board
 #[cfg(test)]
 static mut BOARD: Option<&'static kernel::Kernel> = None;
@@ -94,7 +97,7 @@ static mut RSA_HARDWARE: Option<&lowrisc::rsa::OtbnRsa<'static>> = None;
 #[cfg(test)]
 static mut SHA256SOFT: Option<&capsules_extra::sha256::Sha256Software<'static>> = None;
 
-static mut CHIP: Option<&'static earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig>> = None;
+static mut CHIP: Option<&'static earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>, ChipConfig, BoardPinmuxLayout>> = None;
 static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
 
 // How should the kernel respond when a process faults.
@@ -119,10 +122,10 @@ impl EarlGreyConfig for ChipConfig {
 struct EarlGrey {
     led: &'static capsules_core::led::LedDriver<
         'static,
-        LedHigh<'static, earlgrey::gpio::GpioPin<'static>>,
+        LedHigh<'static, earlgrey::gpio::GpioPin<'static, earlgrey::pinmux::PadConfig>>,
         8,
     >,
-    gpio: &'static capsules_core::gpio::GPIO<'static, earlgrey::gpio::GpioPin<'static>>,
+    gpio: &'static capsules_core::gpio::GPIO<'static, earlgrey::gpio::GpioPin<'static, earlgrey::pinmux::PadConfig>>,
     console: &'static capsules_core::console::Console<'static>,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
@@ -202,7 +205,7 @@ impl SyscallDriverLookup for EarlGrey {
     }
 }
 
-impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripherals<'static, ChipConfig>, ChipConfig>>
+impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripherals<'static, ChipConfig, BoardPinmuxLayout>, ChipConfig, BoardPinmuxLayout>>
     for EarlGrey
 {
     type SyscallDriverLookup = Self;
@@ -244,11 +247,13 @@ impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripheral
 unsafe fn setup() -> (
     &'static kernel::Kernel,
     &'static EarlGrey,
-    &'static earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripherals<'static, ChipConfig>, ChipConfig>,
-    &'static EarlGreyDefaultPeripherals<'static, ChipConfig>,
+    &'static earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripherals<'static, ChipConfig, BoardPinmuxLayout>, ChipConfig, BoardPinmuxLayout>,
+    &'static EarlGreyDefaultPeripherals<'static, ChipConfig, BoardPinmuxLayout>,
 ) {
     // Ibex-specific handler
     earlgrey::chip::configure_trap_handler();
+
+    BoardPinmuxLayout::setup();
 
     // initialize capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
@@ -257,7 +262,7 @@ unsafe fn setup() -> (
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     let peripherals = static_init!(
-        EarlGreyDefaultPeripherals<ChipConfig>,
+        EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>,
         EarlGreyDefaultPeripherals::new()
     );
     peripherals.init();
@@ -279,7 +284,7 @@ unsafe fn setup() -> (
     // LEDs
     // Start with half on and half off
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
-        LedHigh<'static, earlgrey::gpio::GpioPin>,
+        LedHigh<'static, earlgrey::gpio::GpioPin<earlgrey::pinmux::PadConfig>>,
         LedHigh::new(&peripherals.gpio_port[8]),
         LedHigh::new(&peripherals.gpio_port[9]),
         LedHigh::new(&peripherals.gpio_port[10]),
@@ -294,7 +299,7 @@ unsafe fn setup() -> (
         board_kernel,
         capsules_core::gpio::DRIVER_NUM,
         components::gpio_component_helper!(
-            earlgrey::gpio::GpioPin,
+            earlgrey::gpio::GpioPin<earlgrey::pinmux::PadConfig>,
             0 => &peripherals.gpio_port[0],
             1 => &peripherals.gpio_port[1],
             2 => &peripherals.gpio_port[2],
@@ -305,7 +310,7 @@ unsafe fn setup() -> (
             7 => &peripherals.gpio_port[15]
         ),
     )
-    .finalize(components::gpio_component_static!(earlgrey::gpio::GpioPin));
+    .finalize(components::gpio_component_static!(earlgrey::gpio::GpioPin<earlgrey::pinmux::PadConfig>));
 
     let hardware_alarm = static_init!(earlgrey::timer::RvTimer<ChipConfig>, earlgrey::timer::RvTimer::new());
     hardware_alarm.setup();
@@ -352,7 +357,7 @@ unsafe fn setup() -> (
 
     let chip = static_init!(
         earlgrey::chip::EarlGrey<
-            EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig
+            EarlGreyDefaultPeripherals<ChipConfig, BoardPinmuxLayout>, ChipConfig, BoardPinmuxLayout
         >,
         earlgrey::chip::EarlGrey::new(peripherals, hardware_alarm)
     );

--- a/sw/device/silicon_owner/tock/kernel/src/pinmux_layout.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/pinmux_layout.rs
@@ -1,0 +1,137 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use earlgrey::pinmux_config::{EarlGreyPinmuxConfig, INPUT_NUM, OUTPUT_NUM};
+use earlgrey::registers::top_earlgrey::{PinmuxInsel, PinmuxOutsel};
+
+type In = PinmuxInsel;
+type Out = PinmuxOutsel;
+
+/// Pinmux configuration for hyperdebug with cw310. The primary reference for
+/// this config is:
+/// <OPENTITAN_TREE>/hw/top_earlgrey/data/pins_cw310_hyperdebug.xdc
+/// pins_cw310_hyperdebug.xdc sometimes underspecifies the layout (e.g. it
+/// doesn't indicate UART numbering); we resolve the ambiguity by using
+/// <OPENTITAN_TREE>/hw/top_earlgrey/data/pins_cw310.xdc
+pub enum BoardPinmuxLayout {}
+
+impl EarlGreyPinmuxConfig for BoardPinmuxLayout {
+    #[rustfmt::skip]
+    const INPUT: &'static [PinmuxInsel; INPUT_NUM] = &[
+        In::Ioa2,         // GpioGpio0
+        In::Ioa3,         // GpioGpio1
+        In::Ioa6,         // GpioGpio2
+        In::Iob0,         // GpioGpio3
+        In::Iob1,         // GpioGpio4
+        In::Iob2,         // GpioGpio5
+        In::Iob3,         // GpioGpio6
+        In::Iob6,         // GpioGpio7
+        In::Iob7,         // GpioGpio8
+        In::Iob8,         // GpioGpio9
+        In::Ioc0,         // GpioGpio10
+        In::Ioc1,         // GpioGpio11
+        In::Ioc2,         // GpioGpio12
+        In::Ioc5,         // GpioGpio13
+        In::Ioc6,         // GpioGpio14
+        In::Ioc7,         // GpioGpio15
+        In::Ioc8,         // GpioGpio16
+        In::Ioc9,         // GpioGpio17
+        In::Ioc10,        // GpioGpio18
+        In::Ioc11,        // GpioGpio19
+        In::Ioc12,        // GpioGpio20
+        In::Ior0,         // GpioGpio21
+        In::Ior1,         // GpioGpio22
+        In::Ior2,         // GpioGpio23
+        In::Ior3,         // GpioGpio24
+        In::Ior4,         // GpioGpio25
+        In::Ior5,         // GpioGpio26
+        In::Ior6,         // GpioGpio27
+        In::Ior7,         // GpioGpio28
+        In::Ior10,        // GpioGpio29
+        In::Ior11,        // GpioGpio30
+        In::Ior12,        // GpioGpio31
+        In::Iob12,        // I2c0Sda
+        In::Iob11,        // I2c0Scl
+        In::Ioa7,         // I2c1Sda
+        In::Ioa8,         // I2c1Scl
+        In::Iob9,         // I2c2Sda
+        In::Iob10,        // I2c2Scl
+        In::ConstantZero, // SpiHost1Sd0
+        In::ConstantZero, // SpiHost1Sd1
+        In::ConstantZero, // SpiHost1Sd2
+        In::ConstantZero, // SpiHost1Sd3
+        In::Ioc3,         // Uart0Rx
+        In::Iob4,         // Uart1Rx
+        In::Ioa0,         // Uart2Rx
+        In::Ioa4,         // Uart3Rx
+        In::ConstantZero, // SpiDeviceTpmCsb
+        In::ConstantZero, // FlashCtrlTck
+        In::ConstantZero, // FlashCtrlTms
+        In::ConstantZero, // FlashCtrlTdi
+        In::ConstantZero, // SysrstCtrlAonAcPresent
+        In::ConstantZero, // SysrstCtrlAonKey0In
+        In::ConstantZero, // SysrstCtrlAonKey1In
+        In::ConstantZero, // SysrstCtrlAonKey2In
+        In::ConstantZero, // SysrstCtrlAonPwrbIn
+        In::ConstantZero, // SysrstCtrlAonLidOpen
+        In::ConstantZero, // UsbdevSense
+    ];
+
+    #[rustfmt::skip]
+    const OUTPUT: &'static [PinmuxOutsel; OUTPUT_NUM] = &[
+        // __________  BANK IOA __________
+        Out::ConstantHighZ, // Ioa0 UART2_RX
+        Out::Uart2Tx,       // Ioa1 UART2_TX
+        Out::GpioGpio0,     // Ioa2
+        Out::GpioGpio1,     // Ioa3
+        Out::ConstantHighZ, // Ioa4 UART3_RX
+        Out::Uart3Tx,       // Ioa5 UART3_TX
+        Out::GpioGpio2,     // Ioa6
+        Out::I2c1Sda,       // Ioa7 I2C1_SDA
+        Out::I2c1Scl,       // Ioa8 I2C1_SCL
+        // __________ BANK IOB __________
+        Out::GpioGpio3,     // Iob0 SPI_HOST_CS
+        Out::GpioGpio4,     // Iob1 SPI_HOST_DI
+        Out::GpioGpio5,     // Iob2 SPI_HOST_DO
+        Out::GpioGpio6,     // Iob3 SPI_HOST_CLK
+        Out::ConstantHighZ, // Iob4 UART1_RX
+        Out::Uart1Tx,       // Iob5 UART1_TX
+        Out::GpioGpio7,     // Iob6
+        Out::GpioGpio8,     // Iob7
+        Out::GpioGpio9,     // Iob8
+        Out::I2c2Sda,       // Iob9  I2C2_SDA
+        Out::I2c2Scl,       // Iob10 I2C2_SCL
+        Out::I2c0Scl,       // Iob11 I2C0_SCL
+        Out::I2c0Sda,       // Iob12 I2C0_SDA
+        // __________ BANK IOC __________
+        Out::GpioGpio10,    // Ioc0
+        Out::GpioGpio11,    // Ioc1
+        Out::GpioGpio12,    // Ioc2
+        Out::ConstantHighZ, // Ioc3 UART0_RX
+        Out::Uart0Tx,       // Ioc4 UART0_TX
+        Out::ConstantHighZ, // Ioc5 (TAP STRAP 1)
+        Out::GpioGpio14,    // Ioc6
+        Out::GpioGpio15,    // Ioc7
+        Out::ConstantHighZ, // Ioc8 (TAP STRAP 0)
+        Out::GpioGpio17,    // Ioc9
+        Out::GpioGpio18,    // Ioc10
+        Out::GpioGpio19,    // Ioc11
+        Out::GpioGpio20,    // Ioc12
+        // __________ BANK IOR __________
+        Out::GpioGpio21,    // Ior0
+        Out::GpioGpio22,    // Ior1
+        Out::GpioGpio23,    // Ior2
+        Out::GpioGpio24,    // Ior3
+        Out::GpioGpio25,    // Ior4
+        Out::GpioGpio26,    // Ior5
+        Out::GpioGpio27,    // Ior6
+        Out::GpioGpio28,    // Ior7
+        // DIO CW310_hyp    // Ior8
+        // DIO CW310_hyp    // Ior9
+        Out::GpioGpio29,    // Ior10
+        Out::GpioGpio30,    // Ior11
+        Out::GpioGpio31,    // Ior12
+        Out::ConstantHighZ, // Ior13
+    ];
+}

--- a/third_party/tock/repos.bzl
+++ b/third_party/tock/repos.bzl
@@ -40,9 +40,9 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
     bare_repository(
         name = "tock",
         local = tock,
-        strip_prefix = "tock-e81987f6a41e9b92f60fda1d5283f46b3cb597b5",
-        url = "https://github.com/tock/tock/archive/e81987f6a41e9b92f60fda1d5283f46b3cb597b5.tar.gz",
-        sha256 = "b7c239f3bd7e7727eee99814661424e1e50587fe9068cec1943a7bb6743ed777",
+        strip_prefix = "tock-d0042ffb83330d6d874471e0b06cc26591844ece",
+        url = "https://github.com/tock/tock/archive/d0042ffb83330d6d874471e0b06cc26591844ece.tar.gz",
+        sha256 = "cea19af8e364f991e93c8062e776aded3b4a61127d336a3a2eab1b4d6e523549",
         additional_files_content = {
             "BUILD": """exports_files(glob(["**"]))""",
             "arch/riscv/BUILD": crate_build(
@@ -152,9 +152,9 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
     bare_repository(
         name = "libtock",
         local = libtock,
-        strip_prefix = "libtock-rs-a2c6ad80648e3ba073e7433b4330706df052a6ae",
-        url = "https://github.com/tock/libtock-rs/archive/a2c6ad80648e3ba073e7433b4330706df052a6ae.tar.gz",
-        sha256 = "888d1925cd760e818385d13187286d6b87f763c548a4dc1bb26e55786dc95636",
+        strip_prefix = "libtock-rs-75c92fc92c2ee3d8dbbbb288a2521837e069e0be",
+        url = "https://github.com/tock/libtock-rs/archive/75c92fc92c2ee3d8dbbbb288a2521837e069e0be.tar.gz",
+        sha256 = "0c56524b2534313404f600c24328307c565f61621d83ae32ba68ea9174863614",
         additional_files_content = {
             "BUILD": crate_build(
                 name = "libtock",
@@ -167,10 +167,12 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
                     "//apis/buzzer",
                     "//apis/console",
                     "//apis/gpio",
+                    "//apis/i2c_master_slave",
                     "//apis/leds",
                     "//apis/low_level_debug",
                     "//apis/ninedof",
                     "//apis/proximity",
+                    "//apis/rng",
                     "//apis/sound_pressure",
                     "//apis/temperature",
                     "//panic_handlers/debug_panic",
@@ -218,6 +220,11 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
                 crate_name = "libtock_{name}",
                 deps = ["//platform"],
             ),
+            "apis/i2c_master_slave/BUILD": crate_build(
+                name = "i2c_master_slave",
+                crate_name = "libtock_{name}",
+                deps = ["//platform"],
+            ),
             "apis/leds/BUILD": crate_build(
                 name = "leds",
                 crate_name = "libtock_{name}",
@@ -238,6 +245,11 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
             ),
             "apis/proximity/BUILD": crate_build(
                 name = "proximity",
+                crate_name = "libtock_{name}",
+                deps = ["//platform"],
+            ),
+            "apis/rng/BUILD": crate_build(
+                name = "rng",
                 crate_name = "libtock_{name}",
                 deps = ["//platform"],
             ),

--- a/third_party/tock/tockloader_requirements.txt
+++ b/third_party/tock/tockloader_requirements.txt
@@ -5,6 +5,6 @@ pycryptodome==3.18.0
 pyserial==3.5
 questionary==1.10.0
 siphash==0.0.1
-tockloader@git+https://github.com/tock/tockloader.git@122fe2c2626d00c499282b04eba22413f2e122be
+tockloader@git+https://github.com/tock/tockloader.git@a3d173aebbcad2b0bc25e69f224f8d43633084a5
 toml==0.10.2
 tqdm==4.65.0


### PR DESCRIPTION
This updates the Tock repository to just before [PR 3748](https://github.com/tock/tock/pull/3748), which updates the Rust toolchain. It updates the other repositories (libtock-rs, elf2tab, and tockloader) to the latest commits.