### PR TITLE
Uart status interrupts

### DIFF
--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -47,17 +47,20 @@
     { name: "tx", desc: "Serial transmit bit" }
   ],
   interrupt_list: [
-    { name: "tx_watermark"
-      desc: "raised if the transmit FIFO is past the high-water mark."}
-    { name: "rx_watermark"
+    { name:    "tx_watermark",
+      type:    "status",
+      default: "1",
+      desc:    "raised if the transmit FIFO is past the high-water mark."}
+    { name: "rx_watermark",
+      type: "status",
       desc: "raised if the receive FIFO is past the high-water mark."}
-    { name: "tx_empty"
+    { name: "tx_empty",
       desc: "raised if the transmit FIFO has emptied and no transmit is ongoing."}
-    { name: "rx_overflow"
+    { name: "rx_overflow",
       desc: "raised if the receive FIFO has overflowed."}
-    { name: "rx_frame_err"
+    { name: "rx_frame_err",
       desc: "raised if a framing error has been detected on receive."}
-    { name: "rx_break_err"
+    { name: "rx_break_err",
       desc: "raised if break condition has been detected on receive."}
     { name: "rx_timeout"
       desc: '''

--- a/hw/ip/uart/doc/interfaces.md
+++ b/hw/ip/uart/doc/interfaces.md
@@ -24,8 +24,8 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 | Interrupt Name   | Type   | Description                                                                                                    |
 |:-----------------|:-------|:---------------------------------------------------------------------------------------------------------------|
-| tx_watermark     | Event  | raised if the transmit FIFO is past the high-water mark.                                                       |
-| rx_watermark     | Event  | raised if the receive FIFO is past the high-water mark.                                                        |
+| tx_watermark     | Status | raised if the transmit FIFO is past the high-water mark.                                                       |
+| rx_watermark     | Status | raised if the receive FIFO is past the high-water mark.                                                        |
 | tx_empty         | Event  | raised if the transmit FIFO has emptied and no transmit is ongoing.                                            |
 | rx_overflow      | Event  | raised if the receive FIFO has overflowed.                                                                     |
 | rx_frame_err     | Event  | raised if a framing error has been detected on receive.                                                        |

--- a/hw/ip/uart/doc/registers.md
+++ b/hw/ip/uart/doc/registers.md
@@ -22,13 +22,13 @@
 ## INTR_STATE
 Interrupt State Register
 - Offset: `0x0`
-- Reset default: `0x0`
+- Reset default: `0x1`
 - Reset mask: `0xff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "tx_watermark", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_watermark", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "tx_empty", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_overflow", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_frame_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_break_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_timeout", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_parity_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
+{"reg": [{"name": "tx_watermark", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "rx_watermark", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "tx_empty", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_overflow", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_frame_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_break_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_timeout", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rx_parity_err", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name          | Description                                                                                                    |
@@ -40,8 +40,8 @@ Interrupt State Register
 |   4    |  rw1c  |   0x0   | rx_frame_err  | raised if a framing error has been detected on receive.                                                        |
 |   3    |  rw1c  |   0x0   | rx_overflow   | raised if the receive FIFO has overflowed.                                                                     |
 |   2    |  rw1c  |   0x0   | tx_empty      | raised if the transmit FIFO has emptied and no transmit is ongoing.                                            |
-|   1    |  rw1c  |   0x0   | rx_watermark  | raised if the receive FIFO is past the high-water mark.                                                        |
-|   0    |  rw1c  |   0x0   | tx_watermark  | raised if the transmit FIFO is past the high-water mark.                                                       |
+|   1    |   ro   |   0x0   | rx_watermark  | raised if the receive FIFO is past the high-water mark.                                                        |
+|   0    |   ro   |   0x1   | tx_watermark  | raised if the transmit FIFO is past the high-water mark.                                                       |
 
 ## INTR_ENABLE
 Interrupt Enable Register

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -123,9 +123,7 @@ module uart_reg_top (
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic intr_state_we;
   logic intr_state_tx_watermark_qs;
-  logic intr_state_tx_watermark_wd;
   logic intr_state_rx_watermark_qs;
-  logic intr_state_rx_watermark_wd;
   logic intr_state_tx_empty_qs;
   logic intr_state_tx_empty_wd;
   logic intr_state_rx_overflow_qs;
@@ -224,16 +222,16 @@ module uart_reg_top (
   //   F[tx_watermark]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h1),
     .Mubi    (1'b0)
   ) u_intr_state_tx_watermark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_tx_watermark_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.tx_watermark.de),
@@ -251,7 +249,7 @@ module uart_reg_top (
   //   F[rx_watermark]: 1:1
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_rx_watermark (
@@ -259,8 +257,8 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_rx_watermark_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.rx_watermark.de),
@@ -1528,10 +1526,6 @@ module uart_reg_top (
 
   // Generate write-enables
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
-
-  assign intr_state_tx_watermark_wd = reg_wdata[0];
-
-  assign intr_state_rx_watermark_wd = reg_wdata[1];
 
   assign intr_state_tx_empty_wd = reg_wdata[2];
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -13331,15 +13331,15 @@
       width: 1
       type: interrupt
       module_name: uart0
-      intr_type: IntrType.Event
-      default_val: false
+      intr_type: IntrType.Status
+      default_val: true
     }
     {
       name: uart0_rx_watermark
       width: 1
       type: interrupt
       module_name: uart0
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {
@@ -13395,15 +13395,15 @@
       width: 1
       type: interrupt
       module_name: uart1
-      intr_type: IntrType.Event
-      default_val: false
+      intr_type: IntrType.Status
+      default_val: true
     }
     {
       name: uart1_rx_watermark
       width: 1
       type: interrupt
       module_name: uart1
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {
@@ -13459,15 +13459,15 @@
       width: 1
       type: interrupt
       module_name: uart2
-      intr_type: IntrType.Event
-      default_val: false
+      intr_type: IntrType.Status
+      default_val: true
     }
     {
       name: uart2_rx_watermark
       width: 1
       type: interrupt
       module_name: uart2
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {
@@ -13523,15 +13523,15 @@
       width: 1
       type: interrupt
       module_name: uart3
-      intr_type: IntrType.Event
-      default_val: false
+      intr_type: IntrType.Status
+      default_val: true
     }
     {
       name: uart3_rx_watermark
       width: 1
       type: interrupt
       module_name: uart3
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.c
@@ -84,8 +84,8 @@ static bool uart_get_irq_bit_index(dif_uart_irq_t irq,
 }
 
 static dif_irq_type_t irq_types[] = {
-    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
-    kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeStatus, kDifIrqTypeStatus, kDifIrqTypeEvent, kDifIrqTypeEvent,
+    kDifIrqTypeEvent,  kDifIrqTypeEvent,  kDifIrqTypeEvent, kDifIrqTypeEvent,
 };
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -80,7 +80,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_uart_irq_get_type(&uart_, kDifUartIrqTxWatermark, &type));
-  EXPECT_EQ(type, kDifIrqTypeEvent);
+  EXPECT_EQ(type, kDifIrqTypeStatus);
 }
 
 class IrqGetStateTest : public UartTest {};

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -901,6 +901,7 @@ void isr_testutils_sysrst_ctrl_isr(
 }
 
 void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx_t uart_ctx,
+                            bool mute_status_irq,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_uart_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -931,6 +932,9 @@ void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx_t uart_ctx,
   CHECK_DIF_OK(dif_uart_irq_get_type(uart_ctx.uart, irq, &type));
   if (type == kDifIrqTypeEvent) {
     CHECK_DIF_OK(dif_uart_irq_acknowledge(uart_ctx.uart, irq));
+  } else if (mute_status_irq) {
+    CHECK_DIF_OK(
+        dif_uart_irq_set_enabled(uart_ctx.uart, irq, kDifToggleDisabled));
   }
 
   // Complete the IRQ at the PLIC.

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -859,11 +859,13 @@ void isr_testutils_sysrst_ctrl_isr(
  *
  * @param plic_ctx A PLIC ISR context handle.
  * @param uart_ctx A(n) uart ISR context handle.
+ * @param mute_status_irq set to true to disable the serviced status type IRQ.
  * @param[out] peripheral_serviced Out param for the peripheral that was
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx_t uart_ctx,
+                            bool mute_status_irq,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_uart_irq_t *irq_serviced);
 

--- a/sw/device/tests/autogen/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/plic_all_irqs_test.c
@@ -976,11 +976,23 @@ void ottf_external_isr(uint32_t *exc_info) {
 
         dif_uart_irq_state_snapshot_t snapshot;
         CHECK_DIF_OK(dif_uart_irq_get_state(&uart0, &snapshot));
-        CHECK(snapshot == (dif_uart_irq_state_snapshot_t)(1 << irq),
-              "Only uart0 IRQ %d expected to fire. Actual interrupt "
-              "status = %x", irq, snapshot);
+        CHECK(snapshot == (dif_uart_irq_state_snapshot_t)((1 << irq) | 0x1),
+              "Expected uart0 interrupt status %x. Actual interrupt "
+              "status = %x", (1 << irq) | 0x1, snapshot);
 
-        CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart0, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x3 & (1 << irq)) {
+          CHECK_DIF_OK(dif_uart_irq_force(&uart0, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x1 & (1 << irq))) {
+            CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart0, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart0, irq));
+        }
         break;
       }
 #endif
@@ -997,11 +1009,23 @@ void ottf_external_isr(uint32_t *exc_info) {
 
         dif_uart_irq_state_snapshot_t snapshot;
         CHECK_DIF_OK(dif_uart_irq_get_state(&uart1, &snapshot));
-        CHECK(snapshot == (dif_uart_irq_state_snapshot_t)(1 << irq),
-              "Only uart1 IRQ %d expected to fire. Actual interrupt "
-              "status = %x", irq, snapshot);
+        CHECK(snapshot == (dif_uart_irq_state_snapshot_t)((1 << irq) | 0x1),
+              "Expected uart1 interrupt status %x. Actual interrupt "
+              "status = %x", (1 << irq) | 0x1, snapshot);
 
-        CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart1, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x3 & (1 << irq)) {
+          CHECK_DIF_OK(dif_uart_irq_force(&uart1, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x1 & (1 << irq))) {
+            CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart1, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart1, irq));
+        }
         break;
       }
 #endif
@@ -1018,11 +1042,23 @@ void ottf_external_isr(uint32_t *exc_info) {
 
         dif_uart_irq_state_snapshot_t snapshot;
         CHECK_DIF_OK(dif_uart_irq_get_state(&uart2, &snapshot));
-        CHECK(snapshot == (dif_uart_irq_state_snapshot_t)(1 << irq),
-              "Only uart2 IRQ %d expected to fire. Actual interrupt "
-              "status = %x", irq, snapshot);
+        CHECK(snapshot == (dif_uart_irq_state_snapshot_t)((1 << irq) | 0x1),
+              "Expected uart2 interrupt status %x. Actual interrupt "
+              "status = %x", (1 << irq) | 0x1, snapshot);
 
-        CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart2, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x3 & (1 << irq)) {
+          CHECK_DIF_OK(dif_uart_irq_force(&uart2, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x1 & (1 << irq))) {
+            CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart2, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart2, irq));
+        }
         break;
       }
 #endif
@@ -1039,11 +1075,23 @@ void ottf_external_isr(uint32_t *exc_info) {
 
         dif_uart_irq_state_snapshot_t snapshot;
         CHECK_DIF_OK(dif_uart_irq_get_state(&uart3, &snapshot));
-        CHECK(snapshot == (dif_uart_irq_state_snapshot_t)(1 << irq),
-              "Only uart3 IRQ %d expected to fire. Actual interrupt "
-              "status = %x", irq, snapshot);
+        CHECK(snapshot == (dif_uart_irq_state_snapshot_t)((1 << irq) | 0x1),
+              "Expected uart3 interrupt status %x. Actual interrupt "
+              "status = %x", (1 << irq) | 0x1, snapshot);
 
-        CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart3, irq));
+        // If this is a status type interrupt, we do not have to acknowledge the interrupt at
+        // the IP side, but we need to clear the test force register.
+        if (0x3 & (1 << irq)) {
+          CHECK_DIF_OK(dif_uart_irq_force(&uart3, irq, false));
+          // In case this status interrupt is asserted by default, we also disable it at
+          // this point so that it does not interfere with the rest of the test.
+          if ((0x1 & (1 << irq))) {
+            CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart3, irq, false));
+          }
+        // If this is a regular event type interrupt, we acknowledge it at this point.
+        } else {
+          CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart3, irq));
+        }
         break;
       }
 #endif
@@ -1486,8 +1534,12 @@ static void peripheral_irqs_enable(void) {
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 21 && 21 < TEST_MAX_IRQ_PERIPHERAL
+  // Note: this peripheral contains status interrupts that are asserted by
+  // default. Therefore, not all interrupts are enabled here, since that
+  // would interfere with this test. Instead, these interrupts are enabled on
+  // demand once they are being tested.
   dif_uart_irq_state_snapshot_t uart_irqs =
-      (dif_uart_irq_state_snapshot_t)0xffffffff;
+      (dif_uart_irq_state_snapshot_t)0xfffffffe;
 #endif
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 22 && 22 < TEST_MAX_IRQ_PERIPHERAL
@@ -2135,12 +2187,21 @@ static void peripheral_irqs_trigger(void) {
   // non-DV setups.
   if (kDeviceType == kDeviceSimDV) {
     peripheral_expected = kTopEarlgreyPlicPeripheralUart0;
+    status_default_mask = 0x1;
     for (dif_uart_irq_t irq = kDifUartIrqTxWatermark;
          irq <= kDifUartIrqRxParityErr; ++irq) {
 
       uart_irq_expected = irq;
       LOG_INFO("Triggering uart0 IRQ %d.", irq);
       CHECK_DIF_OK(dif_uart_irq_force(&uart0, irq, true));
+
+      // In this case, the interrupt has not been enabled yet because that would
+      // interfere with testing other interrupts. We enable it here and let the
+      // interrupt handler disable it again.
+      if ((status_default_mask & 0x1)) {
+         CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart0, irq, true));
+      }
+      status_default_mask >>= 1;
 
       // This avoids a race where *irq_serviced is read before
       // entering the ISR.
@@ -2152,12 +2213,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 21 && 21 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralUart1;
+  status_default_mask = 0x1;
   for (dif_uart_irq_t irq = kDifUartIrqTxWatermark;
        irq <= kDifUartIrqRxParityErr; ++irq) {
 
     uart_irq_expected = irq;
     LOG_INFO("Triggering uart1 IRQ %d.", irq);
     CHECK_DIF_OK(dif_uart_irq_force(&uart1, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart1, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.
@@ -2168,12 +2238,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 21 && 21 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralUart2;
+  status_default_mask = 0x1;
   for (dif_uart_irq_t irq = kDifUartIrqTxWatermark;
        irq <= kDifUartIrqRxParityErr; ++irq) {
 
     uart_irq_expected = irq;
     LOG_INFO("Triggering uart2 IRQ %d.", irq);
     CHECK_DIF_OK(dif_uart_irq_force(&uart2, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart2, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.
@@ -2184,12 +2263,21 @@ static void peripheral_irqs_trigger(void) {
 
 #if TEST_MIN_IRQ_PERIPHERAL <= 21 && 21 < TEST_MAX_IRQ_PERIPHERAL
   peripheral_expected = kTopEarlgreyPlicPeripheralUart3;
+  status_default_mask = 0x1;
   for (dif_uart_irq_t irq = kDifUartIrqTxWatermark;
        irq <= kDifUartIrqRxParityErr; ++irq) {
 
     uart_irq_expected = irq;
     LOG_INFO("Triggering uart3 IRQ %d.", irq);
     CHECK_DIF_OK(dif_uart_irq_force(&uart3, irq, true));
+
+    // In this case, the interrupt has not been enabled yet because that would
+    // interfere with testing other interrupts. We enable it here and let the
+    // interrupt handler disable it again.
+    if ((status_default_mask & 0x1)) {
+       CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart3, irq, true));
+    }
+    status_default_mask >>= 1;
 
     // This avoids a race where *irq_serviced is read before
     // entering the ISR.


### PR DESCRIPTION
This includes a commit from https://github.com/lowRISC/opentitan/pull/21226 which is a cip_lib change required for all status type interrupts. So need to ensure one of the PRs gets rebased if the other has gone in.