### PR TITLE
[otp_ctrl] Fix OTP_CTRL enums

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -168,7 +168,7 @@ module otp_ctrl_dai
   always_comb begin
     otp_err = otp_err_e'(otp_err_i);
     if (!PartInfo[part_idx].integrity &&
-        otp_err_i inside {MacroEccCorrError, MacroEccUncorrError}) begin
+        otp_err_e'(otp_err_i) inside {MacroEccCorrError, MacroEccUncorrError}) begin
       otp_err = NoError;
     end
   end

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -194,7 +194,7 @@ module otp_ctrl_part_buf
   end else begin : gen_no_integrity
     assign otp_cmd_o = prim_otp_pkg::ReadRaw;
     always_comb begin
-      if (otp_err_i inside {MacroEccCorrError, MacroEccUncorrError}) begin
+      if (otp_err_e'(otp_err_i) inside {MacroEccCorrError, MacroEccUncorrError}) begin
         otp_err = NoError;
       end else begin
         otp_err = otp_err_e'(otp_err_i);

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -150,7 +150,7 @@ module otp_ctrl_part_unbuf
   end else begin : gen_no_integrity
     assign otp_cmd_o = prim_otp_pkg::ReadRaw;
     always_comb begin
-      if (otp_err_i inside {MacroEccCorrError, MacroEccUncorrError}) begin
+      if (otp_err_e'(otp_err_i) inside {MacroEccCorrError, MacroEccUncorrError}) begin
         otp_err = NoError;
       end else begin
         otp_err = otp_err_e'(otp_err_i);


### PR DESCRIPTION
This fixes an error due to a comparison between different enum types. We can use casting here since the error patterns in question have the same encodings in both enums.