### PR TITLE
[opentitantool] Updated HyperDebug firmware

### DIFF
--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240209_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "03c58b220828fc88c9a23ec1b6e93f210354687a5dccd9b957aaaf45f75f82f0",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240216_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "cb932b41a20952f32130d9154e33feece9f09ae7dca0d0b88f9bcdc8a13dedba",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Updated HyperDebug firmware fixing a bug that could cause corruption of SPI waveforms on second and subsequent attempt.

https://chromium-review.googlesource.com/c/chromiumos/platform/ec/+/5299901