### PR TITLE
[pentest] Add FI Ibex RF tests

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
@@ -13,6 +13,8 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj);
 status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj);
 status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj);
 status_t handle_ibex_fi_init_trigger(ujson_t *uj);
+status_t handle_ibex_fi_char_register_file(ujson_t *uj);
+status_t handle_ibex_fi_char_register_file_read(ujson_t *uj);
 status_t handle_ibex_fi(ujson_t *uj);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_IBEX_FI_H_

--- a/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
@@ -16,8 +16,15 @@ extern "C" {
     value(_, CharUnrolledRegOpLoop) \
     value(_, CharRegOpLoop) \
     value(_, CharUnrolledMemOpLoop) \
-    value(_, CharMemOpLoop)
+    value(_, CharMemOpLoop) \
+    value(_, CharRegisterFile) \
+    value(_, CharRegisterFileRead)
 UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
+
+#define IBEXFI_TEST_RESULT(field, string) \
+    field(result, uint32_t) \
+    field(err_status, uint32_t)
+UJSON_SERDE_STRUCT(IbexFiTestResult, ibex_fi_test_result_t, IBEXFI_TEST_RESULT);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \


### PR DESCRIPTION
This PR adds new penetration tests targeting the register file (RF) of Ibex:
- ibex_fi_char_register_file: Test whether a fault can manipulate values in the RF
- ibex_fi_char_register_file_read: Test whether a fault during reading the RF can manipulate values. This is related to #20715