### PR TITLE
[crypto] Support SHA-3 hashes in RSA PKCS#1 v1.5 padding mode

### DIFF
--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -733,7 +733,7 @@ status_t kmac_sha3_224(const uint8_t *message, size_t message_len,
   HARDENED_TRY(kmac_init(kKmacOperationSHA3, kKmacSecurityStrength224,
                          /*hw_backed=*/kHardenedBoolFalse));
 
-  size_t digest_len_words = 224 / 32;
+  size_t digest_len_words = kSha3_224DigestWords;
   return kmac_process_msg_blocks(kKmacOperationSHA3, message, message_len,
                                  digest, digest_len_words);
 }
@@ -743,7 +743,7 @@ status_t kmac_sha3_256(const uint8_t *message, size_t message_len,
   HARDENED_TRY(kmac_init(kKmacOperationSHA3, kKmacSecurityStrength256,
                          /*hw_backed=*/kHardenedBoolFalse));
 
-  size_t digest_len_words = 256 / 32;
+  size_t digest_len_words = kSha3_256DigestWords;
   return kmac_process_msg_blocks(kKmacOperationSHA3, message, message_len,
                                  digest, digest_len_words);
 }
@@ -753,7 +753,7 @@ status_t kmac_sha3_384(const uint8_t *message, size_t message_len,
   HARDENED_TRY(kmac_init(kKmacOperationSHA3, kKmacSecurityStrength384,
                          /*hw_backed=*/kHardenedBoolFalse));
 
-  size_t digest_len_words = 384 / 32;
+  size_t digest_len_words = kSha3_384DigestWords;
   return kmac_process_msg_blocks(kKmacOperationSHA3, message, message_len,
                                  digest, digest_len_words);
 }
@@ -763,7 +763,7 @@ status_t kmac_sha3_512(const uint8_t *message, size_t message_len,
   HARDENED_TRY(kmac_init(kKmacOperationSHA3, kKmacSecurityStrength512,
                          /*hw_backed=*/kHardenedBoolFalse));
 
-  size_t digest_len_words = 512 / 32;
+  size_t digest_len_words = kSha3_512DigestWords;
   return kmac_process_msg_blocks(kKmacOperationSHA3, message, message_len,
                                  digest, digest_len_words);
 }

--- a/sw/device/lib/crypto/drivers/kmac.h
+++ b/sw/device/lib/crypto/drivers/kmac.h
@@ -26,6 +26,22 @@ enum {
   // The size of the sideload key. This parameter is not exposed by KMAC or
   // Keymgr hjson files from HW, so we need to hardcode it for the moment.
   kKmacSideloadKeyLength = 256,
+  // Length of a SHA3-224 digest in bytes.
+  kSha3_224DigestBytes = 224 / 8,
+  // Length of a SHA3-224 digest in 32-bit words.
+  kSha3_224DigestWords = kSha3_224DigestBytes / sizeof(uint32_t),
+  // Length of a SHA3_256 digest in bytes.
+  kSha3_256DigestBytes = 256 / 8,
+  // Length of a SHA3_256 digest in 32-bit words.
+  kSha3_256DigestWords = kSha3_256DigestBytes / sizeof(uint32_t),
+  // Length of a SHA3_384 digest in bytes.
+  kSha3_384DigestBytes = 384 / 8,
+  // Length of a SHA3_384 digest in 32-bit words.
+  kSha3_384DigestWords = kSha3_384DigestBytes / sizeof(uint32_t),
+  // Length of a SHA3_512 digest in bytes.
+  kSha3_512DigestBytes = 512 / 8,
+  // Length of a SHA3_512 digest in 32-bit words.
+  kSha3_512DigestWords = kSha3_512DigestBytes / sizeof(uint32_t),
 };
 
 /**

--- a/sw/device/lib/crypto/impl/rsa/BUILD
+++ b/sw/device/lib/crypto/impl/rsa/BUILD
@@ -64,6 +64,7 @@ cc_library(
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/drivers:kmac",
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:status",
         "//sw/device/lib/crypto/impl/sha2:sha256",


### PR DESCRIPTION
Adds support for SHA-3 hash functions for RSA with the PKCS#1 v1.5 padding mode. The argument validation in `sw/device/lib/crypto/impl/rsa.c` already supports them, but the padding implementation did not, resulting in an invalid argument error that was difficult to trace.

Tests for these hashes will be added in a later PR alongside the rest of the RSA tests as part of the ongoing cryptotest effort.