### PR TITLE
[lc_ctrl/dv] Change DV configuration so that UNR works

### DIFF
--- a/hw/ip/lc_ctrl/dv/lc_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_base_sim_cfg.hjson
@@ -59,17 +59,6 @@
     }
   ]
 
-  build_modes: [
-    {
-      name: volatile_unlock_disabled
-      build_opts: ["+define+SEC_VOLATILE_RAW_UNLOCK_EN=0"]
-    }
-    {
-      name: volatile_unlock_enabled
-        build_opts: ["+define+SEC_VOLATILE_RAW_UNLOCK_EN=1"]
-    }
-  ]
-
   // Default UVM test and seq class name.
   uvm_test: lc_ctrl_base_test
   uvm_test_seq: lc_ctrl_base_vseq

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_disabled_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_disabled_sim_cfg.hjson
@@ -10,8 +10,8 @@
   // Import additional common sim cfg files.
   import_cfgs: ["{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_base_sim_cfg.hjson"]
 
-  // Enable this build mode for all tests
-  en_build_modes: ["volatile_unlock_disabled"]
+  // Disable volatile unlock in this configuration.
+  build_opts: ["+define+SEC_VOLATILE_RAW_UNLOCK_EN=0"]
 
   // exclusion files
   // TODO: redo UNR

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_enabled_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_enabled_sim_cfg.hjson
@@ -10,8 +10,8 @@
   // Import additional common sim cfg files.
   import_cfgs: ["{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_base_sim_cfg.hjson"]
 
-  // Enable this build mode for all tests
-  en_build_modes: ["volatile_unlock_enabled"]
+  // Enable volatile unlock in this configuration.
+  build_opts: ["+define+SEC_VOLATILE_RAW_UNLOCK_EN=1"]
 
   // exclusion files
   // TODO: redo UNR


### PR DESCRIPTION
The variant using dedicated build modes caused issues with UNR. This uses a different approach that makes the build options explicit for each configuration, similarly to the SRAM_CTRL variants.