### PR TITLE
[cryptotest] Add parser for manual hjson ECDSA tests

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -180,6 +180,31 @@ ECDSA_RANDOM_COUNT = 128
 
 [
     run_binary(
+        name = cryptotest_name,
+        srcs = [
+            "//sw/device/tests/crypto/testvectors:{}".format(src_name),
+            "//sw/host/cryptotest/testvectors/data/schemas:ecdsa_sig_ver_schema",
+        ],
+        outs = [":{}.json".format(cryptotest_name)],
+        args = [
+            "--src",
+            "$(location //sw/device/tests/crypto/testvectors:{})".format(src_name),
+            "--dst",
+            "$(location :{}.json)".format(cryptotest_name),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:ecdsa_sig_ver_schema)",
+            "--curve",
+            curve,
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:hjson_ecdsa_parser",
+    )
+    for src_name, cryptotest_name, curve in [
+        ("ecdsa_p256_verify_hardcoded.hjson", "manual_ecdsa_p256", "p256"),
+    ]
+]
+
+[
+    run_binary(
         name = "nist_cavp_{}_{}_{}_json".format(
             src_repo,
             algorithm.lower(),

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -78,6 +78,15 @@ py_binary(
 )
 
 py_binary(
+    name = "hjson_ecdsa_parser",
+    srcs = ["hjson_ecdsa_parser.py"],
+    deps = [
+        requirement("hjson"),
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
     name = "hjson_hash_parser",
     srcs = ["hjson_hash_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/hjson_ecdsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/hjson_ecdsa_parser.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import logging
+import sys
+import jsonschema
+import hjson
+
+
+def parse_test_vectors(raw_data, curve):
+    test_vectors = []
+    count = 1
+    for test in raw_data:
+        test_vec = {
+            "vendor": "manual",
+            "test_case_id": count,
+            "algorithm": "ecdsa",
+            "operation": "verify",
+            "curve": curve,
+            "hash_alg": "sha-256",
+            "message": list(test["msg"].to_bytes(length=test["msg_len"], byteorder="big")),
+            # Encode qx and qy as a string because downstream test vector
+            # consumers may incorrectly handle large integers.
+            "qx": hex(test["x"])[2:],
+            "qy": hex(test["y"])[2:],
+            "r": hex(test["r"])[2:],
+            "s": hex(test["s"])[2:],
+            "result": test["valid"],
+        }
+        test_vectors.append(test_vec)
+        count += 1
+
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--src',
+                        metavar='FILE',
+                        type=argparse.FileType('r'),
+                        help='Read test vectors from this JSON file.')
+    parser.add_argument('--dst',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help='Write output to this file.')
+    parser.add_argument("--schema", type=str, help="Testvector schema file")
+    parser.add_argument('--curve',
+                        type=str,
+                        help='Elliptic curve to use [p256, p384].')
+    args = parser.parse_args()
+
+    testvecs = parse_test_vectors(hjson.loads(args.src.read()), args.curve)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Adds a parser to incorporate the manual hjson ECDSA `verify` tests in `/sw/device/tests/crypto/testvectors/ecdsa_p256_verify_hardcoded.hjson` into the existing cryptotest framework. I verified the tests pass when applied on top of #20853 with the P-256 patch in #21115 applied.