### PR TITLE
[ci] Enable writing to the bitstream cache in sival

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -522,7 +522,7 @@ jobs:
     - chip_earlgrey_cw310
     - chip_earlgrey_cw310_hyperdebug
     - chip_earlgrey_cw340
-  condition: eq(variables['Build.SourceBranchName'], 'master')
+  condition: eq(variables['Build.SourceBranchName'], 'earlgrey_es_sival')
   steps:
     - template: ci/download-artifacts-template.yml
       parameters:
@@ -540,7 +540,7 @@ jobs:
           - "$BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug/manifest.json"
           - "$BIN_DIR/hw/top_earlgrey/chip_earlgrey_cw340/manifest.json"
         gcpKeyFile: "gcpkey.json"
-        bucketURI: "gs://opentitan-bitstreams/master"
+        bucketURI: "gs://opentitan-bitstreams/earlgrey_es_sival"
 
 - job: execute_test_rom_fpga_tests_cw310
   displayName: CW310 Test ROM Tests


### PR DESCRIPTION
This PR enables the `earlgrey_es_sival` branch to write bitstreams to the cache.

I'm not sure if this will actually work:

* I haven't tracked where the GCP key is downloaded for this job just yet.
* The bucket it's writing to is still `bucketURI: "gs://opentitan-bitstreams/master"` - will this cause issues?