### PR TITLE
[dv] Spi_device CFG register Covergroup fix.

### DIFF
--- a/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
@@ -34,13 +34,11 @@ class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
     }
   endgroup
 
-  covergroup bit_order_clk_cfg_cg with function sample(bit tx_order, bit rx_order,
-                                                       bit cpol, bit cpha);
-    cp_bit_order: coverpoint tx_order;
+  covergroup cfg_settings_cg with function sample(bit mailbox_en, bit tx_order, bit rx_order);
+    cp_mailbox_en: coverpoint mailbox_en;
+    cp_tx_order: coverpoint tx_order;
     cp_rx_order: coverpoint rx_order;
-    cp_cpol: coverpoint cpol;
-    cp_cpha: coverpoint cpha;
-    cr_all: cross tx_order, rx_order, cp_cpol, cp_cpha;
+    cr_order: cross tx_order, rx_order;
   endgroup
 
   // TPM related
@@ -277,7 +275,7 @@ class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
       tpm_read_hw_reg_cg_wraps[ALL_TPM_HW_REG_NAMES[i]] = new(ALL_TPM_HW_REG_NAMES[i]);
     end
     all_modes_cg = new();
-    bit_order_clk_cfg_cg = new();
+    cfg_settings_cg = new();
     // tpm
     tpm_cfg_cg = new();
     tpm_transfer_size_cg = new();

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -114,6 +114,9 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
                 UVM_MEDIUM)
       if (cfg.en_cov) begin
         cov.all_modes_cg.sample(device_mode_e'(`gmv(ral.control.mode)), `gmv(ral.tpm_cfg.en));
+
+        cov.cfg_settings_cg.sample(`gmv(ral.cfg.mailbox_en), `gmv(ral.cfg.tx_order),
+                                    `gmv(ral.cfg.rx_order));
       end
 
       case (cfg.spi_host_agent_cfg.spi_func_mode)


### PR DESCRIPTION
Spi_device CFG covergroup updated and sampled regardless of the mode since tx/rx_order affect all modes.
Mailbox_en bit has been added as well.