### PR TITLE
[entropy_src/rtl] Commit for draft PR to avoid dropping entropy

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -122,6 +122,14 @@
                 ''',
       local:   "true"
     },
+    { name:    "DistrFifoDepth",
+      type:    "int unsigned",
+      default: "4",
+      desc:    '''
+                Number of 32-bit entries in the distribution FIFO.
+                ''',
+      local:   "true"
+    },
   ]
   alert_list: [
     { name: "recov_alert",

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -8,6 +8,7 @@ package entropy_src_reg_pkg;
 
   // Param list
   parameter int unsigned ObserveFifoDepth = 64;
+  parameter int unsigned DistrFifoDepth = 4;
   parameter int NumAlerts = 2;
 
   // Address widths within the block


### PR DESCRIPTION
This is the current state of my RTL changes for [#21686](https://github.com/lowRISC/opentitan/issues/21686)
I was able to debug a large chunk of the failing tests but still about 1/5th of the regression fails.

I had to stop while debugging the test below.
The following test fails because the sequence writes to the fw_ov_wr_data reg even though fw_ov_wr_fifo_full is full:
util/dvsim/dvsim.py hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson -i entropy_src_fw_ov -t xcelium --fixed-seed 55095640729099943722273460453939721134202472978342136591142230062072933862139 --waves shm