### PR TITLE
[rom_ctrl,dv] Fix constraint for invalid mubis in vseq

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -260,9 +260,13 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
   endtask
 
   function prim_mubi_pkg::mubi4_t get_invalid_mubi4();
+    // This is a bit of a hack and we're basically inlining the contents of mubi4_test_invalid. This
+    // is because arguments to a function in any particular constraint get fixed before the
+    // constraint is evaluated. This means that you can't use a constraint of the form "is_good(x)"
+    // to ensure x is valid.
     logic [3:0] val;
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(val, mubi4_test_invalid(mubi4_t'(val));)
-    return mubi4_t'(val);
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(val, ~(val inside {MuBi4True, MuBi4False});)
+    return val;
   endfunction
 
 endclass : rom_ctrl_corrupt_sig_fatal_chk_vseq


### PR DESCRIPTION
Getting my head around this problem took... some time! The exact behaviour of function calls in constraints is described in IEEE 1800, section 18.5.12.

What I was trying to do is definitely invalid, because the constraint looked like

    randomize(x) with {is_good(x);}

The constrained randomisation tool doesn't ever look inside functions that it sees. All it can do is to execute the function with some argument. Clearly that isn't going to work in the example above...

I spent a couple of minutes wondering why functions are allowed at all! But this isn't completely crazy, because you might want to do something like this:

  randomize(x,y) with { x < 10; y < pow(x, 3); }

This actually works! Assuming that pow is exponentiation, it picks a pair x, y such that x is less than 10 and y is less than x^3.

The reason that this is possible is that:

 - The "pow(x, 3)" bit depends on "x", so x gets given a higher priority in the variable ordering.

 - Now, the "x < 10" constraint only references variables with the higher priority, which means that it will get solved before the other constraint.

 - Now we pick a value of x less than 10.

 - Then we pick a value of y that is less than x^3.

Neat!