### PR TITLE
[bazel] Fix static library link rule

### DIFF
--- a/rules/opentitan/static_library.bzl
+++ b/rules/opentitan/static_library.bzl
@@ -11,8 +11,8 @@ load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@lowrisc_opentitan//rules:rv.bzl", "rv_rule")
 
 def _ot_static_library_impl(ctx):
-    output_lib = ctx.actions.declare_file("{}.a".format(ctx.attr.name))
-    output_flags = ctx.actions.declare_file("{}.link".format(ctx.attr.name))
+    output_lib = ctx.actions.declare_file("lib{}.a".format(ctx.attr.name))
+    output_flags = ctx.actions.declare_file("lib{}.link".format(ctx.attr.name))
 
     cc_toolchain = find_cc_toolchain(ctx).cc
 


### PR DESCRIPTION
1. Cause the static library rule to emit a library with the the filename `lib{name}.a`, where `{name}` is the rule's name.