### PR TITLE
[pentest] Add support for AES SCA measurements on chip

### DIFF
--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -245,7 +245,7 @@ static void aes_encrypt(const uint8_t *plaintext, size_t plaintext_len) {
   // Using the SecAesStartTriggerDelay hardware parameter, the AES unit is
   // configured to start operation 40 cycles after receiving the start trigger.
   // This allows Ibex to go to sleep in order to not disturb the capture.
-  sca_call_and_sleep(aes_manual_trigger, kIbexAesSleepCycles);
+  sca_call_and_sleep(aes_manual_trigger, kIbexAesSleepCycles, false);
 }
 
 /**

--- a/sw/device/sca/kmac_serial.c
+++ b/sw/device/sca/kmac_serial.c
@@ -480,7 +480,7 @@ static void sha3_serial_absorb(const uint8_t *msg, size_t msg_len) {
   // configured to start operation 40 cycles after receiving the START and PROC
   // commands. This allows Ibex to go to sleep in order to not disturb the
   // capture.
-  sca_call_and_sleep(kmac_msg_proc, kIbexSha3SleepCycles);
+  sca_call_and_sleep(kmac_msg_proc, kIbexSha3SleepCycles, false);
 }
 
 /**

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -309,7 +309,8 @@ void sca_set_trigger_low(void) {
   OT_DISCARD(dif_gpio_write(&gpio, trigger_bit_index, false));
 }
 
-void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles) {
+void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles,
+                        bool sw_trigger) {
   // Disable the IO_DIV4_PERI clock to reduce noise during the actual capture.
   // This also disables the UART(s) and GPIO modules required for
   // communication with the scope. Therefore, it has to be re-enabled after
@@ -328,7 +329,15 @@ void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles) {
   OT_DISCARD(dif_rv_timer_counter_set_enabled(&timer, kRvTimerHart,
                                               kDifToggleEnabled));
 
+  if (sw_trigger) {
+    sca_set_trigger_high();
+  }
+
   callee();
+
+  if (sw_trigger) {
+    sca_set_trigger_low();
+  }
 
   wait_for_interrupt();
 

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -196,8 +196,10 @@ typedef void (*sca_callee)(void);
  *
  * @param callee Function to call before putting Ibex to sleep.
  * @param sleep_cycles Number of cycles to sleep.
+ * @param sw_trigger Raise trigger before calling the target function.
  */
-void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles);
+void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles,
+                        bool sw_trigger);
 
 /**
  * Seeds the software LFSR usable e.g. for key masking.

--- a/sw/device/sca/otbn_vertical/ecc256_keygen_serial.c
+++ b/sw/device/sca/otbn_vertical/ecc256_keygen_serial.c
@@ -204,7 +204,7 @@ static void p256_run_keygen(uint32_t mode, const uint32_t *share0,
 
   // Execute program.
   sca_set_trigger_high();
-  sca_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles);
+  sca_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles, false);
   SS_CHECK_STATUS_OK(otbn_busy_wait_for_done());
   sca_set_trigger_low();
 }

--- a/sw/device/sca/otbn_vertical/ecc256_modinv_serial.c
+++ b/sw/device/sca/otbn_vertical/ecc256_modinv_serial.c
@@ -92,7 +92,7 @@ static void p256_run_modinv(uint32_t *k0, uint32_t *k1) {
 
   // Execute program.
   sca_set_trigger_high();
-  sca_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles);
+  sca_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles, false);
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
 }

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -405,9 +405,7 @@ static void sha3_serial_absorb(const uint8_t *msg, size_t msg_len) {
   // configured to start operation 40 cycles after receiving the START and PROC
   // commands. This allows Ibex to go to sleep in order to not disturb the
   // capture.
-  sca_set_trigger_high();
-  sca_call_and_sleep(kmac_msg_proc, kIbexSha3SleepCycles);
-  sca_set_trigger_low();
+  sca_call_and_sleep(kmac_msg_proc, kIbexSha3SleepCycles, true);
 }
 
 /**

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
@@ -24,6 +24,11 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+/**
+ * Enable FPGA mode.
+ */
+static bool fpga_mode = false;
+
 enum {
   kAesKeyLengthMax = 32,
   kAesKeyLength = 16,
@@ -167,6 +172,7 @@ static aes_sca_error_t aes_key_mask_and_config(const uint8_t *key,
         sca_linear_layer(sca_next_lfsr(1, kScaLfsrMasking)));
     key_shares.share0[i] = *((uint32_t *)key + i) ^ key_shares.share1[i];
   }
