### PR TITLE
[cryptotest] add wycheproof KMAC test vectors

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -131,3 +131,29 @@ run_binary(
         ("ecdh_secp384r1_test.json", "wycheproof_ecdh_p384"),
     ]
 ]
+
+[
+    run_binary(
+        name = cryptotest_name,
+        srcs = [
+            "@wycheproof//testvectors_v1:{}".format(src_name),
+            "//sw/host/cryptotest/testvectors/data/schemas:kmac_schema.json",
+        ],
+        outs = [":{}.json".format(cryptotest_name)],
+        args = [
+            "--src",
+            "$(location @wycheproof//testvectors_v1:{})".format(src_name),
+            "--dst",
+            "$(location :{}.json)".format(cryptotest_name),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:kmac_schema.json)",
+            "--mode",
+            mode,
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_kmac_parser",
+    )
+    for src_name, mode, cryptotest_name in [
+        ("kmac128_no_customization_test.json", "128", "wycheproof_kmac_128"),
+        ("kmac256_no_customization_test.json", "256", "wycheproof_kmac_256"),
+    ]
+]

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -18,4 +18,5 @@ exports_files([
     "ecdh_schema.json",
     "hash_schema.json",
     "hmac_schema.json",
+    "kmac_schema.json",
 ])

--- a/sw/host/cryptotest/testvectors/data/schemas/kmac_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/kmac_schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/kmac_schema.json",
+  "title": "Cryptotest KMAC Test Vector",
+  "description": "A list of testvectors for KMAC testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "test_case_id",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be kmac",
+        "type": "string",
+        "enum": ["kmac"]
+      },
+      "mode": {
+        "description": "Whether to use Kmac128 or Kmac256",
+        "type": "integer",
+        "enum": [128, 256]
+      },
+      "key": {
+        "description": "Key to use for tag generation",
+        "$ref": "#/$defs/byte_array"
+      },
+      "message": {
+        "description": "Message to generate tag for",
+        "$ref": "#/$defs/byte_array"
+      },
+      "customization_string": {
+        "description": "KMAC customization string",
+        "$ref": "#/$defs/byte_array"
+      },
+      "tag": {
+        "description": "Message tag output by KMAC",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Whether the output tag should match `tag`",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -86,3 +86,11 @@ py_binary(
         requirement("pycryptodome"),
     ],
 )
+
+py_binary(
+    name = "wycheproof_kmac_parser",
+    srcs = ["wycheproof_kmac_parser.py"],
+    deps = [
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_kmac_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_kmac_parser.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import jsonschema
+import logging
+import sys
+
+SUPPORTED_MODES = [
+    128,
+    256,
+]
+
+MAX_KEY_BYTES = 64
+
+
+def parse_test_vectors(raw_data, mode):
+    if mode not in SUPPORTED_MODES:
+        raise ValueError(f"Mode {mode} is not supported.")
+    test_groups = raw_data["testGroups"]
+    test_vectors = list()
+    for group in test_groups:
+        # Parse tests within the group
+        for test in group["tests"]:
+            logging.debug(f"Parsing tcId {test['tcId']}")
+            key = list(bytes.fromhex(test["key"]))
+            if len(key) > MAX_KEY_BYTES:
+                # If the key is longer than OpenTitan's HWIP supports, then
+                # skip this test.
+                continue
+            test_vec = {
+                "vendor": "wycheproof",
+                "test_case_id": test['tcId'],
+                "algorithm": "kmac",
+                "mode": mode,
+                "key": key,
+                "message": list(bytes.fromhex(test["msg"])),
+                "customization_string": [],
+                "tag": list(bytes.fromhex(test["tag"])),
+            }
+
+            # Parse the expected result
+            if test["result"] == "valid":
+                test_vec["result"] = True
+            elif test["result"] == "invalid":
+                test_vec["result"] = False
+            elif test["result"] == "acceptable":
+                # Err on the side of caution and reject "acceptable" signatures
+                test_vec["result"] = False
+            else:
+                raise RuntimeError(f"Unexpected result type {test['result']}")
+
+            test_vectors.append(test_vec)
+
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--src',
+        metavar='FILE',
+        type=argparse.FileType('r'),
+        help='Read test vectors from this JSON file.'
+    )
+    parser.add_argument(
+        '--dst',
+        metavar='FILE',
+        type=argparse.FileType('w'),
+        help='Write output to this file.'
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Testvector schema file"
+    )
+    parser.add_argument(
+        "--mode",
+        type = int,
+        help = "Testvector schema file"
+    )
+    args = parser.parse_args()
+
+    testvecs = parse_test_vectors(json.load(args.src), args.mode)
+    args.src.close()
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Adds the wycheproof KMAC test vectors to `/sw/vendor/` and adds a python script and JSON schema to parse the test vectors into the format that will be used in the test harness. The parser and JSON schema are only a slight variation of the ones used for HMAC in #21149 and #21151, respectively.

Dependent on #21599 