### PR TITLE
[test, otbn] Fix misleading otbn_mem_scramble_test error message

### DIFF
--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -241,12 +241,12 @@ bool test_main(void) {
                        &num_matches_imem, &num_intg_errors_imem);
   CHECK(num_intg_errors_imem >= kNumIntgErrorsThreshold,
         "Expecting at least %i IMEM integrity errors, got %i",
-        kNumIntgErrorsThreshold, num_matches_imem);
+        kNumIntgErrorsThreshold, num_intg_errors_imem);
   otbn_check_mem_words(&otbn, kNumAddrs, dmem_offsets, dif_otbn_dmem_read,
                        &num_matches_dmem, &num_intg_errors_dmem);
   CHECK(num_intg_errors_dmem >= kNumIntgErrorsThreshold,
         "Expecting at least %i DMEM integrity errors, got %i",
-        kNumIntgErrorsThreshold, num_matches_dmem);
+        kNumIntgErrorsThreshold, num_intg_errors_dmem);
 
   return true;
 }


### PR DESCRIPTION
The error message should report the number of integrity errors that generated an interrupt but was instead reporting the number of correct memory reads.