### PR TITLE
[pentest] Add OTBN FI characterization tests

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -87,6 +87,31 @@ cc_library(
 )
 
 cc_library(
+    name = "otbn_fi",
+    srcs = ["otbn_fi.c"],
+    hdrs = [
+        "otbn_fi.h",
+        "status.h",
+    ],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/firmware/otbn:otbn_char_hardware_dmem_op_loop",
+        "//sw/device/tests/crypto/cryptotest/firmware/otbn:otbn_char_hardware_reg_op_loop",
+        "//sw/device/tests/crypto/cryptotest/firmware/otbn:otbn_char_unrolled_dmem_op_loop",
+        "//sw/device/tests/crypto/cryptotest/firmware/otbn:otbn_char_unrolled_reg_op_loop",
+        "//sw/device/tests/crypto/cryptotest/json:otbn_fi_commands",
+    ],
+)
+
+cc_library(
     name = "prng_sca",
     srcs = ["prng_sca.c"],
     hdrs = ["prng_sca.h"],
@@ -148,6 +173,7 @@ opentitan_binary(
         ":aes_sca",
         ":ibex_fi",
         ":kmac_sca",
+        ":otbn_fi",
         ":prng_sca",
         ":sha3_sca",
         ":trigger_sca",
@@ -178,6 +204,7 @@ opentitan_test(
         ":aes_sca",
         ":ibex_fi",
         ":kmac_sca",
+        ":otbn_fi",
         ":prng_sca",
         ":sha3_sca",
         ":trigger_sca",

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -16,6 +16,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/otbn_fi_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/prng_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/sha3_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/trigger_sca_commands.h"
@@ -25,6 +26,7 @@
 #include "aes_sca.h"
 #include "ibex_fi.h"
 #include "kmac_sca.h"
+#include "otbn_fi.h"
 #include "prng_sca.h"
 #include "sha3_sca.h"
 #include "trigger_sca.h"
@@ -47,6 +49,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandKmacSca:
         RESP_ERR(uj, handle_kmac_sca(uj));
+        break;
+      case kCryptotestCommandOtbnFi:
+        RESP_ERR(uj, handle_otbn_fi(uj));
         break;
       case kCryptotestCommandPrngSca:
         RESP_ERR(uj, handle_prng_sca(uj));

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn/BUILD
@@ -1,0 +1,35 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:otbn.bzl", "otbn_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+otbn_binary(
+    name = "otbn_char_hardware_dmem_op_loop",
+    srcs = [
+        "otbn_char_hardware_dmem_op_loop.s",
+    ],
+)
+
+otbn_binary(
+    name = "otbn_char_hardware_reg_op_loop",
+    srcs = [
+        "otbn_char_hardware_reg_op_loop.s",
+    ],
+)
+
+otbn_binary(
+    name = "otbn_char_unrolled_dmem_op_loop",
+    srcs = [
+        "otbn_char_unrolled_dmem_op_loop.s",
+    ],
+)
+
+otbn_binary(
+    name = "otbn_char_unrolled_reg_op_loop",
+    srcs = [
+        "otbn_char_unrolled_reg_op_loop.s",
+    ],
+)

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn/otbn_char_hardware_dmem_op_loop.s
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn/otbn_char_hardware_dmem_op_loop.s
@@ -1,0 +1,27 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+    OBTN.CHAR.HARDWARE_DMEM_OP_LOOP FI Penetration Test
+*/
+.section .text.start
+
+    /* Load loop counter from dmem and set num it. of outer loop to 100. */
+    li x1, 100
+    la x3, lc
+    /* Increment loop counter in nested hardware loops. */
+    loop x1, 5
+      loopi 100, 3
+        lw x2, 0(x3)
+        addi x2, x2, 1
+        sw x2, 0(x3)
+      nop
+
+    ecall
+
+.data
+    /* Loop counter (lc) result. */
+    .balign 32
+    .globl lc
+    lc:
+    .zero 32

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn/otbn_char_hardware_reg_op_loop.s
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn/otbn_char_hardware_reg_op_loop.s
@@ -1,0 +1,30 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+    OBTN.CHAR.HARDWARE_REG_OP_LOOP FI Penetration Test
+*/
+.section .text.start
+
+    /* Init x2 with number of iterations (100) for the outer hardware loop. */
+    li  x2, 100
+    /* Init loop counter (x3) register. */
+    li  x3, 0
+    /* Use nested hardware loops too increment x3 10000 times by 1. */
+    loop x2, 3
+      loopi 100, 1
+        addi x3, x3, 1
+      nop
+
+    /* Store result. */
+    la x4, lc
+    sw x3, 0(x4)
+
+    ecall
+  .data
+
+    /* Loop counter (lc) result. */
+    .balign 32
+    .globl lc
+    lc:
+    .zero 32

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn/otbn_char_unrolled_dmem_op_loop.s
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn/otbn_char_unrolled_dmem_op_loop.s
@@ -1,0 +1,319 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+    OBTN.CHAR.UNROLLED_DMEM_OP_LOOP FI Penetration Test
+*/
+.section .text.start
+
+    /* Load loop counter from dmem, increment, and store back. Do 100 times. */
+    la x3, lc
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+    lw x2, 0(x3)
+    addi x2, x2, 1
+    sw x2, 0(x3)
+
+    ecall
+
+.data
+    /* Loop counter (lc) result. */
+    .balign 32
+    .globl lc
+    lc:
+    .zero 32

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn/otbn_char_unrolled_reg_op_loop.s
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn/otbn_char_unrolled_reg_op_loop.s
@@ -1,0 +1,123 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+    OBTN.CHAR.UNROLLED_REG_OP_LOOP FI Penetration Test
+*/
+.section .text.start
+
+    /* Init loop counter (x2) register and increment 100 times. */
+    li  x2, 0
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+    addi x2, x2, 1
+
+    /* Store result. */
+    la x3, lc
+    sw x2, 0(x3)
+
+    ecall
+.data
+
+    /* Loop counter (lc) result. */
+    .balign 32
+    .globl lc
+    lc:
+    .zero 32

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn_fi.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn_fi.c
@@ -1,0 +1,261 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/crypto/cryptotest/firmware/otbn_fi.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/status.h"
+#include "sw/device/tests/crypto/cryptotest/json/otbn_fi_commands.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otbn_regs.h"
+
+/**
+ * Reat the error bits of the OTBN accelerator.
+ *
+ * @returns Error bits.
+ */
+status_t read_otbn_err_bits(dif_otbn_err_bits_t *err_bits) {
+  dif_otbn_t otbn;
+  UJSON_CHECK_DIF_OK(
+      dif_otbn_init(mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR), &otbn));
+  UJSON_CHECK_DIF_OK(dif_otbn_get_err_bits(&otbn, err_bits));
+  return OK_STATUS(0);
+}
+
+/**
+ * otbn.fi.char.hardware.dmem.op.loop command handler.
+ *
+ * This FI penetration tests executes the following instructions on OTBN:
+ * - Initialize register x3=0
+ * - Perform 10000 x3 = x3 + 1 additions using hardware loop instructions.
+ *   Load loop counter from memory and write back after increment.
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
+  // Initialize OTBN app, load it, and get interface to OTBN data memory.
+  OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_dmem_op_loop);
+  OTBN_DECLARE_SYMBOL_ADDR(otbn_char_hardware_dmem_op_loop, lc);
+  const otbn_app_t kOtbnAppCharHardwareDmemOpLoop =
+      OTBN_APP_T_INIT(otbn_char_hardware_dmem_op_loop);
+  static const otbn_addr_t kOtbnAppCharHardwareDmemOpLoopLC =
+      OTBN_ADDR_T_INIT(otbn_char_hardware_dmem_op_loop, lc);
+  otbn_load_app(kOtbnAppCharHardwareDmemOpLoop);
+
+  uint32_t loop_counter;
+
+  // FI code target.
+  sca_set_trigger_high();
+  otbn_execute();
+  otbn_busy_wait_for_done();
+  sca_set_trigger_low();
+
+  // Read loop counter from OTBN data memory.
+  otbn_dmem_read(1, kOtbnAppCharHardwareDmemOpLoopLC, &loop_counter);
+
+  // Read ERR_STATUS register from OTBN.
+  dif_otbn_err_bits_t err_bits;
+  read_otbn_err_bits(&err_bits);
+
+  // Send loop counter & ERR_STATUS to host.
+  otbn_fi_loop_counter_t uj_output;
+  uj_output.loop_counter = loop_counter;
+  uj_output.err_status = err_bits;
+  RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+/**
+ * otbn.fi.char.hardware.reg.op.loop command handler.
+ *
+ * This FI penetration tests executes the following instructions on OTBN:
+ * - Initialize register x3=0
+ * - Perform 10000 x3 = x3 + 1 additions using hardware loop instructions
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
+  // Initialize OTBN app, load it, and get interface to OTBN data memory.
+  OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_reg_op_loop);
+  OTBN_DECLARE_SYMBOL_ADDR(otbn_char_hardware_reg_op_loop, lc);
+  const otbn_app_t kOtbnAppCharHardwareRegOpLoop =
+      OTBN_APP_T_INIT(otbn_char_hardware_reg_op_loop);
+  static const otbn_addr_t kOtbnAppCharHardwareRegOpLoopLC =
+      OTBN_ADDR_T_INIT(otbn_char_hardware_reg_op_loop, lc);
+  otbn_load_app(kOtbnAppCharHardwareRegOpLoop);
+
+  uint32_t loop_counter;
+
+  // FI code target.
+  sca_set_trigger_high();
+  otbn_execute();
+  otbn_busy_wait_for_done();
+  sca_set_trigger_low();
+
+  // Read loop counter from OTBN data memory.
+  otbn_dmem_read(1, kOtbnAppCharHardwareRegOpLoopLC, &loop_counter);
+
+  // Read ERR_STATUS register from OTBN.
+  dif_otbn_err_bits_t err_bits;
+  read_otbn_err_bits(&err_bits);
+
+  // Send loop counter & ERR_STATUS to host.
+  otbn_fi_loop_counter_t uj_output;
+  uj_output.loop_counter = loop_counter;
+  uj_output.err_status = err_bits;
+  RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+/**
+ * otbn.fi.char.unrolled.dmem.op.loop command handler.
+ *
+ * This FI penetration tests executes the following instructions on OTBN:
+ * - Perform 100 times:
+ *  - Load loop counter from memory
+ *  - Increment loop counter
+ *  - Store back to memory
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
+  // Initialize OTBN app, load it, and get interface to OTBN data memory.
+  OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_dmem_op_loop);
+  OTBN_DECLARE_SYMBOL_ADDR(otbn_char_unrolled_dmem_op_loop, lc);
+  const otbn_app_t kOtbnAppCharUnrolledDmemOpLoop =
+      OTBN_APP_T_INIT(otbn_char_unrolled_dmem_op_loop);
+  static const otbn_addr_t kOtbnAppCharUnrolledDmemOpLoopLC =
+      OTBN_ADDR_T_INIT(otbn_char_unrolled_dmem_op_loop, lc);
+  otbn_load_app(kOtbnAppCharUnrolledDmemOpLoop);
+
+  uint32_t loop_counter;
+
+  // FI code target.
+  sca_set_trigger_high();
+  otbn_execute();
+  otbn_busy_wait_for_done();
+  sca_set_trigger_low();
+
+  // Read loop counter from OTBN data memory.
+  otbn_dmem_read(1, kOtbnAppCharUnrolledDmemOpLoopLC, &loop_counter);
+
+  // Read ERR_STATUS register from OTBN.
+  dif_otbn_err_bits_t err_bits;
+  read_otbn_err_bits(&err_bits);
+
+  // Send loop counter & ERR_STATUS to host.
+  otbn_fi_loop_counter_t uj_output;
+  uj_output.loop_counter = loop_counter;
+  uj_output.err_status = err_bits;
+  RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+/**
+ * otbn.char.unrolled.reg.op.loop command handler.
+ *
+ * This FI penetration tests executes the following instructions on OTBN:
+ * - Initialize register x2=0
+ * - Perform 100 x2 = x2 + 1 additions
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
+  // Initialize OTBN app, load it, and get interface to OTBN data memory.
+  OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_reg_op_loop);
+  OTBN_DECLARE_SYMBOL_ADDR(otbn_char_unrolled_reg_op_loop, lc);
+  const otbn_app_t kOtbnAppCharUnrolledRegOpLoop =
+      OTBN_APP_T_INIT(otbn_char_unrolled_reg_op_loop);
+  static const otbn_addr_t kOtbnAppCharUnrolledRegOpLoopLC =
+      OTBN_ADDR_T_INIT(otbn_char_unrolled_reg_op_loop, lc);
+  otbn_load_app(kOtbnAppCharUnrolledRegOpLoop);
+
+  uint32_t loop_counter;
+
+  // FI code target.
+  sca_set_trigger_high();
+  otbn_execute();
+  otbn_busy_wait_for_done();
+  sca_set_trigger_low();
+
+  // Read loop counter from OTBN data memory.
+  otbn_dmem_read(1, kOtbnAppCharUnrolledRegOpLoopLC, &loop_counter);
+
+  // Read ERR_STATUS register from OTBN.
+  dif_otbn_err_bits_t err_bits;
+  read_otbn_err_bits(&err_bits);
+
+  // Send loop counter & ERR_STATUS to host.
+  otbn_fi_loop_counter_t uj_output;
+  uj_output.loop_counter = loop_counter;
+  uj_output.err_status = err_bits;
+  RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
+  return OK_STATUS(0);
+}
+
+/**
+ * Initializes the SCA trigger.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_otbn_fi_init_trigger(ujson_t *uj) {
+  status_t err = entropy_testutils_auto_mode_init();
+  sca_select_trigger_type(kScaTriggerTypeSw);
+  sca_init(kScaTriggerSourceOtbn, kScaPeripheralEntropy | kScaPeripheralIoDiv4 |
+                                      kScaPeripheralOtbn | kScaPeripheralCsrng |
+                                      kScaPeripheralEdn | kScaPeripheralHmac);
+  return err;
+}
+
+/**
+ * OTBN FI command handler.
+ *
+ * Command handler for the OTBN FI command.
+ *
+ * @param uj The received uJSON data.
+ */
+status_t handle_otbn_fi(ujson_t *uj) {
+  otbn_fi_subcommand_t cmd;
+  TRY(ujson_deserialize_otbn_fi_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kOtbnFiSubcommandInitTrigger:
+      return handle_otbn_fi_init_trigger(uj);
+    case kOtbnFiSubcommandCharUnrolledRegOpLoop:
+      return handle_otbn_fi_char_unrolled_reg_op_loop(uj);
+    case kOtbnFiSubcommandCharUnrolledDmemOpLoop:
+      return handle_otbn_fi_char_unrolled_dmem_op_loop(uj);
+    case kOtbnFiSubcommandCharHardwareRegOpLoop:
+      return handle_otbn_fi_char_hardware_reg_op_loop(uj);
+    case kOtbnFiSubcommandCharHardwareDmemOpLoop:
+      return handle_otbn_fi_char_hardware_dmem_op_loop(uj);
+    default:
+      LOG_ERROR("Unrecognized OTBN FI subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn_fi.h
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_OTBN_FI_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_OTBN_FI_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t read_otbn_err_bits(dif_otbn_err_bits_t *err_bits);
+
+status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj);
+status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj);
+status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj);
+status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj);
+status_t handle_otbn_init_trigger(ujson_t *uj);
+status_t handle_otbn_fi(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_OTBN_FI_H_

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -40,6 +40,13 @@ cc_library(
 )
 
 cc_library(
+    name = "otbn_fi_commands",
+    srcs = ["otbn_fi_commands.c"],
+    hdrs = ["otbn_fi_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "prng_sca_commands",
     srcs = ["prng_sca_commands.c"],
     hdrs = ["prng_sca_commands.h"],

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -16,6 +16,7 @@ extern "C" {
     value(_, AesSca) \
     value(_, IbexFi) \
     value(_, KmacSca) \
+    value(_, OtbnFi) \
     value(_, PrngSca) \
     value(_, Sha3Sca) \
     value(_, TriggerSca)

--- a/sw/device/tests/crypto/cryptotest/json/otbn_fi_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/otbn_fi_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "otbn_fi_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/otbn_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/otbn_fi_commands.h
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_OTBN_FI_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_OTBN_FI_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define OTBNFI_SUBCOMMAND(_, value) \
+    value(_, InitTrigger) \
+    value(_, CharUnrolledRegOpLoop) \
+    value(_, CharUnrolledDmemOpLoop) \
+    value(_, CharHardwareRegOpLoop) \
+    value(_, CharHardwareDmemOpLoop)
+UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND);
+
+#define OTBNFI_LOOP_COUNTER_OUTPUT(field, string) \
+    field(loop_counter, uint32_t) \
+    field(err_status, uint32_t)
+UJSON_SERDE_STRUCT(OtbnFiLoopCounterOutput, otbn_fi_loop_counter_t, OTBNFI_LOOP_COUNTER_OUTPUT);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_OTBN_FI_COMMANDS_H_


### PR DESCRIPTION
This PR adds the following OTBN tests that can be used for FI characterization:
- otbn.fi.char.unrolled.reg.op.loop
- otbn.fi.char.unrolled.dmem.op.loop
- otbn.fi.char.hardware.reg.op.loop
- otbn.fi.char.hardware.dmem.op.loop

The host code is located in lowRISC/ot-sca#327