### PR TITLE
[dv,clkmgr] Fix failure in clkmgr_peri_vseq

### DIFF
--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -6,10 +6,21 @@
 //
 // This is more general than the corresponding smoke test since it randomizes the initial
 // value of clk_enables CSR and the ip_clk_en input.
+//
+// The expectation is that the peripheral clocks will be sampled at their rate, so this
+// sequence needs to wait for the slowest clock to tick before changing enable values.
+// The dv environment sets the CSRs clock frequency randomly, so it may run too fast and
+// the updates may become a glitch that ends up not sampled in the SVAs.
+// To be safe this waits for two cycles of the slowest clock (io_div_4) which is eight
+// io_clk cycles.
+
 class clkmgr_peri_vseq extends clkmgr_base_vseq;
   `uvm_object_utils(clkmgr_peri_vseq)
 
   `uvm_object_new
+
+  // IO clock cycles to wait before changing clk enable settings.
+  static int WaitIoCycles = 8;
 
   rand peri_enables_t initial_enables;
 
@@ -27,13 +38,11 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
       control_ip_clocks();
       csr_wr(.ptr(ral.clk_enables), .value(initial_enables));
 
+      cfg.io_clk_rst_vif.wait_clks(WaitIoCycles);
       // Flip all bits of clk_enables.
       flipped_enables = initial_enables ^ ((1 << ral.clk_enables.get_n_bits()) - 1);
       csr_wr(.ptr(ral.clk_enables), .value(flipped_enables));
-      // Allow some time for the side-effects to be observed: the dv environment sets the CSRs
-      // clock frequency randomly, so it may run too fast and the updates may become a glitch
-      // that ends up not sampled in the SVAs.
-      cfg.clk_rst_vif.wait_clks(4);
+      cfg.io_clk_rst_vif.wait_clks(WaitIoCycles);
     end
     // And set it back to the reset value for stress tests.
     cfg.clk_rst_vif.wait_clks(1);


### PR DESCRIPTION
Extend the wait time between updates to CLK_ENABLES csr, or the changes won't be sampled by slower clocks.