### PR TITLE
[i2c] Increase depth of ACQ FIFO to 268 bytes 

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -105,10 +105,18 @@
   param_list: [
     { name: "FifoDepth",
       desc: '''
-            Depth of FMT, RX, TX, and ACQ FIFOs.
+            Depth of FMT, RX, and TX FIFOs.
             The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
             ''',
       type: "int",
+      default: "64",
+    }
+    { name: "AcqFifoDepth",
+      desc: '''
+            Depth of ACQ FIFO.
+            The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
+            ''',
+      type: int
       default: "64",
     }
   ],

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -117,7 +117,7 @@
             The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
             ''',
       type: int
-      default: "64",
+      default: "268",
     }
   ],
   features: [

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -72,7 +72,7 @@ package i2c_env_pkg;
   parameter uint I2C_FMT_FIFO_DEPTH = i2c_reg_pkg::FifoDepth;
   parameter uint I2C_RX_FIFO_DEPTH  = i2c_reg_pkg::FifoDepth;
   parameter uint I2C_TX_FIFO_DEPTH  = i2c_reg_pkg::FifoDepth;
-  parameter uint I2C_ACQ_FIFO_DEPTH = i2c_reg_pkg::FifoDepth;
+  parameter uint I2C_ACQ_FIFO_DEPTH = i2c_reg_pkg::AcqFifoDepth;
 
   // alerts
   parameter uint NUM_ALERTS = i2c_reg_pkg::NumAlerts;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
@@ -17,7 +17,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
   // Number of cycles sequence wait before all of the read states are executed
   parameter uint READ_STATE_WAIT_TIMEOUT_CYCLES = 40;
   // ACQ FIFO size in bytes
-  parameter uint ACQ_FIFO_SIZE = 64;
+  import i2c_env_pkg::I2C_ACQ_FIFO_DEPTH;
   // Period of SCL clock depending on timing parameters
   uint scl_period;
 
@@ -316,7 +316,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
       // Add data items to transaction enter StretchAddr state
       if (addr_states[i] == StretchAddr) begin
         // one transaction for start address and another for stop condition
-        repeat(ACQ_FIFO_SIZE - 2) begin
+        repeat(I2C_ACQ_FIFO_DEPTH - 2) begin
           `uvm_create_obj(i2c_item, req)
           append_data(req, m_i2c_target_seq.req_q);
         end
@@ -331,7 +331,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
         // Add address to the transaction
         `uvm_create_obj(i2c_item, req)
         append_address(req, m_i2c_target_seq.req_q, 1'b0);
-        timeout = (((ACQ_FIFO_SIZE + 2) * 9) + ADDR_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
+        timeout = (((I2C_ACQ_FIFO_DEPTH + 2) * 9) + ADDR_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
       end
       fork
         begin
@@ -397,12 +397,12 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
       append_data(req, m_i2c_target_seq.req_q);
       if (write_states[i] == StretchAcqFull) begin
         // Create ACQ FIFO full condition
-        repeat(ACQ_FIFO_SIZE) begin
+        repeat(I2C_ACQ_FIFO_DEPTH) begin
           `uvm_create_obj(i2c_item, req)
           append_data(req, m_i2c_target_seq.req_q);
         end
         // Each byte requires 9 scl cycles to be transmitted
-        timeout = ((ACQ_FIFO_SIZE * 9)+ WRITE_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
+        timeout = ((I2C_ACQ_FIFO_DEPTH * 9)+ WRITE_STATE_WAIT_TIMEOUT_CYCLES) * scl_period;
       end
       fork
           begin

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -35,9 +35,11 @@ module i2c_core import i2c_pkg::*;
 );
 
   import i2c_reg_pkg::FifoDepth;
+  import i2c_reg_pkg::AcqFifoDepth;
 
   // Number of bits required to represent the FIFO level/depth.
   localparam int unsigned FifoDepthW = $clog2(FifoDepth + 1);
+  localparam int unsigned AcqFifoDepthW = $clog2(AcqFifoDepth+1);
 
   // Maximum number of bits required to represent the level/depth of any FIFO.
   localparam int unsigned MaxFifoDepthW = 12;
@@ -120,7 +122,7 @@ module i2c_core import i2c_pkg::*;
   logic                     acq_fifo_wvalid;
   logic                     acq_fifo_wready;
   logic [9:0]               acq_fifo_wdata;
-  logic [FifoDepthW-1:0]    acq_fifo_depth;
+  logic [AcqFifoDepthW-1:0] acq_fifo_depth;
   logic                     acq_fifo_rvalid;
   logic                     acq_fifo_rready;
   logic [9:0]               acq_fifo_rdata;
@@ -357,7 +359,7 @@ module i2c_core import i2c_pkg::*;
   prim_fifo_sync #(
     .Width(10),
     .Pass(1'b0),
-    .Depth(FifoDepth)
+    .Depth(AcqFifoDepth)
   ) u_i2c_acqfifo (
     .clk_i,
     .rst_ni,
@@ -395,7 +397,8 @@ module i2c_core import i2c_pkg::*;
   );
 
   i2c_fsm #(
-    .FifoDepth(FifoDepth)
+    .FifoDepth(FifoDepth),
+    .AcqFifoDepth(AcqFifoDepth)
   ) u_i2c_fsm (
     .clk_i,
     .rst_ni,
@@ -680,5 +683,6 @@ module i2c_core import i2c_pkg::*;
   );
 
   `ASSERT_INIT(FifoDepthValid_A, FifoDepth > 0 && FifoDepthW <= MaxFifoDepthW)
+  `ASSERT_INIT(AcqFifoDepthValid_A, AcqFifoDepth > 0 && AcqFifoDepthW <= MaxFifoDepthW)
 
 endmodule

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -5,9 +5,7 @@
 // Description: I2C core module
 
 module i2c_core import i2c_pkg::*;
-#(
-  parameter int                    FifoDepth = 64
-) (
+(
   input                            clk_i,
   input                            rst_ni,
 
@@ -35,6 +33,8 @@ module i2c_core import i2c_pkg::*;
   output logic                     intr_unexp_stop_o,
   output logic                     intr_host_timeout_o
 );
+
+  import i2c_reg_pkg::FifoDepth;
 
   // Number of bits required to represent the FIFO level/depth.
   localparam int unsigned FifoDepthW = $clog2(FifoDepth + 1);

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -7,7 +7,9 @@
 module i2c_fsm import i2c_pkg::*;
 #(
   parameter int FifoDepth = 64,
-  localparam int FifoDepthWidth = $clog2(FifoDepth+1)
+  parameter int AcqFifoDepth = 64,
+  localparam int FifoDepthWidth = $clog2(FifoDepth+1),
+  localparam int AcqFifoDepthWidth = $clog2(AcqFifoDepth+1)
 ) (
   input        clk_i,  // clock
   input        rst_ni, // active low reset
@@ -42,7 +44,7 @@ module i2c_fsm import i2c_pkg::*;
 
   output logic       acq_fifo_wvalid_o, // high if there is valid data in acq_fifo
   output logic [9:0] acq_fifo_wdata_o,  // byte and signal in acq_fifo read from target
-  input [FifoDepthWidth-1:0] acq_fifo_depth_i,
+  input [AcqFifoDepthWidth-1:0] acq_fifo_depth_i,
   output logic       acq_fifo_wready_o, // local version of ready
   input [9:0]        acq_fifo_rdata_i,  // only used for assertion
 
@@ -342,9 +344,9 @@ module i2c_fsm import i2c_pkg::*;
   // space for this entry, the target module would need to stretch the
   // repeat start / stop indication.  If a system does not support stretching,
   // there's no good way for a stop to be NACK'd.
-  logic [FifoDepthWidth-1:0] acq_fifo_remainder;
-  assign acq_fifo_remainder = FifoDepth - acq_fifo_depth_i;
-  assign acq_fifo_wready = acq_fifo_remainder > FifoDepthWidth'(1'b1);
+  logic [AcqFifoDepthWidth-1:0] acq_fifo_remainder;
+  assign acq_fifo_remainder = AcqFifoDepth - acq_fifo_depth_i;
+  assign acq_fifo_wready = acq_fifo_remainder > AcqFifoDepthWidth'(1'b1);
 
   // State definitions
   typedef enum logic [5:0] {
@@ -811,7 +813,7 @@ module i2c_fsm import i2c_pkg::*;
   // Only the fifo depth is checked here, because stretch_tx is only evaluated by the
   // fsm on the read path. This means a read start byte has already been deposited.
   assign stretch_tx = ~tx_fifo_rvalid_i |
-                      (acq_fifo_depth_i > FifoDepthWidth'(1'b1));
+                      (acq_fifo_depth_i > AcqFifoDepthWidth'(1'b1));
 
   // Only used for assertion
   logic unused_acq_rdata;

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -8,7 +8,7 @@ package i2c_reg_pkg;
 
   // Param list
   parameter int FifoDepth = 64;
-  parameter int AcqFifoDepth = 64;
+  parameter int AcqFifoDepth = 268;
   parameter int NumAlerts = 1;
 
   // Address widths within the block

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -8,6 +8,7 @@ package i2c_reg_pkg;
 
   // Param list
   parameter int FifoDepth = 64;
+  parameter int AcqFifoDepth = 64;
   parameter int NumAlerts = 1;
 
   // Address widths within the block


### PR DESCRIPTION
This change allows the I2C HW IP module to absorb a max-length SMBus Block Write,
which consists of 1 command code byte, 1 byte defining the number of data bytes in the
block write, up to 255 data bytes, and 1 optional Packet Error Code
(PEC) byte; thus up to 258 bytes in total (from SMBus Specification
version 3.2, section 6.5.7).  Our I2C HW IP module additionally puts the
byte after the Start condition (which contains the address and the R/Wn
bit) and a byte for the Stop condition into the FIFO; thus the total
increases to 260 bytes.

To account for any oversights we may have made in the analysis of the
protocol, we add an extra 8 bytes as margin, thus 268 bytes.

Note that this is larger than required by MCTP, which would be 75 bytes:
- "The size of a transmission unit is defined as the size of the packet
  payload that is carried in an MCTP packet.  The [...] minimum
  transmission unit size for MCTP is 64 bytes.  A message terminus that
  supports MCTP control messages shall always accept valid packets that
  have a transmission unit equal to or less than the baseline
  transmission unit." (from MCTP Base Specification version 1.3.0,
  section 8.3)
- MCTP packets have a 4 byte header followed by the packet payload and
  they are encapsulated between a header and a tailer that is specific
  to the physical medium (from MCTP Base Specification version 1.3.0,
  section 8.1).  For MCTP on SMBus, header and tailer consist of 4 and 1
  byte, respectively (see above).
- Thus 4 + 4 + 64 + 1 = 73 bytes plus two bytes for Start and Stop
  (based on our HW IP module; see above) gives 75 bytes.

If the ACQ FIFO cannot absorb a full SMBus Block Write or MCTP control
message, real-time constraints to process bytes from the ACQ FIFO are
imposed on SW controlling the I2C HW module.  The maximum allowed delays
depend on the protocol:
- SMBus allows target devices to stretch the clock by up to 25 ms per
  message (t_LOW:CEXT in Table 14, 15, and 16 of the SMBus Specification
  version 3.2).
- MCTP allows target devices to stretch the clock by at most 250 us per
  byte (from MCTP SMBbus/I2C Transport Binding Specification version
  1.2.0, section 6.18).

In order to not impose such real-time constraints on SW for top-level
designs that use I2C with SMBus or MCTP, this commit makes the ACQ FIFO
sufficiently deep that any max-length transaction can be absorbed.  If
SW doesn't drain the ACQ FIFO once it's full before the next message,
that message should get NACK'd and the controller has to retry later --
but protocol compliance holds and the I2C lines are not blocked.
Currently our I2C HW IP module doesn't implement this NACKing, but this
will be resolved in a separate commit (see the PR of this commit for
details and links).

Block-level tests pass, except for the known failures listed in #21755, thus not caused by this PR.