### PR TITLE
[cherrypick, rom, rom_ext] Re-arrange retention RAM

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -40,6 +40,7 @@ dual_cc_library(
         ],
         shared = [
             ":error",
+            ":nonce",
             "//sw/device/lib/base:macros",
             "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
             "//sw/device/silicon_creator/lib/drivers:hmac",
@@ -80,6 +81,7 @@ cc_library(
     srcs = ["boot_log.c"],
     hdrs = ["boot_log.h"],
     deps = [
+        ":nonce",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:chip_info",
         "//sw/device/silicon_creator/lib:error",
@@ -429,6 +431,11 @@ cc_library(
 cc_library(
     name = "attestation",
     hdrs = ["attestation.h"],
+)
+
+cc_library(
+    name = "nonce",
+    hdrs = ["nonce.h"],
 )
 
 cc_library(

--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -45,7 +45,7 @@
 /**
  * Maximum size of a boot services message.
  */
-#define CHIP_BOOT_SVC_MSG_SIZE_MAX 52
+#define CHIP_BOOT_SVC_MSG_SIZE_MAX 256
 
 /**
  * Maximum payload size for a boot services message.

--- a/sw/device/silicon_creator/lib/boot_data.h
+++ b/sw/device/silicon_creator/lib/boot_data.h
@@ -10,6 +10,7 @@
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/nonce.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,10 +70,24 @@ typedef struct boot_data {
    */
   uint32_t primary_bl0_slot;
   /**
+   * Next owner key (ECDSA).  Only relevant in the UNLOCKED_ENDORSED ownership
+   * state.
+   */
+  uint32_t next_owner[8];
+  /**
+   * Challenge/response nonce for signed boot_svc commands.
+   */
+  nonce_t nonce;
+  /**
+   * Ownership state.  One of LOCKED_OWNER, LOCKED_UPDATE, UNLOCKED_ANY,
+   * UNLOCKED_ENDORSED, LOCKED_NONE.
+   */
+  uint32_t ownership_state;
+  /**
    * Padding for future enhancements and to make the size of `boot_data_t` a
    * power of two.
    */
-  uint32_t padding[16];
+  uint32_t padding[5];
 } boot_data_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_data_t, digest, 0);
@@ -83,7 +98,10 @@ OT_ASSERT_MEMBER_OFFSET(boot_data_t, counter, 48);
 OT_ASSERT_MEMBER_OFFSET(boot_data_t, min_security_version_rom_ext, 52);
 OT_ASSERT_MEMBER_OFFSET(boot_data_t, min_security_version_bl0, 56);
 OT_ASSERT_MEMBER_OFFSET(boot_data_t, primary_bl0_slot, 60);
-OT_ASSERT_MEMBER_OFFSET(boot_data_t, padding, 64);
+OT_ASSERT_MEMBER_OFFSET(boot_data_t, next_owner, 64);
+OT_ASSERT_MEMBER_OFFSET(boot_data_t, nonce, 96);
+OT_ASSERT_MEMBER_OFFSET(boot_data_t, ownership_state, 104);
+OT_ASSERT_MEMBER_OFFSET(boot_data_t, padding, 108);
 OT_ASSERT_SIZE(boot_data_t, 128);
 
 enum {

--- a/sw/device/silicon_creator/lib/boot_log.c
+++ b/sw/device/silicon_creator/lib/boot_log.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/lib/boot_log.h"
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 
 static void boot_log_digest_compute(const boot_log_t *boot_log,
@@ -81,8 +82,11 @@ void boot_log_check_or_init(boot_log_t *boot_log, uint32_t rom_ext_slot,
   boot_log->chip_version.scm_revision_low = info->scm_revision.scm_revision_low;
   boot_log->chip_version.scm_revision_high =
       info->scm_revision.scm_revision_high;
-  boot_log->bl0_slot = kBootLogUninitialized;
   boot_log->rom_ext_slot = rom_ext_slot;
+  boot_log->bl0_slot = kBootLogUninitialized;
+  for (size_t i = 0; i < ARRAYSIZE(boot_log->reserved); ++i) {
+    boot_log->reserved[i] = 0;
+  }
   boot_log_digest_update(boot_log);
   return;
 }

--- a/sw/device/silicon_creator/lib/boot_log.c
+++ b/sw/device/silicon_creator/lib/boot_log.c
@@ -43,7 +43,7 @@ void boot_log_digest_update(boot_log_t *boot_log) {
 
 static const uint32_t kCheckShares[kHmacDigestNumWords + 1] = {
     0x7b00d08e, 0xfdb69374, 0x336c86df, 0xff2ef417, 0xe1517012,
-    0x4bf5408c, 0x9c6a7b25, 0xf771f8fa, 0xcd458605,
+    0x4bf5408c, 0x9c6a7b25, 0xf771f8fa, 0xcd468505,
 };
 
 rom_error_t boot_log_check(const boot_log_t *boot_log) {

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -23,7 +23,7 @@ extern "C" {
 typedef struct boot_log {
   /** Digest to indicate validity of the boot_log. */
   hmac_digest_t digest;
-  /** Identifier (`BOLG`). */
+  /** Identifier (`BLOG`). */
   uint32_t identifier;
   /** Chip version (from the ROM). */
   chip_info_scm_revision_t chip_version;
@@ -56,9 +56,9 @@ OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 68);
 
 enum {
   /**
-   * Boot log identifier value (ASCII "BOLG").
+   * Boot log identifier value (ASCII "BLOG").
    */
-  kBootLogIdentifier = 0x474c4f42,
+  kBootLogIdentifier = 0x474f4c42,
 
   /**
    * Boot Slot designators

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -11,24 +11,48 @@
 #include "sw/device/silicon_creator/lib/chip_info.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/nonce.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * The boot_log encodes information about how the chip booted.
+ */
 typedef struct boot_log {
+  /** Digest to indicate validity of the boot_log. */
   hmac_digest_t digest;
+  /** Identifier (`BOLG`). */
   uint32_t identifier;
+  /** Chip version (from the ROM). */
   chip_info_scm_revision_t chip_version;
+  /** Which ROM_EXT slot booted. */
   uint32_t rom_ext_slot;
+  /** ROM_EXT major version number. */
+  uint16_t rom_ext_major;
+  /** ROM_EXT minor version number. */
+  uint16_t rom_ext_minor;
+  /** ROM_EXT size in flash. */
+  uint32_t rom_ext_size;
+  /** ROM_EXT nonce for challenge/response boot_svc commands. */
+  nonce_t rom_ext_nonce;
+  /** Which BL0 slot booted. */
   uint32_t bl0_slot;
+  /** Pad to 128 bytes. */
+  uint32_t reserved[15];
 } boot_log_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, digest, 0);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, identifier, 32);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, chip_version, 36);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_slot, 44);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_slot, 48);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_major, 48);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_minor, 50);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_size, 52);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_nonce, 56);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_slot, 64);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 68);
 
 enum {
   /**

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
@@ -26,6 +26,10 @@ extern "C" {
 // clang-format off
 #define BOOT_SVC_MSGS_DEFINE(X) \
   /**
+   * Empty boot services message.
+   */ \
+  X(boot_svc_empty_t, empty) \
+  /**
    * Next Boot BL0 Slot request and response.
    */ \
   X(boot_svc_next_boot_bl0_slot_req_t, next_boot_bl0_slot_req) \
@@ -63,14 +67,12 @@ typedef union boot_svc_msg {
    */
   boot_svc_header_t header;
   /**
-   * Empty boot services message.
-   */
-  boot_svc_empty_t empty;
-  /**
    * Boot services request and response messages.
    */
   BOOT_SVC_MSGS_DEFINE(BOOT_SVC_MSG_FIELD);
 } boot_svc_msg_t;
+
+OT_ASSERT_SIZE(boot_svc_msg_t, 256);
 
 /**
  * Helper macro for generating the equalities for checking that the value of

--- a/sw/device/silicon_creator/lib/dbg_print.c
+++ b/sw/device/silicon_creator/lib/dbg_print.c
@@ -14,6 +14,8 @@
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/epmp_defs.h"
 
+static const char kHexTable[16] = "0123456789abcdef";
+
 static void print_integer(unsigned value, bool is_signed) {
   char buf[12];
   char *b = buf + sizeof(buf);
@@ -70,7 +72,6 @@ void dbg_printf(const char *format, ...) {
         OT_FALLTHROUGH_INTENDED;
       case 'x': {
         // Print an `unsigned int` in hexadecimal.
-        static const char kHexTable[16] = "0123456789abcdef";
         unsigned int v = va_arg(args, unsigned int);
         for (int i = 0; i < sizeof(v) * 2; ++i) {
           int shift = sizeof(v) * 8 - 4;
@@ -146,4 +147,26 @@ void dbg_print_epmp(void) {
                size);
   }
   dbg_printf("mseccfg = %x\r\n", mseccfg);
+}
+
+void dbg_hexdump(const void *data, size_t len) {
+  const uint8_t *p = (const uint8_t *)data;
+  size_t j = 0;
+
+  while (j < len) {
+    // hexbuf is initialized as 48 spaces followed by a nul byte.
+    char hexbuf[] = "                                                ";
+    // ascii is initialized as 17 nul bytes.
+    char ascii[17] = {
+        0,
+    };
+    dbg_printf("%p: ", p);
+    for (size_t i = 0; i < 16 && j < len; ++p, ++i, ++j) {
+      uint8_t val = *p;
+      hexbuf[i * 3 + 0] = kHexTable[val >> 4];
+      hexbuf[i * 3 + 1] = kHexTable[val & 15];
+      ascii[i] = (val >= 32 && val < 127) ? (char)val : '.';
+    }
+    dbg_printf("%s  %s\r\n", hexbuf, ascii);
+  }
 }

--- a/sw/device/silicon_creator/lib/dbg_print.h
+++ b/sw/device/silicon_creator/lib/dbg_print.h
@@ -45,6 +45,14 @@ void dbg_printf(const char *format, ...) __attribute__((format(printf, 1, 2)));
  */
 void dbg_print_epmp(void);
 
+/**
+ * Hexdump a region of memory.
+ *
+ * @param data The memory to dump.
+ * @param len The length of the region to dump.
+ */
+void dbg_hexdump(const void *data, size_t len);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.c
@@ -42,5 +42,24 @@ void retention_sram_scramble(void) {
   abs_mmio_write32(kBase + SRAM_CTRL_CTRL_REG_OFFSET, ctrl);
 }
 
+rom_error_t retention_sram_check_version(void) {
+  retention_sram_t *rr = retention_sram_get();
+  switch (rr->version) {
+    case kRetentionSramVersion1:
+      // Version 1 can be in-place upgraded to version 3.
+      rr->version = kRetentionSramVersion3;
+      break;
+    case kRetentionSramVersion3:
+      // Nothing to do for version 3.
+      break;
+    case kRetentionSramVersion2:
+    default:
+      // Version 2 never went into a product, so we should never see it.
+      // Other versions are not defined.
+      return kErrorRetRamBadVersion;
+  }
+  return kErrorOk;
+}
+
 // Extern declarations for the inline functions in the header.
 extern retention_sram_t *retention_sram_get(void);

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -49,6 +49,7 @@ enum module_ {
   kModuleRomExt =          MODULE_CODE('R', 'E'),
   kModuleRomExtInterrupt = MODULE_CODE('R', 'I'),
   kModuleAsn1 =            MODULE_CODE('A', '1'),
+  kModuleRetRam =          MODULE_CODE('R', 'R'),
   kModuleXModem =          MODULE_CODE('X', 'M'),
   // clang-format on
 };
@@ -179,6 +180,8 @@ enum module_ {
   X(kErrorAsn1PushIntegerInvalidArgument,     ERROR_(5, kModuleAsn1, kInvalidArgument)), \
   X(kErrorAsn1FinishBitstringInvalidArgument, ERROR_(6, kModuleAsn1, kInvalidArgument)), \
   X(kErrorAsn1BufferExhausted,                ERROR_(7, kModuleAsn1, kResourceExhausted)), \
+  \
+  X(kErrorRetRamBadVersion,           ERROR_(1, kModuleRetRam, kUnknown)), \
   /* This comment prevent clang from trying to format the macro. */
 
 // clang-format on

--- a/sw/device/silicon_creator/lib/nonce.h
+++ b/sw/device/silicon_creator/lib/nonce.h
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_NONCE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_NONCE_H_
+
+#include <stdint.h>
+
+/**
+ * A nonce value used for challenge/response in boot services message.
+ */
+typedef struct nonce {
+  uint32_t value[2];
+} nonce_t;
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_NONCE_H_

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -179,7 +179,7 @@ static rom_error_t rom_init(void) {
       otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_RET_RAM_RESET_MASK_OFFSET);
   if ((reset_reasons & reset_mask) != 0) {
     retention_sram_init();
-    retention_sram_get()->version = kRetentionSramVersion2;
+    retention_sram_get()->version = kRetentionSramVersion3;
     retention_sram_get()->creator.last_shutdown_reason = kErrorOk;
   }
   // Store the reset reason in retention RAM and clear the register.

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -255,10 +255,14 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw310",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
+        "//hw/top_earlgrey:silicon_creator",
     ],
     linker_script = ":ld_slot_a",
     manifest = ":manifest_standard",
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    rsa_key = select({
+        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+        "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_test_0"},
+    }),
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -273,10 +277,14 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw310",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
+        "//hw/top_earlgrey:silicon_creator",
     ],
     linker_script = ":ld_slot_b",
     manifest = ":manifest_standard",
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    rsa_key = select({
+        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+        "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_test_0"},
+    }),
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -291,10 +299,14 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw310",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
+        "//hw/top_earlgrey:silicon_creator",
     ],
     linker_script = ":ld_slot_virtual",
     manifest = ":manifest_virtual",
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    rsa_key = select({
+        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+        "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_test_0"},
+    }),
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -142,6 +142,10 @@ static rom_error_t rom_ext_init(void) {
 
   // Conditionally patch AST and check that it is in the expected state.
   HARDENED_RETURN_IF_ERROR(ast_patch(lc_state));
+
+  // Check that the retention RAM is initialized.
+  HARDENED_RETURN_IF_ERROR(retention_sram_check_version());
+
   return kErrorOk;
 }
 


### PR DESCRIPTION
Re-arrange the retention RAM as discussed in the SW WG meeting on
2024-02-13:

Locate the boot_svc message first, followed by reserved space, followed
by the boot_log and last_shutdown_reason. This arrangement allows us
to grow the boot_svc message (growing "down" into the reserved space)
if needed and to add additional fields at the end (growing "up" into
the reserved space).

Also: name the ASCII code for boot log as `BLOG` instead of `BOLG`.