### PR TITLE
[sec_cm,pwrmgr,rstmgr] Update sec_cm_testplans

### DIFF
--- a/hw/ip_templates/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -28,8 +28,6 @@
       desc: '''Verify the countermeasure(s) BUS.INTEGRITY.
             This entry is covered by tl_access_test
             (hw/dv/tools/dvsim/tests/tl_access_tests.hjson)
-            This will not trigger rst_req, but
-            send fatal alert
             '''
       stage: V2S
       tests: ["pwrmgr_tl_intg_err"]
@@ -80,7 +78,8 @@
             - Drive tb.dut.sw_rst_req_i with mixed valid and invalid values
 
             **Check**:
-            - See sw rst only happens when dut gets valid value.
+            - See sw rst only happens when dut gets valid value by
+              probing fast fsm state. The state has to move low power state.
             - Collect coverage by binding cip_mubi_cov_if to
               tb.dut.sw_rst_req_i
             '''
@@ -96,11 +95,12 @@
               or reset failure by stopping clock or asserting reset.
 
             **Check**:
-            - Expecting esc_timeout event and trigger rstreqs[ResetEscIdx]
-              and fatal alert event. After alert agent process
-              the alert by asserting escalation reset, see if dut
-              is back to normal operation state.
-
+            - Expecting fatal alert event and rstreqs[ResetEscIdx].
+            - Add assertion to see if u_esc_timeout happens, then
+              rstreqs[ResetEscIdx] should be asserted.
+            - After the alert agent processese the alert
+              by asserting escalation reset,
+              see if dut is back to normal operation state.
             '''
       stage: V2S
       tests: ["pwrmgr_esc_clk_rst_malfunc"]
@@ -116,7 +116,8 @@
 
             **Check**:
             - Detect fast state transition to FastPwrStateResetPrep.
-              And this will trigger rstreqs[ResetEscIdx].
+            - Add assertion to check if u_sec_timeout happens, then
+              rstreqs[ResetEscIdx] should be asserted.
             '''
       stage: V2S
       tests: ["pwrmgr_sec_cm"]
@@ -139,11 +140,11 @@
             This is caused by any invalid (slow|fast) state.
 
             **Check**:
-            If slow state is invalid, fast state becomes FastPwrStateInvalid,
-            pwr_ast_o.pwr_clamp =1 and pwr_ast_o.main_pd_n = 0.
-            If fast state is invalid, pwr_rst_o.rst_lc_req = 3,
-            pwr_rst_o.rst_sys_req = 3 and pwr_clk_o = 0.
-            Dut should be recovered by asserting rst_n = 0.
+            - If slow state is invalid, fast state becomes FastPwrStateInvalid,
+              pwr_ast_o.pwr_clamp =1 and pwr_ast_o.main_pd_n = 0.
+            - If fast state is invalid, pwr_rst_o.rst_lc_req is all one,
+              pwr_rst_o.rst_sys_req is all one  and pwr_clk_o = 0.
+              Dut should be recovered by asserting rst_n = 0.
             '''
       stage: V2S
       tests: ["pwrmgr_sec_cm"]
@@ -153,11 +154,12 @@
       desc: '''Verify the countermeasure(s) CTRL_FLOW.GLOBAL_ESC.
 
             **Stimulus**:
-            - Send escalation request to esc_rst_tx_i.
+            - Send escalation request to esc_rst_tx_i
 
             **Check**:
             - Check fast state transition to FastPwrStateResetPrep
-              and get pwr_rst_req.
+            - Add assertion to see if we get pwr_rst_o.rstreqs[ResetEscIdx]
+              set when dut receives esc_rst_tx_i
             '''
       stage: V2S
       tests: ["pwrmgr_global_esc"]
