### PR TITLE
[alert_handler_testutils] Revise default ping timeout

### DIFF
--- a/sw/device/lib/testing/alert_handler_testutils.h
+++ b/sw/device/lib/testing/alert_handler_testutils.h
@@ -14,6 +14,10 @@
 
 #include "alert_handler_regs.h"
 
+enum {
+  kAlertHandlerTestutilsDefaultPingTimeout = 256,
+};
+
 typedef enum alert_handler_class_state {
   kCstateIdle = 0,
   kCstateTimeout = 1,

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -189,7 +189,7 @@ static void alert_handler_config(void) {
       .classes = classes,
       .class_configs = class_config,
       .classes_len = ARRAYSIZE(class_config),
-      .ping_timeout = 0,
+      .ping_timeout = kAlertHandlerTestutilsDefaultPingTimeout,
   };
 
   CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,

--- a/sw/device/tests/pwrmgr_sleep_resets_lib.c
+++ b/sw/device/tests/pwrmgr_sleep_resets_lib.c
@@ -149,7 +149,7 @@ void config_alert_handler(void) {
       .classes = classes,
       .class_configs = class_config,
       .classes_len = ARRAYSIZE(class_config),
-      .ping_timeout = 0,
+      .ping_timeout = kAlertHandlerTestutilsDefaultPingTimeout,
   };
 
   CHECK_STATUS_OK(alert_handler_testutils_configure_all(alert_handler, config,

--- a/sw/device/tests/rv_core_ibex_nmi_irq_test.c
+++ b/sw/device/tests/rv_core_ibex_nmi_irq_test.c
@@ -93,7 +93,7 @@ static void alert_handler_config(void) {
       .classes = classes,
       .class_configs = class_config,
       .classes_len = ARRAYSIZE(class_config),
-      .ping_timeout = 0,
+      .ping_timeout = kAlertHandlerTestutilsDefaultPingTimeout,
   };
 
   CHECK_STATUS_OK(

--- a/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
+++ b/sw/device/tests/sim_dv/data_integrity_escalation_reset_test.c
@@ -430,7 +430,7 @@ static void alert_handler_config(void) {
       .classes = classes,
       .class_configs = class_config,
       .classes_len = ARRAYSIZE(class_config),
-      .ping_timeout = 0,
+      .ping_timeout = kAlertHandlerTestutilsDefaultPingTimeout,
   };
 
   CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,

--- a/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_random_sleep_power_glitch_reset_test.c
@@ -211,7 +211,7 @@ static void alert_handler_config(void) {
       .classes = classes,
       .class_configs = class_config,
       .classes_len = ARRAYSIZE(class_config),
-      .ping_timeout = 0,
+      .ping_timeout = kAlertHandlerTestutilsDefaultPingTimeout,
   };
 
   CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,


### PR DESCRIPTION
Add a default ping timeout for tests using alert_handler testutils. A number of tests previously used 0 here, but that value risks timeouts, since alert_handler_testutils_configure_all() enables the ping feature unconditionally. Bump that up to the recommended value for earlgrey.