### PR TITLE
[sival] Add chip_sw_aes_enc bazel target.

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -29,6 +29,7 @@
       lc_states: ["TEST_UNLOCKED", "PROD"]
       tests: ["chip_sw_aes_enc",
               "chip_sw_aes_enc_jitter_en"]
+      bazel: ["//sw/device/tests:aes_smoketest"]
     }
     {
       name: chip_sw_aes_multi_block

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -142,7 +142,15 @@ alias(
 opentitan_test(
     name = "aes_smoketest",
     srcs = ["aes_smoketest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
     deps = [
         "//hw/ip/aes:model",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -19,7 +19,7 @@ test_suite(
 test_suite(
     name = "sv2_tests",
     tests = [
-        "//sw/device/tests:aes_new_smoketest",
+        "//sw/device/tests:aes_smoketest",
         "//sw/device/tests:alert_handler_lpg_clkoff_test",
         "//sw/device/tests:alert_handler_lpg_reset_toggle_test",
         "//sw/device/tests:aon_timer_irq_test",


### PR DESCRIPTION
And remove previous aes_new_smoketest target as it is no longer needed.