+
   // Provide random shares for unused key bits.
   for (size_t i = key_len / 4; i < kAesKeyLengthMax / 4; ++i) {
     key_shares.share1[i] =
@@ -243,7 +249,16 @@ static aes_sca_error_t aes_encrypt(const uint8_t *plaintext,
   }
 
   // Start AES operation (this triggers the capture) and go to sleep.
-  sca_call_and_sleep(aes_manual_trigger, kIbexAesSleepCycles);
+  if (fpga_mode) {
+    // On the FPGA, the AES block automatically sets and unsets the trigger.
+    sca_call_and_sleep(aes_manual_trigger, kIbexAesSleepCycles, false);
+  } else {
+    // On the chip, we need to manually set and unset the trigger. This is done
+    // in this function to have the trigger as close as possible to the AES
+    // operation.
+    sca_call_and_sleep(aes_manual_trigger, kIbexAesSleepCycles, true);
+  }
+
   return aesScaOk;
 }
 
@@ -260,9 +275,7 @@ static status_t aes_send_ciphertext(bool only_first_word, ujson_t *uj) {
   } while (!ready);
 
   dif_aes_data_t ciphertext;
-  if (dif_aes_read_output(&aes, &ciphertext) != kDifOk) {
-    return OUT_OF_RANGE();
-  }
+  UJSON_CHECK_DIF_OK(dif_aes_read_output(&aes, &ciphertext));
 
   cryptotest_aes_sca_ciphertext_t uj_output;
   memset(uj_output.ciphertext, 0, AESSCA_CMD_MAX_DATA_BYTES);
@@ -307,11 +320,15 @@ status_t handle_aes_sca_single_encrypt(ujson_t *uj) {
     block_ctr = 1;
   }
 
-  sca_set_trigger_high();
+  if (fpga_mode) {
+    sca_set_trigger_high();
+  }
   if (aes_encrypt(uj_data.text, uj_data.text_length) != aesScaOk) {
     return ABORTED();
   }
-  sca_set_trigger_low();
+  if (fpga_mode) {
+    sca_set_trigger_low();
+  }
 
   TRY(aes_send_ciphertext(false, uj));
   return OK_STATUS(0);
@@ -396,14 +413,18 @@ status_t handle_aes_sca_batch_encrypt(ujson_t *uj) {
     block_ctr = num_encryptions;
   }
 
-  sca_set_trigger_high();
+  if (fpga_mode) {
+    sca_set_trigger_high();
+  }
   for (uint32_t i = 0; i < num_encryptions; ++i) {
     if (aes_encrypt(plaintext_random, kAesTextLength) != aesScaOk) {
       return ABORTED();
     }
     aes_serial_advance_random();
   }
-  sca_set_trigger_low();
+  if (fpga_mode) {
+    sca_set_trigger_low();
+  }
 
   TRY(aes_send_ciphertext(true, uj));
 
