### PR TITLE
[flash_ctrl] Change FIFO interrupts to status type

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -419,6 +419,7 @@ class cip_base_vseq #(
 
   // generic task to check interrupt test reg functionality
   virtual task run_intr_test_vseq(int num_times = 1);
+    import dv_utils_pkg::interrupt_t;
     dv_base_reg intr_csrs[$];
     dv_base_reg intr_test_csrs[$];
 
@@ -461,9 +462,9 @@ class cip_base_vseq #(
 
         // if it's intr_state, also check the interrupt pin value
         if (!uvm_re_match("intr_state*", intr_csrs[i].get_name())) begin
-          dv_utils_pkg::interrupt_t exp_intr_pin = intr_csrs[i].get_intr_pins_exp_value();
-          dv_utils_pkg::interrupt_t act_intr_pin = cfg.intr_vif.sample();
-          act_intr_pin &= dv_utils_pkg::interrupt_t'((1 << cfg.num_interrupts) - 1);
+          interrupt_t exp_intr_pin = intr_csrs[i].get_intr_pins_exp_value();
+          interrupt_t act_intr_pin = cfg.intr_vif.sample();
+          act_intr_pin &= interrupt_t'((1 << cfg.num_interrupts) - 1);
           `DV_CHECK_CASE_EQ(exp_intr_pin, act_intr_pin)
         end // if (!uvm_re_match
       end // foreach (intr_csrs[i])
@@ -476,22 +477,39 @@ class cip_base_vseq #(
   endtask
 
   // Task to clear register intr status bits
-  virtual task clear_all_interrupts();
-    if (cfg.num_interrupts == 0) return;
-    foreach (intr_state_csrs[i]) begin
-      bit [BUS_DW-1:0] data;
-      csr_rd(.ptr(intr_state_csrs[i]), .value(data));
-      if (data != 0) begin
-        `uvm_info(`gtn, $sformatf("Clearing %0s", intr_state_csrs[i].get_name()), UVM_HIGH)
-        csr_wr(.ptr(intr_state_csrs[i]), .value(data));
-        csr_rd(.ptr(intr_state_csrs[i]), .value(data));
-        if (!cfg.under_reset) `DV_CHECK_EQ(data, 0)
-        else break;
-      end
+  virtual task clear_interrupt_reg(dv_base_reg register, bit [BUS_DW-1:0] ro_mask);
+    bit [BUS_DW-1:0] data;
+    // Status type interrupts are read-only and cannot be cleared by writing 1 to them.
+    // Instead, the underlying condition needs to be resolved (e.g. drain a FIFO that is full).
+    // Therefore, we use the RO bitmask to mask the writes / reads below.
+    csr_rd(.ptr(register), .value(data));
+    if ((data & ~ro_mask) != 0) begin
+      `uvm_info(`gtn, $sformatf("Clearing status bits in %0s", register.get_name()),
+                UVM_HIGH)
+      csr_wr(.ptr(register), .value(data & ~ro_mask));
+      csr_rd(.ptr(register), .value(data));
+      if (!cfg.under_reset) `DV_CHECK_EQ(data & ~ro_mask, 0)
     end
+  endtask
+
+  // Task to clear register intr status bits
+  virtual task clear_all_interrupts();
+    import dv_utils_pkg::interrupt_t;
+    interrupt_t irq_ro_mask = '0;
+    if (cfg.num_interrupts == 0) return;
+
+    // Iterate over all interrupt registers (typically there is only one).
+    foreach (intr_state_csrs[i]) begin
+      irq_ro_mask[i*BUS_DW +: BUS_DW] = BUS_DW'(intr_state_csrs[i].get_ro_mask());
+      clear_interrupt_reg(intr_state_csrs[i], irq_ro_mask[i*BUS_DW +: BUS_DW]);
+      if (cfg.under_reset) break;
+    end
+
     if (!cfg.under_reset) begin
-      dv_utils_pkg::interrupt_t mask = dv_utils_pkg::interrupt_t'((1 << cfg.num_interrupts) - 1);
-      `DV_CHECK_EQ(cfg.intr_vif.sample() & mask, '0)
+      // Status type interrupts may remain asserted, hence we have to mask them away.
+      interrupt_t all_interrupts = interrupt_t'((1 << cfg.num_interrupts) - 1);
+      interrupt_t clearable_mask = all_interrupts & ~irq_ro_mask;
+      `DV_CHECK_EQ(cfg.intr_vif.sample() & clearable_mask, '0)
     end
   endtask
 

--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -102,6 +102,15 @@ class dv_base_reg extends uvm_reg;
     end
   endfunction
 
+  // Return a mask of read-only bits in the register.
+  virtual function uvm_reg_data_t get_ro_mask();
+    dv_base_reg_field flds[$];
+    this.get_dv_base_reg_fields(flds);
+    foreach (flds[i]) begin
+      get_ro_mask |= flds[i].get_ro_mask();
+    end
+  endfunction
+
   // this function can only be called when this reg is intr_state reg
   // Example: ral.intr_state.get_intr_pins_exp_value(). And it returns value of
   // intr_state & intr_enable, which represents value of interrupt pins

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -188,9 +188,17 @@ class dv_base_reg_field extends uvm_reg_field;
     return m_original_access;
   endfunction
 
+  // Return a mask of valid bits in the field.
   virtual function uvm_reg_data_t get_field_mask();
     get_field_mask = (1'b1 << this.get_n_bits()) - 1;
     get_field_mask = get_field_mask << this.get_lsb_pos();
+  endfunction
+
+  // Return a mask of read-only bits in the field.
+  virtual function uvm_reg_data_t get_ro_mask();
+    bit is_ro = (this.get_access() == "RO");
+    get_ro_mask = (is_ro << this.get_n_bits()) - is_ro;
+    get_ro_mask = get_ro_mask << this.get_lsb_pos();
   endfunction
 
   virtual function void set_original_access(string access);

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -143,7 +143,7 @@ class dv_base_reg_field extends uvm_reg_field;
       uvm_reg_field intr_state_fld = get_intr_state_field();
       uvm_reg_data_t predict_val;
       if (intr_state_fld.get_access == "RO") begin // status interrupt
-        predict_val = field_val;
+        predict_val = field_val | intr_state_fld.get_reset();
       end else begin // regular W1C interrupt
         `DV_CHECK_STREQ(intr_state_fld.get_access, "W1C")
         predict_val = field_val | `gmv(intr_state_fld);

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -30,10 +30,10 @@
           commit_id:          "7049fd0d5d48e20772f8ebf32b240faa0dad5528",
       },
       {
-          version:            "1.0.0",
+          version:            "2.0.0",
           life_stage:         "L1",
-          design_stage:       "D2S",
-          verification_stage: "V2S",
+          design_stage:       "D1",
+          verification_stage: "V1",
           dif_stage:          "S2",
       },
   ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -55,12 +55,14 @@
     { name: "tdo", desc: "jtag output" },
   ],
   interrupt_list: [
-    { name: "prog_empty", desc: "Program FIFO empty" },
-    { name: "prog_lvl",   desc: "Program FIFO drained to level" },
-    { name: "rd_full",    desc: "Read FIFO full" },
-    { name: "rd_lvl",     desc: "Read FIFO filled to level" },
-    { name: "op_done",    desc: "Operation complete" },
-    { name: "corr_err",   desc: "Correctable error encountered"},
+    // The first two status interrupts assert by default, since the FIFO is empty.
+    // This is captured in the Hjson via the `default` key so that automatically generated tests can incorporate this information.
+    { name: "prog_empty", type: "status", desc: "Program FIFO empty",            default: "1"},
+    { name: "prog_lvl",   type: "status", desc: "Program FIFO drained to level", default: "1"},
+    { name: "rd_full",    type: "status", desc: "Read FIFO full",                            },
+    { name: "rd_lvl",     type: "status", desc: "Read FIFO filled to level",                 },
+    { name: "op_done",    type: "event",  desc: "Operation complete",                        },
+    { name: "corr_err",   type: "event",  desc: "Correctable error encountered",             },
   ],
 
   alert_list: [

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -41,10 +41,10 @@
           commit_id:          "7049fd0d5d48e20772f8ebf32b240faa0dad5528",
       },
       {
-          version:            "1.0.0",
+          version:            "2.0.0",
           life_stage:         "L1",
-          design_stage:       "D2S",
-          verification_stage: "V2S",
+          design_stage:       "D1",
+          verification_stage: "V1",
           dif_stage:          "S2",
       },
   ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -66,12 +66,14 @@
     { name: "tdo", desc: "jtag output" },
   ],
   interrupt_list: [
-    { name: "prog_empty", desc: "Program FIFO empty" },
-    { name: "prog_lvl",   desc: "Program FIFO drained to level" },
-    { name: "rd_full",    desc: "Read FIFO full" },
-    { name: "rd_lvl",     desc: "Read FIFO filled to level" },
-    { name: "op_done",    desc: "Operation complete" },
-    { name: "corr_err",   desc: "Correctable error encountered"},
+    // The first two status interrupts assert by default, since the FIFO is empty.
+    // This is captured in the Hjson via the `default` key so that automatically generated tests can incorporate this information.
+    { name: "prog_empty", type: "status", desc: "Program FIFO empty",            default: "1"},
+    { name: "prog_lvl",   type: "status", desc: "Program FIFO drained to level", default: "1"},
+    { name: "rd_full",    type: "status", desc: "Read FIFO full",                            },
+    { name: "rd_lvl",     type: "status", desc: "Read FIFO filled to level",                 },
+    { name: "op_done",    type: "event",  desc: "Operation complete",                        },
+    { name: "corr_err",   type: "event",  desc: "Correctable error encountered",             },
   ],
 
   alert_list: [

--- a/hw/ip/flash_ctrl/doc/interfaces.md
+++ b/hw/ip/flash_ctrl/doc/interfaces.md
@@ -48,10 +48,10 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 | Interrupt Name   | Type   | Description                   |
 |:-----------------|:-------|:------------------------------|
-| prog_empty       | Event  | Program FIFO empty            |
-| prog_lvl         | Event  | Program FIFO drained to level |
-| rd_full          | Event  | Read FIFO full                |
-| rd_lvl           | Event  | Read FIFO filled to level     |
+| prog_empty       | Status | Program FIFO empty            |
+| prog_lvl         | Status | Program FIFO drained to level |
+| rd_full          | Status | Read FIFO full                |
+| rd_lvl           | Status | Read FIFO filled to level     |
 | op_done          | Event  | Operation complete            |
 | corr_err         | Event  | Correctable error encountered |
 

--- a/hw/ip/flash_ctrl/doc/registers.md
+++ b/hw/ip/flash_ctrl/doc/registers.md
@@ -122,13 +122,13 @@ It is implemented this way because the access window supports transaction back-p
 ## INTR_STATE
 Interrupt State Register
 - Offset: `0x0`
-- Reset default: `0x0`
+- Reset default: `0x3`
 - Reset mask: `0x3f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "prog_empty", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "prog_lvl", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rd_full", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rd_lvl", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "op_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "corr_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "prog_empty", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "prog_lvl", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "rd_full", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "rd_lvl", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "op_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "corr_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name       | Description                   |
@@ -136,10 +136,10 @@ Interrupt State Register
 |  31:6  |        |         |            | Reserved                      |
 |   5    |  rw1c  |   0x0   | corr_err   | Correctable error encountered |
 |   4    |  rw1c  |   0x0   | op_done    | Operation complete            |
-|   3    |  rw1c  |   0x0   | rd_lvl     | Read FIFO filled to level     |
-|   2    |  rw1c  |   0x0   | rd_full    | Read FIFO full                |
-|   1    |  rw1c  |   0x0   | prog_lvl   | Program FIFO drained to level |
-|   0    |  rw1c  |   0x0   | prog_empty | Program FIFO empty            |
+|   3    |   ro   |   0x0   | rd_lvl     | Read FIFO filled to level     |
+|   2    |   ro   |   0x0   | rd_full    | Read FIFO full                |
+|   1    |   ro   |   0x1   | prog_lvl   | Program FIFO drained to level |
+|   0    |   ro   |   0x1   | prog_empty | Program FIFO empty            |
 
 ## INTR_ENABLE
 Interrupt Enable Register

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -169,7 +169,6 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
 
   // interrupt mode buffer credit
   int       rd_crd = 16;
-  int       wr_crd = 4;
 
   // fifo level to trigger lvl interrupt
   int       rd_lvl = 0;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -254,7 +254,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                                          cfg.rd_lvl, cfg.wr_lvl), UVM_MEDIUM)
 
         flash_ctrl_fifo_levels_cfg_intr(cfg.rd_lvl, cfg.wr_lvl);
