### PR TITLE
[rom_ctrl,dv] Check returns of uvm_hdl_force/uvm_hdl_release

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -206,11 +206,13 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
               cfg.scoreboard.disable_rom_acc_chk = 0;
             end
             begin
+              string rom_idx_path = "tb.dut.bus_rom_rom_index";
+
               wait (cfg.m_tl_agent_cfgs["rom_ctrl_rom_reg_block"].vif.h2d.a_valid);
               $assertoff(0, "tb.dut.BusRomIndicesMatch_A");
-              uvm_hdl_force("tb.dut.bus_rom_rom_index", corr_bus_rom_rom_index_val);
+              `DV_CHECK(uvm_hdl_force(rom_idx_path, corr_bus_rom_rom_index_val));
               wait (!cfg.m_tl_agent_cfgs["rom_ctrl_rom_reg_block"].vif.h2d.a_valid);
-              uvm_hdl_release("tb.dut.bus_rom_rom_index");
+              `DV_CHECK(uvm_hdl_release(rom_idx_path));
             end
           join
         end
@@ -247,18 +249,10 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
       @(negedge cfg.clk_rst_vif.clk);
   endtask: wait_with_bound
 
-  task chk_hdl_path(string path);
-    if(!uvm_hdl_check_path(path))
-      begin
-        `uvm_fatal("PATH NOT FOUND", $sformatf("%s", path))
-      end
-  endtask: chk_hdl_path
-
   task force_sig(string path, int value);
-    chk_hdl_path(path);
-    uvm_hdl_force(path, value);
+    `DV_CHECK(uvm_hdl_force(path, value));
     @(negedge cfg.clk_rst_vif.clk);
-    uvm_hdl_release(path);
+    `DV_CHECK(uvm_hdl_release(path));
   endtask: force_sig
 
   task chk_fsm_state();


### PR DESCRIPTION
This avoids a warning from Xcelium. Doing so also means that we don't have to bother with the call to uvm_hdl_check_path, since the uvm_hdl_force call will return 0 if the path is invalid.