### PR TITLE
[fpga_cw310_sival_rom_ext] Use fake-signed tests  on the master branch

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -214,7 +214,7 @@ fpga_cw310(
         "//sw/device/lib/arch:fpga_cw310",
     ],
     otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
-    rom_ext = "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_a",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
     tags = ["cw310_sival_rom_ext"],
 )

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -258,7 +258,7 @@ opentitan_binary(
     ],
     linker_script = ":ld_slot_a",
     manifest = ":manifest_standard",
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -276,7 +276,7 @@ opentitan_binary(
     ],
     linker_script = ":ld_slot_b",
     manifest = ":manifest_standard",
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -294,7 +294,7 @@ opentitan_binary(
     ],
     linker_script = ":ld_slot_virtual",
     manifest = ":manifest_virtual",
-    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",


### PR DESCRIPTION
~Partially revert #21586 to go back to using the fake keys on the master branch. Allow FPGA tests against ROM_EXT with just the keys in the repo again.~

Change the generic ROM_EXT target to be signed by the fake prod key, so it may be used in the prod life cycle state.

Change the fpga_cw310_sival_rom_ext execution environment to use the generic ROM_EXT with a sival OTP configuration.

This fixes a key mismatch due to earlier changes.