### PR TITLE
[RV_DM]rv_dm_progbuf_busy_vseq

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -464,6 +464,21 @@
       tests: ["rv_dm_halt_resume_whereto"]
     }
     {
+      name: progbuf_busy
+      desc: '''
+            Verify that writing on DM progbuf registers while abstract command is executing
+            causes jtag_dmi_ral.abstractcs.busy to be set to 1.
+
+            - Program jtag_dmi_ral.dmcontrol.haltreq to 1'b1.
+            - Acknowledge haltreq by setting tl_mem_ral.halted to 0.
+            - Send access register abstract command with postexec bit set.
+            - Write on any of progbuf registers.
+            - Verify that jtag_dmi_ral.abstractcs.busy is set to 1.
+            '''
+      stage: V1
+      tests: ["rv_dm_progbuf_busy"]
+    }
+    {
       name: stress_all
       desc: '''
             A 'bug hunt' test that stresses the DUT to its limits.

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -47,6 +47,7 @@ filesets:
       - seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_progbuf_busy_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_busy_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_busy_vseq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_progbuf_busy_vseq extends rv_dm_base_vseq;
+
+  `uvm_object_utils(rv_dm_progbuf_busy_vseq)
+
+  `uvm_object_new
+
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+  task body();
+    uvm_reg_data_t data;
+    uvm_reg_data_t r_data;
+    repeat ($urandom_range(1, 10)) begin
+    data = $urandom_range(0,31);
+      csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(1));
+      csr_wr(.ptr(tl_mem_ral.halted), .value(0));
+      // Access Register command with postexec bit set.
+      csr_wr(.ptr(jtag_dmi_ral.command), .value('h00250000));
+      csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(data));
+      csr_rd(.ptr(jtag_dmi_ral.abstractcs), .value(r_data));
+      `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.abstractcs.busy, r_data));
+    end
+  endtask
+
+endclass:rv_dm_progbuf_busy_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -24,3 +24,4 @@
 `include "rv_dm_jtag_dmi_debug_disabled_vseq.sv"
 `include "rv_dm_jtag_dtm_hard_reset_vseq.sv"
 `include "rv_dm_stress_all_vseq.sv"
+`include "rv_dm_progbuf_busy_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -251,6 +251,11 @@
       reseed: 2
     }
     {
+      name: rv_dm_progbuf_busy
+      uvm_test_seq: rv_dm_progbuf_busy_vseq
+      reseed: 2
+    }
+    {
       name: rv_dm_stress_all
       uvm_test_seq: rv_dm_stress_all_vseq
     }


### PR DESCRIPTION
This commit verify that accessing progbuffer while abstract command is executing causes abstractcs.busy set to 1.