### PR TITLE
[dv,sram_ctrl] Fix a few failing tests

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -678,6 +678,8 @@ class cip_base_vseq #(
                                             bit          do_tl_err = 1,
                                             uint         reset_delay_bound = 10_000_000);
     `DV_CHECK_FATAL(seq != null)
+    `uvm_info(`gfn, $sformatf("running run_seq_with_rand_reset_vseq for sequence %s",
+                               seq.get_full_name()), UVM_MEDIUM)
 
     for (int i = 1; i <= num_times; i++) begin
       bit ongoing_reset;
@@ -704,6 +706,8 @@ class cip_base_vseq #(
                   dv_vseq.do_apply_reset = 0;
                   dv_vseq.set_sequencer(p_sequencer);
                   `DV_CHECK_RANDOMIZE_FATAL(dv_vseq)
+                  `uvm_info(`gfn, $sformatf("Starting sequence %s", dv_vseq.get_full_name()),
+                            UVM_MEDIUM)
                   dv_vseq.start(p_sequencer);
                 end
               join
@@ -769,12 +773,17 @@ class cip_base_vseq #(
 
     cfg.set_intention_to_reset();
 
-    `uvm_info(`gfn, $sformatf("Waiting for %0d cycles with a run of no accesses", wait_cycles),
+    `uvm_info(`gfn, $sformatf(
+              "Waiting up to %0d cycles for a long enough run of no accesses", wait_cycles),
               UVM_MEDIUM)
     for (; cycles_waited < wait_cycles || cycles_with_no_accesses > 0; ++cycles_waited) begin
       if (!has_outstanding_access()) begin
+        `uvm_info(`gfn, "A cycle with no outstanding accesses", UVM_MEDIUM)
         ++cycles_with_no_accesses;
         if (cycles_with_no_accesses > CyclesWithNoAccessesThreshold) begin
+          `uvm_info(`gfn, $sformatf(
+                    "Finally no outstanding accesses after %d cycles", cycles_waited),
+                    UVM_MEDIUM)
           break;
         end
       end else begin

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -7,21 +7,21 @@
 // seq, normal seq with default priority (100) has the priority to access TL driver
 `define create_tl_access_error_case(task_name_, with_c_,
                                     seq_t_ = tl_host_custom_seq #(cip_tl_seq_item),
-                                    seqr_t) \
-  begin \
-    seq_t_ tl_seq; \
-    `uvm_info(`gfn, {"Running ", `"task_name_`"}, UVM_HIGH) \
-    `uvm_create_on(tl_seq, seqr_t) \
-    if (cfg.zero_delays) begin \
-      tl_seq.min_req_delay = 0; \
-      tl_seq.max_req_delay = 0; \
-    end \
-    tl_seq.req_abort_pct = $urandom_range(0, 100); \
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_seq, with_c_) \
-    csr_utils_pkg::increment_outstanding_access(); \
-    `DV_SPINWAIT(`uvm_send_pri(tl_seq, 1), \
+                                    seqr_t)                                                \
+  begin                                                                                    \
+    seq_t_ tl_seq;                                                                         \
+    `uvm_info(`gfn, {"Running ", `"task_name_`"}, UVM_MEDIUM)                              \
+    `uvm_create_on(tl_seq, seqr_t)                                                         \
+    if (cfg.zero_delays) begin                                                             \
+      tl_seq.min_req_delay = 0;                                                            \
+      tl_seq.max_req_delay = 0;                                                            \
+    end                                                                                    \
+    tl_seq.req_abort_pct = $urandom_range(0, 100);                                         \
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_seq, with_c_)                                        \
+    csr_utils_pkg::increment_outstanding_access();                                         \
+    `DV_SPINWAIT(`uvm_send_pri(tl_seq, 1),                                                 \
         $sformatf("Timeout: %0s with addr %0h", `"task_name_`", tl_seq.addr), 100_000_000) \
-    csr_utils_pkg::decrement_outstanding_access(); \
+    csr_utils_pkg::decrement_outstanding_access();                                         \
   end
 
 virtual task tl_access_unmapped_addr(string ral_name);

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -26,10 +26,14 @@ package csr_utils_pkg;
 
   function automatic void increment_outstanding_access();
     outstanding_accesses++;
+    `uvm_info("csr_utils_pkg", $sformatf("increment_outstanding_access %0d", outstanding_accesses),
+              UVM_HIGH)
   endfunction
 
   function automatic void decrement_outstanding_access();
     outstanding_accesses--;
+    `uvm_info("csr_utils_pkg", $sformatf("decrement_outstanding_access %0d", outstanding_accesses),
+              UVM_HIGH)
   endfunction
 
   task automatic wait_no_outstanding_access();
@@ -549,6 +553,7 @@ package csr_utils_pkg;
         fork
           while (!under_reset) begin
             if (spinwait_delay_ns) #(spinwait_delay_ns * 1ns);
+            `uvm_info("csr_utils_pkg", "In csr_spinwait", verbosity)
             csr_rd(.ptr(ptr), .value(read_data), .check(check), .path(path),
                    .blocking(1), .map(map), .user_ftdr(user_ftdr), .backdoor(backdoor));
             `uvm_info(msg_id, $sformatf("ptr %0s == 0x%0h",

--- a/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent_cfg.sv
@@ -142,12 +142,14 @@ class push_pull_agent_cfg #(parameter int HostDataWidth = 32,
   // Setter method for the user data queues - must be called externally to place specific user-data
   // to be sent by the driver.
   function void add_h_user_data(bit [HostDataWidth-1:0] data);
+    `uvm_info(`gfn, $sformatf("Added h user data %p", data), UVM_HIGH)
     h_user_data_q.push_back(data);
   endfunction
 
   // Setter method for the user data queues - must be called externally to place specific user-data
   // to be sent by the driver.
   function void add_d_user_data(bit [DeviceDataWidth-1:0] data);
+    `uvm_info(`gfn, $sformatf("Added d user data %p", data), UVM_HIGH)
     d_user_data_q.push_back(data);
   endfunction
 

