### PR TITLE
[bazel,silicon] Use `teacup` interface for silicon exec_env

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -308,7 +308,7 @@ silicon(
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     param = {
-        "interface": "hyper310",
+        "interface": "teacup",
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -341,7 +341,7 @@ silicon(
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
     manifest = "//sw/device/silicon_owner:manifest_standard",
     param = {
-        "interface": "hyper310",
+        "interface": "teacup",
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{rom_ext}@0 {firmware}@0x10000",

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -1,6 +1,6 @@
 {
   "includes": ["/__builtin__/opentitan.json"],
-  "interface": "hyperdebug",
+  "interface": "teacup",
   "pins": [
     {
       "name": "RESET",

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -104,6 +104,10 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
             hyperdebug::create::<ChipWhispererFlavor<Cw310>>(args)?,
             Some(Path::new("/__builtin__/hyperdebug_cw310.json")),
         ),
+        "teacup" => (
+            hyperdebug::create::<StandardFlavor>(args)?,
+            Some(Path::new("/__builtin__/hyperdebug_teacup.json")),
+        ),
         "hyper340" => (
             hyperdebug::create::<ChipWhispererFlavor<Cw340>>(args)?,
             Some(Path::new("/__builtin__/hyperdebug_cw340.json")),


### PR DESCRIPTION
This PR:
- adds a new `teacup` backend to opentitantool which corresponding to hyperdebug using the `hyperdebug_teacup.json` configuration file
- update the silicon execution to use the teacup interface