### PR TITLE
Usbdev in trans vseq

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// usbdev_pkt_sent test vseq
+class usbdev_in_trans_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_in_trans_vseq)
+
+  `uvm_object_new
+
+  virtual task body();
+    uvm_reg_data_t rxfifo;
+    bit in_sent;
+    super.dut_init("HARD");
+    csr_wr(.ptr(ral.intr_state), .value(32'h0001_ffff));
+    ral.intr_enable.pkt_sent.set(1'b1); // Enable pkt_sent interrupt
+    csr_update(ral.intr_enable);
+    // For IN transaction need to do first OUT transaction
+    // to store data in buffer memory for read through IN.
+    configure_out_trans(); // register configurations for OUT Trans.
+    // Out token packet followed by a data packet
+    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    cfg.clk_rst_vif.wait_clks(20);
+    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    get_out_response_from_device(m_usb20_item, PidTypeAck); // check OUT response
+    cfg.clk_rst_vif.wait_clks(20);
+    // Read rxfifo reg
+    csr_rd(.ptr(ral.rxfifo), .value(rxfifo));
+    // Make sure buffer is availabe for next trans
+    ral.avbuffer.buffer.set(set_buffer_id + 1);
+    csr_update(ral.avbuffer);
+    num_of_bytes = m_data_pkt.data.size();
+    configure_in_trans();  // register configurations for IN Trans.
+    // Token pkt followed by handshake pkt
+    call_token_seq(PktTypeToken, PidTypeInToken, endp);
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    get_data_pid_from_device(m_usb20_item, PidTypeData0);
+    cfg.clk_rst_vif.wait_clks(20);
+    call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+    cfg.clk_rst_vif.wait_clks(20);
+    // Verify Transaction reads register status and verifis that IN transtion is successfull.
+    check_trans_accuracy();
+    // Write 1 to clear particular EPs in_sent
+    csr_wr(.ptr(ral.in_sent[0].sent[endp]), .value(1'b1));
+    csr_rd(.ptr(ral.in_sent[0].sent[endp]), .value(in_sent));
+    `DV_CHECK_EQ(0, in_sent); // verify that after writting one in_sent bit is cleared.
+  endtask
+
+  task check_trans_accuracy();
+    bit pkt_sent;
+    bit sent;
+    csr_rd(.ptr(ral.intr_state.pkt_sent), .value(pkt_sent));
+    csr_rd(.ptr(ral.in_sent[0].sent[endp]), .value(sent));
+    `DV_CHECK_EQ(1, pkt_sent);
+    `DV_CHECK_EQ(1, sent);
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -12,3 +12,4 @@
 `include "usbdev_pkt_sent_vseq.sv"
 `include "usbdev_nak_trans_vseq.sv"
 `include "usbdev_enable_vseq.sv"
+`include "usbdev_in_trans_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/usbdev_pkt_sent_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_nak_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -79,8 +79,8 @@
     {
       name: usbdev_nak_trans
       uvm_test_seq: usbdev_nak_trans_vseq
-    {
     }
+    {
       name: usbdev_enable
       uvm_test_seq: usbdev_enable_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -79,6 +79,14 @@
     {
       name: usbdev_nak_trans
       uvm_test_seq: usbdev_nak_trans_vseq
+    {
+    }
+      name: usbdev_enable
+      uvm_test_seq: usbdev_enable_vseq
+    }
+    {
+      name: in_trans
+      uvm_test_seq: usbdev_in_trans_vseq
     }
     {
       name: usbdev_enable


### PR DESCRIPTION
Adds the USB device test 'usbdev_in_trans,' designed to validate the device functionality for IN transactions. This test also verifies the 'in_sent' register by writing to a specific endpoint's 'in_sent' field. Upon writing, clears the 'in_sent' register when written with a value of one.