### PR TITLE
[RV_DM]rv_dm_progbuf_exception_vseq

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -479,6 +479,22 @@
       tests: ["rv_dm_progbuf_busy"]
     }
     {
+      name: progbuf_exception
+      desc: '''
+            Verify that writing on DM progbuf registers while abstract command is executing
+            causes jtag_dmi_ral.abstractcs.cmderr to be set to 3.
+
+            - Program jtag_dmi_ral.dmcontrol.haltreq to 1'b1.
+            - Acknowledge haltreq by setting tl_mem_ral.halted to 0.
+            - Send access register abstract command with postexec bit set.
+            - Write on any of progbuf registers.
+            - Write on tl_mem_ral.exception register.
+            - Verify that jtag_dmi_ral.abstractcs.cmderr is set to 3.
+            '''
+      stage: V1
+      tests: ["rv_dm_progbuf_exception"]
+    }
+    {
       name: stress_all
       desc: '''
             A 'bug hunt' test that stresses the DUT to its limits.

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -48,6 +48,7 @@ filesets:
       - seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_progbuf_busy_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_progbuf_exception_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_exception_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_exception_vseq.sv
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_progbuf_exception_vseq extends rv_dm_base_vseq;
+
+  `uvm_object_utils(rv_dm_progbuf_exception_vseq)
+
+  `uvm_object_new
+
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+  task body();
+    uvm_reg_data_t data;
+    uvm_reg_data_t r_data;
+    repeat ($urandom_range(1, 10)) begin
+    data = $urandom_range(0,31);
+      csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(1));
+      csr_wr(.ptr(tl_mem_ral.halted), .value(0));
+      // Access Register command with postexec bit set.
+      csr_wr(.ptr(jtag_dmi_ral.command), .value('h00250000));
+      csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(data));
+      csr_wr(.ptr(tl_mem_ral.exception), .value(data));
+      csr_rd(.ptr(jtag_dmi_ral.abstractcs), .value(r_data));
+      `DV_CHECK_EQ(3, get_field_val(jtag_dmi_ral.abstractcs.cmderr, r_data));
+    end
+  endtask
+
+endclass:rv_dm_progbuf_exception_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -25,3 +25,4 @@
 `include "rv_dm_jtag_dtm_hard_reset_vseq.sv"
 `include "rv_dm_stress_all_vseq.sv"
 `include "rv_dm_progbuf_busy_vseq.sv"
+`include "rv_dm_progbuf_exception_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -256,6 +256,11 @@
       reseed: 2
     }
     {
+      name: rv_dm_progbuf_exception
+      uvm_test_seq: rv_dm_progbuf_exception_vseq
+      reseed: 2
+    }
+    {
       name: rv_dm_stress_all
       uvm_test_seq: rv_dm_stress_all_vseq
     }


### PR DESCRIPTION
This PR verify that writing on progbuf registers while abstract command is executing causes exception.