### PR TITLE
[cw340] Relax SPI timing to 12.5 MHz

### DIFF
--- a/hw/top_earlgrey/data/clocks_cw341.xdc
+++ b/hw/top_earlgrey/data/clocks_cw341.xdc
@@ -116,7 +116,7 @@ set_input_delay  -add_delay -clock_fall -clock jtag_tck -min  0.0 [get_ports {IO
 set_input_delay  -add_delay -clock_fall -clock jtag_tck -max 15.0 [get_ports {IOR0 IOR2}]
 
 ## SPI clocks
-set spi_dev_period 50.0
+set spi_dev_period 80.00
 set spi_dev_half_period [expr ${spi_dev_period} / 2]
 # Max board skew between signals
 set spi_dev_board_skew  0.5


### PR DESCRIPTION
Vivado 2021.1 can choose poor placement for the SPI clock path for passthrough, resulting in timing failures at 20 MHz. Relax the SPI timing requirement to 12.5 MHz for now.

Location constraints (or a tool version upgrade) may be the better path forward in the future, but with CW310's SPI constraints still at 20 MHz, it can be the detector for timing issues for passthrough for now.