### PR TITLE
[crypto/rsa] temporarily use constant-time modexp when e != 0x10001

### DIFF
--- a/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
@@ -126,9 +126,12 @@ status_t rsa_modexp_vartime_2048_start(const rsa_2048_int_t *base,
                                        const uint32_t exp,
                                        const rsa_2048_int_t *modulus) {
   if (exp != kExponentF4) {
-    // TODO: add support for other exponents by checking the validity of e and
-    // then calling a variable-time modexp.
-    return OTCRYPTO_NOT_IMPLEMENTED;
+    // TODO for other exponents, we temporarily fall back to the constant-time
+    // implementation until a variable-time implementation is supported.
+    rsa_2048_int_t exp_rsa;
+    memset(exp_rsa.data, 0, kRsa2048NumWords * sizeof(uint32_t));
+    exp_rsa.data[0] = exp;
+    return rsa_modexp_consttime_2048_start(base, &exp_rsa, modulus);
   }
 
   // Load the OTBN app. Fails if OTBN is not idle.
@@ -173,9 +176,12 @@ status_t rsa_modexp_vartime_3072_start(const rsa_3072_int_t *base,
                                        const uint32_t exp,
                                        const rsa_3072_int_t *modulus) {
   if (exp != kExponentF4) {
-    // TODO: add support for other exponents by checking the validity of e and
-    // then calling a variable-time modexp.
-    return OTCRYPTO_NOT_IMPLEMENTED;
+    // TODO for other exponents, we temporarily fall back to the constant-time
+    // implementation until a variable-time implementation is supported.
+    rsa_3072_int_t exp_rsa;
+    memset(exp_rsa.data, 0, kRsa3072NumWords * sizeof(uint32_t));
+    exp_rsa.data[0] = exp;
+    return rsa_modexp_consttime_3072_start(base, &exp_rsa, modulus);
   }
 
   // Load the OTBN app. Fails if OTBN is not idle.
@@ -220,9 +226,12 @@ status_t rsa_modexp_vartime_4096_start(const rsa_4096_int_t *base,
                                        const uint32_t exp,
                                        const rsa_4096_int_t *modulus) {
   if (exp != kExponentF4) {
-    // TODO: add support for other exponents by checking the validity of e and
-    // then calling a variable-time modexp.
-    return OTCRYPTO_NOT_IMPLEMENTED;
+    // TODO for other exponents, we temporarily fall back to the constant-time
+    // implementation until a variable-time implementation is supported.
+    rsa_4096_int_t exp_rsa;
+    memset(exp_rsa.data, 0, kRsa4096NumWords * sizeof(uint32_t));
+    exp_rsa.data[0] = exp;
+    return rsa_modexp_consttime_4096_start(base, &exp_rsa, modulus);
   }
 
   // Load the OTBN app. Fails if OTBN is not idle.


### PR DESCRIPTION
Previously, RSA `verify` operations returned an invalid argument error when passed a value for the public exponent `e` other than 65537 (`2^16 + 1`), because we currently lack a variable-time implementation to perform the `modexp` operation for other exponents. This PR configures RSA to temporarily use the existing constant-time implementation for other exponents until a variable-time implementation is supported. 

This PR allows us to run the NIST CAVP RSA test vectors, which all use `e != 65537`.