### PR TITLE
Aon timer 64 wakeup

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -161,27 +161,53 @@
         }
       ],
     },
-    { name: "WKUP_THOLD",
-      desc: "Wakeup Timer Threshold Register",
+    { name: "WKUP_THOLD_HI",
+      desc: "Wakeup Timer Threshold Register (bits 63 - 32)",
       swaccess: "rw",
       hwaccess: "hro",
       async: "clk_aon_i",
       fields: [
         { bits: "31:0",
-          name: "threshold",
-          desc: "The count at which a wakeup interrupt should be generated",
+          name: "threshold_hi",
+          desc: "The count at which a wakeup interrupt should be generated, top 32 bits",
         }
       ],
     },
-    { name: "WKUP_COUNT",
-      desc: "Wakeup Timer Count Register",
+    { name: "WKUP_THOLD_LO",
+      desc: "Wakeup Timer Threshold Register (bits 31 - 0)",
+      swaccess: "rw",
+      hwaccess: "hro",
+      async: "clk_aon_i",
+      fields: [
+        { bits: "31:0",
+          name: "threshold_lo",
+          desc: "The count at which a wakeup interrupt should be generated, bottom 32 bits",
+        }
+      ],
+    },
+    { name: "WKUP_COUNT_HI",
+      desc: "Wakeup Timer Count Register (bits 63 - 32)",
       swaccess: "rw",
       hwaccess: "hrw",
       async: "clk_aon_i",
       fields: [
         { bits: "31:0",
-          name: "count",
-          desc: "The current wakeup counter value",
+          name: "count_hi",
+          desc: "The current wakeup counter value, top 32 bits",
+        }
+      ],
+      tags: [// this could be updated by HW
+        "excl:CsrNonInitTests:CsrExclWriteCheck"],
+    },
+    { name: "WKUP_COUNT_LO",
+      desc: "Wakeup Timer Count Register (bits 31 - 0)",
+      swaccess: "rw",
+      hwaccess: "hrw",
+      async: "clk_aon_i",
+      fields: [
+        { bits: "31:0",
+          name: "count_lo",
+          desc: "The current wakeup counter value, bottom 32 bits",
         }
       ],
       tags: [// this could be updated by HW

--- a/hw/ip/aon_timer/doc/programmers_guide.md
+++ b/hw/ip/aon_timer/doc/programmers_guide.md
@@ -2,9 +2,9 @@
 
 ## Initialization
 
-1. Write the timer values [`WKUP_COUNT`](registers.md#wkup_count) and [`WDOG_COUNT`](registers.md#wdog_count) to zero.
+1. Set the timer values [`WKUP_COUNT_LO`](registers.md#wkup_count_lo), [`WKUP_COUNT_HI`](registers.md#wkup_count_hi) and [`WDOG_COUNT`](registers.md#wdog_count) to zero.
 2. Program the desired wakeup pre-scaler value in [`WKUP_CTRL`](registers.md#wkup_ctrl).
-3. Program the desired thresholds in [`WKUP_THOLD`](registers.md#wkup_thold), [`WDOG_BARK_THOLD`](registers.md#wdog_bark_thold) and [`WDOG_BITE_THOLD`](registers.md#wdog_bite_thold).
+3. Program the desired thresholds in [`WKUP_THOLD_LO`](registers.md#wkup_thold_lo), [`WKUP_THOLD_HI`](registers.md#wkup_thold_hi), [`WDOG_BARK_THOLD`](registers.md#wdog_bark_thold) and [`WDOG_BITE_THOLD`](registers.md#wdog_bite_thold).
 4. Set the enable bit to 1 in the [`WKUP_CTRL`](registers.md#wkup_ctrl) / [`WDOG_CTRL`](registers.md#wdog_ctrl) registers.
 5. If desired, lock the watchdog configuration by writing 1 to the `regwen` bit in [`WDOG_REGWEN`](registers.md#wdog_regwen).
 
@@ -12,15 +12,82 @@
 
 Pet the watchdog by writing zero to the [`WDOG_COUNT`](registers.md#wdog_count) register.
 
+## Wakeup count and threshold access
+
+The wakeup counter and threshold are both 64-bit values accessed via two 32-bit hi and lo registers.
+It is not possible to read or modify the 64-bit values in a single atomic access.
+Care must be taken to avoid issues due to race conditions caused by this.
+Below are some recommendations on how to access the counter and threshold to avoid problems.
+
+### Reading the counter
+
+The counter might increment between the read of [`WKUP_COUNT_HI`](registers.md#wkup_count_hi) and the read of [`WKUP_COUNT_LO`](registers.md#wkup_count_lo).
+If the [`WKUP_COUNT_LO`](registers.md#wkup_count_lo) value overflows between the two register reads the combined 64-bit value may be incorrect.
+Consider the scenario where the 64-bit counter value is `0x1_ffff_ffff`.
+A read of the [`WKUP_COUNT_HI`](registers.md#wkup_count_hi) value gives `0x1`.
+If the counter then increments to `0x2_0000_0000` then a read of [`WKUP_COUNT_LO`](registers.md#wkup_count_lo) gives `0x0000_00000`.
+The final 64-bit value of `0x1_0000_0000` is incorrect.
+The pseudo code below provides a method to avoid this issue:
+
+```
+counter_hi = REG_READ(WKUP_COUNT_HI);
+counter_lo = REG_READ(WKUP_COUNT_LO);
+counter_hi_2 = REG_READ(WKUP_COUNT_HI);
+
+// If WKUP_COUNT_LO overflowed between first and second read WKUP_COUNT_HI will
+// have changed
+if counter_hi != counter_hi_2 {
+  // Read new WKUP_COUNT_LO value and use second WKUP_COUNT_HI read as top 32 bits
+  counter_lo = REG_READ(WKUP_COUNT_LO);
+  counter_hi = counter_hi_2;
+}
+
+counter_full = counter_hi << 32 | counter_lo;
+```
+
+### Writing the counter
+
+Between the two count register ([`WKUP_COUNT_HI`](registers.md#wkup_count_hi) and [`WKUP_COUNT_LO`](registers.md#wkup_count_lo)) writes the counter may increment.
+If the [`WKUP_COUNT_LO`](registers.md#wkup_count_lo) value overflows between a [`WKUP_COUNT_HI`](registers.md#wkup_count_hi) and [`WKUP_COUNT_LO`](registers.md#wkup_count_lo) write the intended counter value may be incorrect.
+For example an attempt to clear the counter to 0 could result in a counter value of `0x1_0000_0000`.
+It is recommended the wakeup timer is disabled with [`WKUP_CTRL`](registers.md#wkup_ctrl) before writing to the [`WKUP_COUNT_HI`](registers.md#wkup_count_hi) and [`WKUP_COUNT_LO`](registers.md#wkup_count_lo) registers to avoid this problem.
+
+### Reading the threshold
+
+The hardware does not alter the value of the [`WKUP_THOLD_LO`](registers.md#wkup_thold_lo) and [`WKUP_THOLD_HI`](registers.md#wkup_thold_hi) registers so there are no race conditions in reading them.
+
+### Writing the threshold
+
+When writing to [`WKUP_THOLD_LO`](registers.md#wkup_thold_lo) and [`WKUP_THOLD_HI`](registers.md#wkup_thold_hi) between the two writes the 64-bit threshold is effectively an interim value that's not intended to be the real threshold.
+It is possible the interim threshold is lower than the previous threshold triggering a spurious wakeup.
+Use the method in the pseudo code below to avoid this issue:
+
+```
+disable_wakeup_interrupt();
+
+// Guaranteed 64-bit threshold greater than or equal to old threshold. This
+// prevents an interrupt caused by the threshold decreasing.
+REG_WRITE(WKUP_THOLD_LO, UINT32_MAX);
+// Guaranteed 64-bit threshold greater than or equal to intended threshold. If
+// the counter reaches this value before we've completing the final write then
+// the interrupt would have happened with the intended threshold as well.
+REG_WRITE(WKUP_THOLD_HI, new_thold >> 32);
+// 64-bit threshold now intended value
+REG_WRITE(WKUP_THOLD_LO, new_thold & 0xffff_ffff);
+
+enable_wakeup_interrupt();
+```
+
 ## Interrupt Handling
 
 If either timer reaches the programmed threshold, interrupts are generated from the AON_TIMER module.
-Disable or reinitialize the wakeup timer if required by clearing the enable bit in [`WKUP_CTRL`](registers.md#wkup_ctrl) or clearing the timer value in [`WKUP_COUNT`](registers.md#wkup_count).
+Disable the wakeup timer by clearing the enable bit in [`WKUP_CTRL`](registers.md#wkup_ctrl).
+Reset the timer if desired by clearing [`WKUP_COUNT_HI`](registers.md#wkup_count_hi) and [`WKUP_COUNT_LO`](registers.md#wkup_count_lo) and renable by setting the enable bit in [`WKUP_CTRL`](registers.md#wkup_ctrl).
 Clear the interrupt by writing 1 into the Interrupt Status Register [`INTR_STATE`](registers.md#intr_state).
 
 If the timer has caused a wakeup event ([`WKUP_CAUSE`](registers.md#wkup_cause) is set) then clear the wakeup request by writing 0 to [`WKUP_CAUSE`](registers.md#wkup_cause).
 
-If [`WKUP_COUNT`](registers.md#wkup_count) remains above the threshold after clearing the interrupt or wakeup event and the timer remains enabled, the interrupt and wakeup event will trigger again at the next clock tick.
+If {[`WKUP_COUNT_HI`](registers.md#wkup_count_hi), [`WKUP_COUNT_LO`](registers.md#wkup_count_lo)} remains above the threshold after clearing the interrupt or wakeup event and the timer remains enabled, the interrupt and wakeup event will trigger again at the next clock tick.
 
 ## Device Interface Functions (DIFs)
 

--- a/hw/ip/aon_timer/doc/registers.md
+++ b/hw/ip/aon_timer/doc/registers.md
@@ -3,20 +3,22 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/aon_timer/data/aon_timer.hjson -->
 ## Summary
 
-| Name                                            | Offset   |   Length | Description                            |
-|:------------------------------------------------|:---------|---------:|:---------------------------------------|
-| aon_timer.[`ALERT_TEST`](#alert_test)           | 0x0      |        4 | Alert Test Register                    |
-| aon_timer.[`WKUP_CTRL`](#wkup_ctrl)             | 0x4      |        4 | Wakeup Timer Control register          |
-| aon_timer.[`WKUP_THOLD`](#wkup_thold)           | 0x8      |        4 | Wakeup Timer Threshold Register        |
-| aon_timer.[`WKUP_COUNT`](#wkup_count)           | 0xc      |        4 | Wakeup Timer Count Register            |
-| aon_timer.[`WDOG_REGWEN`](#wdog_regwen)         | 0x10     |        4 | Watchdog Timer Write Enable Register   |
-| aon_timer.[`WDOG_CTRL`](#wdog_ctrl)             | 0x14     |        4 | Watchdog Timer Control register        |
-| aon_timer.[`WDOG_BARK_THOLD`](#wdog_bark_thold) | 0x18     |        4 | Watchdog Timer Bark Threshold Register |
-| aon_timer.[`WDOG_BITE_THOLD`](#wdog_bite_thold) | 0x1c     |        4 | Watchdog Timer Bite Threshold Register |
-| aon_timer.[`WDOG_COUNT`](#wdog_count)           | 0x20     |        4 | Watchdog Timer Count Register          |
-| aon_timer.[`INTR_STATE`](#intr_state)           | 0x24     |        4 | Interrupt State Register               |
-| aon_timer.[`INTR_TEST`](#intr_test)             | 0x28     |        4 | Interrupt Test Register                |
-| aon_timer.[`WKUP_CAUSE`](#wkup_cause)           | 0x2c     |        4 | Wakeup request status                  |
+| Name                                            | Offset   |   Length | Description                                    |
+|:------------------------------------------------|:---------|---------:|:-----------------------------------------------|
+| aon_timer.[`ALERT_TEST`](#alert_test)           | 0x0      |        4 | Alert Test Register                            |
+| aon_timer.[`WKUP_CTRL`](#wkup_ctrl)             | 0x4      |        4 | Wakeup Timer Control register                  |
+| aon_timer.[`WKUP_THOLD_HI`](#wkup_thold_hi)     | 0x8      |        4 | Wakeup Timer Threshold Register (bits 63 - 32) |
+| aon_timer.[`WKUP_THOLD_LO`](#wkup_thold_lo)     | 0xc      |        4 | Wakeup Timer Threshold Register (bits 31 - 0)  |
+| aon_timer.[`WKUP_COUNT_HI`](#wkup_count_hi)     | 0x10     |        4 | Wakeup Timer Count Register (bits 63 - 32)     |
+| aon_timer.[`WKUP_COUNT_LO`](#wkup_count_lo)     | 0x14     |        4 | Wakeup Timer Count Register (bits 31 - 0)      |
+| aon_timer.[`WDOG_REGWEN`](#wdog_regwen)         | 0x18     |        4 | Watchdog Timer Write Enable Register           |
+| aon_timer.[`WDOG_CTRL`](#wdog_ctrl)             | 0x1c     |        4 | Watchdog Timer Control register                |
+| aon_timer.[`WDOG_BARK_THOLD`](#wdog_bark_thold) | 0x20     |        4 | Watchdog Timer Bark Threshold Register         |
+| aon_timer.[`WDOG_BITE_THOLD`](#wdog_bite_thold) | 0x24     |        4 | Watchdog Timer Bite Threshold Register         |
+| aon_timer.[`WDOG_COUNT`](#wdog_count)           | 0x28     |        4 | Watchdog Timer Count Register                  |
+| aon_timer.[`INTR_STATE`](#intr_state)           | 0x2c     |        4 | Interrupt State Register                       |
+| aon_timer.[`INTR_TEST`](#intr_test)             | 0x30     |        4 | Interrupt Test Register                        |
+| aon_timer.[`WKUP_CAUSE`](#wkup_cause)           | 0x34     |        4 | Wakeup request status                          |
 
 ## ALERT_TEST
 Alert Test Register
@@ -53,8 +55,8 @@ Wakeup Timer Control register
 |  12:1  |   rw   |   0x0   | prescaler | Pre-scaler value for wakeup timer count    |
 |   0    |   rw   |   0x0   | enable    | When set to 1, the wakeup timer will count |
 
-## WKUP_THOLD
-Wakeup Timer Threshold Register
+## WKUP_THOLD_HI
+Wakeup Timer Threshold Register (bits 63 - 32)
 - Offset: `0x8`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -62,15 +64,15 @@ Wakeup Timer Threshold Register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "threshold", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "threshold_hi", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name      | Description                                               |
-|:------:|:------:|:-------:|:----------|:----------------------------------------------------------|
-|  31:0  |   rw   |   0x0   | threshold | The count at which a wakeup interrupt should be generated |
+|  Bits  |  Type  |  Reset  | Name         | Description                                                            |
+|:------:|:------:|:-------:|:-------------|:-----------------------------------------------------------------------|
+|  31:0  |   rw   |   0x0   | threshold_hi | The count at which a wakeup interrupt should be generated, top 32 bits |
 
-## WKUP_COUNT
-Wakeup Timer Count Register
+## WKUP_THOLD_LO
+Wakeup Timer Threshold Register (bits 31 - 0)
 - Offset: `0xc`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -78,16 +80,48 @@ Wakeup Timer Count Register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "count", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "threshold_lo", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                      |
-|:------:|:------:|:-------:|:-------|:---------------------------------|
-|  31:0  |   rw   |   0x0   | count  | The current wakeup counter value |
+|  Bits  |  Type  |  Reset  | Name         | Description                                                               |
+|:------:|:------:|:-------:|:-------------|:--------------------------------------------------------------------------|
+|  31:0  |   rw   |   0x0   | threshold_lo | The count at which a wakeup interrupt should be generated, bottom 32 bits |
+
+## WKUP_COUNT_HI
+Wakeup Timer Count Register (bits 63 - 32)
+- Offset: `0x10`
+- Reset default: `0x0`
+- Reset mask: `0xffffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count_hi", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name     | Description                                   |
+|:------:|:------:|:-------:|:---------|:----------------------------------------------|
+|  31:0  |   rw   |   0x0   | count_hi | The current wakeup counter value, top 32 bits |
+
+## WKUP_COUNT_LO
+Wakeup Timer Count Register (bits 31 - 0)
+- Offset: `0x14`
+- Reset default: `0x0`
+- Reset mask: `0xffffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count_lo", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name     | Description                                      |
+|:------:|:------:|:-------:|:---------|:-------------------------------------------------|
+|  31:0  |   rw   |   0x0   | count_lo | The current wakeup counter value, bottom 32 bits |
 
 ## WDOG_REGWEN
 Watchdog Timer Write Enable Register
-- Offset: `0x10`
+- Offset: `0x18`
 - Reset default: `0x1`
 - Reset mask: `0x1`
 
@@ -104,7 +138,7 @@ Watchdog Timer Write Enable Register
 
 ## WDOG_CTRL
 Watchdog Timer Control register
-- Offset: `0x14`
+- Offset: `0x1c`
 - Reset default: `0x0`
 - Reset mask: `0x3`
 - Register enable: [`WDOG_REGWEN`](#wdog_regwen)
@@ -123,7 +157,7 @@ Watchdog Timer Control register
 
 ## WDOG_BARK_THOLD
 Watchdog Timer Bark Threshold Register
-- Offset: `0x18`
+- Offset: `0x20`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 - Register enable: [`WDOG_REGWEN`](#wdog_regwen)
@@ -140,7 +174,7 @@ Watchdog Timer Bark Threshold Register
 
 ## WDOG_BITE_THOLD
 Watchdog Timer Bite Threshold Register
-- Offset: `0x1c`
+- Offset: `0x24`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 - Register enable: [`WDOG_REGWEN`](#wdog_regwen)
@@ -157,7 +191,7 @@ Watchdog Timer Bite Threshold Register
 
 ## WDOG_COUNT
 Watchdog Timer Count Register
-- Offset: `0x20`
+- Offset: `0x28`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -173,7 +207,7 @@ Watchdog Timer Count Register
 
 ## INTR_STATE
 Interrupt State Register
-- Offset: `0x24`
+- Offset: `0x2c`
 - Reset default: `0x0`
 - Reset mask: `0x3`
 
@@ -191,7 +225,7 @@ Interrupt State Register
 
 ## INTR_TEST
 Interrupt Test Register
-- Offset: `0x28`
+- Offset: `0x30`
 - Reset default: `0x0`
 - Reset mask: `0x3`
 
@@ -209,7 +243,7 @@ Interrupt Test Register
 
 ## WKUP_CAUSE
 Wakeup request status
-- Offset: `0x2c`
+- Offset: `0x34`
 - Reset default: `0x0`
 - Reset mask: `0x1`
 

--- a/hw/ip/aon_timer/doc/theory_of_operation.md
+++ b/hw/ip/aon_timer/doc/theory_of_operation.md
@@ -12,9 +12,14 @@ This is used to stop the watchdog timer running when in debugging mode or when t
 ## Design Details
 
 The always-on timer will run on a ~200KHz clock.
-The timers themselves are 32b wide, giving a maximum timeout window of roughly ~6 hours.
-For the wakeup timer, the pre-scaler extends the maximum timeout to ~1000 days.
+The wakeup timer is 64b wide and the watchdog timer 32b wide.
+This gives a maximum timeout window of roughly ~6 hours for the watchdog and almost 3 million years for the wakeup timer.
+For the wakeup timer, the pre-scaler can be used to slow the count down so the counter value matches some desired time unit (e.g. milliseconds).
 
 Register reads via the TLUL interface are synchronized to the slow clock using the "async" register generation feature.
 This means that writes can complete before the data has reached its underlying register in the slow clock domain.
 If software needs to guarantee completion of a register write, it can read back the register value (which will guarantee the completion of all previous writes to the peripheral).
+
+The wakeup count and threshold are both 64-bit values accessed through two 32-bit registers.
+It is not possible to do a single atomic read or write of the 64-bit values.
+The programmer's guide suggests some ways to access the wakeup count and threshold to avoid issues from race conditions caused by this.

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cov.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cov.sv
@@ -21,7 +21,7 @@ class aon_timer_env_cov extends cip_base_env_cov #(.CFG_T(aon_timer_env_cfg));
   covergroup timer_cfg_cg(string name) with function sample(bit [11:0] prescale,
                                                             bit [31:0] bark_thold,
                                                             bit [31:0] bite_thold,
-                                                            bit [31:0] wkup_thold,
+                                                            bit [63:0] wkup_thold,
                                                             bit wdog_regwen,
                                                             bit pause_in_sleep,
                                                             bit wkup_cause);
@@ -42,7 +42,7 @@ class aon_timer_env_cov extends cip_base_env_cov #(.CFG_T(aon_timer_env_cfg));
     }
     wkup_thold_cp: coverpoint wkup_thold {
       bins wkup_0 = {0};
-      bins wkup[32] = {[1:$]};
+      bins wkup[64] = {[1:$]};
       bins wkup_max = {'1};
     }
 

--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -12,9 +12,9 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
   // local variables
   local bit  wkup_en;
   local bit  wkup_num_update_due;
-  local uint wkup_count;
+  local bit [63:0] wkup_count;
   local uint prescaler;
-  local uint wkup_thold;
+  local bit [63:0] wkup_thold;
 
   local bit  wdog_en;
   local bit  wdog_regwen;
@@ -25,9 +25,9 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
   local uint bite_thold;
 
   local bit  wkup_cause;
-  local uint wkup_num;
-  local uint wdog_bark_num;
-  local uint wdog_bite_num;
+  local bit [63:0] wkup_num;
+  local bit [31:0] wdog_bark_num;
+  local bit [31:0] wdog_bite_num;
 
   // expected values
   local bit intr_status_exp [2];
@@ -131,12 +131,20 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
         wkup_cause = csr.get_mirrored_value();
         intr_status_exp[WKUP] = item.a_data;
       end
-      "wkup_count": begin
-        wkup_count =  csr.get_mirrored_value();
+      "wkup_count_lo": begin
+        wkup_count[31:0] =  csr.get_mirrored_value();
         if (data_phase_write) wkup_num_update_due = 1;
       end
-      "wkup_thold": begin
-        wkup_thold =  csr.get_mirrored_value();
+      "wkup_count_hi": begin
+        wkup_count[63:32] =  csr.get_mirrored_value();
+        if (data_phase_write) wkup_num_update_due = 1;
+      end
+      "wkup_thold_lo": begin
+        wkup_thold[31:0] =  csr.get_mirrored_value();
+        if (data_phase_write) wkup_num_update_due = 1;
+      end
+      "wkup_thold_hi": begin
+        wkup_thold[73:32] =  csr.get_mirrored_value();
         if (data_phase_write) wkup_num_update_due = 1;
       end
       "wdog_ctrl": begin

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
@@ -7,12 +7,8 @@ class aon_timer_jump_vseq extends aon_timer_base_vseq;
   `uvm_object_utils(aon_timer_jump_vseq)
 
   // Randomize Bark/Bite and Wake-up thresholds for the counter
-  rand bit [31:0] wkup_count;
+  rand bit [63:0] wkup_count;
   rand bit [31:0] wdog_count;
-
-  rand bit [31:0] wkup_thold;
-  rand bit [31:0] wdog_bark_thold;
-  rand bit [31:0] wdog_bite_thold;
 
   constraint count_vals_c {
     wkup_count inside {[wkup_thold-10:wkup_thold+10]};
@@ -30,36 +26,11 @@ class aon_timer_jump_vseq extends aon_timer_base_vseq;
 
   endtask : body
 
-  // setup basic aon_timer features
-  task aon_timer_init();
-
-    `uvm_info(`gfn, "Initializating AON Timer. Writing 0 to WKUP_COUNT and WDOG_COUNT", UVM_LOW)
-    // Register Write
-    csr_utils_pkg::csr_wr(ral.wkup_count, 32'h0000_0000);
-    csr_utils_pkg::csr_wr(ral.wdog_count, 32'h0000_0000);
-
-    `uvm_info(`gfn, "Randomizing AON Timer thresholds", UVM_HIGH)
-
-    `uvm_info(`gfn, $sformatf("Writing 0x%0h to wkup_thold", wkup_thold), UVM_HIGH)
-    csr_utils_pkg::csr_wr(ral.wkup_thold, wkup_thold);
-
-    `uvm_info(`gfn, $sformatf("Writing 0x%0h to wdog_bark_thold", wdog_bark_thold), UVM_HIGH)
-    csr_utils_pkg::csr_wr(ral.wdog_bark_thold, wdog_bark_thold);
-
-    `uvm_info(`gfn, $sformatf("Writing 0x%0h to wdog_bite_thold", wdog_bite_thold), UVM_HIGH)
-    csr_utils_pkg::csr_wr(ral.wdog_bite_thold, wdog_bite_thold);
-
-    cfg.lc_escalate_en_vif.drive(0);
-
-    `uvm_info(`gfn, $sformatf("Writing 0x%0h to WDOG_REGWEN", wdog_regwen), UVM_HIGH)
-    csr_utils_pkg::csr_wr(ral.wdog_regwen, wdog_regwen);
-
-  endtask
-
   task jump_configure();
 
     // Write random value to the COUNT registers
-    csr_utils_pkg::csr_wr(ral.wkup_count, wkup_count);
+    csr_utils_pkg::csr_wr(ral.wkup_count_lo, wkup_count[31:0]);
+    csr_utils_pkg::csr_wr(ral.wkup_count_hi, wkup_count[63:32]);
     `uvm_info(`gfn,
               $sformatf("\n\t Writing random COUNT value of %d to WKUP", wkup_count),
               UVM_HIGH)

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -44,7 +44,7 @@ module aon_timer import aon_timer_reg_pkg::*;
   aon_timer_hw2reg_t         hw2reg;
   // Register write signals
   logic                      aon_wkup_count_reg_wr;
-  logic [31:0]               aon_wkup_count_wr_data;
+  logic [63:0]               aon_wkup_count_wr_data;
   logic                      aon_wdog_count_reg_wr;
   logic [31:0]               aon_wdog_count_wr_data;
   // Other sync signals
@@ -78,8 +78,10 @@ module aon_timer import aon_timer_reg_pkg::*;
     .q_o     (aon_sleep_mode)
   );
 
-  assign hw2reg.wkup_count.de = aon_wkup_count_reg_wr;
-  assign hw2reg.wkup_count.d  = aon_wkup_count_wr_data;
+  assign hw2reg.wkup_count_lo.de = aon_wkup_count_reg_wr;
+  assign hw2reg.wkup_count_hi.de = aon_wkup_count_reg_wr;
+  assign hw2reg.wkup_count_lo.d  = aon_wkup_count_wr_data[31:0];
+  assign hw2reg.wkup_count_hi.d  = aon_wkup_count_wr_data[63:32];
   assign hw2reg.wdog_count.de = aon_wdog_count_reg_wr;
   assign hw2reg.wdog_count.d  = aon_wdog_count_wr_data;
 

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -32,11 +32,19 @@ package aon_timer_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } aon_timer_reg2hw_wkup_thold_reg_t;
+  } aon_timer_reg2hw_wkup_thold_hi_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
-  } aon_timer_reg2hw_wkup_count_reg_t;
+  } aon_timer_reg2hw_wkup_thold_lo_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } aon_timer_reg2hw_wkup_count_hi_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } aon_timer_reg2hw_wkup_count_lo_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -86,7 +94,12 @@ package aon_timer_reg_pkg;
   typedef struct packed {
     logic [31:0] d;
     logic        de;
-  } aon_timer_hw2reg_wkup_count_reg_t;
+  } aon_timer_hw2reg_wkup_count_hi_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } aon_timer_hw2reg_wkup_count_lo_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -111,10 +124,12 @@ package aon_timer_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    aon_timer_reg2hw_alert_test_reg_t alert_test; // [183:182]
-    aon_timer_reg2hw_wkup_ctrl_reg_t wkup_ctrl; // [181:169]
-    aon_timer_reg2hw_wkup_thold_reg_t wkup_thold; // [168:137]
-    aon_timer_reg2hw_wkup_count_reg_t wkup_count; // [136:105]
+    aon_timer_reg2hw_alert_test_reg_t alert_test; // [247:246]
+    aon_timer_reg2hw_wkup_ctrl_reg_t wkup_ctrl; // [245:233]
+    aon_timer_reg2hw_wkup_thold_hi_reg_t wkup_thold_hi; // [232:201]
+    aon_timer_reg2hw_wkup_thold_lo_reg_t wkup_thold_lo; // [200:169]
+    aon_timer_reg2hw_wkup_count_hi_reg_t wkup_count_hi; // [168:137]
+    aon_timer_reg2hw_wkup_count_lo_reg_t wkup_count_lo; // [136:105]
     aon_timer_reg2hw_wdog_ctrl_reg_t wdog_ctrl; // [104:103]
     aon_timer_reg2hw_wdog_bark_thold_reg_t wdog_bark_thold; // [102:71]
     aon_timer_reg2hw_wdog_bite_thold_reg_t wdog_bite_thold; // [70:39]
@@ -126,7 +141,8 @@ package aon_timer_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    aon_timer_hw2reg_wkup_count_reg_t wkup_count; // [71:39]
+    aon_timer_hw2reg_wkup_count_hi_reg_t wkup_count_hi; // [104:72]
+    aon_timer_hw2reg_wkup_count_lo_reg_t wkup_count_lo; // [71:39]
     aon_timer_hw2reg_wdog_count_reg_t wdog_count; // [38:6]
     aon_timer_hw2reg_intr_state_reg_t intr_state; // [5:2]
     aon_timer_hw2reg_wkup_cause_reg_t wkup_cause; // [1:0]
@@ -135,16 +151,18 @@ package aon_timer_reg_pkg;
   // Register offsets
   parameter logic [BlockAw-1:0] AON_TIMER_ALERT_TEST_OFFSET = 6'h 0;
   parameter logic [BlockAw-1:0] AON_TIMER_WKUP_CTRL_OFFSET = 6'h 4;
-  parameter logic [BlockAw-1:0] AON_TIMER_WKUP_THOLD_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] AON_TIMER_WKUP_COUNT_OFFSET = 6'h c;
-  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_REGWEN_OFFSET = 6'h 10;
-  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_CTRL_OFFSET = 6'h 14;
-  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_BARK_THOLD_OFFSET = 6'h 18;
-  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_BITE_THOLD_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_COUNT_OFFSET = 6'h 20;
-  parameter logic [BlockAw-1:0] AON_TIMER_INTR_STATE_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] AON_TIMER_INTR_TEST_OFFSET = 6'h 28;
-  parameter logic [BlockAw-1:0] AON_TIMER_WKUP_CAUSE_OFFSET = 6'h 2c;
+  parameter logic [BlockAw-1:0] AON_TIMER_WKUP_THOLD_HI_OFFSET = 6'h 8;
+  parameter logic [BlockAw-1:0] AON_TIMER_WKUP_THOLD_LO_OFFSET = 6'h c;
+  parameter logic [BlockAw-1:0] AON_TIMER_WKUP_COUNT_HI_OFFSET = 6'h 10;
+  parameter logic [BlockAw-1:0] AON_TIMER_WKUP_COUNT_LO_OFFSET = 6'h 14;
+  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_REGWEN_OFFSET = 6'h 18;
+  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_CTRL_OFFSET = 6'h 1c;
+  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_BARK_THOLD_OFFSET = 6'h 20;
+  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_BITE_THOLD_OFFSET = 6'h 24;
+  parameter logic [BlockAw-1:0] AON_TIMER_WDOG_COUNT_OFFSET = 6'h 28;
+  parameter logic [BlockAw-1:0] AON_TIMER_INTR_STATE_OFFSET = 6'h 2c;
+  parameter logic [BlockAw-1:0] AON_TIMER_INTR_TEST_OFFSET = 6'h 30;
+  parameter logic [BlockAw-1:0] AON_TIMER_WKUP_CAUSE_OFFSET = 6'h 34;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] AON_TIMER_ALERT_TEST_RESVAL = 1'h 0;
@@ -155,8 +173,10 @@ package aon_timer_reg_pkg;
   typedef enum int {
     AON_TIMER_ALERT_TEST,
     AON_TIMER_WKUP_CTRL,
-    AON_TIMER_WKUP_THOLD,
-    AON_TIMER_WKUP_COUNT,
+    AON_TIMER_WKUP_THOLD_HI,
+    AON_TIMER_WKUP_THOLD_LO,
+    AON_TIMER_WKUP_COUNT_HI,
+    AON_TIMER_WKUP_COUNT_LO,
     AON_TIMER_WDOG_REGWEN,
     AON_TIMER_WDOG_CTRL,
     AON_TIMER_WDOG_BARK_THOLD,
@@ -168,19 +188,21 @@ package aon_timer_reg_pkg;
   } aon_timer_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] AON_TIMER_PERMIT [12] = '{
+  parameter logic [3:0] AON_TIMER_PERMIT [14] = '{
     4'b 0001, // index[ 0] AON_TIMER_ALERT_TEST
     4'b 0011, // index[ 1] AON_TIMER_WKUP_CTRL
-    4'b 1111, // index[ 2] AON_TIMER_WKUP_THOLD
-    4'b 1111, // index[ 3] AON_TIMER_WKUP_COUNT
-    4'b 0001, // index[ 4] AON_TIMER_WDOG_REGWEN
-    4'b 0001, // index[ 5] AON_TIMER_WDOG_CTRL
-    4'b 1111, // index[ 6] AON_TIMER_WDOG_BARK_THOLD
-    4'b 1111, // index[ 7] AON_TIMER_WDOG_BITE_THOLD
-    4'b 1111, // index[ 8] AON_TIMER_WDOG_COUNT
-    4'b 0001, // index[ 9] AON_TIMER_INTR_STATE
-    4'b 0001, // index[10] AON_TIMER_INTR_TEST
-    4'b 0001  // index[11] AON_TIMER_WKUP_CAUSE
+    4'b 1111, // index[ 2] AON_TIMER_WKUP_THOLD_HI
+    4'b 1111, // index[ 3] AON_TIMER_WKUP_THOLD_LO
+    4'b 1111, // index[ 4] AON_TIMER_WKUP_COUNT_HI
+    4'b 1111, // index[ 5] AON_TIMER_WKUP_COUNT_LO
+    4'b 0001, // index[ 6] AON_TIMER_WDOG_REGWEN
+    4'b 0001, // index[ 7] AON_TIMER_WDOG_CTRL
+    4'b 1111, // index[ 8] AON_TIMER_WDOG_BARK_THOLD
+    4'b 1111, // index[ 9] AON_TIMER_WDOG_BITE_THOLD
+    4'b 1111, // index[10] AON_TIMER_WDOG_COUNT
+    4'b 0001, // index[11] AON_TIMER_INTR_STATE
+    4'b 0001, // index[12] AON_TIMER_INTR_TEST
+    4'b 0001  // index[13] AON_TIMER_WKUP_CAUSE
   };
 
 endpackage

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -54,9 +54,9 @@ module aon_timer_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [11:0] reg_we_check;
+  logic [13:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(12)
+    .OneHotWidth(14)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -128,12 +128,18 @@ module aon_timer_reg_top (
   logic wkup_ctrl_we;
   logic [12:0] wkup_ctrl_qs;
   logic wkup_ctrl_busy;
-  logic wkup_thold_we;
-  logic [31:0] wkup_thold_qs;
-  logic wkup_thold_busy;
-  logic wkup_count_we;
-  logic [31:0] wkup_count_qs;
-  logic wkup_count_busy;
+  logic wkup_thold_hi_we;
+  logic [31:0] wkup_thold_hi_qs;
+  logic wkup_thold_hi_busy;
+  logic wkup_thold_lo_we;
+  logic [31:0] wkup_thold_lo_qs;
+  logic wkup_thold_lo_busy;
+  logic wkup_count_hi_we;
+  logic [31:0] wkup_count_hi_qs;
+  logic wkup_count_hi_busy;
+  logic wkup_count_lo_we;
+  logic [31:0] wkup_count_lo_qs;
+  logic wkup_count_lo_busy;
   logic wdog_regwen_we;
   logic wdog_regwen_qs;
   logic wdog_regwen_wd;
@@ -203,15 +209,15 @@ module aon_timer_reg_top (
   assign unused_aon_wkup_ctrl_wdata =
       ^aon_wkup_ctrl_wdata;
 
-  logic [31:0]  aon_wkup_thold_qs_int;
-  logic [31:0] aon_wkup_thold_qs;
-  logic [31:0] aon_wkup_thold_wdata;
-  logic aon_wkup_thold_we;
-  logic unused_aon_wkup_thold_wdata;
+  logic [31:0]  aon_wkup_thold_hi_qs_int;
+  logic [31:0] aon_wkup_thold_hi_qs;
+  logic [31:0] aon_wkup_thold_hi_wdata;
+  logic aon_wkup_thold_hi_we;
+  logic unused_aon_wkup_thold_hi_wdata;
 
   always_comb begin
-    aon_wkup_thold_qs = 32'h0;
-    aon_wkup_thold_qs = aon_wkup_thold_qs_int;
+    aon_wkup_thold_hi_qs = 32'h0;
+    aon_wkup_thold_hi_qs = aon_wkup_thold_hi_qs_int;
   end
 
   prim_reg_cdc #(
@@ -219,42 +225,80 @@ module aon_timer_reg_top (
     .ResetVal(32'h0),
     .BitMask(32'hffffffff),
     .DstWrReq(0)
-  ) u_wkup_thold_cdc (
+  ) u_wkup_thold_hi_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
     .src_regwen_i ('0),
-    .src_we_i     (wkup_thold_we),
+    .src_we_i     (wkup_thold_hi_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[31:0]),
-    .src_busy_o   (wkup_thold_busy),
-    .src_qs_o     (wkup_thold_qs), // for software read back
+    .src_busy_o   (wkup_thold_hi_busy),
+    .src_qs_o     (wkup_thold_hi_qs), // for software read back
     .dst_update_i ('0),
     .dst_ds_i     ('0),
-    .dst_qs_i     (aon_wkup_thold_qs),
-    .dst_we_o     (aon_wkup_thold_we),
+    .dst_qs_i     (aon_wkup_thold_hi_qs),
+    .dst_we_o     (aon_wkup_thold_hi_we),
     .dst_re_o     (),
     .dst_regwen_o (),
-    .dst_wd_o     (aon_wkup_thold_wdata)
+    .dst_wd_o     (aon_wkup_thold_hi_wdata)
   );
-  assign unused_aon_wkup_thold_wdata =
-      ^aon_wkup_thold_wdata;
+  assign unused_aon_wkup_thold_hi_wdata =
+      ^aon_wkup_thold_hi_wdata;
 
-  logic [31:0]  aon_wkup_count_ds_int;
-  logic [31:0]  aon_wkup_count_qs_int;
-  logic [31:0] aon_wkup_count_ds;
-  logic aon_wkup_count_qe;
-  logic [31:0] aon_wkup_count_qs;
-  logic [31:0] aon_wkup_count_wdata;
-  logic aon_wkup_count_we;
-  logic unused_aon_wkup_count_wdata;
+  logic [31:0]  aon_wkup_thold_lo_qs_int;
+  logic [31:0] aon_wkup_thold_lo_qs;
+  logic [31:0] aon_wkup_thold_lo_wdata;
+  logic aon_wkup_thold_lo_we;
+  logic unused_aon_wkup_thold_lo_wdata;
 
   always_comb begin
-    aon_wkup_count_qs = 32'h0;
-    aon_wkup_count_ds = 32'h0;
-    aon_wkup_count_ds = aon_wkup_count_ds_int;
-    aon_wkup_count_qs = aon_wkup_count_qs_int;
+    aon_wkup_thold_lo_qs = 32'h0;
+    aon_wkup_thold_lo_qs = aon_wkup_thold_lo_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff),
+    .DstWrReq(0)
+  ) u_wkup_thold_lo_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i ('0),
+    .src_we_i     (wkup_thold_lo_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (wkup_thold_lo_busy),
+    .src_qs_o     (wkup_thold_lo_qs), // for software read back
+    .dst_update_i ('0),
+    .dst_ds_i     ('0),
+    .dst_qs_i     (aon_wkup_thold_lo_qs),
+    .dst_we_o     (aon_wkup_thold_lo_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_wkup_thold_lo_wdata)
+  );
+  assign unused_aon_wkup_thold_lo_wdata =
+      ^aon_wkup_thold_lo_wdata;
+
+  logic [31:0]  aon_wkup_count_hi_ds_int;
+  logic [31:0]  aon_wkup_count_hi_qs_int;
+  logic [31:0] aon_wkup_count_hi_ds;
+  logic aon_wkup_count_hi_qe;
+  logic [31:0] aon_wkup_count_hi_qs;
+  logic [31:0] aon_wkup_count_hi_wdata;
+  logic aon_wkup_count_hi_we;
+  logic unused_aon_wkup_count_hi_wdata;
+
+  always_comb begin
+    aon_wkup_count_hi_qs = 32'h0;
+    aon_wkup_count_hi_ds = 32'h0;
+    aon_wkup_count_hi_ds = aon_wkup_count_hi_ds_int;
+    aon_wkup_count_hi_qs = aon_wkup_count_hi_qs_int;
   end
 
   prim_reg_cdc #(
@@ -262,27 +306,70 @@ module aon_timer_reg_top (
     .ResetVal(32'h0),
     .BitMask(32'hffffffff),
     .DstWrReq(1)
-  ) u_wkup_count_cdc (
+  ) u_wkup_count_hi_cdc (
     .clk_src_i    (clk_i),
     .rst_src_ni   (rst_ni),
     .clk_dst_i    (clk_aon_i),
     .rst_dst_ni   (rst_aon_ni),
     .src_regwen_i ('0),
-    .src_we_i     (wkup_count_we),
+    .src_we_i     (wkup_count_hi_we),
     .src_re_i     ('0),
     .src_wd_i     (reg_wdata[31:0]),
-    .src_busy_o   (wkup_count_busy),
-    .src_qs_o     (wkup_count_qs), // for software read back
-    .dst_update_i (aon_wkup_count_qe),
-    .dst_ds_i     (aon_wkup_count_ds),
-    .dst_qs_i     (aon_wkup_count_qs),
-    .dst_we_o     (aon_wkup_count_we),
+    .src_busy_o   (wkup_count_hi_busy),
+    .src_qs_o     (wkup_count_hi_qs), // for software read back
+    .dst_update_i (aon_wkup_count_hi_qe),
+    .dst_ds_i     (aon_wkup_count_hi_ds),
+    .dst_qs_i     (aon_wkup_count_hi_qs),
+    .dst_we_o     (aon_wkup_count_hi_we),
     .dst_re_o     (),
     .dst_regwen_o (),
-    .dst_wd_o     (aon_wkup_count_wdata)
+    .dst_wd_o     (aon_wkup_count_hi_wdata)
   );
-  assign unused_aon_wkup_count_wdata =
-      ^aon_wkup_count_wdata;
+  assign unused_aon_wkup_count_hi_wdata =
+      ^aon_wkup_count_hi_wdata;
+
+  logic [31:0]  aon_wkup_count_lo_ds_int;
+  logic [31:0]  aon_wkup_count_lo_qs_int;
+  logic [31:0] aon_wkup_count_lo_ds;
+  logic aon_wkup_count_lo_qe;
+  logic [31:0] aon_wkup_count_lo_qs;
+  logic [31:0] aon_wkup_count_lo_wdata;
+  logic aon_wkup_count_lo_we;
+  logic unused_aon_wkup_count_lo_wdata;
+
+  always_comb begin
+    aon_wkup_count_lo_qs = 32'h0;
+    aon_wkup_count_lo_ds = 32'h0;
+    aon_wkup_count_lo_ds = aon_wkup_count_lo_ds_int;
+    aon_wkup_count_lo_qs = aon_wkup_count_lo_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff),
+    .DstWrReq(1)
+  ) u_wkup_count_lo_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_regwen_i ('0),
+    .src_we_i     (wkup_count_lo_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (wkup_count_lo_busy),
+    .src_qs_o     (wkup_count_lo_qs), // for software read back
+    .dst_update_i (aon_wkup_count_lo_qe),
+    .dst_ds_i     (aon_wkup_count_lo_ds),
+    .dst_qs_i     (aon_wkup_count_lo_qs),
+    .dst_we_o     (aon_wkup_count_lo_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_wkup_count_lo_wdata)
+  );
+  assign unused_aon_wkup_count_lo_wdata =
+      ^aon_wkup_count_lo_wdata;
 
   logic  aon_wdog_ctrl_enable_qs_int;
   logic  aon_wdog_ctrl_pause_in_sleep_qs_int;
@@ -566,19 +653,19 @@ module aon_timer_reg_top (
   );
 
 
-  // R[wkup_thold]: V(False)
+  // R[wkup_thold_hi]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_wkup_thold (
+  ) u_wkup_thold_hi (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
 
     // from register interface
-    .we     (aon_wkup_thold_we),
-    .wd     (aon_wkup_thold_wdata[31:0]),
+    .we     (aon_wkup_thold_hi_we),
+    .wd     (aon_wkup_thold_hi_wdata[31:0]),
 
     // from internal hardware
     .de     (1'b0),
@@ -586,41 +673,99 @@ module aon_timer_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.wkup_thold.q),
+    .q      (reg2hw.wkup_thold_hi.q),
     .ds     (),
 
     // to register interface (read)
-    .qs     (aon_wkup_thold_qs_int)
+    .qs     (aon_wkup_thold_hi_qs_int)
   );
 
 
-  // R[wkup_count]: V(False)
-  logic [0:0] wkup_count_flds_we;
-  assign aon_wkup_count_qe = |wkup_count_flds_we;
+  // R[wkup_thold_lo]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0),
     .Mubi    (1'b0)
-  ) u_wkup_count (
+  ) u_wkup_thold_lo (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
 
     // from register interface
-    .we     (aon_wkup_count_we),
-    .wd     (aon_wkup_count_wdata[31:0]),
+    .we     (aon_wkup_thold_lo_we),
+    .wd     (aon_wkup_thold_lo_wdata[31:0]),
 
     // from internal hardware
-    .de     (hw2reg.wkup_count.de),
-    .d      (hw2reg.wkup_count.d),
+    .de     (1'b0),
+    .d      ('0),
 
     // to internal hardware
-    .qe     (wkup_count_flds_we[0]),
-    .q      (reg2hw.wkup_count.q),
-    .ds     (aon_wkup_count_ds_int),
+    .qe     (),
+    .q      (reg2hw.wkup_thold_lo.q),
+    .ds     (),
 
     // to register interface (read)
-    .qs     (aon_wkup_count_qs_int)
+    .qs     (aon_wkup_thold_lo_qs_int)
+  );
+
+
+  // R[wkup_count_hi]: V(False)
+  logic [0:0] wkup_count_hi_flds_we;
+  assign aon_wkup_count_hi_qe = |wkup_count_hi_flds_we;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
+  ) u_wkup_count_hi (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_count_hi_we),
+    .wd     (aon_wkup_count_hi_wdata[31:0]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_count_hi.de),
+    .d      (hw2reg.wkup_count_hi.d),
+
+    // to internal hardware
+    .qe     (wkup_count_hi_flds_we[0]),
+    .q      (reg2hw.wkup_count_hi.q),
+    .ds     (aon_wkup_count_hi_ds_int),
+
+    // to register interface (read)
+    .qs     (aon_wkup_count_hi_qs_int)
+  );
+
+
+  // R[wkup_count_lo]: V(False)
+  logic [0:0] wkup_count_lo_flds_we;
+  assign aon_wkup_count_lo_qe = |wkup_count_lo_flds_we;
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
+  ) u_wkup_count_lo (
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_count_lo_we),
+    .wd     (aon_wkup_count_lo_wdata[31:0]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_count_lo.de),
+    .d      (hw2reg.wkup_count_lo.d),
+
+    // to internal hardware
+    .qe     (wkup_count_lo_flds_we[0]),
+    .q      (reg2hw.wkup_count_lo.q),
+    .ds     (aon_wkup_count_lo_ds_int),
+
+    // to register interface (read)
+    .qs     (aon_wkup_count_lo_qs_int)
   );
 
 
@@ -927,21 +1072,23 @@ module aon_timer_reg_top (
 
 
 
-  logic [11:0] addr_hit;
+  logic [13:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == AON_TIMER_ALERT_TEST_OFFSET);
     addr_hit[ 1] = (reg_addr == AON_TIMER_WKUP_CTRL_OFFSET);
-    addr_hit[ 2] = (reg_addr == AON_TIMER_WKUP_THOLD_OFFSET);
-    addr_hit[ 3] = (reg_addr == AON_TIMER_WKUP_COUNT_OFFSET);
-    addr_hit[ 4] = (reg_addr == AON_TIMER_WDOG_REGWEN_OFFSET);
-    addr_hit[ 5] = (reg_addr == AON_TIMER_WDOG_CTRL_OFFSET);
-    addr_hit[ 6] = (reg_addr == AON_TIMER_WDOG_BARK_THOLD_OFFSET);
-    addr_hit[ 7] = (reg_addr == AON_TIMER_WDOG_BITE_THOLD_OFFSET);
-    addr_hit[ 8] = (reg_addr == AON_TIMER_WDOG_COUNT_OFFSET);
-    addr_hit[ 9] = (reg_addr == AON_TIMER_INTR_STATE_OFFSET);
-    addr_hit[10] = (reg_addr == AON_TIMER_INTR_TEST_OFFSET);
-    addr_hit[11] = (reg_addr == AON_TIMER_WKUP_CAUSE_OFFSET);
+    addr_hit[ 2] = (reg_addr == AON_TIMER_WKUP_THOLD_HI_OFFSET);
+    addr_hit[ 3] = (reg_addr == AON_TIMER_WKUP_THOLD_LO_OFFSET);
+    addr_hit[ 4] = (reg_addr == AON_TIMER_WKUP_COUNT_HI_OFFSET);
+    addr_hit[ 5] = (reg_addr == AON_TIMER_WKUP_COUNT_LO_OFFSET);
+    addr_hit[ 6] = (reg_addr == AON_TIMER_WDOG_REGWEN_OFFSET);
+    addr_hit[ 7] = (reg_addr == AON_TIMER_WDOG_CTRL_OFFSET);
+    addr_hit[ 8] = (reg_addr == AON_TIMER_WDOG_BARK_THOLD_OFFSET);
+    addr_hit[ 9] = (reg_addr == AON_TIMER_WDOG_BITE_THOLD_OFFSET);
+    addr_hit[10] = (reg_addr == AON_TIMER_WDOG_COUNT_OFFSET);
+    addr_hit[11] = (reg_addr == AON_TIMER_INTR_STATE_OFFSET);
+    addr_hit[12] = (reg_addr == AON_TIMER_INTR_TEST_OFFSET);
+    addr_hit[13] = (reg_addr == AON_TIMER_WKUP_CAUSE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -960,7 +1107,9 @@ module aon_timer_reg_top (
                (addr_hit[ 8] & (|(AON_TIMER_PERMIT[ 8] & ~reg_be))) |
                (addr_hit[ 9] & (|(AON_TIMER_PERMIT[ 9] & ~reg_be))) |
                (addr_hit[10] & (|(AON_TIMER_PERMIT[10] & ~reg_be))) |
-               (addr_hit[11] & (|(AON_TIMER_PERMIT[11] & ~reg_be)))));
+               (addr_hit[11] & (|(AON_TIMER_PERMIT[11] & ~reg_be))) |
+               (addr_hit[12] & (|(AON_TIMER_PERMIT[12] & ~reg_be))) |
+               (addr_hit[13] & (|(AON_TIMER_PERMIT[13] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -970,33 +1119,37 @@ module aon_timer_reg_top (
   assign wkup_ctrl_we = addr_hit[1] & reg_we & !reg_error;
 
 
-  assign wkup_thold_we = addr_hit[2] & reg_we & !reg_error;
+  assign wkup_thold_hi_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign wkup_count_we = addr_hit[3] & reg_we & !reg_error;
+  assign wkup_thold_lo_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign wdog_regwen_we = addr_hit[4] & reg_we & !reg_error;
+  assign wkup_count_hi_we = addr_hit[4] & reg_we & !reg_error;
+
+  assign wkup_count_lo_we = addr_hit[5] & reg_we & !reg_error;
+
+  assign wdog_regwen_we = addr_hit[6] & reg_we & !reg_error;
 
   assign wdog_regwen_wd = reg_wdata[0];
-  assign wdog_ctrl_we = addr_hit[5] & reg_we & !reg_error;
+  assign wdog_ctrl_we = addr_hit[7] & reg_we & !reg_error;
 
 
-  assign wdog_bark_thold_we = addr_hit[6] & reg_we & !reg_error;
+  assign wdog_bark_thold_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign wdog_bite_thold_we = addr_hit[7] & reg_we & !reg_error;
+  assign wdog_bite_thold_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign wdog_count_we = addr_hit[8] & reg_we & !reg_error;
+  assign wdog_count_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign intr_state_we = addr_hit[9] & reg_we & !reg_error;
+  assign intr_state_we = addr_hit[11] & reg_we & !reg_error;
 
   assign intr_state_wkup_timer_expired_wd = reg_wdata[0];
 
   assign intr_state_wdog_timer_bark_wd = reg_wdata[1];
-  assign intr_test_we = addr_hit[10] & reg_we & !reg_error;
+  assign intr_test_we = addr_hit[12] & reg_we & !reg_error;
 
   assign intr_test_wkup_timer_expired_wd = reg_wdata[0];
 
   assign intr_test_wdog_timer_bark_wd = reg_wdata[1];
-  assign wkup_cause_we = addr_hit[11] & reg_we & !reg_error;
+  assign wkup_cause_we = addr_hit[13] & reg_we & !reg_error;
 
 
   // Assign write-enables to checker logic vector.
@@ -1004,16 +1157,18 @@ module aon_timer_reg_top (
     reg_we_check = '0;
     reg_we_check[0] = alert_test_we;
     reg_we_check[1] = wkup_ctrl_we;
-    reg_we_check[2] = wkup_thold_we;
-    reg_we_check[3] = wkup_count_we;
-    reg_we_check[4] = wdog_regwen_we;
-    reg_we_check[5] = wdog_ctrl_we;
-    reg_we_check[6] = wdog_bark_thold_we;
-    reg_we_check[7] = wdog_bite_thold_we;
-    reg_we_check[8] = wdog_count_we;
-    reg_we_check[9] = intr_state_we;
-    reg_we_check[10] = intr_test_we;
-    reg_we_check[11] = wkup_cause_we;
+    reg_we_check[2] = wkup_thold_hi_we;
+    reg_we_check[3] = wkup_thold_lo_we;
+    reg_we_check[4] = wkup_count_hi_we;
+    reg_we_check[5] = wkup_count_lo_we;
+    reg_we_check[6] = wdog_regwen_we;
+    reg_we_check[7] = wdog_ctrl_we;
+    reg_we_check[8] = wdog_bark_thold_we;
+    reg_we_check[9] = wdog_bite_thold_we;
+    reg_we_check[10] = wdog_count_we;
+    reg_we_check[11] = intr_state_we;
+    reg_we_check[12] = intr_test_we;
+    reg_we_check[13] = wkup_cause_we;
   end
 
   // Read data return
@@ -1028,38 +1183,44 @@ module aon_timer_reg_top (
         reg_rdata_next = DW'(wkup_ctrl_qs);
       end
       addr_hit[2]: begin
-        reg_rdata_next = DW'(wkup_thold_qs);
+        reg_rdata_next = DW'(wkup_thold_hi_qs);
       end
       addr_hit[3]: begin
-        reg_rdata_next = DW'(wkup_count_qs);
+        reg_rdata_next = DW'(wkup_thold_lo_qs);
       end
       addr_hit[4]: begin
+        reg_rdata_next = DW'(wkup_count_hi_qs);
+      end
+      addr_hit[5]: begin
+        reg_rdata_next = DW'(wkup_count_lo_qs);
+      end
+      addr_hit[6]: begin
         reg_rdata_next[0] = wdog_regwen_qs;
       end
 
-      addr_hit[5]: begin
+      addr_hit[7]: begin
         reg_rdata_next = DW'(wdog_ctrl_qs);
       end
-      addr_hit[6]: begin
+      addr_hit[8]: begin
         reg_rdata_next = DW'(wdog_bark_thold_qs);
       end
-      addr_hit[7]: begin
+      addr_hit[9]: begin
         reg_rdata_next = DW'(wdog_bite_thold_qs);
       end
-      addr_hit[8]: begin
+      addr_hit[10]: begin
         reg_rdata_next = DW'(wdog_count_qs);
       end
-      addr_hit[9]: begin
+      addr_hit[11]: begin
         reg_rdata_next[0] = intr_state_wkup_timer_expired_qs;
         reg_rdata_next[1] = intr_state_wdog_timer_bark_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
       end
 
-      addr_hit[11]: begin
+      addr_hit[13]: begin
         reg_rdata_next = DW'(wkup_cause_qs);
       end
       default: begin
@@ -1082,24 +1243,30 @@ module aon_timer_reg_top (
         reg_busy_sel = wkup_ctrl_busy;
       end
       addr_hit[2]: begin
-        reg_busy_sel = wkup_thold_busy;
+        reg_busy_sel = wkup_thold_hi_busy;
       end
       addr_hit[3]: begin
-        reg_busy_sel = wkup_count_busy;
+        reg_busy_sel = wkup_thold_lo_busy;
+      end
+      addr_hit[4]: begin
+        reg_busy_sel = wkup_count_hi_busy;
       end
       addr_hit[5]: begin
-        reg_busy_sel = wdog_ctrl_busy;
-      end
-      addr_hit[6]: begin
-        reg_busy_sel = wdog_bark_thold_busy;
+        reg_busy_sel = wkup_count_lo_busy;
       end
       addr_hit[7]: begin
-        reg_busy_sel = wdog_bite_thold_busy;
+        reg_busy_sel = wdog_ctrl_busy;
       end
       addr_hit[8]: begin
+        reg_busy_sel = wdog_bark_thold_busy;
+      end
+      addr_hit[9]: begin
+        reg_busy_sel = wdog_bite_thold_busy;
+      end
+      addr_hit[10]: begin
         reg_busy_sel = wdog_count_busy;
       end
-      addr_hit[11]: begin
+      addr_hit[13]: begin
         reg_busy_sel = wkup_cause_busy;
       end
       default: begin

--- a/sw/device/lib/dif/dif_aon_timer.h
+++ b/sw/device/lib/dif/dif_aon_timer.h
@@ -39,7 +39,7 @@ extern "C" {
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_aon_timer_wakeup_start(const dif_aon_timer_t *aon,
-                                        uint32_t threshold, uint32_t prescaler);
+                                        uint64_t threshold, uint32_t prescaler);
 
 /** Stops Always-On Timer (wake-up timer).
  *
@@ -101,7 +101,7 @@ dif_result_t dif_aon_timer_clear_wakeup_cause(const dif_aon_timer_t *aon);
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_aon_timer_wakeup_get_count(const dif_aon_timer_t *aon,
-                                            uint32_t *count);
+                                            uint64_t *count);
 
 /** Starts Always-On Timer (watchdog timer).
  *

--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -17,14 +17,21 @@
 
 #define MODULE_ID MAKE_MODULE_ID('a', 'o', 't')
 
-status_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds,
-                                                    uint32_t *cycles) {
+status_t aon_timer_testutils_get_aon_cycles_32_from_us(uint64_t microseconds,
+                                                       uint32_t *cycles) {
   uint64_t cycles_ = udiv64_slow(microseconds * kClockFreqAonHz, 1000000,
                                  /*rem_out=*/NULL);
   TRY_CHECK(cycles_ <= UINT32_MAX,
             "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
             (cycles_ >> 32), (uint32_t)cycles_);
   *cycles = (uint32_t)cycles_;
+  return OK_STATUS();
+}
+
+status_t aon_timer_testutils_get_aon_cycles_64_from_us(uint64_t microseconds,
+                                                       uint64_t *cycles) {
+  *cycles = udiv64_slow(microseconds * kClockFreqAonHz, 1000000,
+                        /*rem_out=*/NULL);
   return OK_STATUS();
 }
 
@@ -40,7 +47,7 @@ status_t aon_timer_testutils_get_us_from_aon_cycles(uint64_t cycles,
 }
 
 status_t aon_timer_testutils_wakeup_config(const dif_aon_timer_t *aon_timer,
-                                           uint32_t cycles) {
+                                           uint64_t cycles) {
   // Make sure that wake-up timer is stopped.
   TRY(dif_aon_timer_wakeup_stop(aon_timer));
 

--- a/sw/device/lib/testing/aon_timer_testutils.h
+++ b/sw/device/lib/testing/aon_timer_testutils.h
@@ -15,12 +15,24 @@
  *
  * @param aon_timer An Always-On Timer handle.
  * @param microseconds The number of microseconds.
- * @param[out] cycles The number of AON clock cycles.
+ * @param[out] cycles The number of AON clock cycles as a uint32_t
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds,
-                                                    uint32_t *cycles);
+status_t aon_timer_testutils_get_aon_cycles_32_from_us(uint64_t microseconds,
+                                                       uint32_t *cycles);
+
+/**
+ * Compute the number of AON cycles corresponding to the given microseconds.
+ *
+ * @param aon_timer An Always-On Timer handle.
+ * @param microseconds The number of microseconds.
+ * @param[out] cycles The number of AON clock cycles as a uint64_t
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t aon_timer_testutils_get_aon_cycles_64_from_us(uint64_t microseconds,
+                                                       uint64_t *cycles);
 
 /**
  * Compute the number of microseconds corresponding to the given AON cycles.
@@ -43,7 +55,7 @@ status_t aon_timer_testutils_get_us_from_aon_cycles(uint64_t cycles,
  */
 OT_WARN_UNUSED_RESULT
 status_t aon_timer_testutils_wakeup_config(const dif_aon_timer_t *aon_timer,
-                                           uint32_t cycles);
+                                           uint64_t cycles);
 
 /**
  * Configure watchdog counter in number of AON clock cycles.

--- a/sw/device/silicon_creator/rom/e2e/retention_ram/rom_e2e_ret_ram_keep_test.c
+++ b/sw/device/silicon_creator/rom/e2e/retention_ram/rom_e2e_ret_ram_keep_test.c
@@ -94,7 +94,7 @@ rom_error_t retention_ram_keep_test(void) {
     //
     // Adjust the threshold for Verilator since it runs on different clock
     // frequencies.
-    uint32_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 300 : 30;
+    uint64_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 300 : 30;
 
     dif_aon_timer_t aon_timer;
     CHECK_DIF_OK(dif_aon_timer_init(

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -348,7 +348,7 @@ static void execute_test_phases(uint8_t test_phase, uint32_t ping_timeout_cyc) {
 
     // Set the AON timer to send a wakeup signal in ~10-20us.
     CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(
-        &aon_timer, rand_testutils_gen32_range(2, 4)));
+        &aon_timer, (uint32_t)rand_testutils_gen32_range(2, 4)));
     // Enter normal sleep mode.
     enter_low_power(/*deep_sleep=*/false);
   } else { /*wakeup reset*/
@@ -432,7 +432,7 @@ static void execute_test_phases(uint8_t test_phase, uint32_t ping_timeout_cyc) {
 
     // Set the AON timer to send a wakeup signal in ~100-150us.
     CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(
-        &aon_timer, rand_testutils_gen32_range(20, 30)));
+        &aon_timer, (uint32_t)rand_testutils_gen32_range(20, 30)));
 
     // Enter the normal sleep or deep sleep mode
     // Deep sleep mode is time consuming in DV, and normal sleep mode is more

--- a/sw/device/tests/alert_handler_reverse_ping_in_deep_sleep_test.c
+++ b/sw/device/tests/alert_handler_reverse_ping_in_deep_sleep_test.c
@@ -227,13 +227,13 @@ bool test_main(void) {
     irq_global_ctrl(true);
     irq_external_ctrl(true);
 
-    uint32_t wakeup_threshold = 0;
-    CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(
+    uint64_t wakeup_threshold = 0;
+    CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_64_from_us(
         kTestParamWakeupThresholdUsec, &wakeup_threshold));
 
     // Sleep longer in FPGA and silicon targets.
     if (kDeviceType != kDeviceSimDV && kDeviceType != kDeviceSimVerilator) {
-      uint32_t wakeup_threshold_new = wakeup_threshold * 50;
+      uint64_t wakeup_threshold_new = wakeup_threshold * 50;
       CHECK(wakeup_threshold_new > wakeup_threshold,
             "Detected wakeup_threshold overflow.");
       wakeup_threshold = wakeup_threshold_new;

--- a/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
+++ b/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
@@ -49,15 +49,15 @@ bool test_main(void) {
   dif_rstmgr_reset_info_bitfield_t rst_info = rstmgr_testutils_reason_get();
   rstmgr_testutils_reason_clear();
 
-  uint32_t wkup_cnt;
+  uint64_t wkup_cnt;
   uint32_t wdog_cnt;
   if (rst_info == kDifRstmgrResetInfoPor) {
     LOG_INFO("Booting for the first time, setting wdog");
 
     // Configure watchdog sooner then wakeup, but with pause enabled.
-    uint32_t wkup_cycles = 0;
-    CHECK_STATUS_OK(
-        aon_timer_testutils_get_aon_cycles_from_us(WKUP_TIME_US, &wkup_cycles));
+    uint64_t wkup_cycles = 0;
+    CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_64_from_us(
+        WKUP_TIME_US, &wkup_cycles));
 
     // The actual expiration of the watchdog is unimportant, as the test
     // mainly checks the count.

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -29,11 +29,11 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
                         const dif_pwrmgr_t *pwrmgr, uint64_t bark_time_us,
                         uint64_t bite_time_us) {
   uint32_t bark_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bark_time_us, &bark_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(bark_time_us,
+                                                                &bark_cycles));
   uint32_t bite_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bite_time_us, &bite_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(bite_time_us,
+                                                                &bite_cycles));
 
   LOG_INFO("Wdog will bark after %u us and bite after %u us",
            (uint32_t)bark_time_us, (uint32_t)bite_time_us);
@@ -44,8 +44,8 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
                                               kDifToggleEnabled));
 
   // Setup the wdog bark and bite timeouts.
-  CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(aon_timer, bark_cycles,
-                                                      bite_cycles, false));
+  CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(
+      aon_timer, (uint32_t)bark_cycles, (uint32_t)bite_cycles, false));
 }
 
 /**

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -204,11 +204,11 @@ static void alert_handler_config(void) {
  */
 static void execute_test(dif_aon_timer_t *aon_timer) {
   uint32_t bark_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBarkMicros,
-                                                             &bark_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBarkMicros,
+                                                                &bark_cycles));
   uint32_t bite_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBiteMicros,
-                                                             &bite_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBiteMicros,
+                                                                &bite_cycles));
 
   LOG_INFO(
       "Wdog will bark after %u/%u us/cycles and bite after %u/%u us/cycles",

--- a/sw/device/tests/ast_clk_outs_test.c
+++ b/sw/device/tests/ast_clk_outs_test.c
@@ -84,7 +84,7 @@ bool test_main(void) {
     // recoverable errors are not cleared.
     //
     // Set the counters so we should get an error unless they are cleared.
-    uint32_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 1000 : 100;
+    uint64_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 1000 : 100;
     CHECK_STATUS_OK(
         aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold));
 

--- a/sw/device/tests/chip_power_idle_load.c
+++ b/sw/device/tests/chip_power_idle_load.c
@@ -290,8 +290,8 @@ bool test_main(void) {
   CHECK_DIF_OK(
       dif_rv_core_ibex_enable_nmi(&rv_core_ibex, kDifRvCoreIbexNmiSourceWdog));
   uint32_t count_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(kTimeTillBark, &count_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kTimeTillBark,
+                                                                &count_cycles));
   CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(&aon_timer, count_cycles,
                                                       UINT32_MAX, false));
 

--- a/sw/device/tests/chip_power_sleep_load.c
+++ b/sw/device/tests/chip_power_sleep_load.c
@@ -358,8 +358,8 @@ bool test_main(void) {
   CHECK_DIF_OK(
       dif_rv_core_ibex_enable_nmi(&rv_core_ibex, kDifRvCoreIbexNmiSourceWdog));
   uint32_t count_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(kTimeTillBark, &count_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kTimeTillBark,
+                                                                &count_cycles));
 
   if (kDeepSleep) {
     // activate in Wakeup mode (no need for IRQ)
@@ -382,10 +382,10 @@ bool test_main(void) {
   const uint64_t kPowerUpTime = 30;
   const uint64_t kWakeUpTime = 500;
   uint32_t power_up_time_aon_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(
       kPowerUpTime, &power_up_time_aon_cycles));
   uint32_t wake_up_time_aon_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(
       kWakeUpTime, &wake_up_time_aon_cycles));
 
   // ADC configuration

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -118,7 +118,7 @@ static void test_gateable_clocks_off(const dif_clkmgr_t *clkmgr,
   uint32_t bite_us = (kDeviceType == kDeviceSimDV) ? 400 : 800;
   uint32_t bite_cycles = 0;
   CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bite_us, &bite_cycles));
+      aon_timer_testutils_get_aon_cycles_32_from_us(bite_us, &bite_cycles));
   LOG_INFO("Setting bite reset for %u us (%u cycles)", bite_us, bite_cycles);
 
   // Make sure the CSR is accessible before turning the clock off.

--- a/sw/device/tests/clkmgr_off_trans_impl.c
+++ b/sw/device/tests/clkmgr_off_trans_impl.c
@@ -99,7 +99,7 @@ static void test_hintable_clocks_off(const dif_clkmgr_t *clkmgr,
   // CSR read.
   uint32_t bite_cycles = 0;
   CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bite_us, &bite_cycles));
+      aon_timer_testutils_get_aon_cycles_32_from_us(bite_us, &bite_cycles));
   LOG_INFO("Setting bite reset for %u us (%u cycles)", bite_us, bite_cycles);
 
   CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(&aon_timer, UINT32_MAX,

--- a/sw/device/tests/clkmgr_sleep_frequency_test.c
+++ b/sw/device/tests/clkmgr_sleep_frequency_test.c
@@ -119,7 +119,7 @@ bool test_main(void) {
   // entering sleep to have a chance to measure before sleeping. With normal
   // sleep all measurements should remain enabled, and there should be no
   // errors for clocks that were selectively turned off.
-  uint32_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 1000 : 100;
+  uint64_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 1000 : 100;
   CHECK_STATUS_OK(
       aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold));
 

--- a/sw/device/tests/pwrmgr_sleep_disabled_test.c
+++ b/sw/device/tests/pwrmgr_sleep_disabled_test.c
@@ -72,10 +72,10 @@ bool test_main(void) {
   //
   // Adjust the cycles for Verilator since it runs on different clock
   // frequencies.
-  uint32_t wakeup_cycles = 0;
+  uint64_t wakeup_cycles = 0;
   uint32_t wakeup_time_micros = 200;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(wakeup_time_micros,
-                                                             &wakeup_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_64_from_us(
+      wakeup_time_micros, &wakeup_cycles));
   if (kDeviceType == kDeviceSimVerilator) {
     wakeup_cycles *= 10;
   }

--- a/sw/device/tests/pwrmgr_sleep_resets_lib.c
+++ b/sw/device/tests/pwrmgr_sleep_resets_lib.c
@@ -200,10 +200,10 @@ void config_sysrst(dif_pinmux_index_t pad_pin) {
 void config_wdog(uint64_t bark_micros, uint64_t bite_micros) {
   uint32_t bark_cycles = 0;
   CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bark_micros, &bark_cycles));
+      aon_timer_testutils_get_aon_cycles_32_from_us(bark_micros, &bark_cycles));
   uint32_t bite_cycles = 0;
   CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bite_micros, &bite_cycles));
+      aon_timer_testutils_get_aon_cycles_32_from_us(bite_micros, &bite_cycles));
 
   LOG_INFO("Wdog will bark after %u microseconds (%u aon cycles)",
            (uint32_t)bark_micros, bark_cycles);

--- a/sw/device/tests/pwrmgr_smoketest.c
+++ b/sw/device/tests/pwrmgr_smoketest.c
@@ -27,7 +27,7 @@ bool test_main(void) {
   //
   // Adjust the threshold for Verilator since it runs on different clock
   // frequencies.
-  uint32_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 300 : 30;
+  uint64_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 300 : 30;
 
   // Initialize pwrmgr
   dif_pwrmgr_t pwrmgr;

--- a/sw/device/tests/pwrmgr_usb_clk_disabled_when_active_test.c
+++ b/sw/device/tests/pwrmgr_usb_clk_disabled_when_active_test.c
@@ -64,7 +64,7 @@ bool test_main(void) {
     uint32_t bite_us = (kDeviceType == kDeviceSimDV) ? 400 : 800;
     uint32_t bite_cycles = 0;
     CHECK_STATUS_OK(
-        aon_timer_testutils_get_aon_cycles_from_us(bite_us, &bite_cycles));
+        aon_timer_testutils_get_aon_cycles_32_from_us(bite_us, &bite_cycles));
     LOG_INFO("Setting bite reset for %u us (%u cycles)", bite_us, bite_cycles);
 
     // Set bite timer.

--- a/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
+++ b/sw/device/tests/pwrmgr_wdog_reset_reqs_test.c
@@ -29,11 +29,11 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
                         const dif_pwrmgr_t *pwrmgr, uint64_t bark_time_us,
                         uint64_t bite_time_us) {
   uint32_t bark_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bark_time_us, &bark_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(bark_time_us,
+                                                                &bark_cycles));
   uint32_t bite_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bite_time_us, &bite_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(bite_time_us,
+                                                                &bite_cycles));
 
   LOG_INFO("Wdog will bark after %u us and bite after %u us",
            (uint32_t)bark_time_us, (uint32_t)bite_time_us);

--- a/sw/device/tests/rstmgr_cpu_info_test.c
+++ b/sw/device/tests/rstmgr_cpu_info_test.c
@@ -233,10 +233,10 @@ bool test_main(void) {
       // exception to avoid the NMI messing with the fault dump.
       uint32_t bark_cycles = 0;
       CHECK_STATUS_OK(
-          aon_timer_testutils_get_aon_cycles_from_us(1, &bark_cycles));
+          aon_timer_testutils_get_aon_cycles_32_from_us(1, &bark_cycles));
       uint32_t bite_cycles = 0;
       CHECK_STATUS_OK(
-          aon_timer_testutils_get_aon_cycles_from_us(100, &bite_cycles));
+          aon_timer_testutils_get_aon_cycles_32_from_us(100, &bite_cycles));
 
       // Set wdog as a reset source.
       CHECK_DIF_OK(dif_pwrmgr_set_request_sources(

--- a/sw/device/tests/rv_core_ibex_nmi_irq_test.c
+++ b/sw/device/tests/rv_core_ibex_nmi_irq_test.c
@@ -159,8 +159,8 @@ static void wdog_nmi_test(void) {
 
   // Setup the wdog bark interrupt.
   uint32_t count_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBarkMicros,
-                                                             &count_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBarkMicros,
+                                                                &count_cycles));
   CHECK_STATUS_OK(
       aon_timer_testutils_watchdog_config(&aon_timer,
                                           /*bark_cycles=*/count_cycles,

--- a/sw/device/tests/sim_dv/alert_handler_lpg_sleep_mode_alerts.c
+++ b/sw/device/tests/sim_dv/alert_handler_lpg_sleep_mode_alerts.c
@@ -321,7 +321,7 @@ static void execute_test_phases(uint8_t test_phase, uint32_t ping_timeout_cyc) {
 
     // Set the AON timer to send a wakeup signal in ~10-50us.
     CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(
-        &aon_timer, rand_testutils_gen32_range(2, 10)));
+        &aon_timer, (uint32_t)rand_testutils_gen32_range(2, 10)));
 
     // Trigger the SV side to inject fault.
     // DO NOT CHANGE THIS: it is used to notify the SV side.
@@ -375,7 +375,7 @@ static void execute_test_phases(uint8_t test_phase, uint32_t ping_timeout_cyc) {
 
     // Set the AON timer to send a wakeup signal in ~10-50us.
     CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(
-        &aon_timer, rand_testutils_gen32_range(2, 10)));
+        &aon_timer, (uint32_t)rand_testutils_gen32_range(2, 10)));
     // Enter the normal sleep mode
     enter_low_power(/*deep_sleep=*/false);
   } else {

--- a/sw/device/tests/sim_dv/all_escalation_resets_test.c
+++ b/sw/device/tests/sim_dv/all_escalation_resets_test.c
@@ -736,11 +736,11 @@ static void alert_handler_config(void) {
 
 static void set_aon_timers(const dif_aon_timer_t *aon_timer) {
   uint32_t bark_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBarkMicros,
-                                                             &bark_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBarkMicros,
+                                                                &bark_cycles));
   uint32_t bite_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBiteMicros,
-                                                             &bite_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBiteMicros,
+                                                                &bite_cycles));
 
   LOG_INFO(
       "Wdog will bark after %u us (%u cycles) and bite after %u us (%u cycles)",

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -199,9 +199,9 @@ static void configure_adc_ctrl(const dif_adc_ctrl_t *adc_ctrl) {
   uint32_t wake_up_time_aon_cycles = 0;
   uint32_t power_up_time_aon_cycles = 0;
 
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(
       kPowerUpTimeInUs, &power_up_time_aon_cycles));
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(
       kWakeUpTimeInUs, &wake_up_time_aon_cycles));
   CHECK_DIF_OK(dif_adc_ctrl_set_enabled(adc_ctrl, kDifToggleDisabled));
   CHECK_DIF_OK(dif_adc_ctrl_reset(adc_ctrl));

--- a/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
@@ -450,11 +450,11 @@ static void alert_handler_config(void) {
 
 static void set_aon_timers(void) {
   uint32_t bark_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBarkMicros,
-                                                             &bark_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBarkMicros,
+                                                                &bark_cycles));
   uint32_t bite_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBiteMicros,
-                                                             &bite_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBiteMicros,
+                                                                &bite_cycles));
 
   LOG_INFO(
       "Wdog will bark after %u us (%u cycles) and bite after %u us (%u cycles)",

--- a/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_b2b_sleep_reset_test.c
@@ -65,7 +65,7 @@ bool test_main(void) {
   // bring state machine back to active state.
   // This can happen when wake up event comes before low power
   // entry event.
-  uint32_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 3000 : 300;
+  uint64_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 3000 : 300;
 
   // Initialize pwrmgr
   dif_pwrmgr_t pwrmgr;

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
@@ -227,12 +227,12 @@ static void alert_handler_config(void) {
 static void config_escalate(dif_aon_timer_t *aon_timer,
                             const dif_pwrmgr_t *pwrmgr) {
   uint32_t bark_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBarkMicros,
-                                                             &bark_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBarkMicros,
+                                                                &bark_cycles));
   bark_cycles *= alert_handler_testutils_cycle_rescaling_factor();
   uint32_t bite_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_from_us(kWdogBiteMicros,
-                                                             &bite_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(kWdogBiteMicros,
+                                                                &bite_cycles));
   bite_cycles *= alert_handler_testutils_cycle_rescaling_factor();
 
   LOG_INFO(
@@ -283,11 +283,11 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
                         const dif_pwrmgr_t *pwrmgr, uint64_t bark_time_us,
                         uint64_t bite_time_us) {
   uint32_t bark_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bark_time_us, &bark_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(bark_time_us,
+                                                                &bark_cycles));
   uint32_t bite_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bite_time_us, &bite_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(bite_time_us,
+                                                                &bite_cycles));
 
   LOG_INFO("Wdog will bark after %u us and bite after %u us",
            (uint32_t)bark_time_us, (uint32_t)bite_time_us);

--- a/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test.c
@@ -85,11 +85,11 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
                         const dif_pwrmgr_t *pwrmgr, uint64_t bark_time_us,
                         uint64_t bite_time_us) {
   uint32_t bark_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bark_time_us, &bark_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(bark_time_us,
+                                                                &bark_cycles));
   uint32_t bite_cycles = 0;
-  CHECK_STATUS_OK(
-      aon_timer_testutils_get_aon_cycles_from_us(bite_time_us, &bite_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(bite_time_us,
+                                                                &bite_cycles));
 
   LOG_INFO("Wdog will bark after %u us and bite after %u us",
            (uint32_t)bark_time_us, (uint32_t)bite_time_us);

--- a/sw/device/tests/sleep_pwm_pulses_test.c
+++ b/sw/device/tests/sleep_pwm_pulses_test.c
@@ -114,7 +114,7 @@ bool test_main(void) {
   //
   // Adjust the threshold for Verilator since it runs on different clock
   // frequencies.
-  uint32_t wakeup_threshold = 30;
+  uint64_t wakeup_threshold = 30;
   if (kDeviceType == kDeviceSimVerilator) {
     wakeup_threshold = 300;
   }

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
@@ -155,9 +155,10 @@ void set_up_reset_request(void) {
 
   CHECK_DIF_OK(dif_aon_timer_wakeup_stop(&aon_timer));
 
-  // Enter low power mode.
-  CHECK_STATUS_OK(
-      aon_timer_testutils_watchdog_config(&aon_timer, UINT32_MAX, 20, false));
+  // Enter low power mode. Use UINT32_MAX as wakeup threshold as UINT64_MAX far
+  // too long a timeout.
+  CHECK_STATUS_OK(aon_timer_testutils_watchdog_config(
+      &aon_timer, (uint64_t)UINT32_MAX, 20, false));
   LOG_INFO("wait for reset");
   wait_for_interrupt();
   CHECK(false, "Should have a reset to CPU and ret_sram before this line");

--- a/sw/host/opentitanlib/src/dif/aon_timer.rs
+++ b/sw/host/opentitanlib/src/dif/aon_timer.rs
@@ -7,8 +7,10 @@
 pub enum AonTimerReg {
     AlertTest = bindgen::dif::AON_TIMER_ALERT_TEST_REG_OFFSET,
     WkupCtrl = bindgen::dif::AON_TIMER_WKUP_CTRL_REG_OFFSET,
-    WkupThold = bindgen::dif::AON_TIMER_WKUP_THOLD_REG_OFFSET,
-    WkupCount = bindgen::dif::AON_TIMER_WKUP_COUNT_REG_OFFSET,
+    WkupTholdLo = bindgen::dif::AON_TIMER_WKUP_THOLD_LO_REG_OFFSET,
+    WkupTholdHi = bindgen::dif::AON_TIMER_WKUP_THOLD_HI_REG_OFFSET,
+    WkupCountLo = bindgen::dif::AON_TIMER_WKUP_COUNT_LO_REG_OFFSET,
+    WkupCountHi = bindgen::dif::AON_TIMER_WKUP_COUNT_HI_REG_OFFSET,
     WdogRegwen = bindgen::dif::AON_TIMER_WDOG_REGWEN_REG_OFFSET,
     WdogCtrl = bindgen::dif::AON_TIMER_WDOG_CTRL_REG_OFFSET,
     WdogBarkThold = bindgen::dif::AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET,


### PR DESCRIPTION
This expands the wakeup timer of aon_timer to 64-bits as discussed in https://github.com/lowRISC/opentitan/issues/21357

This introduces a new complexity for software as we have two 64-bit values (wakeup count  and threshold) accessed via two 32-bit registers. This means you cannot do an atomic read or write of either of the 64-bit values.

I've added some details to the docs as to how software should approach this (as well as updating the dif to work appropriately), this needs particular scrutiny.