### PR TITLE
[cryptotest] Add NIST AES-KW testvector parser

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -157,3 +157,102 @@ run_binary(
         ("kmac256_no_customization_test.json", "256", "wycheproof_kmac_256"),
     ]
 ]
+
+[
+    run_binary(
+        name = "nist_cavp_aes_{}_{}_json".format(
+            function_name.lower(),
+            keylen_with_tmode,
+        ),
+        srcs = [
+            "@nist_cavp_aes_kw_sp_800_38f//:{}_{}.txt".format(
+                function_name,
+                keylen_with_tmode,
+            ),
+            "//sw/host/cryptotest/testvectors/data/schemas:aes_kw_schema.json",
+        ],
+        outs = [":nist_cavp_aes_{}_{}.json".format(
+            function_name.lower(),
+            keylen_with_tmode,
+        )],
+        args = [
+            "--src",
+            "$(location @nist_cavp_aes_kw_sp_800_38f//:{}_{}.txt)".format(function_name, keylen_with_tmode),
+            "--dst",
+            "$(location :nist_cavp_aes_{}_{}.json)".format(
+                function_name.lower(),
+                keylen_with_tmode,
+            ),
+            "--operation",
+            "{}".format(operation),
+            "--key_len",
+            "{}".format(key_len),
+            "--padding",
+            "{}".format(padding),
+            "--transformation_mode",
+            "{}".format(transformation_mode),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:aes_kw_schema.json)",
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_aes_kw_parser",
+    )
+    for function_name, operation, padding in [
+        ("KW_AD", "decrypt", False),
+        ("KW_AE", "encrypt", False),
+        ("KWP_AD", "decrypt", True),
+        ("KWP_AE", "encrypt", True),
+    ]
+    for keylen_with_tmode, key_len, transformation_mode in [
+        ("128_inv", "128", "inverse"),
+        ("128", "128", "null"),
+        ("192_inv", "192", "inverse"),
+        ("192", "192", "null"),
+        ("256_inv", "256", "inverse"),
+        ("256", "256", "null"),
+    ]
+]
+
+[
+    run_binary(
+        name = "nist_cavp_aes_{}_{}_json".format(
+            function_name.lower(),
+            key_len,
+        ),
+        srcs = [
+            "@nist_cavp_aes_kw_sp_800_38f//:{}.txt".format(
+                function_name,
+            ),
+            "//sw/host/cryptotest/testvectors/data/schemas:aes_kw_schema.json",
+        ],
+        outs = [":nist_cavp_aes_{}_{}.json".format(
+            function_name.lower(),
+            key_len,
+        )],
+        args = [
+            "--src",
+            "$(location @nist_cavp_aes_kw_sp_800_38f//:{}.txt)".format(function_name),
+            "--dst",
+            "$(location :nist_cavp_aes_{}_{}.json)".format(
+                function_name.lower(),
+                key_len,
+            ),
+            "--operation",
+            "{}".format(operation),
+            "--key_len",
+            "{}".format(key_len),
+            "--padding",
+            "{}".format(padding),
+            "--transformation_mode",
+            "{}".format(transformation_mode),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:aes_kw_schema.json)",
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_aes_kw_parser",
+    )
+    for function_name, key_len, operation, padding, transformation_mode in [
+        ("TKW_AD", "192", "decrypt", False, "null"),
+        ("TKW_AE", "192", "encrypt", False, "null"),
+        ("TKW_AD_inv", "192", "decrypt", False, "inverse"),
+        ("TKW_AE_inv", "192", "encrypt", False, "inverse"),
+    ]
+]

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -15,6 +15,7 @@ filegroup(
 )
 
 exports_files([
+    "aes_kw_schema.json",
     "ecdh_schema.json",
     "hash_schema.json",
     "hmac_schema.json",

--- a/sw/host/cryptotest/testvectors/data/schemas/aes_kw_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/aes_kw_schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/aes_kw_schema.json",
+  "title": "Cryptotest AES-KWP Testvector",
+  "description": "A list of testvectors for AES-KWP testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "test_case_id": {
+        "description": "Incremental test case ID -- used for debugging",
+        "type": "integer"
+      },
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "algorithm": {
+        "description": "AES (Advanced Encryption Standard) or TDEA (Triple Data Encryption Algorithm)",
+        "type": "string",
+        "enum": ["aes", "tdea"]
+      },
+      "operation": {
+        "description": "Operation type",
+        "type": "string",
+        "enum": ["encrypt", "decrypt"]
+      },
+      "transformation_mode": {
+        "description": "Cipher transformation mode used for encryption-decryption",
+        "type": "string",
+        "enum": ["null", "inverse", "forward"]
+      },
+      "padding": {
+        "description": "Existence of padding",
+        "type": "boolean"
+      },
+      "key_len": {
+        "description": "Length in bits of the key",
+        "type": "integer",
+        "enum": [128, 192, 256]
+      },
+      "key": {
+        "description": "AES key",
+        "$ref": "#/$defs/byte_array"
+      },
+      "ciphertext": {
+        "description": "Ciphertext",
+        "$ref": "#/$defs/byte_array"
+      },
+      "plaintext": {
+        "description": "Plaintext",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Derivation result",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -41,6 +41,15 @@ py_binary(
 )
 
 py_binary(
+    name = "nist_cavp_aes_kw_parser",
+    srcs = ["nist_cavp_aes_kw_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
     name = "wycheproof_ecdsa_parser",
     srcs = ["wycheproof_ecdsa_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_aes_kw_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_aes_kw_parser.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting NIST AES-KWP testvectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+
+def parse_testcases(args) -> None:
+    raw_testcases = parse_rsp(args.src)
+    testcases = list()
+    for test_case_id, test_vec in enumerate(raw_testcases):
+        tmode = "null"
+        if args.transformation_mode == "inverse":
+            tmode = "forward" if args.operation == "decrypt" else "inverse"
+        testcase = {
+            "test_case_id": test_case_id,
+            "vendor": "nist",
+            "operation": args.operation.lower(),
+            "transformation_mode": tmode,
+            "padding": args.padding,
+            "key_len": args.key_len,
+            "key": str_to_byte_array(test_vec["K"]),
+            "ciphertext": str_to_byte_array(test_vec["C"]),
+            "plaintext": str_to_byte_array(test_vec["P"]) if "P" in test_vec else [],
+            "result": True if "P" in test_vec else False,
+        }
+
+        testcases.append(testcase)
+
+    json_filename = args.dst
+    with open(json_filename, "w") as file:
+        json.dump(testcases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testcases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for AES-KWP testvectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--operation",
+        choices = ["encrypt", "decrypt"],
+        type = str,
+        help="Type of operation."
+    )
+    parser.add_argument(
+        "--transformation_mode",
+        choices = ["null", "inverse", "forward"],
+        type = str,
+        help="Cipher transformation mode used for encryption-decryption."
+    )
+    parser.add_argument(
+        "--key_len",
+        choices = [128, 192, 256],
+        type = int,
+        help = "Length of key in bits."
+    )
+    parser.add_argument(
+        "--padding",
+        type = bool,
+        help = "Existence of padding."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Testvector schema file."
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -31,3 +31,10 @@ def nist_cavp_repos():
         sha256 = "debfebc3157b3ceea002b84ca38476420389a3bf7e97dc5f53ea4689a16de4c7",
         url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/shakebytetestvectors.zip",
     )
+    http_archive(
+        name = "nist_cavp_aes_kw_sp_800_38f",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        strip_prefix = "kwtestvectors",
+        sha256 = "04a4a82e4de65bca505125295003f9c75a5a815afda046dc83661b8b580dfdf3",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/kwtestvectors.zip",
+    )


### PR DESCRIPTION
This PR pulls in the NIST testvectors for AES-KW and includes the associated parser along with the JSON schema.