### PR TITLE
[edn/rtl] Process CSRNG status error responses

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
@@ -22,5 +22,6 @@ class csrng_agent_cfg extends dv_base_agent_cfg;
          reseed_cnt, generate_cnt, generate_between_reseeds_cnt;
   bit    cmd_zero_delays;
   bit    under_reset;
+  bit    rsp_sts_err;
 
 endclass

--- a/hw/dv/sv/csrng_agent/csrng_device_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_device_driver.sv
@@ -32,8 +32,7 @@ class csrng_device_driver extends csrng_driver;
       `DV_SPINWAIT_EXIT(
           repeat(cmd_ack_dly) @(cfg.vif.device_cb);
           cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b1;
-          `DV_CHECK_STD_RANDOMIZE_FATAL(rsp_sts)
-          cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= rsp_sts;
+          cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= cfg.rsp_sts_err;
           @(cfg.vif.device_cb);
           cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
           cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= 1'b0;,

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -525,6 +525,14 @@
                 Writing a zero resets this status bit.
                 '''
         }
+        { bits: "13",
+          name: "CSRNG_ACK_ERR",
+          desc: '''
+                This bit is set when the CSRNG returns an acknowledgement where the status
+                signal is high.
+                Writing a zero resets this status bit.
+                '''
+        }
       ]
     },
     {

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -302,7 +302,7 @@
       ]
     },
     { name: "SW_CMD_STS",
-      desc: "EDN command status register",
+      desc: "EDN software command status register",
       swaccess: "ro",
       hwaccess: "hwo",
       tags: [// Internal HW can modify status register
@@ -332,7 +332,7 @@
           name: "CMD_STS",
           desc: '''
                 This one bit field represents the status code returned with the CSRNG application command ack.
-                It is updated each time a command is acknowledged by CSRNG.
+                It is updated each time a SW command is acknowledged by CSRNG.
                 To check whether a command was succesful, wait for !!INTR_STATE.EDN_CMD_REQ_DONE or
                 !!SW_CMD_STS.CMD_ACK to be high and then check the value of this field.
                 0b0: Request completed successfully.
