### PR TITLE
[cryptolib, kmac] Fix ordering bug in `little_endian_encode`

### DIFF
--- a/sw/device/lib/crypto/drivers/kmac.h
+++ b/sw/device/lib/crypto/drivers/kmac.h
@@ -20,7 +20,9 @@ extern "C" {
  */
 enum {
   // The total size of prefix registers (in bytes), after removing len encodings
-  kKmacPrefixMaxSize = 40,
+  kKmacPrefixMaxSize = 36,
+  // The max size of customization string for KMAC.
+  kKmacCustStrMaxSize = 32,
 };
 
 /**
@@ -209,6 +211,8 @@ status_t kmac_cshake_256(const uint8_t *message, size_t message_len,
  * The caller must ensure that `digest_len` words are allocated at the location
  * pointed to by `digest`.
  *
+ * `cust_str_len` cannot exceed `kKmacCustStrMaxSize`.
+ *
  * @param message The input message.
  * @param message_len The input message length in bytes.
  * @param cust_str The customization string.
@@ -228,6 +232,8 @@ status_t kmac_kmac_128(kmac_blinded_key_t *key, const uint8_t *message,
  *
  * The caller must ensure that `digest_len` words are allocated at the location
  * pointed to by `digest`.
+ *
+ * `cust_str_len` cannot exceed `kKmacCustStrMaxSize`.
  *
  * @param message The input message.
  * @param message_len The input message length in bytes.

--- a/sw/device/tests/crypto/kmac_gen_single_testvector.py
+++ b/sw/device/tests/crypto/kmac_gen_single_testvector.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+import sys
+
+import hjson
+from Crypto.Hash import KMAC128
+from Crypto.Hash import KMAC256
+
+'''
+Read in a JSON test vector file, convert the test vector to C constants, and
+generate a header file with these test vectors.
+'''
+
+
+def validate_lengths(input_msg_len, cust_str_len, digest_len):
+    if input_msg_len % 8 != 0:
+        raise ValueError("input_msg_len needs to be divisible by 8")
+    # The max length limitation comes from the KMAC HWIP.
+    if cust_str_len % 8 != 0 or cust_str_len > 256:
+        raise ValueError("cust_str_len needs to be divisible by 8 and not larger than 256 bits")
+    # The following is a limitation by the current implementation of KMAC driver
+    # function `kmac_kmac_128`, where the digest_len represent number of words
+    # but not bytes.
+    if digest_len % 32 != 0:
+        raise ValueError("digest_len needs to be divisible by 8")
+
+
+def gen_random_test(seed, key_len, security_str, input_msg_len, cust_str_len,
+                    digest_len):
+
+    validate_lengths(input_msg_len, cust_str_len, digest_len)
+
+    random.seed(seed)
+    input_msg = random.randbytes(input_msg_len // 8)
+    cust_str = random.randbytes(cust_str_len // 8)
+    key = random.randbytes(key_len // 8)
+
+    if security_str == 128:
+        kmac = KMAC128.new(key = key,
+                           data = input_msg,
+                           mac_len = digest_len // 8,
+                           custom = cust_str)
+    elif security_str == 256:
+        kmac = KMAC256.new(key = key,
+                           data = input_msg,
+                           mac_len = digest_len // 8,
+                           custom = cust_str)
+
+    digest = kmac.hexdigest()
+    vector_identifier = \
+        "./sw/device/tests/crypto/kmac_gen_single_testvector.py"\
+        "--seed={} --key_len={} --sec_str={} --input_msg_len={} "\
+        "--cust_str_len={} --digest_len={} <output-file>"\
+        .format(seed, security_str, key_len, input_msg_len,
+                cust_str_len, digest_len)
+
+    print(vector_identifier)
+    testvec = {
+        'vector_identifier': vector_identifier,
+        'operation': 'KMAC',
+        'security_str': security_str,
+        'key': '0x' + key.hex(),
+        'input_msg': '0x' + input_msg.hex(),
+        'cust_str': '0x' + cust_str.hex(),
+        'digest': '0x' + digest,
+    }
+    return testvec
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--seed',
+                        required=True,
+                        type=int,
+                        help='Seed for randomness.')
+    parser.add_argument('--key_len',
+                        required=True,
+                        type=int,
+                        choices=[128, 192, 256, 384, 512],
+                        help='Key length (in bits).')
+    parser.add_argument('--sec_str',
+                        required=True,
+                        type=int,
+                        choices=[128, 256],
+                        help='Security strength (either 128 or 256).')
+    parser.add_argument('--input_msg_len',
+                        required=True,
+                        type=int,
+                        help='Input message length (in bits).')
+    parser.add_argument('--cust_str_len',
+                        required=True,
+                        type=int,
+                        help='Customizatoin string length (in bits).')
+    parser.add_argument('--digest_len',
+                        required=True,
+                        type=int,
+                        help='Digest length (in bits).')
+    parser.add_argument('outfile',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help='Write output to this file.')
+
+    args = parser.parse_args()
+
+    testvecs = gen_random_test(args.seed, args.key_len, args.sec_str,
+                               args.input_msg_len, args.cust_str_len,
+                               args.digest_len)
+
+    hjson.dump(testvecs, args.outfile)
+    args.outfile.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sw/device/tests/crypto/testvectors/kmac_hardcoded.hjson
+++ b/sw/device/tests/crypto/testvectors/kmac_hardcoded.hjson
@@ -112,4 +112,13 @@
     cust_str: 0x4d7920546167676564204170706c69636174696f6e
     digest: 0x20c570c31346f703c9ac36c61c03cb64c3970d0cfc787e9b79599d273a68d2f7f69d4cc3de9d104a351689f27cf6f5951f0103f33f4f24871024d9c27773a8dd
   }
+  {
+    vector_identifier: ./sw/device/tests/crypto/kmac_gen_single_testvector.py--seed=1 --key_len=128 --sec_str=128 --input_msg_len=256 --cust_str_len=256 --digest_len=160 <output-file>
+    operation: KMAC
+    security_str: 128
+    key: 0x8c2e0718822ce47ca8c74107e66cb0e4
+    input_msg: 0xf5b165224a58b791df6af1d8303e61cdc4bb86c3d1c427103c344c4189eb2f1e
+    cust_str: 0x7bd5d47e446fcec2a3d811736110e5781bcccea696762e6116c6e9c92d99bf35
+    digest: 0x108bcfadf89ed67c806f5b73216755c38b578488
+  }
 ]


### PR DESCRIPTION
1. As I was testing KDF-KMAC, I encountered a rare bug in `little_endian_encode`. This bug occurs when the customization string is larger than 32 bytes. In this case, the encoded bit-length corresponds to 256.
According to Section 2.3.1 Integer to Byte String Encoding of NIST SP 800-185, `left_encode(x=256)` should be encoded as the byte array `[0x01, 0x01, 0x00]`, however the current implementation encodes this as `[0x01, 0x00, 0x01]`.
The same case applies to `right_encode` as well. I.e. `right_encode(x=256)` should return `[0x01, 0x00, 0x01]`. This side of the bug was circumvented earlier by reversing the order after `little_endian_encode` call. This explains why we did not catch this bug before.

1. This PR also implements a python script to generate arbitrary size KMAC vectors. It also adds one vector with `cust_str_len=32` so that we can test the implementation against the above corner case.

1. Another small change is about the exposed max number of bytes for the prefix. KMAC HWIP has 44 bytes of PREFIX CSR. However, up to 5 bytes of this PREFIX is required for encoding string lengths, leaving 39 bytes for the concatenation of customization string and function name. I think it's better to simply reduce this to 36 bytes. This should explain the change in the `kmac.h` header. 