-        flash_ctrl_intr_enable(6'h3f);
+        flash_ctrl_intr_enable(6'h3c);
       end
     end
     otf_wr_pct_temp     = cfg.otf_wr_pct;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1124,35 +1124,22 @@ module flash_ctrl
     assign hw2reg.ecc_single_err_addr[i].d = {flash_phy_rsp.ecc_addr[i], {BusByteWidth{1'b0}}};
   end
 
-  logic sw_rd_fifo_wr_q;
-  logic prog_fifo_rd_q;
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      sw_rd_fifo_wr_q <= '0;
-      prog_fifo_rd_q <= '0;
-    end else begin
-      sw_rd_fifo_wr_q <= sw_rfifo_wen & sw_rfifo_wready;
-      prog_fifo_rd_q <= prog_fifo_rvalid & prog_fifo_ren;
-    end
-  end
-
-  // general interrupt events
   logic [LastIntrIdx-1:0] intr_event;
+  // Status types
+  assign intr_event[ProgEmpty] = !prog_fifo_rvalid;
+  // Check whether this FIFO has been drained to a certain level.
+  assign intr_event[ProgLvl]   = reg2hw.fifo_lvl.prog.q >= MaxFifoWidth'(prog_fifo_depth);
+  assign intr_event[RdFull]    = sw_rfifo_full;
+  // Check whether this FIFO has been filled to a certain level.
+  assign intr_event[RdLvl]     = reg2hw.fifo_lvl.rd.q <= sw_rfifo_depth;
+  // Event types
+  assign intr_event[OpDone]    = sw_ctrl_done;
+  assign intr_event[CorrErr]   = |flash_phy_rsp.ecc_single_err;
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(1),
-    .EnSync(0)
-  ) u_prog_empty_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(~prog_fifo_rvalid),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[ProgEmpty]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_prog_empty (
+    .IntrT ("Status")
+  ) u_intr_prog_empty (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[ProgEmpty]),
@@ -1165,20 +1152,10 @@ module flash_ctrl
     .intr_o                 (intr_prog_empty_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_prog_lvl_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(prog_fifo_rd_q & (reg2hw.fifo_lvl.prog.q == MaxFifoWidth'(prog_fifo_depth))),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[ProgLvl]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_prog_lvl (
+    .IntrT ("Status")
+  ) u_intr_prog_lvl (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[ProgLvl]),
@@ -1191,20 +1168,10 @@ module flash_ctrl
     .intr_o                 (intr_prog_lvl_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_rd_full_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(sw_rfifo_full),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[RdFull]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_rd_full (
+    .IntrT ("Status")
+  ) u_intr_rd_full (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[RdFull]),
@@ -1217,20 +1184,10 @@ module flash_ctrl
     .intr_o                 (intr_rd_full_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_rd_lvl_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(sw_rd_fifo_wr_q & (reg2hw.fifo_lvl.rd.q == sw_rfifo_depth)),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[RdLvl]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_rd_lvl (
+    .IntrT ("Status")
+  ) u_intr_rd_lvl (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[RdLvl]),
@@ -1243,10 +1200,10 @@ module flash_ctrl
     .intr_o                 (intr_rd_lvl_o)
   );
 
-  assign intr_event[OpDone] = sw_ctrl_done;
-  assign intr_event[CorrErr] = |flash_phy_rsp.ecc_single_err;
-
-  prim_intr_hw #(.Width(1)) u_intr_op_done (
+  prim_intr_hw #(
+    .Width(1),
+    .IntrT ("Event")
+  ) u_intr_op_done (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[OpDone]),
@@ -1259,7 +1216,10 @@ module flash_ctrl
     .intr_o                 (intr_op_done_o)
   );
 
-  prim_intr_hw #(.Width(1)) u_intr_corr_err (
+  prim_intr_hw #(
+    .Width(1),
+    .IntrT ("Event")
+  ) u_intr_corr_err (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[CorrErr]),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -179,13 +179,9 @@ module flash_ctrl_core_reg_top (
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic intr_state_we;
   logic intr_state_prog_empty_qs;
-  logic intr_state_prog_empty_wd;
   logic intr_state_prog_lvl_qs;
-  logic intr_state_prog_lvl_wd;
   logic intr_state_rd_full_qs;
-  logic intr_state_rd_full_wd;
   logic intr_state_rd_lvl_qs;
-  logic intr_state_rd_lvl_wd;
   logic intr_state_op_done_qs;
   logic intr_state_op_done_wd;
   logic intr_state_corr_err_qs;
@@ -1023,16 +1019,16 @@ module flash_ctrl_core_reg_top (
   //   F[prog_empty]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h1),
     .Mubi    (1'b0)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_prog_empty_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.prog_empty.de),
@@ -1050,16 +1046,16 @@ module flash_ctrl_core_reg_top (
   //   F[prog_lvl]: 1:1
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h1),
     .Mubi    (1'b0)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_prog_lvl_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.prog_lvl.de),
@@ -1077,7 +1073,7 @@ module flash_ctrl_core_reg_top (
   //   F[rd_full]: 2:2
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_rd_full (
@@ -1085,8 +1081,8 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_rd_full_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.rd_full.de),
@@ -1104,7 +1100,7 @@ module flash_ctrl_core_reg_top (
   //   F[rd_lvl]: 3:3
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_rd_lvl (
@@ -1112,8 +1108,8 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_rd_lvl_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.rd_lvl.de),
@@ -12049,14 +12045,6 @@ module flash_ctrl_core_reg_top (
 
   // Generate write-enables
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
-
-  assign intr_state_prog_empty_wd = reg_wdata[0];
-
-  assign intr_state_prog_lvl_wd = reg_wdata[1];
-
-  assign intr_state_rd_full_wd = reg_wdata[2];
-
-  assign intr_state_rd_lvl_wd = reg_wdata[3];
 
   assign intr_state_op_done_wd = reg_wdata[4];
 

--- a/hw/ip_templates/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip_templates/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -41,10 +41,10 @@
           commit_id:          "7049fd0d5d48e20772f8ebf32b240faa0dad5528",
       },
       {
-          version:            "1.0.0",
+          version:            "2.0.0",
           life_stage:         "L1",
-          design_stage:       "D2S",
-          verification_stage: "V2S",
+          design_stage:       "D1",
+          verification_stage: "V1",
           dif_stage:          "S2",
       },
   ]

--- a/hw/ip_templates/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip_templates/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -66,12 +66,14 @@
     { name: "tdo", desc: "jtag output" },
   ],
   interrupt_list: [
-    { name: "prog_empty", desc: "Program FIFO empty" },
-    { name: "prog_lvl",   desc: "Program FIFO drained to level" },
-    { name: "rd_full",    desc: "Read FIFO full" },
-    { name: "rd_lvl",     desc: "Read FIFO filled to level" },
-    { name: "op_done",    desc: "Operation complete" },
-    { name: "corr_err",   desc: "Correctable error encountered"},
+    // The first two status interrupts assert by default, since the FIFO is empty.
+    // This is captured in the Hjson via the `default` key so that automatically generated tests can incorporate this information.
+    { name: "prog_empty", type: "status", desc: "Program FIFO empty",            default: "1"},
+    { name: "prog_lvl",   type: "status", desc: "Program FIFO drained to level", default: "1"},
+    { name: "rd_full",    type: "status", desc: "Read FIFO full",                            },
+    { name: "rd_lvl",     type: "status", desc: "Read FIFO filled to level",                 },
+    { name: "op_done",    type: "event",  desc: "Operation complete",                        },
+    { name: "corr_err",   type: "event",  desc: "Correctable error encountered",             },
   ],
 
   alert_list: [

--- a/hw/ip_templates/flash_ctrl/doc/interfaces.md.tpl
+++ b/hw/ip_templates/flash_ctrl/doc/interfaces.md.tpl
@@ -48,10 +48,10 @@ ${"##"} Interrupts
 
 | Interrupt Name   | Type   | Description                   |
 |:-----------------|:-------|:------------------------------|
-| prog_empty       | Event  | Program FIFO empty            |
-| prog_lvl         | Event  | Program FIFO drained to level |
-| rd_full          | Event  | Read FIFO full                |
-| rd_lvl           | Event  | Read FIFO filled to level     |
+| prog_empty       | Status | Program FIFO empty            |
+| prog_lvl         | Status | Program FIFO drained to level |
+| rd_full          | Status | Read FIFO full                |
+| rd_lvl           | Status | Read FIFO filled to level     |
 | op_done          | Event  | Operation complete            |
 | corr_err         | Event  | Correctable error encountered |
 

--- a/hw/ip_templates/flash_ctrl/doc/registers.md.tpl
+++ b/hw/ip_templates/flash_ctrl/doc/registers.md.tpl
@@ -122,13 +122,13 @@ ${"##"} Summary of the **`core`** interface's registers
 ${"##"} INTR_STATE
 Interrupt State Register
 - Offset: `0x0`
-- Reset default: `0x0`
+- Reset default: `0x3`
 - Reset mask: `0x3f`
 
 ${"###"} Fields
 
 ```wavejson
-{"reg": [{"name": "prog_empty", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "prog_lvl", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rd_full", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rd_lvl", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "op_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "corr_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "prog_empty", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "prog_lvl", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "rd_full", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "rd_lvl", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "op_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "corr_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name       | Description                   |
@@ -136,10 +136,10 @@ ${"###"} Fields
 |  31:6  |        |         |            | Reserved                      |
 |   5    |  rw1c  |   0x0   | corr_err   | Correctable error encountered |
 |   4    |  rw1c  |   0x0   | op_done    | Operation complete            |
-|   3    |  rw1c  |   0x0   | rd_lvl     | Read FIFO filled to level     |
-|   2    |  rw1c  |   0x0   | rd_full    | Read FIFO full                |
-|   1    |  rw1c  |   0x0   | prog_lvl   | Program FIFO drained to level |
-|   0    |  rw1c  |   0x0   | prog_empty | Program FIFO empty            |
+|   3    |   ro   |   0x0   | rd_lvl     | Read FIFO filled to level     |
+|   2    |   ro   |   0x0   | rd_full    | Read FIFO full                |
+|   1    |   ro   |   0x1   | prog_lvl   | Program FIFO drained to level |
+|   0    |   ro   |   0x1   | prog_empty | Program FIFO empty            |
 
 ${"##"} INTR_ENABLE
 Interrupt Enable Register

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -169,7 +169,6 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
 
   // interrupt mode buffer credit
   int       rd_crd = 16;
-  int       wr_crd = 4;
 
   // fifo level to trigger lvl interrupt
   int       rd_lvl = 0;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
@@ -44,8 +44,10 @@ class flash_ctrl_disable_vseq extends flash_ctrl_otf_base_vseq;
         mubi4_t dis_val;
         dis_val = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(4));
         csr_wr(.ptr(ral.dis), .value(dis_val));
-        // DIS acts as true if program value is 4b0xxx or xxx0.
-        is_disable = ~(dis_val[3] & dis_val[0]);
+        // DIS acts as true if program value is not 4b0xxx or xxx0.
+        // However, there is additional routine in flash_ctrl_lcmgr makes
+        // disable flash when dis_val is not mubi_false.
+        is_disable = (dis_val != prim_mubi_pkg::MuBi4False);
       end
     endcase // randcase
     exp_err = is_disable;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -254,7 +254,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                                          cfg.rd_lvl, cfg.wr_lvl), UVM_MEDIUM)
 
         flash_ctrl_fifo_levels_cfg_intr(cfg.rd_lvl, cfg.wr_lvl);
-        flash_ctrl_intr_enable(6'h3f);
+        flash_ctrl_intr_enable(6'h3c);
       end
     end
     otf_wr_pct_temp     = cfg.otf_wr_pct;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -26,7 +26,7 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
 
     `DV_CHECK(uvm_hdl_force(path, 2'h0))
 
-    delay = $urandom_range(5, 10);
+    delay = $urandom_range(60, 90);
     #(delay * 10us);
     `DV_CHECK(uvm_hdl_release(path))
     check_fault(ral.fault_status.arb_err);

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -14327,23 +14327,23 @@
       width: 1
       type: interrupt
       module_name: flash_ctrl
-      intr_type: IntrType.Event
-      default_val: false
+      intr_type: IntrType.Status
+      default_val: true
     }
     {
       name: flash_ctrl_prog_lvl
       width: 1
       type: interrupt
       module_name: flash_ctrl
-      intr_type: IntrType.Event
-      default_val: false
+      intr_type: IntrType.Status
+      default_val: true
     }
     {
       name: flash_ctrl_rd_full
       width: 1
       type: interrupt
       module_name: flash_ctrl
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {
@@ -14351,7 +14351,7 @@
       width: 1
       type: interrupt
       module_name: flash_ctrl
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -13335,900 +13335,1200 @@
       width: 1
       type: interrupt
       module_name: uart0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart0_rx_watermark
       width: 1
       type: interrupt
       module_name: uart0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart0_tx_empty
       width: 1
       type: interrupt
       module_name: uart0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart0_rx_overflow
       width: 1
       type: interrupt
       module_name: uart0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart0_rx_frame_err
       width: 1
       type: interrupt
       module_name: uart0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart0_rx_break_err
       width: 1
       type: interrupt
       module_name: uart0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart0_rx_timeout
       width: 1
       type: interrupt
       module_name: uart0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart0_rx_parity_err
       width: 1
       type: interrupt
       module_name: uart0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart1_tx_watermark
       width: 1
       type: interrupt
       module_name: uart1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart1_rx_watermark
       width: 1
       type: interrupt
       module_name: uart1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart1_tx_empty
       width: 1
       type: interrupt
       module_name: uart1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart1_rx_overflow
       width: 1
       type: interrupt
       module_name: uart1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart1_rx_frame_err
       width: 1
       type: interrupt
       module_name: uart1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart1_rx_break_err
       width: 1
       type: interrupt
       module_name: uart1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart1_rx_timeout
       width: 1
       type: interrupt
       module_name: uart1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart1_rx_parity_err
       width: 1
       type: interrupt
       module_name: uart1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart2_tx_watermark
       width: 1
       type: interrupt
       module_name: uart2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart2_rx_watermark
       width: 1
       type: interrupt
       module_name: uart2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart2_tx_empty
       width: 1
       type: interrupt
       module_name: uart2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart2_rx_overflow
       width: 1
       type: interrupt
       module_name: uart2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart2_rx_frame_err
       width: 1
       type: interrupt
       module_name: uart2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart2_rx_break_err
       width: 1
       type: interrupt
       module_name: uart2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart2_rx_timeout
       width: 1
       type: interrupt
       module_name: uart2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart2_rx_parity_err
       width: 1
       type: interrupt
       module_name: uart2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart3_tx_watermark
       width: 1
       type: interrupt
       module_name: uart3
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart3_rx_watermark
       width: 1
       type: interrupt
       module_name: uart3
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart3_tx_empty
       width: 1
       type: interrupt
       module_name: uart3
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart3_rx_overflow
       width: 1
       type: interrupt
       module_name: uart3
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart3_rx_frame_err
       width: 1
       type: interrupt
       module_name: uart3
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart3_rx_break_err
       width: 1
       type: interrupt
       module_name: uart3
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart3_rx_timeout
       width: 1
       type: interrupt
       module_name: uart3
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: uart3_rx_parity_err
       width: 1
       type: interrupt
       module_name: uart3
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: gpio_gpio
       width: 32
       type: interrupt
       module_name: gpio
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_device_upload_cmdfifo_not_empty
       width: 1
       type: interrupt
       module_name: spi_device
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_device_upload_payload_not_empty
       width: 1
       type: interrupt
       module_name: spi_device
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_device_upload_payload_overflow
       width: 1
       type: interrupt
       module_name: spi_device
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_device_readbuf_watermark
       width: 1
       type: interrupt
       module_name: spi_device
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_device_readbuf_flip
       width: 1
       type: interrupt
       module_name: spi_device
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_device_tpm_header_not_empty
       width: 1
       type: interrupt
       module_name: spi_device
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: spi_device_tpm_rdfifo_cmd_end
       width: 1
       type: interrupt
       module_name: spi_device
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_device_tpm_rdfifo_drop
       width: 1
       type: interrupt
       module_name: spi_device
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_fmt_threshold
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c0_rx_threshold
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c0_acq_threshold
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c0_rx_overflow
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_nak
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_scl_interference
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_sda_interference
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_stretch_timeout
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_sda_unstable
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_cmd_complete
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_tx_stretch
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c0_tx_threshold
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c0_acq_full
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c0_unexp_stop
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c0_host_timeout
       width: 1
       type: interrupt
       module_name: i2c0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_fmt_threshold
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c1_rx_threshold
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c1_acq_threshold
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c1_rx_overflow
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_nak
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_scl_interference
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_sda_interference
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_stretch_timeout
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_sda_unstable
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_cmd_complete
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_tx_stretch
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c1_tx_threshold
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c1_acq_full
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c1_unexp_stop
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c1_host_timeout
       width: 1
       type: interrupt
       module_name: i2c1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_fmt_threshold
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c2_rx_threshold
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c2_acq_threshold
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c2_rx_overflow
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_nak
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_scl_interference
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_sda_interference
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_stretch_timeout
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_sda_unstable
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_cmd_complete
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_tx_stretch
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c2_tx_threshold
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c2_acq_full
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: i2c2_unexp_stop
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: i2c2_host_timeout
       width: 1
       type: interrupt
       module_name: i2c2
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: pattgen_done_ch0
       width: 1
       type: interrupt
       module_name: pattgen
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: pattgen_done_ch1
       width: 1
       type: interrupt
       module_name: pattgen
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: rv_timer_timer_expired_hart0_timer0
       width: 1
       type: interrupt
       module_name: rv_timer
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: otp_ctrl_otp_operation_done
       width: 1
       type: interrupt
       module_name: otp_ctrl
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: otp_ctrl_otp_error
       width: 1
       type: interrupt
       module_name: otp_ctrl
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: alert_handler_classa
       width: 1
       type: interrupt
       module_name: alert_handler
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: alert_handler_classb
       width: 1
       type: interrupt
       module_name: alert_handler
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: alert_handler_classc
       width: 1
       type: interrupt
       module_name: alert_handler
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: alert_handler_classd
       width: 1
       type: interrupt
       module_name: alert_handler
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_host0_error
       width: 1
       type: interrupt
       module_name: spi_host0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_host0_spi_event
       width: 1
       type: interrupt
       module_name: spi_host0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_host1_error
       width: 1
       type: interrupt
       module_name: spi_host1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: spi_host1_spi_event
       width: 1
       type: interrupt
       module_name: spi_host1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_pkt_received
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: usbdev_pkt_sent
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: usbdev_disconnected
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_host_lost
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_link_reset
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_link_suspend
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_link_resume
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_av_out_empty
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: usbdev_rx_full
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: usbdev_av_overflow
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_link_in_err
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_rx_crc_err
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_rx_pid_err
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_rx_bitstuff_err
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_frame
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_powered
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_link_out_err
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: usbdev_av_setup_empty
       width: 1
       type: interrupt
       module_name: usbdev
+      intr_type: IntrType.Status
+      default_val: false
     }
     {
       name: pwrmgr_aon_wakeup
       width: 1
       type: interrupt
       module_name: pwrmgr_aon
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: sysrst_ctrl_aon_event_detected
       width: 1
       type: interrupt
       module_name: sysrst_ctrl_aon
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: adc_ctrl_aon_match_done
       width: 1
       type: interrupt
       module_name: adc_ctrl_aon
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: aon_timer_aon_wkup_timer_expired
       width: 1
       type: interrupt
       module_name: aon_timer_aon
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: aon_timer_aon_wdog_timer_bark
       width: 1
       type: interrupt
       module_name: aon_timer_aon
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: sensor_ctrl_aon_io_status_change
       width: 1
       type: interrupt
       module_name: sensor_ctrl_aon
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: sensor_ctrl_aon_init_status_change
       width: 1
       type: interrupt
       module_name: sensor_ctrl_aon
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: flash_ctrl_prog_empty
       width: 1
       type: interrupt
       module_name: flash_ctrl
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: flash_ctrl_prog_lvl
       width: 1
       type: interrupt
       module_name: flash_ctrl
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: flash_ctrl_rd_full
       width: 1
       type: interrupt
       module_name: flash_ctrl
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: flash_ctrl_rd_lvl
       width: 1
       type: interrupt
       module_name: flash_ctrl
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: flash_ctrl_op_done
       width: 1
       type: interrupt
       module_name: flash_ctrl
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: flash_ctrl_corr_err
       width: 1
       type: interrupt
       module_name: flash_ctrl
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: hmac_hmac_done
       width: 1
       type: interrupt
       module_name: hmac
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: hmac_fifo_empty
       width: 1
       type: interrupt
       module_name: hmac
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: hmac_hmac_err
       width: 1
       type: interrupt
       module_name: hmac
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: kmac_kmac_done
       width: 1
       type: interrupt
       module_name: kmac
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: kmac_fifo_empty
       width: 1
       type: interrupt
       module_name: kmac
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: kmac_kmac_err
       width: 1
       type: interrupt
       module_name: kmac
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: otbn_done
       width: 1
       type: interrupt
       module_name: otbn
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: keymgr_op_done
       width: 1
       type: interrupt
       module_name: keymgr
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: csrng_cs_cmd_req_done
       width: 1
       type: interrupt
       module_name: csrng
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: csrng_cs_entropy_req
       width: 1
       type: interrupt
       module_name: csrng
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: csrng_cs_hw_inst_exc
       width: 1
       type: interrupt
       module_name: csrng
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: csrng_cs_fatal_err
       width: 1
       type: interrupt
       module_name: csrng
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: entropy_src_es_entropy_valid
       width: 1
       type: interrupt
       module_name: entropy_src
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: entropy_src_es_health_test_failed
       width: 1
       type: interrupt
       module_name: entropy_src
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: entropy_src_es_observe_fifo_ready
       width: 1
       type: interrupt
       module_name: entropy_src
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: entropy_src_es_fatal_err
       width: 1
       type: interrupt
       module_name: entropy_src
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: edn0_edn_cmd_req_done
       width: 1
       type: interrupt
       module_name: edn0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: edn0_edn_fatal_err
       width: 1
       type: interrupt
       module_name: edn0
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: edn1_edn_cmd_req_done
       width: 1
       type: interrupt
       module_name: edn1
+      intr_type: IntrType.Event
+      default_val: false
     }
     {
       name: edn1_edn_fatal_err
       width: 1
       type: interrupt
       module_name: edn1
+      intr_type: IntrType.Event
+      default_val: false
     }
   ]
   alert_module:

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -61,12 +61,14 @@
     { name: "tdo", desc: "jtag output" },
   ],
   interrupt_list: [
-    { name: "prog_empty", desc: "Program FIFO empty" },
-    { name: "prog_lvl",   desc: "Program FIFO drained to level" },
-    { name: "rd_full",    desc: "Read FIFO full" },
-    { name: "rd_lvl",     desc: "Read FIFO filled to level" },
-    { name: "op_done",    desc: "Operation complete" },
-    { name: "corr_err",   desc: "Correctable error encountered"},
+    // The first two status interrupts assert by default, since the FIFO is empty.
+    // This is captured in the Hjson via the `default` key so that automatically generated tests can incorporate this information.
+    { name: "prog_empty", type: "status", desc: "Program FIFO empty",            default: "1"},
+    { name: "prog_lvl",   type: "status", desc: "Program FIFO drained to level", default: "1"},
+    { name: "rd_full",    type: "status", desc: "Read FIFO full",                            },
+    { name: "rd_lvl",     type: "status", desc: "Read FIFO filled to level",                 },
+    { name: "op_done",    type: "event",  desc: "Operation complete",                        },
+    { name: "corr_err",   type: "event",  desc: "Correctable error encountered",             },
   ],
 
   alert_list: [

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -36,10 +36,10 @@
           commit_id:          "7049fd0d5d48e20772f8ebf32b240faa0dad5528",
       },
       {
-          version:            "1.0.0",
+          version:            "2.0.0",
           life_stage:         "L1",
-          design_stage:       "D2S",
-          verification_stage: "V2S",
+          design_stage:       "D1",
+          verification_stage: "V1",
           dif_stage:          "S2",
       },
   ]

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -1130,35 +1130,22 @@ module flash_ctrl
     assign hw2reg.ecc_single_err_addr[i].d = {flash_phy_rsp.ecc_addr[i], {BusByteWidth{1'b0}}};
   end
 
-  logic sw_rd_fifo_wr_q;
-  logic prog_fifo_rd_q;
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      sw_rd_fifo_wr_q <= '0;
-      prog_fifo_rd_q <= '0;
-    end else begin
-      sw_rd_fifo_wr_q <= sw_rfifo_wen & sw_rfifo_wready;
-      prog_fifo_rd_q <= prog_fifo_rvalid & prog_fifo_ren;
-    end
-  end
-
-  // general interrupt events
   logic [LastIntrIdx-1:0] intr_event;
+  // Status types
+  assign intr_event[ProgEmpty] = !prog_fifo_rvalid;
+  // Check whether this FIFO has been drained to a certain level.
+  assign intr_event[ProgLvl]   = reg2hw.fifo_lvl.prog.q >= MaxFifoWidth'(prog_fifo_depth);
+  assign intr_event[RdFull]    = sw_rfifo_full;
+  // Check whether this FIFO has been filled to a certain level.
+  assign intr_event[RdLvl]     = reg2hw.fifo_lvl.rd.q <= sw_rfifo_depth;
+  // Event types
+  assign intr_event[OpDone]    = sw_ctrl_done;
+  assign intr_event[CorrErr]   = |flash_phy_rsp.ecc_single_err;
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(1),
-    .EnSync(0)
-  ) u_prog_empty_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(~prog_fifo_rvalid),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[ProgEmpty]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_prog_empty (
+    .IntrT ("Status")
+  ) u_intr_prog_empty (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[ProgEmpty]),
@@ -1171,20 +1158,10 @@ module flash_ctrl
     .intr_o                 (intr_prog_empty_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_prog_lvl_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(prog_fifo_rd_q & (reg2hw.fifo_lvl.prog.q == MaxFifoWidth'(prog_fifo_depth))),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[ProgLvl]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_prog_lvl (
+    .IntrT ("Status")
+  ) u_intr_prog_lvl (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[ProgLvl]),
@@ -1197,20 +1174,10 @@ module flash_ctrl
     .intr_o                 (intr_prog_lvl_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_rd_full_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(sw_rfifo_full),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[RdFull]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_rd_full (
+    .IntrT ("Status")
+  ) u_intr_rd_full (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[RdFull]),
@@ -1223,20 +1190,10 @@ module flash_ctrl
     .intr_o                 (intr_rd_full_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_rd_lvl_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(sw_rd_fifo_wr_q & (reg2hw.fifo_lvl.rd.q == sw_rfifo_depth)),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[RdLvl]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_rd_lvl (
+    .IntrT ("Status")
+  ) u_intr_rd_lvl (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[RdLvl]),
@@ -1249,10 +1206,10 @@ module flash_ctrl
     .intr_o                 (intr_rd_lvl_o)
   );
 
-  assign intr_event[OpDone] = sw_ctrl_done;
-  assign intr_event[CorrErr] = |flash_phy_rsp.ecc_single_err;
-
-  prim_intr_hw #(.Width(1)) u_intr_op_done (
+  prim_intr_hw #(
+    .Width(1),
+    .IntrT ("Event")
+  ) u_intr_op_done (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[OpDone]),
@@ -1265,7 +1222,10 @@ module flash_ctrl
     .intr_o                 (intr_op_done_o)
   );
 
-  prim_intr_hw #(.Width(1)) u_intr_corr_err (
+  prim_intr_hw #(
+    .Width(1),
+    .IntrT ("Event")
+  ) u_intr_corr_err (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[CorrErr]),

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -179,13 +179,9 @@ module flash_ctrl_core_reg_top (
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic intr_state_we;
   logic intr_state_prog_empty_qs;
-  logic intr_state_prog_empty_wd;
   logic intr_state_prog_lvl_qs;
-  logic intr_state_prog_lvl_wd;
   logic intr_state_rd_full_qs;
-  logic intr_state_rd_full_wd;
   logic intr_state_rd_lvl_qs;
-  logic intr_state_rd_lvl_wd;
   logic intr_state_op_done_qs;
   logic intr_state_op_done_wd;
   logic intr_state_corr_err_qs;
@@ -1023,16 +1019,16 @@ module flash_ctrl_core_reg_top (
   //   F[prog_empty]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h1),
     .Mubi    (1'b0)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_prog_empty_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.prog_empty.de),
@@ -1050,16 +1046,16 @@ module flash_ctrl_core_reg_top (
   //   F[prog_lvl]: 1:1
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h1),
     .Mubi    (1'b0)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_prog_lvl_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.prog_lvl.de),
@@ -1077,7 +1073,7 @@ module flash_ctrl_core_reg_top (
   //   F[rd_full]: 2:2
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_rd_full (
@@ -1085,8 +1081,8 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_rd_full_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.rd_full.de),
@@ -1104,7 +1100,7 @@ module flash_ctrl_core_reg_top (
   //   F[rd_lvl]: 3:3
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_rd_lvl (
@@ -1112,8 +1108,8 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_rd_lvl_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.rd_lvl.de),
@@ -12049,14 +12045,6 @@ module flash_ctrl_core_reg_top (
 
   // Generate write-enables
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
-
-  assign intr_state_prog_empty_wd = reg_wdata[0];
-
-  assign intr_state_prog_lvl_wd = reg_wdata[1];
-
-  assign intr_state_rd_full_wd = reg_wdata[2];
-
-  assign intr_state_rd_lvl_wd = reg_wdata[3];
 
   assign intr_state_op_done_wd = reg_wdata[4];
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
@@ -30,10 +30,10 @@
           commit_id:          "7049fd0d5d48e20772f8ebf32b240faa0dad5528",
       },
       {
-          version:            "1.0.0",
+          version:            "2.0.0",
           life_stage:         "L1",
-          design_stage:       "D2S",
-          verification_stage: "V2S",
+          design_stage:       "D1",
+          verification_stage: "V1",
           dif_stage:          "S2",
       },
   ]

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
@@ -55,12 +55,14 @@
     { name: "tdo", desc: "jtag output" },
   ],
   interrupt_list: [
-    { name: "prog_empty", desc: "Program FIFO empty" },
-    { name: "prog_lvl",   desc: "Program FIFO drained to level" },
-    { name: "rd_full",    desc: "Read FIFO full" },
-    { name: "rd_lvl",     desc: "Read FIFO filled to level" },
-    { name: "op_done",    desc: "Operation complete" },
-    { name: "corr_err",   desc: "Correctable error encountered"},
+    // The first two status interrupts assert by default, since the FIFO is empty.
+    // This is captured in the Hjson via the `default` key so that automatically generated tests can incorporate this information.
+    { name: "prog_empty", type: "status", desc: "Program FIFO empty",            default: "1"},
+    { name: "prog_lvl",   type: "status", desc: "Program FIFO drained to level", default: "1"},
+    { name: "rd_full",    type: "status", desc: "Read FIFO full",                            },
+    { name: "rd_lvl",     type: "status", desc: "Read FIFO filled to level",                 },
+    { name: "op_done",    type: "event",  desc: "Operation complete",                        },
+    { name: "corr_err",   type: "event",  desc: "Correctable error encountered",             },
   ],
 
   alert_list: [

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/doc/interfaces.md
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/doc/interfaces.md
@@ -48,10 +48,10 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 | Interrupt Name   | Type   | Description                   |
 |:-----------------|:-------|:------------------------------|
-| prog_empty       | Event  | Program FIFO empty            |
-| prog_lvl         | Event  | Program FIFO drained to level |
-| rd_full          | Event  | Read FIFO full                |
-| rd_lvl           | Event  | Read FIFO filled to level     |
+| prog_empty       | Status | Program FIFO empty            |
+| prog_lvl         | Status | Program FIFO drained to level |
+| rd_full          | Status | Read FIFO full                |
+| rd_lvl           | Status | Read FIFO filled to level     |
 | op_done          | Event  | Operation complete            |
 | corr_err         | Event  | Correctable error encountered |
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/doc/registers.md
@@ -122,13 +122,13 @@ It is implemented this way because the access window supports transaction back-p
 ## INTR_STATE
 Interrupt State Register
 - Offset: `0x0`
-- Reset default: `0x0`
+- Reset default: `0x3`
 - Reset mask: `0x3f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "prog_empty", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "prog_lvl", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rd_full", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rd_lvl", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "op_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "corr_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "prog_empty", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "prog_lvl", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "rd_full", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "rd_lvl", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "op_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "corr_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name       | Description                   |
@@ -136,10 +136,10 @@ Interrupt State Register
 |  31:6  |        |         |            | Reserved                      |
 |   5    |  rw1c  |   0x0   | corr_err   | Correctable error encountered |
 |   4    |  rw1c  |   0x0   | op_done    | Operation complete            |
-|   3    |  rw1c  |   0x0   | rd_lvl     | Read FIFO filled to level     |
-|   2    |  rw1c  |   0x0   | rd_full    | Read FIFO full                |
-|   1    |  rw1c  |   0x0   | prog_lvl   | Program FIFO drained to level |
-|   0    |  rw1c  |   0x0   | prog_empty | Program FIFO empty            |
+|   3    |   ro   |   0x0   | rd_lvl     | Read FIFO filled to level     |
+|   2    |   ro   |   0x0   | rd_full    | Read FIFO full                |
+|   1    |   ro   |   0x1   | prog_lvl   | Program FIFO drained to level |
+|   0    |   ro   |   0x1   | prog_empty | Program FIFO empty            |
 
 ## INTR_ENABLE
 Interrupt Enable Register

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -169,7 +169,6 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
 
   // interrupt mode buffer credit
   int       rd_crd = 16;
-  int       wr_crd = 4;
 
   // fifo level to trigger lvl interrupt
   int       rd_lvl = 0;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_disable_vseq.sv
@@ -44,8 +44,10 @@ class flash_ctrl_disable_vseq extends flash_ctrl_otf_base_vseq;
         mubi4_t dis_val;
         dis_val = get_rand_mubi4_val(.t_weight(1), .f_weight(1), .other_weight(4));
         csr_wr(.ptr(ral.dis), .value(dis_val));
-        // DIS acts as true if program value is 4b0xxx or xxx0.
-        is_disable = ~(dis_val[3] & dis_val[0]);
+        // DIS acts as true if program value is not 4b0xxx or xxx0.
+        // However, there is additional routine in flash_ctrl_lcmgr makes
+        // disable flash when dis_val is not mubi_false.
+        is_disable = (dis_val != prim_mubi_pkg::MuBi4False);
       end
     endcase // randcase
     exp_err = is_disable;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -254,7 +254,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                                          cfg.rd_lvl, cfg.wr_lvl), UVM_MEDIUM)
 
         flash_ctrl_fifo_levels_cfg_intr(cfg.rd_lvl, cfg.wr_lvl);
-        flash_ctrl_intr_enable(6'h3f);
+        flash_ctrl_intr_enable(6'h3c);
       end
     end
     otf_wr_pct_temp     = cfg.otf_wr_pct;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -26,7 +26,7 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
 
     `DV_CHECK(uvm_hdl_force(path, 2'h0))
 
-    delay = $urandom_range(5, 10);
+    delay = $urandom_range(60, 90);
     #(delay * 10us);
     `DV_CHECK(uvm_hdl_release(path))
     check_fault(ral.fault_status.arb_err);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -1124,35 +1124,22 @@ module flash_ctrl
     assign hw2reg.ecc_single_err_addr[i].d = {flash_phy_rsp.ecc_addr[i], {BusByteWidth{1'b0}}};
   end
 
-  logic sw_rd_fifo_wr_q;
-  logic prog_fifo_rd_q;
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      sw_rd_fifo_wr_q <= '0;
-      prog_fifo_rd_q <= '0;
-    end else begin
-      sw_rd_fifo_wr_q <= sw_rfifo_wen & sw_rfifo_wready;
-      prog_fifo_rd_q <= prog_fifo_rvalid & prog_fifo_ren;
-    end
-  end
-
-  // general interrupt events
   logic [LastIntrIdx-1:0] intr_event;
+  // Status types
+  assign intr_event[ProgEmpty] = !prog_fifo_rvalid;
+  // Check whether this FIFO has been drained to a certain level.
+  assign intr_event[ProgLvl]   = reg2hw.fifo_lvl.prog.q >= MaxFifoWidth'(prog_fifo_depth);
+  assign intr_event[RdFull]    = sw_rfifo_full;
+  // Check whether this FIFO has been filled to a certain level.
+  assign intr_event[RdLvl]     = reg2hw.fifo_lvl.rd.q <= sw_rfifo_depth;
+  // Event types
+  assign intr_event[OpDone]    = sw_ctrl_done;
+  assign intr_event[CorrErr]   = |flash_phy_rsp.ecc_single_err;
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(1),
-    .EnSync(0)
-  ) u_prog_empty_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(~prog_fifo_rvalid),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[ProgEmpty]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_prog_empty (
+    .IntrT ("Status")
+  ) u_intr_prog_empty (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[ProgEmpty]),
@@ -1165,20 +1152,10 @@ module flash_ctrl
     .intr_o                 (intr_prog_empty_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_prog_lvl_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(prog_fifo_rd_q & (reg2hw.fifo_lvl.prog.q == MaxFifoWidth'(prog_fifo_depth))),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[ProgLvl]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_prog_lvl (
+    .IntrT ("Status")
+  ) u_intr_prog_lvl (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[ProgLvl]),
@@ -1191,20 +1168,10 @@ module flash_ctrl
     .intr_o                 (intr_prog_lvl_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_rd_full_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(sw_rfifo_full),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[RdFull]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_rd_full (
+    .IntrT ("Status")
+  ) u_intr_rd_full (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[RdFull]),
@@ -1217,20 +1184,10 @@ module flash_ctrl
     .intr_o                 (intr_rd_full_o)
   );
 
-  prim_edge_detector #(
+  prim_intr_hw #(
     .Width(1),
-    .ResetValue(0),
-    .EnSync(0)
-  ) u_rd_lvl_event (
-    .clk_i,
-    .rst_ni,
-    .d_i(sw_rd_fifo_wr_q & (reg2hw.fifo_lvl.rd.q == sw_rfifo_depth)),
-    .q_sync_o(),
-    .q_posedge_pulse_o(intr_event[RdLvl]),
-    .q_negedge_pulse_o()
-  );
-
-  prim_intr_hw #(.Width(1)) u_intr_rd_lvl (
+    .IntrT ("Status")
+  ) u_intr_rd_lvl (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[RdLvl]),
@@ -1243,10 +1200,10 @@ module flash_ctrl
     .intr_o                 (intr_rd_lvl_o)
   );
 
-  assign intr_event[OpDone] = sw_ctrl_done;
-  assign intr_event[CorrErr] = |flash_phy_rsp.ecc_single_err;
-
-  prim_intr_hw #(.Width(1)) u_intr_op_done (
+  prim_intr_hw #(
+    .Width(1),
+    .IntrT ("Event")
+  ) u_intr_op_done (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[OpDone]),
@@ -1259,7 +1216,10 @@ module flash_ctrl
     .intr_o                 (intr_op_done_o)
   );
 
-  prim_intr_hw #(.Width(1)) u_intr_corr_err (
+  prim_intr_hw #(
+    .Width(1),
+    .IntrT ("Event")
+  ) u_intr_corr_err (
     .clk_i,
     .rst_ni,
     .event_intr_i           (intr_event[CorrErr]),

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -179,13 +179,9 @@ module flash_ctrl_core_reg_top (
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic intr_state_we;
   logic intr_state_prog_empty_qs;
-  logic intr_state_prog_empty_wd;
   logic intr_state_prog_lvl_qs;
-  logic intr_state_prog_lvl_wd;
   logic intr_state_rd_full_qs;
-  logic intr_state_rd_full_wd;
   logic intr_state_rd_lvl_qs;
-  logic intr_state_rd_lvl_wd;
   logic intr_state_op_done_qs;
   logic intr_state_op_done_wd;
   logic intr_state_corr_err_qs;
@@ -1023,16 +1019,16 @@ module flash_ctrl_core_reg_top (
   //   F[prog_empty]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h1),
     .Mubi    (1'b0)
   ) u_intr_state_prog_empty (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_prog_empty_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.prog_empty.de),
@@ -1050,16 +1046,16 @@ module flash_ctrl_core_reg_top (
   //   F[prog_lvl]: 1:1
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h1),
     .Mubi    (1'b0)
   ) u_intr_state_prog_lvl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_prog_lvl_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.prog_lvl.de),
@@ -1077,7 +1073,7 @@ module flash_ctrl_core_reg_top (
   //   F[rd_full]: 2:2
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_rd_full (
@@ -1085,8 +1081,8 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_rd_full_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.rd_full.de),
@@ -1104,7 +1100,7 @@ module flash_ctrl_core_reg_top (
   //   F[rd_lvl]: 3:3
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_rd_lvl (
@@ -1112,8 +1108,8 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_rd_lvl_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.rd_lvl.de),
@@ -12049,14 +12045,6 @@ module flash_ctrl_core_reg_top (
 
   // Generate write-enables
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
-
-  assign intr_state_prog_empty_wd = reg_wdata[0];
-
-  assign intr_state_prog_lvl_wd = reg_wdata[1];
-
-  assign intr_state_rd_full_wd = reg_wdata[2];
-
-  assign intr_state_rd_lvl_wd = reg_wdata[3];
 
   assign intr_state_op_done_wd = reg_wdata[4];
 

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
@@ -92,8 +92,8 @@ static bool flash_ctrl_get_irq_bit_index(dif_flash_ctrl_irq_t irq,
 }
 
 static dif_irq_type_t irq_types[] = {
-    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
-    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeStatus, kDifIrqTypeStatus, kDifIrqTypeStatus,
+    kDifIrqTypeStatus, kDifIrqTypeEvent,  kDifIrqTypeEvent,
 };
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
@@ -90,7 +90,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_flash_ctrl_irq_get_type(&flash_ctrl_,
                                             kDifFlashCtrlIrqProgEmpty, &type));
-  EXPECT_EQ(type, kDifIrqTypeEvent);
+  EXPECT_EQ(type, kDifIrqTypeStatus);
 }
 
 class IrqGetStateTest : public FlashCtrlTest {};

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -289,7 +289,7 @@ void isr_testutils_entropy_src_isr(
 
 void isr_testutils_flash_ctrl_isr(
     plic_isr_ctx_t plic_ctx, flash_ctrl_isr_ctx_t flash_ctrl_ctx,
-    top_earlgrey_plic_peripheral_t *peripheral_serviced,
+    bool mute_status_irq, top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_flash_ctrl_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
   dif_rv_plic_irq_id_t plic_irq_id;
@@ -323,6 +323,9 @@ void isr_testutils_flash_ctrl_isr(
   if (type == kDifIrqTypeEvent) {
     CHECK_DIF_OK(
         dif_flash_ctrl_irq_acknowledge(flash_ctrl_ctx.flash_ctrl, irq));
+  } else if (mute_status_irq) {
+    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(flash_ctrl_ctx.flash_ctrl, irq,
+                                                kDifToggleDisabled));
   }
 
   // Complete the IRQ at the PLIC.

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -407,6 +407,7 @@ void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx_t hmac_ctx,
 }
 
 void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx_t i2c_ctx,
+                           bool mute_status_irq,
                            top_earlgrey_plic_peripheral_t *peripheral_serviced,
                            dif_i2c_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -437,6 +438,8 @@ void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx_t i2c_ctx,
   CHECK_DIF_OK(dif_i2c_irq_get_type(i2c_ctx.i2c, irq, &type));
   if (type == kDifIrqTypeEvent) {
     CHECK_DIF_OK(dif_i2c_irq_acknowledge(i2c_ctx.i2c, irq));
+  } else if (mute_status_irq) {
+    CHECK_DIF_OK(dif_i2c_irq_set_enabled(i2c_ctx.i2c, irq, kDifToggleDisabled));
   }
 
   // Complete the IRQ at the PLIC.
@@ -763,7 +766,7 @@ void isr_testutils_sensor_ctrl_isr(
 
 void isr_testutils_spi_device_isr(
     plic_isr_ctx_t plic_ctx, spi_device_isr_ctx_t spi_device_ctx,
-    top_earlgrey_plic_peripheral_t *peripheral_serviced,
+    bool mute_status_irq, top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_spi_device_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
   dif_rv_plic_irq_id_t plic_irq_id;
@@ -797,6 +800,9 @@ void isr_testutils_spi_device_isr(
   if (type == kDifIrqTypeEvent) {
     CHECK_DIF_OK(
         dif_spi_device_irq_acknowledge(spi_device_ctx.spi_device, irq));
+  } else if (mute_status_irq) {
+    CHECK_DIF_OK(dif_spi_device_irq_set_enabled(spi_device_ctx.spi_device, irq,
+                                                kDifToggleDisabled));
   }
 
   // Complete the IRQ at the PLIC.
@@ -926,7 +932,7 @@ void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx_t uart_ctx,
 }
 
 void isr_testutils_usbdev_isr(
-    plic_isr_ctx_t plic_ctx, usbdev_isr_ctx_t usbdev_ctx,
+    plic_isr_ctx_t plic_ctx, usbdev_isr_ctx_t usbdev_ctx, bool mute_status_irq,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_usbdev_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -957,6 +963,9 @@ void isr_testutils_usbdev_isr(
   CHECK_DIF_OK(dif_usbdev_irq_get_type(usbdev_ctx.usbdev, irq, &type));
   if (type == kDifIrqTypeEvent) {
     CHECK_DIF_OK(dif_usbdev_irq_acknowledge(usbdev_ctx.usbdev, irq));
+  } else if (mute_status_irq) {
+    CHECK_DIF_OK(
+        dif_usbdev_irq_set_enabled(usbdev_ctx.usbdev, irq, kDifToggleDisabled));
   }
 
   // Complete the IRQ at the PLIC.

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -688,11 +688,13 @@ void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx_t hmac_ctx,
  *
  * @param plic_ctx A PLIC ISR context handle.
  * @param i2c_ctx A(n) i2c ISR context handle.
+ * @param mute_status_irq set to true to disable the serviced status type IRQ.
  * @param[out] peripheral_serviced Out param for the peripheral that was
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx_t i2c_ctx,
+                           bool mute_status_irq,
                            top_earlgrey_plic_peripheral_t *peripheral_serviced,
                            dif_i2c_irq_t *irq_serviced);
 
@@ -811,13 +813,14 @@ void isr_testutils_sensor_ctrl_isr(
  *
  * @param plic_ctx A PLIC ISR context handle.
  * @param spi_device_ctx A(n) spi_device ISR context handle.
+ * @param mute_status_irq set to true to disable the serviced status type IRQ.
  * @param[out] peripheral_serviced Out param for the peripheral that was
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_spi_device_isr(
     plic_isr_ctx_t plic_ctx, spi_device_isr_ctx_t spi_device_ctx,
-    top_earlgrey_plic_peripheral_t *peripheral_serviced,
+    bool mute_status_irq, top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_spi_device_irq_t *irq_serviced);
 
 /**
@@ -866,12 +869,13 @@ void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx_t uart_ctx,
  *
  * @param plic_ctx A PLIC ISR context handle.
  * @param usbdev_ctx A(n) usbdev ISR context handle.
+ * @param mute_status_irq set to true to disable the serviced status type IRQ.
  * @param[out] peripheral_serviced Out param for the peripheral that was
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_usbdev_isr(
-    plic_isr_ctx_t plic_ctx, usbdev_isr_ctx_t usbdev_ctx,
+    plic_isr_ctx_t plic_ctx, usbdev_isr_ctx_t usbdev_ctx, bool mute_status_irq,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_usbdev_irq_t *irq_serviced);
 

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -648,13 +648,14 @@ void isr_testutils_entropy_src_isr(
  *
  * @param plic_ctx A PLIC ISR context handle.
  * @param flash_ctrl_ctx A(n) flash_ctrl ISR context handle.
+ * @param mute_status_irq set to true to disable the serviced status type IRQ.
  * @param[out] peripheral_serviced Out param for the peripheral that was
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_flash_ctrl_isr(
     plic_isr_ctx_t plic_ctx, flash_ctrl_isr_ctx_t flash_ctrl_ctx,
-    top_earlgrey_plic_peripheral_t *peripheral_serviced,
+    bool mute_status_irq, top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_flash_ctrl_irq_t *irq_serviced);
 
 /**

--- a/sw/device/tests/autogen/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/plic_all_irqs_test.c
@@ -354,9 +354,6 @@ void ottf_external_isr(uint32_t *exc_info) {
     CHECK(snapshot == (dif_csrng_irq_state_snapshot_t)(1 << irq),
           "Only csrng IRQ %d expected to fire. Actual interrupt status = %x",
           irq, snapshot);
-
-    // TODO: Check Interrupt type then clear INTR_TEST if needed.
-    CHECK_DIF_OK(dif_csrng_irq_force(&csrng, irq, false));
     CHECK_DIF_OK(dif_csrng_irq_acknowledge(&csrng, irq));
   } else {
     CHECK(peripheral == peripheral_expected,
@@ -378,11 +375,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_adc_ctrl_irq_get_state(&adc_ctrl_aon, &snapshot));
         CHECK(snapshot == (dif_adc_ctrl_irq_state_snapshot_t)(1 << irq),
               "Only adc_ctrl_aon IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_adc_ctrl_irq_force(&adc_ctrl_aon, irq, false));
         CHECK_DIF_OK(dif_adc_ctrl_irq_acknowledge(&adc_ctrl_aon, irq));
         break;
       }
@@ -402,11 +396,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_alert_handler_irq_get_state(&alert_handler, &snapshot));
         CHECK(snapshot == (dif_alert_handler_irq_state_snapshot_t)(1 << irq),
               "Only alert_handler IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_alert_handler_irq_force(&alert_handler, irq, false));
         CHECK_DIF_OK(dif_alert_handler_irq_acknowledge(&alert_handler, irq));
         break;
       }
@@ -426,11 +417,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_aon_timer_irq_get_state(&aon_timer_aon, &snapshot));
         CHECK(snapshot == (dif_aon_timer_irq_state_snapshot_t)(1 << irq),
               "Only aon_timer_aon IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_aon_timer_irq_force(&aon_timer_aon, irq, false));
         CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(&aon_timer_aon, irq));
         break;
       }
@@ -456,11 +444,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_csrng_irq_get_state(&csrng, &snapshot));
         CHECK(snapshot == (dif_csrng_irq_state_snapshot_t)(1 << irq),
               "Only csrng IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_csrng_irq_force(&csrng, irq, false));
         CHECK_DIF_OK(dif_csrng_irq_acknowledge(&csrng, irq));
         break;
       }
@@ -480,11 +465,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_edn_irq_get_state(&edn0, &snapshot));
         CHECK(snapshot == (dif_edn_irq_state_snapshot_t)(1 << irq),
               "Only edn0 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_edn_irq_force(&edn0, irq, false));
         CHECK_DIF_OK(dif_edn_irq_acknowledge(&edn0, irq));
         break;
       }
@@ -504,11 +486,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_edn_irq_get_state(&edn1, &snapshot));
         CHECK(snapshot == (dif_edn_irq_state_snapshot_t)(1 << irq),
               "Only edn1 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_edn_irq_force(&edn1, irq, false));
         CHECK_DIF_OK(dif_edn_irq_acknowledge(&edn1, irq));
         break;
       }
@@ -528,11 +507,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_entropy_src_irq_get_state(&entropy_src, &snapshot));
         CHECK(snapshot == (dif_entropy_src_irq_state_snapshot_t)(1 << irq),
               "Only entropy_src IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_entropy_src_irq_force(&entropy_src, irq, false));
         CHECK_DIF_OK(dif_entropy_src_irq_acknowledge(&entropy_src, irq));
         break;
       }
@@ -552,11 +528,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_flash_ctrl_irq_get_state(&flash_ctrl, &snapshot));
         CHECK(snapshot == (dif_flash_ctrl_irq_state_snapshot_t)(1 << irq),
               "Only flash_ctrl IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_flash_ctrl_irq_force(&flash_ctrl, irq, false));
         CHECK_DIF_OK(dif_flash_ctrl_irq_acknowledge(&flash_ctrl, irq));
         break;
       }
@@ -576,11 +549,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_gpio_irq_get_state(&gpio, &snapshot));
         CHECK(snapshot == (dif_gpio_irq_state_snapshot_t)(1 << irq),
               "Only gpio IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_gpio_irq_force(&gpio, irq, false));
         CHECK_DIF_OK(dif_gpio_irq_acknowledge(&gpio, irq));
         break;
       }
@@ -600,11 +570,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_hmac_irq_get_state(&hmac, &snapshot));
         CHECK(snapshot == (dif_hmac_irq_state_snapshot_t)(1 << irq),
               "Only hmac IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_hmac_irq_force(&hmac, irq, false));
         CHECK_DIF_OK(dif_hmac_irq_acknowledge(&hmac, irq));
         break;
       }
@@ -624,12 +591,21 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_i2c_irq_get_state(&i2c0, &snapshot));
         CHECK(snapshot == (dif_i2c_irq_state_snapshot_t)(1 << irq),
               "Only i2c0 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_i2c_irq_force(&i2c0, irq, false));
-        CHECK_DIF_OK(dif_i2c_irq_acknowledge(&i2c0, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x1c07 & (1 << irq)) {
+          CHECK_DIF_OK(dif_i2c_irq_force(&i2c0, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x0 & (1 << irq))) {
+            CHECK_DIF_OK(dif_i2c_irq_set_enabled(&i2c0, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_i2c_irq_acknowledge(&i2c0, irq));
+        }
         break;
       }
 #endif
@@ -648,12 +624,21 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_i2c_irq_get_state(&i2c1, &snapshot));
         CHECK(snapshot == (dif_i2c_irq_state_snapshot_t)(1 << irq),
               "Only i2c1 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_i2c_irq_force(&i2c1, irq, false));
-        CHECK_DIF_OK(dif_i2c_irq_acknowledge(&i2c1, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x1c07 & (1 << irq)) {
+          CHECK_DIF_OK(dif_i2c_irq_force(&i2c1, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x0 & (1 << irq))) {
+            CHECK_DIF_OK(dif_i2c_irq_set_enabled(&i2c1, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_i2c_irq_acknowledge(&i2c1, irq));
+        }
         break;
       }
 #endif
@@ -672,12 +657,21 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_i2c_irq_get_state(&i2c2, &snapshot));
         CHECK(snapshot == (dif_i2c_irq_state_snapshot_t)(1 << irq),
               "Only i2c2 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_i2c_irq_force(&i2c2, irq, false));
-        CHECK_DIF_OK(dif_i2c_irq_acknowledge(&i2c2, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x1c07 & (1 << irq)) {
+          CHECK_DIF_OK(dif_i2c_irq_force(&i2c2, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x0 & (1 << irq))) {
+            CHECK_DIF_OK(dif_i2c_irq_set_enabled(&i2c2, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_i2c_irq_acknowledge(&i2c2, irq));
+        }
         break;
       }
 #endif
@@ -696,11 +690,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_keymgr_irq_get_state(&keymgr, &snapshot));
         CHECK(snapshot == (dif_keymgr_irq_state_snapshot_t)(1 << irq),
               "Only keymgr IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_keymgr_irq_force(&keymgr, irq, false));
         CHECK_DIF_OK(dif_keymgr_irq_acknowledge(&keymgr, irq));
         break;
       }
@@ -720,11 +711,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_kmac_irq_get_state(&kmac, &snapshot));
         CHECK(snapshot == (dif_kmac_irq_state_snapshot_t)(1 << irq),
               "Only kmac IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_kmac_irq_force(&kmac, irq, false));
         CHECK_DIF_OK(dif_kmac_irq_acknowledge(&kmac, irq));
         break;
       }
@@ -744,11 +732,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_otbn_irq_get_state(&otbn, &snapshot));
         CHECK(snapshot == (dif_otbn_irq_state_snapshot_t)(1 << irq),
               "Only otbn IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_otbn_irq_force(&otbn, irq, false));
         CHECK_DIF_OK(dif_otbn_irq_acknowledge(&otbn, irq));
         break;
       }
@@ -768,11 +753,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_otp_ctrl_irq_get_state(&otp_ctrl, &snapshot));
         CHECK(snapshot == (dif_otp_ctrl_irq_state_snapshot_t)(1 << irq),
               "Only otp_ctrl IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_otp_ctrl_irq_force(&otp_ctrl, irq, false));
         CHECK_DIF_OK(dif_otp_ctrl_irq_acknowledge(&otp_ctrl, irq));
         break;
       }
@@ -792,11 +774,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_pattgen_irq_get_state(&pattgen, &snapshot));
         CHECK(snapshot == (dif_pattgen_irq_state_snapshot_t)(1 << irq),
               "Only pattgen IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_pattgen_irq_force(&pattgen, irq, false));
         CHECK_DIF_OK(dif_pattgen_irq_acknowledge(&pattgen, irq));
         break;
       }
@@ -816,11 +795,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_pwrmgr_irq_get_state(&pwrmgr_aon, &snapshot));
         CHECK(snapshot == (dif_pwrmgr_irq_state_snapshot_t)(1 << irq),
               "Only pwrmgr_aon IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_pwrmgr_irq_force(&pwrmgr_aon, irq, false));
         CHECK_DIF_OK(dif_pwrmgr_irq_acknowledge(&pwrmgr_aon, irq));
         break;
       }
@@ -840,11 +816,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_rv_timer_irq_get_state(&rv_timer, kHart, &snapshot));
         CHECK(snapshot == (dif_rv_timer_irq_state_snapshot_t)(1 << irq),
               "Only rv_timer IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_rv_timer_irq_force(&rv_timer, irq, false));
         CHECK_DIF_OK(dif_rv_timer_irq_acknowledge(&rv_timer, irq));
         break;
       }
@@ -864,11 +837,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_sensor_ctrl_irq_get_state(&sensor_ctrl_aon, &snapshot));
         CHECK(snapshot == (dif_sensor_ctrl_irq_state_snapshot_t)(1 << irq),
               "Only sensor_ctrl_aon IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_sensor_ctrl_irq_force(&sensor_ctrl_aon, irq, false));
         CHECK_DIF_OK(dif_sensor_ctrl_irq_acknowledge(&sensor_ctrl_aon, irq));
         break;
       }
@@ -888,12 +858,21 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_spi_device_irq_get_state(&spi_device, &snapshot));
         CHECK(snapshot == (dif_spi_device_irq_state_snapshot_t)(1 << irq),
               "Only spi_device IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_spi_device_irq_force(&spi_device, irq, false));
-        CHECK_DIF_OK(dif_spi_device_irq_acknowledge(&spi_device, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x20 & (1 << irq)) {
+          CHECK_DIF_OK(dif_spi_device_irq_force(&spi_device, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x0 & (1 << irq))) {
+            CHECK_DIF_OK(dif_spi_device_irq_set_enabled(&spi_device, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_spi_device_irq_acknowledge(&spi_device, irq));
+        }
         break;
       }
 #endif
@@ -912,11 +891,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_spi_host_irq_get_state(&spi_host0, &snapshot));
         CHECK(snapshot == (dif_spi_host_irq_state_snapshot_t)(1 << irq),
               "Only spi_host0 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_spi_host_irq_force(&spi_host0, irq, false));
         CHECK_DIF_OK(dif_spi_host_irq_acknowledge(&spi_host0, irq));
         break;
       }
@@ -936,11 +912,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_spi_host_irq_get_state(&spi_host1, &snapshot));
         CHECK(snapshot == (dif_spi_host_irq_state_snapshot_t)(1 << irq),
               "Only spi_host1 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_spi_host_irq_force(&spi_host1, irq, false));
         CHECK_DIF_OK(dif_spi_host_irq_acknowledge(&spi_host1, irq));
         break;
       }
@@ -960,11 +933,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_sysrst_ctrl_irq_get_state(&sysrst_ctrl_aon, &snapshot));
         CHECK(snapshot == (dif_sysrst_ctrl_irq_state_snapshot_t)(1 << irq),
               "Only sysrst_ctrl_aon IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_sysrst_ctrl_irq_force(&sysrst_ctrl_aon, irq, false));
         CHECK_DIF_OK(dif_sysrst_ctrl_irq_acknowledge(&sysrst_ctrl_aon, irq));
         break;
       }
@@ -984,11 +954,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_uart_irq_get_state(&uart0, &snapshot));
         CHECK(snapshot == (dif_uart_irq_state_snapshot_t)(1 << irq),
               "Only uart0 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_uart_irq_force(&uart0, irq, false));
         CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart0, irq));
         break;
       }
@@ -1008,11 +975,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_uart_irq_get_state(&uart1, &snapshot));
         CHECK(snapshot == (dif_uart_irq_state_snapshot_t)(1 << irq),
               "Only uart1 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_uart_irq_force(&uart1, irq, false));
         CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart1, irq));
         break;
       }
@@ -1032,11 +996,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_uart_irq_get_state(&uart2, &snapshot));
         CHECK(snapshot == (dif_uart_irq_state_snapshot_t)(1 << irq),
               "Only uart2 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_uart_irq_force(&uart2, irq, false));
         CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart2, irq));
         break;
       }
@@ -1056,11 +1017,8 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_uart_irq_get_state(&uart3, &snapshot));
         CHECK(snapshot == (dif_uart_irq_state_snapshot_t)(1 << irq),
               "Only uart3 IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_uart_irq_force(&uart3, irq, false));
         CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart3, irq));
         break;
       }
@@ -1080,12 +1038,21 @@ void ottf_external_isr(uint32_t *exc_info) {
         CHECK_DIF_OK(dif_usbdev_irq_get_state(&usbdev, &snapshot));
         CHECK(snapshot == (dif_usbdev_irq_state_snapshot_t)(1 << irq),
               "Only usbdev IRQ %d expected to fire. Actual interrupt "
-              "status = %x",
-              irq, snapshot);
+              "status = %x", irq, snapshot);
 
-        // TODO: Check Interrupt type then clear INTR_TEST if needed.
-        CHECK_DIF_OK(dif_usbdev_irq_force(&usbdev, irq, false));
-        CHECK_DIF_OK(dif_usbdev_irq_acknowledge(&usbdev, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x20183 & (1 << irq)) {
+          CHECK_DIF_OK(dif_usbdev_irq_force(&usbdev, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x0 & (1 << irq))) {
+            CHECK_DIF_OK(dif_usbdev_irq_set_enabled(&usbdev, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_usbdev_irq_acknowledge(&usbdev, irq));
+        }
         break;
       }
 #endif
@@ -1392,112 +1359,112 @@ static void peripheral_irqs_clear(void) {
 static void peripheral_irqs_enable(void) {
 #if TEST_MIN_IRQ_PERIPHERAL <= 0 && 0 < TEST_MAX_IRQ_PERIPHERAL
   dif_adc_ctrl_irq_state_snapshot_t adc_ctrl_irqs =
-      (dif_adc_ctrl_irq_state_snapshot_t)UINT_MAX;
+      (dif_adc_ctrl_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 1 && 1 < TEST_MAX_IRQ_PERIPHERAL
   dif_alert_handler_irq_state_snapshot_t alert_handler_irqs =
-      (dif_alert_handler_irq_state_snapshot_t)UINT_MAX;
+      (dif_alert_handler_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 3 && 3 < TEST_MAX_IRQ_PERIPHERAL
   dif_csrng_irq_state_snapshot_t csrng_irqs =
-      (dif_csrng_irq_state_snapshot_t)UINT_MAX;
+      (dif_csrng_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 4 && 4 < TEST_MAX_IRQ_PERIPHERAL
   dif_edn_irq_state_snapshot_t edn_irqs =
-      (dif_edn_irq_state_snapshot_t)UINT_MAX;
+      (dif_edn_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 5 && 5 < TEST_MAX_IRQ_PERIPHERAL
   dif_entropy_src_irq_state_snapshot_t entropy_src_irqs =
-      (dif_entropy_src_irq_state_snapshot_t)UINT_MAX;
+      (dif_entropy_src_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 6 && 6 < TEST_MAX_IRQ_PERIPHERAL
   dif_flash_ctrl_irq_state_snapshot_t flash_ctrl_irqs =
-      (dif_flash_ctrl_irq_state_snapshot_t)UINT_MAX;
+      (dif_flash_ctrl_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 7 && 7 < TEST_MAX_IRQ_PERIPHERAL
   dif_gpio_irq_state_snapshot_t gpio_irqs =
-      (dif_gpio_irq_state_snapshot_t)UINT_MAX;
+      (dif_gpio_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 8 && 8 < TEST_MAX_IRQ_PERIPHERAL
   dif_hmac_irq_state_snapshot_t hmac_irqs =
-      (dif_hmac_irq_state_snapshot_t)UINT_MAX;
+      (dif_hmac_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 9 && 9 < TEST_MAX_IRQ_PERIPHERAL
   dif_i2c_irq_state_snapshot_t i2c_irqs =
-      (dif_i2c_irq_state_snapshot_t)UINT_MAX;
+      (dif_i2c_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 10 && 10 < TEST_MAX_IRQ_PERIPHERAL
   dif_keymgr_irq_state_snapshot_t keymgr_irqs =
-      (dif_keymgr_irq_state_snapshot_t)UINT_MAX;
+      (dif_keymgr_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 11 && 11 < TEST_MAX_IRQ_PERIPHERAL
   dif_kmac_irq_state_snapshot_t kmac_irqs =
-      (dif_kmac_irq_state_snapshot_t)UINT_MAX;
+      (dif_kmac_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 12 && 12 < TEST_MAX_IRQ_PERIPHERAL
   dif_otbn_irq_state_snapshot_t otbn_irqs =
-      (dif_otbn_irq_state_snapshot_t)UINT_MAX;
+      (dif_otbn_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 13 && 13 < TEST_MAX_IRQ_PERIPHERAL
   dif_otp_ctrl_irq_state_snapshot_t otp_ctrl_irqs =
-      (dif_otp_ctrl_irq_state_snapshot_t)UINT_MAX;
+      (dif_otp_ctrl_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 14 && 14 < TEST_MAX_IRQ_PERIPHERAL
   dif_pattgen_irq_state_snapshot_t pattgen_irqs =
-      (dif_pattgen_irq_state_snapshot_t)UINT_MAX;
+      (dif_pattgen_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 15 && 15 < TEST_MAX_IRQ_PERIPHERAL
   dif_pwrmgr_irq_state_snapshot_t pwrmgr_irqs =
-      (dif_pwrmgr_irq_state_snapshot_t)UINT_MAX;
+      (dif_pwrmgr_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 16 && 16 < TEST_MAX_IRQ_PERIPHERAL
   dif_rv_timer_irq_state_snapshot_t rv_timer_irqs =
-      (dif_rv_timer_irq_state_snapshot_t)UINT_MAX;
+      (dif_rv_timer_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 17 && 17 < TEST_MAX_IRQ_PERIPHERAL
   dif_sensor_ctrl_irq_state_snapshot_t sensor_ctrl_irqs =
-      (dif_sensor_ctrl_irq_state_snapshot_t)UINT_MAX;
+      (dif_sensor_ctrl_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 18 && 18 < TEST_MAX_IRQ_PERIPHERAL
   dif_spi_device_irq_state_snapshot_t spi_device_irqs =
-      (dif_spi_device_irq_state_snapshot_t)UINT_MAX;
+      (dif_spi_device_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 19 && 19 < TEST_MAX_IRQ_PERIPHERAL
   dif_spi_host_irq_state_snapshot_t spi_host_irqs =
-      (dif_spi_host_irq_state_snapshot_t)UINT_MAX;
+      (dif_spi_host_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 20 && 20 < TEST_MAX_IRQ_PERIPHERAL
   dif_sysrst_ctrl_irq_state_snapshot_t sysrst_ctrl_irqs =
-      (dif_sysrst_ctrl_irq_state_snapshot_t)UINT_MAX;
+      (dif_sysrst_ctrl_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 21 && 21 < TEST_MAX_IRQ_PERIPHERAL
   dif_uart_irq_state_snapshot_t uart_irqs =
-      (dif_uart_irq_state_snapshot_t)UINT_MAX;
+      (dif_uart_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 22 && 22 < TEST_MAX_IRQ_PERIPHERAL
   dif_usbdev_irq_state_snapshot_t usbdev_irqs =
-      (dif_usbdev_irq_state_snapshot_t)UINT_MAX;
+      (dif_usbdev_irq_state_snapshot_t)0xffffffff;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 0 && 0 < TEST_MAX_IRQ_PERIPHERAL
@@ -1662,10 +1629,16 @@ static void peripheral_irqs_enable(void) {
  * expected IRQ from the expected peripheral triggered.
  */
 static void peripheral_irqs_trigger(void) {
+  unsigned int status_default_mask;
+  // Depending on the build configuration, this variable may show up as unused
+  // in the clang linter. This statement waives that error.
+  (void) status_default_mask;
+
 #if TEST_MIN_IRQ_PERIPHERAL <= 0 && 0 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralAdcCtrlAon;
   for (dif_adc_ctrl_irq_t irq = kDifAdcCtrlIrqMatchDone;
        irq <= kDifAdcCtrlIrqMatchDone; ++irq) {
+
     adc_ctrl_irq_expected = irq;
     LOG_INFO("Triggering adc_ctrl_aon IRQ %d.", irq);
     CHECK_DIF_OK(dif_adc_ctrl_irq_force(&adc_ctrl_aon, irq, true));
@@ -1681,6 +1654,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralAlertHandler;
   for (dif_alert_handler_irq_t irq = kDifAlertHandlerIrqClassa;
        irq <= kDifAlertHandlerIrqClassd; ++irq) {
+
     alert_handler_irq_expected = irq;
     LOG_INFO("Triggering alert_handler IRQ %d.", irq);
     CHECK_DIF_OK(dif_alert_handler_irq_force(&alert_handler, irq, true));
@@ -1702,6 +1676,7 @@ static void peripheral_irqs_trigger(void) {
     peripheral_expected = kTopEarlgreyPlicPeripheralAonTimerAon;
     for (dif_aon_timer_irq_t irq = kDifAonTimerIrqWkupTimerExpired;
          irq <= kDifAonTimerIrqWdogTimerBark; ++irq) {
+
       aon_timer_irq_expected = irq;
       LOG_INFO("Triggering aon_timer_aon IRQ %d.", irq);
       CHECK_DIF_OK(dif_aon_timer_irq_force(&aon_timer_aon, irq, true));
@@ -1718,6 +1693,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralCsrng;
   for (dif_csrng_irq_t irq = kDifCsrngIrqCsCmdReqDone;
        irq <= kDifCsrngIrqCsFatalErr; ++irq) {
+
     csrng_irq_expected = irq;
     LOG_INFO("Triggering csrng IRQ %d.", irq);
     CHECK_DIF_OK(dif_csrng_irq_force(&csrng, irq, true));
@@ -1733,6 +1709,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralEdn0;
   for (dif_edn_irq_t irq = kDifEdnIrqEdnCmdReqDone;
        irq <= kDifEdnIrqEdnFatalErr; ++irq) {
+
     edn_irq_expected = irq;
     LOG_INFO("Triggering edn0 IRQ %d.", irq);
     CHECK_DIF_OK(dif_edn_irq_force(&edn0, irq, true));
@@ -1748,6 +1725,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralEdn1;
   for (dif_edn_irq_t irq = kDifEdnIrqEdnCmdReqDone;
        irq <= kDifEdnIrqEdnFatalErr; ++irq) {
+
     edn_irq_expected = irq;
     LOG_INFO("Triggering edn1 IRQ %d.", irq);
     CHECK_DIF_OK(dif_edn_irq_force(&edn1, irq, true));
@@ -1763,6 +1741,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralEntropySrc;
   for (dif_entropy_src_irq_t irq = kDifEntropySrcIrqEsEntropyValid;
        irq <= kDifEntropySrcIrqEsFatalErr; ++irq) {
+
     entropy_src_irq_expected = irq;
     LOG_INFO("Triggering entropy_src IRQ %d.", irq);
     CHECK_DIF_OK(dif_entropy_src_irq_force(&entropy_src, irq, true));
@@ -1778,6 +1757,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralFlashCtrl;
   for (dif_flash_ctrl_irq_t irq = kDifFlashCtrlIrqProgEmpty;
        irq <= kDifFlashCtrlIrqCorrErr; ++irq) {
+
     flash_ctrl_irq_expected = irq;
     LOG_INFO("Triggering flash_ctrl IRQ %d.", irq);
     CHECK_DIF_OK(dif_flash_ctrl_irq_force(&flash_ctrl, irq, true));
@@ -1793,6 +1773,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralGpio;
   for (dif_gpio_irq_t irq = kDifGpioIrqGpio0;
        irq <= kDifGpioIrqGpio31; ++irq) {
+
     gpio_irq_expected = irq;
     LOG_INFO("Triggering gpio IRQ %d.", irq);
     CHECK_DIF_OK(dif_gpio_irq_force(&gpio, irq, true));
@@ -1808,6 +1789,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralHmac;
   for (dif_hmac_irq_t irq = kDifHmacIrqHmacDone;
        irq <= kDifHmacIrqHmacErr; ++irq) {
+
     hmac_irq_expected = irq;
     LOG_INFO("Triggering hmac IRQ %d.", irq);
     CHECK_DIF_OK(dif_hmac_irq_force(&hmac, irq, true));
@@ -1821,11 +1803,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 9 && 9 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralI2c0;
+  status_default_mask = 0x0;
   for (dif_i2c_irq_t irq = kDifI2cIrqFmtThreshold;
        irq <= kDifI2cIrqHostTimeout; ++irq) {
+
     i2c_irq_expected = irq;
     LOG_INFO("Triggering i2c0 IRQ %d.", irq);
     CHECK_DIF_OK(dif_i2c_irq_force(&i2c0, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_i2c_irq_set_enabled(&i2c0, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.
@@ -1836,11 +1828,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 9 && 9 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralI2c1;
+  status_default_mask = 0x0;
   for (dif_i2c_irq_t irq = kDifI2cIrqFmtThreshold;
        irq <= kDifI2cIrqHostTimeout; ++irq) {
+
     i2c_irq_expected = irq;
     LOG_INFO("Triggering i2c1 IRQ %d.", irq);
     CHECK_DIF_OK(dif_i2c_irq_force(&i2c1, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_i2c_irq_set_enabled(&i2c1, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.
@@ -1851,11 +1853,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 9 && 9 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralI2c2;
+  status_default_mask = 0x0;
   for (dif_i2c_irq_t irq = kDifI2cIrqFmtThreshold;
        irq <= kDifI2cIrqHostTimeout; ++irq) {
+
     i2c_irq_expected = irq;
     LOG_INFO("Triggering i2c2 IRQ %d.", irq);
     CHECK_DIF_OK(dif_i2c_irq_force(&i2c2, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_i2c_irq_set_enabled(&i2c2, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.
@@ -1868,6 +1880,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralKeymgr;
   for (dif_keymgr_irq_t irq = kDifKeymgrIrqOpDone;
        irq <= kDifKeymgrIrqOpDone; ++irq) {
+
     keymgr_irq_expected = irq;
     LOG_INFO("Triggering keymgr IRQ %d.", irq);
     CHECK_DIF_OK(dif_keymgr_irq_force(&keymgr, irq, true));
@@ -1883,6 +1896,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralKmac;
   for (dif_kmac_irq_t irq = kDifKmacIrqKmacDone;
        irq <= kDifKmacIrqKmacErr; ++irq) {
+
     kmac_irq_expected = irq;
     LOG_INFO("Triggering kmac IRQ %d.", irq);
     CHECK_DIF_OK(dif_kmac_irq_force(&kmac, irq, true));
@@ -1898,6 +1912,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralOtbn;
   for (dif_otbn_irq_t irq = kDifOtbnIrqDone;
        irq <= kDifOtbnIrqDone; ++irq) {
+
     otbn_irq_expected = irq;
     LOG_INFO("Triggering otbn IRQ %d.", irq);
     CHECK_DIF_OK(dif_otbn_irq_force(&otbn, irq, true));
@@ -1916,6 +1931,7 @@ static void peripheral_irqs_trigger(void) {
     peripheral_expected = kTopEarlgreyPlicPeripheralOtpCtrl;
     for (dif_otp_ctrl_irq_t irq = kDifOtpCtrlIrqOtpOperationDone;
          irq <= kDifOtpCtrlIrqOtpError; ++irq) {
+
       otp_ctrl_irq_expected = irq;
       LOG_INFO("Triggering otp_ctrl IRQ %d.", irq);
       CHECK_DIF_OK(dif_otp_ctrl_irq_force(&otp_ctrl, irq, true));
@@ -1932,6 +1948,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralPattgen;
   for (dif_pattgen_irq_t irq = kDifPattgenIrqDoneCh0;
        irq <= kDifPattgenIrqDoneCh1; ++irq) {
+
     pattgen_irq_expected = irq;
     LOG_INFO("Triggering pattgen IRQ %d.", irq);
     CHECK_DIF_OK(dif_pattgen_irq_force(&pattgen, irq, true));
@@ -1947,6 +1964,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralPwrmgrAon;
   for (dif_pwrmgr_irq_t irq = kDifPwrmgrIrqWakeup;
        irq <= kDifPwrmgrIrqWakeup; ++irq) {
+
     pwrmgr_irq_expected = irq;
     LOG_INFO("Triggering pwrmgr_aon IRQ %d.", irq);
     CHECK_DIF_OK(dif_pwrmgr_irq_force(&pwrmgr_aon, irq, true));
@@ -1962,6 +1980,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralRvTimer;
   for (dif_rv_timer_irq_t irq = kDifRvTimerIrqTimerExpiredHart0Timer0;
        irq <= kDifRvTimerIrqTimerExpiredHart0Timer0; ++irq) {
+
     rv_timer_irq_expected = irq;
     LOG_INFO("Triggering rv_timer IRQ %d.", irq);
     CHECK_DIF_OK(dif_rv_timer_irq_force(&rv_timer, irq, true));
@@ -1977,6 +1996,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralSensorCtrlAon;
   for (dif_sensor_ctrl_irq_t irq = kDifSensorCtrlIrqIoStatusChange;
        irq <= kDifSensorCtrlIrqInitStatusChange; ++irq) {
+
     sensor_ctrl_irq_expected = irq;
     LOG_INFO("Triggering sensor_ctrl_aon IRQ %d.", irq);
     CHECK_DIF_OK(dif_sensor_ctrl_irq_force(&sensor_ctrl_aon, irq, true));
@@ -1990,11 +2010,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 18 && 18 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralSpiDevice;
+  status_default_mask = 0x0;
   for (dif_spi_device_irq_t irq = kDifSpiDeviceIrqUploadCmdfifoNotEmpty;
        irq <= kDifSpiDeviceIrqTpmRdfifoDrop; ++irq) {
+
     spi_device_irq_expected = irq;
     LOG_INFO("Triggering spi_device IRQ %d.", irq);
     CHECK_DIF_OK(dif_spi_device_irq_force(&spi_device, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_spi_device_irq_set_enabled(&spi_device, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.
@@ -2007,6 +2037,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralSpiHost0;
   for (dif_spi_host_irq_t irq = kDifSpiHostIrqError;
        irq <= kDifSpiHostIrqSpiEvent; ++irq) {
+
     spi_host_irq_expected = irq;
     LOG_INFO("Triggering spi_host0 IRQ %d.", irq);
     CHECK_DIF_OK(dif_spi_host_irq_force(&spi_host0, irq, true));
@@ -2022,6 +2053,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralSpiHost1;
   for (dif_spi_host_irq_t irq = kDifSpiHostIrqError;
        irq <= kDifSpiHostIrqSpiEvent; ++irq) {
+
     spi_host_irq_expected = irq;
     LOG_INFO("Triggering spi_host1 IRQ %d.", irq);
     CHECK_DIF_OK(dif_spi_host_irq_force(&spi_host1, irq, true));
@@ -2037,6 +2069,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralSysrstCtrlAon;
   for (dif_sysrst_ctrl_irq_t irq = kDifSysrstCtrlIrqEventDetected;
        irq <= kDifSysrstCtrlIrqEventDetected; ++irq) {
+
     sysrst_ctrl_irq_expected = irq;
     LOG_INFO("Triggering sysrst_ctrl_aon IRQ %d.", irq);
     CHECK_DIF_OK(dif_sysrst_ctrl_irq_force(&sysrst_ctrl_aon, irq, true));
@@ -2058,6 +2091,7 @@ static void peripheral_irqs_trigger(void) {
     peripheral_expected = kTopEarlgreyPlicPeripheralUart0;
     for (dif_uart_irq_t irq = kDifUartIrqTxWatermark;
          irq <= kDifUartIrqRxParityErr; ++irq) {
+
       uart_irq_expected = irq;
       LOG_INFO("Triggering uart0 IRQ %d.", irq);
       CHECK_DIF_OK(dif_uart_irq_force(&uart0, irq, true));
@@ -2074,6 +2108,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralUart1;
   for (dif_uart_irq_t irq = kDifUartIrqTxWatermark;
        irq <= kDifUartIrqRxParityErr; ++irq) {
+
     uart_irq_expected = irq;
     LOG_INFO("Triggering uart1 IRQ %d.", irq);
     CHECK_DIF_OK(dif_uart_irq_force(&uart1, irq, true));
@@ -2089,6 +2124,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralUart2;
   for (dif_uart_irq_t irq = kDifUartIrqTxWatermark;
        irq <= kDifUartIrqRxParityErr; ++irq) {
+
     uart_irq_expected = irq;
     LOG_INFO("Triggering uart2 IRQ %d.", irq);
     CHECK_DIF_OK(dif_uart_irq_force(&uart2, irq, true));
@@ -2104,6 +2140,7 @@ static void peripheral_irqs_trigger(void) {
   peripheral_expected = kTopEarlgreyPlicPeripheralUart3;
   for (dif_uart_irq_t irq = kDifUartIrqTxWatermark;
        irq <= kDifUartIrqRxParityErr; ++irq) {
+
     uart_irq_expected = irq;
     LOG_INFO("Triggering uart3 IRQ %d.", irq);
     CHECK_DIF_OK(dif_uart_irq_force(&uart3, irq, true));
@@ -2117,11 +2154,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 22 && 22 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralUsbdev;
+  status_default_mask = 0x0;
   for (dif_usbdev_irq_t irq = kDifUsbdevIrqPktReceived;
        irq <= kDifUsbdevIrqAvSetupEmpty; ++irq) {
+
     usbdev_irq_expected = irq;
     LOG_INFO("Triggering usbdev IRQ %d.", irq);
     CHECK_DIF_OK(dif_usbdev_irq_force(&usbdev, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_usbdev_irq_set_enabled(&usbdev, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -114,7 +114,8 @@ static volatile bool fired_irqs[FLASH_CTRL_NUM_IRQS];
 void ottf_external_isr(uint32_t *exc_info) {
   top_earlgrey_plic_peripheral_t peripheral_serviced;
   dif_flash_ctrl_irq_t irq_serviced;
-  isr_testutils_flash_ctrl_isr(plic_ctx, flash_ctx, &peripheral_serviced,
+  // Instruct the ISR to mute any status interrupt that is firing.
+  isr_testutils_flash_ctrl_isr(plic_ctx, flash_ctx, true, &peripheral_serviced,
                                &irq_serviced);
   CHECK(peripheral_serviced == kTopEarlgreyPlicPeripheralFlashCtrl,
         "Interurpt from unexpected peripheral: %d", peripheral_serviced);
@@ -134,15 +135,20 @@ static void clear_irq_variables(void) {
 /**
  * Initializes FLASH_CTRL and enables the relevant interrupts.
  */
-static void flash_ctrl_init_with_irqs(mmio_region_t base_addr,
-                                      dif_flash_ctrl_state_t *flash_state,
-                                      dif_flash_ctrl_t *flash_ctrl) {
+static void flash_ctrl_init_with_event_irqs(mmio_region_t base_addr,
+                                            dif_flash_ctrl_state_t *flash_state,
+                                            dif_flash_ctrl_t *flash_ctrl) {
   CHECK_DIF_OK(dif_flash_ctrl_init(base_addr, flash_ctrl));
   CHECK_DIF_OK(dif_flash_ctrl_init_state(flash_state, base_addr));
 
   for (dif_flash_ctrl_irq_t i = 0; i < FLASH_CTRL_NUM_IRQS; ++i) {
-    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
-        flash_ctrl, kDifFlashCtrlIrqProgEmpty + i, kDifToggleEnabled));
+    dif_irq_type_t type;
+    CHECK_DIF_OK(dif_flash_ctrl_irq_get_type(
+        flash_ctrl, kDifFlashCtrlIrqProgEmpty + i, &type));
+    if (type == kDifIrqTypeEvent) {
+      CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+          flash_ctrl, kDifFlashCtrlIrqProgEmpty + i, kDifToggleEnabled));
+    }
   }
   clear_irq_variables();
 }
@@ -195,6 +201,14 @@ static void do_info_partition_test(uint32_t partition_number,
   expected_irqs[kDifFlashCtrlIrqOpDone] = true;
   expected_irqs[kDifFlashCtrlIrqProgEmpty] = true;
   expected_irqs[kDifFlashCtrlIrqProgLvl] = true;
+  // Note: ProgEmpty and ProgLvl interrupts are enabled here and since the
+  // assert by default, they will be serviced and silenced right away. In order
+  // to test them more thoroughly, in this test, we would have to rework the
+  // write operation test utility.
+  CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+      &flash_ctrl, kDifFlashCtrlIrqProgEmpty, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+      &flash_ctrl, kDifFlashCtrlIrqProgLvl, kDifToggleEnabled));
   CHECK_STATUS_OK(
       flash_ctrl_testutils_write(&flash_state, address, kPartitionId, test_data,
                                  kDifFlashCtrlPartitionTypeInfo, kInfoSize));
@@ -205,6 +219,13 @@ static void do_info_partition_test(uint32_t partition_number,
   expected_irqs[kDifFlashCtrlIrqOpDone] = true;
   expected_irqs[kDifFlashCtrlIrqRdLvl] = true;
   expected_irqs[kDifFlashCtrlIrqRdFull] = true;
+  // Note: RdLvl and RdFull interrupts are enabled here and as opposed to
+  // ProgEmpty and ProgLvl above, they will be tested correctly, since they only
+  // assert once the FIFO reaches the respective fill levels.
+  CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+      &flash_ctrl, kDifFlashCtrlIrqRdLvl, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+      &flash_ctrl, kDifFlashCtrlIrqRdFull, kDifToggleEnabled));
   CHECK_STATUS_OK(flash_ctrl_testutils_read(
       &flash_state, address, kPartitionId, readback_data,
       kDifFlashCtrlPartitionTypeInfo, kInfoSize, 1));
@@ -251,7 +272,13 @@ static void do_bank0_data_partition_test(void) {
   expected_irqs[kDifFlashCtrlIrqOpDone] = true;
   expected_irqs[kDifFlashCtrlIrqRdLvl] = true;
   expected_irqs[kDifFlashCtrlIrqRdFull] = true;
-
+  // Note: RdLvl and RdFull interrupts are enabled here and as opposed to
+  // ProgEmpty and ProgLvl above, they will be tested correctly, since they only
+  // assert once the FIFO reaches the respective fill levels.
+  CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+      &flash_ctrl, kDifFlashCtrlIrqRdLvl, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+      &flash_ctrl, kDifFlashCtrlIrqRdFull, kDifToggleEnabled));
   uint32_t readback_data[kDataSize];
   CHECK_STATUS_OK(flash_ctrl_testutils_read(
       &flash_state, address, kPartitionId, readback_data,
@@ -302,6 +329,14 @@ static void do_bank1_data_partition_test(void) {
     expected_irqs[kDifFlashCtrlIrqOpDone] = true;
     expected_irqs[kDifFlashCtrlIrqProgEmpty] = true;
     expected_irqs[kDifFlashCtrlIrqProgLvl] = true;
+    // Note: ProgEmpty and ProgLvl interrupts are enabled here and since the
+    // assert by default, they will be serviced and silenced right away. In
+    // order to test them more thoroughly, in this test, we would have to rework
+    // the write operation test utility.
+    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+        &flash_ctrl, kDifFlashCtrlIrqProgEmpty, kDifToggleEnabled));
+    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+        &flash_ctrl, kDifFlashCtrlIrqProgLvl, kDifToggleEnabled));
     CHECK_STATUS_OK(flash_ctrl_testutils_write(
         &flash_state, address, kPartitionId, test_data,
         kDifFlashCtrlPartitionTypeData, kDataSize));
@@ -312,6 +347,13 @@ static void do_bank1_data_partition_test(void) {
     expected_irqs[kDifFlashCtrlIrqOpDone] = true;
     expected_irqs[kDifFlashCtrlIrqRdLvl] = true;
     expected_irqs[kDifFlashCtrlIrqRdFull] = true;
+    // Note: RdLvl and RdFull interrupts are enabled here and as opposed to
+    // ProgEmpty and ProgLvl above, they will be tested correctly, since they
+    // only assert once the FIFO reaches the respective fill levels.
+    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+        &flash_ctrl, kDifFlashCtrlIrqRdLvl, kDifToggleEnabled));
+    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+        &flash_ctrl, kDifFlashCtrlIrqRdFull, kDifToggleEnabled));
     CHECK_STATUS_OK(flash_ctrl_testutils_read(
         &flash_state, address, kPartitionId, readback_data,
         kDifFlashCtrlPartitionTypeData, kDataSize, 1));
@@ -354,6 +396,13 @@ static void do_bank1_data_partition_test(void) {
     expected_irqs[kDifFlashCtrlIrqOpDone] = true;
     expected_irqs[kDifFlashCtrlIrqRdLvl] = true;
     expected_irqs[kDifFlashCtrlIrqRdFull] = true;
+    // Note: RdLvl and RdFull interrupts are enabled here and as opposed to
+    // ProgEmpty and ProgLvl above, they will be tested correctly, since they
+    // only assert once the FIFO reaches the respective fill levels.
+    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+        &flash_ctrl, kDifFlashCtrlIrqRdLvl, kDifToggleEnabled));
+    CHECK_DIF_OK(dif_flash_ctrl_irq_set_enabled(
+        &flash_ctrl, kDifFlashCtrlIrqRdFull, kDifToggleEnabled));
     CHECK_STATUS_OK(flash_ctrl_testutils_read(
         &flash_state, address, kPartitionId, readback_data,
         kDifFlashCtrlPartitionTypeData, kDataSize, 1));
@@ -372,7 +421,7 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_rv_plic_init(
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic0));
 
-  flash_ctrl_init_with_irqs(
+  flash_ctrl_init_with_event_irqs(
       mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR),
       &flash_state, &flash_ctrl);
   rv_plic_testutils_irq_range_enable(&plic0, plic_ctx.hart_id,

--- a/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
@@ -124,7 +124,7 @@ void ottf_external_isr(uint32_t *exc_info) {
 
   top_earlgrey_plic_peripheral_t peripheral;
   dif_i2c_irq_t i2c_irq;
-  isr_testutils_i2c_isr(plic_ctx, i2c_ctx, &peripheral, &i2c_irq);
+  isr_testutils_i2c_isr(plic_ctx, i2c_ctx, false, &peripheral, &i2c_irq);
 
   switch (i2c_irq) {
     case kDifI2cIrqTxStretch:

--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -72,7 +72,7 @@ void ottf_external_isr(uint32_t *exc_info) {
 
   top_earlgrey_plic_peripheral_t peripheral;
   dif_i2c_irq_t i2c_irq;
-  isr_testutils_i2c_isr(plic_ctx, i2c_ctx, &peripheral, &i2c_irq);
+  isr_testutils_i2c_isr(plic_ctx, i2c_ctx, false, &peripheral, &i2c_irq);
 
   bool disable = false;
   switch (i2c_irq) {

--- a/sw/device/tests/spi_device_tpm_tx_rx_test.c
+++ b/sw/device/tests/spi_device_tpm_tx_rx_test.c
@@ -99,7 +99,7 @@ void ottf_external_isr(uint32_t *exc_info) {
 
   top_earlgrey_plic_peripheral_t peripheral;
   dif_spi_device_irq_t spi_device_irq;
-  isr_testutils_spi_device_isr(plic_ctx, spi_device_ctx, &peripheral,
+  isr_testutils_spi_device_isr(plic_ctx, spi_device_ctx, false, &peripheral,
                                &spi_device_irq);
 
   switch (spi_device_irq) {

--- a/util/autogen_testutils/templates/isr_testutils.h.tpl
+++ b/util/autogen_testutils/templates/isr_testutils.h.tpl
@@ -69,12 +69,18 @@ typedef struct plic_isr_ctx {
      *
      * @param plic_ctx A PLIC ISR context handle.
      * @param ${ip.name_snake}_ctx A(n) ${ip.name_snake} ISR context handle.
+    % if ip.has_status_type_irqs():
+     * @param mute_status_irq set to true to disable the serviced status type IRQ.
+    % endif
      * @param[out] peripheral_serviced Out param for the peripheral that was serviced.
      * @param[out] irq_serviced Out param for the IRQ that was serviced.
      */
     void isr_testutils_${ip.name_snake}_isr(
       plic_isr_ctx_t plic_ctx,
       ${ip.name_snake}_isr_ctx_t ${ip.name_snake}_ctx,
+    % if ip.has_status_type_irqs():
+      bool mute_status_irq,
+    % endif
       top_earlgrey_plic_peripheral_t *peripheral_serviced,
       dif_${ip.name_snake}_irq_t *irq_serviced);
 

--- a/util/make_new_dif/ip.py
+++ b/util/make_new_dif/ip.py
@@ -161,3 +161,10 @@ class Ip:
                 p = Parameter(parameter)
                 parameters[p.name] = p
         return parameters
+
+    def has_status_type_irqs(self):
+        for irq in self.irqs:
+            if irq.type == "status":
+                return True
+        else:
+            return False

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -519,7 +519,7 @@ class RegBlock:
                     hwaccess=hwaccess_rw,
                     hwqe=False,
                     bits=interrupt.bits,
-                    resval=0,
+                    resval=interrupt.default_val,
                     enum=None,
                     mubi=False,
                     auto_split=False))

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -884,6 +884,8 @@ def amend_interrupt(top: OrderedDict, name_to_block: Dict[str, IpBlock]):
             sig_dict = signal.as_nwt_dict('interrupt')
             qual = lib.add_module_prefix_to_signal(sig_dict,
                                                    module=m.lower())
+            qual["intr_type"] = signal.intr_type
+            qual["default_val"] = signal.default_val
             top["interrupt"].append(qual)
 
 


### PR DESCRIPTION
The first two commits patch up common infrastructure:
1) The clear_all_interrupts task in the `cip_base_vseq` needs to be adjusted so that it does not fail when status interrupts remain asserted (since they cannot be cleared via a write to the `INTR_STATE` register.
2) Another optional field `default` is added to the interrupt declaration in the IP Hjson file. This allows us to define what the default expectation of the interrupt should be during automatically generated tests such as the `chip_plic_all_irqs` top-level test. That test is aligned to treat status interrupts differently now. In particular, the ones that are asserted by default will not be enabled until that specific interrupt is being tested.

The last two commits are the changes in `flash_ctrl`, aligning the interrupt type behavior according to #21211.

This fixes #21211
