### PR TITLE
[usbdev] usbdev_config_host test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -34,7 +34,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_vbus"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_vbus_test"]
     }
     {
       name: chip_sw_usbdev_pullup
@@ -59,7 +59,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_pullup"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_pullup_test"]
     }
     {
       name: chip_sw_usbdev_aon_pullup
@@ -138,7 +138,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_setuprx"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_setuprx_test"]
     }
     {
       name: chip_sw_usbdev_config_host
@@ -163,7 +163,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_config_host"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_config_host_test"]
     }
     {
       name: chip_sw_usbdev_pincfg
@@ -190,7 +190,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_pincfg"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_pincfg_test"]
     }
     {
       name: chip_sw_usbdev_tx_rx

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -162,7 +162,7 @@
       stage: V2
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
-      tests: []
+      tests: ["chip_sw_usbdev_config_host"]
       bazel: []
     }
     {

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -605,6 +605,14 @@
       reseed: 1
     }
     {
+      name: chip_sw_usbdev_config_host
+      uvm_test_seq: chip_sw_usbdev_dpi_vseq
+      sw_images: ["//sw/device/tests:usbdev_config_host_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1"]
+      reseed: 1
+    }
+    {
       name: chip_sw_usbdev_pincfg
       uvm_test_seq: chip_sw_usbdev_dpi_vseq
       sw_images: ["//sw/device/tests:usbdev_pincfg_test:1:new_rules"]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3522,6 +3522,26 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "usbdev_config_host_test",
+    srcs = ["usbdev_config_host_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS
+    ),
+    verilator = new_verilator_params(timeout = "long"),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:usb_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "usbdev_test",
     srcs = ["usbdev_test.c"],
     cw310 = new_cw310_params(tags = ["manual"]),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3526,7 +3526,7 @@ opentitan_test(
     srcs = ["usbdev_config_host_test.c"],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
-        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [

--- a/sw/device/tests/usbdev_config_host_test.c
+++ b/sw/device/tests/usbdev_config_host_test.c
@@ -1,0 +1,103 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// USB CONFIG HOST test
+//
+// Test basic configuration of the USB device by the host/DPI.
+//
+// It requires interaction with the USB DPI model or a physical host in order
+// to receive and respond to the Control Transfers that are involved in the
+// identification and configuration of the device.
+//
+// The test configures USB Endpoint 1 as a simpleserial endpoint which should
+// appear as /dev/ttyUSBx on a Linux-based host.
+
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/usb_testutils.h"
+#include "sw/device/lib/testing/usb_testutils_controlep.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+/**
+ * Configuration values for USB.
+ */
+static const uint8_t config_descriptors[] = {
+    USB_CFG_DSCR_HEAD(
+        USB_CFG_DSCR_LEN + USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN, 1),
+    // Single interface...
+    VEND_INTERFACE_DSCR(0, 1, 0x50, 1),
+    // ... describing two Endpoints; endpoint 1 OUT and endpoint 1 IN
+    USB_BULK_EP_DSCR(0, 1, 32, 0),
+    USB_BULK_EP_DSCR(1, 1, 32, 4),
+};
+
+/**
+ * USB device context types.
+ */
+static usb_testutils_ctx_t usbdev;
+static usb_testutils_controlep_ctx_t usbdev_control;
+
+/**
+ * Pinmux handle
+ */
+static dif_pinmux_t pinmux;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  // In simulation the DPI model connects VBUS shortly after reset and
+  // prolonged delays when asserting or deasserting pull ups are wasteful.
+  uint32_t timeout_micros = 6000u;
+  bool prompt = false;
+
+  if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) {
+    // FPGA platforms where user intervention may be required.
+    timeout_micros = 30 * 1000 * 1000u;
+    // Report instructions/progress to user, when driven manually.
+    prompt = true;
+    LOG_INFO("Running USBDEV_CONFIG_HOST test");
+    LOG_INFO("Awaiting configuration from the host");
+  }
+
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  pinmux_testutils_init(&pinmux);
+  CHECK_DIF_OK(dif_pinmux_input_select(
+      &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+      kTopEarlgreyPinmuxInselIoc7));
+
+  // Call `usbdev_init` here so that DPI will not start until the
+  // simulation has finished all of the printing, which takes a while
+  // if `--trace` was passed in.
+  CHECK_STATUS_OK(usb_testutils_init(&usbdev, /*pinflip=*/false,
+                                     /*en_diff_rcvr=*/true,
+                                     /*tx_use_d_se0=*/false));
+  CHECK_STATUS_OK(usb_testutils_controlep_init(
+      &usbdev_control, &usbdev, 0, config_descriptors,
+      sizeof(config_descriptors), NULL, 0));
+
+  // Proceed only when the device has been configured; this allows host-side
+  // software to establish communication.
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured &&
+         !ibex_timeout_check(&timeout)) {
+    CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
+  }
+
+  bool success = (usbdev_control.device_state == kUsbTestutilsDeviceConfigured);
+  if (success && prompt) {
+    LOG_INFO("Configuration received");
+  }
+  CHECK(success);
+
+  CHECK_STATUS_OK(usb_testutils_fin(&usbdev));
+
+  return true;
+}


### PR DESCRIPTION
This PR creates a simple test of USBDEV detection, identification and configuration by the host/DPI model, indicating that bidirectional communication with the host is working.

Control Transfers from the host are received and processed, identifying the USB device as a single 'simpleserial' device to the host, and a Linux-based host will usually present the device as '/dev/ttyUSBx'.

No further communication with the host occurs during this test and no additional software beyond the driver stack is required on the host side for this test to pass. The test has been checked on the CW310 and in chip simulation.

See [#19966](https://github.com/lowRISC/opentitan/issues/19966)