### PR TITLE
[dv] Fix types to allow mubi randomisation

### DIFF
--- a/hw/ip/prim/rtl/prim_mubi_pkg.sv
+++ b/hw/ip/prim/rtl/prim_mubi_pkg.sv
@@ -28,7 +28,7 @@ package prim_mubi_pkg;
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi4ValsComplementary_A, MuBi4True == ~MuBi4False)
 
   // Test whether the multibit value is one of the valid enumerations
-  function automatic logic mubi4_test_invalid(mubi4_t val);
+  function automatic logic mubi4_test_invalid(logic [MuBi4Width-1:0] val);
     return ~(val inside {MuBi4True, MuBi4False});
   endfunction : mubi4_test_invalid
 
@@ -160,7 +160,7 @@ package prim_mubi_pkg;
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi8ValsComplementary_A, MuBi8True == ~MuBi8False)
 
   // Test whether the multibit value is one of the valid enumerations
-  function automatic logic mubi8_test_invalid(mubi8_t val);
+  function automatic logic mubi8_test_invalid(logic [MuBi8Width-1:0] val);
     return ~(val inside {MuBi8True, MuBi8False});
   endfunction : mubi8_test_invalid
 
@@ -292,7 +292,7 @@ package prim_mubi_pkg;
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi12ValsComplementary_A, MuBi12True == ~MuBi12False)
 
   // Test whether the multibit value is one of the valid enumerations
-  function automatic logic mubi12_test_invalid(mubi12_t val);
+  function automatic logic mubi12_test_invalid(logic [MuBi12Width-1:0] val);
     return ~(val inside {MuBi12True, MuBi12False});
   endfunction : mubi12_test_invalid
 
@@ -424,7 +424,7 @@ package prim_mubi_pkg;
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi16ValsComplementary_A, MuBi16True == ~MuBi16False)
 
   // Test whether the multibit value is one of the valid enumerations
-  function automatic logic mubi16_test_invalid(mubi16_t val);
+  function automatic logic mubi16_test_invalid(logic [MuBi16Width-1:0] val);
     return ~(val inside {MuBi16True, MuBi16False});
   endfunction : mubi16_test_invalid
 

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -259,10 +259,11 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
     wait_with_bound(wait_clks);
   endtask
 
-  function prim_mubi_pkg::mubi4_t get_invalid_mubi4();
+  // Return a randomly selected 4-bit value which is neither MuBi4True nor MuBi4False.
+  function bit [MuBi4Width-1:0] get_invalid_mubi4();
     logic [3:0] val;
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(val, mubi4_test_invalid(mubi4_t'(val));)
-    return mubi4_t'(val);
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(val, mubi4_test_invalid(val);)
+    return val;
   endfunction
 
 endclass : rom_ctrl_corrupt_sig_fatal_chk_vseq

--- a/util/design/data/prim_mubi_pkg.sv.tpl
+++ b/util/design/data/prim_mubi_pkg.sv.tpl
@@ -35,7 +35,7 @@ from mubi import prim_mubi
   `ASSERT_STATIC_IN_PACKAGE(CheckMuBi${nbits}ValsComplementary_A, MuBi${nbits}True == ~MuBi${nbits}False)
 
   // Test whether the multibit value is one of the valid enumerations
-  function automatic logic mubi${nbits}_test_invalid(mubi${nbits}_t val);
+  function automatic logic mubi${nbits}_test_invalid(logic [MuBi${nbits}Width-1:0] val);
     return ~(val inside {MuBi${nbits}True, MuBi${nbits}False});
   endfunction : mubi${nbits}_test_invalid
 


### PR DESCRIPTION
This is technically a patch to the RTL code, but it is just changing some types. This is to work around a behaviour in VCS, which won't allow us to randomise an enumeration expression with an invalid value. (Xcelium is more allowing!)

In particular, it should fix a `rom_ctrl` test which currently fails for about half the seeds.