### PR TITLE
[vendor/pulp_riscv_dbg] Update to pulp-platform/riscv-dbg@358f901

### DIFF
--- a/hw/vendor/pulp_riscv_dbg.lock.hjson
+++ b/hw/vendor/pulp_riscv_dbg.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/riscv-dbg
-    rev: 138d74bcaa90c70180c12215db3776813d2a95f2
+    rev: 358f90110220adf7a083f8b65d157e836d706236
   }
 }

--- a/hw/vendor/pulp_riscv_dbg/CHANGELOG.md
+++ b/hw/vendor/pulp_riscv_dbg/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.8.1] - 2023-10-01
+### Changed
+- debug_rom: Add rst
+
 ## [0.8.0] - 2023-04-05
 ### Fixed
 - dm_csrs: Fix W1C behavior of `sberror` (#155) [@andreaskurth](https://github.com/andreaskurth)

--- a/hw/vendor/pulp_riscv_dbg/debug_rom/debug_rom.sv
+++ b/hw/vendor/pulp_riscv_dbg/debug_rom/debug_rom.sv
@@ -16,6 +16,7 @@
 // Auto-generated code
 module debug_rom (
   input  logic         clk_i,
+  input  logic         rst_ni,
   input  logic         req_i,
   input  logic [63:0]  addr_i,
   output logic [63:0]  rdata_o
@@ -47,11 +48,15 @@ module debug_rom (
     64'h00000013_0180006f
   };
 
-  logic [$clog2(RomSize)-1:0] addr_q;
+  logic [$clog2(RomSize)-1:0] addr_d, addr_q;
 
-  always_ff @(posedge clk_i) begin
-    if (req_i) begin
-      addr_q <= addr_i[$clog2(RomSize)-1+3:3];
+  assign addr_d = req_i ? addr_i[$clog2(RomSize)-1+3:3] : addr_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      addr_q <= '0;
+    end else begin
+      addr_q <= addr_d;
     end
   end
 

--- a/hw/vendor/pulp_riscv_dbg/debug_rom/debug_rom_one_scratch.sv
+++ b/hw/vendor/pulp_riscv_dbg/debug_rom/debug_rom_one_scratch.sv
@@ -16,6 +16,7 @@
 // Auto-generated code
 module debug_rom_one_scratch (
   input  logic         clk_i,
+  input  logic         rst_ni,
   input  logic         req_i,
   input  logic [63:0]  addr_i,
   output logic [63:0]  rdata_o
@@ -41,11 +42,15 @@ module debug_rom_one_scratch (
     64'h00000013_0180006f
   };
 
-  logic [$clog2(RomSize)-1:0] addr_q;
+  logic [$clog2(RomSize)-1:0] addr_d, addr_q;
 
-  always_ff @(posedge clk_i) begin
-    if (req_i) begin
-      addr_q <= addr_i[$clog2(RomSize)-1+3:3];
+  assign addr_d = req_i ? addr_i[$clog2(RomSize)-1+3:3] : addr_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      addr_q <= '0;
+    end else begin
+      addr_q <= addr_d;
     end
   end
 

--- a/hw/vendor/pulp_riscv_dbg/debug_rom/gen_rom.py
+++ b/hw/vendor/pulp_riscv_dbg/debug_rom/gen_rom.py
@@ -43,6 +43,7 @@ license = """\
 module = """\
 module $filename (
   input  logic         clk_i,
+  input  logic         rst_ni,
   input  logic         req_i,
   input  logic [63:0]  addr_i,
   output logic [63:0]  rdata_o
@@ -55,11 +56,15 @@ module $filename (
 $content
   };
 
-  logic [$$clog2(RomSize)-1:0] addr_q;
+  logic [$$clog2(RomSize)-1:0] addr_d, addr_q;
 
-  always_ff @(posedge clk_i) begin
-    if (req_i) begin
-      addr_q <= addr_i[$$clog2(RomSize)-1+3:3];
+  assign addr_d = req_i ? addr_i[$$clog2(RomSize)-1+3:3] : addr_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      addr_q <= '0;
+    end else begin
+      addr_q <= addr_d;
     end
   end
 

--- a/hw/vendor/pulp_riscv_dbg/src/dm_mem.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_mem.sv
@@ -562,6 +562,7 @@ module dm_mem #(
   if (HasSndScratch) begin : gen_rom_snd_scratch
     debug_rom i_debug_rom (
       .clk_i,
+      .rst_ni,
       .req_i,
       .addr_i  ( rom_addr  ),
       .rdata_o ( rom_rdata )
@@ -572,6 +573,7 @@ module dm_mem #(
     // be saved.
     debug_rom_one_scratch i_debug_rom (
       .clk_i,
+      .rst_ni,
       .req_i,
       .addr_i  ( rom_addr  ),
       .rdata_o ( rom_rdata )

--- a/hw/vendor/pulp_riscv_dbg/src/dmi_jtag.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dmi_jtag.sv
@@ -17,7 +17,7 @@
 */
 
 module dmi_jtag #(
-  parameter logic [31:0] IdcodeValue = 32'h00000001
+  parameter logic [31:0] IdcodeValue = 32'h00000DB3
 ) (
   input  logic         clk_i,      // DMI Clock
   input  logic         rst_ni,     // Asynchronous reset active low


### PR DESCRIPTION
This updates `hw/vendor/pulp_riscv_dbg` (i.e., the RISC-V debug module instantiated within `rv_dm`) to the latest upstream commit ahead of the upcoming M2 milestone, thus resolves #21715. The main RTL change that this brings is https://github.com/pulp-platform/riscv-dbg/commit/5024399a48b61527b03e89a532c7530da28e7477, which makes the `addr_q` FFs in the `debug_rom` module resettable. Not a fix to a critical problem for us, but still nice to have. The other RTL change (https://github.com/pulp-platform/riscv-dbg/commit/73260e7fb608041d89771971793af5ba1ee209b8) changes the default value of `dmi_jtag`'s `IdcodeValue` parameter, but this doesn't affect us because we assign it to the value we need when we instantiate it in `rv_dm`.