### PR TITLE
Use LLD for linking

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,9 @@ build --features=guards
 # impact of the hardened sequences on code size.
 build:disable_hardening --features=-guards --copt=-DOT_DISABLE_HARDENING=1
 
+# Use LLD for linking
+build --features=use_lld
+
 # Enable toolchain resolution with cc
 build --incompatible_enable_cc_toolchain_resolution
 


### PR DESCRIPTION
This is something that we already wanted to enable, to support LTO, ePIC, etc.
Enabling this now also solves a problem when upgrading the Rust toolchain.