### PR TITLE
[usbdev] Support the safe retraction of IN packets

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -833,6 +833,21 @@
                   '''
           }
           {
+            bits: "29",
+            name: "sending",
+            swaccess: "rw1c",
+            hwaccess: "hwo",
+            desc: '''
+                  This bit indicates that the buffer is in the process of being collected by the
+                  host. It becomes set upon the first attempt by the host to collect a buffer from
+                  this endpoint when the rdy bit was set.
+
+                  It is cleared when the packet has been collected successfully or the pending
+                  transaction has been canceled by the hardware through detection of a
+                  link reset or receipt of a SETUP packet.
+                  '''
+          }
+          {
             bits: "30",
             name: "pend",
             swaccess: "rw1c"

--- a/hw/ip/usbdev/doc/registers.md
+++ b/hw/ip/usbdev/doc/registers.md
@@ -866,7 +866,7 @@ For endpoints that accept SETUP transactions, a SETUP packet will clear the STAL
 ## configin
 Configure IN Transaction
 - Reset default: `0x0`
-- Reset mask: `0xc0007f1f`
+- Reset mask: `0xe0007f1f`
 
 ### Instances
 
@@ -889,17 +889,18 @@ Configure IN Transaction
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "buffer", "bits": 5, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "size", "bits": 7, "attr": ["rw"], "rotate": 0}, {"bits": 15}, {"name": "pend", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rdy", "bits": 1, "attr": ["rw"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "buffer", "bits": 5, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "size", "bits": 7, "attr": ["rw"], "rotate": 0}, {"bits": 14}, {"name": "sending", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "pend", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "rdy", "bits": 1, "attr": ["rw"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 90}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                        |
-|:------:|:------:|:-------:|:----------------------------|
-|   31   |   rw   |   0x0   | [rdy](#configin--rdy)       |
-|   30   |  rw1c  |   0x0   | [pend](#configin--pend)     |
-| 29:15  |        |         | Reserved                    |
-|  14:8  |   rw   |   0x0   | [size](#configin--size)     |
-|  7:5   |        |         | Reserved                    |
-|  4:0   |   rw   |   0x0   | [buffer](#configin--buffer) |
+|  Bits  |  Type  |  Reset  | Name                          |
+|:------:|:------:|:-------:|:------------------------------|
+|   31   |   rw   |   0x0   | [rdy](#configin--rdy)         |
+|   30   |  rw1c  |   0x0   | [pend](#configin--pend)       |
+|   29   |  rw1c  |   0x0   | [sending](#configin--sending) |
+| 28:15  |        |         | Reserved                      |
+|  14:8  |   rw   |   0x0   | [size](#configin--size)       |
+|  7:5   |        |         | Reserved                      |
+|  4:0   |   rw   |   0x0   | [buffer](#configin--buffer)   |
 
 ### configin . rdy
 This bit should be set to indicate the buffer is ready for sending.
@@ -918,6 +919,15 @@ The bit is set when the rdy bit is cleared by hardware because of a
 SETUP packet being received or a link reset being detected.
 
 The bit remains set until cleared by being written with a 1.
+
+### configin . sending
+This bit indicates that the buffer is in the process of being collected by the
+host. It becomes set upon the first attempt by the host to collect a buffer from
+this endpoint when the rdy bit was set.
+
+It is cleared when the packet has been collected successfully or the pending
+transaction has been canceled by the hardware through detection of a
+link reset or receipt of a SETUP packet.
 
 ### configin . size
 The number of bytes to send from the buffer.

--- a/hw/ip/usbdev/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_pe.sv
@@ -71,6 +71,9 @@ module usb_fs_nb_pe #(
   input  logic [NumOutEps-1:0]   out_ep_iso_i, // Configure endpoint in isochronous mode
 
   // in endpoint interfaces
+  output logic                   in_xact_starting_o, // Start of an IN transaction
+  output logic [3:0]             in_xact_start_ep_o, // Capture IN packet details
+
   output logic [3:0]             in_ep_current_o, // Other signals addressed to this ep
   output logic                   in_ep_rollback_o, // Bad termination, rollback transaction
   output logic                   in_ep_xact_end_o, // good termination, transaction complete
@@ -166,6 +169,10 @@ module usb_fs_nb_pe #(
     .link_reset_i          (link_reset_i),
     .link_active_i         (link_active_i),
     .dev_addr_i            (dev_addr_i),
+
+    // transaction starting
+    .in_xact_starting_o    (in_xact_starting_o),
+    .in_xact_start_ep_o    (in_xact_start_ep_o),
 
     // endpoint interface
     .in_ep_current_o       (in_ep_current_o),

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -349,7 +349,7 @@ module usbdev
   logic [3:0]            in_endpoint;
   logic                  in_endpoint_val;
   logic [NEndpoints-1:0] in_rdy;
-  logic [NEndpoints-1:0] clear_rdybit, set_sentbit, update_pend;
+  logic [NEndpoints-1:0] clear_rdybit, set_sentbit, update_pend, set_sending;
   logic                  setup_received, in_ep_xact_end;
   logic [NEndpoints-1:0] ep_out_iso, ep_in_iso;
   logic [NEndpoints-1:0] enable_out, enable_setup, in_ep_stall, out_ep_stall;
@@ -403,6 +403,25 @@ module usbdev
       in_rdy[i] = reg2hw.configin[i].rdy.q;
     end
   end
+
+  // Captured properties of current IN buffer, maintained throughout packet collection as
+  // protection against change during packet retraction by FW.
+  logic [NBufWidth-1:0] in_buf_q, in_buf_d;
+  logic [SizeWidth:0] in_size_q, in_size_d;
+  logic       in_xact_starting;
+  logic [3:0] in_xact_start_ep;
+
+  always_ff @(posedge clk_i or negedge rst_n) begin
+    if (!rst_n) begin
+      in_buf_q  <= '0;
+      in_size_q <= '0;
+    end else begin
+      in_buf_q  <= in_buf_d;
+      in_size_q <= in_size_d;
+    end
+  end
+  assign in_buf_d  = in_xact_starting ? in_buf[in_xact_start_ep]  : in_buf_q;
+  assign in_size_d = in_xact_starting ? in_size[in_xact_start_ep] : in_size_q;
 
   // OUT data toggles are maintained with the packet engine but may be set or
   // cleared by software
@@ -473,15 +492,23 @@ module usbdev
     end else begin
       if (setup_received & out_endpoint_val) begin
         // Clear pending when a SETUP is received
-        clear_rdybit[out_endpoint] = 1'b1;
-        update_pend[out_endpoint]  = 1'b1;
+        clear_rdybit[out_endpoint]   = 1'b1;
+        update_pend[out_endpoint]    = 1'b1;
       end else if (in_ep_xact_end & in_endpoint_val) begin
-        // Clear when an IN transmission was successful
-        clear_rdybit[in_endpoint] = 1'b1;
+        // Clear rdy and sending when an IN transmission was successful
+        clear_rdybit[in_endpoint]   = 1'b1;
       end
     end
   end
 
+  // IN transaction starting on any endpoint?
+  always_comb begin
+    set_sending = '0;
+    if (in_xact_starting) set_sending[in_xact_start_ep] = 1'b1;
+  end
+
+  // Clearing of rdy bit in response to successful IN packet transmission or packet cancellation
+  // through link reset or SETUP packet reception.
   always_comb begin : proc_map_rdy_hw2reg
     for (int i = 0; i < NEndpoints; i++) begin
       hw2reg.configin[i].rdy.de = clear_rdybit[i];
@@ -494,6 +521,15 @@ module usbdev
     for (int i = 0; i < NEndpoints; i++) begin
       hw2reg.configin[i].pend.de = update_pend[i];
       hw2reg.configin[i].pend.d  = reg2hw.configin[i].rdy.q | reg2hw.configin[i].pend.q;
+    end
+  end
+
+  // Update the sending bit to mark that collection of the packet by the USB host has been
+  // attempted and FW shall not attempt retraction of the packet.
+  always_comb begin : proc_map_sending
+    for (int i = 0; i < NEndpoints; i++) begin
+      hw2reg.configin[i].sending.de = set_sending[i] | set_sentbit[i] | update_pend[i];
+      hw2reg.configin[i].sending.d  = ~set_sentbit[i] & ~update_pend[i];
     end
   end
 
@@ -549,8 +585,10 @@ module usbdev
     .out_endpoint_val_o   (out_endpoint_val),
 
     // transmit side
-    .in_buf_i             (in_buf[in_endpoint]),
-    .in_size_i            (in_size[in_endpoint]),
+    .in_xact_starting_o   (in_xact_starting),
+    .in_xact_start_ep_o   (in_xact_start_ep),
+    .in_buf_i             (in_buf_q),
+    .in_size_i            (in_size_q),
     .in_stall_i           (in_ep_stall),
     .in_rdy_i             (in_rdy),
     .in_ep_xact_end_o     (in_ep_xact_end),

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -546,6 +546,10 @@ package usbdev_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } sending;
+    struct packed {
+      logic        d;
+      logic        de;
     } pend;
     struct packed {
       logic        d;
@@ -646,15 +650,15 @@ package usbdev_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [297:262]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [261:254]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [253:224]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [223:207]
-    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [206:183]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [182:159]
-    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [158:135]
-    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [134:111]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [110:63]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [321:286]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [285:278]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [277:248]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [247:231]
+    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [230:207]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [206:183]
+    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [182:159]
+    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [158:135]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [134:63]
     usbdev_hw2reg_out_data_toggle_reg_t out_data_toggle; // [62:39]
     usbdev_hw2reg_in_data_toggle_reg_t in_data_toggle; // [38:15]
     usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [14:6]

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -493,6 +493,8 @@ module usbdev_reg_top (
   logic [4:0] configin_0_buffer_0_wd;
   logic [6:0] configin_0_size_0_qs;
   logic [6:0] configin_0_size_0_wd;
+  logic configin_0_sending_0_qs;
+  logic configin_0_sending_0_wd;
   logic configin_0_pend_0_qs;
   logic configin_0_pend_0_wd;
   logic configin_0_rdy_0_qs;
@@ -502,6 +504,8 @@ module usbdev_reg_top (
   logic [4:0] configin_1_buffer_1_wd;
   logic [6:0] configin_1_size_1_qs;
   logic [6:0] configin_1_size_1_wd;
+  logic configin_1_sending_1_qs;
+  logic configin_1_sending_1_wd;
   logic configin_1_pend_1_qs;
   logic configin_1_pend_1_wd;
   logic configin_1_rdy_1_qs;
@@ -511,6 +515,8 @@ module usbdev_reg_top (
   logic [4:0] configin_2_buffer_2_wd;
   logic [6:0] configin_2_size_2_qs;
   logic [6:0] configin_2_size_2_wd;
+  logic configin_2_sending_2_qs;
+  logic configin_2_sending_2_wd;
   logic configin_2_pend_2_qs;
   logic configin_2_pend_2_wd;
   logic configin_2_rdy_2_qs;
@@ -520,6 +526,8 @@ module usbdev_reg_top (
   logic [4:0] configin_3_buffer_3_wd;
   logic [6:0] configin_3_size_3_qs;
   logic [6:0] configin_3_size_3_wd;
+  logic configin_3_sending_3_qs;
+  logic configin_3_sending_3_wd;
   logic configin_3_pend_3_qs;
   logic configin_3_pend_3_wd;
   logic configin_3_rdy_3_qs;
@@ -529,6 +537,8 @@ module usbdev_reg_top (
   logic [4:0] configin_4_buffer_4_wd;
   logic [6:0] configin_4_size_4_qs;
   logic [6:0] configin_4_size_4_wd;
+  logic configin_4_sending_4_qs;
+  logic configin_4_sending_4_wd;
   logic configin_4_pend_4_qs;
   logic configin_4_pend_4_wd;
   logic configin_4_rdy_4_qs;
@@ -538,6 +548,8 @@ module usbdev_reg_top (
   logic [4:0] configin_5_buffer_5_wd;
   logic [6:0] configin_5_size_5_qs;
   logic [6:0] configin_5_size_5_wd;
+  logic configin_5_sending_5_qs;
+  logic configin_5_sending_5_wd;
   logic configin_5_pend_5_qs;
   logic configin_5_pend_5_wd;
   logic configin_5_rdy_5_qs;
@@ -547,6 +559,8 @@ module usbdev_reg_top (
   logic [4:0] configin_6_buffer_6_wd;
   logic [6:0] configin_6_size_6_qs;
   logic [6:0] configin_6_size_6_wd;
+  logic configin_6_sending_6_qs;
+  logic configin_6_sending_6_wd;
   logic configin_6_pend_6_qs;
   logic configin_6_pend_6_wd;
   logic configin_6_rdy_6_qs;
@@ -556,6 +570,8 @@ module usbdev_reg_top (
   logic [4:0] configin_7_buffer_7_wd;
   logic [6:0] configin_7_size_7_qs;
   logic [6:0] configin_7_size_7_wd;
+  logic configin_7_sending_7_qs;
+  logic configin_7_sending_7_wd;
   logic configin_7_pend_7_qs;
   logic configin_7_pend_7_wd;
   logic configin_7_rdy_7_qs;
@@ -565,6 +581,8 @@ module usbdev_reg_top (
   logic [4:0] configin_8_buffer_8_wd;
   logic [6:0] configin_8_size_8_qs;
   logic [6:0] configin_8_size_8_wd;
+  logic configin_8_sending_8_qs;
+  logic configin_8_sending_8_wd;
   logic configin_8_pend_8_qs;
   logic configin_8_pend_8_wd;
   logic configin_8_rdy_8_qs;
@@ -574,6 +592,8 @@ module usbdev_reg_top (
   logic [4:0] configin_9_buffer_9_wd;
   logic [6:0] configin_9_size_9_qs;
   logic [6:0] configin_9_size_9_wd;
+  logic configin_9_sending_9_qs;
+  logic configin_9_sending_9_wd;
   logic configin_9_pend_9_qs;
   logic configin_9_pend_9_wd;
   logic configin_9_rdy_9_qs;
@@ -583,6 +603,8 @@ module usbdev_reg_top (
   logic [4:0] configin_10_buffer_10_wd;
   logic [6:0] configin_10_size_10_qs;
   logic [6:0] configin_10_size_10_wd;
+  logic configin_10_sending_10_qs;
+  logic configin_10_sending_10_wd;
   logic configin_10_pend_10_qs;
   logic configin_10_pend_10_wd;
   logic configin_10_rdy_10_qs;
@@ -592,6 +614,8 @@ module usbdev_reg_top (
   logic [4:0] configin_11_buffer_11_wd;
   logic [6:0] configin_11_size_11_qs;
   logic [6:0] configin_11_size_11_wd;
+  logic configin_11_sending_11_qs;
+  logic configin_11_sending_11_wd;
   logic configin_11_pend_11_qs;
   logic configin_11_pend_11_wd;
   logic configin_11_rdy_11_qs;
@@ -5141,6 +5165,33 @@ module usbdev_reg_top (
     .qs     (configin_0_size_0_qs)
   );
 
+  //   F[sending_0]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_0_sending_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_0_we),
+    .wd     (configin_0_sending_0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[0].sending.de),
+    .d      (hw2reg.configin[0].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_0_sending_0_qs)
+  );
+
   //   F[pend_0]: 30:30
   prim_subreg #(
     .DW      (1),
@@ -5250,6 +5301,33 @@ module usbdev_reg_top (
 
     // to register interface (read)
     .qs     (configin_1_size_1_qs)
+  );
+
+  //   F[sending_1]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_1_sending_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_1_we),
+    .wd     (configin_1_sending_1_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[1].sending.de),
+    .d      (hw2reg.configin[1].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_1_sending_1_qs)
   );
 
   //   F[pend_1]: 30:30
@@ -5363,6 +5441,33 @@ module usbdev_reg_top (
     .qs     (configin_2_size_2_qs)
   );
 
+  //   F[sending_2]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_2_sending_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_2_we),
+    .wd     (configin_2_sending_2_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[2].sending.de),
+    .d      (hw2reg.configin[2].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_2_sending_2_qs)
+  );
+
   //   F[pend_2]: 30:30
   prim_subreg #(
     .DW      (1),
@@ -5472,6 +5577,33 @@ module usbdev_reg_top (
 
     // to register interface (read)
     .qs     (configin_3_size_3_qs)
+  );
+
+  //   F[sending_3]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_3_sending_3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_3_we),
+    .wd     (configin_3_sending_3_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[3].sending.de),
+    .d      (hw2reg.configin[3].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_3_sending_3_qs)
   );
 
   //   F[pend_3]: 30:30
@@ -5585,6 +5717,33 @@ module usbdev_reg_top (
     .qs     (configin_4_size_4_qs)
   );
 
+  //   F[sending_4]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_4_sending_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_4_we),
+    .wd     (configin_4_sending_4_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[4].sending.de),
+    .d      (hw2reg.configin[4].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_4_sending_4_qs)
+  );
+
   //   F[pend_4]: 30:30
   prim_subreg #(
     .DW      (1),
@@ -5694,6 +5853,33 @@ module usbdev_reg_top (
 
     // to register interface (read)
     .qs     (configin_5_size_5_qs)
+  );
+
+  //   F[sending_5]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_5_sending_5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_5_we),
+    .wd     (configin_5_sending_5_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[5].sending.de),
+    .d      (hw2reg.configin[5].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_5_sending_5_qs)
   );
 
   //   F[pend_5]: 30:30
@@ -5807,6 +5993,33 @@ module usbdev_reg_top (
     .qs     (configin_6_size_6_qs)
   );
 
+  //   F[sending_6]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_6_sending_6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_6_we),
+    .wd     (configin_6_sending_6_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[6].sending.de),
+    .d      (hw2reg.configin[6].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_6_sending_6_qs)
+  );
+
   //   F[pend_6]: 30:30
   prim_subreg #(
     .DW      (1),
@@ -5916,6 +6129,33 @@ module usbdev_reg_top (
 
     // to register interface (read)
     .qs     (configin_7_size_7_qs)
+  );
+
+  //   F[sending_7]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_7_sending_7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_7_we),
+    .wd     (configin_7_sending_7_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[7].sending.de),
+    .d      (hw2reg.configin[7].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_7_sending_7_qs)
   );
 
   //   F[pend_7]: 30:30
@@ -6029,6 +6269,33 @@ module usbdev_reg_top (
     .qs     (configin_8_size_8_qs)
   );
 
+  //   F[sending_8]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_8_sending_8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_8_we),
+    .wd     (configin_8_sending_8_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[8].sending.de),
+    .d      (hw2reg.configin[8].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_8_sending_8_qs)
+  );
+
   //   F[pend_8]: 30:30
   prim_subreg #(
     .DW      (1),
@@ -6138,6 +6405,33 @@ module usbdev_reg_top (
 
     // to register interface (read)
     .qs     (configin_9_size_9_qs)
+  );
+
+  //   F[sending_9]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_9_sending_9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_9_we),
+    .wd     (configin_9_sending_9_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[9].sending.de),
+    .d      (hw2reg.configin[9].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_9_sending_9_qs)
   );
 
   //   F[pend_9]: 30:30
@@ -6251,6 +6545,33 @@ module usbdev_reg_top (
     .qs     (configin_10_size_10_qs)
   );
 
+  //   F[sending_10]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_10_sending_10 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_10_we),
+    .wd     (configin_10_sending_10_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[10].sending.de),
+    .d      (hw2reg.configin[10].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_10_sending_10_qs)
+  );
+
   //   F[pend_10]: 30:30
   prim_subreg #(
     .DW      (1),
@@ -6360,6 +6681,33 @@ module usbdev_reg_top (
 
     // to register interface (read)
     .qs     (configin_11_size_11_qs)
+  );
+
+  //   F[sending_11]: 29:29
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_configin_11_sending_11 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (configin_11_we),
+    .wd     (configin_11_sending_11_wd),
+
+    // from internal hardware
+    .de     (hw2reg.configin[11].sending.de),
+    .d      (hw2reg.configin[11].sending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (configin_11_sending_11_qs)
   );
 
   //   F[pend_11]: 30:30
@@ -8228,6 +8576,8 @@ module usbdev_reg_top (
 
   assign configin_0_size_0_wd = reg_wdata[14:8];
 
+  assign configin_0_sending_0_wd = reg_wdata[29];
+
   assign configin_0_pend_0_wd = reg_wdata[30];
 
   assign configin_0_rdy_0_wd = reg_wdata[31];
@@ -8236,6 +8586,8 @@ module usbdev_reg_top (
   assign configin_1_buffer_1_wd = reg_wdata[4:0];
 
   assign configin_1_size_1_wd = reg_wdata[14:8];
+
+  assign configin_1_sending_1_wd = reg_wdata[29];
 
   assign configin_1_pend_1_wd = reg_wdata[30];
 
@@ -8246,6 +8598,8 @@ module usbdev_reg_top (
 
   assign configin_2_size_2_wd = reg_wdata[14:8];
 
+  assign configin_2_sending_2_wd = reg_wdata[29];
+
   assign configin_2_pend_2_wd = reg_wdata[30];
 
   assign configin_2_rdy_2_wd = reg_wdata[31];
@@ -8254,6 +8608,8 @@ module usbdev_reg_top (
   assign configin_3_buffer_3_wd = reg_wdata[4:0];
 
   assign configin_3_size_3_wd = reg_wdata[14:8];
+
+  assign configin_3_sending_3_wd = reg_wdata[29];
 
   assign configin_3_pend_3_wd = reg_wdata[30];
 
@@ -8264,6 +8620,8 @@ module usbdev_reg_top (
 
   assign configin_4_size_4_wd = reg_wdata[14:8];
 
+  assign configin_4_sending_4_wd = reg_wdata[29];
+
   assign configin_4_pend_4_wd = reg_wdata[30];
 
   assign configin_4_rdy_4_wd = reg_wdata[31];
@@ -8272,6 +8630,8 @@ module usbdev_reg_top (
   assign configin_5_buffer_5_wd = reg_wdata[4:0];
 
   assign configin_5_size_5_wd = reg_wdata[14:8];
+
+  assign configin_5_sending_5_wd = reg_wdata[29];
 
   assign configin_5_pend_5_wd = reg_wdata[30];
 
@@ -8282,6 +8642,8 @@ module usbdev_reg_top (
 
   assign configin_6_size_6_wd = reg_wdata[14:8];
 
+  assign configin_6_sending_6_wd = reg_wdata[29];
+
   assign configin_6_pend_6_wd = reg_wdata[30];
 
   assign configin_6_rdy_6_wd = reg_wdata[31];
@@ -8290,6 +8652,8 @@ module usbdev_reg_top (
   assign configin_7_buffer_7_wd = reg_wdata[4:0];
 
   assign configin_7_size_7_wd = reg_wdata[14:8];
+
+  assign configin_7_sending_7_wd = reg_wdata[29];
 
   assign configin_7_pend_7_wd = reg_wdata[30];
 
@@ -8300,6 +8664,8 @@ module usbdev_reg_top (
 
   assign configin_8_size_8_wd = reg_wdata[14:8];
 
+  assign configin_8_sending_8_wd = reg_wdata[29];
+
   assign configin_8_pend_8_wd = reg_wdata[30];
 
   assign configin_8_rdy_8_wd = reg_wdata[31];
@@ -8308,6 +8674,8 @@ module usbdev_reg_top (
   assign configin_9_buffer_9_wd = reg_wdata[4:0];
 
   assign configin_9_size_9_wd = reg_wdata[14:8];
+
+  assign configin_9_sending_9_wd = reg_wdata[29];
 
   assign configin_9_pend_9_wd = reg_wdata[30];
 
@@ -8318,6 +8686,8 @@ module usbdev_reg_top (
 
   assign configin_10_size_10_wd = reg_wdata[14:8];
 
+  assign configin_10_sending_10_wd = reg_wdata[29];
+
   assign configin_10_pend_10_wd = reg_wdata[30];
 
   assign configin_10_rdy_10_wd = reg_wdata[31];
@@ -8326,6 +8696,8 @@ module usbdev_reg_top (
   assign configin_11_buffer_11_wd = reg_wdata[4:0];
 
   assign configin_11_size_11_wd = reg_wdata[14:8];
+
+  assign configin_11_sending_11_wd = reg_wdata[29];
 
   assign configin_11_pend_11_wd = reg_wdata[30];
 
@@ -8700,6 +9072,7 @@ module usbdev_reg_top (
       addr_hit[17]: begin
         reg_rdata_next[4:0] = configin_0_buffer_0_qs;
         reg_rdata_next[14:8] = configin_0_size_0_qs;
+        reg_rdata_next[29] = configin_0_sending_0_qs;
         reg_rdata_next[30] = configin_0_pend_0_qs;
         reg_rdata_next[31] = configin_0_rdy_0_qs;
       end
@@ -8707,6 +9080,7 @@ module usbdev_reg_top (
       addr_hit[18]: begin
         reg_rdata_next[4:0] = configin_1_buffer_1_qs;
         reg_rdata_next[14:8] = configin_1_size_1_qs;
+        reg_rdata_next[29] = configin_1_sending_1_qs;
         reg_rdata_next[30] = configin_1_pend_1_qs;
         reg_rdata_next[31] = configin_1_rdy_1_qs;
       end
@@ -8714,6 +9088,7 @@ module usbdev_reg_top (
       addr_hit[19]: begin
         reg_rdata_next[4:0] = configin_2_buffer_2_qs;
         reg_rdata_next[14:8] = configin_2_size_2_qs;
+        reg_rdata_next[29] = configin_2_sending_2_qs;
         reg_rdata_next[30] = configin_2_pend_2_qs;
         reg_rdata_next[31] = configin_2_rdy_2_qs;
       end
@@ -8721,6 +9096,7 @@ module usbdev_reg_top (
       addr_hit[20]: begin
         reg_rdata_next[4:0] = configin_3_buffer_3_qs;
         reg_rdata_next[14:8] = configin_3_size_3_qs;
+        reg_rdata_next[29] = configin_3_sending_3_qs;
         reg_rdata_next[30] = configin_3_pend_3_qs;
         reg_rdata_next[31] = configin_3_rdy_3_qs;
       end
@@ -8728,6 +9104,7 @@ module usbdev_reg_top (
       addr_hit[21]: begin
         reg_rdata_next[4:0] = configin_4_buffer_4_qs;
         reg_rdata_next[14:8] = configin_4_size_4_qs;
+        reg_rdata_next[29] = configin_4_sending_4_qs;
         reg_rdata_next[30] = configin_4_pend_4_qs;
         reg_rdata_next[31] = configin_4_rdy_4_qs;
       end
@@ -8735,6 +9112,7 @@ module usbdev_reg_top (
       addr_hit[22]: begin
         reg_rdata_next[4:0] = configin_5_buffer_5_qs;
         reg_rdata_next[14:8] = configin_5_size_5_qs;
+        reg_rdata_next[29] = configin_5_sending_5_qs;
         reg_rdata_next[30] = configin_5_pend_5_qs;
         reg_rdata_next[31] = configin_5_rdy_5_qs;
       end
@@ -8742,6 +9120,7 @@ module usbdev_reg_top (
       addr_hit[23]: begin
         reg_rdata_next[4:0] = configin_6_buffer_6_qs;
         reg_rdata_next[14:8] = configin_6_size_6_qs;
+        reg_rdata_next[29] = configin_6_sending_6_qs;
         reg_rdata_next[30] = configin_6_pend_6_qs;
         reg_rdata_next[31] = configin_6_rdy_6_qs;
       end
@@ -8749,6 +9128,7 @@ module usbdev_reg_top (
       addr_hit[24]: begin
         reg_rdata_next[4:0] = configin_7_buffer_7_qs;
         reg_rdata_next[14:8] = configin_7_size_7_qs;
+        reg_rdata_next[29] = configin_7_sending_7_qs;
         reg_rdata_next[30] = configin_7_pend_7_qs;
         reg_rdata_next[31] = configin_7_rdy_7_qs;
       end
@@ -8756,6 +9136,7 @@ module usbdev_reg_top (
       addr_hit[25]: begin
         reg_rdata_next[4:0] = configin_8_buffer_8_qs;
         reg_rdata_next[14:8] = configin_8_size_8_qs;
+        reg_rdata_next[29] = configin_8_sending_8_qs;
         reg_rdata_next[30] = configin_8_pend_8_qs;
         reg_rdata_next[31] = configin_8_rdy_8_qs;
       end
@@ -8763,6 +9144,7 @@ module usbdev_reg_top (
       addr_hit[26]: begin
         reg_rdata_next[4:0] = configin_9_buffer_9_qs;
         reg_rdata_next[14:8] = configin_9_size_9_qs;
+        reg_rdata_next[29] = configin_9_sending_9_qs;
         reg_rdata_next[30] = configin_9_pend_9_qs;
         reg_rdata_next[31] = configin_9_rdy_9_qs;
       end
@@ -8770,6 +9152,7 @@ module usbdev_reg_top (
       addr_hit[27]: begin
         reg_rdata_next[4:0] = configin_10_buffer_10_qs;
         reg_rdata_next[14:8] = configin_10_size_10_qs;
+        reg_rdata_next[29] = configin_10_sending_10_qs;
         reg_rdata_next[30] = configin_10_pend_10_qs;
         reg_rdata_next[31] = configin_10_rdy_10_qs;
       end
@@ -8777,6 +9160,7 @@ module usbdev_reg_top (
       addr_hit[28]: begin
         reg_rdata_next[4:0] = configin_11_buffer_11_qs;
         reg_rdata_next[14:8] = configin_11_size_11_qs;
+        reg_rdata_next[29] = configin_11_sending_11_qs;
         reg_rdata_next[30] = configin_11_pend_11_qs;
         reg_rdata_next[31] = configin_11_rdy_11_qs;
       end

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -56,6 +56,8 @@ module usbdev_usbif  #(
   output logic                     out_endpoint_val_o,
 
   // transmit (IN) side
+  output logic                     in_xact_starting_o,
+  output logic [3:0]               in_xact_start_ep_o,
   input  logic [NBufWidth - 1:0]   in_buf_i,
   input  logic [PktW:0]            in_size_i,
   input  logic [NEndpoints-1:0]    in_stall_i,
@@ -344,6 +346,9 @@ module usbdev_usbif  #(
     .out_ep_iso_i          (out_ep_iso_i),
 
     // in endpoint interfaces
+    .in_xact_starting_o    (in_xact_starting_o),
+    .in_xact_start_ep_o    (in_xact_start_ep_o),
+
     .in_ep_current_o       (in_ep_current),
     .in_ep_rollback_o      (link_in_err_o),
     .in_ep_xact_end_o      (in_ep_xact_end_o),


### PR DESCRIPTION
This ~~draft~~ PR relates to a discussion of perfective changes in #19435 (open) and #18942 (closed and subsumed).


There are two distinct cases when we may want to retract IN packets that have been presented for collection by the USB host, and which are still marked as ready for transmission ('rdy' bit set in 'configin'):

- Isochronous IN traffic, when there is new data available (for Isochronous streams the more recent data is more important than older data)
- Loss of ACKnowledgement of the final IN packet within the Data Stage of a Control Transfer; in this case, the missing acknowledgement is to be detected by the lack of a 'pkt_sent' interrupt for the IN Endpoint and the arrival of the zero-length OUT DATA packet that is the Status Stage. (See '8.5.3.3 Error Handling on the Last Data Transaction')
  - this requires us to retract the final IN packet since it has indeed been sent (just not successfully), and invert the IN Data Toggle on that endpoint, to realign with the host's state.

There may be other cases, especially in handling error cases/edge conditions, that this form of IN packet retraction is required.

This PR proposes minimal changes to the IN-side hardware that involve an additional status bit in the 'configin' register. The 'sending' bit becomes set when the hardware first attempts to transmit the IN packet, and it remains set until such time as the packet is successfully transmitted (when both 'rdy' and 'sending' are cleared) or the packet is canceled by the hardware ('rdy' and 'sending' both cleared, and instead 'pend' is set).

Packet retraction operates as follows:

1. FW writes to the 'configin' register with the 'rdy' bit clear. The intention would be to write the 'buf' number and 'size' with their current values, but this PR incorporates logic to capture these properties of the current IN transaction so that they cannot be changed throughout the current transaction. It is therefore safe just to write '0' to the 'rdy' bit.
2. FW reads back from the 'configin' register to check the 'sending' and 'pend' bits.
3. If 'sending' is set then FW must wait until either successful transmission is communicated via the 'pkt_sent' interrupt, or the 'pend' bit becomes set because of transaction cancelation, as per normal IN packet transmission.
4. If 'pend' is already set, or 'sending' is clear, then the buffer may safely be reallocated and the new packet supplied immediately.

~~This remains a draft PR presently to encourage discussion and~~ because, although I have reasoned through the logic, I have not yet had a chance to test the implementation properly. Basic simulations and inspection of the logic behavior in waveforms are okay, but there are obviously no new tests to exercise this functionality at this point.

@a-will 
