### PR TITLE
[warnings,otbn,chip_level] Clean up some VCS warnings

### DIFF
--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -67,8 +67,6 @@ module otbn_start_stop_control
   output logic fatal_error_o
 );
 
-  import otbn_pkg::*;
-
   // Create lint errors to reduce the risk of accidentally enabling these features.
   `ASSERT_STATIC_LINT_ERROR(OtbnSecMuteUrndNonDefault, SecMuteUrnd == 0)
   `ASSERT_STATIC_LINT_ERROR(OtbnSecSkipUrndReseedAtStartNonDefault, SecSkipUrndReseedAtStart == 0)

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -230,7 +230,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
   // This performs an ecc check at a given address. The address and data need to be de-scrambled,
   // so the actual address to be checked will most likely be different, and at a different tile.
-  local function logic [1:0] _sram_bkdr_inject_ecc_error(
+  local function void _sram_bkdr_inject_ecc_error(
       bit [bus_params_pkg::BUS_AW-1:0] addr,
       bit is_main_ram, // if 1, main ram, otherwise, ret ram
       bit [sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0]   key,
@@ -1146,7 +1146,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     `DV_SPINWAIT(
       do begin
         @(cfg.clk_rst_vif.cb);
-        uvm_hdl_read(mypath, rma_wipe_idx);
+        `DV_CHECK_EQ(uvm_hdl_read(mypath, rma_wipe_idx), 1, "hdl read failure")
       end while (rma_wipe_idx != 3'h3);,
       "waiting for rma index = 3", 100_000_000
     )
@@ -1160,7 +1160,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     `DV_SPINWAIT(
       do begin
         @(cfg.clk_rst_vif.cb);
-        uvm_hdl_read(mypath, rma_ack);
+        `DV_CHECK_EQ(uvm_hdl_read(mypath, rma_ack), 1, "hdl read failure")
       end while (rma_ack != lc_ctrl_pkg::On);,
       "waiting for rma ack == On", 120_000_000
     )

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_i2c_tx_rx_vseq.sv
@@ -15,7 +15,7 @@ class chip_sw_i2c_tx_rx_vseq extends chip_sw_base_vseq;
   int clock_period_cycles = ((i2c_clock_period_nanos - 1) / clock_period_nanos) + 1;
   int half_period_cycles = ((i2c_clock_period_nanos/2 - 1) / clock_period_nanos) + 1;
 
-  function print_i2c_timing_cfg(uint i2c_idx);
+  function void print_i2c_timing_cfg(uint i2c_idx);
     string str;
     str = {str, $sformatf("\n    timing_cfg.tSetupStart       : %d",
               cfg.m_i2c_agent_cfgs[i2c_idx].timing_cfg.tSetupStart)};

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_dpi_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_usbdev_dpi_vseq.sv
@@ -8,7 +8,7 @@ class chip_sw_usbdev_dpi_vseq extends chip_sw_base_vseq;
   `uvm_object_new
 
   // Zero initialize the usbdev packet memory
-  function init_packet_mem();
+  function void init_packet_mem();
     cfg.mem_bkdr_util_h[UsbdevBuf].clear_mem();
   endfunction
 


### PR DESCRIPTION
These warning fixes are really simple:
- Duplicate package import
- Incorrect return type for functions
- Missing checks of return values