### PR TITLE
[pentest] Fix KMAC SCA code

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
@@ -449,7 +449,7 @@ status_t handle_kmac_sca_init(ujson_t *uj) {
   // Read mode. FPGA or discrete.
   cryptotest_kmac_sca_fpga_mode_t uj_data;
   TRY(ujson_deserialize_cryptotest_kmac_sca_fpga_mode_t(uj, &uj_data));
-  if (read_32(uj_data.fpga_mode) == 0x01) {
+  if (uj_data.fpga_mode == 0x01) {
     fpga_mode = true;
   }
   // Setup the trigger.
@@ -665,6 +665,7 @@ status_t handle_kmac_sca_batch(ujson_t *uj) {
   }
 
   for (uint32_t i = 0; i < num_encryptions; ++i) {
+    kmac_reset();
     memcpy(kmac_key.share0, kmac_batch_keys[i], kKeyLength);
 
     sca_set_trigger_high();

--- a/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
@@ -369,7 +369,7 @@ status_t handle_sha3_sca_disable_masking(ujson_t *uj) {
   UJSON_CHECK_DIF_OK(
       dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
 
-  if (read_32(uj_data.masks_off) == 0x01) {
+  if (uj_data.masks_off == 0x01) {
     config.entropy_fast_process = kDifToggleEnabled;
     config.msg_mask = kDifToggleDisabled;
   } else {
@@ -381,7 +381,7 @@ status_t handle_sha3_sca_disable_masking(ujson_t *uj) {
   kmac_block_until_idle();
   // Acknowledge the command. This is crucial to be in sync with the host.
   cryptotest_sha3_sca_status_t uj_status;
-  *uj_status.status = 0;
+  uj_status.status = 0;
   RESP_OK(ujson_serialize_cryptotest_sha3_sca_status_t, uj, &uj_status);
 
   return OK_STATUS(0);
@@ -554,7 +554,7 @@ status_t handle_sha3_sca_batch(ujson_t *uj) {
 
   // Acknowledge the batch command. This is crucial to be in sync with the host
   cryptotest_sha3_sca_status_t uj_status;
-  *uj_status.status = 0;
+  uj_status.status = 0;
   RESP_OK(ujson_serialize_cryptotest_sha3_sca_status_t, uj, &uj_status);
   // Send the batch digest to the host for verification.
   cryptotest_sha3_sca_batch_digest_t uj_output;

--- a/sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h
@@ -11,7 +11,6 @@ extern "C" {
 
 #define KMACSCA_CMD_MAX_BATCH_DIGEST_BYTES 32
 #define KMACSCA_CMD_MAX_DATA_BYTES 16
-#define KMACSCA_CMD_MAX_FPGA_MODE_BYTES 1
 #define KMACSCA_CMD_MAX_KEY_BYTES 16
 #define KMACSCA_CMD_MAX_LFSR_BYTES 4
 #define KMACSCA_CMD_MAX_MSG_BYTES 16
@@ -37,7 +36,7 @@ UJSON_SERDE_STRUCT(CryptotestKmacScaKey, cryptotest_kmac_sca_key_t, KMAC_SCA_KEY
 UJSON_SERDE_STRUCT(CryptotestKmacScaLfsr, cryptotest_kmac_sca_lfsr_t, KMAC_SCA_LFSR);
 
 #define KMAC_SCA_FPGA_MODE(field, string) \
-    field(fpga_mode, uint8_t, KMACSCA_CMD_MAX_FPGA_MODE_BYTES)
+    field(fpga_mode, uint8_t)
 UJSON_SERDE_STRUCT(CryptotestKmacScaFpgaMode, cryptotest_kmac_sca_fpga_mode_t, KMAC_SCA_FPGA_MODE);
 
 #define KMAC_SCA_DATA(field, string) \

--- a/sw/device/tests/crypto/cryptotest/json/sha3_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/sha3_sca_commands.h
@@ -11,8 +11,6 @@ extern "C" {
 
 #define SHA3SCA_CMD_MAX_BATCH_DIGEST_BYTES 32
 #define SHA3SCA_CMD_MAX_DATA_BYTES 16
-#define SHA3SCA_CMD_MAX_FPGA_MODE_BYTES 1
-#define SHA3SCA_CMD_MAX_MASKS_OFF_BYTES 1
 #define SHA3SCA_CMD_MAX_LFSR_BYTES 4
 #define SHA3SCA_CMD_MAX_MSG_BYTES 16
 #define SHA3SCA_CMD_MAX_STATUS_BYTES 1
@@ -29,7 +27,7 @@ extern "C" {
 UJSON_SERDE_ENUM(Sha3ScaSubcommand, sha3_sca_subcommand_t, SHA3_SCA_SUBCOMMAND);
 
 #define SHA3_SCA_MASKS(field, string) \
-    field(masks_off, uint8_t, SHA3SCA_CMD_MAX_MASKS_OFF_BYTES)
+    field(masks_off, uint8_t)
 UJSON_SERDE_STRUCT(CryptotestSha3ScaMasks, cryptotest_sha3_sca_masks_off_t, SHA3_SCA_MASKS);
 
 #define SHA3_SCA_LFSR(field, string) \
@@ -50,7 +48,7 @@ UJSON_SERDE_STRUCT(CryptotestSha3ScaFpgaMode, cryptotest_sha3_sca_fpga_mode_t, S
 UJSON_SERDE_STRUCT(CryptotestSha3ScaMsg, cryptotest_sha3_sca_msg_t, SHA3_SCA_MSG);
 
 #define SHA3_SCA_STATUS(field, string) \
-    field(status, uint8_t, SHA3SCA_CMD_MAX_STATUS_BYTES)
+    field(status, uint8_t)
 UJSON_SERDE_STRUCT(CryptotestSha3ScaStatus, cryptotest_sha3_sca_status_t, SHA3_SCA_STATUS);
 
 #define SHA3_SCA_BATCH_DIGEST(field, string) \


### PR DESCRIPTION
This PR fixes two bugs that were previously introduced:
- Use data field for fpga_mode & masks_off instead of array. This is related to #20946 
- Revert removal of kmac_reset() in batch mode. This was accidently removed in #20772.