### PR TITLE
[boot_services] Add functional tests for the OTBN boot services library.

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -483,6 +483,29 @@ cc_library(
     ],
 )
 
+opentitan_test(
+    name = "otbn_boot_services_functest",
+    srcs = ["otbn_boot_services_functest.c"],
+    broken = cw310_params(tags = ["broken"]),
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+        },
+    ),
+    # This target uses OTBN pointers internally, so it cannot work host-side.
+    deps = [
+        ":otbn_boot_services",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/testing:keymgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
+        "//sw/otbn/crypto:boot",
+    ],
+)
+
 cc_library(
     name = "xmodem",
     srcs = ["xmodem.c"],

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -98,7 +98,7 @@ static rom_error_t load_attestation_keygen_seed(
                           });
 
   // Read seed from flash info page.
-  uint32_t seed_flash_offset = 0 + (additional_seed * kAttestationSeedWords);
+  uint32_t seed_flash_offset = 0 + (additional_seed * kAttestationSeedBytes);
   rom_error_t err =
       flash_ctrl_info_read(&kFlashCtrlInfoPageAttestationKeySeeds,
                            seed_flash_offset, kAttestationSeedWords, seed);

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -12,6 +12,8 @@
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/otbn.h"
 
+#include "otbn_regs.h"  // Generated.
+
 static_assert(kAttestationSeedWords <= 16,
               "Additional attestation seed needs must be <= 516 bits.");
 
@@ -205,7 +207,24 @@ rom_error_t otbn_boot_attestation_key_save(
 }
 
 rom_error_t otbn_boot_attestation_key_clear(void) {
-  return otbn_dmem_sec_wipe();
+  // Trigger a full DMEM wipe.
+  RETURN_IF_ERROR(otbn_dmem_sec_wipe());
+  HARDENED_RETURN_IF_ERROR(otbn_busy_wait_for_done());
+
+  // Re-load the data portion of the boot services app. This is like a
+  // stripped-down version of `otbn_load_app`, where we skip the IMEM.
+  if (kOtbnAppBoot.dmem_data_end < kOtbnAppBoot.dmem_data_start) {
+    return kErrorOtbnInvalidArgument;
+  }
+  HARDENED_CHECK_GE(kOtbnAppBoot.dmem_data_end, kOtbnAppBoot.dmem_data_start);
+  const size_t data_num_words =
+      (size_t)(kOtbnAppBoot.dmem_data_end - kOtbnAppBoot.dmem_data_start);
+  if (data_num_words > 0) {
+    HARDENED_RETURN_IF_ERROR(
+        otbn_dmem_write(data_num_words, kOtbnAppBoot.dmem_data_start,
+                        kOtbnAppBoot.dmem_data_start_addr));
+  }
+  return kErrorOk;
 }
 
 rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -98,6 +98,10 @@ rom_error_t otbn_boot_attestation_key_clear(void);
  * caller should hash the certificate with SHA-256 before calling this
  * function.
  *
+ * Note that the digest gets interpreted by OTBN in little-endian order. If the
+ * HMAC block has not been set to produce little-endian digests, then the
+ * digest bytes should be reversed before they are passed here.
+ *
  * Expects the OTBN boot-services program to already be loaded; see
  * `otbn_boot_app_load`.
  *

