### PR TITLE
[hmac] Bump version to 2.0.0 and reset development stages

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -33,6 +33,15 @@
       design_stage:       "D3",
       verification_stage: "V2S",
       dif_stage:          "S2",
+      commit_id:          "2290dcc119067538aaf3fb5fd43c3dc2418458d1",
+      notes:              "",
+    }
+    {
+      version:            "2.0.0",
+      life_stage:         "L1",
+      design_stage:       "D1",
+      verification_stage: "V0",
+      dif_stage:          "S0",
       notes:              "",
     }
   ]


### PR DESCRIPTION
With the addition of *save & restore* (PR #21307) and *wider digest and configurable key length* (PR #21604), HMAC will see major changes.  For this reason, this commit gives HMAC a major version bump to 2.0.0 and resets its development stages to L1 (Development), D1 (Functional), V0 (*Initial Work* because the DV environment may not be completely functional for some time), and S0 (*Initial Work* because the DIF may not be completely functional for some time).

The previous version 1.0.0 got assigned a commit ID for future reference even though it had not reached L2, V3, and S3.