### PR TITLE
[cryptotest] refactor `parse_rsp` and clean up test vector build script

### DIFF
--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -6,19 +6,22 @@ load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 
 package(default_visibility = ["//visibility:public"])
 
-genrule(
+run_binary(
     name = "nist_cavp_ecdsa_fips_186_4_sig_ver_json",
     srcs = [
-        "@nist_cavp_ecdsa_fips_186_4//:SigVer.rsp",
         "//sw/host/cryptotest/testvectors/data/schemas:ecdsa_sig_ver_schema",
+        "@nist_cavp_ecdsa_fips_186_4//:SigVer.rsp",
     ],
-    outs = ["nist_cavp_ecdsa_fips_186_4_sig_ver.json"],
-    cmd = """$(location //sw/host/cryptotest/testvectors/parsers:nist_cavp_ecdsa_parser) \
-            --src $(location @nist_cavp_ecdsa_fips_186_4//:SigVer.rsp) \
-            --dst $(RULEDIR)/nist_cavp_ecdsa_fips_186_4_sig_ver \
-            --schema $(location //sw/host/cryptotest/testvectors/data/schemas:ecdsa_sig_ver_schema)""",
-    message = "Parsing testvector - NIST CAVP Digital Signatures FIPS 186-4 - ECDSA",
-    tools = ["//sw/host/cryptotest/testvectors/parsers:nist_cavp_ecdsa_parser"],
+    outs = [":nist_cavp_ecdsa_fips_186_4_sig_ver.json"],
+    args = [
+        "--src",
+        "$(location @nist_cavp_ecdsa_fips_186_4//:SigVer.rsp)",
+        "--dst",
+        "$(location :nist_cavp_ecdsa_fips_186_4_sig_ver.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:ecdsa_sig_ver_schema)",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_ecdsa_parser",
 )
 
 [

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
@@ -10,6 +10,15 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "cryptotest_util",
     srcs = ["cryptotest_util.py"],
+    visibility = ["//visibility:private"],
+)
+
+py_test(
+    name = "cryptotest_util_test",
+    srcs = [
+        "cryptotest_util.py",
+        "cryptotest_util_test.py",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
+++ b/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
@@ -2,53 +2,103 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-def parse_rsp(file_path: str) -> dict:
+def parse_rsp(file_path: str, persists: list[str] = []) -> dict:
     """Parser for NIST `.rsp` files.
 
     NIST response files (.rsp) provide the expected results of cryptographic
     operations. No formal standard exists for these files, but they generally take
     the following format:
-      - Each file contains zero or more sections. The start of each section is
-          denoted by a line beginning with "[" and ending with "]". The text between
-          the brackets is the title of the section.
-      - Each section contains at least one entry where an entry is a collection of
-        key-value pairs. Entries are separated from each other by an empty line.
+      - Lines beginning with a "[" are headers. Headers contain either a bare name,
+        like "Section Name", a single key-value pair, like "Hash = SHA-256", or a
+        list of strings, like "RSA-2048, SHA-256".
       - A line that starts with a "#" is a comment and is ignored.
+      - Other non-blank lines contain a single key-value pair.
+    Due to the heterogeneity of these files, this function applies multiple complex
+    rules to parse the content into a set of test vectors:
+      - Some key-value pairs are applied to multiple test cases. These include the
+        key-value pairs in headers, as well as those with keys specified in the
+        argument array `persists`.
+      - A group of non-header key-value pair lines (delimited by newlines or a header
+        line) constitutes a test case if it does not contain any keys in `persists`.
+      - If a group of non-header key-value pair lines contains the same key multiple
+        times without a newline in between, all of their associated values will be
+        kept in a list.
     """
-    result = dict()
-    curr_section = list()
-    curr_section_name = ""
-    curr_entry = dict()
+    persistent_variables = {}
+    test_cases = []
+    test_case = None
+    exclude_group = False
+    group_variables = []
     with open(file_path, "r") as file:
         for line_num, line in enumerate(file):
             line = line.strip()
+            # Ignore comments
             if line.startswith("#"):
                 continue
             elif line.startswith("["):
-                # Store the previous section and start a new section
-                if curr_section:
-                    result[curr_section_name] = curr_section
-                    curr_section = list()
-                curr_section_name = line.strip("[]")
+                # We have a header. If the header is a single title, store
+                # it as the section name. If it is a key-value pair, store
+                # the pair in our set of persistent variables.
+
+                # If we were working on a test case, add it.
+                if test_case is not None:
+                    if not exclude_group:
+                        test_cases.append(test_case)
+                    test_case = None
+                    group_variables = []
+                    exclude_group = False
+                header_text = line.strip("[]")
+                kv = [s.strip() for s in header_text.split("=", maxsplit=1)]
+                if len(kv) == 1:
+                    # We don't have a key-value pair. See if we have a CSV list.
+                    csv = [s.strip() for s in header_text.split(",")]
+                    if len(csv) == 1:
+                        # Just a name. Store it as a string.
+                        persistent_variables["section_name"] = header_text
+                    else:
+                        # We have a CSV list. Store it as an array.
+                        persistent_variables["section_name"] = csv
+                else:
+                    # We have a key-value pair to store.
+                    persistent_variables[kv[0]] = kv[1]
             elif line == "":
-                # Store the previous entry and start a new entry
-                if curr_entry:
-                    curr_section.append(curr_entry)
-                    curr_entry = dict()
+                # We are staring a new group. Add the test case if we have one,
+                # and clear our list of variables for the current group.
+                if test_case is not None and not exclude_group:
+                    test_cases.append(test_case)
+                test_case = None
+                group_variables = []
+                exclude_group = False
             elif line and "=" in line:
-                # Append the key-value pair to the current entry
+                if test_case is None:
+                    test_case = persistent_variables.copy()
+                # Get the key and value
                 key, value = [s.strip() for s in line.split("=", maxsplit=1)]
-                if key in curr_entry.keys():
-                    raise SyntaxError(f"Line {line_num}: Duplicate key ({key}) in entry")
-                curr_entry[key] = value
+                d = test_case
+                # If we have a variable intended to persist, store it properly and
+                # remember the current group does not constitute a test case.
+                if key in persists:
+                    d = persistent_variables
+                    exclude_group = True
+                if key in group_variables:
+                    # We've already seen this variable in the current group. Store all
+                    # the values in a list.
+                    if type(d[key]) == str:
+                        d[key] = [d[key], value]
+                    else:
+                        d[key].append(value)
+                else:
+                    # We haven't seen this variable yet in the current
+                    # group. Store its value and remember we've seen
+                    # it.
+                    d[key] = value
+                    group_variables.append(key)
 
         # If there is no newline at the end of the rsp file, then append the
         # last entry to the section
-        if curr_entry:
-            curr_section.append(curr_entry)
-        # Append the last section to the result
-        result[curr_section_name] = curr_section
-    return result
+        if test_case is not None:
+            test_cases.append(test_case)
+    return test_cases
 
 
 def str_to_byte_array(s: str) -> list:

--- a/sw/host/cryptotest/testvectors/parsers/cryptotest_util_test.py
+++ b/sw/host/cryptotest/testvectors/parsers/cryptotest_util_test.py
@@ -1,0 +1,210 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+import os
+import unittest
+
+from cryptotest_util import parse_rsp
+
+
+def createRsp(content: bytes) -> str:
+    with tempfile.NamedTemporaryFile(delete=False, dir=os.environ["TEST_TMPDIR"]) as temp:
+        temp.write(content)
+        return temp.name
+
+
+class RspTests(unittest.TestCase):
+
+    """Check that we can parse headers and variables."""
+    def test_simple(self):
+        rsp = createRsp(b"""
+[section name]
+
+x = 1234
+y = 5678
+
+""")
+        expected = [{
+            "section_name": "section name",
+            "x": "1234",
+            "y": "5678",
+        }]
+        self.assertEqual(expected, parse_rsp(rsp, []))
+
+    def test_no_trailing_newline(self):
+        """Check that we can parse a test case at the end of the file with no trailing newline."""
+        rsp = createRsp(b"""
+[section name]
+
+x = 1234
+y = 5678
+""")
+        expected = [{
+            "section_name": "section name",
+            "x": "1234",
+            "y": "5678",
+        }]
+        self.assertEqual(expected, parse_rsp(rsp, []))
+
+    def test_csv_header(self):
+        """Check that we can operate without headers and parse multiple test cases."""
+        rsp = createRsp(b"""
+[a, b, c]
+x = 1234
+y = 5678
+
+""")
+        expected = [
+            {
+                "section_name": ["a", "b", "c"],
+                "x": "1234",
+                "y": "5678",
+            },
+        ]
+        self.assertEqual(expected, parse_rsp(rsp, ["m", "n"]))
+
+    def test_multiple_tests_no_headers(self):
+        """Check that we can operate without headers and parse multiple test cases."""
+        rsp = createRsp(b"""
+x = 1234
+y = 5678
+
+x = 1111
+y = 2222
+""")
+        expected = [
+            {
+                "x": "1234",
+                "y": "5678",
+            },
+            {
+                "x": "1111",
+                "y": "2222",
+            },
+        ]
+        self.assertEqual(expected, parse_rsp(rsp, ["m", "n"]))
+
+    def test_header_variables(self):
+        """Check that header variables are stored persistently."""
+        rsp = createRsp(b"""
+[section name]
+[a = hello]
+[b = world]
+
+x = 1234
+y = 5678
+
+x = 1111
+y = 2222
+""")
+        expected = [
+            {
+                "section_name": "section name",
+                "a": "hello",
+                "b": "world",
+                "x": "1234",
+                "y": "5678",
+            },
+            {
+                "section_name": "section name",
+                "a": "hello",
+                "b": "world",
+                "x": "1111",
+                "y": "2222",
+            },
+        ]
+        self.assertEqual(expected, parse_rsp(rsp, []))
+
+    def test_header_delimiter(self):
+        """Check that headers can delimit test cases."""
+        rsp = createRsp(b"""
+[a = hello]
+x = 1234
+y = 5678
+[a = world]
+x = 1111
+y = 2222
+""")
+        expected = [
+            {
+                "a": "hello",
+                "x": "1234",
+                "y": "5678",
+            },
+            {
+                "a": "world",
+                "x": "1111",
+                "y": "2222",
+            },
+        ]
+        self.assertEqual(expected, parse_rsp(rsp, []))
+
+    def test_persistent_variables(self):
+        """Check that the user-specified persistent variables are respected."""
+        rsp = createRsp(b"""
+m = 1
+n = 2
+o = 3
+
+x = 1234
+y = 5678
+
+x = 1111
+y = 2222
+""")
+        expected = [
+            {
+                "m": "1",
+                "n": "2",
+                "x": "1234",
+                "y": "5678",
+            },
+            {
+                "m": "1",
+                "n": "2",
+                "x": "1111",
+                "y": "2222",
+            },
+        ]
+        self.assertEqual(expected, parse_rsp(rsp, ["m", "n"]))
+
+    def test_duplicate_variables(self):
+        """Check that duplicate values of variables in the same group are stored in lists."""
+        rsp = createRsp(b"""
+m = abc
+m = def
+
+n = efg
+
+n = hij
+
+x = 1234
+y = 5678
+x = 1111
+y = 2222
+
+x = 3333
+y = 4444
+""")
+        expected = [
+            {
+                "m": ["abc", "def"],
+                # Should not duplicate, because the copies are in different groups
+                "n": "hij",
+                "x": ["1234", "1111"],
+                "y": ["5678", "2222"],
+            },
+            {
+                "m": ["abc", "def"],
+                "n": "hij",
+                "x": "3333",
+                "y": "4444",
+            },
+        ]
+        self.assertEqual(expected, parse_rsp(rsp, ["m", "n"]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sw/host/cryptotest/testvectors/parsers/nist_aes_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_aes_parser.py
@@ -20,33 +20,33 @@ from cryptotest_util import parse_rsp, str_to_byte_array
 def parse_testcases(args) -> None:
     raw_testcases = parse_rsp(args.src)
     testcases = list()
-    for operation in raw_testcases.keys():
+    for test_vec in raw_testcases:
         # RSP file is expected to contain two groups: ENCRYPT and DECRYPT
+        operation = test_vec["section_name"]
         if operation not in ["ENCRYPT", "DECRYPT"]:
             raise ValueError(f"Unexpected group name {operation} in RSP file")
-        for test_vec in raw_testcases[operation]:
-            testcase = {
-                "algorithm": "aes",
-                "operation": operation.lower(),
-                "key_len": args.key_len,
-                "mode": args.mode,
-                "padding": "null",
-                "key": str_to_byte_array(test_vec["KEY"]),
-            }
+        testcase = {
+            "algorithm": "aes",
+            "operation": operation.lower(),
+            "key_len": args.key_len,
+            "mode": args.mode,
+            "padding": "null",
+            "key": str_to_byte_array(test_vec["KEY"]),
+        }
 
-            # ECB does not have an IV
-            if args.mode != "ecb":
-                testcase["iv"] = str_to_byte_array(test_vec["IV"])
+        # ECB does not have an IV
+        if args.mode != "ecb":
+            testcase["iv"] = str_to_byte_array(test_vec["IV"])
 
-            # CFB1 is a special case where the block size is only 1 bit
-            if args.mode == "cfb1":
-                testcase["ciphertext"] = [int(test_vec["CIPHERTEXT"])]
-                testcase["plaintext"] = [int(test_vec["PLAINTEXT"])]
-            else:
-                testcase["ciphertext"] = str_to_byte_array(test_vec["CIPHERTEXT"])
-                testcase["plaintext"] = str_to_byte_array(test_vec["PLAINTEXT"])
+        # CFB1 is a special case where the block size is only 1 bit
+        if args.mode == "cfb1":
+            testcase["ciphertext"] = [int(test_vec["CIPHERTEXT"])]
+            testcase["plaintext"] = [int(test_vec["PLAINTEXT"])]
+        else:
+            testcase["ciphertext"] = str_to_byte_array(test_vec["CIPHERTEXT"])
+            testcase["plaintext"] = str_to_byte_array(test_vec["PLAINTEXT"])
 
-            testcases.append(testcase)
+        testcases.append(testcase)
 
     json_filename = f"{args.dst}.json"
     with open(json_filename, "w") as file:

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_hash_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_hash_parser.py
@@ -38,32 +38,31 @@ def parse_testcases(args) -> None:
         digest_key = "Output"
     else:
         digest_key = "MD"
-    for section_name in raw_testcases.keys():
-        count = 1
-        for test_vec in raw_testcases[section_name]:
-            # The test vector includes a single placeholder zero byte if its
-            # intended message length is 0, so we need to ignore that byte.
-            if "Len" in test_vec and int(test_vec["Len"]) == 0:
-                message = []
-            else:
-                message = str_to_byte_array(test_vec["Msg"])
-            if "COUNT" in test_vec:
-                test_case_id = int(test_vec["COUNT"])
-            else:
-                test_case_id = count
-            test_case = {
-                "vendor": "nist",
-                "test_case_id": test_case_id,
-                "algorithm": algorithm,
-                "message": message,
-                "digest": str_to_byte_array(test_vec[digest_key]),
-                # All NIST hash test vectors are expected to have the
-                # right message digest
-                "result": True,
-            }
+    count = 1
+    for test_vec in raw_testcases:
+        # The test vector includes a single placeholder zero byte if its
+        # intended message length is 0, so we need to ignore that byte.
+        if "Len" in test_vec and int(test_vec["Len"]) == 0:
+            message = []
+        else:
+            message = str_to_byte_array(test_vec["Msg"])
+        if "COUNT" in test_vec:
+            test_case_id = int(test_vec["COUNT"])
+        else:
+            test_case_id = count
+        test_case = {
+            "vendor": "nist",
+            "test_case_id": test_case_id,
+            "algorithm": algorithm,
+            "message": message,
+            "digest": str_to_byte_array(test_vec[digest_key]),
+            # All NIST hash test vectors are expected to have the
+            # right message digest
+            "result": True,
+        }
 
-            test_cases.append(test_case)
-            count += 1
+        test_cases.append(test_case)
+        count += 1
 
     json_filename = f"{args.dst}"
     with open(json_filename, "w") as file:

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_hmac_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_hmac_parser.py
@@ -19,11 +19,11 @@ from cryptotest_util import parse_rsp
 # However, the test vectors only include the longest length for each
 # hash (i.e. the entire hash is the MAC).
 LENGTH_TO_HASH = {
-    "20": "sha1",
-    "28": "sha224",
-    "32": "sha256",
-    "48": "sha384",
-    "64": "sha512",
+    "20": "sha-1",
+    "28": "sha-224",
+    "32": "sha-256",
+    "48": "sha-384",
+    "64": "sha-512",
 }
 
 
@@ -33,24 +33,21 @@ def parse_testcases(args) -> None:
 
     # NIST splits the rsp files into sections based on tag length
     # (which implies which hash function should be used)
-    for section_name in raw_testcases.keys():
-        _, mac_len = section_name.split("=")
-        hash_alg = LENGTH_TO_HASH[mac_len]
-        for test_vec in raw_testcases[section_name]:
-            test_case = {
-                "vendor": "nist",
-                "test_case_id": test_vec["Count"],
-                "algorithm": "hmac",
-                "hash_alg": hash_alg,
-                "key": list(bytes.fromhex(test_vec["Key"])),
-                "message": list(bytes.fromhex(test_vec["Msg"])),
-                "tag": list(bytes.fromhex(test_vec["Mac"])),
-                # All NIST HMAC vectors are expected to pass
-                "result": True,
-            }
-            test_cases.append(test_case)
+    for test_vec in raw_testcases:
+        test_case = {
+            "vendor": "nist",
+            "test_case_id": int(test_vec["Count"]),
+            "algorithm": "hmac",
+            "hash_alg": LENGTH_TO_HASH[test_vec["L"]],
+            "key": list(bytes.fromhex(test_vec["Key"])),
+            "message": list(bytes.fromhex(test_vec["Msg"])),
+            "tag": list(bytes.fromhex(test_vec["Mac"])),
+            # All NIST HMAC vectors are expected to pass
+            "result": True,
+        }
+        test_cases.append(test_case)
 
-    json_filename = f"{args.dst}.json"
+    json_filename = f"{args.dst}"
     with open(json_filename, "w") as file:
         json.dump(test_cases, file, indent=4)
 


### PR DESCRIPTION
Performs a massive overhaul (and breaking API change) of the `parse_rsp` function in the cryptotest framework's utility library for test vector parsers.

The heterogeneous formatting styles of the test vector files meant that the caller of `parse_rsp` was still having to do a lot of heavy lifting to get the data into the shape they wanted, and some test vectors were impossible to support using the previous version, such as AES-GCM and DRBG, which declare multiple of the same variable in the same test vector. Likewise, this PR is largely a response to the issues that came up during #21617 .

The new API does the following:

- Rather than sort the test vectors into sections based on the headers that looked like `[header]`, the test vectors are instead returned in a single long array. Headers are now interpreted in one of the following three ways:
    - If the header looks like `[key = value]`, then the key/value pair is simply inserted like a normal variable into every test vector that follows, until another value is set for the same key.
    - If the header looks like `[comma, separated, values]`, then the field `test_vec["section_name"]` is set to an array of the comma-separated strings, where `test_vec` is the test vector.
    - Otherwise, `test_vec["section_name"]` is set to a string equal to the entire text between the `[]`.
- Additionally, the API allows the caller to specify _persistent variables_, which flag the group of lines containing key-value pairs as variables that should be applied to multiple test cases, rather than having the group of lines being treated as a test case itself.
    - To specify that a variable is persistent, pass its name into the API like this: `parse_rsp(filename, ["n"])`. Then, any instance of the variable `n` will apply to all following test cases until another value is assigned to it.
    - Marking any variable in a line group as persistent will cause the group not to be added as a test case, but only the specified variables will be added to the following test vectors.
    - Persistent variables are treated the same as key/value pairs in headers, where the value will be applied to all test vectors until another value is assigned for the same key.
    - For an example of why this behavior is needed / how it works, check out how the variables `n`, `p`, and `q` are specified in the [NIST RSA test vectors](https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/components/RSA2SP1testvectors.zip).
- Blank lines and headers are considered delimiters between line groups / test cases.
- If a key occurs more than once in a line group, all of the values will be included in the test vector in an array.
    - This also applies to caller-specified persistent variables, but not headers.

The implementation of the new semantics was complex enough to warrant its own set of unit tests, which are included with this PR.

Along for the ride are also a few minor changes to the test vector build script (e.g. changing `genrule` to `run_binary`).