### PR TITLE
[cryptotest] Test vectors for SPHINCS+

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -128,6 +128,10 @@ nist_cavp_repos()
 load("//third_party/wycheproof:repos.bzl", "wycheproof_repos")
 wycheproof_repos()
 
+# SPHINCS+ Test Vectors
+load("//third_party/sphincsplus:repos.bzl", "sphincsplus_repos")
+sphincsplus_repos()
+
 # Bitstreams from https://storage.googleapis.com/opentitan-bitstreams/
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -158,3 +158,29 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
 )
+
+DRBG_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:nist_cavp_drbg_sp_800_90a_reseed_json",
+    "//sw/host/cryptotest/testvectors/data:nist_cavp_drbg_sp_800_90a_no_reseed_json",
+]
+
+DRBG_TESTVECTOR_ARGS = " ".join([
+    "--drbg-json=\"$(rootpath {})\"".format(target)
+    for target in DRBG_TESTVECTOR_TARGETS
+])
+
+opentitan_test(
+    name = "drbg_kat",
+    cw310 = cw310_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        data = DRBG_TESTVECTOR_TARGETS,
+        test_cmd = """
+                --bootstrap={firmware}
+            """ + DRBG_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/drbg_kat:harness",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    },
+)

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -68,6 +68,25 @@ cc_library(
 )
 
 cc_library(
+    name = "drbg",
+    srcs = ["drbg.c"],
+    hdrs = ["drbg.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:drbg",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
+    ],
+)
+
+cc_library(
     name = "hash",
     srcs = ["hash.c"],
     hdrs = ["hash.h"],
@@ -205,6 +224,7 @@ opentitan_binary(
     deps = [
         ":aes",
         ":aes_sca",
+        ":drbg",
         ":ecdh",
         ":ecdsa",
         ":hash",
@@ -221,6 +241,7 @@ opentitan_binary(
         "//sw/device/lib/ujson",
         "//sw/device/tests/crypto/cryptotest/json:aes_commands",
         "//sw/device/tests/crypto/cryptotest/json:commands",
+        "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
         "//sw/device/tests/crypto/cryptotest/json:ecdh_commands",
         "//sw/device/tests/crypto/cryptotest/json:hash_commands",
         "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
@@ -240,6 +261,7 @@ opentitan_test(
     deps = [
         ":aes",
         ":aes_sca",
+        ":drbg",
         ":ecdh",
         ":ecdsa",
         ":hash",
@@ -256,6 +278,7 @@ opentitan_test(
         "//sw/device/lib/ujson",
         "//sw/device/tests/crypto/cryptotest/json:aes_commands",
         "//sw/device/tests/crypto/cryptotest/json:commands",
+        "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
         "//sw/device/tests/crypto/cryptotest/json:ecdh_commands",
         "//sw/device/tests/crypto/cryptotest/json:ecdsa_commands",
         "//sw/device/tests/crypto/cryptotest/json:hash_commands",

--- a/sw/device/tests/crypto/cryptotest/firmware/drbg.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/drbg.c
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/drbg.h"
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/drbg_commands.h"
+
+status_t handle_drbg(ujson_t *uj) {
+  cryptotest_drbg_input_t uj_input;
+  // Deserialize test arguments from UART
+  TRY(ujson_deserialize_cryptotest_drbg_input_t(uj, &uj_input));
+
+  // Entropy for initialization
+  uint8_t entropy_buf[kEntropySeedBytes];
+  memset(entropy_buf, 0, kEntropySeedBytes);
+  memcpy(entropy_buf, uj_input.entropy, uj_input.entropy_len);
+  otcrypto_const_byte_buf_t entropy = {
+      .len = kEntropySeedBytes,
+      .data = entropy_buf,
+  };
+
+  // Personalization string
+  uint8_t perso_string_buf[uj_input.personalization_string_len];
+  memcpy(perso_string_buf, uj_input.personalization_string,
+         uj_input.personalization_string_len);
+  otcrypto_const_byte_buf_t perso_string = {
+      .len = uj_input.personalization_string_len,
+      .data = perso_string_buf,
+  };
+
+  // Reseed entropy
+  uint8_t reseed_entropy_buf[uj_input.reseed_entropy_len];
+  memcpy(reseed_entropy_buf, uj_input.reseed_entropy,
+         uj_input.reseed_entropy_len);
+  otcrypto_const_byte_buf_t reseed_entropy = {
+      .len = uj_input.reseed_entropy_len,
+      .data = uj_input.reseed_entropy,
+  };
+
+  // Reseed additional input
+  uint8_t reseed_addl_buf[uj_input.reseed_additional_input_len];
+  memcpy(reseed_addl_buf, uj_input.reseed_additional_input,
+         uj_input.reseed_additional_input_len);
+  otcrypto_const_byte_buf_t reseed_addl = {
+      .len = uj_input.reseed_additional_input_len,
+      .data = uj_input.reseed_additional_input,
+  };
+
+  // First additional input
+  uint8_t addl_1_buf[uj_input.additional_input_1_len];
+  memcpy(addl_1_buf, uj_input.additional_input_1,
+         uj_input.additional_input_1_len);
+  otcrypto_const_byte_buf_t addl_1 = {
+      .len = uj_input.additional_input_1_len,
+      .data = uj_input.additional_input_1,
+  };
+
+  // Second additional input
+  uint8_t addl_2_buf[uj_input.additional_input_2_len];
+  memcpy(addl_2_buf, uj_input.additional_input_2,
+         uj_input.additional_input_2_len);
+  otcrypto_const_byte_buf_t addl_2 = {
+      .len = uj_input.additional_input_2_len,
+      .data = uj_input.additional_input_2,
+  };
+
+  // Buffer for random output
+  cryptotest_drbg_output_t uj_output = {
+      .output_len = uj_input.output_len,
+  };
+  size_t output_words = ceil_div(uj_output.output_len, sizeof(uint32_t));
+  otcrypto_word32_buf_t output = {
+      .len = output_words,
+      .data = (uint32_t *)uj_output.output,
+  };
+
+  // Instantiate DRBG system. We cannot use the FIPS-compliant APIs
+  // because the test vector specifies an entropy string to use.
+  TRY(otcrypto_drbg_manual_instantiate(entropy, perso_string));
+
+  // Reseed if the test says we need to
+  if (uj_input.reseed) {
+    TRY(otcrypto_drbg_manual_reseed(reseed_entropy, reseed_addl));
+  }
+
+  // Add first additional input (the test vectors require generating
+  // `output_len` bits of output here, but they may be discarded).
+  TRY(otcrypto_drbg_manual_generate(addl_1, output));
+
+  // Add second additional input and generate random output
+  TRY(otcrypto_drbg_manual_generate(addl_2, output));
+
+  // Uninstantiate the DRBG system
+  otcrypto_drbg_uninstantiate();
+
+  // Send output to host via UART
+  RESP_OK(ujson_serialize_cryptotest_drbg_output_t, uj, &uj_output);
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/drbg.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/drbg.h
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_DRBG_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_DRBG_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_drbg(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_DRBG_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -14,6 +14,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/aes_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/drbg_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdh_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdsa_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
@@ -26,6 +27,7 @@
 // Include handlers
 #include "aes.h"
 #include "aes_sca.h"
+#include "drbg.h"
 #include "ecdh.h"
 #include "ecdsa.h"
 #include "hash.h"
@@ -44,6 +46,9 @@ status_t process_cmd(ujson_t *uj) {
     switch (cmd) {
       case kCryptotestCommandAes:
         RESP_ERR(uj, handle_aes(uj));
+        break;
+      case kCryptotestCommandDrbg:
+        RESP_ERR(uj, handle_drbg(uj));
         break;
       case kCryptotestCommandEcdsa:
         RESP_ERR(uj, handle_ecdsa(uj));

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -19,6 +19,13 @@ cc_library(
 )
 
 cc_library(
+    name = "drbg_commands",
+    srcs = ["drbg_commands.c"],
+    hdrs = ["drbg_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "ecdsa_commands",
     srcs = ["ecdsa_commands.c"],
     hdrs = ["ecdsa_commands.h"],

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -13,6 +13,7 @@ extern "C" {
 
 #define COMMAND(_, value) \
     value(_, Aes) \
+    value(_, Drbg) \
     value(_, Ecdsa) \
     value(_, Ecdh) \
     value(_, Hash) \

--- a/sw/device/tests/crypto/cryptotest/json/drbg_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/drbg_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "drbg_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/drbg_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/drbg_commands.h
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_DRBG_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_DRBG_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DRBG_CMD_MAX_ENTROPY_BYTES 48
+#define DRBG_CMD_MAX_PERSONALIZATION_STRING_BYTES 48
+#define DRBG_CMD_MAX_ADDITIONAL_INPUT_BYTES 48
+#define DRBG_CMD_MAX_OUTPUT_BYTES 64
+
+// clang-format off
+
+#define DRBG_INPUT(field, string) \
+    field(entropy, uint8_t, DRBG_CMD_MAX_ENTROPY_BYTES) \
+    field(entropy_len, size_t) \
+    field(personalization_string, uint8_t, DRBG_CMD_MAX_PERSONALIZATION_STRING_BYTES) \
+    field(personalization_string_len, size_t) \
+    field(reseed, uint8_t) \
+    field(reseed_entropy, uint8_t, DRBG_CMD_MAX_ENTROPY_BYTES) \
+    field(reseed_entropy_len, size_t) \
+    field(reseed_additional_input, uint8_t, DRBG_CMD_MAX_ADDITIONAL_INPUT_BYTES) \
+    field(reseed_additional_input_len, size_t) \
+    field(additional_input_1, uint8_t, DRBG_CMD_MAX_ADDITIONAL_INPUT_BYTES) \
+    field(additional_input_1_len, size_t) \
+    field(additional_input_2, uint8_t, DRBG_CMD_MAX_ADDITIONAL_INPUT_BYTES) \
+    field(additional_input_2_len, size_t) \
+    field(output_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestDrbgInput, cryptotest_drbg_input_t, DRBG_INPUT);
+
+#define DRBG_OUTPUT(field, string) \
+    field(output, uint8_t, DRBG_CMD_MAX_OUTPUT_BYTES) \
+    field(output_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestDrbgOutput, cryptotest_drbg_output_t, DRBG_OUTPUT);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_DRBG_COMMANDS_H_

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -396,3 +396,23 @@ run_binary(
         ("verify", "Ver", "rsp"),
     ]
 ]
+
+run_binary(
+    name = "rsp_sphincsplus_shake256_128s_simple_json",
+    srcs = [
+        "//sw/host/cryptotest/testvectors/data/schemas:sphincsplus_schema.json",
+        "@sphincsplus_kat//:sphincs-shake256-128s-simple/PQCsignKAT_64.rsp",
+    ],
+    outs = [":rsp_sphincsplus_shake256_128s_simple.json"],
+    args = [
+        "--src",
+        "$(location @sphincsplus_kat//:sphincs-shake256-128s-simple/PQCsignKAT_64.rsp)",
+        "--dst",
+        "$(location :rsp_sphincsplus_shake256_128s_simple.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:sphincsplus_schema.json)",
+        "--hash_alg",
+        "shake-256",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:rsp_sphincsplus_parser",
+)

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -6,6 +6,45 @@ load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+# Strip the inner layer of the DRBG repository, which is a zip of zips
+genrule(
+    name = "nist_cavp_drbg_sp_800_90a_reseed",
+    srcs = ["@nist_cavp_drbg_sp_800_90a_root//:drbgvectors_pr_false.zip"],
+    outs = [":CTR_DRBG_RESEED.rsp"],
+    cmd = "unzip -p $(location @nist_cavp_drbg_sp_800_90a_root//:drbgvectors_pr_false.zip) CTR_DRBG.rsp > $(location :CTR_DRBG_RESEED.rsp)",
+)
+
+genrule(
+    name = "nist_cavp_drbg_sp_800_90a_no_reseed",
+    srcs = ["@nist_cavp_drbg_sp_800_90a_root//:drbgvectors_no_reseed.zip"],
+    outs = [":CTR_DRBG_NO_RESEED.rsp"],
+    cmd = "unzip -p $(location @nist_cavp_drbg_sp_800_90a_root//:drbgvectors_no_reseed.zip) CTR_DRBG.rsp > $(location :CTR_DRBG_NO_RESEED.rsp)",
+)
+
+[
+    run_binary(
+        name = "nist_cavp_drbg_sp_800_90a_{}_json".format(mode),
+        srcs = [
+            ":CTR_DRBG_{}.rsp".format(mode.upper()),
+            "//sw/host/cryptotest/testvectors/data/schemas:drbg_schema.json",
+        ],
+        outs = [":nist_cavp_drbg_sp_800_90a_{}.json".format(mode)],
+        args = [
+            "--src",
+            "$(location :CTR_DRBG_{}.rsp)".format(mode.upper()),
+            "--dst",
+            "$(location :nist_cavp_drbg_sp_800_90a_{}.json)".format(mode),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:drbg_schema.json)",
+        ] + (["--reseed"] if reseed else []),
+        tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_drbg_parser",
+    )
+    for mode, reseed in [
+        ("reseed", True),
+        ("no_reseed", False),
+    ]
+]
+
 run_binary(
     name = "nist_cavp_ecdsa_fips_186_4_sig_ver_json",
     srcs = [

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -316,3 +316,44 @@ run_binary(
         "256",
     ]
 ]
+
+[
+    run_binary(
+        name = "nist_cavp_rsa_{}_{}_json".format(
+            padding_mode,
+            operation,
+        ),
+        srcs = [
+            "@nist_cavp_rsa_fips_186_3//:Sig{}{}_186-3.{}".format(prefix, infix, suffix),
+            "//sw/host/cryptotest/testvectors/data/schemas:rsa_schema.json",
+        ],
+        outs = [":nist_rsa_{}_{}.json".format(
+            padding_mode,
+            operation,
+        )],
+        args = [
+            "--src",
+            "$(location @nist_cavp_rsa_fips_186_3//:Sig{}{}_186-3.{})".format(prefix, infix, suffix),
+            "--dst",
+            "$(location :nist_rsa_{}_{}.json)".format(
+                padding_mode,
+                operation,
+            ),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:rsa_schema.json)",
+            "--operation",
+            operation,
+            "--padding",
+            padding_mode,
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_rsa_parser",
+    )
+    for padding_mode, infix in [
+        ("pkcs1_1.5", "15"),
+        ("pss", "PSS"),
+    ]
+    for operation, prefix, suffix in [
+        ("sign", "Gen", "txt"),
+        ("verify", "Ver", "rsp"),
+    ]
+]

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -21,4 +21,5 @@ exports_files([
     "hash_schema.json",
     "hmac_schema.json",
     "kmac_schema.json",
+    "rsa_schema.json",
 ])

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -17,6 +17,7 @@ filegroup(
 exports_files([
     "aes_kw_schema.json",
     "aes_gcm_schema.json",
+    "drbg_schema.json",
     "ecdh_schema.json",
     "hash_schema.json",
     "hmac_schema.json",

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -23,4 +23,5 @@ exports_files([
     "hmac_schema.json",
     "kmac_schema.json",
     "rsa_schema.json",
+    "sphincsplus_schema.json",
 ])

--- a/sw/host/cryptotest/testvectors/data/schemas/drbg_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/drbg_schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/hmac_schema.json",
+  "title": "Cryptotest HMAC Test Vector",
+  "description": "A list of testvectors for HMAC testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID number -- used for debugging",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be drbg",
+        "type": "string",
+        "enum": ["drbg"]
+      },
+      "entropy": {
+        "description": "Initial entropy value",
+        "$ref": "#/$defs/byte_array"
+      },
+      "personalization_string": {
+        "description": "Personalization string for instantiation",
+        "$ref": "#/$defs/byte_array"
+      },
+      "reseed": {
+        "description": "Whether the test requires reseeding",
+	"type": "boolean"
+      },
+      "reseed_entropy": {
+        "description": "Reseed entropy if reseed = True",
+        "$ref": "#/$defs/byte_array"
+      },
+      "reseed_additional_input": {
+        "description": "Additional value for reseed if reseed = True",
+        "$ref": "#/$defs/byte_array"
+      },
+      "additional_input_1": {
+        "description": "First additional value",
+        "$ref": "#/$defs/byte_array"
+      },
+      "additional_input_2": {
+        "description": "Second additional value",
+        "$ref": "#/$defs/byte_array"
+      },
+      "output": {
+        "description": "Expected random returned bits",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Whether the returned bits should match `output`",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json",
+  "title": "Cryptotest RSA Signature Verification Test Vector",
+  "description": "A list of testvectors for RSA Signature Verification testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID from test vector source -- used for debugging",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be rsa",
+        "type": "string",
+        "enum": ["rsa"]
+      },
+      "operation": {
+        "description": "RSA operation",
+        "type": "string",
+        "enum": ["sign", "verify", "encrypt", "decrypt"]
+      },
+      "padding": {
+        "description": "RSA padding type",
+        "type": "string",
+        "enum": ["pkcs1_1.5", "pss", "oaep"]
+      },
+      "security_level": {
+        "description": "RSA security level",
+        "type": "integer",
+        "enum": [2048, 3072, 4096]
+      },
+      "hash_alg": {
+        "description": "Hash algorithm for message encoding",
+        "type": "string",
+        "enum": ["sha-256", "sha-384", "sha-512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "shake-128", "shake-256"]
+      },
+      "message": {
+        "description": "Un-hashed plaintext message",
+        "$ref": "#/$defs/byte_array"
+      },
+      "label": {
+        "description": "Label for OAEP encryption",
+        "$ref": "#/$defs/byte_array"
+      },
+      "n": {
+        "description": "RSA public value n",
+        "$ref": "#/$defs/byte_array"
+      },
+      "e": {
+        "description": "RSA exponent e",
+        "type": "integer"
+      },
+      "d": {
+        "description": "RSA private value d",
+        "$ref": "#/$defs/byte_array"
+      },
+      "signature": {
+        "description": "RSA signature",
+        "$ref": "#/$defs/byte_array"
+      },
+      "ciphertext": {
+        "description": "Ciphertext to decrypt",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Expected signature verification result",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/data/schemas/sphincsplus_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/sphincsplus_schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/sphincsplus_schema.json",
+  "title": "Cryptotest HMAC Test Vector",
+  "description": "A list of testvectors for SPHINCS+ testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID number (used for debugging)",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be sphincs+",
+        "type": "string",
+        "enum": ["sphincs+"]
+      },
+      "operation": {
+        "description": "SPHINCS+ operation",
+        "type": "string",
+        "enum": ["verify"]
+      },
+      "hash_alg": {
+        "description": "Hash algorithm to use",
+        "type": "string",
+        "enum": ["sha-256", "shake-256"]
+      },
+      "public": {
+        "description": "Public key bytes (big-endian)",
+        "$ref": "#/$defs/byte_array"
+      },
+      "message": {
+        "description": "Un-hashed input message",
+        "$ref": "#/$defs/byte_array"
+      },
+      "signature": {
+        "description": "Signature bytes (big-endian)",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Whether the signature verification should succeed",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -121,3 +121,12 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "nist_cavp_rsa_parser",
+    srcs = ["nist_cavp_rsa_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -139,3 +139,12 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "rsp_sphincsplus_parser",
+    srcs = ["rsp_sphincsplus_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -41,6 +41,15 @@ py_binary(
 )
 
 py_binary(
+    name = "nist_cavp_drbg_parser",
+    srcs = ["nist_cavp_drbg_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
     name = "nist_cavp_ecdsa_parser",
     srcs = ["nist_cavp_ecdsa_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
+++ b/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
@@ -109,9 +109,9 @@ def str_to_byte_array(s: str) -> list:
     For example, str_to_byte_array("01020a0b") -> [1, 2, 10, 11]
     """
     if s.startswith("0x"):
-        s = s[1:]
+        s = s[2:]
     if len(s) % 2 != 0:
-        raise ValueError(f"String {s} has an odd number of digits; cannot convert into byte array.")
+        s = "0" + s
 
     byte_array = list()
     for i in range(0, len(s), 2):

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_drbg_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_drbg_parser.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting NIST CAVP DRBG test vectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+
+def parse_testcases(args) -> None:
+    raw_testcases = parse_rsp(args.src)
+    test_cases = list()
+
+    # NIST splits the rsp files into sections based on tag length
+    # (which implies which hash function should be used)
+    for test_vec in raw_testcases:
+        # The only configuration supported by cryptolib is AES-256
+        # without a derivation function. Exclude tests for other
+        # configs.
+        if test_vec["section_name"] != "AES-256 no df":
+            continue
+        test_case = {
+            "vendor": "nist",
+            "test_case_id": int(test_vec["COUNT"]),
+            "algorithm": "drbg",
+            "entropy": str_to_byte_array(test_vec["EntropyInput"]),
+            "personalization_string": str_to_byte_array(test_vec["PersonalizationString"]),
+            "reseed": args.reseed,
+            "additional_input_1": str_to_byte_array(test_vec["AdditionalInput"][0]),
+            "additional_input_2": str_to_byte_array(test_vec["AdditionalInput"][1]),
+            "output": str_to_byte_array(test_vec["ReturnedBits"]),
+            # All NIST DRBG vectors include the correct output in `ReturnedBits`.
+            "result": True,
+        }
+        if args.reseed:
+            test_case["reseed_entropy"] = str_to_byte_array(test_vec["EntropyInputReseed"])
+            test_case["reseed_additional_input"] = str_to_byte_array(
+                test_vec["AdditionalInputReseed"])
+
+        test_cases.append(test_case)
+
+    json_filename = f"{args.dst}"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP DRBG test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    parser.add_argument(
+        "--reseed",
+        action="store_true",
+        help = "Whether the tests require reseeding"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_rsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_rsa_parser.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting NIST CAVP RSA test vectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+SUPPORTED_SECURITY_LEVELS = [
+    2048,
+    3072,
+    4096,
+]
+
+HASH_NAME_MAPPING = {
+    "SHA256": "sha-256",
+    "SHA384": "sha-384",
+    "SHA512": "sha-512",
+}
+
+
+def parse_testcases(args) -> None:
+    # Depending on the operation, we have to notify the parser that certain
+    # variables in the rsp file are not intended to be treated as a test case
+    # on their own; instead, the values apply to all following test cases until
+    # the variable is assigned another value.
+    persists = []
+    if args.operation == "sign":
+        persists = ["n", "e", "d"]
+    elif args.operation == "verify":
+        persists = ["n", "p", "q"]
+    else:
+        raise ValueError(f"Unsupported RSA operation: {args.operation}")
+
+    raw_testcases = parse_rsp(args.src, persists=persists)
+
+    test_cases = list()
+    # NIST splits the rsp files into sections with named after (curve, hash
+    # algorithm) pairs
+    count = 0
+    for test_vec in raw_testcases:
+        count += 1
+        # Filter out unsupported configurations
+        if int(test_vec["mod"]) not in SUPPORTED_SECURITY_LEVELS:
+            continue
+        if test_vec["SHAAlg"] not in HASH_NAME_MAPPING:
+            continue
+        test_case = {
+            "vendor": "nist",
+            "test_case_id": count,
+            "algorithm": "rsa",
+            "operation": args.operation,
+            "padding": args.padding,
+            "security_level": int(test_vec["mod"]),
+            "hash_alg": HASH_NAME_MAPPING[test_vec["SHAAlg"]],
+            "message": str_to_byte_array(test_vec["Msg"]),
+            # Pad n and d with leading zero byte for compatibility
+            # with signed hexadecimal notation.
+            "n": [0] + str_to_byte_array(test_vec["n"]),
+            "e": int(test_vec["e"], 16),
+            "d": [0] + str_to_byte_array(test_vec["d"]) if "d" in test_vec else [],
+            "signature": str_to_byte_array(test_vec["S"]),
+        }
+        if args.operation == "sign":
+            # `Sign` tests always include the correct expected
+            # signature.
+            test_case["result"] = True
+        elif args.operation == "verify":
+            result_str = test_vec["Result"][:1]
+            if result_str == "P":
+                test_case["result"] = True
+            elif result_str == "F":
+                test_case["result"] = False
+            else:
+                raise ValueError(f"Unknown verification result value: {result_str}")
+
+        test_cases.append(test_case)
+
+    json_filename = f"{args.dst}"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP Digital Signatures test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    parser.add_argument(
+        "--operation",
+        type = str,
+        help = "RSA operation [sign, verify]"
+    )
+    parser.add_argument(
+        "--padding",
+        type = str,
+        help = "RSA padding type [pkcs1_1.5, pss]"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/host/cryptotest/testvectors/parsers/rsp_sphincsplus_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/rsp_sphincsplus_parser.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting SPHINCS+ RSP test vectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+
+def parse_testcases(args) -> None:
+    raw_testcases = parse_rsp(args.src)
+    test_cases = list()
+
+    # The SPHINCS+ RSP files do not use named sections.
+    for test_vec in raw_testcases:
+        test_cases.append({
+            "vendor": "sphincs+",
+            "test_case_id": int(test_vec["count"]),
+            "algorithm": "sphincs+",
+            "operation": "verify",
+            "hash_alg": args.hash_alg,
+            "public": str_to_byte_array(test_vec["pk"]),
+            "message": str_to_byte_array(test_vec["msg"]),
+            # Parse the signature from `sm` by removing the message from the end.
+            "signature": str_to_byte_array(test_vec['sm'][:-len(test_vec['msg'])]),
+            "result": True,
+        })
+
+    json_filename = f"{args.dst}"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP Digital Signatures test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    parser.add_argument(
+        "--hash_alg",
+        type= str,
+        help = "Hash algorithm to use"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -18,6 +18,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "drbg_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:drbg_commands"],
+)
+
+ujson_rust(
     name = "hash_commands_rust",
     srcs = ["//sw/device/tests/crypto/cryptotest/json:hash_commands"],
 )
@@ -37,6 +42,7 @@ rust_library(
     srcs = [
         "src/aes_commands.rs",
         "src/commands.rs",
+        "src/drbg_commands.rs",
         "src/ecdh_commands.rs",
         "src/ecdsa_commands.rs",
         "src/hash_commands.rs",
@@ -46,6 +52,7 @@ rust_library(
         ":commands_rust",
         ":aes_commands_rust",
         ":ecdh_commands_rust",
+        ":drbg_commands_rust",
         ":ecdsa_commands_rust",
         ":hash_commands_rust",
     ],
@@ -53,6 +60,7 @@ rust_library(
         "commands_loc": "$(execpath :commands_rust)",
         "aes_commands_loc": "$(execpath :aes_commands_rust)",
         "ecdh_commands_loc": "$(execpath :ecdh_commands_rust)",
+        "drbg_commands_loc": "$(execpath :drbg_commands_rust)",
         "ecdsa_commands_loc": "$(execpath :ecdsa_commands_rust)",
         "hash_commands_loc": "$(execpath :hash_commands_rust)",
     },

--- a/sw/host/cryptotest/ujson_lib/src/drbg_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/drbg_commands.rs
@@ -1,9 +1,4 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-pub mod aes_commands;
-pub mod commands;
-pub mod drbg_commands;
-pub mod ecdh_commands;
-pub mod ecdsa_commands;
-pub mod hash_commands;
+include!(env!("drbg_commands_loc"));

--- a/sw/host/tests/crypto/drbg_kat/BUILD
+++ b/sw/host/tests/crypto/drbg_kat/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -1,0 +1,162 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use std::fs;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::drbg_commands::{CryptotestDrbgInput, CryptotestDrbgOutput};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    drbg_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DrbgTestCase {
+    vendor: String,
+    test_case_id: usize,
+    entropy: Vec<u8>,
+    personalization_string: Vec<u8>,
+    reseed: bool,
+    #[serde(default)]
+    reseed_entropy: Vec<u8>,
+    #[serde(default)]
+    reseed_additional_input: Vec<u8>,
+    additional_input_1: Vec<u8>,
+    additional_input_2: Vec<u8>,
+    output: Vec<u8>,
+    result: bool,
+}
+
+fn run_drbg_testcase(
+    test_case: &DrbgTestCase,
+    opts: &Opts,
+    transport: &TransportWrapper,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "vendor: {}, test case: {}",
+        test_case.vendor,
+        test_case.test_case_id
+    );
+    let uart = transport.uart("console")?;
+
+    CryptotestCommand::Drbg.send(&*uart)?;
+
+    // Convert all inputs to little-endian
+    let mut entropy_le = Vec::from(test_case.entropy.as_slice());
+    let mut perso_string_le = Vec::from(test_case.personalization_string.as_slice());
+    let mut reseed_entropy_le = Vec::from(test_case.reseed_entropy.as_slice());
+    let mut reseed_addl_le = Vec::from(test_case.reseed_additional_input.as_slice());
+    let mut addl_1_le = Vec::from(test_case.additional_input_1.as_slice());
+    let mut addl_2_le = Vec::from(test_case.additional_input_2.as_slice());
+    entropy_le.reverse();
+    perso_string_le.reverse();
+    reseed_entropy_le.reverse();
+    reseed_addl_le.reverse();
+    addl_1_le.reverse();
+    addl_2_le.reverse();
+
+    // Send everything
+    CryptotestDrbgInput {
+        entropy: ArrayVec::try_from(entropy_le.as_slice()).unwrap(),
+        entropy_len: entropy_le.len(),
+        personalization_string: ArrayVec::try_from(perso_string_le.as_slice()).unwrap(),
+        personalization_string_len: perso_string_le.len(),
+        reseed: if test_case.reseed { 1 } else { 0 },
+        reseed_entropy: ArrayVec::try_from(reseed_entropy_le.as_slice()).unwrap(),
+        reseed_entropy_len: reseed_entropy_le.len(),
+        reseed_additional_input: ArrayVec::try_from(reseed_addl_le.as_slice()).unwrap(),
+        reseed_additional_input_len: reseed_addl_le.len(),
+        additional_input_1: ArrayVec::try_from(addl_1_le.as_slice()).unwrap(),
+        additional_input_1_len: addl_1_le.len(),
+        additional_input_2: ArrayVec::try_from(addl_2_le.as_slice()).unwrap(),
+        additional_input_2_len: addl_2_le.len(),
+        output_len: test_case.output.len(),
+    }
+    .send(&*uart)?;
+
+    // Get output
+    let drbg_output = CryptotestDrbgOutput::recv(&*uart, opts.timeout, false)?;
+    // The expected output is in a mixed-endian format (32-bit words
+    // are in little-endian order, but the bytes within the words are
+    // in big-endian order). Convert the actual output to match this
+    // format.
+    let mut output = Vec::from(&drbg_output.output[..drbg_output.output_len]);
+    let mut i = 0;
+    while i + 4 <= output.len() {
+        output[i..i + 4].reverse();
+        i += 4;
+    }
+    // Output byte length not a multiple of 4 is currently unsupported.
+    if i != output.len() {
+        panic!("Output length in bytes was not a multiple of 4.");
+    }
+    let success = test_case.output == output;
+    if test_case.result != success {
+        log::info!(
+            "FAILED test #{}: expected = {}, actual = {}",
+            test_case.test_case_id,
+            test_case.result,
+            success
+        );
+        *fail_counter += 1;
+    }
+    Ok(())
+}
+
+fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.drbg_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let drbg_tests: Vec<DrbgTestCase> = serde_json::from_str(&raw_json)?;
+
+        for drbg_test in &drbg_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_drbg_testcase(drbg_test, opts, transport, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_drbg, &opts, &transport);
+    Ok(())
+}

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -15,6 +15,19 @@ def nist_cavp_repos():
     archive instead of the NIST website.
     """
     http_archive(
+        name = "nist_cavp_drbg_sp_800_90a_root",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "5f7e5658ebd5b4e6785a7b12fa32333511d2acc2f2d9c5ae1ffa16b699377769",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/drbg/drbgtestvectors.zip",
+	visibility = ["//visibility:private"],
+    )
+    http_archive(
+        name = "nist_cavp_drbg_sp_800_90a",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "8f9644adc655dd651c90b73190175b1d99164dc5a4861edab16e39862ead27ad",
+	url = "file://$(location @nist_cavp_drbg_sp_800_90a_root//:drbgvectors_no_reseed.zip)",
+    )
+    http_archive(
         name = "nist_cavp_ecdsa_fips_186_4",
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         strip_prefix = "186-4ecdsatestvectors",

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -77,3 +77,9 @@ def nist_cavp_repos():
         sha256 = "5fff092551f2d72e89a3d9362711878708f9a14b502f0dfae819649105b0ea39",
         url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/components/ecccdhtestvectors.zip",
     )
+    http_archive(
+        name = "nist_cavp_rsa_fips_186_3",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "8405aeb3572a4f98ed4b1a3ccb3f2f49e725462dd28ec4759d6a15d88855d19c",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-3rsatestvectors.zip",
+    )

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -19,13 +19,6 @@ def nist_cavp_repos():
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         sha256 = "5f7e5658ebd5b4e6785a7b12fa32333511d2acc2f2d9c5ae1ffa16b699377769",
         url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/drbg/drbgtestvectors.zip",
-	visibility = ["//visibility:private"],
-    )
-    http_archive(
-        name = "nist_cavp_drbg_sp_800_90a",
-        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
-        sha256 = "8f9644adc655dd651c90b73190175b1d99164dc5a4861edab16e39862ead27ad",
-	url = "file://$(location @nist_cavp_drbg_sp_800_90a_root//:drbgvectors_no_reseed.zip)",
     )
     http_archive(
         name = "nist_cavp_ecdsa_fips_186_4",

--- a/third_party/sphincsplus/BUILD
+++ b/third_party/sphincsplus/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/sphincsplus/BUILD.sphincsplus_common.bazel
+++ b/third_party/sphincsplus/BUILD.sphincsplus_common.bazel
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))

--- a/third_party/sphincsplus/repos.bzl
+++ b/third_party/sphincsplus/repos.bzl
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def sphincsplus_repos():
+    http_archive(
+        name = "sphincsplus_kat",
+        build_file = Label("//third_party/sphincsplus:BUILD.sphincsplus_common.bazel"),
+        strip_prefix = "NIST-PQ-Submission-SPHINCS-20201001/KAT",
+        sha256 = "798c9ef5a851cd92e52e6c2fcc8403530a5f827bf07bf542e3dfdf98c1916338",
+        urls = [
+            # Self-hosted GCB ZIP that contains only the 128s/SHAKE256 test
+            # vectors. The original archive hosted at
+            # https://sphincs.org/data/sphincs+-round3-submission-nist.zip
+            # which includes the test vectors for all versions is not included
+            # here because the checksum differs.
+            "https://storage.googleapis.com/ot-crypto-test-vectors/sphincsplus/sphincsplus_shake256_128s_round3.zip ",
+        ],
+    )


### PR DESCRIPTION
1. Adds an `http_archive` pull rule for the test vectors for SPHINCS+, removing the need to vendor the test vectors in `/sw/device/tests/crypto/testvectors/sphincsplus_kat`.
2. Adds a python parser and JSON schema to integrate the SPHINCS+ test vectors with the rest of the cryptotest framework, allowing automated testing of the implementation in `/sw/device/silicon_creator/lib/sigverify/sphincsplus`