### PR TITLE
[sival] Port sysrst_ctrl_ec_rst_l

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_sysrst_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sysrst_ctrl_testplan.hjson
@@ -155,6 +155,7 @@
       si_stage:SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_sysrst_ctrl_ec_rst_l"]
+      bazel: ["//sw/device/tests:sysrst_ctrl_ec_rst_l_test"]
     }
     {
       name: chip_sw_sysrst_ctrl_flash_wp_l
@@ -167,6 +168,7 @@
       si_stage:SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_sysrst_ctrl_ec_rst_l"]
+      bazel: ["//sw/device/tests:sysrst_ctrl_ec_rst_l_test"]
     }
     {
       name: chip_sw_sysrst_ctrl_ulp_z3_wakeup

--- a/sw/device/lib/testing/sysrst_ctrl_testutils.c
+++ b/sw/device/lib/testing/sysrst_ctrl_testutils.c
@@ -4,13 +4,14 @@
 
 #include "sw/device/lib/testing/sysrst_ctrl_testutils.h"
 
+#include "sw/device/lib/base/math.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-void setup_dio_pins(dif_pinmux_t *pinmux, dif_sysrst_ctrl_t *sysrst_ctrl) {
-  // Make sure the DIO pins EC reset and flash WP are configured correctly:
+void sysrst_ctrl_testutils_setup_dio(dif_pinmux_t *pinmux) {
+  // Make sure that the DIO pins EC reset and flash WP are configured correctly
   // https://opentitan.org/book/hw/ip/sysrst_ctrl/doc/theory_of_operation.html#ec-and-power-on-reset
   // https://opentitan.org/book/hw/ip/sysrst_ctrl/doc/theory_of_operation.html#flash-write-protect-output
   //
@@ -39,30 +40,50 @@ void setup_dio_pins(dif_pinmux_t *pinmux, dif_sysrst_ctrl_t *sysrst_ctrl) {
   CHECK_DIF_OK(dif_pinmux_pad_write_attrs(
       pinmux, kTopEarlgreyDirectPadsSysrstCtrlAonFlashWpL, kDifPinmuxPadKindDio,
       in_attr, &out_attr));
+}
+
+void sysrst_ctrl_testutils_release_dio(dif_sysrst_ctrl_t *sysrst_ctrl,
+                                       bool release_ec, bool release_flash) {
+  // Make sure that the DIO pins EC reset and flash WP are released according to
+  // the documentation:
+  // https://opentitan.org/book/hw/ip/sysrst_ctrl/doc/theory_of_operation.html#ec-and-power-on-reset
+  // https://opentitan.org/book/hw/ip/sysrst_ctrl/doc/theory_of_operation.html#flash-write-protect-output
   // We also need to disable the output override mecanism (i.e. "release the
   // pin").
-  dif_sysrst_ctrl_pin_config_t cfg_ec_reset = {
-      .enabled = kDifToggleDisabled,
-      .allow_zero = true,
-      .allow_one = true,
-      .override_value = false,
-  };
-  CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_configure(
-      sysrst_ctrl, kDifSysrstCtrlPinEcResetInOut, cfg_ec_reset));
+  if (release_ec) {
+    dif_sysrst_ctrl_pin_config_t cfg_ec_reset = {
+        .enabled = kDifToggleDisabled,
+        .allow_zero = true,
+        .allow_one = true,
+        .override_value = false,
+    };
+    CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_configure(
+        sysrst_ctrl, kDifSysrstCtrlPinEcResetInOut, cfg_ec_reset));
+  }
   // Confusingly, the flash WP is different: the value of flash_wp_l_o defaults
   // to logic 0 when it is not explicitly driven via the override function.
   // Therefore to disable the driver we need to *enable* the override and set
   // to 1.
-  dif_sysrst_ctrl_pin_config_t cfg_flash_wp = {
-      .enabled = kDifToggleEnabled,
-      .allow_zero = false,
-      .allow_one = true,
-      .override_value = true,
-  };
-  CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_configure(
-      sysrst_ctrl, kDifSysrstCtrlPinFlashWriteProtectInOut, cfg_flash_wp));
-  // Disable the EC reset debounce timer because it could interfere with
-  // reading the pins.
+  if (release_flash) {
+    dif_sysrst_ctrl_pin_config_t cfg_flash_wp = {
+        .enabled = kDifToggleEnabled,
+        .allow_zero = false,
+        .allow_one = true,
+        .override_value = true,
+    };
+    CHECK_DIF_OK(dif_sysrst_ctrl_output_pin_override_configure(
+        sysrst_ctrl, kDifSysrstCtrlPinFlashWriteProtectInOut, cfg_flash_wp));
+  }
+}
+
+void sysrst_ctrl_testutils_set_ec_rst_pulse_width(
+    dif_sysrst_ctrl_t *sysrst_ctrl, uint32_t pulse_us) {
+  // The register field counts in aon_clock ticks.
+  uint64_t ticks =
+      udiv64_slow((uint64_t)pulse_us * kClockFreqAonHz, 1000 * 1000, NULL);
+  // The register field is 16-bit wide.
+  OT_ASSERT_ENUM_VALUE(SYSRST_CTRL_EC_RST_CTL_EC_RST_PULSE_OFFSET, 0);
+  CHECK(ticks <= SYSRST_CTRL_EC_RST_CTL_EC_RST_PULSE_MASK);
   mmio_region_write32(sysrst_ctrl->base_addr, SYSRST_CTRL_EC_RST_CTL_REG_OFFSET,
-                      0);
+                      (uint16_t)ticks);
 }

