### PR TITLE
[cryptotest] Add manual tests for KMAC and hash functions

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -115,27 +115,29 @@ HASH_TESTVECTOR_TARGETS = [
         msg_type.lower(),
     )
     for algorithm, src_repo, extra_msg_types in [
-        ("SHA256", "sha2_fips_180_4", []),
-        ("SHA384", "sha2_fips_180_4", []),
-        ("SHA512", "sha2_fips_180_4", []),
-        ("SHA3_256", "sha3_fips_202", []),
-        ("SHA3_384", "sha3_fips_202", []),
-        ("SHA3_512", "sha3_fips_202", []),
-        (
-            "SHAKE128",
-            "shake_fips_202",
-            ["VariableOut"],
-        ),
-        (
-            "SHAKE256",
-            "shake_fips_202",
-            ["VariableOut"],
-        ),
+        #        ("SHA256", "sha2_fips_180_4", []),
+        #        ("SHA384", "sha2_fips_180_4", []),
+        #        ("SHA512", "sha2_fips_180_4", []),
+        #        ("SHA3_256", "sha3_fips_202", []),
+        #        ("SHA3_384", "sha3_fips_202", []),
+        #        ("SHA3_512", "sha3_fips_202", []),
+        #        (
+        #            "SHAKE128",
+        #            "shake_fips_202",
+        #            ["VariableOut"],
+        #        ),
+        #        (
+        #            "SHAKE256",
+        #            "shake_fips_202",
+        #            ["VariableOut"],
+        #        ),
     ]
     for msg_type in [
         "ShortMsg",
-        #        "LongMsg",
+        "LongMsg",
     ] + extra_msg_types
