### PR TITLE
Cherry-pick USB sival tests to earlgrey_es_sival

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -364,7 +364,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_aon_wake_reset"]
     }
     {
       name: chip_sw_usbdev_aon_wake_disconnect

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -34,7 +34,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_vbus"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_vbus_test"]
     }
     {
       name: chip_sw_usbdev_pullup
@@ -59,7 +59,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_pullup"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_pullup_test"]
     }
     {
       name: chip_sw_usbdev_aon_pullup
@@ -138,7 +138,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_setuprx"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_setuprx_test"]
     }
     {
       name: chip_sw_usbdev_config_host
@@ -163,7 +163,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_config_host"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_config_host_test"]
     }
     {
       name: chip_sw_usbdev_pincfg
@@ -190,7 +190,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_usbdev_pincfg"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_pincfg_test"]
     }
     {
       name: chip_sw_usbdev_tx_rx

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -162,7 +162,7 @@
       stage: V2
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
-      tests: []
+      tests: ["chip_sw_usbdev_config_host"]
       bazel: []
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -83,8 +83,8 @@
       stage: V2
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
-      tests: []
-      bazel: []
+      tests: ["chip_sw_usbdev_aon_pullup"]
+      bazel: ["//sw/device/tests:usbdev_aon_pullup_test"]
     }
     {
       name: chip_sw_usbdev_sof

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -589,6 +589,14 @@
       reseed: 1
     }
     {
+      name: chip_sw_usbdev_aon_pullup
+      uvm_test_seq: chip_sw_usbdev_dpi_vseq
+      sw_images: ["//sw/device/tests:usbdev_aon_pullup_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1"]
+      reseed: 1
+    }
+    {
       name: chip_sw_usbdev_setuprx
       uvm_test_seq: chip_sw_usbdev_dpi_vseq
       sw_images: ["//sw/device/tests:usbdev_setuprx_test:1:new_rules"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -597,6 +597,14 @@
       reseed: 1
     }
     {
+      name: chip_sw_usbdev_config_host
+      uvm_test_seq: chip_sw_usbdev_dpi_vseq
+      sw_images: ["//sw/device/tests:usbdev_config_host_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+uart_idx=0", "+calibrate_usb_clk=1"]
+      reseed: 1
+    }
+    {
       name: chip_sw_usbdev_pincfg
       uvm_test_seq: chip_sw_usbdev_dpi_vseq
       sw_images: ["//sw/device/tests:usbdev_pincfg_test:1:new_rules"]

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -541,3 +541,15 @@ cc_library(
         "//sw/device/lib/testing/test_framework:check",
     ],
 )
+
+cc_library(
+    name = "usb_logging",
+    srcs = ["usb_logging.c"],
+    hdrs = ["usb_logging.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":pinmux_testutils",
+        ":usb_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+    ],
+)

--- a/sw/device/lib/testing/usb_logging.c
+++ b/sw/device/lib/testing/usb_logging.c
@@ -1,0 +1,546 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/usb_logging.h"
+
+#include <ctype.h>
+
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/usb_testutils.h"
+#include "sw/device/lib/testing/usb_testutils_controlep.h"
+
+#define MODULE_ID MAKE_MODULE_ID('u', 's', 'l')
+
+enum {
+  // Size of each logging buffer; data is collected in a buffer until the buffer
+  // is full (or the periodic flush occurs) and is then transmitted as a single
+  // transfer at higher throughput.
+  kUSBLogBufferSize = 0x800u,
+
+  // Total number of logging buffers to be shared among all active streams.
+  kUSBLogNumBuffers = 8u,
+
+  // Maximum delay before logging data is flushed upstream to the host;
+  // microseconds.
+  kUSBLogFlushInterval = 500u * 1000u,
+};
+
+// Maximum length of the configuration descriptor.
+enum {
+  kCfgDscrLenMax =
+      (USB_CFG_DSCR_LEN +
+       kUSBLogMaxStreams * (USB_INTERFACE_DSCR_LEN + 1u * USB_EP_DSCR_LEN)),
+};
+
+// Forward reference required for linked list.
+typedef struct usb_logging_buf usb_logging_buf_t;
+
+// USB logging buffer description.
+struct usb_logging_buf {
+  /**
+   * Link to the next buffer for this stream, or the next free buffer.
+   */
+  usb_logging_buf_t *next;
+  /**
+   * Number of used bytes; index at which next write shall occur.
+   */
+  uint16_t bytes_used;
+  /**
+   * Data buffer holding logging data.
+   */
+  uint8_t data[kUSBLogBufferSize];
+};
+
+// Forwards reference to logging context.
+typedef struct usb_logging_ctx usb_logging_ctx_t;
+
+// Per-stream state information.
+typedef struct usb_logging_stream {
+  /**
+   * Context pointer; for use within callback handler.
+   */
+  usb_logging_ctx_t *ctx;
+  /**
+   * Reliable delivery required?
+   */
+  bool reliable;
+  /**
+   * Remapping for non-printable characters required?
+   */
+  bool remap;
+  /**
+   * The USB device endpoint that we're using.
+   */
+  uint8_t ep;
+  /**
+   * Currently sending a buffer?
+   */
+  bool sending;
+  /**
+   * The oldest logging buffer filled by this stream; this is either being
+   * sent (`sending` == true) or shall be the next to send. May be NULL iff
+   * this stream has no completed buffers to send.
+   */
+  usb_logging_buf_t *send_buf;
+  /**
+   * Time at which the most recently-populated buffer should be sent to the
+   * host; prevent log data being retained indefinitely in the event of no
+   * further log output.
+   */
+  ibex_timeout_t flush_time;
+  /**
+   * The current logging buffer; may be partially-filled or full (see
+   * `bytes_used` field), or NULL iff this stream has no pending logging data.
+   */
+  usb_logging_buf_t *wr_buf;
+} usb_logging_stream_t;
+
+// USB Logging context.
+struct usb_logging_ctx {
+  /**
+   * Access to usb_testutils layer.
+   */
+  usb_testutils_ctx_t *usbutils;
+  /**
+   * Number of logging streams.
+   */
+  uint8_t nstreams;
+  /**
+   * Linked-list of free buffers.
+   */
+  usb_logging_buf_t *free;
+  /**
+   * Per-stream state information.
+   */
+  usb_logging_stream_t streams[kUSBLogMaxStreams];
+  /**
+   * Pool of logging buffers; shared among all active streams.
+   */
+  usb_logging_buf_t buf[kUSBLogNumBuffers];
+};
+
+/**
+ * USB device context types.
+ */
+static usb_testutils_ctx_t usbdev;
+static usb_testutils_controlep_ctx_t usbdev_control;
+
+// Note: for now there is a single logging context.
+static usb_logging_ctx_t the_ctx;
+
+/**
+ * Pinmux handle
+ */
+static dif_pinmux_t pinmux;
+
+/**
+ * Internal development logging; be careful about using this if stdout has been
+ * redirected!
+ */
+static const bool kDevLogging = false;
+
+/**
+ * Character map, used to ensure that non-printable characters are dropped;
+ * isprint() available so this assumes ASCII and drops the control characters
+ * that could could issues with inappropriate terminal settings at the host.
+ */
+static const uint32_t kCtrlChars =
+    ((uint32_t)1u << '\t') | ((uint32_t)1u << '\n') | ((uint32_t)1u << '\r');
+static const uint32_t kMap[0x100u / 0x20u] = {
+    // suppress control characters and ASCII 127 (Delete)
+    kCtrlChars, ~0u, ~0u, 0x7fffffffu,
+    // top-bit set characters are harmless; propagate them unchanged.
+    ~0u, ~0u, ~0u, ~0u};
+
+// Our stdout function
+static size_t usb_log(void *data, const char *buf, size_t len);
+
+/**
+ * Configuration values for USB.
+ */
+static uint8_t config_descriptors[kCfgDscrLenMax];
+
+// Since isprint() is unavailable, use a simple bitmap to test whether it is
+// safe to transmit the given ASCII character unmodified.
+static bool isprintable(uint8_t ch) {
+  return ((kMap[ch >> 5] >> (ch & 0x1fu)) & 1u) != 0u;
+}
+
+// Place all buffers into the free list
+static void free_list_init(usb_logging_ctx_t *ctx) {
+  usb_logging_buf_t *prev = NULL;  // End of list.
+  unsigned idx = kUSBLogNumBuffers;
+  // Order them such that the first buffer is initially at the head.
+  while (idx-- > 0u) {
+    ctx->buf[idx].next = prev;
+    prev = &ctx->buf[idx];
+  }
+  ctx->free = ctx->buf;
+}
+
+// Attempt to claim a buffer from the free list.
+static inline usb_logging_buf_t *buffer_claim(usb_logging_ctx_t *ctx) {
+  usb_logging_buf_t *buf = ctx->free;
+  if (buf) {
+    ctx->free = buf->next;
+    buf->next = NULL;
+    buf->bytes_used = 0u;
+  }
+  return buf;
+}
+
+// Return a buffer to the free list.
+static inline void buffer_release(usb_logging_ctx_t *ctx,
+                                  usb_logging_buf_t *buf) {
+  buf->next = ctx->free;
+  ctx->free = buf;
+}
+
+static status_t buffer_send(usb_logging_ctx_t *ctx, usb_logging_stream_t *s) {
+  TRY_CHECK(ctx && s && s->send_buf);
+
+  const uint8_t *data = s->send_buf->data;
+  uint16_t len = s->send_buf->bytes_used;
+
+  if (kDevLogging) {
+    LOG_INFO("sending %p %p %u\n", ctx, data, len);
+  }
+
+  TRY(usb_testutils_transfer_send(ctx->usbutils, s->ep, data, len,
+                                  kUsbTestutilsXfrDoubleBuffered));
+  // Have at least started to send the buffer...
+  s->sending = true;
+  return OK_STATUS();
+}
+
+static status_t buffer_completed(usb_logging_ctx_t *ctx,
+                                 usb_logging_stream_t *s) {
+  TRY_CHECK(s->wr_buf);
+
+  // Make the buffer available for sending.
+  usb_logging_buf_t **prev = &s->send_buf;
+  while (*prev) {
+    prev = &(*prev)->next;
+  }
+  *prev = s->wr_buf;
+  s->wr_buf = NULL;
+
+  // Attempt to send.
+  status_t res = OK_STATUS();
+  if (!s->sending) {
+    res = buffer_send(ctx, s);
+  }
+  return res;
+}
+
+// Attempt to close a logging stream, flushing any remaining data upstream to
+// the host if required.
+// Returns true iff the stream has closed successfully; otherwise there is still
+// work to be done.
+static inline bool stream_close(usb_logging_ctx_t *ctx,
+                                usb_logging_stream_t *s) {
+  if (s->wr_buf) {
+    buffer_completed(ctx, s);
+  }
+  return !s->send_buf;
+}
+
+// A buffer of logging data has been received by the host; we may try to
+// send another buffer if one is available.
+static status_t tx_done(void *s_v, usb_testutils_xfr_result_t result) {
+  usb_logging_stream_t *s = (usb_logging_stream_t *)s_v;
+  usb_logging_ctx_t *ctx = s->ctx;
+
+  s->sending = false;
+
+  // Return this buffer to the free list.
+  usb_logging_buf_t *buf = s->send_buf;
+  TRY_CHECK(buf != NULL);
+  s->send_buf = buf->next;
+  buffer_release(ctx, buf);
+
+  // Send the next, if there is one
+  if (s->send_buf) {
+    TRY(buffer_send(ctx, s));
+  }
+  return OK_STATUS();
+}
+
+// Callback function from the usb_testutils layer; presently this is called
+// every 16ms, provided that usb_testutils_poll is being called often.
+static status_t tx_flush(void *s_v) {
+  usb_logging_stream_t *s = (usb_logging_stream_t *)s_v;
+  usb_logging_ctx_t *ctx = s->ctx;
+
+  // We use this to prevent incomplete buffers of log data sitting here
+  // indefinitely and not reaching the host.
+  usb_logging_buf_t *buf = s->wr_buf;
+  if (buf && ibex_timeout_check(&s->flush_time)) {
+    if (buf->bytes_used > 0u) {
+      // Send everything that we have thus far collected in this buffer,
+      buffer_completed(ctx, s);
+    }
+    // Earliest time at which we shall again attempt flushing of log data on
+    // this stream.
+    s->flush_time = ibex_timeout_init(kUSBLogFlushInterval);
+  }
+
+  return OK_STATUS();
+}
+
+// Internal function for all USB logging.
+static status_t usb_logging_send(usb_logging_ctx_t *ctx,
+                                 usb_logging_stream_t *s, const uint8_t *data,
+                                 size_t len) {
+  do {
+    // We must poll the testutils layer to keep things going...do this even if
+    // we've somehow been asked to log zero bytes of data.
+    TRY(usb_testutils_poll(ctx->usbutils));
+
+    // Try to ensure that we have a logging buffer.
+    if (!s->wr_buf) {
+      s->wr_buf = buffer_claim(ctx);
+    }
+    if (s->wr_buf) {
+      usb_logging_buf_t *buf = s->wr_buf;
+
+      // Add as much as we can to the current logging buffer.
+      size_t chunk = kUSBLogBufferSize - buf->bytes_used;
+      if (chunk > len) {
+        chunk = len;
+      }
+      if (s->remap) {
+        // Remap non-printable characters, to avoid issues with accidentally
+        // stimulated software flow control (XON/XOFF) at the host.
+        uint8_t *dp = &buf->data[buf->bytes_used];
+        for (size_t i = 0u; i < chunk; ++i) {
+          dp[i] = isprintable(data[i]) ? data[i] : '.';
+        }
+      } else {
+        memcpy(&buf->data[buf->bytes_used], data, chunk);
+      }
+      // Advance beyond the chunk that we've handled.
+      data += chunk;
+      len -= chunk;
+
+      // Initialize timeout at the point of starting to fill a buffer, since it
+      // will be sent as a complete unit.
+      if (!buf->bytes_used) {
+        s->flush_time = ibex_timeout_init(kUSBLogFlushInterval);
+      }
+
+      // Is this packet buffer now ready to be sent?
+      buf->bytes_used += chunk;
+      if (buf->bytes_used >= kUSBLogBufferSize) {
+        buffer_completed(ctx, s);
+      }
+    } else if (!s->reliable) {
+      // Blocked awaiting another buffer; drop logging data.
+      break;
+    }
+  } while (len);  // Any more to send?
+
+  return OK_STATUS();
+}
+
+// Interface for known-length (binary) data.
+status_t usb_logging_data(uint8_t s, const uint8_t *data, size_t len) {
+  usb_logging_ctx_t *ctx = &the_ctx;
+  TRY_CHECK(s < ctx->nstreams);
+
+  return usb_logging_send(ctx, &ctx->streams[s], data, len);
+}
+
+// Interface for ASCIIZ text message.
+status_t usb_logging_text(uint8_t s, const char *text) {
+  usb_logging_ctx_t *ctx = &the_ctx;
+  TRY_CHECK(s < ctx->nstreams);
+  TRY_CHECK(text);
+
+  // Note: no strlen() available.
+  uint32_t len = (uint32_t)((char *)memchr(text, 0, SIZE_MAX) - text);
+  return usb_logging_send(ctx, &ctx->streams[s], (const uint8_t *)text, len);
+}
+
+// stdout redirection.
+static size_t usb_log(void *data, const char *buf, size_t len) {
+  usb_logging_stream_t *s = (usb_logging_stream_t *)data;
+  if (s) {
+    usb_logging_ctx_t *ctx = s->ctx;
+    status_t res = usb_logging_send(ctx, s, (uint8_t *)buf, len);
+    if (status_ok(res)) {
+      return len;
+    }
+  }
+  return 0u;
+}
+
+status_t usb_logging_enable(void) {
+  usb_logging_ctx_t *ctx = &the_ctx;
+
+  // Set up a single reliable logging stream; if `ctx->usbutils` is non-zero
+  // then the usb_testutils has already been initialized.
+  // Should be no need to incur the performance hit of remapping characters,
+  // if base_printf/usage is well-behaved.
+  TRY(usb_logging_init(ctx->usbutils, 1u, 1u, 1u, false));
+
+  // Construct the descriptor of our USB sink function for stdout.
+  buffer_sink_t sink;
+  sink.data = &ctx->streams[0];
+  sink.sink = usb_log;
+  // Redirect stdout to us
+  base_set_stdout(sink);
+
+  return OK_STATUS();
+}
+
+status_t usb_logging_init(usb_testutils_ctx_t *usbutils, uint8_t ep_first,
+                          uint8_t nstreams, uint32_t reliable, bool remap) {
+  usb_logging_ctx_t *ctx = &the_ctx;
+
+  // Validate input arguments.
+  TRY_CHECK(nstreams > 0u && nstreams <= kUSBLogMaxStreams);
+
+  // Set up the software layers, if required.
+  if (usbutils) {
+    // usb_testutils layer already initialized, so an endpoint number must be
+    // supplied.
+    ctx->usbutils = usbutils;
+    TRY_CHECK(ep_first >= 1u && USBDEV_NUM_ENDPOINTS >= ep_first + nstreams);
+  } else {
+    // Pointers to context for lower software layers.
+    ctx->usbutils = &usbdev;
+    ep_first = 1u;
+
+    TRY(dif_pinmux_init(
+        mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+    pinmux_testutils_init(&pinmux);
+    TRY(dif_pinmux_input_select(&pinmux,
+                                kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+                                kTopEarlgreyPinmuxInselIoc7));
+
+    // Total length of the configuration descriptor; validate caller buffer.
+    size_t cfg_len = USB_CFG_DSCR_LEN +
+                     nstreams * (USB_INTERFACE_DSCR_LEN + USB_EP_DSCR_LEN);
+    TRY_CHECK(cfg_len <= sizeof(config_descriptors));
+
+    // Configuration Descriptor header.
+    uint8_t *cfg = config_descriptors;
+    uint8_t head[USB_CFG_DSCR_LEN] = {
+        USB_CFG_DSCR_HEAD((uint16_t)cfg_len, (uint8_t)nstreams)};
+    memcpy(cfg, head, USB_CFG_DSCR_LEN);
+    cfg += USB_CFG_DSCR_LEN;
+
+    // Followed by programmatically-generated list of interface descriptors.
+    for (uint8_t id = 0U; id < nstreams; ++id) {
+      uint8_t ep_in = ep_first + id;
+      // Description of a single interface.
+      uint8_t int_dscr[USB_INTERFACE_DSCR_LEN + USB_EP_DSCR_LEN] = {
+          VEND_INTERFACE_DSCR(id, 1, 0x50, 1),
+          // Declare only an IN endpoint because we don't require OUT traffic
+          // and any character echo would just be wasting bus bandwidth.
+          USB_EP_DSCR(1, ep_in, (uint8_t)kUsbTransferTypeBulk,
+                      USBDEV_MAX_PACKET_SIZE, 0),
+      };
+
+      // Append interface descriptor to the configuration descriptor.
+      memcpy(cfg, int_dscr, sizeof(int_dscr));
+      cfg += sizeof(int_dscr);
+    }
+
+    // Call `usbdev_init` here so that DPI will not start until the
+    // simulation has finished all of the printing, which takes a while
+    // if `--trace` was passed in.
+    TRY(usb_testutils_init(ctx->usbutils, /*pinflip=*/false,
+                           /*en_diff_rcvr=*/true,
+                           /*tx_use_d_se0=*/false));
+    TRY(usb_testutils_controlep_init(&usbdev_control, ctx->usbutils, 0,
+                                     config_descriptors, cfg_len, NULL,
+                                     0u));  // No need for test descriptor.
+  }
+
+  // Initialize list of free buffers.
+  free_list_init(ctx);
+
+  // Initialize the time of the next flush on each stream; stagger them to
+  // avoid all flush operations coinciding and producing traffic that is more
+  // bursty.
+  const uint32_t flush_inc = kUSBLogFlushInterval / nstreams;
+  uint32_t interval_us = kUSBLogFlushInterval / 2u;
+
+  for (uint8_t s = 0u; s < nstreams; ++s) {
+    usb_logging_stream_t *stream = &ctx->streams[s];
+    // Context pointer, for use within callback handler.
+    stream->ctx = ctx;
+    // Reliable delivery required?
+    stream->reliable = (((reliable >> s) & 1u) != 0u);
+    // Remapping required?
+    stream->remap = remap;
+    // Endpoint(s) to be used.
+    // Note: this could be modified to permit concurrent operation with other
+    // interfaces.
+    stream->ep = 1u + s;
+    // Sending state; nothing to send or being sent.
+    stream->sending = false;
+    stream->send_buf = NULL;
+    // Earliest time of next flush attempt.
+    stream->flush_time = ibex_timeout_init(interval_us);
+    interval_us += flush_inc;
+    // Writing state; no buffer initially.
+    stream->wr_buf = NULL;
+
+    TRY(usb_testutils_in_endpoint_setup(ctx->usbutils, stream->ep,
+                                        kUsbTransferTypeBulk, stream, tx_done,
+                                        tx_flush, NULL));
+  }
+
+  if (!usbutils) {
+    // Proceed only when the device has been configured; this allows host-side
+    // software to establish communication.
+    const uint32_t kTimeoutUsecs = 30 * 1000000;
+    ibex_timeout_t timeout = ibex_timeout_init(kTimeoutUsecs);
+    while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured &&
+           !ibex_timeout_check(&timeout)) {
+      TRY(usb_testutils_poll(ctx->usbutils));
+    }
+    if (usbdev_control.device_state != kUsbTestutilsDeviceConfigured) {
+      // Don't wait indefinitely because there may be no usable connection.
+      return UNAVAILABLE();
+    }
+  }
+
+  // Remember the stream count, now that everything is configured.
+  ctx->nstreams = nstreams;
+
+  return OK_STATUS();
+}
+
+status_t usb_logging_fin(bool wait, bool disconnect) {
+  usb_logging_ctx_t *ctx = &the_ctx;
+
+  // Wait for captured logging traffic to be transmitted?
+  if (wait) {
+    uint8_t s = 0u;
+    while (s < ctx->nstreams) {
+      usb_logging_stream_t *stream = &ctx->streams[s];
+      if (!stream_close(ctx, stream)) {
+        TRY(usb_testutils_poll(ctx->usbutils));
+        // Stay with this logging stream until it completes.
+        continue;
+      }
+      // Check the next logging stream.
+      ++s;
+    }
+  }
+
+  // Optionally finalize the testutils layer, disconnecting us from the USB.
+  if (disconnect) {
+    TRY(usb_testutils_fin(ctx->usbutils));
+    ctx->usbutils = NULL;
+  }
+
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/usb_logging.h
+++ b/sw/device/lib/testing/usb_logging.h
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_USB_LOGGING_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_USB_LOGGING_H_
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/testing/usb_testutils.h"
+
+// Maximum number of streams supported by logging over USB.
+enum {
+  kUSBLogMaxStreams = 4u,
+};
+
+/**
+ * Initiate logging of stdout traffic over USB, using internal state
+ * structure and a single stream, for minimal external code.
+ *
+ * @return The result of the operation.
+ */
+
+OT_WARN_UNUSED_RESULT
+status_t usb_logging_enable(void);
+
+/**
+ * Generic initialization of logging streams via USB device; traffic delivery
+ * for each stream may optionally be reliable, meaning that the calling code
+ * will block if there is insufficient buffer space and/or the USB host has not
+ * yet received earlier traffic.
+ *
+ * To integrate with other code that is using the USB testutils, specify the
+ * context pointer for the usb_testutils layer, along with the number of the
+ * first endpoint to used for logging.
+ *
+ * If logging is the only user of the USB device, simply pass NULL and ep_first
+ * may be zero.
+ *
+ * @param  usbutils   Context for usb_testutils layer or NULL.
+ * @param  nstreams   Number of logging streams.
+ * @param  ep_first   First endpoint number to be used.
+ * @param  mreliable  Bitmap of which logging streams shall provide reliable
+ *                    delivery.
+ * @param  remap      Is remapping of non-printable characters required?
+ * @return The result of the operation.
+ */
+
+OT_WARN_UNUSED_RESULT
+status_t usb_logging_init(usb_testutils_ctx_t *usbutils, uint8_t ep_first,
+                          uint8_t nstreams, uint32_t reliable, bool remap);
+
+/**
+ * Send a log message via the given stream.
+ *
+ * @param  stream     Stream number.
+ * @param  text       The text to be sent.
+ * @return The result of the operation.
+ */
+// Use of result not required for unreliable logging traffic.
+status_t usb_logging_text(uint8_t stream, const char *text);
+
+/**
+ * Send a sequence of bytes via the given stream.
+ *
+ * @param  stream     Stream number.
+ * @param  data       Start of byte sequence.
+ * @param  len        Number of bytes to be sent.
+ * @return The result of the operation.
+ */
+// Use of result not required for unreliable logging traffic.
+status_t usb_logging_data(uint8_t stream, const uint8_t *data, unsigned len);
+
+/**
+ * Ensure that all log data on this stream is flushed upstream to the host;
+ * this should be employed only where absolutely necessary, to ensure visibility
+ * of specific output.
+ *
+ * In normal usage, log data will be periodically flushed
+ */
+status_t usb_logging_flush(uint8_t stream);
+
+/**
+ * Finalize USB logging streams, optionally waiing until all buffered logging
+ * data has been transmitted to the host.
+ *
+ * @param  wait       Whether to wait for all buffered data to be transmitted.
+ * @param  disconnect Indicates whether to disconnect from the USB.
+ * @return The result of the operation.
+ */
+
+OT_WARN_UNUSED_RESULT
+status_t usb_logging_fin(bool wait, bool disconnect);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_USB_LOGGING_H_

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3512,6 +3512,24 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "usbdev_aon_pullup_test",
+    srcs = ["usbdev_aon_pullup_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "usbdev_setuprx_test",
     srcs = ["usbdev_setuprx_test.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3529,6 +3529,37 @@ opentitan_test(
     ],
 )
 
+# This test requires that the harness has sufficient permissions to
+# open the USB parent hub of the device under test so it can issue
+# requests directly. For this reason, the test is tagged as manual
+# until the CI can provide such an access.
+opentitan_test(
+    name = "usbdev_aon_wake_reset_test",
+    srcs = ["usbdev_aon_wake_reset_test.c"],
+    cw310 = new_cw310_params(
+        tags = ["manual"],
+        test_cmd = """
+            --bitstream="{bitstream}"
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
+    ),
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:usb_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 opentitan_test(
     name = "usbdev_setuprx_test",
     srcs = ["usbdev_setuprx_test.c"],

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3457,11 +3457,10 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_pincfg_test",
     srcs = ["usbdev_pincfg_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3479,11 +3478,10 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_vbus_test",
     srcs = ["usbdev_vbus_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -3498,11 +3496,10 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_pullup_test",
     srcs = ["usbdev_pullup_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -3517,11 +3514,10 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_setuprx_test",
     srcs = ["usbdev_setuprx_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -3537,11 +3533,10 @@ opentitan_test(
     name = "usbdev_test",
     srcs = ["usbdev_test.c"],
     cw310 = new_cw310_params(tags = ["manual"]),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3563,11 +3558,10 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3588,11 +3582,10 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3613,11 +3606,10 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3644,6 +3644,32 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "usbdev_logging_test",
+    srcs = ["usbdev_logging_test.c"],
+    cw310 = new_cw310_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    verilator = new_verilator_params(timeout = "long"),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:usb_logging",
+        "//sw/device/lib/testing:usb_testutils",
+        "//sw/device/lib/testing:usb_testutils_streams",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "rstmgr_alert_info_test",
     srcs = ["rstmgr_alert_info_test.c"],
     exec_env = {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3530,6 +3530,26 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "usbdev_config_host_test",
+    srcs = ["usbdev_config_host_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS
+    ),
+    verilator = new_verilator_params(timeout = "long"),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:usb_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "usbdev_test",
     srcs = ["usbdev_test.c"],
     cw310 = new_cw310_params(tags = ["manual"]),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3534,7 +3534,7 @@ opentitan_test(
     srcs = ["usbdev_config_host_test.c"],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
-        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     verilator = new_verilator_params(timeout = "long"),
     deps = [

--- a/sw/device/tests/usbdev_aon_pullup_test.c
+++ b/sw/device/tests/usbdev_aon_pullup_test.c
@@ -1,0 +1,281 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// USB AON PULLUP test
+//
+// Test the driving of pull up resistor(s) on the USB, and check that the
+// AON Wake module is able to maintain the state of the bus.
+//
+// 1.  Check for the presence of VBUS.
+// 2.  Check the DP line is not in the desired state,
+//     ie. initially it should be Low.
+// 3.  Drive the DP line to the desired state.
+// 4.  Check the DP line has changed as intended.
+// 5.  Hand over control of the pull ups to the AON Wake module.
+// 6.  Attempt to drive the DP line to the opposite state.
+// 7.  Check that the DP line has not changed.
+// 8.  Remove attempted change to the line state.
+// 9.  Reclaim control of the pull ups from the AON Wake module.
+// 10. Repeat steps 2 through 9 for driving DP low.
+// [ Optionally
+// 11. Enable pin flipping.
+// 12. Repeat all of steps 2 through 10 for the DN line.
+// ]
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_usbdev.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#define USBDEV_BASE_ADDR TOP_EARLGREY_USBDEV_BASE_ADDR
+
+/**
+ * Are we expecting VBUS to be low at the start of the test, ie. no connection
+ * to the physical host or the DPI model is inactive?
+ */
+static const bool kCheckLowFirst = false;
+
+/**
+ * USB device handle
+ */
+static dif_usbdev_t usbdev;
+static dif_usbdev_buffer_pool_t buffer_pool;
+
+/**
+ * Pinmux handle
+ */
+static dif_pinmux_t pinmux;
+
+// Set the usbdev configuration according to whether or not pin flipping is
+// desired.
+static status_t config_set(bool pinflip) {
+  dif_usbdev_config_t config = {
+      .have_differential_receiver = kDifToggleEnabled,
+      .use_tx_d_se0 = kDifToggleDisabled,
+      .single_bit_eop = kDifToggleDisabled,
+      .pin_flip = dif_bool_to_toggle(pinflip),
+      .clock_sync_signals = kDifToggleEnabled,
+  };
+
+  TRY(dif_usbdev_configure(&usbdev, &buffer_pool, config));
+
+  return OK_STATUS();
+}
+
+// Wait with timeout until the VBUS/SENSE signal is in the expected state.
+static status_t vbus_wait(bool expected, uint32_t timeout_micros) {
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  do {
+    // Read the current state of VBUS.
+    bool vbus;
+    TRY(dif_usbdev_status_get_sense(&usbdev, &vbus));
+    if (vbus == expected) {
+      return OK_STATUS();
+    }
+  } while (!ibex_timeout_check(&timeout));
+
+  return DEADLINE_EXCEEDED();
+}
+
+// Wait with timeout for the specified USB data line to be in the expected
+// state.
+static status_t line_wait(bool dp, bool expected, uint32_t timeout_micros) {
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  do {
+    // Sense the current state of the pins.
+    dif_usbdev_phy_pins_sense_t status;
+    TRY(dif_usbdev_get_phy_pins_status(&usbdev, &status));
+
+    if ((dp && status.rx_dp == expected) || (!dp && status.rx_dn == expected)) {
+      return OK_STATUS();
+    }
+  } while (!ibex_timeout_check(&timeout));
+
+  return DEADLINE_EXCEEDED();
+}
+
+// Ensure that the specified USB data line remains in the expected state for
+// (most of) the given time interval.
+static status_t line_check(bool dp, bool expected, uint32_t interval_micros) {
+  // The caveat here is that if we are connected to the host, we may
+  // observe brief deviations from the expected state because the host
+  // is trying to communicate with us.
+  ibex_timeout_t timeout = ibex_timeout_init(interval_micros);
+  uint32_t mismatched = 0u;
+  uint32_t count = 0u;
+  do {
+    // Sense the current state of the pins.
+    dif_usbdev_phy_pins_sense_t status;
+    TRY(dif_usbdev_get_phy_pins_status(&usbdev, &status));
+
+    mismatched += (dp ? status.rx_dp : status.rx_dn) ^ expected;
+    ++count;
+  } while (!ibex_timeout_check(&timeout));
+
+  if ((mismatched << 3) > count) {
+    // Line not in the expected state.
+    return INTERNAL();
+  }
+
+  return OK_STATUS();
+}
+
+// Delay for the specified number of microseconds, with user reporting for
+// appropriate targets.
+static status_t delay(bool prompt, uint32_t timeout_micros) {
+  if (prompt) {
+    LOG_INFO("Delaying...");
+  }
+  busy_spin_micros(timeout_micros);
+
+  return OK_STATUS();
+}
+
+// Enable/disable the AON Wake module, and wait with timeout until that has
+// been confirmed.
+static status_t aon_wait(bool prompt, dif_toggle_t enable) {
+  // We must be sure that any alteration to the USBDEV pull up enables has
+  // propagated through the CDC synchronizer and been sampled on the lower
+  // frequency (200kHz) AON clock; allow 3 clock cycles.
+  TRY(delay(prompt, 15u));
+  TRY(dif_usbdev_set_wake_enable(&usbdev, enable));
+  // The AON Wake module operates on a 200kHz clock, so the clock period is
+  // 5us; we have CDC between USBDEV and AON Wake, but it responds within a
+  // couple of its clock cycles, so this is plenty.
+  ibex_timeout_t timeout = ibex_timeout_init(20);
+  do {
+    dif_usbdev_wake_status_t status;
+    TRY(dif_usbdev_get_wake_status(&usbdev, &status));
+    // In the requested state yet?
+    if (status.active == dif_toggle_to_bool(enable)) {
+      return OK_STATUS();
+    }
+  } while (!ibex_timeout_check(&timeout));
+
+  return DEADLINE_EXCEEDED();
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  // In simulation the DPI model connects VBUS shortly after reset and
+  // prolonged delays when asserting or deasserting pull ups are wasteful.
+  uint32_t timeout_micros = 1000u;
+  uint32_t delay_micros = 1u;
+  uint32_t hold_micros = 50u;
+  bool can_flip = true;
+  bool prompt = false;
+
+  if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) {
+    // FPGA platforms where user intervention may be required.
+    timeout_micros = 30 * 1000 * 1000u;
+    // A short delay here permits the activity of the host controller to be
+    // observed (eg. dmesg -w on a Linux host).
+    delay_micros = 2 * 1000 * 1000u;
+    // Duration for which we should monitor the USB signal to check that it
+    // doesn't change whilst AON Wake is holding it.
+    hold_micros = 2 * 1000;
+    // The CW310/340 board and their FPGA builds cannot raise the DN pull up
+    // because the required resistor is not mounted by default.
+    can_flip = false;
+    // Report instructions/progress to user, when driven manually.
+    prompt = true;
+  }
+
+  // Ensure that the VBUS/SENSE signal is routed through to the usbdev.
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  pinmux_testutils_init(&pinmux);
+  CHECK_DIF_OK(dif_pinmux_input_select(
+      &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+      kTopEarlgreyPinmuxInselIoc7));
+
+  // DP line first (Full Speed device), and for some targets the only line that
+  // has a pull up to be tested.
+  bool dp = true;
+  do {
+    // Initialize and configure the usbdev with pin flipping set appropriately.
+    CHECK_DIF_OK(
+        dif_usbdev_init(mmio_region_from_addr(USBDEV_BASE_ADDR), &usbdev));
+    CHECK_STATUS_OK(config_set(!dp));
+
+    // Initially the VBUS may be expected to be low; if so, ensure that this is
+    // the case.
+    if (kCheckLowFirst) {
+      if (prompt) {
+        bool vbus;
+        CHECK_DIF_OK(dif_usbdev_status_get_sense(&usbdev, &vbus));
+        if (vbus) {
+          LOG_INFO("Disconnect or power down the USB");
+        }
+      }
+
+      CHECK_STATUS_OK(vbus_wait(false, timeout_micros));
+
+      if (prompt) {
+        LOG_INFO("Connect or power up the USB");
+      }
+    }
+
+    // Check for VBUS present/risen.
+    CHECK_STATUS_OK(vbus_wait(true, timeout_micros));
+
+    // Check that the AON Wake module can maintain Dx the both Low
+    // (disconnected) and High (connected) line states.
+    bool desired = true;
+    do {
+      if (prompt) {
+        LOG_INFO("Testing AON can hold %s %s", dp ? "DP" : "DN",
+                 desired ? "High" : "Low");
+      }
+      // Check the Dx line is not in the desired state.
+      CHECK_STATUS_OK(line_wait(dp, !desired, 1000u));
+
+      // Delay a little, mostly to slow things on user-driven FPGA for
+      // observation.
+      CHECK_STATUS_OK(delay(prompt, delay_micros));
+
+      // Assert the Dx pull up, indicating the presence of a Full Speed device.
+      CHECK_DIF_OK(dif_usbdev_interface_enable(&usbdev, desired));
+
+      // Hand over control of the pull ups to the AON Wake module
+      CHECK_STATUS_OK(aon_wait(prompt, kDifToggleEnabled));
+
+      // Attempt to drive the Dx pull up into the opposite state
+      if (prompt) {
+        LOG_INFO(" - Attempting to drive %s %s", dp ? "DP" : "DN",
+                 desired ? "Low" : "High");
+      }
+      CHECK_DIF_OK(dif_usbdev_interface_enable(&usbdev, !desired));
+
+      // Check that the AON Wake module has kept the pull ups in their original
+      // state.
+      CHECK_STATUS_OK(line_check(dp, desired, hold_micros));
+
+      // Retract our efforts at changing Dx; this also should not change the
+      // line state, just the intent of USBDEV.
+      CHECK_DIF_OK(dif_usbdev_interface_enable(&usbdev, desired));
+
+      // Reclaim control of the pull ups by disabling the AON Wake module.
+      CHECK_STATUS_OK(aon_wait(prompt, kDifToggleDisabled));
+
+      // Check the Dx line is still in the desired state.
+      CHECK_STATUS_OK(line_wait(dp, desired, 1000u));
+      desired = !desired;
+    } while (!desired);
+
+    // Try again with the other line.
+    dp = !dp;
+  } while (can_flip && !dp);
+
+  return true;
+}

--- a/sw/device/tests/usbdev_aon_wake_reset_test.c
+++ b/sw/device/tests/usbdev_aon_wake_reset_test.c
@@ -1,0 +1,146 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/usb_testutils.h"
+#include "sw/device/lib/testing/usb_testutils_controlep.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+/**
+ * Configuration values for USB.
+ */
+static const uint8_t config_descriptors[] = {
+    USB_CFG_DSCR_HEAD(USB_CFG_DSCR_LEN + USB_INTERFACE_DSCR_LEN, 1),
+    // Single interface with no endpoint, just to make the host happy.
+    VEND_INTERFACE_DSCR(0, 0, 0x50, 0),
+};
+
+/**
+ * USB device context types.
+ */
+static usb_testutils_ctx_t usbdev;
+static usb_testutils_controlep_ctx_t usbdev_control;
+
+/**
+ * Pinmux handle
+ */
+static dif_pinmux_t pinmux;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static void init_peripherals(void) {
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  pinmux_testutils_init(&pinmux);
+  CHECK_DIF_OK(dif_pinmux_input_select(
+      &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+      kTopEarlgreyPinmuxInselIoc7));
+
+  CHECK_STATUS_OK(usb_testutils_init(&usbdev, /*pinflip=*/false,
+                                     /*en_diff_rcvr=*/true,
+                                     /*tx_use_d_se0=*/false));
+  CHECK_STATUS_OK(usb_testutils_controlep_init(
+      &usbdev_control, &usbdev, 0, config_descriptors,
+      sizeof(config_descriptors), NULL, 0));
+}
+
+// Enable/disable the AON Wake module, and wait with timeout until that has
+// been confirmed.
+static status_t aon_wait(dif_toggle_t enable) {
+  // We must be sure that any alteration to the USBDEV pull up enables has
+  // propagated through the CDC synchronizer and been sampled on the lower
+  // frequency (200kHz) AON clock; allow 3 clock cycles.
+  busy_spin_micros(15u);
+  TRY(dif_usbdev_set_wake_enable(usbdev.dev, enable));
+  // The AON Wake module operates on a 200kHz clock, so the clock period is
+  // 5us; we have CDC between USBDEV and AON Wake, but it responds within a
+  // couple of its clock cycles, so this is plenty.
+  ibex_timeout_t timeout = ibex_timeout_init(20);
+  do {
+    dif_usbdev_wake_status_t status;
+    TRY(dif_usbdev_get_wake_status(usbdev.dev, &status));
+    // In the requested state yet?
+    if (status.active == dif_toggle_to_bool(enable)) {
+      return OK_STATUS();
+    }
+  } while (!ibex_timeout_check(&timeout));
+
+  return DEADLINE_EXCEEDED();
+}
+
+static status_t wait_until_configured(uint32_t timeout_micros) {
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  while (!ibex_timeout_check(&timeout)) {
+    CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
+    if (usbdev_control.device_state == kUsbTestutilsDeviceConfigured)
+      return OK_STATUS();
+  }
+  return DEADLINE_EXCEEDED();
+}
+
+static status_t wait_until_suspended(uint32_t timeout_micros) {
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  while (usbdev_control.device_state == kUsbTestutilsDeviceConfigured &&
+         !ibex_timeout_check(&timeout)) {
+    CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
+    dif_usbdev_link_state_t link_state;
+    CHECK_DIF_OK(dif_usbdev_status_get_link_state(usbdev.dev, &link_state));
+    if (link_state == kDifUsbdevLinkStateSuspended) {
+      return OK_STATUS();
+    }
+  }
+  return DEADLINE_EXCEEDED();
+}
+
+static status_t wait_until_aon_bus_reset(uint32_t timeout_micros) {
+  dif_usbdev_wake_status_t status;
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  while (!ibex_timeout_check(&timeout)) {
+    CHECK_DIF_OK(dif_usbdev_get_wake_status(usbdev.dev, &status));
+    CHECK(status.active, "AON wake is not active?!");
+    CHECK(!status.disconnected,
+          "device was disconnected while waiting for reset");
+    if (status.bus_reset)
+      return OK_STATUS();
+  }
+  return DEADLINE_EXCEEDED();
+}
+
+bool test_main(void) {
+  uint32_t timeout_micros = 30 * 1000 * 1000u;
+  CHECK(kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator);
+
+  init_peripherals();
+
+  // Proceed only when the device has been configured.
+  LOG_INFO("wait for host to configure device...");
+  CHECK_STATUS_OK(wait_until_configured(timeout_micros));
+
+  // Wait for the host to suspend the device.
+  LOG_INFO("configured, waiting for suspend");
+  CHECK_STATUS_OK(wait_until_suspended(timeout_micros));
+
+  // Hand over control of the USB to the AON Wake module
+  CHECK_STATUS_OK(aon_wait(kDifToggleEnabled));
+
+  // Wait until AON reports a bus reset.
+  LOG_INFO("suspended, waiting for reset");
+  CHECK_STATUS_OK(wait_until_aon_bus_reset(timeout_micros));
+
+  LOG_INFO("reset, take control back from aon");
+  // Reclaim control of the USB by disabling the AON Wake module.
+  CHECK_STATUS_OK(aon_wait(kDifToggleDisabled));
+
+  CHECK_STATUS_OK(usb_testutils_fin(&usbdev));
+
+  return true;
+}

--- a/sw/device/tests/usbdev_config_host_test.c
+++ b/sw/device/tests/usbdev_config_host_test.c
@@ -1,0 +1,103 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// USB CONFIG HOST test
+//
+// Test basic configuration of the USB device by the host/DPI.
+//
+// It requires interaction with the USB DPI model or a physical host in order
+// to receive and respond to the Control Transfers that are involved in the
+// identification and configuration of the device.
+//
+// The test configures USB Endpoint 1 as a simpleserial endpoint which should
+// appear as /dev/ttyUSBx on a Linux-based host.
+
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/usb_testutils.h"
+#include "sw/device/lib/testing/usb_testutils_controlep.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+/**
+ * Configuration values for USB.
+ */
+static const uint8_t config_descriptors[] = {
+    USB_CFG_DSCR_HEAD(
+        USB_CFG_DSCR_LEN + USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN, 1),
+    // Single interface...
+    VEND_INTERFACE_DSCR(0, 1, 0x50, 1),
+    // ... describing two Endpoints; endpoint 1 OUT and endpoint 1 IN
+    USB_BULK_EP_DSCR(0, 1, 32, 0),
+    USB_BULK_EP_DSCR(1, 1, 32, 4),
+};
+
+/**
+ * USB device context types.
+ */
+static usb_testutils_ctx_t usbdev;
+static usb_testutils_controlep_ctx_t usbdev_control;
+
+/**
+ * Pinmux handle
+ */
+static dif_pinmux_t pinmux;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  // In simulation the DPI model connects VBUS shortly after reset and
+  // prolonged delays when asserting or deasserting pull ups are wasteful.
+  uint32_t timeout_micros = 6000u;
+  bool prompt = false;
+
+  if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) {
+    // FPGA platforms where user intervention may be required.
+    timeout_micros = 30 * 1000 * 1000u;
+    // Report instructions/progress to user, when driven manually.
+    prompt = true;
+    LOG_INFO("Running USBDEV_CONFIG_HOST test");
+    LOG_INFO("Awaiting configuration from the host");
+  }
+
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  pinmux_testutils_init(&pinmux);
+  CHECK_DIF_OK(dif_pinmux_input_select(
+      &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
+      kTopEarlgreyPinmuxInselIoc7));
+
+  // Call `usbdev_init` here so that DPI will not start until the
+  // simulation has finished all of the printing, which takes a while
+  // if `--trace` was passed in.
+  CHECK_STATUS_OK(usb_testutils_init(&usbdev, /*pinflip=*/false,
+                                     /*en_diff_rcvr=*/true,
+                                     /*tx_use_d_se0=*/false));
+  CHECK_STATUS_OK(usb_testutils_controlep_init(
+      &usbdev_control, &usbdev, 0, config_descriptors,
+      sizeof(config_descriptors), NULL, 0));
+
+  // Proceed only when the device has been configured; this allows host-side
+  // software to establish communication.
+  ibex_timeout_t timeout = ibex_timeout_init(timeout_micros);
+  while (usbdev_control.device_state != kUsbTestutilsDeviceConfigured &&
+         !ibex_timeout_check(&timeout)) {
+    CHECK_STATUS_OK(usb_testutils_poll(&usbdev));
+  }
+
+  bool success = (usbdev_control.device_state == kUsbTestutilsDeviceConfigured);
+  if (success && prompt) {
+    LOG_INFO("Configuration received");
+  }
+  CHECK(success);
+
+  CHECK_STATUS_OK(usb_testutils_fin(&usbdev));
+
+  return true;
+}

--- a/sw/device/tests/usbdev_iso_test.c
+++ b/sw/device/tests/usbdev_iso_test.c
@@ -34,9 +34,9 @@
 //
 // Note: because Isochronous streams are guaranteed the requested amount of
 // bus bandwidth, the number of concurrent streams that may be supported is
-// limited to six.
-#if !defined(NUM_STREAMS) || NUM_STREAMS > 6U
-#define NUM_STREAMS 6U
+// limited to four if connected through a hub (6 without hub(s)).
+#if !defined(NUM_STREAMS) || NUM_STREAMS > 4U
+#define NUM_STREAMS 4U
 #endif
 
 // This takes about 256s presently with 10MHz CPU in CW310 FPGA and physical
@@ -172,6 +172,8 @@ bool test_main(void) {
       break;
     case kDeviceSimDV:
       transfer_bytes = TRANSFER_BYTES_DVSIM;
+      break;
+    case kDeviceSilicon:
       break;
     case kDeviceFpgaCw340:
       break;

--- a/sw/device/tests/usbdev_logging_test.c
+++ b/sw/device/tests/usbdev_logging_test.c
@@ -1,0 +1,94 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// USB logging test
+//
+// This test exercises the USB logging functionality. It first initializes
+// 4 logging streams via the USB device and cable to the host, and then
+// transmits a number of tests messages to each stream directly.
+//
+// Subsequently, it reinitializes the software layer with redirection of
+// stdout via a single stream and performs, to check that the LOG_INFO()
+// and base_printf() functionality works over the USB connection.
+//
+// Currently this test requires manual support on the host side; on a Linux-
+// based host, running 4 processes as follows will allow the test to complete:
+//
+//  cat /dev/ttyUSB0
+//  cat /dev/ttyUSB1
+//  cat /dev/ttyUSB2
+//  cat /dev/ttyUSB3
+//
+// Note that the assigned port numbers on the host may differ from the defaults
+// shown above. Since the logging streams have been initialized for reliable
+// transfer, the CPU/test will stall until the receiving processes on the host
+// have collected all of the logging output.
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/usb_logging.h"
+
+// Presently we must reinstate the UART output manually.
+#include "sw/device/lib/dif/dif_uart.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+/**
+ * Number of concurrent logging streams to test.
+ */
+static const unsigned kNumStreams = 4u;
+/**
+ * Number of iterations of logging message.
+ */
+static const unsigned kNumIters = 1000u;
+
+// Because this test redirects the console output to the USB, we need to
+// indicate to OTTF that the console must be reinitialized before test
+// completion can be reported.
+OTTF_DEFINE_TEST_CONFIG(.console.test_may_clobber = true);
+
+bool test_main(void) {
+  LOG_INFO("Running USBDEV_LOGGING test");
+
+  // ----------------- Test the more generic, direct interface ----------------
+
+  // Enable USB logging
+  CHECK_STATUS_OK(
+      usb_logging_init(NULL, 0u, kNumStreams, (1u << kNumStreams) - 1u, true));
+
+  for (uint8_t s = 0u; s < kNumStreams; ++s) {
+    usb_logging_text(s, "USB - Logging via direct interface\n");
+  }
+
+  for (unsigned iter = 0u; iter < kNumIters; ++iter) {
+    for (uint8_t s = 0u; s < kNumStreams; ++s) {
+      char buf[44];
+      size_t len = base_snprintf(buf, sizeof(buf),
+                                 "S%u: Now logging %u over USB\n", s, iter);
+      CHECK_STATUS_OK(usb_logging_data(s, (uint8_t *)buf, len));
+    }
+  }
+
+  // Finalize the logging code.
+  CHECK_STATUS_OK(usb_logging_fin(true, false));
+
+  // ------------------- Test redirection of stdout via OTTF ------------------
+
+  // Enable logging of stdout traffic over USB
+  CHECK_STATUS_OK(usb_logging_enable());
+
+  for (unsigned iter = 0u; iter < kNumIters; ++iter) {
+    LOG_INFO("Now logging %u over USB", iter);
+  }
+
+  // Just a quantity of data as ASCII hex...
+  const uint32_t kSramStart = TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR;
+  const uint32_t kSramSize = TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES;
+  base_hexdump((char *)kSramStart, kSramSize);
+
+  CHECK_STATUS_OK(usb_logging_fin(true, true));
+
+  return true;
+}

--- a/sw/device/tests/usbdev_mixed_test.c
+++ b/sw/device/tests/usbdev_mixed_test.c
@@ -71,13 +71,13 @@ static const char *xfr_name[] = {
 //
 // Note: because Isochronous and Interrupt streams are guaranteed the requested
 // amount of bus bandwidth, the number of concurrent streams of these types is
-// limited to six.
+// limited to four if connected through a hub (six without hub(s)).
 static const usb_testutils_transfer_type_t xfr_types[USBUTILS_STREAMS_MAX] = {
-    kUsbTransferTypeIsochronous, kUsbTransferTypeInterrupt,
+    kUsbTransferTypeIsochronous, kUsbTransferTypeBulk,
     kUsbTransferTypeBulk,        kUsbTransferTypeBulk,
 
     kUsbTransferTypeIsochronous, kUsbTransferTypeInterrupt,
-    kUsbTransferTypeBulk,        kUsbTransferTypeIsochronous,
+    kUsbTransferTypeBulk,        kUsbTransferTypeBulk,
 
     kUsbTransferTypeInterrupt,   kUsbTransferTypeBulk,
     kUsbTransferTypeBulk,
@@ -184,6 +184,8 @@ bool test_main(void) {
       break;
     case kDeviceSimDV:
       transfer_bytes = TRANSFER_BYTES_DVSIM;
+      break;
+    case kDeviceSilicon:
       break;
     case kDeviceFpgaCw340:
       break;

--- a/sw/device/tests/usbdev_pincfg_test.c
+++ b/sw/device/tests/usbdev_pincfg_test.c
@@ -110,6 +110,8 @@ bool test_main(void) {
       // DV simulation can exercise pin-flipping and differential rcvr on/off
       // but there's no point wasting simulation time trying both tx modes;
       // D+/D- are always used directly as differential signals.
+      OT_FALLTHROUGH_INTENDED;
+    case kDeviceSilicon:
       ntests = 4U;
       for (unsigned test = 0U; test < ntests; ++test) {
         test_cfg[test].pinflip = ((test & 1U) != 0U);

--- a/sw/device/tests/usbdev_setuprx_test.c
+++ b/sw/device/tests/usbdev_setuprx_test.c
@@ -125,12 +125,6 @@ static status_t delay(bool prompt, uint32_t timeout_micros) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  CHECK(kDeviceType == kDeviceSimDV || kDeviceType == kDeviceSimVerilator ||
-            kDeviceType == kDeviceFpgaCw310,
-        "This test is not expected to run on platforms other than the "
-        "Verilator/DV simulation or CW310 FPGA. It needs either the DPI model "
-        "or a physical host, OS and drivers.");
-
   // In simulation the DPI model connects VBUS shortly after reset and
   // prolonged delays when asserting or deasserting pull ups are wasteful.
   uint32_t timeout_micros = 1000u;
@@ -138,7 +132,7 @@ bool test_main(void) {
   bool prompt = false;
 
   if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) {
-    // FPGA platforms where user intervention may be required.
+    // FPGA or Silicon platform, where user intervention may be required.
     timeout_micros = 30 * 1000 * 1000u;
     // A short delay here permits the activity of the host controller to be
     // observed (eg. dmesg -w on a Linux host).

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -193,6 +193,10 @@ bool test_main(void) {
     case kDeviceSimDV:
       transfer_bytes = TRANSFER_BYTES_DVSIM;
       break;
+    case kDeviceSilicon:
+      break;
+    case kDeviceFpgaCw340:
+      break;
     default:
       CHECK(kDeviceType == kDeviceFpgaCw310);
       break;

--- a/sw/host/tests/chip/usb/BUILD
+++ b/sw/host/tests/chip/usb/BUILD
@@ -1,0 +1,38 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "usb",
+    srcs = [
+        "mod.rs",
+        "usb.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:log",
+        "@crate_index//:rusb",
+    ],
+)
+
+rust_binary(
+    name = "usbdev_aon_wake",
+    srcs = [
+        "usbdev_aon_wake.rs",
+    ],
+    deps = [
+        ":usb",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:rusb",
+    ],
+)

--- a/sw/host/tests/chip/usb/mod.rs
+++ b/sw/host/tests/chip/usb/mod.rs
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod usb;

--- a/sw/host/tests/chip/usb/usb.rs
+++ b/sw/host/tests/chip/usb/usb.rs
@@ -1,0 +1,167 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, Context, Result};
+use clap::Parser;
+
+use std::collections::HashSet;
+use std::time::{Instant,Duration};
+
+#[derive(Debug, Parser)]
+pub struct UsbOpts {
+    /// USB vendor ID, default value is Google VID
+    #[arg(long, value_parser = usb_id_parser, default_value = "18d1")]
+    pub vid: u16,
+
+    /// USB product ID, default value is lowRISC generic FS USB (allocated by Google).
+    #[arg(long, value_parser = usb_id_parser, default_value = "503a")]
+    pub pid: u16,
+
+    /// Frequency at which to poll the USB bus for new device.
+    #[arg(long, default_value = "10")]
+    pub usb_poll_freq: u64,
+}
+
+// Parse a USB VID/PID which must be a hex-string (e.g. "18d1").
+fn usb_id_parser(id: &str) -> Result<u16> {
+    Ok(u16::from_str_radix(id, 16)?)
+}
+
+// Represent an already seen device. Rely on the physical location (port numbers)
+// instead of device address.
+#[derive(Hash, PartialEq, Eq)]
+struct DeviceLoc {
+    bus: u8,
+    port_numbers: Vec<u8>,
+}
+
+impl DeviceLoc {
+    fn from_device(dev: &rusb::Device<rusb::GlobalContext>) -> Result<DeviceLoc> {
+        Ok(DeviceLoc {
+            bus: dev.bus_number(),
+            port_numbers: dev.port_numbers()?
+        })
+    }
+}
+
+impl UsbOpts {
+    // Wait for a device that matches the USB VID/PID. If a device that matches
+    // is found, it will try to open it: if that fails, a warning message will
+    // logged (for debugging) and the function will continue waiting until a
+    // a new device that can be opened is found. If several devices are found
+    // at the time that match and can be open, all of them will be returned.
+    // On timeout, the function will return an empty list.
+    //
+    // This function will return an error on critical failures such as failing to poll
+    // the USB bus.
+    pub fn wait_for_device(&self, timeout: Duration) -> Result<Vec<rusb::DeviceHandle<rusb::GlobalContext>>> {
+        let start = Instant::now();
+        // Keep a list of devices to not warn against again.
+        let mut warned_desc = HashSet::<DeviceLoc>::new();
+        let mut warned_open = HashSet::<DeviceLoc>::new();
+        loop {
+            let mut devices = Vec::new();
+            for device in rusb::devices().context("USB error")?.iter() {
+                let seen_dev = DeviceLoc::from_device(&device)?;
+                let descriptor = match device.device_descriptor() {
+                    Ok(desc) => desc,
+                    Err(e) => {
+                        // Ignore device if we have already seen it.
+                        if !warned_desc.contains(&seen_dev) {
+                            warned_desc.insert(seen_dev);
+                            log::warn!("Could not read device descriptor for device at bus={} address={}: {}",
+                                device.bus_number(),
+                                device.address(),
+                                e);
+                        }
+                        continue;
+                    }
+                };
+                if descriptor.vendor_id() != self.vid {
+                    continue;
+                }
+                if descriptor.product_id() != self.pid {
+                    continue;
+                }
+                let handle = match device.open() {
+                    Ok(handle) => handle,
+                    Err(e) => {
+                        // Ignore device if we have already seen it.
+                        if !warned_open.contains(&seen_dev) {
+                            warned_open.insert(seen_dev);
+                            log::warn!("Could not open device at bus={} address={}: {}",
+                                device.bus_number(),
+                                device.address(),
+                                e);
+                        }
+                        continue;
+                    }
+                };
+                devices.push(handle);
+            }
+            // Return if we found at least one device or if timeout has expired.
+            if !devices.is_empty() || start.elapsed() >= timeout {
+                return Ok(devices)
+            }
+            // Wait a bit before polling again.
+            std::thread::sleep(Duration::from_micros(1_000_000u64 / self.usb_poll_freq));
+        }
+    }
+}
+
+// Structure representing a USB hub. The device needs to have sufficient permission
+// to be opened.
+pub struct UsbHub {
+    handle: rusb::DeviceHandle<rusb::GlobalContext>
+}
+
+// USB hub operation.
+pub enum UsbHubOp {
+    // Suspend a specific port.
+    Suspend,
+    // Suspend a specific port.
+    Resume,
+    // Reset a specific port.
+    Reset,
+}
+
+const PORT_SUSPEND: u16 = 2;
+const PORT_RESET: u16 = 4;
+
+impl UsbHub {
+    // Construct a hub from a device.
+    pub fn from_device(dev: &rusb::Device<rusb::GlobalContext>) -> Result<UsbHub> {
+        // Make sure the device is a hub.
+        let dev_desc = dev.device_descriptor()?;
+        // Assume that if the device has the HUB class then Linux will already enforce
+        // that it follows the specification.
+        ensure!(dev_desc.class_code() == rusb::constants::LIBUSB_CLASS_HUB, "device is not a hub");
+        Ok(UsbHub {
+            handle: dev.open().context("cannot open hub")?
+        })
+    }
+
+    // Perform an operation.
+    pub fn op(&self, op: UsbHubOp, port: u8, timeout: Duration) -> Result<()> {
+        let (value, set_feature) = match op {
+            UsbHubOp::Suspend => (PORT_SUSPEND, true),
+            UsbHubOp::Resume => (PORT_SUSPEND, false),
+            UsbHubOp::Reset => (PORT_RESET, true),
+        };
+        let req = if set_feature { rusb::constants::LIBUSB_REQUEST_SET_FEATURE }
+        else { rusb::constants::LIBUSB_REQUEST_CLEAR_FEATURE };
+        let req_type = rusb::constants::LIBUSB_RECIPIENT_OTHER |
+            rusb::constants::LIBUSB_REQUEST_TYPE_CLASS |
+            rusb::constants::LIBUSB_ENDPOINT_OUT;
+        let _ =self.handle.write_control(
+            req_type,
+            req,
+            value,
+            port as u16,
+            &[],
+            timeout
+        )?;
+        Ok(())
+    }
+}

--- a/sw/host/tests/chip/usb/usbdev_aon_wake.rs
+++ b/sw/host/tests/chip/usb/usbdev_aon_wake.rs
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+use opentitanlib::execute_test;
+
+use usb::{UsbHub, UsbHubOp, UsbOpts};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console/USB timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    /// USB options.
+    #[command(flatten)]
+    usb: UsbOpts,
+}
+
+// Wait for a device to appear and then return the parent device and port number.
+fn wait_for_device_and_get_parent(opts: &Opts) -> Result<(rusb::Device<rusb::GlobalContext>, u8)> {
+    // Wait for USB device to appear.
+    log::info!("waiting for device...");
+    let devices = opts.usb.wait_for_device(opts.timeout)?;
+    if devices.is_empty() {
+        bail!("no USB device found");
+    }
+    if devices.len() > 1 {
+        bail!("several USB devices found");
+    }
+    let device = &devices[0];
+    log::info!("device found at bus={} address={}", device.device().bus_number(), device.device().address());
+
+    // Important note: here the handle will be dropped and the device handle
+    // will be closed.
+    Ok((device.device().get_parent().context("device has no parent, you need to connect it via a hub for this test")?,
+       device.device().port_number()))
+}
+
+fn usbdev_aon_wake(
+    opts: &Opts,
+    _transport: &TransportWrapper,
+    uart: &dyn Uart,
+) -> Result<()> {
+    // Wait for device.
+    let (parent, port) = wait_for_device_and_get_parent(opts)?;
+    log::info!("parent hub at bus={}, address={}, port numbers={:?}", parent.bus_number(), parent.address(), parent.port_numbers()?);
+    log::info!("device under test is on port {}", port);
+    // At this point, we are not holding any device handle. If we really want to make sure,
+    // we could unbind the device from the driver but this requires a lot of privileges.
+
+    // Next, we suspend the device by directly accessing the parent hub.
+    let _ = UartConsole::wait_for(uart, r"configured, waiting for suspend", opts.timeout)?;
+    let hub = UsbHub::from_device(&parent).context("for this test, you need to make sure that the program has sufficient permissions to access the hub")?;
+    log::info!("suspend device");
+    hub.op(UsbHubOp::Suspend, port, Duration::from_millis(100))?;
+    let _ = UartConsole::wait_for(uart, r"suspended, waiting for reset", opts.timeout)?;
+    log::info!("device has suspended");
+
+    // While suspended, we issue a bus reset.
+    log::info!("reset device");
+    hub.op(UsbHubOp::Reset, port, Duration::from_millis(100))?;
+    let _ = UartConsole::wait_for(uart, r"reset, take control back from aon", opts.timeout)?;
+
+    let _ = UartConsole::wait_for(uart, r"PASS!", opts.timeout)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let uart = transport.uart("console")?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    execute_test!(usbdev_aon_wake, &opts, &transport, &*uart);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR cherry picks the following from master to earlgrey_es_sival:

* https://github.com/lowRISC/opentitan/pull/21238
* https://github.com/lowRISC/opentitan/pull/21145
* https://github.com/lowRISC/opentitan/pull/19249
* https://github.com/lowRISC/opentitan/pull/21363

I see that we've also had lots of changes to the USB device DIFs because the RTL has changed. I haven't cherry-picked those over, so unsure whether every single one of these will be okay just yet.