### PR TITLE
[rom_ext,rescue] Rescue protocol infrastructure

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -235,18 +235,27 @@ opentitan_test(
     ],
 )
 
-cc_library(
+dual_cc_library(
     name = "ibex",
-    srcs = ["ibex.c"],
-    hdrs = ["ibex.h"],
-    deps = [
-        "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:abs_mmio",
-        "//sw/device/lib/base:macros",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/silicon_creator/lib/base:sec_mmio",
-    ],
+    srcs = dual_inputs(
+        host = ["ibex_host.c"],
+        shared = ["ibex.c"],
+    ),
+    hdrs = dual_inputs(
+        shared = ["ibex.h"],
+    ),
+    deps = dual_inputs(
+        shared = [
+            "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/arch:device",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:csr",
+            "//sw/device/lib/base:macros",
+            "//sw/device/lib/runtime:hart",
+            "//sw/device/silicon_creator/lib/base:sec_mmio",
+        ],
+    ),
 )
 
 cc_test(
@@ -466,6 +475,7 @@ cc_library(
     srcs = ["pinmux.c"],
     hdrs = ["pinmux.h"],
     deps = [
+        "//hw/ip/gpio/data:gpio_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -670,11 +680,13 @@ cc_library(
     srcs = ["uart.c"],
     hdrs = ["uart.h"],
     deps = [
+        ":ibex",
         "//hw/ip/uart/data:uart_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/lib:error",
     ],
 )
@@ -686,6 +698,7 @@ cc_test(
         ":uart",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/drivers/ibex.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex.c
@@ -50,3 +50,8 @@ void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
   sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_1_REG_OFFSET, 1);
   icache_invalidate();
 }
+
+// `extern` declarations to give the inline functions in the corresponding
+// header a link location.
+extern uint64_t ibex_mcycle(void);
+extern uint64_t ibex_time_to_cycles(uint64_t time_us);

--- a/sw/device/silicon_creator/lib/drivers/ibex.h
+++ b/sw/device/silicon_creator/lib/drivers/ibex.h
@@ -8,6 +8,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/macros.h"
 
 #ifdef __cplusplus
@@ -21,6 +23,26 @@ extern "C" {
  */
 OT_WARN_UNUSED_RESULT
 uint32_t ibex_fpga_version(void);
+
+#ifdef OT_PLATFORM_RV32
+OT_WARN_UNUSED_RESULT
+inline uint64_t ibex_mcycle(void) {
+  uint32_t lo, hi, hi2;
+  do {
+    CSR_READ(CSR_REG_MCYCLEH, &hi);
+    CSR_READ(CSR_REG_MCYCLE, &lo);
+    CSR_READ(CSR_REG_MCYCLEH, &hi2);
+  } while (hi != hi2);
+  return ((uint64_t)hi << 32) | lo;
+}
+
+inline uint64_t ibex_time_to_cycles(uint64_t time_us) {
+  return to_cpu_cycles(time_us);
+}
+#else
+extern uint64_t ibex_mcycle(void);
+extern uint64_t ibex_time_to_cycles(uint64_t time_us);
+#endif
 
 /**
  * The following constants represent the expected number of sec_mmio register

--- a/sw/device/silicon_creator/lib/drivers/ibex_host.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex_host.c
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <time.h>
+
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
+
+// These ibex functions are used to implement milli- or micro-second timeout
+// loops in the firmware.  The host implementations are supplied so that
+// host-based unit tests will compile and link and allow rudimentary testing of
+// the timeout functionality.
+
+uint64_t ibex_mcycle(void) {
+  struct timespec tp;
+  clock_gettime(CLOCK_MONOTONIC, &tp);
+  return tp.tv_sec * 1000000 + tp.tv_nsec / 1000;
+}
+
+uint64_t ibex_time_to_cycles(uint64_t time_us) { return time_us; }

--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -11,6 +11,7 @@
 #include "sw/device/silicon_creator/lib/base/chip.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 
+#include "gpio_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otp_ctrl_regs.h"
 #include "pinmux_regs.h"
@@ -103,15 +104,58 @@ static void configure_input(pinmux_input_t input) {
 }
 
 /**
- * Enables pull-down for the specified pad.
+ * Enables or disables pull-up/pull-down for the specified pad.
  *
  * @param pad A MIO pad.
+ * @param enable Whether the internal pull resistor should be enabled.
+ * @param up Whether the pull resistor should pull up(true) or down(false).
  */
-static void enable_pull_down(top_earlgrey_muxed_pads_t pad) {
-  uint32_t reg =
-      bitfield_bit32_write(0, PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, true);
+static void enable_pull(top_earlgrey_muxed_pads_t pad, bool enable, bool up) {
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(reg, PINMUX_MIO_PAD_ATTR_0_PULL_EN_0_BIT, enable);
+  reg = bitfield_bit32_write(reg, PINMUX_MIO_PAD_ATTR_0_PULL_SELECT_0_BIT, up);
   abs_mmio_write32(
       kBase + PINMUX_MIO_PAD_ATTR_0_REG_OFFSET + pad * sizeof(uint32_t), reg);
+}
+
+/**
+ * Delay while we wait for pinmux values to stabilize after changing resistor
+ * pull-up/down values.
+ */
+static void pinmux_prop_delay(void) {
+  // Wait for pull downs to propagate to the physical pads.
+  CSR_WRITE(CSR_REG_MCYCLE, 0);
+  uint32_t mcycle;
+  do {
+    CSR_READ(CSR_REG_MCYCLE, &mcycle);
+  } while (mcycle < PINMUX_PAD_ATTR_PROP_CYCLES);
+}
+
+/**
+ * Read a single strap pin considering weak/strong pull resistors.
+ *
+ * @param input The input pin to read.
+ * @return The value of the pin.
+ */
+static uint32_t read_strap_pin(pinmux_input_t input) {
+  // First, disable all pull resistors and read the state of the pin.
+  enable_pull(input.pad, false, false);
+  pinmux_prop_delay();
+  uint32_t val =
+      abs_mmio_read32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET);
+  uint32_t state = bitfield_bit32_read(val, input.periph);
+  uint32_t res = state ? 2 : 0;
+
+  // Then, enable the opposite pull to the observed state.
+  // If the external signal is weak, the internal pull resistor will win; if
+  // the external signal is strong, the external resistor will win.
+  enable_pull(input.pad, true, !state);
+  pinmux_prop_delay();
+
+  val = abs_mmio_read32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET);
+  state = bitfield_bit32_read(val, input.periph);
+  res += state ? 1 : 0;
+  return res;
 }
 
 /**
@@ -132,15 +176,12 @@ void pinmux_init(void) {
     HARDENED_CHECK_NE(bootstrap_dis, kHardenedBoolTrue);
     // Note: attributes should be configured before the pinmux matrix to avoid
     // "undesired electrical behavior and/or contention at the pads".
-    enable_pull_down(kInputSwStrap0.pad);
-    enable_pull_down(kInputSwStrap1.pad);
-    enable_pull_down(kInputSwStrap2.pad);
+    enable_pull(kInputSwStrap0.pad, /*enable=*/true, /*up=*/false);
+    enable_pull(kInputSwStrap1.pad, /*enable=*/true, /*up=*/false);
+    enable_pull(kInputSwStrap2.pad, /*enable=*/true, /*up=*/false);
     // Wait for pull downs to propagate to the physical pads.
-    CSR_WRITE(CSR_REG_MCYCLE, 0);
-    uint32_t mcycle;
-    do {
-      CSR_READ(CSR_REG_MCYCLE, &mcycle);
-    } while (mcycle < PINMUX_PAD_ATTR_PROP_CYCLES);
+    pinmux_prop_delay();
+
     configure_input(kInputSwStrap0);
     configure_input(kInputSwStrap1);
     configure_input(kInputSwStrap2);
@@ -148,4 +189,12 @@ void pinmux_init(void) {
 
   configure_input(kInputUart0);
   configure_output(kOutputUart0);
+}
+
+uint32_t pinmux_read_straps(void) {
+  uint32_t value = 0;
+  value |= read_strap_pin(kInputSwStrap0);
+  value |= read_strap_pin(kInputSwStrap1) << 2;
+  value |= read_strap_pin(kInputSwStrap2) << 4;
+  return value;
 }

--- a/sw/device/silicon_creator/lib/drivers/pinmux.h
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.h
@@ -23,6 +23,25 @@ extern "C" {
  */
 void pinmux_init(void);
 
+/**
+ * Read the SW_STRAP value.
+ *
+ * The straping value is encoded with two bits per pin and encodes the
+ * strength of the external pull resistors in the returned value.
+ *
+ * Each 2-bit field encodes the following values:
+ * - 0: Strong pull down
+ * - 1: Weak pull down
+ * - 2: Weak pull up
+ * - 3: Strong pull up
+ *
+ * The values of the 3 strapping pins are concatenated together, yielding a
+ * 6-bit strapping value.
+ *
+ * @return The strapping value 0-63.
+ */
+uint32_t pinmux_read_straps(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/uart.h
+++ b/sw/device/silicon_creator/lib/drivers/uart.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 #ifdef __cplusplus
@@ -23,11 +24,24 @@ extern "C" {
 void uart_init(uint32_t precalculated_nco);
 
 /**
+ * Enable the receiver on the UART.
+ */
+void uart_enable_receiver(void);
+
+/**
  * Write a single byte to the UART.
  *
  * @param byte Byte to send.
  */
 void uart_putchar(uint8_t byte);
+
+/**
+ * Read a single byte from the UART.
+ *
+ * @param timeout_ms How long to wait.
+ * @return The character received or -1 if timeout.
+ */
+int uart_getchar(uint32_t timeout_ms);
 
 /**
  * Write a buffer to the UART.
@@ -38,8 +52,31 @@ void uart_putchar(uint8_t byte);
  * @param len Length of the buffer to write.
  * @return Number of bytes written.
  */
-OT_WARN_UNUSED_RESULT
 size_t uart_write(const uint8_t *data, size_t len);
+
+/**
+ * Read from the UART into a buffer.
+ *
+ * Reads up to `len` bytes into a buffer before the timeout.
+ *
+ * @param data Pointer to buffer to write.
+ * @param len Length of the buffer to write.
+ * @param timeout_ms The timeout to receive the complete buffer.
+ * @return Number of bytes written.
+ */
+OT_WARN_UNUSED_RESULT
+size_t uart_read(uint8_t *data, size_t len, uint32_t timeout_ms);
+
+/**
+ * Detect if a UART break is asserted for a given period of time.
+ *
+ * UART break must already be asserted upon entry to this function and must
+ * remain asserted for the duration of `timeout_ms`.
+ *
+ * @param timeout_us The time for which break must be asserted.
+ * @return kHardenedBoolTrue if break is asserted.
+ */
+hardened_bool_t uart_break_detect(uint32_t timeout_us);
 
 /**
  * Sink a buffer to the UART.


### PR DESCRIPTION
1. Add function to get the mcycle timer to `ibex`.
2. Add UART receive functions to the `uart` driver.
3. Add `pinmux` support for UART receieve and reading strapping pins.