### PR TITLE
Cherry-pick to master: #21239 and #21200

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -6,6 +6,7 @@ load(
     "cw310_params",
     "opentitan_binary",
     "opentitan_test",
+    "silicon_params",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -163,6 +164,38 @@ opentitan_binary(
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310_test_rom",
     ],
+    deps = [
+        ":aes",
+        ":aes_sca",
+        ":hash",
+        ":ibex_fi",
+        ":kmac_sca",
+        ":prng_sca",
+        ":sha3_sca",
+        ":trigger_sca",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:aes_commands",
+        "//sw/device/tests/crypto/cryptotest/json:commands",
+        "//sw/device/tests/crypto/cryptotest/json:hash_commands",
+        "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
+    ],
+)
+
+opentitan_test(
+    name = "chip_pen_test",
+    srcs = [":firmware.c"],
+    exec_env = {
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
+        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
+    },
+    silicon_owner = silicon_params(
+        tags = ["broken"],
+    ),
     deps = [
         ":aes",
         ":aes_sca",


### PR DESCRIPTION
This PR manually cherry-picks PRs #21200 and #21239 from the earlgreay_es_sival branch to master because the automated cherry- picking failed.

Commit messages:
[pentest] Add SCA/FI pen. test bazel rule
This PR adds a bazel rule allowing to compile a signed binary that can be used for penetration testing.

[pentest] Add prodc target to pentest build script
This PR adds the silicon_owner_prodc_rom_ext target for building the penetration testing binary.