### PR TITLE
[dv] Update spi-device testplan for V1 sign-off.

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -205,6 +205,17 @@
       tests: ["spi_device_intercept", "spi_device_flash_all"]
     }
     {
+      name: cmd_read_pipeline
+      desc: '''
+            - Configure proper fast read command info slot with the read data pipeline feature.
+            - Issue fast read command.
+            - Check propagation of fast read command, including dummy cycles for read data pipeline.
+            - Initiate response to the fast read.
+            - Check proper reception of response.'''
+      stage: V2
+      tests: ["spi_device_intercept", "spi_device_flash_all"]
+    }
+    {
       name: flash_cmd_upload
       desc: '''
             - Configure spi_device on flash or passthrough mode.
@@ -405,6 +416,7 @@
             Cover payload swap enable.
             Cover upload enable.
             Cover busy enable.
+            Cover all read_pipeline_mode values
             Cover all dummy sizes.
             Cover number of payload lanes (single, dual and quad modes or no payload).
 


### PR DESCRIPTION
The testplan has been updated to directly mention the new RTL features for V1 sign-off:
- equivalent r/w access when using 1r1w SRAMs as opposed to the 2PSRAM
- Mention of read_pipeline feature as a testpoint
- new covergroup to sample the type of SRAM instantiated
- addition of read_pipeline_mode coverpoint to existing flash_cmd_info_cg