### PR TITLE
[sival, plic] add plic_sw_irq_test bazel target to testplan

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
@@ -42,6 +42,7 @@
       si_stage: SV3
       features: ["RV_PLIC.PRIORITY", "RV_PLIC.ENABLE"]
       tests: ["chip_sw_plic_sw_irq"]
+      bazel: ["//sw/device/tests:plic_sw_irq_test"],
     }
     {
       name: chip_sw_plic_alerts


### PR DESCRIPTION
The test is already enabled for cw310_sival_rom_ext exec env (`bazel test //sw/device/tests:plic_sw_irq_test_fpga_cw310_sival_rom_ext` works). Update the testplan to reflect that.

Fix #19863 