@@ -456,7 +477,9 @@ status_t handle_aes_sca_batch_alternative_encrypt(ujson_t *uj) {
   // Set trigger high outside of loop
   // On FPGA, the trigger is AND-ed with AES !IDLE and creates a LO-HI-LO per
   // AES operation
-  sca_set_trigger_high();
+  if (fpga_mode) {
+    sca_set_trigger_high();
+  }
   dif_aes_data_t ciphertext;
   for (uint32_t i = 0; i < num_encryptions; ++i) {
     // Encrypt
@@ -477,7 +500,9 @@ status_t handle_aes_sca_batch_alternative_encrypt(ujson_t *uj) {
     // Use ciphertext as next plaintext (incl. next call to this function)
     memcpy(batch_plaintext, ciphertext.data, kAesTextLength);
   }
-  sca_set_trigger_low();
+  if (fpga_mode) {
+    sca_set_trigger_low();
+  }
 
   // send last ciphertext
   cryptotest_aes_sca_ciphertext_t uj_output;
@@ -647,7 +672,9 @@ status_t handle_aes_sca_fvsr_key_batch_encrypt(ujson_t *uj) {
     return OUT_OF_RANGE();
   }
 
-  sca_set_trigger_high();
+  if (fpga_mode) {
+    sca_set_trigger_high();
+  }
   for (uint32_t i = 0; i < num_encryptions; ++i) {
     if (aes_key_mask_and_config(batch_keys[i], kAesKeyLength) != aesScaOk) {
       return ABORTED();
@@ -656,7 +683,9 @@ status_t handle_aes_sca_fvsr_key_batch_encrypt(ujson_t *uj) {
       return ABORTED();
     }
   }
-  sca_set_trigger_low();
+  if (fpga_mode) {
+    sca_set_trigger_low();
+  }
 
   TRY(aes_send_ciphertext(false, uj));
 
@@ -714,12 +743,16 @@ status_t handle_aes_sca_fvsr_data_batch_encrypt(ujson_t *uj) {
     sample_fixed = sca_next_lfsr(1, kScaLfsrOrder) & 0x1;
   }
 
-  sca_set_trigger_high();
+  if (fpga_mode) {
+    sca_set_trigger_high();
+  }
   for (uint32_t i = 0; i < num_encryptions; ++i) {
     aes_key_mask_and_config(batch_keys[i], kAesKeyLength);
     aes_encrypt(batch_plaintexts[i], kAesTextLength);
   }
-  sca_set_trigger_low();
+  if (fpga_mode) {
+    sca_set_trigger_low();
+  }
 
   TRY(aes_send_ciphertext(false, uj));
 
@@ -859,16 +892,17 @@ status_t handle_aes_sca_fvsr_key_start_batch_generate(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_aes_sca_init(ujson_t *uj) {
+  // Read mode. FPGA or discrete.
+  cryptotest_aes_sca_fpga_mode_t uj_data;
+  TRY(ujson_deserialize_cryptotest_aes_sca_fpga_mode_t(uj, &uj_data));
+  if (uj_data.fpga_mode == 0x01) {
+    fpga_mode = true;
+  }
   sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4 | kScaPeripheralAes);
 
-  if (dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes) !=
-      kDifOk) {
-    return ABORTED();
-  }
-
-  if (dif_aes_reset(&aes) != kDifOk) {
-    return ABORTED();
-  }
+  UJSON_CHECK_DIF_OK(
+      dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  UJSON_CHECK_DIF_OK(dif_aes_reset(&aes));
 
   // Disable the instruction cache and dummy instructions for better SCA
   // measurements.

--- a/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
@@ -542,7 +542,8 @@ static kmac_sca_error_t sha3_ujson_absorb(const uint8_t *msg, size_t msg_len) {
   if (fpga_mode == false) {
     // Start command. On the chip, we need to first issue a START command
     // before writing to the message FIFO.
-    sca_call_and_sleep(kmac_start_cmd, kIbexLoadHashPrefixKeySleepCycles);
+    sca_call_and_sleep(kmac_start_cmd, kIbexLoadHashPrefixKeySleepCycles,
+                       false);
   }
 
   // Write data to message FIFO.
@@ -556,11 +557,12 @@ static kmac_sca_error_t sha3_ujson_absorb(const uint8_t *msg, size_t msg_len) {
     // configured to start operation 320 cycles after receiving the START and
     // PROC commands. This allows Ibex to go to sleep in order to not disturb
     // the capture.
-    sca_call_and_sleep(kmac_start_process_cmd, kIbexSha3SleepCycles);
+    sca_call_and_sleep(kmac_start_process_cmd, kIbexSha3SleepCycles, false);
   } else {
     // On the chip, issue a PROCESS command to start operation and put Ibex
     // into sleep.
-    sca_call_and_sleep(kmac_process_cmd, kIbexLoadHashMessageSleepCycles);
+    sca_call_and_sleep(kmac_process_cmd, kIbexLoadHashMessageSleepCycles,
+                       false);
   }
 
   return kmacScaOk;

--- a/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
@@ -418,15 +418,11 @@ sha3_sca_error_t sha3_serial_absorb(const uint8_t *msg, size_t msg_len) {
     // configured to start operation 320 cycles after receiving the START and
     // PROC commands. This allows Ibex to go to sleep in order to not disturb
     // the capture.
-    sca_set_trigger_high();
-    sca_call_and_sleep(kmac_start_process_cmd, kIbexSha3SleepCycles);
-    sca_set_trigger_low();
+    sca_call_and_sleep(kmac_start_process_cmd, kIbexSha3SleepCycles, true);
   } else {
     // On the chip, issue a PROCESS command to start operation and put Ibex
     // into sleep.
-    sca_set_trigger_high();
-    sca_call_and_sleep(kmac_process_cmd, kIbexLoadHashMessageSleepCycles);
-    sca_set_trigger_low();
+    sca_call_and_sleep(kmac_process_cmd, kIbexLoadHashMessageSleepCycles, true);
   }
 
   return sha3ScaOk;

--- a/sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h
@@ -56,6 +56,10 @@ UJSON_SERDE_STRUCT(CryptotestAesScaLfsr, cryptotest_aes_sca_lfsr_t, AES_SCA_LFSR
     field(ciphertext, uint8_t, AESSCA_CMD_MAX_MSG_BYTES) \
     field(ciphertext_length, uint32_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaCiphertext, cryptotest_aes_sca_ciphertext_t, AES_SCA_CIPHERTEXT);
+
+#define AES_SCA_FPGA_MODE(field, string) \
+    field(fpga_mode, uint8_t)
+UJSON_SERDE_STRUCT(CryptotestAesScaFpgaMode, cryptotest_aes_sca_fpga_mode_t, AES_SCA_FPGA_MODE);
 // clang-format on
 
 #ifdef __cplusplus


### PR DESCRIPTION
On the FPGA, the AES block automatically raises the trigger allowing to perform SCA analysis. As this is not available on the chip, this PR extends the AES SCA code to manually handling the trigger.

The arming of the trigger is implemented in the `sca_call_and_sleep_trigger` to keep the trigger window as narrow as possible (this reduces the number of samples needed and helps to easier setup the SCA gear).

The host code is located in lowRISC/ot-sca#329.