### PR TITLE
DO NOT MERGE][ci] Improve handling of bitstream jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -450,19 +450,13 @@ jobs:
       top_name: earlgrey
       design_suffix: cw310_hyperdebug
 
-- job: chip_earlgrey_cw340
-  displayName: CW340's Earl Grey Bitstream
-  # Build CW340 variant of the Earl Grey toplevel design using Vivado
-  dependsOn:
-    - lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
-  pool: ci-public-eda
-  timeoutInMinutes: 150
-  steps:
-  - template: ci/fpga-template.yml
-    parameters:
-      top_name: earlgrey
-      design_suffix: cw340
+- template: ci/fpga-job.yml
+  parameters:
+    top_name: earlgrey
+    design_suffix: cw340
+    display_name: CW340's Earl Grey Bitstream
+    job_name: chip_earlgrey_cw340
+    build_timeout: 150
 
 - job: chip_englishbreakfast_cw305
   displayName: CW305's Bitstream

--- a/ci/fpga-job.yml
+++ b/ci/fpga-job.yml
@@ -1,0 +1,75 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Azure template for an FPGA bitstream job.
+# This script contains several jobs and ensures that we do not dispatch
+# a job to ci-public-eda unless we actually need to build a bitstream.
+
+parameters:
+- name: top_name
+  type: string
+- name: design_suffix
+  type: string
+# Name to display for the jobs.
+- name: display_name
+  type: string
+# Name of the job that other jobs can rely depend on.
+- name: job_name
+  type: string
+# Timeout for the build.
+- name: build_timeout
+  type: number
+
+jobs:
+# Configure the bitstream strategy and download if the strategy is 'cached'
+- job: "${{ parameters.job_name }}_strategy"
+  displayName: "Configure ${{ parameters.display_name }} strategy"
+  dependsOn:
+    - lint
+  pool:
+    vmImage: ubuntu-20.04
+  # Skip job if there is no need to need for a bitstream.
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
+  steps:
+  - template: ./fpga-template.yml
+    parameters:
+      top_name: ${{ parameters.top_name }}
+      design_suffix: ${{ parameters.design_suffix }}
+      bin_name: ${{ parameters.job_name }}
+      do_build: false
+
+# Build the bitstream on the EDA pool if necessary.
+# NOTE: this will recompute the strategy which could be different from
+# the strategy first determined because the job could have to wait for
+# some time before getting access to an EDA machine. This gives another
+# opportunity to cache.
+- job: "${{ parameters.job_name }}_build"
+  displayName: "Build ${{ parameters.display_name }}"
+  dependsOn: "${{ parameters.job_name }}_strategy"
+  variables:
+    bitstreamStrategy: $[ dependencies.${{ parameters.job_name }}_strategy.outputs['strategy.bitstreamStrategy'] ]
+  # Use the ci-public-eda pool to build.
+  pool: ci-public-eda
+  condition: eq(variables.bitstreamStrategy, 'build')
+  timeoutInMinutes: ${{ parameters.build_timeout }}
+  steps:
+  - template: ./fpga-template.yml
+    parameters:
+      top_name: ${{ parameters.top_name }}
+      design_suffix: ${{ parameters.design_suffix }}
+      bin_name: ${{ parameters.job_name }}
+      do_build: true
+
+# This job does nothing but it is there to for dependency purposes.
+- job: "${{ parameters.job_name }}"
+  displayName: "${{ parameters.display_name }}"
+  dependsOn:
+    - "${{ parameters.job_name }}_strategy"
+    - "${{ parameters.job_name }}_build"
+  variables:
+    bitstreamStrategy: $[ dependencies.${{ parameters.job_name }}_strategy.outputs['strategy.bitstreamStrategy'] ]
+  # We explicitely want to succeed if build was skipped due to the strategy being 'cached'.
+  condition: or(eq(variables.bitstreamStrategy, 'cached'), eq(dependencies.${{ parameters.job_name }}_build.result, 'Succeeded'))
+  pool:
+    vmImage: ubuntu-20.04

--- a/ci/fpga-template.yml
+++ b/ci/fpga-template.yml
@@ -9,6 +9,16 @@ parameters:
   type: string
 - name: design_suffix
   type: string
+# If set to true, this template will include a building step when
+# the strategy is not 'cached'.
+- name: do_build
+  type: boolean
+  default: true
+# Name of the binary artifact produced (prefixed by partial-build-bin-)
+# If not set, uses the current job's name.
+- name: bin_name
+  type: string
+  default: ""
 
 steps:
 - template: ./checkout-template.yml
@@ -28,6 +38,8 @@ steps:
       ':!/hw/**/dv/*' \
       ':!/hw/dv/'
   displayName: Configure bitstream strategy
+  # The output variable `bitstreamStrategy` is set by the previous script.
+  name: strategy
 - bash: |
     set -ex
     . util/build_consts.sh
@@ -39,38 +51,43 @@ steps:
     cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
   condition: eq(variables.bitstreamStrategy, 'cached')
   displayName: Extract cached bitstream