@@ -343,11 +343,69 @@
         { bits: "3",
           name: "CMD_ACK",
           desc: '''
-                This one bit field indicates when a command has been acknowledged by the CSRNG.
+                This one bit field indicates when a SW command has been acknowledged by the CSRNG.
                 It is set to low each time a new command is written to !!SW_CMD_REQ.
                 The field is set to high once a SW command request has been acknowledged by the CSRNG.
-                0b0: The last command has not been acknowledged yet.
-                0b1: The last command has been acknowledged.
+                0b0: The last SW command has not been acknowledged yet.
+                0b1: The last SW command has been acknowledged.
+                '''
+          resval: "0"
+        }
+      ]
+    },
+    { name: "HW_CMD_STS",
+      desc: "EDN hardware command status register",
+      swaccess: "ro",
+      hwaccess: "hwo",
+      tags: [// Internal HW can modify status register
+                 "excl:CsrNonInitTests:CsrExclCheck"]
+      fields: [
+        { bits: "0",
+          name: "BOOT_MODE",
+          desc: '''
+                This one bit field indicates whether the EDN is in the hardware controlled boot mode.
+                0b0: The EDN is not in boot mode.
+                0b1: The EDN is in boot mode.
+                '''
+          resval: "0"
+        }
+        { bits: "1",
+          name: "AUTO_MODE",
+          desc: '''
+                This one bit field indicates whether the EDN is in the hardware controlled part of auto mode.
+                The instantiate command is issued via SW interface and is thus not part of the hardware controlled part of auto mode.
+                0b0: The EDN is not in the hardware controlled part of auto mode.
+                0b1: The EDN is in the hardware controlled part of auto mode.
+                '''
+          resval: "0"
+        }
+        { bits: "2",
+          name: "CMD_STS",
+          desc: '''
+                This one bit field represents the status code returned with the CSRNG application command ack.
+                It is updated each time a HW command is acknowledged by CSRNG.
+                0b0: Request completed successfully.
+                0b1: Request completed with an error.
+                '''
+          resval: "0"
+        }
+        { bits: "3",
+          name: "CMD_ACK",
+          desc: '''
+                This one bit field indicates when a HW command has been acknowledged by the CSRNG.
+                It is set to low each time a new command is sent to the CSRNG.
+                The field is set to high once a HW command request has been acknowledged by the CSRNG.
+                0b0: The last HW command has not been acknowledged yet.
+                0b1: The last HW command has been acknowledged.
+                '''
+          resval: "0"
+        }
+        { bits: "7:4",
+          name: "CMD_TYPE",
+          desc: '''
+                This field contains the application command type of the hardware controlled command issued last.
+                The application command selects one of five operations to perform.
+                A description of the application command types can be found [here](https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#command-description).
                 '''
           resval: "0"
         }

--- a/hw/ip/edn/doc/registers.md
+++ b/hw/ip/edn/doc/registers.md
@@ -400,17 +400,18 @@ automatic reseed when it reaches zero.
 Recoverable alert status register
 - Offset: `0x38`
 - Reset default: `0x0`
-- Reset mask: `0x100f`
+- Reset mask: `0x300f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "EDN_ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "BOOT_REQ_MODE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "AUTO_REQ_MODE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_FIFO_RST_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 8}, {"name": "EDN_BUS_CMP_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 19}], "config": {"lanes": 1, "fontsize": 10, "vspace": 270}}
+{"reg": [{"name": "EDN_ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "BOOT_REQ_MODE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "AUTO_REQ_MODE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_FIFO_RST_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 8}, {"name": "EDN_BUS_CMP_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CSRNG_ACK_ERR", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 18}], "config": {"lanes": 1, "fontsize": 10, "vspace": 270}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                      | Description                                                                                                                                                                                     |
 |:------:|:------:|:-------:|:--------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 31:13  |        |         |                           | Reserved                                                                                                                                                                                        |
+| 31:14  |        |         |                           | Reserved                                                                                                                                                                                        |
+|   13   |  rw0c  |   0x0   | CSRNG_ACK_ERR             | This bit is set when the CSRNG returns an acknowledgement where the status signal is high. Writing a zero resets this status bit.                                                               |
 |   12   |  rw0c  |   0x0   | EDN_BUS_CMP_ALERT         | This bit is set when the interal entropy bus value is equal to the prior valid value on the bus, indicating a possible attack. Writing a zero resets this status bit.                           |
 |  11:4  |        |         |                           | Reserved                                                                                                                                                                                        |
 |   3    |  rw0c  |   0x0   | CMD_FIFO_RST_FIELD_ALERT  | This bit is set when the CMD_FIFO_RST field is set to an illegal value, something other than kMultiBitBool4True or kMultiBitBool4False. Writing a zero resets this status bit.                  |

--- a/hw/ip/edn/doc/registers.md
+++ b/hw/ip/edn/doc/registers.md
@@ -1,6 +1,3 @@
-# Registers
-
-<!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/edn/data/edn.hjson -->
 ## Summary
 
 | Name                                                                | Offset   |   Length | Description                                                  |
@@ -14,14 +11,15 @@
 | edn.[`BOOT_INS_CMD`](#boot_ins_cmd)                                 | 0x18     |        4 | EDN boot instantiate command register                        |
 | edn.[`BOOT_GEN_CMD`](#boot_gen_cmd)                                 | 0x1c     |        4 | EDN boot generate command register                           |
 | edn.[`SW_CMD_REQ`](#sw_cmd_req)                                     | 0x20     |        4 | EDN csrng app command request register                       |
-| edn.[`SW_CMD_STS`](#sw_cmd_sts)                                     | 0x24     |        4 | EDN command status register                                  |
-| edn.[`RESEED_CMD`](#reseed_cmd)                                     | 0x28     |        4 | EDN csrng reseed command register                            |
-| edn.[`GENERATE_CMD`](#generate_cmd)                                 | 0x2c     |        4 | EDN csrng generate command register                          |
-| edn.[`MAX_NUM_REQS_BETWEEN_RESEEDS`](#max_num_reqs_between_reseeds) | 0x30     |        4 | EDN maximum number of requests between reseeds register      |
-| edn.[`RECOV_ALERT_STS`](#recov_alert_sts)                           | 0x34     |        4 | Recoverable alert status register                            |
-| edn.[`ERR_CODE`](#err_code)                                         | 0x38     |        4 | Hardware detection of fatal error conditions status register |
-| edn.[`ERR_CODE_TEST`](#err_code_test)                               | 0x3c     |        4 | Test error conditions register                               |
-| edn.[`MAIN_SM_STATE`](#main_sm_state)                               | 0x40     |        4 | Main state machine state observation register                |
+| edn.[`SW_CMD_STS`](#sw_cmd_sts)                                     | 0x24     |        4 | EDN software command status register                         |
+| edn.[`HW_CMD_STS`](#hw_cmd_sts)                                     | 0x28     |        4 | EDN hardware command status register                         |
+| edn.[`RESEED_CMD`](#reseed_cmd)                                     | 0x2c     |        4 | EDN csrng reseed command register                            |
+| edn.[`GENERATE_CMD`](#generate_cmd)                                 | 0x30     |        4 | EDN csrng generate command register                          |
+| edn.[`MAX_NUM_REQS_BETWEEN_RESEEDS`](#max_num_reqs_between_reseeds) | 0x34     |        4 | EDN maximum number of requests between reseeds register      |
+| edn.[`RECOV_ALERT_STS`](#recov_alert_sts)                           | 0x38     |        4 | Recoverable alert status register                            |
+| edn.[`ERR_CODE`](#err_code)                                         | 0x3c     |        4 | Hardware detection of fatal error conditions status register |
+| edn.[`ERR_CODE_TEST`](#err_code_test)                               | 0x40     |        4 | Test error conditions register                               |
+| edn.[`MAIN_SM_STATE`](#main_sm_state)                               | 0x44     |        4 | Main state machine state observation register                |
 
 ## INTR_STATE
 Interrupt State Register
@@ -223,7 +221,7 @@ Note that CSRNG command format details can be found
 in the CSRNG documentation.
 
 ## SW_CMD_STS
-EDN command status register
+EDN software command status register
 - Offset: `0x24`
 - Reset default: `0x0`
 - Reset mask: `0xf`
@@ -243,15 +241,15 @@ EDN command status register
 |   0    |   ro   |   0x0   | [CMD_REG_RDY](#sw_cmd_sts--cmd_reg_rdy) |
 
 ### SW_CMD_STS . CMD_ACK
-This one bit field indicates when a command has been acknowledged by the CSRNG.
+This one bit field indicates when a SW command has been acknowledged by the CSRNG.
 It is set to low each time a new command is written to [`SW_CMD_REQ.`](#sw_cmd_req)
 The field is set to high once a SW command request has been acknowledged by the CSRNG.
-0b0: The last command has not been acknowledged yet.
-0b1: The last command has been acknowledged.
+0b0: The last SW command has not been acknowledged yet.
+0b1: The last SW command has been acknowledged.
 
 ### SW_CMD_STS . CMD_STS
 This one bit field represents the status code returned with the CSRNG application command ack.
-It is updated each time a command is acknowledged by CSRNG.
+It is updated each time a SW command is acknowledged by CSRNG.
 To check whether a command was succesful, wait for [`INTR_STATE.EDN_CMD_REQ_DONE`](#intr_state) or
 [`SW_CMD_STS.CMD_ACK`](#sw_cmd_sts) to be high and then check the value of this field.
 0b0: Request completed successfully.
@@ -269,9 +267,59 @@ This bit has to be polled before each word of a command is written to [`SW_CMD_R
 0b0: The EDN is not ready to accept the next word yet.
 0b1: The EDN is ready to accept the next word.
 
+## HW_CMD_STS
+EDN hardware command status register
+- Offset: `0x28`
+- Reset default: `0x0`
+- Reset mask: `0xff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "BOOT_MODE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "AUTO_MODE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_STS", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_ACK", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_TYPE", "bits": 4, "attr": ["ro"], "rotate": -90}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                                |
+|:------:|:------:|:-------:|:------------------------------------|
+|  31:8  |        |         | Reserved                            |
+|  7:4   |   ro   |   0x0   | [CMD_TYPE](#hw_cmd_sts--cmd_type)   |
+|   3    |   ro   |   0x0   | [CMD_ACK](#hw_cmd_sts--cmd_ack)     |
+|   2    |   ro   |   0x0   | [CMD_STS](#hw_cmd_sts--cmd_sts)     |
+|   1    |   ro   |   0x0   | [AUTO_MODE](#hw_cmd_sts--auto_mode) |
+|   0    |   ro   |   0x0   | [BOOT_MODE](#hw_cmd_sts--boot_mode) |
+
+### HW_CMD_STS . CMD_TYPE
+This field contains the application command type of the hardware controlled command issued last.
+The application command selects one of five operations to perform.
+A description of the application command types can be found [here](https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#command-description).
+
+### HW_CMD_STS . CMD_ACK
+This one bit field indicates when a HW command has been acknowledged by the CSRNG.
+It is set to low each time a new command is sent to the CSRNG.
+The field is set to high once a HW command request has been acknowledged by the CSRNG.
+0b0: The last HW command has not been acknowledged yet.
+0b1: The last HW command has been acknowledged.
+
+### HW_CMD_STS . CMD_STS
+This one bit field represents the status code returned with the CSRNG application command ack.
+It is updated each time a HW command is acknowledged by CSRNG.
+0b0: Request completed successfully.
+0b1: Request completed with an error.
+
+### HW_CMD_STS . AUTO_MODE
+This one bit field indicates whether the EDN is in the hardware controlled part of auto mode.
+The instantiate command is issued via SW interface and is thus not part of the hardware controlled part of auto mode.
+0b0: The EDN is not in the hardware controlled part of auto mode.
+0b1: The EDN is in the hardware controlled part of auto mode.
+
+### HW_CMD_STS . BOOT_MODE
+This one bit field indicates whether the EDN is in the hardware controlled boot mode.
+0b0: The EDN is not in boot mode.
+0b1: The EDN is in boot mode.
+
 ## RESEED_CMD
 EDN csrng reseed command register
-- Offset: `0x28`
+- Offset: `0x2c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -299,7 +347,7 @@ in the CSRNG documentation.
 
 ## GENERATE_CMD
 EDN csrng generate command register
-- Offset: `0x2c`
+- Offset: `0x30`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -327,7 +375,7 @@ in the CSRNG documentation.
 
 ## MAX_NUM_REQS_BETWEEN_RESEEDS
 EDN maximum number of requests between reseeds register
-- Offset: `0x30`
+- Offset: `0x34`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -350,7 +398,7 @@ automatic reseed when it reaches zero.
 
 ## RECOV_ALERT_STS
 Recoverable alert status register
-- Offset: `0x34`
+- Offset: `0x38`
 - Reset default: `0x0`
 - Reset mask: `0x100f`
 
@@ -372,7 +420,7 @@ Recoverable alert status register
 
 ## ERR_CODE
 Hardware detection of fatal error conditions status register
-- Offset: `0x38`
+- Offset: `0x3c`
 - Reset default: `0x0`
 - Reset mask: `0x70700003`
 
@@ -444,7 +492,7 @@ When this bit is set, a fatal error condition will result.
 
 ## ERR_CODE_TEST
 Test error conditions register
-- Offset: `0x3c`
+- Offset: `0x40`
 - Reset default: `0x0`
 - Reset mask: `0x1f`
 
@@ -469,7 +517,7 @@ an interrupt or an alert.
 
 ## MAIN_SM_STATE
 Main state machine state observation register
-- Offset: `0x40`
+- Offset: `0x44`
 - Reset default: `0xc1`
 - Reset mask: `0x1ff`
 
@@ -483,6 +531,3 @@ Main state machine state observation register
 |:------:|:------:|:-------:|:--------------|:---------------------------------------------------------------------------------------------------------------|
 |  31:9  |        |         |               | Reserved                                                                                                       |
 |  8:0   |   ro   |  0xc1   | MAIN_SM_STATE | This is the state of the EDN main state machine. See the RTL file `edn_main_sm` for the meaning of the values. |
-
-
-<!-- END CMDGEN -->

--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -126,11 +126,19 @@ package edn_env_pkg;
   } state_ack_e;
 
   typedef enum int {
-    cmd_reg_rdy = 0,
-    cmd_rdy  = 1,
-    cmd_sts = 2,
-    cmd_ack = 3
+    sw_cmd_reg_rdy = 0,
+    sw_cmd_rdy  = 1,
+    sw_cmd_sts = 2,
+    sw_cmd_ack = 3
   } sw_cmd_sts_e;
+
+  typedef enum int {
+    hw_cmd_boot_mode = 0,
+    hw_cmd_auto_mode = 1,
+    hw_cmd_sts = 2,
+    hw_cmd_ack = 3,
+    hw_cmd_type = 4
+  } hw_cmd_sts_e;
 
   // package sources
   `include "edn_env_cfg.sv"

--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -101,7 +101,8 @@ package edn_env_pkg;
     boot_req_mode_field_alert = 1,
     auto_req_mode_field_alert = 2,
     cmd_fifo_rst_field_alert  = 3,
-    edn_bus_cmp_alert         = 12
+    edn_bus_cmp_alert         = 12,
+    csrng_ack_err             = 13
   } recov_alert_bit_e;
 
   typedef enum int {

--- a/hw/ip/edn/dv/env/edn_if.sv
+++ b/hw/ip/edn/dv/env/edn_if.sv
@@ -36,4 +36,8 @@ interface edn_if(input clk, input rst_n);
     edn_disable_o = val;
   endfunction
 
+  function automatic string genbits_valid_path();
+    return {core_path, ".csrng_cmd_i.genbits_valid"};
+  endfunction // genbits_valid_path
+
 endinterface // edn_if

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -310,6 +310,9 @@ class edn_scoreboard extends cip_base_scoreboard #(
           end
         end
       end
+      "hw_cmd_sts": begin
+        do_read_check = 1'b0;
+      end
       "boot_ins_cmd": begin
         if (addr_phase_write) begin
           boot_ins_cmd_comp = item.a_data;

--- a/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
@@ -12,7 +12,153 @@ class edn_alert_vseq extends edn_base_vseq;
   bit [csrng_pkg::GENBITS_BUS_WIDTH - 1:0]                genbits;
   bit [entropy_src_pkg::FIPS_BUS_WIDTH - 1:0]             fips;
   bit [31:0]                                              exp_recov_alert_sts;
+  bit [31:0]                                              value;
   uint                                                    endpoint_port;
+
+
+  task start_transition_to_main_sm_state(state_e exp_state);
+    // Create background thread that transitions the main sm to the expected state.
+    fork
+      begin
+        // Send an instantiate command if we are in auto mode.
+        if (cfg.boot_req_mode != MuBi4True && cfg.auto_req_mode == MuBi4True) begin
+          // Send INS cmd to start the auto/SW mode operation.
+          wr_cmd(.cmd_type(edn_env_pkg::Sw), .acmd(csrng_pkg::INS), .clen(0),
+                 .flags(MuBi4False), .glen(0), .mode(edn_env_pkg::AutoReqMode), .wait_for_ack(1));
+        end
+      end
+    join_none
+  endtask
+
+  task test_edn_cs_sts_alert();
+    string state_path;
+    state_e exp_state;
+    bit [31:0] exp_hw_cmd_sts;
+    bit send_generate;
+    state_path = cfg.edn_vif.sm_err_path("edn_main_sm");
+    // Re-randomize config without invalid mubi values and without clearing the FIFOs.
+    cfg.use_invalid_mubi  = 0;
+    cfg.cmd_fifo_rst_pct  = 0;
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(endpoint_port,
+                                       endpoint_port inside { [0:cfg.num_endpoints - 1] };)
+
+    m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
+        create("m_endpoint_pull_seq");
+
+    if (cfg.boot_req_mode == MuBi4True) begin
+      // If EDN is configured in Boot mode, randomly select one of the Boot states.
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(exp_state,
+                                         exp_state inside {BootLoadIns, BootInsAckWait,
+                                                           BootLoadGen, BootGenAckWait,
+                                                           BootPulse, BootDone,
+                                                           BootLoadUni};)
+      // Set the boot generate command to request the minimal amount of entropy.
+      wr_cmd(.cmd_type(edn_env_pkg::BootGen), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4False),
+             .glen(1), .mode(edn_env_pkg::BootReqMode));
+    end else if (cfg.auto_req_mode == MuBi4True) begin
+      // If instead EDN is configured in auto mode, randomly select one of the auto mode states.
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(exp_state,
+                                         exp_state inside {AutoAckWait, AutoDispatch,
+                                                           AutoCaptGenCnt, AutoSendGenCmd,
+                                                           AutoCaptReseedCnt, AutoSendReseedCmd};)
+      // In auto mode, minimize number of requests between reseeds and set the reseed command.
+      csr_wr(.ptr(ral.max_num_reqs_between_reseeds), .value(1));
+      wr_cmd(.cmd_type(edn_env_pkg::AutoRes), .acmd(csrng_pkg::RES), .clen(0),
+             .flags(MuBi4False), .mode(edn_env_pkg::AutoReqMode));
+      wr_cmd(.cmd_type(edn_env_pkg::AutoGen), .acmd(csrng_pkg::GEN), .clen(0), .flags(MuBi4False),
+             .glen(1), .mode(edn_env_pkg::AutoReqMode));
+    end
+
+    // Wait for the EDN main SM to enter the desired state and apply the rsp_sts_err setting to
+    // make the next CSRNG acknowledgement return an error.
+    fork
+      `DV_SPINWAIT(
+        `uvm_info(`gfn, $sformatf("Waiting for main_sm to reach state %s",
+                                  exp_state.name()), UVM_HIGH)
+        forever begin
+          uvm_hdl_data_t val;
+          state_e act_state;
+          cfg.clk_rst_vif.wait_n_clks(1);
+          `DV_CHECK(uvm_hdl_read(state_path, val))
+          act_state = state_e'(val);
+          if (act_state == exp_state) break;
+        end
+        `uvm_info(`gfn, $sformatf("State reached"), UVM_HIGH)
+        // The next acknowledgement should return an error status.
+        cfg.m_csrng_agent_cfg.rsp_sts_err = 1;
+      )
+    join_none
+
+    // Set the EDN ctrl values.
+    ral.ctrl.edn_enable.set(cfg.enable);
+    ral.ctrl.boot_req_mode.set(cfg.boot_req_mode);
+    ral.ctrl.auto_req_mode.set(cfg.auto_req_mode);
+    ral.ctrl.cmd_fifo_rst.set(cfg.cmd_fifo_rst);
+    csr_update(.csr(ral.ctrl));
+
+    // Issue the commands that are needed to get to exp_state in a fork.
+    start_transition_to_main_sm_state(exp_state);
+    send_generate = (exp_state inside {BootLoadGen, BootGenAckWait, BootPulse, BootDone,
+                                       BootLoadUni, AutoCaptReseedCnt, AutoSendReseedCmd});
+
+    // Load constant genbits data to complete the generate request if needed.
+    if (send_generate) begin
+      `DV_CHECK_STD_RANDOMIZE_FATAL(fips)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(genbits)
+      cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+    end
+    // Disable the boot mode to trigger the uninstaniate command if needed.
+    if (exp_state inside {BootLoadGen, BootGenAckWait, BootPulse, BootDone, BootLoadUni}) begin
+      ral.ctrl.boot_req_mode.set(MuBi4False);
+      csr_update(.csr(ral.ctrl));
+    end
+
+    // Wait for the CSRNG error status response to propagate through the EDN
+    // to the hw_cmd_sts register.
+    csr_spinwait(.ptr(ral.hw_cmd_sts.cmd_sts), .exp_data(1'b1), .backdoor(1'b1));
+    cfg.clk_rst_vif.wait_clks(10);
+    // Expect the csrng_ack_err bit to be set in the recov_alert_sts register.
+    exp_recov_alert_sts = 32'b0;
+    exp_recov_alert_sts[csrng_ack_err] = 1;
+    csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
+    // Check hw_cmd_sts in scoreboard.
+    exp_hw_cmd_sts[hw_cmd_boot_mode] = (cfg.boot_req_mode == MuBi4True) ? 1'b1 : 1'b0;
+    exp_hw_cmd_sts[hw_cmd_auto_mode] = (cfg.auto_req_mode == MuBi4True) ? 1'b1 : 1'b0;
+    exp_hw_cmd_sts[hw_cmd_sts] = 1'b1;
+    exp_hw_cmd_sts[hw_cmd_ack] = 1'b1;
+    exp_hw_cmd_sts[hw_cmd_type+:4] =
+        (exp_state inside {BootLoadIns, BootInsAckWait}) ? csrng_pkg::INS :
+        (exp_state inside {BootPulse, BootDone, BootLoadUni}) ? csrng_pkg::UNI :
+        (exp_state inside {AutoCaptReseedCnt, AutoSendReseedCmd}) ? csrng_pkg::RES :
+        csrng_pkg::GEN;
+    csr_rd_check(.ptr(ral.hw_cmd_sts), .compare_value(exp_hw_cmd_sts));
+    csr_rd_check(.ptr(ral.main_sm_state), .compare_value(edn_pkg::RejectCsrngEntropy));
+    // See if we can request some data if the generate has been issued.
+    if (send_generate) begin
+      m_endpoint_pull_seq.num_trans =
+          csrng_pkg::GENBITS_BUS_WIDTH/edn_pkg::ENDPOINT_BUS_WIDTH;
+      m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+    end
+    // From now on we want the CSRNG status responses to be valid again.
+    cfg.m_csrng_agent_cfg.rsp_sts_err = 0;
+    `DV_CHECK_STD_RANDOMIZE_FATAL(fips)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(genbits)
+    // Load constant genbits data to check that the EDN does not accept any entropy.
+    // We wait for more than max_genbits_dly to see that the assertion CsErrAcceptNoEntropy_A
+    // does not trigger.
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+    cfg.clk_rst_vif.wait_clks(1000);
+    // Clear the genbits user data to prepare for the next test.
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.clear_h_user_data();
+    // Disable the EDN to prepare for the next test.
+    value = {prim_mubi_pkg::MuBi4False,  // edn_enable
+             prim_mubi_pkg::MuBi4False,  // boot_req_mode
+             prim_mubi_pkg::MuBi4False,  // auto_req_mode
+             prim_mubi_pkg::MuBi4False}; // cmd_fifo_rst
+    csr_wr(.ptr(ral.ctrl), .value(value));
+  endtask // edn_bus_cmp_alert
 
   task test_edn_bus_cmp_alert();
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(endpoint_port,
@@ -67,7 +213,7 @@ class edn_alert_vseq extends edn_base_vseq;
     // Check recov_alert_sts register
     cfg.clk_rst_vif.wait_clks(100);
     exp_recov_alert_sts = 32'b0;
-    exp_recov_alert_sts[ral.recov_alert_sts.edn_bus_cmp_alert.get_lsb_pos()] = 1;
+    exp_recov_alert_sts[edn_bus_cmp_alert] = 1;
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
     if (cfg.en_cov) begin
       cov_vif.cg_alert_sample(.recov_alert_sts(exp_recov_alert_sts));
@@ -104,7 +250,8 @@ class edn_alert_vseq extends edn_base_vseq;
     first_index = find_index("_", fld_name, "first");
 
     csr = ral.get_reg_by_name(reg_name);
-    fld = csr.get_field_by_name({fld_name.substr(first_index+1, fld_name.len()-1), "_field_alert"});
+    fld = csr.get_field_by_name({fld_name.substr(first_index+1, fld_name.len()-1),
+                                 "_field_alert"});
 
     exp_recov_alert_sts = 32'b0;
     exp_recov_alert_sts[fld.get_lsb_pos()] = 1;
@@ -113,17 +260,45 @@ class edn_alert_vseq extends edn_base_vseq;
       cov_vif.cg_alert_sample(.recov_alert_sts(exp_recov_alert_sts));
     end
 
-    // Write valid values
-    ral.ctrl.edn_enable.set(prim_mubi_pkg::MuBi4True);
+    // CSRNG requests can drop if the EDN is disabled.
+    // The corresponding assertions can be disabled shortly since CSRNG must be disabled
+    // any time the EDN is disabled according to specification.
+    // https://opentitan.org/book/hw/ip/edn/doc/programmers_guide.html
+    $assertoff(0, "tb.csrng_if.cmd_push_if.H_DataStableWhenValidAndNotReady_A");
+    $assertoff(0, "tb.csrng_if.cmd_push_if.ValidHighUntilReady_A");
+    // Set the CTRL register fields back to some valid MuBi4 value.
+    value = {prim_mubi_pkg::MuBi4False, // edn_enable
+             prim_mubi_pkg::MuBi4False, // boot_req_mode
+             prim_mubi_pkg::MuBi4False, // auto_req_mode
+             prim_mubi_pkg::MuBi4True}; // cmd_fifo_rst
+    csr_wr(.ptr(ral.ctrl), .value(value));
+    // Stop clearing the EDN FIFOs.
+    csr_wr(.ptr(ral.ctrl.cmd_fifo_rst), .value(prim_mubi_pkg::MuBi4False));
+    // Turn the assertions back on.
+    $asserton(0, "tb.csrng_if.cmd_push_if.H_DataStableWhenValidAndNotReady_A");
+    $asserton(0, "tb.csrng_if.cmd_push_if.ValidHighUntilReady_A");
+
+    // Clear the recov_alert_sts register.
+    csr_wr(.ptr(ral.recov_alert_sts), .value(32'b0));
+    // Check the recov_alert_sts register.
+    cfg.clk_rst_vif.wait_clks(100);
+    csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
+
+    // Start the CSRNG error status response alert test.
+    test_edn_cs_sts_alert();
+
+    // Disable the EDN and clear the FIFOs.
+    ral.ctrl.edn_enable.set(prim_mubi_pkg::MuBi4False);
     ral.ctrl.boot_req_mode.set(prim_mubi_pkg::MuBi4False);
     ral.ctrl.auto_req_mode.set(prim_mubi_pkg::MuBi4False);
     ral.ctrl.cmd_fifo_rst.set(prim_mubi_pkg::MuBi4True);
     csr_update(.csr(ral.ctrl));
+    csr_wr(.ptr(ral.ctrl.cmd_fifo_rst), .value(prim_mubi_pkg::MuBi4False));
+    csr_wr(.ptr(ral.ctrl.edn_enable), .value(prim_mubi_pkg::MuBi4True));
 
-    // Clear recov_alert_sts register
+    // Clear the recov_alert_sts register.
     csr_wr(.ptr(ral.recov_alert_sts), .value(32'b0));
-
-    // Check recov_alert_sts register
+    // Check the recov_alert_sts register.
     cfg.clk_rst_vif.wait_clks(100);
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
 

--- a/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
@@ -246,6 +246,12 @@ class edn_err_vseq extends edn_base_vseq;
 
     // Insert the selected error.
     `uvm_info(`gfn, $sformatf("which_err_code = %s", cfg.which_err_code.name()), UVM_HIGH)
+    // CSRNG requests can drop if the SM reaches an error state.
+    // The corresponding assertions can be disabled shortly since CSRNG must be disabled
+    // any time the EDN is disabled according to specification.
+    // https://opentitan.org/book/hw/ip/edn/doc/programmers_guide.html
+    $assertoff(0, "tb.csrng_if.cmd_push_if.H_DataStableWhenValidAndNotReady_A");
+    $assertoff(0, "tb.csrng_if.cmd_push_if.ValidHighUntilReady_A");
     case (cfg.which_err_code) inside
       sfifo_rescmd_err, sfifo_gencmd_err, sfifo_output_err: begin
         fld = csr.get_field_by_name(fld_name);
@@ -326,6 +332,8 @@ class edn_err_vseq extends edn_base_vseq;
     endcase // case (cfg.which_err_code)
 
     // Turn assertions back on
+    $asserton(0, "tb.csrng_if.cmd_push_if.H_DataStableWhenValidAndNotReady_A");
+    $asserton(0, "tb.csrng_if.cmd_push_if.ValidHighUntilReady_A");
     cfg.edn_assert_vif.assert_on();
   endtask
 

--- a/hw/ip/edn/dv/tests/edn_alert_test.sv
+++ b/hw/ip/edn/dv/tests/edn_alert_test.sv
@@ -12,7 +12,9 @@ class edn_alert_test extends edn_base_test;
 
     cfg.en_scb            = 0;
     cfg.enable_pct        = 100;
-    cfg.boot_req_mode_pct = 0;
+    // For test_edn_cs_sts_alert() only hardware controlled modes can be tested.
+    cfg.boot_req_mode_pct = 50;
+    cfg.auto_req_mode_pct = 50;
     cfg.cmd_fifo_rst_pct  = 100;
     cfg.use_invalid_mubi  = 1;
     cfg.num_endpoints     = MIN_NUM_ENDPOINTS;

--- a/hw/ip/edn/dv/tests/edn_base_test.sv
+++ b/hw/ip/edn/dv/tests/edn_base_test.sv
@@ -33,6 +33,7 @@ class edn_base_test extends cip_base_test #(
     cfg.m_csrng_agent_cfg.max_genbits_dly = 32;
     cfg.m_csrng_agent_cfg.min_cmd_rdy_dly = 0;
     cfg.m_csrng_agent_cfg.max_cmd_rdy_dly = 1;
+    cfg.m_csrng_agent_cfg.rsp_sts_err     = 0; // CSRNG should not return errors
   endfunction
 
 endclass : edn_base_test

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -63,6 +63,7 @@ module edn_core import edn_pkg::*;
     CsrngCmdReqOut,
     CsrngCmdReqValidOut,
     SwCmdSts,
+    HwCmdSts,
     MainFsmEn,
     CmdFifoCnt,
     CsrngPackerClr,
@@ -200,7 +201,12 @@ module edn_core import edn_pkg::*;
   logic                               cs_rdata_capt_vld_q, cs_rdata_capt_vld_d;
   logic                               cmd_rdy_q, cmd_rdy_d;
   logic                               csrng_cmd_sts_q, csrng_cmd_sts_d;
-  logic                               csrng_cmd_ack_q, csrng_cmd_ack_d;
+  logic                               csrng_sw_cmd_ack_q, csrng_sw_cmd_ack_d;
+  logic                               csrng_hw_cmd_ack_q, csrng_hw_cmd_ack_d;
+  logic                               csrng_hw_cmd_sts_q, csrng_hw_cmd_sts_d;
+  logic                               boot_mode_q, boot_mode_d,
+                                      auto_mode_q, auto_mode_d;
+  logic [3:0]                         cmd_type_q, cmd_type_d;
   logic                               cmd_reg_rdy_d, cmd_reg_rdy_q;
 
   always_ff @(posedge clk_i or negedge rst_ni)
@@ -216,7 +222,11 @@ module edn_core import edn_pkg::*;
       cs_rdata_capt_vld_q <= '0;
       cmd_rdy_q   <= '0;
       csrng_cmd_sts_q   <= '0;
-      csrng_cmd_ack_q   <= '0;
+      csrng_sw_cmd_ack_q   <= '0;
+      csrng_hw_cmd_sts_q   <= '0;
+      boot_mode_q   <= '0;
+      auto_mode_q   <= '0;
+      cmd_type_q   <= '0;
       cmd_reg_rdy_q   <= '0;
     end else begin
       cs_cmd_req_q  <= cs_cmd_req_d;
@@ -230,7 +240,12 @@ module edn_core import edn_pkg::*;
       cs_rdata_capt_vld_q <= cs_rdata_capt_vld_d;
       cmd_rdy_q   <= cmd_rdy_d;
       csrng_cmd_sts_q   <= csrng_cmd_sts_d;
-      csrng_cmd_ack_q   <= csrng_cmd_ack_d;
+      csrng_sw_cmd_ack_q   <= csrng_sw_cmd_ack_d;
+      csrng_hw_cmd_ack_q   <= csrng_hw_cmd_ack_d;
+      csrng_hw_cmd_sts_q   <= csrng_hw_cmd_sts_d;
+      boot_mode_q   <= boot_mode_d;
+      auto_mode_q   <= auto_mode_d;
+      cmd_type_q   <= cmd_type_d;
       cmd_reg_rdy_q   <= cmd_reg_rdy_d;
     end
 
@@ -557,12 +572,54 @@ module edn_core import edn_pkg::*;
 
   // cmd_ack goes high only when a command is acknowledged that has been loaded into sw_cmd_req.
   assign hw2reg.sw_cmd_sts.cmd_ack.de = 1'b1;
-  assign hw2reg.sw_cmd_sts.cmd_ack.d = csrng_cmd_ack_d;
-  assign csrng_cmd_ack_d =
+  assign hw2reg.sw_cmd_sts.cmd_ack.d = csrng_sw_cmd_ack_d;
+  assign csrng_sw_cmd_ack_d =
          !edn_enable_fo[SwCmdSts] ? 1'b0 :
          sw_cmd_req_load ? 1'b0 :
          (csrng_cmd_i.csrng_rsp_ack && sw_cmd_valid) ? 1'b1 :
-         csrng_cmd_ack_q;
+         csrng_sw_cmd_ack_q;
+
+  //--------------------------------------------
+  // hw_cmd_sts register
+  //--------------------------------------------
+  // Set the boot_mode field to one when boot mode is entered and to zero when it is left.
+  assign hw2reg.hw_cmd_sts.boot_mode.de = 1'b1;
+  assign hw2reg.hw_cmd_sts.boot_mode.d = boot_mode_d;
+  assign boot_mode_d = main_sm_done_pulse || !edn_enable_fo[HwCmdSts] ? 1'b0 :
+                       boot_wr_ins_cmd ? 1'b1 :
+                       boot_mode_q;
+  // Set the auto_mode field to one when auto mode is entered and to zero when it is left.
+  assign hw2reg.hw_cmd_sts.auto_mode.de = 1'b1;
+  assign hw2reg.hw_cmd_sts.auto_mode.d = auto_mode_d;
+  assign auto_mode_d = main_sm_done_pulse || !edn_enable_fo[HwCmdSts] ? 1'b0 :
+                       auto_req_mode_busy ? 1'b1 :
+                       auto_mode_q;
+  // Record the cmd_sts signal each time a hardware command is acknowledged.
+  // Reset it each time a new hardware command is issued.
+  assign hw2reg.hw_cmd_sts.cmd_sts.de = 1'b1;
+  assign hw2reg.hw_cmd_sts.cmd_sts.d = csrng_hw_cmd_sts_d;
+  assign csrng_hw_cmd_sts_d =
+         !edn_enable_fo[HwCmdSts] ? 1'b0 :
+         sw_cmd_valid ? csrng_hw_cmd_sts_q :
+         (cs_cmd_req_vld_out_q && csrng_cmd_i.csrng_req_ready) ? 1'b0 :
+         csrng_cmd_i.csrng_rsp_ack && csrng_cmd_i.csrng_rsp_sts ? 1'b1 :
+         csrng_hw_cmd_sts_q;
+  // Set the cmd_ack signal to high whenever a hardware command is acknowledged and set it
+  // to low whenever a new hardware command is issued to the CSRNG.
+  assign hw2reg.hw_cmd_sts.cmd_ack.de = 1'b1;
+  assign hw2reg.hw_cmd_sts.cmd_ack.d = csrng_hw_cmd_ack_d;
+  assign csrng_hw_cmd_ack_d =
+         !edn_enable_fo[HwCmdSts] ? 1'b0 :
+         sw_cmd_valid ? csrng_hw_cmd_ack_q :
+         (cs_cmd_req_vld_out_q && csrng_cmd_i.csrng_req_ready) ? 1'b0 :
+         csrng_cmd_i.csrng_rsp_ack ? 1'b1 :
+         csrng_hw_cmd_ack_q;
+  // Set the cmd_type to the application command type value of the hardware controlled
+  // command issued last.
+  assign hw2reg.hw_cmd_sts.cmd_type.de = 1'b1;
+  assign hw2reg.hw_cmd_sts.cmd_type.d = cmd_type_d;
+  assign cmd_type_d = (edn_enable_fo[HwCmdSts] && !sw_cmd_valid && cs_cmd_req_vld_out_q
+                       && csrng_cmd_i.csrng_req_ready) ? cs_cmd_req_out_q[3:0] : cmd_type_q;
 
   // rescmd fifo
   prim_fifo_sync #(

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -8,6 +8,8 @@
 //    end points.
 //
 
+`include "prim_assert.sv"
+
 module edn_core import edn_pkg::*;
 #(
   parameter int NumEndPoints = 4
@@ -936,6 +938,16 @@ module edn_core import edn_pkg::*;
   // state machine status
   assign hw2reg.main_sm_state.de = 1'b1;
   assign hw2reg.main_sm_state.d = edn_main_sm_state;
+
+  //--------------------------------------------
+  // Assertions
+  //--------------------------------------------
+  // Do not accept new genbits into the CSRNG interface genbits FIFO if we are in the alert state
+  // due to a CSRNG status error response.
+  `ASSERT(CsErrAcceptNoEntropy_A, reject_csrng_entropy |-> packer_cs_push == 0)
+  // Do not issue new commands to the CSRNG if we are in the alert state
+  // due to a CSRNG status error response.
+  `ASSERT(CsErrIssueNoCommands_A, reject_csrng_entropy |-> csrng_cmd_o.csrng_req_valid == 0)
 
   //--------------------------------------------
   // unused signals

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -92,7 +92,6 @@ module edn_main_sm import edn_pkg::*; #(
         end
       end
       BootPulse: begin
-        main_sm_done_pulse_o = 1'b1;
         state_d = BootDone;
       end
       BootDone: begin
@@ -106,6 +105,7 @@ module edn_main_sm import edn_pkg::*; #(
       end
       BootUniAckWait: begin
         if (csrng_cmd_ack_i) begin
+          main_sm_done_pulse_o = 1'b1;
           state_d = Idle;
         end
       end

--- a/hw/ip/edn/rtl/edn_pkg.sv
+++ b/hw/ip/edn/rtl/edn_pkg.sv
@@ -28,7 +28,7 @@ package edn_pkg;
   parameter csrng_pkg::csrng_cmd_t BOOT_UNINSTANTIATE = 32'h5;
 
   // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 19 -n 9 \
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 20 -n 9 \
   //     -s 2596398066 --language=sv
   //
   // Hamming distance histogram:
@@ -36,12 +36,12 @@ package edn_pkg;
   //  0: --
   //  1: --
   //  2: --
-  //  3: ||||||||||||| (21.05%)
-  //  4: |||||||||||||||||||| (30.41%)
-  //  5: ||||||||||||||| (23.98%)
-  //  6: |||||||||| (15.79%)
-  //  7: |||| (6.43%)
-  //  8: | (2.34%)
+  //  3: |||||||||||||| (21.05%)
+  //  4: |||||||||||||||||||| (30.00%)
+  //  5: ||||||||||||||| (23.68%)
+  //  6: |||||||||| (15.26%)
+  //  7: |||| (7.37%)
+  //  8: | (2.63%)
   //  9: --
   //
   // Minimum Hamming distance: 3
@@ -51,25 +51,26 @@ package edn_pkg;
   //
   localparam int StateWidth = 9;
   typedef enum logic [StateWidth-1:0] {
-    Idle              = 9'b011000001, // idle
-    BootLoadIns       = 9'b111000111, // boot: load the instantiate command
-    BootInsAckWait    = 9'b001111001, // boot: wait for instantiate command ack
-    BootLoadGen       = 9'b000000011, // boot: load the generate command
-    BootGenAckWait    = 9'b001110111, // boot: wait for generate command ack
-    BootPulse         = 9'b100110101, // boot: signal a done pulse
-    BootDone          = 9'b000101100, // boot: stay in done state until leaving boot mode
-    BootLoadUni       = 9'b010101001, // boot: load the uninstantiate command
-    BootUniAckWait    = 9'b011110000, // boot: wait for uninstantiate command ack
-    AutoLoadIns       = 9'b110111100, // auto: load the instantiate command
-    AutoFirstAckWait  = 9'b110100011, // auto: wait for first instantiate command ack
-    AutoAckWait       = 9'b010010010, // auto: wait for instantiate command ack
-    AutoDispatch      = 9'b101100001, // auto: determine next command to be sent
-    AutoCaptGenCnt    = 9'b100001110, // auto: capture the gen fifo count
-    AutoSendGenCmd    = 9'b111011101, // auto: send the generate command
-    AutoCaptReseedCnt = 9'b010111111, // auto: capture the reseed fifo count
-    AutoSendReseedCmd = 9'b001101010, // auto: send the reseed command
-    SWPortMode        = 9'b010010101, // swport: no hw request mode
-    Error             = 9'b000011000  // illegal state reached and hang
+    Idle                = 9'b011000001, // idle
+    BootLoadIns         = 9'b111000111, // boot: load the instantiate command
+    BootInsAckWait      = 9'b001111001, // boot: wait for instantiate command ack
+    BootLoadGen         = 9'b000000011, // boot: load the generate command
+    BootGenAckWait      = 9'b001110111, // boot: wait for generate command ack
+    BootPulse           = 9'b010101001, // boot: signal a done pulse
+    BootDone            = 9'b011110000, // boot: stay in done state until leaving boot mode
+    BootLoadUni         = 9'b100110101, // boot: load the uninstantiate command
+    BootUniAckWait      = 9'b000101100, // boot: wait for uninstantiate command ack
+    AutoLoadIns         = 9'b110111100, // auto: load the instantiate command
+    AutoFirstAckWait    = 9'b110100011, // auto: wait for first instantiate command ack
+    AutoAckWait         = 9'b010010010, // auto: wait for instantiate command ack
+    AutoDispatch        = 9'b101100001, // auto: determine next command to be sent
+    AutoCaptGenCnt      = 9'b100001110, // auto: capture the gen fifo count
+    AutoSendGenCmd      = 9'b111011101, // auto: send the generate command
+    AutoCaptReseedCnt   = 9'b010111111, // auto: capture the reseed fifo count
+    AutoSendReseedCmd   = 9'b001101010, // auto: send the reseed command
+    SWPortMode          = 9'b010010101, // swport: no hw request mode
+    RejectCsrngEntropy  = 9'b000011000, // stop accepting entropy from CSRNG
+    Error               = 9'b101111110  // illegal state reached and hang
   } state_e;
 
 endpackage : edn_pkg

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -142,6 +142,29 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } boot_mode;
+    struct packed {
+      logic        d;
+      logic        de;
+    } auto_mode;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmd_sts;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmd_ack;
+    struct packed {
+      logic [3:0]  d;
+      logic        de;
+    } cmd_type;
+  } edn_hw2reg_hw_cmd_sts_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
     } edn_enable_field_alert;
     struct packed {
       logic        d;
@@ -219,8 +242,9 @@ package edn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    edn_hw2reg_intr_state_reg_t intr_state; // [47:44]
-    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [43:36]
+    edn_hw2reg_intr_state_reg_t intr_state; // [60:57]
+    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [56:49]
+    edn_hw2reg_hw_cmd_sts_reg_t hw_cmd_sts; // [48:36]
     edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [35:26]
     edn_hw2reg_err_code_reg_t err_code; // [25:10]
     edn_hw2reg_main_sm_state_reg_t main_sm_state; // [9:0]
@@ -237,13 +261,14 @@ package edn_reg_pkg;
   parameter logic [BlockAw-1:0] EDN_BOOT_GEN_CMD_OFFSET = 7'h 1c;
   parameter logic [BlockAw-1:0] EDN_SW_CMD_REQ_OFFSET = 7'h 20;
   parameter logic [BlockAw-1:0] EDN_SW_CMD_STS_OFFSET = 7'h 24;
-  parameter logic [BlockAw-1:0] EDN_RESEED_CMD_OFFSET = 7'h 28;
-  parameter logic [BlockAw-1:0] EDN_GENERATE_CMD_OFFSET = 7'h 2c;
-  parameter logic [BlockAw-1:0] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS_OFFSET = 7'h 30;
-  parameter logic [BlockAw-1:0] EDN_RECOV_ALERT_STS_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] EDN_ERR_CODE_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] EDN_ERR_CODE_TEST_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] EDN_MAIN_SM_STATE_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] EDN_HW_CMD_STS_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] EDN_RESEED_CMD_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] EDN_GENERATE_CMD_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] EDN_RECOV_ALERT_STS_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] EDN_ERR_CODE_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] EDN_ERR_CODE_TEST_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] EDN_MAIN_SM_STATE_OFFSET = 7'h 44;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] EDN_INTR_TEST_RESVAL = 2'h 0;
@@ -268,6 +293,7 @@ package edn_reg_pkg;
     EDN_BOOT_GEN_CMD,
     EDN_SW_CMD_REQ,
     EDN_SW_CMD_STS,
