### PR TITLE
[opentitantool] Increase TPM timeout to match ChromeOS

### DIFF
--- a/sw/host/opentitanlib/src/tpm/driver.rs
+++ b/sw/host/opentitanlib/src/tpm/driver.rs
@@ -147,7 +147,8 @@ pub trait Driver {
 
     /// Poll the status register until the status is valid and data is available or time out.
     fn poll_for_data_available(&self) -> Result<TpmStatus> {
-        const STATUS_POLL_TIMEOUT: Duration = Duration::from_millis(30000);
+        // Some TPM operations, such as generating RSA keys can take several minutes.
+        const STATUS_POLL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
         let deadline = Instant::now() + STATUS_POLL_TIMEOUT;
         let mut sts = self.read_status()?;
         // If the device is busy and doesn't actually respond, the status comes back as !0. This


### PR DESCRIPTION
Some TPM operations, such as generating RSA keypairs can take several minutes (at least on Google's legacy Titan chips).  This PR increases the time that opentitantool is willing to wait for the TPM status register to indicate that a command is done being processed.