### PR TITLE
[usbdev,dv] Drop some arguments from the call_token_seq task

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -17,7 +17,7 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
     // Configure transaction
     configure_trans();
     // Out token packet followed by a data packet of 8 bytes
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(rsp_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -10,13 +10,8 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
 
   usb20_item      item;
   RSP             rsp_item;
-  rand bit [3:0]  endp;
   bit      [6:0]  num_of_bytes = 8;
   bit             rand_or_not = 0;
-
-  constraint endpoint_c {
-    endp inside {[0:11]};
-  }
 
   task body();
     // Configure transaction

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -17,7 +17,7 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
     // Configure transaction
     configure_trans();
     // Out token packet followed by a data packet of 8 bytes
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(rsp_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -100,9 +100,9 @@ virtual task dut_init(string reset_kind = "HARD");
   if (do_usbdev_init) usbdev_init();
 endtask
 
-  virtual task call_token_seq(input pkt_type_e pkt_type, input pid_type_e pid_type);
+  virtual task call_token_seq(input pid_type_e pid_type);
     `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
-    m_token_pkt.m_pkt_type = pkt_type;
+    m_token_pkt.m_pkt_type = PktTypeToken;
     m_token_pkt.m_pid_type = pid_type;
     assert(m_token_pkt.randomize() with {m_token_pkt.address inside {7'b0};
                                          m_token_pkt.endpoint == endp;});

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -100,7 +100,7 @@ virtual task dut_init(string reset_kind = "HARD");
   if (do_usbdev_init) usbdev_init();
 endtask
 
-  virtual task call_token_seq(input pkt_type_e pkt_type, input pid_type_e pid_type, bit [3:0] endp);
+  virtual task call_token_seq(input pkt_type_e pkt_type, input pid_type_e pid_type);
     `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
     m_token_pkt.m_pkt_type = pkt_type;
     m_token_pkt.m_pid_type = pid_type;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -27,7 +27,7 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     cfg.clk_rst_vif.wait_clks(100);
     configure_out_trans(); // register configurations for OUT Trans.
     cfg.clk_rst_vif.wait_clks(20);
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -27,7 +27,7 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     cfg.clk_rst_vif.wait_clks(100);
     configure_out_trans(); // register configurations for OUT Trans.
     cfg.clk_rst_vif.wait_clks(20);
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -19,7 +19,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // to store data in buffer memory for read through IN.
     configure_out_trans(); // register configurations for OUT Trans.
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);
@@ -35,7 +35,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(out_buffer_id);  // register configurations for IN Trans.
     // Token pkt followed by handshake pkt
-    call_token_seq(PktTypeToken, PidTypeInToken, endp);
+    call_token_seq(PktTypeToken, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeData0);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -19,7 +19,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // to store data in buffer memory for read through IN.
     configure_out_trans(); // register configurations for OUT Trans.
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);
@@ -35,7 +35,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(out_buffer_id);  // register configurations for IN Trans.
     // Token pkt followed by handshake pkt
