### PR TITLE
[sival,gpio] gpio interrupt test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
@@ -8,7 +8,8 @@
       name: chip_sw_gpio_out
       desc: '''Verify GPIO outputs.
 
-            SW test configures the GPIOs to be in the output mode. The test walks a 1 through the
+            SW test configures the GPIOs to be in the output mode. Configure pinmux such as
+            gpio output signal loopback to gpio input. The test walks a 1 through the
             pins. The testbench checks the value for correctness and verifies that there is no
             aliasing between the pins.
             '''
@@ -43,6 +44,7 @@
       stage: V1
       si_stage: SV3
       tests: ["chip_sw_gpio"]
+      bazel: ["//sw/device/tests:gpio_intr_test"]
     }
   ]
 }

--- a/sw/device/lib/testing/json/gpio.c
+++ b/sw/device/lib/testing/json/gpio.c
@@ -39,6 +39,20 @@ status_t gpio_set(ujson_t *uj, const dif_gpio_t *gpio) {
       TRY(dif_gpio_input_noise_filter_set_enabled(
           gpio, (dif_gpio_mask_t)op.pin_mask, (dif_gpio_state_t)op.state));
       break;
+    case kGpioActionIrqRestoreAll:
+      TRY(dif_gpio_irq_restore_all(gpio, (dif_gpio_mask_t *)&op.state));
+      break;
+    case kGpioActionIrqDisableAll:
+      TRY(dif_gpio_irq_disable_all(gpio, (dif_gpio_mask_t *)&op.state));
+      break;
+    case kGpioActionIrqSetTriggerRisingEdge:
+      TRY(dif_gpio_irq_set_trigger(gpio, (dif_gpio_mask_t)op.state,
+                                   kDifGpioIrqTriggerEdgeRising));
+      break;
+    case kGpioActionIrqSetTriggerFallingEdge:
+      TRY(dif_gpio_irq_set_trigger(gpio, (dif_gpio_mask_t)op.state,
+                                   kDifGpioIrqTriggerEdgeFalling));
+      break;
     default:
       return INVALID_ARGUMENT();
   }

