### PR TITLE
[ott] Remove UUCP-style locking for serial ports

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -27,7 +27,7 @@ use crate::io::uart::Uart;
 use crate::transport::chip_whisperer::board::Board;
 use crate::transport::chip_whisperer::ChipWhisperer;
 use crate::transport::common::fpga::{ClearBitstream, FpgaProgram};
-use crate::transport::common::uart::{flock_serial, SerialPortExclusiveLock};
+use crate::transport::common::uart::flock_serial;
 use crate::transport::{
     Capabilities, Capability, Transport, TransportError, TransportInterfaceType, UpdateFirmware,
 };
@@ -485,7 +485,6 @@ impl Inner {
             .console_tty
             .to_str()
             .ok_or(TransportError::UnicodePathError)?;
-        let _lock = SerialPortExclusiveLock::lock(port_name)?;
         let mut port = TTYPort::open(
             &serialport::new(port_name, 115_200).timeout(std::time::Duration::from_millis(100)),
         )


### PR DESCRIPTION
OpenTitanTool creates two locks for serial ports: a `flock` and a UUCP-style `/var/lock/LCK..ttyUSB{n}` file.

From what I can tell, we support UUCP locks for compatability with `minicom` which doesn't use `flock`. This lockfile is left behind very often by OTT, though we're not sure why. On shared machines, OTT is unable to clean up stale locks because `/var/lock/` has a stick bit set which prevents other users deleting files.

We think that the hassle this causes is not worth the compatability with `minicom`. If you use `minicom` and are having trouble with concurrent access, I would recommend other tools that support `flock` such as `picocom`. Please let me know if you do use `minicom` regularly and don't want to lose this support - we can come up with some other solution.