### PR TITLE
[hw,dma,rtl] Enable TL-UL integrity checks on response

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -38,6 +38,13 @@
       local: "false",
       expose: "true",
     },
+    { name: "EnableRspDataIntgCheck",
+      desc: "Enable integrity checks on the response TL-UL D channel",
+      type: "bit",
+      default: "1'b1",
+      local: "false",
+      expose: "true",
+    },
     { name: "TlUserRsvd",
       desc: "Value of `rsvd` field in A channel of all TL-UL host ports",
       type: "logic [tlul_pkg::RsvdWidth-1:0]"

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -9,11 +9,12 @@ module dma
   import dma_pkg::*;
   import dma_reg_pkg::*;
 #(
-    parameter logic [NumAlerts-1:0] AlertAsyncOn         = {NumAlerts{1'b1}},
-    parameter bit                   EnableDataIntgGen    = 1'b1,
-    parameter logic [RsvdWidth-1:0] TlUserRsvd           = '0,
-    parameter logic [SYS_RACL_WIDTH-1:0] SysRacl         = '0,
-    parameter int unsigned          OtAgentId            = 0
+    parameter logic [NumAlerts-1:0]      AlertAsyncOn           = {NumAlerts{1'b1}},
+    parameter bit                        EnableDataIntgGen      = 1'b1,
+    parameter bit                        EnableRspDataIntgCheck = 1'b1,
+    parameter logic [RsvdWidth-1:0]      TlUserRsvd             = '0,
+    parameter logic [SYS_RACL_WIDTH-1:0] SysRacl                = '0,
+    parameter int unsigned               OtAgentId              = 0
 ) (
   input logic                                       clk_i,
   input logic                                       rst_ni,
@@ -189,7 +190,8 @@ module dma
   // Adapter from the DMA to Host
   tlul_adapter_host #(
     .MAX_REQS(NUM_MAX_OUTSTANDING_REQS),
-    .EnableDataIntgGen(EnableDataIntgGen)
+    .EnableDataIntgGen(EnableDataIntgGen),
+    .EnableRspDataIntgCheck(EnableRspDataIntgCheck)
   ) u_dma_host_tlul_host (
     .clk_i          ( gated_clk                        ),
     .rst_ni         ( rst_ni                           ),
@@ -215,7 +217,8 @@ module dma
   // Adapter from the DMA to the CTN
   tlul_adapter_host #(
     .MAX_REQS(NUM_MAX_OUTSTANDING_REQS),
-    .EnableDataIntgGen(EnableDataIntgGen)
+    .EnableDataIntgGen(EnableDataIntgGen),
+    .EnableRspDataIntgCheck(EnableRspDataIntgCheck)
   ) u_dma_ctn_tlul_host (
     .clk_i          ( gated_clk                        ),
     .rst_ni         ( rst_ni                           ),

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -6810,6 +6810,14 @@
           name_top: DmaEnableDataIntgGen
         }
         {
+          name: EnableRspDataIntgCheck
+          desc: Enable integrity checks on the response TL-UL D channel
+          type: bit
+          default: 1'b1
+          expose: "true"
+          name_top: DmaEnableRspDataIntgCheck
+        }
+        {
           name: TlUserRsvd
           desc: Value of `rsvd` field in A channel of all TL-UL host ports
           type: logic [tlul_pkg::RsvdWidth-1:0]

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -86,6 +86,7 @@ module top_darjeeling #(
   parameter bit SecRomCtrl1DisableScrambling = 1'b0,
   // parameters for dma
   parameter bit DmaEnableDataIntgGen = 1'b1,
+  parameter bit DmaEnableRspDataIntgCheck = 1'b1,
   parameter logic [tlul_pkg::RsvdWidth-1:0] DmaTlUserRsvd = '0,
   parameter logic [dma_pkg::SYS_RACL_WIDTH-1:0] DmaSysRacl = '0,
   parameter int unsigned DmaOtAgentId = 0,
@@ -2093,6 +2094,7 @@ module top_darjeeling #(
   dma #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[74:74]),
     .EnableDataIntgGen(DmaEnableDataIntgGen),
+    .EnableRspDataIntgCheck(DmaEnableRspDataIntgCheck),
     .TlUserRsvd(DmaTlUserRsvd),
     .SysRacl(DmaSysRacl),
     .OtAgentId(DmaOtAgentId)


### PR DESCRIPTION
It was discovered that integrity checks on the TL-UL response were not enabled. This PR adds a new parameter to enable integrity checks for both TL-UL ports