### PR TITLE
[rv_dm,dv] Add some trivial checks to the return value of randomize() calls

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
@@ -38,8 +38,8 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
   task body();
     repeat ($urandom_range(1, 10)) begin
       bit [31:0] value0, value1;
-      std::randomize(value0);
-      std::randomize(value1);
+      `DV_CHECK_STD_RANDOMIZE_FATAL(value0)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(value1)
 
       // Write value0 to abstractdata[0], then read it back, checking the value has arrived as
       // expected.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
@@ -25,86 +25,65 @@ class rv_dm_tap_fsm_vseq extends rv_dm_base_vseq;
     scanmode == prim_mubi_pkg::MuBi4False;
   }
 
+  task send_req(bit dummy_ir = 1'b0,
+                bit dummy_dr = 1'b0,
+                bit skip_reselected_ir = 1'b0,
+                bit reset_tap_fsm = 1'b0);
+    jtag_item req;
+
+    `uvm_create_on(req, p_sequencer.jtag_sequencer_h)
+    start_item(req);
+
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(
+      req,
+
+      ir == 'h0;
+      ir_len == 'd5;
+      dr == 'h0;
+      dr_len == cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode.get_n_bits();
+      ir_pause_count == 0;
+      dr_pause_count == 0;
+      exit_via_pause_dr == 0;
+      exit_via_pause_ir == 0;
+      exit_to_rti_dr == 0;
+      exit_to_rti_ir == 0;)
+
+    // The randomisation constraints in jtag_item don't have any "cross-field" items on fields that
+    // we touch, so it's reasonable to randomise and then update the occasional field afterwards.
+
+    if (dummy_ir) req.dummy_ir = 1;
+    if (dummy_dr) req.dummy_dr = 1;
+    if (reset_tap_fsm) req.reset_tap_fsm = 1;
+
+    req.skip_reselected_ir = skip_reselected_ir;
+
+    finish_item(req);
+  endtask
+
   task body();
     // Read the JTAG IDCODE register and verify that it matches the expected value.
-    jtag_item req;
-    rv_dm_smoke_vseq seq;
-    uvm_reg_data_t data;
-    uint dr_width = cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode.get_n_bits();
-    uint ir = cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode.get_address();
     run_smoke();
     `uvm_info(`gfn, "Starting fsm_tap sequence", UVM_LOW)
-    `uvm_create_on(req, p_sequencer.jtag_sequencer_h)
+
     `uvm_info(`gfn, "Test TAP FSM transition from CaptureIr->Exit1Ir", UVM_LOW)
-    start_item(req);
-    req.randomize() with { ir == 'h0;
-        ir_len == 'd5;
-        dr == 'h0;
-        dr_len == dr_width;
-        skip_reselected_ir == 0;
-        ir_pause_count == 0;
-        dr_pause_count == 0;
-        dummy_ir == 1;
-        exit_via_pause_dr == 0;
-        exit_via_pause_ir == 0;
-        exit_to_rti_dr == 0;
-        exit_to_rti_ir == 0;};
-    finish_item(req);
-    // Test transition from UpdateIr->SelectDrScan
+    send_req(.dummy_ir(1'b1));
+
     `uvm_info(`gfn, "Test TAP FSM transition from UpdateIr->SelectDrScan", UVM_LOW)
-    start_item(req);
-    req.randomize() with { ir == 'h0;
-        ir_len == 'd5;
-        dr == 'h0;
-        dr_len == dr_width;
-        skip_reselected_ir == 0;
-        ir_pause_count == 0;
-        dr_pause_count == 0;
-        exit_via_pause_dr == 0;
-        exit_via_pause_ir == 0;
-        exit_to_rti_dr == 0;
-        exit_to_rti_ir == 0;};
-    finish_item(req);
-    // Test transition from UpdateDr->SelectDrScan
+    send_req();
+
     `uvm_info(`gfn, "Test TAP FSM transition from UpdateDr->SelectDrScan", UVM_LOW)
-    start_item(req);
-    req.randomize() with { ir == 'h0;
-        ir_len == 'd5;
-        dr == 'h0;
-        dr_len == dr_width;
-        ir_pause_count == 0;
-        dr_pause_count == 0;
-        exit_via_pause_dr == 0;
-        exit_via_pause_ir == 0 ;
-        skip_reselected_ir == 1;
-        exit_to_rti_dr == 0;};
-    finish_item(req);
+    send_req(.skip_reselected_ir(1));
+
     run_smoke();
-    // Test transition from CaptureDr->Exit1Dr
+
     `uvm_info(`gfn, "Test TAP FSM transition from CaptureDr->Exit1Dr", UVM_LOW)
-    start_item(req);
-    req.randomize() with { ir == 'h0;
-        ir_len == 'd5;
-        dr == 'h0;
-        dr_len == dr_width;
-        dummy_dr == 1;
-        ir_pause_count == 0;
-        dr_pause_count == 0;
-        exit_via_pause_dr == 0;
-        exit_via_pause_ir == 0 ;
-        skip_reselected_ir == 1;
-        exit_to_rti_dr == 0;};
-    finish_item(req);
+    send_req(.skip_reselected_ir(1), .dummy_dr(1));
+
     run_smoke();
-    // Test TAP FSM reset
+
     `uvm_info(`gfn, "Test TAP FSM reset", UVM_LOW)
-    start_item(req);
-    req.randomize() with { ir == 'h0;
-        ir_len == 'd5;
-        dr == 'h0;
-        dr_len == dr_width;
-        reset_tap_fsm == 1;};
-    finish_item(req);
+    send_req(.reset_tap_fsm(1));
+
     run_smoke();
   endtask : body
 


### PR DESCRIPTION
No functional change intended, but it avoids some warning messages from Xcelium.