### PR TITLE
[usbdev] Support Si device type in USBDEV tests

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3405,11 +3405,10 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_pincfg_test",
     srcs = ["usbdev_pincfg_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3427,11 +3426,10 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_vbus_test",
     srcs = ["usbdev_vbus_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -3446,11 +3444,10 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_pullup_test",
     srcs = ["usbdev_pullup_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -3465,11 +3462,10 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_setuprx_test",
     srcs = ["usbdev_setuprx_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -3485,11 +3481,10 @@ opentitan_test(
     name = "usbdev_test",
     srcs = ["usbdev_test.c"],
     cw310 = new_cw310_params(tags = ["manual"]),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3511,11 +3506,10 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3536,11 +3530,10 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3561,11 +3554,10 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/usbdev_iso_test.c
+++ b/sw/device/tests/usbdev_iso_test.c
@@ -34,9 +34,9 @@
 //
 // Note: because Isochronous streams are guaranteed the requested amount of
 // bus bandwidth, the number of concurrent streams that may be supported is
-// limited to six.
-#if !defined(NUM_STREAMS) || NUM_STREAMS > 6U
-#define NUM_STREAMS 6U
+// limited to four if connected through a hub (6 without hub(s)).
+#if !defined(NUM_STREAMS) || NUM_STREAMS > 4U
+#define NUM_STREAMS 4U
 #endif
 
 // This takes about 256s presently with 10MHz CPU in CW310 FPGA and physical
@@ -172,6 +172,8 @@ bool test_main(void) {
       break;
     case kDeviceSimDV:
       transfer_bytes = TRANSFER_BYTES_DVSIM;
+      break;
+    case kDeviceSilicon:
       break;
     case kDeviceFpgaCw340:
       break;

--- a/sw/device/tests/usbdev_mixed_test.c
+++ b/sw/device/tests/usbdev_mixed_test.c
@@ -71,13 +71,13 @@ static const char *xfr_name[] = {
 //
 // Note: because Isochronous and Interrupt streams are guaranteed the requested
 // amount of bus bandwidth, the number of concurrent streams of these types is
-// limited to six.
+// limited to four if connected through a hub (six without hub(s)).
 static const usb_testutils_transfer_type_t xfr_types[USBUTILS_STREAMS_MAX] = {
-    kUsbTransferTypeIsochronous, kUsbTransferTypeInterrupt,
+    kUsbTransferTypeIsochronous, kUsbTransferTypeBulk,
     kUsbTransferTypeBulk,        kUsbTransferTypeBulk,
 
     kUsbTransferTypeIsochronous, kUsbTransferTypeInterrupt,
-    kUsbTransferTypeBulk,        kUsbTransferTypeIsochronous,
+    kUsbTransferTypeBulk,        kUsbTransferTypeBulk,
 
     kUsbTransferTypeInterrupt,   kUsbTransferTypeBulk,
     kUsbTransferTypeBulk,
@@ -184,6 +184,8 @@ bool test_main(void) {
       break;
     case kDeviceSimDV:
       transfer_bytes = TRANSFER_BYTES_DVSIM;
+      break;
+    case kDeviceSilicon:
       break;
     case kDeviceFpgaCw340:
       break;

--- a/sw/device/tests/usbdev_pincfg_test.c
+++ b/sw/device/tests/usbdev_pincfg_test.c
@@ -110,6 +110,8 @@ bool test_main(void) {
       // DV simulation can exercise pin-flipping and differential rcvr on/off
       // but there's no point wasting simulation time trying both tx modes;
       // D+/D- are always used directly as differential signals.
+      OT_FALLTHROUGH_INTENDED;
+    case kDeviceSilicon:
       ntests = 4U;
       for (unsigned test = 0U; test < ntests; ++test) {
         test_cfg[test].pinflip = ((test & 1U) != 0U);

--- a/sw/device/tests/usbdev_setuprx_test.c
+++ b/sw/device/tests/usbdev_setuprx_test.c
@@ -125,12 +125,6 @@ static status_t delay(bool prompt, uint32_t timeout_micros) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK(kDeviceType == kDeviceSimDV || kDeviceType == kDeviceSimVerilator ||
-            kDeviceType == kDeviceFpgaCw310,
-        "This test is not expected to run on platforms other than the "
-        "Verilator/DV simulation or CW310 FPGA. It needs either the DPI model "
-        "or a physical host, OS and drivers.");
-
   // In simulation the DPI model connects VBUS shortly after reset and
   // prolonged delays when asserting or deasserting pull ups are wasteful.
   uint32_t timeout_micros = 1000u;
@@ -138,7 +132,7 @@ bool test_main(void) {
   bool prompt = false;
 
   if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) {
-    // FPGA platforms where user intervention may be required.
+    // FPGA or Silicon platform, where user intervention may be required.
     timeout_micros = 30 * 1000 * 1000u;
     // A short delay here permits the activity of the host controller to be
     // observed (eg. dmesg -w on a Linux host).

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -193,6 +193,10 @@ bool test_main(void) {
     case kDeviceSimDV:
       transfer_bytes = TRANSFER_BYTES_DVSIM;
       break;
+    case kDeviceSilicon:
+      break;
+    case kDeviceFpgaCw340:
+      break;
     default:
       CHECK(kDeviceType == kDeviceFpgaCw310);
       break;


### PR DESCRIPTION
Minor modifications to support use of kDeviceSilicon as a build target, and BUILD file changes for SiVal.