### PR TITLE
[dv] Tweaks to csr_peek to make the code simpler

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -182,7 +182,7 @@ virtual task poke_and_check_storage_error(dv_base_reg shadowed_csr);
 
   `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(
       kind, kind inside {BkdrRegPathRtl, BkdrRegPathRtlShadow};)
-  csr_peek(.ptr(shadowed_csr), .value(origin_val), .kind(kind));
+  origin_val = csr_peek(.ptr(shadowed_csr), .kind(kind));
   err_val = get_shadow_reg_diff_val(shadowed_csr, origin_val);
 
   csr_poke(.ptr(shadowed_csr), .value(err_val), .kind(kind), .predict(1));

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -383,10 +383,10 @@ package csr_utils_pkg;
 
   // backdoor read csr
   // uvm_reg::peek() returns a 2-state value, directly get data from hdl path
-  task automatic csr_peek(input uvm_object      ptr,
-                          output uvm_reg_data_t value,
-                          input uvm_check_e     check = default_csr_check,
-                          input bkdr_reg_path_e kind = BkdrRegPathRtl);
+  function automatic void csr_peek(input uvm_object      ptr,
+                                   output uvm_reg_data_t value,
+                                   input uvm_check_e     check = default_csr_check,
+                                   input bkdr_reg_path_e kind = BkdrRegPathRtl);
     string      msg_id = {csr_utils_pkg::msg_id, "::csr_peek"};
     csr_field_t csr_or_fld = decode_csr_or_field(ptr);
     uvm_reg     csr = csr_or_fld.csr;
@@ -411,7 +411,7 @@ package csr_utils_pkg;
 
     // if it's field, only return field value
     if (csr_or_fld.field != null) value = get_field_val(csr_or_fld.field, value);
-  endtask
+  endfunction
 
   task automatic csr_rd_check(input  uvm_object         ptr,
                               input  uvm_check_e        check = default_csr_check,

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -398,7 +398,7 @@ package csr_utils_pkg;
       foreach (paths[0].slices[i]) begin
         uvm_reg_data_t field_val;
         if (uvm_hdl_read(paths[0].slices[i].path, field_val)) begin
-          if (check == UVM_CHECK) `DV_CHECK_EQ($isunknown(value), 0, "", error, msg_id)
+          if (check == UVM_CHECK) `DV_CHECK_EQ($isunknown(field_val), 0, "", error, msg_id)
           value |= field_val << paths[0].slices[i].offset;
         end else begin
           `uvm_fatal(msg_id, $sformatf("uvm_hdl_read failed for %0s", csr.get_full_name()))

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -340,7 +340,7 @@ package csr_utils_pkg;
                             input  uvm_reg_map        map = null,
                             input  uvm_reg_frontdoor  user_ftdr = default_user_frontdoor);
     if (backdoor) begin
-      csr_peek(ptr, value, check);
+      value = csr_peek(ptr, check);
       status = UVM_IS_OK;
       return;
     end
@@ -383,13 +383,13 @@ package csr_utils_pkg;
 
   // backdoor read csr
   // uvm_reg::peek() returns a 2-state value, directly get data from hdl path
-  function automatic void csr_peek(input uvm_object      ptr,
-                                   output uvm_reg_data_t value,
-                                   input uvm_check_e     check = default_csr_check,
-                                   input bkdr_reg_path_e kind = BkdrRegPathRtl);
-    string      msg_id = {csr_utils_pkg::msg_id, "::csr_peek"};
-    csr_field_t csr_or_fld = decode_csr_or_field(ptr);
-    uvm_reg     csr = csr_or_fld.csr;
+  function automatic uvm_reg_data_t csr_peek(uvm_object      ptr,
+                                             uvm_check_e     check = default_csr_check,
+                                             bkdr_reg_path_e kind = BkdrRegPathRtl);
+    string         msg_id = {csr_utils_pkg::msg_id, "::csr_peek"};
+    csr_field_t    csr_or_fld = decode_csr_or_field(ptr);
+    uvm_reg        csr = csr_or_fld.csr;
+    uvm_reg_data_t value = 0;
 
     uvm_hdl_path_concat paths[$];
     csr.get_full_hdl_path(paths, kind.name);
@@ -414,6 +414,8 @@ package csr_utils_pkg;
     // register, it will be laid out in the same way as the field is laid out in the register.
     // That's no problem: we can just extract the relevant field from the laid-out value here.
     if (csr_or_fld.field != null) value = get_field_val(csr_or_fld.field, value);