--- a/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
@@ -1,0 +1,321 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/keymgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Keymgr handle for this test.
+static dif_keymgr_t keymgr;
+
+// sw/device/silicon_creator/rom/keys/fake/test_key_0_rsa_3072_exp_f4.public.der
+static const sigverify_rsa_key_t kRsaKey = {
+    .n = {{
+        0x5801a2bd, 0xeff64a46, 0xc8cf2251, 0xa7cd62cb, 0x634a39c2, 0x55c936d3,
+        0x463d61fc, 0x762ebbaa, 0x01aadfb2, 0x23da15d1, 0x8475fdc6, 0x4ec67b7b,
+        0xe9364570, 0xd23ec7c7, 0x98038d63, 0x5688a56b, 0x68037add, 0xb20ff289,
+        0x9d96c1ce, 0xbac0b8cd, 0xead33d0b, 0x195f89c8, 0xd7dc110e, 0xf5bccc12,
+        0x8dfa33dc, 0xedc404d2, 0x74ef8524, 0x9197c0c8, 0x79cc448e, 0x4c9c505d,
+        0x4a586ad7, 0xe2d0f071, 0x589f28c2, 0x2ca7fc22, 0x0354b0e2, 0xefb63b44,
+        0x33a75b04, 0x9e194454, 0x1b4b2cde, 0x8e3f78e0, 0x5260877c, 0x05685b72,
+        0x4868ad4e, 0x10303ac9, 0x05ac2411, 0x5e797381, 0xd5407668, 0xe3522348,
+        0xa33134f8, 0x38f7a953, 0xd926f672, 0x136f6753, 0xb186b0ab, 0x5ccab586,
+        0x61e5bf2e, 0x9fc0eebb, 0x788ed0bd, 0x47b5fc70, 0xf971262a, 0x3b40d99b,
+        0x5b9fd926, 0xce3c93bf, 0xd406005e, 0x72b9e555, 0xc9b9273e, 0xfcef747f,
+        0xf0a35598, 0x2761e8f6, 0xec1799df, 0x462bc52d, 0x8e47218b, 0x429ccdae,
+        0xe7e7d66c, 0x70c70b03, 0x0356c3d2, 0x3cb3e7d1, 0xd42d035d, 0x83c529a3,
+        0x8df9930e, 0xb082e1f0, 0x07509c30, 0x5c33a350, 0x4f6884b9, 0x7b9d2de0,
+        0x0f1d16b3, 0x38dbcf55, 0x168580ea, 0xc2f2aca4, 0x43f0ae60, 0x227dd2ed,
+        0xd8dc61f4, 0x9404e8bc, 0x0db76fe3, 0x3491d3b0, 0x6ca44e27, 0xcda63719,
+    }},
+    .n0_inv =
+        {
+            0x9c9a176b,
+            0x44d6fa52,
+            0x71a63ec4,
+            0xadc94595,
+            0x3fd9bc73,
+            0xa83cdc95,
+            0xbe1bc819,
+            0x2b421fae,
+        },
+};
+
+// Signature for "test message".
+static const sigverify_rsa_buffer_t kRsaSignature = {
+    .data = {
+        0x725bfa2c, 0xdb359e00, 0x4dd50e25, 0x344ce68a, 0x2d49dc6b, 0x4a53a013,
+        0x2abd4a7c, 0x762dd4aa, 0xe1935a41, 0xb807b2c2, 0xdf0222d7, 0x2dc12fdf,
+        0xe432fb54, 0x2a12e15d, 0xf290eb01, 0x2529d6d4, 0x0813ab70, 0x78bd8229,
+        0x63f3064e, 0x1cceba14, 0x4beff42b, 0xb9e98de4, 0x84a7f442, 0xb03649bc,
+        0x7726af3d, 0xeaf2656d, 0xf82f963b, 0x31082a3d, 0x194ff701, 0x86588b75,
+        0x5732f5de, 0x35d14195, 0x262c612d, 0x3f66ce59, 0xa2742c75, 0x276341fb,
+        0x8cb84d0a, 0x1222f7f6, 0xbbd8ec56, 0x36e629b1, 0x891fd231, 0xfb351d0c,
+        0x598dab98, 0x64534c32, 0xbcc39e4c, 0x256e4544, 0x3a3205ab, 0x02c5878c,
+        0x99a7e70a, 0xc65c4d5d, 0xe5bedc24, 0x83de5d15, 0x16429111, 0x05d0b216,
+        0xbf8d4dfe, 0x4be3707f, 0x004d6b75, 0xd64b4c66, 0x6e9e4375, 0xa5e1fc9f,
+        0x4ca3c8f2, 0x544cf3d2, 0x34767ef2, 0xc361639c, 0x6062f836, 0x558ebb62,
+        0xec7ee0af, 0x11033e71, 0x873742d3, 0x0ad49285, 0x6f163385, 0xd880305f,
+        0x76e79003, 0x2bd4c955, 0x4a00fd2a, 0x7a045dd4, 0xdf671f3f, 0xd986e081,
+        0x96cfc193, 0xd211ece5, 0x4486f7cb, 0x47be12f5, 0xe513619c, 0xe1a5f41c,
+        0xbc4fbcb3, 0x78b903b7, 0xc8dcbff8, 0x5c088a19, 0x66301acc, 0x12b05bf9,
+        0xa9c795a9, 0xe229e3ca, 0xe928d10b, 0x96eda9d9, 0x162f4a58, 0x069b950c,
+    }};
+
+// Expected encoded message = (sig ^ 65537) mod N.
+static const sigverify_rsa_buffer_t kRsaExpEncodedMessage = {
+    .data = {
+        0x05468728, 0x3ed0c5ca, 0x025d4fda, 0xcfa3e704, 0x507ce0d8, 0xecb616f6,
+        0xa0a4a460, 0x3f0a377b, 0x05000420, 0x03040201, 0x86480165, 0x0d060960,
+        0x00303130, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0x0001ffff,
+    }};
+
+// Sample key manager diversification data for testing.
+static const keymgr_diversification_t kDiversification = {
+    .salt = {0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f, 0xf0f1f2f3,
+             0xf4f5f6f7, 0xf8f9fafb, 0xfcfdfeff},
+    .version = 0,
+};
+
+// Test values for attestation key seeds.
+static const uint32_t kSeedValues[3][kAttestationSeedWords] = {
+    {
+        0x70717273,
+        0x74757677,
+        0x78797a7b,
+        0x7c7d7e7f,
+        0x80818283,
+        0x84858687,
+        0x88898a8b,
+        0x8c8d8e8f,
+        0x90b1b2b3,
+        0x94959697,
+    },
+    {
+        0xa0a1a2a3,
+        0xa4a5a6a7,
+        0xa8a9aaab,
+        0xacadaeaf,
+        0xb0b1b2b3,
+        0xb4b5b6b7,
+        0xb8b9babb,
+        0xbcbdbebf,
+        0xc0b1b2b3,
+        0xc4c5c6c7,
+    },
+    {
+        0xd0d1d2d3,
+        0xd4d5d6d7,
+        0xd8d9dadb,
+        0xdcdddedf,
+        0xe0e1e2e3,
+        0xe4e5e6e7,
+        0xe8e9eaeb,
+        0xecedeeef,
+        0xf0b1b2b3,
+        0xf4f5f6f7,
+    },
+};
+
+// Message to sign for endorsement tests.
+const char kEndorseTestMessage[] = "Test message.";
+const size_t kEndorseTestMessageLen = sizeof(kEndorseTestMessage) - 1;
+
+rom_error_t modexp_test(void) {
+  sigverify_rsa_buffer_t encoded_message;
+  RETURN_IF_ERROR(
+      otbn_boot_sigverify_mod_exp(&kRsaKey, &kRsaSignature, &encoded_message));
+  CHECK_ARRAYS_EQ(encoded_message.data, kRsaExpEncodedMessage.data,
+                  ARRAYSIZE(kRsaExpEncodedMessage.data));
+  return kErrorOk;
+}
+
+rom_error_t attestation_keygen_test(void) {
+  // Check that key generations with different seeds result in different keys.
+  attestation_public_key_t pk_uds;
+  RETURN_IF_ERROR(otbn_boot_attestation_keygen(kUdsAttestationKeySeed,
+                                               kDiversification, &pk_uds));
+  attestation_public_key_t pk_cdi0;
+  RETURN_IF_ERROR(otbn_boot_attestation_keygen(kCdi0AttestationKeySeed,
+                                               kDiversification, &pk_cdi0));
+  attestation_public_key_t pk_cdi1;
+  RETURN_IF_ERROR(otbn_boot_attestation_keygen(kCdi1AttestationKeySeed,
+                                               kDiversification, &pk_cdi1));
+  CHECK_ARRAYS_NE((unsigned char *)&pk_uds, (unsigned char *)&pk_cdi0,
+                  sizeof(pk_uds));
+  CHECK_ARRAYS_NE((unsigned char *)&pk_uds, (unsigned char *)&pk_cdi1,
+                  sizeof(pk_uds));
+  CHECK_ARRAYS_NE((unsigned char *)&pk_cdi0, (unsigned char *)&pk_cdi1,
+                  sizeof(pk_uds));
+
+  // Check that running the same key generation twice results in the same key.
+  attestation_public_key_t pk_uds_again;
+  RETURN_IF_ERROR(otbn_boot_attestation_keygen(
+      kUdsAttestationKeySeed, kDiversification, &pk_uds_again));
+  CHECK_ARRAYS_EQ((unsigned char *)&pk_uds_again, (unsigned char *)&pk_uds,
+                  sizeof(pk_uds));
+
+  // Check that key generations with different diversification result in
+  // different keys.
+  keymgr_diversification_t diversification_modified;
+  memcpy(&diversification_modified, &kDiversification,
+         sizeof(diversification_modified));
+  diversification_modified.salt[0] ^= 1;
+  attestation_public_key_t pk_uds_div;
+  RETURN_IF_ERROR(otbn_boot_attestation_keygen(
+      kUdsAttestationKeySeed, diversification_modified, &pk_uds_div));
+  CHECK_ARRAYS_NE((unsigned char *)&pk_uds_div, (unsigned char *)&pk_uds,
+                  sizeof(pk_uds));
+  return kErrorOk;
+}
+
+rom_error_t attestation_advance_and_endorse_test(void) {
+  // Generate and save the a keypair.
+  attestation_public_key_t pk;
+  RETURN_IF_ERROR(otbn_boot_attestation_keygen(kUdsAttestationKeySeed,
+                                               kDiversification, &pk));
+  RETURN_IF_ERROR(
+      otbn_boot_attestation_key_save(kUdsAttestationKeySeed, kDiversification));
+
+  // Advance keymgr to the next stage.
+  CHECK_STATUS_OK(
+      keymgr_testutils_check_state(&keymgr, kDifKeymgrStateCreatorRootKey));
+  CHECK_STATUS_OK(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
+
+  // Run endorsement (should overwrite the key with randomness when done).
+  hmac_digest_t digest;
+  hmac_sha256(kEndorseTestMessage, kEndorseTestMessageLen, &digest);
+  attestation_signature_t sig;
+  RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
+
+  // TODO: run an ECDSA signature verification here once we have code for that.
+  // For now, just log the key and signature so we can check offline.
+  LOG_INFO("x = 0x%08x%08x%08x%08x%08x%08x%08x%08x", pk.x[7], pk.x[6], pk.x[5],
+           pk.x[4], pk.x[3], pk.x[2], pk.x[1], pk.x[0]);
+  LOG_INFO("y = 0x%08x%08x%08x%08x%08x%08x%08x%08x", pk.y[7], pk.y[6], pk.y[5],
+           pk.y[4], pk.y[3], pk.y[2], pk.y[1], pk.y[0]);
+  LOG_INFO("digest = 0x%08x%08x%08x%08x%08x%08x%08x%08x", digest.digest[7],
+           digest.digest[6], digest.digest[5], digest.digest[4],
+           digest.digest[3], digest.digest[2], digest.digest[1],
+           digest.digest[0]);
+  LOG_INFO("Signature (expected valid):");
+  LOG_INFO("r = 0x%08x%08x%08x%08x%08x%08x%08x%08x", sig.r[7], sig.r[6],
+           sig.r[5], sig.r[4], sig.r[3], sig.r[2], sig.r[1], sig.r[0]);
+  LOG_INFO("s = 0x%08x%08x%08x%08x%08x%08x%08x%08x", sig.s[7], sig.s[6],
+           sig.s[5], sig.s[4], sig.s[3], sig.s[2], sig.s[1], sig.s[0]);
+
+  // Run endorsement again (should not return an error, but should produce an
+  // invalid signature).
+  RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
+
+  // TODO: run an ECDSA signature verification here once we have code for that.
+  LOG_INFO("Signature (expected invalid):");
+  LOG_INFO("r = 0x%08x%08x%08x%08x%08x%08x%08x%08x", sig.r[7], sig.r[6],
+           sig.r[5], sig.r[4], sig.r[3], sig.r[2], sig.r[1], sig.r[0]);
+  LOG_INFO("s = 0x%08x%08x%08x%08x%08x%08x%08x%08x", sig.s[7], sig.s[6],
+           sig.s[5], sig.s[4], sig.s[3], sig.s[2], sig.s[1], sig.s[0]);
+
+  return kErrorOk;
+}
+
+// N.B. This test will lock OTBN, so it needs to be the last test that runs.
+rom_error_t attestation_save_clear_key_test(void) {
+  // Save and then clear a private key.
+  RETURN_IF_ERROR(
+      otbn_boot_attestation_key_save(kUdsAttestationKeySeed, kDiversification));
+  RETURN_IF_ERROR(otbn_boot_attestation_key_clear());
+
+  // Save the private key again and check that endorsing succeeds.
+  RETURN_IF_ERROR(
+      otbn_boot_attestation_key_save(kUdsAttestationKeySeed, kDiversification));
+  hmac_digest_t digest;
+  hmac_sha256(kEndorseTestMessage, kEndorseTestMessageLen, &digest);
+  attestation_signature_t sig;
+  RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
+
+  // Clear the key and check that endorsing now fails (it should even lock
+  // OTBN).
+  RETURN_IF_ERROR(otbn_boot_attestation_key_clear());
+  hmac_sha256(kEndorseTestMessage, kEndorseTestMessageLen, &digest);
+  CHECK(otbn_boot_attestation_endorse(&digest, &sig) ==
+        kErrorOtbnExecutionFailed);
+  return kErrorOk;
+}
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+
+  // Initialize the entropy complex, KMAC, and the key manager.
+  CHECK_STATUS_OK(entropy_complex_init());
+  dif_kmac_t kmac;
+  CHECK_STATUS_OK(keymgr_testutils_startup(&keymgr, &kmac));
+  CHECK_STATUS_OK(
+      keymgr_testutils_check_state(&keymgr, kDifKeymgrStateCreatorRootKey));
+
+  // Initialize flash.
+  dif_flash_ctrl_state_t flash_ctrl;
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash_ctrl,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+  CHECK_STATUS_OK(flash_ctrl_testutils_wait_for_init(&flash_ctrl));
+
+  // Program the attestation key seeds in flash. The setup step only needs to
+  // be done once, since the seeds are on the same page.
+  flash_info_field_t seed_fields[] = {
+      kFlashInfoFieldUdsAttestationKeySeed,
+      kFlashInfoFieldCdi0AttestationKeySeed,
+      kFlashInfoFieldCdi1AttestationKeySeed,
+  };
+  uint32_t page_address = 0;
+  CHECK_STATUS_OK(flash_ctrl_testutils_info_region_scrambled_setup(
+      &flash_ctrl, seed_fields[0].page, seed_fields[0].bank,
+      seed_fields[0].partition, &page_address));
+  CHECK_STATUS_OK(flash_ctrl_testutils_erase_and_write_page(
+      &flash_ctrl, page_address, seed_fields[0].partition, kSeedValues[0],
+      kDifFlashCtrlPartitionTypeInfo, kAttestationSeedWords));
+  CHECK(ARRAYSIZE(seed_fields) == ARRAYSIZE(kSeedValues));
+  for (size_t i = 1; i < ARRAYSIZE(seed_fields); i++) {
+    CHECK(seed_fields[i].page == seed_fields[i - 1].page);
+    CHECK(seed_fields[i].bank == seed_fields[i - 1].bank);
+    CHECK(seed_fields[i].partition == seed_fields[i - 1].partition);
+    CHECK_STATUS_OK(flash_ctrl_testutils_write(
+        &flash_ctrl, page_address + seed_fields[i].byte_offset,
+        seed_fields[i].partition, kSeedValues[i],
+        kDifFlashCtrlPartitionTypeInfo, kAttestationSeedWords));
+  }
+
+  // Load the boot services OTBN app.
+  CHECK(otbn_boot_app_load() == kErrorOk);
+
+  EXECUTE_TEST(result, modexp_test);
+  EXECUTE_TEST(result, attestation_keygen_test);
+  EXECUTE_TEST(result, attestation_advance_and_endorse_test);
+  EXECUTE_TEST(result, attestation_save_clear_key_test);
+
+  return status_ok(result);
+}

