### PR TITLE
[MBX, DV] - Coverage infrastructure first pass for MBX IP

### DIFF
--- a/hw/ip/mbx/data/mbx_testplan.hjson
+++ b/hw/ip/mbx/data/mbx_testplan.hjson
@@ -15,6 +15,12 @@
     { name: mbx_smoke
       desc: '''
             Smoke test
+            -REQ/RSP transactions
+            -Variable latency and lengths
+            -Valid configurations
+            -Support for Abort/Errors/Panic
+            -Support for Abort/Errors/Panic
+            -Zero Access Delay option for TL agents
             '''
       stage: V1
       tests: ["mbx_smoke"]
@@ -22,9 +28,38 @@
     { name: mbx_stress
       desc: '''
             Stress test
+            -Smoke REQ/RSP transactions with Abort/Errors/Panic constrained on
+            -Zero Access Delay option for TL agents
             '''
       stage: V3
-      tests: ["mbx_stress_all"]
+      tests: ["mbx_stress"]
+    }
+  ]
+
+  covergroups: [
+    {
+      name: err_inj_cg
+      desc: '''
+        Indicates what error conditions have been injected.
+      '''
+    }
+    {
+      name: mbx_fsm_cg
+      desc: '''
+        mbx_fsm states and arcs
+      '''
+    }
+    {
+      name: mbx_host_if_cg
+      desc: '''
+        mbx_host reg2hw, hw2reg covergroups
+      '''
+    }
+    {
+      name: mbx_sys_if_cg
+      desc: '''
+        mbx_sys reg2hw, hw2reg covergroups
+      '''
     }
   ]
 }

--- a/hw/ip/mbx/dv/cov/mbx_cov.core
+++ b/hw/ip/mbx/dv/cov/mbx_cov.core
@@ -2,8 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:mbx_sim:0.1"
-description: "MBX DV sim target"
+name: "lowrisc:dv:mbx_cov"
+description: "MBX functional coverage and bind files"
 filesets:
   files_rtl:
     depend:
@@ -11,20 +11,17 @@ filesets:
 
   files_dv:
     depend:
-      - lowrisc:dv:mbx_test
-      - lowrisc:dv:mbx_sva
-      - lowrisc:dv:mbx_cov
+      - lowrisc:dv:dv_utils
     files:
-      - tb.sv
+      - mbx_fsm_cov_if.sv
+      - mbx_host_cov_if.sv
+      - mbx_sys_cov_if.sv
+      - mbx_cov_if.sv
+      - mbx_cov_bind.sv
     file_type: systemVerilogSource
 
 targets:
-  sim: &sim_target
-    toplevel: tb
+  default:
     filesets:
       - files_rtl
       - files_dv
-    default_tool: vcs
-
-  lint:
-    <<: *sim_target

--- a/hw/ip/mbx/dv/cov/mbx_cov_bind.sv
+++ b/hw/ip/mbx/dv/cov/mbx_cov_bind.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binds MBX functional coverage interaface to the top level MBX module.
+module mbx_cov_bind;
+  // MBX _if coverage
+  bind mbx mbx_cov_if u_mbx_cov_if (.clk(clk_i));
+  bind mbx_hostif mbx_host_cov_if u_mbx_cov_hostif (.clk(clk_i), .reg2hw, .hw2reg);
+  bind mbx_sysif mbx_sys_cov_if u_mbx_cov_sysif (.clk(clk_i), .reg2hw, .hw2reg);
+
+  // MBX FSM coverage
+  bind mbx_fsm mbx_fsm_cov_if u_mbx_fsm_cov_if (.*);
+
+  //FIXME: Review, cip_lc_tx/cip_mubi
+
+endmodule

