### PR TITLE
[mbx,keymgr_dpe] Disable unimplemented stress tests

### DIFF
--- a/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson
+++ b/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson
@@ -33,7 +33,9 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                // Disable stress_all and stress_all_with_rand_reset tests as they are not
+                // implemented yet #21299
+                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
                 ]
 
   // Add additional tops for simulation.

--- a/hw/ip/mbx/dv/mbx_sim_cfg.hjson
+++ b/hw/ip/mbx/dv/mbx_sim_cfg.hjson
@@ -30,7 +30,10 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+                // Disable stress_all and stress_all_with_rand_reset tests as they are not
+                // implemented yet #21298
+                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                ]
 
   // Add additional tops for simulation.
 //  sim_tops: ["mbx_bind", "mbx_cov_bind"]


### PR DESCRIPTION
This PR disables the unimplemented stress tests from their respective IP simulation configuration. This removes them from the full configuration that is inferred when using `dvsim` with `all`, `all_once`, or `nightly` as the test input list.