### PR TITLE
[hw,spi_host,i2c,soc_proxy] Fix CDC issue for lsio_triggers

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -589,7 +589,14 @@ module spi_host
     end
   end
 
-  assign lsio_trigger_o = tx_wm_q | rx_wm_q;
+  // Flop trigger signal to avoid glitches on the output
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      lsio_trigger_o <= 1'b0;
+    end else begin
+      lsio_trigger_o <= tx_wm_q | rx_wm_q;
+    end
+  end
 
   prim_intr_hw #(.Width(1)) intr_hw_spi_event (
     .clk_i,

--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -321,7 +321,14 @@ module uart_core (
     endcase
   end
 
-  assign lsio_trigger_o = tx_watermark_prev_q | rx_watermark_prev_q;
+  // Flop trigger signal to avoid glitches on the output
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      lsio_trigger_o <= 1'b0;
+    end else begin
+      lsio_trigger_o <= tx_watermark_prev_q | rx_watermark_prev_q;
+    end
+  end
 
   assign event_tx_watermark = tx_watermark_d & ~tx_watermark_prev_q;
 

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -3852,7 +3852,7 @@
         }
         {
           name: dma_lsio_trigger
-          desc: Collated LSIO trigger signals for DMA
+          desc: Collated synchronous LSIO trigger signals for DMA
           struct: lsio_trigger
           package: dma_pkg
           type: uni
@@ -19596,7 +19596,7 @@
       }
       {
         name: dma_lsio_trigger
-        desc: Collated LSIO trigger signals for DMA
+        desc: Collated synchronous LSIO trigger signals for DMA
         struct: lsio_trigger
         package: dma_pkg
         type: uni

--- a/hw/top_darjeeling/ip/soc_proxy/data/soc_proxy.hjson
+++ b/hw/top_darjeeling/ip/soc_proxy/data/soc_proxy.hjson
@@ -220,7 +220,7 @@
       type:    "uni"
       name:    "dma_lsio_trigger"
       act:     "req"
-      desc:    "Collated LSIO trigger signals for DMA"
+      desc:    "Collated synchronous LSIO trigger signals for DMA"
     }
     { struct:  "soc_alert"
       package: "soc_proxy_pkg"

--- a/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy.sv
+++ b/hw/top_darjeeling/ip/soc_proxy/rtl/soc_proxy.sv
@@ -305,12 +305,42 @@ module soc_proxy
     .filter_o (rst_req_external_o)
   );
 
+  // CDC sync of LSIO trigger signals between the peripheral and the high-speed clock domain
+  logic uart_lsio_trigger_sync, spi_host_lsio_trigger_sync, i2c_lsio_trigger_sync;
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_uart_lsio_trigger_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i      (uart_lsio_trigger_i),
+    .q_o      (uart_lsio_trigger_sync)
+  );
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_spi_host_lsio_trigger_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i      (spi_host_lsio_trigger_i),
+    .q_o      (spi_host_lsio_trigger_sync)
+  );
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_i2c_lsio_trigger_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i    (i2c_lsio_trigger_i),
+    .q_o    (i2c_lsio_trigger_sync)
+  );
+
   // Collate LSIO trigger inputs into signal for DMA
   assign dma_lsio_trigger_o = {
     soc_lsio_trigger_i,
-    uart_lsio_trigger_i,
-    spi_host_lsio_trigger_i,
-    i2c_lsio_trigger_i
+    uart_lsio_trigger_sync,
+    spi_host_lsio_trigger_sync,
+    i2c_lsio_trigger_sync
   };
 
   // Assertions


### PR DESCRIPTION
This PR flops the LSIO triggers at the source IP with their respective peripheral clock and then uses a synchronizer cell at the soc_proxy IP with the fast SoC clock to fix a CDC issue between both domains.

The LSIO trigger of the I2C IP is already flopped.