### PR TITLE
[rom_ctrl,dv] Start CSR accesses later in passthru_mem_tl_intg_err

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -10,6 +10,10 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
   }
   `uvm_object_new
 
+  // If this flag is set, we will wait a short time after coming out of reset to allow the DUT to
+  // finish its start-up sequence and become available for TL accesses.
+  bit pause_after_dut_init = 1'b0;
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body
@@ -36,5 +40,38 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
     super.check_sec_cm_fi_resp(if_proxy);
     `DV_CHECK_EQ(cfg.rom_ctrl_vif.checker_fsm_state, rom_ctrl_pkg::Invalid)
   endtask : check_sec_cm_fi_resp
+
+  // Wait while the dut's checker FSM is in the "ReadingLow" state. This waits the bulk of the time
+  // after reset and will finish when the dut is almost ready to start handling TL transactions.
+  virtual task wait_while_reading_low();
+    while (cfg.rom_ctrl_vif.checker_fsm_state == rom_ctrl_pkg::ReadingLow) begin
+      #1000ns;
+    end
+  endtask
+
+  // A slightly tweaked version of the base dut_init which obeys pause_after_dut_init
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+
+    if (pause_after_dut_init) begin
+      wait_while_reading_low();
+    end
+  endtask
+
+  // This task is defined in cip_base_vseq. It tries to run some TL accesses and injects integrity
+  // errors in parallel. To make it work for rom_ctrl, we need to wait a bit for the DUT to be ready
+  // for TL accesses.
+  virtual task run_passthru_mem_tl_intg_err_vseq(int num_times = 1);
+    wait_while_reading_low();
+    pause_after_dut_init = 1'b1;
+
+    // Waiting like this takes quite a while, so running with a large value of num_times will cause
+    // the test to fail with a UVM phase timeout. Rather than overriding the test_timeout_ns
+    // argument in dv_base_test.sv, we have a simple bodge to divide the count down to something
+    // that takes a similar time to the other blocks.
+    num_times = (num_times + 3) / 4;
+
+    super.run_passthru_mem_tl_intg_err_vseq(num_times);
+  endtask
 
 endclass


### PR DESCRIPTION
I suspect that there will be several sequences which could use this change. This is just meant to be an easy framework to implement the same thing for other sequences.

The change in this commit avoids two timeouts:

(1) If you try to start a CSR access right after coming out of reset,
    you crash into a timeout in csr_spinwait. This timeout is
    default_spinwait_timeout_ns and is configured in csr_utils_pkg.sv
    with an initial value of 10ms.

(2) If you wait a little after coming out of reset to avoid *that*

    timeout, you crash into a timeout for the run phase (20ms). One
    solution would be to increase that timeout but that seems a bit
    tricky and I suspect it shows that we're using UVM in a slightly
    unconventional way here.

    A simpler bodge is to run fewer iterations of the test, so that's
    what I've done in this commit.