--- a/sw/otbn/crypto/boot.s
+++ b/sw/otbn/crypto/boot.s
@@ -99,7 +99,7 @@ start:
  * Assumes that the Montgomery constant m0_inv is provided, but computes the RR
  * constant on the fly. The only exponent supported is e=65537.
  *
- * @param[in] dmem[rsa_mod]: Modulus of the RSA public key
+ * @param[in] dmem[in_mod]: Modulus of the RSA public key
  * @param[in] dmem[rsa_inout]: Signature to check against
  * @param[in] dmem[m0inv]: Montgomery constant (-(M^-1)) mod 2^256
  * @param[out] dmem[rsa_inout]: Recovered message digest
@@ -109,9 +109,9 @@ sec_boot_modexp:
   jal      x1, compute_rr
 
   /* Set pointers to buffers for modexp. */
-  la        x24, rsa_inout
-  la        x16, rsa_mod
-  la        x23, rsa_inout
+  la        x24, rsa_out
+  la        x16, in_mod
+  la        x23, rsa_in
   la        x26, rr
   la        x17, m0inv
 
@@ -284,24 +284,28 @@ mode:
 .zero 4
 
 /* Input buffer for RSA-3072 modulus. */
-.globl rsa_mod
+.globl in_mod
 .balign 32
