### PR TITLE
[fpga_cw310_sival_rom_ext] Fix key mismatch

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -214,8 +214,14 @@ fpga_cw310(
         "//sw/device/lib/arch:fpga_cw310",
     ],
     otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
-    rom_ext = "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_a",
-    rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
+    rom_ext = select({
+        "//signing:test_keys": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_a",
+    }),
+    rsa_key = select({
+        "//signing:test_keys": {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
+        "//conditions:default": {"//sw/device/silicon_creator/rom_ext/sival/keys:keyset": "earlgrey_z0_sival_1"},
+    }),
     tags = ["cw310_sival_rom_ext"],
 )
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -276,7 +276,7 @@ opentitan_binary(
     linker_script = ":ld_slot_a",
     manifest = ":manifest_standard",
     rsa_key = select({
-        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
         "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_test_0"},
     }),
     deps = [
@@ -298,7 +298,7 @@ opentitan_binary(
     linker_script = ":ld_slot_b",
     manifest = ":manifest_standard",
     rsa_key = select({
-        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
         "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_test_0"},
     }),
     deps = [
@@ -320,7 +320,7 @@ opentitan_binary(
     linker_script = ":ld_slot_virtual",
     manifest = ":manifest_virtual",
     rsa_key = select({
-        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+        "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
         "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_test_0"},
     }),
     deps = [


### PR DESCRIPTION
Change the generic ROM_EXT target to be signed by the fake prod key, so it may be used in the prod life cycle state.

Change the fpga_cw310_sival_rom_ext execution environment to optionally use the generic ROM_EXT with a sival OTP configuration. A build setting allows it to be built with the real keys, however.

This fixes a key mismatch due to earlier changes.