### PR TITLE
[lc_ctrl] Add lc_ctrl_otp_hw_cfg_test to testplans

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
@@ -65,7 +65,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: ["chip_sw_lc_ctrl_otp_hw_cfg"]
-      bazel: []
+      bazel: ["//sw/device/tests:lc_ctrl_otp_hw_cfg_test"]
     }
     {
       name: chip_sw_lc_ctrl_init

--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -124,6 +124,7 @@
       stage: V2
       si_stage: SV1
       tests: ["chip_sw_lc_ctrl_otp_hw_cfg"]
+      bazel: ["//sw/device/tests:lc_ctrl_otp_hw_cfg_test"]
     }
     {
       name: chip_sw_otp_ctrl_lc_signals


### PR DESCRIPTION
I saw these tests had been ported to sival so have added `bazel: [...]` links in the testplan.