### PR TITLE
Revert "[dv,top_earlgrey] Remove dv flag to set OTP ast_init"

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_creator_sw_cfg.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_creator_sw_cfg.hjson
@@ -17,11 +17,6 @@
                     value: "0x0",
                 },
                 {
-                    name: "CREATOR_SW_CFG_AST_INIT_EN",
-                    // Use MuBi4True to enable initialization.
-                    value: "0x6",
-                },
-                {
                     name: "CREATOR_SW_CFG_SIGVERIFY_RSA_MOD_EXP_IBEX_EN",
                     // Use software mod_exp implementation for signature
                     // verification. See the definition of `hardened_bool_t` in

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -891,6 +891,7 @@
       ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
       run_opts: [
+        "+do_creator_sw_cfg_ast_cfg=0",
         "+sw_test_timeout_ns=200_000_000",
         "+use_otp_image=OtpTypeLcStRaw",
         "+chip_clock_source=ChipClockSourceExternal48Mhz",

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -44,6 +44,10 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // before invoking super.dut_init(), or any other suitable place.
   rand uint creator_sw_cfg_ast_cfg_data[ast_pkg::AstRegsNum];
 
+  // A knob that controls whether the AST initialization is done, enabled by default.
+  // Can be updated with plusarg.
+  bit do_creator_sw_cfg_ast_cfg = 1;
+
   // sw related
   // In OpenTitan, the same SW test image can be built for DV, Verilator and FPGA. SW build for
   // other platforms can be run on DV as well. We allow that by specifying the SW build device.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -289,6 +289,12 @@ class chip_base_vseq #(
 
   // Initialize the OTP creator SW cfg region with AST configuration data.
   virtual function void initialize_otp_creator_sw_cfg_ast_cfg();
+    // The knob controls whether the AST is actually programmed.
+    if (cfg.do_creator_sw_cfg_ast_cfg) begin
+      cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset,
+                                       prim_mubi_pkg::MuBi4True);
+    end
+
     // Ensure that the allocated size of the AST cfg region in OTP is equal to the number of AST
     // registers to be programmed.
     `DV_CHECK_EQ_FATAL(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgSize, ast_pkg::AstRegsNum * 4)

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -55,6 +55,9 @@ class chip_base_test extends cip_base_test #(
       cfg.parse_sw_images_string(sw_images_plusarg);
     end
 
+    // Knob to perform the AST configuration.
+    void'($value$plusargs("do_creator_sw_cfg_ast_cfg=%0b", cfg.do_creator_sw_cfg_ast_cfg));
+
     // Knob to use small page rma
     void'($value$plusargs("en_small_rma=%0b", cfg.en_small_rma));
 


### PR DESCRIPTION
This reverts commit 114807de2b6955106f80ddc1b02ac3b0f6970ce3 as discussed in the sync today
We will come back to this change and discuss its inclusion after M2 and after the NTIL environment is stable,