### PR TITLE
[kmac,pre_dv] Check digests produced by kmac_reduced_tb using DPI model

### DIFF
--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/kmac_reduced_tb.core
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/kmac_reduced_tb.core
@@ -8,6 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:kmac
+      - lowrisc:dv:digestpp_dpi:0.1
     files:
       - rtl/kmac_reduced_tb.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
Having such a check is beneficial for simulating actual netlists prior to the analysis using PROLEAD to capture cases where synthesis fails.