### PR TITLE
[spi_host,rtl] Change 'spi_event' interrupt to CIP 'Status' type

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -96,6 +96,7 @@
                information.'''
     },
     { name: "spi_event",
+      type: "status",
       desc: '''Event-related interrupts, see !!EVENT_ENABLE register for more
                information.'''
     }

--- a/hw/ip/spi_host/doc/interfaces.md
+++ b/hw/ip/spi_host/doc/interfaces.md
@@ -27,7 +27,7 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 | Interrupt Name   | Type   | Description                                                                                              |
 |:-----------------|:-------|:---------------------------------------------------------------------------------------------------------|
 | error            | Event  | Error-related interrupts, see [`ERROR_ENABLE`](registers.md#error_enable) register for more information. |
-| spi_event        | Event  | Event-related interrupts, see [`EVENT_ENABLE`](registers.md#event_enable) register for more information. |
+| spi_event        | Status | Event-related interrupts, see [`EVENT_ENABLE`](registers.md#event_enable) register for more information. |
 
 ## Security Alerts
 

--- a/hw/ip/spi_host/doc/registers.md
+++ b/hw/ip/spi_host/doc/registers.md
@@ -29,13 +29,13 @@ Interrupt State Register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "error", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "spi_event", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
+{"reg": [{"name": "error", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "spi_event", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name      | Description                                                                                  |
 |:------:|:------:|:-------:|:----------|:---------------------------------------------------------------------------------------------|
 |  31:2  |        |         |           | Reserved                                                                                     |
-|   1    |  rw1c  |   0x0   | spi_event | Event-related interrupts, see [`EVENT_ENABLE`](#event_enable) register for more information. |
+|   1    |   ro   |   0x0   | spi_event | Event-related interrupts, see [`EVENT_ENABLE`](#event_enable) register for more information. |
 |   0    |  rw1c  |   0x0   | error     | Error-related interrupts, see [`ERROR_ENABLE`](#error_enable) register for more information. |
 
 ## INTR_ENABLE

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -527,69 +527,46 @@ module spi_host
     .intr_o                 (intr_error_o)
   );
 
-  logic event_spi_event;
-  logic event_idle, event_ready, event_tx_wm, event_rx_wm, event_tx_empty, event_rx_full;
+  logic status_spi_event;
+  logic status_idle, status_ready, status_tx_wm, status_rx_wm, status_tx_empty, status_rx_full;
   logic [5:0] event_vector;
   logic [5:0] event_mask;
 
-  assign event_vector= {
-      event_idle, event_ready, event_tx_wm,
-      event_rx_wm, event_tx_empty, event_rx_full
+  assign status_idle     = ~active;
+  assign status_ready    = ~command_busy;
+  assign status_tx_wm    = tx_wm;
+  assign status_rx_wm    = rx_wm;
+  assign status_tx_empty = tx_empty;
+  assign status_rx_full  = rx_full;
+
+  assign event_vector = {
+    status_idle,
+    status_ready,
+    status_tx_wm,
+    status_rx_wm,
+    status_tx_empty,
+    status_rx_full
   };
 
   assign event_mask = {
-      reg2hw.event_enable.idle.q,
-      reg2hw.event_enable.ready.q,
-      reg2hw.event_enable.txwm.q,
-      reg2hw.event_enable.rxwm.q,
-      reg2hw.event_enable.txempty.q,
-      reg2hw.event_enable.rxfull.q
+    reg2hw.event_enable.idle.q,
+    reg2hw.event_enable.ready.q,
+    reg2hw.event_enable.txwm.q,
+    reg2hw.event_enable.rxwm.q,
+    reg2hw.event_enable.txempty.q,
+    reg2hw.event_enable.rxfull.q
   };
 
-  assign event_spi_event = |(event_vector & event_mask);
+  // Qualify interrupt sources individually with dedicated mask register CSR.EVENT_ENABLE
+  assign status_spi_event = |(event_vector & event_mask);
 
-  logic idle_d, idle_q;
-  logic ready_d, ready_q;
-  logic tx_wm_d, tx_wm_q;
-  logic rx_wm_d, rx_wm_q;
-  logic tx_empty_d, tx_empty_q;
-  logic rx_full_d, rx_full_q;
-
-  assign event_idle     = idle_d & ~idle_q;
-  assign idle_d         = ~active;
-  assign event_ready    = ready_d & ~ready_q;
-  assign ready_d        = ~command_busy;
-  assign event_tx_wm    = tx_wm_d & ~tx_wm_q;
-  assign tx_wm_d        = tx_wm;
-  assign event_rx_wm    = rx_wm_d & ~rx_wm_q;
-  assign rx_wm_d        = rx_wm;
-  assign event_tx_empty = tx_empty_d & ~tx_empty_q;
-  assign tx_empty_d     = tx_empty;
-  assign event_rx_full  = rx_full_d & ~rx_full_q;
-  assign rx_full_d      = rx_full;
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      idle_q     <= 1'b0;
-      ready_q    <= 1'b0;
-      tx_wm_q    <= 1'b0;
-      rx_wm_q    <= 1'b0;
-      tx_empty_q <= 1'b0;
-      rx_full_q  <= 1'b0;
-    end else begin
-      idle_q     <= idle_d;
-      ready_q    <= ready_d;
-      tx_wm_q    <= tx_wm_d;
-      rx_wm_q    <= rx_wm_d;
-      tx_empty_q <= tx_empty_d;
-      rx_full_q  <= rx_full_d;
-    end
-  end
-
-  prim_intr_hw #(.Width(1)) intr_hw_spi_event (
+  prim_intr_hw #(
+    .Width(1),
+    .IntrT("Status")
+  ) intr_hw_spi_event (
     .clk_i,
     .rst_ni,
-    .event_intr_i           (event_spi_event),
+    .event_intr_i           (status_spi_event),
     .reg2hw_intr_enable_q_i (reg2hw.intr_enable.spi_event.q),
     .reg2hw_intr_test_q_i   (reg2hw.intr_test.spi_event.q),
     .reg2hw_intr_test_qe_i  (reg2hw.intr_test.spi_event.qe),

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -177,7 +177,6 @@ module spi_host_reg_top (
   logic intr_state_error_qs;
   logic intr_state_error_wd;
   logic intr_state_spi_event_qs;
-  logic intr_state_spi_event_wd;
   logic intr_enable_we;
   logic intr_enable_error_qs;
   logic intr_enable_error_wd;
@@ -306,7 +305,7 @@ module spi_host_reg_top (
   //   F[spi_event]: 1:1
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_spi_event (
@@ -314,8 +313,8 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_spi_event_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.spi_event.de),
@@ -1756,8 +1755,6 @@ module spi_host_reg_top (
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
   assign intr_state_error_wd = reg_wdata[0];
-
-  assign intr_state_spi_event_wd = reg_wdata[1];
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
   assign intr_enable_error_wd = reg_wdata[0];

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -14107,7 +14107,7 @@
       width: 1
       type: interrupt
       module_name: spi_host0
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {
@@ -14123,7 +14123,7 @@
       width: 1
       type: interrupt
       module_name: spi_host1
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
@@ -69,7 +69,7 @@ static bool spi_host_get_irq_bit_index(dif_spi_host_irq_t irq,
 
 static dif_irq_type_t irq_types[] = {
     kDifIrqTypeEvent,
-    kDifIrqTypeEvent,
+    kDifIrqTypeStatus,
 };
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -826,7 +826,7 @@ void isr_testutils_spi_device_isr(
 
 void isr_testutils_spi_host_isr(
     plic_isr_ctx_t plic_ctx, spi_host_isr_ctx_t spi_host_ctx,
-    top_earlgrey_plic_peripheral_t *peripheral_serviced,
+    bool mute_status_irq, top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_spi_host_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
   dif_rv_plic_irq_id_t plic_irq_id;
@@ -857,6 +857,9 @@ void isr_testutils_spi_host_isr(
   CHECK_DIF_OK(dif_spi_host_irq_get_type(spi_host_ctx.spi_host, irq, &type));
   if (type == kDifIrqTypeEvent) {
     CHECK_DIF_OK(dif_spi_host_irq_acknowledge(spi_host_ctx.spi_host, irq));
+  } else if (mute_status_irq) {
+    CHECK_DIF_OK(dif_spi_host_irq_set_enabled(spi_host_ctx.spi_host, irq,
+                                              kDifToggleDisabled));
   }
 
   // Complete the IRQ at the PLIC.

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -834,13 +834,14 @@ void isr_testutils_spi_device_isr(
  *
  * @param plic_ctx A PLIC ISR context handle.
  * @param spi_host_ctx A(n) spi_host ISR context handle.
+ * @param mute_status_irq set to true to disable the serviced status type IRQ.
  * @param[out] peripheral_serviced Out param for the peripheral that was
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_spi_host_isr(
     plic_isr_ctx_t plic_ctx, spi_host_isr_ctx_t spi_host_ctx,
-    top_earlgrey_plic_peripheral_t *peripheral_serviced,
+    bool mute_status_irq, top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_spi_host_irq_t *irq_serviced);
 
 /**

--- a/sw/device/tests/autogen/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/plic_all_irqs_test.c
@@ -941,7 +941,19 @@ void ottf_external_isr(uint32_t *exc_info) {
               "Only spi_host0 IRQ %d expected to fire. Actual interrupt "
               "status = %x", irq, snapshot);
 
-        CHECK_DIF_OK(dif_spi_host_irq_acknowledge(&spi_host0, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x2 & (1 << irq)) {
+          CHECK_DIF_OK(dif_spi_host_irq_force(&spi_host0, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x0 & (1 << irq))) {
+            CHECK_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host0, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_spi_host_irq_acknowledge(&spi_host0, irq));
+        }
         break;
       }
 #endif
@@ -962,7 +974,19 @@ void ottf_external_isr(uint32_t *exc_info) {
               "Only spi_host1 IRQ %d expected to fire. Actual interrupt "
               "status = %x", irq, snapshot);
 
-        CHECK_DIF_OK(dif_spi_host_irq_acknowledge(&spi_host1, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x2 & (1 << irq)) {
+          CHECK_DIF_OK(dif_spi_host_irq_force(&spi_host1, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x0 & (1 << irq))) {
+            CHECK_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host1, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_spi_host_irq_acknowledge(&spi_host1, irq));
+        }
         break;
       }
 #endif
@@ -2175,12 +2199,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 19 && 19 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralSpiHost0;
+  status_default_mask = 0x0;
   for (dif_spi_host_irq_t irq = kDifSpiHostIrqError;
        irq <= kDifSpiHostIrqSpiEvent; ++irq) {
 
     spi_host_irq_expected = irq;
     LOG_INFO("Triggering spi_host0 IRQ %d.", irq);
     CHECK_DIF_OK(dif_spi_host_irq_force(&spi_host0, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host0, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.
@@ -2191,12 +2224,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 19 && 19 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralSpiHost1;
+  status_default_mask = 0x0;
   for (dif_spi_host_irq_t irq = kDifSpiHostIrqError;
        irq <= kDifSpiHostIrqSpiEvent; ++irq) {
 
     spi_host_irq_expected = irq;
     LOG_INFO("Triggering spi_host1 IRQ %d.", irq);
     CHECK_DIF_OK(dif_spi_host_irq_force(&spi_host1, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host1, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.


### PR DESCRIPTION
Use prim_intr_hw #(.IntrT("status")) to create the status-type logic, which is
still driven from the 6 individual interrupt sources. Each input now becomes a
level-based signal, allowing removal of the flops which created pulses when the
inputs toggled.

TODO

- [x] `//sw/device/tests:spi_host_irq_test_fpga_cw310_test_rom` is failing in CI, needs its interrupt handling adjusted too

Closes #21208