### PR TITLE
[dv,random_reset] Enhance handling of random resets

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -63,6 +63,7 @@ virtual task run_shadow_reg_errors(int num_times, bit en_csr_rw_seq = 0);
     shadowed_csrs.shuffle();
 
     for (int i = 0; i < max_idx; i++) begin
+      if (cfg.stop_transaction_generators()) break;
       `uvm_info(`gfn, $sformatf("mycsr: %s    en_csr_rw_seq:%d",
                 shadowed_csrs[i].get_name(), en_csr_rw_seq), UVM_HIGH);
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -36,7 +36,7 @@ virtual task tl_access_unmapped_addr(string ral_name);
     // Randomly pick which unmapped address range to target
     int idx = $urandom_range(0, loc_unmapped_addr_ranges.size()-1);
 
-    if (cfg.under_reset) return;
+    if (cfg.stop_transaction_generators()) return;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(unmapped_addr,
         (unmapped_addr & csr_addr_mask[ral_name])
             inside {[loc_unmapped_addr_ranges[idx].start_addr :
@@ -60,7 +60,7 @@ virtual task tl_write_less_than_csr_width(string ral_name);
     uint             msb_pos;
     bit [BUS_AW-1:0] addr;
 
-    if (cfg.under_reset) return;
+    if (cfg.stop_transaction_generators()) return;
     `DV_CHECK_FATAL($cast(csr, all_csrs[i]))
     msb_pos = csr.get_msb_pos();
     addr    = csr.get_address();
@@ -85,7 +85,7 @@ endtask
 
 virtual task tl_protocol_err(tl_sequencer tl_sequencer_h = p_sequencer.tl_sequencer_h);
   repeat ($urandom_range(10, 100)) begin
-    if (cfg.under_reset) return;
+    if (cfg.stop_transaction_generators()) return;
     `create_tl_access_error_case(
         tl_protocol_err, , tl_host_protocol_err_seq #(cip_tl_seq_item), tl_sequencer_h
         )
@@ -97,7 +97,7 @@ virtual task tl_write_mem_less_than_word(string ral_name);
   dv_base_mem mem;
   addr_range_t loc_mem_ranges[$] = updated_mem_ranges[ral_name];
   repeat ($urandom_range(10, 100)) begin
-    if (cfg.under_reset) return;
+    if (cfg.stop_transaction_generators()) return;
     // if more than one memories, randomly select one memory
     mem_idx = $urandom_range(0, loc_mem_ranges.size - 1);
     // only test when mem doesn't support partial write
@@ -121,7 +121,7 @@ virtual task tl_read_wo_mem_err(string ral_name);
   uint mem_idx;
   addr_range_t loc_mem_ranges[$] = updated_mem_ranges[ral_name];
   repeat ($urandom_range(10, 100)) begin
-    if (cfg.under_reset) return;
+    if (cfg.stop_transaction_generators()) return;
     // if more than one memories, randomly select one memory
     mem_idx = $urandom_range(0, loc_mem_ranges.size - 1);
     if (get_mem_access_by_addr(cfg.ral_models[ral_name],
@@ -141,7 +141,7 @@ virtual task tl_write_ro_mem_err(string ral_name);
   uint mem_idx;
   addr_range_t loc_mem_ranges[$] = updated_mem_ranges[ral_name];
   repeat ($urandom_range(10, 100)) begin
-    if (cfg.under_reset) return;
+    if (cfg.stop_transaction_generators()) return;
     // if more than one memories, randomly select one memory
     mem_idx = $urandom_range(0, loc_mem_ranges.size - 1);
     if (get_mem_access_by_addr(cfg.ral_models[ral_name],
@@ -164,7 +164,7 @@ virtual task tl_instr_type_err(string ral_name);
     bit [BUS_DW-1:0] data;
     mubi4_t          instr_type;
 
-    if (cfg.under_reset) return;
+    if (cfg.stop_transaction_generators()) return;
     `DV_CHECK_STD_RANDOMIZE_FATAL(addr);
     `DV_CHECK_STD_RANDOMIZE_FATAL(data);
 
@@ -192,7 +192,7 @@ endtask
 virtual task run_tl_errors_vseq(int num_times = 1, bit do_wait_clk = 0);
   set_tl_assert_en(.enable(0));
   for (int trans = 1; trans <= num_times; trans++) begin
-    if (cfg.under_reset) return;
+    if (cfg.stop_transaction_generators()) return;
     `uvm_info(`gfn, $sformatf("Running run_tl_errors_vseq %0d/%0d", trans, num_times), UVM_LOW)
     `loop_ral_models_to_create_threads(run_tl_errors_vseq_sub(do_wait_clk, ral_name);)
   end

--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -12,6 +12,7 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   bit en_cov            = 0; // Enable via plusarg, only if coverage collection is turned on.
   bit en_dv_cdc         = 0; // Enable via plusarg.
 
+  local bit will_reset  = 0;
   bit under_reset       = 0;
   bit is_initialized;        // Indicates that the initialize() method has been called.
 
@@ -107,8 +108,22 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
   endfunction
 
+  // This can be used to stop transaction generators either upon reset or in preparation to
+  // issue a random reset.
+  virtual function bit stop_transaction_generators();
+    return this.will_reset || this.under_reset;
+  endfunction
+
+  // This can be used to announce the intention to generate a random reset soon, to allow
+  // transaction generators to stop, and fire a reset with no outstanding transactions.
+  virtual function void set_intention_to_reset();
+    `uvm_info(`gfn, "Setting intention to reset", UVM_MEDIUM)
+    this.will_reset = 1'b1;
+  endfunction
+
   virtual function void reset_asserted();
     this.under_reset = 1;
+    this.will_reset = 0;
     csr_utils_pkg::reset_asserted();
   endfunction
 


### PR DESCRIPTION
Declare the intention to issue a random reset in the near future in order to halt transaction generators. Without this there are occasionally failure for stress_all_with_rand_reset because of timing out waiting for no outstanding accesses, either because the generators have too many pending transactions, or because of a single cycle with no outstanding accesses followed by more accesses.

Fixes #21531