### PR TITLE
[sival,testplans] Set si_stage to NA for non-sival tests

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -104,9 +104,10 @@
             - Verify after the escalation reset all faults are cleared, and that the alert
               info captured the correct alert.
             - Check that no additional resets occur.
+            SiVal: It is not possible to trigger internal integrity errors.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_all_escalation_resets"]
     }
     {
@@ -131,9 +132,12 @@
             - Verify that the alert_handler can request EDN to provide entropy.
             - Ensure that the alert ping handshake to all alert sources and escalation receivers
               complete without errors.
+            SiVal: This test is not necessary:
+            - We cannot explicitly detect an EDN request.
+            - There are plenty of tests checking ping behavior.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_alert_handler_entropy"]
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -156,7 +156,7 @@
             SiVal: This is implicitly tested by the success of OTP updates for calibration.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_clkmgr_external_clk_src_for_lc"]
       bazel: []
     }
@@ -176,7 +176,7 @@
             with the right frequency after calibration. There are a few such tests already.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       lc_states: [
         "DEV",
       ]
@@ -198,10 +198,10 @@
             clk_src_sys_jen_i input using formal.
 
             X-ref with various specific jitter enable tests.
-            SiVal: This is a connecivity test ony, not suitable for sival.
+            SiVal: This is a connectivity test only, not suitable for sival.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: [
         "chip_sw_clkmgr_jitter",
         "chip_sw_flash_ctrl_ops_jitter_en",
@@ -268,7 +268,7 @@
             No specific work may be needed other than configuring external clocks.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: [
         "chip_sw_clkmgr_jitter_reduced_freq",
         "chip_sw_flash_ctrl_ops_jitter_en_reduced_freq",
@@ -373,7 +373,7 @@
             add extra checks for specific units having been reset.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_all_escalation_resets"]
       bazel: []
     }

--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -103,10 +103,11 @@
               for kTopEarlgreyAlertIdLcCtrlFatalProgError.
             - Verify that, after escalation reset, the alert handler cause and the fault register are cleared.
             - Verify after the escalation reset that the alert info captured the correct alert.
+            SiVal: Forcing this illegal condition is not feasible in sival.
             '''
       features: ["OTP_CTRL.ERROR_HANDLING.FATAL"]
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_lc_ctrl_program_error"]
     }
     {
@@ -209,10 +210,11 @@
               the alert interface to make sure alert and escalation is triggered.
 
             X'ref with chip_sw_all_escalation_resets.
+            SiVal: It is not feasible to inject ECC fatal errors in OTP macro.
             '''
       features: ["OTP_CTRL.ERROR_HANDLING.FATAL"]
       stage: V3
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_otp_ctrl_escalation"]
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -16,7 +16,7 @@
             when they start.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       lc_states: [
         "RAW",
         "TEST_LOCKED",
@@ -85,7 +85,7 @@
             SiVal: No need to run this, run chip_sw_pwrmgr_random_sleep_all_wake_ups instead.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_pwrmgr_normal_sleep_all_wake_ups"]
       bazel: []
     }
@@ -198,7 +198,7 @@
             SiVal: This test can only run in sim_dv.
             '''
       stage: V3
-      si_stage: None
+      si_stage: NA
       features: [
         "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE",
         "PWRMGR.LOW_POWER.SENSOR_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST",
@@ -220,7 +220,7 @@
             SiVal: No need to run this, run chip_sw_pwrmgr_random_sleep_all_reset_reqs instead.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       features: [
         "PWRMGR.LOW_POWER.ENTRY",
         "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
@@ -270,7 +270,7 @@
             SiVal: AON power glitch cannot be triggered at will.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_pwrmgr_full_aon_reset"]
       bazel: []
     }
@@ -284,7 +284,7 @@
             SiVal: Main power glitch cannot be triggered at will.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_pwrmgr_main_power_glitch_reset"]
       bazel: []
     }
@@ -307,7 +307,7 @@
             SiVal: Main power glitch cannot be triggered at will.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_pwrmgr_random_sleep_power_glitch_reset"]
       bazel: []
     }
@@ -327,7 +327,7 @@
             SiVal: Main power glitch cannot be triggered at will.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_pwrmgr_deep_sleep_power_glitch_reset"]
       bazel: []
     }
@@ -342,7 +342,7 @@
             SiVal: Main power glitch cannot be triggered at will.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_pwrmgr_sleep_power_glitch_reset"]
       bazel: []
     }
@@ -396,7 +396,7 @@
             The chip_sw_all_resets is a superset of this testpoint.
             '''
       stage: V2
-      si_stage: None
+      si_stage: SV3
       tests: [
         "chip_sw_pwrmgr_sysrst_ctrl_reset",
         "chip_sw_pwrmgr_all_reset_reqs",
@@ -409,7 +409,7 @@
             time, one after the other. Use POR_N PAD to trigger reset.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_pwrmgr_b2b_sleep_reset_req"]
       bazel: []
     }
@@ -495,7 +495,7 @@
             alert_handler to immediately trip escalation reset.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       lc_states: [
         "TEST_UNLOCKED1",
         "DEV",

--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -39,7 +39,7 @@
             '''
       features: ["ROM_CTRL.DIGESTS", "ROM_CTRL.EXP_DIGESTS"]
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {
@@ -54,9 +54,10 @@
             - Verify that KMAC returns an error signal to the ROM controller.
             - Verify that the ROM controller itself transitions to invalid state and the chip is
               effectively dead.
+            SiVal: Creating a glitch is not feasible, so this is not a sival test.
             '''
       stage: V3
-      si_stage: None
+      si_stage: NA
       tests: []
     }
     {


### PR DESCRIPTION
Add suitable comments explaining the reason some tests are not feasible or needed for sival.