### PR TITLE
[entropy_src/dv] Fix a failing rng_vseq test

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -768,7 +768,10 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
         // will likely fail.
         altcfg.bypass_window_size   = cfg.dut_cfg.bypass_window_size;
         altcfg.fips_window_size     = cfg.dut_cfg.fips_window_size;
-        altcfg.ht_threshold_scope   = cfg.dut_cfg.ht_threshold_scope;
+        // Do not pass ht_threshold_scope from cfg to altcfg if it is invalid.
+        altcfg.ht_threshold_scope   = mubi4_test_invalid(cfg.dut_cfg.ht_threshold_scope) ?
+                                          altcfg.ht_threshold_scope :
+                                          cfg.dut_cfg.ht_threshold_scope;
       end
 
       // Force the DUT to not absorb the new config (to test write protect), unless


### PR DESCRIPTION
This commit fixes the rng_vseq test which was failing because the ht_threshold_scope was set to an invalid mubi value in the config. Whenever the entropy_src enters an alert state due to the configuration, it reconfigures the DUT in a safe way to run the test. However, for the ht_threshold_scope the same value is kept. The issue here is, that when the initialization fails because of the ht_threshold_scope we still have to set it to a safe value.