--- a/hw/ip/mbx/dv/cov/mbx_cov_if.sv
+++ b/hw/ip/mbx/dv/cov/mbx_cov_if.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface mbx_cov_if
+(
+  input              clk
+);
+  `include "dv_fcov_macros.svh"
+  //FIXME: add mbx top functional coverage
+
+endinterface

--- a/hw/ip/mbx/dv/cov/mbx_fsm_cov_if.sv
+++ b/hw/ip/mbx/dv/cov/mbx_fsm_cov_if.sv
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Implements functional coverage for MBX FSM
+
+typedef enum logic [2:0] {
+  MbxIdle          = 3'b000,
+  MbxWrite         = 3'b001,
+  MbxWaitFinalWord = 3'b010,
+  MbxRead          = 3'b011,
+  MbxError         = 3'b100,
+  MbxSysAbortHost  = 3'b101
+} mbx_ctrl_state_e;
+
+interface mbx_fsm_cov_if
+(
+  input logic clk_i,
+  input logic rst_ni,
+  input mbx_ctrl_state_e fsm_state_d,
+  input mbx_ctrl_state_e fsm_state_q,
+  input logic hostif_abort_ack_i,
+  input logic sysif_control_abort_set_i,
+  input logic mbx_error_set_i,
+  input logic mbx_error_set_o
+);
+  `include "dv_fcov_macros.svh"
+
+  covergroup mbx_fsm_cg @(posedge clk_i);
+    fsm_state_q_cp: coverpoint fsm_state_q {
+      bins MbxIdle = {MbxIdle};
+      bins MbxWrite = {MbxWrite};
+      bins MbxWaitFinalWord = {MbxWaitFinalWord};
+      bins MbxRead = {MbxRead};
+      bins MbxError = {MbxError};
+      bins MbxSysAbortHost = {MbxSysAbortHost};
+      bins IllegalEncoding = default;
+
+      //FIXME: populabe MBX FSM ctrl state arcs
+      bins arcs[] =
+        (MbxIdle => MbxWrite),
+        (MbxIdle => MbxRead),
+        (MbxRead => MbxError),
+        (MbxWrite => MbxError);
+    }
+
+    //FIXME: review
+    hostif_abort_ack_i_cp: coverpoint hostif_abort_ack_i;
+    sysif_control_abort_set_i_cp: coverpoint sysif_control_abort_set_i;
+
+    //FIXME: Review cross
+    hostif_abort_ack_state_xp: cross hostif_abort_ack_i_cp, fsm_state_q;
+    sysif_control_abort_set_state_xp: cross sysif_control_abort_set_i_cp, fsm_state_q;
+
+  endgroup
+
+  `DV_FCOV_INSTANTIATE_CG(mbx_fsm_cg)
+endinterface

--- a/hw/ip/mbx/dv/cov/mbx_host_cov_if.sv
+++ b/hw/ip/mbx/dv/cov/mbx_host_cov_if.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface mbx_host_cov_if
+  import mbx_reg_pkg::*;
+(
+  input              clk,
+  input mbx_core_reg2hw_t reg2hw,
+  input mbx_core_hw2reg_t hw2reg 
+);
+  `include "dv_fcov_macros.svh"
+  //FIXME: add mbx top functional coverage
+
+endinterface

--- a/hw/ip/mbx/dv/cov/mbx_sys_cov_if.sv
+++ b/hw/ip/mbx/dv/cov/mbx_sys_cov_if.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface mbx_sys_cov_if
+  import mbx_reg_pkg::*;
+(
+  input              clk,
+  input mbx_soc_reg2hw_t reg2hw,
+  input mbx_soc_hw2reg_t hw2reg 
+);
+  `include "dv_fcov_macros.svh"
+  //FIXME: add mbx top functional coverage
+
+endinterface


### PR DESCRIPTION
First set of coverage files for MBX IP.

- [x] FSM Coverage
- [ ] SRAM occupancy Coverage
- [x] Configuration Register Coverage
- [ ] Address Ranges
- [ ] Error Scenarios Coverage
- [ ] TestPlan Updates: Coverage Descriptions, updated test descriptions.

First Pass Coverage files and commit. Pending push of commits with completion of items above. 