### PR TITLE
[usbdev,dv] Set num_of_bytes earlier in usbdev_in_trans_vseq

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -11,6 +11,9 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
   virtual task body();
     uvm_reg_data_t rxfifo;
     bit in_sent;
+
+    num_of_bytes = $urandom_range(1, 64);
+
     super.dut_init("HARD");
     clear_all_interrupts();
     ral.intr_enable.pkt_sent.set(1'b1); // Enable pkt_sent interrupt
@@ -31,7 +34,6 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // Make sure buffer is availabe for next trans
     ral.avoutbuffer.buffer.set(out_buffer_id + 1);
     csr_update(ral.avoutbuffer);
-    num_of_bytes = m_data_pkt.data.size();
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(out_buffer_id);  // register configurations for IN Trans.
     // Token pkt followed by handshake pkt

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -11,8 +11,10 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
   virtual task body();
     uvm_reg_data_t read_rxfifo;
 
-     super.dut_init("HARD");
-     clear_all_interrupts();
+    num_of_bytes = $urandom_range(1, 64);
+
+    super.dut_init("HARD");
+    clear_all_interrupts();
 
     // OUT TRANS
     // -------------------------------
@@ -38,7 +40,6 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // IN TRANS
     // --------------------------------
     // Configure in transaction
-    num_of_bytes = m_data_pkt.data.size();
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(out_buffer_id);
     // Token pkt followed by handshake pkt


### PR DESCRIPTION
The existing code was pretty unclear. The m_data_pkt.data queue is created inside call_data_seq() in the base class, where its size is constrained to num_of_bytes: a variable that is passed in uninitialised.

I think that the existing implementation was picking a random 7-bit number to use as an argument, but it was *very* unclear.

This implementation is a little more obvious. I suspect there are further improvements possible, but at least it's now obvious what this does.

(@MubashirSaleem775: I think this code came from you originally. Would you mind checking that I've understood the behaviour correctly?)