### PR TITLE
[tlul] Choose valid default depths

### DIFF
--- a/hw/ip/tlul/README.md
+++ b/hw/ip/tlul/README.md
@@ -596,7 +596,7 @@ The TL-UL socket `M:1` is a bus element that connects `M` TL-UL
 hosts to 1 TL-UL device. Along with a `tlul_socket_1n`, this could
 be used to build the TL-UL fabric, and uses `tlul_fifo` as its
 building block. `tlul_socket_m1` has several parameterization settings
-available. The `tlul_socket_m1` is synchronous, so a `tlul_async_fifo`
+available. The `tlul_socket_m1` is synchronous, so a `tlul_fifo_async`
 must be instantiated on any ports that run asynchronously.
 
 | name | description |

--- a/hw/ip/tlul/rtl/tlul_fifo_async.sv
+++ b/hw/ip/tlul/rtl/tlul_fifo_async.sv
@@ -9,8 +9,8 @@
 `include "prim_assert.sv"
 
 module tlul_fifo_async #(
-  parameter int unsigned ReqDepth = 3,
-  parameter int unsigned RspDepth = 3
+  parameter int unsigned ReqDepth = 4,
+  parameter int unsigned RspDepth = 4
 ) (
   input                      clk_h_i,
   input                      rst_h_ni,


### PR DESCRIPTION
Use ReqDepth and RspDepth that the submodule 'prim_fifo_async' supports.
Although the submodule includes an assertion to check for validity, the assertion is eliminated on some targets such as Verilator simulations and synthesis.

Also correct a module name in documentation.