### PR TITLE
[crypto] Fix a broken trap condition in RSA

### DIFF
--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -964,7 +964,7 @@ otcrypto_status_t otcrypto_rsa_decrypt_async_finalize(
                                     plaintext_bytelen));
 
   // Consistency check; this should never happen.
-  if (launder32(*plaintext_bytelen) >= plaintext.len) {
+  if (launder32(*plaintext_bytelen) > plaintext.len) {
     HARDENED_TRAP();
     return OTCRYPTO_FATAL_ERR;
   }


### PR DESCRIPTION
Previously, the RSA OAEP decryption logic incorrectly performed a hardware trap after completing the decryption if the passed buffer for the plaintext is exactly the correct size. This PR fixes this bug. The correctness of this fix has been verified using the wycheproof test vectors.