### PR TITLE
[Test utils ] Macro ATOMIC_WAIT_FOR_IRQ

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -523,4 +523,17 @@ class SignConverter {
 #endif  // !defined(__ASSEMBLER__) && !defined(NOSTDINC) &&
         // !defined(RUST_PREPROCESSOR_EMIT)
 
+// This routine makes sure that a condition that can be changed by IRQs
+// is evaluated inside a critical session. It executes a `wfi` between
+// evaluations.
+#define ATOMIC_WAIT_FOR_INTERRUPT(_volatile_condition) \
+  while (true) {                                       \
+    irq_global_ctrl(false);                            \
+    if ((_volatile_condition)) {                       \
+      break;                                           \
+    }                                                  \
+    wait_for_interrupt();                              \
+    irq_global_ctrl(true);                             \
+  }                                                    \
+  irq_global_ctrl(true)
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -123,27 +123,11 @@ static void execute_test(dif_aon_timer_t *aon_timer, uint64_t irq_time_us,
   }
   // Capture the current tick to measure the time the IRQ will take.
   uint32_t start_tick = (uint32_t)tick_count_get();
-  uint32_t time_elapsed = 0;
 
-  // Disable interrupts to be certain interrupt doesn't occur between while
-  // condition check and `wait_for_interrupt` (so WFI misses that interrupt).
-  irq_global_ctrl(false);
+  ATOMIC_WAIT_FOR_INTERRUPT(peripheral ==
+                            kTopEarlgreyPlicPeripheralAonTimerAon);
 
-  // Only enter WFI loop if we haven't already seen the interrupt.
-  if (peripheral != kTopEarlgreyPlicPeripheralAonTimerAon) {
-    do {
-      wait_for_interrupt();
-      // WFI ignores global interrupt enable, so enable it now and then
-      // immediately disable it. If there is an interrupt pending it will be
-      // taken here between the enable and disable. This confines the interrupt
-      // to a known place avoiding missed wakeup issues.
-      irq_global_ctrl(true);
-      irq_global_ctrl(false);
-      time_elapsed = (uint32_t)irq_tick - start_tick;
-    } while (peripheral != kTopEarlgreyPlicPeripheralAonTimerAon &&
-             time_elapsed < sleep_range_h);
-  }
-
+  uint32_t time_elapsed = (uint32_t)irq_tick - start_tick;
   CHECK(time_elapsed < sleep_range_h && time_elapsed > sleep_range_l,
         "Timer took %u usec which is not in the range %u usec and %u usec",
         (uint32_t)time_elapsed, (uint32_t)sleep_range_l,

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -136,20 +136,7 @@ static void otbn_wait_for_done_irq(dif_otbn_t *otbn) {
 
   // At this point, OTBN should be running. Wait for an interrupt that says
   // it's done.
-  while (true) {
-    // This looks a bit odd, but is needed to avoid a race condition where the
-    // OTBN interrupt comes in after we load the otbn_finished flag but before
-    // we run the WFI instruction. The trick is that WFI returns when an
-    // interrupt comes in even if interrupts are globally disabled, which means
-    // that the WFI can actually sit *inside* the critical section.
-    irq_global_ctrl(false);
-    if (plic_peripheral != UINT32_MAX) {
-      break;
-    }
-    wait_for_interrupt();
-    irq_global_ctrl(true);
-  }
-  irq_global_ctrl(true);
+  ATOMIC_WAIT_FOR_INTERRUPT(plic_peripheral != UINT32_MAX);
 
   CHECK(plic_peripheral == kTopEarlgreyPlicPeripheralOtbn,
         "Interrupt from incorrect peripheral: (exp: %d, obs: %s)",

--- a/sw/device/tests/otbn_irq_test.c
+++ b/sw/device/tests/otbn_irq_test.c
@@ -87,19 +87,7 @@ static void run_test_with_irqs(dif_otbn_t *otbn, otbn_app_t app,
 
   // At this point, OTBN should be running. Wait for an interrupt that says
   // it's done.
-  for (;;) {
-    // This looks a bit odd, but is needed to avoid a race condition where the
-    // OTBN interrupt comes in after we load the otbn_finished flag but before
-    // we run the WFI instruction. The trick is that WFI returns when an
-    // interrupt comes in even if interrupts are globally disabled, which means
-    // that the WFI can actually sit *inside* the critical section.
-    irq_global_ctrl(false);
-    if (otbn_finished)
-      break;
-    wait_for_interrupt();
-    irq_global_ctrl(true);
-  }
-  irq_global_ctrl(true);
+  ATOMIC_WAIT_FOR_INTERRUPT(otbn_finished);
 
   check_otbn_status(otbn, expected_status);
   check_otbn_err_bits(otbn, expected_insn_cnt);

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -76,21 +76,7 @@ static void otbn_wait_for_done_irq(dif_otbn_t *otbn) {
 
   // OTBN should be running. Wait for an interrupt that says
   // it's done.
-  while (true) {
-    // This looks a bit odd, but is needed to avoid a race condition where the
-    // OTBN interrupt comes in after we load the otbn_finished flag but before
-    // we run the WFI instruction. The trick is that WFI returns when an
-    // interrupt comes in even if interrupts are globally disabled, which means
-    // that the WFI can actually sit *inside* the critical section.
-    irq_global_ctrl(false);
-    if (plic_peripheral != UINT32_MAX) {
-      break;
-    }
-
-    wait_for_interrupt();
-    irq_global_ctrl(true);
-  }
-
+  ATOMIC_WAIT_FOR_INTERRUPT(plic_peripheral != UINT32_MAX);
   CHECK(plic_peripheral == kTopEarlgreyPlicPeripheralOtbn,
         "Interrupt from incorrect peripheral: (exp: %d, obs: %s)",
         kTopEarlgreyPlicPeripheralOtbn, plic_peripheral);

--- a/sw/device/tests/spi_device_tpm_tx_rx_test.c
+++ b/sw/device/tests/spi_device_tpm_tx_rx_test.c
@@ -136,21 +136,6 @@ static void ack_spi_tpm_header_irq(dif_spi_device_handle_t *spi_device) {
       &spi_device->dev, kDifSpiDeviceIrqTpmHeaderNotEmpty, kDifToggleEnabled));
 }
 
-// This routine is needed to make sure that an interrupt does not sneak in
-// and jump execution away between the boolean check and the actual invocation
-// of wait_for_interrupt.
-static void atomic_wait_for_interrupt(void) {
-  while (true) {
-    irq_global_ctrl(false);
-    if (header_interrupt_received) {
-      break;
-    }
-    wait_for_interrupt();
-    irq_global_ctrl(true);
-  }
-  irq_global_ctrl(true);
-}
-
 bool test_main(void) {
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
@@ -195,7 +180,7 @@ bool test_main(void) {
     LOG_INFO("Iteration %d", i);
 
     // Wait for write interrupt.
-    atomic_wait_for_interrupt();
+    ATOMIC_WAIT_FOR_INTERRUPT(header_interrupt_received);
 
     // Check what command we have received. Store it as expected variables
     // and compare when the read command is issued.
@@ -223,7 +208,7 @@ bool test_main(void) {
     LOG_INFO("SYNC: Waiting Read");
     // Send the written data right back out for reads.
     // Wait for read interrupt.
-    atomic_wait_for_interrupt();
+    ATOMIC_WAIT_FOR_INTERRUPT(header_interrupt_received);
     // Send the written data right back out for reads.
     CHECK_DIF_OK(dif_spi_device_tpm_write_data(&spi_device, num_bytes, buf));
 

--- a/sw/device/tests/spi_host_irq_test.c
+++ b/sw/device/tests/spi_host_irq_test.c
@@ -83,16 +83,6 @@ static status_t external_isr(void) {
 
 void ottf_external_isr(uint32_t *exc_info) { test_result = external_isr(); }
 
-static status_t check_irq_eq(uint32_t irq) {
-  irq_global_ctrl(false);
-  if (irq_fired == UINT32_MAX) {
-    wait_for_interrupt();
-  }
-  irq_global_ctrl(true);
-  TRY_CHECK(irq_fired == irq);
-  return OK_STATUS();
-}
-
 static status_t ready_event_irq(void) {
   enum { kDataSize = 260, kCommands = 5 };
   static_assert(kDataSize % kCommands == 0, "Must be multiple.");
@@ -121,7 +111,7 @@ static status_t ready_event_irq(void) {
   TRY_CHECK(status.active);
 
   // Wait for the event irq and check that it was triggered by `STATUS.ready`.
-  TRY(check_irq_eq(kDifSpiHostIrqSpiEvent));
+  ATOMIC_WAIT_FOR_INTERRUPT(irq_fired == kDifSpiHostIrqSpiEvent);
   TRY(dif_spi_host_get_status(&spi_host, &status));
   TRY_CHECK(status.ready);
 
@@ -151,7 +141,7 @@ static status_t active_event_irq(void) {
   TRY_CHECK(status.active);
 
   // Wait for the event irq and check that it was triggered by `STATUS.active`.
-  check_irq_eq(kDifSpiHostIrqSpiEvent);
+  ATOMIC_WAIT_FOR_INTERRUPT(irq_fired == kDifSpiHostIrqSpiEvent);
   TRY(dif_spi_host_get_status(&spi_host, &status));
   TRY_CHECK(!status.active);
 
@@ -181,7 +171,7 @@ static status_t tx_empty_event_irq(void) {
   TRY_CHECK(!status.tx_empty);
 
   // Wait for the irq and check that it was triggered by `STATUS.tx_empty`.
-  check_irq_eq(kDifSpiHostIrqSpiEvent);
+  ATOMIC_WAIT_FOR_INTERRUPT(irq_fired == kDifSpiHostIrqSpiEvent);
   TRY(dif_spi_host_get_status(&spi_host, &status));
   TRY_CHECK(status.tx_empty);
 
@@ -213,7 +203,7 @@ static status_t tx_wm_event_irq(void) {
                                  kDifSpiHostDirectionTx, true));
 
   // Wait for the event irq and check that it was triggered by `STATUS.txwm`.
-  check_irq_eq(kDifSpiHostIrqSpiEvent);
+  ATOMIC_WAIT_FOR_INTERRUPT(irq_fired == kDifSpiHostIrqSpiEvent);
   TRY(dif_spi_host_get_status(&spi_host, &status));
   TRY_CHECK(status.tx_water_mark);
 
@@ -260,7 +250,7 @@ static status_t rx_full_event_irq(void) {
   TRY(dummy_read_from_flash(/*address=*/0x00, /*len=*/kRxFifoLen));
 
   // Wait for the event irq and check that it was triggered by `STATUS.rx_full`.
-  check_irq_eq(kDifSpiHostIrqSpiEvent);
+  ATOMIC_WAIT_FOR_INTERRUPT(irq_fired == kDifSpiHostIrqSpiEvent);
   TRY(dif_spi_host_get_status(&spi_host, &status));
   TRY_CHECK(status.rx_full);
 
@@ -282,7 +272,7 @@ static status_t rx_wm_event_irq(void) {
 
   TRY(dummy_read_from_flash(/*address=*/0x00, /*len=*/kRxWmLen));
 
-  check_irq_eq(kDifSpiHostIrqSpiEvent);
+  ATOMIC_WAIT_FOR_INTERRUPT(irq_fired == kDifSpiHostIrqSpiEvent);
   TRY(dif_spi_host_get_status(&spi_host, &status));
   TRY_CHECK(status.rx_water_mark);
 
@@ -324,7 +314,7 @@ static status_t cmd_busy_error_irq(void) {
 
   // Wait for the error irq and check that it was triggered by
   // command busy.
-  TRY(check_irq_eq(kDifSpiHostIrqError));
+  ATOMIC_WAIT_FOR_INTERRUPT(irq_fired == kDifSpiHostIrqError);
   dif_spi_host_errors_t errors;
   TRY(dif_spi_host_get_error(&spi_host, &errors));
   TRY_CHECK(errors & kDifSpiHostErrorCmdBusy, "Expect 0x%x, got 0x%x",


### PR DESCRIPTION
Centralize the implementation of waiting for IRQ throughout the tests.