### PR TITLE
[opentitanlib] update default JTAG speed

### DIFF
--- a/sw/host/opentitanlib/src/io/jtag.rs
+++ b/sw/host/opentitanlib/src/io/jtag.rs
@@ -21,7 +21,7 @@ pub struct JtagParams {
     #[arg(long, default_value = "openocd")]
     pub openocd: PathBuf,
 
-    #[arg(long, default_value = "200")]
+    #[arg(long, default_value = "1000")]
     pub adapter_speed_khz: u64,
 }
 


### PR DESCRIPTION
This updates the default JTAG speed to 1MHz to descrease test time in CI for tests that make use of JTAG.