### PR TITLE
[spi_device] Add separate constraints for TPM and fast passthrough

### DIFF
--- a/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc
+++ b/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc
@@ -572,22 +572,19 @@ set_output_delay -max ${SPI_TPM_MISO_OUT_DEL_MAX} [get_ports SPI_DEV_D1] \
     -clock SPI_TPM_CLK -add_delay
 
 # SPI TPM CSB, the chip-select for TPM mode.
-# Any muxed port could be a SPI TPM CSB.
-set MUXED_IOA_PORTS [get_ports IOA*]
-set MUXED_IOB_PORTS [get_ports IOB*]
-set MUXED_IOC_PORTS [get_ports IOC*]
-set MUXED_IOR_PORTS [get_ports "IOR0 IOR1 IOR2 IOR3 IOR4 IOR5 IOR6 IOR7 IOR10 IOR11 IOR12 IOR13"]
-set ALL_MUXED_PORTS [get_ports "${MUXED_IOA_PORTS} ${MUXED_IOB_PORTS} ${MUXED_IOC_PORTS} ${MUXED_IOR_PORTS}"]
+# Any muxed port could be a SPI TPM CSB, but we only guarantee IOA7 meets
+# timing.
+set TPM_CSB_PORT [get_ports IOA7]
 
 # TPM CSB input delays.
-set_input_delay -min ${SPI_TPM_CSB_IN_DEL_MIN} [get_ports ${ALL_MUXED_PORTS}] \
+set_input_delay -min ${SPI_TPM_CSB_IN_DEL_MIN} [get_ports ${TPM_CSB_PORT}] \
     -clock SPI_TPM_CLK -clock_fall -add_delay
-set_input_delay -max ${SPI_TPM_CSB_IN_DEL_MAX} [get_ports ${ALL_MUXED_PORTS}] \
+set_input_delay -max ${SPI_TPM_CSB_IN_DEL_MAX} [get_ports ${TPM_CSB_PORT}] \
     -clock SPI_TPM_CLK -clock_fall -add_delay
 
 # Relax hold path for TPM CSB, since CSB changes nominally on the same edge as
 # SPI_TPM_OUT_CLK, but the latter isn't actually toggling.
-set_multicycle_path -hold -end 1 -from [get_ports ${ALL_MUXED_PORTS}] \
+set_multicycle_path -hold -end 1 -from [get_ports ${TPM_CSB_PORT}] \
     -to [get_clocks SPI_TPM_OUT_CLK] \
     -through [get_pins -leaf -filter "@pin_direction == in" -of_objects \
         [get_nets -segments -of_objects \


### PR DESCRIPTION
Add constraints that are specific to TPM and fast passthrough commands. This might be excessive, but now there are five constraints modes:

- 50 MHz, full-cycle sampling, no passthrough, flash I/O delays
- 25 MHz, half-cycle sampling, no passthrough, flash I/O delays
- 25 MHz, half-cycle sampling, TPM I/O delays
- 25 MHz, full-cycle sampling, all passthrough, flash I/O delays
- 40 MHz, full-cycle sampling, pipelined passthrough only, flash I/O delays

We may be able to consolidate these, but we'll likely want to take a look at the data first.

In addition to the new constraint sets, some generic mode-specific exceptions get removed, and we select IOA7 as the only timed pad for SPI TPM's CSB. _We should confirm that this is the correct chosen pad._

Finally, just a note, but for real synthesis, the pads should be set to the appropriate configuration to effect the intended data sheet. The defaults (e.g. minimum drive strength) will likely lead to very long pad delays used in analysis.