### PR TITLE
[dv] fix rom_ctrl dvsim output path

### DIFF
--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -50,6 +50,18 @@
   vcs_cov_excl_files: ["{proj_root}/hw/ip/rom_ctrl/dv/cov/rom_ctrl_cov_unr_excl.el",
                        "{proj_root}/hw/ip/rom_ctrl/dv/cov/rom_ctrl_cov_excl.el"]
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
+    }
+    {
+      name: rel_path
+      value: "hw/ip/{name}_{variant}/dv"
+    }
+  ]
+
   // Default UVM test and seq class name.
   uvm_test: rom_ctrl_base_test
   uvm_test_seq: rom_ctrl_base_vseq


### PR DESCRIPTION
Currently it uses the default output path, which does not have the variant in it. This causes the files of ROM_CTRL/32KB run to be overwritten by ROM_CTRL/64KB run silently, and will cause error if parallelism > 3.

Follow what other blocks are doing and specify an output path with variant name in it.