### PR TITLE
[hmac,verilator] Remove lint waivers for nonexistent file

### DIFF
--- a/hw/ip/hmac/lint/hmac.vlt
+++ b/hw/ip/hmac/lint/hmac.vlt
@@ -10,8 +10,6 @@
 // currently used, but we're keeping them attached for future use.
 lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_secret'"
 lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_v'"
-lint_off -rule UNUSED -file "*/rtl/sha2_pad.sv" -match "Signal is not used: 'wipe_secret'"
-lint_off -rule UNUSED -file "*/rtl/sha2_pad.sv" -match "Signal is not used: 'wipe_v'"
 
 // 1 bit adder to optimize the count ones logic
 lint_off -rule WIDTH -file "*/rtl/hmac.sv" -match "*RHS's SEL generates 1 bits*"


### PR DESCRIPTION
sha2_pad was removed from hmac with 2290dcc11, because the code now lives in prim_sha2_pad. I suspect we'll want to put in a lint waiver there at some point too, but there's no real advantage to keeping this stale one.

I found this because I was searching through the repository for the various ports of `hmac` when thinking about #21666 (and whether we could "just do it"). Here's a waiver that definitely wouldn't need renaming...