-rsa_mod:
+in_mod:
 .zero 384
 
 /* Input buffer for precomputed RSA-3072 Montgomery constant:
       m0' = (- M) mod 2^256. */
-.globl rsa_m0inv
+.globl m0inv
 .balign 32
-rsa_m0inv:
+m0inv:
 .zero 32
 
-/* Input/output buffer for RSA-3072 modexp:
-     input: signature
-     output: recovered message = (signature ^ 65537) mod M */
-.globl rsa_inout
+/* Input buffer for RSA-3072 modexp: holds the signature. */
+.globl rsa_in
 .balign 32
-rsa_inout:
+rsa_in:
+.zero 384
+
+/* Output buffer for RSA-3072 modexp: holds the recovered message. */
+.globl rsa_out
+.balign 32
+rsa_out:
 .zero 384
 
 /* Input buffer for an ECDSA-P256 message digest. */

--- a/sw/otbn/crypto/boot.s
+++ b/sw/otbn/crypto/boot.s
@@ -143,6 +143,10 @@ attestation_keygen:
 
   /* Call scalar multiplication with base point.
      R = (x_p, y_p, z_p) = (w8, w9, w10) <= d*G */
+  bn.mov    w0, w20
+  bn.mov    w2, w10
+  bn.mov    w1, w21
+  bn.mov    w3, w11
   la        x21, p256_gx
   la        x22, p256_gy
   jal       x1, scalar_mult_int
