### PR TITLE
[dv,cov_merge] Do serial coverage merge for vcs

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -147,10 +147,14 @@
                      "-full64",
                      // No need of generating report when merging coverage.
                      "-noreport",
+                     // Parallel merge is slower than serial merge for most
+                     // small blocks, and the corresponding flags are commented
+                     // out. If this becomes problematic and you have a powerful
+                     // machine available, uncomment the three flags below.
                      // Merge results from tests in parallel.
-                     "-parallel",
-                     "-parallel_split 20",
-                     "-parallel_temproot {cov_merge_dir}",
+                     // "-parallel",
+                     // "-parallel_split 20",
+                     // "-parallel_temproot {cov_merge_dir}",
                      "+urg+lic+wait",
                      // Merge same assert instances found in different VDBs.
                      "-merge_across_libs",


### PR DESCRIPTION
Parallel merge needs a very powerful machine, and serial merge is fine for many blocks. Leave a comment for how to enable parallel in case someone needs it.

Fixes #21522