### PR TITLE
[dv,sram_ctrl] Improve detection of init_done and key_scr_valid

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -100,7 +100,6 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
         req_mem_init();
       end
 
-
       // Do some random memory accesses
       `uvm_info(`gfn,
                 $sformatf("Performing %0d random memory accesses!", num_ops),

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
@@ -17,8 +17,10 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
     cfg.m_tl_agent_cfgs[cfg.sram_ral_name].allow_a_valid_drop_wo_a_ready = 0;
 
     req_mem_init();
-    // And wait for any side_effect of ram_init, since detection of the end is not very accurate.
-    cfg.clk_rst_vif.wait_clks(3);
+    // And wait for side_effects of ram_init to be done, since detection of the end is not very
+    // accurate and memory transactions wll be blocked until init is completely done. The number
+    // 20 below is not special, it is just a sensible guess.
+    cfg.clk_rst_vif.wait_clks(20);
 
     for (int i = 0; i < num_trans; i++) begin
       int num_cycles;


### PR DESCRIPTION
The older scheme for this detection used csr_spinwait for the duration of init and key request. This only uses csr_spinwait once the request is satisfied, to detect the actual CSR updates. This is just as accurate as the older scheme, and by avoiding csr_spinwait for the full time it simplifies handling of random reset.