### PR TITLE
[csr_seq_lib] Avoid slicing a queue

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -88,12 +88,13 @@ class csr_base_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item));
     end_idx = test_csr_chunk * chunk_size;
     if (end_idx >= all_csrs.size()) end_idx = all_csrs.size() - 1;
 
-    test_csrs = all_csrs[start_idx:end_idx];
     `uvm_info(`gtn, $sformatf("Testing %0d csrs [%0d - %0d] in all supplied models.",
                               test_csrs.size(), start_idx, end_idx), UVM_MEDIUM)
-    foreach (test_csrs[i]) begin
-      `uvm_info(`gtn, $sformatf("Testing CSR %0s, reset: 0x%0x.", test_csrs[i].get_full_name(),
-                                test_csrs[i].get_mirrored_value()), UVM_HIGH)
+    test_csrs.delete();
+    for (int i = start_idx; i <= end_idx; i++) begin
+      test_csrs.push_back(all_csrs[i]);
+      `uvm_info(`gtn, $sformatf("Testing CSR %0s, reset: 0x%0x.", all_csrs[i].get_full_name(),
+                                all_csrs[i].get_mirrored_value()), UVM_HIGH)
     end
     test_csrs.shuffle();
   endfunction


### PR DESCRIPTION
Here, all_csrs is a queue and SystemVerilog doesn't technically allow the part-select that we were using when we created test_csrs.

Fortunately, it does allow access by index, so we can sort of build the subsequence by hand, which is what this commit does.

This avoids the *W,RTSVQR warning from Xcelium.