### PR TITLE
[pentest] Fix bugs in AES SCA

### DIFF
--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -186,7 +186,7 @@ static void aes_key_mask_and_config(const uint8_t *key, size_t key_len) {
     key_shares.share0[i] = *((uint32_t *)key + i) ^ key_shares.share1[i];
   }
   // Provide random shares for unused key bits.
-  for (size_t i = key_len; i < kAesKeyLengthMax / 4; ++i) {
+  for (size_t i = key_len / 4; i < kAesKeyLengthMax / 4; ++i) {
     key_shares.share1[i] =
         sca_non_linear_layer(sca_next_lfsr(1, kScaLfsrMasking));
     key_shares.share0[i] =

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -345,7 +345,7 @@ void sca_seed_lfsr(uint32_t seed, sca_lfsr_context_t context) {
     sca_lfsr_state_masking = seed;
   }
   if (context == kScaLfsrOrder) {
-    sca_lfsr_state_masking = seed;
+    sca_lfsr_state_order = seed;
   }
 }
 

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -53,12 +53,16 @@ cc_library(
 cc_library(
     name = "aes_sca",
     srcs = ["aes_sca.c"],
-    hdrs = ["aes_sca.h"],
+    hdrs = [
+        "aes_sca.h",
+        "status.h",
+    ],
     deps = [
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aes_testutils",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:aes",

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
@@ -163,7 +163,7 @@ static aes_sca_error_t aes_key_mask_and_config(const uint8_t *key,
     key_shares.share0[i] = *((uint32_t *)key + i) ^ key_shares.share1[i];
   }
   // Provide random shares for unused key bits.
-  for (size_t i = key_len; i < kAesKeyLengthMax / 4; ++i) {
+  for (size_t i = key_len / 4; i < kAesKeyLengthMax / 4; ++i) {
     key_shares.share1[i] =
         sca_non_linear_layer(sca_next_lfsr(1, kScaLfsrMasking));
     key_shares.share0[i] =


### PR DESCRIPTION
This PR fixes three bugs in the AES used for SCA in separate commits:
- Set the seed to the correct state
- Set the unused key shares
- Configure entropy complex for SCA measurements