### PR TITLE
I2C NACK when full

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -213,6 +213,14 @@
           tags: [// Exclude from write-checks: writing 1'b1 to this bit causes interrupts unexpectedly asserted
                 "excl:CsrAllTests:CsrExclWrite"]
         }
+        { bits: "3"
+          resval: "0"
+          name: "NACKWHENFULL"
+          desc: '''
+                Instead of stretching the clock when the ACQ FIFO is full send a NACK instead.
+                This happens both after having received an address as well as a byte.
+                '''
+        }
       ]
     }
     { name:     "STATUS"

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -145,20 +145,21 @@ Alert Test Register
 I2C Control Register
 - Offset: `0x10`
 - Reset default: `0x0`
-- Reset mask: `0x7`
+- Reset mask: `0xf`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "ENABLEHOST", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ENABLETARGET", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "LLPBK", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 29}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
+{"reg": [{"name": "ENABLEHOST", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ENABLETARGET", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "LLPBK", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "NACKWHENFULL", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name         | Description                                                                                                |
-|:------:|:------:|:-------:|:-------------|:-----------------------------------------------------------------------------------------------------------|
-|  31:3  |        |         |              | Reserved                                                                                                   |
-|   2    |   rw   |   0x0   | LLPBK        | Enable I2C line loopback test If line loopback is enabled, the internal design sees ACQ and RX data as "1" |
-|   1    |   rw   |   0x0   | ENABLETARGET | Enable Target I2C functionality                                                                            |
-|   0    |   rw   |   0x0   | ENABLEHOST   | Enable Host I2C functionality                                                                              |
+|  Bits  |  Type  |  Reset  | Name         | Description                                                                                                                                          |
+|:------:|:------:|:-------:|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:4  |        |         |              | Reserved                                                                                                                                             |
+|   3    |   rw   |   0x0   | NACKWHENFULL | Instead of stretching the clock when the ACQ FIFO is full send a NACK instead. This happens both after having received an address as well as a byte. |
+|   2    |   rw   |   0x0   | LLPBK        | Enable I2C line loopback test If line loopback is enabled, the internal design sees ACQ and RX data as "1"                                           |
+|   1    |   rw   |   0x0   | ENABLETARGET | Enable Target I2C functionality                                                                                                                      |
+|   0    |   rw   |   0x0   | ENABLEHOST   | Enable Host I2C functionality                                                                                                                        |
 
 ## STATUS
 I2C Live Status Register for Host and Target modes

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -140,6 +140,7 @@ module i2c_core import i2c_pkg::*;
 
   logic        host_enable;
   logic        target_enable;
+  logic        nack_when_full;
   logic        line_loopback;
   logic        target_loopback;
 
@@ -188,6 +189,7 @@ module i2c_core import i2c_pkg::*;
   assign host_enable = reg2hw.ctrl.enablehost.q;
   assign target_enable = reg2hw.ctrl.enabletarget.q;
   assign line_loopback = reg2hw.ctrl.llpbk.q;
+  assign nack_when_full = reg2hw.ctrl.nackwhenfull.q;
 
   // Target loopback simply plays back whatever is received from the external host
   // back to it.
@@ -407,6 +409,7 @@ module i2c_core import i2c_pkg::*;
 
     .host_enable_i           (host_enable),
     .target_enable_i         (target_enable),
+    .nack_when_full_i        (nack_when_full),
 
     .fmt_fifo_rvalid_i       (fmt_fifo_rvalid),
     .fmt_fifo_wvalid_i       (fmt_fifo_wvalid),

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -570,8 +570,8 @@ module i2c_fsm import i2c_pkg::*;
         host_idle_o = 1'b0;
         scl_d = 1'b0;
         if (bit_index == '0 && tcount_q == 20'd1) begin
-          rx_fifo_wdata_o = read_byte;  // transfer read data to rx_fifo
           rx_fifo_wvalid_o = 1'b1;      // assert that rx_fifo has valid data
+          rx_fifo_wdata_o = read_byte;  // transfer read data to rx_fifo
         end
       end
       // HostClockLowAck: SCL pulled low, SDA is conditional
@@ -739,8 +739,8 @@ module i2c_fsm import i2c_pkg::*;
         sda_d = 1'b0;
 
         if (tcount_q == 20'd1) begin
+          acq_fifo_wvalid_o = acq_fifo_wready;      // assert that acq_fifo has valid data
           acq_fifo_wdata_o = {AcqData, input_byte}; // transfer data to acq_fifo
-          acq_fifo_wvalid_o = acq_fifo_wready;         // assert that acq_fifo has valid data
         end
       end
       // StretchAddr: target stretches the clock if matching address cannot be
@@ -769,8 +769,8 @@ module i2c_fsm import i2c_pkg::*;
         scl_d = 1'b0;
 
         // When space becomes available, deposit entry
-        acq_fifo_wdata_o = {AcqData, input_byte}; // transfer data to acq_fifo
         acq_fifo_wvalid_o = acq_fifo_wready;      // assert that acq_fifo has valid data
+        acq_fifo_wdata_o = {AcqData, input_byte}; // transfer data to acq_fifo
       end
       // default
       default : begin

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -34,17 +34,17 @@ module i2c_fsm import i2c_pkg::*;
   output logic       rx_fifo_wvalid_o, // high if there is valid data in rx_fifo
   output logic [7:0] rx_fifo_wdata_o,  // byte in rx_fifo read from target
 
-  input        tx_fifo_rvalid_i, // indicates there is valid data in tx_fifo
-  input        tx_fifo_wvalid_i, // indicates data is being put into tx_fifo
-  input [FifoDepthWidth-1:0]  tx_fifo_depth_i,  // tx_fifo_depth
-  output logic tx_fifo_rready_o, // pop entry from tx_fifo
-  input [7:0]  tx_fifo_rdata_i,  // byte in tx_fifo to be sent to host
+  input                      tx_fifo_rvalid_i, // indicates there is valid data in tx_fifo
+  input                      tx_fifo_wvalid_i, // indicates data is being put into tx_fifo
+  input [FifoDepthWidth-1:0] tx_fifo_depth_i,  // fill level of tx_fifo
+  output logic               tx_fifo_rready_o, // pop entry from tx_fifo
+  input [7:0]                tx_fifo_rdata_i,  // byte in tx_fifo to be sent to host
 
-  output logic       acq_fifo_wvalid_o, // high if there is valid data in acq_fifo
-  output logic [9:0] acq_fifo_wdata_o,  // byte and signal in acq_fifo read from target
-  input [FifoDepthWidth-1:0] acq_fifo_depth_i,
-  output logic       acq_fifo_wready_o, // local version of ready
-  input [9:0]        acq_fifo_rdata_i,  // only used for assertion
+  output logic               acq_fifo_wvalid_o, // high if there is valid data in acq_fifo
+  output logic [9:0]         acq_fifo_wdata_o,  // byte and signal in acq_fifo read from target
+  input [FifoDepthWidth-1:0] acq_fifo_depth_i,  // fill level of acq_fifo
+  output logic               acq_fifo_wready_o, // local version of ready
+  input [9:0]                acq_fifo_rdata_i,  // only used for assertion
 
   output logic       host_idle_o,      // indicates the host is idle
   output logic       target_idle_o,    // indicates the target is idle
@@ -328,7 +328,7 @@ module i2c_fsm import i2c_pkg::*;
     end
   end
 
-  // Detection by the target of ACK bit send by the host
+  // Detection by the target of ACK bit sent by the host
   always_ff @ (posedge clk_i or negedge rst_ni) begin : host_ack_register
     if (!rst_ni) begin
       host_ack <= 1'b0;

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -744,7 +744,7 @@ module i2c_fsm import i2c_pkg::*;
         end
       end
       // StretchAddr: target stretches the clock if matching address cannot be
-      // despoited yet.
+      // desposited yet.
       StretchAddr : begin
         target_idle_o = 1'b0;
         scl_d = 1'b0;
@@ -843,7 +843,6 @@ module i2c_fsm import i2c_pkg::*;
           if (fmt_fifo_rvalid_i) state_d = Active;
         end
       end
-
       // SetupStart: SDA and SCL are released
       SetupStart : begin
         if (tcount_q == 20'd1) begin
@@ -883,7 +882,6 @@ module i2c_fsm import i2c_pkg::*;
           end
         end
       end
-
       // ClockPulse: SCL is released, SDA keeps the indexed bit value
       ClockPulse : begin
         en_sda_interf_det = 1'b1;
@@ -1014,7 +1012,6 @@ module i2c_fsm import i2c_pkg::*;
           end
         end
       end
-
       // ClockStop: SCL is pulled low, SDA stays low
       ClockStop : begin
         if (tcount_q == 20'd1) begin
@@ -1048,7 +1045,6 @@ module i2c_fsm import i2c_pkg::*;
           end
         end
       end
-
       // Active: continue while keeping SCL low
       Active : begin
         if (fmt_flag_read_bytes_i) begin
@@ -1067,7 +1063,6 @@ module i2c_fsm import i2c_pkg::*;
           tcount_sel = tClockLow;
         end
       end
-
       // PopFmtFifo: populate fmt_fifo
       PopFmtFifo : begin
         if (!host_enable_i) begin
@@ -1084,7 +1079,6 @@ module i2c_fsm import i2c_pkg::*;
           tcount_sel = tNoDelay;
         end
       end
-
       // AcquireStart: hold start condition
       AcquireStart : begin
         if (scl_i_q && !scl_i) begin
@@ -1093,7 +1087,6 @@ module i2c_fsm import i2c_pkg::*;
           input_byte_clr = 1'b1;
         end
       end
-
       // AddrRead: read and compare target address
       AddrRead : begin
         if (bit_ack && address_match) begin
@@ -1104,7 +1097,6 @@ module i2c_fsm import i2c_pkg::*;
           state_d = Idle;
         end
       end
-
       // AddrAckWait: pause before acknowledging
       AddrAckWait : begin
         if (tcount_q == 20'd1 && !scl_i) begin
@@ -1172,14 +1164,12 @@ module i2c_fsm import i2c_pkg::*;
           end
         end
       end
-
       // Wait for clock to become positive.
       TransmitAck : begin
         if (scl_i) begin
           state_d = TransmitAckPulse;
         end
       end
-
       // TransmitAckPulse: target waits for host to ACK transmission
       // If a nak is received, that means a stop is incoming.
       TransmitAckPulse : begin
@@ -1193,14 +1183,12 @@ module i2c_fsm import i2c_pkg::*;
           end
         end
       end
-
       // An inert state just waiting for host to issue a stop
       // Cannot cycle back to idle directly as other events depend on the system being
       // non-idle.
       WaitForStop: begin
         state_d = WaitForStop;
       end
-
       // AcquireByte: target acquires a byte
       AcquireByte : begin
         if (bit_ack) begin
@@ -1209,7 +1197,6 @@ module i2c_fsm import i2c_pkg::*;
           tcount_sel = tClockStart;
         end
       end
-
       // AcquireAckWait: pause before acknowledging
       AcquireAckWait : begin
         if (tcount_q == 20'd1 && !scl_i) begin
@@ -1267,6 +1254,7 @@ module i2c_fsm import i2c_pkg::*;
           event_tx_stretch_o = 1'b0;
         end
       end
+      // StretchTxSetup: Wait for tSetupData before going to transmit
       StretchTxSetup : begin
         if (tcount_q == 20'd1) begin
           state_d = TransmitSetup;
@@ -1278,7 +1266,6 @@ module i2c_fsm import i2c_pkg::*;
       StretchAcqFull : begin
         if (acq_fifo_wready) state_d = AcquireByte;
       end
-
       // default
       default : begin
         state_d = Idle;

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -184,6 +184,9 @@ package i2c_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } nackwhenfull;
+    struct packed {
+      logic        q;
     } llpbk;
     struct packed {
       logic        q;
@@ -505,11 +508,11 @@ package i2c_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [428:414]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [413:399]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [398:369]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [368:367]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [366:364]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [429:415]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [414:400]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [399:370]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [369:368]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [367:364]
     i2c_reg2hw_rdata_reg_t rdata; // [363:355]
     i2c_reg2hw_fdata_reg_t fdata; // [354:336]
     i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [335:328]

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -202,6 +202,8 @@ module i2c_reg_top (
   logic ctrl_enabletarget_wd;
   logic ctrl_llpbk_qs;
   logic ctrl_llpbk_wd;
+  logic ctrl_nackwhenfull_qs;
+  logic ctrl_nackwhenfull_wd;
   logic status_re;
   logic status_fmtfull_qs;
   logic status_rxfull_qs;
@@ -1461,6 +1463,33 @@ module i2c_reg_top (
 
     // to register interface (read)
     .qs     (ctrl_llpbk_qs)
+  );
+
+  //   F[nackwhenfull]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ctrl_nackwhenfull (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ctrl_we),
+    .wd     (ctrl_nackwhenfull_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ctrl.nackwhenfull.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ctrl_nackwhenfull_qs)
   );
 
 
@@ -2956,6 +2985,8 @@ module i2c_reg_top (
   assign ctrl_enabletarget_wd = reg_wdata[1];
 
   assign ctrl_llpbk_wd = reg_wdata[2];
+
+  assign ctrl_nackwhenfull_wd = reg_wdata[3];
   assign status_re = addr_hit[5] & reg_re & !reg_error;
   assign rdata_re = addr_hit[6] & reg_re & !reg_error;
   assign fdata_we = addr_hit[7] & reg_we & !reg_error;
@@ -3143,6 +3174,7 @@ module i2c_reg_top (
         reg_rdata_next[0] = ctrl_enablehost_qs;
         reg_rdata_next[1] = ctrl_enabletarget_qs;
         reg_rdata_next[2] = ctrl_llpbk_qs;
+        reg_rdata_next[3] = ctrl_nackwhenfull_qs;
       end
 
       addr_hit[5]: begin


### PR DESCRIPTION
This PR adds NACK functionality to the I2C target. It adds a mode bit in the control register to control whether target stretches the clock when ACQ FIFO is full or sends a non-acknowledge instead.

Closes: https://github.com/lowRISC/opentitan/issues/15227