### PR TITLE
[spi_host,rtl] Use sd_en_o[0] to only drive sd_o[0] during TX (Standard speed mode)

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -564,7 +564,7 @@ module spi_host_fsm
     end else begin
       unique case (speed_o)
         Standard: begin
-          sd_en_o[0]   = 1'b1;
+          sd_en_o[0]   = cmd_wr_en_q;
           sd_en_o[1]   = 1'b0;
           sd_en_o[3:2] = 2'b00;
         end


### PR DESCRIPTION
Change the behaviour as suggested/proposed in https://github.com/lowRISC/opentitan/issues/14969.

The fix suggested [here](https://github.com/lowRISC/opentitan/issues/14969#issuecomment-1501348019) does indeed seem to make logical sense, and after observing the waveforms I can see the expected masking behaviour.

TODO
- [x] ~~Broken block-level DV~~ (spi_host_speed, spi_host_spien)
<details>
  <summary>..failures appear to be just spurious, same as nightlies.</summary>

      There appears to be a sampling issue on the final bit of the final byte of a segment.
```
UVM_FATAL @ 373563549 ps: (spi_host_scoreboard.sv:155) uvm_test_top.env.scoreboard [uvm_test_top.env.scoreboard] 
	 WRITE: actual data did not match exp data 
|	 (len 4) 
|	 byte      actual     expected
|	 [0] 			 3 			 3
|	 [1] 			 37 			 37
|	 [2] 			 8a 			 8a
|	 [3] 			 cd 			 cc
```

</details>

Closes https://github.com/lowRISC/opentitan/issues/14969