### PR TITLE
[hmac] Initial implementation of save & restore

### DIFF
--- a/hw/ip/hmac/README.md
+++ b/hw/ip/hmac/README.md
@@ -37,6 +37,8 @@ The 256-bit secret key is written in [`KEY_0`](doc/registers.md#key) to [`KEY_7`
 The message to authenticate is written to [`MSG_FIFO`](doc/registers.md#msg_fifo) and the HMAC generates a 256-bit digest value which can be read from [`DIGEST_0`](doc/registers.md#digest) to [`DIGEST_7`](doc/registers.md#digest).
 The `hash_done` interrupt is raised to report to software that the final digest is available.
 
+This module allows software to save and restore the hashing context so that different message streams can be interleaved; please check the [Programmer's Guide](doc/programmers_guide.md#saving-and-restoring-the-context) for more information.
+
 The HMAC IP can run in SHA-256-only mode, whose purpose is to check the
 correctness of the received message. The same digest registers above are used to
 represent the hash result. SHA-256 mode doesn't use the given secret key. It

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -168,6 +168,12 @@
                 the digest.
                 ''',
           resval: "0",
+          tags: [
+            // Don't enable/disable digest swap in automated CSR tests because it will have side
+            // effects on the DIGEST_* CSRs that the automated tests don't know of.  This field is
+            // covered in functional tests instead.
+            "excl:CsrAllTests:CsrExclWrite"
+          ]
         }
       ]
     }

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -201,6 +201,24 @@
                 based on currently received message.
                 '''
         }
+        { bits: "2",
+          name: "hash_stop",
+          desc: '''
+                When 1 is written to this field, SHA or HMAC will afterwards set the `hmac_done`
+                interrupt as soon as the current block has been hashed. The hash can then be read
+                from the registers !!DIGEST_0 to !!DIGEST_7. Together with the message length in
+                !!MSG_LENGTH_LOWER and !!MSG_LENGTH_UPPER, this forms the information that has to be
+                saved before switching context.
+                '''
+        }
+        { bits: "3",
+          name: "hash_continue",
+          desc: '''
+                When 1 is written to this field, SHA or HMAC will continue hashing based on the
+                current hash in the digest registers and the message length, which both have to be
+                restored to switch context.
+                '''
+        }
       ],
     }
     { name: "STATUS",

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -306,17 +306,27 @@
       desc: '''Received Message Length calculated by the HMAC in bits [31:0]
 
             Message is byte granularity.
-            lower 3bits [2:0] are ignored.''',
-      swaccess: "ro",
-      hwaccess: "hwo",
+            lower 3bits [2:0] are ignored.
+
+            When `CFG.sha_en` is 0, this register can be written by software.
+            ''',
+      swaccess: "rw",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe: "true",
       fields: [
         { bits: "31:0", name: "v", desc: "Message Length [31:0]" }
       ]
     }
     { name: "MSG_LENGTH_UPPER",
-      desc: "Received Message Length calculated by the HMAC in bits [63:32]",
-      swaccess: "ro",
-      hwaccess: "hwo",
+      desc: '''Received Message Length calculated by the HMAC in bits [63:32]
+
+            When `CFG.sha_en` is 0, this register can be written by software.
+            ''',
+      swaccess: "rw",
+      hwaccess: "hrw",
+      hwext: "true",
+      hwqe: "true",
       fields: [
         { bits: "31:0", name: "v", desc: "Message Length [63:32]" }
       ]

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -287,12 +287,16 @@
 
               Order of the digest is:
               digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST7};
+
+              The digest gets cleared when `CFG.sha_en` transitions from 1 to 0.
+              When `CFG.sha_en` is 0, these registers can be written by software.
               ''',
         count: "NumWords",
         cname: "HMAC",
-        swaccess: "ro",
-        hwaccess: "hwo",
+        swaccess: "rw",
+        hwaccess: "hrw",
         hwext: "true",
+        hwqe: "true",
         fields: [
           { bits: "31:0", name: "digest", desc: "32-bit chunk of 256-bit Digest" }
         ]

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -246,6 +246,11 @@
       fields: [
         { bits: "31:0", name:"secret", desc: "Secret value" }
       ]
+      tags: [
+        // Exclude automated tests that write this register, which will have side effects that the
+        // automated tests don't understand.
+        "excl:CsrAllTests:CsrExclWrite"
+      ]
     }
     { multireg: {
         name: "KEY",

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -171,19 +171,43 @@ If this bit is 1, HMAC operates when `hash_start` toggles.
 HMAC command register
 - Offset: `0x14`
 - Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset mask: `0xf`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "hash_start", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"name": "hash_process", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
+{"reg": [{"name": "hash_start", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"name": "hash_process", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"name": "hash_stop", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"name": "hash_continue", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name         | Description                                                                                                                                            |
-|:------:|:------:|:-------:|:-------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:2  |        |         |              | Reserved                                                                                                                                               |
-|   1    | r0w1c  |    x    | hash_process | If writes 1 into this field, SHA256 or HMAC calculates the digest or signing based on currently received message.                                      |
-|   0    | r0w1c  |    x    | hash_start   | If writes 1 into this field, SHA256 or HMAC begins its operation. CPU should configure relative information first, such as message_length, secret_key. |
+|  Bits  |  Type  |  Reset  | Name                                 |
+|:------:|:------:|:-------:|:-------------------------------------|
+|  31:4  |        |         | Reserved                             |
+|   3    | r0w1c  |    x    | [hash_continue](#cmd--hash_continue) |
+|   2    | r0w1c  |    x    | [hash_stop](#cmd--hash_stop)         |
+|   1    | r0w1c  |    x    | [hash_process](#cmd--hash_process)   |
+|   0    | r0w1c  |    x    | [hash_start](#cmd--hash_start)       |
+
+### CMD . hash_continue
+When 1 is written to this field, SHA or HMAC will continue hashing based on the
+current hash in the digest registers and the message length, which both have to be
+restored to switch context.
+
+### CMD . hash_stop
+When 1 is written to this field, SHA or HMAC will afterwards set the `hmac_done`
+interrupt as soon as the current block has been hashed. The hash can then be read
+from the registers [`DIGEST_0`](#digest_0) to [`DIGEST_7.`](#digest_7) Together with the message length in
+[`MSG_LENGTH_LOWER`](#msg_length_lower) and [`MSG_LENGTH_UPPER`](#msg_length_upper), this forms the information that has to be
+saved before switching context.
+
+### CMD . hash_process
+If writes 1 into this field, SHA256 or HMAC calculates the digest or signing
+based on currently received message.
+
+### CMD . hash_start
+If writes 1 into this field, SHA256 or HMAC begins its operation.
+
+CPU should configure relative information first, such as message_length,
+secret_key.
 
 ## STATUS
 HMAC Status register

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -317,6 +317,8 @@ Received Message Length calculated by the HMAC in bits [31:0]
 
 Message is byte granularity.
 lower 3bits [2:0] are ignored.
+
+When `CFG.sha_en` is 0, this register can be written by software.
 - Offset: `0x64`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -324,15 +326,17 @@ lower 3bits [2:0] are ignored.
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "v", "bits": 32, "attr": ["ro"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "v", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description           |
 |:------:|:------:|:-------:|:-------|:----------------------|
-|  31:0  |   ro   |   0x0   | v      | Message Length [31:0] |
+|  31:0  |   rw   |    x    | v      | Message Length [31:0] |
 
 ## MSG_LENGTH_UPPER
 Received Message Length calculated by the HMAC in bits [63:32]
+
+When `CFG.sha_en` is 0, this register can be written by software.
 - Offset: `0x68`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -340,12 +344,12 @@ Received Message Length calculated by the HMAC in bits [63:32]
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "v", "bits": 32, "attr": ["ro"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "v", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description            |
 |:------:|:------:|:-------:|:-------|:-----------------------|
-|  31:0  |   ro   |   0x0   | v      | Message Length [63:32] |
+|  31:0  |   rw   |    x    | v      | Message Length [63:32] |
 
 ## MSG_FIFO
 Message FIFO. Any write to this window will be appended to the FIFO. Only the lower [1:0] bits of the address matter to writes within the window (for correctly dealing with non 32-bit writes)

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -282,6 +282,9 @@ Digest output. If HMAC is disabled, the register shows result of SHA256
 
 Order of the digest is:
 digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST7};
+
+The digest gets cleared when `CFG.sha_en` transitions from 1 to 0.
+When `CFG.sha_en` is 0, these registers can be written by software.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -302,12 +305,12 @@ digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST7};
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "digest", "bits": 32, "attr": ["ro"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "digest", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name   | Description                    |
 |:------:|:------:|:-------:|:-------|:-------------------------------|
-|  31:0  |   ro   |    x    | digest | 32-bit chunk of 256-bit Digest |
+|  31:0  |   rw   |    x    | digest | 32-bit chunk of 256-bit Digest |
 
 ## MSG_LENGTH_LOWER
 Received Message Length calculated by the HMAC in bits [31:0]

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -11,6 +11,12 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
   // This would help trying to issue reset at specific timing during hmac hashing.
   bit hash_process_triggered;
 
+  // Randomization knob that controls how often an opportunity for save and restore is taken.  'Save
+  // and restore' means that on a complete block, we stop hashing, read the digest and message
+  // length via CSRs, disable SHA, write digest and message length back via CSRs, re-enable SHA and
+  // continue hashing.
+  int save_and_restore_pct;
+
   hmac_vif hmac_vif;
 
   `uvm_object_utils(hmac_env_cfg)

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -61,7 +61,9 @@ package hmac_env_pkg;
 
   typedef enum {
     HashStart,
-    HashProcess
+    HashProcess,
+    HashStop,
+    HashContinue
   } hmac_cmd_e;
 
   typedef enum bit [TL_DW-1:0] {

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -132,11 +132,11 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
             // Do nothing
           end
           "digest_0", "digest_1", "digest_2", "digest_3", "digest_4", "digest_5", "digest_6",
-          "digest_7": begin
+          "digest_7", "msg_length_upper", "msg_length_lower": begin
             // Predict updated value coming from write iff SHA core is disabled.
             do_predict = !sha_en;
           end
-          "status", "msg_length_lower", "msg_length_upper": begin
+          "status": begin
             `uvm_error(`gfn, $sformatf("this reg does not have write access: %0s",
                                        csr.get_full_name()))
           end

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -411,8 +411,10 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
                                        bit       hmac_en = ral.cfg.hmac_en.get_mirrored_value());
     if (hmac_en) begin
       cryptoc_dpi_pkg::sv_dpi_get_hmac_sha256(key, msg_q, exp_digest);
+      `uvm_info(`gfn, $sformatf("HMAC of key=%p, msq_q=%p: %p", key, msg_q, exp_digest), UVM_LOW)
     end else begin
       cryptoc_dpi_pkg::sv_dpi_get_sha256_digest(msg_q, exp_digest);
+      `uvm_info(`gfn, $sformatf("SHA256 digest of msq_q=%p: %p", msg_q, exp_digest), UVM_LOW)
     end
   endfunction
 

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -119,6 +119,11 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     foreach (digest[i]) csr_rd(.ptr(ral.digest[i]), .value(digest[i]));
   endtask
 
+  // write digest value
+  virtual task csr_wr_digest(bit [TL_DW-1:0] digest[8]);
+    foreach (digest[i]) csr_wr(.ptr(ral.digest[i]), .value(digest[i]));
+  endtask
+
   // write 256-bit hashed key
   //
   // can safely assume that the input array will always have 8 elements

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -89,13 +89,26 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     csr_wr(ral.key[key_idx], rand_key_value);
   endtask
 
-  // trigger hash computation to start
+  // start hash computations
   virtual task trigger_hash();
     csr_wr(.ptr(ral.cmd), .value(1'b1 << HashStart));
-    // if sha is not enabled, assert error interrupt and check error code
+    // If SHA is not enabled, check that an error is signaled.
     if (!ral.cfg.sha_en.get_mirrored_value()) check_error_code();
   endtask
 
+  // continue hash computations
+  virtual task trigger_hash_continue();
+    csr_wr(.ptr(ral.cmd), .value(1'b1 << HashContinue));
+    // If SHA is not enabled, check that an error is signaled.
+    if (!ral.cfg.sha_en.get_mirrored_value()) check_error_code();
+  endtask
+
+  // stop hash computations
+  virtual task trigger_hash_stop();
+    csr_wr(.ptr(ral.cmd), .value(1'b1 << HashStop));
+  endtask
+
+  // trigger calculation of digest at the end of a message
   virtual task trigger_process();
     csr_wr(.ptr(ral.cmd), .value(1'b1 << HashProcess));
     cfg.hash_process_triggered = 1;

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -216,11 +216,16 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     end
   endtask
 
-  // read the message length from the DUT reg
+  // read the message length from the DUT reg (but discard it)
   virtual task rd_msg_length();
-    bit [TL_DW-1:0] length_upper, length_lower;
-    csr_rd(ral.msg_length_upper, length_upper);
-    csr_rd(ral.msg_length_lower, length_lower);
+    bit [2*TL_DW-1:0] unused;
+    csr_rd_msg_length(unused);
+  endtask
+
+  // read the message length from the DUT reg
+  virtual task csr_rd_msg_length(output bit [2*TL_DW-1:0] msg_length);
+    csr_rd(ral.msg_length_upper, msg_length[2*TL_DW-1:TL_DW]);
+    csr_rd(ral.msg_length_lower, msg_length[TL_DW-1:0]);
   endtask
 
   // read status FIFO FULL and check intr FIFO FULL

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -116,7 +116,10 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
 
     // read digest value and output read value
   virtual task csr_rd_digest(output bit [TL_DW-1:0] digest[8]);
-    foreach (digest[i]) csr_rd(.ptr(ral.digest[i]), .value(digest[i]));
+    foreach (digest[i]) begin
+      csr_rd(.ptr(ral.digest[i]), .value(digest[i]));
+      `uvm_info(`gfn, $sformatf("digest[%0d]=32'h%08x", i, digest[i]), UVM_MEDIUM)
+    end
   endtask
 
   // write digest value

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -228,6 +228,12 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     csr_rd(ral.msg_length_lower, msg_length[TL_DW-1:0]);
   endtask
 
+  // write message length to the DUT reg
+  virtual task csr_wr_msg_length(bit [2*TL_DW-1:0] msg_length);
+    csr_wr(.ptr(ral.msg_length_upper), .value(msg_length[2*TL_DW-1:TL_DW]));
+    csr_wr(.ptr(ral.msg_length_lower), .value(msg_length[TL_DW-1:0]));
+  endtask
+
   // read status FIFO FULL and check intr FIFO FULL
   // if intr_fifo_full_enable is disable, check intr_fifo_full_state and clear it
   virtual task check_status_intr();

--- a/hw/ip/hmac/dv/tests/hmac_base_test.sv
+++ b/hw/ip/hmac/dv/tests/hmac_base_test.sv
@@ -7,4 +7,9 @@ class hmac_base_test extends cip_base_test #(.ENV_T(hmac_env),
   `uvm_component_utils(hmac_base_test)
   `uvm_component_new
 
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    cfg.save_and_restore_pct = 0;
+  endfunction
+
 endclass : hmac_base_test

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -439,6 +439,8 @@ module hmac
     .hash_process_i       (sha_hash_process),
     .hash_done_o          (sha_hash_done),
     .message_length_i     ({{64'b0},sha_message_length}),
+    .digest_i             ('0),
+    .digest_we_i          ('0),
     .digest_o             (digest), // digest[0:7][63:32] not read and tied out in unused_signals
     .idle_o               (sha_core_idle)
   );

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -447,6 +447,7 @@ module hmac
     .fifo_rready_o        (shaf_rready),
     .sha_en_i             (sha_en),
     .hash_start_i         (sha_hash_start),
+    .hash_continue_i      (1'b0),
     .digest_mode_i        (None),    // unused input port tied to ground
     .hash_process_i       (sha_hash_process),
     .hash_done_o          (sha_hash_done),

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -617,17 +617,12 @@ module hmac
   end
 
   // the host doesn't write data after hash_process until hash_start.
-  // Same as "message_length shouldn't be changed between hash_process and done
   `ASSERT(ValidWriteAssert, msg_fifo_req |-> !in_process)
 
   // `hash_process` shall be toggle and paired with `hash_start`.
   // Below condition is covered by the design (2020-02-19)
   //`ASSERT(ValidHashStartAssert, hash_start |-> !initiated)
   `ASSERT(ValidHashProcessAssert, reg_hash_process |-> initiated)
-
-  // between `hash_done` and `hash_start`, message FIFO should be empty
-  `ASSERT(MsgFifoEmptyWhenNoOpAssert,
-          !in_process && !initiated |-> $stable(message_length))
 
   // hmac_en should be modified only when the logic is Idle
   `ASSERT(ValidHmacEnConditionAssert,

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -223,14 +223,11 @@ module hmac
   end
   assign fifo_empty_event = fifo_empty & ~fifo_empty_q;
 
-  logic [2:0] event_intr;
-  assign event_intr = {err_valid, fifo_empty_event, reg_hash_done};
-
   // instantiate interrupt hardware primitive
   prim_intr_hw #(.Width(1)) intr_hw_hmac_done (
     .clk_i,
     .rst_ni,
-    .event_intr_i           (event_intr[0]),
+    .event_intr_i           (reg_hash_done),
     .reg2hw_intr_enable_q_i (reg2hw.intr_enable.hmac_done.q),
     .reg2hw_intr_test_q_i   (reg2hw.intr_test.hmac_done.q),
     .reg2hw_intr_test_qe_i  (reg2hw.intr_test.hmac_done.qe),
@@ -242,7 +239,7 @@ module hmac
   prim_intr_hw #(.Width(1)) intr_hw_fifo_empty (
     .clk_i,
     .rst_ni,
-    .event_intr_i           (event_intr[1]),
+    .event_intr_i           (fifo_empty_event),
     .reg2hw_intr_enable_q_i (reg2hw.intr_enable.fifo_empty.q),
     .reg2hw_intr_test_q_i   (reg2hw.intr_test.fifo_empty.q),
     .reg2hw_intr_test_qe_i  (reg2hw.intr_test.fifo_empty.qe),
@@ -254,7 +251,7 @@ module hmac
   prim_intr_hw #(.Width(1)) intr_hw_hmac_err (
     .clk_i,
     .rst_ni,
-    .event_intr_i           (event_intr[2]),
+    .event_intr_i           (err_valid),
     .reg2hw_intr_enable_q_i (reg2hw.intr_enable.hmac_err.q),
     .reg2hw_intr_test_q_i   (reg2hw.intr_test.hmac_err.q),
     .reg2hw_intr_test_qe_i  (reg2hw.intr_test.hmac_err.qe),

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -461,6 +461,7 @@ module hmac
     .digest_i             (digest_sw),
     .digest_we_i          (digest_sw_we),
     .digest_o             (digest), // digest[0:7][63:32] not read and tied out in unused_signals
+    .hash_running_o       (),
     .idle_o               (sha_core_idle)
   );
 

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -85,6 +85,7 @@ module hmac
 
   logic        reg_hash_start;
   logic        sha_hash_start;
+  logic        reg_hash_stop;
   logic        reg_hash_continue;
   logic        sha_hash_continue;
   logic        hash_start; // reg_hash_start gated with when it is allowed
@@ -162,6 +163,7 @@ module hmac
   assign hw2reg.cfg.digest_swap.d = cfg_reg.digest_swap.q;
 
   assign reg_hash_start    = reg2hw.cmd.hash_start.qe & reg2hw.cmd.hash_start.q;
+  assign reg_hash_stop     = reg2hw.cmd.hash_stop.qe & reg2hw.cmd.hash_stop.q;
   assign reg_hash_continue = reg2hw.cmd.hash_continue.qe & reg2hw.cmd.hash_continue.q;
   assign reg_hash_process  = reg2hw.cmd.hash_process.qe & reg2hw.cmd.hash_process.q;
 
@@ -181,7 +183,7 @@ module hmac
       cfg_block <= '0;
     end else if (hash_start_or_continue) begin
       cfg_block <= 1'b 1;
-    end else if (reg_hash_done) begin
+    end else if (reg_hash_done || reg_hash_stop) begin
       cfg_block <= 1'b 0;
     end
   end

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -408,10 +408,12 @@ module hmac
 
     .hmac_en,
 
-    .reg_hash_start   (hash_start),
-    .reg_hash_process (packer_flush_done), // Trigger after all msg written
-    .hash_done        (reg_hash_done),
+    .reg_hash_start    (hash_start),
+    .reg_hash_continue (1'b0),
+    .reg_hash_process  (packer_flush_done), // Trigger after all msg written
+    .hash_done         (reg_hash_done),
     .sha_hash_start,
+    .sha_hash_continue (),
     .sha_hash_process,
     .sha_hash_done,
 

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -343,16 +343,24 @@ module hmac
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       message_length <= '0;
-    end else if (hash_start) begin
-      message_length <= '0;
-    end else if (msg_write && sha_en && packer_ready) begin
-      message_length <= message_length + 64'(wmask_ones);
+    end else begin
+      if (!cfg_block) begin
+        if (reg2hw.msg_length_lower.qe) begin
+          message_length[31:0] <= reg2hw.msg_length_lower.q;
+        end
+        if (reg2hw.msg_length_upper.qe) begin
+          message_length[63:32] <= reg2hw.msg_length_upper.q;
+        end
+      end
+      if (hash_start) begin
+        message_length <= '0;
+      end else if (msg_write && sha_en && packer_ready) begin
+        message_length <= message_length + 64'(wmask_ones);
+      end
     end
   end
 
-  assign hw2reg.msg_length_upper.de = 1'b1;
   assign hw2reg.msg_length_upper.d = message_length[63:32];
-  assign hw2reg.msg_length_lower.de = 1'b1;
   assign hw2reg.msg_length_lower.d = message_length[31:0];
 
 

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -107,6 +107,16 @@ package hmac_reg_pkg;
   } hmac_reg2hw_digest_mreg_t;
 
   typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } hmac_reg2hw_msg_length_lower_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } hmac_reg2hw_msg_length_upper_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -163,37 +173,37 @@ package hmac_reg_pkg;
 
   typedef struct packed {
     logic [31:0] d;
-    logic        de;
   } hmac_hw2reg_msg_length_lower_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
-    logic        de;
   } hmac_hw2reg_msg_length_upper_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    hmac_reg2hw_intr_state_reg_t intr_state; // [586:584]
-    hmac_reg2hw_intr_enable_reg_t intr_enable; // [583:581]
-    hmac_reg2hw_intr_test_reg_t intr_test; // [580:575]
-    hmac_reg2hw_alert_test_reg_t alert_test; // [574:573]
-    hmac_reg2hw_cfg_reg_t cfg; // [572:565]
-    hmac_reg2hw_cmd_reg_t cmd; // [564:561]
-    hmac_reg2hw_wipe_secret_reg_t wipe_secret; // [560:528]
-    hmac_reg2hw_key_mreg_t [7:0] key; // [527:264]
-    hmac_reg2hw_digest_mreg_t [7:0] digest; // [263:0]
+    hmac_reg2hw_intr_state_reg_t intr_state; // [652:650]
+    hmac_reg2hw_intr_enable_reg_t intr_enable; // [649:647]
+    hmac_reg2hw_intr_test_reg_t intr_test; // [646:641]
+    hmac_reg2hw_alert_test_reg_t alert_test; // [640:639]
+    hmac_reg2hw_cfg_reg_t cfg; // [638:631]
+    hmac_reg2hw_cmd_reg_t cmd; // [630:627]
+    hmac_reg2hw_wipe_secret_reg_t wipe_secret; // [626:594]
+    hmac_reg2hw_key_mreg_t [7:0] key; // [593:330]
+    hmac_reg2hw_digest_mreg_t [7:0] digest; // [329:66]
+    hmac_reg2hw_msg_length_lower_reg_t msg_length_lower; // [65:33]
+    hmac_reg2hw_msg_length_upper_reg_t msg_length_upper; // [32:0]
   } hmac_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    hmac_hw2reg_intr_state_reg_t intr_state; // [627:622]
-    hmac_hw2reg_cfg_reg_t cfg; // [621:618]
-    hmac_hw2reg_status_reg_t status; // [617:611]
-    hmac_hw2reg_err_code_reg_t err_code; // [610:578]
-    hmac_hw2reg_key_mreg_t [7:0] key; // [577:322]
-    hmac_hw2reg_digest_mreg_t [7:0] digest; // [321:66]
-    hmac_hw2reg_msg_length_lower_reg_t msg_length_lower; // [65:33]
-    hmac_hw2reg_msg_length_upper_reg_t msg_length_upper; // [32:0]
+    hmac_hw2reg_intr_state_reg_t intr_state; // [625:620]
+    hmac_hw2reg_cfg_reg_t cfg; // [619:616]
+    hmac_hw2reg_status_reg_t status; // [615:609]
+    hmac_hw2reg_err_code_reg_t err_code; // [608:576]
+    hmac_hw2reg_key_mreg_t [7:0] key; // [575:320]
+    hmac_hw2reg_digest_mreg_t [7:0] digest; // [319:64]
+    hmac_hw2reg_msg_length_lower_reg_t msg_length_lower; // [63:32]
+    hmac_hw2reg_msg_length_upper_reg_t msg_length_upper; // [31:0]
   } hmac_hw2reg_t;
 
   // Register offsets
@@ -255,6 +265,8 @@ package hmac_reg_pkg;
   parameter logic [31:0] HMAC_DIGEST_5_RESVAL = 32'h 0;
   parameter logic [31:0] HMAC_DIGEST_6_RESVAL = 32'h 0;
   parameter logic [31:0] HMAC_DIGEST_7_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_MSG_LENGTH_LOWER_RESVAL = 32'h 0;
+  parameter logic [31:0] HMAC_MSG_LENGTH_UPPER_RESVAL = 32'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] HMAC_MSG_FIFO_OFFSET = 12'h 800;

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -102,6 +102,11 @@ package hmac_reg_pkg;
   } hmac_reg2hw_key_mreg_t;
 
   typedef struct packed {
+    logic [31:0] q;
+    logic        qe;
+  } hmac_reg2hw_digest_mreg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -168,14 +173,15 @@ package hmac_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    hmac_reg2hw_intr_state_reg_t intr_state; // [322:320]
-    hmac_reg2hw_intr_enable_reg_t intr_enable; // [319:317]
-    hmac_reg2hw_intr_test_reg_t intr_test; // [316:311]
-    hmac_reg2hw_alert_test_reg_t alert_test; // [310:309]
-    hmac_reg2hw_cfg_reg_t cfg; // [308:301]
-    hmac_reg2hw_cmd_reg_t cmd; // [300:297]
-    hmac_reg2hw_wipe_secret_reg_t wipe_secret; // [296:264]
-    hmac_reg2hw_key_mreg_t [7:0] key; // [263:0]
+    hmac_reg2hw_intr_state_reg_t intr_state; // [586:584]
+    hmac_reg2hw_intr_enable_reg_t intr_enable; // [583:581]
+    hmac_reg2hw_intr_test_reg_t intr_test; // [580:575]
+    hmac_reg2hw_alert_test_reg_t alert_test; // [574:573]
+    hmac_reg2hw_cfg_reg_t cfg; // [572:565]
+    hmac_reg2hw_cmd_reg_t cmd; // [564:561]
+    hmac_reg2hw_wipe_secret_reg_t wipe_secret; // [560:528]
+    hmac_reg2hw_key_mreg_t [7:0] key; // [527:264]
+    hmac_reg2hw_digest_mreg_t [7:0] digest; // [263:0]
   } hmac_reg2hw_t;
 
   // HW -> register type

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -84,6 +84,14 @@ package hmac_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
+    } hash_continue;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } hash_stop;
+    struct packed {
+      logic        q;
+      logic        qe;
     } hash_process;
     struct packed {
       logic        q;
@@ -181,12 +189,12 @@ package hmac_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    hmac_reg2hw_intr_state_reg_t intr_state; // [652:650]
-    hmac_reg2hw_intr_enable_reg_t intr_enable; // [649:647]
-    hmac_reg2hw_intr_test_reg_t intr_test; // [646:641]
-    hmac_reg2hw_alert_test_reg_t alert_test; // [640:639]
-    hmac_reg2hw_cfg_reg_t cfg; // [638:631]
-    hmac_reg2hw_cmd_reg_t cmd; // [630:627]
+    hmac_reg2hw_intr_state_reg_t intr_state; // [656:654]
+    hmac_reg2hw_intr_enable_reg_t intr_enable; // [653:651]
+    hmac_reg2hw_intr_test_reg_t intr_test; // [650:645]
+    hmac_reg2hw_alert_test_reg_t alert_test; // [644:643]
+    hmac_reg2hw_cfg_reg_t cfg; // [642:635]
+    hmac_reg2hw_cmd_reg_t cmd; // [634:627]
     hmac_reg2hw_wipe_secret_reg_t wipe_secret; // [626:594]
     hmac_reg2hw_key_mreg_t [7:0] key; // [593:330]
     hmac_reg2hw_digest_mreg_t [7:0] digest; // [329:66]
@@ -245,7 +253,7 @@ package hmac_reg_pkg;
   parameter logic [3:0] HMAC_CFG_RESVAL = 4'h 0;
   parameter logic [0:0] HMAC_CFG_ENDIAN_SWAP_RESVAL = 1'h 0;
   parameter logic [0:0] HMAC_CFG_DIGEST_SWAP_RESVAL = 1'h 0;
-  parameter logic [1:0] HMAC_CMD_RESVAL = 2'h 0;
+  parameter logic [3:0] HMAC_CMD_RESVAL = 4'h 0;
   parameter logic [8:0] HMAC_STATUS_RESVAL = 9'h 1;
   parameter logic [0:0] HMAC_STATUS_FIFO_EMPTY_RESVAL = 1'h 1;
   parameter logic [31:0] HMAC_WIPE_SECRET_RESVAL = 32'h 0;

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -258,8 +258,14 @@ module hmac_reg_top (
   logic digest_7_we;
   logic [31:0] digest_7_qs;
   logic [31:0] digest_7_wd;
+  logic msg_length_lower_re;
+  logic msg_length_lower_we;
   logic [31:0] msg_length_lower_qs;
+  logic [31:0] msg_length_lower_wd;
+  logic msg_length_upper_re;
+  logic msg_length_upper_we;
   logic [31:0] msg_length_upper_qs;
+  logic [31:0] msg_length_upper_wd;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1038,60 +1044,44 @@ module hmac_reg_top (
   assign reg2hw.digest[7].qe = digest_7_qe;
 
 
-  // R[msg_length_lower]: V(False)
-  prim_subreg #(
-    .DW      (32),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+  // R[msg_length_lower]: V(True)
+  logic msg_length_lower_qe;
+  logic [0:0] msg_length_lower_flds_we;
+  assign msg_length_lower_qe = &msg_length_lower_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_msg_length_lower (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.msg_length_lower.de),
+    .re     (msg_length_lower_re),
+    .we     (msg_length_lower_we),
+    .wd     (msg_length_lower_wd),
     .d      (hw2reg.msg_length_lower.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
+    .qre    (),
+    .qe     (msg_length_lower_flds_we[0]),
+    .q      (reg2hw.msg_length_lower.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (msg_length_lower_qs)
   );
+  assign reg2hw.msg_length_lower.qe = msg_length_lower_qe;
 
 
-  // R[msg_length_upper]: V(False)
-  prim_subreg #(
-    .DW      (32),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0),
-    .Mubi    (1'b0)
+  // R[msg_length_upper]: V(True)
+  logic msg_length_upper_qe;
+  logic [0:0] msg_length_upper_flds_we;
+  assign msg_length_upper_qe = &msg_length_upper_flds_we;
+  prim_subreg_ext #(
+    .DW    (32)
   ) u_msg_length_upper (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.msg_length_upper.de),
+    .re     (msg_length_upper_re),
+    .we     (msg_length_upper_we),
+    .wd     (msg_length_upper_wd),
     .d      (hw2reg.msg_length_upper.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
+    .qre    (),
+    .qe     (msg_length_upper_flds_we[0]),
+    .q      (reg2hw.msg_length_upper.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     (msg_length_upper_qs)
   );
+  assign reg2hw.msg_length_upper.qe = msg_length_upper_qe;
 
 
 
@@ -1261,6 +1251,14 @@ module hmac_reg_top (
   assign digest_7_we = addr_hit[24] & reg_we & !reg_error;
 
   assign digest_7_wd = reg_wdata[31:0];
+  assign msg_length_lower_re = addr_hit[25] & reg_re & !reg_error;
+  assign msg_length_lower_we = addr_hit[25] & reg_we & !reg_error;
+
+  assign msg_length_lower_wd = reg_wdata[31:0];
+  assign msg_length_upper_re = addr_hit[26] & reg_re & !reg_error;
+  assign msg_length_upper_we = addr_hit[26] & reg_we & !reg_error;
+
+  assign msg_length_upper_wd = reg_wdata[31:0];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -1290,8 +1288,8 @@ module hmac_reg_top (
     reg_we_check[22] = digest_5_we;
     reg_we_check[23] = digest_6_we;
     reg_we_check[24] = digest_7_we;
-    reg_we_check[25] = 1'b0;
-    reg_we_check[26] = 1'b0;
+    reg_we_check[25] = msg_length_lower_we;
+    reg_we_check[26] = msg_length_upper_we;
   end
 
   // Read data return

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -227,21 +227,37 @@ module hmac_reg_top (
   logic key_7_we;
   logic [31:0] key_7_wd;
   logic digest_0_re;
+  logic digest_0_we;
   logic [31:0] digest_0_qs;
+  logic [31:0] digest_0_wd;
   logic digest_1_re;
+  logic digest_1_we;
   logic [31:0] digest_1_qs;
+  logic [31:0] digest_1_wd;
   logic digest_2_re;
+  logic digest_2_we;
   logic [31:0] digest_2_qs;
+  logic [31:0] digest_2_wd;
   logic digest_3_re;
+  logic digest_3_we;
   logic [31:0] digest_3_qs;
+  logic [31:0] digest_3_wd;
   logic digest_4_re;
+  logic digest_4_we;
   logic [31:0] digest_4_qs;
+  logic [31:0] digest_4_wd;
   logic digest_5_re;
+  logic digest_5_we;
   logic [31:0] digest_5_qs;
+  logic [31:0] digest_5_wd;
   logic digest_6_re;
+  logic digest_6_we;
   logic [31:0] digest_6_qs;
+  logic [31:0] digest_6_wd;
   logic digest_7_re;
+  logic digest_7_we;
   logic [31:0] digest_7_qs;
+  logic [31:0] digest_7_wd;
   logic [31:0] msg_length_lower_qs;
   logic [31:0] msg_length_upper_qs;
 
@@ -856,138 +872,170 @@ module hmac_reg_top (
 
   // Subregister 0 of Multireg digest
   // R[digest_0]: V(True)
+  logic digest_0_qe;
+  logic [0:0] digest_0_flds_we;
+  assign digest_0_qe = &digest_0_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_0 (
     .re     (digest_0_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (digest_0_we),
+    .wd     (digest_0_wd),
     .d      (hw2reg.digest[0].d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (digest_0_flds_we[0]),
+    .q      (reg2hw.digest[0].q),
     .ds     (),
     .qs     (digest_0_qs)
   );
+  assign reg2hw.digest[0].qe = digest_0_qe;
 
 
   // Subregister 1 of Multireg digest
   // R[digest_1]: V(True)
+  logic digest_1_qe;
+  logic [0:0] digest_1_flds_we;
+  assign digest_1_qe = &digest_1_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_1 (
     .re     (digest_1_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (digest_1_we),
+    .wd     (digest_1_wd),
     .d      (hw2reg.digest[1].d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (digest_1_flds_we[0]),
+    .q      (reg2hw.digest[1].q),
     .ds     (),
     .qs     (digest_1_qs)
   );
+  assign reg2hw.digest[1].qe = digest_1_qe;
 
 
   // Subregister 2 of Multireg digest
   // R[digest_2]: V(True)
+  logic digest_2_qe;
+  logic [0:0] digest_2_flds_we;
+  assign digest_2_qe = &digest_2_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_2 (
     .re     (digest_2_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (digest_2_we),
+    .wd     (digest_2_wd),
     .d      (hw2reg.digest[2].d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (digest_2_flds_we[0]),
+    .q      (reg2hw.digest[2].q),
     .ds     (),
     .qs     (digest_2_qs)
   );
+  assign reg2hw.digest[2].qe = digest_2_qe;
 
 
   // Subregister 3 of Multireg digest
   // R[digest_3]: V(True)
+  logic digest_3_qe;
+  logic [0:0] digest_3_flds_we;
+  assign digest_3_qe = &digest_3_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_3 (
     .re     (digest_3_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (digest_3_we),
+    .wd     (digest_3_wd),
     .d      (hw2reg.digest[3].d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (digest_3_flds_we[0]),
+    .q      (reg2hw.digest[3].q),
     .ds     (),
     .qs     (digest_3_qs)
   );
+  assign reg2hw.digest[3].qe = digest_3_qe;
 
 
   // Subregister 4 of Multireg digest
   // R[digest_4]: V(True)
+  logic digest_4_qe;
+  logic [0:0] digest_4_flds_we;
+  assign digest_4_qe = &digest_4_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_4 (
     .re     (digest_4_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (digest_4_we),
+    .wd     (digest_4_wd),
     .d      (hw2reg.digest[4].d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (digest_4_flds_we[0]),
+    .q      (reg2hw.digest[4].q),
     .ds     (),
     .qs     (digest_4_qs)
   );
+  assign reg2hw.digest[4].qe = digest_4_qe;
 
 
   // Subregister 5 of Multireg digest
   // R[digest_5]: V(True)
+  logic digest_5_qe;
+  logic [0:0] digest_5_flds_we;
+  assign digest_5_qe = &digest_5_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_5 (
     .re     (digest_5_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (digest_5_we),
+    .wd     (digest_5_wd),
     .d      (hw2reg.digest[5].d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (digest_5_flds_we[0]),
+    .q      (reg2hw.digest[5].q),
     .ds     (),
     .qs     (digest_5_qs)
   );
+  assign reg2hw.digest[5].qe = digest_5_qe;
 
 
   // Subregister 6 of Multireg digest
   // R[digest_6]: V(True)
+  logic digest_6_qe;
+  logic [0:0] digest_6_flds_we;
+  assign digest_6_qe = &digest_6_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_6 (
     .re     (digest_6_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (digest_6_we),
+    .wd     (digest_6_wd),
     .d      (hw2reg.digest[6].d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (digest_6_flds_we[0]),
+    .q      (reg2hw.digest[6].q),
     .ds     (),
     .qs     (digest_6_qs)
   );
+  assign reg2hw.digest[6].qe = digest_6_qe;
 
 
   // Subregister 7 of Multireg digest
   // R[digest_7]: V(True)
+  logic digest_7_qe;
+  logic [0:0] digest_7_flds_we;
+  assign digest_7_qe = &digest_7_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_7 (
     .re     (digest_7_re),
-    .we     (1'b0),
-    .wd     ('0),
+    .we     (digest_7_we),
+    .wd     (digest_7_wd),
     .d      (hw2reg.digest[7].d),
     .qre    (),
-    .qe     (),
-    .q      (),
+    .qe     (digest_7_flds_we[0]),
+    .q      (reg2hw.digest[7].q),
     .ds     (),
     .qs     (digest_7_qs)
   );
+  assign reg2hw.digest[7].qe = digest_7_qe;
 
 
   // R[msg_length_lower]: V(False)
@@ -1182,13 +1230,37 @@ module hmac_reg_top (
 
   assign key_7_wd = reg_wdata[31:0];
   assign digest_0_re = addr_hit[17] & reg_re & !reg_error;
+  assign digest_0_we = addr_hit[17] & reg_we & !reg_error;
+
+  assign digest_0_wd = reg_wdata[31:0];
   assign digest_1_re = addr_hit[18] & reg_re & !reg_error;
+  assign digest_1_we = addr_hit[18] & reg_we & !reg_error;
+
+  assign digest_1_wd = reg_wdata[31:0];
   assign digest_2_re = addr_hit[19] & reg_re & !reg_error;
+  assign digest_2_we = addr_hit[19] & reg_we & !reg_error;
+
+  assign digest_2_wd = reg_wdata[31:0];
   assign digest_3_re = addr_hit[20] & reg_re & !reg_error;
+  assign digest_3_we = addr_hit[20] & reg_we & !reg_error;
+
+  assign digest_3_wd = reg_wdata[31:0];
   assign digest_4_re = addr_hit[21] & reg_re & !reg_error;
+  assign digest_4_we = addr_hit[21] & reg_we & !reg_error;
+
+  assign digest_4_wd = reg_wdata[31:0];
   assign digest_5_re = addr_hit[22] & reg_re & !reg_error;
+  assign digest_5_we = addr_hit[22] & reg_we & !reg_error;
+
+  assign digest_5_wd = reg_wdata[31:0];
   assign digest_6_re = addr_hit[23] & reg_re & !reg_error;
+  assign digest_6_we = addr_hit[23] & reg_we & !reg_error;
+
+  assign digest_6_wd = reg_wdata[31:0];
   assign digest_7_re = addr_hit[24] & reg_re & !reg_error;
+  assign digest_7_we = addr_hit[24] & reg_we & !reg_error;
+
+  assign digest_7_wd = reg_wdata[31:0];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -1210,14 +1282,14 @@ module hmac_reg_top (
     reg_we_check[14] = key_5_we;
     reg_we_check[15] = key_6_we;
     reg_we_check[16] = key_7_we;
-    reg_we_check[17] = 1'b0;
-    reg_we_check[18] = 1'b0;
-    reg_we_check[19] = 1'b0;
-    reg_we_check[20] = 1'b0;
-    reg_we_check[21] = 1'b0;
-    reg_we_check[22] = 1'b0;
-    reg_we_check[23] = 1'b0;
-    reg_we_check[24] = 1'b0;
+    reg_we_check[17] = digest_0_we;
+    reg_we_check[18] = digest_1_we;
+    reg_we_check[19] = digest_2_we;
+    reg_we_check[20] = digest_3_we;
+    reg_we_check[21] = digest_4_we;
+    reg_we_check[22] = digest_5_we;
+    reg_we_check[23] = digest_6_we;
+    reg_we_check[24] = digest_7_we;
     reg_we_check[25] = 1'b0;
     reg_we_check[26] = 1'b0;
   end

--- a/hw/ip/prim/rtl/prim_sha2.sv
+++ b/hw/ip/prim/rtl/prim_sha2.sv
@@ -37,6 +37,8 @@ module prim_sha2 import prim_sha2_pkg::*;
   input  sha_word64_t [7:0] digest_i,
   input  logic [7:0]        digest_we_i,
   output sha_word64_t [7:0] digest_o, // tie off unused port slice when MultimodeEn = 0
+  output logic hash_running_o, // `1` iff hash computation is active (as opposed to `idle_o`, which
+                               // is also `0` and thus 'busy' when waiting for a FIFO input)
   output logic idle_o
 );
 
@@ -484,6 +486,8 @@ module prim_sha2 import prim_sha2_pkg::*;
     .message_length_i,
     .msg_feed_complete_o (msg_feed_complete)
   );
+
+  assign hash_running_o = init_hash | run_hash | update_digest;
 
   // Idle
   assign idle_o = (fifo_st_q == FifoIdle) && (sha_st_q == ShaIdle) && !hash_go;

--- a/hw/ip/prim/rtl/prim_sha2_32.sv
+++ b/hw/ip/prim/rtl/prim_sha2_32.sv
@@ -26,6 +26,8 @@ module prim_sha2_32 import prim_sha2_pkg::*;
   input                     hash_process_i,
   output logic              hash_done_o,
   input [127:0]             message_length_i, // use extended message length 128 bits
+  input  sha_word64_t [7:0] digest_i,
+  input  logic [7:0]        digest_we_i,
   output sha_word64_t [7:0] digest_o,         // use extended digest length
   output logic              idle_o
 );
@@ -205,6 +207,8 @@ module prim_sha2_32 import prim_sha2_pkg::*;
       .hash_process_i     (sha_process),
       .hash_done_o        (hash_done_o),
       .message_length_i   (message_length_i),
+      .digest_i           (digest_i),
+      .digest_we_i        (digest_we_i),
       .digest_o           (digest_o),
       .idle_o             (idle_o)
     );
@@ -252,6 +256,8 @@ module prim_sha2_32 import prim_sha2_pkg::*;
       .hash_process_i     (hash_process_i), // feed input port directly to SHA-2 engine
       .hash_done_o        (hash_done_o),
       .message_length_i   ({{64'b0}, message_length_i[63:0]}),
+      .digest_i           (digest_i),
+      .digest_we_i        (digest_we_i),
       .digest_o           (digest_o),
       .idle_o             (idle_o)
     );

--- a/hw/ip/prim/rtl/prim_sha2_32.sv
+++ b/hw/ip/prim/rtl/prim_sha2_32.sv
@@ -30,6 +30,7 @@ module prim_sha2_32 import prim_sha2_pkg::*;
   input  sha_word64_t [7:0] digest_i,
   input  logic [7:0]        digest_we_i,
   output sha_word64_t [7:0] digest_o,         // use extended digest length
+  output logic              hash_running_o,
   output logic              idle_o
 );
   // signal definitions shared for both 256-bit and multi-mode
@@ -216,6 +217,7 @@ module prim_sha2_32 import prim_sha2_pkg::*;
       .digest_i           (digest_i),
       .digest_we_i        (digest_we_i),
       .digest_o           (digest_o),
+      .hash_running_o     (hash_running_o),
       .idle_o             (idle_o)
     );
 
@@ -266,6 +268,7 @@ module prim_sha2_32 import prim_sha2_pkg::*;
       .digest_i           (digest_i),
       .digest_we_i        (digest_we_i),
       .digest_o           (digest_o),
+      .hash_running_o     (hash_running_o),
       .idle_o             (idle_o)
     );
   end


### PR DESCRIPTION
This is an initial implementation of save & restore for HMAC (issue #49), which should allow SW to switch between different parallel message streams. In short, SW usage follows a pattern like this:
1. Start processing message stream A by configuring HMAC and then setting the `CMD.hash_start` bit.
2. Write an arbitrary number of message blocks to HMAC's `MSG_FIFO`.
3. Stop HMAC by setting the `CMD.hash_stop` bit and wait for the `hmac_done` interrupt (or poll the interrupt status register).
4. Save the context by reading the `DIGEST_0`..`7` and `MSG_LENGTH_`{`LOWER`,`UPPER`} registers. (The values in the `CFG` register must also be preserved, but that is purely SW-controlled so doesn't need to be read from HW.)
5. Repeat steps 1-4 for message stream B.
6. Restore the context of message stream A by writing the `CFG`, `DIGEST_0`..`7`, and `MSG_LENGTH_`{`LOWER`,`UPPER`} registers.
7. Continue processing message stream A by setting the `CMD.hash_continue` bit.
8. Write an arbitrary number of message blocks to HMAC's `MSG_FIFO`.
9. Continue this with as many message blocks and parallel message streams as needed. The final hash for any message stream can be obtained at any time (no need for complete blocks) as before by setting `CMD.hash_process` and waiting for the `hmac_done` interrupt / status bit, finally reading the digest from the `DIGEST` registers.

A noteworthy limitation of this implementation is that context can only be switched on complete message blocks (512 bit for SHA-256). This is so that no additional internal state (i.e., working variables and round counter) needs to be exposed to and controlled from SW. As noted in [issue #49](https://github.com/lowRISC/opentitan/issues/49#issuecomment-1935538297), this shouldn't be a major limitation for SW, though.

Although this PR adds preliminary DV support for the changes, save & restore does not yet get checked by the tests (the `save_and_restore_pct` randomization knob is currently 0 for all tests). I have manually verified that save & restore works under the basic operating conditions for HMAC and SHA but this needs to be tested much more thoroughly, especially the corner cases. When one enables save & restores in the tests, one will get errors from DV. My first assessment is that these are DV limitations, not RTL bugs, though.

I ran a full regression on HMAC to check that this doesn't break existing functionality or DV, and I got the same pass rates as reported in nightlies -- so no breakage of existing RTL & DV expected.

Opens before this PR can be merged:
- [x] Update documentation (mainly Programmer's Guide and Theory of Operation).

Opens that can be resolved in a follow-up PR:
- [ ] Extend testplan and coverplan to test and cover save & restore feature.
- [ ] Enable save & restores in tests and make necessary extensions to the scoreboard as well as `burst_wr_msg` so this gets correctly checked and fully covered.
- [ ] Add additional directed test that covers context switching between multiple message streams (not sure if this has to be an UVM test, maybe a SW test would suffice?).