### PR TITLE
[RV_DM]rv_dm_mem_tl_access_resuming_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_resuming_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_resuming_vseq.sv
@@ -18,6 +18,9 @@ class rv_dm_mem_tl_access_resuming_vseq extends rv_dm_base_vseq;
   task body();
     uvm_reg_data_t wdata;
     uvm_reg_data_t rdata;
+    // Disable unavailable signal to make sure that hart should be in known
+    // state. If hart is unavailable then it could not halted.
+    cfg.rv_dm_if.unavailable <= 0;
     repeat ($urandom_range(1, 10)) begin
       wdata = $urandom_range(0,1);
       // Verify that writing to RESUMING results in anyresumeack and


### PR DESCRIPTION
This commit is just to correct typo in unavailable signal in (#21103).