### PR TITLE
[spi_device] Remove all timing mode CSRs

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -291,16 +291,6 @@
             '''
     }
     {
-      name: "SPI_DEVICE.HW.CPOL",
-      desc: '''The SPI clock polarity is configurable at runtime via the "CSR.CFG.CPOL" register.
-            '''
-    }
-    {
-      name: "SPI_DEVICE.HW.CPHA",
-      desc: '''The SPI clock phase is configurable at runtime via the "CSR.CFG.CPHA" register.
-            '''
-    }
-    {
       name: "SPI_DEVICE.HW.LANES",
       desc: '''1,2 or 4 lane operation is supported by the block.
             '''
@@ -509,16 +499,6 @@
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-        { bits: "0",
-          name: "CPOL",
-          desc: "Clock polarity. 0 for normal SPI, 1 for negative edge latch",
-          resval: "0",
-        },
-        { bits: "1",
-          name: "CPHA",
-          desc: "Data phase. 0 for negative edge change, 1 for positive edge change",
-          resval: "0",
-        },
         { bits: "2",
           name: "tx_order",
           desc: "TX bit order on SDO. 0 for MSB to LSB, 1 for LSB to MSB",

--- a/hw/ip/spi_device/doc/registers.md
+++ b/hw/ip/spi_device/doc/registers.md
@@ -208,12 +208,12 @@ This CSR automatically resets to 0.
 Configuration Register
 - Offset: `0x14`
 - Reset default: `0x0`
-- Reset mask: `0x100000f`
+- Reset mask: `0x100000c`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "CPOL", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "CPHA", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "tx_order", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "rx_order", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 20}, {"name": "mailbox_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 7}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"bits": 2}, {"name": "tx_order", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "rx_order", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 20}, {"name": "mailbox_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 7}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name       | Description                                                                                                                                                                                                                    |
@@ -223,8 +223,7 @@ Configuration Register
 |  23:4  |        |         |            | Reserved                                                                                                                                                                                                                       |
 |   3    |   rw   |   0x0   | rx_order   | RX bit order on SDI. Module stores bitstream from MSB to LSB if value is 0.                                                                                                                                                    |
 |   2    |   rw   |   0x0   | tx_order   | TX bit order on SDO. 0 for MSB to LSB, 1 for LSB to MSB                                                                                                                                                                        |
-|   1    |   rw   |   0x0   | CPHA       | Data phase. 0 for negative edge change, 1 for positive edge change                                                                                                                                                             |
-|   0    |   rw   |   0x0   | CPOL       | Clock polarity. 0 for normal SPI, 1 for negative edge latch                                                                                                                                                                    |
+|  1:0   |        |         |            | Reserved                                                                                                                                                                                                                       |
 
 ## STATUS
 SPI Device status register

--- a/hw/ip/spi_device/doc/theory_of_operation.md
+++ b/hw/ip/spi_device/doc/theory_of_operation.md
@@ -393,10 +393,6 @@ SW is recommended to discard the current context if any transaction is ongoing t
 
 ## Clock and Phase
 
-The SPI device module has two programmable register bits to control the SPI clock, [`CFG.CPOL`](registers.md#cfg) and [`CFG.CPHA`](registers.md#cfg).
-CPOL controls clock polarity and CPHA controls the clock phase.
+The SPI device module only internally supports mode 0, where data is shifted out on the falling edge and sampled on the rising edge, and SPI clock returns to low at the end of the transaction.
 For further details, please refer to this diagram from Wikipedia:
 [File:SPI_timing_diagram2.svg](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface#/media/File:SPI_timing_diagram2.svg)
-
-This version of SPI_DEVICE HWIP supports mode 0 (CPHA and CPOL as 0) for Flash and Passthrough modes. Mode 3 (CPHA and CPOL as 1) is not supported in the current version.
-SW should configure the SPI_DEVICE to mode 0 to enable TPM mode along with other modes.

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -319,18 +319,13 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     if (`gmv(ral.tpm_cfg.en)) begin
       sck_polarity_phase = 0;
     end else begin
-      // flash mode only supports these 2 values.
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(sck_polarity_phase,
-          // TODO (#16339), add back 'b11 once this issue is fixed
-          sck_polarity_phase inside {0};)
+      // flash mode only supports mode 0
+      sck_polarity_phase = 0;
     end
     cfg.spi_host_agent_cfg.sck_polarity[0] = sck_polarity_phase[0];
     cfg.spi_host_agent_cfg.sck_phase[0] = sck_polarity_phase[1];
     cfg.spi_device_agent_cfg.sck_polarity[0] = sck_polarity_phase[0];
     cfg.spi_device_agent_cfg.sck_phase[0] = sck_polarity_phase[1];
-
-    ral.cfg.cpol.set(sck_polarity_phase[0]);
-    ral.cfg.cpha.set(sck_polarity_phase[1]);
 
     // bit dir is only supported in fw mode. Need to be 0 for other modes
     cfg.spi_host_agent_cfg.host_bit_dir = 0;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_base_vseq.sv
@@ -61,8 +61,6 @@ class spi_device_tpm_base_vseq extends spi_device_base_vseq;
     cfg.spi_host_agent_cfg.device_bit_dir = 0;
     ral.cfg.tx_order.set(cfg.spi_host_agent_cfg.host_bit_dir);
     ral.cfg.rx_order.set(cfg.spi_host_agent_cfg.device_bit_dir);
-    ral.cfg.cpol.set(1'b0);
-    ral.cfg.cpha.set(1'b0);
     csr_update(.csr(ral.cfg));
 
     // tpm_cfg needs to be included in cfg.spi_cfg_sema, because tpm and flash may be enabled

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -178,8 +178,6 @@ module spi_device
   // Control signals //
   /////////////////////
 
-  logic cpol; // Clock polarity
-  logic cpha; // Phase : Not complete
   logic txorder; // TX bitstream order: 0(bit 7 to 0), 1(bit 0 to 7)
   logic rxorder; // RX bitstream order: 0(bit 7 to 0), 1(bit 0 to 7)
 
@@ -365,8 +363,6 @@ module spi_device
   // Connect phase (between control signals above and register module //
   //////////////////////////////////////////////////////////////////////
 
-  assign cpol = reg2hw.cfg.cpol.q;
-  assign cpha = reg2hw.cfg.cpha.q;
   assign txorder = reg2hw.cfg.tx_order.q;
   assign rxorder = reg2hw.cfg.rx_order.q;
 
@@ -1084,7 +1080,6 @@ module spi_device
     .s_en_o       (internal_sd_en),
     .s_o          (internal_sd),
 
-    .cpha_i       (cpha),
     .order_i      (txorder),
     .io_mode_i    (io_mode_outclk)
   );
@@ -1447,9 +1442,6 @@ module spi_device
     .rst_ni    (rst_spi_n),
     .clk_out_i (clk_spi_out_buf),
 
-    // Configurations
-    .cfg_cpol_i (cpol),
-
     .cfg_cmd_filter_i (cmd_filter),
 
     .cfg_addr_mask_i  (addr_swap_mask),
@@ -1469,7 +1461,6 @@ module spi_device
 
     // Host SPI
     .host_sck_i  (cio_sck_i),
-    .host_isck_i (sck_n    ), // inverted cio_sck_i
     .host_csb_i  (cio_csb_i),
     .host_s_i    (cio_sd_i),
     .host_s_o    (passthrough_sd),

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -129,12 +129,6 @@ package spi_device_reg_pkg;
     struct packed {
       logic        q;
     } tx_order;
-    struct packed {
-      logic        q;
-    } cpha;
-    struct packed {
-      logic        q;
-    } cpol;
   } spi_device_reg2hw_cfg_reg_t;
 
   typedef struct packed {
@@ -563,12 +557,12 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1564:1559]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1558:1553]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1552:1541]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1540:1539]
-    spi_device_reg2hw_control_reg_t control; // [1538:1536]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1535:1531]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1562:1557]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1556:1551]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1550:1539]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1538:1537]
+    spi_device_reg2hw_control_reg_t control; // [1536:1534]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1533:1531]
     spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1530:1527]
     spi_device_reg2hw_addr_mode_reg_t addr_mode; // [1526:1525]
     spi_device_reg2hw_flash_status_reg_t flash_status; // [1524:1498]

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -213,10 +213,6 @@ module spi_device_reg_top (
   logic [1:0] control_mode_qs;
   logic [1:0] control_mode_wd;
   logic cfg_we;
-  logic cfg_cpol_qs;
-  logic cfg_cpol_wd;
-  logic cfg_cpha_qs;
-  logic cfg_cpha_wd;
   logic cfg_tx_order_qs;
   logic cfg_tx_order_wd;
   logic cfg_rx_order_qs;
@@ -2046,60 +2042,6 @@ module spi_device_reg_top (
 
 
   // R[cfg]: V(False)
-  //   F[cpol]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_cfg_cpol (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (cfg_we),
-    .wd     (cfg_cpol_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.cfg.cpol.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (cfg_cpol_qs)
-  );
-
-  //   F[cpha]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_cfg_cpha (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (cfg_we),
-    .wd     (cfg_cpha_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.cfg.cpha.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (cfg_cpha_qs)
-  );
-
   //   F[tx_order]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -19567,10 +19509,6 @@ module spi_device_reg_top (
   assign control_mode_wd = reg_wdata[5:4];
   assign cfg_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign cfg_cpol_wd = reg_wdata[0];
-
-  assign cfg_cpha_wd = reg_wdata[1];
-
   assign cfg_tx_order_wd = reg_wdata[2];
 
   assign cfg_rx_order_wd = reg_wdata[3];
@@ -20989,8 +20927,6 @@ module spi_device_reg_top (
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[0] = cfg_cpol_qs;
-        reg_rdata_next[1] = cfg_cpha_qs;
         reg_rdata_next[2] = cfg_tx_order_qs;
         reg_rdata_next[3] = cfg_rx_order_qs;
         reg_rdata_next[24] = cfg_mailbox_en_qs;

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -27,12 +27,12 @@
  * attached SPI Flash device, mainly in order to not introduce glitches on the
  * CSb line. If the module does not hold the SPI_CLK, then CSb needs one more
  * clock to remove the glitch. The timing delay means that this design will miss
- * the tming to raise CSb in order to cancel the self-complete commands such as
+ * the timing to raise CSb in order to cancel the self-complete commands such as
  * chip erase command.
  *
  * To make CSb de-assertion work, there are a few assumptions:
  *
- * 1. De-asserting CSb in the middle of transmit does not degrade the device
+ * 1. De-asserting CSb in the middle of transaction does not degrade the device
  *    quality.
  * 2. If CSb is de-asserted prior to the 8th SPI_CLK, the SPI flash device
  *    cancels the process without making any assumptions about the expected
@@ -78,16 +78,6 @@ module spi_passthrough
 
   input clk_out_i, // SPI output clk
 
-  // Configurations
-  //
-  // Clock polarity
-  //
-  // CFG.CPOL informs the logic if the host sends inverted SCK or not. If
-  // CFG.CPOL is set, the filtering logic needs to account for the inverted
-  // clock. The logic gates the `host_inverted_sck_i` then sends out the
-  // inverted clock rather than `host_sck_i`.
-  input cfg_cpol_i,
-
   // command filter information is given as 256bit register. It is subject to be
   // changed if command config is stored in DPSRAM. If that is supported, the
   // command config is valid at the 6th command cycle and given only 8 bits.
@@ -122,7 +112,6 @@ module spi_passthrough
   // and cmdparse, but passthrough has to implement its own s2p and cmdparse to
   // support the A/B binary scheme.
   input              host_sck_i,
-  input              host_isck_i, // inverted SCK for CPOL:=1 case
   input              host_csb_i,
   input        [3:0] host_s_i,
   output logic [3:0] host_s_o,    // clk_out_i domain
@@ -694,7 +683,7 @@ module spi_passthrough
     else         host_s_en_o <= host_s_en_inclk;
   end
 
-  logic pt_gated_sck, pt_gated_isck, pt_gated_isck_inv;
+  logic pt_gated_sck;
   prim_clock_gating #(
     .NoFpgaGate    (1'b 0),
     .FpgaBufGlobal (1'b 1) // Going outside of chip
@@ -704,18 +693,8 @@ module spi_passthrough
     .test_en_i (1'b 0       ), // No FF connected to this gated SCK
     .clk_o     (pt_gated_sck)
   );
-  prim_clock_gating #(
-    .NoFpgaGate    (1'b 0),
-    .FpgaBufGlobal (1'b 1)  // Going outside of chip
-  ) u_pt_isck_cg (
-    .clk_i     (host_isck_i  ),
-    .en_i      (sck_gate_en  ),
-    .test_en_i (1'b 0        ), // No FF connected to this gated SCK
-    .clk_o     (pt_gated_isck)
-  );
-  assign pt_gated_isck_inv = ~pt_gated_isck;
 
-  assign passthrough_o.sck    = (cfg_cpol_i) ? pt_gated_isck_inv : pt_gated_sck;
+  assign passthrough_o.sck    = pt_gated_sck;
   assign passthrough_o.sck_en = 1'b 1;
 
   // CSb propagation:  csb_deassert signal should be an output of FF or latch to

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -41,11 +41,6 @@ static inline uint32_t build_control_word(
     const dif_spi_device_config_t config) {
   uint32_t val = 0;
 
-  val =
-      bitfield_bit32_write(val, SPI_DEVICE_CFG_CPOL_BIT,
-                           config.clock_polarity == kDifSpiDeviceEdgeNegative);
-  val = bitfield_bit32_write(val, SPI_DEVICE_CFG_CPHA_BIT,
-                             config.data_phase == kDifSpiDeviceEdgePositive);
   val = bitfield_bit32_write(val, SPI_DEVICE_CFG_TX_ORDER_BIT,
                              config.tx_order == kDifSpiDeviceBitOrderLsbToMsb);
   val = bitfield_bit32_write(val, SPI_DEVICE_CFG_RX_ORDER_BIT,

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -47,20 +47,6 @@ typedef enum dif_spi_device_mode {
 } dif_spi_device_mode_t;
 
 /**
- * A signal edge type: positive or negative.
- */
-typedef enum dif_spi_device_edge {
-  /**
-   * Represents a positive edge (i.e., from low to high).
-   */
-  kDifSpiDeviceEdgePositive,
-  /**
-   * Represents a negative edge (i.e., from high to low).
-   */
-  kDifSpiDeviceEdgeNegative,
-} dif_spi_device_edge_t;
-
-/**
  * A bit ordering within a byte.
  */
 typedef enum dif_spi_device_bit_order {
@@ -81,8 +67,6 @@ typedef enum dif_spi_device_bit_order {
  * hardware.
  */
 typedef struct dif_spi_device_config {
-  dif_spi_device_edge_t clock_polarity;
-  dif_spi_device_edge_t data_phase;
   dif_spi_device_bit_order_t tx_order;
   dif_spi_device_bit_order_t rx_order;
   dif_spi_device_mode_t device_mode;

--- a/sw/device/lib/dif/dif_spi_device_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_device_unittest.cc
@@ -30,8 +30,6 @@ class SpiTest : public testing::Test, public MmioTest {
 };
 
 static constexpr dif_spi_device_config_t kDefaultConfig = {
-    .clock_polarity = kDifSpiDeviceEdgePositive,
-    .data_phase = kDifSpiDeviceEdgeNegative,
     .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
     .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
     .device_mode = kDifSpiDeviceModeDisabled,
@@ -42,8 +40,6 @@ class ConfigTest : public SpiTest {};
 TEST_F(ConfigTest, BasicInit) {
   EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                  {
-                     {SPI_DEVICE_CFG_CPOL_BIT, 0},
-                     {SPI_DEVICE_CFG_CPHA_BIT, 0},
                      {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
                      {SPI_DEVICE_CFG_RX_ORDER_BIT, 0},
                  });
@@ -67,8 +63,6 @@ TEST_F(ConfigTest, NullArgs) {
 class FlashTest : public SpiTest {
   void SetUp() {
     const dif_spi_device_config_t config = {
-        .clock_polarity = kDifSpiDeviceEdgePositive,
-        .data_phase = kDifSpiDeviceEdgeNegative,
         .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
         .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
         .device_mode = kDifSpiDeviceModePassthrough,
@@ -76,8 +70,6 @@ class FlashTest : public SpiTest {
     EXPECT_DIF_OK(dif_spi_device_init_handle(dev().region(), &spi_));
     EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                    {
-                       {SPI_DEVICE_CFG_CPOL_BIT, 0},
-                       {SPI_DEVICE_CFG_CPHA_BIT, 0},
                        {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
                        {SPI_DEVICE_CFG_RX_ORDER_BIT, 0},
                    });
@@ -236,26 +228,26 @@ TEST_F(FlashTest, MailboxConfigTest) {
   uint32_t address = 0x3f0000;
   EXPECT_WRITE32(SPI_DEVICE_MAILBOX_ADDR_REG_OFFSET, address);
   EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET, {
-                                               {SPI_DEVICE_CFG_CPOL_BIT, 1},
-                                               {SPI_DEVICE_CFG_CPHA_BIT, 1},
+                                               {SPI_DEVICE_CFG_TX_ORDER_BIT, 1},
+                                               {SPI_DEVICE_CFG_RX_ORDER_BIT, 1},
                                            });
   EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                  {
-                     {SPI_DEVICE_CFG_CPOL_BIT, 1},
-                     {SPI_DEVICE_CFG_CPHA_BIT, 1},
                      {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                     {SPI_DEVICE_CFG_TX_ORDER_BIT, 1},
+                     {SPI_DEVICE_CFG_RX_ORDER_BIT, 1},
                  });
   EXPECT_DIF_OK(dif_spi_device_enable_mailbox(&spi_, address));
   EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
                 {
                     {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
-                    {SPI_DEVICE_CFG_TX_ORDER_BIT, 1},
+                    {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
                     {SPI_DEVICE_CFG_RX_ORDER_BIT, 1},
                 });
   EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
                  {
                      {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 0},
-                     {SPI_DEVICE_CFG_TX_ORDER_BIT, 1},
+                     {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
                      {SPI_DEVICE_CFG_RX_ORDER_BIT, 1},
                  });
   EXPECT_DIF_OK(dif_spi_device_disable_mailbox(&spi_));

--- a/sw/device/lib/testing/spi_device_testutils.c
+++ b/sw/device/lib/testing/spi_device_testutils.c
@@ -13,8 +13,6 @@ status_t spi_device_testutils_configure_passthrough(
     dif_spi_device_handle_t *spi_device, uint32_t filters,
     bool upload_write_commands) {
   dif_spi_device_config_t spi_device_config = {
-      .clock_polarity = kDifSpiDeviceEdgePositive,
-      .data_phase = kDifSpiDeviceEdgeNegative,
       .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
       .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
       .device_mode = kDifSpiDeviceModePassthrough,

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -83,8 +83,6 @@ void ottf_console_init(void) {
       CHECK_DIF_OK(dif_spi_device_configure(
           &ottf_console_spi_device,
           (dif_spi_device_config_t){
-              .clock_polarity = kDifSpiDeviceEdgePositive,
-              .data_phase = kDifSpiDeviceEdgeNegative,
               .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
               .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
               .device_mode = kDifSpiDeviceModeFlashEmulation,

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -498,9 +498,7 @@ static void cmd_info_set(cmd_info_t cmd_info) {
 
 void spi_device_init(void) {
   // CPOL = 0, CPHA = 0, MSb-first TX and RX, 3-byte addressing.
-  uint32_t reg = bitfield_bit32_write(0, SPI_DEVICE_CFG_CPOL_BIT, false);
-  reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_CPHA_BIT, false);
-  reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_TX_ORDER_BIT, false);
+  uint32_t reg = bitfield_bit32_write(0, SPI_DEVICE_CFG_TX_ORDER_BIT, false);
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_RX_ORDER_BIT, false);
   reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_MAILBOX_EN_BIT, false);
   abs_mmio_write32(kBase + SPI_DEVICE_CFG_REG_OFFSET, reg);

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -35,8 +35,6 @@ class InitTest : public SpiDeviceTest {};
 TEST_F(InitTest, Init) {
   EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CFG_REG_OFFSET,
                      {
-                         {SPI_DEVICE_CFG_CPOL_BIT, 0},
-                         {SPI_DEVICE_CFG_CPHA_BIT, 0},
                          {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
                          {SPI_DEVICE_CFG_RX_ORDER_BIT, 0},
                          {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 0},

--- a/sw/device/tests/rstmgr_sw_rst_ctrl_test.c
+++ b/sw/device/tests/rstmgr_sw_rst_ctrl_test.c
@@ -65,8 +65,6 @@ static void spi_device_config(void *dif) {
       ((uintptr_t)dif - offsetof(dif_spi_device_handle_t, dev));
   dif_spi_device_handle_t *handle = (dif_spi_device_handle_t *)handle_address;
   dif_spi_device_config_t cfg = {
-      .clock_polarity = kDifSpiDeviceEdgePositive,
-      .data_phase = kDifSpiDeviceEdgeNegative,
       .tx_order = kDifSpiDeviceBitOrderLsbToMsb,
       .rx_order = kDifSpiDeviceBitOrderLsbToMsb,
       .device_mode = kDifSpiDeviceModeDisabled,


### PR DESCRIPTION
spi_device only supports mode 0 now, so eliminate the CSRs for changing modes. The TPM spec requires mode 0, and SPI passthrough is unable to support other modes as well.

Resolves #16339