@@ -167,11 +169,12 @@
       desc: '''Verify the countermeasure(s) MAIN_PD.RST.LOCAL_ESC.
 
             **Stimulus**:
-            - Create power reset glitch by setting 'tb.dut.rst_main_ni' to 0.
+            - Create power reset glitch by setting tb.dut.rst_main_ni
+              and tb.dut.pwr_ast_i.main_pok to 0
 
             **Check**:
             - Check fast state transition to FastPwrStateResetPrep
-              and get pwr_rst_req.
+            - Add assertion to see if we get pwr_rst_o.rstreqs[ResetMainPwrIdx]
             '''
       stage: V2S
       tests: ["pwrmgr_glitch"]
@@ -189,7 +192,7 @@
             **Check**:
             - After the csr update under PWRMGR.CTRL_CFG_REGWEN = 0,
               read back and check the value is not updated by
-              the csr udate attempt.
+              the csr update attempt.
             '''
       stage: V2S
       tests: ["pwrmgr_sec_cm_ctrl_config_regwen"]

--- a/hw/ip_templates/rstmgr/data/rstmgr_sec_cm_testplan.hjson
+++ b/hw/ip_templates/rstmgr/data/rstmgr_sec_cm_testplan.hjson
@@ -40,7 +40,7 @@
             value during the test.
 
             **Check**:
-            If dut accepts any of invalid values, test will fail by turing dut to scanmode.
+            If dut accepts any of invalid values, test will fail by turning dut to scanmode.
             '''
       stage: V2S
       tests: ["rstmgr_sec_cm_scan_intersig_mubi"]
@@ -50,10 +50,12 @@
       desc: '''Verify the countermeasure(s) LEAF.RST.BKGN_CHK.
 
             ** Stimulus**:
-            Execute a series of reset event - lowpower, hwreq, ndm, and
+            Execute a series of reset event - lowpower, hwreq, and
             sw reset -. And at the beginning of these events, create
-            reset consistency error to one of 27 leaf modules.
-            Do the same test for all 27 modules.
+            reset consistency error to one of 25 leaf modules.
+            (exclude u_daon_por_io_div4 and u_daon_por_io_div4_shadowed,
+            see #11858, #12729 for details)
+            Do the same test for all 25 modules.
 
             **Check**:
             Upon asserting each reset consistency error,

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -28,8 +28,6 @@
       desc: '''Verify the countermeasure(s) BUS.INTEGRITY.
             This entry is covered by tl_access_test
             (hw/dv/tools/dvsim/tests/tl_access_tests.hjson)
-            This will not trigger rst_req, but
-            send fatal alert
             '''
       stage: V2S
       tests: ["pwrmgr_tl_intg_err"]
@@ -80,7 +78,8 @@
             - Drive tb.dut.sw_rst_req_i with mixed valid and invalid values
 
             **Check**:
-            - See sw rst only happens when dut gets valid value.
+            - See sw rst only happens when dut gets valid value by
+              probing fast fsm state. The state has to move low power state.
             - Collect coverage by binding cip_mubi_cov_if to
               tb.dut.sw_rst_req_i
             '''
@@ -96,11 +95,12 @@
               or reset failure by stopping clock or asserting reset.
 
             **Check**:
-            - Expecting esc_timeout event and trigger rstreqs[ResetEscIdx]
-              and fatal alert event. After alert agent process
-              the alert by asserting escalation reset, see if dut
-              is back to normal operation state.
-
+            - Expecting fatal alert event and rstreqs[ResetEscIdx].
+            - Add assertion to see if u_esc_timeout happens, then
+              rstreqs[ResetEscIdx] should be asserted.
+            - After the alert agent processese the alert
+              by asserting escalation reset,
+              see if dut is back to normal operation state.
             '''
       stage: V2S
       tests: ["pwrmgr_esc_clk_rst_malfunc"]
@@ -116,7 +116,8 @@
 
             **Check**:
             - Detect fast state transition to FastPwrStateResetPrep.
-              And this will trigger rstreqs[ResetEscIdx].
+            - Add assertion to check if u_sec_timeout happens, then
+              rstreqs[ResetEscIdx] should be asserted.
             '''
       stage: V2S
       tests: ["pwrmgr_sec_cm"]
@@ -139,11 +140,11 @@
             This is caused by any invalid (slow|fast) state.
 
             **Check**:
