### PR TITLE
[otbn] Fix interpretation of lc_rma_req signal values

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -552,7 +552,6 @@ module otbn_controller
   // into fatal_escalate_en_i, RND errors factor into recov_escalate_en_i).
   assign mubi_err_d = |{mubi4_test_invalid(fatal_escalate_en_i),
                         mubi4_test_invalid(recov_escalate_en_i),
-                        mubi4_test_invalid(rma_req_i),
                         mubi_err_q};
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -648,7 +647,7 @@ module otbn_controller
   // and eventually acknowledging the RMA request.
   assign fatal_err = |{internal_fatal_err,
                        mubi4_test_true_loose(fatal_escalate_en_i),
-                       mubi4_test_true_loose(rma_req_i)};
+                       mubi4_test_true_strict(rma_req_i)};
 
   assign recoverable_err_o = recoverable_err | (software_err & ~software_errs_fatal_i);
   assign mems_sec_wipe_o   = (state_d == OtbnStateLocked) & (state_q != OtbnStateLocked);
@@ -664,7 +663,7 @@ module otbn_controller
   `ASSERT(ErrBitSetOnErr,
       err & (mubi4_test_false_strict(fatal_escalate_en_i) &
              mubi4_test_false_strict(recov_escalate_en_i) &
-             mubi4_test_false_strict(rma_req_i)) |=>
+             mubi4_test_false_loose(rma_req_i)) |=>
           err_bits_o)
   `ASSERT(ErrSetOnFatalErr, fatal_err |-> err)
   `ASSERT(SoftwareErrIfNonInsnAddrSoftwareErr, non_insn_addr_software_err |-> software_err)

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -354,12 +354,12 @@ module otbn_start_stop_control
     end
 
     // If the MuBi signals take on invalid values, something bad is happening. Put them back to
-    // a safe value (if possible) and signal an error.
+    // a safe value (if possible) and signal an error. The only exception is rma_req_i. This LC
+    // signal may experience staggered transitions due to CDCs leading to invalid values. In
+    // accordance with the spec, invalid values of non-escalation LC signals must be treated as
+    // OFF. rma_ack_d/q is driven by rma_req_i but only at the end of the secure wipe. By that
+    // time rma_req_i has for sure stabilized.
     if (mubi4_test_invalid(escalate_en_i)) begin
-      mubi_err_d = 1'b1;
-      state_d = OtbnStartStopStateLocked;
-    end
-    if (mubi4_test_invalid(rma_req_i)) begin
       mubi_err_d = 1'b1;
       state_d = OtbnStartStopStateLocked;
     end


### PR DESCRIPTION
Now that #21267 changes LC_CTRL to receive multiple RMA ack signals in parallel and the RMA req/ack signals for Flash and OTBN are no longer daisy-chained in Earlgrey, this change can and must be done because:
- A glitch into the RMA req/ack signals can no longer bypass Flash wiping before RMA entry. I.e., the checking of the RMA req signal in OTBN can thus be fully aligned with the LC_CTRL spec.
- The RMA req signal seen by OTBN is no coming from a different clock domain and OTBN will observe staggered transitions. By aligning the signal interpretation in OTBN with the LC_CTRL spec, it can actually handle that.

Note that this is a cherry pick of 388567fbf833f1504fd8d6b374b2ffd87a3c8704 from the `intergrated_dev` branch:

> According to the lc_ctrl spec, all values of non-escalation lc signals other than ON must be intrepreted as OFF. Also, no detection of invalid values should be performed as these signals might experience staggered transitions due to CDCs naturally leading to invalid values.
>
>This commit changes the design accordingly to match this spec.
>
>This resolves lowRISC/OpenTitan#19050.