### PR TITLE
[opentitanlib] Order ECDSA keys and signature correctly 

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -200,6 +200,7 @@ rust_library(
         "src/util/bitfield.rs",
         "src/util/bitbang.rs",
         "src/util/file.rs",
+        "src/util/hexdump.rs",
         "src/util/mod.rs",
         "src/util/num_de.rs",
         "src/util/openocd.rs",

--- a/sw/host/opentitanlib/src/crypto/ecdsa.rs
+++ b/sw/host/opentitanlib/src/crypto/ecdsa.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{anyhow, ensure, Result};
 use ecdsa::elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey};
 use ecdsa::elliptic_curve::pkcs8::{DecodePublicKey, EncodePublicKey};
 use ecdsa::signature::hazmat::PrehashVerifier;
@@ -10,9 +10,11 @@ use p256::ecdsa::{Signature, SigningKey, VerifyingKey};
 use rand::rngs::OsRng;
 use serde::Serialize;
 use serde_annotate::Annotate;
+use std::io::{Read, Write};
 use std::path::Path;
 
-use crate::crypto::sha256::Sha256Digest;
+use crate::crypto::rsa::Error;
+use crate::crypto::sha256::{sha256, Sha256Digest};
 
 pub struct EcdsaPrivateKey {
     pub key: SigningKey,
@@ -20,16 +22,6 @@ pub struct EcdsaPrivateKey {
 
 pub struct EcdsaPublicKey {
     pub key: VerifyingKey,
-}
-
-#[derive(Debug, Serialize, Annotate)]
-pub struct EcdsaRawPublicKey {
-    #[serde(with = "serde_bytes")]
-    #[annotate(format = hexstr)]
-    pub x: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    #[annotate(format = hexstr)]
-    pub y: Vec<u8>,
 }
 
 impl Default for EcdsaPrivateKey {
@@ -61,10 +53,85 @@ impl EcdsaPrivateKey {
         }
     }
 
-    pub fn sign(&self, digest: &Sha256Digest) -> Result<Vec<u8>> {
+    pub fn sign(&self, digest: &Sha256Digest) -> Result<EcdsaRawSignature> {
         let (sig, _) = self.key.sign_prehash_recoverable(&digest.to_be_bytes())?;
-        let bytes = sig.to_bytes().as_slice().to_vec();
-        Ok(bytes)
+        let bytes = sig.to_bytes();
+        let half = bytes.len() / 2;
+        // The signature bytes are (R || S).  Since opentitan is a little-endian
+        // machine, we want to reverse the byte order of each component of the
+        // signature.
+        let mut r = Vec::new();
+        r.extend(bytes[..half].iter().rev());
+        let mut s = Vec::new();
+        s.extend(bytes[half..].iter().rev());
+        Ok(EcdsaRawSignature { r, s })
+    }
+
+    pub fn digest_and_sign(&self, data: &[u8]) -> Result<EcdsaRawSignature> {
+        let digest = sha256(data);
+        self.sign(&digest)
+    }
+}
+
+#[derive(Debug, Serialize, Annotate)]
+pub struct EcdsaRawSignature {
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub r: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub s: Vec<u8>,
+}
+
+impl Default for EcdsaRawSignature {
+    fn default() -> Self {
+        Self {
+            r: vec![0u8; 32],
+            s: vec![0u8; 32],
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for EcdsaRawSignature {
+    type Error = Error;
+    fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
+        if value.len() != 64 {
+            return Err(Error::InvalidSignature(anyhow!(
+                "bad length: {}",
+                value.len()
+            )));
+        }
+        let mut value = std::io::Cursor::new(value);
+        EcdsaRawSignature::read(&mut value).map_err(Error::InvalidSignature)
+    }
+}
+
+impl EcdsaRawSignature {
+    pub fn read(src: &mut impl Read) -> Result<Self> {
+        let mut sig = Self::default();
+        src.read_exact(&mut sig.r)?;
+        src.read_exact(&mut sig.s)?;
+        Ok(sig)
+    }
+
+    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+        ensure!(
+            self.r.len() == 32,
+            Error::InvalidSignature(anyhow!("bad r length: {}", self.r.len()))
+        );
+        ensure!(
+            self.s.len() == 32,
+            Error::InvalidSignature(anyhow!("bad s length: {}", self.s.len()))
+        );
+        dest.write_all(&self.r)?;
+        dest.write_all(&self.s)?;
+        Ok(())
+    }
+
+    pub fn to_vec(&self) -> Result<Vec<u8>> {
+        let mut sig = Vec::new();
+        self.write(&mut sig)?;
+        Ok(sig)
     }
 }
 
@@ -81,15 +148,66 @@ impl EcdsaPublicKey {
 
     pub fn to_raw(&self) -> EcdsaRawPublicKey {
         let point = self.key.to_encoded_point(false);
-        EcdsaRawPublicKey {
-            x: point.x().unwrap().as_slice().to_vec(),
-            y: point.y().unwrap().as_slice().to_vec(),
-        }
+        // Since opentitan is a little-endian machine, we reverse the byte
+        // order of the X and Y values.
+        let mut x = point.x().unwrap().as_slice().to_vec();
+        let mut y = point.y().unwrap().as_slice().to_vec();
+        x.reverse();
+        y.reverse();
+        EcdsaRawPublicKey { x, y }
     }
 
-    pub fn verify(&self, digest: &Sha256Digest, signature: &[u8]) -> Result<()> {
-        let signature = Signature::from_slice(signature)?;
+    pub fn verify(&self, digest: &Sha256Digest, signature: &EcdsaRawSignature) -> Result<()> {
+        let mut bytes = signature.to_vec()?;
+        let half = bytes.len() / 2;
+        // The signature bytes are (R || S).  Since opentitan is a little-endian
+        // machine, we expect the input signature to have R and S in
+        // little-endian order.  Reverse the bytes back to big-endian ordering.
+        bytes[..half].reverse();
+        bytes[half..].reverse();
+        let signature = Signature::from_slice(&bytes)?;
         self.key.verify_prehash(&digest.to_be_bytes(), &signature)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Annotate)]
+pub struct EcdsaRawPublicKey {
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub x: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub y: Vec<u8>,
+}
+
+impl Default for EcdsaRawPublicKey {
+    fn default() -> Self {
+        Self {
+            x: vec![0u8; 32],
+            y: vec![0u8; 32],
+        }
+    }
+}
+
+impl EcdsaRawPublicKey {
+    pub fn read(src: &mut impl Read) -> Result<Self> {
+        let mut key = Self::default();
+        src.read_exact(&mut key.x)?;
+        src.read_exact(&mut key.y)?;
+        Ok(key)
+    }
+    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+        ensure!(
+            self.x.len() == 32,
+            Error::InvalidPublicKey(anyhow!("bad x length: {}", self.x.len()))
+        );
+        ensure!(
+            self.y.len() == 32,
+            Error::InvalidPublicKey(anyhow!("bad y length: {}", self.y.len()))
+        );
+        dest.write_all(&self.x)?;
+        dest.write_all(&self.y)?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/crypto/rsa.rs
+++ b/sw/host/opentitanlib/src/crypto/rsa.rs
@@ -34,8 +34,8 @@ fixed_size_bigint!(N0Inv, at_most OTBN_BITS);
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Invalid public key")]
-    InvalidPublicKey(#[source] Option<anyhow::Error>),
+    #[error("Invalid public key: {0:?}")]
+    InvalidPublicKey(#[source] anyhow::Error),
     #[error("Invalid DER file: {der}")]
     InvalidDerFile {
         der: PathBuf,
@@ -69,7 +69,7 @@ pub enum Error {
 /// Ensure the components of `key` have the correct bit length.
 fn validate_key(key: &impl PublicKeyParts) -> Result<()> {
     if key.n().bits() != MODULUS_BIT_LEN || key.e() != &BigUint::from(65537u32) {
-        bail!(Error::InvalidPublicKey(None))
+        bail!(Error::InvalidPublicKey(anyhow!("bad modulus or exponent")));
     } else {
         Ok(())
     }
@@ -91,7 +91,7 @@ impl RsaPublicKey {
                 BigUint::from_bytes_le(n.to_le_bytes().as_slice()),
                 BigUint::from(65537u32),
             )
-            .map_err(|e| Error::InvalidPublicKey(Some(anyhow!(e))))?,
+            .map_err(|e| Error::InvalidPublicKey(anyhow!(e)))?,
         })
     }
 

--- a/sw/host/opentitanlib/src/util/hexdump.rs
+++ b/sw/host/opentitanlib/src/util/hexdump.rs
@@ -1,0 +1,183 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use regex::RegexBuilder;
+use std::io::Write;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum HexdumpError {
+    #[error("odd number of input characters")]
+    BadLength,
+    #[error("unrecognized hexdump format")]
+    UnrecognizedFormat,
+}
+
+/// Print a hexdump of a buffer to `writer`.
+/// The hexdump includes the offset, hex bytes and printable ASCII characters.
+///
+///  00000000: 53 46 44 50 06 01 02 ff 00 06 01 10 30 00 00 ff  SFDP........0...
+///  00000010: c2 00 01 04 10 01 00 ff 84 00 01 02 c0 00 00 ff  ................
+///  00000020: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff  ................
+///  00000030: e5 20 fb ff ff ff ff 3f 44 eb 08 6b 08 3b 04 bb  . .....?D..k.;..
+///
+/// Note: This format can be consumed by `xxd -r` and converted back into binary.
+pub fn hexdump(mut writer: impl Write, buf: &[u8]) -> Result<()> {
+    for (i, chunk) in buf.chunks(16).enumerate() {
+        let mut ascii = [b'.'; 16];
+        write!(writer, "{:08x}:", i * 16)?;
+        for (j, byte) in chunk.iter().copied().enumerate() {
+            write!(writer, " {:02x}", byte)?;
+            // For printable ASCII chars, place them in the ascii buffer.
+            if byte == b' ' || byte.is_ascii_graphic() {
+                ascii[j] = byte;
+            }
+        }
+        // Align and print the ascii buffer.
+        let j = chunk.len();
+        for _ in 0..(16 - j) {
+            write!(writer, "   ")?;
+        }
+        writeln!(writer, "  {}", std::str::from_utf8(&ascii[0..j]).unwrap())?;
+    }
+    Ok(())
+}
+
+/// Print a hexdump of a buffer to a string.
+pub fn hexdump_string(buf: &[u8]) -> Result<String> {
+    let mut s = Vec::new();
+    hexdump(&mut s, buf)?;
+    Ok(String::from_utf8(s)?)
+}
+
+// Translate an ASCII byte into its hex numerical value.
+fn unhex(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    }
+}
+
+// Given a hex string, parse hex bytes and append them to `vec`.
+fn from_hex(text: &str, vec: &mut Vec<u8>) -> Result<()> {
+    let mut it = text.bytes().filter_map(unhex);
+    while let Some(a) = it.next() {
+        if let Some(b) = it.next() {
+            vec.push(a << 4 | b);
+        } else {
+            return Err(HexdumpError::BadLength.into());
+        }
+    }
+    Ok(())
+}
+
+/// Parses a hexdump string in a variety of forms, returning the resulting bytes.
+pub fn hexdump_parse(text: &str) -> Result<Vec<u8>> {
+    // Detects `xxd -g<n>` formats.
+    let xxd = RegexBuilder::new(r"^[[:xdigit:]]{8}:\s+((?:[[:xdigit:]]{2,}\s)+)\s+.{1,16}$")
+        .multi_line(true)
+        .build()
+        .unwrap();
+    // Detects `hexdump -vC`
+    let hexdump =
+        RegexBuilder::new(r"^[[:xdigit:]]{8}\s+((?:[[:xdigit:]]{2}\s+?){1,16})\s+\|.*\|$")
+            .multi_line(true)
+            .build()
+            .unwrap();
+    // Detects a simple hex string with optional whitespace.
+    let hexstr = RegexBuilder::new(r"(?:0[xX])?((?:[[:xdigit:]]{2}\s*)+)")
+        .multi_line(false)
+        .build()
+        .unwrap();
+
+    let mut res = Vec::new();
+    let captures = if xxd.is_match(text) {
+        xxd.captures_iter(text)
+    } else if hexdump.is_match(text) {
+        hexdump.captures_iter(text)
+    } else if hexstr.is_match(text) {
+        hexstr.captures_iter(text)
+    } else {
+        return Err(HexdumpError::UnrecognizedFormat.into());
+    };
+    for c in captures {
+        from_hex(c.get(1).unwrap().as_str(), &mut res)?;
+    }
+    Ok(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    const TEST_STR: &str = "The quick brown fox jumped over the lazy dog!";
+
+    // Output from `hexdump -vC ...`
+    const HEXDUMP_C: &str = "\
+00000000  54 68 65 20 71 75 69 63  6b 20 62 72 6f 77 6e 20  |The quick brown |\n\
+00000010  66 6f 78 20 6a 75 6d 70  65 64 20 6f 76 65 72 20  |fox jumped over |\n\
+00000020  74 68 65 20 6c 61 7a 79  20 64 6f 67 21           |the lazy dog!|\n";
+
+    // Output from `xxd -g<n> ...` where n = {1,2,4,8}
+    const XXD_G1: &str = "\
+00000000: 54 68 65 20 71 75 69 63 6b 20 62 72 6f 77 6e 20  The quick brown \n\
+00000010: 66 6f 78 20 6a 75 6d 70 65 64 20 6f 76 65 72 20  fox jumped over \n\
+00000020: 74 68 65 20 6c 61 7a 79 20 64 6f 67 21           the lazy dog!\n";
+
+    const XXD_G2: &str = "\
+00000000: 5468 6520 7175 6963 6b20 6272 6f77 6e20  The quick brown \n\
+00000010: 666f 7820 6a75 6d70 6564 206f 7665 7220  fox jumped over \n\
+00000020: 7468 6520 6c61 7a79 2064 6f67 21         the lazy dog!\n";
+
+    const XXD_G4: &str = "\
+00000000: 54686520 71756963 6b206272 6f776e20  The quick brown \n\
+00000010: 666f7820 6a756d70 6564206f 76657220  fox jumped over \n\
+00000020: 74686520 6c617a79 20646f67 21        the lazy dog!\n";
+
+    const XXD_G8: &str = "\
+00000000: 5468652071756963 6b2062726f776e20  The quick brown \n\
+00000010: 666f78206a756d70 6564206f76657220  fox jumped over \n\
+00000020: 746865206c617a79 20646f6721        the lazy dog!\n";
+
+    const XXD: [&str; 4] = [XXD_G1, XXD_G2, XXD_G4, XXD_G8];
+
+    #[test]
+    fn test_hexdump() -> Result<()> {
+        let buf = TEST_STR;
+        let res = hexdump_string(buf.as_bytes())?;
+        assert_eq!(res, XXD_G1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_hexstr() -> Result<()> {
+        let buf = "5468652071756963\n6b2062726f776e20";
+        let res = hexdump_parse(buf)?;
+        let s = std::str::from_utf8(&res)?;
+        assert_eq!(s, "The quick brown ");
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_hexdump() -> Result<()> {
+        let res = hexdump_parse(HEXDUMP_C)?;
+        let s = std::str::from_utf8(&res)?;
+        assert_eq!(s, TEST_STR);
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_xxd() -> Result<()> {
+        for xxd in &XXD {
+            let res = hexdump_parse(xxd)?;
+            let s = std::str::from_utf8(&res)?;
+            assert_eq!(s, TEST_STR);
+        }
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -6,6 +6,7 @@ pub mod bigint;
 pub mod bitbang;
 pub mod bitfield;
 pub mod file;
+pub mod hexdump;
 pub mod num_de;
 pub mod openocd;
 pub mod parse_int;

--- a/sw/host/opentitantool/src/command/ecdsa.rs
+++ b/sw/host/opentitantool/src/command/ecdsa.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
-use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey};
+use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawSignature};
 use opentitanlib::crypto::sha256::Sha256Digest;
 use opentitanlib::util::parse_int::ParseInt;
 
@@ -134,18 +134,14 @@ impl CommandDispatch for EcdsaKeyExportCommand {
         writeln!(&mut file)?;
         writeln!(&mut file, "#define {} \\", keyname)?;
         writeln!(&mut file, " {{ \\")?;
-        let mut x = key.x.clone();
-        x.reverse();
-        for val in x.as_slice().chunks(4) {
+        for val in key.x.as_slice().chunks(4) {
             writeln!(
                 &mut file,
                 "    0x{:02x}{:02x}{:02x}{:02x}, \\",
                 val[3], val[2], val[1], val[0]
             )?;
         }
-        let mut y = key.y.clone();
-        y.reverse();
-        for val in y.as_slice().chunks(4) {
+        for val in key.y.as_slice().chunks(4) {
             writeln!(
                 &mut file,
                 "    0x{:02x}{:02x}{:02x}{:02x}, \\",
@@ -212,7 +208,7 @@ impl CommandDispatch for EcdsaSignCommand {
         } else {
             self.digest.clone().unwrap()
         };
-        let signature = private_key.sign(&digest)?;
+        let signature = private_key.sign(&digest)?.to_vec()?;
         if let Some(output) = &self.output {
             std::fs::write(output, &signature)?;
         }
@@ -231,7 +227,7 @@ pub struct EcdsaVerifyCommand {
     /// SHA256 digest of the message as a hex string (big-endian), i.e. 0x...
     #[arg(value_name = "SHA256_DIGEST")]
     digest: String,
-    /// Signature to be verified as a hex string (big-endian), i.e. 0x...
+    /// Signature to be verified as a hex string.
     signature: String,
 }
 
@@ -243,7 +239,7 @@ impl CommandDispatch for EcdsaVerifyCommand {
     ) -> Result<Option<Box<dyn Annotate>>> {
         let key = load_pub_or_priv_key(&self.der_file)?;
         let digest = Sha256Digest::from_str(&self.digest)?;
-        let signature = hex::decode(&self.signature)?;
+        let signature = EcdsaRawSignature::try_from(hex::decode(&self.signature)?.as_slice())?;
         key.verify(&digest, &signature)?;
         Ok(None)
     }

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -19,6 +19,7 @@ use opentitanlib::spiflash::{EraseMode, ReadMode, SpiFlash};
 use opentitanlib::tpm;
 use opentitanlib::transport::Capability;
 use opentitanlib::transport::ProgressIndicator;
+use opentitanlib::util::hexdump::hexdump;
 
 /// Read and parse an SFDP table.
 #[derive(Debug, Args)]
@@ -30,36 +31,6 @@ pub struct SpiSfdp {
     /// Start reading SFDP at offset.  Only valid with --raw.
     #[arg(short, long)]
     offset: Option<u32>,
-}
-
-// Print a hexdump of a buffer to `writer`.
-// The hexdump includes the offset, hex bytes and printable ASCII characters.
-//
-//  00000000: 53 46 44 50 06 01 02 ff 00 06 01 10 30 00 00 ff  SFDP........0...
-//  00000010: c2 00 01 04 10 01 00 ff 84 00 01 02 c0 00 00 ff  ................
-//  00000020: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff  ................
-//  00000030: e5 20 fb ff ff ff ff 3f 44 eb 08 6b 08 3b 04 bb  . .....?D..k.;..
-//
-// Note: This format can be consumed by `xxd -r` and converted back into binary.
-fn hexdump(mut writer: impl Write, buf: &[u8]) -> Result<()> {
-    for (i, chunk) in buf.chunks(16).enumerate() {
-        let mut ascii = [b'.'; 16];
-        write!(writer, "{:08x}:", i * 16)?;
-        for (j, byte) in chunk.iter().copied().enumerate() {
-            write!(writer, " {:02x}", byte)?;
-            // For printable ASCII chars, place them in the ascii buffer.
-            if byte == b' ' || byte.is_ascii_graphic() {
-                ascii[j] = byte;
-            }
-        }
-        // Align and print the ascii buffer.
-        let j = chunk.len();
-        for _ in 0..(16 - j) {
-            write!(writer, "   ")?;
-        }
-        writeln!(writer, "  {}", std::str::from_utf8(&ascii[0..j]).unwrap())?;
-    }
-    Ok(())
 }
 
 impl CommandDispatch for SpiSfdp {


### PR DESCRIPTION
1. Order ECDSA keys and signatures in little-endian order.
2. Add hexdump emit and parse functions (needed in the future for tests that check binary data).