### PR TITLE
[opentitanlib] Address upcoming lints, UartKey comparison fix.

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -57,8 +57,9 @@ impl Default for StagedProgressBar {
 }
 
 impl StagedProgressBar {
-    const DEFAULT_TEMPLATE: &str = "[{elapsed_precise}] [{wide_bar}] {bytes}/{total_bytes} ({eta})";
-    const STAGE_TEMPLATE: &str =
+    const DEFAULT_TEMPLATE: &'static str =
+        "[{elapsed_precise}] [{wide_bar}] {bytes}/{total_bytes} ({eta})";
+    const STAGE_TEMPLATE: &'static str =
         "{msg}: [{elapsed_precise}] [{wide_bar}] {bytes}/{total_bytes} ({eta})";
 
     pub fn new() -> Self {

--- a/sw/host/opentitanlib/src/rescue/xmodem.rs
+++ b/sw/host/opentitanlib/src/rescue/xmodem.rs
@@ -199,8 +199,7 @@ impl Xmodem {
             let cancel = block != bnum || bnum != 255 - bcom;
 
             // The next `block_len` bytes are the packet itself.
-            let mut buffer = Vec::new();
-            buffer.resize(block_len, 0);
+            let mut buffer = vec![0; block_len];
             let mut total = 0;
             while total < block_len {
                 let n = uart.read(&mut buffer[total..])?;


### PR DESCRIPTION
Address compiler lints from `nightly-2024-01-01`. This will enable updating the nightly Rust toolchain.

One of those lints points out that `proxy::nonblocking_uart::UartKey` compares wide pointers including metadata. Instead, UartKey should only consider the address portion of the pointer. This adjust UartKey's Hash and PartialEq implementations to only consider the address portion of the pointer, and adds a test for the Hash implementation.