-    call_token_seq(PktTypeToken, PidTypeInToken);
+    call_token_seq(PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeData0);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -24,7 +24,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     csr_update(ral.set_nak_out[0]);
 
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
@@ -49,7 +49,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     csr_update(ral.avoutbuffer);
 
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData1, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -24,7 +24,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     csr_update(ral.set_nak_out[0]);
 
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
@@ -49,7 +49,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     csr_update(ral.avoutbuffer);
 
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData1, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -18,7 +18,7 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
     ral.out_stall[0].endpoint[endp].set(1'b1);
     csr_update(ral.out_stall[0]);
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -18,7 +18,7 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
     ral.out_stall[0].endpoint[endp].set(1'b1);
     csr_update(ral.out_stall[0]);
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -18,7 +18,7 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
     ral.rxenable_out[0].out[endp].set(1'b0);
     csr_update(ral.rxenable_out[0]);
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -18,7 +18,7 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
     ral.rxenable_out[0].out[endp].set(1'b0);
     csr_update(ral.rxenable_out[0]);
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -10,16 +10,11 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
 
   usb20_item     item;
   RSP            rsp_item;
-  rand bit [3:0] endp;
   bit            rand_or_not = 1;
   bit      [6:0] num_of_bytes;
   bit            pkt_received;
   uvm_reg_data_t read_rxfifo;
   uvm_reg_data_t intr_state;
-
-  constraint endpoint_c {
-    endp inside {[0:11]};
-  }
 
   task body();
     // Configure transaction

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     // Configure transaction
     configure_trans();
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(rsp_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     // Configure transaction
     configure_trans();
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(rsp_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -23,7 +23,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     csr_update(ral.intr_enable);
 
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     // Get response from DUT
@@ -42,7 +42,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(out_buffer_id);
     // Token pkt followed by handshake pkt
-    call_token_seq(PktTypeToken, PidTypeInToken, endp);
+    call_token_seq(PktTypeToken, PidTypeInToken);
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -23,7 +23,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     csr_update(ral.intr_enable);
 
     // Out token packet followed by a data packet
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     // Get response from DUT
@@ -42,7 +42,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(out_buffer_id);
     // Token pkt followed by handshake pkt
-    call_token_seq(PktTypeToken, PidTypeInToken);
+    call_token_seq(PidTypeInToken);
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -12,7 +12,7 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
     // Configure out transaction
     configure_out_trans();
     // Out token packet followed by a data packet of random bytes
-    call_token_seq(PktTypeToken, PidTypeOutToken, endp);
+    call_token_seq(PktTypeToken, PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -12,7 +12,7 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
     // Configure out transaction
     configure_out_trans();
     // Out token packet followed by a data packet of random bytes
-    call_token_seq(PktTypeToken, PidTypeOutToken);
+    call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_trans_ignored_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_trans_ignored_vseq.sv
@@ -17,7 +17,7 @@ class usbdev_setup_trans_ignored_vseq extends usbdev_base_vseq;
     ral.intr_enable.pkt_received.set(1'b1); // Enable pkt_received interrupt
     csr_update(ral.intr_enable);
     // Setup token packet
-    call_token_seq(PktTypeToken, PidTypeSetupToken);
+    call_token_seq(PidTypeSetupToken);
     cfg.clk_rst_vif.wait_clks(20);
     csr_rd(.ptr(ral.intr_state.pkt_received), .value(pkt_received));
     // Verify the packet received bit must be zero.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_trans_ignored_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_trans_ignored_vseq.sv
@@ -17,7 +17,7 @@ class usbdev_setup_trans_ignored_vseq extends usbdev_base_vseq;
     ral.intr_enable.pkt_received.set(1'b1); // Enable pkt_received interrupt
     csr_update(ral.intr_enable);
     // Setup token packet
-    call_token_seq(PktTypeToken, PidTypeSetupToken, endp);
+    call_token_seq(PktTypeToken, PidTypeSetupToken);
     cfg.clk_rst_vif.wait_clks(20);
     csr_rd(.ptr(ral.intr_state.pkt_received), .value(pkt_received));
     // Verify the packet received bit must be zero.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -34,7 +34,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     ral.intr_enable.pkt_received.set(1'b1); // Enable pkt_received interrupt
     csr_update(ral.intr_enable);
     // Setup token packet followed by a data packet of 8 bytes
-    call_token_sequence(PktTypeToken, PidTypeSetupToken);
+    call_token_sequence(PidTypeSetupToken);
     cfg.clk_rst_vif.wait_clks(20);
     call_data_sequence(PktTypeData, PidTypeData0);
     cfg.clk_rst_vif.wait_clks(20);
@@ -45,10 +45,10 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     `DV_CHECK_EQ(rx_fifo_expected, rx_fifo_read);
   endtask
 
-  task call_token_sequence(input pkt_type_e pkt_type, input pid_type_e pid_type);
+  task call_token_sequence(input pid_type_e pid_type);
     RSP rsp_item;
     `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
-    m_token_pkt.m_pkt_type = pkt_type;
+    m_token_pkt.m_pkt_type = PktTypeToken;
     m_token_pkt.m_pid_type = pid_type;
     assert(m_token_pkt.randomize() with {m_token_pkt.address inside {7'b0};
                                          m_token_pkt.endpoint inside {4'd0};});


### PR DESCRIPTION
The values are the same at every call site. Get rid of the argument, since it's just confusing!