### PR TITLE
[sw/tests] Mark more tests as broken in SiVal ROM_EXT

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2542,10 +2542,12 @@ cc_library(
 opentitan_test(
     name = "pwrmgr_all_reset_reqs_test",
     srcs = ["pwrmgr_all_reset_reqs_test.c"],
+    broken = new_cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "test_harness",
+            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
             "//hw/top_earlgrey:fpga_cw310_sival": "test_harness",
             "//hw/top_earlgrey:fpga_cw310_test_rom": "test_harness",
             "//hw/top_earlgrey:silicon_creator": None,
@@ -2580,11 +2582,13 @@ opentitan_test(
 opentitan_test(
     name = "pwrmgr_random_sleep_all_reset_reqs_test",
     srcs = ["pwrmgr_random_sleep_all_reset_reqs_test.c"],
+    broken = new_cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": "test_harness",
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "test_harness",
+            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
             "//hw/top_earlgrey:fpga_cw310_test_rom": "test_harness",
             "//hw/top_earlgrey:silicon_creator": None,
             "//hw/top_earlgrey:sim_dv": None,


### PR DESCRIPTION
The following tests also seem to be part of issue https://github.com/lowRISC/opentitan/issues/21706:
- //sw/device/tests:pwrmgr_all_reset_reqs_test
- //sw/device/tests:pwrmgr_random_sleep_all_reset_reqs_test

Thus this commit marks them as broken in SiVal ROM_EXT.

This should contribute to fixing the currently failing CI checks on
`master`.

Examples of this test failing in CI:
- https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=143751&view=logs&jobId=6d7ef521-d3a1-575b-de1b-a7342dcf1a8e&j=6d7ef521-d3a1-575b-de1b-a7342dcf1a8e&t=5fbf7d75-9dee-5f42-7084-95893df8eb52
- https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=143812&view=logs&jobId=6d7ef521-d3a1-575b-de1b-a7342dcf1a8e&j=6d7ef521-d3a1-575b-de1b-a7342dcf1a8e&t=5fbf7d75-9dee-5f42-7084-95893df8eb52

## TODO (post merge, if this gets merged)
- [ ] Add tests to the list in #21706.