### PR TITLE
[kmac,pre_dv] Add kmac_reduced module suitable for SCA including scratch Verilator TB

### DIFF
--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -33,6 +33,7 @@ filesets:
       - rtl/kmac_entropy.sv
       - rtl/kmac_errchk.sv
       - rtl/kmac.sv
+      - rtl/kmac_reduced.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/README.md
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/README.md
@@ -1,0 +1,27 @@
+KMAC Reduced Verilator Testbench
+================================
+
+This directory contains a very basic, scratch Verilator testbench of the SHA3 core and the PRNG instantiated inside KMAC.
+The main use of this testbench is to help understanding how to operate and properly interface them, e.g., for evaluating security properties.
+
+How to build and run the testbench
+----------------------------------
+
+From the OpenTitan top level execute
+
+```sh
+   fusesoc --verbose --cores-root=. run --setup --build lowrisc:dv_verilator:kmac_reduced_tb
+```
+to build the testbench and afterwards
+
+```sh
+   ./build/lowrisc_dv_verilator_kmac_reduced_tb_0/default-verilator/Vkmac_reduced_tb --trace
+```
+to run it.
+
+Details of the testbench
+------------------------
+
+- `rtl/kmac_reduced_tb.sv`: SystemVerilog testbench, instantiates and drives the SHA3 core and the PRNG, checks whether the SHA3 core finishes without errors, signals test end and result
+  (pass/fail) to C++ via output ports.
+- `cpp/kmac_reduced_tb.cc`: Contains main function and instantiation of SimCtrl, reads output ports of DUT and signals simulation termination to Verilator.

--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/cpp/kmac_reduced_tb.cc
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/cpp/kmac_reduced_tb.cc
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <functional>
+#include <iostream>
+#include <signal.h>
+
+#include "Vkmac_reduced_tb.h"
+#include "sim_ctrl_extension.h"
+#include "verilated_toplevel.h"
+#include "verilator_sim_ctrl.h"
+
+class KMACReducedTB : public SimCtrlExtension {
+  using SimCtrlExtension::SimCtrlExtension;
+
+ public:
+  KMACReducedTB(kmac_reduced_tb *top);
+
+  void OnClock(unsigned long sim_time);
+
+ private:
+  kmac_reduced_tb *top_;
+};
+
+// Constructor:
+// - Set up top_ ptr
+KMACReducedTB::KMACReducedTB(kmac_reduced_tb *top)
+    : SimCtrlExtension{}, top_(top) {}
+
+// Function called once every clock cycle from SimCtrl
+void KMACReducedTB::OnClock(unsigned long sim_time) {
+  if (top_->test_done_o) {
+    VerilatorSimCtrl::GetInstance().RequestStop(top_->test_passed_o);
+  }
+}
+
+int main(int argc, char **argv) {
+  int ret_code;
+
+  // Init verilog instance
+  kmac_reduced_tb top;
+
+  // Init sim
+  VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
+  simctrl.SetTop(&top, &top.clk_i, &top.rst_ni,
+                 VerilatorSimCtrlFlags::ResetPolarityNegative);
+
+  // Create and register VerilatorSimCtrl extension
+  KMACReducedTB kmac_reduced_tb(&top);
+  simctrl.RegisterExtension(&kmac_reduced_tb);
+
+  std::cout << "Simulation of KMAC Reduced" << std::endl
+            << "==========================" << std::endl
+            << std::endl;
+
+  // Get pass / fail from Verilator
+  ret_code = simctrl.Exec(argc, argv).first;
+
+  return ret_code;
+}

