### PR TITLE
[pentest] Add prodc target to pentest build script

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -168,6 +168,7 @@ opentitan_test(
     srcs = [":firmware.c"],
     exec_env = {
         "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
+        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
     },
     silicon_owner = silicon_params(
         tags = ["broken"],


### PR DESCRIPTION
This PR adds the silicon_owner_prodc_rom_ext target for building the penetration testing binary.