### PR TITLE
[rom_ctrl,dv] Minor tidy-up in rom_ctrl vseqs

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
@@ -8,26 +8,12 @@ class rom_ctrl_kmac_err_chk_vseq extends rom_ctrl_base_vseq;
   `uvm_object_new
 
   task body();
-    bit [$bits(rom_ctrl_pkg::fsm_state_e)-1:0] rdata_state;
-    uvm_reg_data_t act_val;
-
     cfg.m_kmac_agent_cfg.error_rsp_pct = 100;
 
     wait(cfg.m_kmac_agent_cfg.vif.mon_cb.rsp_done);
 
-    cfg.scoreboard.set_exp_alert("fatal", .is_fatal(1'b1));
-    fork
-      begin
-        ral.fatal_alert_cause.predict(.value('b1), .kind(UVM_PREDICT_READ), .be(4'hF));
-        wait_alert_trigger ("fatal", .wait_complete(1));
-        csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
-      end
-      begin
-        repeat(3) wait_alert_trigger ("fatal", .wait_complete(1));
-      end
-    join
-    uvm_hdl_read("tb.dut.gen_fsm_scramble_enabled.u_checker_fsm.state_q", rdata_state);
-    `DV_CHECK_EQ(rdata_state, rom_ctrl_pkg::Invalid)
+    wait_for_fatal_alert(.max_delay(0), .max_wait_cycle(7));
+
     `DV_CHECK_EQ(cfg.rom_ctrl_vif.pwrmgr_data.done, MuBi4False)
     cfg.m_kmac_agent_cfg.error_rsp_pct = 0;
     dut_init();


### PR DESCRIPTION
This PR has three commits, but the first two are actually from separate PRs, which should be merged first (#21335 and #21336). The commit message for the last commit (the reason for this PR) is below:

The main change here was in `rom_ctrl_corrupt_sig_fatal_chk_vseq`, where
I've squashed the contents of the `chk_fsm_state` task into the
`check_for_alert` task. This means that we can combine the explicit
calls to the two tasks that appeared in that vseq.

I suspect that the original author intended to do the FSM state check
every time, but the code didn't quite do that. In this commit, I'm
using a `check_fsm_state` argument in order to reproduce the behaviour
that we have.

It turns out that the contents of this task were also inlined in
`rom_ctrl_kmac_err_chk_vseq`. To get rid of the duplication, I've moved
the task into the base vseq and used it in both places.

There are some small differences (number of wait cycles in two
places). I've passed them as an argument to the task and made the
default be the value that was used at most of the call sites.

To make things a bit clearer, I've also been explicit on how
the (default) `check=UVM_CHECK` argument to `csr_rd` makes the call to
`uvm_reg::predict()` do something.

Finally, that return value from predict() gets cast to void. This
return value will be 1 to say that the prediction did something and
Xcelium produces warnings about an ignored return value if there's no
cast.
