### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@5a8a1a99

### DIFF
--- a/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
+++ b/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
@@ -112,14 +112,16 @@ waive -rules RESET_DRIVER         -location {ibex_lockstep.sv} -regexp {'(rst_sh
       -comment "A synchronous counter is needed to release the shadow core reset with a delay of LockstepOffset clock cycles"
 waive -rules RESET_DRIVER         -location {ibex_lockstep.sv} -regexp {'(rst_shadow_set_q|rst_shadow_n)' driven in module 'ibex_lockstep'}
       -comment "A synchronous counter is needed to release the shadow core reset with a delay of LockstepOffset clock cycles"
-waive -rules RESET_DRIVER         -location {ibex_lockstep.sv} -regexp {'rst_shadow_set_q' is driven by instance 'u_prim_rst_shadow_set_flop' of module 'prim_flop', and used as an asynchronous reset 'rst_ni' at}
+waive -rules RESET_DRIVER         -location {ibex_lockstep.sv} -regexp {'rst_shadow_set_q\[0\]' is driven by instance 'u_prim_rst_shadow_set_flop' of module 'prim_flop', and used as an asynchronous reset 'rst_ni' at}
       -comment "A synchronous counter is needed to release the shadow core reset with a delay of LockstepOffset clock cycles"
-waive -rules RESET_DRIVER         -location {ibex_lockstep.sv} -regexp {'q_o[0]' is driven in module '(prim_flop|prim_generic_flop)'}
+waive -rules RESET_DRIVER         -location {ibex_lockstep.sv} -regexp {'q_o\[0\]' is driven in module '(prim_flop|prim_generic_flop)'}
       -comment "A synchronous counter is needed to release the shadow core reset with a delay of LockstepOffset clock cycles"
 waive -rules RESET_MUX            -location {ibex_lockstep.sv} -regexp {Asynchronous reset 'rst_shadow_n' is driven by a multiplexer here}
       -comment "The test enable input used to control the bypass can be considered static"
 waive -rules RESET_USE            -location {ibex_lockstep.sv} -regexp {'rst_shadow_set_q' is used for some other purpose, and as asynchronous reset 'rst_ni' at}
       -comment "A synchronous counter is needed to release the shadow core reset with a delay of LockstepOffset clock cycles and start the comparison logic one clock cycle later"
+waive -rules RESET_USE            -location {ibex_lockstep.sv} -regexp {'enable_cmp_d\[0\]' is connected to 'prim_flop' port 'd_i\[0\]', and used as an asynchronous reset or set 'rst_ni' at}
+      -comment "enable_cmp_d[0] is assigned to rst_shadow_set_q[0] which is drive by a synchronous counter which is needed to release the shadow core reset with a delay of LockstepOffset clock cycles"
 waive -rules {CLOCK_USE RESET_USE} -location {ibex_register_file_ff.sv} \
       -regexp {'(clk_i|rst_ni)' is connected to '(prim_onehot_mux)' port} \
       -comment {The module is fully combinatorial, clk/rst are only used for assertions.}

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -989,5 +989,8 @@ module rv_core_ibex
       lsu_store_resp_intg_err)
   `ASSERT_IBEX_CORE_ERROR_TRIGGER_ALERT(IbexInstrIntgErrCheck_A, alert_tx_o[2], u_ibex_core,
       instr_intg_err)
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(IbexLockstepResetCountAlertCheck_A,
+      u_core.gen_lockstep.u_ibex_lockstep.u_rst_shadow_cnt, alert_tx_o[2])
+
 `endif // ifdef INC_ASSERT
 endmodule

--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 56413ecf103342fb7d53c31f182ac930209267df
+    rev: 27dd6b2e06f3110904dda9db1abc4e1d466db30a
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/cs_registers.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/cs_registers.rst
@@ -72,7 +72,7 @@ Ibex implements all the Control and Status Registers (CSRs) listed in the follow
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x7B3  | ``dscratch1``      | RW     | Debug Scratch Register 1                      |
 +---------+--------------------+--------+-----------------------------------------------+
-|  0x7C0  | ``cpuctrl``        | WARL   | CPU Control Register (Custom CSR)             |
+|  0x7C0  | ``cpuctrlsts``     | WARL   | CPU Control and Status Register (Custom CSR)  |
 +---------+--------------------+--------+-----------------------------------------------+
 |  0x7C1  | ``secureseed``     | WARL   | Security feature random seed (Custom CSR)     |
 +---------+--------------------+--------+-----------------------------------------------+

--- a/hw/vendor/lowrisc_ibex/doc/requirements.txt
+++ b/hw/vendor/lowrisc_ibex/doc/requirements.txt
@@ -1,5 +1,5 @@
 setuptools_scm