+
+    return value;
   endfunction
 
   task automatic csr_rd_check(input  uvm_object         ptr,

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -410,7 +410,9 @@ package csr_utils_pkg;
       value |= field_val << paths[0].slices[i].offset;
     end
 
-    // if it's field, only return field value
+    // We now have the contents of the field or register in value. If ptr was a sub-field of some
+    // register, it will be laid out in the same way as the field is laid out in the register.
+    // That's no problem: we can just extract the relevant field from the laid-out value here.
     if (csr_or_fld.field != null) value = get_field_val(csr_or_fld.field, value);
   endfunction
 

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -391,23 +391,23 @@ package csr_utils_pkg;
     csr_field_t csr_or_fld = decode_csr_or_field(ptr);
     uvm_reg     csr = csr_or_fld.csr;
 
-    if (csr.has_hdl_path(kind.name)) begin
-      uvm_hdl_path_concat paths[$];
+    uvm_hdl_path_concat paths[$];
+    csr.get_full_hdl_path(paths, kind.name);
 
-      csr.get_full_hdl_path(paths, kind.name);
-      foreach (paths[0].slices[i]) begin
-        uvm_reg_data_t field_val;
-        `DV_CHECK_FATAL(uvm_hdl_read(paths[0].slices[i].path, field_val),
-                        $sformatf("Failed to read %s, slice %d, at path %s",
-                                  csr.get_full_name(), i, paths[0].slices[i].path),
-                        msg_id)
-        if (check == UVM_CHECK) `DV_CHECK_EQ($isunknown(field_val), 0, "", error, msg_id)
+    `DV_CHECK_FATAL(paths.size() > 0,
+                    $sformatf("No backdoor defined for %0s path's %0s",
+                              csr.get_full_name(), kind.name),
+                    msg_id)
 
-        value |= field_val << paths[0].slices[i].offset;
-      end
-    end else begin
-      `uvm_fatal(msg_id, $sformatf("No backdoor defined for %0s path's %0s",
-                                   csr.get_full_name(), kind.name))
+    foreach (paths[0].slices[i]) begin
+      uvm_reg_data_t field_val;
+      `DV_CHECK_FATAL(uvm_hdl_read(paths[0].slices[i].path, field_val),
+                      $sformatf("Failed to read %s, slice %d, at path %s",
+                                csr.get_full_name(), i, paths[0].slices[i].path),
+                      msg_id)
+      if (check == UVM_CHECK) `DV_CHECK_EQ($isunknown(field_val), 0, "", error, msg_id)
+
+      value |= field_val << paths[0].slices[i].offset;
     end
 
     // if it's field, only return field value

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -397,12 +397,13 @@ package csr_utils_pkg;
       csr.get_full_hdl_path(paths, kind.name);
       foreach (paths[0].slices[i]) begin
         uvm_reg_data_t field_val;
-        if (uvm_hdl_read(paths[0].slices[i].path, field_val)) begin
-          if (check == UVM_CHECK) `DV_CHECK_EQ($isunknown(field_val), 0, "", error, msg_id)
-          value |= field_val << paths[0].slices[i].offset;
-        end else begin
-          `uvm_fatal(msg_id, $sformatf("uvm_hdl_read failed for %0s", csr.get_full_name()))
-        end
+        `DV_CHECK_FATAL(uvm_hdl_read(paths[0].slices[i].path, field_val),
+                        $sformatf("Failed to read %s, slice %d, at path %s",
+                                  csr.get_full_name(), i, paths[0].slices[i].path),
+                        msg_id)
+        if (check == UVM_CHECK) `DV_CHECK_EQ($isunknown(field_val), 0, "", error, msg_id)
+
+        value |= field_val << paths[0].slices[i].offset;
       end
     end else begin
       `uvm_fatal(msg_id, $sformatf("No backdoor defined for %0s path's %0s",

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1522,7 +1522,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
                   `DV_SPINWAIT(forever begin
                     sw_regupd = `gmv(ral.sw_regupd.sw_regupd);
                     if (!sw_regupd) break; // Device will be conlusively locked via sw_regupd
-                    csr_peek(.ptr(ral.regwen.regwen), .value(regwen_obs));
+                    regwen_obs = csr_peek(.ptr(ral.regwen.regwen));
                     if (regwen_obs == do_disable) break;
                     cfg.clk_rst_vif.wait_clks(1);
                     obs_delay++;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
@@ -246,10 +246,10 @@ class chip_sw_flash_init_vseq extends chip_sw_base_vseq;
           `DV_CHECK(lc_seed_hw_rd_en, lc_ctrl_pkg::On)
         end else begin
           bit [63:0] secret0_digest, secret2_digest;
-          csr_peek(ral.otp_ctrl_core.secret0_digest[0], secret0_digest[31:0]);
-          csr_peek(ral.otp_ctrl_core.secret0_digest[1], secret0_digest[63:32]);
-          csr_peek(ral.otp_ctrl_core.secret2_digest[0], secret2_digest[31:0]);
-          csr_peek(ral.otp_ctrl_core.secret2_digest[1], secret2_digest[63:32]);
+          secret0_digest = {csr_peek(ral.otp_ctrl_core.secret0_digest[1]),
+                            csr_peek(ral.otp_ctrl_core.secret0_digest[0])};
+          secret2_digest = {csr_peek(ral.otp_ctrl_core.secret2_digest[1]),
+                            csr_peek(ral.otp_ctrl_core.secret2_digest[0])};
           `uvm_info("SEQ", $sformatf("read secret digest:  digest0:0x%16x  digest2:0x%16x",
                                      secret0_digest, secret2_digest), UVM_MEDIUM)
           if (secret0_digest == 0 || secret2_digest == 0) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
@@ -224,8 +224,7 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     creator_data.HardwareRevisionSecret = top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrRevisionSeed;
 
     for (int i = 0; i < keymgr_pkg::DevIdWidth / TL_DW; i++) begin
-      bit [TL_DW-1:0] rdata;
-      csr_peek(ral.lc_ctrl.device_id[i], rdata);
+      bit [TL_DW-1:0] rdata = csr_peek(ral.lc_ctrl.device_id[i]);
       creator_data.DeviceIdentifier[TL_DW * i +: TL_DW] = rdata;
     end
     `uvm_info(`gfn, $sformatf("DeviceIdentifier 0x%0h", creator_data.DeviceIdentifier),
@@ -241,8 +240,7 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     end
 
     for (int i = 0; i < keymgr_pkg::KeyWidth / TL_DW; i++) begin
-      bit [TL_DW-1:0] rdata;
-      csr_peek(ral.rom_ctrl_regs.digest[i], rdata);
+      bit [TL_DW-1:0] rdata = csr_peek(ral.rom_ctrl_regs.digest[i]);
       creator_data.RomDigest[TL_DW * i +: TL_DW] = rdata;
     end
     `uvm_info(`gfn, $sformatf("RomDigest 0x%0h", creator_data.RomDigest),
@@ -351,13 +349,11 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
   virtual task get_sw_shares(output bit [keymgr_pkg::KeyWidth-1:0] sw_shares);
     key_shares_t key_shares;
     for (int i = 0; i < keymgr_pkg::KeyWidth / TL_DW; i++) begin
-      bit [TL_DW-1:0] rdata;
-      csr_peek(ral.keymgr.sw_share0_output[i], rdata);
+      bit [TL_DW-1:0] rdata = csr_peek(ral.keymgr.sw_share0_output[i]);
       key_shares[0][TL_DW * i +: TL_DW] = rdata;
     end
     for (int i = 0; i < keymgr_pkg::KeyWidth / TL_DW; i++) begin
-      bit [TL_DW-1:0] rdata;
-      csr_peek(ral.keymgr.sw_share1_output[i], rdata);
+      bit [TL_DW-1:0] rdata = csr_peek(ral.keymgr.sw_share1_output[i]);
       key_shares[1][TL_DW * i +: TL_DW] = rdata;
     end
     `uvm_info(`gfn, $sformatf("Read SW shares 0x%0h, 0x%0h", key_shares[0], key_shares[1]),

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
@@ -190,7 +190,7 @@ class chip_tap_straps_vseq extends chip_sw_base_vseq;
   virtual task test_lc_access_via_jtag();
     foreach (ral.lc_ctrl.device_id[i]) begin
       bit [31:0] act_device_id, exp_device_id;
-      csr_peek(ral.lc_ctrl.device_id[i], exp_device_id);
+      exp_device_id = csr_peek(ral.lc_ctrl.device_id[i]);
       jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.device_id[i].get_offset(),
                                           p_sequencer.jtag_sequencer_h,
                                           act_device_id);


### PR DESCRIPTION
This follows on from Andreas's https://github.com/lowRISC/opentitan/pull/21104 (applied on the integrated branch) and does some general cleanups that it enables.

Detailed descriptions in the individual commits. There's no big intended change to behaviour.