### PR TITLE
[sival,uart] Update UART sival test plan for baud rate test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -41,12 +41,11 @@
       bazel: ["//sw/device/tests:uart_tx_rx_test"]
     }
     {
-      name: chip_sw_uart_rand_baudrate
+      name: chip_sw_uart_baud_rate
       desc: '''Verify UART transmission of data at various speeds.
 
-            Randomly pick one of the UART instances and configure it to run with any of these baud
-            rates - 9600bps, 115200bps, 230400bps, 128Kbps, 256Kbps, 1Mbps, 1.5Mbps.
-
+            Test data transfer in both directions for each UART instance configured for each of
+            these baud rates: 9600Bd, 115200Bd, 230400Bd, 128kBd, 256kBd, 1MBd, 1.5MBd.
             '''
       stage: V1
       si_stage: SV3

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -51,6 +51,7 @@
       si_stage: SV3
       features: ["UART.BAUD_RATE_CONTROL"]
       tests: ["chip_sw_uart_rand_baudrate"]
+      bazel: ["//sw/device/tests:uart_baud_rate_test"]
     }
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq


### PR DESCRIPTION
This PR changes the description (and name) for the UART chip test plan.

The original test description suggests running the test at a random Baud rate on one of the UARTs, but it seems more useful to test all of the Bauds on all of the UART instances.

Is this a change we actually want? It seems that the DV tests are more random-style than exhaustive, so the original description fits for DV more than it does for SiVal.

This PR also connects the test plan to the Bazel target.