### PR TITLE
[cryptolib] Export cryptolib as a stand-alone library

### DIFF
--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -4,7 +4,10 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load("//rules/opentitan:static_library.bzl", "ot_static_library")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 # Top-level cryptolib target.
 ot_static_library(
@@ -20,4 +23,31 @@ ot_static_library(
         "//sw/device/lib/crypto/impl:rsa",
         "//sw/device/lib/crypto/include:datatypes",
     ],
+)
+
+cc_import(
+    name = "crypto",
+    static_library = ":otcrypto",
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/crypto/include:crypto_hdrs",
+    ],
+)
+
+pkg_files(
+    name = "package",
+    srcs = [
+        ":otcrypto",
+    ],
+    prefix = "crypto",
+)
+
+pkg_tar(
+    name = "cryptolib",
+    srcs = [
+        ":package",
+        "//sw/device/lib/crypto/include:package",
+        "//sw/device/lib/crypto/include/freestanding:package",
+    ],
+    extension = "tar.xz",
 )

--- a/sw/device/lib/crypto/include/BUILD
+++ b/sw/device/lib/crypto/include/BUILD
@@ -4,14 +4,45 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
 # Export all headers.
 exports_files(glob(["*.h"]))
 
 cc_library(
     name = "datatypes",
     hdrs = ["datatypes.h"],
+    defines = ["OTCRYPTO_IN_REPO=1"],
+    includes = ["."],
     deps = [
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:status",
     ],
+)
+
+cc_library(
+    name = "crypto_hdrs",
+    hdrs = [
+        "aes.h",
+        "datatypes.h",
+        "drbg.h",
+        "ecc.h",
+        "hash.h",
+        "kdf.h",
+        "key_transport.h",
+        "mac.h",
+        "rsa.h",
+    ],
+    defines = ["OTCRYPTO_IN_REPO=1"],
+    includes = ["."],
+    deps = [
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:status",
+    ],
+)
+
+pkg_files(
+    name = "package",
+    srcs = glob(["*.h"]),
+    prefix = "crypto/include",
 )

