### PR TITLE
[ret_sram, sw] Add is_testrom utils

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -418,6 +418,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -275,5 +275,4 @@ status_t flash_ctrl_testutils_backdoor_wait_update(const volatile uint8_t *addr,
 OT_WARN_UNUSED_RESULT
 status_t flash_ctrl_testutils_show_faults(
     const dif_flash_ctrl_state_t *flash_state);
-
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_

--- a/sw/device/lib/testing/ret_sram_testutils.c
+++ b/sw/device/lib/testing/ret_sram_testutils.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -89,5 +90,15 @@ status_t ret_sram_testutils_scratch_write(size_t offset, size_t size,
   for (size_t i = 0; i < size; ++i) {
     testing_utilities->scratch[offset + i] = src[i];
   }
+  return OK_STATUS();
+}
+
+status_t ret_sram_testutils_is_testrom(bool *is_testrom) {
+  *is_testrom =
+      retention_sram_get()
+          ->creator
+          .reserved[ARRAYSIZE((retention_sram_t){0}.creator.reserved) - 1] ==
+      TEST_ROM_IDENTIFIER;
+
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/ret_sram_testutils.h
+++ b/sw/device/lib/testing/ret_sram_testutils.h
@@ -89,4 +89,15 @@ OT_WARN_UNUSED_RESULT
 status_t ret_sram_testutils_scratch_write(size_t offset, size_t size,
                                           uint32_t *src);
 
+/**
+ * Read rom identity from retention_sram and indicate
+ * whether current test platform uses test_rom.c or not.
+ *
+ * @param true : current test platform uses test_rom.c
+ *        false : current test platform doesn't use test_rom.c
+ *                which can imply it uses rom.c
+ */
+OT_WARN_UNUSED_RESULT
+status_t ret_sram_testutils_is_testrom(bool *is_testrom);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_RET_SRAM_TESTUTILS_H_


### PR DESCRIPTION
This function becomes handy when I debug test over multiple platform.
Add to ret_sram_utils