### PR TITLE
[manuf] send endorsed UDS cert back to the device

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -134,6 +134,18 @@ UJSON_SERDE_STRUCT(ManufCertPersoDataOut, \
                    STRUCT_MANUF_CERT_PERSO_DATA_OUT);
 // clang-format on
 
+/**
+ * Endorsed certificates imported during device personalization.
+ */
+// clang-format off
+#define STRUCT_MANUF_ENDORSED_CERTS(field, string) \
+    field(uds_certificate, uint8_t, 596) \
+    field(uds_certificate_size, size_t)
+UJSON_SERDE_STRUCT(ManufEndorsedCerts, \
+                   manuf_endorsed_certs_t, \
+                   STRUCT_MANUF_ENDORSED_CERTS);
+// clang-format on
+
 #undef MODULE_ID
 // clang-format on
 

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -14,6 +14,32 @@ extern "C" {
 #define MODULE_ID MAKE_MODULE_ID('j', 'p', 'd')
 
 /**
+ * Provisioning data imported onto the device in CP.
+ */
+// clang-format off
+#define STRUCT_MANUF_CP_PROVISIONING_DATA(field, string) \
+    field(device_id, uint32_t, 8) \
+    field(manuf_state, uint32_t, 8) \
+    field(wafer_auth_secret, uint32_t, 8) \
+    field(test_unlock_token, uint32_t, 4) \
+    field(test_exit_token, uint32_t, 4)
+UJSON_SERDE_STRUCT(ManufCpProvisioningData, \
+                   manuf_cp_provisioning_data_t, \
+                   STRUCT_MANUF_CP_PROVISIONING_DATA);
+// clang-format on
+
+/**
+ * Provisioning data imported onto the device in FT during individualization.
+ */
+// clang-format off
+#define STRUCT_MANUF_FT_INDIVIDUALIZE_DATA(field, string) \
+    field(device_id, uint32_t, 8)
+UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
+                   manuf_ft_individualize_data_t, \
+                   STRUCT_MANUF_FT_INDIVIDUALIZE_DATA);
+// clang-format on
+
+/**
  * Ephemeral HSM ECC public key used to derive ECDH shared secret key for
  * wrapping the RMA unlock token.
  */
@@ -35,22 +61,6 @@ UJSON_SERDE_STRUCT(EccP256PublicKey, \
 UJSON_SERDE_STRUCT(ManufRmaTokenPersoDataIn, \
                    manuf_rma_token_perso_data_in_t, \
                    STRUCT_MANUF_RMA_TOKEN_PERSO_DATA_IN);
-// clang-format on
-
-/**
- * Data imported during device (attestation) certificate personalization.
- */
-// clang-format off
-#define STRUCT_MANUF_CERT_PERSO_DATA_IN(field, string) \
-    field(rom_ext_measurement, uint32_t, 8) \
-    field(rom_ext_security_version, uint32_t) \
-    field(owner_manifest_measurement, uint32_t, 8) \
-    field(owner_measurement, uint32_t, 8) \
-    field(owner_security_version, uint32_t) \
-    field(auth_key_key_id, uint8_t, 20)
-UJSON_SERDE_STRUCT(ManufCertPersoDataIn, \
-                   manuf_cert_perso_data_in_t, \
-                   STRUCT_MANUF_CERT_PERSO_DATA_IN);
 // clang-format on
 
 /**
@@ -93,6 +103,22 @@ UJSON_SERDE_STRUCT(ManufRmaTokenPersoDataOut, \
 // clang-format on
 
 /**
+ * Data imported during device (attestation) certificate personalization.
+ */
+// clang-format off
+#define STRUCT_MANUF_CERT_PERSO_DATA_IN(field, string) \
+    field(rom_ext_measurement, uint32_t, 8) \
+    field(rom_ext_security_version, uint32_t) \
+    field(owner_manifest_measurement, uint32_t, 8) \
+    field(owner_measurement, uint32_t, 8) \
+    field(owner_security_version, uint32_t) \
+    field(auth_key_key_id, uint8_t, 20)
+UJSON_SERDE_STRUCT(ManufCertPersoDataIn, \
+                   manuf_cert_perso_data_in_t, \
+                   STRUCT_MANUF_CERT_PERSO_DATA_IN);
+// clang-format on
+
+/**
  * Certificates exported during device personalization.
  */
 // clang-format off
@@ -106,32 +132,6 @@ UJSON_SERDE_STRUCT(ManufRmaTokenPersoDataOut, \
 UJSON_SERDE_STRUCT(ManufCertPersoDataOut, \
                    manuf_cert_perso_data_out_t, \
                    STRUCT_MANUF_CERT_PERSO_DATA_OUT);
-// clang-format on
-
-/**
- * Provisioning data imported onto the device in CP.
- */
-// clang-format off
-#define STRUCT_MANUF_CP_PROVISIONING_DATA(field, string) \
-    field(device_id, uint32_t, 8) \
-    field(manuf_state, uint32_t, 8) \
-    field(wafer_auth_secret, uint32_t, 8) \
-    field(test_unlock_token, uint32_t, 4) \
-    field(test_exit_token, uint32_t, 4)
-UJSON_SERDE_STRUCT(ManufCpProvisioningData, \
-                   manuf_cp_provisioning_data_t, \
-                   STRUCT_MANUF_CP_PROVISIONING_DATA);
-// clang-format on
-
-/**
- * Provisioning data imported onto the device in FT during individualization.
- */
-// clang-format off
-#define STRUCT_MANUF_FT_INDIVIDUALIZE_DATA(field, string) \
-    field(device_id, uint32_t, 8)
-UJSON_SERDE_STRUCT(ManufFtIndividualizeData, \
-                   manuf_ft_individualize_data_t, \
-                   STRUCT_MANUF_FT_INDIVIDUALIZE_DATA);
 // clang-format on
 
 #undef MODULE_ID

--- a/sw/host/provisioning/ft_lib/BUILD
+++ b/sw/host/provisioning/ft_lib/BUILD
@@ -18,6 +18,7 @@ rust_library(
         "@crate_index//:arrayvec",
         "@crate_index//:clap",
         "@crate_index//:elliptic-curve",
+        "@crate_index//:hex",
         "@crate_index//:log",
         "@crate_index//:num-bigint-dig",
         "@crate_index//:p256",


### PR DESCRIPTION
This updates the FT provisioning flow to send the endorsed UDS cert back to the device and writes it to flash. This partially addresses #19455.