-            If slow state is invalid, fast state becomes FastPwrStateInvalid,
-            pwr_ast_o.pwr_clamp =1 and pwr_ast_o.main_pd_n = 0.
-            If fast state is invalid, pwr_rst_o.rst_lc_req = 3,
-            pwr_rst_o.rst_sys_req = 3 and pwr_clk_o = 0.
-            Dut should be recovered by asserting rst_n = 0.
+            - If slow state is invalid, fast state becomes FastPwrStateInvalid,
+              pwr_ast_o.pwr_clamp =1 and pwr_ast_o.main_pd_n = 0.
+            - If fast state is invalid, pwr_rst_o.rst_lc_req is all one,
+              pwr_rst_o.rst_sys_req is all one  and pwr_clk_o = 0.
+              Dut should be recovered by asserting rst_n = 0.
             '''
       stage: V2S
       tests: ["pwrmgr_sec_cm"]
@@ -153,11 +154,12 @@
       desc: '''Verify the countermeasure(s) CTRL_FLOW.GLOBAL_ESC.
 
             **Stimulus**:
-            - Send escalation request to esc_rst_tx_i.
+            - Send escalation request to esc_rst_tx_i
 
             **Check**:
             - Check fast state transition to FastPwrStateResetPrep
-              and get pwr_rst_req.
+            - Add assertion to see if we get pwr_rst_o.rstreqs[ResetEscIdx]
+              set when dut receives esc_rst_tx_i
             '''
       stage: V2S
       tests: ["pwrmgr_global_esc"]
@@ -167,11 +169,12 @@
       desc: '''Verify the countermeasure(s) MAIN_PD.RST.LOCAL_ESC.
 
             **Stimulus**:
-            - Create power reset glitch by setting 'tb.dut.rst_main_ni' to 0.
+            - Create power reset glitch by setting tb.dut.rst_main_ni
+              and tb.dut.pwr_ast_i.main_pok to 0
 
             **Check**:
             - Check fast state transition to FastPwrStateResetPrep
-              and get pwr_rst_req.
+            - Add assertion to see if we get pwr_rst_o.rstreqs[ResetMainPwrIdx]
             '''
       stage: V2S
       tests: ["pwrmgr_glitch"]
@@ -189,7 +192,7 @@
             **Check**:
             - After the csr update under PWRMGR.CTRL_CFG_REGWEN = 0,
               read back and check the value is not updated by
-              the csr udate attempt.
+              the csr update attempt.
             '''
       stage: V2S
       tests: ["pwrmgr_sec_cm_ctrl_config_regwen"]

--- a/hw/top_earlgrey/ip_autogen/rstmgr/data/rstmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/data/rstmgr_sec_cm_testplan.hjson
@@ -40,7 +40,7 @@
             value during the test.
 
             **Check**:
-            If dut accepts any of invalid values, test will fail by turing dut to scanmode.
+            If dut accepts any of invalid values, test will fail by turning dut to scanmode.
             '''
       stage: V2S
       tests: ["rstmgr_sec_cm_scan_intersig_mubi"]
@@ -50,10 +50,12 @@
       desc: '''Verify the countermeasure(s) LEAF.RST.BKGN_CHK.
 
             ** Stimulus**:
-            Execute a series of reset event - lowpower, hwreq, ndm, and
+            Execute a series of reset event - lowpower, hwreq, and
             sw reset -. And at the beginning of these events, create
-            reset consistency error to one of 27 leaf modules.
-            Do the same test for all 27 modules.
+            reset consistency error to one of 25 leaf modules.
+            (exclude u_daon_por_io_div4 and u_daon_por_io_div4_shadowed,
+            see #11858, #12729 for details)
+            Do the same test for all 25 modules.
 
             **Check**:
             Upon asserting each reset consistency error,


### PR DESCRIPTION
The old contents were lost in the transition to ipgen. Update the sec_cm_testplan files in ip_templates. These testplans are
top-specific, so they may need to become templates.
