### PR TITLE
[usbdev,sival] Implement usbdev_aon_wake_reset

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -364,7 +364,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_aon_wake_reset"]
     }
     {
       name: chip_sw_usbdev_aon_wake_disconnect

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3479,6 +3479,37 @@ opentitan_test(
     ],
 )
 
+# This test requires that the harness has sufficient permissions to
+# open the USB parent hub of the device under test so it can issue
+# requests directly. For this reason, the test is tagged as manual
+# until the CI can provide such an access.
+opentitan_test(
+    name = "usbdev_aon_wake_reset_test",
+    srcs = ["usbdev_aon_wake_reset_test.c"],
+    cw310 = new_cw310_params(
+        tags = ["manual"],
+        test_cmd = """
+            --bitstream="{bitstream}"
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
+    ),
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:usb_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 opentitan_test(
     name = "usbdev_setuprx_test",
     srcs = ["usbdev_setuprx_test.c"],

--- a/sw/device/tests/usbdev_aon_wake_reset_test.c
+++ b/sw/device/tests/usbdev_aon_wake_reset_test.c
@@ -1,0 +1,146 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/usb_testutils.h"
+#include "sw/device/lib/testing/usb_testutils_controlep.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+/**
+ * Configuration values for USB.
+ */
+static const uint8_t config_descriptors[] = {
+    USB_CFG_DSCR_HEAD(USB_CFG_DSCR_LEN + USB_INTERFACE_DSCR_LEN, 1),
+    // Single interface with no endpoint, just to make the host happy.
+    VEND_INTERFACE_DSCR(0, 0, 0x50, 0),
+};
+
+/**
+ * USB device context types.
+ */
+static usb_testutils_ctx_t usbdev;
+static usb_testutils_controlep_ctx_t usbdev_control;
+
+/**
+ * Pinmux handle
+ */
+static dif_pinmux_t pinmux;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static void init_peripherals(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  pinmux_testutils_init(&pinmux);
+  CHECK_DIF_OK(dif_pinmux_input_select(
+      &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+      kTopEarlgreyPinmuxInselIoc7));
+
+  CHECK_STATUS_OK(usb_testutils_init(&usbdev, /*pinflip=*/false,
+                                     /*en_diff_rcvr=*/true,
+                                     /*tx_use_d_se0=*/false));
+  CHECK_STATUS_OK(usb_testutils_controlep_init(
+      &usbdev_control, &usbdev, 0, config_descriptors,
+      sizeof(config_descriptors), NULL, 0));
+}
+
+// Enable/disable the AON Wake module, and wait with timeout until that has
+// been confirmed.
+static status_t aon_wait(dif_toggle_t enable) {
+  // We must be sure that any alteration to the USBDEV pull up enables has
+  // propagated through the CDC synchronizer and been sampled on the lower
+  // frequency (200kHz) AON clock; allow 3 clock cycles.
+  busy_spin_micros(15u);
+  TRY(dif_usbdev_set_wake_enable(usbdev.dev, enable));
+  // The AON Wake module operates on a 200kHz clock, so the clock period is
+  // 5us; we have CDC between USBDEV and AON Wake, but it responds within a
+  // couple of its clock cycles, so this is plenty.
+  ibex_timeout_t timeout = ibex_timeout_init(20);
+  do {
+    dif_usbdev_wake_status_t status;
+    TRY(dif_usbdev_get_wake_status(usbdev.dev, &status));
+    // In the requested state yet?
+    if (status.active == dif_toggle_to_bool(enable)) {
+      return OK_STATUS();
+    }
+  } while (!ibex_timeout_check(&timeout));
+
+  return DEADLINE_EXCEEDED();
+}
+
+static status_t wait_until_configured(uint32_t timeout_micros) {
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  while (!ibex_timeout_check(&timeout)) {
+    CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
+    if (usbdev_control.device_state == kUsbTestutilsDeviceConfigured)
+      return OK_STATUS();
+  }
+  return DEADLINE_EXCEEDED();
+}
+
+static status_t wait_until_suspended(uint32_t timeout_micros) {
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  while (usbdev_control.device_state == kUsbTestutilsDeviceConfigured &&
+         !ibex_timeout_check(&timeout)) {
+    CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
+    dif_usbdev_link_state_t link_state;
+    CHECK_DIF_OK(dif_usbdev_status_get_link_state(usbdev.dev, &link_state));
+    if (link_state == kDifUsbdevLinkStateSuspended) {
+      return OK_STATUS();
+    }
+  }
+  return DEADLINE_EXCEEDED();
+}
+
+static status_t wait_until_aon_bus_reset(uint32_t timeout_micros) {
+  dif_usbdev_wake_status_t status;
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  while (!ibex_timeout_check(&timeout)) {
+    CHECK_DIF_OK(dif_usbdev_get_wake_status(usbdev.dev, &status));
+    CHECK(status.active, "AON wake is not active?!");
+    CHECK(!status.disconnected,
+          "device was disconnected while waiting for reset");
+    if (status.bus_reset)
+      return OK_STATUS();
+  }
+  return DEADLINE_EXCEEDED();
+}
+
+bool test_main(void) {
+  uint32_t timeout_micros = 30 * 1000 * 1000u;
+  CHECK(kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator);
+
+  init_peripherals();
+
+  // Proceed only when the device has been configured.
+  LOG_INFO("wait for host to configure device...");
+  CHECK_STATUS_OK(wait_until_configured(timeout_micros));
+
+  // Wait for the host to suspend the device.
+  LOG_INFO("configured, waiting for suspend");
+  CHECK_STATUS_OK(wait_until_suspended(timeout_micros));
+
+  // Hand over control of the USB to the AON Wake module
+  CHECK_STATUS_OK(aon_wait(kDifToggleEnabled));
+
+  // Wait until AON reports a bus reset.
+  LOG_INFO("suspended, waiting for reset");
+  CHECK_STATUS_OK(wait_until_aon_bus_reset(timeout_micros));
+
+  LOG_INFO("reset, take control back from aon");
+  // Reclaim control of the USB by disabling the AON Wake module.
+  CHECK_STATUS_OK(aon_wait(kDifToggleDisabled));
+
+  CHECK_STATUS_OK(usb_testutils_fin(&usbdev));
+
+  return true;
+}

--- a/sw/host/tests/chip/usb/BUILD
+++ b/sw/host/tests/chip/usb/BUILD
@@ -1,0 +1,38 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "usb",
+    srcs = [
+        "mod.rs",
+        "usb.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:log",
+        "@crate_index//:rusb",
+    ],
+)
+
+rust_binary(
+    name = "usbdev_aon_wake",
+    srcs = [
+        "usbdev_aon_wake.rs",
+    ],
+    deps = [
+        ":usb",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:rusb",
+    ],
+)

--- a/sw/host/tests/chip/usb/mod.rs
+++ b/sw/host/tests/chip/usb/mod.rs
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod usb;

--- a/sw/host/tests/chip/usb/usb.rs
+++ b/sw/host/tests/chip/usb/usb.rs
@@ -1,0 +1,167 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, Context, Result};
+use clap::Parser;
+
+use std::collections::HashSet;
+use std::time::{Instant,Duration};
+
+#[derive(Debug, Parser)]
+pub struct UsbOpts {
+    /// USB vendor ID, default value is Google VID
+    #[arg(long, value_parser = usb_id_parser, default_value = "18d1")]
+    pub vid: u16,
+
+    /// USB product ID, default value is lowRISC generic FS USB (allocated by Google).
+    #[arg(long, value_parser = usb_id_parser, default_value = "503a")]
+    pub pid: u16,
+
+    /// Frequency at which to poll the USB bus for new device.
+    #[arg(long, default_value = "10")]
+    pub usb_poll_freq: u64,
+}
+
+// Parse a USB VID/PID which must be a hex-string (e.g. "18d1").
+fn usb_id_parser(id: &str) -> Result<u16> {
+    Ok(u16::from_str_radix(id, 16)?)
+}
+
+// Represent an already seen device. Rely on the physical location (port numbers)
+// instead of device address.
+#[derive(Hash, PartialEq, Eq)]
+struct DeviceLoc {
+    bus: u8,
+    port_numbers: Vec<u8>,
+}
+
+impl DeviceLoc {
+    fn from_device(dev: &rusb::Device<rusb::GlobalContext>) -> Result<DeviceLoc> {
+        Ok(DeviceLoc {
+            bus: dev.bus_number(),
+            port_numbers: dev.port_numbers()?
+        })
+    }
+}
+
+impl UsbOpts {
+    // Wait for a device that matches the USB VID/PID. If a device that matches
+    // is found, it will try to open it: if that fails, a warning message will
+    // logged (for debugging) and the function will continue waiting until a
+    // a new device that can be opened is found. If several devices are found
+    // at the time that match and can be open, all of them will be returned.
+    // On timeout, the function will return an empty list.
+    //
+    // This function will return an error on critical failures such as failing to poll
+    // the USB bus.
+    pub fn wait_for_device(&self, timeout: Duration) -> Result<Vec<rusb::DeviceHandle<rusb::GlobalContext>>> {
+        let start = Instant::now();
+        // Keep a list of devices to not warn against again.
+        let mut warned_desc = HashSet::<DeviceLoc>::new();
+        let mut warned_open = HashSet::<DeviceLoc>::new();
+        loop {
+            let mut devices = Vec::new();
+            for device in rusb::devices().context("USB error")?.iter() {
+                let seen_dev = DeviceLoc::from_device(&device)?;
+                let descriptor = match device.device_descriptor() {
+                    Ok(desc) => desc,
+                    Err(e) => {
+                        // Ignore device if we have already seen it.
+                        if !warned_desc.contains(&seen_dev) {
+                            warned_desc.insert(seen_dev);
+                            log::warn!("Could not read device descriptor for device at bus={} address={}: {}",
+                                device.bus_number(),
+                                device.address(),
+                                e);
+                        }
+                        continue;
+                    }
+                };
+                if descriptor.vendor_id() != self.vid {
+                    continue;
+                }
+                if descriptor.product_id() != self.pid {
+                    continue;
+                }
+                let handle = match device.open() {
+                    Ok(handle) => handle,
+                    Err(e) => {
+                        // Ignore device if we have already seen it.
+                        if !warned_open.contains(&seen_dev) {
+                            warned_open.insert(seen_dev);
+                            log::warn!("Could not open device at bus={} address={}: {}",
+                                device.bus_number(),
+                                device.address(),
+                                e);
+                        }
+                        continue;
+                    }
+                };
+                devices.push(handle);
+            }
+            // Return if we found at least one device or if timeout has expired.
+            if !devices.is_empty() || start.elapsed() >= timeout {
+                return Ok(devices)
+            }
+            // Wait a bit before polling again.
+            std::thread::sleep(Duration::from_micros(1_000_000u64 / self.usb_poll_freq));
+        }
+    }
+}
+
+// Structure representing a USB hub. The device needs to have sufficient permission
+// to be opened.
+pub struct UsbHub {
+    handle: rusb::DeviceHandle<rusb::GlobalContext>
+}
+
+// USB hub operation.
+pub enum UsbHubOp {
+    // Suspend a specific port.
+    Suspend,
+    // Suspend a specific port.
+    Resume,
+    // Reset a specific port.
+    Reset,
+}
+
+const PORT_SUSPEND: u16 = 2;
+const PORT_RESET: u16 = 4;
+
+impl UsbHub {
+    // Construct a hub from a device.
+    pub fn from_device(dev: &rusb::Device<rusb::GlobalContext>) -> Result<UsbHub> {
+        // Make sure the device is a hub.
+        let dev_desc = dev.device_descriptor()?;
+        // Assume that if the device has the HUB class then Linux will already enforce
+        // that it follows the specification.
+        ensure!(dev_desc.class_code() == rusb::constants::LIBUSB_CLASS_HUB, "device is not a hub");
+        Ok(UsbHub {
+            handle: dev.open().context("cannot open hub")?
+        })
+    }
+
+    // Perform an operation.
+    pub fn op(&self, op: UsbHubOp, port: u8, timeout: Duration) -> Result<()> {
+        let (value, set_feature) = match op {
+            UsbHubOp::Suspend => (PORT_SUSPEND, true),
+            UsbHubOp::Resume => (PORT_SUSPEND, false),
+            UsbHubOp::Reset => (PORT_RESET, true),
+        };
+        let req = if set_feature { rusb::constants::LIBUSB_REQUEST_SET_FEATURE }
+        else { rusb::constants::LIBUSB_REQUEST_CLEAR_FEATURE };
+        let req_type = rusb::constants::LIBUSB_RECIPIENT_OTHER |
+            rusb::constants::LIBUSB_REQUEST_TYPE_CLASS |
+            rusb::constants::LIBUSB_ENDPOINT_OUT;
+        let _ =self.handle.write_control(
+            req_type,
+            req,
+            value,
+            port as u16,
+            &[],
+            timeout
+        )?;
+        Ok(())
+    }
+}

--- a/sw/host/tests/chip/usb/usbdev_aon_wake.rs
+++ b/sw/host/tests/chip/usb/usbdev_aon_wake.rs
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+use opentitanlib::execute_test;
+
+use usb::{UsbHub, UsbHubOp, UsbOpts};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console/USB timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    /// USB options.
+    #[command(flatten)]
+    usb: UsbOpts,
+}
+
+// Wait for a device to appear and then return the parent device and port number.
+fn wait_for_device_and_get_parent(opts: &Opts) -> Result<(rusb::Device<rusb::GlobalContext>, u8)> {
+    // Wait for USB device to appear.
+    log::info!("waiting for device...");
+    let devices = opts.usb.wait_for_device(opts.timeout)?;
+    if devices.is_empty() {
+        bail!("no USB device found");
+    }
+    if devices.len() > 1 {
+        bail!("several USB devices found");
+    }
+    let device = &devices[0];
+    log::info!("device found at bus={} address={}", device.device().bus_number(), device.device().address());
+
+    // Important note: here the handle will be dropped and the device handle
+    // will be closed.
+    Ok((device.device().get_parent().context("device has no parent, you need to connect it via a hub for this test")?,
+       device.device().port_number()))
+}
+
+fn usbdev_aon_wake(
+    opts: &Opts,
+    _transport: &TransportWrapper,
+    uart: &dyn Uart,
+) -> Result<()> {
+    // Wait for device.
+    let (parent, port) = wait_for_device_and_get_parent(opts)?;
+    log::info!("parent hub at bus={}, address={}, port numbers={:?}", parent.bus_number(), parent.address(), parent.port_numbers()?);
+    log::info!("device under test is on port {}", port);
+    // At this point, we are not holding any device handle. If we really want to make sure,
+    // we could unbind the device from the driver but this requires a lot of privileges.
+
+    // Next, we suspend the device by directly accessing the parent hub.
+    let _ = UartConsole::wait_for(uart, r"configured, waiting for suspend", opts.timeout)?;
+    let hub = UsbHub::from_device(&parent).context("for this test, you need to make sure that the program has sufficient permissions to access the hub")?;
+    log::info!("suspend device");
+    hub.op(UsbHubOp::Suspend, port, Duration::from_millis(100))?;
+    let _ = UartConsole::wait_for(uart, r"suspended, waiting for reset", opts.timeout)?;
+    log::info!("device has suspended");
+
+    // While suspended, we issue a bus reset.
+    log::info!("reset device");
+    hub.op(UsbHubOp::Reset, port, Duration::from_millis(100))?;
+    let _ = UartConsole::wait_for(uart, r"reset, take control back from aon", opts.timeout)?;
+
+    let _ = UartConsole::wait_for(uart, r"PASS!", opts.timeout)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    execute_test!(usbdev_aon_wake, &opts, &transport, &*uart);
+
+    Ok(())
+}


### PR DESCRIPTION
This test is a bit tricky because it requires to manually suspend the device and issue a reset while in suspended state. On linux, suspended a device is not trivial and requires poking at various sysfs files, and resetting a suspended device is not possible. Instead, the approach used here is to directly talk to the parent hub of the device and issue suspend/reset requests directly. This is a bit risky in that it assumes that linux won't mess with the hub state while we do that but that seems to work. As stated in the tests, we could make this actually safe by manually unbinding the device from the driver first to ensure no intereference but again this requires some sysfs magic and more persmissions.

A side effect of this is that the test requires access not only to the USB device under test but also its parent hub. This access is not available currently in CI so the test is tagged as manual for now.