--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/kmac_reduced_tb.core
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/kmac_reduced_tb.core
@@ -1,0 +1,54 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv_verilator:kmac_reduced_tb"
+description: "KMAC Reduced Verilator TB"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:kmac
+    files:
+      - rtl/kmac_reduced_tb.sv
+    file_type: systemVerilogSource
+
+  files_dv_verilator:
+    depend:
+      - lowrisc:dv_verilator:simutil_verilator
+
+    files:
+      - cpp/kmac_reduced_tb.cc
+    file_type: cppSource
+
+targets:
+  default:
+    default_tool: verilator
+    filesets:
+      - files_rtl
+      - files_dv_verilator
+    toplevel: kmac_reduced_tb
+    tools:
+      verilator:
+        mode: cc
+        verilator_options:
+# Disabling tracing reduces compile times by multiple times, but doesn't have a
+# huge influence on runtime performance. (Based on early observations.)
+          - '--trace'
+          - '--trace-fst' # this requires -DVM_TRACE_FMT_FST in CFLAGS below!
+          - '--trace-structs'
+          - '--trace-params'
+          - '--trace-max-array 1024'
+# compiler flags
+#
+# -O
+#   Optimization levels have a large impact on the runtime performance of the
+#   simulation model. -O2 and -O3 are pretty similar, -Os is slower than -O2/-O3
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=kmac_reduced_tb -g -O0"'
+          - '-LDFLAGS "-pthread -lutil -lelf"'
+          - "-Wall"
+          # This TB is mainly used for developing and prototyping security
+          # countermeasures. Typically, many iterations are needed for this
+          # and the design is often not lint clean while doing this. We want
+          # to know about lint warnings but Verilator shouldn't exit just
+          # because of them.
+          - "-Wno-fatal"