-sphinx~=4.2
+sphinx>=7.0
 sphinx_rtd_theme
 sphinxcontrib-wavedrom
 wavedrom>=1.9.0rc1

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/ibex_dv.f
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/ibex_dv.f
@@ -21,6 +21,7 @@
 ${PRJ_DIR}/dv/uvm/core_ibex/common/prim/prim_pkg.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_assert.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_util_pkg.sv
+${LOWRISC_IP_DIR}/ip/prim/rtl/prim_count.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_pkg.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_22_16_dec.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_22_16_enc.sv

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -331,6 +331,13 @@ module core_ibex_tb_top;
     run_test();
   end
 
+  // Manually set unused_assert_connected = 1 to disable the AssertConnected_A assertion for
+  // prim_count in case lockstep (set by SecureIbex) is enabled. If not disabled, DV fails.
+  if (SecureIbex) begin : gen_disable_count_check
+    assign dut.u_ibex_top.gen_lockstep.u_ibex_lockstep.u_rst_shadow_cnt.
+          unused_assert_connected = 1;
+  end
+
   // Disable the assertion for onhot check in case WrenCheck (set by SecureIbex) is enabled.
   if (SecureIbex) begin : gen_disable_onehot_check
     assign dut.u_ibex_top.gen_regfile_ff.register_file_i.gen_wren_check.u_prim_onehot_check.

--- a/hw/vendor/lowrisc_ibex/ibex_top.core
+++ b/hw/vendor/lowrisc_ibex/ibex_top.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:and2
       - lowrisc:prim:buf
       - lowrisc:prim:clock_mux2
