### PR TITLE
[i2c] Add `AcqFifoDepth` parameter

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -100,7 +100,10 @@
   ],
   param_list: [
     { name: "FifoDepth",
-      desc: "Depth of FMT, RX, TX, and ACQ FIFOs",
+      desc: '''
+            Depth of FMT, RX, TX, and ACQ FIFOs.
+            The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
+            ''',
       type: "int",
       default: "64",
     }
@@ -388,27 +391,37 @@
         }
       ]
     }
-    { name: "FIFO_STATUS"
-      desc: "I2C FIFO status register"
+    { name: "HOST_FIFO_STATUS"
+      desc: "Host mode FIFO status register"
       swaccess: "ro"
       hwaccess: "hwo"
       hwext: "true"
       fields: [
-        { bits: "6:0"
+        { bits: "11:0"
           name: "FMTLVL"
-          desc: "Current fill level of FMT fifo (Host mode)"
+          desc: "Current fill level of FMT fifo"
         }
-        { bits: "22:16"
+        { bits: "23:12"
           name: "RXLVL"
-          desc: "Current fill level of RX fifo (Host mode)"
+          desc: "Current fill level of RX fifo"
         }
-        { bits: "14:8"
+      ]
+      tags: [// Updated by the hw. Exclude from write-checks.
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
+    }
+    { name: "TARGET_FIFO_STATUS"
+      desc: "Target mode FIFO status register"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwext: "true"
+      fields: [
+        { bits: "11:0"
           name: "TXLVL"
-          desc: "Current fill level of TX fifo (Target mode)"
+          desc: "Current fill level of TX fifo"
         }
-        { bits: "30:24"
+        { bits: "23:12"
           name: "ACQLVL"
-          desc: "Current fill level of ACQ fifo (Target mode)"
+          desc: "Current fill level of ACQ fifo"
         }
       ]
       tags: [// Updated by the hw. Exclude from write-checks.

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -101,11 +101,21 @@
   param_list: [
     { name: "FifoDepth",
       desc: '''
-            Depth of FMT, RX, TX, and ACQ FIFOs.
+            Depth of FMT, RX, and TX FIFOs.
             The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
             ''',
       type: "int",
       default: "64",
+    }
+    { name: "AcqFifoDepth",
+      desc: '''
+            Depth of ACQ FIFO.
+            The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
+            ''',
+      type: int
+      default: "64",
+      local: "false",
+      expose: "true",
     }
   ],
   features: [

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -521,7 +521,7 @@
              Cover the trigger level for FMT_FIFO and RX_FIFO interupts
              * Cross fmt_threshold interrupt with FMT_FIFO trigger level
              * Cross rx_threshold interrupt with RX_FIFO trigger level
-             Cover the FIFO levels in FIFO_STATUS
+             Cover the FIFO levels in HOST_FIFO_STATUS
             '''
     }
     {

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -3,30 +3,31 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/i2c/data/i2c.hjson -->
 ## Summary
 
-| Name                                          | Offset   |   Length | Description                                                                          |
-|:----------------------------------------------|:---------|---------:|:-------------------------------------------------------------------------------------|
-| i2c.[`INTR_STATE`](#intr_state)               | 0x0      |        4 | Interrupt State Register                                                             |
-| i2c.[`INTR_ENABLE`](#intr_enable)             | 0x4      |        4 | Interrupt Enable Register                                                            |
-| i2c.[`INTR_TEST`](#intr_test)                 | 0x8      |        4 | Interrupt Test Register                                                              |
-| i2c.[`ALERT_TEST`](#alert_test)               | 0xc      |        4 | Alert Test Register                                                                  |
-| i2c.[`CTRL`](#ctrl)                           | 0x10     |        4 | I2C Control Register                                                                 |
-| i2c.[`STATUS`](#status)                       | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                   |
-| i2c.[`RDATA`](#rdata)                         | 0x18     |        4 | I2C Read Data                                                                        |
-| i2c.[`FDATA`](#fdata)                         | 0x1c     |        4 | I2C Host Format Data                                                                 |
-| i2c.[`FIFO_CTRL`](#fifo_ctrl)                 | 0x20     |        4 | I2C FIFO control register                                                            |
-| i2c.[`FIFO_STATUS`](#fifo_status)             | 0x24     |        4 | I2C FIFO status register                                                             |
-| i2c.[`OVRD`](#ovrd)                           | 0x28     |        4 | I2C Override Control Register                                                        |
-| i2c.[`VAL`](#val)                             | 0x2c     |        4 | Oversampled RX values                                                                |
-| i2c.[`TIMING0`](#timing0)                     | 0x30     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING1`](#timing1)                     | 0x34     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING2`](#timing2)                     | 0x38     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING3`](#timing3)                     | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
-| i2c.[`TIMING4`](#timing4)                     | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
-| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)           | 0x44     |        4 | I2C clock stretching timeout control                                                 |
-| i2c.[`TARGET_ID`](#target_id)                 | 0x48     |        4 | I2C target address and mask pairs                                                    |
-| i2c.[`ACQDATA`](#acqdata)                     | 0x4c     |        4 | I2C target acquired data                                                             |
-| i2c.[`TXDATA`](#txdata)                       | 0x50     |        4 | I2C target transmit data                                                             |
-| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl) | 0x54     |        4 | I2C host clock generation timeout value (in units of input clock frequency)          |
+| Name                                            | Offset   |   Length | Description                                                                          |
+|:------------------------------------------------|:---------|---------:|:-------------------------------------------------------------------------------------|
+| i2c.[`INTR_STATE`](#intr_state)                 | 0x0      |        4 | Interrupt State Register                                                             |
+| i2c.[`INTR_ENABLE`](#intr_enable)               | 0x4      |        4 | Interrupt Enable Register                                                            |
+| i2c.[`INTR_TEST`](#intr_test)                   | 0x8      |        4 | Interrupt Test Register                                                              |
+| i2c.[`ALERT_TEST`](#alert_test)                 | 0xc      |        4 | Alert Test Register                                                                  |
+| i2c.[`CTRL`](#ctrl)                             | 0x10     |        4 | I2C Control Register                                                                 |
+| i2c.[`STATUS`](#status)                         | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                   |
+| i2c.[`RDATA`](#rdata)                           | 0x18     |        4 | I2C Read Data                                                                        |
+| i2c.[`FDATA`](#fdata)                           | 0x1c     |        4 | I2C Host Format Data                                                                 |
+| i2c.[`FIFO_CTRL`](#fifo_ctrl)                   | 0x20     |        4 | I2C FIFO control register                                                            |
+| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)     | 0x24     |        4 | Host mode FIFO status register                                                       |
+| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status) | 0x28     |        4 | Target mode FIFO status register                                                     |
+| i2c.[`OVRD`](#ovrd)                             | 0x2c     |        4 | I2C Override Control Register                                                        |
+| i2c.[`VAL`](#val)                               | 0x30     |        4 | Oversampled RX values                                                                |
+| i2c.[`TIMING0`](#timing0)                       | 0x34     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
+| i2c.[`TIMING1`](#timing1)                       | 0x38     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
+| i2c.[`TIMING2`](#timing2)                       | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
+| i2c.[`TIMING3`](#timing3)                       | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
+| i2c.[`TIMING4`](#timing4)                       | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
+| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)             | 0x48     |        4 | I2C clock stretching timeout control                                                 |
+| i2c.[`TARGET_ID`](#target_id)                   | 0x4c     |        4 | I2C target address and mask pairs                                                    |
+| i2c.[`ACQDATA`](#acqdata)                       | 0x50     |        4 | I2C target acquired data                                                             |
+| i2c.[`TXDATA`](#txdata)                         | 0x54     |        4 | I2C target transmit data                                                             |
+| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)   | 0x58     |        4 | I2C host clock generation timeout value (in units of input clock frequency)          |
 
 ## INTR_STATE
 Interrupt State Register
@@ -282,32 +283,45 @@ FMT fifo reset. Write 1 to the register resets FMT_FIFO. Read returns 0
 ### FIFO_CTRL . RXRST
 RX fifo reset. Write 1 to the register resets RX_FIFO. Read returns 0
 
-## FIFO_STATUS
-I2C FIFO status register
+## HOST_FIFO_STATUS
+Host mode FIFO status register
 - Offset: `0x24`
 - Reset default: `0x0`
-- Reset mask: `0x7f7f7f7f`
+- Reset mask: `0xffffff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "FMTLVL", "bits": 7, "attr": ["ro"], "rotate": 0}, {"bits": 1}, {"name": "TXLVL", "bits": 7, "attr": ["ro"], "rotate": 0}, {"bits": 1}, {"name": "RXLVL", "bits": 7, "attr": ["ro"], "rotate": 0}, {"bits": 1}, {"name": "ACQLVL", "bits": 7, "attr": ["ro"], "rotate": 0}, {"bits": 1}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "FMTLVL", "bits": 12, "attr": ["ro"], "rotate": 0}, {"name": "RXLVL", "bits": 12, "attr": ["ro"], "rotate": 0}, {"bits": 8}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                  |
-|:------:|:------:|:-------:|:-------|:---------------------------------------------|
-|   31   |        |         |        | Reserved                                     |
-| 30:24  |   ro   |    x    | ACQLVL | Current fill level of ACQ fifo (Target mode) |
-|   23   |        |         |        | Reserved                                     |
-| 22:16  |   ro   |    x    | RXLVL  | Current fill level of RX fifo (Host mode)    |
-|   15   |        |         |        | Reserved                                     |
-|  14:8  |   ro   |    x    | TXLVL  | Current fill level of TX fifo (Target mode)  |
-|   7    |        |         |        | Reserved                                     |
-|  6:0   |   ro   |    x    | FMTLVL | Current fill level of FMT fifo (Host mode)   |
+|  Bits  |  Type  |  Reset  | Name   | Description                    |
+|:------:|:------:|:-------:|:-------|:-------------------------------|
+| 31:24  |        |         |        | Reserved                       |
+| 23:12  |   ro   |    x    | RXLVL  | Current fill level of RX fifo  |
+|  11:0  |   ro   |    x    | FMTLVL | Current fill level of FMT fifo |
+
+## TARGET_FIFO_STATUS
+Target mode FIFO status register
+- Offset: `0x28`
+- Reset default: `0x0`
+- Reset mask: `0xffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "TXLVL", "bits": 12, "attr": ["ro"], "rotate": 0}, {"name": "ACQLVL", "bits": 12, "attr": ["ro"], "rotate": 0}, {"bits": 8}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                    |
+|:------:|:------:|:-------:|:-------|:-------------------------------|
+| 31:24  |        |         |        | Reserved                       |
+| 23:12  |   ro   |    x    | ACQLVL | Current fill level of ACQ fifo |
+|  11:0  |   ro   |    x    | TXLVL  | Current fill level of TX fifo  |
 
 ## OVRD
 I2C Override Control Register
-- Offset: `0x28`
+- Offset: `0x2c`
 - Reset default: `0x0`
 - Reset mask: `0x7`
 
@@ -326,7 +340,7 @@ I2C Override Control Register
 
 ## VAL
 Oversampled RX values
-- Offset: `0x2c`
+- Offset: `0x30`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -345,7 +359,7 @@ Oversampled RX values
 Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
 All values are expressed in units of the input clock period.
 These must be greater than 2 in order for the change in SCL to propagate to the input of the FSM so that acknowledgements are detected correctly.
-- Offset: `0x30`
+- Offset: `0x34`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -363,7 +377,7 @@ These must be greater than 2 in order for the change in SCL to propagate to the 
 ## TIMING1
 Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
 All values are expressed in units of the input clock period.
-- Offset: `0x34`
+- Offset: `0x38`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -381,7 +395,7 @@ All values are expressed in units of the input clock period.
 ## TIMING2
 Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
 All values are expressed in units of the input clock period.
-- Offset: `0x38`
+- Offset: `0x3c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -399,7 +413,7 @@ All values are expressed in units of the input clock period.
 ## TIMING3
 Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
 All values are expressed in units of the input clock period.
-- Offset: `0x3c`
+- Offset: `0x40`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -417,7 +431,7 @@ All values are expressed in units of the input clock period.
 ## TIMING4
 Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
 All values are expressed in units of the input clock period.
-- Offset: `0x40`
+- Offset: `0x44`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -434,7 +448,7 @@ All values are expressed in units of the input clock period.
 
 ## TIMEOUT_CTRL
 I2C clock stretching timeout control
-- Offset: `0x44`
+- Offset: `0x48`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -451,7 +465,7 @@ I2C clock stretching timeout control
 
 ## TARGET_ID
 I2C target address and mask pairs
-- Offset: `0x48`
+- Offset: `0x4c`
 - Reset default: `0x0`
 - Reset mask: `0xfffffff`
 
@@ -471,7 +485,7 @@ I2C target address and mask pairs
 
 ## ACQDATA
 I2C target acquired data
-- Offset: `0x4c`
+- Offset: `0x50`
 - Reset default: `0x0`
 - Reset mask: `0x3ff`
 
@@ -503,7 +517,7 @@ Address for accepted transaction or acquired byte
 
 ## TXDATA
 I2C target transmit data
-- Offset: `0x50`
+- Offset: `0x54`
 - Reset default: `0x0`
 - Reset mask: `0xff`
 
@@ -520,7 +534,7 @@ I2C target transmit data
 
 ## HOST_TIMEOUT_CTRL
 I2C host clock generation timeout value (in units of input clock frequency)
-- Offset: `0x54`
+- Offset: `0x58`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -72,7 +72,10 @@ package i2c_env_pkg;
   parameter uint I2C_FMT_FIFO_DEPTH = i2c_reg_pkg::FifoDepth;
   parameter uint I2C_RX_FIFO_DEPTH  = i2c_reg_pkg::FifoDepth;
   parameter uint I2C_TX_FIFO_DEPTH  = i2c_reg_pkg::FifoDepth;
-  parameter uint I2C_ACQ_FIFO_DEPTH = i2c_reg_pkg::FifoDepth;
+  // The depth of the ACQ FIFO can be different from that of the other FIFOs.  In DV, we use a fixed
+  // value that differs from the `FifoDepth` constant.  Ideally, DV would randomly assign a value
+  // from the range of legal values (with a reasonable distribution).
+  parameter uint I2C_ACQ_FIFO_DEPTH = i2c_reg_pkg::FifoDepth + 32;
 
   // alerts
   parameter uint NUM_ALERTS = i2c_reg_pkg::NumAlerts;

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -199,8 +199,8 @@ class i2c_scoreboard extends cip_base_scoreboard #(
             wait(cfg.intr_vif.pins[TxStretch]);
             wait(cfg.intr_vif.pins[AcqFull]);
           join_any
-          csr_rd(.ptr(ral.fifo_status.acqlvl), .value(acqlvl), .backdoor(UVM_BACKDOOR));
-          csr_rd(.ptr(ral.fifo_status.txlvl), .value(txlvl), .backdoor(UVM_BACKDOOR));
+          csr_rd(.ptr(ral.target_fifo_status.acqlvl), .value(acqlvl), .backdoor(UVM_BACKDOOR));
+          csr_rd(.ptr(ral.target_fifo_status.txlvl), .value(txlvl), .backdoor(UVM_BACKDOOR));
           cov.scl_stretch_cg.sample(
             .host_mode(host_init),
             .intr_stretch_timeout(cfg.intr_vif.pins[StretchTimeout]),
@@ -390,10 +390,10 @@ class i2c_scoreboard extends cip_base_scoreboard #(
               fmt_fifo_data_q.delete();
             end
             cov.fmt_fifo_level_cg.sample(.irq(cfg.intr_vif.pins[FmtThreshold]),
-                                         .fifolvl(`gmv(ral.fifo_status.fmtlvl)),
+                                         .fifolvl(`gmv(ral.host_fifo_status.fmtlvl)),
                                          .rst(fmtrst_val));
             cov.rx_fifo_level_cg.sample(.irq(cfg.intr_vif.pins[RxThreshold]),
-                                        .fifolvl(`gmv(ral.fifo_status.rxlvl)),
+                                        .fifolvl(`gmv(ral.host_fifo_status.rxlvl)),
                                         .rst(rxrst_val));
             cov.fifo_reset_cg.sample(.fmtrst(fmtrst_val),
                                      .rxrst (rxrst_val),
@@ -579,7 +579,8 @@ class i2c_scoreboard extends cip_base_scoreboard #(
           end
         end
 
-        "fifo_status": do_read_check = 1'b0;
+        "host_fifo_status": do_read_check = 1'b0;
+        "target_fifo_status": do_read_check = 1'b0;
 
         "acqdata": begin
           i2c_item obs;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -557,7 +557,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     bit [7:0] abyte;
     bit [1:0] signal;
     csr_rd_check(.ptr(ral.status.acqempty), .compare_value(0));
-    csr_rd(.ptr(ral.fifo_status.acqlvl), .value(acqlvl));
+    csr_rd(.ptr(ral.target_fifo_status.acqlvl), .value(acqlvl));
     `DV_CHECK_EQ(acqlvl, (num_bytes+2)) // addr byte + data bytes + junk byte
     for (int i = 0; i < (num_bytes+2); i++) begin
       csr_rd(.ptr(ral.acqdata), .value({signal,abyte}));
@@ -1153,7 +1153,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     // if fifo is empty.
       csr_rd(.ptr(ral.status.acqempty), .value(acq_fifo_empty));
       read_data = (acq_fifo_empty)? 0 : 1;
-    end else csr_rd(.ptr(ral.fifo_status.acqlvl), .value(read_data));
+    end else csr_rd(.ptr(ral.target_fifo_status.acqlvl), .value(read_data));
 
     repeat(read_data) begin
       // read one entry and compare

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
@@ -17,7 +17,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
   // Number of cycles sequence wait before all of the read states are executed
   parameter uint READ_STATE_WAIT_TIMEOUT_CYCLES = 40;
   // ACQ FIFO size in bytes
-  parameter uint ACQ_FIFO_SIZE = 64;
+  import i2c_env_pkg::I2C_ACQ_FIFO_DEPTH;
   // Period of SCL clock depending on timing parameters
   uint scl_period;
 
@@ -316,7 +316,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
       // Add data items to transaction enter StretchAddr state
       if (addr_states[i] == StretchAddr) begin
         // one transaction for start address and another for stop condition
-        repeat(ACQ_FIFO_SIZE - 2) begin
+        repeat(I2C_ACQ_FIFO_DEPTH - 2) begin
           `uvm_create_obj(i2c_item, req)
           append_data(req, m_i2c_target_seq.req_q);
         end
@@ -331,7 +331,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
         // Add address to the transaction
         `uvm_create_obj(i2c_item, req)
         append_address(req, m_i2c_target_seq.req_q, 1'b0);
-        timeout = (((ACQ_FIFO_SIZE + 2) * 9) + ADDR_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
+        timeout = (((I2C_ACQ_FIFO_DEPTH + 2) * 9) + ADDR_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
       end
       fork
         begin
@@ -397,12 +397,12 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
       append_data(req, m_i2c_target_seq.req_q);
       if (write_states[i] == StretchAcqFull) begin
         // Create ACQ FIFO full condition
-        repeat(ACQ_FIFO_SIZE) begin
+        repeat(I2C_ACQ_FIFO_DEPTH) begin
           `uvm_create_obj(i2c_item, req)
           append_data(req, m_i2c_target_seq.req_q);
         end
         // Each byte requires 9 scl cycles to be transmitted
-        timeout = ((ACQ_FIFO_SIZE * 9)+ WRITE_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
+        timeout = ((I2C_ACQ_FIFO_DEPTH * 9)+ WRITE_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
       end
       fork
           begin

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_full_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_full_vseq.sv
@@ -63,8 +63,8 @@ class i2c_host_fifo_full_vseq extends i2c_rx_tx_vseq;
     fmt_empty = bit'(get_field_val(ral.status.fmtempty, status));
     rx_full   = bit'(get_field_val(ral.status.rxfull, status));
     rx_empty  = bit'(get_field_val(ral.status.rxempty, status));
-    csr_rd(.ptr(ral.fifo_status.fmtlvl), .value(fmt_lvl), .backdoor(1'b1));
-    csr_rd(.ptr(ral.fifo_status.rxlvl), .value(rx_lvl), .backdoor(1'b1));
+    csr_rd(.ptr(ral.host_fifo_status.fmtlvl), .value(fmt_lvl), .backdoor(1'b1));
+    csr_rd(.ptr(ral.host_fifo_status.rxlvl), .value(rx_lvl), .backdoor(1'b1));
     if (!cfg.under_reset) begin
       if (fmt_full)  begin
         `DV_CHECK_EQ(fmt_lvl, I2C_FMT_FIFO_DEPTH);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_reset_fmt_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_reset_fmt_vseq.sv
@@ -50,7 +50,7 @@ class i2c_host_fifo_reset_fmt_vseq extends i2c_rx_tx_vseq;
         end
         program_format_flag(fmt_item, "program_write_data_to_target");
       end // for num wr bytes
-      csr_rd_check(.ptr(ral.fifo_status.fmtlvl), .compare_value(num_wr_bytes));
+      csr_rd_check(.ptr(ral.host_fifo_status.fmtlvl), .compare_value(num_wr_bytes));
       csr_rd_check(.ptr(ral.status.fmtempty), .compare_value(0));
       cfg.clk_rst_vif.wait_clks($urandom_range(100, 2000));
       reset_fmt_fifo();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_reset_rx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_reset_rx_vseq.sv
@@ -60,8 +60,8 @@ class i2c_host_fifo_reset_rx_vseq extends i2c_rx_tx_vseq;
     fmt_empty = bit'(get_field_val(ral.status.fmtempty, status));
     rx_full   = bit'(get_field_val(ral.status.rxfull, status));
     rx_empty  = bit'(get_field_val(ral.status.rxempty, status));
-    csr_rd(.ptr(ral.fifo_status.fmtlvl), .value(fmt_lvl), .backdoor(1'b1));
-    csr_rd(.ptr(ral.fifo_status.rxlvl), .value(rx_lvl), .backdoor(1'b1));
+    csr_rd(.ptr(ral.host_fifo_status.fmtlvl), .value(fmt_lvl), .backdoor(1'b1));
+    csr_rd(.ptr(ral.host_fifo_status.rxlvl), .value(rx_lvl), .backdoor(1'b1));
     if (!cfg.under_reset) begin
       if (fmt_full)  begin
         `DV_CHECK_EQ(fmt_lvl, I2C_FMT_FIFO_DEPTH);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_watermark_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_watermark_vseq.sv
@@ -107,7 +107,7 @@ class i2c_host_fifo_watermark_vseq extends i2c_rx_tx_vseq;
       cnt_fmt_threshold++;
       // read registers
       csr_rd(.ptr(ral.fifo_ctrl.fmtilvl), .value(fmt_ilvl));
-      csr_rd(.ptr(ral.fifo_status.fmtlvl), .value(fmt_lvl));
+      csr_rd(.ptr(ral.host_fifo_status.fmtlvl), .value(fmt_lvl));
       `uvm_info(`gfn, $sformatf("\n fmtilvl %0d, fmtlvl %0d", fmt_ilvl, fmt_lvl), UVM_DEBUG)
       // bound checking for fmt_lvl w.r.t fmt_ilvl because rx_fifo can received an extra data
       // before fmt_threshold intr pin is asserted (corner case)
@@ -132,7 +132,7 @@ class i2c_host_fifo_watermark_vseq extends i2c_rx_tx_vseq;
     if (intr_enable[RxThreshold] && cfg.intr_vif.pins[RxThreshold]) begin
       cnt_rx_threshold++;
       // read registers
-      csr_rd(.ptr(ral.fifo_status.rxlvl), .value(rx_lvl));
+      csr_rd(.ptr(ral.host_fifo_status.rxlvl), .value(rx_lvl));
       csr_rd(.ptr(ral.fifo_ctrl.rxilvl), .value(rx_ilvl));
       // bound checking for rx_lvl w.r.t rx_ilvl because rx_fifo can received an extra data
       // before rx_threshold intr pin is asserted (corner case)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_runtime_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_runtime_base_vseq.sv
@@ -77,7 +77,7 @@ class i2c_target_runtime_base_vseq extends i2c_target_smoke_vseq;
     uvm_reg_data_t data;
     delay = $urandom_range(0, 10);
     cfg.clk_rst_vif.wait_clks(delay * acq_rd_cyc);
-    csr_rd(.ptr(ral.fifo_status.txlvl), .value(data));
+    csr_rd(.ptr(ral.target_fifo_status.txlvl), .value(data));
     data = 64 - data;
 
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(lvl, lvl dist {[1:16] := 7, [17:63] := 1, 64 := 2};)

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -79,7 +79,9 @@ module tb;
   `DV_ALERT_IF_CONNECT()
 
   // dut
-  i2c dut (
+  i2c #(
+    .AcqFifoDepth(i2c_env_pkg::I2C_ACQ_FIFO_DEPTH)
+  ) dut (
     .clk_i                   (clk        ),
     .rst_ni                  (rst_n      ),
 

--- a/hw/ip/i2c/rtl/i2c.sv
+++ b/hw/ip/i2c/rtl/i2c.sv
@@ -9,7 +9,8 @@
 module i2c
   import i2c_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  parameter int AcqFifoDepth = 64
 ) (
   input                     clk_i,
   input                     rst_ni,
@@ -88,7 +89,9 @@ module i2c
   logic scl_int;
   logic sda_int;
 
-  i2c_core i2c_core (
+  i2c_core #(
+    .AcqFifoDepth(AcqFifoDepth)
+  ) i2c_core (
     .clk_i,
     .rst_ni,
     .reg2hw,

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -36,6 +36,8 @@ module i2c_core import i2c_pkg::*;
   output logic                     intr_host_timeout_o
 );
 
+  localparam int FifoDepthWidth = $clog2(FifoDepth+1);
+
   logic [15:0] thigh;
   logic [15:0] tlow;
   logic [15:0] t_r;
@@ -75,69 +77,69 @@ module i2c_core import i2c_pkg::*;
 
   logic override;
 
-  logic        fmt_fifo_wvalid;
-  logic        fmt_fifo_wready;
-  logic [12:0] fmt_fifo_wdata;
-  logic [6:0]  fmt_fifo_depth;
-  logic        fmt_fifo_rvalid;
-  logic        fmt_fifo_rready;
-  logic [12:0] fmt_fifo_rdata;
-  logic [7:0]  fmt_byte;
-  logic        fmt_flag_start_before;
-  logic        fmt_flag_stop_after;
-  logic        fmt_flag_read_bytes;
-  logic        fmt_flag_read_continue;
-  logic        fmt_flag_nak_ok;
+  logic                         fmt_fifo_wvalid;
+  logic                         fmt_fifo_wready;
+  logic [12:0]                  fmt_fifo_wdata;
+  logic [FifoDepthWidth-1:0]    fmt_fifo_depth;
+  logic                         fmt_fifo_rvalid;
+  logic                         fmt_fifo_rready;
+  logic [12:0]                  fmt_fifo_rdata;
+  logic [7:0]                   fmt_byte;
+  logic                         fmt_flag_start_before;
+  logic                         fmt_flag_stop_after;
+  logic                         fmt_flag_read_bytes;
+  logic                         fmt_flag_read_continue;
+  logic                         fmt_flag_nak_ok;
 
-  logic        i2c_fifo_rxrst;
-  logic        i2c_fifo_fmtrst;
-  logic [2:0]  i2c_fifo_rxilvl;
-  logic [1:0]  i2c_fifo_fmtilvl;
+  logic                         i2c_fifo_rxrst;
+  logic                         i2c_fifo_fmtrst;
+  logic [2:0]                   i2c_fifo_rxilvl;
+  logic [1:0]                   i2c_fifo_fmtilvl;
 
-  logic        rx_fifo_wvalid;
-  logic        rx_fifo_wready;
-  logic [7:0]  rx_fifo_wdata;
-  logic [6:0]  rx_fifo_depth;
-  logic        rx_fifo_rvalid;
-  logic        rx_fifo_rready;
-  logic [7:0]  rx_fifo_rdata;
+  logic                         rx_fifo_wvalid;
+  logic                         rx_fifo_wready;
+  logic [7:0]                   rx_fifo_wdata;
+  logic [FifoDepthWidth-1:0]    rx_fifo_depth;
+  logic                         rx_fifo_rvalid;
+  logic                         rx_fifo_rready;
+  logic [7:0]                   rx_fifo_rdata;
 
-  logic        fmt_threshold_d;
-  logic        fmt_threshold_q;
-  logic        rx_threshold_d;
-  logic        rx_threshold_q;
+  logic                         fmt_threshold_d;
+  logic                         fmt_threshold_q;
+  logic                         rx_threshold_d;
+  logic                         rx_threshold_q;
 
-  logic        tx_fifo_wvalid;
-  logic        tx_fifo_wready;
-  logic [7:0]  tx_fifo_wdata;
-  logic [6:0]  tx_fifo_depth;
-  logic        tx_fifo_rvalid;
-  logic        tx_fifo_rready;
-  logic [7:0]  tx_fifo_rdata;
+  logic                         tx_fifo_wvalid;
+  logic                         tx_fifo_wready;
+  logic [7:0]                   tx_fifo_wdata;
+  logic [FifoDepthWidth-1:0]    tx_fifo_depth;
+  logic                         tx_fifo_rvalid;
+  logic                         tx_fifo_rready;
+  logic [7:0]                   tx_fifo_rdata;
 
-  logic        acq_fifo_wvalid;
-  logic        acq_fifo_wready;
-  logic [9:0]  acq_fifo_wdata;
-  logic [6:0]  acq_fifo_depth;
-  logic        acq_fifo_rvalid;
-  logic        acq_fifo_rready;
-  logic [9:0]  acq_fifo_rdata;
+  logic                         acq_fifo_wvalid;
+  logic                         acq_fifo_wready;
+  logic [9:0]                   acq_fifo_wdata;
+  logic [FifoDepthWidth-1:0]    acq_fifo_depth;
+  logic                         acq_fifo_rvalid;
+  logic                         acq_fifo_rready;
+  logic [9:0]                   acq_fifo_rdata;
 
-  logic        i2c_fifo_txrst;
-  logic        i2c_fifo_acqrst;
+  logic                         i2c_fifo_txrst;
+  logic                         i2c_fifo_acqrst;
 
-  logic        host_idle;
-  logic        target_idle;
+  logic                         host_idle;
+  logic                         target_idle;
 
-  logic        host_enable;
-  logic        target_enable;
-  logic        line_loopback;
-  logic        target_loopback;
+  logic                         host_enable;
+  logic                         target_enable;
+  logic                         line_loopback;
+  logic                         target_loopback;
 
-  logic [6:0]  target_address0;
-  logic [6:0]  target_mask0;
-  logic [6:0]  target_address1;
-  logic [6:0]  target_mask1;
+  logic [6:0]                   target_address0;
+  logic [6:0]                   target_mask0;
+  logic [6:0]                   target_address1;
+  logic [6:0]                   target_mask1;
 
   // Unused parts of exposed bits
   logic        unused_fifo_ctrl_rxilvl_qe;
@@ -232,10 +234,10 @@ module i2c_core import i2c_pkg::*;
 
   always_comb begin
     unique case(i2c_fifo_fmtilvl)
-      2'h0:    fmt_threshold_d = (fmt_fifo_depth <= 7'd1);
-      2'h1:    fmt_threshold_d = (fmt_fifo_depth <= 7'd4);
-      2'h2:    fmt_threshold_d = (fmt_fifo_depth <= 7'd8);
-      default: fmt_threshold_d = (fmt_fifo_depth <= 7'd16);
+      2'h0:    fmt_threshold_d = (fmt_fifo_depth <= FifoDepthWidth'(1'd1));
+      2'h1:    fmt_threshold_d = (fmt_fifo_depth <= FifoDepthWidth'(3'd4));
+      2'h2:    fmt_threshold_d = (fmt_fifo_depth <= FifoDepthWidth'(4'd8));
+      default: fmt_threshold_d = (fmt_fifo_depth <= FifoDepthWidth'(5'd16));
     endcase
   end
 
@@ -243,11 +245,11 @@ module i2c_core import i2c_pkg::*;
 
   always_comb begin
     unique case(i2c_fifo_rxilvl)
-      3'h0:    rx_threshold_d = (rx_fifo_depth >= 7'd1);
-      3'h1:    rx_threshold_d = (rx_fifo_depth >= 7'd4);
-      3'h2:    rx_threshold_d = (rx_fifo_depth >= 7'd8);
-      3'h3:    rx_threshold_d = (rx_fifo_depth >= 7'd16);
-      3'h4:    rx_threshold_d = (rx_fifo_depth >= 7'd30);
+      3'h0:    rx_threshold_d = (rx_fifo_depth >= FifoDepthWidth'(1'd1));
+      3'h1:    rx_threshold_d = (rx_fifo_depth >= FifoDepthWidth'(3'd4));
+      3'h2:    rx_threshold_d = (rx_fifo_depth >= FifoDepthWidth'(4'd8));
+      3'h3:    rx_threshold_d = (rx_fifo_depth >= FifoDepthWidth'(5'd16));
+      3'h4:    rx_threshold_d = (rx_fifo_depth >= FifoDepthWidth'(5'd30));
       default: rx_threshold_d = 1'b0;
     endcase
   end

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -37,6 +37,7 @@ module i2c_core import i2c_pkg::*;
 );
 
   localparam int FifoDepthWidth = $clog2(FifoDepth+1);
+  localparam int MaxFifoDepthWidth = 12;
 
   logic [15:0] thigh;
   logic [15:0] tlow;
@@ -157,8 +158,10 @@ module i2c_core import i2c_pkg::*;
   assign hw2reg.status.targetidle.d = target_idle;
   assign hw2reg.status.rxempty.d = ~rx_fifo_rvalid;
   assign hw2reg.rdata.d = rx_fifo_rdata;
-  assign hw2reg.fifo_status.fmtlvl.d = fmt_fifo_depth;
-  assign hw2reg.fifo_status.rxlvl.d = rx_fifo_depth;
+  assign hw2reg.host_fifo_status.fmtlvl.d = {{(MaxFifoDepthWidth - FifoDepthWidth){1'b0}},
+                                             fmt_fifo_depth};
+  assign hw2reg.host_fifo_status.rxlvl.d = {{(MaxFifoDepthWidth - FifoDepthWidth){1'b0}},
+                                            rx_fifo_depth};
   assign hw2reg.val.scl_rx.d = scl_rx_val;
   assign hw2reg.val.sda_rx.d = sda_rx_val;
 
@@ -166,8 +169,10 @@ module i2c_core import i2c_pkg::*;
   assign hw2reg.status.acqfull.d = ~acq_fifo_wready;
   assign hw2reg.status.txempty.d = ~tx_fifo_rvalid;
   assign hw2reg.status.acqempty.d = ~acq_fifo_rvalid;
-  assign hw2reg.fifo_status.txlvl.d = tx_fifo_depth;
-  assign hw2reg.fifo_status.acqlvl.d = acq_fifo_depth;
+  assign hw2reg.target_fifo_status.txlvl.d = {{(MaxFifoDepthWidth - FifoDepthWidth){1'b0}},
+                                              tx_fifo_depth};
+  assign hw2reg.target_fifo_status.acqlvl.d = {{(MaxFifoDepthWidth - FifoDepthWidth){1'b0}},
+                                               acq_fifo_depth};
   assign hw2reg.acqdata.abyte.d = acq_fifo_rdata[7:0];
   assign hw2reg.acqdata.signal.d = acq_fifo_rdata[9:8];
 
@@ -682,5 +687,7 @@ module i2c_core import i2c_pkg::*;
     .hw2reg_intr_state_d_o  (hw2reg.intr_state.host_timeout.d),
     .intr_o                 (intr_host_timeout_o)
   );
+
+  `ASSERT_INIT(FifoDepthValid_A, FifoDepth > 0 && FifoDepthWidth <= MaxFifoDepthWidth)
 
 endmodule

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -6,7 +6,8 @@
 
 module i2c_core import i2c_pkg::*;
 #(
-  parameter int                    FifoDepth = 64
+  parameter int                    FifoDepth = 64,
+  parameter int                    AcqFifoDepth = 64
 ) (
   input                            clk_i,
   input                            rst_ni,
@@ -37,6 +38,7 @@ module i2c_core import i2c_pkg::*;
 );
 
   localparam int FifoDepthWidth = $clog2(FifoDepth+1);
+  localparam int AcqFifoDepthWidth = $clog2(AcqFifoDepth+1);
   localparam int MaxFifoDepthWidth = 12;
 
   logic [15:0] thigh;
@@ -121,7 +123,7 @@ module i2c_core import i2c_pkg::*;
   logic                         acq_fifo_wvalid;
   logic                         acq_fifo_wready;
   logic [9:0]                   acq_fifo_wdata;
-  logic [FifoDepthWidth-1:0]    acq_fifo_depth;
+  logic [AcqFifoDepthWidth-1:0] acq_fifo_depth;
   logic                         acq_fifo_rvalid;
   logic                         acq_fifo_rready;
   logic [9:0]                   acq_fifo_rdata;
@@ -378,7 +380,7 @@ module i2c_core import i2c_pkg::*;
   prim_fifo_sync #(
     .Width(10),
     .Pass(1'b0),
-    .Depth(FifoDepth)
+    .Depth(AcqFifoDepth)
   ) u_i2c_acqfifo (
     .clk_i,
     .rst_ni,
@@ -416,7 +418,8 @@ module i2c_core import i2c_pkg::*;
   );
 
   i2c_fsm #(
-    .FifoDepth(FifoDepth)
+    .FifoDepth(FifoDepth),
+    .AcqFifoDepth(AcqFifoDepth)
   ) u_i2c_fsm (
     .clk_i,
     .rst_ni,
@@ -689,5 +692,6 @@ module i2c_core import i2c_pkg::*;
   );
 
   `ASSERT_INIT(FifoDepthValid_A, FifoDepth > 0 && FifoDepthWidth <= MaxFifoDepthWidth)
+  `ASSERT_INIT(AcqFifoDepthValid_A, AcqFifoDepth > 0 && AcqFifoDepthWidth <= MaxFifoDepthWidth)
 
 endmodule

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -7,7 +7,9 @@
 module i2c_fsm import i2c_pkg::*;
 #(
   parameter int FifoDepth = 64,
-  localparam int FifoDepthWidth = $clog2(FifoDepth+1)
+  parameter int AcqFifoDepth = 64,
+  localparam int FifoDepthWidth = $clog2(FifoDepth+1),
+  localparam int AcqFifoDepthWidth = $clog2(AcqFifoDepth+1)
 ) (
   input        clk_i,  // clock
   input        rst_ni, // active low reset
@@ -42,7 +44,7 @@ module i2c_fsm import i2c_pkg::*;
 
   output logic       acq_fifo_wvalid_o, // high if there is valid data in acq_fifo
   output logic [9:0] acq_fifo_wdata_o,  // byte and signal in acq_fifo read from target
-  input [FifoDepthWidth-1:0] acq_fifo_depth_i,
+  input [AcqFifoDepthWidth-1:0] acq_fifo_depth_i,
   output logic       acq_fifo_wready_o, // local version of ready
   input [9:0]        acq_fifo_rdata_i,  // only used for assertion
 
@@ -342,9 +344,9 @@ module i2c_fsm import i2c_pkg::*;
   // space for this entry, the target module would need to stretch the
   // repeat start / stop indication.  If a system does not support stretching,
   // there's no good way for a stop to be NACK'd.
-  logic [FifoDepthWidth-1:0] acq_fifo_remainder;
-  assign acq_fifo_remainder = FifoDepth - acq_fifo_depth_i;
-  assign acq_fifo_wready = acq_fifo_remainder > FifoDepthWidth'(1'b1);
+  logic [AcqFifoDepthWidth-1:0] acq_fifo_remainder;
+  assign acq_fifo_remainder = AcqFifoDepth - acq_fifo_depth_i;
+  assign acq_fifo_wready = acq_fifo_remainder > AcqFifoDepthWidth'(1'b1);
 
   // State definitions
   typedef enum logic [5:0] {
@@ -811,7 +813,7 @@ module i2c_fsm import i2c_pkg::*;
   // Only the fifo depth is checked here, because stretch_tx is only evaluated by the
   // fsm on the read path. This means a read start byte has already been deposited.
   assign stretch_tx = ~tx_fifo_rvalid_i |
-                      (acq_fifo_depth_i > FifoDepthWidth'(1'b1));
+                      (acq_fifo_depth_i > AcqFifoDepthWidth'(1'b1));
 
   // Only used for assertion
   logic unused_acq_rdata;

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -455,18 +455,21 @@ package i2c_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [6:0]  d;
+      logic [11:0] d;
     } fmtlvl;
     struct packed {
-      logic [6:0]  d;
+      logic [11:0] d;
+    } rxlvl;
+  } i2c_hw2reg_host_fifo_status_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [11:0] d;
     } txlvl;
     struct packed {
-      logic [6:0]  d;
-    } rxlvl;
-    struct packed {
-      logic [6:0]  d;
+      logic [11:0] d;
     } acqlvl;
-  } i2c_hw2reg_fifo_status_reg_t;
+  } i2c_hw2reg_target_fifo_status_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -511,10 +514,11 @@ package i2c_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    i2c_hw2reg_intr_state_reg_t intr_state; // [117:88]
-    i2c_hw2reg_status_reg_t status; // [87:78]
-    i2c_hw2reg_rdata_reg_t rdata; // [77:70]
-    i2c_hw2reg_fifo_status_reg_t fifo_status; // [69:42]
+    i2c_hw2reg_intr_state_reg_t intr_state; // [137:108]
+    i2c_hw2reg_status_reg_t status; // [107:98]
+    i2c_hw2reg_rdata_reg_t rdata; // [97:90]
+    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [89:66]
+    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [65:42]
     i2c_hw2reg_val_reg_t val; // [41:10]
     i2c_hw2reg_acqdata_reg_t acqdata; // [9:0]
   } i2c_hw2reg_t;
@@ -529,19 +533,20 @@ package i2c_reg_pkg;
   parameter logic [BlockAw-1:0] I2C_RDATA_OFFSET = 7'h 18;
   parameter logic [BlockAw-1:0] I2C_FDATA_OFFSET = 7'h 1c;
   parameter logic [BlockAw-1:0] I2C_FIFO_CTRL_OFFSET = 7'h 20;
-  parameter logic [BlockAw-1:0] I2C_FIFO_STATUS_OFFSET = 7'h 24;
-  parameter logic [BlockAw-1:0] I2C_OVRD_OFFSET = 7'h 28;
-  parameter logic [BlockAw-1:0] I2C_VAL_OFFSET = 7'h 2c;
-  parameter logic [BlockAw-1:0] I2C_TIMING0_OFFSET = 7'h 30;
-  parameter logic [BlockAw-1:0] I2C_TIMING1_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] I2C_TIMING2_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] I2C_TIMING3_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] I2C_TIMING4_OFFSET = 7'h 40;
-  parameter logic [BlockAw-1:0] I2C_TIMEOUT_CTRL_OFFSET = 7'h 44;
-  parameter logic [BlockAw-1:0] I2C_TARGET_ID_OFFSET = 7'h 48;
-  parameter logic [BlockAw-1:0] I2C_ACQDATA_OFFSET = 7'h 4c;
-  parameter logic [BlockAw-1:0] I2C_TXDATA_OFFSET = 7'h 50;
-  parameter logic [BlockAw-1:0] I2C_HOST_TIMEOUT_CTRL_OFFSET = 7'h 54;
+  parameter logic [BlockAw-1:0] I2C_HOST_FIFO_STATUS_OFFSET = 7'h 24;
+  parameter logic [BlockAw-1:0] I2C_TARGET_FIFO_STATUS_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] I2C_OVRD_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] I2C_VAL_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] I2C_TIMING0_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] I2C_TIMING1_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] I2C_TIMING2_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] I2C_TIMING3_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] I2C_TIMING4_OFFSET = 7'h 44;
+  parameter logic [BlockAw-1:0] I2C_TIMEOUT_CTRL_OFFSET = 7'h 48;
+  parameter logic [BlockAw-1:0] I2C_TARGET_ID_OFFSET = 7'h 4c;
+  parameter logic [BlockAw-1:0] I2C_ACQDATA_OFFSET = 7'h 50;
+  parameter logic [BlockAw-1:0] I2C_TXDATA_OFFSET = 7'h 54;
+  parameter logic [BlockAw-1:0] I2C_HOST_TIMEOUT_CTRL_OFFSET = 7'h 58;
 
   // Reset values for hwext registers and their fields
   parameter logic [14:0] I2C_INTR_TEST_RESVAL = 15'h 0;
@@ -570,7 +575,8 @@ package i2c_reg_pkg;
   parameter logic [0:0] I2C_STATUS_TXEMPTY_RESVAL = 1'h 1;
   parameter logic [0:0] I2C_STATUS_ACQEMPTY_RESVAL = 1'h 1;
   parameter logic [7:0] I2C_RDATA_RESVAL = 8'h 0;
-  parameter logic [30:0] I2C_FIFO_STATUS_RESVAL = 31'h 0;
+  parameter logic [23:0] I2C_HOST_FIFO_STATUS_RESVAL = 24'h 0;
+  parameter logic [23:0] I2C_TARGET_FIFO_STATUS_RESVAL = 24'h 0;
   parameter logic [31:0] I2C_VAL_RESVAL = 32'h 0;
   parameter logic [9:0] I2C_ACQDATA_RESVAL = 10'h 0;
 
@@ -585,7 +591,8 @@ package i2c_reg_pkg;
     I2C_RDATA,
     I2C_FDATA,
     I2C_FIFO_CTRL,
-    I2C_FIFO_STATUS,
+    I2C_HOST_FIFO_STATUS,
+    I2C_TARGET_FIFO_STATUS,
     I2C_OVRD,
     I2C_VAL,
     I2C_TIMING0,
@@ -601,7 +608,7 @@ package i2c_reg_pkg;
   } i2c_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] I2C_PERMIT [22] = '{
+  parameter logic [3:0] I2C_PERMIT [23] = '{
     4'b 0011, // index[ 0] I2C_INTR_STATE
     4'b 0011, // index[ 1] I2C_INTR_ENABLE
     4'b 0011, // index[ 2] I2C_INTR_TEST
@@ -611,19 +618,20 @@ package i2c_reg_pkg;
     4'b 0001, // index[ 6] I2C_RDATA
     4'b 0011, // index[ 7] I2C_FDATA
     4'b 0011, // index[ 8] I2C_FIFO_CTRL
-    4'b 1111, // index[ 9] I2C_FIFO_STATUS
-    4'b 0001, // index[10] I2C_OVRD
-    4'b 1111, // index[11] I2C_VAL
-    4'b 1111, // index[12] I2C_TIMING0
-    4'b 1111, // index[13] I2C_TIMING1
-    4'b 1111, // index[14] I2C_TIMING2
-    4'b 1111, // index[15] I2C_TIMING3
-    4'b 1111, // index[16] I2C_TIMING4
-    4'b 1111, // index[17] I2C_TIMEOUT_CTRL
-    4'b 1111, // index[18] I2C_TARGET_ID
-    4'b 0011, // index[19] I2C_ACQDATA
-    4'b 0001, // index[20] I2C_TXDATA
-    4'b 1111  // index[21] I2C_HOST_TIMEOUT_CTRL
+    4'b 0111, // index[ 9] I2C_HOST_FIFO_STATUS
+    4'b 0111, // index[10] I2C_TARGET_FIFO_STATUS
+    4'b 0001, // index[11] I2C_OVRD
+    4'b 1111, // index[12] I2C_VAL
+    4'b 1111, // index[13] I2C_TIMING0
+    4'b 1111, // index[14] I2C_TIMING1
+    4'b 1111, // index[15] I2C_TIMING2
+    4'b 1111, // index[16] I2C_TIMING3
+    4'b 1111, // index[17] I2C_TIMING4
+    4'b 1111, // index[18] I2C_TIMEOUT_CTRL
+    4'b 1111, // index[19] I2C_TARGET_ID
+    4'b 0011, // index[20] I2C_ACQDATA
+    4'b 0001, // index[21] I2C_TXDATA
+    4'b 1111  // index[22] I2C_HOST_TIMEOUT_CTRL
   };
 
 endpackage

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -902,7 +902,22 @@
         "0"
       ]
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: AcqFifoDepth
+          desc:
+            '''
+            Depth of ACQ FIFO.
+            The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
+            '''
+          type: int
+          default: "64"
+          expose: "true"
+          name_top: I2c0AcqFifoDepth
+        }
+      ]
       inter_signal_list:
       [
         {
@@ -949,7 +964,22 @@
         "0"
       ]
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: AcqFifoDepth
+          desc:
+            '''
+            Depth of ACQ FIFO.
+            The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
+            '''
+          type: int
+          default: "64"
+          expose: "true"
+          name_top: I2c1AcqFifoDepth
+        }
+      ]
       inter_signal_list:
       [
         {
@@ -996,7 +1026,22 @@
         "0"
       ]
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: AcqFifoDepth
+          desc:
+            '''
+            Depth of ACQ FIFO.
+            The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
+            '''
+          type: int
+          default: "64"
+          expose: "true"
+          name_top: I2c2AcqFifoDepth
+        }
+      ]
       inter_signal_list:
       [
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -23,8 +23,11 @@ module top_earlgrey #(
   // parameters for spi_device
   parameter spi_device_pkg::sram_type_e SpiDeviceSramType = spi_device_pkg::DefaultSramType,
   // parameters for i2c0
+  parameter int I2c0AcqFifoDepth = 64,
   // parameters for i2c1
+  parameter int I2c1AcqFifoDepth = 64,
   // parameters for i2c2
+  parameter int I2c2AcqFifoDepth = 64,
   // parameters for pattgen
   // parameters for rv_timer
   // parameters for otp_ctrl
@@ -1210,7 +1213,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_spi_device_n[rstmgr_pkg::Domain0Sel])
   );
   i2c #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[6:6])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[6:6]),
+    .AcqFifoDepth(I2c0AcqFifoDepth)
   ) u_i2c0 (
 
       // Input
@@ -1252,7 +1256,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_i2c0_n[rstmgr_pkg::Domain0Sel])
   );
   i2c #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[7:7])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[7:7]),
+    .AcqFifoDepth(I2c1AcqFifoDepth)
   ) u_i2c1 (
 
       // Input
@@ -1294,7 +1299,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_i2c1_n[rstmgr_pkg::Domain0Sel])
   );
   i2c #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[8:8])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[8:8]),
+    .AcqFifoDepth(I2c2AcqFifoDepth)
   ) u_i2c2 (
 
       // Input

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -421,31 +421,33 @@ dif_result_t dif_i2c_override_sample_pins(const dif_i2c_t *i2c,
 }
 
 dif_result_t dif_i2c_get_fifo_levels(const dif_i2c_t *i2c,
-                                     uint8_t *fmt_fifo_level,
-                                     uint8_t *rx_fifo_level,
-                                     uint8_t *tx_fifo_level,
-                                     uint8_t *acq_fifo_level) {
+                                     uint16_t *fmt_fifo_level,
+                                     uint16_t *rx_fifo_level,
+                                     uint16_t *tx_fifo_level,
+                                     uint16_t *acq_fifo_level) {
   if (i2c == NULL) {
     return kDifBadArg;
   }
 
   uint32_t values =
-      mmio_region_read32(i2c->base_addr, I2C_FIFO_STATUS_REG_OFFSET);
+      mmio_region_read32(i2c->base_addr, I2C_HOST_FIFO_STATUS_REG_OFFSET);
   if (fmt_fifo_level != NULL) {
-    *fmt_fifo_level =
-        (uint8_t)bitfield_field32_read(values, I2C_FIFO_STATUS_FMTLVL_FIELD);
+    *fmt_fifo_level = (uint16_t)bitfield_field32_read(
+        values, I2C_HOST_FIFO_STATUS_FMTLVL_FIELD);
   }
   if (rx_fifo_level != NULL) {
-    *rx_fifo_level =
-        (uint8_t)bitfield_field32_read(values, I2C_FIFO_STATUS_RXLVL_FIELD);
+    *rx_fifo_level = (uint16_t)bitfield_field32_read(
+        values, I2C_HOST_FIFO_STATUS_RXLVL_FIELD);
   }
+  values =
+      mmio_region_read32(i2c->base_addr, I2C_TARGET_FIFO_STATUS_REG_OFFSET);
   if (tx_fifo_level != NULL) {
-    *tx_fifo_level =
-        (uint8_t)bitfield_field32_read(values, I2C_FIFO_STATUS_TXLVL_FIELD);
+    *tx_fifo_level = (uint16_t)bitfield_field32_read(
+        values, I2C_TARGET_FIFO_STATUS_TXLVL_FIELD);
   }
   if (acq_fifo_level != NULL) {
-    *acq_fifo_level =
-        (uint8_t)bitfield_field32_read(values, I2C_FIFO_STATUS_ACQLVL_FIELD);
+    *acq_fifo_level = (uint16_t)bitfield_field32_read(
+        values, I2C_TARGET_FIFO_STATUS_ACQLVL_FIELD);
   }
 
   return kDifOk;

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -551,10 +551,10 @@ dif_result_t dif_i2c_override_sample_pins(const dif_i2c_t *i2c,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_i2c_get_fifo_levels(const dif_i2c_t *i2c,
-                                     uint8_t *fmt_fifo_level,
-                                     uint8_t *rx_fifo_level,
-                                     uint8_t *tx_fifo_level,
-                                     uint8_t *acq_fifo_level);
+                                     uint16_t *fmt_fifo_level,
+                                     uint16_t *rx_fifo_level,
+                                     uint16_t *tx_fifo_level,
+                                     uint16_t *acq_fifo_level);
 
 /**
  * Pops an entry (a byte) off of the RX FIFO. Passing in `NULL` to the out-param

--- a/sw/device/lib/dif/dif_i2c_unittest.cc
+++ b/sw/device/lib/dif/dif_i2c_unittest.cc
@@ -541,67 +541,74 @@ TEST_F(OverrideTest, SampleNullArgs) {
 class FifoTest : public I2cTest {};
 
 TEST_F(FifoTest, GetLevels) {
-  uint8_t rx, fmt, tx, acq;
-  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  uint16_t rx, fmt, tx, acq;
+  EXPECT_READ32(I2C_HOST_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_TARGET_FIFO_STATUS_REG_OFFSET, 0xb3898628);
   EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, &fmt, &rx, &tx, &acq));
-  EXPECT_EQ(fmt, 0x47);
-  EXPECT_EQ(rx, 0x29);
-  EXPECT_EQ(tx, 0x38);
-  EXPECT_EQ(acq, 0x10);
+  EXPECT_EQ(fmt, 0x847);
+  EXPECT_EQ(rx, 0x293);
+  EXPECT_EQ(tx, 0x628);
+  EXPECT_EQ(acq, 0x898);
 
   rx = 0, fmt = 0, tx = 0, acq = 0;
-  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_HOST_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_TARGET_FIFO_STATUS_REG_OFFSET, 0xb3898628);
   EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, &fmt, &rx, nullptr, nullptr));
-  EXPECT_EQ(fmt, 0x47);
-  EXPECT_EQ(rx, 0x29);
+  EXPECT_EQ(fmt, 0x847);
+  EXPECT_EQ(rx, 0x293);
   EXPECT_EQ(tx, 0x0);
   EXPECT_EQ(acq, 0x0);
 
   rx = 0, fmt = 0, tx = 0, acq = 0;
-  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_HOST_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_TARGET_FIFO_STATUS_REG_OFFSET, 0xb3898628);
   EXPECT_DIF_OK(
       dif_i2c_get_fifo_levels(&i2c_, &fmt, nullptr, nullptr, nullptr));
   EXPECT_EQ(rx, 0x0);
-  EXPECT_EQ(fmt, 0x47);
+  EXPECT_EQ(fmt, 0x847);
   EXPECT_EQ(tx, 0x0);
   EXPECT_EQ(acq, 0x0);
 
   rx = 0, fmt = 0, tx = 0, acq = 0;
-  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_HOST_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_TARGET_FIFO_STATUS_REG_OFFSET, 0xb3898628);
   EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, nullptr, &rx, nullptr, nullptr));
-  EXPECT_EQ(rx, 0x29);
+  EXPECT_EQ(rx, 0x293);
   EXPECT_EQ(fmt, 0x0);
   EXPECT_EQ(tx, 0x0);
   EXPECT_EQ(acq, 0x0);
 
   rx = 0, fmt = 0, tx = 0, acq = 0;
-  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_HOST_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_TARGET_FIFO_STATUS_REG_OFFSET, 0xb3898628);
   EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, nullptr, nullptr, &tx, &acq));
   EXPECT_EQ(fmt, 0x0);
   EXPECT_EQ(rx, 0x0);
-  EXPECT_EQ(tx, 0x38);
-  EXPECT_EQ(acq, 0x10);
+  EXPECT_EQ(tx, 0x628);
+  EXPECT_EQ(acq, 0x898);
 
   rx = 0, fmt = 0, tx = 0, acq = 0;
-  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_HOST_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_TARGET_FIFO_STATUS_REG_OFFSET, 0xb3898628);
   EXPECT_DIF_OK(dif_i2c_get_fifo_levels(&i2c_, nullptr, nullptr, &tx, nullptr));
   EXPECT_EQ(rx, 0x0);
   EXPECT_EQ(fmt, 0x0);
-  EXPECT_EQ(tx, 0x38);
+  EXPECT_EQ(tx, 0x628);
   EXPECT_EQ(acq, 0x0);
 
   rx = 0, fmt = 0, tx = 0, acq = 0;
-  EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_HOST_FIFO_STATUS_REG_OFFSET, 0x10293847);
+  EXPECT_READ32(I2C_TARGET_FIFO_STATUS_REG_OFFSET, 0xb3898628);
   EXPECT_DIF_OK(
       dif_i2c_get_fifo_levels(&i2c_, nullptr, nullptr, nullptr, &acq));
   EXPECT_EQ(rx, 0x0);
   EXPECT_EQ(fmt, 0x0);
   EXPECT_EQ(tx, 0x0);
-  EXPECT_EQ(acq, 0x10);
+  EXPECT_EQ(acq, 0x898);
 }
 
 TEST_F(FifoTest, GetLevelsNullArgs) {
-  uint8_t rx, fmt;
+  uint16_t rx, fmt;
   EXPECT_DIF_BADARG(
       dif_i2c_get_fifo_levels(nullptr, &rx, &fmt, nullptr, nullptr));
 }

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -217,7 +217,7 @@ status_t i2c_testutils_read(const dif_i2c_t *i2c, uint8_t addr,
 }
 
 status_t i2c_testutils_target_check_start(const dif_i2c_t *i2c, uint8_t *addr) {
-  uint8_t acq_fifo_lvl;
+  uint16_t acq_fifo_lvl;
   TRY(dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl));
   TRY_CHECK(acq_fifo_lvl > 1);
 
@@ -233,7 +233,7 @@ status_t i2c_testutils_target_check_start(const dif_i2c_t *i2c, uint8_t *addr) {
 
 status_t i2c_testutils_target_check_end(const dif_i2c_t *i2c,
                                         uint8_t *cont_byte) {
-  uint8_t acq_fifo_lvl;
+  uint16_t acq_fifo_lvl;
   TRY(dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl));
   TRY_CHECK(acq_fifo_lvl >= 1);
 
@@ -252,9 +252,9 @@ status_t i2c_testutils_target_check_end(const dif_i2c_t *i2c,
   return OK_STATUS(true);
 }
 
-status_t i2c_testutils_target_read(const dif_i2c_t *i2c, uint8_t byte_count,
+status_t i2c_testutils_target_read(const dif_i2c_t *i2c, uint16_t byte_count,
                                    const uint8_t *data) {
-  uint8_t tx_fifo_lvl, acq_fifo_lvl;
+  uint16_t tx_fifo_lvl, acq_fifo_lvl;
   TRY(dif_i2c_get_fifo_levels(i2c, NULL, NULL, &tx_fifo_lvl, &acq_fifo_lvl));
   // Check there's space in tx_fifo and acq_fifo
   TRY_CHECK(tx_fifo_lvl + byte_count <= I2C_PARAM_FIFO_DEPTH);
@@ -275,8 +275,8 @@ status_t i2c_testutils_target_check_read(const dif_i2c_t *i2c, uint8_t *addr,
   return i2c_testutils_target_check_end(i2c, cont_byte);
 }
 
-status_t i2c_testutils_target_write(const dif_i2c_t *i2c, uint8_t byte_count) {
-  uint8_t acq_fifo_lvl;
+status_t i2c_testutils_target_write(const dif_i2c_t *i2c, uint16_t byte_count) {
+  uint16_t acq_fifo_lvl;
   TRY(dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl));
   TRY_CHECK(acq_fifo_lvl + 2 + byte_count <= I2C_PARAM_FIFO_DEPTH);
 
@@ -285,9 +285,9 @@ status_t i2c_testutils_target_write(const dif_i2c_t *i2c, uint8_t byte_count) {
 }
 
 status_t i2c_testutils_target_check_write(const dif_i2c_t *i2c,
-                                          uint8_t byte_count, uint8_t *addr,
+                                          uint16_t byte_count, uint8_t *addr,
                                           uint8_t *bytes, uint8_t *cont_byte) {
-  uint8_t acq_fifo_lvl;
+  uint16_t acq_fifo_lvl;
   TRY(dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl));
   TRY_CHECK(acq_fifo_lvl >= 2 + byte_count);
 

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -74,7 +74,7 @@ status_t i2c_testutils_target_check_end(const dif_i2c_t *i2c,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t i2c_testutils_target_read(const dif_i2c_t *i2c, uint8_t byte_count,
+status_t i2c_testutils_target_read(const dif_i2c_t *i2c, uint16_t byte_count,
                                    const uint8_t *data);
 
 /**
@@ -100,7 +100,7 @@ status_t i2c_testutils_target_check_read(const dif_i2c_t *i2c, uint8_t *addr,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t i2c_testutils_target_write(const dif_i2c_t *i2c, uint8_t byte_count);
+status_t i2c_testutils_target_write(const dif_i2c_t *i2c, uint16_t byte_count);
 
 /**
  * Check completion of an I2C write as an I2C device.
@@ -117,7 +117,7 @@ status_t i2c_testutils_target_write(const dif_i2c_t *i2c, uint8_t byte_count);
  */
 OT_WARN_UNUSED_RESULT
 status_t i2c_testutils_target_check_write(const dif_i2c_t *i2c,
-                                          uint8_t byte_count, uint8_t *addr,
+                                          uint16_t byte_count, uint8_t *addr,
                                           uint8_t *bytes, uint8_t *cont_byte);
 
 /**

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -130,9 +130,9 @@ static status_t configure_device_address(ujson_t *uj, dif_i2c_t *i2c) {
   return RESP_OK_STATUS(uj);
 }
 
-static status_t wait_for_acq_fifo(dif_i2c_t *i2c, uint8_t at_least,
+static status_t wait_for_acq_fifo(dif_i2c_t *i2c, uint16_t at_least,
                                   const ibex_timeout_t *deadline) {
-  uint8_t acq_fifo_lvl;
+  uint16_t acq_fifo_lvl;
   while (!ibex_timeout_check(deadline)) {
     if (dif_i2c_get_fifo_levels(i2c, NULL, NULL, NULL, &acq_fifo_lvl) ==
             kDifOk &&

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -1350,7 +1350,7 @@ static void max_power(void) {
 
   // Check I2C bits TXed were echoed back by the DV agent. (Only for DV.)
   if (kDeviceType == kDeviceSimDV) {
-    uint8_t fmt_fifo_lvl, rx_fifo_lvl;
+    uint16_t fmt_fifo_lvl, rx_fifo_lvl;
 
     // Make sure all TX FIFOs have been drained.
     for (size_t ii = 0; ii < ARRAYSIZE(i2c_handles); ++ii) {

--- a/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
@@ -221,7 +221,7 @@ bool test_main(void) {
     expected_data[i] = (uint8_t)rand_testutils_gen32_range(0, 0xff);
   };
 
-  uint8_t tx_fifo_lvl;
+  uint16_t tx_fifo_lvl;
   CHECK_DIF_OK(dif_i2c_get_fifo_levels(&i2c, NULL, NULL, &tx_fifo_lvl, NULL));
   IBEX_SPIN_FOR(!(tx_fifo_lvl > 0 && tx_empty_irq_seen == false), 100);
   CHECK_STATUS_OK(
@@ -230,7 +230,7 @@ bool test_main(void) {
 
   LOG_INFO("Data written to fifo");
 
-  uint8_t acq_fifo_lvl;
+  uint16_t acq_fifo_lvl;
   do {
     CHECK_DIF_OK(
         dif_i2c_get_fifo_levels(&i2c, NULL, NULL, &tx_fifo_lvl, &acq_fifo_lvl));

--- a/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_host_tx_rx_test.c
@@ -253,7 +253,7 @@ void issue_test_transactions(bool skip_stop) {
   CHECK_STATUS_OK(i2c_testutils_write(&i2c, device_addr, byte_count,
                                       expected_data, skip_stop));
 
-  uint8_t tx_fifo_lvl, rx_fifo_lvl;
+  uint16_t tx_fifo_lvl, rx_fifo_lvl;
 
   // Make sure all fifo entries have been drained.
   do {


### PR DESCRIPTION
**This PR currently depends on https://github.com/lowRISC/opentitan/pull/21709 and includes commits from that PR. Only the last commit is unique to this PR. Other than this dependency, this PR is ready for review but kept as draft for now until it can be rebased on `master` once #21709 got merged.**

This commit splits the depth of the ACQ FIFO from the `FifoDepth`
parameter into a separate, new parameter named `AcqFifoDepth`.  This
allows instantiators to make the ACQ FIFO of any `i2c` instance deeper
or shallower than the other FIFOs.

This commit also makes initial DV changes to cover the new parameter,
although for now `AcqFifoDepth` in DV is simply set to a fixed value
that is different from that of `FifoDepth`.  Later work should cover
different values of the parameter.

The three `i2c` instances in Earlgrey have the new parameter set to 64,
which is equal to the value of the `FifoDepth` parameter, for now.