+] + [
+    "//sw/host/cryptotest/testvectors/data:hjson_hash",
 ]
 
 HASH_TESTVECTOR_ARGS = " ".join([

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -94,6 +94,7 @@ cc_library(
         "//sw/device/lib/base:math",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/drivers:kmac",
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:integrity",
         "//sw/device/lib/crypto/impl:keyblob",

--- a/sw/device/tests/crypto/cryptotest/json/hash_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/hash_commands.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 #define HASH_CMD_MAX_MESSAGE_BYTES 17068
+#define HASH_CMD_MAX_CUSTOMIZATION_STRING_BYTES 16
 #define HASH_CMD_MAX_DIGEST_BYTES 256
 
 // clang-format off
@@ -18,11 +19,14 @@ extern "C" {
     value(_, Sha256) \
     value(_, Sha384) \
     value(_, Sha512) \
+    value(_, Sha3_224) \
     value(_, Sha3_256) \
     value(_, Sha3_384) \
     value(_, Sha3_512) \
     value(_, Shake128) \
-    value(_, Shake256)
+    value(_, Shake256) \
+    value(_, Cshake128) \
+    value(_, Cshake256)
 UJSON_SERDE_ENUM(CryptotestHashAlgorithm, cryptotest_hash_algorithm_t, HASH_ALGORITHM);
 
 #define SHAKE_DIGEST_LENGTH(field, string) \
@@ -31,7 +35,9 @@ UJSON_SERDE_STRUCT(CryptotestHashShakeDigestLength, cryptotest_hash_shake_digest
 
 #define HASH_MESSAGE(field, string) \
     field(message, uint8_t, HASH_CMD_MAX_MESSAGE_BYTES) \
-    field(message_len, size_t)
+    field(message_len, size_t) \
+    field(customization_string, uint8_t, HASH_CMD_MAX_CUSTOMIZATION_STRING_BYTES) \
+    field(customization_string_len, size_t)
 UJSON_SERDE_STRUCT(CryptotestHashMessage, cryptotest_hash_message_t, HASH_MESSAGE);
 
 #define HASH_OUTPUT(field, string) \

--- a/sw/device/tests/crypto/testvectors/BUILD
+++ b/sw/device/tests/crypto/testvectors/BUILD
@@ -36,3 +36,7 @@ autogen_cryptotest_hjson_external(
     src = "@wycheproof//testvectors:rsa_signature_3072_sha256_test.json",
     parser = "//sw/device/tests/crypto/testvectors/wycheproof:rsa_3072_verify_parse_testvectors",
 )
+
+exports_files([
+    "hash_hardcoded.hjson",
+])

--- a/sw/device/tests/crypto/testvectors/cshake_hardcoded.hjson
+++ b/sw/device/tests/crypto/testvectors/cshake_hardcoded.hjson
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The following vectors are obtained from:
+// https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+
+[
+  {
+    vector_identifier: "NIST SP 800-185, cSHAKE_samples.pdf, Sample #1"
+    operation: CSHAKE
+    security_str: 128
+    input_msg: 0x00010203
+    cust_str: 0x456d61696c205369676e6174757265
+    digest: 0xc1c36925b6409a04f1b504fcbca9d82b4017277cb5ed2b2065fc1d3814d5aaf5
+  }
+  {
+    vector_identifier: "NIST SP 800-185, cSHAKE_samples.pdf, Sample #3"
+    operation: CSHAKE
+    security_str: 256
+    input_msg: 0x00010203
+    cust_str: 0x456d61696c205369676e6174757265
+    digest: 0xd008828e2b80ac9d2218ffee1d070c48b8e4c87bff32c9699d5b6896eee0edd164020e2be0560858d9c00c037e34a96937c561a74c412bb4c746469527281c8c
+  }
+]

--- a/sw/device/tests/crypto/testvectors/hash_hardcoded.hjson
+++ b/sw/device/tests/crypto/testvectors/hash_hardcoded.hjson
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The following vectors are obtained from two different sources:
+// SHAKE/SHA3: https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing
+// CSHAKE: https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+
+[
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHAKE128ShortMsg_msg.rsp, Len = 56"
+    operation: SHAKE
+    security_str: 128
+    input_msg: 0x7216a825029da1
+    digest: 0x9de6ffacf3e59693a3de81b02f7db77a
+  }
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHAKE128ShortMsg_msg.rsp, Len = 128"
+    operation: SHAKE
+    security_str: 128
+    input_msg: 0xd4d67b00ca51397791b81205d5582c0a
+    digest: 0xd0acfb2a14928caf8c168ae514925e4e
+  }
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHAKE128ShortMsg_msg.rsp, Len = 1336"
+    operation: SHAKE
+    security_str: 128
+    input_msg: 0x18636f702f216b1b9302e59d82192f4e002f82d526c3f04cbd4f9b9f0bcd2535ed7a67d326da66bdf7fc821ef0fff1a905d56c81e4472856863908d104301133ad111e39552cd542ef78d9b35f20419b893f4a93aee848e9f86ae3fd53d27fea7fb1fc69631fa0f3a5ff51267785086ab4f682d42baf394b3b6992e9a0bb58a38ce0692df9bbaf183e18523ee1352c5fad817e0c04a3e1c476be7f5e92f482a6fb29cd4bbf09ea
+    digest: 0xb7b9db481898f888e5ee4ed629859844
+  }
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHAKE256ShortMsg.rsp, Len = 312"
+    operation: SHAKE
+    security_str: 256
+    input_msg: 0xf532d0ece583bebaec55d030c93fcd43ad7c96a493ef15e7d06470e5eb19825fae7d8be47d3726
+    digest: 0x225ace4d5140a3d75993ca8c7b993662030d046fa0201ee9c5c335d92b4d5801
+  }
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHAKE256VariableOut.rsp, Count = 1245, Len = 2000"
+    operation: SHAKE
+    security_str: 256
+    input_msg: 0x8d8001e2c096f1b88e7c9224a086efd4797fbf74a8033a2d422a2b6b8f6747e4
+    digest: 0x2e975f6a8a14f0704d51b13667d8195c219f71e6345696c49fa4b9d08e9225d3d39393425152c97e71dd24601c11abcfa0f12f53c680bd3ae757b8134a9c10d429615869217fdd5885c4db174985703a6d6de94a667eac3023443a8337ae1bc601b76d7d38ec3c34463105f0d3949d78e562a039e4469548b609395de5a4fd43c46ca9fd6ee29ada5efc07d84d553249450dab4a49c483ded250c9338f85cd937ae66bb436f3b4026e859fda1ca571432f3bfc09e7c03ca4d183b741111ca0483d0edabc03feb23b17ee48e844ba2408d9dcfd0139d2e8c7310125aee801c61ab7900d1efc47c078281766f361c5e6111346235e1dc38325666c
+  }
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHA3_224ShortMsg.rsp, Len = 8"
+    operation: SHA3
+    security_str: 224
+    input_msg: 0x01
+    digest: 0x488286d9d32716e5881ea1ee51f36d3660d70f0db03b3f612ce9eda4
+  }
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHA3_256ShortMsg.rsp, Len = 152"
+    operation: SHA3
+    security_str: 256
+    input_msg: 0xd751ccd2cd65f27db539176920a70057a08a6b
+    digest: 0x7aaca80dbeb8dc3677d18b84795985463650d72f2543e0ec709c9e70b8cd7b79
+  }
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHA3_384LongMsg.rsp, Len = 1672"
+    operation: SHA3
+    security_str: 384
+    input_msg: 0x5fe35923b4e0af7dd24971812a58425519850a506dfa9b0d254795be785786c319a2567cbaa5e35bcf8fe83d943e23fa5169b73adc1fcf8b607084b15e6a013df147e46256e4e803ab75c110f77848136be7d806e8b2f868c16c3a90c14463407038cb7d9285079ef162c6a45cedf9c9f066375c969b5fcbcda37f02aacff4f31cded3767570885426bebd9eca877e44674e9ae2f0c24cdd0e7e1aaf1ff2fe7f80a1c4f5078eb34cd4f06fa94a2d1eab5806ca43fd0f06c60b63d5402b95c70c21ea65a151c5cfaf8262a46be3c722264b
+    digest: 0x3054d249f916a6039b2a9c3ebec1418791a0608a170e6d36486035e5f92635eaba98072a85373cb54e2ae3f982ce132b
+  }
+  {
+    vector_identifier: "NIST CAVP, byte-oriented, SHA3_512ShortMsg.rsp, Len = 296"
+    operation: SHA3
+    security_str: 512
+    input_msg: 0xf34d100269aee3ead156895e8644d4749464d5921d6157dffcbbadf7a719aee35ae0fd4872
+    digest: 0x565a1dd9d49f8ddefb79a3c7a209f53f0bc9f5396269b1ce2a2b283a3cb45ee3ae652e4ca10b26ced7e5236227006c94a37553db1b6fe5c0c2eded756c896bb1
+  }
+  {
+    vector_identifier: "NIST SP 800-185, cSHAKE_samples.pdf, Sample #1"
+    operation: CSHAKE
+    security_str: 128
+    input_msg: 0x00010203
+    cust_str: 0x456d61696c205369676e6174757265
+    digest: 0xc1c36925b6409a04f1b504fcbca9d82b4017277cb5ed2b2065fc1d3814d5aaf5
+  }
+  {
+    vector_identifier: "NIST SP 800-185, cSHAKE_samples.pdf, Sample #3"
+    operation: CSHAKE
+    security_str: 256
+    input_msg: 0x00010203
+    cust_str: 0x456d61696c205369676e6174757265
+    digest: 0xd008828e2b80ac9d2218ffee1d070c48b8e4c87bff32c9699d5b6896eee0edd164020e2be0560858d9c00c037e34a96937c561a74c412bb4c746469527281c8c
+  }
+]