--- a/sw/device/lib/crypto/include/aes.h
+++ b/sw/device/lib/crypto/include/aes.h
@@ -5,7 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_AES_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_AES_H_
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 /**
  * @file

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -5,8 +5,13 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DATATYPES_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DATATYPES_H_
 
+#ifdef OTCRYPTO_IN_REPO
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/status.h"
+#else
+#include "freestanding/absl_status.h"
+#include "freestanding/hardened.h"
+#endif
 
 /**
  * @file

--- a/sw/device/lib/crypto/include/drbg.h
+++ b/sw/device/lib/crypto/include/drbg.h
@@ -5,7 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DRBG_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DRBG_H_
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 /**
  * @file

--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -5,7 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_ECC_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_ECC_H_
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 /**
  * @file

--- a/sw/device/lib/crypto/include/freestanding/BUILD
+++ b/sw/device/lib/crypto/include/freestanding/BUILD
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+pkg_files(
+    name = "package",
+    srcs = glob(["*.h"]),
+    prefix = "crypto/include/freestanding",
+)

--- a/sw/device/lib/crypto/include/freestanding/absl_status.h
+++ b/sw/device/lib/crypto/include/freestanding/absl_status.h
@@ -1,0 +1,230 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_ABSL_STATUS_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_ABSL_STATUS_H_
+
+// Note: the status definitions were taken directly from the abseil-cpp
+// library, and in particular from the file:
+// https://github.com/abseil/abseil-cpp/blob/master/absl/status/status.h
+// The copyright is preserved below:
+// -----------------------------------------------------------------------------
+// Copyright 2019 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * This enum was taken directly from the abseil-cpp library:
+ * https://github.com/abseil/abseil-cpp/blob/master/absl/status/status.h
+ *
+ * These error codes serve as general error classifications which are used to
+ * build up more specific error codes.
+ *
+ * DO NOT USE THESE CODES DIRECTLY. Use these codes to build per-module error
+ * codes in error.h.  Although these error codes are generally used at
+ * Google by RPC servers, the advice about how to use them and how to
+ * categorize errors is generally sound.
+ */
+typedef enum absl_status_code {
+  // StatusCode::kOk
+  //
+  // kOK (gRPC code "OK") does not indicate an error; this value is returned on
+  // success. It is typical to check for this value before proceeding on any
+  // given call across an API or RPC boundary. To check this value, use the
+  // `absl::Status::ok()` member function rather than inspecting the raw code.
+  kOk = 0,
+
+  // StatusCode::kCancelled
+  //
+  // kCancelled (gRPC code "CANCELLED") indicates the operation was cancelled,
+  // typically by the caller.
+  kCancelled = 1,
+
+  // StatusCode::kUnknown
+  //
+  // kUnknown (gRPC code "UNKNOWN") indicates an unknown error occurred. In
+  // general, more specific errors should be raised, if possible. Errors raised
+  // by APIs that do not return enough error information may be converted to
+  // this error.
+  kUnknown = 2,
+
+  // StatusCode::kInvalidArgument
+  //
+  // kInvalidArgument (gRPC code "INVALID_ARGUMENT") indicates the caller
+  // specified an invalid argument, such a malformed filename. Note that such
+  // errors should be narrowly limited to indicate to the invalid nature of the
+  // arguments themselves. Errors with validly formed arguments that may cause
+  // errors with the state of the receiving system should be denoted with
+  // `kFailedPrecondition` instead.
+  kInvalidArgument = 3,
+
+  // StatusCode::kDeadlineExceeded
+  //
+  // kDeadlineExceeded (gRPC code "DEADLINE_EXCEEDED") indicates a deadline
+  // expired before the operation could complete. For operations that may change
+  // state within a system, this error may be returned even if the operation has
+  // completed successfully. For example, a successful response from a server
+  // could have been delayed long enough for the deadline to expire.
+  kDeadlineExceeded = 4,
+
+  // StatusCode::kNotFound
+  //
+  // kNotFound (gRPC code "NOT_FOUND") indicates some requested entity (such as
+  // a file or directory) was not found.
+  //
+  // `kNotFound` is useful if a request should be denied for an entire class of
+  // users, such as during a gradual feature rollout or undocumented allow list.
+  // If, instead, a request should be denied for specific sets of users, such as
+  // through user-based access control, use `kPermissionDenied` instead.
+  kNotFound = 5,
+
+  // StatusCode::kAlreadyExists
+  //
+  // kAlreadyExists (gRPC code "ALREADY_EXISTS") indicates the entity that a
+  // caller attempted to create (such as file or directory) is already present.
+  kAlreadyExists = 6,
+
+  // StatusCode::kPermissionDenied
+  //
+  // kPermissionDenied (gRPC code "PERMISSION_DENIED") indicates that the caller
+  // does not have permission to execute the specified operation. Note that this
+  // error is different than an error due to an *un*authenticated user. This
+  // error code does not imply the request is valid or the requested entity
+  // exists or satisfies any other pre-conditions.
+  //
+  // `kPermissionDenied` must not be used for rejections caused by exhausting
+  // some resource. Instead, use `kResourceExhausted` for those errors.
+  // `kPermissionDenied` must not be used if the caller cannot be identified.
+  // Instead, use `kUnauthenticated` for those errors.
+  kPermissionDenied = 7,
+
+  // StatusCode::kResourceExhausted
+  //
+  // kResourceExhausted (gRPC code "RESOURCE_EXHAUSTED") indicates some resource
+  // has been exhausted, perhaps a per-user quota, or perhaps the entire file
+  // system is out of space.
+  kResourceExhausted = 8,
+
+  // StatusCode::kFailedPrecondition
+  //
+  // kFailedPrecondition (gRPC code "FAILED_PRECONDITION") indicates that the
+  // operation was rejected because the system is not in a state required for
+  // the operation's execution. For example, a directory to be deleted may be
+  // non-empty, an "rmdir" operation is applied to a non-directory, etc.
+  //
+  // Some guidelines that may help a service implementer in deciding between
+  // `kFailedPrecondition`, `kAborted`, and `kUnavailable`:
+  //
+  //  (a) Use `kUnavailable` if the client can retry just the failing call.
+  //  (b) Use `kAborted` if the client should retry at a higher transaction
+  //      level (such as when a client-specified test-and-set fails, indicating
+  //      the client should restart a read-modify-write sequence).
+  //  (c) Use `kFailedPrecondition` if the client should not retry until
+  //      the system state has been explicitly fixed. For example, if an "rmdir"
+  //      fails because the directory is non-empty, `kFailedPrecondition`
+  //      should be returned since the client should not retry unless
+  //      the files are deleted from the directory.
+  kFailedPrecondition = 9,
+
+  // StatusCode::kAborted
+  //
+  // kAborted (gRPC code "ABORTED") indicates the operation was aborted,
+  // typically due to a concurrency issue such as a sequencer check failure or a
+  // failed transaction.
+  //
+  // See the guidelines above for deciding between `kFailedPrecondition`,
+  // `kAborted`, and `kUnavailable`.
+  kAborted = 10,
+
+  // StatusCode::kOutOfRange
+  //
+  // kOutOfRange (gRPC code "OUT_OF_RANGE") indicates the operation was
+  // attempted past the valid range, such as seeking or reading past an
+  // end-of-file.
+  //
+  // Unlike `kInvalidArgument`, this error indicates a problem that may
+  // be fixed if the system state changes. For example, a 32-bit file
+  // system will generate `kInvalidArgument` if asked to read at an
+  // offset that is not in the range [0,2^32-1], but it will generate
+  // `kOutOfRange` if asked to read from an offset past the current
+  // file size.
+  //
+  // There is a fair bit of overlap between `kFailedPrecondition` and
+  // `kOutOfRange`.  We recommend using `kOutOfRange` (the more specific
+  // error) when it applies so that callers who are iterating through
+  // a space can easily look for an `kOutOfRange` error to detect when
+  // they are done.
+  kOutOfRange = 11,
+
+  // StatusCode::kUnimplemented
+  //
+  // kUnimplemented (gRPC code "UNIMPLEMENTED") indicates the operation is not
+  // implemented or supported in this service. In this case, the operation
+  // should not be re-attempted.
+  kUnimplemented = 12,
+
+  // StatusCode::kInternal
+  //
+  // kInternal (gRPC code "INTERNAL") indicates an internal error has occurred
+  // and some invariants expected by the underlying system have not been
+  // satisfied. This error code is reserved for serious errors.
+  kInternal = 13,
+
+  // StatusCode::kUnavailable
+  //
+  // kUnavailable (gRPC code "UNAVAILABLE") indicates the service is currently
+  // unavailable and that this is most likely a transient condition. An error
+  // such as this can be corrected by retrying with a backoff scheme. Note that
+  // it is not always safe to retry non-idempotent operations.
+  //
+  // See the guidelines above for deciding between `kFailedPrecondition`,
+  // `kAborted`, and `kUnavailable`.
+  kUnavailable = 14,
+
+  // StatusCode::kDataLoss
+  //
+  // kDataLoss (gRPC code "DATA_LOSS") indicates that unrecoverable data loss or
+  // corruption has occurred. As this error is serious, proper alerting should
+  // be attached to errors such as this.
+  kDataLoss = 15,
+
+  // StatusCode::kUnauthenticated
+  //
+  // kUnauthenticated (gRPC code "UNAUTHENTICATED") indicates that the request
+  // does not have valid authentication credentials for the operation. Correct
+  // the authentication and try again.
+  kUnauthenticated = 16,
+
+  // StatusCode::DoNotUseReservedForFutureExpansionUseDefaultInSwitchInstead_
+  //
+  // NOTE: this error code entry should not be used and you should not rely on
+  // its value, which may change.
+  //
+  // The purpose of this enumerated value is to force people who handle status
+  // codes with `switch()` statements to *not* simply enumerate all possible
+  // values, but instead provide a "default:" case. Providing such a default
+  // case ensures that code will compile when new codes are added.
+  kDoNotUseReservedForFutureExpansionUseDefaultInSwitchInstead_ = 20
+} absl_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_ABSL_STATUS_H_

