### PR TITLE
[usbdev,dv] Fix names in usbdev_sim_cfg.hjson

### DIFF
--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -94,23 +94,23 @@
     }
     {
       name: usbdev_random_length_out_trans
-      uvm_test_seq: random_length_out_transaction_vseq
+      uvm_test_seq: usbdev_random_length_out_transaction_vseq
     }
     {
       name: usbdev_min_length_out_transaction
-      uvm_test_seq: min_length_out_transaction_vseq
+      uvm_test_seq: usbdev_min_length_out_transaction_vseq
     }
     {
       name: usbdev_max_length_out_transaction
-      uvm_test_seq: max_length_out_transaction_vseq
+      uvm_test_seq: usbdev_max_length_out_transaction_vseq
     }
     {
       name: usbdev_out_stall
-      uvm_test_seq: out_stall_vseq
+      uvm_test_seq: usbdev_out_stall_vseq
     }
     {
       name: usbdev_out_trans_nak
-      uvm_test_seq: out_trans_nak_vseq
+      uvm_test_seq: usbdev_out_trans_nak_vseq
     }
     {
       name: usbdev_fifo_rst


### PR DESCRIPTION
The vseq names all have a "usbdev_" prefix, but some of the tests were missing that prefix, which will have stopped them from working properly. Put it back.

This change came from a bugfix that was part of #21556. I'm "cherry-picking" the obvious bug fix here to buy some time to review the rest of the PR properly.