--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/rtl/kmac_reduced_tb.sv
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/rtl/kmac_reduced_tb.sv
@@ -1,0 +1,315 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// KMAC reduced testbench
+
+module kmac_reduced_tb #(
+) (
+  input  logic clk_i,
+  input  logic rst_ni,
+
+  output logic test_done_o,
+  output logic test_passed_o
+);
+
+  import kmac_pkg::*;
+  import kmac_reg_pkg::*;
+  import sha3_pkg::*;
+
+  // EnMasking: Enable masking security hardening inside keccak_round.
+  parameter bit EnMasking = 1;
+  localparam int NumShares = (EnMasking) ? 2 : 1;
+
+  // For now, we use a fixed message length of 128 bits to mirror some of the initial FPGA
+  // experiments.
+  parameter int unsigned MsgWidthChunks = 2;
+  parameter int unsigned MsgLen = MsgWidth * MsgWidthChunks;
+  parameter int unsigned EntropyWidth = 32;
+
+  // DUT signals
+  logic [MsgLen-1:0] msg [NumShares];
+  logic msg_valid, msg_ready;
+  logic sha3_start, sha3_process;
+  prim_mubi_pkg::mubi4_t done, absorbed;
+  sha3_st_e sha3_fsm;
+  logic entropy_ready;
+  logic entropy_refresh_req;
+  logic [EntropyWidth-1:0] entropy;
+  logic entropy_req;
+  logic error;
+
+  // Instantiate DUT
+  kmac_reduced #(
+    .EnMasking(EnMasking),
+    .MsgLen(MsgLen),
+    .EntropyWidth(EntropyWidth),
+  ) u_kmac_reduced (
+    .clk_i,
+    .rst_ni,
+
+    // Inputs exercised by SCA tools.
+    // Pre-masked message input. The message is provided in one shot to facilitate the interfacing.
+    .msg_i(msg),
+    .msg_valid_i(msg_valid),
+    .msg_ready_o(msg_ready),
+
+    // SHA3 control and status
+    .start_i(sha3_start),      // 1 pulse after reseeding PRNG and injecting
+                               // messsage
+    .process_i(sha3_process),  // 1 pulse after loading message into SHA3
+    .run_i(1'b0),              // drive to 0
+    .done_i(done),             // drive to MuBi4True after
+                               // absorbed_o == MuBi4True
+    .absorbed_o(absorbed),
+    .squeezing_o(),
+    .block_processed_o(),
+    .sha3_fsm_o(sha3_fsm),
+
+    // Entropy interface
+    .entropy_ready_i(entropy_ready),
+    .entropy_refresh_req_i(entropy_refresh_req),
+    .entropy_i(entropy),
+    .entropy_req_o(entropy_req),
+    .entropy_ack_i(1'b1),
+
+    // Inputs driven with constant values for evaluation but we want to avoid synthesis optimizing
+    // them.
+    // SHA3 configuration
+    .mode_i(Sha3),                     // sha3_pkg::Sha3
+    .strength_i(L256),                 // sha3_pkg::L256
+    .ns_prefix_i(352'h4341_4D4B_2001), // Ignored for Sha3,
+                                       // 48'h4341_4D4B_2001 ("KMAC") for CShake
+    .msg_strb_i({MsgStrbW{1'b1}}),     // drive to all-1
+
+    // Entropy configuration
+    .msg_mask_en_i(1'b1),            // drive to 1
+    .entropy_mode_i(EntropyModeEdn), // drive to kmac_pkg::EntropyModeEdn
+    .entropy_fast_process_i(1'b0),   // drive to 0
+    .entropy_in_keyblock_i(1'b1),    // drive to 1
+
+    // Entropy reseed control
+    .entropy_seed_update_i('0),                 // drive to 0
+    .entropy_seed_data_i('0),                   // drive to 0
+    .wait_timer_prescaler_i('0),                // drive to 0
+    .wait_timer_limit_i({EdnWaitTimerW{1'b1}}), // drive to EdnWaitTimerW'1
+
+    // Signals primarily kept to prevent them from being optimized away during synthesis.
+    // State output
+    .state_o(),
+    .state_valid_o(),
+
+    // Entropy status signals
+    .entropy_configured_o(),
+    .entropy_hash_threshold_i({HashCntW{1'b1}}), // drive to max
+    .entropy_hash_clr_i(1'b0),                   // drive to 0
+    .entropy_hash_cnt_o(),
+
+    // Life cycle interface
+    .lc_escalate_en_i(lc_ctrl_pkg::Off),
+
+    // Error signaling
+    .err_o(error),
+    .err_processed_i(1'b0)  // drive 0
+  );
+
+  // TB signals.
+  localparam int KmacReducedTbStateWidth = 3;
+  typedef enum logic [KmacReducedTbStateWidth-1:0] {
+    IDLE,
+    INIT_RESEED,
+    START_TRIGGER,
+    MSG_VALID,
+    MSG_LOAD,
+    PROCESSING,
+    DONE,
+    FINISH
+  } kmac_reduced_tb_e;
+  kmac_reduced_tb_e kmac_reduced_tb_state_d, kmac_reduced_tb_state_q;
+  logic             entropy_req_d, entropy_req_q, entropy_req_fell;
+  logic       [7:0] reseed_count_d, reseed_count_q;
+  logic             reseed_count_increment;
+  logic             msg_handshake, test_done;
+
+  // Counter to control the simulation.
+  localparam int unsigned CountWidth = 10;
+  logic [CountWidth-1:0] count_d, count_q;
+  assign count_d = count_q + 10'd1;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_count
+    if (!rst_ni) begin
+      count_q <= '0;
+    end else begin
+      count_q <= count_d;
+    end
+  end
+
+  // Count the number of encrypted/decrypted blocks. We're doing 8 blocks with each
+  // key length.
+  assign reseed_count_d = reseed_count_increment ? reseed_count_q + 8'h1 : reseed_count_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_reseed_count
+    if (!rst_ni) begin
+      reseed_count_q <= '0;
+    end else begin
+      reseed_count_q <= reseed_count_d;
+    end
+  end
+
+  assign msg_handshake = msg_valid & msg_ready;
+
+  // Randomness generation.
+  // Track falling edges of entropy_req.
+  // Since there are 5 x 5 32-bit LFSRs and every reseed just reseeds 5 LFSRs,
+  // we need to do 5 consecutive reseed operations. The end of each reseed
+  // operation is signaled with entropy_req going low.
+  assign entropy_req_d = entropy_req;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_entropy_req
+    if (!rst_ni) begin
+      entropy_req_q <= '0;
+    end else begin
+      entropy_req_q <= entropy_req_d;
+    end
+  end
+  assign entropy_req_fell = entropy_req_q & ~entropy_req;
+
+  // Update whenever requested.
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_entropy
+    if (!rst_ni) begin
+      entropy <= $urandom;
+    end else if (entropy_req) begin
+      entropy <= $urandom;
+    end
+  end
+
+  // Input generation.
+  // We use random messages.
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_msg
+    if (!rst_ni) begin
+      msg[0] <= {2*MsgWidthChunks{$urandom}};
+    end else if (msg_handshake) begin
+      msg[0] <= {2*MsgWidthChunks{$urandom}};
+    end
+  end
+  // The second share is fixed to a deterministic value. This is clearly not how this should be
+  // done in practice but using one deterministic share eases visual inspection of the message
+  // remasking performed internally to the module.
+  for (genvar i = 0; i < MsgLen / 32; i++) begin: gen_msg_share1
+    assign msg[1][i*32 +: 32] = {8{i[3:0]}};
+  end
+
+  always_comb begin : kmac_reduced_tb_fsm
+    // DUT
+    msg_valid = 1'b0;
+    sha3_start = 1'b0;
+    sha3_process = 1'b0;
+    done = prim_mubi_pkg::MuBi4False;
+    entropy_ready = 1'b0;
+    entropy_refresh_req = 1'b0;
+
+    // TB
+    kmac_reduced_tb_state_d = kmac_reduced_tb_state_q;
+    reseed_count_increment = 1'b0;
+    test_done = 1'b0;
+
+    unique case (kmac_reduced_tb_state_q)
+
+      IDLE: begin
+        // Just move to INIT_RESEED
+        if (count_q > 10'd2) begin
+          entropy_ready = 1'b1;
+          kmac_reduced_tb_state_d = INIT_RESEED;
+        end
+      end
+
+      INIT_RESEED: begin
+        // Perform an initial reseed of the PRNG to put it into a random state.
+        // Since there are 5 x 5 32-bit LFSRs and every reseed just reseeds 5 LFSRs,
+        // we need to do 5 consecutive reseed operations.
+        entropy_refresh_req = 1'b1;
+        reseed_count_increment = entropy_req_fell;
+        if (reseed_count_q == 8'd5) begin
+          entropy_refresh_req = 1'b0;
+          kmac_reduced_tb_state_d = START_TRIGGER;
+        end
+      end
+
+      START_TRIGGER: begin
+        // Simply send the Start pulse.
+        sha3_start = 1'b1;
+        kmac_reduced_tb_state_d = MSG_VALID;
+      end
+
+      MSG_VALID: begin
+        // Write the full message into the unpacker FIFOs in one shot.
+        msg_valid = 1'b1;
+        kmac_reduced_tb_state_d = MSG_LOAD;
+      end
+
+      MSG_LOAD: begin
+        // Wait until the unpacker FIFOs become ready again. This means the entire message has
+        // been loaded into the SHA3 core and the Process pulse can be sent.
+        if (msg_ready) begin
+          sha3_process = 1'b1;
+          kmac_reduced_tb_state_d = PROCESSING;
+        end
+      end
+
+      PROCESSING: begin
+        // Wait for the actual absorption process to finish. Note block_processed_o just indicates
+        // that the SHA3 core did a full operation. This might be related to the prefix or the
+        // message.
+        if (absorbed == prim_mubi_pkg::MuBi4True) begin
+          kmac_reduced_tb_state_d = DONE;
+        end
+      end
+
+      DONE: begin
+        // Send a Done pulse to trigger wiping the state.
+        done = prim_mubi_pkg::MuBi4True;
+        kmac_reduced_tb_state_d = FINISH;
+      end
+
+      FINISH: begin
+        // Wait for the SHA3 FSM to enter the idle state again after wiping before signaling the
+        // end of the simulation.
+        if (sha3_fsm == StIdle) begin
+          test_done = 1'b1;
+        end
+      end
+
+      default: begin
+        kmac_reduced_tb_state_d = FINISH;
+      end
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_fsm
+    if (!rst_ni) begin
+      kmac_reduced_tb_state_q <= IDLE;
+    end else begin
+      kmac_reduced_tb_state_q <= kmac_reduced_tb_state_d;
+    end
+  end
+
+  // Check responses, signal end of simulation
+  always_ff @(posedge clk_i or negedge rst_ni) begin : tb_ctrl
+    test_done_o   <= 1'b0;
+    test_passed_o <= 1'b0;
+
+    if (rst_ni && (kmac_reduced_tb_state_q != IDLE)) begin
+      if (error) begin
+        $display("\nERROR: error condition detected.");
+        test_done_o   <= 1'b1;
+      end else if (test_done) begin
+        $display("\nSUCCESS: processing finished without errors.");
+        test_passed_o <= 1'b1;
+        test_done_o   <= 1'b1;
+      end
+    end
+
+    if (count_q == 10'd500) begin
+      $display("\nERROR: Simulation timed out.");
+      test_done_o <= 1'b1;
+    end
+  end
+
+endmodule

--- a/hw/ip/kmac/pre_syn/tcl/lr_synth_flow_var_setup.tcl
+++ b/hw/ip/kmac/pre_syn/tcl/lr_synth_flow_var_setup.tcl
@@ -19,7 +19,7 @@ set_flow_var rpt_out "./${lr_synth_out_dir}/reports" "Report output directory"
 set_flow_bool_var flatten 1 "flatten"
 set_flow_bool_var timing_run 0 "timing run"
 set_flow_var width 1600 "Width of the SHA3 core datapath"
-set_flow_bool_var en_masking 0 "Enable 1st order masking of the SHA3 core"
+set_flow_bool_var en_masking 1 "Enable 1st order masking of the SHA3 core"
 
 source $lr_synth_config_file
 

--- a/hw/ip/kmac/pre_syn/tcl/yosys_run_synth.tcl
+++ b/hw/ip/kmac/pre_syn/tcl/yosys_run_synth.tcl
@@ -17,7 +17,10 @@ if { $lr_synth_timing_run } {
 yosys "read_verilog -sv $lr_synth_out_dir/generated/*.v"
 
 # Set top-module parameters.
-yosys "chparam -set EnMasking $lr_synth_en_masking $lr_synth_top_module"
+if { $lr_synth_top_module != "kmac_reduced"} {
+  # For an unknown reason, synthesis of the kmac_reduced modules fails with an error if we try to set this top-level paramater.
+  yosys "chparam -set EnMasking $lr_synth_en_masking $lr_synth_top_module"
+}
 if { $lr_synth_top_module == "keccak_2share" || $lr_synth_top_module == "keccak_round"} {
   yosys "chparam -set Width $lr_synth_width $lr_synth_top_module"
 }

--- a/hw/ip/kmac/rtl/kmac_reduced.sv
+++ b/hw/ip/kmac/rtl/kmac_reduced.sv
@@ -1,0 +1,300 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Reduced KMAC/SHA3 core including PRNG but without TL-UL interface. This module is suitable for
+// SCA using e.g. PROLEAD.
+
+`include "prim_assert.sv"
+
+module kmac_reduced
+  import kmac_pkg::*;
+  import kmac_reg_pkg::*;
+  import sha3_pkg::*;
+#(
+  // EnMasking: Enable masking security hardening inside keccak_round.
+  parameter bit EnMasking = 1,
+  localparam int NumShares = (EnMasking) ? 2 : 1, // derived parameter
+
+  // For now, we use a fixed message length of 128 bits to mirror some of the initial FPGA
+  // experiments.
+  parameter int unsigned MsgLen = 128,
+  parameter int unsigned EntropyWidth = 32,
+
+  parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
+  parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
+  parameter lfsr_fwd_perm_t RndCnstLfsrFwdPerm = RndCnstLfsrFwdPermDefault,
+  parameter msg_perm_t RndCnstMsgPerm  = RndCnstMsgPermDefault
+) (
+  input logic clk_i,
+  input logic rst_ni,
+
+  // Inputs exercised by SCA tools.
+  // Pre-masked message input. The message is provided in one shot to facilitate the interfacing.
+  input  logic [MsgLen-1:0] msg_i [NumShares],
+  input  logic              msg_valid_i,
+  output logic              msg_ready_o,
+
+  // SHA3 control and status
+  input  logic                  start_i,           // 1 pulse after reseeding PRNG and injecting
+                                                   // messsage
+  input  logic                  process_i,         // 1 pulse after loading message into SHA3
+  input  logic                  run_i,             // drive to 0
+  input  prim_mubi_pkg::mubi4_t done_i,            // drive to MuBi4True after
+                                                   // absorbed_o == MuBi4True
+  output prim_mubi_pkg::mubi4_t absorbed_o,
+  output logic                  squeezing_o,
+  output logic                  block_processed_o,
+  output sha3_st_e              sha3_fsm_o,
+
+  // Entropy interface
+  input  logic                    entropy_ready_i,       // drive to 1 once ready
+  input  logic                    entropy_refresh_req_i, // one pulse at the beginning
+  input  logic [EntropyWidth-1:0] entropy_i,
+  output logic                    entropy_req_o,
+  input  logic                    entropy_ack_i,
+
+  // Inputs driven with constant values for evaluation but we want to avoid synthesis optimizing
+  // them.
+  // SHA3 configuration
+  input sha3_mode_e                    mode_i,      // e.g. sha3_pkg::Sha3
+  input keccak_strength_e              strength_i,  // e.g. sha3_pkg::L256
+  input logic [NSRegisterSize*8-1:0]   ns_prefix_i, // Ignored for Sha3,
+                                                    // 48'h4341_4D4B_2001 for CShake
+  input logic [sha3_pkg::MsgStrbW-1:0] msg_strb_i,  // drive to all-1
+
+  // Entropy configuration
+  input logic          msg_mask_en_i,          // drive to 1
+  input entropy_mode_e entropy_mode_i,         // drive to kmac_pkg::EntropyModeEdn
+  input logic          entropy_fast_process_i, // drive to 0
+  input logic          entropy_in_keyblock_i,  // drive to 1
+
+  // Entropy reseed control
+  input logic [NumSeedsEntropyLfsr-1:0]       entropy_seed_update_i,  // drive to 0
+  input logic [NumSeedsEntropyLfsr-1:0][31:0] entropy_seed_data_i,    // drive to 0
+  input logic [TimerPrescalerW-1:0]           wait_timer_prescaler_i, // drive to 0
+  input logic [EdnWaitTimerW-1:0]             wait_timer_limit_i,     // drive to EdnWaitTimerW'1
+
+  // Signals primarily kept to prevent them from being optimized away during synthesis.
+  // State output
+  output logic [StateW-1:0] state_o [NumShares],
+  output logic              state_valid_o,
+
+  // Entropy status signals
+  output prim_mubi_pkg::mubi4_t entropy_configured_o,
+  input  logic [HashCntW-1:0]   entropy_hash_threshold_i, // drive to max
+  input  logic                  entropy_hash_clr_i,       // drive to 0
+  output logic [HashCntW-1:0]   entropy_hash_cnt_o,
+
+  // Life cycle interface
+  input lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
+
+  // Error signaling
+  output logic err_o,
+  input  logic err_processed_i // drive 0
+);
+
+  ///////////////////////////////////
+  // Message unpacking & injection //
+  ///////////////////////////////////
+  // Message packer FIFO
+  logic [sha3_pkg::MsgWidth-1:0] msg [NumShares];
+  logic msg_valid, msg_ready;
+
+  prim_packer_fifo #(
+    .InW(MsgLen),
+    .OutW(sha3_pkg::MsgWidth),
+    .ClearOnRead(1'b1)
+  ) u_msg_unpacker_share0 (
+    .clk_i,
+    .rst_ni,
+    .clr_i   (1'b0),
+    .wvalid_i(msg_valid_i),
+    .wdata_i (msg_i[0]),
+    .wready_o(msg_ready_o),
+    .rvalid_o(msg_valid),
+    .rdata_o (msg[0]),
+    .rready_i(msg_ready),
+    .depth_o ()
+  );
+
+  prim_packer_fifo #(
+    .InW(MsgLen),
+    .OutW(sha3_pkg::MsgWidth),
+    .ClearOnRead(1'b1)
+  ) u_msg_unpacker_share1 (
+    .clk_i,
+    .rst_ni,
+    .clr_i   (1'b0),
+    .wvalid_i(msg_valid_i),
+    .wdata_i (msg_i[1]),
+    .wready_o(msg_ready_o),
+    .rvalid_o(msg_valid),
+    .rdata_o (msg[1]),
+    .rready_i(msg_ready),
+    .depth_o ()
+  );
+
+  //////////////////////////
+  // Message (re-)masking //
+  //////////////////////////
+  logic msg_mask_en;
+  logic [sha3_pkg::MsgWidth-1:0] msg_mask, msg_mask_permuted;
+  logic [sha3_pkg::MsgWidth-1:0] msg_masked [NumShares];
+
+  // Permute the PRNG output.
+  always_comb begin
+    msg_mask_permuted = '0;
+    for (int unsigned i = 0 ; i < sha3_pkg::MsgWidth ; i++) begin
+      // Loop through the MsgPerm constant and swap between the bits
+      msg_mask_permuted[i] = msg_mask[RndCnstMsgPerm[i]];
+    end
+  end
+
+  // Perform the actual (re-)masking
+  for (genvar i = 0; i < NumShares; i++) begin: gen_msg_masking
+    assign msg_masked[i] =
+        msg[i] ^ ({sha3_pkg::MsgWidth{msg_mask_en_i}} & msg_mask_permuted);
+  end
+
+  assign msg_mask_en = msg_mask_en_i & msg_valid & msg_ready;
+
+  // SHA3 entropy interface
+  logic sha3_rand_valid, sha3_rand_early, sha3_rand_consumed;
+  logic [StateW/2-1:0] sha3_rand_data;
+  logic sha3_rand_aux;
+
+  // Life cycle signals
+  localparam int unsigned NumLcSyncCopies = 2;
+  lc_ctrl_pkg::lc_tx_t [NumLcSyncCopies-1:0] lc_escalate_en;
+
+  // Synchronize life cycle input.
+  prim_lc_sync #(
+    .NumCopies (NumLcSyncCopies)
+  ) u_prim_lc_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_escalate_en_i),
+    .lc_en_o(lc_escalate_en)
+  );
+
+  // Error signals
+  sha3_pkg::err_t sha3_err, entropy_err;
+  logic sha3_state_error, sha3_count_error, sha3_storage_rst_error;
+  logic entropy_state_error, entropy_hash_counter_error;
+
+  // Collect error signals.
+  assign err_o = |{sha3_err, sha3_state_error, sha3_count_error, sha3_storage_rst_error,
+                   entropy_err, entropy_state_error, entropy_hash_counter_error};
+
+  /////////////////
+  // SHA3 engine //
+  /////////////////
+  sha3 #(
+    .EnMasking(EnMasking)
+  ) u_sha3 (
+    .clk_i,
+    .rst_ni,
+
+    // MSG_FIFO interface (or from KMAC)
+    .msg_valid_i(msg_valid),
+    .msg_data_i (msg_masked),
+    .msg_strb_i (msg_strb_i),
+    .msg_ready_o(msg_ready),
+
+    // Entropy interface
+    .rand_valid_i    (sha3_rand_valid),
+    .rand_early_i    (sha3_rand_early),
+    .rand_data_i     (sha3_rand_data),
+    .rand_aux_i      (sha3_rand_aux),
+    .rand_consumed_o (sha3_rand_consumed),
+
+    // N, S: Used in cSHAKE mode
+    .ns_data_i (ns_prefix_i),
+
+    // Configurations
+    .mode_i,
+    .strength_i,
+
+    // Control and status
+    .start_i,           // Start receiving message.
+    .process_i,         // Stop receiving message, start padding and afterwards processing.
+    .run_i,             // Manually trigger processing after absorption.
+    .done_i,            // Clear internal variables and move back into Idle state.
+    .absorbed_o,        // Absorption process is done.
+    .squeezing_o,       // Currently running manually triggered processing after absorption.
+    .block_processed_o,
+    .sha3_fsm_o,
+
+    // State output
+    .state_valid_o(state_valid_o),
+    .state_o      (state_o),
+
+    // LC escalation
+    .lc_escalate_en_i(lc_escalate_en[0]),
+
+    // Error signals
+    .error_o                   (sha3_err),
+    .sparse_fsm_error_o        (sha3_state_error),
+    .count_error_o             (sha3_count_error),
+    .keccak_storage_rst_error_o(sha3_storage_rst_error)
+  );
+
+  //////////
+  // PRNG //
+  //////////
+  kmac_entropy #(
+   .RndCnstLfsrPerm(RndCnstLfsrPerm),
+   .RndCnstLfsrSeed(RndCnstLfsrSeed),
+   .RndCnstLfsrFwdPerm(RndCnstLfsrFwdPerm)
+  ) u_entropy (
+    .clk_i,
+    .rst_ni,
+
+    // EDN interface
+    .entropy_req_o (entropy_req_o),
+    .entropy_ack_i (entropy_ack_i),
+    .entropy_data_i(entropy_i),
+
+    // SHA3 interface
+    .rand_valid_o   (sha3_rand_valid),
+    .rand_early_o   (sha3_rand_early),
+    .rand_data_o    (sha3_rand_data),
+    .rand_aux_o     (sha3_rand_aux),
+    .rand_consumed_i(sha3_rand_consumed),
+
+    // Message Masking
+    .msg_mask_en_i(msg_mask_en),
+    .msg_mask_o   (msg_mask),
+
+    // Configuration
+    .mode_i         (entropy_mode_i),
+    .entropy_ready_i(entropy_ready_i),
+    .fast_process_i (entropy_fast_process_i),
+    .in_keyblock_i  (entropy_in_keyblock_i),
+
+    // Reseed control
+    .entropy_refresh_req_i (entropy_refresh_req_i),
+    .seed_update_i         (entropy_seed_update_i),
+    .seed_data_i           (entropy_seed_data_i),
+    .wait_timer_prescaler_i(wait_timer_prescaler_i),
+    .wait_timer_limit_i    (wait_timer_limit_i),
+
+    // Status
+    .hash_threshold_i(entropy_hash_threshold_i),
+    .hash_cnt_clr_i  (entropy_hash_clr_i),
+    .hash_cnt_o      (entropy_hash_cnt_o),
+
+    .entropy_configured_o(entropy_configured_o),
+
+    // LC escalation
+    .lc_escalate_en_i(lc_escalate_en[1]),
+
+    // Error signals
+    .err_o             (entropy_err),
+    .sparse_fsm_error_o(entropy_state_error),
+    .count_error_o     (entropy_hash_counter_error),
+    .err_processed_i   (err_processed_i)
+  );
+
+endmodule


### PR DESCRIPTION
This PR contains two commits:
1. A new RTL module containing just the SHA3 core and the PRNG to enable SCA using e.g. PROLEAD. The main advantages of this module compared to the full KMAC design are:
    - All relevant I/Os directly exposed rather through TL-UL interface. This simplifies interfacing with analysis tools. For example, the masked message (the secret to track with the analysis tools) can be provided in one shot rather than in 32-bit words. The unpacking is handled internally.
    - Significantly lower circuit area which speeds up analysis.
2. A scratch Verilator testbench for this new kmac_reduced module is added. This helps understanding how to operate and properly interface the kmac_reduced module and thereby working out the configuration file for PROLEAD.