### PR TITLE
[cryptotest] Add KMAC test harness

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -219,3 +219,32 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
 )
+
+KMAC_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_kmac_{}.json".format(config)
+    for config in [
+        "128",
+        "256",
+    ]
+]
+
+KMAC_TESTVECTOR_ARGS = " ".join([
+    "--kmac-json=\"$(rootpath {})\"".format(target)
+    for target in KMAC_TESTVECTOR_TARGETS
+])
+
+opentitan_test(
+    name = "kmac_kat",
+    cw310 = cw310_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        data = KMAC_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + KMAC_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/kmac_kat:harness",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    },
+)

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -126,6 +126,24 @@ cc_library(
 )
 
 cc_library(
+    name = "kmac",
+    srcs = ["kmac.c"],
+    hdrs = ["kmac.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/impl:mac",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:kmac_commands",
+    ],
+)
+
+cc_library(
     name = "aes_sca",
     srcs = ["aes_sca.c"],
     hdrs = ["aes_sca.h"],
@@ -248,6 +266,7 @@ opentitan_binary(
         ":hash",
         ":hmac",
         ":ibex_fi",
+        ":kmac",
         ":kmac_sca",
         ":prng_sca",
         ":sha3_sca",
@@ -287,6 +306,7 @@ opentitan_test(
         ":hash",
         ":hmac",
         ":ibex_fi",
+        ":kmac",
         ":kmac_sca",
         ":prng_sca",
         ":sha3_sca",
@@ -305,5 +325,6 @@ opentitan_test(
         "//sw/device/tests/crypto/cryptotest/json:hash_commands",
         "//sw/device/tests/crypto/cryptotest/json:hmac_commands",
         "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
+        "//sw/device/tests/crypto/cryptotest/json:kmac_commands",
     ],
 )

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -20,6 +20,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hmac_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/kmac_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/prng_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/sha3_sca_commands.h"
@@ -34,6 +35,7 @@
 #include "hash.h"
 #include "hmac.h"
 #include "ibex_fi.h"
+#include "kmac.h"
 #include "kmac_sca.h"
 #include "prng_sca.h"
 #include "sha3_sca.h"
@@ -63,6 +65,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandHmac:
         RESP_ERR(uj, handle_hmac(uj));
+        break;
+      case kCryptotestCommandKmac:
+        RESP_ERR(uj, handle_kmac(uj));
         break;
       case kCryptotestCommandAesSca:
         RESP_ERR(uj, handle_aes_sca(uj));

--- a/sw/device/tests/crypto/cryptotest/firmware/kmac.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/kmac.c
@@ -1,0 +1,127 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/mac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/kmac_commands.h"
+
+const int MaxCustomizationStringBytes = 36;
+
+const int MaxKmacTagBytes = 64;
+const int MaxKmacTagWords = MaxKmacTagBytes / sizeof(uint32_t);
+
+const unsigned int kOtcryptoKmacTagBytesKmac128 = 32;
+const unsigned int kOtcryptoKmacTagBytesKmac256 = 64;
+
+// Random value for masking, as large as the longest test key. This value
+// should not affect the result.
+static const uint32_t kTestMask[48] = {
+    0x61A5D83D, 0x55D6B114, 0xFD2771B8, 0xF70CB89D, 0x342A1205, 0x03571376,
+    0xA23651E3, 0xD246D8E6, 0x9A6AAAA0, 0x105880E2, 0x0C22EA57, 0xB86D07D5,
+    0x6BAA9320, 0xD09F20D8, 0xE9A4520E, 0xEB0BA531, 0x19FEBE66, 0xEAEA1CF1,
+    0x3618EFF5, 0x66FB71DC, 0x703A9932, 0x8C7C7807, 0xFA5D68E5, 0x8364B8C5,
+    0x5BAFF5E7, 0x32BDD917, 0x66254D17, 0xABAB9FD4, 0x7FAE4EE8, 0x3D1F7A0D,
+    0x00C2C8A6, 0xC6ED700E, 0xD86D283C, 0xD6753A6E, 0x0555D290, 0x08C0DA0A,
+    0x9F18BE27, 0x263EA1FC, 0xCA8D6517, 0x88156B88, 0xE6BE966E, 0xD6D8E410,
+    0x2E5A7583, 0xDDB18102, 0x0C9157A7, 0x8437AA66, 0x88EF488A, 0x45A1B1B1,
+};
+
+status_t handle_kmac(ujson_t *uj) {
+  // Declare test arguments
+  cryptotest_kmac_mode_t uj_mode;
+  cryptotest_kmac_required_tag_length_t uj_required_tag_length;
+  cryptotest_kmac_key_t uj_key;
+  cryptotest_kmac_message_t uj_message;
+  cryptotest_kmac_customization_string_t uj_customization_string;
+  // Deserialize test arguments from UART
+  TRY(ujson_deserialize_cryptotest_kmac_mode_t(uj, &uj_mode));
+  TRY(ujson_deserialize_cryptotest_kmac_required_tag_length_t(
+      uj, &uj_required_tag_length));
+  TRY(ujson_deserialize_cryptotest_kmac_key_t(uj, &uj_key));
+  TRY(ujson_deserialize_cryptotest_kmac_message_t(uj, &uj_message));
+  TRY(ujson_deserialize_cryptotest_kmac_customization_string_t(
+      uj, &uj_customization_string));
+
+  otcrypto_kmac_mode_t mode;
+  otcrypto_key_mode_t key_mode;
+  switch (uj_mode) {
+    case kCryptotestKmacModeKmac128:
+      key_mode = kOtcryptoKeyModeKmac128;
+      mode = kOtcryptoKmacModeKmac128;
+      break;
+    case kCryptotestKmacModeKmac256:
+      key_mode = kOtcryptoKeyModeKmac256;
+      mode = kOtcryptoKmacModeKmac256;
+      break;
+    default:
+      LOG_ERROR("Unsupported KMAC mode: %d", uj_mode);
+      return INVALID_ARGUMENT();
+  }
+  // Build the key configuration
+  otcrypto_key_config_t config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = key_mode,
+      .key_length = uj_key.key_len,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+  // Create buffer to store key
+  uint32_t key_buf[uj_key.key_len];
+  memcpy(key_buf, uj_key.key, uj_key.key_len);
+  // Create keyblob
+  uint32_t keyblob[keyblob_num_words(config)];
+  // Create blinded key
+  TRY(keyblob_from_key_and_mask(key_buf, kTestMask, config, keyblob));
+  otcrypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  // Create input message
+  uint8_t msg_buf[uj_message.message_len];
+  memcpy(msg_buf, uj_message.message, uj_message.message_len);
+  otcrypto_const_byte_buf_t input_message = {
+      .len = uj_message.message_len,
+      .data = msg_buf,
+  };
+
+  // Create customization string
+  uint8_t customization_string_buf[uj_customization_string
+                                       .customization_string_len];
+  memcpy(customization_string_buf, uj_customization_string.customization_string,
+         uj_customization_string.customization_string_len);
+  otcrypto_const_byte_buf_t customization_string = {
+      .len = uj_customization_string.customization_string_len,
+      .data = customization_string_buf,
+  };
+
+  // Create tag
+  uint32_t tag_buf[MaxKmacTagWords];
+  otcrypto_word32_buf_t tag = {
+      .len = uj_required_tag_length.required_tag_length / sizeof(uint32_t),
+      .data = tag_buf,
+  };
+  otcrypto_status_t status =
+      otcrypto_kmac(&key, input_message, mode, customization_string,
+                    uj_required_tag_length.required_tag_length, tag);
+  if (status.value != kOtcryptoStatusValueOk) {
+    return INTERNAL(status.value);
+  }
+  // Copy tag to uJSON type
+  cryptotest_kmac_tag_t uj_tag;
+  memcpy(uj_tag.tag, tag_buf, uj_required_tag_length.required_tag_length);
+  uj_tag.tag_len = uj_required_tag_length.required_tag_length;
+
+  // Send tag to host via UART
+  RESP_OK(ujson_serialize_cryptotest_kmac_tag_t, uj, &uj_tag);
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/kmac.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/kmac.h
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_KMAC_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_KMAC_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_kmac(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_KMAC_H_

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -54,6 +54,13 @@ cc_library(
 )
 
 cc_library(
+    name = "kmac_commands",
+    srcs = ["kmac_commands.c"],
+    hdrs = ["kmac_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "aes_sca_commands",
     srcs = ["aes_sca_commands.c"],
     hdrs = ["aes_sca_commands.h"],

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -18,6 +18,7 @@ extern "C" {
     value(_, Ecdh) \
     value(_, Hash) \
     value(_, Hmac) \
+    value(_, Kmac) \
     value(_, AesSca) \
     value(_, IbexFi) \
     value(_, KmacSca) \

--- a/sw/device/tests/crypto/cryptotest/json/kmac_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/kmac_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "kmac_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/kmac_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/kmac_commands.h
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_KMAC_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_KMAC_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// These two are >= the longest size our test vectors happen to use.
+#define KMAC_CMD_MAX_MESSAGE_BYTES 256
+#define KMAC_CMD_MAX_TAG_BYTES 64
+
+// These two are the longest size OpenTitan's KMAC hardware IP supports
+#define KMAC_CMD_MAX_CUSTOMIZATION_STRING_BYTES 36
+#define KMAC_CMD_MAX_KEY_BYTES 64
+
+// clang-format off
+
+#define KMAC_MODE(_, value) \
+    value(_, Kmac128) \
+    value(_, Kmac256)
+UJSON_SERDE_ENUM(CryptotestKmacMode, cryptotest_kmac_mode_t, KMAC_MODE);
+
+#define KMAC_REQUIRED_TAG_LENGTH(field, string) \
+    field(required_tag_length, size_t)
+UJSON_SERDE_STRUCT(CryptotestKmacRequiredTagLength, cryptotest_kmac_required_tag_length_t, KMAC_REQUIRED_TAG_LENGTH);
+
+#define KMAC_MESSAGE(field, string) \
+    field(message, uint8_t, KMAC_CMD_MAX_MESSAGE_BYTES) \
+    field(message_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestKmacMessage, cryptotest_kmac_message_t, KMAC_MESSAGE);
+
+#define KMAC_KEY(field, string) \
+    field(key, uint8_t, KMAC_CMD_MAX_KEY_BYTES) \
+    field(key_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestKmacKey, cryptotest_kmac_key_t, KMAC_KEY);
+
+#define KMAC_CUSTOMIZATION_STRING(field, string) \
+    field(customization_string, uint8_t, KMAC_CMD_MAX_CUSTOMIZATION_STRING_BYTES) \
+    field(customization_string_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestKmacCustomizationString, cryptotest_kmac_customization_string_t, KMAC_CUSTOMIZATION_STRING);
+
+#define KMAC_TAG(field, string) \
+    field(tag, uint8_t, KMAC_CMD_MAX_TAG_BYTES) \
+    field(tag_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestKmacTag, cryptotest_kmac_tag_t, KMAC_TAG);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_KMAC_COMMANDS_H_

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -42,6 +42,11 @@ ujson_rust(
     srcs = ["//sw/device/tests/crypto/cryptotest/json:hmac_commands"],
 )
 
+ujson_rust(
+    name = "kmac_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:kmac_commands"],
+)
+
 rust_library(
     name = "cryptotest_commands",
     srcs = [
@@ -52,6 +57,7 @@ rust_library(
         "src/ecdsa_commands.rs",
         "src/hash_commands.rs",
         "src/hmac_commands.rs",
+        "src/kmac_commands.rs",
         "src/lib.rs",
     ],
     compile_data = [
@@ -62,6 +68,7 @@ rust_library(
         ":ecdsa_commands_rust",
         ":hash_commands_rust",
         ":hmac_commands_rust",
+        ":kmac_commands_rust",
     ],
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
@@ -71,6 +78,7 @@ rust_library(
         "ecdsa_commands_loc": "$(execpath :ecdsa_commands_rust)",
         "hash_commands_loc": "$(execpath :hash_commands_rust)",
         "hmac_commands_loc": "$(execpath :hmac_commands_rust)",
+        "kmac_commands_loc": "$(execpath :kmac_commands_rust)",
     },
     deps = [
         "//sw/host/opentitanlib",

--- a/sw/host/cryptotest/ujson_lib/src/kmac_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/kmac_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("kmac_commands_loc"));

--- a/sw/host/cryptotest/ujson_lib/src/lib.rs
+++ b/sw/host/cryptotest/ujson_lib/src/lib.rs
@@ -8,3 +8,4 @@ pub mod ecdh_commands;
 pub mod ecdsa_commands;
 pub mod hash_commands;
 pub mod hmac_commands;
+pub mod kmac_commands;

--- a/sw/host/tests/crypto/kmac_kat/BUILD
+++ b/sw/host/tests/crypto/kmac_kat/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/kmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/kmac_kat/src/main.rs
@@ -1,0 +1,176 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use std::fs;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::kmac_commands::{
+    CryptotestKmacCustomizationString, CryptotestKmacKey, CryptotestKmacMessage,
+    CryptotestKmacMode, CryptotestKmacRequiredTagLength, CryptotestKmacTag,
+};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    kmac_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KmacTestCase {
+    vendor: String,
+    test_case_id: usize,
+    algorithm: String,
+    mode: usize,
+    key: Vec<u8>,
+    message: Vec<u8>,
+    customization_string: Vec<u8>,
+    tag: Vec<u8>,
+    result: bool,
+}
+
+const KMAC_CMD_MAX_MESSAGE_BYTES: usize = 256;
+
+// These values are limitations of OpenTitan's KMAC HWIP
+const KMAC_CMD_MAX_CUSTOMIZATION_STRING_BYTES: usize = 36;
+const KMAC_CMD_MAX_KEY_BYTES: usize = 64;
+
+fn run_kmac_testcase(
+    test_case: &KmacTestCase,
+    opts: &Opts,
+    transport: &TransportWrapper,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "vendor: {}, test case: {}",
+        test_case.vendor,
+        test_case.test_case_id
+    );
+    let uart = transport.uart("console")?;
+
+    assert_eq!(test_case.algorithm.as_str(), "kmac");
+    CryptotestCommand::Kmac.send(&*uart)?;
+
+    assert!(
+        test_case.key.len() <= KMAC_CMD_MAX_KEY_BYTES,
+        "Key too long for device (got = {}, max = {})",
+        test_case.key.len(),
+        KMAC_CMD_MAX_KEY_BYTES,
+    );
+    assert!(
+        test_case.message.len() <= KMAC_CMD_MAX_MESSAGE_BYTES,
+        "Message too long for device firmware configuration (got = {}, max = {})",
+        test_case.message.len(),
+        KMAC_CMD_MAX_MESSAGE_BYTES,
+    );
+    assert!(
+        test_case.customization_string.len() <= KMAC_CMD_MAX_CUSTOMIZATION_STRING_BYTES,
+        "Customization string too long for device (got = {}, max = {})",
+        test_case.customization_string.len(),
+        KMAC_CMD_MAX_CUSTOMIZATION_STRING_BYTES,
+    );
+
+    match test_case.mode {
+        128 => CryptotestKmacMode::Kmac128,
+        256 => CryptotestKmacMode::Kmac256,
+        _ => panic!("Unsupported KMAC mode"),
+    }
+    .send(&*uart)?;
+
+    CryptotestKmacRequiredTagLength {
+        // Set this to the expected tag length, so we guarantee we perform a fair comparison with
+        // the expected value.
+        required_tag_length: test_case.tag.len(),
+    }
+    .send(&*uart)?;
+
+    CryptotestKmacKey {
+        key: ArrayVec::try_from(test_case.key.as_slice()).unwrap(),
+        key_len: test_case.key.len(),
+    }
+    .send(&*uart)?;
+
+    CryptotestKmacMessage {
+        message: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
+        message_len: test_case.message.len(),
+    }
+    .send(&*uart)?;
+
+    CryptotestKmacCustomizationString {
+        customization_string: ArrayVec::try_from(test_case.customization_string.as_slice())
+            .unwrap(),
+        customization_string_len: test_case.customization_string.len(),
+    }
+    .send(&*uart)?;
+
+    let kmac_tag = CryptotestKmacTag::recv(&*uart, opts.timeout, false)?;
+    // Cryptolib could have chosen to return more tag bytes than we asked for. If it did, we can
+    // ignore the extra ones.
+    let success = test_case.tag[..] == kmac_tag.tag[..test_case.tag.len()];
+    if test_case.result != success {
+        log::info!(
+            "FAILED test #{}: expected = {}, actual = {}",
+            test_case.test_case_id,
+            test_case.result,
+            success
+        );
+    }
+    if success != test_case.result {
+        *fail_counter += 1;
+    }
+    Ok(())
+}
+
+fn test_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.kmac_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let kmac_tests: Vec<KmacTestCase> = serde_json::from_str(&raw_json)?;
+
+        for kmac_test in &kmac_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_kmac_testcase(kmac_test, opts, transport, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_kmac, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the test harness for KMAC. The PR structure is identical to #21181, which serves the same purpose for HMAC.