### PR TITLE
[rv_plic] Add SEC_CM assertion and fill out checklist

### DIFF
--- a/hw/ip_templates/rv_plic/doc/checklist.md
+++ b/hw/ip_templates/rv_plic/doc/checklist.md
@@ -217,11 +217,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_PROVEN][]                   | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Waived      | Waived since only 1 standard sec_cm - bus integrity.
+Tests         | [FPV_SEC_CM_PROVEN][]                   | Done        | The bus integrity cm has been proven formally.
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | N/A         | This module only has an FPV testbench.
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | N/A         | This module only has an FPV testbench.
+Review        | [SEC_CM_DV_REVIEWED][]                  | Waived      | Waived since only 1 standard sec_cm - bus integrity.
 
 [SEC_CM_TESTPLAN_COMPLETED]:  ../../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
 [FPV_SEC_CM_PROVEN]:          ../../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_proven

--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -253,6 +253,12 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   // Assume
   `ASSUME(Irq0Tied_A, intr_src_i[0] == 1'b0)
 
+ // RV_PLIC does not have a block-level DV environment, hence we add an FPV assertion to test this.
+  `ASSERT(FpvSecCmBusIntegrity_A,
+          $rose(u_reg.intg_err)
+          |->
+          ${'##'}[0:`_SEC_CM_ALERT_MAX_CYC] (alert_tx_o[0].alert_p))
+
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])
 endmodule

--- a/hw/top_earlgrey/ip_autogen/rv_plic/doc/checklist.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/doc/checklist.md
@@ -217,11 +217,11 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Not Started |
-Tests         | [FPV_SEC_CM_PROVEN][]                   | Not Started |
-Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Not Started |
-Review        | [SEC_CM_DV_REVIEWED][]                  | Not Started |
+Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Waived      | Waived since only 1 standard sec_cm - bus integrity.
+Tests         | [FPV_SEC_CM_PROVEN][]                   | Done        | The bus integrity cm has been proven formally.
+Tests         | [SIM_SEC_CM_VERIFIED][]                 | N/A         | This module only has an FPV testbench.
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | N/A         | This module only has an FPV testbench.
+Review        | [SEC_CM_DV_REVIEWED][]                  | Waived      | Waived since only 1 standard sec_cm - bus integrity.
 
 [SEC_CM_TESTPLAN_COMPLETED]:  ../../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed
 [FPV_SEC_CM_PROVEN]:          ../../../../../doc/project_governance/checklist/README.md#fpv_sec_cm_proven

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -424,6 +424,12 @@ module rv_plic import rv_plic_reg_pkg::*; #(
   // Assume
   `ASSUME(Irq0Tied_A, intr_src_i[0] == 1'b0)
 
+ // RV_PLIC does not have a block-level DV environment, hence we add an FPV assertion to test this.
+  `ASSERT(FpvSecCmBusIntegrity_A,
+          $rose(u_reg.intg_err)
+          |->
+          ##[0:`_SEC_CM_ALERT_MAX_CYC] (alert_tx_o[0].alert_p))
+
   // Alert assertions for reg_we onehot check
   `ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegWeOnehotCheck_A, u_reg, alert_tx_o[0])
 endmodule


### PR DESCRIPTION
Looks like filling out the checklist got overlooked in the past. 
This patch amends that and adds a missing SVA for the one standardized bus integrity CM in the design.

The SecCm SVAs all pass:
```  
[16]  rv_plic.FpvSecCmBusIntegrity_A                    proven          N      Infinite    1.546 s      
[17]  rv_plic.FpvSecCmBusIntegrity_A:precondition1      covered         Ht            2    0.082 s      
[18]  rv_plic.FpvSecCmRegWeOnehotCheck_A                proven          Hp     Infinite    3.732 s      
[19]  rv_plic.FpvSecCmRegWeOnehotCheck_A:precondition1  covered         Ht           22    0.085 s   
...
|      name      |  pass_rate  |  stimuli_cov  |  coi_cov  |  prove_cov  |
|:--------------:|:-----------:|:-------------:|:---------:|:-----------:|
| rv_plic_sec_cm |  100.00 %   |      N/A      |    N/A    |     N/A     |
```
