### PR TITLE
[flash_ctrl/dv] carry over DV fix to ip_autogen

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -57,7 +57,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   constraint flash_op_c {
     flash_op.op inside {FlashOpRead, FlashOpProgram, FlashOpErase};
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
-
+    flash_op.otf_addr == flash_op.addr[OTFHostId-1:0];
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
     flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -57,7 +57,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   constraint flash_op_c {
     flash_op.op inside {FlashOpRead, FlashOpProgram, FlashOpErase};
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
-
+    flash_op.otf_addr == flash_op.addr[OTFHostId-1:0];
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
     flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;


### PR DESCRIPTION
This needs to be carried over to ip_autogen since the IPgen transition has not been fully completed yet.