### PR TITLE
[cryptotest] Test harness for SHA2/3 and SHAKE

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -38,3 +38,55 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
 )
+
+HASH_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:nist_cavp_{}_{}_{}_json".format(
+        src_repo,
+        algorithm.lower(),
+        msg_type.lower(),
+    )
+    for algorithm, src_repo, extra_msg_types in [
+        ("SHA256", "sha2_fips_180_4", []),
+        ("SHA384", "sha2_fips_180_4", []),
+        ("SHA512", "sha2_fips_180_4", []),
+        ("SHA3_256", "sha3_fips_202", []),
+        ("SHA3_384", "sha3_fips_202", []),
+        ("SHA3_512", "sha3_fips_202", []),
+        (
+            "SHAKE128",
+            "shake_fips_202",
+            ["VariableOut"],
+        ),
+        (
+            "SHAKE256",
+            "shake_fips_202",
+            ["VariableOut"],
+        ),
+    ]
+    for msg_type in [
+        "ShortMsg",
+        #        "LongMsg",
+    ] + extra_msg_types
+]
+
+HASH_TESTVECTOR_ARGS = " ".join([
+    "--hash-json=\"$(rootpath {})\"".format(target)
+    for target in HASH_TESTVECTOR_TARGETS
+])
+
+opentitan_test(
+    name = "hash_kat",
+    cw310 = cw310_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        data = HASH_TESTVECTOR_TARGETS,
+        test_cmd = """
+                --bootstrap={firmware}
+                --bitstream={bitstream}
+            """ + HASH_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/hash_kat:harness",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    },
+)

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -29,6 +29,27 @@ cc_library(
 )
 
 cc_library(
+    name = "hash",
+    srcs = ["hash.c"],
+    hdrs = ["hash.h"],
+    deps = [
+        "//sw/device/lib/base:math",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:hash",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/impl/sha2:sha256",
+        "//sw/device/lib/crypto/impl/sha2:sha512",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:hash_commands",
+    ],
+)
+
+cc_library(
     name = "aes_sca",
     srcs = ["aes_sca.c"],
     hdrs = ["aes_sca.h"],
@@ -145,6 +166,7 @@ opentitan_binary(
     deps = [
         ":aes",
         ":aes_sca",
+        ":hash",
         ":ibex_fi",
         ":kmac_sca",
         ":prng_sca",
@@ -158,6 +180,7 @@ opentitan_binary(
         "//sw/device/lib/ujson",
         "//sw/device/tests/crypto/cryptotest/json:aes_commands",
         "//sw/device/tests/crypto/cryptotest/json:commands",
+        "//sw/device/tests/crypto/cryptotest/json:hash_commands",
         "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
     ],
 )

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -14,6 +14,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/aes_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/prng_sca_commands.h"
@@ -23,6 +24,7 @@
 // Include handlers
 #include "aes.h"
 #include "aes_sca.h"
+#include "hash.h"
 #include "ibex_fi.h"
 #include "kmac_sca.h"
 #include "prng_sca.h"
@@ -38,6 +40,9 @@ status_t process_cmd(ujson_t *uj) {
     switch (cmd) {
       case kCryptotestCommandAes:
         RESP_ERR(uj, handle_aes(uj));
+        break;
+      case kCryptotestCommandHash:
+        RESP_ERR(uj, handle_hash(uj));
         break;
       case kCryptotestCommandAesSca:
         RESP_ERR(uj, handle_aes_sca(uj));

--- a/sw/device/tests/crypto/cryptotest/firmware/hash.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/hash.c
@@ -1,0 +1,159 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/hash.h"
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/impl/sha2/sha256.h"
+#include "sw/device/lib/crypto/impl/sha2/sha512.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
+
+enum {
+  kSha3_256DigestWords = kSha256DigestWords,
+  kSha3_384DigestWords = kSha384DigestWords,
+  kSha3_512DigestWords = kSha512DigestWords,
+};
+
+status_t handle_hash(ujson_t *uj) {
+  // Declare test arguments
+  cryptotest_hash_algorithm_t uj_algorithm;
+  cryptotest_hash_shake_digest_length_t uj_shake_digest_length;
+  cryptotest_hash_message_t uj_message;
+  // Deserialize test arguments from UART
+  TRY(ujson_deserialize_cryptotest_hash_algorithm_t(uj, &uj_algorithm));
+  TRY(ujson_deserialize_cryptotest_hash_shake_digest_length_t(
+      uj, &uj_shake_digest_length));
+  TRY(ujson_deserialize_cryptotest_hash_message_t(uj, &uj_message));
+
+  // Create input message
+  uint8_t msg_buf[uj_message.message_len];
+  memcpy(msg_buf, uj_message.message, uj_message.message_len);
+  otcrypto_const_byte_buf_t input_message = {
+      .len = uj_message.message_len,
+      .data = msg_buf,
+  };
+
+  // Handle to correct oneshot hash API for the provided algorithm
+  otcrypto_status_t (*hash_oneshot)(otcrypto_const_byte_buf_t,
+                                    otcrypto_hash_digest_t);
+
+  // Digest length in 32-bit words
+  size_t digest_len;
+  uint8_t test_stepwise = false;
+  otcrypto_hash_mode_t mode;
+  switch (uj_algorithm) {
+    case kCryptotestHashAlgorithmSha256:
+      mode = kOtcryptoHashModeSha256;
+      digest_len = kSha256DigestWords;
+      hash_oneshot = otcrypto_hash;
+      test_stepwise = true;
+      break;
+    case kCryptotestHashAlgorithmSha384:
+      mode = kOtcryptoHashModeSha384;
+      digest_len = kSha384DigestWords;
+      hash_oneshot = otcrypto_hash;
+      test_stepwise = true;
+      break;
+    case kCryptotestHashAlgorithmSha512:
+      mode = kOtcryptoHashModeSha512;
+      digest_len = kSha512DigestWords;
+      hash_oneshot = otcrypto_hash;
+      test_stepwise = true;
+      break;
+    case kCryptotestHashAlgorithmSha3_256:
+      mode = kOtcryptoHashModeSha3_256;
+      digest_len = kSha3_256DigestWords;
+      hash_oneshot = otcrypto_hash;
+      break;
+    case kCryptotestHashAlgorithmSha3_384:
+      mode = kOtcryptoHashModeSha3_384;
+      digest_len = kSha3_384DigestWords;
+      hash_oneshot = otcrypto_hash;
+      break;
+    case kCryptotestHashAlgorithmSha3_512:
+      mode = kOtcryptoHashModeSha3_512;
+      digest_len = kSha3_512DigestWords;
+      hash_oneshot = otcrypto_hash;
+      break;
+    case kCryptotestHashAlgorithmShake128:
+      mode = kOtcryptoHashXofModeShake128;
+      digest_len = ceil_div(uj_shake_digest_length.length, sizeof(uint32_t));
+      hash_oneshot = otcrypto_xof_shake;
+      break;
+    case kCryptotestHashAlgorithmShake256:
+      mode = kOtcryptoHashXofModeShake256;
+      digest_len = ceil_div(uj_shake_digest_length.length, sizeof(uint32_t));
+      hash_oneshot = otcrypto_xof_shake;
+      break;
+    default:
+      LOG_ERROR("Unsupported hash algorithm: %d", uj_algorithm);
+      return INVALID_ARGUMENT();
+  }
+
+  // Create digest skeleton
+  uint32_t digest_buf[digest_len];
+  memset(digest_buf, 0, digest_len * sizeof(uint32_t));
+  otcrypto_hash_digest_t digest = {
+      .data = digest_buf,
+      .mode = mode,
+      .len = digest_len,
+  };
+
+  // Test oneshot API
+  otcrypto_status_t status = hash_oneshot(input_message, digest);
+  if (status.value != kOtcryptoStatusValueOk) {
+    return INTERNAL(status.value);
+  }
+  cryptotest_hash_output_t uj_output;
+  uj_output.digest_len = digest_len * sizeof(uint32_t);
+  // Copy oneshot digest to uJSON type
+  memcpy(uj_output.oneshot_digest, digest_buf, digest_len * sizeof(uint32_t));
+  // Zero out digest_buf to mitigate chance of a false positive in the
+  // stepwise test
+  memset(digest_buf, 0, digest_len * sizeof(uint32_t));
+  // Test the stepwise API for algorithms that support it
+  if (test_stepwise) {
+    otcrypto_hash_context_t ctx;
+    status = otcrypto_hash_init(&ctx, mode);
+    if (status.value != kOtcryptoStatusValueOk) {
+      return INTERNAL(status.value);
+    }
+    // Split up input mesasge into 2 shares for better coverage of stepwise
+    // hashing
+    otcrypto_const_byte_buf_t input_message_share1 = {
+        .len = uj_message.message_len / 2,
+        .data = msg_buf,
+    };
+    otcrypto_const_byte_buf_t input_message_share2 = {
+        .len = ceil_div(uj_message.message_len, 2),
+        .data = &msg_buf[uj_message.message_len / 2],
+    };
+    status = otcrypto_hash_update(&ctx, input_message_share1);
+    if (status.value != kOtcryptoStatusValueOk) {
+      return INTERNAL(status.value);
+    }
+    status = otcrypto_hash_update(&ctx, input_message_share2);
+    if (status.value != kOtcryptoStatusValueOk) {
+      return INTERNAL(status.value);
+    }
+    status = otcrypto_hash_final(&ctx, digest);
+    if (status.value != kOtcryptoStatusValueOk) {
+      return INTERNAL(status.value);
+    }
+    // Copy stepwise result to uJSON type
+    memcpy(uj_output.stepwise_digest, digest_buf,
+           digest_len * sizeof(uint32_t));
+  }
+  // Send digest to host via UART
+  RESP_OK(ujson_serialize_cryptotest_hash_output_t, uj, &uj_output);
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/hash.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/hash.h
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_HASH_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_HASH_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_hash(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_HASH_H_

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -33,6 +33,13 @@ cc_library(
 )
 
 cc_library(
+    name = "hash_commands",
+    srcs = ["hash_commands.c"],
+    hdrs = ["hash_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "aes_sca_commands",
     srcs = ["aes_sca_commands.c"],
     hdrs = ["aes_sca_commands.h"],

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -14,6 +14,7 @@ extern "C" {
 #define COMMAND(_, value) \
     value(_, Aes) \
     value(_, Ecdsa) \
+    value(_, Hash) \
     value(_, Hmac) \
     value(_, AesSca) \
     value(_, IbexFi) \

--- a/sw/device/tests/crypto/cryptotest/json/hash_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/hash_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "hash_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/hash_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/hash_commands.h
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_HASH_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_HASH_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HASH_CMD_MAX_MESSAGE_BYTES 17068
+#define HASH_CMD_MAX_DIGEST_BYTES 256
+
+// clang-format off
+
+#define HASH_ALGORITHM(_, value) \
+    value(_, Sha256) \
+    value(_, Sha384) \
+    value(_, Sha512) \
+    value(_, Sha3_256) \
+    value(_, Sha3_384) \
+    value(_, Sha3_512) \
+    value(_, Shake128) \
+    value(_, Shake256)
+UJSON_SERDE_ENUM(CryptotestHashAlgorithm, cryptotest_hash_algorithm_t, HASH_ALGORITHM);
+
+#define SHAKE_DIGEST_LENGTH(field, string) \
+    field(length, size_t)
+UJSON_SERDE_STRUCT(CryptotestHashShakeDigestLength, cryptotest_hash_shake_digest_length_t, SHAKE_DIGEST_LENGTH);
+
+#define HASH_MESSAGE(field, string) \
+    field(message, uint8_t, HASH_CMD_MAX_MESSAGE_BYTES) \
+    field(message_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestHashMessage, cryptotest_hash_message_t, HASH_MESSAGE);
+
+#define HASH_OUTPUT(field, string) \
+    field(oneshot_digest, uint8_t, HASH_CMD_MAX_DIGEST_BYTES) \
+    field(stepwise_digest, uint8_t, HASH_CMD_MAX_DIGEST_BYTES) \
+    field(digest_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestHashOutput, cryptotest_hash_output_t, HASH_OUTPUT);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_HASH_COMMANDS_H_

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -17,20 +17,28 @@ ujson_rust(
     srcs = ["//sw/device/tests/crypto/cryptotest/json:aes_commands"],
 )
 
+ujson_rust(
+    name = "hash_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:hash_commands"],
+)
+
 rust_library(
     name = "cryptotest_commands",
     srcs = [
         "src/aes_commands.rs",
         "src/commands.rs",
+        "src/hash_commands.rs",
         "src/lib.rs",
     ],
     compile_data = [
         ":commands_rust",
         ":aes_commands_rust",
+        ":hash_commands_rust",
     ],
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
         "aes_commands_loc": "$(execpath :aes_commands_rust)",
+        "hash_commands_loc": "$(execpath :hash_commands_rust)",
     },
     deps = [
         "//sw/host/opentitanlib",

--- a/sw/host/cryptotest/ujson_lib/src/hash_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/hash_commands.rs
@@ -1,6 +1,4 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-pub mod aes_commands;
-pub mod commands;
-pub mod hash_commands;
+include!(env!("hash_commands_loc"));

--- a/sw/host/tests/crypto/hash_kat/BUILD
+++ b/sw/host/tests/crypto/hash_kat/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/hash_kat/src/main.rs
+++ b/sw/host/tests/crypto/hash_kat/src/main.rs
@@ -1,0 +1,177 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use std::fs;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::hash_commands::{
+    CryptotestHashAlgorithm, CryptotestHashMessage, CryptotestHashOutput,
+    CryptotestHashShakeDigestLength,
+};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    hash_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HashTestCase {
+    vendor: String,
+    test_case_id: usize,
+    algorithm: String,
+    message: Vec<u8>,
+    digest: Vec<u8>,
+    result: bool,
+}
+
+const HASH_CMD_MAX_MESSAGE_BYTES: usize = 17068;
+
+fn run_hash_testcase(
+    test_case: &HashTestCase,
+    opts: &Opts,
+    transport: &TransportWrapper,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "vendor: {}, algorithm: {}, test case: {}",
+        test_case.vendor,
+        test_case.algorithm,
+        test_case.test_case_id
+    );
+    let uart = transport.uart("console")?;
+
+    CryptotestCommand::Hash.send(&*uart)?;
+
+    assert!(
+        test_case.message.len() <= HASH_CMD_MAX_MESSAGE_BYTES,
+        "Message too long for device firmware configuration (got = {}, max = {})",
+        test_case.message.len(),
+        HASH_CMD_MAX_MESSAGE_BYTES,
+    );
+
+    // Send algorithm type
+    match test_case.algorithm.as_str() {
+        "sha-256" => CryptotestHashAlgorithm::Sha256,
+        "sha-384" => CryptotestHashAlgorithm::Sha384,
+        "sha-512" => CryptotestHashAlgorithm::Sha512,
+        "sha3-256" => CryptotestHashAlgorithm::Sha3_256,
+        "sha3-384" => CryptotestHashAlgorithm::Sha3_384,
+        "sha3-512" => CryptotestHashAlgorithm::Sha3_512,
+        "shake-128" => CryptotestHashAlgorithm::Shake128,
+        "shake-256" => CryptotestHashAlgorithm::Shake256,
+        _ => panic!("Unsupported hash algorithm"),
+    }
+    .send(&*uart)?;
+
+    // Send required digest size for SHAKE tests (this value is
+    // ignored for SHA2/3)
+    CryptotestHashShakeDigestLength {
+        length: test_case.digest.len(),
+    }
+    .send(&*uart)?;
+
+    // Send hash preimage
+    CryptotestHashMessage {
+        message: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
+        message_len: test_case.message.len(),
+    }
+    .send(&*uart)?;
+
+    // Get hash output
+    let hash_output = CryptotestHashOutput::recv(&*uart, opts.timeout, false)?;
+    // Stepwise hashing is currently supported by SHA2 only.
+    let mut failed = false;
+    match test_case.algorithm.as_str() {
+        "sha-256" | "sha-384" | "sha-512" => {
+            vec![
+                ("oneshot", hash_output.oneshot_digest),
+                ("stepwise", hash_output.stepwise_digest),
+            ]
+        }
+        _ => vec![("oneshot", hash_output.oneshot_digest)],
+    }
+    .into_iter()
+    .for_each(|(mode, digest)| {
+        let success = if test_case.digest.len() > hash_output.digest_len {
+            // If we got a shorter digest back then the test asks for, we
+            // can't accept the digest, even if the beginning bytes match.
+            false
+        } else {
+            // Some test cases only specify the beginning bytes of the
+            // expected digest, so we only check up to what the test
+            // specifies.
+            test_case.digest[..] == digest[..test_case.digest.len()]
+        };
+        if test_case.result != success {
+            log::info!(
+                "FAILED {} test #{} in {} mode: expected = {}, actual = {}",
+                test_case.algorithm,
+                test_case.test_case_id,
+                mode,
+                test_case.result,
+                success
+            );
+            failed = true;
+        }
+    });
+    if failed {
+        *fail_counter += 1;
+    }
+    Ok(())
+}
+
+fn test_hash(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.hash_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let hash_tests: Vec<HashTestCase> = serde_json::from_str(&raw_json)?;
+
+        for hash_test in &hash_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_hash_testcase(hash_test, opts, transport, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_hash, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the test harness for the SHA2/3 and SHAKE hash functions, using the NIST test vectors added in #21261. The test implementation contains a Rust host-side test driver, a device-side firmware handler, and a uJSON API allowing the two to communicate.

The SHA-2 tests test both the oneshot API and the stepwise APIs (init, update, final). At present, SHA-3 and SHAKE only support the oneshot API, so it is the only one tested.

The hash tests take about an hour to run in total, so this will certainly need to go in the nightly CI run eventually.

~Dependent on #21261~