### PR TITLE
[RV_DM]rv_dm_progbuf_exception_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -50,6 +50,7 @@ filesets:
       - seq_lib/rv_dm_progbuf_busy_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_abstractcmd_status_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_rom_read_access_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_progbuf_exception_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_exception_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_exception_vseq.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_progbuf_exception_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_progbuf_exception_vseq)
+
+  `uvm_object_new
+
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+  task body();
+    uvm_reg_data_t data;
+    uvm_reg_data_t r_data;
+    repeat (2) begin
+      data = $urandom;
+      request_halt();
+      csr_wr(.ptr(jtag_dmi_ral.command), .value(data));
+      csr_wr(.ptr(tl_mem_ral.exception), .value(data));
+      csr_rd(.ptr(jtag_dmi_ral.abstractcs), .value(r_data));
+      `DV_CHECK_EQ(AbstractCmdErrException, get_field_val(jtag_dmi_ral.abstractcs.cmderr,
+                                                          r_data));
+    end
+  endtask
+
+endclass:rv_dm_progbuf_exception_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -27,3 +27,4 @@
 `include "rv_dm_progbuf_busy_vseq.sv"
 `include "rv_dm_abstractcmd_status_vseq.sv"
 `include "rv_dm_rom_read_access_vseq.sv"
+`include "rv_dm_progbuf_exception_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -266,6 +266,11 @@
       reseed: 2
     }
     {
+      name: rv_dm_progbuf_exception
+      uvm_test_seq: rv_dm_progbuf_exception_vseq
+      reseed: 2
+    }
+    {
       name: rv_dm_stress_all
       uvm_test_seq: rv_dm_stress_all_vseq
     }


### PR DESCRIPTION
This commit contains vseq which verify that writing on tl_mem_ral.exception register causes the jtag_dmi_ral.abstractcs.cmderr set to 3.