### PR TITLE
[lc_ctrl] Always allow transitions into scrap 

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -15,10 +15,10 @@
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_lc_ctrl",
-  version:            "1.0.0",
+  version:            "2.0.0",
   life_stage:         "L1",
-  design_stage:       "D3",
-  verification_stage: "V2S",
+  design_stage:       "D1",
+  verification_stage: "V1",
   dif_stage:          "S2",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -545,7 +545,10 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     end
 
     // Transition to SCRAP state always programs LcCnt24
-    if (LcTargetState == LcStScrap) lc_cnt_exp = LcCnt24;
+    if (LcTargetState == LcStScrap) begin
+      lc_cnt_exp = LcCnt24;
+      lc_state_exp = LcStScrap;
+    end
 
     `uvm_info(`gfn, $sformatf(
               "predict_otp_prog_req: state=%s count=%s", lc_state_exp.name(), lc_cnt_exp.name),

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -78,7 +78,7 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
       cfg.set_test_phase(LcCtrlDutReady);
 
       // SW transition request
-      if (valid_state_for_trans(lc_state) && lc_cnt != LcCnt24) begin
+      if (valid_state_for_trans(lc_state)) begin
         lc_ctrl_state_pkg::lc_token_t token_val = get_random_token();
         randomize_next_lc_state(dec_lc_state(lc_state));
         `uvm_info(`gfn, $sformatf(
@@ -109,7 +109,10 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
   // need to randomize here because associative array's index cannot be a rand input in constraint
   virtual function void randomize_next_lc_state(dec_lc_state_e curr_lc_state);
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(next_lc_state,
-                                       next_lc_state inside {VALID_NEXT_STATES[curr_lc_state]};)
+                                       next_lc_state inside {VALID_NEXT_STATES[curr_lc_state]};
+                                       // The only valid transition when the counter is maxed is
+                                       // a transition into scrap.
+                                       if (lc_cnt == LcCnt24) next_lc_state == DecLcStScrap;)
   endfunction
 
   // This function add otp_program_i's error bit field from the otp_prog_pull_agent device driver.

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_transition.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_transition.sv
@@ -110,9 +110,15 @@ module lc_ctrl_state_transition
         default:  trans_cnt_oflw_error_o = 1'b1;
       endcase // lc_cnt_i
 
-      // In case the transition target is SCRAP, max out the counter.
+      // We always allow transitions into the SCRAP state, so the overflow error is silenced in that
+      // particular case. In that case we max out the transition counter and force the
+      // next_lc_state already into SCRAP so that the error silencing above cannot be abused. This
+      // means that when moving to SCRAP state, we program LcStScrap twice: once during the counter
+      // increment phase, and once during the actual state programming phase.
       if (trans_target_i == {DecLcStateNumRep{DecLcStScrap}}) begin
         next_lc_cnt_o = LcCnt24;
+        next_lc_state_o = LcStScrap;
+        trans_cnt_oflw_error_o = 1'b0;
       end
     end
 


### PR DESCRIPTION
We should always allow transitions into scrap, no matter whether the transition counter is maxed out or not.

In order to prevent any abuse of this unconditional transition path, we max out the counter and program the LC state to SCRAP already in the transition counter increment phase instead of programming the counter state and LC state separately in two phases as all other transitions.

This fixes https://github.com/lowRISC/opentitan/issues/13617.