### PR TITLE
[top_darjeeling/dv] Enable `chip_sw_keymgr_dpe_key_derivation_jitter_en_reduced_freq`

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -1613,9 +1613,9 @@
       run_opts: ["+en_jitter=1", "+cal_sys_clk_70mhz=1"]
     }
     {
-      name: chip_sw_keymgr_key_derivation_jitter_en_reduced_freq
-      uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
-      sw_images: ["//sw/device/tests:keymgr_key_derivation_test:6"]
+      name: chip_sw_keymgr_dpe_key_derivation_jitter_en_reduced_freq
+      uvm_test_seq: chip_sw_keymgr_dpe_key_derivation_vseq
+      sw_images: ["//sw/device/tests:keymgr_dpe_key_derivation_test:6"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=20_000_000", "+en_jitter=1", "+cal_sys_clk_70mhz=1"]
     }


### PR DESCRIPTION
The `chip_sw_keymgr_key_derivation_jitter_en_reduced_freq` test had been using the non-DPE `chip_sw_keymgr_key_derivation_vseq` and `keymgr_key_derivation_test` code, which don't work with `keymgr_dpe`. The variant of this test that doesn't have a reduced sys clock frequency, `chip_sw_keymgr_dpe_key_derivation_jitter_en`, had already been ported to `keymgr_dpe`, so the changes required to enable `chip_sw_keymgr_dpe_key_derivation_jitter_en_reduced_freq` were minor.

I ran three random reseeds of this test, and they all passed.