-- bash: |
-    set -ex
-    bazel_package=//hw/bitstream/vivado
-    bitstream_target=${bazel_package}:fpga_${{ parameters.design_suffix }}
-    archive_target=${bazel_package}:${{ parameters.top_name }}_${{ parameters.design_suffix }}_archive
-    trap 'get_logs' EXIT
-    get_logs() {
-      design_name=chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}
-      SUB_PATH="hw/top_${{ parameters.top_name }}/${design_name}"
-      mkdir -p "$OBJ_DIR/$SUB_PATH" "$BIN_DIR/$SUB_PATH"
-      cp -rLvt "$OBJ_DIR/$SUB_PATH/" \
-        $($REPO_TOP/bazelisk.sh outquery-all ${bitstream_target})
-      bitstream_archive=$($REPO_TOP/bazelisk.sh outquery ${archive_target})
-      cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
-    }
+- ${{ if eq(parameters.do_build, true) }}:
+  - bash: |
+      set -ex
+      bazel_package=//hw/bitstream/vivado
+      bitstream_target=${bazel_package}:fpga_${{ parameters.design_suffix }}
+      archive_target=${bazel_package}:${{ parameters.top_name }}_${{ parameters.design_suffix }}_archive
+      trap 'get_logs' EXIT
+      get_logs() {
+        design_name=chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}
+        SUB_PATH="hw/top_${{ parameters.top_name }}/${design_name}"
+        mkdir -p "$OBJ_DIR/$SUB_PATH" "$BIN_DIR/$SUB_PATH"
+        cp -rLvt "$OBJ_DIR/$SUB_PATH/" \
+          $($REPO_TOP/bazelisk.sh outquery-all ${bitstream_target})
+        bitstream_archive=$($REPO_TOP/bazelisk.sh outquery ${archive_target})
+        cp -Lv ${bitstream_archive} ${BUILD_ROOT}/build-bin.tar
+      }
 
-    . util/build_consts.sh
-    module load "xilinx/vivado/$(VIVADO_VERSION)"
-    ci/bazelisk.sh build ${archive_target}
-  condition: ne(variables.bitstreamStrategy, 'cached')
-  displayName: Build and splice bitstream with Vivado
-- bash: |
-    . util/build_consts.sh
-    echo "Synthesis log"
-    cat $OBJ_DIR/hw/top_${{ parameters.top_name }}/build.fpga_${{ parameters.design_suffix }}/synth-vivado/lowrisc_systems_chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}_0.1.runs/synth_1/runme.log || true
+      . util/build_consts.sh
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/bazelisk.sh build ${archive_target}
+    condition: ne(variables.bitstreamStrategy, 'cached')
+    displayName: Build and splice bitstream with Vivado
+  - bash: |
+      . util/build_consts.sh
+      echo "Synthesis log"
+      cat $OBJ_DIR/hw/top_${{ parameters.top_name }}/build.fpga_${{ parameters.design_suffix }}/synth-vivado/lowrisc_systems_chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}_0.1.runs/synth_1/runme.log || true
 
-    echo "Implementation log"
-    cat $OBJ_DIR/hw/top_${{ parameters.top_name }}/build.fpga_${{ parameters.design_suffix }}/synth-vivado/lowrisc_systems_chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}_0.1.runs/impl_1/runme.log || true
-  condition: ne(variables.bitstreamStrategy, 'cached')
-  displayName: Display synthesis & implementation logs
+      echo "Implementation log"
+      cat $OBJ_DIR/hw/top_${{ parameters.top_name }}/build.fpga_${{ parameters.design_suffix }}/synth-vivado/lowrisc_systems_chip_${{ parameters.top_name }}_${{ parameters.design_suffix }}_0.1.runs/impl_1/runme.log || true
+    condition: ne(variables.bitstreamStrategy, 'cached')
+    displayName: Display synthesis & implementation logs
 - publish: "$(Build.ArtifactStagingDirectory)/build-bin.tar"
-  artifact: partial-build-bin-$(System.PhaseName)
+  ${{ if parameters.bin_name }}:
+    artifact: partial-build-bin-$(System.PhaseName)
+  ${{ else }}:
+    artifact: partial-build-bin-${{ parameters.bin_name }}
+  condition: or(eq(variables.bitstreamStrategy, 'cached'), eq(${{ parameters.do_build }}, true))
   displayName: Upload step outputs
 - publish: "$(Build.ArtifactStagingDirectory)"
   artifact: chip_${{ parameters.top_name }}_cw310-build-out

--- a/ci/scripts/get-bitstream-strategy.sh
+++ b/ci/scripts/get-bitstream-strategy.sh
@@ -63,3 +63,4 @@ fi
 echo
 echo "Bitstream strategy is ${bitstream_strategy}"
 echo "##vso[task.setvariable variable=bitstreamStrategy]${bitstream_strategy}"
+echo "##vso[task.setvariable variable=bitstreamStrategy;isOutput=true]${bitstream_strategy}"


### PR DESCRIPTION
With this commit, the bitstream jobs will now only use the EDA pool if they need to build a bitstream. If the bitstream can be downloaded from the cache, then the download will use a normal runners which avoids waiting uselessly for an EDA machine.

My suggestion is to only convert the CW340 job first, make sure that it works over a week and then convert the other jobs. Any thoughts?

**Comments welcome but note that this is a WIP!**