--- a/sw/device/lib/crypto/include/freestanding/hardened.h
+++ b/sw/device/lib/crypto/include/freestanding/hardened.h
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_HARDENED_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_HARDENED_H_
+
+/**
+ * @file
+ * @brief Data Types for use in Hardened Code.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * This is a boolean type for use in hardened contexts.
+ *
+ * The intention is that this is used instead of `<stdbool.h>`'s #bool, where a
+ * higher hamming distance is required between the truthy and the falsey value.
+ *
+ * The values below were chosen at random, with some specific restrictions. They
+ * have a Hamming Distance of 8, and they are 11-bit values so they can be
+ * materialized with a single instruction on RISC-V. They are also specifically
+ * not the complement of each other.
+ */
+typedef enum hardened_bool {
+  /**
+   * The truthy value, expected to be used like #true.
+   */
+  kHardenedBoolTrue = HARDENED_BOOL_TRUE,
+  /**
+   * The falsey value, expected to be used like #false.
+   */
+  kHardenedBoolFalse = HARDENED_BOOL_FALSE,
+} hardened_bool_t;
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_HARDENED_H_

--- a/sw/device/lib/crypto/include/hash.h
+++ b/sw/device/lib/crypto/include/hash.h
@@ -5,7 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_HASH_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_HASH_H_
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 /**
  * @file

--- a/sw/device/lib/crypto/include/kdf.h
+++ b/sw/device/lib/crypto/include/kdf.h
@@ -5,7 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KDF_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KDF_H_
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 /**
  * @file

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -5,7 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KEY_TRANSPORT_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_KEY_TRANSPORT_H_
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 /**
  * @file

--- a/sw/device/lib/crypto/include/mac.h
+++ b/sw/device/lib/crypto/include/mac.h
@@ -5,8 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MAC_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MAC_H_
 
-#include "sw/device/lib/crypto/include/datatypes.h"
-#include "sw/device/lib/crypto/include/hash.h"
+#include "datatypes.h"
+#include "hash.h"
 
 /**
  * @file

--- a/sw/device/lib/crypto/include/rsa.h
+++ b/sw/device/lib/crypto/include/rsa.h
@@ -5,7 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_RSA_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_RSA_H_
 
-#include "sw/device/lib/crypto/include/datatypes.h"
+#include "datatypes.h"
 
 /**
  * @file

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -663,6 +663,21 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "otcrypto_hash_test",
+    srcs = ["otcrypto_hash_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    deps = [
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 filegroup(
     name = "template_files",
     srcs = [

--- a/sw/device/tests/crypto/otcrypto_hash_test.c
+++ b/sw/device/tests/crypto/otcrypto_hash_test.c
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/include/hash.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// This test checks that the static-linked `otcrypto` library is usable.
+
+// From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
+static const char kGettysburgPrelude[] =
+    "Four score and seven years ago our fathers brought forth on this "
+    "continent, a new nation, conceived in Liberty, and dedicated to the "
+    "proposition that all men are created equal.";
+
+// The following shell command will produce the sha256sum and convert the
+// digest into valid C hexadecimal constants:
+//
+// $ echo -n "Four score and seven years ago our fathers brought forth on this
+// continent, a new nation, conceived in Liberty, and dedicated to the
+// proposition that all men are created equal." |
+//     sha256sum - | cut -f1 -d' ' | sed -e "s/../0x&, /g"
+//
+static const uint8_t kGettysburgDigest[] = {
+    0x1e, 0x6f, 0xd4, 0x03, 0x0f, 0x90, 0x34, 0xcd, 0x77, 0x57, 0x08,
+    0xa3, 0x96, 0xc3, 0x24, 0xed, 0x42, 0x0e, 0xc5, 0x87, 0xeb, 0x3d,
+    0xd4, 0x33, 0xe2, 0x9f, 0x6a, 0xc0, 0x8b, 0x8c, 0xc7, 0xba,
+};
+
+status_t hash_test(void) {
+  uint32_t digest_content[8];
+  otcrypto_hash_context_t ctx;
+  otcrypto_hash_digest_t digest = {
+      .mode = kOtcryptoHashModeSha256,
+      .len = ARRAYSIZE(digest_content),
+      .data = digest_content,
+  };
+  otcrypto_const_byte_buf_t buf = {
+      .len = sizeof(kGettysburgPrelude) - 1,
+      .data = (const uint8_t *)kGettysburgPrelude,
+  };
+
+  TRY(otcrypto_hash_init(&ctx, kOtcryptoHashModeSha256));
+  TRY(otcrypto_hash_update(&ctx, buf));
+  TRY(otcrypto_hash_final(&ctx, &digest));
+
+  TRY_CHECK_ARRAYS_EQ((const uint8_t *)digest.data, kGettysburgDigest,
+                      ARRAYSIZE(kGettysburgDigest));
+  return OK_STATUS();
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+  result = hash_test();
+  return status_ok(result);
+}


### PR DESCRIPTION
1. Rewrite header includes from full paths to basenames.  This will allow the header files to be exported as packagable resource without regard to the file locations within the OT repo.
2. Add freestanding version of the `hardened.h` and `status.h` files. This allows `datatypes.h` to use those definitions once exported out of the OT repo.
3. Add packaging rules to package the cryptolib binary and headers into a tar archive (ie: an exported release artifact).
4. Create a `cc_import` library that uses the output of the static_library rule to create a useful cryptolib resource within the codebase.