### PR TITLE
Testplan formatter

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_adc_ctrl
   testpoints: [
-    // ADC_CTRL (pre-verified IP) integration tests:
     {
       name: chip_sw_adc_ctrl_debug_cable_irq
-      desc: '''Verify that the ADC correctly detects the voltage level programmed for each channel.
+      desc: '''
+            Verify that the ADC correctly detects the voltage level programmed for each channel.
 
             - Program both ADC channels to detect mutually exclusive range of voltages. Setting only
               one filter CSR is sufficient.
@@ -24,7 +24,7 @@
               filter caused the interrupt to fire. Read the ADC channel value register to verify the
               correctness of the detected value that was forced in the AST for each channel.
             '''
-      features:["ADC_CTRL.MODE.LOW_POWER"]
+      features: ["ADC_CTRL.MODE.LOW_POWER"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -32,7 +32,8 @@
     }
     {
       name: chip_sw_adc_ctrl_sleep_debug_cable_wakeup
-      desc: '''Verify that in deep sleep, ADC ctrl can signal the ADC within the AST to power down.
+      desc: '''
+            Verify that in deep sleep, ADC ctrl can signal the ADC within the AST to power down.
 
             - Read the reset cause register in rstmgr to confirm we are in POR reset phase.
             - Follow the same steps as chip_adc_ctrl_debug_cable_irq, but instead of programming the
@@ -49,7 +50,7 @@
               that was forced in the AST.
             - Repeat for both ADC channels.
             '''
-      features:["ADC_CTRL.MODE.LOW_POWER"]
+      features: ["ADC_CTRL.MODE.LOW_POWER"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -57,8 +58,8 @@
     }
     {
       name: chip_sw_adc_ctrl_normal
-      desc:"Verifiy that ADC can sample from channel 0 and 1 in normal mode."
-      features:["ADC_CTRL.MODE.NORMAL"]
+      desc: Verifiy that ADC can sample from channel 0 and 1 in normal mode.
+      features: ["ADC_CTRL.MODE.NORMAL"]
       stage: V3
       si_stage: SV2
       lc_states: ["PROD"]
@@ -66,8 +67,8 @@
     }
     {
       name: chip_sw_adc_ctrl_oneshot
-      desc:"Verifiy that ADC can sample from channel 0 and 1 in normal mode with oneshot filter config."
-      features:["ADC_CTRL.ONESHOT", "ADC_CTRL.MODE.NORMAL"]
+      desc: Verifiy that ADC can sample from channel 0 and 1 in normal mode with oneshot filter config.
+      features: ["ADC_CTRL.ONESHOT", "ADC_CTRL.MODE.NORMAL"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -6,7 +6,8 @@
   testpoints: [
     {
       name: chip_sw_aes_enc
-      desc: '''Verify the AES operation.
+      desc: '''
+            Verify the AES operation.
 
             Procedure:
             -Set up the desired operation, ECB mode, 256b key length, and set the engine to
@@ -19,21 +20,17 @@
             decryption of the result using the same key.
             -Check that the decryption result matches the original plaintext.
             '''
-      features: [
-        "AES.MODE.ECB",
-        "AES.KEY_LEN.256",
-        "AES.MANUAL_OPERATION",
-      ]
+      features: ["AES.MODE.ECB", "AES.KEY_LEN.256", "AES.MANUAL_OPERATION"]
       stage: V2
       si_stage: SV2
       lc_states: ["TEST_UNLOCKED", "PROD"]
-      tests: ["chip_sw_aes_enc",
-              "chip_sw_aes_enc_jitter_en"]
+      tests: ["chip_sw_aes_enc", "chip_sw_aes_enc_jitter_en"]
       bazel: ["//sw/device/tests:aes_smoketest"]
     }
     {
       name: chip_sw_aes_multi_block
-      desc: '''Verify the AES operations on multi-block messages.
+      desc: '''
+            Verify the AES operations on multi-block messages.
             This test should be performed for all supported modes (ECB, CBC, CFB-128, OFB and CTR)
             and all supported key lengths (128/192/256).
 
@@ -52,16 +49,7 @@
             decryption of the result using the same key (and same IV if needed).
             -Check that the decryption result matches the original plaintext.
             '''
-      features: [
-        "AES.MODE.ECB",
-        "AES.MODE.CBC",
-        "AES.MODE.CFB-128",
-        "AES.MODE.OFB",
-        "AES.MODE.CTR",
-        "AES.KEY_LEN.128",
-        "AES.KEY_LEN.192",
-        "AES.KEY_LEN.256",
-      ]
+      features: ["AES.MODE.ECB", "AES.MODE.CBC", "AES.MODE.CFB-128", "AES.MODE.OFB", "AES.MODE.CTR", "AES.KEY_LEN.128", "AES.KEY_LEN.192", "AES.KEY_LEN.256"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -69,7 +57,8 @@
     }
     {
       name: chip_sw_aes_interrupt_encryption
-      desc: '''Verify that a multi-block encryption can be interrupted and continued.
+      desc: '''
+            Verify that a multi-block encryption can be interrupted and continued.
 
             This test should:
               - start the encryption of a four-block message.
@@ -95,12 +84,7 @@
             -Decrypt the result (using the original key and IV)
             -Check that the decryption result matches the original plaintext.
             '''
-      features: [
-        "AES.MODE.CBC",
-        "AES.MODE.CFB-128",
-        "AES.MODE.OFB",
-        "AES.MODE.CTR",
-      ]
+      features: ["AES.MODE.CBC", "AES.MODE.CFB-128", "AES.MODE.OFB", "AES.MODE.CTR"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -108,7 +92,8 @@
     }
     {
       name: chip_sw_aes_entropy
-      desc: '''Verify the AES entropy input used by the internal PRNGs.
+      desc: '''
+            Verify the AES entropy input used by the internal PRNGs.
 
             - Configure encryption using the CBC mode, key length 256, and set the engine to
               manual operation.
@@ -123,11 +108,7 @@
             - Assertion check verifies that the IV are also garbage, i.e. different from the
               originally written values.
             '''
-      features: [
-        "AES.MODE.CBC",
-        "AES.CLEAR.DATA_OUT",
-        "AES.CLEAR.KEY_IV_DATA_IN",
-      ]
+      features: ["AES.MODE.CBC", "AES.CLEAR.DATA_OUT", "AES.CLEAR.KEY_IV_DATA_IN"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -136,7 +117,8 @@
     }
     {
       name: chip_sw_aes_prng_reseed
-      desc: '''Verify that PRNG reseeding is triggered
+      desc: '''
+            Verify that PRNG reseeding is triggered
 
             This test should start encryption, disable the EDN, and verify that the
             encryption stalls when reseed is required. Afterwards it should verify that AES
@@ -165,10 +147,7 @@
             -Repeat the test for a reseed rate kDifAesReseedPer8kBlock and a message longer than 8K
             blocks.
             '''
-      features: [
-        "AES.MODE.ECB",
-        "AES.PRNG.RESEED_RATE",
-      ]
+      features: ["AES.MODE.ECB", "AES.PRNG.RESEED_RATE"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -176,7 +155,8 @@
     }
     {
       name: chip_sw_aes_force_prng_reseed
-      desc: '''Verify that when KEY_TOUCH_FORCES_RESEED is set, the PRNG reseed is
+      desc: '''
+            Verify that when KEY_TOUCH_FORCES_RESEED is set, the PRNG reseed is
                triggered every time a key changes
 
             Procedure:
@@ -198,10 +178,7 @@
                 -Enable EDN
             -Verify that the AES completes encryption.
             '''
-      features: [
-        "AES.MODE.ECB",
-        "AES.PRNG.KEY_TOUCH_FORCES_RESEED",
-      ]
+      features: ["AES.MODE.ECB", "AES.PRNG.KEY_TOUCH_FORCES_RESEED"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -209,7 +186,8 @@
     }
     {
       name: chip_sw_aes_idle
-      desc: '''Verify AES idle signaling to clkmgr.
+      desc: '''
+            Verify AES idle signaling to clkmgr.
 
             - Write the AES clk hint to 0 within clkmgr to indicate AES clk can be gated and
               verify that the AES clk hint status within clkmgr reads 0 (AES is disabled).
@@ -221,9 +199,7 @@
               clkmgr now reads 0 again (AES is disabled).
             - Write the AES clk hint to 1, read and check the AES output for correctness.
             '''
-      features: [
-        "AES.MODE.ECB",
-      ]
+      features: ["AES.MODE.ECB"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -232,7 +208,8 @@
     }
     {
       name: chip_sw_aes_sideload
-      desc: '''Verify the AES sideload mechanism.
+      desc: '''
+            Verify the AES sideload mechanism.
 
             - Configure the keymgr to generate an aes key.
             - Configure the AES to use the sideloaded key.
@@ -245,10 +222,7 @@
             - Clear the key in the keymgr and decrypt the ciphertext again.
             - Verify that output is not equal to the plain text.
             '''
-      features: [
-        "AES.MODE.ECB",
-        "AES.KEY.SIDELOAD",
-      ]
+      features: ["AES.MODE.ECB", "AES.KEY.SIDELOAD"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD", "DEV"]
@@ -256,7 +230,8 @@
     }
     {
       name: chip_sw_aes_masking_off
-      desc: '''Verify the AES masking off feature for ES.
+      desc: '''
+            Verify the AES masking off feature for ES.
 
             - Perform known-answer test using CSRNG SW application interface.
             - Verify CSRNG produces the deterministic seed leading to an all-zero output of the AES
@@ -286,12 +261,10 @@
               The only thing that can be tested on silicon / FPGA for SiVal is the known-answer test using the CSRNG SW application interface for which a dedicated SiVal test exists.
               For this reason, the chip_sw_aes_masking_off test is run in simulation only.
             '''
-      features: [
-        "AES.PRNG.FORCE_MASKS"
-      ]
+      features: ["AES.PRNG.FORCE_MASKS"]
       stage: V2S
       si_stage: NA
       tests: ["chip_sw_aes_masking_off"]
-     }
+    }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_alert_handler
   testpoints: [
-    // ALERT_HANDLER (pre-verified IP) integration tests:
     {
       name: chip_sw_alert_handler_alerts
-      desc: '''Verify all alerts coming into the alert_handler.
+      desc: '''
+            Verify all alerts coming into the alert_handler.
 
             An automated SW test, which does the following (applies to all alerts in all IPs):
             - Program the alert_test CSR in each block to trigger each alert one by one.
@@ -17,8 +17,7 @@
             Note for silicon validation:
             - Ensure this test makes no alterations to OTP (use NMI escalation path).
             '''
-      features: ["ALERT_HANDLER.ALERT.OBSERVE",
-                 "ALERT_HANDLER.ALERT.ESCALATE"]
+      features: ["ALERT_HANDLER.ALERT.OBSERVE", "ALERT_HANDLER.ALERT.ESCALATE"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -27,7 +26,8 @@
     }
     {
       name: chip_sw_alert_handler_escalations
-      desc: '''Verify all alert escalation paths.
+      desc: '''
+            Verify all alert escalation paths.
 
             Verify all escalation paths triggered by an alert.
             - Verify the first escalation results in NMI interrupt serviced by the CPU.
@@ -37,18 +37,18 @@
               - This cannot be checked in sival as the handshake signals cannot
                 be directly observed.
             '''
-      features: ["ALERT_HANDLER.ALERT.ESCALATE",
-                 "ALERT_HANDLER.ESCALATION.PHASES"]
+      features: ["ALERT_HANDLER.ALERT.ESCALATE", "ALERT_HANDLER.ESCALATION.PHASES"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_escalation"]
-      otp_mutate: true
-      host_support: true
+      otp_mutate: True
+      host_support: True
     }
     {
       name: chip_sw_alert_handler_escalation_nmi_reset
-      desc: '''Verify NMI and reset alert escalation paths.
+      desc: '''
+            Verify NMI and reset alert escalation paths.
 
             - Program the alert classes to only use escalation signals 0 and 3 (NMI interrupt and
               chip reset)
@@ -61,17 +61,17 @@
               info captured the correct alert.
             - Check that no additional resets occur.
             '''
-      features: ["ALERT_HANDLER.ALERT.ESCALATE",
-                 "ALERT_HANDLER.ESCALATION.PHASES"]
+      features: ["ALERT_HANDLER.ALERT.ESCALATE", "ALERT_HANDLER.ESCALATION.PHASES"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      otp_mutate: false
+      otp_mutate: False
     }
     {
       name: chip_sw_alert_handler_escalation_methods
-      desc: '''Verify the different escalation trigger methods
+      desc: '''
+            Verify the different escalation trigger methods
 
             For each escalation class, verify the escalation occurs (just the first stage, NMI
             escalation) with all of the possible trigger methods.
@@ -79,8 +79,7 @@
               threshold
             - Escalation triggered when initial interrupt isn't acknowledged within the timeout
             '''
-      features: ["ALERT_HANDLER.ESCALATION.COUNT",
-                 "ALERT_HANDLER.ESCALATION.TIMEOUT"]
+      features: ["ALERT_HANDLER.ESCALATION.COUNT", "ALERT_HANDLER.ESCALATION.TIMEOUT"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -88,7 +87,8 @@
     }
     {
       name: chip_sw_all_escalation_resets
-      desc: '''Verify escalation from all unit integrity errors.
+      desc: '''
+            Verify escalation from all unit integrity errors.
 
             Inject integrity errors in any unit that has a one-hot checker for CSR register
             writes, and verify escalation is triggered. Allow escalation to go through reset.
@@ -112,7 +112,8 @@
     }
     {
       name: chip_sw_alert_handler_irqs
-      desc: '''Verify all classes of alert handler interrupts to the CPU.
+      desc: '''
+            Verify all classes of alert handler interrupts to the CPU.
 
             X-ref'ed with the automated PLIC test.
             '''
@@ -125,7 +126,8 @@
     }
     {
       name: chip_sw_alert_handler_entropy
-      desc: '''Verify the alert handler entropy input to ensure pseudo-random ping timer.
+      desc: '''
+            Verify the alert handler entropy input to ensure pseudo-random ping timer.
 
             - Force `alert_handler_ping_timer` input signal `wait_cyc_mask_i` to `8'h07` to
               shorten the simulation time.
@@ -142,7 +144,8 @@
     }
     {
       name: chip_sw_alert_handler_crashdump
-      desc: '''Verify the alert handler crashdump signal.
+      desc: '''
+            Verify the alert handler crashdump signal.
 
             When the chip resets due to alert escalating to cause the chip to reset, verify the
             reset cause to verify the alert crashdump.
@@ -158,7 +161,8 @@
     }
     {
       name: chip_sw_alert_handler_ping_timeout
-      desc: '''Verify the alert senders' ping timeout.
+      desc: '''
+            Verify the alert senders' ping timeout.
 
             Set alert_handler's ping timeout cycle to 2 and enable alert_senders. Verify that
             alert_handler detects the ping timeout and reflects it on the `loc_alert_cause`
@@ -173,7 +177,8 @@
     }
     {
       name: chip_sw_alert_handler_lpg_sleep_mode_alerts
-      desc: '''Verify alert_handler can preserve alerts during low_power mode.
+      desc: '''
+            Verify alert_handler can preserve alerts during low_power mode.
 
             - Trigger fatal alerts for all IPs but configure alert_handler so it won't trigger
               reset.
@@ -193,7 +198,8 @@
     }
     {
       name: chip_sw_alert_handler_lpg_sleep_mode_pings
-      desc: '''Verify alert_handler's ping mechanism works correctly during sleep and wake up.
+      desc: '''
+            Verify alert_handler's ping mechanism works correctly during sleep and wake up.
 
             There are two scenarios to check:
             - Configure alert_handler's ping timeout register to a reasonble value that won't cause
@@ -218,7 +224,8 @@
     }
     {
       name: chip_sw_alert_handler_lpg_clock_off
-      desc: '''Verify alert_handler's works correctly when sender clock is turned off.
+      desc: '''
+            Verify alert_handler's works correctly when sender clock is turned off.
 
             - Configure clkmgr to randomly turn off one of the IP's clock and check alert_handler
               won't trigger a ping timeout error on that block.
@@ -232,21 +239,23 @@
     }
     {
       name: chip_sw_alert_handler_lpg_reset_toggle
-      desc: '''Verify alert_handler's works correctly when sender reset is toggled.
+      desc: '''
+            Verify alert_handler's works correctly when sender reset is toggled.
 
             - Configure rstmgr to randomly toggle one IP block's SW reset and check alert_handler
               won't trigger a ping timeout error on that block.
-           '''
+            '''
       features: ["ALERT_HANDLER.PING_TIMER"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_lpg_reset_toggle"]
       bazel: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test"]
-   }
-   {
+    }
+    {
       name: chip_sw_alert_handler_reverse_ping_in_deep_sleep
-      desc: '''Verify escalation reverse ping timer disabled in sleep mode.
+      desc: '''
+            Verify escalation reverse ping timer disabled in sleep mode.
 
             Check that escalation receivers located inside always-on blocks do not auto-escalate
             due to the reverse ping feature while the system is in deep sleep.

--- a/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
@@ -6,7 +6,8 @@
   testpoints: [
     {
       name: chip_sw_aon_timer_wakeup_irq
-      desc: '''Verify the AON timer wake up interrupt in normal operating state.
+      desc: '''
+            Verify the AON timer wake up interrupt in normal operating state.
 
             - Program the PLIC to let the AON timer wake up interrupt the CPU.
             - Program the AON timer to generate the wake up timeout interrupt after some time.
@@ -23,7 +24,8 @@
     }
     {
       name: chip_sw_aon_timer_sleep_wakeup
-      desc: '''Verify that AON timer can wake up the chip from a deep sleep state.
+      desc: '''
+            Verify that AON timer can wake up the chip from a deep sleep state.
 
             - Read the reset cause register in rstmgr to confirm that the SW is in the POR reset
               phase.
@@ -45,7 +47,8 @@
     }
     {
       name: chip_sw_aon_timer_wdog_bark_irq
-      desc: '''Verify the watchdog bark reception in normal state.
+      desc: '''
+            Verify the watchdog bark reception in normal state.
 
             - Program the PLIC to let the wdog bark signal interrupt the CPU.
             - Program the AON timer wdog to 'bark' after some time and enable the bark interrupt.
@@ -60,7 +63,8 @@
     }
     {
       name: chip_sw_aon_timer_wdog_bite_reset
-      desc: '''Verify the watchdog bite causing reset in the normal state.
+      desc: '''
+            Verify the watchdog bite causing reset in the normal state.
 
             - Read the reset cause register in rstmgr to confirm that the SW is in the POR reset
               phase.
@@ -78,7 +82,8 @@
     }
     {
       name: chip_sw_aon_timer_sleep_wdog_bite_reset
-      desc: '''Verify the watchdog bite causing reset in sleep state.
+      desc: '''
+            Verify the watchdog bite causing reset in sleep state.
 
             - Repeat the steps in chip_aon_timer_wdog_bite_reset test, but with following changes:
             - Program the pwrmgr to go to deep sleep state (clocks off, power off).
@@ -96,7 +101,8 @@
     }
     {
       name: chip_sw_aon_timer_sleep_wdog_sleep_pause
-      desc: '''Verify that the wdog can be paused in sleep state.
+      desc: '''
+            Verify that the wdog can be paused in sleep state.
 
             - Repeat the steps in chip_aon_timer_sleep_wakeup test, but with following changes:
             - Program the wdog to 'bite' a little sooner than the AON timer wake up.
@@ -116,7 +122,8 @@
     }
     {
       name: chip_sw_aon_timer_wdog_lc_escalate
-      desc: '''Verify that the LC escalation signal disables the AON timer wdog.
+      desc: '''
+            Verify that the LC escalation signal disables the AON timer wdog.
 
             - Program the AON timer wdog to 'bark' after some time and enable the bark interrupt.
             - Start the escalation process and fail the test in the interrupt handler in case the

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_clkmgr
   testpoints: [
-    // CLKMGR tests:
     {
       name: chip_sw_clkmgr_idle_trans
-      desc: '''Verify the ability to turn off the transactional clock via SW.
+      desc: '''
+            Verify the ability to turn off the transactional clock via SW.
 
             Ensure that the clock to transactional units will be turned off after any activity
             completes in the transactional IP.  Verify it is off via spinwait in hints_status CSR.
@@ -19,28 +19,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "CLKMGR.HINT.AES",
-        "CLKMGR.HINT.HMAC",
-        "CLKMGR.HINT.KMAC",
-        "CLKMGR.HINT.OTBN",
-      ]
-      tests: [
-        "chip_sw_aes_idle",
-        "chip_sw_hmac_enc_idle",
-        "chip_sw_kmac_idle",
-        "chip_sw_otbn_randomness",
-      ]
-      bazel: [
-        "//sw/device/tests:aes_idle_test",
-        "//sw/device/tests:hmac_enc_idle_test",
-        "//sw/device/tests:kmac_idle_test",
-        "//sw/device/tests:otbn_randomness_test",
-      ]
+      features: ["CLKMGR.HINT.AES", "CLKMGR.HINT.HMAC", "CLKMGR.HINT.KMAC", "CLKMGR.HINT.OTBN"]
+      tests: ["chip_sw_aes_idle", "chip_sw_hmac_enc_idle", "chip_sw_kmac_idle", "chip_sw_otbn_randomness"]
+      bazel: ["//sw/device/tests:aes_idle_test", "//sw/device/tests:hmac_enc_idle_test", "//sw/device/tests:kmac_idle_test", "//sw/device/tests:otbn_randomness_test"]
     }
     {
       name: chip_sw_clkmgr_off_trans
-      desc: '''Verify the turned off transactional units.
+      desc: '''
+            Verify the turned off transactional units.
 
             Verify CSR accesses do not complete in units that are off.  Using the watchdog timers,
             turn off a transactional unit's clock, issue a CSR access to that unit, verify a
@@ -55,28 +41,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "CLKMGR.HINT.AES",
-        "CLKMGR.HINT.HMAC",
-        "CLKMGR.HINT.KMAC",
-        "CLKMGR.HINT.OTBN",
-      ]
-      tests: [
-        "chip_sw_clkmgr_off_aes_trans",
-        "chip_sw_clkmgr_off_hmac_trans",
-        "chip_sw_clkmgr_off_kmac_trans",
-        "chip_sw_clkmgr_off_otbn_trans",
-      ]
-      bazel: [
-        "//sw/device/tests:clkmgr_off_aes_trans_test",
-        "//sw/device/tests:clkmgr_off_hmac_trans_test",
-        "//sw/device/tests:clkmgr_off_kmac_trans_test",
-        "//sw/device/tests:clkmgr_off_otbn_trans_test",
-      ]
+      features: ["CLKMGR.HINT.AES", "CLKMGR.HINT.HMAC", "CLKMGR.HINT.KMAC", "CLKMGR.HINT.OTBN"]
+      tests: ["chip_sw_clkmgr_off_aes_trans", "chip_sw_clkmgr_off_hmac_trans", "chip_sw_clkmgr_off_kmac_trans", "chip_sw_clkmgr_off_otbn_trans"]
+      bazel: ["//sw/device/tests:clkmgr_off_aes_trans_test", "//sw/device/tests:clkmgr_off_hmac_trans_test", "//sw/device/tests:clkmgr_off_kmac_trans_test", "//sw/device/tests:clkmgr_off_otbn_trans_test"]
     }
     {
       name: chip_sw_clkmgr_off_peri
-      desc: '''Verify the ability to turn off the peripheral clock via SW.
+      desc: '''
+            Verify the ability to turn off the peripheral clock via SW.
 
             Verify CSR accesses do not complete in peripherals that are off.  Using the watchdog
             timers, turn off a peripheral's clock, issue a CSR access to that peripheral, verify a
@@ -88,18 +60,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "CLKMGR.ENABLE.IO",
-        "CLKMGR.ENABLE.IO_DIV2",
-        "CLKMGR.ENABLE.IO_DIV4",
-        "CLKMGR.ENABLE.USB",
-      ]
+      features: ["CLKMGR.ENABLE.IO", "CLKMGR.ENABLE.IO_DIV2", "CLKMGR.ENABLE.IO_DIV4", "CLKMGR.ENABLE.USB"]
       tests: ["chip_sw_clkmgr_off_peri"]
       bazel: ["//sw/device/tests:clkmgr_off_peri_test"]
     }
     {
       name: chip_sw_clkmgr_div
-      desc: '''Verify clk division logic is working correctly.
+      desc: '''
+            Verify clk division logic is working correctly.
 
             The IP level checks the divided clocks via SVA, and these are also bound at chip level.
             Connectivity tests check peripherals are connected to the clock they expect.
@@ -110,36 +78,15 @@
             '''
       stage: V2
       si_stage: SV2
-      features: [
-        "CLKMGR.MEAS_CTRL.REGWEN",
-        "CLKMGR.MEAS_CTRL.IO",
-        "CLKMGR.MEAS_CTRL.IO_DIV2",
-        "CLKMGR.MEAS_CTRL.IO_DIV4",
-        "CLKMGR.MEAS_CTRL.MAIN",
-        "CLKMGR.MEAS_CTRL.USB",
-      ]
-      lc_states: [
-        "TEST_UNLOCKED0",
-        "DEV",
-      ]
-      tests: [
-        "chip_sw_ast_clk_outputs",
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0",
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0",
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma",
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma",
-      ]
-      bazel: [
-        "//sw/device/tests:ast_clk_outs_test",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test",
-        "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test",
-      ]
+      features: ["CLKMGR.MEAS_CTRL.REGWEN", "CLKMGR.MEAS_CTRL.IO", "CLKMGR.MEAS_CTRL.IO_DIV2", "CLKMGR.MEAS_CTRL.IO_DIV4", "CLKMGR.MEAS_CTRL.MAIN", "CLKMGR.MEAS_CTRL.USB"]
+      lc_states: ["TEST_UNLOCKED0", "DEV"]
+      tests: ["chip_sw_ast_clk_outputs", "chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0", "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0", "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev", "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev", "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma", "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma"]
+      bazel: ["//sw/device/tests:ast_clk_outs_test", "//sw/device/tests:clkmgr_external_clk_src_for_sw_fast_test", "//sw/device/tests:clkmgr_external_clk_src_for_sw_slow_test"]
     }
     {
       name: chip_sw_clkmgr_external_clk_src_for_lc
-      desc: '''Verify the clkmgr requests ext clk src during certain LC states.
+      desc: '''
+            Verify the clkmgr requests ext clk src during certain LC states.
 
             On POR lc asserts lc_clk_byp_req on some LC states, and de-asserts
             it when lc_program completes. This also triggers divided clocks to step down. It may be
@@ -153,7 +100,8 @@
     }
     {
       name: chip_sw_clkmgr_external_clk_src_for_sw
-      desc: '''Verify SW causes the clkmgr requests ext clk src during certain LC states.
+      desc: '''
+            Verify SW causes the clkmgr requests ext clk src during certain LC states.
 
             In DEV, TEST_UNLOCKED, and RMA lc states the external clock is enabled in response to
             `extclk_ctrl.sel` CSR writes. In addition `extclk_ctrl.hi_speed_sel` CSR causes the
@@ -168,21 +116,14 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "DEV",
-      ]
-      tests: [
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",
-      ]
-      bazel: [
-        "//sw/device/tests:clkmgr_sleep_frequency_test",
-        "//sw/device/tests:clkmgr_reset_frequency_test",
-      ]
+      lc_states: ["DEV"]
+      tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast_dev", "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev"]
+      bazel: ["//sw/device/tests:clkmgr_sleep_frequency_test", "//sw/device/tests:clkmgr_reset_frequency_test"]
     }
     {
       name: chip_sw_clkmgr_jitter
-      desc: '''Verify the clock jitter functionality.
+      desc: '''
+            Verify the clock jitter functionality.
 
             Enable clock jitter setting the clkmgr `jitter_enable` CSR high. This causes the
             jitter_o clkmgr output to toggle. Verify this output is connected to AST's
@@ -193,23 +134,13 @@
             '''
       stage: V2
       si_stage: NA
-      tests: [
-        "chip_sw_clkmgr_jitter",
-        "chip_sw_flash_ctrl_ops_jitter_en",
-        "chip_sw_flash_ctrl_access_jitter_en",
-        "chip_sw_otbn_ecdsa_op_irq_jitter_en",
-        "chip_sw_aes_enc_jitter_en",
-        "chip_sw_hmac_enc_jitter_en",
-        "chip_sw_keymgr_key_derivation_jitter_en",
-        "chip_sw_kmac_mode_kmac_jitter_en",
-        "chip_sw_sram_ctrl_scrambled_access_jitter_en",
-        "chip_sw_edn_entropy_reqs_jitter",
-      ]
+      tests: ["chip_sw_clkmgr_jitter", "chip_sw_flash_ctrl_ops_jitter_en", "chip_sw_flash_ctrl_access_jitter_en", "chip_sw_otbn_ecdsa_op_irq_jitter_en", "chip_sw_aes_enc_jitter_en", "chip_sw_hmac_enc_jitter_en", "chip_sw_keymgr_key_derivation_jitter_en", "chip_sw_kmac_mode_kmac_jitter_en", "chip_sw_sram_ctrl_scrambled_access_jitter_en", "chip_sw_edn_entropy_reqs_jitter"]
       bazel: []
     }
     {
       name: chip_sw_clkmgr_jitter_cycle_measurements
-      desc: '''Verify jitter via clock cycle measurements after calibration.
+      desc: '''
+            Verify jitter via clock cycle measurements after calibration.
             The clock count thresholds for main clk need to be set wider than when jitter is disabled.
             SiVal: This is only useful on real silicon.
             Should be done after clock calibration.
@@ -217,22 +148,14 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "CLKMGR.JITTER.REGWEN",
-        "CLKMGR.JITTER.ENABLE",
-        "CLKMGR.MEAS_CTRL.REGWEN",
-        "CLKMGR.MEAS_CTRL.IO",
-        "CLKMGR.MEAS_CTRL.IO_DIV2",
-        "CLKMGR.MEAS_CTRL.IO_DIV4",
-        "CLKMGR.MEAS_CTRL.MAIN",
-        "CLKMGR.MEAS_CTRL.USB",
-      ]
+      features: ["CLKMGR.JITTER.REGWEN", "CLKMGR.JITTER.ENABLE", "CLKMGR.MEAS_CTRL.REGWEN", "CLKMGR.MEAS_CTRL.IO", "CLKMGR.MEAS_CTRL.IO_DIV2", "CLKMGR.MEAS_CTRL.IO_DIV4", "CLKMGR.MEAS_CTRL.MAIN", "CLKMGR.MEAS_CTRL.USB"]
       tests: ["chip_sw_clkmgr_jitter_frequency"]
       bazel: ["//sw/device/tests:clkmgr_jitter_frequency_test"]
     }
     {
       name: chip_sw_clkmgr_extended_range
-      desc: '''Verify that the system can run at a reduced, calibrated clock frequency.
+      desc: '''
+            Verify that the system can run at a reduced, calibrated clock frequency.
 
             This test should check that the system can run at a reduced, calibrated clock frequency
             (70MHz) with jitter enabled (which can lower the frequency down to ~55 MHz
@@ -257,23 +180,12 @@
             '''
       stage: V2
       si_stage: NA
-      tests: [
-        "chip_sw_clkmgr_jitter_reduced_freq",
-        "chip_sw_flash_ctrl_ops_jitter_en_reduced_freq",
-        "chip_sw_flash_ctrl_access_jitter_en_reduced_freq",
-        "chip_sw_otbn_ecdsa_op_irq_jitter_en_reduced_freq",
-        "chip_sw_aes_enc_jitter_en_reduced_freq",
-        "chip_sw_hmac_enc_jitter_en_reduced_freq",
-        "chip_sw_keymgr_key_derivation_jitter_en_reduced_freq",
-        "chip_sw_kmac_mode_kmac_jitter_en_reduced_freq",
-        "chip_sw_sram_ctrl_scrambled_access_jitter_en_reduced_freq",
-        "chip_sw_flash_init_reduced_freq",
-        "chip_sw_csrng_edn_concurrency_reduced_freq",
-      ]
+      tests: ["chip_sw_clkmgr_jitter_reduced_freq", "chip_sw_flash_ctrl_ops_jitter_en_reduced_freq", "chip_sw_flash_ctrl_access_jitter_en_reduced_freq", "chip_sw_otbn_ecdsa_op_irq_jitter_en_reduced_freq", "chip_sw_aes_enc_jitter_en_reduced_freq", "chip_sw_hmac_enc_jitter_en_reduced_freq", "chip_sw_keymgr_key_derivation_jitter_en_reduced_freq", "chip_sw_kmac_mode_kmac_jitter_en_reduced_freq", "chip_sw_sram_ctrl_scrambled_access_jitter_en_reduced_freq", "chip_sw_flash_init_reduced_freq", "chip_sw_csrng_edn_concurrency_reduced_freq"]
     }
     {
       name: chip_sw_clkmgr_deep_sleep_frequency
-      desc: '''Verify the frequency measurement through deep sleep.
+      desc: '''
+            Verify the frequency measurement through deep sleep.
 
             Enable clock cycle counts. Put the chip in deep sleep. Upon wakeup reset the
             clock measurements should be off, but the recoverable fault status should not
@@ -282,21 +194,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "CLKMGR.MEAS_CTRL.REGWEN",
-        "CLKMGR.MEAS_CTRL.IO",
-        "CLKMGR.MEAS_CTRL.IO_DIV2",
-        "CLKMGR.MEAS_CTRL.IO_DIV4",
-        "CLKMGR.MEAS_CTRL.MAIN",
-        "CLKMGR.MEAS_CTRL.USB",
-        "CLKMGR.MEAS_CTRL.RECOV_ERR",
-      ]
+      features: ["CLKMGR.MEAS_CTRL.REGWEN", "CLKMGR.MEAS_CTRL.IO", "CLKMGR.MEAS_CTRL.IO_DIV2", "CLKMGR.MEAS_CTRL.IO_DIV4", "CLKMGR.MEAS_CTRL.MAIN", "CLKMGR.MEAS_CTRL.USB", "CLKMGR.MEAS_CTRL.RECOV_ERR"]
       tests: ["chip_sw_ast_clk_outputs"]
       bazel: ["//sw/device/tests:ast_clk_outs_test"]
     }
     {
       name: chip_sw_clkmgr_sleep_frequency
-      desc: '''Verify the frequency measurement through shallow sleep.
+      desc: '''
+            Verify the frequency measurement through shallow sleep.
 
             Enable clock cycle counts. Put the chip in shallow sleep with pwrmgr's CONTROL CSR
             keeping some clocks disabled. Upon wakeup the clock measurements should be on, and the
@@ -307,21 +212,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "CLKMGR.MEAS_CTRL.REGWEN",
-        "CLKMGR.MEAS_CTRL.IO",
-        "CLKMGR.MEAS_CTRL.IO_DIV2",
-        "CLKMGR.MEAS_CTRL.IO_DIV4",
-        "CLKMGR.MEAS_CTRL.MAIN",
-        "CLKMGR.MEAS_CTRL.USB",
-        "CLKMGR.MEAS_CTRL.RECOV_ERR",
-      ]
+      features: ["CLKMGR.MEAS_CTRL.REGWEN", "CLKMGR.MEAS_CTRL.IO", "CLKMGR.MEAS_CTRL.IO_DIV2", "CLKMGR.MEAS_CTRL.IO_DIV4", "CLKMGR.MEAS_CTRL.MAIN", "CLKMGR.MEAS_CTRL.USB", "CLKMGR.MEAS_CTRL.RECOV_ERR"]
       tests: ["chip_sw_clkmgr_sleep_frequency"]
       bazel: ["//sw/device/tests:clkmgr_sleep_frequency_test"]
     }
     {
       name: chip_sw_clkmgr_reset_frequency
-      desc: '''Verify the frequency measurement through reset.
+      desc: '''
+            Verify the frequency measurement through reset.
 
             Enable clock cycle counts, configured to cause errors. Trigger a chip reset via SW.
             After reset the clock measurements should be off and the recoverable fault status
@@ -332,21 +230,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "CLKMGR.MEAS_CTRL.REGWEN",
-        "CLKMGR.MEAS_CTRL.IO",
-        "CLKMGR.MEAS_CTRL.IO_DIV2",
-        "CLKMGR.MEAS_CTRL.IO_DIV4",
-        "CLKMGR.MEAS_CTRL.MAIN",
-        "CLKMGR.MEAS_CTRL.USB",
-        "CLKMGR.MEAS_CTRL.RECOV_ERR",
-      ]
+      features: ["CLKMGR.MEAS_CTRL.REGWEN", "CLKMGR.MEAS_CTRL.IO", "CLKMGR.MEAS_CTRL.IO_DIV2", "CLKMGR.MEAS_CTRL.IO_DIV4", "CLKMGR.MEAS_CTRL.MAIN", "CLKMGR.MEAS_CTRL.USB", "CLKMGR.MEAS_CTRL.RECOV_ERR"]
       tests: ["chip_sw_clkmgr_reset_frequency"]
       bazel: ["//sw/device/tests:clkmgr_reset_frequency_test"]
     }
     {
       name: chip_sw_clkmgr_escalation_reset
-      desc: '''Verify the clock manager resets to a clean state after an escalation reset.
+      desc: '''
+            Verify the clock manager resets to a clean state after an escalation reset.
 
             Trigger an internal fatal fault for the regfile onehot checker and let it escalate to
             reset. Upon alert escalation reset, the internal status should be clear and clkmgr
@@ -360,7 +251,8 @@
     }
     {
       name: chip_sw_clkmgr_alert_handler_clock_enables
-      desc: '''Verify the clock manager sends the correct information to the alert handler
+      desc: '''
+            Verify the clock manager sends the correct information to the alert handler
             regarding individual clocks being active so it can ignore missing ping responses
             from them and avoid triggering spurious escalation. This scenario is caused by
             peripheral and transactional clocks being disabled among others. The check is

--- a/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_csrng
   testpoints: [
-    // CSRNG (pre-verified IP) integration tests:
     {
       name: chip_sw_csrng_edn_cmd
-      desc: '''Verify incoming command interface from EDN.
+      desc: '''
+            Verify incoming command interface from EDN.
 
             - Have each EDN instance issue an instantiate, reseed and generate command to CSRNG.
             - On each command done, verify the reception of edn_cmd_req_done interrupt.
@@ -18,11 +18,7 @@
             - In silicon, the connectivity cannot be checked using assertions.
               However, checking that the OTBN randomness test finishes allows to quickly assess if both EDNs deliver any entropy which is very fundamental.
             '''
-      features: [
-        "CSRNG.INTERFACE.HARDWARE0",
-        "CSRNG.INTERFACE.HARDWARE1",
-        "CSRNG.MODE.NONDETERMINISTIC",
-      ]
+      features: ["CSRNG.INTERFACE.HARDWARE0", "CSRNG.INTERFACE.HARDWARE1", "CSRNG.MODE.NONDETERMINISTIC"]
       stage: V2
       si_stage: SV2
       lc_states: ["TEST_UNLOCKED", "PROD"]
@@ -31,7 +27,8 @@
     }
     {
       name: chip_sw_csrng_fuse_en_sw_app_read
-      desc: '''Verify the fuse input to CSRNG.
+      desc: '''
+            Verify the fuse input to CSRNG.
 
             - Initialize the OTP with the fuse that control whether the SW can read the CSRNG state
               enabled.
@@ -45,10 +42,7 @@
             - The current understanding is that the en_csrng_sw_app_read OTP switch controlling the CSRNG.READ_INT_STATE feature will need to be enabled also in the PROD life-cycle state for validation and known-answer testing.
               Thus, burning the en_csrng_sw_app_read OTP fuses is not advisable for silicon validation.
             '''
-      features: [
-        "CSRNG.INTERFACE.SOFTWARE",
-        "CSRNG.READ_INT_STATE",
-      ]
+      features: ["CSRNG.INTERFACE.SOFTWARE", "CSRNG.READ_INT_STATE"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -56,7 +50,8 @@
     }
     {
       name: chip_sw_csrng_lc_hw_debug_en
-      desc: '''Verify the effect of LC HW debug enable on CSRNG.
+      desc: '''
+            Verify the effect of LC HW debug enable on CSRNG.
 
             lc_hw_debug_en is used to diversify the csrng seed.
             - Configure ENTROPY_SRC into bypassing the conditioner and directly inject known
@@ -74,11 +69,7 @@
             - This test goes through life-cycle stages that will permanently change the characteristic of the chip.
             - These tests will need to be done in secure environments where there is access to chips in the TEST_UNLOCKED or DEV life-cycle states.
             '''
-      features: [
-        "CSRNG.INTERFACE.SOFTWARE",
-        "CSRNG.MODE.NONDETERMINISTIC",
-        "CSRNG.LIFECYCLE.DEBUGENABLE",
-      ]
+      features: ["CSRNG.INTERFACE.SOFTWARE", "CSRNG.MODE.NONDETERMINISTIC", "CSRNG.LIFECYCLE.DEBUGENABLE"]
       stage: V2
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END"]
@@ -86,7 +77,8 @@
     }
     {
       name: chip_sw_csrng_known_answer_tests
-      desc: '''Verify our ability to run known-answer tests in SW.
+      desc: '''
+            Verify our ability to run known-answer tests in SW.
 
             - Configure the software instance in deterministic mode with the expected seed (as per
               the NIST-specified test for CTR_DRBG operation).
@@ -99,11 +91,7 @@
               The current understanding is that this will need to be enabled also in the PROD life-cycle state for validation and known-answer testing.
               Thus, the test doesn't need to be run in a secure environment.
             '''
-      features: [
-        "CSRNG.INTERFACE.SOFTWARE",
-        "CSRNG.MODE.DETERMINISTIC",
-        "CSRNG.READ_INT_STATE",
-      ]
+      features: ["CSRNG.INTERFACE.SOFTWARE", "CSRNG.MODE.DETERMINISTIC", "CSRNG.READ_INT_STATE"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]

--- a/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_edn
   testpoints: [
-    // EDN (pre-verified IP) integration tests:
     {
       name: chip_sw_edn_entropy_reqs
-      desc: '''Verify the entropy requests from all peripherals.
+      desc: '''
+            Verify the entropy requests from all peripherals.
 
             Verify that there are no misconnects between each peripheral requesting entropy.
             TODO: system level scenario: have all entropy sources request entropy in the same test
@@ -18,16 +18,13 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["chip_sw_edn_entropy_reqs",
-              "chip_sw_csrng_edn_concurrency",
-              "chip_sw_entropy_src_ast_rng_req",]
-      bazel: ["//sw/device/tests:entropy_src_edn_reqs_test",
-              "//sw/device/tests:csrng_edn_concurrency_test",
-              "//sw/device/tests:entropy_src_ast_rng_req_test",]
-    },
+      tests: ["chip_sw_edn_entropy_reqs", "chip_sw_csrng_edn_concurrency", "chip_sw_entropy_src_ast_rng_req"]
+      bazel: ["//sw/device/tests:entropy_src_edn_reqs_test", "//sw/device/tests:csrng_edn_concurrency_test", "//sw/device/tests:entropy_src_ast_rng_req_test"]
+    }
     {
       name: chip_sw_edn_boot_mode
-      desc: '''Verify EDN operation in boot-time request mode.
+      desc: '''
+            Verify EDN operation in boot-time request mode.
 
             Verify that EDN delivers entropy in boot-time request mode and that the `edn_fips` bit correctly signals to endpoints whether the delivered entropy is derived from a FIPS/CC compliant seed or not.
 
@@ -61,20 +58,17 @@
             - Verify that the OTBN program completes (entropy available) and that OTBN does not set ERR_BITS.RND_FIPS_CHK_FAIL.
             - Consume entropy through rv_core_ibex.RND_DATA and verify, using rv_core_ibex.RND_STATUS, that the received bits are FIPS compliant.
             '''
-      features: [
-        EDN.MODE.BOOT,
-        EDN.MODE.AUTO,
-        EDN.TRACK_SEED_COMPLIANCE
-      ]
+      features: ["EDN.MODE.BOOT,", "EDN.MODE.AUTO,", "EDN.TRACK_SEED_COMPLIANCE"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_edn_boot_mode"]
       bazel: ["//sw/device/tests:edn_boot_mode"]
-    },
+    }
     {
       name: chip_sw_edn_auto_mode
-      desc: '''Verify EDN operation in auto request mode.
+      desc: '''
+            Verify EDN operation in auto request mode.
 
             Verify that EDN delivers entropy in auto request mode.
 
@@ -91,18 +85,17 @@
               - The generate length parameter.
               - The MAX_NUM_REQS_BETWEEN_RESEEDS register.
             '''
-      features: [
-        EDN.MODE.AUTO
-      ]
+      features: ["EDN.MODE.AUTO"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_edn_auto_mode"]
       bazel: ["//sw/device/tests:edn_auto_mode"]
-    },
+    }
     {
       name: chip_sw_edn_sw_mode
-      desc: '''Verify EDN operation in software port mode.
+      desc: '''
+            Verify EDN operation in software port mode.
 
             Verify that EDN delivers entropy in software port mode.
 
@@ -117,18 +110,17 @@
             - Provide the required commands to EDN0 via SW_CMD_REQ register to start generating and delivering entropy to consumers.
             - Verify that the entropy consuming endpoint can finish its operations and does not hang.
             '''
-      features: [
-        EDN.MODE.SW
-      ]
+      features: ["EDN.MODE.SW"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_edn_sw_mode"]
       bazel: ["//sw/device/tests:edn_sw_mode"]
-    },
+    }
     {
       name: chip_sw_edn_kat
-      desc: '''Perform a Known-Answer Test with EDN.
+      desc: '''
+            Perform a Known-Answer Test with EDN.
 
             Verify that EDN delivers the expected entropy bits when running CSRNG in fully deterministic mode.
 
@@ -158,15 +150,12 @@
               - For an example, refer to `chip_sw_aes_masking_off_test`.
             - Verify that EDN0 triggers a recoverable alert and sets the RECOV_ALERT_STS.EDN_BUS_CMP_ALERT bit as more entropy is consumed via rv_core_ibex.RND_DATA and CSRNG continues to provide the same entropy bits to EDN0.
             '''
-      features: [
-        EDN.MODE.AUTO,
-        EDN.BUS_CMP_ALERT
-      ]
+      features: ["EDN.MODE.AUTO,", "EDN.BUS_CMP_ALERT"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_edn_kat"]
       bazel: ["//sw/device/tests:edn_kat"]
-    },
+    }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_entropy_src
   testpoints: [
-    // ENTROPY_SRC (pre-verified IP) integration tests:
     {
       name: chip_sw_entropy_src_ast_rng_req
-      desc: '''Verify the RNG req to AST.
+      desc: '''
+            Verify the RNG req to AST.
 
             - Enable ENTROPY_SRC in FIPS mode.
             - Enable Firmware Override - Extract & Insert to route entropy received from AST to the observe FIFO.
@@ -26,10 +26,11 @@
       lc_states: ["PROD"]
       tests: ["chip_sw_entropy_src_ast_rng_req"]
       bazel: ["//sw/device/tests:entropy_src_ast_rng_req_test"]
-    },
+    }
     {
       name: chip_sw_entropy_src_csrng
-      desc: '''Verify the transfer of entropy bits to CSRNG.
+      desc: '''
+            Verify the transfer of entropy bits to CSRNG.
 
             Verify the entropy valid interrupt.
             At the CSRNG, validate the reception of entropy req interrupt.
@@ -50,10 +51,11 @@
       lc_states: ["PROD"]
       tests: ["chip_sw_entropy_src_csrng"]
       bazel: ["//sw/device/tests:entropy_src_csrng_test"]
-    },
+    }
     {
       name: chip_sw_entropy_src_known_answer_tests
-      desc: '''Verify our ability to run known-answer tests in SW.
+      desc: '''
+            Verify our ability to run known-answer tests in SW.
 
             - Enable ENTROPY_SRC in FIPS mode.
             - Enable Firmware Override - Extract & Insert.
@@ -65,16 +67,13 @@
             - This test requires access to the ENTROPY_SRC.ROUTE_TO_FIRMWARE and ENTROPY_SRC.FW_OV.EXTRACT_AND_INSERT features, which are gated by OTP.
               This test might thus need to be done in a secure facility.
             '''
-      features: [
-        "ENTROPY_SRC.ROUTE_TO_FIRMWARE",
-        "ENTROPY_SRC.FW_OV.EXTRACT_AND_INSERT"
-      ]
+      features: ["ENTROPY_SRC.ROUTE_TO_FIRMWARE", "ENTROPY_SRC.FW_OV.EXTRACT_AND_INSERT"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_entropy_src_kat_test"]
       bazel: ["//sw/device/tests:entropy_src_kat_test"]
-    },
+    }
     {
       name: chip_sw_entropy_src_bypass_mode_health_tests
       desc: '''
@@ -100,16 +99,13 @@
             - Enable both EDNs in boot-time request mode.
             - Verify that ENTROPY_SRC triggers a recoverable alert and sets the RECOV_ALERT_STS.ES_MAIN_SM_ALERT bit.
             '''
-      features: [
-        "ENTROPY_SRC.MODE.BYPASS",
-        "ENTROPY_SRC.HEALTH_TESTS",
-      ]
+      features: ["ENTROPY_SRC.MODE.BYPASS", "ENTROPY_SRC.HEALTH_TESTS"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
       bazel: []
-    },
+    }
     {
       name: chip_sw_entropy_src_fips_mode_health_tests
       desc: '''
@@ -137,16 +133,13 @@
             - Verify that ENTROPY_SRC triggers a recoverable alert and sets the RECOV_ALERT_STS.ES_MAIN_SM_ALERT bit.
             - Verify that various entropy consuming endpoints hang as ENTROPY_SRC stops generating entropy after triggering the recoverable alert.
             '''
-      features: [
-        "ENTROPY_SRC.MODE.FIPS",
-        "ENTROPY_SRC.HEALTH_TESTS",
-      ]
+      features: ["ENTROPY_SRC.MODE.FIPS", "ENTROPY_SRC.HEALTH_TESTS"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
       bazel: []
-    },
+    }
     {
       name: chip_sw_entropy_src_validation
       desc: '''
@@ -168,20 +161,17 @@
             - This test requires access to the ENTROPY_SRC.FW_OV.OBSERVE feature, which is gated by OTP.
               This test might thus need to be done in a secure facility.
             '''
-      features: [
-        "ENTROPY_SRC.MODE.FIPS",
-        "ENTROPY_SRC.FW_OV.OBSERVE",
-        "ENTROPY_SRC.RNG_BIT_ENABLE",
-      ]
+      features: ["ENTROPY_SRC.MODE.FIPS", "ENTROPY_SRC.FW_OV.OBSERVE", "ENTROPY_SRC.RNG_BIT_ENABLE"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
       bazel: []
-    },
+    }
     {
       name: chip_sw_entropy_src_fw_observe_many_contiguous
-      desc: '''Verify that the software can observe samples fast enough to extract many contiguous samples.
+      desc: '''
+            Verify that the software can observe samples fast enough to extract many contiguous samples.
 
             Procedure:
             - Disable the entropy complex.
@@ -202,20 +192,17 @@
             - This test requires access to the ENTROPY_SRC.FW_OV.OBSERVE feature, which is gated by OTP.
               This test might thus need to be done in a secure facility.
             '''
-      features: [
-        "ENTROPY_SRC.MODE.FIPS",
-        "ENTROPY_SRC.FW_OV.OBSERVE"
-        "ENTROPY_SRC.RNG_BIT_ENABLE",
-      ]
+      features: ["ENTROPY_SRC.MODE.FIPS", "ENTROPY_SRC.FW_OV.OBSERVE", "ENTROPY_SRC.RNG_BIT_ENABLE"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
       bazel: ["//sw/device/tests:entropy_src_fw_observe_many_contiguous_test"]
-    },
+    }
     {
       name: chip_sw_entropy_src_fw_extract_and_insert
-      desc: '''Verify that the software can observe samples fast enough to extract many contiguous samples.
+      desc: '''
+            Verify that the software can observe samples fast enough to extract many contiguous samples.
 
             Procedure:
             - Disable the entropy complex.
@@ -242,16 +229,12 @@
             - This test requires access to the ENTROPY_SRC.ROUTE_TO_FIRMWARE and ENTROPY_SRC.FW_OV.EXTRACT_AND_INSERT features, which are gated by OTP.
               This test might thus need to be done in a secure facility.
             '''
-      features: [
-        "ENTROPY_SRC.MODE.FIPS",
-        "ENTROPY_SRC.FW_OV.EXTRACT_AND_INSERT",
-        "ENTROPY_SRC.RNG_BIT_ENABLE"
-      ]
+      features: ["ENTROPY_SRC.MODE.FIPS", "ENTROPY_SRC.FW_OV.EXTRACT_AND_INSERT", "ENTROPY_SRC.RNG_BIT_ENABLE"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
       bazel: []
-    },
+    }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_flash_ctrl
   testpoints: [
-    // FLASH integration tests
     {
       name: chip_sw_flash_init
-      desc: '''Verify that flash initialization routine works correctly.
+      desc: '''
+            Verify that flash initialization routine works correctly.
 
             - Initialize the flash ctrl by writing 1 to the INIT register.
             - Poll the status register for the initialization to complete.
@@ -20,8 +20,7 @@
             - This test needs to execute as a boot rom image.
             - In sival, this will be covered by manuf_ft_provision_rma_token_and_personalization.
             '''
-      features: ["FLASH_CTRL.INIT.SCRAMBLING_KEYS", "FLASH_CTRL.INIT.ROOT_SEEDS",
-                 "FLASH_CTRL.INFO.CREATOR_PARTITION", "FLASH_CTRL.INFO.OWNER_PARTITION"]
+      features: ["FLASH_CTRL.INIT.SCRAMBLING_KEYS", "FLASH_CTRL.INIT.ROOT_SEEDS", "FLASH_CTRL.INFO.CREATOR_PARTITION", "FLASH_CTRL.INFO.OWNER_PARTITION"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -30,7 +29,8 @@
     }
     {
       name: chip_sw_flash_host_access
-      desc: '''Verify that the flash memory contents can be read by the CPU.
+      desc: '''
+            Verify that the flash memory contents can be read by the CPU.
 
             Nothing extra to do here - most SW based tests fetch code from flash.
             '''
@@ -38,13 +38,13 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["chip_sw_flash_ctrl_access",
-              "chip_sw_flash_ctrl_access_jitter_en"]
+      tests: ["chip_sw_flash_ctrl_access", "chip_sw_flash_ctrl_access_jitter_en"]
       bazel: ["//sw/device/tests:flash_ctrl_ops_test"]
     }
     {
       name: chip_sw_flash_ctrl_ops
-      desc: '''Verify the SW can initiate flash operations via the controller.
+      desc: '''
+            Verify the SW can initiate flash operations via the controller.
 
             Verify that the CPU can read / program and erase the flash mem. Pick an operation on
             all data and info partitions. Erase both, bank and page. SW validates the reception of
@@ -59,7 +59,8 @@
     }
     {
       name: chip_sw_flash_memory_protection
-      desc: '''Extend chip_sw_flash_ctrl_access test to over following features.
+      desc: '''
+            Extend chip_sw_flash_ctrl_access test to over following features.
             Perform READ/ PROGRAM/ ERASE operations over protected regions and pages of data and
             info partitions.
             Use set and reset values of corresponding read, program and erase enable bits.
@@ -75,7 +76,8 @@
     }
     {
       name: chip_sw_flash_rma_unlocked
-      desc: '''Verify the flash memory contents can be accessed after in RMA unlock.
+      desc: '''
+            Verify the flash memory contents can be accessed after in RMA unlock.
 
             - Provision an RMA_UNLOCK token in OTP.
             - Repeat the following a few times:
@@ -97,7 +99,8 @@
     }
     {
       name: chip_sw_flash_scramble
-      desc: '''Verify flash scrambling via the controller.
+      desc: '''
+            Verify flash scrambling via the controller.
 
             - Extends the chip_flash_init test.
             - Verify flash scrambling with different key values programmed in OTP.
@@ -116,7 +119,8 @@
     }
     {
       name: chip_sw_flash_idle_low_power
-      desc: '''Verify flash_idle signaling to pwrmgr.
+      desc: '''
+            Verify flash_idle signaling to pwrmgr.
 
             - Initiate flash program or erase over the controller.
             - Program the pwrmgr to go into deep sleep.
@@ -131,7 +135,8 @@
     }
     {
       name: chip_sw_flash_keymgr_seeds
-      desc: '''Verify the creator and owner seeds are read on flash init provided lc_hw_seed_rd_en
+      desc: '''
+            Verify the creator and owner seeds are read on flash init provided lc_hw_seed_rd_en
             is set.
 
             X-ref'ed with keymgr test.
@@ -144,7 +149,8 @@
     }
     {
       name: chip_sw_flash_lc_creator_seed_sw_rw_en
-      desc: '''Verify the lc_creator_seed_sw_rw_en signal from LC ctrl.
+      desc: '''
+            Verify the lc_creator_seed_sw_rw_en signal from LC ctrl.
 
             - Transition from TEST_LOCKED to DEV/PROD to ESCALATION/SCRAP state via OTP and verify
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
@@ -155,14 +161,11 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
-      bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states",
-              "//sw/device/tests:flash_ctrl_info_access_lc_states_personalized"]
-
+      bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states", "//sw/device/tests:flash_ctrl_info_access_lc_states_personalized"]
     }
     {
       name: chip_sw_flash_creator_seed_wipe_on_rma
-      desc: '''Verify that the creator seed is wiped by the flash ctrl on RMA entry.
-            '''
+      desc: Verify that the creator seed is wiped by the flash ctrl on RMA entry.
       features: ["FLASH_CTRL.RMA"]
       stage: V2
       si_stage: SV3
@@ -172,7 +175,8 @@
     }
     {
       name: chip_sw_flash_lc_owner_seed_sw_rw_en
-      desc: '''Verify the lc_owner_seed_sw_rw_en signal from LC ctrl.
+      desc: '''
+            Verify the lc_owner_seed_sw_rw_en signal from LC ctrl.
 
             - Transition from TEST_LOCKED to DEV/PROD to ESCALATION/SCRAP state via OTP and verify
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
@@ -187,7 +191,8 @@
     }
     {
       name: chip_sw_flash_lc_iso_part_sw_rd_en
-      desc: '''Verify the lc_iso_part_sw_rd_en signal from LC ctrl.
+      desc: '''
+            Verify the lc_iso_part_sw_rd_en signal from LC ctrl.
 
             - Transition from DEV or PROD to ESCALATION/SCRAP state via OTP and verify
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
@@ -202,7 +207,8 @@
     }
     {
       name: chip_sw_flash_lc_iso_part_sw_wr_en
-      desc: '''Verify the lc_creator_seed_sw_wr_en signal from LC ctrl.
+      desc: '''
+            Verify the lc_creator_seed_sw_wr_en signal from LC ctrl.
 
             - Transition from TEST_LOCKED to DEV/PROD to ESCALATION/SCRAP state via OTP and verify
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
@@ -217,7 +223,8 @@
     }
     {
       name: chip_sw_flash_lc_seed_hw_rd_en
-      desc: '''Verify the lc_seed_hw_rd_en signal from LC ctrl.
+      desc: '''
+            Verify the lc_seed_hw_rd_en signal from LC ctrl.
 
             - Transition from TEST_LOCKED to DEV/PROD to ESCALATION/SCRAP state via OTP and verify
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the flash ctrl
@@ -233,7 +240,8 @@
     }
     {
       name: chip_sw_flash_lc_escalate_en
-      desc: '''Verify the lc_escalate_en signal from LC ctrl.
+      desc: '''
+            Verify the lc_escalate_en signal from LC ctrl.
 
             - Trigger an LC escalation signal by generating an alert.
             - Verify that all flash accesses are disabled when the escalation kicks in.
@@ -250,7 +258,8 @@
     }
     {
       name: chip_sw_flash_prim_tl_access
-      desc: '''Verify that the SW can read / write the prim tlul interface in flash phy.
+      desc: '''
+            Verify that the SW can read / write the prim tlul interface in flash phy.
 
             - The prim tlul interface is a open source placeholder for the closed source CSRs that
               will be implemented in a translation 'shim'.
@@ -262,7 +271,8 @@
     }
     {
       name: chip_sw_flash_ctrl_clock_freqs
-      desc: '''Verify flash program and erase operations over the ctrl over a range of clock freqs.
+      desc: '''
+            Verify flash program and erase operations over the ctrl over a range of clock freqs.
 
             - Enable jitter on the clock while performing erase, write and read operations
               to the flash.
@@ -276,7 +286,8 @@
     }
     {
       name: chip_sw_flash_ctrl_escalation_reset
-      desc: '''Verify the flash ctrl fatal error does not disturb escalation process
+      desc: '''
+            Verify the flash ctrl fatal error does not disturb escalation process
             and operation of ibex core.
 
             Trigger an internal fatal fault (host_gnt_err) from flash_ctrl
@@ -289,7 +300,8 @@
     }
     {
       name: chip_sw_flash_ctrl_write_clear
-      desc: '''Verify the flash is able to process a second write to clear all bits
+      desc: '''
+            Verify the flash is able to process a second write to clear all bits
             when ECC is enabled.
 
             Configure memory protected entries to override the default flash configuration as follows:

--- a/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
@@ -6,7 +6,8 @@
   testpoints: [
     {
       name: chip_sw_gpio_out
-      desc: '''Verify GPIO outputs.
+      desc: '''
+            Verify GPIO outputs.
 
             SW test configures the GPIOs to be in the output mode. Configure pinmux such as
             gpio output signal loopback to gpio input. The test walks a 1 through the
@@ -22,7 +23,8 @@
     }
     {
       name: chip_sw_gpio_in
-      desc: '''Verify GPIO inputs.
+      desc: '''
+            Verify GPIO inputs.
 
             The SW test configures the GPIOs to be in input mode. The testbench walks a 1 through
             the pins. SW test ensures that the GPIO values read from the CSR is correct.
@@ -36,7 +38,8 @@
     }
     {
       name: chip_sw_gpio_irq
-      desc: '''Verify GPIO interrupts.
+      desc: '''
+            Verify GPIO interrupts.
 
             The SW test configures the GPIOs to be in input mode and enables all of them to generate
             an interrupt. The testbench walks a 1 through the pins. SW test ensures that the

--- a/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_hmac
   testpoints: [
-    // HMAC integration tests
     {
       name: chip_sw_hmac_enc
-      desc: '''Verify HMAC operation.
+      desc: '''
+            Verify HMAC operation.
 
             SW test verifies an HMAC operation with a known key, plain text and digest (pick one of
             the NIST vectors). SW test verifies the digest against the pre-computed value. Verify
@@ -16,13 +16,13 @@
       stage: V2
       si_stage: SV2
       lc_states: ["PROD"]
-      tests: ["chip_sw_hmac_enc",
-              "chip_sw_hmac_enc_jitter_en"]
+      tests: ["chip_sw_hmac_enc", "chip_sw_hmac_enc_jitter_en"]
       bazel: ["//sw/device/tests:hmac_enc_test"]
     }
     {
       name: chip_sw_hmac_idle
-      desc: '''Verify the HMAC clk idle signal to clkmgr.
+      desc: '''
+            Verify the HMAC clk idle signal to clkmgr.
 
             - Write the HMAC clk hint to 0 within clkmgr to indicate HMAC clk can be gated and
               verify that the HMAC clk hint status within clkmgr reads 0 (HMAC is disabled).
@@ -44,7 +44,8 @@
     }
     {
       name: chip_sw_hmac_sha2_stress
-      desc: '''Verify SHA2 mode of operation.
+      desc: '''
+            Verify SHA2 mode of operation.
 
             - Verify the following digest sizes: 256
             - Verify input message size of 0 bytes.
@@ -60,7 +61,8 @@
     }
     {
       name: chip_sw_hmac_stress
-      desc: '''Verify HMAC mode of operation.
+      desc: '''
+            Verify HMAC mode of operation.
 
             - Verify the following security configurations: HMAC-SHA2-256
             - Verify input message size of 0 bytes.
@@ -76,17 +78,15 @@
     }
     {
       name: chip_sw_hmac_endianness
-      desc: '''Verify all HMAC endianness options
+      desc: '''
+            Verify all HMAC endianness options
 
             This is a low priority test P3.
 
             Test the permutation of all endianness configuration options for message and digest
             registers.
             '''
-      features: [
-        "HMAC.ENDIANNESS.MESSAGE",
-        "HMAC.ENDIANNESS.DIGEST",
-      ]
+      features: ["HMAC.ENDIANNESS.MESSAGE", "HMAC.ENDIANNESS.DIGEST"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -95,7 +95,8 @@
     }
     {
       name: chip_sw_hmac_secure_wipe
-      desc: '''Verify HMAC secure wipe
+      desc: '''
+            Verify HMAC secure wipe
 
             - Perform HMAC operation with known key and message.
             - Store MAC digest in memory after finalizing HMAC operation.
@@ -113,7 +114,8 @@
     }
     {
       name: chip_sw_hmac_error_conditions
-      desc: '''Verify reporting of HMAC errors
+      desc: '''
+            Verify reporting of HMAC errors
 
             This is a negative test case covering the following error conditions:
 

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_i2c
   testpoints: [
-    // I2C (pre-verified IP) integration tests:
     {
       name: chip_sw_i2c_host_tx_rx
-      desc: '''Verify the transmission of data over the chip's I2C host interface.
+      desc: '''
+            Verify the transmission of data over the chip's I2C host interface.
 
             - Program the I2C to be in host mode.
             - The SW test writes a known payload over the chip's I2C host interface, which is
@@ -27,13 +27,12 @@
       si_stage: SV2
       lc_states: ["PROD"]
       bazel: ["//sw/device/tests/pmod:i2c_host_eeprom_test"]
-      tests: ["chip_sw_i2c_host_tx_rx",
-              "chip_sw_i2c_host_tx_rx_idx1",
-              "chip_sw_i2c_host_tx_rx_idx2"]
+      tests: ["chip_sw_i2c_host_tx_rx", "chip_sw_i2c_host_tx_rx_idx1", "chip_sw_i2c_host_tx_rx_idx2"]
     }
     {
       name: chip_sw_i2c_device_tx_rx
-      desc: '''Verify the transmission of data over the chip's I2C device interface.
+      desc: '''
+            Verify the transmission of data over the chip's I2C device interface.
 
             - Program the I2C to be in device mode.
             - The testbench writes a known payload over the chip's I2C device interface, which is
@@ -56,7 +55,8 @@
     }
     {
       name: chip_sw_i2c_speed
-      desc: '''Verify the transmission speed of data over the chip's I2C interfaces.
+      desc: '''
+            Verify the transmission speed of data over the chip's I2C interfaces.
 
             Run the following for standard, fast and fast plus speeds:
             - Program the I2C to be in the appropriate mode (host/target).
@@ -83,7 +83,8 @@
     }
     {
       name: chip_sw_i2c_override
-      desc: '''Verify overriding SDA and SCL on I2C interfaces.
+      desc: '''
+            Verify overriding SDA and SCL on I2C interfaces.
 
             For all I2C host mode instances:
             - Software cycles through all SDA/SCL combinations with long delays.
@@ -102,7 +103,8 @@
     }
     {
       name: chip_sw_i2c_clockstretching
-      desc: '''Verify clock stretching on I2C interfaces.
+      desc: '''
+            Verify clock stretching on I2C interfaces.
 
             For all I2C host mode instances:
             - Do a read and make target stretch after reading an address.
@@ -128,7 +130,8 @@
     }
     {
       name: chip_sw_i2c_nack
-      desc: '''Verify correct behavior of nack detection.
+      desc: '''
+            Verify correct behavior of nack detection.
 
             For all I2C host mode instances:
             - Program the I2C to be in host mode.
@@ -149,7 +152,8 @@
     }
     {
       name: chip_sw_i2c_repeatedstart
-      desc: '''Verify correct behavior of repeated start.
+      desc: '''
+            Verify correct behavior of repeated start.
 
             For all I2C target mode instances:
             - Program the I2C to be in target mode.

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_keymgr
   testpoints: [
-    // KEYMGR integration tests
     {
       name: chip_sw_keymgr_key_derivation
-      desc: '''Verify the keymgr advances to all states and generate identity / SW output.
+      desc: '''
+            Verify the keymgr advances to all states and generate identity / SW output.
 
             - In the SW test, write fixed value to OTP for root_key and write creator and owner
               seeds in flash. And then roboot the chip.
@@ -39,10 +39,7 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: [
-        "chip_sw_keymgr_key_derivation",
-        "chip_sw_keymgr_key_derivation_jitter_en",
-      ]
+      tests: ["chip_sw_keymgr_key_derivation", "chip_sw_keymgr_key_derivation_jitter_en"]
     }
     {
       name: chip_sw_keymgr_sideload_kmac_error
@@ -64,7 +61,8 @@
     }
     {
       name: chip_sw_keymgr_sideload_kmac
-      desc: '''Verify the keymgr sideload interface to KMAC.
+      desc: '''
+            Verify the keymgr sideload interface to KMAC.
 
             - Configure the keymgr and advance to the `OwnerIntKey` state.
             - Request keymgr to generate hw key for KMAC sideload key slot.
@@ -101,7 +99,8 @@
     }
     {
       name: chip_sw_keymgr_sideload_aes
-      desc: '''Verify the keymgr sideload interface to AES.
+      desc: '''
+            Verify the keymgr sideload interface to AES.
 
                Same as `chip_keymgr_sideload_kmac`, except, sideload to AES.
             '''
@@ -114,7 +113,8 @@
     }
     {
       name: chip_sw_keymgr_sideload_otbn
-      desc: '''Verify the keymgr sideload interface to OTBN.
+      desc: '''
+            Verify the keymgr sideload interface to OTBN.
 
                Load OTBN binary image, the rest is similar to `chip_keymgr_sideload_kmac`, except
                sideloading to otbn.
@@ -130,7 +130,8 @@
     }
     {
       name: chip_sw_keymgr_derive_attestation
-      desc: '''Verify the Attestation CDI.
+      desc: '''
+            Verify the Attestation CDI.
 
             - For each keymgr operational state: `CreatorRootKey`, `OwnerIntKey` and `OwnerKey`:
               - Generate identity SW output for the Attestation CDI.
@@ -153,20 +154,17 @@
             - The test should check for any error or fault code status, to ensure all operations
               executed successfully.
             '''
-            features: [
-              "KEYMGR.DERIVE.ATTESTATION",
-              "KEYMGR.GENERATE.OUTPUT",
-              "KEYMGR.GENERATE.IDENTITY",
-            ]
-            stage: V3
-            si_stage: SV2
-            lc_states: ["PROD"]
-            tests: []
-            bazel: []
+      features: ["KEYMGR.DERIVE.ATTESTATION", "KEYMGR.GENERATE.OUTPUT", "KEYMGR.GENERATE.IDENTITY"]
+      stage: V3
+      si_stage: SV2
+      lc_states: ["PROD"]
+      tests: []
+      bazel: []
     }
     {
       name: chip_sw_keymgr_derive_sealing
-      desc: '''Verify the Sealing CDI.
+      desc: '''
+            Verify the Sealing CDI.
 
             Same as `chip_sw_keymgr_derive_attestation`, except using Sealing CDI outputs.
 
@@ -176,17 +174,12 @@
             - Test a valid and an invalid key version when generating SW and sideload keys.
 
             '''
-            features: [
-              "KEYMGR.DERIVE.SEALING",
-              "KEYMGR.GENERATE.OUTPUT",
-              "KEYMGR.GENERATE.IDENTITY",
-              "KEYMGR.KEY_VERSIONING",
-            ]
-            stage: V3
-            si_stage: SV3
-            lc_states: ["PROD"]
-            tests: []
-            bazel: []
+      features: ["KEYMGR.DERIVE.SEALING", "KEYMGR.GENERATE.OUTPUT", "KEYMGR.GENERATE.IDENTITY", "KEYMGR.KEY_VERSIONING"]
+      stage: V3
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -4,27 +4,24 @@
 {
   name: chip_kmac
   testpoints: [
-    // KMAC integration tests
     {
       name: chip_sw_kmac_enc
-      desc: '''Verify the SHA3 operation.
+      desc: '''
+            Verify the SHA3 operation.
 
             SW test verifies SHA3 operation with a known key, plain text and digest (pick one of
             the NIST vectors). SW validates the reception of kmac done and fifo empty interrupts.
             '''
       stage: V2
       si_stage: SV2
-      tests: [
-        "chip_sw_kmac_mode_cshake",
-        "chip_sw_kmac_mode_kmac",
-        "chip_sw_kmac_mode_kmac_jitter_en",
-      ]
+      tests: ["chip_sw_kmac_mode_cshake", "chip_sw_kmac_mode_kmac", "chip_sw_kmac_mode_kmac_jitter_en"]
       lc_states: ["PROD"]
       bazel: ["//sw/device/tests:kmac_mode_kmac_test"]
     }
     {
       name: chip_sw_kmac_app_keymgr
-      desc: '''Verify the keymgr interface to KMAC.
+      desc: '''
+            Verify the keymgr interface to KMAC.
 
             - Configure the keymgr to start sending known message data to the KMAC.
             - Keymgr should transmit a sideloaded key to the KMAC as well.
@@ -41,7 +38,8 @@
     }
     {
       name: chip_sw_kmac_app_lc
-      desc: '''Verify the LC interface to KMAC.
+      desc: '''
+            Verify the LC interface to KMAC.
 
             - Configure the LC_CTRL to start a token hash using KMAC interface.
             - KMAC should finish hashing successfully (not visible to SW) and return digest to
@@ -55,7 +53,8 @@
     }
     {
       name: chip_sw_kmac_app_rom
-      desc: '''Verify the ROM interface to KMAC.
+      desc: '''
+            Verify the ROM interface to KMAC.
 
             - Backdoor initialize ROM memory immediately out of reset.
             - ROM will send message to the KMAC containing its memory contents,
@@ -71,7 +70,8 @@
     }
     {
       name: chip_sw_kmac_entropy
-      desc: '''Verify the EDN interface to KMAC.
+      desc: '''
+            Verify the EDN interface to KMAC.
 
             Requires `EnMasking` parameter to be enabled.
             SW randomly configures the KMAC in any hashing mode/strength, and enable EDN mode.
@@ -99,7 +99,8 @@
     }
     {
       name: chip_sw_kmac_idle
-      desc: '''Verify the KMAC idle signaling to clkmgr.
+      desc: '''
+            Verify the KMAC idle signaling to clkmgr.
 
             - Write the KMAC clk hint to 0 within clkmgr to indicate KMAC clk can be gated and
               verify that the KMAC clk hint status within clkmgr reads 0 (KMAC is disabled).
@@ -119,7 +120,8 @@
     }
     {
       name: chip_sw_kmac_sha3_stress
-      desc: '''Verify all SHA3 modes of operation.
+      desc: '''
+            Verify all SHA3 modes of operation.
 
             - Verify the following digest sizes: 224, 256, 384, 512
             - Verify input message size of 0 bytes.
@@ -135,7 +137,8 @@
     }
     {
       name: chip_sw_kmac_shake_stress
-      desc: '''Verify all SHAKE modes of operation.
+      desc: '''
+            Verify all SHAKE modes of operation.
 
             - Verify the following security configurations: 128, 256
             - Verify input message size of 0 bytes.
@@ -143,10 +146,7 @@
             - Use endianess configuration used in the crypto library.
             - Verify multiple XOF configurations.
             '''
-      features: [
-        "KMAC.MODE.SHAKE",
-        "KMAC.MODE.XOF",
-      ]
+      features: ["KMAC.MODE.SHAKE", "KMAC.MODE.XOF"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -155,7 +155,8 @@
     }
     {
       name: chip_sw_kmac_cshake_stress
-      desc: '''Verify all cSHAKE modes of operation.
+      desc: '''
+            Verify all cSHAKE modes of operation.
 
             - Verify the following security configurations: 128, 256
             - Verify input message size of 0 bytes.
@@ -163,10 +164,7 @@
             - Use endianess configuration used in the crypto library.
             - Verify multiple XOF configurations.
             '''
-      features: [
-        "KMAC.MODE.CSHAKE",
-        "KMAC.MODE.XOF",
-      ]
+      features: ["KMAC.MODE.CSHAKE", "KMAC.MODE.XOF"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -175,7 +173,8 @@
     }
     {
       name: chip_sw_kmac_kmac_stress
-      desc: '''Verify all KMAC modes of operation.
+      desc: '''
+            Verify all KMAC modes of operation.
 
             - Verify the following security configurations: 128, 256
             - Verify input message size of 0 bytes.
@@ -183,10 +182,7 @@
             - Use endianess configuration used in the crypto library.
             - Verify multiple XOF configurations.
             '''
-      features: [
-        "KMAC.MODE.KMAC",
-        "KMAC.MODE.XOF",
-      ]
+      features: ["KMAC.MODE.KMAC", "KMAC.MODE.XOF"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -195,7 +191,8 @@
     }
     {
       name: chip_sw_kmac_kmac_key_sideload
-      desc: '''Verify all KMAC key sideload.
+      desc: '''
+            Verify all KMAC key sideload.
 
             Procedure:
 
@@ -221,17 +218,15 @@
     }
     {
       name: chip_sw_kmac_endianess
-      desc: '''Verify all KMAC endinaness options
+      desc: '''
+            Verify all KMAC endinaness options
 
             This is a low priority test P3.
 
             Test the permutation of all endinaness configuration options for message and digest
             registers.
             '''
-      features: [
-        "KMAC.ENDIANNESS.MESSAGE",
-        "KMAC.ENDIANNESS.DIGEST",
-      ]
+      features: ["KMAC.ENDIANNESS.MESSAGE", "KMAC.ENDIANNESS.DIGEST"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -240,7 +235,8 @@
     }
     {
       name: chip_sw_kmac_entropy_stress
-      desc: '''Verify all KMAC entropy configuration options.
+      desc: '''
+            Verify all KMAC entropy configuration options.
 
             Verify all entropy modes of operation (e.g. software, EDN). Depending on the mode of
             operation, exercise relevant functionality, for example:
@@ -252,10 +248,7 @@
             Process many message blocks in KMAC configuration for all entropy modes, and verify
             that there are no error conditions.
             '''
-      features: [
-        "KMAC.ENDIANNESS.MESSAGE",
-        "KMAC.ENDIANNESS.DIGEST",
-      ]
+      features: ["KMAC.ENDIANNESS.MESSAGE", "KMAC.ENDIANNESS.DIGEST"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -264,7 +257,8 @@
     }
     {
       name: chip_sw_kmac_error_conditions
-      desc: '''Verify reporting of KMAC errors
+      desc: '''
+            Verify reporting of KMAC errors
 
             This is a negative test case covering the following error conditions:
 

--- a/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_lc_ctrl
   testpoints: [
-    // LC_CTRL integration tests
     {
       name: chip_sw_lc_ctrl_alert_handler_escalation
-      desc: '''Verify that the escalation signals from the alert handler are connected to LC ctrl.
+      desc: '''
+            Verify that the escalation signals from the alert handler are connected to LC ctrl.
 
             - Trigger an alert to initiate the escalations.
             - Check that the escalation signals are connected to the LC ctrl:
@@ -35,7 +35,8 @@
     }
     {
       name: chip_sw_lc_ctrl_jtag_access
-      desc: '''Verify enable to access LC ctrl via JTAG.
+      desc: '''
+            Verify enable to access LC ctrl via JTAG.
 
             Using the JTAG agent, write and read LC ctrl CSRs, verify the read value for
             correctness. Repeat test with clk_ext configuration.
@@ -50,7 +51,8 @@
     }
     {
       name: chip_sw_lc_ctrl_otp_hw_cfg0
-      desc: '''Verify the device_ID and ID_state CSRs.
+      desc: '''
+            Verify the device_ID and ID_state CSRs.
 
             - Preload the hw_cfg0 partition in OTP ctrl with random data.
             - Read the device ID and the ID state CSRs to verify their correctness.
@@ -69,7 +71,8 @@
     }
     {
       name: chip_sw_lc_ctrl_init
-      desc: '''Verify the LC ctrl initialization on power up.
+      desc: '''
+            Verify the LC ctrl initialization on power up.
 
             Verify that the chip powers up correctly on POR.
             - The pwrmgr initiates a handshake with OTP ctrl and later, with LC ctrl in subsequent
@@ -82,7 +85,8 @@
     }
     {
       name: chip_sw_lc_ctrl_transitions
-      desc: '''Verify the LC ctrl can transit from one state to another valid state with the
+      desc: '''
+            Verify the LC ctrl can transit from one state to another valid state with the
             correct tokens.
 
             - Preload OTP image with a LC state and required tokens to transfer to next state.
@@ -99,23 +103,19 @@
             X-ref'ed manuf_cp_test_lock
             X-ref'ed manuf_ft_exit_token
             '''
-      features: [
-        "LC_CTRL.AUTHENTICATED_TRANSITIONS"
-        "LC_CTRL.STATE.RAW",
-        "LC_CTRL.STATE.TEST_UNLOCKED",
-        "LC_CTRL.STATE.TEST_LOCKED",
-      ]
+      features: ["LC_CTRL.AUTHENTICATED_TRANSITIONS", "LC_CTRL.STATE.RAW", "LC_CTRL.STATE.TEST_UNLOCKED", "LC_CTRL.STATE.TEST_LOCKED"]
       tags: ["dv", "fpga", "silicon"]
       stage: V2
       si_stage: SV3
-      otp_mutate: true
+      otp_mutate: True
       lc_states: ["RAW", "TEST_UNLOCKED", "TEST_LOCKED"]
       tests: ["chip_sw_lc_ctrl_transition"]
       bazel: []
     }
     {
       name: chip_sw_lc_ctrl_kmac_req
-      desc: '''Verify the token requested from KMAC.
+      desc: '''
+            Verify the token requested from KMAC.
 
             - For conditional transition, the LC ctrl will send out a token request to KMAC.
             - Verify that the KMAC returns a hashed token, which should match one of the
@@ -131,14 +131,15 @@
       tags: ["dv", "fpga", "silicon"]
       stage: V2
       si_stage: SV1
-      otp_mutate: true
+      otp_mutate: True
       lc_states: ["RAW", "TEST_UNLOCKED", "TEST_LOCKED", "DEV", "PROD", "PROD_END"]
       tests: ["chip_sw_lc_ctrl_transition"]
       bazel: []
     }
     {
       name: chip_sw_lc_ctrl_key_div
-      desc: '''Verify the keymgr div output to keymgr.
+      desc: '''
+            Verify the keymgr div output to keymgr.
 
             - Verify in different LC states, LC ctrl outputs the correct `key_div_o` to keymgr.
             - Verify that the keymgr uses the given `key_div_o` value to compute the keys.
@@ -148,7 +149,8 @@
     }
     {
       name: chip_sw_lc_ctrl_broadcast
-      desc: '''Verify broadcast signals from lc_ctrl.
+      desc: '''
+            Verify broadcast signals from lc_ctrl.
 
             - Preload the LC partition in the otp_ctrl with the following states: RMA, DEV,
               TEST_LOCKED[N] & SCRAP.
@@ -178,30 +180,7 @@
               - lc_escalate_en_o (multiple)
             '''
       stage: V2
-      tests: [
-        "chip_prim_tl_access",                         // lc_dft_en_o: otp_ctrl
-        "chip_tap_straps_dev",                         // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        "chip_tap_straps_prod",                        // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        "chip_tap_straps_rma",                         // lc_dft_en_o, lc_hw_debug_en_o: pinmux
-        "chip_sw_rom_ctrl_integrity_check",            // lc_dft_en_o, lc_hw_debug_en_o: pwrmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0", // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0", // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev",            // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev",            // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma",            // lc_hw_debug_en_o: clkmgr
-        "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma",            // lc_hw_debug_en_o: clkmgr
-        "chip_sw_sram_ctrl_execution_main",            // lc_hw_debug_en_o: sram_ctrl main
-        "chip_rv_dm_lc_disabled"                       // lc_hw_debug_en_o: rv_dm
-        "chip_sw_keymgr_key_derivation",               // lc_keymgr_en_o: keymgr
-        "chip_sw_clkmgr_external_clk_src_for_lc",      // lc_clk_byp_req_o: clkmgr
-        "chip_sw_flash_rma_unlocked",                  // lc_flash_rma_req_o, lc_flash_rma_seed_o: flash_ctrl
-        "chip_sw_lc_ctrl_transition",                  // lc_check_byp_en_o: otp_ctrl
-        "chip_sw_flash_ctrl_lc_rw_en",                 // lc_creator*, lc_seed*, lc_owner*, lc_iso*: flash_ctrl
-        "chip_sw_otp_ctrl_lc_signals_test_unlocked0",  // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
-        "chip_sw_otp_ctrl_lc_signals_dev",             // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
-        "chip_sw_otp_ctrl_lc_signals_prod",            // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
-        "chip_sw_otp_ctrl_lc_signals_rma",             // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, lc_keymgr_en_i: otp_ctrl
-      ]
+      tests: ["chip_prim_tl_access", "chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma", "chip_sw_rom_ctrl_integrity_check", "chip_sw_clkmgr_external_clk_src_for_sw_fast_test_unlocked0", "chip_sw_clkmgr_external_clk_src_for_sw_slow_test_unlocked0", "chip_sw_clkmgr_external_clk_src_for_sw_fast_dev", "chip_sw_clkmgr_external_clk_src_for_sw_slow_dev", "chip_sw_clkmgr_external_clk_src_for_sw_fast_rma", "chip_sw_clkmgr_external_clk_src_for_sw_slow_rma", "chip_sw_sram_ctrl_execution_main", "chip_rv_dm_lc_disabled", "chip_sw_keymgr_key_derivation", "chip_sw_clkmgr_external_clk_src_for_lc", "chip_sw_flash_rma_unlocked", "chip_sw_lc_ctrl_transition", "chip_sw_flash_ctrl_lc_rw_en", "chip_sw_otp_ctrl_lc_signals_test_unlocked0", "chip_sw_otp_ctrl_lc_signals_dev", "chip_sw_otp_ctrl_lc_signals_prod", "chip_sw_otp_ctrl_lc_signals_rma"]
     }
     {
       name: chip_sw_lc_ctrl_kmac_error
@@ -219,7 +198,8 @@
     }
     {
       name: chip_lc_scrap
-      desc: '''Ensure it is possible to enter scrap state from every legal life cycle state.
+      desc: '''
+            Ensure it is possible to enter scrap state from every legal life cycle state.
 
             -  Request transition to SCRAP state using the JTAG interface.
             -  It should be possible to transition from every legal state using external clock.
@@ -238,17 +218,15 @@
       tags: ["dv", "fpga", "silicon"]
       stage: V2
       si_stage: SV3
-      otp_mutate: true
+      otp_mutate: True
       lc_states: ["RAW", "TEST_UNLOCKED", "TEST_LOCKED", "DEV", "PROD", "PROD_END", "RMA"]
-      tests: ["chip_sw_lc_ctrl_rand_to_scrap",
-              "chip_sw_lc_ctrl_raw_to_scrap",
-              "chip_sw_lc_ctrl_rma_to_scrap",
-              "chip_sw_lc_ctrl_test_locked0_to_scrap"]
+      tests: ["chip_sw_lc_ctrl_rand_to_scrap", "chip_sw_lc_ctrl_raw_to_scrap", "chip_sw_lc_ctrl_rma_to_scrap", "chip_sw_lc_ctrl_test_locked0_to_scrap"]
       bazel: []
     }
     {
       name: chip_lc_test_locked
-      desc: '''Transition from TEST_UNLOCKED to TEST_LOCKED using LC JTAG interface.
+      desc: '''
+            Transition from TEST_UNLOCKED to TEST_LOCKED using LC JTAG interface.
 
             -  Check in TEST_UNLOCKED RV JTAG interface is available.
             -  Verify When in TEST_LOCKED state:
@@ -266,15 +244,15 @@
       tags: ["dv", "fpga", "silicon"]
       stage: V2
       si_stage: SV3
-      otp_mutate: true
+      otp_mutate: True
       lc_states: ["TEST_UNLOCKED"]
-      tests: ["chip_sw_lc_walkthrough_testunlocks",
-              "chip_rv_dm_lc_disabled"]
+      tests: ["chip_sw_lc_walkthrough_testunlocks", "chip_rv_dm_lc_disabled"]
       bazel: []
     }
     {
       name: chip_sw_lc_walkthrough
-      desc: '''Walk through the life cycle stages from RAW state and reseting the chip each time.
+      desc: '''
+            Walk through the life cycle stages from RAW state and reseting the chip each time.
 
              - Pre-load OTP image with RAW lc_state.
              - Initiate the LC transition to one of the test unlock state.
@@ -282,17 +260,15 @@
              - Move forward to next valid LC states via JTAG interface or SW interface if CPU is
                enabled.
              Verify that the features that should indeed be disabled are indeed disabled.
-             '''
+
+            '''
       stage: V2
-      tests: ["chip_sw_lc_walkthrough_dev",
-              "chip_sw_lc_walkthrough_prod",
-              "chip_sw_lc_walkthrough_prodend",
-              "chip_sw_lc_walkthrough_rma",
-              "chip_sw_lc_walkthrough_testunlocks"]
+      tests: ["chip_sw_lc_walkthrough_dev", "chip_sw_lc_walkthrough_prod", "chip_sw_lc_walkthrough_prodend", "chip_sw_lc_walkthrough_rma", "chip_sw_lc_walkthrough_testunlocks"]
     }
     {
       name: chip_sw_lc_ctrl_volatile_raw_unlock
-      desc: '''Configure VOLATILE_RAW_UNLOCK via LC TAP interface and enable CPU execution.
+      desc: '''
+            Configure VOLATILE_RAW_UNLOCK via LC TAP interface and enable CPU execution.
 
              - Pre-load OTP image with RAW lc_state.
              - Initiate the LC transition to test_unlocked0 state using the
@@ -312,40 +288,26 @@
                when it is programmed to 1.
              - Check that the transition results in a token error (the real RAW unlock transition
                expects the unhashed token instead of the hashed token supplied for volatile RAW unlock).
-             '''
-      features: [
-        "LC_CTRL.STATE.RAW",
-        "LC_CTRL.STATE.TEST_UNLOCKED",
-        "LC_CTRL.ACCESS.JTAG",
-        "LC_CTRL.ACCESS.EXT_CLK",
-        "LC_CTRL.AUTHENTICATED_TRANSITIONS",
-      ]
+
+            '''
+      features: ["LC_CTRL.STATE.RAW", "LC_CTRL.STATE.TEST_UNLOCKED", "LC_CTRL.ACCESS.JTAG", "LC_CTRL.ACCESS.EXT_CLK", "LC_CTRL.AUTHENTICATED_TRANSITIONS"]
       tags: ["dv", "fpga", "silicon"]
       stage: V2
       si_stage: SV2
       lc_states: ["RAW"]
-      tests: ["chip_sw_lc_ctrl_volatile_raw_unlock",
-              "chip_sw_lc_ctrl_volatile_raw_unlock_ext_clk_48mhz",
-              "rom_volatile_raw_unlock"]
+      tests: ["chip_sw_lc_ctrl_volatile_raw_unlock", "chip_sw_lc_ctrl_volatile_raw_unlock_ext_clk_48mhz", "rom_volatile_raw_unlock"]
       bazel: []
     }
     {
       name: chip_sw_lc_ctrl_debug_access
-      desc: '''Verify debug access for each lifecycle state.
+      desc: '''
+            Verify debug access for each lifecycle state.
 
              For each lifecycle state verify the debug and CPU access to make sure it matches the
              specification.
-             '''
-      features: [
-        "LC_CTRL.STATE.RAW",
-        "LC_CTRL.STATE.TEST_UNLOCKED",
-        "LC_CTRL.STATE.TEST_LOCKED",
-        "LC_CTRL.STATE.DEV",
-        "LC_CTRL.STATE.PROD",
-        "LC_CTRL.STATE.PROD_END",
-        "LC_CTRL.STATE.RMA",
-        "LC_CTRL.STATE.SCRAP",
-      ]
+
+            '''
+      features: ["LC_CTRL.STATE.RAW", "LC_CTRL.STATE.TEST_UNLOCKED", "LC_CTRL.STATE.TEST_LOCKED", "LC_CTRL.STATE.DEV", "LC_CTRL.STATE.PROD", "LC_CTRL.STATE.PROD_END", "LC_CTRL.STATE.RMA", "LC_CTRL.STATE.SCRAP"]
       tags: ["dv", "fpga", "silicon"]
       stage: V3
       si_stage: SV2

--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -6,7 +6,8 @@
   testpoints: [
     {
       name: chip_sw_otbn_isa
-      desc: '''Run every OTBN instruction and check final state.
+      desc: '''
+            Run every OTBN instruction and check final state.
 
                 Utilizing the existing OTBN smoke test which uses every instruction
                 (hw/ip/otbn/dv/smoke/smoke_test.s). Check the final register state matches the
@@ -17,20 +18,19 @@
                 Following the smoke test run a new program just to dump out the register state to
                 dmem, check the values do not match the previous values from the smoke test run to
                 ensure the internal state secure wipe has worked.
-             '''
+
+            '''
       stage: V2
       si_stage: SV3
       tests: []
       bazel: ["//sw/device/tests:otbn_isa_test"]
       lc_states: ["PROD"]
-      features: [
-        "OTBN.ISA",
-        "OTBN.SECUREWIPE"
-      ]
+      features: ["OTBN.ISA", "OTBN.SECUREWIPE"]
     }
     {
       name: chip_sw_otbn_op
-      desc: '''Verify an OTBN operation.
+      desc: '''
+            Verify an OTBN operation.
 
             - SW test directs the OTBN engine to perform an ECDSA operation.
             - SW validates the reception of the otbn done interrupt once the operation is complete.
@@ -39,17 +39,15 @@
             '''
       stage: V2
       si_stage: SV3
-      tests: ["chip_sw_otbn_ecdsa_op_irq",
-              "chip_sw_otbn_ecdsa_op_irq_jitter_en"]
+      tests: ["chip_sw_otbn_ecdsa_op_irq", "chip_sw_otbn_ecdsa_op_irq_jitter_en"]
       bazel: ["//sw/device/tests:otbn_ecdsa_op_irq_test"]
       lc_states: ["PROD"]
-      features: [
-        "OTBN.ISA"
-      ]
+      features: ["OTBN.ISA"]
     }
     {
       name: chip_sw_otbn_rnd_entropy
-      desc: '''Verify OTBN can fetch RND numbers from the entropy src.
+      desc: '''
+            Verify OTBN can fetch RND numbers from the entropy src.
 
             - SW initializes the entropy subsystem to generate randomness.
             - SW loads an OTBN app that executes instructions to read the RND bits.
@@ -62,28 +60,26 @@
       tests: ["chip_sw_otbn_randomness"]
       bazel: ["//sw/device/tests:otbn_randomness_test"]
       lc_states: ["PROD"]
-      features: [
-        "OTBN.RANDOM"
-      ]
+      features: ["OTBN.RANDOM"]
     }
     {
       name: chip_sw_otbn_urnd_entropy
-      desc: '''Verify OTBN can fetch URND numbers from the entropy src.
+      desc: '''
+            Verify OTBN can fetch URND numbers from the entropy src.
 
             - Similar to chip_otbn_rnd_entropy, but verifies the URND bits.
             '''
       stage: V2
       si_stage: SV3
-      tests:  ["chip_sw_otbn_randomness"]
+      tests: ["chip_sw_otbn_randomness"]
       bazel: ["//sw/device/tests:otbn_randomness_test"]
       lc_states: ["PROD"]
-      features: [
-        "OTBN.RANDOM"
-      ]
+      features: ["OTBN.RANDOM"]
     }
     {
       name: chip_sw_otbn_idle
-      desc: '''Verify the OTBN idle signal to clkmgr.
+      desc: '''
+            Verify the OTBN idle signal to clkmgr.
 
             - Write the OTBN clk hint to 0 within clkmgr to indicate OTBN clk can be gated
               and verify that the OTBN clk hint status within clkmgr reads 0 (OTBN is disabled).
@@ -105,7 +101,8 @@
     }
     {
       name: chip_sw_otbn_mem_scramble
-      desc: '''Verify the OTBN can receive keys from the OTP to scramble the OTBN imem and dmem.
+      desc: '''
+            Verify the OTBN can receive keys from the OTP to scramble the OTBN imem and dmem.
 
             - Initialize the entropy_src subsystem to enable OTP_CTRL fetch random data (already
               done by the test_rom startup code).
@@ -127,28 +124,24 @@
       si_stage: SV3
       tests: ["chip_sw_otbn_mem_scramble"]
       lc_states: ["PROD"]
-      features: [
-        "OTBN.MEM_SCRAMBLE",
-        "OTBN.SECUREWIPE"
-      ]
+      features: ["OTBN.MEM_SCRAMBLE", "OTBN.SECUREWIPE"]
     }
     {
       name: chip_sw_otbn_keymgr
-      desc: '''Check the OTBN keymgr connection is functional.
+      desc: '''
+            Check the OTBN keymgr connection is functional.
 
             Setup the keymgr and any other blocks required to provide OTBN with a valid sideload
             key. Run an OTBN program to read the key via the KEY_S[0|1]_[H|L] WSRs and write it to
             dmem. Sanity check the returned value (e.g. != 0) and check OTBN completed successfully
             with no errors.
-      '''
+            '''
       stage: V2
       si_stage: SV2
       tests: []
       bazel: ["//sw/device/tests:keymgr_sideload_otbn_simple_test"]
       lc_states: ["PROD"]
-      features: [
-        "OTBN.KEYMGR",
-      ]
+      features: ["OTBN.KEYMGR"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_otp_ctrl
   testpoints: [
-    // OTP (pre-verified IP) integration tests:
     {
       name: chip_otp_ctrl_init
-      desc: '''Verify the OTP ctrl initialization on chip power up.
+      desc: '''
+            Verify the OTP ctrl initialization on chip power up.
 
             Verify that the chip powers up correctly on POR.
             - The pwrmgr initiates a handshake with OTP ctrl and later, with LC ctrl in subsequent
@@ -22,7 +22,8 @@
     }
     {
       name: chip_sw_otp_ctrl_keys
-      desc: '''Verify the proliferation of keys to security peripherals.
+      desc: '''
+            Verify the proliferation of keys to security peripherals.
 
             - Verify the correctness of keys provided to SRAM ctrl (main & ret), flash ctrl, keymgr,
               (note that keymgr does not have handshake).
@@ -42,16 +43,12 @@
       stage: V2
       si_stage: SV1
       lc_states: ["PROD"]
-      tests: [// Verifies both, main and retention SRAM scrambling.
-              "chip_sw_sram_ctrl_scrambled_access",
-              "chip_sw_flash_init",
-              "chip_sw_keymgr_key_derivation",
-              "chip_sw_otbn_mem_scramble",
-              "chip_sw_rv_core_ibex_icache_invalidate"]
+      tests: ["chip_sw_sram_ctrl_scrambled_access", "chip_sw_flash_init", "chip_sw_keymgr_key_derivation", "chip_sw_otbn_mem_scramble", "chip_sw_rv_core_ibex_icache_invalidate"]
     }
     {
       name: chip_sw_otp_ctrl_entropy
-      desc: '''Verify the entropy interface from OTP ctrl to EDN.
+      desc: '''
+            Verify the entropy interface from OTP ctrl to EDN.
 
             This is X-ref'ed with the chip_otp_ctrl_keys test, which needs to handshake with the EDN
             to receive some entropy bits before the keys for SRAM ctrl and OTBN are computed.
@@ -63,15 +60,12 @@
       stage: V2
       si_stage: SV1
       lc_states: ["PROD"]
-      tests: ["chip_sw_sram_ctrl_scrambled_access",
-              "chip_sw_flash_init",
-              "chip_sw_keymgr_key_derivation",
-              "chip_sw_otbn_mem_scramble",
-              "chip_sw_rv_core_ibex_icache_invalidate"]
+      tests: ["chip_sw_sram_ctrl_scrambled_access", "chip_sw_flash_init", "chip_sw_keymgr_key_derivation", "chip_sw_otbn_mem_scramble", "chip_sw_rv_core_ibex_icache_invalidate"]
     }
     {
       name: chip_sw_otp_ctrl_program
-      desc: '''Verify the program request from lc_ctrl.
+      desc: '''
+            Verify the program request from lc_ctrl.
 
             - Verify that upon an LC state transition request, LC ctrl signals the OTP ctrl with a
               program request.
@@ -84,8 +78,7 @@
             For sival, this test can be done by
             - manuf_ft_sku_individualization_preop
             '''
-      features: ["OTP_CTRL.PROGRAM", "OTP_CTRL.PARTITION.SECRET0",
-                 "OTP_CTRL.PARTITION.LIFE_CYCLE", "OTP_CTRL.PARTITION.SECRET2"]
+      features: ["OTP_CTRL.PROGRAM", "OTP_CTRL.PARTITION.SECRET0", "OTP_CTRL.PARTITION.LIFE_CYCLE", "OTP_CTRL.PARTITION.SECRET2"]
       stage: V2
       si_stage: SV1
       lc_states: ["PROD"]
@@ -93,7 +86,8 @@
     }
     {
       name: chip_sw_otp_ctrl_program_error
-      desc: '''Verify the otp program error.
+      desc: '''
+            Verify the otp program error.
 
             - Initiate an illegal program request from LC ctrl to OTP ctrl by forcing the
               `lc_otp_program_i`.
@@ -114,7 +108,8 @@
     }
     {
       name: chip_sw_otp_ctrl_hw_cfg0
-      desc: '''Verify the correctness of otp_hw_cfg0 bus in all peripherals that receive it.
+      desc: '''
+            Verify the correctness of otp_hw_cfg0 bus in all peripherals that receive it.
 
             Preload the OTP ctrl's `hw_cfg0` partition with random data and verify that all
             consumers of the hardware configuration bits are receiving the correct values.
@@ -132,7 +127,8 @@
     }
     {
       name: chip_sw_otp_ctrl_lc_signals
-      desc: '''Verify the broadcast signals from LC ctrl.
+      desc: '''
+            Verify the broadcast signals from LC ctrl.
 
             - `lc_creator_seed_sw_rw_en_i`: verify that the SECRET2 partition is locked.
             - `lc_seed_hw_rd_en_i`: verify that the keymgr outputs a default value when enabled.
@@ -152,22 +148,12 @@
       features: ["OTP_CTRL.PARTITION.SECRET2"]
       stage: V2
       si_stage: NA
-      tests: [
-        // lc_dft_en_i
-        "chip_prim_tl_access",
-        // lc_check_byp_en_i
-        "chip_sw_lc_ctrl_transition",
-        // lc_seed_hw_rd_en_i, lc_creator_seed_sw_rw_en_i, also checks lc_keymgr_en_i since it uses
-        // the keymgr.
-        "chip_sw_otp_ctrl_lc_signals_test_unlocked0",
-        "chip_sw_otp_ctrl_lc_signals_dev",
-        "chip_sw_otp_ctrl_lc_signals_prod",
-        "chip_sw_otp_ctrl_lc_signals_rma",
-        ]
+      tests: ["chip_prim_tl_access", "chip_sw_lc_ctrl_transition", "chip_sw_otp_ctrl_lc_signals_test_unlocked0", "chip_sw_otp_ctrl_lc_signals_dev", "chip_sw_otp_ctrl_lc_signals_prod", "chip_sw_otp_ctrl_lc_signals_rma"]
     }
     {
       name: chip_sw_otp_prim_tl_access
-      desc: '''Verify that the SW can read / write the prim tlul interface.
+      desc: '''
+            Verify that the SW can read / write the prim tlul interface.
 
             - The prim tlul interface is a open source placeholder for the closed source CSRs that
               will be implemented in a translation 'shim'.
@@ -197,16 +183,15 @@
             - For sival, real vendor test will be done by a silicon vendor and nothing need to be done
               in the open source side.
             '''
-      features: ["OTP_CTRL.PARTITION.VENDOR_TEST",
-                 "OTP_CTRL.PARTITIONS_FEATURE.READ_LOCK",
-                 "OTP_CTRL.PARTITIONS_FEATURE.WRITE_LOCK"]
+      features: ["OTP_CTRL.PARTITION.VENDOR_TEST", "OTP_CTRL.PARTITIONS_FEATURE.READ_LOCK", "OTP_CTRL.PARTITIONS_FEATURE.WRITE_LOCK"]
       stage: V3
       si_stage: NA
       tests: ["chip_sw_otp_ctrl_vendor_test_csr_access"]
     }
     {
       name: chip_sw_otp_ctrl_escalation
-      desc: '''Verify escalation from otp_ctrl macro fatal error.
+      desc: '''
+            Verify escalation from otp_ctrl macro fatal error.
 
             - Inject ECC fatal error into OTP macro's HW cfg partition, and read back this macro
               via DAI interface.
@@ -223,10 +208,11 @@
     }
     {
       name: otp_ctrl_calibration
-      desc: '''Verify all calibrated parameters are programmed during manufacturing stage calibration test phase.
+      desc: '''
+            Verify all calibrated parameters are programmed during manufacturing stage calibration test phase.
             For sival this test can be done by
             - manuf_cp_ast_test_execution
-      '''
+            '''
       features: ["OTP_CTRL.PARTITION.CREATOR_SW_CFG"]
       stage: V3
       si_stage: SV1
@@ -235,30 +221,31 @@
     }
     {
       name: otp_ctrl_partition_access_locked
-      desc: '''Verify accessibily of all partition except life_cycle partition.
+      desc: '''
+            Verify accessibily of all partition except life_cycle partition.
 
             - Without locking state, try random write and read back test over all sw accessible partitions.
             - Per each partition, enable write lock and try to do subsequent write then readback.
             - Dut should generate recoverable error (access error) and 2nd write won't go through.
             - Per each partition, enable read lock and try to read.
             - Dut should generate recoverable error (access error).
-      '''
-      features: ["OTP_CTRL.PARTITIONS_FEATURE.READ_LOCK", "OTP_CTRL.PARTITIONS_FEATURE.WRITE_LOCK",
-                 "OTP_CTRL.ERROR_HANDLING.RECOVERABLE"]
+            '''
+      features: ["OTP_CTRL.PARTITIONS_FEATURE.READ_LOCK", "OTP_CTRL.PARTITIONS_FEATURE.WRITE_LOCK", "OTP_CTRL.ERROR_HANDLING.RECOVERABLE"]
       stage: V3
       si_stage: NA
       tests: []
     }
     {
       name: otp_ctrl_check_timeout
-      desc: '''Verify check_tiemout feature.
+      desc: '''
+            Verify check_tiemout feature.
 
             - Program otp_ctrl.check_timeout value small value (e.g. 1000 cycles).
             - Write 1 to otp_ctrl.check_trigger.integrity.
             - After timeout cycle, check otp_ctrl.status.timeout_error = 1.
             - Write 1 to otp_ctrl.check_trigger.consistency.
             - After timeout cycle, check otp_ctrl.status.timeout_error = 1.
-      '''
+            '''
       features: ["OTP_CTRL.BACKGROUND_CHECK.CHECK_TIMEOUT"]
       stage: V3
       si_stage: NA

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_pwrmgr
   testpoints: [
-    // PWRMGR tests:
     {
       name: chip_sw_pwrmgr_external_full_reset
-      desc: '''Verify the cold boot sequence by wiggling of chip's `POR_N`.
+      desc: '''
+            Verify the cold boot sequence by wiggling of chip's `POR_N`.
 
             This ensures that both FSMs are properly reset on the POR signal. The check is that
             the processor ends up running. Also verify, the rstmgr recorded POR in `reset_info` CSR
@@ -23,7 +23,8 @@
     }
     {
       name: chip_sw_pwrmgr_random_sleep_all_wake_ups
-      desc: '''Verify that the chip can go into random low power states and be woken up by ALL wake
+      desc: '''
+            Verify that the chip can go into random low power states and be woken up by ALL wake
             up sources.
 
             This verifies ALL wake up sources. This also verifies that the pwrmgr sequencing is
@@ -46,27 +47,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "PWRMGR.LOW_POWER.SYSRST_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE",
-        "PWRMGR.LOW_POWER.SYSRST_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST",
-        "PWRMGR.LOW_POWER.ADC_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE",
-        "PWRMGR.LOW_POWER.ADC_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST",
-        "PWRMGR.LOW_POWER.PINMUX_AON_PIN_WKUP_REQ_WAKEUP_ENABLE",
-        "PWRMGR.LOW_POWER.PINMUX_AON_PIN_WKUP_REQ_WAKEUP_REQUEST",
-        "PWRMGR.LOW_POWER.PINMUX_AON_USB_WKUP_REQ_WAKEUP_ENABLE",
-        "PWRMGR.LOW_POWER.PINMUX_AON_USB_WKUP_REQ_WAKEUP_REQUEST",
-        "PWRMGR.LOW_POWER.AON_TIMER_AON_WKUP_REQ_WAKEUP_ENABLE",
-        "PWRMGR.LOW_POWER.AON_TIMER_AON_WKUP_REQ_WAKEUP_REQUEST",
-        "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE",
-        "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST",
-        "PWRMGR.LOW_POWER.WAKE_INFO"
-      ]
+      features: ["PWRMGR.LOW_POWER.SYSRST_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE", "PWRMGR.LOW_POWER.SYSRST_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST", "PWRMGR.LOW_POWER.ADC_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE", "PWRMGR.LOW_POWER.ADC_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST", "PWRMGR.LOW_POWER.PINMUX_AON_PIN_WKUP_REQ_WAKEUP_ENABLE", "PWRMGR.LOW_POWER.PINMUX_AON_PIN_WKUP_REQ_WAKEUP_REQUEST", "PWRMGR.LOW_POWER.PINMUX_AON_USB_WKUP_REQ_WAKEUP_ENABLE", "PWRMGR.LOW_POWER.PINMUX_AON_USB_WKUP_REQ_WAKEUP_REQUEST", "PWRMGR.LOW_POWER.AON_TIMER_AON_WKUP_REQ_WAKEUP_ENABLE", "PWRMGR.LOW_POWER.AON_TIMER_AON_WKUP_REQ_WAKEUP_REQUEST", "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE", "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST", "PWRMGR.LOW_POWER.WAKE_INFO"]
       tests: ["chip_sw_pwrmgr_random_sleep_all_wake_ups"]
       bazel: ["//sw/device/tests:pwrmgr_random_sleep_all_wake_ups"]
     }
     {
       name: chip_sw_pwrmgr_normal_sleep_all_wake_ups
-      desc: '''Verify that the chip can go into normal sleep state and be woken up by ALL wake up
+      desc: '''
+            Verify that the chip can go into normal sleep state and be woken up by ALL wake up
             sources.
 
             This verifies ALL wake up sources. This also verifies that the pwrmgr sequencing is
@@ -84,7 +72,8 @@
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_por_reset
-      desc: '''Verify POR in deep sleep mode.
+      desc: '''
+            Verify POR in deep sleep mode.
 
             This verifies that the pwrmgr can handle POR in deep sleep. The chip is placed
             in deep sleep, a POR is sent, and the wakeup cause is checked to be POR. This
@@ -95,17 +84,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "PWRMGR.LOW_POWER.DISABLE_POWER",
-        "PWRMGR.LOW_POWER.ENTRY",
-        "PWRMGR.RESET.POR_REQUEST",
-      ]
+      features: ["PWRMGR.LOW_POWER.DISABLE_POWER", "PWRMGR.LOW_POWER.ENTRY", "PWRMGR.RESET.POR_REQUEST"]
       tests: ["chip_sw_pwrmgr_deep_sleep_por_reset"]
       bazel: ["//sw/device/tests:pwrmgr_deep_sleep_por_reset_test"]
     }
     {
       name: chip_sw_pwrmgr_normal_sleep_por_reset
-      desc: '''Verify POR in normal sleep mode.
+      desc: '''
+            Verify POR in normal sleep mode.
 
             This verifies that the pwrmgr can handle POR in normal sleep. The chip is placed
             in normal sleep, a POR is sent, and the wakeup cause is checked to be POR. This
@@ -116,16 +102,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "PWRMGR.LOW_POWER.ENTRY",
-        "PWRMGR.RESET.POR_REQUEST",
-      ]
+      features: ["PWRMGR.LOW_POWER.ENTRY", "PWRMGR.RESET.POR_REQUEST"]
       tests: ["chip_sw_pwrmgr_normal_sleep_por_reset"]
       bazel: ["//sw/device/tests:pwrmgr_normal_sleep_por_reset_test"]
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_all_wake_ups
-      desc: '''Verify that the chip can go into deep sleep state and be woken up by ALL wake up
+      desc: '''
+            Verify that the chip can go into deep sleep state and be woken up by ALL wake up
             sources.
 
             This verifies ALL wake up sources. This also verifies that the pwrmgr sequencing is
@@ -140,7 +124,8 @@
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_all_reset_reqs
-      desc: '''Verify resets by relevant reset sources in deep sleep mode.
+      desc: '''
+            Verify resets by relevant reset sources in deep sleep mode.
 
             - 4 resets are generated with deep sleep mode
             - sysrst, wdog timer reset, rstmgr sw reset, and escalation reset
@@ -157,28 +142,14 @@
             '''
       stage: V2
       si_stage: NA
-      features: [
-        "PWRMGR.LOW_POWER.ENTRY",
-        "PWRMGR.LOW_POWER.DISABLE_POWER"
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
-        "PWRMGR.RESET.ESCALATION_REQUEST",
-        "PWRMGR.RESET.SW_RST_REQUEST",
-        "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_ENABLE",
-        "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST",
-      ]
-      tests: [
-        "chip_sw_aon_timer_wdog_bite_reset",
-        "chip_sw_pwrmgr_deep_sleep_all_reset_reqs",
-      ]
-      bazel: [
-        "//sw/device/tests:aon_timer_wdog_bite_reset_test",
-        "//sw/device/tests:pwrmgr_deep_sleep_all_reset_reqs_test",
-      ]
+      features: ["PWRMGR.LOW_POWER.ENTRY", "PWRMGR.LOW_POWER.DISABLE_POWER", "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE", "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST", "PWRMGR.RESET.ESCALATION_REQUEST", "PWRMGR.RESET.SW_RST_REQUEST", "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_ENABLE", "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST"]
+      tests: ["chip_sw_aon_timer_wdog_bite_reset", "chip_sw_pwrmgr_deep_sleep_all_reset_reqs"]
+      bazel: ["//sw/device/tests:aon_timer_wdog_bite_reset_test", "//sw/device/tests:pwrmgr_deep_sleep_all_reset_reqs_test"]
     }
     {
       name: chip_sw_sensor_ctrl_deep_sleep_wake_up
-      desc: '''Verify that the chip will wake up from deep sleep by sensor_ctrl.
+      desc: '''
+            Verify that the chip will wake up from deep sleep by sensor_ctrl.
 
             This forces the sensor_ctrl alert input from AST to trigger wake up.
             It does this while the chip is in deep sleep, so clocks are off.
@@ -186,17 +157,14 @@
             '''
       stage: V3
       si_stage: NA
-      features: [
-        "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE",
-        "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST",
-        "PWRMGR.LOW_POWER.WAKE_INFO"
-      ]
+      features: ["PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE", "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST", "PWRMGR.LOW_POWER.WAKE_INFO"]
       tests: ["chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up"]
       bazel: []
     }
     {
       name: chip_sw_pwrmgr_normal_sleep_all_reset_reqs
-      desc: '''Verify that the chip can go into normal sleep state and be reset up by ALL reset req
+      desc: '''
+            Verify that the chip can go into normal sleep state and be reset up by ALL reset req
             sources.
 
             This verifies ALL reset sources.
@@ -209,21 +177,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "PWRMGR.LOW_POWER.ENTRY",
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
-        "PWRMGR.RESET.ESCALATION_REQUEST",
-        "PWRMGR.RESET.SW_RST_REQUEST",
-        "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_ENABLE",
-        "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST",
-      ]
+      features: ["PWRMGR.LOW_POWER.ENTRY", "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE", "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST", "PWRMGR.RESET.ESCALATION_REQUEST", "PWRMGR.RESET.SW_RST_REQUEST", "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_ENABLE", "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST"]
       tests: ["chip_sw_pwrmgr_normal_sleep_all_reset_reqs"]
       bazel: ["//sw/device/tests:pwrmgr_normal_sleep_all_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_wdog_reset
-      desc: '''Verify that the chip can be reset by watchdog timer reset source.
+      desc: '''
+            Verify that the chip can be reset by watchdog timer reset source.
 
             This verifies watchdog timer reset source. This also verifies that the pwrmgr sequencing
             is working correctly as expected. X-ref'ed with all individual IP tests. Similar to
@@ -234,18 +195,16 @@
       stage: V2
       si_stage: SV2
       lc_states: ["PROD"]
-      features: [
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
-      ]
+      features: ["PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE", "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST"]
       tests: ["chip_sw_pwrmgr_wdog_reset"]
       bazel: ["//sw/device/tests:pwrmgr_wdog_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_aon_power_glitch_reset
-      desc: '''Verify the cold boot sequence through an AON power glitch.
+      desc: '''
+            Verify the cold boot sequence through an AON power glitch.
 
-
+            
             Pulsing the AST vcaon_supp_i input causes an AON power glitch which becomes a POR.
             This ensures that both FSMs are properly reset on the POR signal. The check is that
             the processor ends up running. Also verify, the rstmgr recorded POR in `reset_info` CSR
@@ -259,7 +218,8 @@
     }
     {
       name: chip_sw_pwrmgr_main_power_glitch_reset
-      desc: '''Verify the effect of a glitch in main power rail.
+      desc: '''
+            Verify the effect of a glitch in main power rail.
 
             The vcmain_supp_i AST input is forced to drop once the test is running. This triggers
             a MainPwr reset request, which is checked by reading retention SRAM's reset_reason to
@@ -272,7 +232,8 @@
     }
     {
       name: chip_sw_pwrmgr_random_sleep_power_glitch_reset
-      desc: '''Verify the effect of a glitch in main power rail in random sleep states.
+      desc: '''
+            Verify the effect of a glitch in main power rail in random sleep states.
 
             The vcmain_supp_i AST input is forced to drop right after putting the chip in a random
             sleep state. This triggers a MainPwr reset request, which is checked by reading
@@ -294,7 +255,8 @@
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_power_glitch_reset
-      desc: '''Verify the effect of a glitch in main power rail in deep sleep.
+      desc: '''
+            Verify the effect of a glitch in main power rail in deep sleep.
 
             The vcmain_supp_i AST input is forced to drop right after putting the chip in deep
             sleep. This triggers a MainPwr reset request, which is checked by reading retention
@@ -313,7 +275,8 @@
     }
     {
       name: chip_sw_pwrmgr_sleep_power_glitch_reset
-      desc: '''Verify the effect of a glitch in main power rail in shallow sleep.
+      desc: '''
+            Verify the effect of a glitch in main power rail in shallow sleep.
 
             The vcmain_supp_i AST input is forced to drop after putting the chip in shallow sleep.
             This triggers a MainPwr reset request, which is checked by reading the retention SRAM's
@@ -327,7 +290,8 @@
     }
     {
       name: chip_sw_pwrmgr_random_sleep_all_reset_reqs
-      desc: '''Verify resets by relevant reset sources in sleep modes.
+      desc: '''
+            Verify resets by relevant reset sources in sleep modes.
 
             - 4 resets are generated with normal and deep sleep mode each
             - sysrst, wdog timer reset, rstmgr sw reset, and escalation reset
@@ -344,22 +308,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "PWRMGR.LOW_POWER.ENTRY",
-        "PWRMGR.LOW_POWER.DISABLE_POWER"
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
-        "PWRMGR.RESET.ESCALATION_REQUEST",
-        "PWRMGR.RESET.SW_RST_REQUEST",
-        "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_ENABLE",
-        "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST",
-      ]
+      features: ["PWRMGR.LOW_POWER.ENTRY", "PWRMGR.LOW_POWER.DISABLE_POWER", "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE", "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST", "PWRMGR.RESET.ESCALATION_REQUEST", "PWRMGR.RESET.SW_RST_REQUEST", "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_ENABLE", "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST"]
       tests: ["chip_sw_pwrmgr_random_sleep_all_reset_reqs"]
       bazel: ["//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_sysrst_ctrl_reset
-      desc: '''Verify sysrst_ctrl and watchdog reset.
+      desc: '''
+            Verify sysrst_ctrl and watchdog reset.
 
             - Read the reset cause register in rstmgr to confirm that the SW is in the POR reset
               phase.
@@ -374,15 +330,13 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: [
-        "chip_sw_pwrmgr_sysrst_ctrl_reset",
-        "chip_sw_pwrmgr_all_reset_reqs",
-      ]
+      tests: ["chip_sw_pwrmgr_sysrst_ctrl_reset", "chip_sw_pwrmgr_all_reset_reqs"]
       bazel: ["//sw/device/tests:pwrmgr_all_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_b2b_sleep_reset_req
-      desc: '''Verify that the pwrmgr sequences sleep_req and reset req coming in almost at the same
+      desc: '''
+            Verify that the pwrmgr sequences sleep_req and reset req coming in almost at the same
             time, one after the other. Use POR_N PAD to trigger reset.
             '''
       stage: V2
@@ -391,7 +345,8 @@
     }
     {
       name: chip_sw_pwrmgr_sleep_disabled
-      desc: '''Verify that the chip does not go to sleep on WFI when low power hint is 0.
+      desc: '''
+            Verify that the chip does not go to sleep on WFI when low power hint is 0.
 
             This calls WFI with low_power_hint disabled and pwrmgr interrupts enabled,
             and fails if the pwrmgr ISR is called.
@@ -407,7 +362,8 @@
     }
     {
       name: chip_sw_pwrmgr_usb_clk_disabled_when_active
-      desc: '''Verify that the USB stops responding when its clock is disabled in active state.
+      desc: '''
+            Verify that the USB stops responding when its clock is disabled in active state.
 
             Configure the pwrmgr CONTROL CSR with USB_CLK_EN_ACTIVE off, and issue a CSR read
             to the USB.  This CSR read should cause the CPU to hung.  Prior to this read,
@@ -424,33 +380,27 @@
     }
     {
       name: chip_sw_all_resets
-      desc: '''Verify resets by relevant reset sources when active.
+      desc: '''
+            Verify resets by relevant reset sources when active.
 
             - POR (HW PAD) reset, SW POR, sysrst, wdog timer reset, esc rst.
             - rstmgr sw reset is in rstmgr testplan.
             - ndm reset is in rv_dm testplan.
-	    This test is like the pwrmgr_*_sleep_all_reset_reqs tests, except the CPU will
-	    just spin_wait for a reset, so the pwrmgr will be in active state.
-	    SiVal: The CPU must be enabled to configure the test.
+            This test is like the pwrmgr_*_sleep_all_reset_reqs tests, except the CPU will
+            just spin_wait for a reset, so the pwrmgr will be in active state.
+            SiVal: The CPU must be enabled to configure the test.
             '''
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
-        "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
-        "PWRMGR.RESET.ESCALATION_REQUEST",
-        "PWRMGR.RESET.SW_RST_REQUEST",
-        "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_ENABLE",
-        "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST",
-        "PWRMGR.RESET.POR_REQUEST",
-      ]
+      features: ["PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE", "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST", "PWRMGR.RESET.ESCALATION_REQUEST", "PWRMGR.RESET.SW_RST_REQUEST", "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_ENABLE", "PWRMGR.RESET.SYSRST_CTRL_AON_RST_REQ_REQUEST", "PWRMGR.RESET.POR_REQUEST"]
       tests: ["chip_sw_pwrmgr_all_reset_reqs"]
       bazel: ["//sw/device/tests:pwrmgr_all_reset_reqs_test"]
     }
     {
       name: chip_sw_pwrmgr_escalation_reset
-      desc: '''Verify the power manager resets to a clean state after an escalation reset.
+      desc: '''
+            Verify the power manager resets to a clean state after an escalation reset.
 
             Trigger an internal fatal fault for the regfile onehot checker and let it escalate to
             reset. Upon alert escalation reset, the internal status should be clear and pwrmgr

--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -6,20 +6,22 @@
   testpoints: [
     {
       name: chip_sw_rom_access
-      desc: '''Verify that the CPU can access the rom contents.
+      desc: '''
+            Verify that the CPU can access the rom contents.
 
             - Verify that the CPU can fetch instructions from the ROM.
             '''
       features: ["ROM_CTRL.SCRAMBLED"]
       stage: V2
       si_stage: SV1
-      bazel:["//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test"]
+      bazel: ["//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test"]
       lc_states: ["PROD"]
       tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {
       name: chip_sw_rom_ctrl_integrity_check
-      desc: '''Verify that the ROM ctrl performs the integrity check of the ROM on power up.
+      desc: '''
+            Verify that the ROM ctrl performs the integrity check of the ROM on power up.
 
             - In non-PROD LC state, the computed digest does not have to match the top 8 words in
               the ROM. Verify that we can successfully power up the chip in this case.
@@ -64,14 +66,14 @@
       name: chip_sw_rom_ctrl_digests
       desc: '''
 
-        Check that the (real and expected) ROM digests are accessible
-        through CSRs.
+            Check that the (real and expected) ROM digests are accessible
+            through CSRs.
 
-        - Read the DIGEST_* and EXP_DIGEST_* CSRs and check they match
-          (if they differed, we wouldn't be running!)
-        - Check that they also match the digest words that we expect.
+            - Read the DIGEST_* and EXP_DIGEST_* CSRs and check they match
+            (if they differed, we wouldn't be running!)
+            - Check that they also match the digest words that we expect.
 
-      '''
+            '''
       features: ["ROM_CTRL.DIGESTS", "ROM_CTRL.EXP_DIGESTS"]
       stage: V3
       si_stage: SV3

--- a/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_rstmgr
   testpoints: [
-    // RSTMGR tests:
     {
       name: chip_sw_rstmgr_non_sys_reset_info
-      desc: '''Verify the `reset_info` CSR register for lc or higher resets.
+      desc: '''
+            Verify the `reset_info` CSR register for lc or higher resets.
 
             Generate the 5 types of reset at `lc` level or higher, and check the retention SRAM's
             reset_reason to show that `reset_info` CSR is as expected. This and other rstmgr
@@ -29,25 +29,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "RSTMGR.RESET_INFO.CAPTURE",
-        "RSTMGR.RESET_INFO.CLEAR"
-      ]
-      tests: [
-        "chip_sw_pwrmgr_smoketest",
-        "chip_sw_pwrmgr_random_sleep_all_reset_reqs",
-        "chip_sw_pwrmgr_all_reset_reqs",
-        "chip_sw_pwrmgr_wdog_reset",
-      ]
-      bazel: [
-        "//sw/device/tests:pwrmgr_all_reset_reqs_test",
-        "//sw/device/tests:pwrmgr_wdog_reset_reqs_test",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_test",
-      ]
+      features: ["RSTMGR.RESET_INFO.CAPTURE", "RSTMGR.RESET_INFO.CLEAR"]
+      tests: ["chip_sw_pwrmgr_smoketest", "chip_sw_pwrmgr_random_sleep_all_reset_reqs", "chip_sw_pwrmgr_all_reset_reqs", "chip_sw_pwrmgr_wdog_reset"]
+      bazel: ["//sw/device/tests:pwrmgr_all_reset_reqs_test", "//sw/device/tests:pwrmgr_wdog_reset_reqs_test", "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_test"]
     }
     {
       name: chip_sw_rstmgr_sys_reset_info
-      desc: '''Verify the `reset_info` CSR register for sys reset.
+      desc: '''
+            Verify the `reset_info` CSR register for sys reset.
 
             Generate reset triggered by `rv_dm`, which results in a sys level reset, and check the
             retention SRAM's reset_reason to show that the `reset_info` CSR is as expected. This
@@ -65,16 +54,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "RSTMGR.RESET_INFO.CAPTURE",
-        "RSTMGR.RESET_INFO.CLEAR",
-      ]
+      features: ["RSTMGR.RESET_INFO.CAPTURE", "RSTMGR.RESET_INFO.CLEAR"]
       tests: ["chip_rv_dm_ndm_reset_req"]
-      bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"],
+      bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"]
     }
     {
       name: chip_sw_rstmgr_cpu_info
-      desc: '''Verify the expected values from the `cpu_info` CSR on reset.
+      desc: '''
+            Verify the expected values from the `cpu_info` CSR on reset.
 
             For some software induced resets we can predict the expected contents of `cpu_info`;
             reads of writes to unmapped addresses for example. Generate these resets and verify
@@ -88,16 +75,14 @@
       stage: V2
       si_stage: SV2
       lc_states: ["PROD"]
-      features: [
-        "RSTMGR.CPU_INFO.CAPTURE",
-        "RSTMGR.CPU_INFO.ENABLE",
-      ]
+      features: ["RSTMGR.CPU_INFO.CAPTURE", "RSTMGR.CPU_INFO.ENABLE"]
       tests: ["chip_sw_rstmgr_cpu_info"]
       bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
     }
     {
       name: chip_sw_rstmgr_sw_req_reset
-      desc: '''Verify software requested device reset.
+      desc: '''
+            Verify software requested device reset.
 
             Generate a reset request by directly writing the `reset_req` CSR.
             The reset created should be identical to those caused by hardware sources.
@@ -113,14 +98,12 @@
       lc_states: ["PROD"]
       features: ["RSTMGR.SW_RST.CHIP_RESET"]
       tests: ["chip_sw_rstmgr_sw_req"]
-      bazel: [
-        "//sw/device/tests:rstmgr_sw_req_test",
-        "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs",
-      ]
+      bazel: ["//sw/device/tests:rstmgr_sw_req_test", "//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs"]
     }
     {
       name: chip_sw_rstmgr_alert_info
-      desc: '''Verify the expected values from the `alert_info` CSR on reset.
+      desc: '''
+            Verify the expected values from the `alert_info` CSR on reset.
 
             Various alerts can be created, for example, timeouts, and integrity errors, and at
             least part of the `alert_info` CSR can be predicted. To cause some of these to
@@ -135,16 +118,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "RSTMGR.ALERT_INFO.CAPTURE",
-        "RSTMGR.ALERT_INFO.ENABLE",
-      ]
+      features: ["RSTMGR.ALERT_INFO.CAPTURE", "RSTMGR.ALERT_INFO.ENABLE"]
       tests: ["chip_sw_rstmgr_alert_info"]
       bazel: ["//sw/device/tests:rstmgr_alert_info_test"]
     }
     {
       name: chip_sw_rstmgr_sw_rst
-      desc: '''Verify `sw_rst_ctrl_n` CSR resets individual peripherals.
+      desc: '''
+            Verify `sw_rst_ctrl_n` CSR resets individual peripherals.
 
             - Pick a rw type CSR in each peripheral and program arbitrary value
               that does not cause any adverse side-effects.
@@ -161,28 +142,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "RSTMGR.SW_RST.I2C2_ENABLE",
-        "RSTMGR.SW_RST.I2C2_REQUEST",
-        "RSTMGR.SW_RST.I2C1_ENABLE",
-        "RSTMGR.SW_RST.I2C1_REQUEST",
-        "RSTMGR.SW_RST.I2C0_ENABLE",
-        "RSTMGR.SW_RST.I2C0_REQUEST",
-        "RSTMGR.SW_RST.USB_ENABLE",
-        "RSTMGR.SW_RST.USB_REQUEST",
-        "RSTMGR.SW_RST.SPI_HOST1_ENABLE",
-        "RSTMGR.SW_RST.SPI_HOST1_REQUEST",
-        "RSTMGR.SW_RST.SPI_HOST0_ENABLE",
-        "RSTMGR.SW_RST.SPI_HOST0_REQUEST",
-        "RSTMGR.SW_RST.SPI_DEVICE_ENABLE",
-        "RSTMGR.SW_RST.SPI_DEVICE_REQUEST",
-      ]
+      features: ["RSTMGR.SW_RST.I2C2_ENABLE", "RSTMGR.SW_RST.I2C2_REQUEST", "RSTMGR.SW_RST.I2C1_ENABLE", "RSTMGR.SW_RST.I2C1_REQUEST", "RSTMGR.SW_RST.I2C0_ENABLE", "RSTMGR.SW_RST.I2C0_REQUEST", "RSTMGR.SW_RST.USB_ENABLE", "RSTMGR.SW_RST.USB_REQUEST", "RSTMGR.SW_RST.SPI_HOST1_ENABLE", "RSTMGR.SW_RST.SPI_HOST1_REQUEST", "RSTMGR.SW_RST.SPI_HOST0_ENABLE", "RSTMGR.SW_RST.SPI_HOST0_REQUEST", "RSTMGR.SW_RST.SPI_DEVICE_ENABLE", "RSTMGR.SW_RST.SPI_DEVICE_REQUEST"]
       tests: ["chip_sw_rstmgr_sw_rst"]
       bazel: ["//sw/device/tests:rstmgr_sw_rst_ctrl_test"]
     }
     {
       name: chip_sw_rstmgr_escalation_reset
-      desc: '''Verify the reset manager resets to a clean state after an escalation reset.
+      desc: '''
+            Verify the reset manager resets to a clean state after an escalation reset.
 
             Trigger an internal fatal fault for the regfile onehot checker and let it escalate to
             reset. Upon alert escalation reset, the internal status should be clear and rstmgr
@@ -197,16 +164,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: [
-        "RSTMGR.RESET_INFO.CAPTURE",
-        "RSTMGR.ALERT_INFO.CAPTURE",
-      ]
+      features: ["RSTMGR.RESET_INFO.CAPTURE", "RSTMGR.ALERT_INFO.CAPTURE"]
       tests: ["chip_sw_all_escalation_resets"]
       bazel: ["//sw/device/tests:pwrmgr_random_sleep_all_reset_reqs"]
     }
     {
       name: chip_sw_rstmgr_alert_handler_reset_enables
-      desc: '''Verify the reset manager sends the correct information to the alert handler
+      desc: '''
+            Verify the reset manager sends the correct information to the alert handler
             regarding individual resets being active so it can ignore missing ping responses
             from them and avoid triggering spurious escalation. This scenario is caused by
             software induced peripheral resets among others. The check is that spurious

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -6,7 +6,8 @@
   testpoints: [
     {
       name: chip_sw_nmi_irq
-      desc: '''Verify the NMI interrupt to the CPU and correctness of the cause.
+      desc: '''
+            Verify the NMI interrupt to the CPU and correctness of the cause.
 
             Randomly use these two methods (simultaneously or choose one of them) to trigger the
             NMI interrupt:
@@ -23,13 +24,12 @@
       tests: ["chip_sw_rv_core_ibex_nmi_irq"]
       bazel: ["//sw/device/tests:rv_core_ibex_nmi_irq_test"]
       lc_states: ["PROD"]
-      features: [
-        "RV_CORE_IBEX.CPU.INTERRUPTS"
-      ]
+      features: ["RV_CORE_IBEX.CPU.INTERRUPTS"]
     }
     {
       name: chip_sw_rv_core_ibex_rnd
-      desc: '''Verify the functionality of the random number generation CSRs.
+      desc: '''
+            Verify the functionality of the random number generation CSRs.
 
                - Enable entropy complex so `RND_DATA` can get entropy.
                - Perform multiple reads from `RND_DATA` polling `RND_STATUS` in
@@ -44,14 +44,13 @@
       si_stage: SV1
       tests: ["chip_sw_rv_core_ibex_rnd"]
       lc_states: ["PROD"]
-      features: [
-        "RV_CORE_IBEX.RND"
-      ]
+      features: ["RV_CORE_IBEX.RND"]
       bazel: ["//sw/device/tests:rv_core_ibex_rnd_test"]
     }
     {
       name: chip_sw_rv_core_ibex_address_translation
-      desc: '''Verify the simple address translation functionality.
+      desc: '''
+            Verify the simple address translation functionality.
 
                - Setup address translation for both slots on the I and D
                  side and check correct translation for I and D accesses.
@@ -66,14 +65,13 @@
       si_stage: SV3
       tests: ["chip_sw_rv_core_ibex_address_translation"]
       lc_states: ["PROD"]
-      features: [
-        "RV_CORE_IBEX.ADDRESS_TRANSLATION"
-      ]
+      features: ["RV_CORE_IBEX.ADDRESS_TRANSLATION"]
       bazel: ["//sw/device/tests:rv_core_ibex_address_translation_test"]
     }
     {
       name: chip_sw_rv_core_ibex_icache_scrambled_access
-      desc: '''Verify scrambled memory accesses to CPU icache.
+      desc: '''
+            Verify scrambled memory accesses to CPU icache.
 
             - Initialize the entropy_src subsystem to enable OTP_CTRL fetch random data (already
               done by the test_rom startup code).
@@ -88,69 +86,66 @@
       si_stage: SV3
       tests: ["chip_sw_rv_core_ibex_icache_invalidate"]
       lc_states: ["PROD"]
-      features: [
-        "RV_CORE_IBEX.CPU.ICACHE"
-      ]
+      features: ["RV_CORE_IBEX.CPU.ICACHE"]
       bazel: ["//sw/device/tests:rv_core_ibex_icache_invalidate_test"]
     }
     {
-       name: chip_sw_rv_core_ibex_fault_dump
-       desc: '''Verify the functionality of the ibex fault dump.
+      name: chip_sw_rv_core_ibex_fault_dump
+      desc: '''
+            Verify the functionality of the ibex fault dump.
 
-                - Purposely create an ibex exception during execution through reads to an ummapped
-                  address.
-                - Ensure the rstmgr fault dump correctly captures the related addresses to the
-                  exception.
-             '''
-       stage: V2
-       si_stage: SV1
-       tests: ["chip_sw_rstmgr_cpu_info"]
-       bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
-       lc_states: ["PROD"]
-       features: [
-         "RV_CORE_IBEX.CRASH_DUMP"
-       ]
+               - Purposely create an ibex exception during execution through reads to an ummapped
+                 address.
+               - Ensure the rstmgr fault dump correctly captures the related addresses to the
+                 exception.
+            '''
+      stage: V2
+      si_stage: SV1
+      tests: ["chip_sw_rstmgr_cpu_info"]
+      bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
+      lc_states: ["PROD"]
+      features: ["RV_CORE_IBEX.CRASH_DUMP"]
     }
     {
-       name: chip_sw_rv_core_ibex_double_fault
-       desc: '''Verify the functionality of the ibex double fault dump.
+      name: chip_sw_rv_core_ibex_double_fault
+      desc: '''
+            Verify the functionality of the ibex double fault dump.
 
-                - Purposely create an ibex double exception during execution, by performing an
-                  unmapped read and in the exception handler perform another unmapped read.
-                - Ensure the rstmgr fault dump correctly captures both dumps correctly and indicates
-                  the previous dump is valid.
-             '''
-       stage: V2
-       si_stage: SV1
-       tests: ["chip_sw_rstmgr_cpu_info"]
-       bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
-       lc_states: ["PROD"]
-       features: [
-         "RV_CORE_IBEX.CRASH_DUMP"
-       ]
+               - Purposely create an ibex double exception during execution, by performing an
+                 unmapped read and in the exception handler perform another unmapped read.
+               - Ensure the rstmgr fault dump correctly captures both dumps correctly and indicates
+                 the previous dump is valid.
+            '''
+      stage: V2
+      si_stage: SV1
+      tests: ["chip_sw_rstmgr_cpu_info"]
+      bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
+      lc_states: ["PROD"]
+      features: ["RV_CORE_IBEX.CRASH_DUMP"]
     }
     {
       name: chip_sw_rv_core_ibex_smoke
-      desc: '''Execute each instruction implemented by Ibex at least once. Then check the register
+      desc: '''
+            Execute each instruction implemented by Ibex at least once. Then check the register
                 state against expected values.
 
                 The core of this test will be written in assembler and at least partially
                 auto-generated. It should be constructed such that a failure of any of the
                 instructions should (but is not guaranteed) to have some impact on the final
                 register state
-             '''
-       stage: V2
-       si_stage: SV1
-       tests: []
-       bazel: ["//sw/device/tests:rv_core_ibex_isa_test_functest"]
-       lc_states: ["PROD"]
-       features: [
-         "RV_CORE_IBEX.CPU.ISA"
-       ]
+
+            '''
+      stage: V2
+      si_stage: SV1
+      tests: []
+      bazel: ["//sw/device/tests:rv_core_ibex_isa_test_functest"]
+      lc_states: ["PROD"]
+      features: ["RV_CORE_IBEX.CPU.ISA"]
     }
     {
       name: chip_sw_rv_core_ibex_epmp_smoke
-      desc: '''Setup and test a few epmp regions
+      desc: '''
+            Setup and test a few epmp regions
 
                 Check a range of ePMP access modes, ensure these include:
                   - Shared execute, read and write
@@ -163,19 +158,19 @@
                 and run before the boot ROM executes in DEV/TEST_UNLOCKED, however a more limited
                 version can run in all lifecycle states using the standard load/execute mechanism
                 for all tests.
-                '''
-       stage: V2
-       si_stage: SV1
-       tests: []
-       bazel: ["//sw/device/tests:rv_core_ibex_epmp_test_functest"]
-       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
-       features: [
-         "RV_CORE_IBEX.CPU.EPMP"
-       ]
+
+            '''
+      stage: V2
+      si_stage: SV1
+      tests: []
+      bazel: ["//sw/device/tests:rv_core_ibex_epmp_test_functest"]
+      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      features: ["RV_CORE_IBEX.CPU.EPMP"]
     }
     {
       name: chip_sw_rv_core_ibex_mem_smoke
-      desc: '''Check access to each kind of memory from Ibex
+      desc: '''
+            Check access to each kind of memory from Ibex
 
                 Read a known value from each of the following and check it
                 matches the expected value:
@@ -198,32 +193,32 @@
 
                 First with the ICache disabled and then with the ICache enabled.  (Note that SRAM
                 execution may be unavailable in some lifecycle states).
-             '''
-       stage: V2
-       si_stage: SV1
-       tests: []
-       lc_states: ["PROD"]
-       features: [
-         "RV_CORE_IBEX.CPU.ICACHE",
-         "RV_CORE_IBEX.CPU.MEMORY"
-       ]
-       bazel: ["//sw/device/tests:rv_core_ibex_mem_test_functest"]
+
+            '''
+      stage: V2
+      si_stage: SV1
+      tests: []
+      lc_states: ["PROD"]
+      features: ["RV_CORE_IBEX.CPU.ICACHE", "RV_CORE_IBEX.CPU.MEMORY"]
+      bazel: ["//sw/device/tests:rv_core_ibex_mem_test_functest"]
     }
     {
-     name: chip_sw_rv_core_ibex_lockstep_glitch
-     desc: '''Verify lockstep checking of the Ibex core.
+      name: chip_sw_rv_core_ibex_lockstep_glitch
+      desc: '''
+            Verify lockstep checking of the Ibex core.
 
-              Ensure suitable alerts are triggered when:
-              - Outputs from the lockstep or the main core are corrupted.
-              - Inputs into the lockstep core are corrupted.
-           '''
-     stage: V2S
-     si_stage: None
-     tests: ["chip_sw_rv_core_ibex_lockstep_glitch"]
+               Ensure suitable alerts are triggered when:
+               - Outputs from the lockstep or the main core are corrupted.
+               - Inputs into the lockstep core are corrupted.
+            '''
+      stage: V2S
+      si_stage: None
+      tests: ["chip_sw_rv_core_ibex_lockstep_glitch"]
     }
     {
       name: chip_sw_rv_core_ibex_alerts
-      desc: '''Inject and verify all available faults in rv_core_ibex / ibex_top.
+      desc: '''
+            Inject and verify all available faults in rv_core_ibex / ibex_top.
 
              Inject faults in the following areas and verify the alert is fired leading to an
              escalation.

--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -4,7 +4,6 @@
 {
   name: rv_dm
   testpoints: [
-    // RV_DM (JTAG) tests:
     {
       name: chip_jtag_csr_rw
       desc: '''
@@ -22,13 +21,10 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_jtag_csr_rw"]
-      bazel: ["//sw/device/tests:rv_dm_csr_rw"],
+      bazel: ["//sw/device/tests:rv_dm_csr_rw"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM"]
     }
     {
       name: chip_jtag_mem_access
@@ -53,14 +49,10 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_jtag_mem_access"]
-      bazel: ["//sw/device/tests:rv_dm_mem_access"],
+      bazel: ["//sw/device/tests:rv_dm_mem_access"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM",
-        "RV_DM.DBG.SBA"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM", "RV_DM.DBG.SBA"]
     }
     {
       name: chip_rv_dm_perform_debug
@@ -75,19 +67,15 @@
             '''
       stage: V3
       si_stage: SV3
-      tests: ["rom_e2e_jtag_debug_test_unlocked0", "rom_e2e_jtag_debug_dev",
-              "rom_e2e_jtag_debug_rma"]
+      tests: ["rom_e2e_jtag_debug_test_unlocked0", "rom_e2e_jtag_debug_dev", "rom_e2e_jtag_debug_rma"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM",
-        "RV_DM.DBG.GDB"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM", "RV_DM.DBG.GDB"]
     }
     {
       name: chip_rv_dm_ndm_reset_req
-      desc: '''Verify non-debug reset request initiated from RV_DM when the chip is awake.
+      desc: '''
+            Verify non-debug reset request initiated from RV_DM when the chip is awake.
 
             - Program some CSRs / mem that are under life cycle reset tree and system reset tree.
             - Configure RV_DM to send NDM reset request to reset sytem reset tree.
@@ -100,18 +88,15 @@
       stage: V2
       si_stage: SV2
       tests: ["chip_rv_dm_ndm_reset_req"]
-      bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"],
+      bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM",
-        "RV_DM.DBG.NDM_RESET"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM", "RV_DM.DBG.NDM_RESET"]
     }
     {
       name: chip_sw_rv_dm_ndm_reset_req_when_cpu_halted
-      desc: '''Verify non-debug reset request initiated from RV_DM when the CPU  is in halted state.
+      desc: '''
+            Verify non-debug reset request initiated from RV_DM when the CPU  is in halted state.
 
             - Initialize the DUT in a HW-debug enabled life cycle state.
             - Activate the RISCV debug module.
@@ -132,18 +117,15 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_rv_dm_ndm_reset_req_when_cpu_halted"]
-      bazel: ["//sw/device/tests:rv_dm_ndm_reset_req_when_cpu_halted"],
+      bazel: ["//sw/device/tests:rv_dm_ndm_reset_req_when_cpu_halted"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM",
-        "RV_DM.DBG.NDM_RESET"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM", "RV_DM.DBG.NDM_RESET"]
     }
     {
       name: chip_rv_dm_access_after_wakeup
-      desc: '''Verify RV_DM works after wakes up from sleep.
+      desc: '''
+            Verify RV_DM works after wakes up from sleep.
 
             - Put the chip into sleep mode and then wake up (both deep sleep and normal sleep).
             - If waking up from normal sleep, an activation should not be required for RV_DM CSR
@@ -153,17 +135,15 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_rv_dm_access_after_wakeup"]
-      bazel: ["//sw/device/tests:rv_dm_access_after_wakeup"],
+      bazel: ["//sw/device/tests:rv_dm_access_after_wakeup"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM"]
     }
     {
       name: chip_sw_rv_dm_access_after_hw_reset
-      desc: '''Verify RV_DM works after a watchdog or escalated reset.
+      desc: '''
+            Verify RV_DM works after a watchdog or escalated reset.
 
             - Access some RV_DM CSRs both before and after resets.
             - An activation would be required, as the tap strap would also be sampled again.
@@ -171,16 +151,14 @@
       stage: V3
       si_stage: SV3
       tests: ["chip_sw_rv_dm_access_after_escalation_reset"]
-      bazel: ["//sw/device/tests:rv_dm_access_after_hw_reset"],
+      bazel: ["//sw/device/tests:rv_dm_access_after_hw_reset"]
       lc_states: ["DEV"]
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM"
-      ]
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM"]
     }
     {
       name: chip_sw_rv_dm_jtag_tap_sel
-      desc: '''Verify ability to select all available TAPs.
+      desc: '''
+            Verify ability to select all available TAPs.
 
             - Put life cycle on Test or RMA state, so that TAPs can be selected between life cycle
               RV_DM and DFT.
@@ -190,17 +168,15 @@
       stage: V2
       si_stage: SV2
       tests: ["chip_tap_straps_rma"]
-      bazel: ["//sw/device/tests:rv_dm_jtag_tap_sel"],
+      bazel: ["//sw/device/tests:rv_dm_jtag_tap_sel"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM"]
     }
     {
       name: chip_rv_dm_lc_disabled
-      desc: '''Verify that the debug capabilities are disabled in certain life cycle stages.
+      desc: '''
+            Verify that the debug capabilities are disabled in certain life cycle stages.
 
             - Put life cycle in a random life cycle state.
             - Verify that the rv_dm bus device is inaccessible from the CPU as well as external JTAG
@@ -218,22 +194,16 @@
             '''
       stage: V2
       si_stage: SV2
-      tests: ["chip_rv_dm_lc_disabled"],
-      bazel: [
-        "//sw/device/tests:rv_dm_lc_disabled_tl",
-        "//sw/device/tests:rv_dm_lc_disabled_jtag",
-      ],
-      lc_states: ["RAW", "TEST_LOCKED", "TEST_UNLOCKED", "DEV", "RMA", "PROD",
-        "PROD_END", "SCRAP"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM"
-      ]
+      tests: ["chip_rv_dm_lc_disabled"]
+      bazel: ["//sw/device/tests:rv_dm_lc_disabled_tl", "//sw/device/tests:rv_dm_lc_disabled_jtag"]
+      lc_states: ["RAW", "TEST_LOCKED", "TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END", "SCRAP"]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM"]
     }
     {
       name: chip_rv_dm_jtag
-      desc: '''Verify basic JTAG functionality
+      desc: '''
+            Verify basic JTAG functionality
                 - Read IDCODE, check it is the expected value
                 - Attempt to write IDCODE, check the expected value remains
                   after a read
@@ -243,16 +213,15 @@
       stage: V2
       si_stage: SV3
       tests: []
-      bazel: ["//sw/device/tests:rv_dm_jtag"],
+      bazel: ["//sw/device/tests:rv_dm_jtag"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM"]
     }
     {
       name: chip_rv_dm_dtm
-      desc: '''Verify basic DTM functionality
+      desc: '''
+            Verify basic DTM functionality
                 - Select Ibex CPU with write to hartsel
                 - Read hartinfo and check value is as expected
                 - Write random values to data0 and data1
@@ -262,19 +231,15 @@
       stage: V2
       si_stage: SV3
       tests: []
-      bazel: ["//sw/device/tests:rv_dm_dtm"],
+      bazel: ["//sw/device/tests:rv_dm_dtm"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM",
-        "RV_DM.DBG.HARTINFO_REG",
-        "RV_DM.DBG.DATA_REGS"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM", "RV_DM.DBG.HARTINFO_REG", "RV_DM.DBG.DATA_REGS"]
     }
     {
       name: chip_rv_dm_control_status
-      desc: '''Verify the functionality of dmcontrol/dmstatus
+      desc: '''
+            Verify the functionality of dmcontrol/dmstatus
                 - Write 0 to hartsel (select Ibex)
                 - Check dmstatus indicates havereset for Ibex (power-on reset)
                 - Write 1 to ackhavereset
@@ -293,15 +258,10 @@
       stage: V2
       si_stage: SV3
       tests: []
-      bazel: ["//sw/device/tests:rv_dm_control_status"],
+      bazel: ["//sw/device/tests:rv_dm_control_status"]
       lc_states: ["DEV"]
-      host_support: "true"
-      features: [
-        "RV_DM.JTAG.FSM",
-        "RV_DM.JTAG.DTM",
-        "RV_DM.DBG.DMSTATUS_REG",
-        "RV_DM.DBG.DMCONTROL_REG"
-      ]
+      host_support: True
+      features: ["RV_DM.JTAG.FSM", "RV_DM.JTAG.DTM", "RV_DM.DBG.DMSTATUS_REG", "RV_DM.DBG.DMCONTROL_REG"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: rv_plic
   testpoints: [
-    // PLIC integration tests:
     {
       name: chip_sw_plic_all_irqs
-      desc: '''Verify all interrupts from all peripherals aggregated at the PLIC.
+      desc: '''
+            Verify all interrupts from all peripherals aggregated at the PLIC.
 
             The automated SW test enables all interrupts at the PLIC to interrupt the core. It uses
             the `intr_test` CSR in each peripheral to mock assert an interrupt, looping through all
@@ -20,20 +20,13 @@
       si_stage: SV2
       lc_states: ["PROD"]
       features: ["RV_PLIC.PRIORITY", "RV_PLIC.ENABLE"]
-      tests: [
-        "chip_plic_all_irqs_0",
-        "chip_plic_all_irqs_10",
-        "chip_plic_all_irqs_20",
-      ]
-      bazel: [
-        "//sw/device/tests/autogen:plic_all_irqs_test_0",
-        "//sw/device/tests/autogen:plic_all_irqs_test_10",
-        "//sw/device/tests/autogen:plic_all_irqs_test_20",
-      ]
+      tests: ["chip_plic_all_irqs_0", "chip_plic_all_irqs_10", "chip_plic_all_irqs_20"]
+      bazel: ["//sw/device/tests/autogen:plic_all_irqs_test_0", "//sw/device/tests/autogen:plic_all_irqs_test_10", "//sw/device/tests/autogen:plic_all_irqs_test_20"]
     }
     {
       name: chip_sw_plic_sw_irq
-      desc: '''Verify the SW interrupt to the CPU.
+      desc: '''
+            Verify the SW interrupt to the CPU.
 
             Enable all peripheral interrupts at PLIC. Enable all types of interrupt at the CPU core.
             Write to the MSIP CSR to generate a SW interrupt to the CPU. Verify that the only
@@ -44,11 +37,12 @@
       lc_states: ["PROD"]
       features: ["RV_PLIC.PRIORITY", "RV_PLIC.ENABLE"]
       tests: ["chip_sw_plic_sw_irq"]
-      bazel: ["//sw/device/tests:plic_sw_irq_test"],
+      bazel: ["//sw/device/tests:plic_sw_irq_test"]
     }
     {
       name: chip_sw_plic_alerts
-      desc: '''Verify alerts from PLIC due to both, TL intg and reg WE onehot check faults.
+      desc: '''
+            Verify alerts from PLIC due to both, TL intg and reg WE onehot check faults.
 
             - Since PLIC is not pre-verified in a DV environment, we need to ensure these are tested
               separately.

--- a/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
@@ -6,7 +6,8 @@
   testpoints: [
     {
       name: chip_sw_timer
-      desc: '''Verify the timeout interrupt assertion.
+      desc: '''
+            Verify the timeout interrupt assertion.
 
             - Configure RV_TIMER to generate an interrupt after a set timeout.
             - Issue a WFI to wait for the interrupt to trigger.
@@ -16,14 +17,14 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT",
-                 "RV_TIMER.COUNTER"]
+      features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT", "RV_TIMER.COUNTER"]
       tests: ["chip_sw_rv_timer_irq"]
       bazel: ["//sw/device/tests:rv_timer_smoketest"]
     }
     {
       name: tick_configuration
-      desc: '''Verify that the timer can be configured to generate a system tick.
+      desc: '''
+            Verify that the timer can be configured to generate a system tick.
 
             - Configure the timer to generate a tick of `T` microseconds long.
             - Enable the timer.
@@ -42,7 +43,8 @@
     }
     {
       name: counter_wrap
-      desc: '''Verify that the timer counter will wrap to zero when the limit is reached.
+      desc: '''
+            Verify that the timer counter will wrap to zero when the limit is reached.
 
             - Enable interrupts.
             - Set the counter to `UINT64_MAX - 5 milliseconds`.
@@ -55,8 +57,7 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT",
-                 "RV_TIMER.COUNTER", "RV_TIMER.RISCV_CSRS_INTEGRATION"]
+      features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT", "RV_TIMER.COUNTER", "RV_TIMER.RISCV_CSRS_INTEGRATION"]
       tests: ["chip_sw_rv_timer_systick_test"]
       bazel: ["//sw/device/tests:rv_timer_systick_test"]
     }

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -1,14 +1,13 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
 {
   name: chip_spi_device
   testpoints: [
-    // SPI_DEVICE (pre-verified IP) integration tests:
     {
       name: chip_sw_spi_device_flash_mode
-      desc: '''Verify the SPI device in flash mode.
+      desc: '''
+            Verify the SPI device in flash mode.
 
             - SW puts the SPI device in flash mode.
             - Load a firmware image (bootstrap) through flash commands to the spi_device memory.
@@ -18,20 +17,15 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [ "PROD" ]
-      features: [
-        "SPI_DEVICE.MODE.FLASH_EMULATION",
-        "SPI_DEVICE.MODE.FLASH_EMULATION.COMMANDS",
-        "SPI_DEVICE.MODE.FLASH_EMULATION.READ_COMMAND_PROCESSOR",
-        "SPI_DEVICE.HW.FLASH_EMULATION_BLOCKS",
-        "SPI_DEVICE.HW.LAST_READ_ADDR",
-      ]
+      lc_states: ["PROD"]
+      features: ["SPI_DEVICE.MODE.FLASH_EMULATION", "SPI_DEVICE.MODE.FLASH_EMULATION.COMMANDS", "SPI_DEVICE.MODE.FLASH_EMULATION.READ_COMMAND_PROCESSOR", "SPI_DEVICE.HW.FLASH_EMULATION_BLOCKS", "SPI_DEVICE.HW.LAST_READ_ADDR"]
       tests: ["rom_e2e_smoke"]
       bazel: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_smoke", "//sw/device/tests:spi_device_flash_smoketest"]
     }
     {
       name: chip_sw_spi_device_pass_through
-      desc: '''Verify the passthrough mode from an end-to-end perspective.
+      desc: '''
+            Verify the passthrough mode from an end-to-end perspective.
 
             - Configure the SPI device and host in passthrough mode.
             - Program the cmd_filter_* CSRs to filter out random commands.
@@ -54,19 +48,15 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [ "PROD" ]
-      features: [
-        "SPI_DEVICE.MODE.PASSTHROUGH",
-        "SPI_DEVICE.HW.LANES",
-        "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
-      ]
+      lc_states: ["PROD"]
+      features: ["SPI_DEVICE.MODE.PASSTHROUGH", "SPI_DEVICE.HW.LANES", "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER"]
       tests: ["chip_sw_spi_device_pass_through"]
       bazel: []
     }
-
     {
       name: chip_sw_spi_device_pass_through_flash_model
-      desc: '''Verify the command filtering mechanism in passthrough mode.
+      desc: '''
+            Verify the command filtering mechanism in passthrough mode.
 
             - Extend the chip_spi_device_pass_through test.
             - Connect with a real flash model on spi_host.
@@ -75,16 +65,13 @@
             '''
       stage: V3
       si_stage: NA
-      features: [
-        "SPI_DEVICE.MODE.PASSTHROUGH",
-        "SPI_DEVICE.HW.LANES",
-        "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
-      ]
+      features: ["SPI_DEVICE.MODE.PASSTHROUGH", "SPI_DEVICE.HW.LANES", "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER"]
       tests: []
     }
     {
       name: chip_sw_spi_device_pass_through_collision
-      desc: '''Verify the collisions on driving spi_host is handled properly.
+      desc: '''
+            Verify the collisions on driving spi_host is handled properly.
 
             - Enable upload-related interrupts and configure the spi_device in passthrough mode.
             - Configure a command slot to enable upload for a flash program/erase command.
@@ -101,20 +88,15 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [ "PROD" ]
-      features: [
-        "SPI_DEVICE.MODE.PASSTHROUGH",
-        "SPI_DEVICE.HW.CMDINFOS",
-        "SPI_DEVICE.HW.COMMAND_UPLOAD",
-        "SPI_DEVICE.HW.FLASH_EMULATION_BLOCKS",
-        "SPI_DEVICE.MODE.PASSTHROUGH.INTERCEPT_EN",
-      ]
+      lc_states: ["PROD"]
+      features: ["SPI_DEVICE.MODE.PASSTHROUGH", "SPI_DEVICE.HW.CMDINFOS", "SPI_DEVICE.HW.COMMAND_UPLOAD", "SPI_DEVICE.HW.FLASH_EMULATION_BLOCKS", "SPI_DEVICE.MODE.PASSTHROUGH.INTERCEPT_EN"]
       tests: ["chip_sw_spi_device_pass_through_collision"]
       bazel: []
     }
     {
       name: chip_sw_spi_device_tpm
-      desc: '''Verify the basic operation of the spi_device in TPM mode.
+      desc: '''
+            Verify the basic operation of the spi_device in TPM mode.
 
             - The testbench sends a known payload to the spi_device TPM input port.
             - The testbench sends a read command.
@@ -124,17 +106,14 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [ "PROD" ]
-      features: [
-        "SPI_DEVICE.MODE.TPM",
-        "SPI_DEVICE.MODE.TPM.READ_FIFO_MODE",
-      ]
+      lc_states: ["PROD"]
+      features: ["SPI_DEVICE.MODE.TPM", "SPI_DEVICE.MODE.TPM.READ_FIFO_MODE"]
       tests: ["chip_sw_spi_device_tpm"]
     }
     {
-      // This test is more a pinmux/padctrl test than a spi_device one. Consider reclassification.
       name: chip_sw_spi_device_output_when_disabled_or_sleeping
-      desc: '''Verify spi_device output values when spi_device is disabled or the chip is sleeping.
+      desc: '''
+            Verify spi_device output values when spi_device is disabled or the chip is sleeping.
 
                SW needs to be able to set the SPI output value when spi_device is disabled or the
                chip is sleeping, to either all-zeros or all-ones, depending on integration
@@ -159,10 +138,11 @@
                Notes for silicon targets:
                This test currently does not exercise any features of the spi_device block itself,
                which is why the "features" list is empty. It may be reclassifed in the future.
-             '''
+
+            '''
       stage: V3
       si_stage: None
-      lc_states: [ "PROD" ]
+      lc_states: ["PROD"]
       features: []
       tests: []
       bazel: []

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_spi_host
   testpoints: [
-    // SPI_HOST (pre-verified IP) integration tests:
     {
       name: chip_sw_spi_host_tx_rx
-      desc: '''Verify the transmission of data on the chip's SPI host port.
+      desc: '''
+            Verify the transmission of data on the chip's SPI host port.
 
             - Program the SPI host to send a known payload out of the chip on the SPI host ports.
             - The testbench receives the payload and plays it back to the SPI host interface.
@@ -21,23 +21,17 @@
             - The testbench that mimics a physical SPI device should measure the clock to verify that the frequencies for each speed mode is correct.
               This can be done by checking timing of the beginning and the end of the packet.
             '''
-      features: [
-        "SPIHOST.RATE.STANDARD",
-        "SPIHOST.RATE.DUAL",
-        "SPIHOST.RATE.QUAD",
-      ]
+      features: ["SPIHOST.RATE.STANDARD", "SPIHOST.RATE.DUAL", "SPIHOST.RATE.QUAD"]
       stage: V2
       si_stage: SV2
       lc_states: ["PROD"]
       tests: ["chip_sw_spi_host_tx_rx"]
-      bazel: [
-        "//sw/device/tests:spi_host_winbond_flash_test",
-        "//sw/device/tests/pmod:spi_host_macronix_flash_test"
-      ]
+      bazel: ["//sw/device/tests:spi_host_winbond_flash_test", "//sw/device/tests/pmod:spi_host_macronix_flash_test"]
     }
     {
       name: chip_sw_spi_host_pass_through
-      desc: '''Verify that the SPI host can be configured in pass through mode.
+      desc: '''
+            Verify that the SPI host can be configured in pass through mode.
             Essentially the configuration is as follows: (real) host -> OT -> flash device
 
             - Connect one of the OpenTitan SPI hosts to a SPI device on a serial NOR flash.
@@ -46,10 +40,7 @@
             - Let the testbench read that word back, again through the pass through of the SPI host and device on OpenTitan.
             - The testbench should check that the word read back is the same as the one written.
             '''
-      features: [
-        "SPIHOST.USECASE.SERIALNORFLASH",
-        "SPIHOST.USECASE.PASSTHROUGH",
-      ]
+      features: ["SPIHOST.USECASE.SERIALNORFLASH", "SPIHOST.USECASE.PASSTHROUGH"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -57,7 +48,8 @@
     }
     {
       name: chip_sw_spi_host_configuration
-      desc: ''' Verifiy that the polarity and clock divider configurations work appropriately.
+      desc: '''
+            Verifiy that the polarity and clock divider configurations work appropriately.
 
             1. Send a packet with no clock division and no polarity switch.
             2. Send a packet with no clock division and a polarity switch.
@@ -65,10 +57,7 @@
 
             The testbench should compare the three packets that are received; the second packet should be inverted from the first and the third should be send half as fast as the second.
             '''
-      features: [
-        "SPIHOST.CONFIG.CPOL",
-        "SPIHOST.CONFIG.CLOCKDIV",
-      ]
+      features: ["SPIHOST.CONFIG.CPOL", "SPIHOST.CONFIG.CLOCKDIV"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -76,7 +65,8 @@
     }
     {
       name: chip_sw_spi_host_events
-      desc: ''' Verify that various events are correctly triggered by the SPI host.
+      desc: '''
+            Verify that various events are correctly triggered by the SPI host.
 
             - For the transmit empty and watermark events:
               - Fill the transmit queue on the Ibex side.
@@ -89,11 +79,7 @@
               - Testbench sends as much data as the receive queue can hold for the full interrupt or the amount necessary to hit the watermark.
               - Ibex checks that the receive full or watermark interrupt is raised.
             '''
-      features: [
-        "SPIHOST.EVENT.WATERMARK",
-        "SPIHOST.EVENT.FULL",
-        "SPIHOST.EVENT.EMPTY",
-      ]
+      features: ["SPIHOST.EVENT.WATERMARK", "SPIHOST.EVENT.FULL", "SPIHOST.EVENT.EMPTY"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]

--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_sram_ctrl
   testpoints: [
-    // SRAM (pre-verified IP) integration tests:
     {
       name: chip_sw_sram_scrambled_access
-      desc: '''Verify scrambled memory accesses to both main and retention SRAMs.
+      desc: '''
+            Verify scrambled memory accesses to both main and retention SRAMs.
 
             - Initialize the entropy_src subsystem to enable OTP_CTRL fetch random data (already
               done by the test_rom startup code).
@@ -27,12 +27,12 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["chip_sw_sram_ctrl_scrambled_access",
-              "chip_sw_sram_ctrl_scrambled_access_jitter_en"]
+      tests: ["chip_sw_sram_ctrl_scrambled_access", "chip_sw_sram_ctrl_scrambled_access_jitter_en"]
     }
     {
       name: chip_sw_sleep_sram_ret_contents
-      desc: '''Verify that the data within the retention SRAM survives low power entry-exit and reset.
+      desc: '''
+            Verify that the data within the retention SRAM survives low power entry-exit and reset.
 
             Ensure that the data within the retention SRAM survives as described in this table.
               |             Mode             | Scrambled | Data Preserved |
@@ -52,18 +52,13 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: [
-        "chip_sw_sleep_sram_ret_contents_no_scramble",
-        "chip_sw_sleep_sram_ret_contents_scramble",
-      ]
-      bazel: [
-        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test",
-        "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test",
-      ]
+      tests: ["chip_sw_sleep_sram_ret_contents_no_scramble", "chip_sw_sleep_sram_ret_contents_scramble"]
+      bazel: ["//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_no_scramble_test", "//sw/device/tests:sram_ctrl_sleep_sram_ret_contents_scramble_test"]
     }
     {
       name: chip_sw_sram_execution
-      desc: '''Verify that CPU can fetch instructions from SRAM if enabled.
+      desc: '''
+            Verify that CPU can fetch instructions from SRAM if enabled.
 
             - Create the following combinations of 8 scenarios:
               - The fetch enable bit in the HW_CFG1 partition of OTP controller set and not set.
@@ -110,7 +105,8 @@
     }
     {
       name: chip_sw_sram_lc_escalation
-      desc: '''Verify the LC escalation path to the SRAMs.
+      desc: '''
+            Verify the LC escalation path to the SRAMs.
 
             - Configure the LC_CTRL to trigger an escalation request to the SRAMs.
             - Verify that the SRAMs stop accepting and responding to new memory requests.
@@ -124,13 +120,12 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["chip_sw_all_escalation_resets",
-              "chip_sw_data_integrity_escalation"]
+      tests: ["chip_sw_all_escalation_resets", "chip_sw_data_integrity_escalation"]
     }
-
     {
       name: chip_sw_sram_memset
-      desc: '''Use the LFSR-based initialisation mechanism to wipe the contents of SRAM.
+      desc: '''
+            Use the LFSR-based initialisation mechanism to wipe the contents of SRAM.
 
              - Write some known data to the main SRAM and read it back to make sure the write worked
                as expected.
@@ -139,7 +134,8 @@
              - Read the location from the SRAM and check that the data has been wiped.
              - Repeat the steps above for the retention SRAM.
 
-             '''
+             
+            '''
       features: ["SRAM_CTRL.MEMSET"]
       stage: V3
       si_stage: SV3
@@ -149,7 +145,8 @@
     }
     {
       name: chip_sw_sram_subword_access
-      desc: '''Check that subword access works for each SRAM.
+      desc: '''
+            Check that subword access works for each SRAM.
 
              - Initialise a region of the SRAM with known patterns.
              - Read subwords (each length from one byte upwards; each address modulo 8) and check
@@ -157,7 +154,8 @@
              - Write subwords (same list as above) and read back the whole word that we touch in
                each case. Check that only the expected bytes have been changed.
 
-             '''
+             
+            '''
       features: ["SRAM_CTRL.SUBWORD_ACCESS"]
       stage: V3
       si_stage: SV3

--- a/hw/top_earlgrey/data/ip/chip_sysrst_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sysrst_ctrl_testplan.hjson
@@ -6,7 +6,8 @@
   testpoints: [
     {
       name: chip_sw_sysrst_ctrl_reset
-      desc: '''Verify the SYSRST ctrl can reset the chip from normal state.
+      desc: '''
+            Verify the SYSRST ctrl can reset the chip from normal state.
 
             - Read the reset cause register in rstmgr to confirm we are in POR reset phase.
             - Program one of the com_sel_ctl_* CSRs to choose a set of inputs to be detected as
@@ -32,7 +33,8 @@
     }
     {
       name: chip_sw_sysrst_ctrl_inputs
-      desc: '''Verify that the SYSRST ctrl input pin values can be read.
+      desc: '''
+            Verify that the SYSRST ctrl input pin values can be read.
 
             - Drive a known value on ac_reset, ec_rst_l, flash_wp_l, pwrb, lid_open and key* pins at
               the chip inputs.
@@ -47,7 +49,8 @@
     }
     {
       name: chip_sw_sysrst_ctrl_outputs
-      desc: '''Verify that the SYSRST ctrl output pin values can be set.
+      desc: '''
+            Verify that the SYSRST ctrl output pin values can be set.
 
             - Drive a known value on ac_reset, ec_rst_l, flash_wp_l, pwrb, lid_open and key* pins
               at the chip inputs.
@@ -70,7 +73,8 @@
     }
     {
       name: chip_sw_sysrst_ctrl_in_irq
-      desc: '''Verify the SYSRST ctrl can detect an input combination to signal an interrupt.
+      desc: '''
+            Verify the SYSRST ctrl can detect an input combination to signal an interrupt.
 
             - Program a specific combination of transitions on pwrb, key*, ac_present and ec_reset_l
               pins to trigger an interrupt by writing to key_intr_ctl register.
@@ -92,7 +96,8 @@
     }
     {
       name: chip_sw_sysrst_ctrl_sleep_wakeup
-      desc: '''Verify the SYSRST ctrl can wake up the chip from deep sleep.
+      desc: '''
+            Verify the SYSRST ctrl can wake up the chip from deep sleep.
 
             - Read the reset cause register in rstmgr to confirm we are in POR reset phase.
             - Program one of the com_sel_ctl_* CSRs to choose a set of inputs to be detected as
@@ -111,14 +116,15 @@
             '''
       features: ["SYSRST_CTRL.ULTRA_LOW_POWER_WAKEUP"]
       stage: V2
-      si_stage:SV3
+      si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_reset"]
       bazel: ["//sw/device/tests:sysrst_ctrl_reset_test"]
     }
     {
       name: chip_sw_sysrst_ctrl_sleep_reset
-      desc: '''Verify the SYSRST ctrl can reset the chip from deep sleep.
+      desc: '''
+            Verify the SYSRST ctrl can reset the chip from deep sleep.
 
             - Read the reset cause register in rstmgr to confirm we are in POR reset phase.
             - Program one of the com_sel_ctl_* CSRs to choose a set of inputs to be detected as
@@ -139,14 +145,15 @@
             '''
       features: ["SYSRST_CTRL.ULTRA_LOW_POWER_RESET"]
       stage: V2
-      si_stage:SV3
+      si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_reset"]
       bazel: ["//sw/device/tests:sysrst_ctrl_reset_test"]
     }
     {
       name: chip_sw_sysrst_ctrl_ec_rst_l
-      desc: '''Verify that the ec_rst_l stays asserted on power-on-reset until SW can control it.
+      desc: '''
+            Verify that the ec_rst_l stays asserted on power-on-reset until SW can control it.
 
             - Verify that ec_rst_l stays asserted as the chip is brought out of reset.
             - Verify that the pin continues to remain low until SW is alive.
@@ -157,27 +164,29 @@
             '''
       features: ["SYSRST_CTRL.EC_RESET_POR"]
       stage: V2
-      si_stage:SV3
+      si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_ec_rst_l"]
       bazel: ["//sw/device/tests:sysrst_ctrl_ec_rst_l_test"]
     }
     {
       name: chip_sw_sysrst_ctrl_flash_wp_l
-      desc: '''Verify that the flash_wp_l stays asserted on power-on-reset until SW can control it.
+      desc: '''
+            Verify that the flash_wp_l stays asserted on power-on-reset until SW can control it.
 
             - Exactly the same as chip_sysrst_ctrl_ec_rst_l, but covers the flash_wp_l pin.
             '''
       features: ["SYSRST_CTRL.FLASH_WP_POR"]
       stage: V2
-      si_stage:SV3
+      si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_ec_rst_l"]
       bazel: ["//sw/device/tests:sysrst_ctrl_ec_rst_l_test"]
     }
     {
       name: chip_sw_sysrst_ctrl_ulp_z3_wakeup
-      desc: '''Verify the z3_wakeup signaling.
+      desc: '''
+            Verify the z3_wakeup signaling.
 
             - Start off with ac_present = 0, lid_open = 0 and pwrb = 0 at the chip inputs.
             - Program the ulp_ac|lid|pwrb_debounce_ctl registers to debounce these inputs for an
@@ -191,12 +200,9 @@
             '''
       features: ["SYSRST_CTRL.ULTRA_LOW_POWER_WAKEUP"]
       stage: V2
-      si_stage:SV3
+      si_stage: SV3
       lc_states: ["PROD"]
-      tests: [
-        "chip_sw_adc_ctrl_sleep_debug_cable_wakeup",
-        "chip_sw_sysrst_ctrl_ulp_z3_wakeup"
-      ]
+      tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup", "chip_sw_sysrst_ctrl_ulp_z3_wakeup"]
       bazel: ["//sw/device/tests:sysrst_ctrl_ulp_z3_wakeup_test"]
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -6,7 +6,8 @@
   testpoints: [
     {
       name: chip_sw_uart_tx_rx
-      desc: '''Verify transmission of data over the TX and RX port.
+      desc: '''
+            Verify transmission of data over the TX and RX port.
 
             SW test sends a known payload over the TX port. The testbench, at the same time
             sends a known payload over RX. On reception, both payloads are checked for integrity.
@@ -26,7 +27,8 @@
     }
     {
       name: chip_sw_uart_rx_overflow
-      desc: '''Verify the RX overflow interrupt.
+      desc: '''
+            Verify the RX overflow interrupt.
 
             The testbench sends a random payload of size greater than the RX fifo size (32). The SW
             ignores the received the data to allow the RX overflow interrupt to assert.
@@ -38,13 +40,13 @@
       si_stage: SV3
       lc_states: ["PROD"]
       features: ["UART.FIFO_INTERRUPTS"]
-      tests: ["chip_sw_uart_tx_rx", "chip_sw_uart_tx_rx_idx1", "chip_sw_uart_tx_rx_idx2",
-              "chip_sw_uart_tx_rx_idx3"]
+      tests: ["chip_sw_uart_tx_rx", "chip_sw_uart_tx_rx_idx1", "chip_sw_uart_tx_rx_idx2", "chip_sw_uart_tx_rx_idx3"]
       bazel: ["//sw/device/tests:uart_tx_rx_test"]
     }
     {
       name: chip_sw_uart_baud_rate
-      desc: '''Verify UART transmission of data at various speeds.
+      desc: '''
+            Verify UART transmission of data at various speeds.
 
             Test data transfer in both directions for each UART instance configured for each of
             these baud rates: 9600Bd, 115200Bd, 230400Bd, 128kBd, 256kBd, 1MBd, 1.5MBd.
@@ -58,7 +60,8 @@
     }
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq
-      desc: '''Verify the transmission of UART via using external clock as uart core clock.
+      desc: '''
+            Verify the transmission of UART via using external clock as uart core clock.
 
             Extend from chip_sw_uart_rand_baudrate with following added settings.
             - Configure LC to RMA state, so that it allows clkmgr to use external clock.
@@ -80,7 +83,8 @@
     }
     {
       name: chip_sw_uart_parity
-      desc: '''Verify transmission of data in both directions with parity enabled.
+      desc: '''
+            Verify transmission of data in both directions with parity enabled.
 
             This is very similar to chip_sw_uart_tx_rx except that parity (generation and checking)
             should be enabled. Control expected word parity by configuring CTRL.PARITY_ODD register.
@@ -96,7 +100,8 @@
     }
     {
       name: chip_sw_uart_line_loopback
-      desc: '''Verify UART line loopback feature.
+      desc: '''
+            Verify UART line loopback feature.
 
             Configure the UART to enable RX, TX and line loopback. Send it some data and check that
             the bits appear on its TX side.
@@ -108,10 +113,11 @@
       features: ["UART.LINE_LOOPBACK"]
       tests: []
       bazel: ["//sw/device/tests:uart_loopback_test"]
-    },
+    }
     {
       name: chip_sw_uart_system_loopback
-      desc: '''Verify UART system loopback feature.
+      desc: '''
+            Verify UART system loopback feature.
 
             Configure the UART to enable RX, TX and system loopback. Transmit some data and check
             that the data that was transmitted also appears on the RX side.
@@ -123,10 +129,11 @@
       features: ["UART.SYSTEM_LOOPBACK"]
       tests: []
       bazel: ["//sw/device/tests:uart_loopback_test"]
-    },
+    }
     {
       name: chip_sw_uart_line_break
-      desc: '''Check that the UART can detect line breaks.
+      desc: '''
+            Check that the UART can detect line breaks.
 
             Enable RX and configure the line break threshold. On the host side, send data but hold
             the signal low for enough characters that this should be detected as a line break. Check
@@ -141,10 +148,11 @@
       lc_states: ["PROD"]
       features: ["UART.LINE_BREAK"]
       tests: []
-    },
+    }
     {
       name: chip_sw_uart_watermarks
-      desc: '''Observe UART watermark interrupts.
+      desc: '''
+            Observe UART watermark interrupts.
 
             Transmit data from the host and receive it on the OT side by servicing the rx_watermark
             interrupt. Check that the data matches the sequence that the host was expected to send.
@@ -160,7 +168,6 @@
       features: ["UART.FIFO_INTERRUPTS"]
       tests: ["chip_sw_uart_tx_rx"]
       bazel: ["//sw/device/tests:uart_tx_rx_test"]
-    },
-
+    }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -4,10 +4,10 @@
 {
   name: chip_usbdev
   testpoints: [
-    // USBDEV integration tests
     {
       name: chip_sw_usbdev_mem
-      desc: '''Verify that the USB device packet memory works reliably from the CPU side.
+      desc: '''
+            Verify that the USB device packet memory works reliably from the CPU side.
 
             - With the USB device powered but not connected (pull up not enabled),
               check that the packet buffer memory works reliably from the CPU side.
@@ -23,7 +23,8 @@
     }
     {
       name: chip_sw_usbdev_vbus
-      desc: '''Verify that the USB device can detect the presence of VBUS from the USB host.
+      desc: '''
+            Verify that the USB device can detect the presence of VBUS from the USB host.
 
             - Set up the pinmux to ensure that the SENSE/VBUS input can reach usbdev
             - Check that VBUS is asserted indicating the presence of a connection to the
@@ -38,7 +39,8 @@
     }
     {
       name: chip_sw_usbdev_pullup
-      desc: '''Verify that the USB device can assert the pull up to indicate its presence.
+      desc: '''
+            Verify that the USB device can assert the pull up to indicate its presence.
 
             - This test extends from `chip_sw_usbdev_vbus` by checking that the DP line of
               the USB is deasserted after VBUS detection.
@@ -51,10 +53,7 @@
               for the DN line using the usbdev pin-flipping feature.
             - No other communication with the host, so indicating Low Speed is harmless.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -63,7 +62,8 @@
     }
     {
       name: chip_sw_usbdev_aon_pullup
-      desc: '''Verify that the AON Wake module can assume control of the pull ups.
+      desc: '''
+            Verify that the AON Wake module can assume control of the pull ups.
 
             - This test extends from `chip_sw_usbdev_pullup` by additionally exercising the
               ability of the 'usbdev_aon_wake' module to assume control of the DP/DN pull up
@@ -75,11 +75,7 @@
             - Repeat the above test with the DP line in the opposite state.
             - For those targets which support pinflipping, repeat the above for the DN line too.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.POWER.AON",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.POWER.AON"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -88,7 +84,8 @@
     }
     {
       name: chip_sw_usbdev_sof
-      desc: '''Verify that the USB device can detect SOF and respond with `usb_ref_pulse_o`
+      desc: '''
+            Verify that the USB device can detect SOF and respond with `usb_ref_pulse_o`
             and `usb_ref_val_o`.
 
             - This test extends from `chip_sw_usbdev_pullup` by connecting to the host/DPI
@@ -101,11 +98,7 @@
             - Ascertain that the reference pulse is being used to adjust the usb clock
               frequency appropriately.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.CONN.REF_PULSE",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.CONN.REF_PULSE"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -114,7 +107,8 @@
     }
     {
       name: chip_sw_usbdev_setup_rx
-      desc: '''Verify that the USB device can receive the SETUP stage of a Control Transfer
+      desc: '''
+            Verify that the USB device can receive the SETUP stage of a Control Transfer
             from the host/DPI model.
 
             - This test extends from `chip_sw_usbdev_pullup` by checking that the device
@@ -129,11 +123,7 @@
               This makes the test robust against alternative host behaviors, since the
               first Control Transfer to be sent upon connection is unspecified.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -142,7 +132,8 @@
     }
     {
       name: chip_sw_usbdev_config_host
-      desc: '''Verify that the USB device can be configured by the host/DPI.
+      desc: '''
+            Verify that the USB device can be configured by the host/DPI.
 
             - This test extends from `chip_sw_usbdev_setup_rx` by using the usb_testutils
               software layer to receive, decode and respond to Control Transfers.
@@ -153,12 +144,7 @@
             - The device should present two serial ports (as /dev/ttyUSBn on a Linux
               host).
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -167,7 +153,8 @@
     }
     {
       name: chip_sw_usbdev_pincfg
-      desc: '''Verify that the USB device can operate in all pin configurations.
+      desc: '''
+            Verify that the USB device can operate in all pin configurations.
 
             - This test extends from `chip_sw_usbdev_config_host` by testing all pin
               configurations.
@@ -178,14 +165,7 @@
               transmission on/off, and (iii) external differential receiver yes/no.
             - Targets differ in which modes/pin configurations are supported.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-        "USBDEV.CONN.PIN_CONFIG",
-        "USBDEV.CONN.RESET",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX", "USBDEV.CONN.PIN_CONFIG", "USBDEV.CONN.RESET"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -194,7 +174,8 @@
     }
     {
       name: chip_sw_usbdev_tx_rx
-      desc: '''Verify operation of simple Bulk Transfers to/from host/DPI model.
+      desc: '''
+            Verify operation of simple Bulk Transfers to/from host/DPI model.
 
             - DPI model provides a simulation of a simple USB host; asserts VBUS
             - SW sets up the USB device, and enables the interface.
@@ -206,14 +187,7 @@
             - With a physical host this just requires character echo in response to
               a serial connection (eg. `cat /dev/ttyUSB0`).
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-        "USBDEV.TRANSFER.ENDPOINTS",
-        "USBDEV.TRANSFER.BULK",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX", "USBDEV.TRANSFER.ENDPOINTS", "USBDEV.TRANSFER.BULK"]
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
@@ -222,7 +196,8 @@
     }
     {
       name: chip_sw_usbdev_stream
-      desc: '''Verify the transmission of randomized Bulk Transfer stream data
+      desc: '''
+            Verify the transmission of randomized Bulk Transfer stream data
             to/from host/DPI model.
 
             - This test extends from `chip_sw_usbdev_tx_rx`.
@@ -234,14 +209,7 @@
             - With a physical host this requires the `usbdev/stream_test` host-
               side test application.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-        "USBDEV.TRANSFER.ENDPOINTS",
-        "USBDEV.TRANSFER.BULK",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX", "USBDEV.TRANSFER.ENDPOINTS", "USBDEV.TRANSFER.BULK"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -250,7 +218,8 @@
     }
     {
       name: chip_sw_usbdev_iso
-      desc: '''Verify the transmission of randomized Isochronous Transfer stream
+      desc: '''
+            Verify the transmission of randomized Isochronous Transfer stream
             data to/from host/DPI model.
 
             - This test extends from `chip_sw_usbdev_stream`.
@@ -263,14 +232,7 @@
             - With a physical host this requires the `usbdev/stream_test` host-
               side test application.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-        "USBDEV.TRANSFER.ENDPOINTS",
-        "USBDEV.TRANSFER.ISOCHRONOUS",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX", "USBDEV.TRANSFER.ENDPOINTS", "USBDEV.TRANSFER.ISOCHRONOUS"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -279,7 +241,8 @@
     }
     {
       name: chip_sw_usbdev_mixed
-      desc: '''Verify the transmission of randomized Control, Interrupt, Bulk and
+      desc: '''
+            Verify the transmission of randomized Control, Interrupt, Bulk and
             Isochronous Transfer stream data to/from host/DPI model.
 
             - This test extends from `chip_sw_usbdev_iso` by adding Control
@@ -289,16 +252,7 @@
             - With a physical host this requires the `usbdev/stream_test` host-
               side test application.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-        "USBDEV.TRANSFER.ENDPOINTS",
-        "USBDEV.TRANSFER.ISOCHRONOUS",
-        "USBDEV.TRANSFER.CONTROL",
-        "USBDEV.TRANSFER.INTERRUPT",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX", "USBDEV.TRANSFER.ENDPOINTS", "USBDEV.TRANSFER.ISOCHRONOUS", "USBDEV.TRANSFER.CONTROL", "USBDEV.TRANSFER.INTERRUPT"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -307,7 +261,8 @@
     }
     {
       name: chip_sw_usbdev_suspend_resume
-      desc: '''Verify that the USB device can detect Suspend and Resume Signaling
+      desc: '''
+            Verify that the USB device can detect Suspend and Resume Signaling
             from the host.
 
             - Host configures the USB device as normal.
@@ -321,14 +276,7 @@
               application to perform Suspend/Resume Signaling.
             - Note: this test does not engage the AON Wake module or enter a low power state.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-        "USBDEV.POWER.SUSPEND",
-        "USBDEV.POWER.RESUME",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX", "USBDEV.POWER.SUSPEND", "USBDEV.POWER.RESUME"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -337,7 +285,8 @@
     }
     {
       name: chip_sw_usbdev_aon_wake_reset
-      desc: '''Verify that the USB AON Wake module can detect Bus Resets from the host.
+      desc: '''
+            Verify that the USB AON Wake module can detect Bus Resets from the host.
 
             - Host configures the USB device as normal and subsequently performs
               Suspend signaling.
@@ -351,15 +300,7 @@
             - Note: this test does not exercise power manager-related functionality and does
               not enter any low power mode.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-        "USBDEV.POWER.SUSPEND",
-        "USBDEV.POWER.AON",
-        "USBDEV.POWER.WAKE_BUS_RESET",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX", "USBDEV.POWER.SUSPEND", "USBDEV.POWER.AON", "USBDEV.POWER.WAKE_BUS_RESET"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -368,7 +309,8 @@
     }
     {
       name: chip_sw_usbdev_aon_wake_disconnect
-      desc: '''Verify that the USB AON Wake module can detect USB Disconnects.
+      desc: '''
+            Verify that the USB AON Wake module can detect USB Disconnects.
 
             - Host configures the USB device as normal and subsequently performs
               Suspend signaling.
@@ -384,15 +326,7 @@
             - Note: this test does not exercise power manager-related functionality and does
               not enter any low power mode.
             '''
-      features: [
-        "USBDEV.CONN.VBUS",
-        "USBDEV.CONN.PULLUP",
-        "USBDEV.TRANSFER.CONTROL_RX",
-        "USBDEV.TRANSFER.CONTROL_TX",
-        "USBDEV.POWER.SUSPEND",
-        "USBDEV.POWER.AON",
-        "USBDEV.POWER.WAKE_DISCONNECT",
-      ]
+      features: ["USBDEV.CONN.VBUS", "USBDEV.CONN.PULLUP", "USBDEV.TRANSFER.CONTROL_RX", "USBDEV.TRANSFER.CONTROL_TX", "USBDEV.POWER.SUSPEND", "USBDEV.POWER.AON", "USBDEV.POWER.WAKE_DISCONNECT"]
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
@@ -401,7 +335,8 @@
     }
     {
       name: chip_sw_usbdev_toggle_restore
-      desc: '''Verify that the USB device is able to save and restore arbitrary permutations
+      desc: '''
+            Verify that the USB device is able to save and restore arbitrary permutations
             of the Data Toggle flags on both the IN and OUT sides.
 
             - With the USB device powered but not connected (pull up not enabled),

--- a/util/lint_testplan.py
+++ b/util/lint_testplan.py
@@ -1,0 +1,156 @@
+"""
+This script lint the various opentitan testplan.hjson
+usage:
+    python3 ./util/lint_testplan.py --rules hw/lint/sival_testplan_rules.json --dir hw/top_earlgrey/data/ip/
+"""
+
+import argparse
+import difflib
+import glob
+import json
+import logging
+import sys
+import re
+
+import hjson
+
+LOWRISC_HEADER = """// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+"""
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--logging",
+    default="info",
+    choices=["debug", "info", "warning", "error", "critical"],
+    help="Logging level",
+)
+parser.add_argument(
+    "--dir",
+    required=True,
+    help="A dir with all the testplan.hjson.",
+)
+parser.add_argument(
+    "--formatting-check",
+    action=argparse.BooleanOptionalAction,
+    help="Check the formatting.",
+)
+parser.add_argument(
+    "--formatting-fix",
+    action=argparse.BooleanOptionalAction,
+    help="Check the formatting.",
+)
+
+
+def main(args) -> int:
+    if not (args.formatting_check or args.formatting_fix):
+        args.print_help(sys.stderr)
+        return -1
+
+    files = [f for f in glob.glob(f"{args.dir}/*.hjson")]
+
+    if args.formatting_fix:
+        Formatting().check(files, True)
+    elif args.formatting_check:
+        return Formatting().check(files)
+    return 0
+
+
+class CustomEncoder(hjson.HjsonEncoder):
+    level = 0
+    newline = '\n'
+     # Strings inside lists must have double quotes.
+    is_list_of_dict = True
+    current_key = ""
+    def encode(self, obj):
+        if isinstance(obj, dict):
+            if self.level > 0:
+                yield f'{self.newline}{self.indent*self.level}'
+            yield '{'
+            self.level +=1
+            self.is_list_of_dict = True
+            for key, value in obj.items():
+                self.current_key = key
+                yield f'{self.newline}{self.indent*self.level}{key}: '
+                yield from self.encode(value)
+            self.level -= 1
+            yield f'{self.newline}{self.indent*self.level}}}'
+        elif isinstance(obj, list):
+            self.level +=1
+            yield '['
+            self.is_list_of_dict = False
+            for (enum,item) in enumerate(obj):
+                yield from self.encode(item)
+                if not self.is_list_of_dict and enum < len(obj)-1:
+                    yield ', '
+            self.level -=1
+            if self.is_list_of_dict:
+                yield f'{self.newline}{self.indent*self.level}'
+            yield ']'
+            self.is_list_of_dict = True
+        elif isinstance(obj, str):
+            if f'{self.newline}' in obj:
+                yield self.multiline_str(obj)
+            else:
+                yield f'{obj}' if self.is_list_of_dict else f'"{obj}"'
+        else:
+            yield str(obj)
+
+    def multiline_str(self, text):
+        align = len(self.current_key) + 2
+        indented = f'{self.newline}' + text + f'{self.newline}'
+        # Add indentation
+        indented = indented.replace(f'{self.newline}', f'{self.newline}{self.indent*(self.level)}{" "*align}')
+        # Remove indentation from empty lines
+        indented = re.sub(f'{self.newline}{self.indent}+{self.newline}', f'{self.newline}\n', indented)
+        return f"'''{indented}'''"
+        
+    def iterencode(	self, obj, _one_shot=False):
+        for chunk in self.encode(obj):
+            yield chunk
+
+class Formatting:
+    def check(self, files, fix=False) -> int:
+        WORK_FILE = "/tmp/linter_test.hjson"
+        for filename in files:
+            testplan = hjson.load(open(filename, "r"))
+            logging.debug(f"Checking {filename}.")
+            self.__dump_to_file(WORK_FILE, testplan)
+            try:
+                self.__diff_files(WORK_FILE, filename)
+            except TestplanLintException as e:
+                if fix:
+                    logging.info(f"Fixing file {filename}.")
+                    self.__dump_to_file(filename, testplan)
+                    continue
+
+                logging.info(f"Error found in file {filename}: {e}")
+                return -1
+        return 0
+
+    def __dump_to_file(self, filename, testplan):
+        with open(filename, "w") as f:
+            f.write(LOWRISC_HEADER)
+            hjson.dump(testplan, f, cls=CustomEncoder, indent="  ")
+            f.write("\n")
+
+    def __diff_files(self, ref_file, file):
+        text = open(file, "r").readlines()
+        ref_text = open(ref_file, "r").readlines()
+        diff = difflib.unified_diff(
+            text, ref_text, fromfile=file, tofile=ref_file, lineterm="\n"
+        )
+        msg = "".join(diff)
+
+        if len(msg) > 0:
+            raise TestplanLintException("\n" + msg)
+
+class TestplanLintException(Exception):
+    pass
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    logging.basicConfig(level=args.logging.upper())
+    sys.exit(main(args))


### PR DESCRIPTION
Auto format the tests plans using the python hjson library.
The script reads the hjson file to a python `dict` and write it back to guarantee a standard format.
The downside is that we lose comments.

```
 python3 ./util/lint_testplan.py --formatting-fix  --dir hw/top_earlgrey/data/ip/
```

### Note
The first commit contains the script and the second commit contains the testplans formatted by the script.