### PR TITLE
[dv] Minor improvements to cip_base_vseq and rv_dm TB

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -23,6 +23,7 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
       csr_wr(.ptr(jtag_dtm_ral.idcode), .value(data));
       csr_rd(.ptr(jtag_dtm_ral.idcode), .value(data));
       `DV_CHECK_EQ(data, RV_DM_JTAG_IDCODE)
+      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
     end
     repeat ($urandom_range(1, 10)) begin
       data = $urandom_range(0, 1);

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -22,7 +22,6 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     csr_wr(.ptr(jtag_dtm_ral.idcode), .value(data));
     csr_rd(.ptr(jtag_dtm_ral.idcode), .value(data));
     `DV_CHECK_EQ(data, RV_DM_JTAG_IDCODE)
-    cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
   endtask
 
   // Verify that writing to haltreq causes debug_req output to be set.
@@ -31,7 +30,6 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(data));
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
     `DV_CHECK_EQ(cfg.rv_dm_vif.cb.debug_req, data)
-    cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
   endtask
 
   // Verify that writing to ndmreset causes ndmreset output to be set.
@@ -40,7 +38,6 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(data));
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
     `DV_CHECK_EQ(cfg.rv_dm_vif.cb.ndmreset_req, data)
-    cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
   endtask
 
   // Verify that the dmstatus[*unavail] field tracks the unavailable_i input.
@@ -52,7 +49,6 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
                  get_field_val(jtag_dmi_ral.dmstatus.anyunavail, data))
     `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
                  get_field_val(jtag_dmi_ral.dmstatus.allunavail, data))
-    cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
   endtask
 
   // Verify that writing to dmactive causes dmactive output to be set.
@@ -61,15 +57,24 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(data));
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
     `DV_CHECK_EQ(cfg.rv_dm_vif.cb.dmactive, data)
-    cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
   endtask
 
   task body();
-    repeat ($urandom_range(1, 10)) check_idcode();
-    repeat ($urandom_range(1, 10)) check_haltreq();
-    repeat ($urandom_range(1, 10)) check_ndmreset();
-    repeat ($urandom_range(1, 10)) check_unavailable();
-    repeat ($urandom_range(1, 10)) check_dmactive();
+    repeat ($urandom_range(20, 50)) begin
+      randcase
+        1: check_idcode();
+        1: check_haltreq();
+        1: check_ndmreset();
+        1: check_unavailable();
+      endcase
+      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+    end
+
+    repeat ($urandom_range(1, 5)) begin
+      check_dmactive();
+      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+    end
+
   endtask : body
 
 endclass : rv_dm_smoke_vseq


### PR DESCRIPTION
This is all driven by me trying to get an rv_dm test to (finally!) pass. Frustratingly, I'm not there yet, but I'm reasonably convinced that these changes make things better.

The general commits are all to `cip_base_vseq`. This vseq has a `wait_to_issue_reset` task. The idea is that this task picks an arbitrary count, with a bound, and then waits that many cycles. This task is used by `run_seq_with_rand_reset_vseq` (to be the "rand reset" bit). Unfortunately, there's a bit of a problem: if the TB happens to be in the middle of a CSR access then we end up failing a check (which expects `has_outstanding_access()` to return false). This was added by @cindychip with commit 4c81f2388c9 in Summer 2022. I think the problem is that if we reset in the middle of a CSR access then things get a bit out of whack and we end up with an infinite chain of nested accesses. Cindy's change adds an early-failure path if this happens, which is *much* easier to diagnose.

Anyway, the first two commits in this PR just add a bit of a "fuzz factor": if we were going to try to reset at a particular time when there is an outstanding CSR access, we just wait a few cycles to see whether it clears up.

This wasn't quite enough! It turns out that the `rv_dm` smoke sequence sometimes ends up with long chains of back-to-back CSR accesses. Looking at the code, I think this is because the initial implementation (0af12018727f1bf086cef985c031c67a9d09c593) was missing a wait at the end of one of the repeat loops. The third commit in this PR adds that wait, and then the following two commits try to tidy up the sequence a bit, to avoid some repetition.

Annoyingly, this *still* doesn't get the darn test to work! If you run `util/dvsim/dvsim.py hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson --tool=xcelium -i rv_dm_tap_fsm_rand_reset --fixed-seed 123` with the head of this commit, it will fail! But now the problem is that the injected reset is killing the process behind a sequence that's running. Definitely something to fix, but I think it's orthogonal to what this PR does.