+      - lowrisc:prim:count
       - lowrisc:prim:flop
       - lowrisc:prim:ram_1p_scr
       - lowrisc:prim:onehot_check

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
@@ -46,7 +46,11 @@ module ibex_core import ibex_pkg::*; #(
 ) (
   // Clock and Reset
   input  logic                         clk_i,
+  // Internally generated resets in ibex_lockstep cause IMPERFECTSCH warnings.
+  // TODO: Remove when upgrading Verilator #2134.
+  /* verilator lint_off IMPERFECTSCH */
   input  logic                         rst_ni,
+  /* verilator lint_on IMPERFECTSCH */
 
   input  logic [31:0]                  hart_id_i,
   input  logic [31:0]                  boot_addr_i,

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
@@ -120,33 +120,51 @@ module ibex_lockstep import ibex_pkg::*; #(
   // - The reset of the shadow core is synchronously released.
   // The comparison is started in the following clock cycle.
 
-  logic [LockstepOffsetW-1:0] rst_shadow_cnt_d, rst_shadow_cnt_q, rst_shadow_cnt_incr;
-  // Internally generated resets cause IMPERFECTSCH warnings
-  /* verilator lint_off IMPERFECTSCH */
-  logic                       rst_shadow_set_d, rst_shadow_set_q;
-  logic                       rst_shadow_n, enable_cmp_q;
-  /* verilator lint_on IMPERFECTSCH */
+  logic [LockstepOffsetW-1:0] rst_shadow_cnt;
+  logic                       rst_shadow_cnt_err;
+  ibex_mubi_t                 rst_shadow_set_d, rst_shadow_set_q;
+  logic                       rst_shadow_n, rst_shadow_set_single_bit;
+  ibex_mubi_t                 enable_cmp_d, enable_cmp_q;
 
-  assign rst_shadow_cnt_incr = rst_shadow_cnt_q + 1'b1;
+  // This counter primitive starts counting to LockstepOffset after a system
+  // reset. The counter value saturates at LockstepOffset.
+  prim_count #(
+    .Width      (LockstepOffsetW        ),
+    .ResetValue (LockstepOffsetW'(1'b0) )
+  ) u_rst_shadow_cnt (
+    .clk_i              (clk_i                  ),
+    .rst_ni             (rst_ni                 ),
+    .clr_i              (1'b0                   ),
+    .set_i              (1'b0                   ),
+    .set_cnt_i          ('0                     ),
+    .incr_en_i          (1'b1                   ),
+    .decr_en_i          (1'b0                   ),
+    .step_i             (LockstepOffsetW'(1'b1) ),
+    .commit_i           (1'b1                   ),
+    .cnt_o              (rst_shadow_cnt         ),
+    .cnt_after_commit_o (                       ),
+    .err_o              (rst_shadow_cnt_err     )
+  );
 
-  assign rst_shadow_set_d = (rst_shadow_cnt_q == LockstepOffsetW'(LockstepOffset - 1));
-  assign rst_shadow_cnt_d = rst_shadow_set_d ? rst_shadow_cnt_q : rst_shadow_cnt_incr;
+  // When the LockstepOffset counter value is reached, activate the lockstep
+  // comparison. We do not explicitly check whether rst_shadow_set_q forms a valid
+  // multibit signal as this value is implicitly checked by the enable_cmp
+  // comparison below.
+  assign rst_shadow_set_d =
+    (rst_shadow_cnt >= LockstepOffsetW'(LockstepOffset - 1)) ? IbexMuBiOn : IbexMuBiOff;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      rst_shadow_cnt_q <= '0;
-      enable_cmp_q     <= '0;
-    end else begin
-      rst_shadow_cnt_q <= rst_shadow_cnt_d;
-      enable_cmp_q     <= rst_shadow_set_q;
-    end
-  end
+  // Enable lockstep comparison.
+  assign enable_cmp_d = rst_shadow_set_q;
+
+  // This assignment is needed in order to avoid "Warning-IMPERFECTSCH" messages.
+  // TODO: Remove when updating Verilator #2134.
+  assign rst_shadow_set_single_bit = rst_shadow_set_q[0];
 
   // The primitives below are used to place size-only constraints in order to prevent
   // synthesis optimizations and preserve anchor points for constraining backend tools.
   prim_flop #(
-    .Width(1),
-    .ResetValue(1'b0)
+    .Width(IbexMuBiWidth),
+    .ResetValue(IbexMuBiOff)
   ) u_prim_rst_shadow_set_flop (
     .clk_i (clk_i),
     .rst_ni(rst_ni),
@@ -154,10 +172,20 @@ module ibex_lockstep import ibex_pkg::*; #(
     .q_o   (rst_shadow_set_q)
   );
 
+  prim_flop #(
+    .Width(IbexMuBiWidth),
+    .ResetValue(IbexMuBiOff)
+  ) u_prim_enable_cmp_flop (
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
+    .d_i   (enable_cmp_d),
+    .q_o   (enable_cmp_q)
+  );
+
   prim_clock_mux2 #(
     .NoFpgaBufG(1'b1)
   ) u_prim_rst_shadow_n_mux2 (
-    .clk0_i(rst_shadow_set_q),
+    .clk0_i(rst_shadow_set_single_bit),
     .clk1_i(scan_rst_ni),
     .sel_i (test_en_i),
     .clk_o (rst_shadow_n)
@@ -458,8 +486,10 @@ module ibex_lockstep import ibex_pkg::*; #(
 
   logic outputs_mismatch;
 
-  assign outputs_mismatch       = enable_cmp_q & (shadow_outputs_q != core_outputs_q[0]);
-  assign alert_major_internal_o = outputs_mismatch | shadow_alert_major_internal;
+  assign outputs_mismatch =
+    (enable_cmp_q != IbexMuBiOff) & (shadow_outputs_q != core_outputs_q[0]);
+  assign alert_major_internal_o
+    = outputs_mismatch | shadow_alert_major_internal | rst_shadow_cnt_err;
   assign alert_major_bus_o      = shadow_alert_major_bus;
   assign alert_minor_o          = shadow_alert_minor;
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_pkg.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_pkg.sv
@@ -655,7 +655,8 @@ package ibex_pkg;
 
   // Mult-bit signal used for security hardening. For non-secure implementation all bits other than
   // the bottom bit are ignored.
-  typedef logic [3:0] ibex_mubi_t;
+  parameter int IbexMuBiWidth = 4;
+  typedef logic [IbexMuBiWidth-1:0] ibex_mubi_t;
 
   // Note that if adjusting these parameters it is assumed the bottom bit is set for On and unset
   // for Off. This allows the use of IbexMuBiOn/IbexMuBiOff to work for both secure and non-secure

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_tracer.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_tracer.sv
@@ -136,10 +136,10 @@ module ibex_tracer (
     if ((data_accessed & MEM) != 0) begin
       $fwrite(fh, " PA:0x%08x", rvfi_mem_addr);
 
-      if (rvfi_mem_rmask != 4'b0000) begin
+      if (rvfi_mem_wmask != 4'b0000) begin
         $fwrite(fh, " store:0x%08x", rvfi_mem_wdata);
       end
-      if (rvfi_mem_wmask != 4'b0000) begin
+      if (rvfi_mem_rmask != 4'b0000) begin
         $fwrite(fh, " load:0x%08x", rvfi_mem_rdata);
       end
     end


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
5a8a1a99930afbb9efe107ff2c80d482239d7a5f

* [tracer] Fix reporting of load/store data (Adrian Lees)
* Update old `cpuctrl` CSR name in `cs_registers.rst` (Luís Marques)
* [doc] Require sphinx version >= 7.0 (Greg Chadwick)
* [rtl] Harden lockstep enable against FI (Pascal Nasahl)