### PR TITLE
[spi_host,rtl] Factor the byte_sel block into TX FIFO status signals

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -236,8 +236,7 @@
         { bits: "28",
           name: "TXEMPTY",
           desc: '''When high, indicates that the transmit data fifo is empty.
-                   Note, one transmit item can be pending in the internal transmit datapath (inside the spi_host_byte_select module).
-                   This means the transmit data fifo is empty and TXEMTPY will be high, while there is still one packet that needs to be transmitted.'''
+                '''
           resval: "0x0"
         },
         { bits: "27"
@@ -300,7 +299,6 @@
           desc: '''Transmit queue depth.
                    Indicates how many unsent 32-bit words are currently in the TX FIFO.
                    When active, this result may be an overestimate due to synchronization delays.
-                   It may also be an underestimate by 1 because of one pending transmit packet in the internal transmit datapath (inside the spi_host_byte_select module).
                 ''',
           resval: "0x0"
         }

--- a/hw/ip/spi_host/doc/registers.md
+++ b/hw/ip/spi_host/doc/registers.md
@@ -150,85 +150,23 @@ Status register
 {"reg": [{"name": "TXQD", "bits": 8, "attr": ["ro"], "rotate": 0}, {"name": "RXQD", "bits": 8, "attr": ["ro"], "rotate": 0}, {"name": "CMDQD", "bits": 4, "attr": ["ro"], "rotate": 0}, {"name": "RXWM", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 1}, {"name": "BYTEORDER", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "RXSTALL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "RXEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "RXFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TXWM", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TXSTALL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TXEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TXFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ACTIVE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "READY", "bits": 1, "attr": ["ro"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                            |
-|:------:|:------:|:-------:|:--------------------------------|
-|   31   |   ro   |   0x0   | [READY](#status--ready)         |
-|   30   |   ro   |   0x0   | [ACTIVE](#status--active)       |
-|   29   |   ro   |   0x0   | [TXFULL](#status--txfull)       |
-|   28   |   ro   |   0x0   | [TXEMPTY](#status--txempty)     |
-|   27   |   ro   |   0x0   | [TXSTALL](#status--txstall)     |
-|   26   |   ro   |   0x0   | [TXWM](#status--txwm)           |
-|   25   |   ro   |   0x0   | [RXFULL](#status--rxfull)       |
-|   24   |   ro   |   0x0   | [RXEMPTY](#status--rxempty)     |
-|   23   |   ro   |   0x0   | [RXSTALL](#status--rxstall)     |
-|   22   |   ro   |   0x0   | [BYTEORDER](#status--byteorder) |
-|   21   |        |         | Reserved                        |
-|   20   |   ro   |   0x0   | [RXWM](#status--rxwm)           |
-| 19:16  |   ro   |   0x0   | [CMDQD](#status--cmdqd)         |
-|  15:8  |   ro   |   0x0   | [RXQD](#status--rxqd)           |
-|  7:0   |   ro   |   0x0   | [TXQD](#status--txqd)           |
-
-### STATUS . READY
-When high, indicates the SPI host is ready to receive
-   commands. Writing to COMMAND when READY is low is
-   an error, and will trigger an interrupt.
-
-### STATUS . ACTIVE
-When high, indicates the SPI host is processing a previously
-   issued command.
-
-### STATUS . TXFULL
-When high, indicates that the transmit data fifo is full.
-   Any further writes to [`RXDATA`](#rxdata) will create an error interrupt.
-
-### STATUS . TXEMPTY
-When high, indicates that the transmit data fifo is empty.
-   Note, one transmit item can be pending in the internal transmit datapath (inside the spi_host_byte_select module).
-   This means the transmit data fifo is empty and TXEMTPY will be high, while there is still one packet that needs to be transmitted.
-
-### STATUS . TXSTALL
-If high, signifies that an ongoing transaction has stalled
-   due to lack of data in the TX FIFO
-
-### STATUS . TXWM
-If high, the amount of data in the TX FIFO has fallen below the
-   level of [`CONTROL.TX_WATERMARK`](#control) words (32b each).
-
-### STATUS . RXFULL
-When high, indicates that the receive fifo is full.  Any
-   ongoing transactions will stall until firmware reads some
-   data from [`RXDATA.`](#rxdata)
-
-### STATUS . RXEMPTY
-When high, indicates that the receive fifo is empty.
-   Any reads from RX FIFO will cause an error interrupt.
-
-### STATUS . RXSTALL
-If high, signifies that an ongoing transaction has stalled
-   due to lack of available space in the RX FIFO
-
-### STATUS . BYTEORDER
-The value of the ByteOrder parameter, provided so that firmware
-   can confirm proper IP configuration.
-
-### STATUS . RXWM
-If high, the number of 32-bits in the RX FIFO now exceeds the
-   [`CONTROL.RX_WATERMARK`](#control) entries (32b each).
-
-### STATUS . CMDQD
-Command queue depth. Indicates how many unread 32-bit words are
-   currently in the command segment queue.
-
-### STATUS . RXQD
-Receive queue depth. Indicates how many unread 32-bit words are
-   currently in the RX FIFO.  When active, this result may an
-   underestimate due to synchronization delays.
-
-### STATUS . TXQD
-Transmit queue depth.
-   Indicates how many unsent 32-bit words are currently in the TX FIFO.
-   When active, this result may be an overestimate due to synchronization delays.
-   It may also be an underestimate by 1 because of one pending transmit packet in the internal transmit datapath (inside the spi_host_byte_select module).
+|  Bits  |  Type  |  Reset  | Name      | Description                                                                                                                                                               |
+|:------:|:------:|:-------:|:----------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   31   |   ro   |   0x0   | READY     | When high, indicates the SPI host is ready to receive commands. Writing to COMMAND when READY is low is an error, and will trigger an interrupt.                          |
+|   30   |   ro   |   0x0   | ACTIVE    | When high, indicates the SPI host is processing a previously issued command.                                                                                              |
+|   29   |   ro   |   0x0   | TXFULL    | When high, indicates that the transmit data fifo is full. Any further writes to [`RXDATA`](#rxdata) will create an error interrupt.                                       |
+|   28   |   ro   |   0x0   | TXEMPTY   | When high, indicates that the transmit data fifo is empty.                                                                                                                |
+|   27   |   ro   |   0x0   | TXSTALL   | If high, signifies that an ongoing transaction has stalled due to lack of data in the TX FIFO                                                                             |
+|   26   |   ro   |   0x0   | TXWM      | If high, the amount of data in the TX FIFO has fallen below the level of [`CONTROL.TX_WATERMARK`](#control) words (32b each).                                             |
+|   25   |   ro   |   0x0   | RXFULL    | When high, indicates that the receive fifo is full.  Any ongoing transactions will stall until firmware reads some data from [`RXDATA.`](#rxdata)                         |
+|   24   |   ro   |   0x0   | RXEMPTY   | When high, indicates that the receive fifo is empty. Any reads from RX FIFO will cause an error interrupt.                                                                |
+|   23   |   ro   |   0x0   | RXSTALL   | If high, signifies that an ongoing transaction has stalled due to lack of available space in the RX FIFO                                                                  |
+|   22   |   ro   |   0x0   | BYTEORDER | The value of the ByteOrder parameter, provided so that firmware can confirm proper IP configuration.                                                                      |
+|   21   |        |         |           | Reserved                                                                                                                                                                  |
+|   20   |   ro   |   0x0   | RXWM      | If high, the number of 32-bits in the RX FIFO now exceeds the [`CONTROL.RX_WATERMARK`](#control) entries (32b each).                                                      |
+| 19:16  |   ro   |   0x0   | CMDQD     | Command queue depth. Indicates how many unread 32-bit words are currently in the command segment queue.                                                                   |
+|  15:8  |   ro   |   0x0   | RXQD      | Receive queue depth. Indicates how many unread 32-bit words are currently in the RX FIFO.  When active, this result may an underestimate due to synchronization delays.   |
+|  7:0   |   ro   |   0x0   | TXQD      | Transmit queue depth. Indicates how many unsent 32-bit words are currently in the TX FIFO. When active, this result may be an overestimate due to synchronization delays. |
 
 ## CONFIGOPTS
 Configuration options register.

--- a/hw/ip/spi_host/doc/theory_of_operation.md
+++ b/hw/ip/spi_host/doc/theory_of_operation.md
@@ -431,7 +431,6 @@ The SPI_HOST supports interrupts for the following SPI events:
 - `RXFULL`: The SPI_HOST has run out of room in the RXFIFO.
 - `RXWM`: The number of 32-bit words in the RXFIFO currently exceeds the value set in [`CONTROL.RX_WATERMARK`](registers.md#control).
 - `TXEMPTY`: The SPI_HOST has transmitted all the data in the TX FIFO.
-  Note the transmit FIFO may be empty while there is still one packet pending in the internal transmit datapath (inside the `spi_host_byte_select` module).
 - `TXWM`: The number of 32-bit words in the TX FIFO currently is currently less than the value set in [`CONTROL.TX_WATERMARK`](registers.md#control)
 
 Most SPI events signal a particular condition that persists until it is fixed, and these conditions can be detected by polling the corresponding field in the [`STATUS`](registers.md#status) register.
@@ -546,7 +545,11 @@ The RX and TX FIFOs store the transmitted and received data, which are stored in
 The RX FIFO is 32 bits wide, matching the width of the TLUL register bus.
 The TX FIFO on the other hand is 36 bits wide, with 32 bits of SPI data (again to match the TLUL bus width) plus 4 byte enable-bits, which are passed into the core to allow the processing of unaligned writes.
 
-The depth of these FIFOs is controlled by two independent parameters for the RX and TX queues.
+The depth of these FIFOs is controlled by two independent parameters for the RX and TX queues, .
+
+Note that the [`Byte Select`](#byte-select) module greedily pops data from the TX FIFO, so the fifo is observed as having an effective depth of N+1 where N is the parameterized depth.
+This extra word of data is incorporated into the TX FIFO status signals, and is also reset/cleared in tandem with the fifo.
+Therefore, this extra storage is transparent to software.
 
 ## Byte Select
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_event_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_event_vseq.sv
@@ -33,7 +33,7 @@ class spi_host_event_vseq extends spi_host_tx_rx_vseq;
     program_spi_host_regs();
     check_event(ral.status.ready, 1, 1);
 
-    while (segms_words <=  spi_host_ctrl_reg.tx_watermark)  begin
+    while (segms_words < spi_host_ctrl_reg.tx_watermark) begin
       gen_trans();
     end
     check_event(ral.status.txwm, 0, 0);

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -312,6 +312,7 @@ module spi_host
   logic [3:0]  core_tx_be;
   logic        core_tx_valid;
   logic        core_tx_ready;
+  logic        core_tx_byte_select_full;
 
   logic [31:0] core_rx_data;
   logic        core_rx_valid;
@@ -391,36 +392,37 @@ module spi_host
     .clk_i,
     .rst_ni,
 
-    .tx_data_i         (tx_data),
-    .tx_be_i           (tx_be),
-    .tx_valid_i        (tx_valid_checked),
-    .tx_ready_o        (tx_ready),
-    .tx_watermark_i    (tx_watermark),
+    .tx_data_i                  (tx_data),
+    .tx_be_i                    (tx_be),
+    .tx_valid_i                 (tx_valid_checked),
+    .tx_ready_o                 (tx_ready),
+    .tx_watermark_i             (tx_watermark),
 
-    .core_tx_data_o    (core_tx_data),
-    .core_tx_be_o      (core_tx_be),
-    .core_tx_valid_o   (core_tx_valid),
-    .core_tx_ready_i   (core_tx_ready),
+    .core_tx_data_o             (core_tx_data),
+    .core_tx_be_o               (core_tx_be),
+    .core_tx_valid_o            (core_tx_valid),
+    .core_tx_ready_i            (core_tx_ready),
+    .core_tx_byte_select_full_i (core_tx_byte_select_full),
 
-    .core_rx_data_i    (core_rx_data),
-    .core_rx_valid_i   (core_rx_valid),
-    .core_rx_ready_o   (core_rx_ready),
+    .core_rx_data_i             (core_rx_data),
+    .core_rx_valid_i            (core_rx_valid),
+    .core_rx_ready_o            (core_rx_ready),
 
-    .rx_data_o         (rx_data),
-    .rx_valid_o        (rx_valid),
-    .rx_ready_i        (rx_ready),
-    .rx_watermark_i    (rx_watermark),
+    .rx_data_o                  (rx_data),
+    .rx_valid_o                 (rx_valid),
+    .rx_ready_i                 (rx_ready),
+    .rx_watermark_i             (rx_watermark),
 
-    .tx_empty_o        (tx_empty),
-    .tx_full_o         (tx_full),
-    .tx_qd_o           (tx_qd),
-    .tx_wm_o           (tx_wm),
-    .rx_empty_o        (rx_empty),
-    .rx_full_o         (rx_full),
-    .rx_qd_o           (rx_qd),
-    .rx_wm_o           (rx_wm),
+    .tx_empty_o                 (tx_empty),
+    .tx_full_o                  (tx_full),
+    .tx_qd_o                    (tx_qd),
+    .tx_wm_o                    (tx_wm),
+    .rx_empty_o                 (rx_empty),
+    .rx_full_o                  (rx_full),
+    .rx_qd_o                    (rx_qd),
+    .rx_wm_o                    (rx_wm),
 
-    .sw_rst_i          (sw_rst)
+    .sw_rst_i                   (sw_rst)
 );
 
   logic en_sw;
@@ -437,26 +439,27 @@ module spi_host
     .clk_i,
     .rst_ni,
 
-    .command_i       (core_command),
-    .command_valid_i (core_command_valid),
-    .command_ready_o (core_command_ready),
-    .en_i            (en),
-    .tx_data_i       (core_tx_data),
-    .tx_be_i         (core_tx_be),
-    .tx_valid_i      (core_tx_valid),
-    .tx_ready_o      (core_tx_ready),
-    .rx_data_o       (core_rx_data),
-    .rx_valid_o      (core_rx_valid),
-    .rx_ready_i      (core_rx_ready),
-    .sck_o           (sck),
-    .csb_o           (csb),
-    .sd_o            (sd_out),
-    .sd_en_o         (sd_en_core),
+    .command_i             (core_command),
+    .command_valid_i       (core_command_valid),
+    .command_ready_o       (core_command_ready),
+    .en_i                  (en),
+    .tx_data_i             (core_tx_data),
+    .tx_be_i               (core_tx_be),
+    .tx_valid_i            (core_tx_valid),
+    .tx_ready_o            (core_tx_ready),
+    .tx_byte_select_full_o (core_tx_byte_select_full),
+    .rx_data_o             (core_rx_data),
+    .rx_valid_o            (core_rx_valid),
+    .rx_ready_i            (core_rx_ready),
+    .sck_o                 (sck),
+    .csb_o                 (csb),
+    .sd_o                  (sd_out),
+    .sd_en_o               (sd_en_core),
     .sd_i,
-    .rx_stall_o      (rx_stall),
-    .tx_stall_o      (tx_stall),
-    .sw_rst_i        (sw_rst),
-    .active_o        (active)
+    .rx_stall_o            (rx_stall),
+    .tx_stall_o            (tx_stall),
+    .sw_rst_i              (sw_rst),
+    .active_o              (active)
   );
 
   logic event_error;

--- a/hw/ip/spi_host/rtl/spi_host_core.sv
+++ b/hw/ip/spi_host/rtl/spi_host_core.sv
@@ -20,6 +20,7 @@ module spi_host_core #(
   input        [3:0]                tx_be_i,
   input                             tx_valid_i,
   output logic                      tx_ready_o,
+  output logic                      tx_byte_select_full_o,
 
   output logic [31:0]               rx_data_o,
   output logic                      rx_valid_o,
@@ -87,6 +88,12 @@ module spi_host_core #(
     .flush_i      (tx_flush_sr),
     .sw_rst_i
   );
+  // The byte_select module greedily pops data from the TX FIFO, so
+  // the FIFO is observed as having an effective depth of N+1.
+  // The byte_valid_o signal indicates when the byte_select contains
+  // a valid word. Pass this on up to the TX FIFO to adjust the
+  // reported depth/full/empty flags.
+  assign tx_byte_select_full_o = tx_valid_sr;
 
   spi_host_shift_register u_shift_reg (
     .clk_i,


### PR DESCRIPTION
As the byte_select block greedily fetches TX words from the TX FIFO and is backpressured by the shift_register when outputting bytes, we can consider the byte_select to be effectively an N+1'th stage for the TX FIFO.

To avoid this storage being untracked from the perspective of software, use the byte_valid_o to augment the fifo status signals (tx_qd,txfull,txempty) so that they incorporate this extra word of data.

TODO:
- [x] Update docs to account for extra FIFO depth
- [x] Remove warnings introduced in https://github.com/lowRISC/opentitan/pull/18317


The DV around the `txqd` / `txwm` is quite limited, it would be good to add more robust checking into the scoreboard as a follow up to this change. 

Should close https://github.com/lowRISC/opentitan/issues/17644