### PR TITLE
[ot_certs] Make sure that EC public key creates padded integers

### DIFF
--- a/sw/device/silicon_creator/lib/cert/asn1.c
+++ b/sw/device/silicon_creator/lib/cert/asn1.c
@@ -184,6 +184,24 @@ rom_error_t asn1_push_integer(asn1_state_t *state, uint8_t tag, bool is_signed,
   return asn1_finish_tag(&tag_st);
 }
 
+rom_error_t asn1_push_integer_pad(asn1_state_t *state, bool is_signed,
+                                  const uint8_t *bytes_be, size_t size,
+                                  size_t padded_size) {
+  if (size == 0 || size > padded_size) {
+    return kErrorAsn1InvalidArgument;
+  }
+  // Determine the padding byte.
+  uint8_t padding = 0;
+  if (is_signed && (bytes_be[0] >> 7) == 1) {
+    padding = 0xff;
+  }
+  // Output padding.
+  while (padded_size-- > size) {
+    RETURN_IF_ERROR(asn1_push_byte(state, padding));
+  }
+  return asn1_push_bytes(state, bytes_be, size);
+}
+
 rom_error_t asn1_push_oid_raw(asn1_state_t *state, const uint8_t *bytes,
                               size_t size) {
   asn1_tag_t tag;

--- a/sw/device/silicon_creator/lib/cert/asn1.h
+++ b/sw/device/silicon_creator/lib/cert/asn1.h
@@ -204,6 +204,26 @@ rom_error_t asn1_push_integer(asn1_state_t *state, uint8_t tag, bool is_signed,
                               const uint8_t *bytes_be, size_t size);
 
 /**
+ * Push a padded integer into the buffer.
+ *
+ * If the integer is unsigned, it will be padded to the required length with
+ * zeroes. If the integer is signed, it will be padded so as to preserve its
+ * value in two's complement. If the integer size is larger than the requested
+ * size with padding, an error will be reported.
+ *
+ * @param state Pointer to the state initialized by asn1_start.
+ * @param is_signed If true, the byte array represents a signed integer in two's
+ * complement.
+ * @param bytes_be Pointer to a byte array holding an integer in big-endian
+ * format.
+ * @param size Number of the bytes in the array.
+ * @param size Number of the bytes to output with padding.
+ */
+rom_error_t asn1_push_integer_pad(asn1_state_t *state, bool is_signed,
+                                  const uint8_t *bytes_be, size_t size,
+                                  size_t padded_size);
+
+/**
  * Push an object identifier into the buffer.
  *
  * The object identifier must already be encoded according to the X.690 spec,

--- a/sw/host/ot_certs/src/asn1/codegen.rs
+++ b/sw/host/ot_certs/src/asn1/codegen.rs
@@ -425,7 +425,7 @@ impl Builder for Codegen<'_> {
                         // There is not tag, we are just pushing the data itself.
                         self.max_out_size += size;
                         self.push_str_with_indent(&format!(
-                            "RETURN_IF_ERROR(asn1_push_bytes(&state, {ptr_expr}, {size_expr}));\n"
+                            "RETURN_IF_ERROR(asn1_push_integer_pad(&state, false, {ptr_expr}, {size_expr}, {size}));\n"
                         ))
                     }
                     _ => bail!(

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -104,7 +104,7 @@ impl SubstValue {
             SubstValue::ByteArray(bytes) => {
                 // Integer are represented as byte arrays.
                 ensure!(
-                    size == 0 || bytes.len() == size,
+                    size == 0 || bytes.len() <= size,
                     "expected an integer that fits on {size} bytes but it uses {} bytes",
                     bytes.len()
                 );
@@ -575,12 +575,15 @@ mod tests {
                 .unwrap(),
             byte_array
         );
+        // Size does not need not match exactly.
+        assert_eq!(
+            byte_array
+                .parse(&VariableType::Integer { size: 5 })
+                .unwrap(),
+            byte_array
+        );
         assert!(byte_array
             .parse(&VariableType::Integer { size: 3 })
-            .is_err());
-        // Size must match exactly.
-        assert!(byte_array
-            .parse(&VariableType::Integer { size: 5 })
             .is_err());
 
         let byte_array_int = SubstValue::Int32(0x3f2e1d0c);


### PR DESCRIPTION
The EC public key uses fixed-size integers so they must be padded. For some reason, the code only padded literals but not variables.

Those random tests should really use a seed but this has lower priority than many other items.