### PR TITLE
[cryptotest] Add NIST CAVP RSA tests vectors and parser

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -316,3 +316,44 @@ run_binary(
         "256",
     ]
 ]
+
+[
+    run_binary(
+        name = "nist_cavp_rsa_{}_{}_json".format(
+            padding_mode,
+            operation,
+        ),
+        srcs = [
+            "@nist_cavp_rsa_fips_186_3//:Sig{}{}_186-3.{}".format(prefix, infix, suffix),
+            "//sw/host/cryptotest/testvectors/data/schemas:rsa_schema.json",
+        ],
+        outs = [":nist_rsa_{}_{}.json".format(
+            padding_mode,
+            operation,
+        )],
+        args = [
+            "--src",
+            "$(location @nist_cavp_rsa_fips_186_3//:Sig{}{}_186-3.{})".format(prefix, infix, suffix),
+            "--dst",
+            "$(location :nist_rsa_{}_{}.json)".format(
+                padding_mode,
+                operation,
+            ),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:rsa_schema.json)",
+            "--operation",
+            operation,
+            "--padding",
+            padding_mode,
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_rsa_parser",
+    )
+    for padding_mode, infix in [
+        ("pkcs1_1.5", "15"),
+        ("pss", "PSS"),
+    ]
+    for operation, prefix, suffix in [
+        ("sign", "Gen", "txt"),
+        ("verify", "Ver", "rsp"),
+    ]
+]

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -21,4 +21,5 @@ exports_files([
     "hash_schema.json",
     "hmac_schema.json",
     "kmac_schema.json",
+    "rsa_schema.json",
 ])

--- a/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json",
+  "title": "Cryptotest RSA Signature Verification Test Vector",
+  "description": "A list of testvectors for RSA Signature Verification testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID from test vector source -- used for debugging",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be rsa",
+        "type": "string",
+        "enum": ["rsa"]
+      },
+      "operation": {
+        "description": "RSA operation",
+        "type": "string",
+        "enum": ["sign", "verify", "encrypt", "decrypt"]
+      },
+      "padding": {
+        "description": "RSA padding type",
+        "type": "string",
+        "enum": ["pkcs1_1.5", "pss", "oaep"]
+      },
+      "security_level": {
+        "description": "RSA security level",
+        "type": "integer",
+        "enum": [2048, 3072, 4096]
+      },
+      "hash_alg": {
+        "description": "Hash algorithm for message encoding",
+        "type": "string",
+        "enum": ["sha-256", "sha-384", "sha-512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "shake-128", "shake-256"]
+      },
+      "message": {
+        "description": "Un-hashed plaintext message",
+        "$ref": "#/$defs/byte_array"
+      },
+      "label": {
+        "description": "Label for OAEP encryption",
+        "$ref": "#/$defs/byte_array"
+      },
+      "n": {
+        "description": "RSA public value n",
+        "$ref": "#/$defs/byte_array"
+      },
+      "e": {
+        "description": "RSA exponent e",
+        "type": "integer"
+      },
+      "d": {
+        "description": "RSA private value d",
+        "$ref": "#/$defs/byte_array"
+      },
+      "signature": {
+        "description": "RSA signature",
+        "$ref": "#/$defs/byte_array"
+      },
+      "ciphertext": {
+        "description": "Ciphertext to decrypt",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Expected signature verification result",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -121,3 +121,12 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "nist_cavp_rsa_parser",
+    srcs = ["nist_cavp_rsa_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
+++ b/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
@@ -109,9 +109,9 @@ def str_to_byte_array(s: str) -> list:
     For example, str_to_byte_array("01020a0b") -> [1, 2, 10, 11]
     """
     if s.startswith("0x"):
-        s = s[1:]
+        s = s[2:]
     if len(s) % 2 != 0:
-        raise ValueError(f"String {s} has an odd number of digits; cannot convert into byte array.")
+        s = "0" + s
 
     byte_array = list()
     for i in range(0, len(s), 2):

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_rsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_rsa_parser.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting NIST CAVP RSA test vectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+SUPPORTED_SECURITY_LEVELS = [
+    2048,
+    3072,
+    4096,
+]
+
+HASH_NAME_MAPPING = {
+    "SHA256": "sha-256",
+    "SHA384": "sha-384",
+    "SHA512": "sha-512",
+}
+
+
+def parse_testcases(args) -> None:
+    # Depending on the operation, we have to notify the parser that certain
+    # variables in the rsp file are not intended to be treated as a test case
+    # on their own; instead, the values apply to all following test cases until
+    # the variable is assigned another value.
+    persists = []
+    if args.operation == "sign":
+        persists = ["n", "e", "d"]
+    elif args.operation == "verify":
+        persists = ["n", "p", "q"]
+    else:
+        raise ValueError(f"Unsupported RSA operation: {args.operation}")
+
+    raw_testcases = parse_rsp(args.src, persists=persists)
+
+    test_cases = list()
+    # NIST splits the rsp files into sections with named after (curve, hash
+    # algorithm) pairs
+    count = 0
+    for test_vec in raw_testcases:
+        count += 1
+        # Filter out unsupported configurations
+        if int(test_vec["mod"]) not in SUPPORTED_SECURITY_LEVELS:
+            continue
+        if test_vec["SHAAlg"] not in HASH_NAME_MAPPING:
+            continue
+        test_case = {
+            "vendor": "nist",
+            "test_case_id": count,
+            "algorithm": "rsa",
+            "operation": args.operation,
+            "padding": args.padding,
+            "security_level": int(test_vec["mod"]),
+            "hash_alg": HASH_NAME_MAPPING[test_vec["SHAAlg"]],
+            "message": str_to_byte_array(test_vec["Msg"]),
+            # Pad n and d with leading zero byte for compatibility
+            # with signed hexadecimal notation.
+            "n": [0] + str_to_byte_array(test_vec["n"]),
+            "e": int(test_vec["e"], 16),
+            "d": [0] + str_to_byte_array(test_vec["d"]) if "d" in test_vec else [],
+            "signature": str_to_byte_array(test_vec["S"]),
+        }
+        if args.operation == "sign":
+            # `Sign` tests always include the correct expected
+            # signature.
+            test_case["result"] = True
+        elif args.operation == "verify":
+            result_str = test_vec["Result"][:1]
+            if result_str == "P":
+                test_case["result"] = True
+            elif result_str == "F":
+                test_case["result"] = False
+            else:
+                raise ValueError(f"Unknown verification result value: {result_str}")
+
+        test_cases.append(test_case)
+
+    json_filename = f"{args.dst}"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP Digital Signatures test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    parser.add_argument(
+        "--operation",
+        type = str,
+        help = "RSA operation [sign, verify]"
+    )
+    parser.add_argument(
+        "--padding",
+        type = str,
+        help = "RSA padding type [pkcs1_1.5, pss]"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -77,3 +77,9 @@ def nist_cavp_repos():
         sha256 = "5fff092551f2d72e89a3d9362711878708f9a14b502f0dfae819649105b0ea39",
         url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/components/ecccdhtestvectors.zip",
     )
+    http_archive(
+        name = "nist_cavp_rsa_fips_186_3",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "8405aeb3572a4f98ed4b1a3ccb3f2f49e725462dd28ec4759d6a15d88855d19c",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-3rsatestvectors.zip",
+    )


### PR DESCRIPTION
This PR is the first in a series for the RSA test harness. This PR declares the JSON schema for RSA test vectors, implements the python parser to translate the NIST CAVP test vectors into that JSON format, and adds a bazel rule to fetch the NIST vectors.