### PR TITLE
[opentitantool] Fix crippled I2C TPM support

### DIFF
--- a/sw/host/opentitanlib/src/tpm/driver.rs
+++ b/sw/host/opentitanlib/src/tpm/driver.rs
@@ -394,7 +394,7 @@ impl I2cDriver {
     }
 
     fn try_read_register(&self, register: Register, data: &mut [u8]) -> Result<()> {
-        if self.gsc_ready_pin.is_some() {
+        if self.gsc_ready_pin.is_none() {
             // Do two I2C transfers in one call, for lowest latency.
             self.i2c.run_transaction(
                 None, /* default addr */

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -278,7 +278,7 @@ impl CommandDispatch for I2cTpm {
             Some(pin) => Some((transport.gpio_pin(pin)?, transport.gpio_monitoring()?)),
             None => None,
         };
-        let tpm_driver = Box::new(tpm::I2cDriver::new(
+        let tpm_driver: Box<dyn tpm::Driver> = Box::new(tpm::I2cDriver::new(
             context.params.create(transport, "TPM")?,
             ready_pin,
         )?);


### PR DESCRIPTION
Is seems that PR #21289 introduced a bug that prevents `opentitantool i2c tpm ...` from working at all.

This PR restores the proper use of `Any<>` to allow passing the I2C driver object to the TPM command handler in the way that it expects.

Also, a logic condition was accidentally reversed, making the new `--gsc-ready` flag ineffective for I2C.