### PR TITLE
[dif] Fix type checking of first interrupt

### DIFF
--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -84,7 +84,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(
       dif_adc_ctrl_irq_get_type(&adc_ctrl_, kDifAdcCtrlIrqMatchDone, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public AdcCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -65,7 +65,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_alert_handler_irq_get_type(
       &alert_handler_, kDifAlertHandlerIrqClassa, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public AlertHandlerTest {};

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
@@ -85,7 +85,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_aon_timer_irq_get_type(
       &aon_timer_, kDifAonTimerIrqWkupTimerExpired, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public AonTimerTest {};

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -87,7 +87,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(
       dif_csrng_irq_get_type(&csrng_, kDifCsrngIrqCsCmdReqDone, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public CsrngTest {};

--- a/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
@@ -85,7 +85,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_edn_irq_get_type(&edn_, kDifEdnIrqEdnCmdReqDone, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public EdnTest {};

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -91,7 +91,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_entropy_src_irq_get_type(
       &entropy_src_, kDifEntropySrcIrqEsEntropyValid, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public EntropySrcTest {};

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
@@ -90,7 +90,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_flash_ctrl_irq_get_type(&flash_ctrl_,
                                             kDifFlashCtrlIrqProgEmpty, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public FlashCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -77,7 +77,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_gpio_irq_get_type(&gpio_, kDifGpioIrqGpio0, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public GpioTest {};

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -79,7 +79,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_hmac_irq_get_type(&hmac_, kDifHmacIrqHmacDone, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public HmacTest {};

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -80,7 +80,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_i2c_irq_get_type(&i2c_, kDifI2cIrqFmtThreshold, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public I2cTest {};

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -87,7 +87,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_keymgr_irq_get_type(&keymgr_, kDifKeymgrIrqOpDone, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public KeymgrTest {};

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -85,7 +85,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_kmac_irq_get_type(&kmac_, kDifKmacIrqKmacDone, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public KmacTest {};

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -82,7 +82,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_otbn_irq_get_type(&otbn_, kDifOtbnIrqDone, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public OtbnTest {};

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -90,7 +90,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_otp_ctrl_irq_get_type(
       &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public OtpCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
@@ -83,7 +83,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(
       dif_pattgen_irq_get_type(&pattgen_, kDifPattgenIrqDoneCh0, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public PattgenTest {};

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -80,7 +80,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_pwrmgr_irq_get_type(&pwrmgr_, kDifPwrmgrIrqWakeup, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public PwrmgrTest {};

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
@@ -86,7 +86,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_rv_timer_irq_get_type(
       &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public RvTimerTest {};

--- a/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen_unittest.cc
@@ -91,7 +91,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_sensor_ctrl_irq_get_type(
       &sensor_ctrl_, kDifSensorCtrlIrqIoStatusChange, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public SensorCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -85,7 +85,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_spi_device_irq_get_type(
       &spi_device_, kDifSpiDeviceIrqUploadCmdfifoNotEmpty, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public SpiDeviceTest {};

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
@@ -84,7 +84,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(
       dif_spi_host_irq_get_type(&spi_host_, kDifSpiHostIrqError, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public SpiHostTest {};

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
@@ -85,7 +85,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(dif_sysrst_ctrl_irq_get_type(
       &sysrst_ctrl_, kDifSysrstCtrlIrqEventDetected, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public SysrstCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -80,7 +80,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_uart_irq_get_type(&uart_, kDifUartIrqTxWatermark, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public UartTest {};

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -82,7 +82,7 @@ TEST_F(IrqGetTypeTest, Success) {
 
   EXPECT_DIF_OK(
       dif_usbdev_irq_get_type(&usbdev_, kDifUsbdevIrqPktReceived, &type));
-  EXPECT_EQ(type, 0);
+  EXPECT_EQ(type, kDifIrqTypeEvent);
 }
 
 class IrqGetStateTest : public UsbdevTest {};

--- a/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
@@ -146,7 +146,11 @@ namespace {
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
         &type));
-    EXPECT_EQ(type, 0);
+      % if ip.irqs[0].type == "event":
+    EXPECT_EQ(type, kDifIrqTypeEvent);
+      % else:
+    EXPECT_EQ(type, kDifIrqTypeStatus);
+      % endif
   }
 
   class IrqGetStateTest : public ${ip.name_camel}Test {};


### PR DESCRIPTION
This PR makes a small correction to the template for the auto-generated DIF unit test code, and regenerates the affected files.

 - In the auto-generated unit test code, check the returned type of the first interrupt against its actual type; previously it seems all initial interrupts have been of Event type so these tests passed accidentally.
With planned I2C changes, this shall no longer be true.

The code for mapping the hjson key value to the DIF constant mirrors that in `dif_autogen.c.tpl`