### PR TITLE
[ci] Disable test ROM and ROM E2E CI jobs for sival branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -542,32 +542,6 @@ jobs:
         gcpKeyFile: "gcpkey.json"
         bucketURI: "gs://opentitan-bitstreams/earlgrey_es_sival"
 
-- job: execute_test_rom_fpga_tests_cw310
-  displayName: CW310 Test ROM Tests
-  pool:
-    name: $(fpga_pool)
-    demands: BOARD -equals cw310
-  timeoutInMinutes: 60
-  dependsOn:
-    - chip_earlgrey_cw310
-    - sw_build
-  condition: succeeded( 'chip_earlgrey_cw310', 'sw_build' )
-  steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - template: ci/download-artifacts-template.yml
-    parameters:
-      downloadPartialBuildBinFrom:
-        - chip_earlgrey_cw310
-        - sw_build
-  - bash: |
-      set -e
-      . util/build_consts.sh
-      module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/scripts/run-fpga-tests.sh cw310 cw310_test_rom,-manuf,-hyper310 || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
-    displayName: Execute tests
-  - template: ci/publish-bazel-test-results.yml
-
 - job: execute_rom_fpga_tests_cw310
   displayName: CW310 ROM Tests
   pool:

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -85,29 +85,6 @@ jobs:
         $(bash ./bazelisk.sh query 'attr("tags", "hyper310", tests(//...))')
     displayName: "Run all the hyperdebug tests"
 
-- job: rom_e2e
-  displayName: "ROM E2E Tests"
-  timeoutInMinutes: 180
-  dependsOn: checkout
-  pool:
-    name: FPGA
-    demands: BOARD -equals cw310
-  steps:
-  - template: ../ci/checkout-template.yml
-  - template: ../ci/install-package-dependencies.yml
-  - bash: |
-      set -x
-      module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/bazelisk.sh test \
-        --define DISABLE_VERILATOR_BUILD=true \
-        --define bitstream=gcp_splice \
-        --test_tag_filters=-verilator,-dv,-broken \
-        --build_tests_only \
-        --test_output=errors \
-        //sw/device/silicon_creator/rom/e2e/...
-    displayName: "Run all ROM E2E tests"
-  - template: ../ci/publish-bazel-test-results.yml
-
 - job: slow_otbn_crypto_tests
   displayName: "Slow OTBN Crypto Tests"
   timeoutInMinutes: 180


### PR DESCRIPTION
This PR disables the test ROM and ROM e2e test jobs in CI for the `earlgrey_es_sival` branch.

This is to reduce the number of FPGA jobs being executed.