--- a/sw/device/lib/testing/json/gpio.c
+++ b/sw/device/lib/testing/json/gpio.c
@@ -45,6 +45,9 @@ status_t gpio_set(ujson_t *uj, const dif_gpio_t *gpio) {
     case kGpioActionIrqDisableAll:
       TRY(dif_gpio_irq_disable_all(gpio, (dif_gpio_mask_t *)&op.state));
       break;
+    case kGpioActionIrqAcknowledgeAll:
+      TRY(dif_gpio_irq_acknowledge_all(gpio));
+      break;
     case kGpioActionIrqSetTriggerRisingEdge:
       TRY(dif_gpio_irq_set_trigger(gpio, (dif_gpio_mask_t)op.state,
                                    kDifGpioIrqTriggerEdgeRising));
@@ -52,6 +55,14 @@ status_t gpio_set(ujson_t *uj, const dif_gpio_t *gpio) {
     case kGpioActionIrqSetTriggerFallingEdge:
       TRY(dif_gpio_irq_set_trigger(gpio, (dif_gpio_mask_t)op.state,
                                    kDifGpioIrqTriggerEdgeFalling));
+      break;
+    case kGpioActionIrqSetTriggerHigh:
+      TRY(dif_gpio_irq_set_trigger(gpio, (dif_gpio_mask_t)op.state,
+                                   kDifGpioIrqTriggerLevelHigh));
+      break;
+    case kGpioActionIrqSetTriggerLow:
+      TRY(dif_gpio_irq_set_trigger(gpio, (dif_gpio_mask_t)op.state,
+                                   kDifGpioIrqTriggerLevelLow));
       break;
     default:
       return INVALID_ARGUMENT();

--- a/sw/device/lib/testing/json/gpio.h
+++ b/sw/device/lib/testing/json/gpio.h
@@ -22,8 +22,12 @@ extern "C" {
     value(_, SetInputNoiseFilter) \
     value(_, IrqRestoreAll) \
     value(_, IrqDisableAll) \
+    value(_, IrqAcknowledgeAll) \
     value(_, IrqSetTriggerRisingEdge) \
-    value(_, IrqSetTriggerFallingEdge)
+    value(_, IrqSetTriggerFallingEdge) \
+    value(_, IrqSetTriggerHigh) \
+    value(_, IrqSetTriggerLow)
+
 UJSON_SERDE_ENUM(GpioAction, gpio_action_t, ENUM_GPIO_SET_ACTION);
 
 #define STRUCT_GPIO_SET(field, string) \

--- a/sw/device/lib/testing/json/gpio.h
+++ b/sw/device/lib/testing/json/gpio.h
@@ -19,7 +19,11 @@ extern "C" {
     value(_, SetEnabled) \
     value(_, SetEnabledAll) \
     value(_, SetEnabledMasked) \
-    value(_, SetInputNoiseFilter)
+    value(_, SetInputNoiseFilter) \
+    value(_, IrqRestoreAll) \
+    value(_, IrqDisableAll) \
+    value(_, IrqSetTriggerRisingEdge) \
+    value(_, IrqSetTriggerFallingEdge)
 UJSON_SERDE_ENUM(GpioAction, gpio_action_t, ENUM_GPIO_SET_ACTION);
 
 #define STRUCT_GPIO_SET(field, string) \

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1816,6 +1816,42 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "gpio_intr_test",
+    srcs = ["gpio_intr_test.c"],
+    cw310 = new_cw310_params(
+        test_cmd = """
+            --bitstream={bitstream}
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/chip/gpio_intr",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
+    },
+    silicon_owner = silicon_params(
+        test_cmd = """
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/gpio_intr",
+    ),
+    deps = [
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/json:gpio",
+        "//sw/device/lib/testing/json:pinmux_config",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "hmac_enc_test",
     srcs = ["hmac_enc_test.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/gpio_intr_test.c
+++ b/sw/device/tests/gpio_intr_test.c
@@ -31,7 +31,8 @@ static dif_gpio_t gpio;
 static dif_pinmux_t pinmux;
 static dif_uart_t uart0;
 static dif_rv_plic_t plic;
-static const uint32_t kExpected_intr[] = {17, 18, 19, 20, 21, 22, 25, 26, 27, 28};
+static const uint32_t kExpected_intr[] = {17, 18, 19, 20, 21,
+                                          22, 25, 26, 27, 28};
 static uint32_t intr_index = 0;
 
 status_t command_processor(ujson_t *uj) {
@@ -100,8 +101,11 @@ void ottf_external_isr(uint32_t *exc_info) {
     // handler need to disable interrupt before it clear.
     // Interrupt is enabled by the host right before the test.
     // Disable and clear the interrupt at GPIO.
-    CHECK_DIF_OK(dif_gpio_irq_set_enabled(&gpio, gpio_pin_irq_fired, kDifToggleDisabled));
+    CHECK_DIF_OK(dif_gpio_irq_set_enabled(&gpio, gpio_pin_irq_fired,
+                                          kDifToggleDisabled));
     CHECK_DIF_OK(dif_gpio_irq_acknowledge(&gpio, gpio_pin_irq_fired));
+    CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kTopEarlgreyPlicTargetIbex0,
+                                          plic_irq_id));
   }
 }
 

--- a/sw/device/tests/gpio_intr_test.c
+++ b/sw/device/tests/gpio_intr_test.c
@@ -1,0 +1,130 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/json/gpio.h"
+#include "sw/device/lib/testing/json/pinmux_config.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_isrs.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+static dif_gpio_t gpio;
+static dif_pinmux_t pinmux;
+static dif_uart_t uart0;
+static dif_rv_plic_t plic;
+static const uint32_t kExpected_intr[] = {17, 18, 19, 20, 21, 22, 25, 26, 27, 28};
+static uint32_t intr_index = 0;
+
+status_t command_processor(ujson_t *uj) {
+  while (true) {
+    test_command_t command;
+    TRY(ujson_deserialize_test_command_t(uj, &command));
+    switch (command) {
+      case kTestCommandGpioSet:
+        RESP_ERR(uj, gpio_set(uj, &gpio));
+        break;
+      case kTestCommandGpioGet:
+        RESP_ERR(uj, gpio_get(uj, &gpio));
+        break;
+      case kTestCommandPinmuxConfig:
+        RESP_ERR(uj, pinmux_config(uj, &pinmux));
+        break;
+      default:
+        LOG_ERROR("Unrecognized command: %d", command);
+        RESP_ERR(uj, INVALID_ARGUMENT());
+    }
+  }
+  // We should never reach here.
+  return INTERNAL();
+}
+
+/**
+ * Provides external irq handling for this test.
+ *
+ * This function overrides the default OTTF external ISR.
+ */
+
+void ottf_external_isr(uint32_t *exc_info) {
+  // Find which interrupt fired at PLIC by claiming it.
+  dif_rv_plic_irq_id_t plic_irq_id;
+  CHECK_DIF_OK(
+      dif_rv_plic_irq_claim(&plic, kTopEarlgreyPlicTargetIbex0, &plic_irq_id));
+  // Check if it is the right peripheral.
+  top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
+      top_earlgrey_plic_interrupt_for_peripheral[plic_irq_id];
+
+  // Hyper debug tests get uart interrupt by design.
+  // Filter uart interrupt.
+  if (peripheral == kTopEarlgreyPlicPeripheralUart0) {
+    // Complete the IRQ at PLIC.
+    CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kTopEarlgreyPlicTargetIbex0,
+                                          plic_irq_id));
+    return;
+  }
+
+  // For each test, interrupt triggers in order.
+  // Once all interrupts are triggered, `intr_index` will be set to 0 for the
+  // next test.
+  if (peripheral == kTopEarlgreyPlicPeripheralGpio) {
+    // Correlate the interrupt fired from GPIO.
+    uint32_t gpio_pin_irq_fired = plic_irq_id - kTopEarlgreyPlicIrqIdGpioGpio0;
+    CHECK(gpio_pin_irq_fired == kExpected_intr[intr_index],
+          "Unexpected interrupt rcv:%d  exp:%d", gpio_pin_irq_fired,
+          kExpected_intr[intr_index]);
+    intr_index += 1;
+    if (intr_index == ARRAYSIZE(kExpected_intr)) {
+      intr_index = 0;
+      LOG_INFO("index back to 0");
+    }
+
+    // To test low frequency level interrupt,
+    // handler need to disable interrupt before it clear.
+    // Interrupt is enabled by the host right before the test.
+    // Disable and clear the interrupt at GPIO.
+    CHECK_DIF_OK(dif_gpio_irq_set_enabled(&gpio, gpio_pin_irq_fired, kDifToggleDisabled));
+    CHECK_DIF_OK(dif_gpio_irq_acknowledge(&gpio, gpio_pin_irq_fired));
+  }
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
+
+  rv_plic_testutils_irq_range_enable(
+      &plic, kTopEarlgreyPlicTargetIbex0, kTopEarlgreyPlicIrqIdGpioGpio0,
+      kTopEarlgreyPlicIrqIdGpioGpio0 + kDifGpioNumPins);
+
+  // Anker for the host
+  LOG_INFO("gpio_intr_test ");
+
+  ujson_t uj = ujson_ottf_console();
+
+  status_t s = command_processor(&uj);
+  LOG_INFO("status = %r", s);
+  return status_ok(s);
+}

--- a/sw/host/opentitanlib/src/test_utils/gpio.rs
+++ b/sw/host/opentitanlib/src/test_utils/gpio.rs
@@ -95,6 +95,14 @@ impl GpioSet {
         };
         payload.execute(uart)
     }
+    pub fn irq_acknowledge_all(uart: &dyn Uart) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::IrqAcknowledgeAll,
+            pin_mask: 0,
+            state: 0,
+        };
+        payload.execute(uart)
+    }
     pub fn irq_set_trigger(uart: &dyn Uart, state: u32, trigger: String) -> Result<()> {
         match trigger.as_str() {
             "rising" => {
@@ -108,6 +116,22 @@ impl GpioSet {
             "falling" => {
                 let payload = GpioSet {
                     action: GpioAction::IrqSetTriggerFallingEdge,
+                    pin_mask: 0,
+                    state,
+                };
+                payload.execute(uart)
+            }
+            "high" => {
+                let payload = GpioSet {
+                    action: GpioAction::IrqSetTriggerHigh,
+                    pin_mask: 0,
+                    state,
+                };
+                payload.execute(uart)
+            }
+            "low" => {
+                let payload = GpioSet {
+                    action: GpioAction::IrqSetTriggerLow,
                     pin_mask: 0,
                     state,
                 };

--- a/sw/host/opentitanlib/src/test_utils/gpio.rs
+++ b/sw/host/opentitanlib/src/test_utils/gpio.rs
@@ -79,6 +79,46 @@ impl GpioSet {
         };
         payload.execute(uart)
     }
+    pub fn irq_restore_all(uart: &dyn Uart, state: u32) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::IrqRestoreAll,
+            pin_mask: 0,
+            state,
+        };
+        payload.execute(uart)
+    }
+    pub fn irq_disable_all(uart: &dyn Uart, state: u32) -> Result<()> {
+        let payload = GpioSet {
+            action: GpioAction::IrqDisableAll,
+            pin_mask: 0,
+            state,
+        };
+        payload.execute(uart)
+    }
+    pub fn irq_set_trigger(uart: &dyn Uart, state: u32, trigger: String) -> Result<()> {
+        match trigger.as_str() {
+            "rising" => {
+                let payload = GpioSet {
+                    action: GpioAction::IrqSetTriggerRisingEdge,
+                    pin_mask: 0,
+                    state,
+                };
+                payload.execute(uart)
+            }
+            "falling" => {
+                let payload = GpioSet {
+                    action: GpioAction::IrqSetTriggerFallingEdge,
+                    pin_mask: 0,
+                    state,
+                };
+                payload.execute(uart)
+            }
+            _ => {
+                log::error!("unsupport trigger: {:?}", trigger);
+                Ok(())
+            }
+        }
+    }
 }
 
 impl GpioGet {

--- a/sw/host/tests/chip/gpio_intr/BUILD
+++ b/sw/host/tests/chip/gpio_intr/BUILD
@@ -1,0 +1,23 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "gpio_intr",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:once_cell",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/gpio_intr/src/main.rs
+++ b/sw/host/tests/chip/gpio_intr/src/main.rs
@@ -1,0 +1,299 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::gpio::PinMode;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::gpio::{GpioGet, GpioSet};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::pinmux_config::PinmuxConfig;
+use opentitanlib::uart::console::UartConsole;
+use opentitanlib::{collection, execute_test};
+
+use opentitanlib::chip::autogen::earlgrey::{
+    PinmuxInsel, PinmuxMioOut, PinmuxOutsel, PinmuxPeripheralIn,
+};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+}
+
+struct Config {
+    input: HashMap<PinmuxPeripheralIn, PinmuxInsel>,
+    output: HashMap<PinmuxMioOut, PinmuxOutsel>,
+}
+
+static CONFIG: Lazy<HashMap<&'static str, Config>> = Lazy::new(|| {
+    collection! {
+         // from:https://github.com/lowRISC/opentitan/
+         // blob/master/hw/top_earlgrey/data/pins_cw310_hyperdebug.xdc
+        "hyper310" => Config {
+            input: collection! {
+                // The commented lines represent multi-fuction pins.  These will
+                // be added back in when the hyperdebug firmware can set these
+                // multifunction pins into GPIO mode.
+                // ioc0~2: sw strap0~2
+                // ioc5: tap strap1
+                // ioc6: pwm ext)_clk
+                PinmuxPeripheralIn::GpioGpio17 => PinmuxInsel::Ioc10,
+                PinmuxPeripheralIn::GpioGpio18 => PinmuxInsel::Ioc11,
+                PinmuxPeripheralIn::GpioGpio19 => PinmuxInsel::Ioc12,
+
+                PinmuxPeripheralIn::GpioGpio20 => PinmuxInsel::Ior5,
+                PinmuxPeripheralIn::GpioGpio21 => PinmuxInsel::Ior6,
+                PinmuxPeripheralIn::GpioGpio22 => PinmuxInsel::Ior7,
+                // IOR8-9 aren't MIOs.
+                PinmuxPeripheralIn::GpioGpio25 => PinmuxInsel::Ior10,
+                PinmuxPeripheralIn::GpioGpio26 => PinmuxInsel::Ior11,
+                PinmuxPeripheralIn::GpioGpio27 => PinmuxInsel::Ior12,
+                PinmuxPeripheralIn::GpioGpio28 => PinmuxInsel::Ior13,
+
+            },
+            output: collection! {
+                // The commented lines represent multi-fuction pins.  These will
+                // be added back in when the hyperdebug firmware can set these
+                // multifunction pins into GPIO mode.
+                // ioc0~2: sw strap0~2
+                // ioc5: tap strap1
+                // ioc6: pwm ext)_clk
+                PinmuxMioOut::Ioc10 => PinmuxOutsel::GpioGpio17,
+                PinmuxMioOut::Ioc11 => PinmuxOutsel::GpioGpio18,
+                PinmuxMioOut::Ioc12 => PinmuxOutsel::GpioGpio19,
+
+                PinmuxMioOut::Ior5 => PinmuxOutsel::GpioGpio20,
+                PinmuxMioOut::Ior6 => PinmuxOutsel::GpioGpio21,
+                PinmuxMioOut::Ior7 => PinmuxOutsel::GpioGpio22,
+                // IOR8-9 aren't MIOs.
+                PinmuxMioOut::Ior10 => PinmuxOutsel::GpioGpio25,
+                PinmuxMioOut::Ior11 => PinmuxOutsel::GpioGpio26,
+                PinmuxMioOut::Ior12 => PinmuxOutsel::GpioGpio27,
+                PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio28,
+            },
+        },
+    }
+});
+
+fn gpio_write(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    value: u32,
+    config: &HashMap<PinmuxMioOut, PinmuxOutsel>,
+    invert: u8,
+) -> Result<()> {
+    let mask = config.values().fold(0, |acc, v| {
+        let i = u32::from(*v) - u32::from(PinmuxOutsel::GpioGpio0);
+        acc | 1u32 << i
+    });
+    let masked_value = value & mask;
+
+    log::info!(
+        "write & verify pattern: {:08x} & {:08x} -> {:08x}",
+        value,
+        mask,
+        masked_value
+    );
+    if masked_value != 0 {
+        log::info!(
+            "skipping: {:08x} has no bits in common with the pinmux configuration",
+            value
+        );
+    } else {
+        // invert == 1: use for walking 0
+        // invert == 0: use for walking 1
+        let write_val = if invert == 1 {
+            !masked_value
+        } else {
+            masked_value
+        };
+
+        GpioSet::write_all(uart, write_val)?;
+        let mut result = 0u32;
+        for (k, v) in config.iter() {
+            let n = u32::from(transport.gpio_pin(&k.to_string())?.read()?);
+            let i = u32::from(*v) - u32::from(PinmuxOutsel::GpioGpio0);
+            result |= n << i;
+        }
+        if invert == 1 {
+            assert_eq!(write_val & mask, result);
+        } else {
+            assert_eq!(write_val, result);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Ok(())
+}
+
+fn gpio_read(
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    value: u32,
+    config: &HashMap<PinmuxPeripheralIn, PinmuxInsel>,
+    invert: u32,
+) -> Result<()> {
+    let mask;
+    if invert == 1 {
+        // all 1 for target pins.
+        mask = GpioGet::read_all(uart)?;
+    } else {
+        mask = config.keys().fold(0, |acc, k| {
+            let i = u32::from(*k) - u32::from(PinmuxPeripheralIn::GpioGpio0);
+            acc | 1u32 << i
+        });
+    }
+    let masked_value = value & mask;
+    log::info!(
+        "read & verify pattern: {:08x} & {:08x} -> {:08x}",
+        value,
+        mask,
+        masked_value
+    );
+    if masked_value == 0 {
+        log::info!(
+            "skipping: {:08x} has no bits in common with the pinmux configuration",
+            value
+        );
+    } else {
+        for (k, v) in config.iter() {
+            let i = u32::from(*k) - u32::from(PinmuxPeripheralIn::GpioGpio0);
+            transport
+                .gpio_pin(&v.to_string())?
+                .write(((masked_value >> i) & 1) != invert)?;
+        }
+        // issue dummy read to make sure write complete.
+        let _ = GpioGet::read_all(uart)? & mask;
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Ok(())
+}
+
+fn test_gpio_outputs(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    log::info!(
+        "Configuring pinmux for {:?}",
+        opts.init.backend_opts.interface
+    );
+    let config = CONFIG
+        .get(opts.init.backend_opts.interface.as_str())
+        .expect("interface");
+    PinmuxConfig::configure(&*uart, Some(&config.input), Some(&config.output))?;
+
+    log::info!("Configuring debugger GPIOs as inputs");
+    // The outputs (with respect to pinmux config) correspond to the input pins on the debug board.
+    for pin in config.output.keys() {
+        transport
+            .gpio_pin(&pin.to_string())?
+            .set_mode(PinMode::Input)?;
+    }
+
+    log::info!("Enabling outputs on the DUT");
+
+    // Output Rising Edge test
+    GpioSet::irq_set_trigger(&*uart, u32::MAX, "rising".into())?;
+    GpioSet::irq_restore_all(&*uart, u32::MAX)?;
+    GpioSet::set_enabled_all(&*uart, u32::MAX)?;
+
+    log::info!("test: output rising edge test");
+
+    // Walking 1
+    for i in 0..32 {
+        gpio_write(transport, &*uart, 1 << i, &config.output, 0)?;
+    }
+    GpioSet::irq_disable_all(&*uart, u32::MAX)?;
+
+    // Output Falling Edge test
+    log::info!("test: output falling edge test");
+    GpioSet::irq_set_trigger(&*uart, u32::MAX, "falling".into())?;
+    GpioSet::irq_restore_all(&*uart, u32::MAX)?;
+    gpio_write(transport, &*uart, u32::MAX, &config.output, 0)?;
+
+    // Walking 0
+    for i in 0..32 {
+        gpio_write(transport, &*uart, 1 << i, &config.output, 1)?;
+    }
+    Ok(())
+}
+
+fn test_gpio_inputs(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    log::info!(
+        "Configuring pinmux for {:?}",
+        opts.init.backend_opts.interface
+    );
+    let config = CONFIG
+        .get(opts.init.backend_opts.interface.as_str())
+        .expect("interface");
+    PinmuxConfig::configure(&*uart, Some(&config.input), None)?;
+
+    log::info!("Configuring debugger GPIOs as outputs");
+    // The inputs (with respect to pinmux config) correspond to the output pins on the debug board.
+    for pin in config.input.values() {
+        transport
+            .gpio_pin(&pin.to_string())?
+            .set_mode(PinMode::PushPull)?;
+    }
+
+    log::info!("Disabling outputs on the DUT");
+    GpioSet::set_enabled_all(&*uart, 0x0)?;
+    GpioSet::set_input_noise_filter(&*uart, u32::MAX, 1)?;
+
+    // Initialize pins to 0
+    for pin in config.input.values() {
+        transport.gpio_pin(&pin.to_string())?.write(false)?;
+    }
+
+    // Input Rising Edge test
+    log::info!("test: input rising edge test");
+    GpioSet::irq_set_trigger(&*uart, u32::MAX, "rising".into())?;
+//    GpioSet::irq_restore_all(&*uart, u32::MAX)?;
+
+    // Walking 1
+    for i in 0..32 {
+        let mut val = 1 << i;
+        GpioSet::irq_restore_all(&*uart, val)?;
+        gpio_read(transport, &*uart, val, &config.input, 0)?;
+    }
+//    GpioSet::irq_disable_all(&*uart, u32::MAX)?;
+
+    // Output Falling Edge test
+    log::info!("test: input falling edge test");
+    GpioSet::irq_set_trigger(&*uart, u32::MAX, "falling".into())?;
+    GpioSet::irq_restore_all(&*uart, u32::MAX)?;
+
+    // Initialize pins to 1
+    for pin in config.input.values() {
+        transport.gpio_pin(&pin.to_string())?.write(true)?;
+    }
+
+    // Walking 0
+    for i in 0..32 {
+        gpio_read(transport, &*uart, 1 << i, &config.input, 1)?;
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"gpio_intr_test [^\r\n]*", opts.timeout)?;
+
+    execute_test!(test_gpio_inputs, &opts, &transport);
+//    execute_test!(test_gpio_outputs, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This PR includes

- gpio input mode interrupt test
- gpio output mode interrupt test

Since gpio interrupt only depends on its input, for output mode test, pinmux configured s.t. it loopbacks to the gpio input.
For each mode, four tests are included (Rising edge, Falling edge, level high and level low).