### PR TITLE
[cryptotest] Add NIST test vectors and parser for SHA2/3, SHAKE

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -44,3 +44,57 @@ genrule(
         ("ecdsa_secp384r1_sha384_test.json", "wycheproof_ecdsa_p384_sha384"),
     ]
 ]
+
+[
+    run_binary(
+        name = "nist_cavp_{}_{}_{}_json".format(
+            src_repo,
+            algorithm.lower(),
+            msg_type.lower(),
+        ),
+        srcs = [
+            "@nist_cavp_{}//:{}{}.rsp".format(src_repo, algorithm, msg_type),
+            "//sw/host/cryptotest/testvectors/data/schemas:hash_schema.json",
+        ],
+        outs = [":nist_{}_{}.json".format(
+            algorithm.lower(),
+            msg_type.lower(),
+        )],
+        args = [
+            "--src",
+            "$(location @nist_cavp_{}//:{}{}.rsp)".format(src_repo, algorithm, msg_type),
+            "--dst",
+            "$(location :nist_{}_{}.json)".format(
+                algorithm.lower(),
+                msg_type.lower(),
+            ),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:hash_schema.json)",
+            "--algorithm",
+            algorithm,
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_hash_parser",
+    )
+    for algorithm, src_repo, extra_msg_types in [
+        ("SHA256", "sha2_fips_180_4", []),
+        ("SHA384", "sha2_fips_180_4", []),
+        ("SHA512", "sha2_fips_180_4", []),
+        ("SHA3_256", "sha3_fips_202", []),
+        ("SHA3_384", "sha3_fips_202", []),
+        ("SHA3_512", "sha3_fips_202", []),
+        (
+            "SHAKE128",
+            "shake_fips_202",
+            ["VariableOut"],
+        ),
+        (
+            "SHAKE256",
+            "shake_fips_202",
+            ["VariableOut"],
+        ),
+    ]
+    for msg_type in [
+        "ShortMsg",
+        "LongMsg",
+    ] + extra_msg_types
+]

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -14,4 +14,7 @@ filegroup(
     srcs = ["ecdsa_sig_ver_schema.json"],
 )
 
-exports_files(["hmac_schema.json"])
+exports_files([
+    "hash_schema.json",
+    "hmac_schema.json",
+])

--- a/sw/host/cryptotest/testvectors/data/schemas/hash_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/hash_schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/hash_schema.json",
+  "title": "Cryptotest Hash Function Test Vector",
+  "description": "A list of testvectors for SHA-2, SHA-3, SHAKE, and cSHAKE testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test_case_id",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "The hash algorithm being tested",
+        "type": "string",
+          "enum": ["sha-224", "sha-256", "sha-384", "sha-512", "sha3-256", "sha3-384", "sha3-512", "shake-128", "shake-256"]
+      },
+      "message": {
+        "description": "Message to be hashed",
+        "$ref": "#/$defs/byte_array"
+      },
+      "digest": {
+        "description": "Digest output by the hash function",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Whether the hash of `message` should be equal to `digest`",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -42,6 +42,15 @@ py_binary(
 )
 
 py_binary(
+    name = "nist_cavp_hash_parser",
+    srcs = ["nist_cavp_hash_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
     name = "nist_cavp_hmac_parser",
     srcs = ["nist_cavp_hmac_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_hash_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_hash_parser.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting NIST CAVP Hash Function test vectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+# Map hash function names as formatted in the test vectors to their
+# JSON schema names
+HASH_FUNCTION_NAME_MAPPING = {
+    "SHA256": "sha-256",
+    "SHA384": "sha-384",
+    "SHA512": "sha-512",
+    "SHA3_256": "sha3-256",
+    "SHA3_384": "sha3-384",
+    "SHA3_512": "sha3-512",
+    "SHAKE128": "shake-128",
+    "SHAKE256": "shake-256",
+}
+
+
+def parse_testcases(args) -> None:
+    raw_testcases = parse_rsp(args.src)
+    test_cases = list()
+    algorithm = HASH_FUNCTION_NAME_MAPPING[args.algorithm]
+    # The test vectors for the SHA functions use "MD" as the key for
+    # the message digest. SHAKE functions use "Output".
+    if algorithm.startswith("shake"):
+        digest_key = "Output"
+    else:
+        digest_key = "MD"
+    for section_name in raw_testcases.keys():
+        count = 1
+        for test_vec in raw_testcases[section_name]:
+            # The test vector includes a single placeholder zero byte if its
+            # intended message length is 0, so we need to ignore that byte.
+            if "Len" in test_vec and int(test_vec["Len"]) == 0:
+                message = []
+            else:
+                message = str_to_byte_array(test_vec["Msg"])
+            if "COUNT" in test_vec:
+                test_case_id = int(test_vec["COUNT"])
+            else:
+                test_case_id = count
+            test_case = {
+                "vendor": "nist",
+                "test_case_id": test_case_id,
+                "algorithm": algorithm,
+                "message": message,
+                "digest": str_to_byte_array(test_vec[digest_key]),
+                # All NIST hash test vectors are expected to have the
+                # right message digest
+                "result": True,
+            }
+
+            test_cases.append(test_case)
+            count += 1
+
+    json_filename = f"{args.dst}"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP Hash Function test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    parser.add_argument(
+        "--algorithm",
+        type = str,
+        help = "Hash algorithm the test vectors are testing"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -12,3 +12,22 @@ def nist_cavp_repos():
         sha256 = "fe47cc92b4cee418236125c9ffbcd9bb01c8c34e74a4ba195d954bcb72824752",
         url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-4ecdsatestvectors.zip",
     )
+    http_archive(
+        name = "nist_cavp_sha2_fips_180_4",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        strip_prefix = "shabytetestvectors",
+        sha256 = "929ef80b7b3418aca026643f6f248815913b60e01741a44bba9e118067f4c9b8",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip",
+    )
+    http_archive(
+        name = "nist_cavp_sha3_fips_202",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "cd07701af2e47f5cc889d642528b4bf11f8b6eb55797c7307a96828ed8d8fc8c",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/sha-3bytetestvectors.zip",
+    )
+    http_archive(
+        name = "nist_cavp_shake_fips_202",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "debfebc3157b3ceea002b84ca38476420389a3bf7e97dc5f53ea4689a16de4c7",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/shakebytetestvectors.zip",
+    )


### PR DESCRIPTION
This PR pulls in the NIST test vectors for SHA2, SHA3, and SHAKE, and includes the associated parser and JSON schema. All algorithms in these three families of hash functions were able to share a single parser and JSON schema.