### PR TITLE
[sival,aes] Clarify purpose of chip_sw_aes_masking_off test

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -305,7 +305,7 @@
       name: "AES.PRNG.FORCE_MASKS",
       desc: '''
             AES can block advancing of the internal PRNG used for masking, thereby forcing masks to a constant value.
-            This feature can be disabled using tha compile-time Verilog parameter.
+            This feature can be disabled using a compile-time Verilog parameter.
             '''
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -277,9 +277,18 @@
             - Verify that the produced cipher text is correct.
             - Repeat the entire procedure with PRNG_RESEED_RATE set to PER_1. Verify that the
               second share of intermediate and output state is not zero.
+
+            Notes for silicon targets:
+            - The AES.PRNG.FORCE_MASKS feature is relevant for penetration testing only and a SCA evaluation setup is required for its verification.
+              This is done using other routines as part of the experimental setup for penetration testing.
+              The only thing that can be tested on silicon / FPGA for SiVal is the known-answer test using the CSRNG SW application interface for which a dedicated SiVal test exists.
+              For this reason, the chip_sw_aes_masking_off test is run in simulation only.
             '''
+      features: [
+        "AES.PRNG.FORCE_MASKS"
+      ]
       stage: V2S
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_aes_masking_off"]
      }
   ]


### PR DESCRIPTION
This resolves lowRISC/OpenTitan#21511.