### PR TITLE
[entropy_src/rtl] Fix observe fifo overflow reg

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1351,7 +1351,7 @@
     },
     { name:     "FW_OV_RD_FIFO_OVERFLOW",
       desc:     "Firmware override observe FIFO overflow status",
-      swaccess: "rw0c",
+      swaccess: "ro",
       hwaccess: "hwo",
       hwext: "false",
       fields: [
@@ -1362,7 +1362,7 @@
                 in the observe FIFO. The RNG data rate is slow enough that firmware should always
                 be able to keep up. This register meanwhile provides an additional check to confirm
                 that bytes read from the !!FW_OV_RD_DATA register represent contiguous RNG samples.
-                If an overflow event occurs, this bit must be cleared by software.
+                If an overflow event occurs, this bit is cleared by hardware as soon as the FIFO is emptied.
                 '''
         }
       ]

--- a/hw/ip/entropy_src/doc/registers.md
+++ b/hw/ip/entropy_src/doc/registers.md
@@ -1236,20 +1236,20 @@ Firmware override observe FIFO overflow status
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "FW_OV_RD_FIFO_OVERFLOW", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 240}}
+{"reg": [{"name": "FW_OV_RD_FIFO_OVERFLOW", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 240}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                                                      |
 |:------:|:------:|:-------:|:--------------------------------------------------------------------------|
 |  31:1  |        |         | Reserved                                                                  |
-|   0    |  rw0c  |   0x0   | [FW_OV_RD_FIFO_OVERFLOW](#fw_ov_rd_fifo_overflow--fw_ov_rd_fifo_overflow) |
+|   0    |   ro   |   0x0   | [FW_OV_RD_FIFO_OVERFLOW](#fw_ov_rd_fifo_overflow--fw_ov_rd_fifo_overflow) |
 
 ### FW_OV_RD_FIFO_OVERFLOW . FW_OV_RD_FIFO_OVERFLOW
 This bit is set by hardware whenever RNG data is lost due to an overflow condition
 in the observe FIFO. The RNG data rate is slow enough that firmware should always
 be able to keep up. This register meanwhile provides an additional check to confirm
 that bytes read from the [`FW_OV_RD_DATA`](#fw_ov_rd_data) register represent contiguous RNG samples.
-If an overflow event occurs, this bit must be cleared by software.
+If an overflow event occurs, this bit is cleared by hardware as soon as the FIFO is emptied.
 
 ## FW_OV_RD_DATA
 Firmware override observe FIFO read register

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -663,7 +663,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   mubi4_t [1:0] mubi_rng_fips_fanout;
   assign mubi_rng_fips  = mubi4_t'(reg2hw.conf.rng_fips.q);
   assign rng_fips_pfa = mubi4_test_invalid(mubi_rng_fips_fanout[1]);
-  assign rng_fips_pfe = mubi4_test_true_strict(mubi_rng_fips_fanout[0]);
+  assign rng_fips_pfe = prim_mubi_pkg::mubi4_test_true_loose(mubi_rng_fips_fanout[0]);
   assign hw2reg.recov_alert_sts.rng_fips_field_alert.de = rng_fips_pfa;
   assign hw2reg.recov_alert_sts.rng_fips_field_alert.d  = rng_fips_pfa;
 

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2417,8 +2417,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   // contiguous as possible.
   logic sfifo_observe_gate_d, sfifo_observe_gate_q;
 
-  assign sfifo_observe_gate_d = (sfifo_observe_push && sfifo_observe_full) ? 1'b0 :
-                                !sfifo_observe_not_empty                   ? 1'b1 :
+  assign sfifo_observe_gate_d = (pfifo_postht_pop && sfifo_observe_full) ? 1'b0 :
+                                !sfifo_observe_not_empty                 ? 1'b1 :
                                 sfifo_observe_gate_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -2429,7 +2429,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     end
   end
 
-  assign hw2reg.fw_ov_rd_fifo_overflow.d  = (pfifo_postht_pop && sfifo_observe_full);
+  assign hw2reg.fw_ov_rd_fifo_overflow.d  = !sfifo_observe_gate_d;
   assign hw2reg.fw_ov_rd_fifo_overflow.de = 1'b1;
 
   assign observe_fifo_thresh_met = fw_ov_mode && (observe_fifo_thresh != '0) &&

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -314,9 +314,7 @@ module entropy_src_reg_top (
   logic [3:0] fw_ov_sha3_start_wd;
   logic fw_ov_wr_fifo_full_re;
   logic fw_ov_wr_fifo_full_qs;
-  logic fw_ov_rd_fifo_overflow_we;
   logic fw_ov_rd_fifo_overflow_qs;
-  logic fw_ov_rd_fifo_overflow_wd;
   logic fw_ov_rd_data_re;
   logic [31:0] fw_ov_rd_data_qs;
   logic fw_ov_wr_data_we;
@@ -2282,7 +2280,7 @@ module entropy_src_reg_top (
   // R[fw_ov_rd_fifo_overflow]: V(False)
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_fw_ov_rd_fifo_overflow (
@@ -2290,8 +2288,8 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fw_ov_rd_fifo_overflow_we),
-    .wd     (fw_ov_rd_fifo_overflow_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.fw_ov_rd_fifo_overflow.de),
@@ -3624,9 +3622,6 @@ module entropy_src_reg_top (
 
   assign fw_ov_sha3_start_wd = reg_wdata[3:0];
   assign fw_ov_wr_fifo_full_re = addr_hit[46] & reg_re & !reg_error;
-  assign fw_ov_rd_fifo_overflow_we = addr_hit[47] & reg_we & !reg_error;
-
-  assign fw_ov_rd_fifo_overflow_wd = reg_wdata[0];
   assign fw_ov_rd_data_re = addr_hit[48] & reg_re & !reg_error;
   assign fw_ov_wr_data_we = addr_hit[49] & reg_we & !reg_error;
 
@@ -3725,7 +3720,7 @@ module entropy_src_reg_top (
     reg_we_check[44] = fw_ov_control_gated_we;
     reg_we_check[45] = fw_ov_sha3_start_we;
     reg_we_check[46] = 1'b0;
-    reg_we_check[47] = fw_ov_rd_fifo_overflow_we;
+    reg_we_check[47] = 1'b0;
     reg_we_check[48] = 1'b0;
     reg_we_check[49] = fw_ov_wr_data_we;
     reg_we_check[50] = observe_fifo_thresh_gated_we;

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -651,18 +651,6 @@ dif_result_t dif_entropy_src_has_fifo_overflowed(
   return kDifOk;
 }
 
-dif_result_t dif_entropy_src_clear_fifo_overflow(
-    const dif_entropy_src_t *entropy_src) {
-  if (entropy_src == NULL) {
-    return kDifBadArg;
-  }
-
-  mmio_region_write32(entropy_src->base_addr,
-                      ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW_REG_OFFSET, 0);
-
-  return kDifOk;
-}
-
 dif_result_t dif_entropy_src_get_fifo_depth(
     const dif_entropy_src_t *entropy_src, uint32_t *fifo_depth) {
   if (entropy_src == NULL || fifo_depth == NULL) {

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -770,16 +770,6 @@ dif_result_t dif_entropy_src_has_fifo_overflowed(
     const dif_entropy_src_t *entropy_src, bool *has_overflowed);
 
 /**
- * Clears the firmware override read FIFO overflow status.
- *
- * @param entropy_src An entropy source handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_clear_fifo_overflow(
-    const dif_entropy_src_t *entropy_src);
-
-/**
  * Read the firmware override FIFO depth.
  *
  * @param entropy_src An entropy source handle.

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -727,17 +727,6 @@ TEST_F(HasFifoOverflowedTest, Success) {
   EXPECT_FALSE(has_overflowed);
 }
 
-class ClearFifoOverflowTest : public EntropySrcTest {};
-
-TEST_F(ClearFifoOverflowTest, NullHandle) {
-  EXPECT_DIF_BADARG(dif_entropy_src_clear_fifo_overflow(nullptr));
-}
-
-TEST_F(ClearFifoOverflowTest, Success) {
-  EXPECT_WRITE32(ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW_REG_OFFSET, 0);
-  EXPECT_DIF_OK(dif_entropy_src_clear_fifo_overflow(&entropy_src_));
-}
-
 class ReadFifoDepthTest : public EntropySrcTest {};
 
 TEST_F(ReadFifoDepthTest, EntropyBadArg) {

--- a/sw/device/tests/entropy_src_fw_observe_many_contiguous.c
+++ b/sw/device/tests/entropy_src_fw_observe_many_contiguous.c
@@ -56,21 +56,16 @@ static dif_edn_t edn1;
 
 /**
  * Determine whether the observe FIFO has overflowed.
- *
- * TODO(#21279) Normally, one would rely on the FW_OV_RD_FIFO_OVERFLOW
- * register but due to an RTL bug, the overflow bit is pulsed
- * instead of latched so we cannot rely on it. Instead, rely
- * on OBSERVE_FIFO_DEPTH and assume that if the FIFO is full
- * then it has overflowed.
  */
 bool entropy_src_fifo_has_overflowed(void) {
-  uint32_t fifo_depth;
-  CHECK_DIF_OK(dif_entropy_src_get_fifo_depth(&entropy_src, &fifo_depth));
-  return fifo_depth == ENTROPY_SRC_PARAM_OBSERVE_FIFO_DEPTH;
+  bool has_overflowed;
+  CHECK_DIF_OK(
+      dif_entropy_src_has_fifo_overflowed(&entropy_src, &has_overflowed));
+  return has_overflowed;
 }
 
 /**
- * Drain observe FIFO and clear overflow status if set.
+ * Drain observe FIFO.
  */
 static void drain_observe_fifo(void) {
   // This value is arbitrary, it could be 1 but since there is some
@@ -86,7 +81,6 @@ static void drain_observe_fifo(void) {
     CHECK_DIF_OK(dif_entropy_src_observe_fifo_nonblocking_read(&entropy_src,
                                                                NULL, &len));
   } while (len == kDrainCount);
-  CHECK_DIF_OK(dif_entropy_src_clear_fifo_overflow(&entropy_src));
 }
 
 /**


### PR DESCRIPTION
This PR latches the observe FIFO overflow register signal instead of only pulsing it.
For a more detailed explanation have a look at the individual commit messages.

This PR also contains a commit that changes a mubi4 test true signal from strict to loose.
This is done as a follow up for #21369.

Closes [#21279](https://github.com/lowRISC/opentitan/issues/21279)