### PR TITLE
[bazel] Rework bitstream clearing in tests

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -407,6 +407,14 @@ opentitan_test = rv_rule(
             cfg = _testing_bitstream,
             doc = "Bitstream override for this test",
         ),
+        "post_test_harness": attr.label(
+            executable = True,
+            cfg = "exec",
+            doc = "Executable to run after the test (e.g. cleanup, clear bitstream, ...)",
+        ),
+        "post_test_cmd": attr.string(
+            doc = "Arguments to the post_test_harness",
+        ),
         # Note: an `args` attr exists as an override for exec_env.args.  It is
         # not listed here because all test rules have an implicit `args`
         # attribute which is a list of strings subject to location and make

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -219,6 +219,8 @@ def opentitan_test(
             rom_ext = tparam.rom_ext,
             otp = tparam.otp,
             bitstream = tparam.bitstream,
+            post_test_cmd = getattr(tparam, "post_test_cmd", ""),
+            post_test_harness = getattr(tparam, "post_test_harness", None),
             test_cmd = tparam.test_cmd,
             param = tparam.param,
             data = tparam.data,


### PR DESCRIPTION
At the moment, some tests manually clear the bitstream *before* the tests but really we ought to be doing the opposite which is to clear the bitstream *after* the test if it touches the OTP. This way, such a test can be safely followed by a "normal" tests.

This commit introduces the notion of a post_test_{harness,cmd} that is run after the normal test_harness (on success and failure). The fpga310 parameters are modified so that they take an extra "clear_bitstream" argument that uses this post test command to clear the bitstream if requested.

This should be combined with #21645