### PR TITLE
[ci] disable CI on backport-* branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,9 @@ trigger:
   branches:
     include:
     - "*"
+    # Don't run workflow on auto-created backport branches (PR workflow will be run)
+    exclude:
+    - "backport-*"
   tags:
     include:
     - "*"

--- a/ci/azp-private.yml
+++ b/ci/azp-private.yml
@@ -10,6 +10,8 @@ trigger:
   branches:
     include:
     - '*'
+    exclude:
+    - 'backport-*'
   tags:
     include:
     - "*"


### PR DESCRIPTION
Currently we have backport branches running CI for a push, but that's already covered by PR CI run, so it's duplicated work. Disabling it.