### PR TITLE
[hw,dma|mbx,rtl] No instantiation of prim_generic*

### DIFF
--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -278,7 +278,7 @@ module dma
       reg2hw.control.memory_buffer_auto_increment_enable.q;
   end
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width($bits(control_state_t))
   ) u_opcode (
     .clk_i  ( gated_clk     ),
@@ -303,7 +303,7 @@ module dma
   logic [TRANSFER_BYTES_WIDTH-1:0] chunk_remaining_bytes;
   logic [TRANSFER_BYTES_WIDTH-1:0] remaining_bytes;
   logic                            capture_transfer_byte;
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(TRANSFER_BYTES_WIDTH)
   ) aff_transfer_byte (
     .clk_i  ( gated_clk             ),
@@ -315,7 +315,7 @@ module dma
 
   logic [TRANSFER_BYTES_WIDTH-1:0] chunk_byte_q, chunk_byte_d;
   logic                            capture_chunk_byte;
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(TRANSFER_BYTES_WIDTH)
   ) aff_chunk_byte (
     .clk_i  ( gated_clk          ),
@@ -327,7 +327,7 @@ module dma
 
   logic       capture_transfer_width;
   logic [2:0] transfer_width_q, transfer_width_d;
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(3)
   ) aff_transfer_width (
     .clk_i ( gated_clk              ),
@@ -340,7 +340,7 @@ module dma
   logic                      capture_addr;
   logic [SYS_ADDR_WIDTH-1:0] src_addr_q, src_addr_d;
   logic [SYS_ADDR_WIDTH-1:0] dst_addr_q, dst_addr_d;
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_ADDR_WIDTH)
   ) aff_src_addr (
     .clk_i ( gated_clk    ),
@@ -350,7 +350,7 @@ module dma
     .q_o   ( src_addr_q   )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_ADDR_WIDTH)
   ) aff_dst_addr (
     .clk_i ( gated_clk    ),
@@ -363,7 +363,7 @@ module dma
   logic                       capture_be;
   logic [top_pkg::TL_DBW-1:0] req_src_be_q, req_src_be_d;
   logic [top_pkg::TL_DBW-1:0] req_dst_be_q, req_dst_be_d;
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(top_pkg::TL_DBW)
   ) aff_req_src_be (
     .clk_i ( gated_clk    ),
@@ -373,7 +373,7 @@ module dma
     .q_o   ( req_src_be_q )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(top_pkg::TL_DBW)
   ) aff_req_dst_be (
     .clk_i ( gated_clk    ),
@@ -383,7 +383,7 @@ module dma
     .q_o   ( req_dst_be_q )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(INTR_CLEAR_SOURCES_WIDTH)
   ) u_clear_index (
     .clk_i ( gated_clk      ),
@@ -1059,7 +1059,7 @@ module dma
   end
 
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(top_pkg::TL_DW)
   ) aff_read_return_data (
     .clk_i ( gated_clk             ),
@@ -1372,7 +1372,7 @@ module dma
     .q_o   ( sys_o.vld_vec     )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_METADATA_WIDTH)
   ) u_sys_metadata_write_vec (
     .clk_i ( gated_clk                           ),
@@ -1383,7 +1383,7 @@ module dma
   );
 
   logic [$bits(sys_opc_e)-1:0] sys_req_opcode_write_vec_q;
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width($bits(sys_opc_e))
   ) u_sys_opcode_write_vec (
     .clk_i ( gated_clk                         ),
@@ -1394,7 +1394,7 @@ module dma
   );
   assign sys_o.opcode_vec[SysCmdWrite] = sys_opc_e'(sys_req_opcode_write_vec_q);
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_ADDR_WIDTH)
   ) u_sys_iova_write_vec (
     .clk_i ( gated_clk                       ),
@@ -1404,7 +1404,7 @@ module dma
     .q_o   ( sys_o.iova_vec[SysCmdWrite]     )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_RACL_WIDTH)
   ) u_sys_racl_write_vec (
     .clk_i ( gated_clk                       ),
@@ -1414,7 +1414,7 @@ module dma
     .q_o   ( sys_o.racl_vec[SysCmdWrite]     )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_METADATA_WIDTH)
   ) u_sys_metadata_read_vec (
     .clk_i ( gated_clk                          ),
@@ -1425,7 +1425,7 @@ module dma
   );
 
   logic [$bits(sys_opc_e)-1:0] sys_req_opcode_read_vec_q;
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width($bits(sys_opc_e))
   ) u_sys_opcode_read_vec (
     .clk_i ( gated_clk                        ),
@@ -1436,7 +1436,7 @@ module dma
   );
   assign sys_o.opcode_vec[SysCmdRead] = sys_opc_e'(sys_req_opcode_read_vec_q);
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_ADDR_WIDTH)
   ) u_sys_iova_read_vec (
     .clk_i ( gated_clk                      ),
@@ -1446,7 +1446,7 @@ module dma
     .q_o   ( sys_o.iova_vec[SysCmdRead]     )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_RACL_WIDTH)
   ) u_sys_racl_read_vec (
     .clk_i ( gated_clk                      ),
@@ -1456,7 +1456,7 @@ module dma
     .q_o   ( sys_o.racl_vec[SysCmdRead]     )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_DATA_WIDTH)
   ) u_sys_write_data (
     .clk_i ( gated_clk                      ),
@@ -1466,7 +1466,7 @@ module dma
     .q_o   ( sys_o.write_data               )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_DATA_BYTEWIDTH)
   ) u_sys_write_be (
     .clk_i ( gated_clk                      ),
@@ -1476,7 +1476,7 @@ module dma
     .q_o   ( sys_o.write_be                 )
   );
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(SYS_DATA_BYTEWIDTH)
   ) u_sys_read_be (
     .clk_i ( gated_clk                      ),

--- a/hw/ip/mbx/rtl/mbx_imbx.sv
+++ b/hw/ip/mbx/rtl/mbx_imbx.sv
@@ -100,7 +100,7 @@ module mbx_imbx #(
     end
   end
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(CfgSramAddrWidth)
   ) u_sram_write_ptr (
     .clk_i ( clk_i                              ),

--- a/hw/ip/mbx/rtl/mbx_ombx.sv
+++ b/hw/ip/mbx/rtl/mbx_ombx.sv
@@ -140,7 +140,7 @@ module mbx_ombx #(
     end
   end
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(CfgSramAddrWidth)
   ) u_sram_read_ptr (
     .clk_i ( clk_i                            ),
@@ -164,7 +164,7 @@ module mbx_ombx #(
                            hostif_control_abort_clear_i;  // Abort ack or FW reset from host side
 
   // Advance the SRAM read response to read data
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(CfgSramDataWidth)
   ) u_sram_read_data (
     .clk_i ( clk_i                                                        ),
@@ -216,7 +216,7 @@ module mbx_ombx #(
   assign sram_read_ptr_limit_d = hostif_base_i +
                                  CfgSramAddrWidth'({hostif_ombx_object_size_i, 2'b0});
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(CfgSramAddrWidth)
   ) u_sram_read_ptr_limit (
     .clk_i ( clk_i                                                    ),

--- a/hw/ip/mbx/rtl/mbx_sramrwarb.sv
+++ b/hw/ip/mbx/rtl/mbx_sramrwarb.sv
@@ -80,7 +80,7 @@ module mbx_sramrwarb
   // Update the count of outstanding requests.
   assign update_cnt = inc_cnt | dec_cnt | hostif_control_abort_clear_i;
 
-  prim_generic_flop_en #(
+  prim_flop_en #(
     .Width(LCFG_MAX_REQS_LOG2)
   ) u_outstanding_req_cnt (
     .clk_i  ( clk_i                   ),


### PR DESCRIPTION
This PR removes the direct instanzation of `prim_generic_flop_en` to use the auto-generated wrapper module.