### PR TITLE
[rom, rom_ext] Re-arrange retention RAM

### DIFF
--- a/sw/device/silicon_creator/lib/boot_log.c
+++ b/sw/device/silicon_creator/lib/boot_log.c
@@ -43,7 +43,7 @@ void boot_log_digest_update(boot_log_t *boot_log) {
 
 static const uint32_t kCheckShares[kHmacDigestNumWords + 1] = {
     0x7b00d08e, 0xfdb69374, 0x336c86df, 0xff2ef417, 0xe1517012,
-    0x4bf5408c, 0x9c6a7b25, 0xf771f8fa, 0xcd458605,
+    0x4bf5408c, 0x9c6a7b25, 0xf771f8fa, 0xcd468505,
 };
 
 rom_error_t boot_log_check(const boot_log_t *boot_log) {

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -23,7 +23,7 @@ extern "C" {
 typedef struct boot_log {
   /** Digest to indicate validity of the boot_log. */
   hmac_digest_t digest;
-  /** Identifier (`BOLG`). */
+  /** Identifier (`BLOG`). */
   uint32_t identifier;
   /** Chip version (from the ROM). */
   chip_info_scm_revision_t chip_version;
@@ -56,9 +56,9 @@ OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 68);
 
 enum {
   /**
-   * Boot log identifier value (ASCII "BOLG").
+   * Boot log identifier value (ASCII "BLOG").
    */
-  kBootLogIdentifier = 0x474c4f42,
+  kBootLogIdentifier = 0x474f4c42,
 
   /**
    * Boot Slot designators


### PR DESCRIPTION
Re-arrange the retention RAM as discussed in the SW WG meeting on 2024-02-13:

Locate the boot_svc message first, followed by reserved space, followed by the boot_log and last_shutdown_reason. This arrangement allows us to grow the boot_svc message (growing "down" into the reserved space) if needed and to add additional fields at the end (growing "up" into the reserved space).