### PR TITLE
[cryptotest] Add parser for RSA manual hjson tests

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -671,6 +671,31 @@ WYCHEPROOF_RSA_PSS_SUFFIXES = {
     for wy_suffix in suffixes
 ]
 
+[
+    run_binary(
+        name = cryptotest_name,
+        srcs = [
+            "//sw/device/tests/crypto/testvectors:{}".format(src_name),
+            "//sw/host/cryptotest/testvectors/data/schemas:rsa_schema.json",
+        ],
+        outs = [":{}.json".format(cryptotest_name)],
+        args = [
+            "--src",
+            "$(location //sw/device/tests/crypto/testvectors:{})".format(src_name),
+            "--dst",
+            "$(location :{}.json)".format(cryptotest_name),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:rsa_schema.json)",
+            "--security_level",
+            str(security_level),
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:hjson_rsa_parser",
+    )
+    for src_name, cryptotest_name, security_level in [
+        ("rsa_3072_verify_hardcoded.hjson", "manual_rsa_3072", 3072),
+    ]
+]
+
 run_binary(
     name = "rsp_sphincsplus_shake256_128s_simple_json",
     srcs = [

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -196,3 +196,13 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "hjson_rsa_parser",
+    srcs = ["hjson_rsa_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("hjson"),
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
+++ b/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
@@ -123,6 +123,27 @@ def str_to_byte_array(s: str) -> list:
     return byte_array
 
 
+def int_to_byte_array(num: int, byteorder="big") -> list:
+    """
+    Converts an integer to a list of bytes with the specified
+    byte order.
+
+    """
+    # Remove the '0x'
+    h = hex(num)[2:]
+    # Append a leading zero if we do not have an even number of
+    # hexadecimal digits.
+    if len(h) % 2 == 1:
+        h = "0" + h
+    arr = list(bytes.fromhex(h))
+    if byteorder == "big":
+        return arr
+    elif byteorder == "little":
+        return arr[::-1]
+    else:
+        raise ValueError("Unrecognized byte order: " + byteorder)
+
+
 def rng() -> Callable[[int], bytes]:
     """
     Initializes the `random` module for generating random test vectors.

--- a/sw/host/cryptotest/testvectors/parsers/hjson_rsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/hjson_rsa_parser.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import logging
+import sys
+import jsonschema
+import hjson
+from cryptotest_util import int_to_byte_array
+
+
+def parse_test_vectors(raw_data, security_level):
+    test_vectors = []
+    count = 1
+    for test in raw_data:
+        test_vec = {
+            "vendor": "manual",
+            "test_case_id": count,
+            "algorithm": "rsa",
+            "operation": "verify",
+            "security_level": security_level,
+            "padding": "pkcs1_1.5",
+            "hash_alg": "sha-256",
+            "message": int_to_byte_array(test["msg"]),
+            "n": [0] + int_to_byte_array(test["n"]),
+            "e": test["e"],
+            "signature": int_to_byte_array(test["signature"]),
+            "result": test["valid"],
+        }
+        test_vectors.append(test_vec)
+        count += 1
+
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--src',
+                        metavar='FILE',
+                        type=argparse.FileType('r'),
+                        help='Read test vectors from this JSON file.')
+    parser.add_argument('--dst',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help='Write output to this file.')
+    parser.add_argument("--schema", type=str, help="Testvector schema file")
+    parser.add_argument("--security_level", type=int, help="RSA security level [2048, 3072, 4096]")
+    args = parser.parse_args()
+
+    testvecs = parse_test_vectors(hjson.loads(args.src.read()), args.security_level)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
The second in the series of RSA test PRs. This PR adds a parser to integrate the existing RSA manual test vectors in `/sw/device/tests/crypto/testvectors/` with the cryptotest framework. 

During writing of this PR, I noticed that the C header templates the manual tests previously used before the current cryptotest framework was developed call into a different RSA-3072 verify API than the normal `otcrypto_rsa_verify` API, and the former calls into a dedicated OTBN routine, which will need to be separately tested within the test harness.

~Dependent on #21590~