### PR TITLE
[usbdev,i2c] Drop local clear_all_interrupts

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -100,47 +100,6 @@ virtual task dut_init(string reset_kind = "HARD");
   if (do_usbdev_init) usbdev_init();
 endtask
 
-  // TODO: Temporary override of the task in cip_base_vseq, because it requires modification to
-  // support Status Type interrupts. Remove this when cip_base_vseq has been updated.
-  //
-  // Task to clear register intr status bits
-  virtual task clear_all_interrupts();
-    dv_utils_pkg::interrupt_t signal_ro_mask = '0;
-    int sig_idx = 0;
-    if (cfg.num_interrupts == 0) return;
-    foreach (intr_state_csrs[i]) begin
-      dv_base_reg_field flds[$];
-      bit [bus_params_pkg::BUS_DW-1:0] csr_ro_mask = 0;
-      bit [bus_params_pkg::BUS_DW-1:0] data;
-      // Status type interrupts are read-only and cannot be cleared by writing 1 to them.
-      // Instead, the underlying condition needs to be resolved (e.g. drain a FIFO that is full).
-      // Therefore, we extract the RO bitmask so that we can mask the writes / reads below.
-      intr_state_csrs[i].get_dv_base_reg_fields(flds);
-      foreach (flds[j]) begin
-        if (flds[j].get_access() == "RO") begin
-          csr_ro_mask[j] = 1'b1;
-          // Remember the mask for the interrupt signals below.
-          signal_ro_mask[sig_idx] = 1'b1;
-        end
-        sig_idx++;
-      end
-      csr_rd(.ptr(intr_state_csrs[i]), .value(data));
-      if (data & ~csr_ro_mask != 0) begin
-        `uvm_info(`gtn, $sformatf("Clearing %0s", intr_state_csrs[i].get_name()), UVM_HIGH)
-        csr_wr(.ptr(intr_state_csrs[i]), .value(data & ~csr_ro_mask));
-        csr_rd(.ptr(intr_state_csrs[i]), .value(data));
-        if (!cfg.under_reset) `DV_CHECK_EQ(data & ~csr_ro_mask, 0)
-        else break;
-      end
-    end
-    if (!cfg.under_reset) begin
-      // Status type interrupts may remain asserted, hence we have to mask them away.
-      dv_utils_pkg::interrupt_t mask = dv_utils_pkg::interrupt_t'((1 << cfg.num_interrupts) - 1) &
-                                       ~signal_ro_mask;
-      `DV_CHECK_EQ(cfg.intr_vif.sample() & mask, '0)
-    end
-  endtask
-
   virtual task call_token_seq(input pkt_type_e pkt_type, input pid_type_e pid_type, bit [3:0] endp);
     `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
     m_token_pkt.m_pkt_type = pkt_type;


### PR DESCRIPTION
Local implementation of 'clear_all_interrupts' is no longer required/appropriate because the cip_base_vseq class has been updated.