### PR TITLE
[regtool/rtl] Add missing CM annotations

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_sideload_key_ctrl.sv
@@ -60,6 +60,7 @@ module keymgr_sideload_key_ctrl import keymgr_pkg::*;(
 
   keymgr_sideload_e state_q, state_d;
 
+  // SEC_CM: SIDELOAD_CTRL.FSM.SPARSE
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
   `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, keymgr_sideload_e, StSideloadReset)

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -276,6 +276,7 @@ module kmac
   // Indicating AppIntf is active. This signal is used to check SW error
   logic app_active;
 
+  // SEC_CM: SW_CMD.CTRL.SPARSE
   // Command
   // sw_cmd is the command written by SW
   // checked_sw_cmd is checked in the kmac_errchk module.

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -68,6 +68,7 @@ package kmac_pkg;
   } key_len_e;
 
 
+  // SEC_CM: SW_CMD.CTRL.SPARSE
   // kmac_cmd_e defines the possible command sets that software issues via
   // !!CMD register. This is mainly to limit the error scenario that SW writes
   // multiple commands at once. Additionally they are sparse encoded to harden

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -419,6 +419,7 @@ module otbn_start_stop_control
   assign sec_wipe_addr_o = addr_cnt_q[4:0];
   `ASSERT(NoSecWipeAbove32Bit_A, addr_cnt_q[5] |-> (!sec_wipe_wdr_o && !sec_wipe_acc_urnd_o))
 
+  // SEC_CM: START_STOP_CTRL.STATE.CONSISTENCY
   // A check for spurious or dropped secure wipe requests.
   // We only expect to start a secure wipe when running.
   assign spurious_secure_wipe_req = secure_wipe_req_i & ~allow_secure_wipe;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -53,9 +53,10 @@ module rom_ctrl
   localparam int unsigned RomSizeWords = RomSizeByte >> 2;
   localparam int unsigned RomIndexWidth = vbits(RomSizeWords);
 
-  // DataWidth is normally 39, representing 32 bits of actual data plus 7 ECC check bits. If
-  // scrambling is disabled ("insecure mode"), we store a raw 32-bit image and generate ECC check
-  // bits on the fly.
+  // SEC_CM: CTRL.MEM.INTEGRITY
+  // DataWidth is normally 39, representing 32 bits of actual data plus 7 ECC check bits for the bus
+  // end-to-end integrity scheme. If scrambling is disabled("insecure mode"), we store a raw 32-bit
+  // image and generate ECC check bits on the fly.
   localparam int unsigned DataWidth = SecDisableScrambling ? 32 : 39;
 
   mubi4_t                   rom_select_bus;


### PR DESCRIPTION
This fixes #20887.

Note that #10071 can only be closed once all autogen'd IPs have been transitioned to IPGen, since the annotation checker does not look in the right RTL locations otherwise. I.e., there are some IPs like `pinmux` which are correctly annotated, but will fail since the top-specific Hjson resides in a different subtree than the associated RTL (which will be fixes once transitioned to IPGen).