### PR TITLE
[primgen] Uniquify prim_abstract core file

### DIFF
--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -434,7 +434,7 @@ def _generate_abstract_impl(gapi):
     # Create core file depending on all primitive implementations we have in the
     # techlibs.
     print("Creating core file for primitive %s." % (prim_name, ))
-    abstract_prim_core_filepath = os.path.abspath('prim_%s.core' % (prim_name))
+    abstract_prim_core_filepath = os.path.abspath('prim_abstract_%s.core' % (prim_name))
     dependencies = []
     dependencies.append('lowrisc:prim:prim_pkg')
     dependencies += [


### PR DESCRIPTION
Previously, there exist two core files named `prim_xyz.core` defining `lowrisc:prim:xyz` and `lowrisc:prim_abstract:xyz`. 

This PR uniquifies the filename for the second case to match the core  it defines.