@@ -265,10 +269,10 @@ attestation_secret_key_from_seed:
        w20, w21 <= seed0 ^ dmem[attestation_additional_seed] */
   la       x2, attestation_additional_seed
   li       x3, 22
-  bn.xor   w20, w20, w22
   bn.lid   x3++, 0(x2)
-  bn.xor   w21, w21, w23
+  bn.xor   w20, w20, w22
   bn.lid   x3, 32(x2)
+  bn.xor   w21, w21, w23
 
   /* Tail-call `p256_key_from_seed` to generate secret key shares.
        w20, w21 <= d0

--- a/sw/otbn/crypto/p256_sign.s
+++ b/sw/otbn/crypto/p256_sign.s
@@ -56,10 +56,10 @@
  * @param[in]  dmem[k0]:  first share of secret scalar (320 bits)
  * @param[in]  dmem[k1]:  second share of secret scalar (320 bits)
  * @param[in]  dmem[msg]: message to be signed (256 bits)
- * @param[in]  dmem[r]:   dmem buffer for r component of signature (256 bits)
- * @param[in]  dmem[s]:   dmem buffer for s component of signature (256 bits)
  * @param[in]  dmem[d0]:  first share of private key d (320 bits)
  * @param[in]  dmem[d1]:  second share of private key d (320 bits)
+ * @param[out] dmem[r]:   dmem buffer for r component of signature (256 bits)
+ * @param[out] dmem[s]:   dmem buffer for s component of signature (256 bits)
  *
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.


### PR DESCRIPTION
These tests caught a few bugs and places where comments were needed; the first commits fix bugs and the last commit adds the test code.

Thanks to @ballifatih for finding one bug in the OTBN code, which brought to my attention that we were missing tests for this! Once I started writing them I found more, so it's really good that this came up.