--- a/sw/device/tests/crypto/testvectors/kmac_hardcoded.hjson
+++ b/sw/device/tests/crypto/testvectors/kmac_hardcoded.hjson
@@ -2,90 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// The following vectors are obtained from two different sources:
-// SHAKE/SHA3: https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing
-// CSHAKE/KMAC: https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+// The following vectors are obtained from:
+// https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
 
 [
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHAKE128ShortMsg_msg.rsp, Len = 56"
-    operation: SHAKE
-    security_str: 128
-    input_msg: 0x7216a825029da1
-    digest: 0x9de6ffacf3e59693a3de81b02f7db77a
-  }
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHAKE128ShortMsg_msg.rsp, Len = 128"
-    operation: SHAKE
-    security_str: 128
-    input_msg: 0xd4d67b00ca51397791b81205d5582c0a
-    digest: 0xd0acfb2a14928caf8c168ae514925e4e
-  }
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHAKE128ShortMsg_msg.rsp, Len = 1336"
-    operation: SHAKE
-    security_str: 128
-    input_msg: 0x18636f702f216b1b9302e59d82192f4e002f82d526c3f04cbd4f9b9f0bcd2535ed7a67d326da66bdf7fc821ef0fff1a905d56c81e4472856863908d104301133ad111e39552cd542ef78d9b35f20419b893f4a93aee848e9f86ae3fd53d27fea7fb1fc69631fa0f3a5ff51267785086ab4f682d42baf394b3b6992e9a0bb58a38ce0692df9bbaf183e18523ee1352c5fad817e0c04a3e1c476be7f5e92f482a6fb29cd4bbf09ea
-    digest: 0xb7b9db481898f888e5ee4ed629859844
-  }
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHAKE256ShortMsg.rsp, Len = 312"
-    operation: SHAKE
-    security_str: 256
-    input_msg: 0xf532d0ece583bebaec55d030c93fcd43ad7c96a493ef15e7d06470e5eb19825fae7d8be47d3726
-    digest: 0x225ace4d5140a3d75993ca8c7b993662030d046fa0201ee9c5c335d92b4d5801
-  }
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHAKE256VariableOut.rsp, Count = 1245, Len = 2000"
-    operation: SHAKE
-    security_str: 256
-    input_msg: 0x8d8001e2c096f1b88e7c9224a086efd4797fbf74a8033a2d422a2b6b8f6747e4
-    digest: 0x2e975f6a8a14f0704d51b13667d8195c219f71e6345696c49fa4b9d08e9225d3d39393425152c97e71dd24601c11abcfa0f12f53c680bd3ae757b8134a9c10d429615869217fdd5885c4db174985703a6d6de94a667eac3023443a8337ae1bc601b76d7d38ec3c34463105f0d3949d78e562a039e4469548b609395de5a4fd43c46ca9fd6ee29ada5efc07d84d553249450dab4a49c483ded250c9338f85cd937ae66bb436f3b4026e859fda1ca571432f3bfc09e7c03ca4d183b741111ca0483d0edabc03feb23b17ee48e844ba2408d9dcfd0139d2e8c7310125aee801c61ab7900d1efc47c078281766f361c5e6111346235e1dc38325666c
-  }
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHA3_224ShortMsg.rsp, Len = 8"
-    operation: SHA3
-    security_str: 224
-    input_msg: 0x01
-    digest: 0x488286d9d32716e5881ea1ee51f36d3660d70f0db03b3f612ce9eda4
-  }
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHA3_256ShortMsg.rsp, Len = 152"
-    operation: SHA3
-    security_str: 256
-    input_msg: 0xd751ccd2cd65f27db539176920a70057a08a6b
-    digest: 0x7aaca80dbeb8dc3677d18b84795985463650d72f2543e0ec709c9e70b8cd7b79
-  }
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHA3_384LongMsg.rsp, Len = 1672"
-    operation: SHA3
-    security_str: 384
-    input_msg: 0x5fe35923b4e0af7dd24971812a58425519850a506dfa9b0d254795be785786c319a2567cbaa5e35bcf8fe83d943e23fa5169b73adc1fcf8b607084b15e6a013df147e46256e4e803ab75c110f77848136be7d806e8b2f868c16c3a90c14463407038cb7d9285079ef162c6a45cedf9c9f066375c969b5fcbcda37f02aacff4f31cded3767570885426bebd9eca877e44674e9ae2f0c24cdd0e7e1aaf1ff2fe7f80a1c4f5078eb34cd4f06fa94a2d1eab5806ca43fd0f06c60b63d5402b95c70c21ea65a151c5cfaf8262a46be3c722264b
-    digest: 0x3054d249f916a6039b2a9c3ebec1418791a0608a170e6d36486035e5f92635eaba98072a85373cb54e2ae3f982ce132b
-  }
-  {
-    vector_identifier: "NIST CAVP, byte-oriented, SHA3_512ShortMsg.rsp, Len = 296"
-    operation: SHA3
-    security_str: 512
-    input_msg: 0xf34d100269aee3ead156895e8644d4749464d5921d6157dffcbbadf7a719aee35ae0fd4872
-    digest: 0x565a1dd9d49f8ddefb79a3c7a209f53f0bc9f5396269b1ce2a2b283a3cb45ee3ae652e4ca10b26ced7e5236227006c94a37553db1b6fe5c0c2eded756c896bb1
-  }
-  {
-    vector_identifier: "NIST SP 800-185, cSHAKE_samples.pdf, Sample #1"
-    operation: CSHAKE
-    security_str: 128
-    input_msg: "0x00010203"
-    cust_str: 0x456d61696c205369676e6174757265
-    digest: 0xc1c36925b6409a04f1b504fcbca9d82b4017277cb5ed2b2065fc1d3814d5aaf5
-  }
-  {
-    vector_identifier: "NIST SP 800-185, cSHAKE_samples.pdf, Sample #3"
-    operation: CSHAKE
-    security_str: 256
-    input_msg: 0x00010203
-    cust_str: 0x456d61696c205369676e6174757265
-    digest: 0xd008828e2b80ac9d2218ffee1d070c48b8e4c87bff32c9699d5b6896eee0edd164020e2be0560858d9c00c037e34a96937c561a74c412bb4c746469527281c8c
-  }
   {
     vector_identifier: "NIST SP 800-185, KMAC_samples.pdf, Sample #1"
     operation: KMAC

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -207,6 +207,24 @@ run_binary(
     tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_hmac_parser",
 )
 
+run_binary(
+    name = "hjson_hash",
+    srcs = [
+        "//sw/device/tests/crypto/testvectors:hash_hardcoded.hjson",
+        "//sw/host/cryptotest/testvectors/data/schemas:hash_schema.json",
+    ],
+    outs = [":hjson_hash.json"],
+    args = [
+        "--src",
+        "$(location //sw/device/tests/crypto/testvectors:hash_hardcoded.hjson)",
+        "--dst",
+        "$(location :hjson_hash.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:hash_schema.json)",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:hjson_hash_parser",
+)
+
 [
     run_binary(
         name = cryptotest_name,

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -464,3 +464,21 @@ run_binary(
     ],
     tool = "//sw/host/cryptotest/testvectors/parsers:rsp_sphincsplus_parser",
 )
+
+run_binary(
+    name = "hjson_kmac",
+    srcs = [
+        "//sw/device/tests/crypto/testvectors:kmac_hardcoded.hjson",
+        "//sw/host/cryptotest/testvectors/data/schemas:kmac_schema.json",
+    ],
+    outs = [":hjson_kmac.json"],
+    args = [
+        "--src",
+        "$(location //sw/device/tests/crypto/testvectors:kmac_hardcoded.hjson)",
+        "--dst",
+        "$(location :hjson_kmac.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:kmac_schema.json)",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:hjson_kmac_parser",
+)

--- a/sw/host/cryptotest/testvectors/data/schemas/hash_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/hash_schema.json
@@ -30,10 +30,14 @@
       "algorithm": {
         "description": "The hash algorithm being tested",
         "type": "string",
-          "enum": ["sha-224", "sha-256", "sha-384", "sha-512", "sha3-256", "sha3-384", "sha3-512", "shake-128", "shake-256"]
+          "enum": ["sha-224", "sha-256", "sha-384", "sha-512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "shake-128", "shake-256", "cshake-128", "cshake-256"]
       },
       "message": {
         "description": "Message to be hashed",
+        "$ref": "#/$defs/byte_array"
+      },
+      "customization_string": {
+        "description": "Customization string if using cSHAKE",
         "$ref": "#/$defs/byte_array"
       },
       "digest": {

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -124,6 +124,16 @@ py_binary(
 )
 
 py_binary(
+    name = "hjson_kmac_parser",
+    srcs = ["hjson_kmac_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("hjson"),
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
     name = "wycheproof_kmac_parser",
     srcs = ["wycheproof_kmac_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -78,6 +78,16 @@ py_binary(
 )
 
 py_binary(
+    name = "hjson_hash_parser",
+    srcs = ["hjson_hash_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("hjson"),
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
     name = "nist_cavp_hash_parser",
     srcs = ["nist_cavp_hash_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/hjson_hash_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/hjson_hash_parser.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import logging
+import sys
+import jsonschema
+import hjson
+from cryptotest_util import str_to_byte_array
+
+ALGORITHMS = {
+    "SHA3": {
+        224: "sha3-224",
+        256: "sha3-256",
+        384: "sha3-384",
+        512: "sha3-512",
+    },
+    "SHAKE": {
+        128: "shake-128",
+        256: "shake-256",
+    },
+    "CSHAKE": {
+        128: "cshake-128",
+        256: "cshake-256",
+    },
+}
+
+
+def parse_test_vectors(raw_data):
+    test_vectors = []
+    count = 1
+    for test in raw_data:
+        test_vec = {
+            "vendor": "manual",
+            "test_case_id": count,
+            "algorithm": ALGORITHMS[test["operation"]][test["security_str"]],
+            "message": str_to_byte_array(test["input_msg"]),
+            "digest": str_to_byte_array(test["digest"]),
+            "result": True,
+        }
+        if test["operation"] == "CSHAKE":
+            test_vec["customization_string"] = str_to_byte_array(test["cust_str"])
+
+        test_vectors.append(test_vec)
+        count += 1
+
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--src',
+                        metavar='FILE',
+                        type=argparse.FileType('r'),
+                        help='Read test vectors from this JSON file.')
+    parser.add_argument('--dst',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help='Write output to this file.')
+    parser.add_argument("--schema", type=str, help="Testvector schema file")
+    args = parser.parse_args()
+
+    testvecs = parse_test_vectors(hjson.loads(args.src.read()))
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sw/host/cryptotest/testvectors/parsers/hjson_kmac_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/hjson_kmac_parser.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import logging
+import sys
+import jsonschema
+import hjson
+from cryptotest_util import str_to_byte_array
+
+
+def parse_test_vectors(raw_data):
+    test_vectors = []
+    count = 1
+    for test in raw_data:
+        if "cust_str" in test:
+            customization_string = str_to_byte_array(test["cust_str"])
+        else:
+            customization_string = []
+        test_vec = {
+            "vendor": "manual",
+            "test_case_id": count,
+            "algorithm": "kmac",
+            "mode": test["security_str"],
+            "key": str_to_byte_array(test["key"]),
+            "message": str_to_byte_array(test["input_msg"]),
+            "customization_string": customization_string,
+            "tag": str_to_byte_array(test["digest"]),
+        }
+        test_vectors.append(test_vec)
+        count += 1
+
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--src',
+                        metavar='FILE',
+                        type=argparse.FileType('r'),
+                        help='Read test vectors from this JSON file.')
+    parser.add_argument('--dst',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help='Write output to this file.')
+    parser.add_argument("--schema", type=str, help="Testvector schema file")
+    args = parser.parse_args()
+
+    testvecs = parse_test_vectors(hjson.loads(args.src.read()))
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.src.close()
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This PR is a follow-on to #21195 and #21281 

- Split the KMAC and hash hjson test vectors into separate files
- Added parsers for hjson tests for KMAC and hash functions
- Updated test harness for hash functions to support SHA3-224 and cSHAKE

~Dependent on #21193~