### PR TITLE
[doc] Fix typo in OTBN

### DIFF
--- a/hw/ip/otbn/doc/developing_otbn.md
+++ b/hw/ip/otbn/doc/developing_otbn.md
@@ -23,7 +23,7 @@ For more details about the toolchain, see the [user
 guide](../../../../doc/contributing/sw/otbn_sw.md)).
 
 `otbn_as.py` and `otbn_ld.py` can be used to build .elf files for use with
-simulations. They work work similarly to binutils programs they wrap.
+simulations. They work similarly to binutils programs they wrap.
 
 ```
 hw/ip/otbn/util/otbn_as.py -o prog_bin/prog.o prog.s

--- a/hw/ip/otbn/doc/programmers_guide.md
+++ b/hw/ip/otbn/doc/programmers_guide.md
@@ -62,9 +62,9 @@ All data passing must be done when OTBN [is idle](./theory_of_operation.md#opera
 
 ### Returning from an application
 
-The software running on OTBN signals completion by executing the {{#otbn-insn-ref ECALL}} instruction.
+The software running on OTBN signals completion by executing the [`ECALL`](isa.md#ecall)  instruction.
 
-Once OTBN has executed the {{#otbn-insn-ref ECALL}} instruction, the following things happen:
+Once OTBN has executed the [`ECALL`](isa.md#ecall) instruction, the following things happen:
 
 - No more instructions are fetched or executed.
 - A [secure wipe of internal state](./theory_of_operation.md#internal-state-secure-wipe) is performed.
@@ -76,7 +76,7 @@ Refer to the section [Passing of data between the host CPU and OTBN](#passing-of
 
 ### Using hardware loops
 
-OTBN provides two hardware loop instructions: {{#otbn-insn-ref LOOP}} and {{#otbn-insn-ref LOOPI}}.
+OTBN provides two hardware loop instructions: [`LOOP`](isa.md#loop)  and [`LOOPI`](isa.md#loopi) .
 
 #### Loop nesting
 
@@ -147,8 +147,8 @@ outer_body:
 ### Algorithic Examples: Multiplication with BN.MULQACC
 
 The big number instruction subset of OTBN generally operates on WLEN bit numbers.
-{{#otbn-insn-ref BN.MULQACC}} operates with WLEN/4 bit operands (with a full WLEN accumulator).
-This section outlines two techniques to perform larger multiplies by composing multiple {{#otbn-insn-ref BN.MULQACC}} instructions.
+[`BN.MULQACC`](isa.md#bnmulqacc) operates with WLEN/4 bit operands (with a full WLEN accumulator).
+This section outlines two techniques to perform larger multiplies by composing multiple [`BN.MULQACC`](isa.md#bnmulqacc) instructions.
 
 #### Multiplying two WLEN/2 numbers with BN.MULQACC
 


### PR DESCRIPTION
This PR fixes a typo in the Develop OTBN section of the OTBN documentation.