### PR TITLE
[opentitantool] Add support for Google TPM "ready signal"

### DIFF
--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -261,6 +261,10 @@ impl CommandDispatch for I2cPrepareRead {
 pub struct I2cTpm {
     #[command(subcommand)]
     command: super::tpm::TpmSubCommand,
+
+    /// Pin used for signalling by Google security chips
+    #[arg(long)]
+    gsc_ready: Option<String>,
 }
 
 impl CommandDispatch for I2cTpm {
@@ -270,8 +274,13 @@ impl CommandDispatch for I2cTpm {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         let context = context.downcast_ref::<I2cCommand>().unwrap();
+        let ready_pin = match &self.gsc_ready {
+            Some(pin) => Some((transport.gpio_pin(pin)?, transport.gpio_monitoring()?)),
+            None => None,
+        };
         let tpm_driver = Box::new(tpm::I2cDriver::new(
             context.params.create(transport, "TPM")?,
+            ready_pin,
         )?);
         self.command.run(&tpm_driver, transport)
     }

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -270,9 +270,10 @@ impl CommandDispatch for I2cTpm {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         let context = context.downcast_ref::<I2cCommand>().unwrap();
-        let tpm_driver = tpm::I2cDriver::new(context.params.create(transport, "TPM")?);
-        let bus: Box<dyn tpm::Driver> = Box::new(tpm_driver);
-        self.command.run(&bus, transport)
+        let tpm_driver = Box::new(tpm::I2cDriver::new(
+            context.params.create(transport, "TPM")?,
+        )?);
+        self.command.run(&tpm_driver, transport)
     }
 }
 

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -319,10 +319,10 @@ impl CommandDispatch for SpiTpm {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         let context = context.downcast_ref::<SpiCommand>().unwrap();
-        let bus: Box<dyn tpm::Driver> = Box::new(tpm::SpiDriver::new(
+        let tpm_driver: Box<dyn tpm::Driver> = Box::new(tpm::SpiDriver::new(
             context.params.create(transport, "TPM")?,
-        ));
-        self.command.run(&bus, transport)
+        )?);
+        self.command.run(&tpm_driver, transport)
     }
 }
 

--- a/sw/host/tests/chip/spi_device_tpm_test/src/main.rs
+++ b/sw/host/tests/chip/spi_device_tpm_test/src/main.rs
@@ -39,7 +39,7 @@ fn tpm_read_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 
     /* Wait sync message. */
     let _ = UartConsole::wait_for(&*uart, r"SYNC: Begin TPM Test\r\n", opts.timeout)?;
-    let tpm = tpm::SpiDriver::new(spi);
+    let tpm = tpm::SpiDriver::new(spi, None)?;
     const SIZE: usize = 10;
 
     for _ in 0..10 {


### PR DESCRIPTION
Google security chips deviate from the TPM standard.  Because the chips are not able to meet the requirements for response/processing time, they employ an additional "ready" signal, generated by the GSC to indicate when it has finished processing the most recent request, and is ready to receive a new request.

This CL adds an optional flag `--gsc_ready` to `opentitantool {spi,i2c} tpm` and to `tpm2_test_server`.  Omitting this flag will result in `opentitantool` use the standard TPM protocol, specifying the flag will make `opentitantool` wait for the Google-specific ready signal at each transaction.

It is worth noting that the existing TPM driver for I2C is not implementing the protocol specified by TCG, but instead a Google-specific protocol, as the first use of I2C by legacy Titan GSC chips predates the TCG standard for I2C.  In the future, we ought to enhance the driver to use the new standard I2C protocol, when `--gsc_ready` is not provided.  