### PR TITLE
[pre_syn] Include csrng_pkg.sv to re-enable Yosys synthesis

### DIFF
--- a/hw/ip/aes/pre_syn/syn_yosys.sh
+++ b/hw/ip/aes/pre_syn/syn_yosys.sh
@@ -82,6 +82,7 @@ OT_DEP_SOURCES=(
 OT_DEP_PACKAGES=(
     "$LR_SYNTH_SRC_DIR"/../../top_earlgrey/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../edn/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../csrng/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../entropy_src/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../lc_ctrl/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../tlul/rtl/*_pkg.sv

--- a/hw/ip/kmac/pre_syn/syn_yosys.sh
+++ b/hw/ip/kmac/pre_syn/syn_yosys.sh
@@ -98,6 +98,7 @@ OT_DEP_SOURCES=(
 OT_DEP_PACKAGES=(
     "$LR_SYNTH_SRC_DIR"/../../top_earlgrey/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../edn/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../csrng/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../entropy_src/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../lc_ctrl/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../tlul/rtl/*_pkg.sv

--- a/hw/ip/otbn/pre_syn/syn_yosys.sh
+++ b/hw/ip/otbn/pre_syn/syn_yosys.sh
@@ -106,6 +106,7 @@ OT_DEP_SOURCES=(
 OT_DEP_PACKAGES=(
     "$LR_SYNTH_SRC_DIR"/../../top_earlgrey/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../edn/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../csrng/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../entropy_src/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../lc_ctrl/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../tlul/rtl/*_pkg.sv


### PR DESCRIPTION
This package is now referenced in edn_pkg.sv.