--- a/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
@@ -21,6 +21,7 @@ class push_pull_monitor #(parameter int HostDataWidth = 32,
 
   task run_phase(uvm_phase phase);
     @(posedge cfg.vif.rst_n);
+    cfg.in_reset = 0;
     fork
       monitor_reset();
       collect_trans(phase);

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -40,7 +40,7 @@ module prim_fifo_sync #(
 
     assign depth_o = 1'b0; //output is meaningless
 
-    // devie facing
+    // device facing
     assign rvalid_o = wvalid_i;
     assign rdata_o = wdata_i;
 

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_bijection_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_bijection_vseq.sv
@@ -32,12 +32,14 @@ class sram_ctrl_bijection_vseq extends sram_ctrl_smoke_vseq;
 
       // Write the corresponding address to each entry in the SRAM
       for (int j = 0; j < sram_depth; j++) begin
+        if (cfg.stop_transaction_generators()) return;
         do_single_write(.addr(j*4), .data(j*4), .mask('1));
       end
 
       // Read each location back, the read data should be the same as its address
       for (int j = 0; j < sram_depth; j++) begin
         logic [TL_DW-1:0] rdata;
+        if (cfg.stop_transaction_generators()) return;
         do_single_read(.addr(j*4), .mask('1), .check_rdata(1),
                        .exp_rdata(j*4), .rdata(rdata));
       end

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
@@ -35,6 +35,8 @@ class sram_ctrl_executable_vseq extends sram_ctrl_multiple_keys_vseq;
     csr_wr(ral.exec, en_exec_csr);
     cfg.exec_vif.drive_lc_hw_debug_en(hw_debug_en);
     cfg.exec_vif.drive_otp_en_sram_ifetch(en_sram_ifetch);
+    // Wait a few cycles for synchronizers to settle.
+    cfg.clk_rst_vif.wait_clks(4);
   endtask
 
 endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_all_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_all_vseq.sv
@@ -46,6 +46,7 @@ class sram_ctrl_stress_all_vseq extends sram_ctrl_base_vseq;
       sram_vseq.do_sram_ctrl_init = 0;
       `uvm_info(`gfn, $sformatf("iteration[%0d]: starting %0s", i, cur_vseq_name), UVM_LOW)
       sram_vseq.start(p_sequencer);
+      `uvm_info(`gfn, $sformatf("iteration[%0d]: finishing %0s", i, cur_vseq_name), UVM_MEDIUM)
     end
   endtask
 

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
@@ -17,6 +17,9 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
     cfg.m_tl_agent_cfgs[cfg.sram_ral_name].allow_a_valid_drop_wo_a_ready = 0;
 
     req_mem_init();
+    // And wait for any side_effect of ram_init, since detection of the end is not very accurate.
+    cfg.clk_rst_vif.wait_clks(3);
+
     for (int i = 0; i < num_trans; i++) begin
       int num_cycles;
 

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
@@ -52,11 +52,8 @@ class sram_ctrl_env #(parameter int AddrWidth = 10) extends cip_base_env #(
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-
-    if (cfg.en_scb) begin
-      // connect KDI port
-      m_kdi_agent.monitor.analysis_port.connect(scoreboard.kdi_fifo.analysis_export);
-    end
+    // Connect KDI port.
+    m_kdi_agent.monitor.analysis_port.connect(scoreboard.kdi_fifo.analysis_export);
   endfunction
 
 endclass

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -12,6 +12,12 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
 
   string sram_ral_name = "sram_ctrl_prim_reg_block";
 
+  // This tracks a key request.
+  bit in_key_req = 1'b0;
+
+  // This tracks when the ram is undergoing initialization in the scoreboard.
+  bit in_init = 1'b0;
+
   // ext component cfgs
   rand push_pull_agent_cfg#(.DeviceDataWidth(KDI_DATA_SIZE)) m_kdi_cfg;
 
@@ -47,6 +53,7 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
     m_kdi_cfg = push_pull_agent_cfg#(.DeviceDataWidth(KDI_DATA_SIZE))::type_id::create("m_kdi_cfg");
     m_kdi_cfg.agent_type = push_pull_agent_pkg::PullAgent;
     m_kdi_cfg.if_mode = dv_utils_pkg::Device;
+    m_kdi_cfg.pull_handshake_type = push_pull_agent_pkg::TwoPhase;
 
     // CDC synchronization between OTP and SRAM clock domains requires that the scrambling seed data
     // should be held for at least a few cycles before it can be safely latched by the SRAM domain.
@@ -55,7 +62,7 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
     m_kdi_cfg.hold_d_data_until_next_req = 1'b1;
 
     // KDI interface will never need zero delay mode.
-    // As per SRAM spec, KDI process will generally take around 800 CPU cyclesj
+    // As per SRAM spec, KDI process will generally take around 800 CPU cycles.
     m_kdi_cfg.zero_delays.rand_mode(0);
 
     `uvm_info(`gfn, $sformatf("ral_model_names: %0p", ral_model_names), UVM_LOW)


### PR DESCRIPTION
Improve handling of ram initialization: refine the CSR expectations, and
move most processing outside process_tl_access since it is not called for
the CIP common tests; also, ram initialization blocks RAM accesses so
there could be a long time with transactions outstanding, which can cause
random reset timeouts.

Handle re-scramble during test execution, letting the push_pull agent
become active. In case of re-scrambling, invalidate the expected memory
state since it becomes invalid.

Add missing calls to cfg.stop_transaction_generators.