--- a/sw/device/lib/testing/sysrst_ctrl_testutils.h
+++ b/sw/device/lib/testing/sysrst_ctrl_testutils.h
@@ -12,8 +12,7 @@
 
 /**
  * Setup the sysrst_ctrl direct IO (DIO) pins, that is flash write protect (WP)
- * and EC reset. Also disable the EC reset debounce timer and release the flash
- * WP so that the output is not overidden to low by the block.
+ * and EC reset.
  *
  * This function will try to setup the DIO pins as open drain. If this fails,
  * it will then try virtual open drain.
@@ -21,8 +20,34 @@
  * This function will panic on error.
  *
  * @param pinmux Pointer to an initialized pinmux DIF.
- * @param pinmux Pointer to an initialized sysrst_ctrl DIF.
  */
-void setup_dio_pins(dif_pinmux_t *pinmux, dif_sysrst_ctrl_t *sysrst_ctrl);
+void sysrst_ctrl_testutils_setup_dio(dif_pinmux_t *pinmux);
+
+/**
+ * Release the flash WP and EC reset so that the output is not overidden to low
+ * by the block.
+ *
+ * This function will panic on error.
+ *
+ * @param pinmux Pointer to an initialized sysrst_ctrl DIF.
+ * @param release_ec Whether to release the EC reset pin.
+ * @param release_flash Whether to release the flast write protect pin.
+ */
+void sysrst_ctrl_testutils_release_dio(dif_sysrst_ctrl_t *sysrst_ctrl,
+                                       bool release_ec, bool release_flash);
+
+/**
+ * Set the EC reset pulse width.
+ *
+ * The supplied pulse width is converted into a count of AON clock ticks.
+ * If the width is not an exact multiple of the AON clock period, the conversion
+ * rounds down. The function will panic if the converted pulse width does not
+ * fit into the RST_CTL register.
+ *
+ * @param pinmux Pointer to an initialized sysrst_ctrl DIF.
+ * @param pulse_us Pulse width in microseconds.
+ */
+void sysrst_ctrl_testutils_set_ec_rst_pulse_width(
+    dif_sysrst_ctrl_t *sysrst_ctrl, uint32_t pulse_us);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SYSRST_CTRL_TESTUTILS_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4403,6 +4403,36 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "sysrst_ctrl_ec_rst_l_test",
+    srcs = ["sysrst_ctrl_ec_rst_l_test.c"],
+    cw310 = new_cw310_params(
+        test_cmd = """
+            --bitstream="{bitstream}"
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_ec_rst_l",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:sim_dv": None,
+    },
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing:sysrst_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_utils",
+    ],
+)
+
+opentitan_test(
     name = "sysrst_ctrl_ulp_z3_wakeup_test",
     srcs = ["sysrst_ctrl_ulp_z3_wakeup_test.c"],
     cw310 = new_cw310_params(

--- a/sw/device/tests/sysrst_ctrl_ec_rst_l_test.c
+++ b/sw/device/tests/sysrst_ctrl_ec_rst_l_test.c
@@ -1,0 +1,133 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/sysrst_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/* We need control flow for the ujson messages exchanged
+ * with the host in OTTF_WAIT_FOR on real devices. */
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+static dif_pinmux_t pinmux;
+static dif_sysrst_ctrl_t sysrst_ctrl;
+static dif_pwrmgr_t pwrmgr;
+static dif_rstmgr_t rstmgr;
+static dif_rstmgr_reset_info_bitfield_t rstmgr_reset_info;
+
+enum {
+  kAllZero = 0x0,
+  kAllOne = 0x3,
+  kNumMioInputs = 0x2,
+};
+
+static const dif_pinmux_index_t kPeripheralInputs[] = {
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey0In,
+    kTopEarlgreyPinmuxPeripheralInSysrstCtrlAonKey1In,
+};
+
+static const dif_pinmux_index_t kInputPads[] = {
+    kTopEarlgreyPinmuxInselIor6,
+    kTopEarlgreyPinmuxInselIor7,
+};
+
+// Threshold/Duration values are not specific to a real-world debounce
+// scenario so are kept short to avoid excessive simulation time.
+// Assuming a 5us aon clock period.
+enum {
+  kDetectionTimeThreshold = 1024,  // ~5ms
+  kEcResetStretchDurationMicros = 200 * 1000,
+  kDebounceTimeThreshold = 128,  // ~0.6ms
+};
+
+// Sets up the pinmux to assign input and output pads
+// to the sysrst_ctrl peripheral as required.
+static void pinmux_setup(void) {
+  for (int i = 0; i < kNumMioInputs; ++i) {
+    CHECK_DIF_OK(
+        dif_pinmux_input_select(&pinmux, kPeripheralInputs[i], kInputPads[i]));
+  }
+}
+
+static void configure_combo_reset(void) {
+  CHECK_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl, kDifSysrstCtrlKeyCombo0,
+      (dif_sysrst_ctrl_key_combo_config_t){
+          .actions = kDifSysrstCtrlKeyComboActionSelfReset,
+          .detection_time_threshold = kDetectionTimeThreshold,
+          .embedded_controller_reset_duration = 0,
+          .keys = kDifSysrstCtrlKey0 | kDifSysrstCtrlKey1}));
+  // Use testutils to computes the value using the actual aon clock frequency.
+  CHECK_DIF_OK(dif_sysrst_ctrl_input_change_detect_configure(
+      &sysrst_ctrl, (dif_sysrst_ctrl_input_change_config_t){
+                        .debounce_time_threshold = kDebounceTimeThreshold,
+                        .input_changes = kDifSysrstCtrlInputKey0H2L |
+                                         kDifSysrstCtrlInputKey1H2L}));
+  // Prepare rstmgr for a reset with sysrst_ctrl (source one).
+  CHECK_STATUS_OK(rstmgr_testutils_pre_reset(&rstmgr));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
+                                              kDifPwrmgrResetRequestSourceOne,
+                                              kDifToggleEnabled));
+  // Issue WFI and wait for reset condition.
+  LOG_INFO("wait for combo (key0&1 low)");
+  test_status_set(kTestStatusInWfi);
+  wait_for_interrupt();
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(dif_sysrst_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SYSRST_CTRL_AON_BASE_ADDR),
+      &sysrst_ctrl));
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  pinmux_setup();
+  sysrst_ctrl_testutils_setup_dio(&pinmux);
+  rstmgr_reset_info = rstmgr_testutils_reason_get();
+
+  // On a POR, start the test: prepare the sysrst_ctrl with a combo to reset
+  // the chip and wait for the host to reset the device using that combo.
+  if (rstmgr_reset_info == kDifRstmgrResetInfoPor) {
+    sysrst_ctrl_testutils_release_dio(&sysrst_ctrl, true, true);
+    configure_combo_reset();
+    LOG_ERROR("We should have reset before this line.");
+  } else {
+    // Otherwise, check that we got reset because of sysrst_ctrl.
+    CHECK(rstmgr_reset_info == kDifRstmgrResetInfoSysRstCtrl);
+    // Key0 is low since the reset was triggered by the combo. Wait until host
+    // pulls key0 up.
+    LOG_INFO("wait for key0 to go high");
+    test_status_set(kTestStatusInWfi);
+    bool key0_up = false;
+    while (!key0_up) {
+      CHECK_DIF_OK(dif_sysrst_ctrl_input_pin_read(
+          &sysrst_ctrl, kDifSysrstCtrlPinKey0In, &key0_up));
+    }
+    // Release the pins
+    LOG_INFO("releasing ec_rst and flash_wp");
+    // Now release the pins.
+    sysrst_ctrl_testutils_set_ec_rst_pulse_width(&sysrst_ctrl, 0);
+    sysrst_ctrl_testutils_release_dio(&sysrst_ctrl, true, true);
+    // Setup the EC reset stretch pulse width so that the host can check that it
+    // works.
+    sysrst_ctrl_testutils_set_ec_rst_pulse_width(&sysrst_ctrl,
+                                                 kEcResetStretchDurationMicros);
+    test_status_set(kTestStatusInWfi);
+  }
+  return true;
+}

--- a/sw/device/tests/sysrst_ctrl_in_irq_test.c
+++ b/sw/device/tests/sysrst_ctrl_in_irq_test.c
@@ -262,8 +262,13 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
 
   // On real devices, we also need to configure the DIO pins.
-  if (kDeviceType != kDeviceSimDV)
-    setup_dio_pins(&pinmux, &sysrst_ctrl);
+  if (kDeviceType != kDeviceSimDV) {
+    sysrst_ctrl_testutils_setup_dio(&pinmux);
+    // Release pins so the host can control them.
+    sysrst_ctrl_testutils_release_dio(&sysrst_ctrl, true, true);
+    // Disable the EC reset pulse so that it does not interfere with the test.
+    sysrst_ctrl_testutils_set_ec_rst_pulse_width(&sysrst_ctrl, 0);
+  }
   const dif_pinmux_index_t *kInputPads =
       kDeviceType == kDeviceSimDV ? kInputPadsDV : kInputPadsReal;
   for (int i = 0; i < kOutputNumMioPads; ++i) {

--- a/sw/device/tests/sysrst_ctrl_inputs_test.c
+++ b/sw/device/tests/sysrst_ctrl_inputs_test.c
@@ -88,8 +88,13 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
 
   /* On real devices, we also need to configure the DIO pins */
-  if (kDeviceType != kDeviceSimDV)
-    setup_dio_pins(&pinmux, &sysrst_ctrl);
+  if (kDeviceType != kDeviceSimDV) {
+    sysrst_ctrl_testutils_setup_dio(&pinmux);
+    // Release pins so the host can control them.
+    sysrst_ctrl_testutils_release_dio(&sysrst_ctrl, true, true);
+    // Disable the EC reset pulse so that it does not interfere with the test.
+    sysrst_ctrl_testutils_set_ec_rst_pulse_width(&sysrst_ctrl, 0);
+  }
   const dif_pinmux_index_t *kInputPads =
       kDeviceType == kDeviceSimDV ? kInputPadsDV : kInputPadsReal;
   for (int i = 0; i < kOutputNumMioPads; ++i) {

--- a/sw/device/tests/sysrst_ctrl_outputs_test.c
+++ b/sw/device/tests/sysrst_ctrl_outputs_test.c
@@ -109,7 +109,11 @@ static volatile const uint8_t kTestPhaseReal = kTestPhaseSetup;
 static void pinmux_setup(void) {
   /* On real devices, we also need to configure the DIO pins */
   if (kDeviceType != kDeviceSimDV) {
-    setup_dio_pins(&pinmux, &sysrst_ctrl);
+    sysrst_ctrl_testutils_setup_dio(&pinmux);
+    // Release pins so the host can control them.
+    sysrst_ctrl_testutils_release_dio(&sysrst_ctrl, true, true);
+    // Disable the EC reset pulse so that it does not interfere with the test.
+    sysrst_ctrl_testutils_set_ec_rst_pulse_width(&sysrst_ctrl, 0);
   }
   const dif_pinmux_index_t *kInputPads =
       kDeviceType == kDeviceSimDV ? kInputPadsDV : kInputPadsReal;

--- a/sw/host/tests/chip/sysrst_ctrl/BUILD
+++ b/sw/host/tests/chip/sysrst_ctrl/BUILD
@@ -90,3 +90,21 @@ rust_binary(
         "@crate_index//:serde_json",
     ],
 )
+
+rust_binary(
+    name = "sysrst_ctrl_ec_rst_l",
+    srcs = [
+        "sysrst_ctrl_ec_rst_l.rs",
+    ],
+    deps = [
+        ":sysrst_ctrl",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:object",
+        "@crate_index//:once_cell",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ec_rst_l.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ec_rst_l.rs
@@ -1,0 +1,232 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, ensure, Result};
+use clap::Parser;
+use once_cell::sync::Lazy;
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::gpio::{ClockNature, Edge, MonitoringEvent, PinMode};
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::test_status::TestStatus;
+use opentitanlib::uart::console::UartConsole;
+use opentitanlib::{collection, execute_test};
+
+use sysrst_ctrl::{Config, setup_pins, set_pins, read_pins};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+}
+
+struct Params<'a> {
+    opts: &'a Opts,
+    transport: &'a TransportWrapper,
+    uart: &'a dyn Uart,
+    config: &'a Config,
+}
+
+static CONFIG: Lazy<HashMap<&'static str, Config>> = Lazy::new(|| {
+    collection! {
+        "hyper310" => Config {
+            // key0_in, key1_in
+            output_pins: vec!["IOR6", "IOR7"],
+            open_drain: vec![false, false],
+            // ec_rst, flash_wp
+            input_pins: vec!["IOR8", "IOR9"],
+            // ec_rst, flash_wp
+            pullup_pins: vec!["IOR8", "IOR9"],
+        },
+    }
+});
+
+const COMBO_PINS_HIGH: u8 = 0x3;
+const COMBO_PINS_LOW: u8 = 0;
+const COMBO_PINS_KEY0_HIGH: u8 = 1;
+const EC_RST_FLASH_WP_HIGH: u8 = 0x3;
+const EC_RST_PIN_INDEX: u8 = 0;
+const FLASH_WP_PIN_INDEX: u8 = 1;
+const EC_RST_PIN: &str = "IOR8";
+
+const EC_RST_COMBO_PULSE_WIDTH_USEC: u64 = 100_000; // Set on the device.
+const EC_RST_STRETCH_PULSE_WIDTH_USEC: u64 = 200_000; // Set on the device.
+const EC_RST_PULE_WIDTH_MARGIN_USEC: u64 = 5_000;
+
+fn sync_with_sw(params: &Params) -> Result<()> {
+    UartConsole::wait_for(params.uart, &TestStatus::InWfi.wait_pattern(), params.opts.timeout)?;
+    Ok(())
+}
+
+fn chip_sw_sysrst_ctrl_input(
+    params: &Params,
+) -> Result<()> {
+
+    // Setup transport pins.
+    setup_pins(params.transport, params.config)?;
+    // Set combo pins to high.
+    set_pins(params.transport, params.config, COMBO_PINS_HIGH)?;
+
+    // Reset target now so that we can be sure that the pins are in the right
+    // configuration before running the test.
+    params.transport.reset_target(params.opts.init.bootstrap.options.reset_delay, true)?;
+
+    // Wait until device has setup pins and is waiting for combo.
+    sync_with_sw(params)?;
+    // On POR, the device releases the EC_RST and FLASH_WP pins.
+    ensure!(read_pins(params.transport, params.config)? == EC_RST_FLASH_WP_HIGH);
+
+    // We are going to set the combo pins to low and monitor the GPIO.
+    let gpio_monitoring = params.transport.gpio_monitoring()?;
+    let clock_nature = gpio_monitoring.get_clock_nature()?;
+    let ClockNature::Wallclock { resolution, .. } = clock_nature else {
+        bail!("Cannot measure EC reset pulse width: the transport GPIO monitor does not have reliable clock source");
+    };
+    log::info!("GPIO monitor clock resolution: {resolution}");
+    let gpio_pins = &params.config.input_pins.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+    let gpio_pins = params.transport.gpio_pins(gpio_pins)?;
+    let gpios_pins = &gpio_pins
+                .iter()
+                .map(Rc::borrow)
+                .collect::<Vec<_>>();
+    let start_resp = gpio_monitoring.monitoring_start(gpios_pins)?;
+    // The initial levels should match the pins: all ones.
+    ensure!(!start_resp.initial_levels.iter().any(|level| !level));
+
+    // Set combo pins to low which triggers the combo and resets the device.
+    set_pins(params.transport, params.config, COMBO_PINS_LOW)?;
+    // Wait until device has rebooted and is waiting for our signal.
+    sync_with_sw(params)?;
+    // Wait for a short time just to make sure that the EC reset line stays down.
+    std::thread::sleep(Duration::from_millis(500));
+    // Stop monitoring and check that ec_rst and flash_wp were held low during
+    // the entire time.
+    let events = gpio_monitoring.monitoring_read(gpios_pins, false)?;
+    for event in &events.events {
+        log::info!("{event:?}");
+    }
+    let mut events_iter = events.events.iter();
+    let Some(first_event) = events_iter.next() else {
+        bail!("Expected at least one GPIO event during reset");
+    };
+    let Some(second_event) = events_iter.next() else {
+        bail!("Expected at least two GPIO events during reset");
+    };
+    if let Some(third_event) = events_iter.next() {
+        bail!("Unexpected third GPIO event during reset: {third_event:?}");
+    }
+    match (first_event, second_event) {
+        (&MonitoringEvent {
+            signal_index: first_index,
+            edge: Edge::Falling,
+            ..
+        },
+        &MonitoringEvent {
+            signal_index: second_index,
+            edge: Edge::Falling,
+            ..
+        }) => {
+            // Sanity check: make sure each pin (ec_rst and flash_wp) is now low.
+            ensure!((first_index == EC_RST_PIN_INDEX && second_index == FLASH_WP_PIN_INDEX) || (first_index == FLASH_WP_PIN_INDEX && second_index == EC_RST_PIN_INDEX));
+        }
+        _ => bail!("the GPIO events do not match what was expected: {first_event:?}, {second_event:?}")
+    }
+    // Set key0 to high to continue the test.
+    set_pins(params.transport, params.config, COMBO_PINS_KEY0_HIGH)?;
+    // In reponse, the device should release the pins.
+    sync_with_sw(params)?;
+    ensure!(read_pins(params.transport, params.config)? == EC_RST_FLASH_WP_HIGH);
+
+    // Exercise the EC reset pulse: pull ec_rst low and then high, measure how long
+    // it is held low.
+    let start_resp = gpio_monitoring.monitoring_start(gpios_pins)?;
+    // The initial levels should be all ones.
+    ensure!(!start_resp.initial_levels.iter().any(|level| !level));
+    // Change the EC_RST pin to output, pull low and reset to input.
+    params.transport.gpio_pin(EC_RST_PIN)?.set_mode(PinMode::OpenDrain)?;
+    params.transport.gpio_pin(EC_RST_PIN)?.write(false)?;
+    std::thread::sleep(Duration::from_millis(1));
+    params.transport.gpio_pin(EC_RST_PIN)?.write(true)?;
+    // We expect OT to pulse EC for a while, so wait with some margin.
+    std::thread::sleep(Duration::from_micros(EC_RST_COMBO_PULSE_WIDTH_USEC) + Duration::from_millis(100));
+    // Stop monitoring.
+    let events = gpio_monitoring.monitoring_read(gpios_pins, false)?;
+    // We expect to see EC_RST go low and then high.
+    let mut events_iter = events.events.iter();
+    let Some(first_event) = events_iter.next() else {
+        bail!("Expected at least one GPIO event during reset");
+    };
+    let Some(second_event) = events_iter.next() else {
+        bail!("Expected at least two GPIO events during reset");
+    };
+    if let Some(third_event) = events_iter.next() {
+        bail!("Unexpected third GPIO event during reset: {third_event:?}");
+    }
+    match (first_event, second_event) {
+        (&MonitoringEvent {
+            signal_index: EC_RST_PIN_INDEX,
+            edge: Edge::Falling,
+            timestamp: fall_timestamp,
+        },
+        &MonitoringEvent {
+            signal_index: EC_RST_PIN_INDEX,
+            edge: Edge::Rising,
+            timestamp: rise_timestamp,
+        }) => {
+            // Convert a timestamp in transport unit to something in nanoseconds.
+            let timestamp_to_ns = |timestamp: u64| -> u64 {
+                timestamp * 1000000000u64 / resolution
+            };
+            // Make sure the pulse width matches what we expect.
+            let pulse_width_us = (timestamp_to_ns(rise_timestamp) - timestamp_to_ns(fall_timestamp)) / 1000;
+            let delta = EC_RST_STRETCH_PULSE_WIDTH_USEC.abs_diff(pulse_width_us);
+            log::info!("reset pulse width =  {pulse_width_us} us, delta = {delta} us");
+            ensure!(delta <= EC_RST_PULE_WIDTH_MARGIN_USEC);
+        }
+        _ => bail!("the GPIO events do not match what was expected: {first_event:?}, {second_event:?}")
+    }
+
+    // Wait until device has done its work.
+    let _ = UartConsole::wait_for(params.uart, r"PASS!", params.opts.timeout)?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    log::info!(
+        "Use pin configuration for {:?}",
+        opts.init.backend_opts.interface
+    );
+    let config = CONFIG
+        .get(opts.init.backend_opts.interface.as_str())
+        .expect("interface");
+
+    execute_test!(
+        chip_sw_sysrst_ctrl_input,
+        &Params {
+            opts: &opts,
+            transport: &transport,
+            uart: &*uart,
+            config,
+        }
+    );
+    Ok(())
+}


### PR DESCRIPTION
The existing sim_dv test was too DV specific so I created a test from scratch. I intentionally avoid backdoor writes to make it simpler and instead leverage the GPIO monitor functionality. The test goes further than DV and does the optional part of the testplan: make sure the EC reset stretch functionality works.

Fixes #21177, fixes #21178 