### PR TITLE
[sival] cross-reference SV2 tests

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
@@ -27,6 +27,7 @@
       si_stage: SV2
       lc_states: ["TEST_UNLOCKED", "PROD"]
       tests: ["chip_sw_entropy_src_csrng"]
+      bazel: ["//sw/device/tests:entropy_src_csrng_test"]
     }
     {
       name: chip_sw_csrng_fuse_en_sw_app_read

--- a/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
@@ -18,7 +18,7 @@
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_hmac_enc",
               "chip_sw_hmac_enc_jitter_en"]
-      bazel: []
+      bazel: ["//sw/device/tests:hmac_enc_test"]
     }
     {
       name: chip_sw_hmac_idle

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -20,7 +20,7 @@
         "chip_sw_kmac_mode_kmac_jitter_en",
       ]
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
-      bazel: []
+      bazel: ["//sw/device/tests:kmac_mode_kmac_test"]
     }
     {
       name: chip_sw_kmac_app_keymgr


### PR DESCRIPTION
Add bazel target cross references for some SV2 tests against csrng, hmac and kmac top level test plans.

Fixes https://github.com/lowRISC/opentitan/issues/20440
Fixes https://github.com/lowRISC/opentitan/issues/20443