### PR TITLE
[otp] Fix OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END value

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_owner_sw_cfg.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_owner_sw_cfg.hjson
@@ -233,7 +233,7 @@
                 },
                 {
                     name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END",
-                    value: "0x8a12908b",
+                    value: "0x10f153e1",
                 },
                 {
                     name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA",


### PR DESCRIPTION
It seems something messed up for the values. I just re-generated the digest values and got the diff.
Thats the output of the opentitantool:
```
{
  partitions: [
    {
      name: "OWNER_SW_CFG",
      items: [
        {
          name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD",
          value: 3837441892
        },
        {
          name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_PROD_END",
          value: 284251105
        },
        {
          name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_DEV",
          value: 2316472459
        },
        {
          name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA",
          value: 1321476032
        }
      ]
    }
  ]
}
```