### PR TITLE
[usbdev] Software resets for internal buffer FIFOs

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -1158,7 +1158,6 @@
         }
       ]
     }
-
     { name: "wake_control",
       desc: "USB wake module control for suspend / resume",
       swaccess: "wo",
@@ -1197,7 +1196,6 @@
         },
       ]
     }
-
     { name: "wake_events",
       desc: "USB wake module events and debug",
       swaccess: "ro",
@@ -1230,7 +1228,49 @@
         }
       ]
     }
-
+    { name: "fifo_ctrl",
+      desc: "FIFO control register",
+      swaccess: "wo",
+      hwaccess: "hro",
+      fields: [
+        {
+          bits: "0",
+          resval: "0",
+          name: "avout_rst",
+          desc: '''
+                Software reset of the Available OUT Buffer FIFO. This must be used only when the USB device
+                is not connected to the USB.
+                '''
+          hwqe: "true"
+          tags: [// Prevent interaction with the Av OUT FIFO state indicators.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+        {
+          bits: "1",
+          resval: "0",
+          name: "avsetup_rst",
+          desc: '''
+                Software reset of the Available SETUP Buffer FIFO. This must be used only when the USB device
+                is not connected to the USB.
+                '''
+          hwqe: "true"
+          tags: [// Prevent interaction with the Av SETUP FIFO state indicators.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+        {
+          bits: "2",
+          resval: "0",
+          name: "rx_rst",
+          desc: '''
+                Software reset the of Rx Buffer FIFO. This must be used only when the USB device is not
+                connected to the USB.
+                '''
+          hwqe: "true"
+          tags: [// Prevent interaction with the Rx FIFO state indicators.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
     { window: {
         name: "buffer",
         items: "512",

--- a/hw/ip/usbdev/doc/registers.md
+++ b/hw/ip/usbdev/doc/registers.md
@@ -43,6 +43,7 @@
 | usbdev.[`phy_config`](#phy_config)           | 0x8c     |        4 | USB PHY Configuration                                                      |
 | usbdev.[`wake_control`](#wake_control)       | 0x90     |        4 | USB wake module control for suspend / resume                               |
 | usbdev.[`wake_events`](#wake_events)         | 0x94     |        4 | USB wake module events and debug                                           |
+| usbdev.[`fifo_ctrl`](#fifo_ctrl)             | 0x98     |        4 | FIFO control register                                                      |
 | usbdev.[`buffer`](#buffer)                   | 0x800    |     2048 | 2 kB packet buffer. Divided into 32 64-byte buffers.                       |
 
 ## INTR_STATE
@@ -1332,6 +1333,25 @@ USB wake module events and debug
 |   8    |   ro   |   0x0   | disconnected  | USB aon wake module detected VBUS was interrupted while monitoring events.     |
 |  7:1   |        |         |               | Reserved                                                                       |
 |   0    |   ro   |   0x0   | module_active | USB aon wake module is active, monitoring events and controlling the pull-ups. |
+
+## fifo_ctrl
+FIFO control register
+- Offset: `0x98`
+- Reset default: `0x0`
+- Reset mask: `0x7`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "avout_rst", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "avsetup_rst", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "rx_rst", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+```
+
+|  Bits  |  Type  |  Reset  | Name        | Description                                                                                                                |
+|:------:|:------:|:-------:|:------------|:---------------------------------------------------------------------------------------------------------------------------|
+|  31:3  |        |         |             | Reserved                                                                                                                   |
+|   2    |   wo   |   0x0   | rx_rst      | Software reset the of Rx Buffer FIFO. This must be used only when the USB device is not connected to the USB.              |
+|   1    |   wo   |   0x0   | avsetup_rst | Software reset of the Available SETUP Buffer FIFO. This must be used only when the USB device is not connected to the USB. |
+|   0    |   wo   |   0x0   | avout_rst   | Software reset of the Available OUT Buffer FIFO. This must be used only when the USB device is not connected to the USB.   |
 
 ## buffer
 2 kB packet buffer. Divided into 32 64-byte buffers.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_fifo_rst_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_fifo_rst_vseq.sv
@@ -1,0 +1,129 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// FIFO RST sequence
+//
+// Since the FIFO RST functionality can only be employed safely whilst the USB device is not
+// connected to the USB, the verification of this functionality can be achieved almost entirely
+// from the CSR side.
+//
+// TODO: The one complication is that in order to place packets in the Rx FIFO we must connect to
+// the device and sent it traffic over the USB.
+class usbdev_fifo_rst_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_fifo_rst_vseq)
+
+  `uvm_object_new
+
+  // Number of transactions to perform
+  //rand uint num_txns;
+  constraint num_trans_c {num_trans inside {[64:256]};}
+
+  // Widths of buffer numbers, in bits
+  localparam uint BufW = $clog2(usbdev_env_pkg::NumBuffers + 1);
+
+  // Widths of FIFO levels/depths in bits
+  localparam uint AvOutDepthW   = $clog2(usbdev_env_pkg::AvOutFIFODepth + 1);
+  localparam uint AvSetupDepthW = $clog2(usbdev_env_pkg::AvSetupFIFODepth + 1);
+  localparam uint RxDepthW      = $clog2(usbdev_env_pkg::RxFIFODepth + 1);
+
+  // Initial FIFO levels are randomized
+  rand bit [AvOutDepthW  -1:0] avout_level;
+  rand bit [AvSetupDepthW-1:0] avsetup_level;
+  rand bit [RxDepthW     -1:0] rx_level;
+
+  constraint avout_level_c {avout_level inside {[0:usbdev_env_pkg::AvOutFIFODepth]};}
+  constraint avsetup_level_c {avsetup_level inside {[0:usbdev_env_pkg::AvSetupFIFODepth]};}
+  constraint rx_level_c {rx_level inside {[0:usbdev_env_pkg::RxFIFODepth]};}
+
+  // FIFO selection
+  typedef enum {
+    AvOutFifo,
+    AvSetupFifo,
+    RxFifo
+  } fifo_type_e;
+
+  // Populate a FIFOs with the given number of buffers.
+  //
+  // Note: the buffer numbers chosen don't actually matter for this test because the buffers
+  // themselves shall never be used.
+  task populate_fifo(fifo_type_e fifo, uint nbuf);
+    for (uint b = 0; b < nbuf; b++) begin
+      bit [BufW-1:0] buffer;
+      // Choose a random buffer number
+      buffer = $urandom_range(0, usbdev_env_pkg::NumBuffers - 1);
+      unique case (fifo)
+        AvOutFifo:   csr_wr(ral.avoutbuffer, buffer);
+        AvSetupFifo: csr_wr(ral.avsetupbuffer, buffer);
+        // Writing into the Rx FIFO require packet transmission from the host
+        // TODO: here we need to connect the device, with some appropriate configuration of at least
+        // one endpoint, and then transmit the appropriate number of packets to the OUT endpoint
+        // in question.
+        default:     `uvm_fatal(`gfn, "Rx FIFO writing not yet implemented")
+      endcase
+    end
+  endtask
+
+  task body();
+    // Set each of the FIFOs to its initial state.
+    populate_fifo(AvOutFifo, avout_level);
+    populate_fifo(AvSetupFifo, avsetup_level);
+    // populate_fifo(RxFifo, rx_level);
+    for (int unsigned txn = 0; txn < num_trans; txn++) begin
+      bit avout_full, avsetup_full, rx_empty;
+      uvm_reg_data_t usbstat;
+
+      if (cfg.under_reset) begin
+        avsetup_level = 0;
+        avout_level = 0;
+        rx_level = 0;
+      end else begin
+        uint new_level;
+        // Choose a FIFO to reset
+        fifo_type_e fifo;
+        // TODO: Rx FIFO not yet supported.
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(fifo, fifo != RxFifo;)
+        // Hit the reset
+        unique case (fifo)
+          AvOutFifo: begin
+            ral.fifo_ctrl.avout_rst.set(1'b1);
+            csr_update(.csr(ral.fifo_ctrl));
+            new_level = $urandom_range(0, usbdev_env_pkg::AvOutFIFODepth);
+            avout_level = new_level;
+          end
+          AvSetupFifo: begin
+            ral.fifo_ctrl.avsetup_rst.set(1'b1);
+            csr_update(.csr(ral.fifo_ctrl));
+            new_level = $urandom_range(0, usbdev_env_pkg::AvSetupFIFODepth);
+            avsetup_level = new_level;
+          end
+          default: begin
+            ral.fifo_ctrl.rx_rst.set(1'b1);
+            csr_update(.csr(ral.fifo_ctrl));
+            new_level = $urandom_range(0, usbdev_env_pkg::RxFIFODepth);
+            rx_level = new_level;
+          end
+        endcase
+        populate_fifo(fifo, new_level);
+      end
+
+      // Expected status indicators.
+      avout_full   = (avout_level   >= usbdev_env_pkg::AvOutFIFODepth);
+      avsetup_full = (avsetup_level >= usbdev_env_pkg::AvSetupFIFODepth);
+      rx_empty     = 1'b1;
+
+      // Read the new FIFO levels and status indicators.
+      csr_rd(ral.usbstat, usbstat);
+      // Check the FIFO levels are as expected
+      `DV_CHECK_EQ(get_field_val(ral.usbstat.av_out_depth,   usbstat), avout_level);
+      `DV_CHECK_EQ(get_field_val(ral.usbstat.av_setup_depth, usbstat), avsetup_level);
+      // TODO: Rx FIFO not yet supported.
+      `DV_CHECK_EQ(get_field_val(ral.usbstat.rx_depth,       usbstat), 0);
+      // Check the other status indications as well for completeness.
+      `DV_CHECK_EQ(get_field_val(ral.usbstat.av_out_full,    usbstat), avout_full);
+      `DV_CHECK_EQ(get_field_val(ral.usbstat.av_setup_full,  usbstat), avsetup_full);
+      `DV_CHECK_EQ(get_field_val(ral.usbstat.rx_empty,       usbstat), rx_empty);
+    end
+  endtask
+
+endclass : usbdev_fifo_rst_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -18,3 +18,4 @@
 `include "usbdev_max_length_out_transaction_vseq.sv"
 `include "usbdev_out_stall_vseq.sv"
 `include "usbdev_out_trans_nak_vseq.sv"
+`include "usbdev_fifo_rst_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -40,6 +40,7 @@ filesets:
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_stall_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_trans_nak_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_fifo_rst_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
@@ -21,6 +21,13 @@ package usbdev_env_pkg;
 
   // parameters
 
+  // Number of packet buffers available within the USB device
+  parameter uint NumBuffers       = 32;
+  // FIFO Depths; number of entries
+  parameter uint AvOutFIFODepth   = 8;
+  parameter uint AvSetupFIFODepth = 4;
+  parameter uint RxFIFODepth      = 8;
+
   // alerts
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -398,6 +398,9 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
       "wake_events": begin
         // TODO
       end
+      "fifo_ctrl": begin
+        // TODO
+      end
       "buffer": begin
         do_read_check = 1'b1;
       end

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -112,7 +112,10 @@
       name: usbdev_out_trans_nak
       uvm_test_seq: out_trans_nak_vseq
     }
-
+    {
+      name: usbdev_fifo_rst
+      uvm_test_seq: usbdev_fifo_rst_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -223,11 +223,14 @@ module usbdev
   // Receive interface fifos //
   /////////////////////////////
 
+  logic              avsetup_fifo_rst;
   logic              avsetup_fifo_wready;
+  logic              avout_fifo_rst;
   logic              avout_fifo_wready;
   logic              event_pkt_received;
   logic              avsetup_rvalid, avsetup_rready;
   logic              avout_rvalid, avout_rready;
+  logic              rx_fifo_rst;
   logic              rx_wvalid, rx_wready;
   logic              rx_wready_setup, rx_wready_out;
   logic              rx_fifo_rvalid;
@@ -238,6 +241,11 @@ module usbdev
   logic [RXFifoWidth - 1:0] rx_wdata, rx_rdata;
 
   logic [NEndpoints-1:0] clear_rxenable_out;
+
+  // Software reset signals
+  assign avsetup_fifo_rst = reg2hw.fifo_ctrl.avsetup_rst.qe & reg2hw.fifo_ctrl.avsetup_rst.q;
+  assign avout_fifo_rst = reg2hw.fifo_ctrl.avout_rst.qe & reg2hw.fifo_ctrl.avout_rst.q;
+  assign rx_fifo_rst = reg2hw.fifo_ctrl.rx_rst.qe & reg2hw.fifo_ctrl.rx_rst.q;
 
   // Separate 'FIFO empty' interrupts for the OUT and SETUP FIFOs because each interrupt cannot be
   // cleared without writing a buffer into the FIFO
@@ -257,7 +265,7 @@ module usbdev
   ) usbdev_avsetupfifo (
     .clk_i,
     .rst_ni    (rst_n),
-    .clr_i     (1'b0),
+    .clr_i     (avsetup_fifo_rst),
 
     .wvalid_i  (reg2hw.avsetupbuffer.qe),
     .wready_o  (avsetup_fifo_wready),
@@ -280,7 +288,7 @@ module usbdev
   ) usbdev_avoutfifo (
     .clk_i,
     .rst_ni    (rst_n),
-    .clr_i     (1'b0),
+    .clr_i     (avout_fifo_rst),
 
     .wvalid_i  (reg2hw.avoutbuffer.qe),
     .wready_o  (avout_fifo_wready),
@@ -316,7 +324,7 @@ module usbdev
   ) usbdev_rxfifo (
     .clk_i,
     .rst_ni    (rst_n),
-    .clr_i     (1'b0),
+    .clr_i     (rx_fifo_rst),
 
     .wvalid_i  (rx_wvalid),
     .wready_o  (rx_wready),

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -394,6 +394,21 @@ package usbdev_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+      logic        qe;
+    } rx_rst;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } avsetup_rst;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } avout_rst;
+  } usbdev_reg2hw_fifo_ctrl_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
       logic        de;
     } pkt_received;
@@ -618,30 +633,31 @@ package usbdev_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [475:458]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [457:440]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [439:404]
-    usbdev_reg2hw_alert_test_reg_t alert_test; // [403:402]
-    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [401:392]
-    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [391:380]
-    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [379:368]
-    usbdev_reg2hw_avoutbuffer_reg_t avoutbuffer; // [367:362]
-    usbdev_reg2hw_avsetupbuffer_reg_t avsetupbuffer; // [361:356]
-    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [355:335]
-    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [334:323]
-    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [322:311]
-    usbdev_reg2hw_set_nak_out_mreg_t [11:0] set_nak_out; // [310:299]
-    usbdev_reg2hw_in_sent_mreg_t [11:0] in_sent; // [298:287]
-    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [286:275]
-    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [274:263]
-    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [262:95]
-    usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [94:83]
-    usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [82:71]
-    usbdev_reg2hw_out_data_toggle_reg_t out_data_toggle; // [70:45]
-    usbdev_reg2hw_in_data_toggle_reg_t in_data_toggle; // [44:19]
-    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [18:10]
-    usbdev_reg2hw_phy_config_reg_t phy_config; // [9:4]
-    usbdev_reg2hw_wake_control_reg_t wake_control; // [3:0]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [481:464]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [463:446]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [445:410]
+    usbdev_reg2hw_alert_test_reg_t alert_test; // [409:408]
+    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [407:398]
+    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [397:386]
+    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [385:374]
+    usbdev_reg2hw_avoutbuffer_reg_t avoutbuffer; // [373:368]
+    usbdev_reg2hw_avsetupbuffer_reg_t avsetupbuffer; // [367:362]
+    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [361:341]
+    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [340:329]
+    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [328:317]
+    usbdev_reg2hw_set_nak_out_mreg_t [11:0] set_nak_out; // [316:305]
+    usbdev_reg2hw_in_sent_mreg_t [11:0] in_sent; // [304:293]
+    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [292:281]
+    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [280:269]
+    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [268:101]
+    usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [100:89]
+    usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [88:77]
+    usbdev_reg2hw_out_data_toggle_reg_t out_data_toggle; // [76:51]
+    usbdev_reg2hw_in_data_toggle_reg_t in_data_toggle; // [50:25]
+    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [24:16]
+    usbdev_reg2hw_phy_config_reg_t phy_config; // [15:10]
+    usbdev_reg2hw_wake_control_reg_t wake_control; // [9:6]
+    usbdev_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [5:0]
   } usbdev_reg2hw_t;
 
   // HW -> register type
@@ -700,6 +716,7 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 8c;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_CONTROL_OFFSET = 12'h 90;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_EVENTS_OFFSET = 12'h 94;
+  parameter logic [BlockAw-1:0] USBDEV_FIFO_CTRL_OFFSET = 12'h 98;
 
   // Reset values for hwext registers and their fields
   parameter logic [17:0] USBDEV_INTR_TEST_RESVAL = 18'h 0;
@@ -777,11 +794,12 @@ package usbdev_reg_pkg;
     USBDEV_PHY_PINS_DRIVE,
     USBDEV_PHY_CONFIG,
     USBDEV_WAKE_CONTROL,
-    USBDEV_WAKE_EVENTS
+    USBDEV_WAKE_EVENTS,
+    USBDEV_FIFO_CTRL
   } usbdev_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] USBDEV_PERMIT [38] = '{
+  parameter logic [3:0] USBDEV_PERMIT [39] = '{
     4'b 0111, // index[ 0] USBDEV_INTR_STATE
     4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
     4'b 0111, // index[ 2] USBDEV_INTR_TEST
@@ -819,7 +837,8 @@ package usbdev_reg_pkg;
     4'b 0111, // index[34] USBDEV_PHY_PINS_DRIVE
     4'b 0001, // index[35] USBDEV_PHY_CONFIG
     4'b 0001, // index[36] USBDEV_WAKE_CONTROL
-    4'b 0011  // index[37] USBDEV_WAKE_EVENTS
+    4'b 0011, // index[37] USBDEV_WAKE_EVENTS
+    4'b 0001  // index[38] USBDEV_FIFO_CTRL
   };
 
 endpackage


### PR DESCRIPTION
This PR introduces low-impact software resets for the internal buffer FIFOs, controlled by a new register, as a contingency against unanticipated error conditions, and for future deployments of the USB device where the use of the asynchronous block-level reset is not a viable option. Block-level reset may impact other IP blocks and/or firmware within other chips that contain the USB device, and it may be very time-consuming.

Use of the software resets is only safe when the USB device is not connected to the USB, because packets may be received at any time when the USB is active. Therefore, the pull up should be disabled first. Documentation update to follow in a separate PR, accompanying documentation updates for other recent changes.

The second commit introduces a simple test sequence that randomly resets the FIFO to check that the FIFO level and status indications are updated as expected in response to the resets. Some further DV work will be required later to extend this sequence to exercise resetting of the Rx FIFO.

Fixes #17300 