### PR TITLE
[prim] Add synchronizer cell primitive

### DIFF
--- a/hw/ip/prim/lint/prim_sync_cell.waiver
+++ b/hw/ip/prim/lint/prim_sync_cell.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_sync_cell
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_sync_cell.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/prim_sync_cell.core
+++ b/hw/ip/prim/prim_sync_cell.core
@@ -3,19 +3,14 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:flop_2sync"
-description: "Primitive synchronizer"
+name: "lowrisc:prim:sync_cell"
+description: "Generic sync_cell"
 filesets:
-  files_rtl:
+  primgen_dep:
     depend:
       - lowrisc:prim:prim_pkg
-      # Needed because the generic prim_flop_2sync has a
-      # dependency on prim:sync_cell.
-      - lowrisc:prim:sync_cell
-      - lowrisc:prim:cdc_rand_delay
-    files:
-      - rtl/prim_flop_2sync.sv
-    file_type: systemVerilogSource
+      - lowrisc:prim:primgen
+      - lowrisc:prim:assert
 
   files_verilator_waiver:
     depend:
@@ -29,7 +24,7 @@ filesets:
       # common waivers
       - lowrisc:lint:common
     files:
-      - lint/prim_flop_2sync.waiver
+      - lint/prim_sync_cell.waiver
     file_type: waiver
 
   files_veriblelint_waiver:
@@ -37,10 +32,18 @@ filesets:
       # common waivers
       - lowrisc:lint:common
 
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: sync_cell
+
 targets:
   default:
     filesets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - files_rtl
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim_generic/prim_generic_sync_cell.core
+++ b/hw/ip/prim_generic/prim_generic_sync_cell.core
@@ -3,18 +3,14 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:flop_2sync"
-description: "Primitive synchronizer"
+name: "lowrisc:prim_generic:sync_cell"
+description: "generic sync_cell"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:prim_pkg
-      # Needed because the generic prim_flop_2sync has a
-      # dependency on prim:sync_cell.
-      - lowrisc:prim:sync_cell
-      - lowrisc:prim:cdc_rand_delay
+      - lowrisc:prim_generic:flop
     files:
-      - rtl/prim_flop_2sync.sv
+      - rtl/prim_generic_sync_cell.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
@@ -29,7 +25,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
     files:
-      - lint/prim_flop_2sync.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim_generic/rtl/prim_generic_sync_cell.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_sync_cell.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_generic_sync_cell #(
+  parameter int               Width      = 1,
+  parameter logic [Width-1:0] ResetValue = 0
+) (
+  input                    clk_i,
+  input                    rst_ni,
+  input        [Width-1:0] d_i,
+  output logic [Width-1:0] q_o
+);
+
+  // Since this is already a "generic" implementation,
+  // we don't use the primgen'd 'prim_flop' here, but
+  // instantiate prim_generic_flop directly.
+  logic [Width-1:0] q1;
+  prim_generic_flop #(
+    .Width(Width),
+    .ResetValue(ResetValue)
+  ) u_sync_1 (
+    .clk_i,
+    .rst_ni,
+    .d_i,
+    .q_o(q1)
+  );
+
+  prim_generic_flop #(
+    .Width(Width),
+    .ResetValue(ResetValue)
+  ) u_sync_2 (
+    .clk_i,
+    .rst_ni,
+    .d_i(q1),
+    .q_o
+  );
+
+endmodule

--- a/hw/ip/prim_xilinx/prim_xilinx_sync_cell.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_sync_cell.core
@@ -3,18 +3,14 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:flop_2sync"
-description: "Primitive synchronizer"
+name: "lowrisc:prim_xilinx:sync_cell"
+description: "xilinx sync_cell"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:prim:prim_pkg
-      # Needed because the generic prim_flop_2sync has a
-      # dependency on prim:sync_cell.
-      - lowrisc:prim:sync_cell
-      - lowrisc:prim:cdc_rand_delay
+      - lowrisc:prim_xilinx:flop
     files:
-      - rtl/prim_flop_2sync.sv
+      - rtl/prim_xilinx_sync_cell.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
@@ -29,7 +25,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
     files:
-      - lint/prim_flop_2sync.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_sync_cell.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_sync_cell.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_xilinx_sync_cell #(
+  parameter int               Width      = 1,
+  parameter logic [Width-1:0] ResetValue = 0
+) (
+  input                    clk_i,
+  input                    rst_ni,
+  input        [Width-1:0] d_i,
+  output logic [Width-1:0] q_o
+);
+
+  // Since this is already a "xilinx" implementation,
+  // we don't use the primgen'd 'prim_flop' here, but
+  // instantiate prim_xilinx_flop directly.
+  logic [Width-1:0] q1;
+  prim_xilinx_flop #(
+    .Width(Width),
+    .ResetValue(ResetValue)
+  ) u_sync_1 (
+    .clk_i,
+    .rst_ni,
+    .d_i,
+    .q_o(q1)
+  );
+
+  prim_xilinx_flop #(
+    .Width(Width),
+    .ResetValue(ResetValue)
+  ) u_sync_2 (
+    .clk_i,
+    .rst_ni,
+    .d_i(q1),
+    .q_o
+  );
+
+endmodule


### PR DESCRIPTION
This is an alternative solution to #21139 which is more in line with what has initially been discussed here https://github.com/lowRISC/opentitan/pull/10609.

Specifically, it adds a synchronizer cell primitive that can be used to wrap a 2 flop synchronizer from the standard cell library.

The reason why we're not converting the `prim_flop_2sync` primitive to a technology dependent one is that that module contains additional CDC randomization code for DV which we would like to keep in one place. Having a separate synchronizer cell primitive that is tech dependent allows us to do just that.
