### PR TITLE
[mbx/dif] DIF function to access IPI configuration

### DIFF
--- a/sw/ip/mbx/dif/dif_mbx.c
+++ b/sw/ip/mbx/dif/dif_mbx.c
@@ -72,6 +72,21 @@ dif_result_t dif_mbx_is_busy(const dif_mbx_t *mbx, bool *is_busy) {
   return kDifOk;
 }
 
+dif_result_t dif_mbx_ipi_configuration_get(const dif_mbx_t *mbx,
+                                           uint32_t *doe_intr_addr,
+                                           uint32_t *doe_intr_data) {
+  if (mbx == NULL || doe_intr_addr == NULL || doe_intr_data == NULL) {
+    return kDifBadArg;
+  }
+
+  *doe_intr_addr =
+      mmio_region_read32(mbx->base_addr, MBX_DOE_INTR_MSG_ADDR_REG_OFFSET);
+  *doe_intr_data =
+      mmio_region_read32(mbx->base_addr, MBX_DOE_INTR_MSG_DATA_REG_OFFSET);
+
+  return kDifOk;
+}
+
 dif_result_t dif_mbx_process_request(const dif_mbx_t *mbx,
                                      dif_mbx_transaction_t *request) {
   if (mbx == NULL || request == NULL || request->data_dwords == NULL) {

--- a/sw/ip/mbx/dif/dif_mbx.h
+++ b/sw/ip/mbx/dif/dif_mbx.h
@@ -76,6 +76,19 @@ dif_result_t dif_mbx_range_get(const dif_mbx_t *mbx,
                                dif_mbx_range_config_t *config);
 
 /**
+ * Reads the DOE interrupt configuration for inter-processor interrupts (IPI).
+ *
+ * @param mbx A DOE Mailbox handle.
+ * @param[out] doe_intr_addr Mailbox interrupt address.
+ * @param[out] doe_intr_data Mailbox interrupt value.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_mbx_ipi_configuration_get(const dif_mbx_t *mbx,
+                                           uint32_t *doe_intr_addr,
+                                           uint32_t *doe_intr_data);
+
+/**
  * Host reads the DoE Mailbox request from internal SRAM
  *
  * @param mbx A DOE Mailbox handle.

--- a/sw/ip/mbx/dif/dif_mbx_unittest.cc
+++ b/sw/ip/mbx/dif/dif_mbx_unittest.cc
@@ -131,6 +131,32 @@ TEST_F(MemoryRangeTests, GetBadArg) {
   EXPECT_DIF_BADARG(dif_mbx_range_get(&mbx_, nullptr));
 }
 
+class IpiConfigurationTests : public MbxTestInitialized {};
+
+TEST_F(IpiConfigurationTests, GetSuccess) {
+  uint32_t doe_intr_addr, doe_intr_data;
+
+  EXPECT_READ32(MBX_DOE_INTR_MSG_ADDR_REG_OFFSET, 0x52001234);
+  EXPECT_READ32(MBX_DOE_INTR_MSG_DATA_REG_OFFSET, 0xFFABCDEF);
+
+  EXPECT_DIF_OK(
+      dif_mbx_ipi_configuration_get(&mbx_, &doe_intr_addr, &doe_intr_data));
+
+  EXPECT_EQ(doe_intr_addr, 0x52001234);
+  EXPECT_EQ(doe_intr_data, 0xFFABCDEF);
+}
+
+TEST_F(IpiConfigurationTests, GetBadArg) {
+  uint32_t doe_intr_addr, doe_intr_data;
+
+  EXPECT_DIF_BADARG(
+      dif_mbx_ipi_configuration_get(nullptr, &doe_intr_addr, &doe_intr_data));
+  EXPECT_DIF_BADARG(
+      dif_mbx_ipi_configuration_get(&mbx_, nullptr, &doe_intr_data));
+  EXPECT_DIF_BADARG(
+      dif_mbx_ipi_configuration_get(&mbx_, &doe_intr_addr, nullptr));
+}
+
 typedef struct status_reg {
   uint32_t reg;
   bool is_busy;


### PR DESCRIPTION
Add a DIF function to read out the IPI configuration that is set from the requester side.