### PR TITLE
[spi_device] Clean up TODOs and add a mechanism to reinit the read buffer

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -487,6 +487,22 @@
           tags: [// This CSR only briefly pulses to anything other than 0.
                  "excl:CsrNonInitTests:CsrExclWrite"]
         },
+        { bits: "1",
+          name: "FLASH_READ_BUFFER_CLR",
+          swaccess: "rw1s",
+          hwaccess: "hrw",
+          desc: '''Set to clear the read buffer state.
+
+            When set to 1, resets the flash read buffer state that tracks the host read address.
+            The reset should only be used when the upstream SPI host is known to be inactive.
+            This function is intended to allow restoring initial values when the upstream SPI host is reset.
+
+            This CSR automatically resets to 0.
+            '''
+          resval: "0",
+          tags: [// This CSR only briefly pulses to anything other than 0.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        },
         { bits: "5:4",
           name: "MODE",
           desc: "SPI Device flash operation mode.",

--- a/hw/ip/spi_device/doc/programmers_guide.md
+++ b/hw/ip/spi_device/doc/programmers_guide.md
@@ -13,6 +13,16 @@ In addition to the various buffers for Flash and Passthrough modes, the TPM Read
 The TPM Read FIFO presents a FIFO interface to software, which writes the [`TPM_READ_FIFO` CSR](registers.md#tpm_read_fifo) for each word instead of the underlying TPM Read Buffer SRAM region directly.
 The TPM Write FIFO, however, presents only the RAM interface to software, with data for each command always starting at the lowest address of the TPM Write Buffer region.
 
+The SRAM is divided into two large blocks.
+The first block is for the egress flows, where software writes data to the SRAM, and the SPI host reads it.
+That first block includes the flash read buffer, the mailbox, the SFDP, and the TPM Read FIFO.
+The second block is for the ingress flows, where the SPI host writes to the SRAM, and software reads from it.
+That second block includes the flash command upload buffers and the TPM Write FIFO.
+
+This separation of flows allows the memory to be implemented by two SRAM instances that each have one read-only and one write-only port (the "1r1w" SRAM macro).
+In addition, regardless of whether the memory is implemented using a single instance with two read-write ports or the two 1r1w instances, the access controls are the same.
+Software can only write to the egress memory, and it can only read from the ingress memory.
+
 ## TPM over SPI
 
 ### Initialization

--- a/hw/ip/spi_device/doc/registers.md
+++ b/hw/ip/spi_device/doc/registers.md
@@ -174,19 +174,20 @@ Alert Test Register
 Control register
 - Offset: `0x10`
 - Reset default: `0x10`
-- Reset mask: `0x31`
+- Reset mask: `0x33`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "FLASH_STATUS_FIFO_CLR", "bits": 1, "attr": ["rw1s"], "rotate": -90}, {"bits": 3}, {"name": "MODE", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+{"reg": [{"name": "FLASH_STATUS_FIFO_CLR", "bits": 1, "attr": ["rw1s"], "rotate": -90}, {"name": "FLASH_READ_BUFFER_CLR", "bits": 1, "attr": ["rw1s"], "rotate": -90}, {"bits": 2}, {"name": "MODE", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                                     |
 |:------:|:------:|:-------:|:---------------------------------------------------------|
 |  31:6  |        |         | Reserved                                                 |
 |  5:4   |   rw   |   0x1   | [MODE](#control--mode)                                   |
-|  3:1   |        |         | Reserved                                                 |
+|  3:2   |        |         | Reserved                                                 |
+|   1    |  rw1s  |   0x0   | [FLASH_READ_BUFFER_CLR](#control--flash_read_buffer_clr) |
 |   0    |  rw1s  |   0x0   | [FLASH_STATUS_FIFO_CLR](#control--flash_status_fifo_clr) |
 
 ### CONTROL . MODE
@@ -199,6 +200,15 @@ SPI Device flash operation mode.
 | 0x2     | passthrough | In passthrough mode, SPI Device IP forwards the incoming SPI flash traffics to the attached downstream flash device. HW may processes commands internally and returns data. SW may configure the device to drop inadmissable commands.                                     |
 
 Other values are reserved.
+
+### CONTROL . FLASH_READ_BUFFER_CLR
+Set to clear the read buffer state.
+
+When set to 1, resets the flash read buffer state that tracks the host read address.
+The reset should only be used when the upstream SPI host is known to be inactive.
+This function is intended to allow restoring initial values when the upstream SPI host is reset.
+
+This CSR automatically resets to 0.
 
 ### CONTROL . FLASH_STATUS_FIFO_CLR
 Set to clear the flash status FIFO.

--- a/hw/ip/spi_device/doc/theory_of_operation.md
+++ b/hw/ip/spi_device/doc/theory_of_operation.md
@@ -191,6 +191,7 @@ The IP returns data from the read buffer based on the given address in the recei
 In the current version, the read buffer size is 2kB.
 The IP only uses lower 11 bits of the received read command address (`addr[10:0]`) to issue the read requests to the DPSRAM.
 
+The read buffer feature is intended for an upstream device's initial firmware load, which manifests as a contiguous block read (typically a single SPI flash read command).
 SW is responsible for updating the read buffer contents.
 The HW notifies the SW to update the buffer contents when needed.
 The HW provides a SW configurable read watermark CSR and read-only [`LAST_READ_ADDR`](registers.md#last_read_addr) CSR.

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1668,12 +1668,8 @@ module spi_device
     assign sys_sram_m2l[i].rdata  = sys_sram_rdata[i];
     assign sys_sram_m2l[i].rerror = sys_sram_rerror[i];
 
-    // Other than SYS access (tlul), other requesters can't wait the grant.
-    // It should be instantly available to not introduce the latency.
-    // If prim_sram_arbiter has fixed arbitration, then FW access should be
-    // lowest priority.
-    //
-    // ICEBOX(#10065): Implement grant in upload module and sram interface
+    // There is only ever a single source of requests on the SYS port (SW), so
+    // requests should always be granted.
     `ASSERT(ReqAlwaysAccepted_A, sys_sram_req[i] |-> sys_sram_gnt[i])
   end : g_sram_connect
 

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -245,6 +245,9 @@ module spi_device
   // Threshold value of a buffer in bytes
   logic [BufferAw:0] readbuf_threshold;
 
+  // Synchronous clear of read buffer tracking.
+  logic readbuf_clr;
+
   // Passthrouth config signals
   logic [255:0] cmd_filter;
 
@@ -547,6 +550,9 @@ module spi_device
                       };
 
   assign readbuf_threshold = reg2hw.read_threshold.q[BufferAw:0];
+  assign readbuf_clr = reg2hw.control.flash_read_buffer_clr.q;
+  assign hw2reg.control.flash_read_buffer_clr.d  = '0;
+  assign hw2reg.control.flash_read_buffer_clr.de = 1'b1;
 
   localparam int unsigned MailboxAw = $clog2(SramMailboxDepth*SramDw/8);
   assign cfg_mailbox_en = reg2hw.cfg.mailbox_en.q;
@@ -1091,6 +1097,7 @@ module spi_device
 
     .clk_out_i (clk_spi_out_buf),
 
+    .sys_clk_i  (clk_i),
     .sys_rst_ni (rst_ni),
 
     .sel_dp_i   (cmd_dp_sel),
@@ -1114,6 +1121,7 @@ module spi_device
     .cmd_info_idx_i (cmd_info_idx_broadcast),
 
     .readbuf_threshold_i (readbuf_threshold),
+    .sys_readbuf_clr_i   (readbuf_clr),
 
     .addr_4b_en_i (cfg_addr_4b_en),
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -139,6 +139,9 @@ package spi_device_reg_pkg;
     } mode;
     struct packed {
       logic        q;
+    } flash_read_buffer_clr;
+    struct packed {
+      logic        q;
     } flash_status_fifo_clr;
   } spi_device_reg2hw_control_reg_t;
 
@@ -459,6 +462,10 @@ package spi_device_reg_pkg;
       logic        d;
       logic        de;
     } flash_status_fifo_clr;
+    struct packed {
+      logic        d;
+      logic        de;
+    } flash_read_buffer_clr;
   } spi_device_hw2reg_control_reg_t;
 
   typedef struct packed {
@@ -586,11 +593,11 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1562:1555]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1554:1547]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1546:1531]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1530:1529]
-    spi_device_reg2hw_control_reg_t control; // [1528:1526]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1563:1556]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1555:1548]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1547:1532]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1531:1530]
+    spi_device_reg2hw_control_reg_t control; // [1529:1526]
     spi_device_reg2hw_cfg_reg_t cfg; // [1525:1523]
     spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1522:1519]
     spi_device_reg2hw_addr_mode_reg_t addr_mode; // [1518:1517]
@@ -627,8 +634,8 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [209:194]
-    spi_device_hw2reg_control_reg_t control; // [193:192]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [211:196]
+    spi_device_hw2reg_control_reg_t control; // [195:192]
     spi_device_hw2reg_status_reg_t status; // [191:190]
     spi_device_hw2reg_addr_mode_reg_t addr_mode; // [189:188]
     spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [187:156]

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -220,6 +220,8 @@ module spi_device_reg_top (
   logic control_we;
   logic control_flash_status_fifo_clr_qs;
   logic control_flash_status_fifo_clr_wd;
+  logic control_flash_read_buffer_clr_qs;
+  logic control_flash_read_buffer_clr_wd;
   logic [1:0] control_mode_qs;
   logic [1:0] control_mode_wd;
   logic cfg_we;
@@ -2163,6 +2165,33 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (control_flash_status_fifo_clr_qs)
+  );
+
+  //   F[flash_read_buffer_clr]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1S),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_control_flash_read_buffer_clr (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (control_we),
+    .wd     (control_flash_read_buffer_clr_wd),
+
+    // from internal hardware
+    .de     (hw2reg.control.flash_read_buffer_clr.de),
+    .d      (hw2reg.control.flash_read_buffer_clr.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.control.flash_read_buffer_clr.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (control_flash_read_buffer_clr_qs)
   );
 
   //   F[mode]: 5:4
@@ -19645,6 +19674,8 @@ module spi_device_reg_top (
 
   assign control_flash_status_fifo_clr_wd = reg_wdata[0];
 
+  assign control_flash_read_buffer_clr_wd = reg_wdata[1];
+
   assign control_mode_wd = reg_wdata[5:4];
   assign cfg_we = addr_hit[5] & reg_we & !reg_error;
 
@@ -21070,6 +21101,7 @@ module spi_device_reg_top (
 
       addr_hit[4]: begin
         reg_rdata_next[0] = control_flash_status_fifo_clr_qs;
+        reg_rdata_next[1] = control_flash_read_buffer_clr_qs;
         reg_rdata_next[5:4] = control_mode_qs;
       end
 

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -112,6 +112,7 @@ module spi_readcmd
 
   input clk_out_i, // Output clock (inverted SPI_CLK)
 
+  input sys_clk_i,
   input sys_rst_ni, // System reset for buffer tracking pointers
 
   // From Command Parser
@@ -143,6 +144,9 @@ module spi_readcmd
 
   // Double buffering in bytes
   input [SramBufferAw-1:0] readbuf_threshold_i,
+
+  // Clear read buffer address tracker.
+  input sys_readbuf_clr_i,
 
   // The command mode is 4B mode. Every read command receives 4B address
   input addr_4b_en_i,
@@ -754,7 +758,9 @@ module spi_readcmd
     .clk_i,
     .rst_ni,
 
+    .sys_clk_i,
     .sys_rst_ni,
+    .sys_clr_i (sys_readbuf_clr_i),
 
     .spi_mode_i,
 

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -1262,9 +1262,6 @@ module spi_tpm
         sck_p2s_valid = 1'b 1;
         sck_data_sel  = SelRdFifo;
 
-        // ICEBOX(#18354): RdFifo rready (sck --> isck)
-
-        // ICEBOX(#18354): check xfer_size handling
         if (isck_p2s_sent && xfer_size_met) begin
           sck_st_d = StEnd;
         end
@@ -1285,7 +1282,6 @@ module spi_tpm
         wrdata_shift_en = 1'b 1;
         // Processed by the logic. Does not have to do
 
-        // ICEBOX(#18354): check xfer_size handling
         if (sck_wrfifo_wvalid && xfer_size_met) begin
           // With complete command, upload for SW to process
           sck_cmdaddr_wvalid = 1'b 1;
@@ -1302,8 +1298,6 @@ module spi_tpm
       end // StInvalid
 
       StEnd: begin // TERMINAL_STATE
-        // TODO(#18355): Check if open pull-up cancel the transaction?
-        // If yes, then drive 0x00 for the read command
         if (cmd_type == Read) begin
           sck_p2s_valid = 1'b 1;
           sck_data_sel  = SelWait; // drive 0x00

--- a/hw/ip/spi_device/rtl/spid_readbuffer.sv
+++ b/hw/ip/spi_device/rtl/spid_readbuffer.sv
@@ -90,9 +90,6 @@ module spid_readbuffer
 
   // The logic keeps next buffer address. Compare this with the
   // current_address and if it hits with mask, then the flip event occurs.
-  //
-  // ICEBOX(#10038): If the device goes sleep, the next_buffer_addr should be
-  //                 recoverable.
   logic [31-SramBufferAw:0] next_buffer_addr;
 
   logic active;
@@ -157,12 +154,6 @@ module spid_readbuffer
   end
 
   assign event_flip_o = active && flip && !flip_q;
-
-  // ICEBOX(#10037): Consider the case if host jumps the address? (report
-  //                 error?)
-
-  // ICEBOX(#10038): Consider the case of sleep and recover. Provide a way to
-  //                 recover `next_buffer_addr`?
 
   // Watermark event: Threshold should not be 0 to enable the event
   assign watermark_cross = (current_address_i[SramBufferAw-1:0] >= threshold_i)

--- a/hw/ip/spi_device/rtl/spid_status.sv
+++ b/hw/ip/spi_device/rtl/spid_status.sv
@@ -189,7 +189,7 @@ module spid_status
   // HW-originated WEL and WIP updates bypass the flop so they are committed
   // immediately. The changes still must be placed in the flops above, so the
   // staged values are correct for the next update.
-  // TODO: HW changes should not be allowed while BUSY
+  // TODO(#21700): HW changes should not be allowed while BUSY
   always_comb begin
     sck_status_to_commit = sck_status_staged;
     if (inclk_we_set_i) begin

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -209,6 +209,16 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_device_get_4b_address_mode(dif_spi_device_handle_t *spi,
                                                 dif_toggle_t *addr_4b);
 
+/**
+ * Clear any pending software-originated flash status change requests.
+ *
+ * @param spi A SPI device.
+ * @return kDifBadArg if spi is NULL. kDifOk otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_clear_flash_status_request(
+    dif_spi_device_handle_t *spi);
+
 typedef struct dif_spi_device_flash_id {
   /** The device ID for the SPI flash. */
   uint16_t device_id;
@@ -311,6 +321,17 @@ dif_result_t dif_spi_device_get_last_read_address(dif_spi_device_handle_t *spi,
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_device_set_eflash_read_threshold(
     dif_spi_device_handle_t *spi, uint32_t address);
+
+/**
+ * Clear eflash read buffer state.
+ *
+ * Reinitialize the eflash read buffer to initial state.
+ *
+ * @param spi A SPI device.
+ * @return kDifBadArg if spi is NULL. kDifOk otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_reset_eflash_buffer(dif_spi_device_handle_t *spi);
 
 typedef enum dif_spi_device_flash_address_type {
   /** No address for this command */

--- a/sw/device/lib/dif/dif_spi_device_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_device_unittest.cc
@@ -107,6 +107,7 @@ TEST_F(FlashTest, NullArgs) {
       dif_spi_device_set_4b_address_mode(nullptr, kDifToggleEnabled));
   EXPECT_DIF_BADARG(dif_spi_device_get_4b_address_mode(nullptr, &toggle_arg));
   EXPECT_DIF_BADARG(dif_spi_device_get_4b_address_mode(&spi_, nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_clear_flash_status_request(nullptr));
   EXPECT_DIF_BADARG(dif_spi_device_get_flash_id(nullptr, &id_arg));
   EXPECT_DIF_BADARG(dif_spi_device_get_flash_id(&spi_, nullptr));
   EXPECT_DIF_BADARG(dif_spi_device_set_flash_id(nullptr, id_arg));
@@ -116,6 +117,7 @@ TEST_F(FlashTest, NullArgs) {
   EXPECT_DIF_BADARG(dif_spi_device_get_last_read_address(&spi_, nullptr));
   EXPECT_DIF_BADARG(
       dif_spi_device_set_eflash_read_threshold(nullptr, /*address=*/0));
+  EXPECT_DIF_BADARG(dif_spi_device_reset_eflash_buffer(nullptr));
   EXPECT_DIF_BADARG(dif_spi_device_get_flash_command_slot(
       nullptr, /*slot=*/0, &toggle_arg, &command_arg));
   EXPECT_DIF_BADARG(dif_spi_device_get_flash_command_slot(
@@ -379,6 +381,14 @@ TEST_F(FlashTest, FlashWatermark) {
 
   EXPECT_WRITE32(SPI_DEVICE_READ_THRESHOLD_REG_OFFSET, 0x26a);
   EXPECT_DIF_OK(dif_spi_device_set_eflash_read_threshold(&spi_, 0x26a));
+
+  EXPECT_WRITE32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CONTROL_MODE_OFFSET,
+                      SPI_DEVICE_CONTROL_MODE_VALUE_PASSTHROUGH},
+                     {SPI_DEVICE_CONTROL_FLASH_READ_BUFFER_CLR_BIT, 1},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_reset_eflash_buffer(&spi_));
 }
 
 TEST_F(FlashTest, CommandInfo) {
@@ -718,6 +728,14 @@ TEST_F(FlashTest, StatusRegisters) {
   EXPECT_READ32(SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0x765432);
   EXPECT_DIF_OK(dif_spi_device_get_flash_status_registers(&spi_, &status));
   EXPECT_EQ(status, 0x765432);
+
+  EXPECT_WRITE32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CONTROL_MODE_OFFSET,
+                      SPI_DEVICE_CONTROL_MODE_VALUE_PASSTHROUGH},
+                     {SPI_DEVICE_CONTROL_FLASH_STATUS_FIFO_CLR_BIT, 1},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_clear_flash_status_request(&spi_));
 }
 
 class TpmTest : public SpiTest {};


### PR DESCRIPTION
- Remove outdated TODOs / ICEBOXs.
- DIFs only: Add a mechanism to clear outstanding requests to the status registers
- Add a mechanism to reinit the read buffer without needing to reset the entire spi_device IP
- Document the SRAM layout and its relationship to 1r1w memories.