### PR TITLE
[rom_ext, rescue] Implement the rescue protocol

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -460,6 +460,7 @@
       - [Shutdown Specification](./sw/device/silicon_creator/rom/doc/shutdown.md)
     - [ROM\_EXT](./sw/device/silicon_creator/rom_ext/README.md)
       - [ROM\_EXT for Silicon Validation](./sw/device/silicon_creator/rom_ext/doc/si_val.md)
+      - [ROM\_EXT Rescue Protocol](./sw/device/silicon_creator/rom_ext/doc/rescue.md)
     - [Manifest Format](./sw/device/silicon_creator/rom_ext/doc/manifest.md)
     - [Boot Log](./sw/device/silicon_creator/doc/boot_log.md)
   - [Top-Level Tests](./sw/device/tests/README.md)

--- a/sw/device/silicon_creator/lib/dbg_print.c
+++ b/sw/device/silicon_creator/lib/dbg_print.c
@@ -53,6 +53,18 @@ void dbg_printf(const char *format, ...) {
         uart_putchar((char)ch);
         break;
       }
+      case 'C': {
+        uint8_t ch = (uint8_t)va_arg(args, int);
+        if (ch >= 32 && ch < 127) {
+          uart_putchar((char)ch);
+        } else {
+          uart_putchar('\\');
+          uart_putchar('x');
+          uart_putchar(kHexTable[ch >> 4]);
+          uart_putchar(kHexTable[ch & 15]);
+        }
+        break;
+      }
       case 's': {
         // Print a null-terminated string.
         const char *str = va_arg(args, const char *);

--- a/sw/device/silicon_creator/lib/dbg_print.h
+++ b/sw/device/silicon_creator/lib/dbg_print.h
@@ -19,6 +19,7 @@ extern "C" {
  * This function only supports the format specifiers required by the
  * ROM:
  * - %c, which prints a single character.
+ * - %C, which prints a printable character or a C-style hex escape.
  * - %d, which prints a signed int in decimal.
  * - %u, which prints an unsigned int in decimal.
  * - %s, which prints a nul-terminated string.

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -51,6 +51,7 @@ enum module_ {
   kModuleAsn1 =            MODULE_CODE('A', '1'),
   kModuleRetRam =          MODULE_CODE('R', 'R'),
   kModuleXModem =          MODULE_CODE('X', 'M'),
+  kModuleRescue =          MODULE_CODE('R', 'S'),
   // clang-format on
 };
 
@@ -178,6 +179,11 @@ enum module_ {
   X(kErrorAsn1BufferExhausted,        ERROR_(3, kModuleAsn1, kResourceExhausted)), \
   \
   X(kErrorRetRamBadVersion,           ERROR_(1, kModuleRetRam, kUnknown)), \
+  \
+  X(kErrorRescueReboot,               ERROR_(0, kModuleRescue, kInternal)), \
+  X(kErrorRescueBadMode,              ERROR_(1, kModuleRescue, kInvalidArgument)), \
+  X(kErrorRescueImageTooBig,          ERROR_(2, kModuleRescue, kFailedPrecondition)), \
+  \
   /* This comment prevent clang from trying to format the macro. */
 
 // clang-format on

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -24,6 +24,22 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "rescue",
+    srcs = ["rescue.c"],
+    hdrs = ["rescue.h"],
+    deps = [
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:xmodem",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)
+
 dual_cc_library(
     name = "rom_ext_boot_policy_ptrs",
     srcs = dual_inputs(
@@ -195,7 +211,7 @@ cc_library(
     hdrs = ["rom_ext.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
-        ":bootstrap",
+        ":rescue",
         ":rom_ext_boot_policy",
         ":rom_ext_boot_policy_ptrs",
         ":rom_ext_epmp",

--- a/sw/device/silicon_creator/rom_ext/doc/rescue.md
+++ b/sw/device/silicon_creator/rom_ext/doc/rescue.md
@@ -1,0 +1,145 @@
+# ROM_EXT Rescue Protocol
+
+## Introduction
+
+The ROM_EXT rescue protocol permits the chip owner to perform device diagnostic and management actions when there is no functional application firmware.
+
+These actions include:
+- Flashing a new application image.
+- Interacting with Boot Services.
+- Requesting the Boot Log data.
+- Performing Ownership Transfer.
+
+Currently, the rescue protocol uses the console UART as the main communication channel.
+In the future, rescue operations may be available via additional interfaces.
+
+## Basic Operation
+
+In order to interact with the rescue protocol, the user needs to signal to the ROM_EXT that rescue a rescue operation is desired.
+
+Once signalled, the ROM_EXT will acknowledge entry into rescue mode and the user can then specify a specific rescue action and either upload or download any data block associated with that action.
+
+Rescue mode is exited via either an in-band or out-of-band reset signal.
+
+## Serial Rescue Protocol
+
+### Requesting Rescue
+
+In order to signal to the ROM_EXT that a rescue operation is desired, the user should assert the serial break condition for at least 350us while the ROM_EXT boots.
+When the ROM_EXT detects the serial break condition, it will respond with an acknowledgement:
+
+```
+rescue: remember to clear break
+```
+
+Upon entry into rescue mode, the user should clear the serial break condition to allow further interaction with rescue mode.
+
+### Rescue Operations
+
+By default, rescue will enter firmware rescue mode and will prompt the user to upload a new firmware image via the Xmodem-CRC protocol.
+Alternate modes are requested by sending the mode's 4-byte code followed by a newline character.
+
+> NOTE: All of the mode codes avoid using capical `C` (ASCII `0x43`) because that character is part of Xmodem-CRC's signaling.
+
+The following sections detail each of the supported alternate modes.
+
+#### Firmware Rescue (`RESQ`)
+
+The firmware rescue mode may be requested with the 4-byte code `RESQ`.
+The ROM_EXT will acknowledge entry of this mode with the following message:
+
+```
+mode: RESQ
+ok: send firmware via xmodem-crc
+```
+
+The ROM_EXT will then prompt for the transfer to start by sending the Xmodem-CRC start character (which is the ASCII character `C`).
+
+#### Request Boot Log Data (`BLOG`)
+
+The user may request a copy of the Boot Log with the 4-byte code `BLOG`.
+The ROM_EXT will acknowledge this request with the following message:
+
+```
+mode: BLOG
+ok: receive boot_log via xmodem-crc
+```
+
+The ROM_EXT will then transmit the boot log data structure to the user via the Xmodem-CRC protocol.
+After completing this action, the ROM_EXT will switch back to firmware rescue mode.
+
+#### Send a Boot Services Request (`BREQ`)
+
+The user may request to send a Boot Services request to the ROM_EXT with the 4-byte code `BREQ`.
+The ROM_EXT will acknowledge this request with the following message:
+
+```
+mode: BREQ
+ok: send boot_svc request via xmodem-crc
+```
+
+The ROM_EXT will then will prompt for the transfer to start by sending the Xmodem-CRC start character (which is the ASCII character `C`).
+After completing this action, the ROM_EXT will switch back to firmware rescue mode.
+
+
+#### Request the last Boot Services Response (`BRSP`)
+
+The user may request the last boot services response with the 4-byte code `BRSP`.
+The ROM_EXT will acknowledge this request with the following message:
+
+```
+mode: BRSP
+ok: receive boot_svc response via xmodem-crc
+```
+
+The ROM_EXT will then transmit the boot services response data structure to the user via the Xmodem-CRC protocol.
+After completing this action, the ROM_EXT will switch back to firmware rescue mode.
+
+
+#### Send an Owner Block (`OWNR`)
+
+The user may request to send an Owner Block to the ROM_EXT with the 4-byte code `OWNR`.
+The ROM_EXT will acknowledge this request with the following message:
+
+```
+mode: OWNR
+ok: send owner_block via xmodem-crc
+```
+
+The ROM_EXT will then will prompt for the transfer to start by sending the Xmodem-CRC start character (which is the ASCII character `C`).
+After completing this action, the ROM_EXT will switch back to firmware rescue mode.
+
+Note: the ROM_EXT will only accept the Owner Block if the chip is in an ownership transfer state and the receive owner block meets all validity criteria.
+
+#### Request a Reboot (`REBO`)
+
+The user may request a reboot operation with the 4-byte code `REBO`.
+
+The ROM_EXT will acknowledge this request with the following message:
+
+```
+mode: REBO
+ok: reboot
+```
+
+The ROM_EXT will then exit rescue mode and reboot the chip.
+
+### Error Conditions
+
+#### Bad Mode
+
+A bad mode request will result in the following message:
+
+```
+mode: <4-byte code>
+error: unrecognized mode
+```
+
+The current rescue mode will remain unchanged.
+
+#### Xmodem-CRC errors
+
+The following errors and error responses can occur during Xmodem-CRC.
+- An invalid start-of-packet: the transfer is aborted.
+- An invalid block number: the transfer is cancelled.
+- An invalid CRC checksum: the frame is NAKed and the sender should retry the frame.

--- a/sw/device/silicon_creator/rom_ext/rescue.c
+++ b/sw/device/silicon_creator/rom_ext/rescue.c
@@ -1,0 +1,228 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom_ext/rescue.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/dbg_print.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/xmodem.h"
+
+#include "flash_ctrl_regs.h"
+
+// All of the xmodem functions accept an opaque iohandle pointer.
+// The iohandle is used to facilitate unit tests and doesn't have
+// any function in real firmware.
+#define iohandle NULL
+
+static rescue_state_t rescue_state;
+
+rom_error_t flash_firmware_block(rescue_state_t *state) {
+  if (state->flash_offset == 0) {
+    flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
+        .read = kMultiBitBool4True,
+        .write = kMultiBitBool4True,
+        .erase = kMultiBitBool4True,
+    });
+    for (uint32_t addr = state->flash_start; addr < state->flash_limit;
+         addr += FLASH_CTRL_PARAM_BYTES_PER_PAGE) {
+      HARDENED_RETURN_IF_ERROR(
+          flash_ctrl_data_erase(addr, kFlashCtrlEraseTypePage));
+    }
+    state->flash_offset = state->flash_start;
+  }
+  if (state->flash_offset < state->flash_limit) {
+    HARDENED_RETURN_IF_ERROR(flash_ctrl_data_write(
+        state->flash_offset, sizeof(state->data) / sizeof(uint32_t),
+        state->data));
+    state->flash_offset += sizeof(state->data);
+  } else {
+    return kErrorRescueImageTooBig;
+  }
+  return kErrorOk;
+}
+
+rom_error_t flash_owner_block(rescue_state_t *state) {
+  // FIXME: validate that we're in a state capable of accepting an owner
+  // block and validate the block before flashing it.
+  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot1,
+                                                 kFlashCtrlEraseTypePage));
+  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
+      &kFlashCtrlInfoPageOwnerSlot1, 0, sizeof(state->data) / sizeof(uint32_t),
+      state->data));
+  return kErrorOk;
+}
+
+static void validate_mode(uint32_t mode, rescue_state_t *state) {
+  char *m = (char *)&mode;
+  dbg_printf("\r\nmode: %C%C%C%C\r\n", m[3], m[2], m[1], m[0]);
+  switch (mode) {
+    case kRescueModeBootLog:
+      dbg_printf("ok: receive boot_log via xmodem-crc\r\n");
+      break;
+    case kRescueModeBootSvcRsp:
+      dbg_printf("ok: receive boot_svc response via xmodem-crc\r\n");
+      break;
+    case kRescueModeBootSvcReq:
+      dbg_printf("ok: send boot_svc request via xmodem-crc\r\n");
+      break;
+    case kRescueModeOwnerBlock:
+      dbg_printf("ok: send owner_block via xmodem-crc\r\n");
+      break;
+    case kRescueModeFirmware:
+      dbg_printf("ok: send firmware via xmodem-crc\r\n");
+      break;
+    case kRescueModeReboot:
+      dbg_printf("ok: reboot\r\n");
+      break;
+    case kRescueModeDWIM:
+      // Easter egg :)
+      dbg_printf("error: i don't know what you mean\r\n");
+      return;
+    default:
+      // User input error.  Do not change modes.
+      dbg_printf("error: unrecognized mode\r\n");
+      return;
+  }
+  state->mode = (rescue_mode_t)mode;
+  state->frame = 1;
+  state->offset = 0;
+  state->flash_offset = 0;
+}
+
+static rom_error_t handle_send_modes(rescue_state_t *state) {
+  const retention_sram_t *rr = retention_sram_get();
+  switch (state->mode) {
+    case kRescueModeBootLog:
+      HARDENED_RETURN_IF_ERROR(xmodem_send(iohandle, &rr->creator.boot_log,
+                                           sizeof(rr->creator.boot_log)));
+      break;
+    case kRescueModeBootSvcRsp:
+      HARDENED_RETURN_IF_ERROR(xmodem_send(iohandle, &rr->creator.boot_svc_msg,
+                                           sizeof(rr->creator.boot_svc_msg)));
+      break;
+    case kRescueModeBootSvcReq:
+    case kRescueModeOwnerBlock:
+    case kRescueModeFirmware:
+      // Nothing to do for receive modes.
+      return kErrorOk;
+    case kRescueModeReboot:
+      // If a reboot was requested, return an error and go through the normal
+      // shutdown process.
+      return kErrorRescueReboot;
+    default:
+      // This state should be impossible.
+      return kErrorRescueBadMode;
+  }
+  validate_mode(kRescueModeFirmware, state);
+  return kErrorOk;
+}
+
+static rom_error_t handle_recv_modes(rescue_state_t *state) {
+  retention_sram_t *rr = retention_sram_get();
+  switch (state->mode) {
+    case kRescueModeBootLog:
+    case kRescueModeBootSvcRsp:
+      // Nothing to do for send modes.
+      break;
+    case kRescueModeBootSvcReq:
+      if (state->offset >= sizeof(rr->creator.boot_svc_msg)) {
+        memcpy(&rr->creator.boot_svc_msg, state->data,
+               sizeof(rr->creator.boot_svc_msg));
+        state->offset = 0;
+      }
+      break;
+    case kRescueModeOwnerBlock:
+      if (state->offset == sizeof(state->data)) {
+        HARDENED_RETURN_IF_ERROR(flash_owner_block(state));
+        state->offset = 0;
+      }
+      break;
+    case kRescueModeFirmware:
+      if (state->offset == sizeof(state->data)) {
+        HARDENED_RETURN_IF_ERROR(flash_firmware_block(state));
+        state->offset = 0;
+      }
+      break;
+    case kRescueModeReboot:
+    default:
+      // This state should be impossible.
+      return kErrorRescueBadMode;
+  }
+  return kErrorOk;
+}
+
+static rom_error_t protocol(rescue_state_t *state) {
+  rom_error_t result;
+  size_t rxlen;
+  uint8_t command;
+  uint32_t next_mode = 0;
+
+  validate_mode(kRescueModeFirmware, &rescue_state);
+
+  // The rescue region starts immediately after the ROM_EXT and ends
+  // at the end of the flash bank.
+  // TODO(cfrantz): This needs to be owner-configurable.
+  state->flash_start = 0x10000;
+  state->flash_limit = 0x80000;
+
+  xmodem_recv_start(iohandle);
+  while (true) {
+    HARDENED_RETURN_IF_ERROR(handle_send_modes(&rescue_state));
+    result = xmodem_recv_frame(iohandle, state->frame,
+                               state->data + state->offset, &rxlen, &command);
+    if (state->frame == 1 && result == kErrorXModemTimeoutStart) {
+      xmodem_recv_start(iohandle);
+      continue;
+    }
+    switch (result) {
+      case kErrorOk:
+        // Packet ok.
+        state->offset += rxlen;
+        HARDENED_RETURN_IF_ERROR(handle_recv_modes(&rescue_state));
+        xmodem_ack(iohandle, true);
+        break;
+      case kErrorXModemEndOfFile:
+        if (state->offset % 2048 != 0) {
+          // If there is unhandled residue, extend out to a full block and
+          // then handle it.
+          while (state->offset % 2048 != 0) {
+            state->data[state->offset++] = 0xFF;
+          }
+          HARDENED_RETURN_IF_ERROR(handle_recv_modes(&rescue_state));
+        }
+        xmodem_ack(iohandle, true);
+        return kErrorRescueReboot;
+      case kErrorXModemCrc:
+        xmodem_ack(iohandle, false);
+        continue;
+      case kErrorXModemCancel:
+        return result;
+      case kErrorXModemUnknown:
+        if (state->frame == 1) {
+          if (command == '\r') {
+            validate_mode(next_mode, &rescue_state);
+            next_mode = 0;
+          } else {
+            next_mode = (next_mode << 8) | command;
+          }
+          continue;
+        }
+        OT_FALLTHROUGH_INTENDED;
+      default:
+        return result;
+    }
+    state->frame += 1;
+  }
+}
+
+rom_error_t rescue_protocol(void) {
+  rom_error_t result = protocol(&rescue_state);
+  if (result == kErrorRescueReboot) {
+    rstmgr_reset();
+  }
+  return result;
+}

--- a/sw/device/silicon_creator/rom_ext/rescue.h
+++ b/sw/device/silicon_creator/rom_ext/rescue.h
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_RESCUE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_RESCUE_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/error.h"
+
+enum {
+  // Rescue is signalled by asserting serial break to the UART for at least
+  // 4 byte periods.  At 115200 bps, one byte period is about 87us; four is
+  // about 348us.  We'll wait for 350.
+  kRescueDetectTime = 350,
+};
+
+typedef enum {
+  /** `BLOG` */
+  kRescueModeBootLog = 0x424c4f47,
+  /** `BRSP` */
+  kRescueModeBootSvcRsp = 0x42525350,
+  /** `BREQ` */
+  kRescueModeBootSvcReq = 0x42524551,
+  /** `OWNR` */
+  kRescueModeOwnerBlock = 0x4f574e52,
+  /** `RESQ` */
+  kRescueModeFirmware = 0x52455351,
+  /** `REBO` */
+  kRescueModeReboot = 0x5245424f,
+  /** `DWIM` */
+  kRescueModeDWIM = 0x4457494d,
+} rescue_mode_t;
+
+typedef struct RescueState {
+  rescue_mode_t mode;
+  uint32_t frame;
+  uint32_t offset;
+  uint32_t flash_offset;
+  uint32_t flash_start;
+  uint32_t flash_limit;
+  uint8_t data[2048];
+} rescue_state_t;
+
+rom_error_t rescue_protocol(void);
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_RESCUE_H_


### PR DESCRIPTION
Implement the shell of the rescue protocol.
1. Trigger rescue entry via the serial break condition.
2. Support Xmodem-CRC for uploading rescue images or other resources.
3. Support Xmodem-CRC for downloading selected info from the chip.
4. Support requesting the rescue mode via a set of 4-byte identifiers. These include:
    - `RESU`: The default rescue mode (ie: upload firmware).
    - `BREQ`: Request to upload a boot_svc request message.
    - `BRSP`: Request to download the boot_svc response message.
    - `BLOG`: Request to download the boot_log data structure.
    - `OWNR`: Request to upload an owner block.
    - `REBO`: Request to exit rescue mode and reboot.

- Currently, BREQ, BRSP, BLOG and REBO are implemented.
- The RESU command erases and flashes the data in partition A.  The appropriate flash limits aren't yet set.
- The OWNR command erases and flashes the data in Owner Page 1. Currently, no validation is performed.