### PR TITLE
[pentest] Disable iCache and dummy instr.

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -64,6 +64,7 @@ cc_library(
         "//sw/device/sca/lib:aes",
         "//sw/device/sca/lib:prng",
         "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/firmware:sca_lib",
         "//sw/device/tests/crypto/cryptotest/json:aes_sca_commands",
     ],
 )
@@ -83,6 +84,7 @@ cc_library(
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/firmware:sca_lib",
         "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
     ],
 )
@@ -103,6 +105,7 @@ cc_library(
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:prng",
         "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/firmware:sca_lib",
         "//sw/device/tests/crypto/cryptotest/json:kmac_sca_commands",
     ],
 )
@@ -123,6 +126,16 @@ cc_library(
 )
 
 cc_library(
+    name = "sca_lib",
+    srcs = ["sca_lib.c"],
+    hdrs = ["sca_lib.h"],
+    deps = [
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+cc_library(
     name = "sha3_sca",
     srcs = ["sha3_sca.c"],
     hdrs = [
@@ -138,6 +151,7 @@ cc_library(
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:prng",
         "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/firmware:sca_lib",
         "//sw/device/tests/crypto/cryptotest/json:sha3_sca_commands",
     ],
 )
@@ -173,6 +187,7 @@ opentitan_binary(
         ":prng_sca",
         ":sha3_sca",
         ":trigger_sca",
+        "//sw/device/lib/base:csr",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/testing/test_framework:check",
@@ -205,6 +220,7 @@ opentitan_test(
         ":prng_sca",
         ":sha3_sca",
         ":trigger_sca",
+        "//sw/device/lib/base:csr",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
@@ -14,6 +14,7 @@
 #include "sw/device/sca/lib/aes.h"
 #include "sw/device/sca/lib/prng.h"
 #include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/sca_lib.h"
 #include "sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -852,6 +853,11 @@ status_t handle_aes_sca_init(ujson_t *uj) {
   if (dif_aes_reset(&aes) != kDifOk) {
     return ABORTED();
   }
+
+  // Disable the instruction cache and dummy instructions for better SCA
+  // measurements.
+  sca_configure_cpu();
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.c
@@ -12,6 +12,7 @@
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"
 #include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/sca_lib.h"
 #include "sw/device/tests/crypto/cryptotest/firmware/status.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
 
@@ -265,6 +266,10 @@ status_t handle_ibex_fi_init_trigger(ujson_t *uj) {
   // As we are using the software defined trigger, the first argument of
   // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
   sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4);
+
+  // Disable the instruction cache and dummy instructions for FI attacks.
+  sca_configure_cpu();
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/ujson/ujson.h"
 #include "sw/device/sca/lib/prng.h"
 #include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/sca_lib.h"
 #include "sw/device/tests/crypto/cryptotest/firmware/status.h"
 #include "sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h"
 
@@ -470,6 +471,11 @@ status_t handle_kmac_sca_init(ujson_t *uj) {
   UJSON_CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
 
   kmac_block_until_idle();
+
+  // Disable the instruction cache and dummy instructions for better SCA
+  // measurements.
+  sca_configure_cpu();
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/crypto/cryptotest/firmware/sca_lib.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sca_lib.c
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+/**
+ * Configures Ibex for SCA and FI.
+ *
+ * This function disables the iCache and the dummy instructions using the
+ * CPU Control and Status Register (cpuctrlsts).
+ *
+ */
+void sca_configure_cpu(void) {
+  uint32_t cpuctrl_csr;
+  // Get current config.
+  CSR_READ(CSR_REG_CPUCTRL, &cpuctrl_csr);
+  // Disable the iCache.
+  cpuctrl_csr = bitfield_field32_write(
+      cpuctrl_csr, (bitfield_field32_t){.mask = 0x1, .index = 0}, 0);
+  // Disable dummy instructions.
+  cpuctrl_csr = bitfield_field32_write(
+      cpuctrl_csr, (bitfield_field32_t){.mask = 0x1, .index = 2}, 0);
+  // Write back config.
+  CSR_WRITE(CSR_REG_CPUCTRL, cpuctrl_csr);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/sca_lib.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/sca_lib.h
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_SCA_LIB_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_SCA_LIB_H_
+
+void sca_configure_cpu(void);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_SCA_LIB_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/ujson/ujson.h"
 #include "sw/device/sca/lib/prng.h"
 #include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/sca_lib.h"
 #include "sw/device/tests/crypto/cryptotest/firmware/status.h"
 #include "sw/device/tests/crypto/cryptotest/json/sha3_sca_commands.h"
 
@@ -606,6 +607,11 @@ status_t handle_sha3_sca_init(ujson_t *uj) {
   UJSON_CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
 
   kmac_block_until_idle();
+
+  // Disable the instruction cache and dummy instructions for better SCA
+  // measurements.
+  sca_configure_cpu();
+
   return OK_STATUS(0);
 }
 


### PR DESCRIPTION
Instruction caching and dummy instructions could negatively affect the alignment of SCA traces. Hence, this PR adds code to disable the iCache and dummy instructions before starting SCA & FI penetration tests.

The effect of the iCache can be seen in the picture below. Here, I recorded 100 power traces and the corresponding trigger signal when executing NOP instructions.
![image](https://github.com/lowRISC/opentitan/assets/5767400/45352369-9049-4dba-8477-b268f269c6d2)
With the enabled instruction cache (left side), the falling edge of the trigger signal is captured at different points in time. For SCA and FI, this makes the analysis much harder. When disabling the iCache (right side), the falling edge of all 100 triggers are now aligned.

Thanks to @johannheyszl, @moidx, and @a-will for the discussion on this!