### PR TITLE
[opentitantool] Remove eprint during legacy_rescue

### DIFF
--- a/sw/host/opentitanlib/src/bootstrap/legacy_rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy_rescue.rs
@@ -326,7 +326,6 @@ impl UpdateProtocol for LegacyRescue {
         progress.new_stage("", frames.len() * Frame::DATA_LEN);
         'next_block: for (idx, frame) in frames.iter().enumerate() {
             for consecutive_errors in 0..Self::MAX_CONSECUTIVE_ERRORS {
-                eprint!("{}.", idx);
                 progress.progress(idx * Frame::DATA_LEN);
                 uart.write(frame.as_bytes())?;
                 let mut response = [0u8; Frame::HASH_LEN];


### PR DESCRIPTION
When OTT is used in scripts, the stderr is typically mapped to stdout. If we print something to stderr for every progress iteration, it breaks the progress bar updating in place, and instead each progress bar update will print on a newline instead of replacing itself.

With this change, the progress bar can update in place.