### PR TITLE
[cryptotest] HMAC test vector JSON schema

### DIFF
--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -19,6 +19,13 @@ cc_library(
 )
 
 cc_library(
+    name = "hmac_commands",
+    srcs = ["hmac_commands.c"],
+    hdrs = ["hmac_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "aes_sca_commands",
     srcs = ["aes_sca_commands.c"],
     hdrs = ["aes_sca_commands.h"],

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -13,6 +13,7 @@ extern "C" {
 
 #define COMMAND(_, value) \
     value(_, Aes) \
+    value(_, Hmac) \
     value(_, AesSca) \
     value(_, IbexFi) \
     value(_, KmacSca) \

--- a/sw/device/tests/crypto/cryptotest/json/hmac_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/hmac_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "hmac_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/hmac_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/hmac_commands.h
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_HMAC_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_HMAC_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HMAC_CMD_MAX_MESSAGE_BYTES 256
+#define HMAC_CMD_MAX_KEY_BYTES 142
+#define HMAC_CMD_MAX_TAG_BYTES 64
+
+// clang-format off
+
+#define HMAC_HASH_ALG(_, value) \
+    value(_, Sha256) \
+    value(_, Sha384) \
+    value(_, Sha512) \
+    value(_, Sha3_256) \
+    value(_, Sha3_512)
+UJSON_SERDE_ENUM(CryptotestHmacHashAlg, cryptotest_hmac_hash_alg_t, HMAC_HASH_ALG);
+
+#define HMAC_MESSAGE(field, string) \
+    field(message, uint8_t, HMAC_CMD_MAX_MESSAGE_BYTES) \
+    field(message_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestHmacMessage, cryptotest_hmac_message_t, HMAC_MESSAGE);
+
+#define HMAC_KEY(field, string) \
+    field(key, uint8_t, HMAC_CMD_MAX_KEY_BYTES) \
+    field(key_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestHmacKey, cryptotest_hmac_key_t, HMAC_KEY);
+
+#define HMAC_TAG(field, string) \
+    field(tag, uint8_t, HMAC_CMD_MAX_TAG_BYTES) \
+    field(tag_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestHmacTag, cryptotest_hmac_tag_t, HMAC_TAG);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_HMAC_COMMANDS_H_

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -13,3 +13,5 @@ filegroup(
     name = "ecdsa_sig_ver_schema",
     srcs = ["ecdsa_sig_ver_schema.json"],
 )
+
+exports_files(["hmac_schema.json"])

--- a/sw/host/cryptotest/testvectors/data/schemas/hmac_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/hmac_schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/hmac_schema.json",
+  "title": "Cryptotest HMAC Test Vector",
+  "description": "A list of testvectors for HMAC testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "test_case_id",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be hmac",
+        "type": "string",
+        "enum": ["hmac"]
+      },
+      "hash_alg": {
+        "description": "Hash algorithm",
+        "type": "string",
+        "enum": ["sha-1", "sha-224", "sha-256", "sha-384", "sha-512"]
+      },
+      "key": {
+        "description": "Key to use for tag generation",
+        "$ref": "#/$defs/byte_array"
+      },
+      "message": {
+        "description": "Message to generate tag for",
+        "$ref": "#/$defs/byte_array"
+      },
+      "tag": {
+        "description": "Message tag output by HMAC",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Whether the output tag should match `tag`",
+        "type": "boolean"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the JSON schema file for the HMAC test harness. The schema file specifies the common test vector format output by the test vector parsers in #21148 and #21149.