### PR TITLE
[chip-level/entropy_src] Link bazel tests in testplan

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -25,7 +25,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "PROD"]
       tests: ["chip_sw_entropy_src_ast_rng_req"]
-      bazel: []
+      bazel: ["//sw/device/tests:entropy_src_ast_rng_req_test"]
     },
     {
       name: chip_sw_entropy_src_csrng
@@ -49,7 +49,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_entropy_src_csrng"]
-      bazel: []
+      bazel: ["//sw/device/tests:entropy_src_csrng_test"]
     },
     {
       name: chip_sw_entropy_src_known_answer_tests
@@ -73,7 +73,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "PROD"]
       tests: ["chip_sw_entropy_src_kat_test"]
-      bazel: []
+      bazel: ["//sw/device/tests:entropy_src_kat_test"]
     },
     {
       name: chip_sw_entropy_src_bypass_mode_health_tests


### PR DESCRIPTION
This commit links two chip-level entropy_src tests to the bazel tag in the test plan.

Closes #20142
Closes #21391
Closes #20144