### PR TITLE
[usbdev] 'Status' interrupt types

### DIFF
--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -766,7 +766,7 @@ module usbdev
   end
 
   // Interrupts
-  prim_intr_hw #(.Width(1)) intr_hw_pkt_received (
+  prim_intr_hw #(.Width(1), .IntrT("Status")) intr_hw_pkt_received (
     .clk_i,
     .rst_ni, // not stubbed off so that the interrupt regs still work.
     .event_intr_i           (event_pkt_received),
@@ -779,7 +779,7 @@ module usbdev
     .intr_o                 (intr_pkt_received_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_hw_pkt_sent (
+  prim_intr_hw #(.Width(1), .IntrT("Status")) intr_hw_pkt_sent (
     .clk_i,
     .rst_ni, // not stubbed off so that the interrupt regs still work.
     .event_intr_i           (sent_event_pending),
@@ -870,7 +870,7 @@ module usbdev
     .intr_o                 (intr_link_resume_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_av_empty (
+  prim_intr_hw #(.Width(1), .IntrT("Status")) intr_av_empty (
     .clk_i,
     .rst_ni, // not stubbed off so that the interrupt regs still work.
     .event_intr_i           (event_av_empty),
@@ -883,7 +883,7 @@ module usbdev
     .intr_o                 (intr_av_empty_o)
   );
 
-  prim_intr_hw #(.Width(1)) intr_rx_full (
+  prim_intr_hw #(.Width(1), .IntrT("Status")) intr_rx_full (
     .clk_i,
     .rst_ni, // not stubbed off so that the interrupt regs still work.
     .event_intr_i           (event_rx_full),


### PR DESCRIPTION
Four of the usbdev interrupts are changed to 'Status' interrupt types because they already exhibited that behavior and could not be cleared until the triggering FIFO/register status had been addressed.

Should close #21210, although there's no proper interrupt-related DV testing for USBDEV at present.