+    EDN_HW_CMD_STS,
     EDN_RESEED_CMD,
     EDN_GENERATE_CMD,
     EDN_MAX_NUM_REQS_BETWEEN_RESEEDS,
@@ -278,7 +304,7 @@ package edn_reg_pkg;
   } edn_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] EDN_PERMIT [17] = '{
+  parameter logic [3:0] EDN_PERMIT [18] = '{
     4'b 0001, // index[ 0] EDN_INTR_STATE
     4'b 0001, // index[ 1] EDN_INTR_ENABLE
     4'b 0001, // index[ 2] EDN_INTR_TEST
@@ -289,13 +315,14 @@ package edn_reg_pkg;
     4'b 1111, // index[ 7] EDN_BOOT_GEN_CMD
     4'b 1111, // index[ 8] EDN_SW_CMD_REQ
     4'b 0001, // index[ 9] EDN_SW_CMD_STS
-    4'b 1111, // index[10] EDN_RESEED_CMD
-    4'b 1111, // index[11] EDN_GENERATE_CMD
-    4'b 1111, // index[12] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS
-    4'b 0011, // index[13] EDN_RECOV_ALERT_STS
-    4'b 1111, // index[14] EDN_ERR_CODE
-    4'b 0001, // index[15] EDN_ERR_CODE_TEST
-    4'b 0011  // index[16] EDN_MAIN_SM_STATE
+    4'b 0001, // index[10] EDN_HW_CMD_STS
+    4'b 1111, // index[11] EDN_RESEED_CMD
+    4'b 1111, // index[12] EDN_GENERATE_CMD
+    4'b 1111, // index[13] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS
+    4'b 0011, // index[14] EDN_RECOV_ALERT_STS
+    4'b 1111, // index[15] EDN_ERR_CODE
+    4'b 0001, // index[16] EDN_ERR_CODE_TEST
+    4'b 0011  // index[17] EDN_MAIN_SM_STATE
   };
 
 endpackage

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -182,6 +182,10 @@ package edn_reg_pkg;
       logic        d;
       logic        de;
     } edn_bus_cmp_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } csrng_ack_err;
   } edn_hw2reg_recov_alert_sts_reg_t;
 
   typedef struct packed {
@@ -242,10 +246,10 @@ package edn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    edn_hw2reg_intr_state_reg_t intr_state; // [60:57]
-    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [56:49]
-    edn_hw2reg_hw_cmd_sts_reg_t hw_cmd_sts; // [48:36]
-    edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [35:26]
+    edn_hw2reg_intr_state_reg_t intr_state; // [62:59]
+    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [58:51]
+    edn_hw2reg_hw_cmd_sts_reg_t hw_cmd_sts; // [50:38]
+    edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [37:26]
     edn_hw2reg_err_code_reg_t err_code; // [25:10]
     edn_hw2reg_main_sm_state_reg_t main_sm_state; // [9:0]
   } edn_hw2reg_t;

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -52,9 +52,9 @@ module edn_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [16:0] reg_we_check;
+  logic [17:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(17)
+    .OneHotWidth(18)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -161,6 +161,11 @@ module edn_reg_top (
   logic sw_cmd_sts_cmd_rdy_qs;
   logic sw_cmd_sts_cmd_sts_qs;
   logic sw_cmd_sts_cmd_ack_qs;
+  logic hw_cmd_sts_boot_mode_qs;
+  logic hw_cmd_sts_auto_mode_qs;
+  logic hw_cmd_sts_cmd_sts_qs;
+  logic hw_cmd_sts_cmd_ack_qs;
+  logic [3:0] hw_cmd_sts_cmd_type_qs;
   logic reseed_cmd_we;
   logic [31:0] reseed_cmd_wd;
   logic generate_cmd_we;
@@ -706,6 +711,143 @@ module edn_reg_top (
   );
 
 
+  // R[hw_cmd_sts]: V(False)
+  //   F[boot_mode]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_hw_cmd_sts_boot_mode (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.hw_cmd_sts.boot_mode.de),
+    .d      (hw2reg.hw_cmd_sts.boot_mode.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (hw_cmd_sts_boot_mode_qs)
+  );
+
+  //   F[auto_mode]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_hw_cmd_sts_auto_mode (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.hw_cmd_sts.auto_mode.de),
+    .d      (hw2reg.hw_cmd_sts.auto_mode.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (hw_cmd_sts_auto_mode_qs)
+  );
+
+  //   F[cmd_sts]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_hw_cmd_sts_cmd_sts (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.hw_cmd_sts.cmd_sts.de),
+    .d      (hw2reg.hw_cmd_sts.cmd_sts.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (hw_cmd_sts_cmd_sts_qs)
+  );
+
+  //   F[cmd_ack]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_hw_cmd_sts_cmd_ack (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.hw_cmd_sts.cmd_ack.de),
+    .d      (hw2reg.hw_cmd_sts.cmd_ack.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (hw_cmd_sts_cmd_ack_qs)
+  );
+
+  //   F[cmd_type]: 7:4
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (4'h0),
+    .Mubi    (1'b0)
+  ) u_hw_cmd_sts_cmd_type (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.hw_cmd_sts.cmd_type.de),
+    .d      (hw2reg.hw_cmd_sts.cmd_type.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (hw_cmd_sts_cmd_type_qs)
+  );
+
+
   // R[reseed_cmd]: V(True)
   logic reseed_cmd_qe;
   logic [0:0] reseed_cmd_flds_we;
@@ -1210,7 +1352,7 @@ module edn_reg_top (
 
 
 
-  logic [16:0] addr_hit;
+  logic [17:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == EDN_INTR_STATE_OFFSET);
@@ -1223,13 +1365,14 @@ module edn_reg_top (
     addr_hit[ 7] = (reg_addr == EDN_BOOT_GEN_CMD_OFFSET);
     addr_hit[ 8] = (reg_addr == EDN_SW_CMD_REQ_OFFSET);
     addr_hit[ 9] = (reg_addr == EDN_SW_CMD_STS_OFFSET);
-    addr_hit[10] = (reg_addr == EDN_RESEED_CMD_OFFSET);
-    addr_hit[11] = (reg_addr == EDN_GENERATE_CMD_OFFSET);
-    addr_hit[12] = (reg_addr == EDN_MAX_NUM_REQS_BETWEEN_RESEEDS_OFFSET);
-    addr_hit[13] = (reg_addr == EDN_RECOV_ALERT_STS_OFFSET);
-    addr_hit[14] = (reg_addr == EDN_ERR_CODE_OFFSET);
-    addr_hit[15] = (reg_addr == EDN_ERR_CODE_TEST_OFFSET);
-    addr_hit[16] = (reg_addr == EDN_MAIN_SM_STATE_OFFSET);
+    addr_hit[10] = (reg_addr == EDN_HW_CMD_STS_OFFSET);
+    addr_hit[11] = (reg_addr == EDN_RESEED_CMD_OFFSET);
+    addr_hit[12] = (reg_addr == EDN_GENERATE_CMD_OFFSET);
+    addr_hit[13] = (reg_addr == EDN_MAX_NUM_REQS_BETWEEN_RESEEDS_OFFSET);
+    addr_hit[14] = (reg_addr == EDN_RECOV_ALERT_STS_OFFSET);
+    addr_hit[15] = (reg_addr == EDN_ERR_CODE_OFFSET);
+    addr_hit[16] = (reg_addr == EDN_ERR_CODE_TEST_OFFSET);
+    addr_hit[17] = (reg_addr == EDN_MAIN_SM_STATE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1253,7 +1396,8 @@ module edn_reg_top (
                (addr_hit[13] & (|(EDN_PERMIT[13] & ~reg_be))) |
                (addr_hit[14] & (|(EDN_PERMIT[14] & ~reg_be))) |
                (addr_hit[15] & (|(EDN_PERMIT[15] & ~reg_be))) |
-               (addr_hit[16] & (|(EDN_PERMIT[16] & ~reg_be)))));
+               (addr_hit[16] & (|(EDN_PERMIT[16] & ~reg_be))) |
+               (addr_hit[17] & (|(EDN_PERMIT[17] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -1298,16 +1442,16 @@ module edn_reg_top (
   assign sw_cmd_req_we = addr_hit[8] & reg_we & !reg_error;
 
   assign sw_cmd_req_wd = reg_wdata[31:0];
-  assign reseed_cmd_we = addr_hit[10] & reg_we & !reg_error;
+  assign reseed_cmd_we = addr_hit[11] & reg_we & !reg_error;
 
   assign reseed_cmd_wd = reg_wdata[31:0];
-  assign generate_cmd_we = addr_hit[11] & reg_we & !reg_error;
+  assign generate_cmd_we = addr_hit[12] & reg_we & !reg_error;
 
   assign generate_cmd_wd = reg_wdata[31:0];
-  assign max_num_reqs_between_reseeds_we = addr_hit[12] & reg_we & !reg_error;
+  assign max_num_reqs_between_reseeds_we = addr_hit[13] & reg_we & !reg_error;
 
   assign max_num_reqs_between_reseeds_wd = reg_wdata[31:0];
-  assign recov_alert_sts_we = addr_hit[13] & reg_we & !reg_error;
+  assign recov_alert_sts_we = addr_hit[14] & reg_we & !reg_error;
 
   assign recov_alert_sts_edn_enable_field_alert_wd = reg_wdata[0];
 
@@ -1318,7 +1462,7 @@ module edn_reg_top (
   assign recov_alert_sts_cmd_fifo_rst_field_alert_wd = reg_wdata[3];
 
   assign recov_alert_sts_edn_bus_cmp_alert_wd = reg_wdata[12];
-  assign err_code_test_we = addr_hit[15] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[16] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
 
@@ -1335,13 +1479,14 @@ module edn_reg_top (
     reg_we_check[7] = boot_gen_cmd_we;
     reg_we_check[8] = sw_cmd_req_we;
     reg_we_check[9] = 1'b0;
-    reg_we_check[10] = reseed_cmd_we;
-    reg_we_check[11] = generate_cmd_we;
-    reg_we_check[12] = max_num_reqs_between_reseeds_we;
-    reg_we_check[13] = recov_alert_sts_we;
-    reg_we_check[14] = 1'b0;
-    reg_we_check[15] = err_code_test_we;
-    reg_we_check[16] = 1'b0;
+    reg_we_check[10] = 1'b0;
+    reg_we_check[11] = reseed_cmd_we;
+    reg_we_check[12] = generate_cmd_we;
+    reg_we_check[13] = max_num_reqs_between_reseeds_we;
+    reg_we_check[14] = recov_alert_sts_we;
+    reg_we_check[15] = 1'b0;
+    reg_we_check[16] = err_code_test_we;
+    reg_we_check[17] = 1'b0;
   end
 
   // Read data return
@@ -1399,7 +1544,11 @@ module edn_reg_top (
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[0] = hw_cmd_sts_boot_mode_qs;
+        reg_rdata_next[1] = hw_cmd_sts_auto_mode_qs;
+        reg_rdata_next[2] = hw_cmd_sts_cmd_sts_qs;
+        reg_rdata_next[3] = hw_cmd_sts_cmd_ack_qs;
+        reg_rdata_next[7:4] = hw_cmd_sts_cmd_type_qs;
       end
 
       addr_hit[11]: begin
@@ -1407,10 +1556,14 @@ module edn_reg_top (
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[31:0] = max_num_reqs_between_reseeds_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[13]: begin
+        reg_rdata_next[31:0] = max_num_reqs_between_reseeds_qs;
+      end
+
+      addr_hit[14]: begin
         reg_rdata_next[0] = recov_alert_sts_edn_enable_field_alert_qs;
         reg_rdata_next[1] = recov_alert_sts_boot_req_mode_field_alert_qs;
         reg_rdata_next[2] = recov_alert_sts_auto_req_mode_field_alert_qs;
@@ -1418,7 +1571,7 @@ module edn_reg_top (
         reg_rdata_next[12] = recov_alert_sts_edn_bus_cmp_alert_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[15]: begin
         reg_rdata_next[0] = err_code_sfifo_rescmd_err_qs;
         reg_rdata_next[1] = err_code_sfifo_gencmd_err_qs;
         reg_rdata_next[20] = err_code_edn_ack_sm_err_qs;
@@ -1429,11 +1582,11 @@ module edn_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[8:0] = main_sm_state_qs;
       end
 

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -184,6 +184,8 @@ module edn_reg_top (
   logic recov_alert_sts_cmd_fifo_rst_field_alert_wd;
   logic recov_alert_sts_edn_bus_cmp_alert_qs;
   logic recov_alert_sts_edn_bus_cmp_alert_wd;
+  logic recov_alert_sts_csrng_ack_err_qs;
+  logic recov_alert_sts_csrng_ack_err_wd;
   logic err_code_sfifo_rescmd_err_qs;
   logic err_code_sfifo_gencmd_err_qs;
   logic err_code_edn_ack_sm_err_qs;
@@ -1064,6 +1066,33 @@ module edn_reg_top (
     .qs     (recov_alert_sts_edn_bus_cmp_alert_qs)
   );
 
+  //   F[csrng_ack_err]: 13:13
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_recov_alert_sts_csrng_ack_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_csrng_ack_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.csrng_ack_err.de),
+    .d      (hw2reg.recov_alert_sts.csrng_ack_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_csrng_ack_err_qs)
+  );
+
 
   // R[err_code]: V(False)
   //   F[sfifo_rescmd_err]: 0:0
@@ -1462,6 +1491,8 @@ module edn_reg_top (
   assign recov_alert_sts_cmd_fifo_rst_field_alert_wd = reg_wdata[3];
 
   assign recov_alert_sts_edn_bus_cmp_alert_wd = reg_wdata[12];
+
+  assign recov_alert_sts_csrng_ack_err_wd = reg_wdata[13];
   assign err_code_test_we = addr_hit[16] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
@@ -1569,6 +1600,7 @@ module edn_reg_top (
         reg_rdata_next[2] = recov_alert_sts_auto_req_mode_field_alert_qs;
         reg_rdata_next[3] = recov_alert_sts_cmd_fifo_rst_field_alert_qs;
         reg_rdata_next[12] = recov_alert_sts_edn_bus_cmp_alert_qs;
+        reg_rdata_next[13] = recov_alert_sts_csrng_ack_err_qs;
       end
 
       addr_hit[15]: begin

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -169,19 +169,19 @@ typedef enum dif_edn_sm_state {
   /**
    * Boot mode: signal a done pulse.
    */
-  kDifEdnSmStateBootPulse = 309,
+  kDifEdnSmStateBootPulse = 169,
   /**
    * Boot mode: stay in done state until reset.
    */
-  kDifEdnSmStateBootDone = 44,
+  kDifEdnSmStateBootDone = 240,
   /**
    * Boot mode: load the uninstantiate command.
    */
-  kDifEdnSmStateBootLoadUni = 169,
+  kDifEdnSmStateBootLoadUni = 309,
   /**
    * Boot mode: wait for uninstantiate command ack.
    */
-  kDifEdnSmStateBootUniAckWait = 240,
+  kDifEdnSmStateBootUniAckWait = 44,
   /**
    * Auto mode: load the instantiate command.
    */
@@ -219,9 +219,13 @@ typedef enum dif_edn_sm_state {
    */
   kDifEdnSmStateSWPortMode = 149,
   /**
+   * Stop accepting entropy from CSRNG.
+   */
+  kDifEdnSmStateRejectCsrngEntropy = 24,
+  /**
    * Illegal state reached and hang.
    */
-  kDifEdnSmStateError = 24,
+  kDifEdnSmStateError = 382,
 } dif_edn_sm_state_t;
 
 /**


### PR DESCRIPTION
This PR adds functionality to the EDN to process status error responses from CSRNG.
For further information please have a look at the individual commit messages.

This resolves [#15894](https://github.com/lowRISC/opentitan/issues/15894)