### PR TITLE
[sw/i2c_testutils] Take I2C instance ID into account for pins

### DIFF
--- a/sw/device/lib/testing/pinmux_testutils.h
+++ b/sw/device/lib/testing/pinmux_testutils.h
@@ -17,16 +17,16 @@
  * Define a pinmux configuration for a peripheral input and output .
  */
 typedef struct pinmux_testutils_peripheral_pin {
-  const top_earlgrey_pinmux_peripheral_in_t peripheral_in;
-  const top_earlgrey_pinmux_outsel_t outsel;
+  top_earlgrey_pinmux_peripheral_in_t peripheral_in;
+  top_earlgrey_pinmux_outsel_t outsel;
 } pinmux_testutils_peripheral_pin_t;
 
 /**
  * Define a pinmux configuration for a mio input and output.
  */
 typedef struct pinmux_testutils_mio_pin {
-  const top_earlgrey_pinmux_mio_out_t mio_out;
-  const top_earlgrey_pinmux_insel_t insel;
+  top_earlgrey_pinmux_mio_out_t mio_out;
+  top_earlgrey_pinmux_insel_t insel;
 } pinmux_testutils_mio_pin_t;
 
 /**

--- a/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/i2c_device_tx_rx_test.c
@@ -165,7 +165,8 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_rv_plic_init(
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
 
-  CHECK_STATUS_OK(i2c_testutils_select_pinmux(&pinmux, kI2cIdx, kI2cIdx));
+  CHECK_STATUS_OK(
+      i2c_testutils_select_pinmux(&pinmux, kI2cIdx, I2cPinmuxPlatformIdDvsim));
 
   // Enable functional interrupts as well as error interrupts to make sure
   // everything is behaving as expected.


### PR DESCRIPTION
The previous `kI2cPlatformPins` array mapped to pins solely based on the platform.  This works for CW310 (with PMOD and HyperDebug) where I2C is mapped to one pair of pins for all I2C instances.  In DV, however, each I2C instance has its own agent, which is connected to its own pair of (muxed) pins.  Coincidentally, when the I2C instance ID (i.e., 0 to 2) is (incorrectly) used to index the `kI2cPlatformPins` array, that would result in the correct pair of pins for DV.  When pins change for one of the platforms or the number of I2C instances changes, however, this will no longer work.

This commit takes the I2C instance ID into account when mapping to pins. The result is the same as before on the condition that the platform argument to a call of `i2c_testutils_select_pinmux` in `i2c_device_tx_rx_test.c` gets fixed (which this commit also does).

This got split out of the closed PR #21676.