### PR TITLE
[usbdev,dv] Remove unneeded arguments from call_data_seq

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet of 8 bytes
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     get_response(rsp_item);
     $cast(item, rsp_item);
     get_out_response_from_device(item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet of 8 bytes
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     get_response(rsp_item);
     $cast(item, rsp_item);
     get_out_response_from_device(item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet of 8 bytes
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     get_response(rsp_item);
     $cast(item, rsp_item);
     get_out_response_from_device(item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -10,10 +10,10 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
 
   usb20_item      item;
   RSP             rsp_item;
-  bit      [6:0]  num_of_bytes = 8;
 
   task body();
     rand_or_not = 1'b0;
+    num_of_bytes = 8;
 
     // Configure transaction
     configure_trans();

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -11,9 +11,10 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
   usb20_item      item;
   RSP             rsp_item;
   bit      [6:0]  num_of_bytes = 8;
-  bit             rand_or_not = 0;
 
   task body();
+    rand_or_not = 1'b0;
+
     // Configure transaction
     configure_trans();
     // Out token packet followed by a data packet of 8 bytes

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -111,7 +111,7 @@ endtask
     finish_item(m_token_pkt);
   endtask
 
-  virtual task call_data_seq(input pid_type_e pid_type, input bit [6:0] num_of_bytes);
+  virtual task call_data_seq(input pid_type_e pid_type);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
     m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -111,10 +111,10 @@ endtask
     finish_item(m_token_pkt);
   endtask
 
-  virtual task call_data_seq(input pkt_type_e pkt_type, input pid_type_e pid_type,
+  virtual task call_data_seq(input pid_type_e pid_type,
                              input bit rand_or_not, input bit [6:0] num_of_bytes);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
-    m_data_pkt.m_pkt_type = pkt_type;
+    m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;
     if (rand_or_not) assert(m_data_pkt.randomize());
     else assert(m_data_pkt.randomize() with {m_data_pkt.data.size() == num_of_bytes;});

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -111,8 +111,7 @@ endtask
     finish_item(m_token_pkt);
   endtask
 
-  virtual task call_data_seq(input pid_type_e pid_type,
-                             input bit rand_or_not, input bit [6:0] num_of_bytes);
+  virtual task call_data_seq(input pid_type_e pid_type, input bit [6:0] num_of_bytes);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
     m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -24,7 +24,7 @@ bit [4:0] out_buffer_id = 5'd7;
 // Current IN buffer number
 bit [4:0] in_buffer_id = 5'd13;
 bit      [6:0] num_of_bytes;
-bit            rand_or_not = 1;
+bit            rand_or_not = 1'b1;
 
 constraint endpoint_c {
   endp inside {[0:11]};

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -31,7 +31,7 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     cfg.clk_rst_vif.wait_clks(20);
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -14,13 +14,15 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     // Therefore, if we want to accurately test the device enable function,
     // we need to manually set this.
     do_usbdev_init = 1'b0;
+
+    rand_or_not = 1'b0;
+    num_of_bytes = 8;
+
     super.pre_start();
   endtask
 
   task body();
     uvm_reg_data_t rd_data;
-    num_of_bytes = 8;
-    rand_or_not = 0;
     ral.usbctrl.enable.set(1'b1);  // Set usbdev control register enable bit.
     ral.usbctrl.device_address.set(0);
     csr_update(ral.usbctrl);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -31,7 +31,7 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     cfg.clk_rst_vif.wait_clks(20);
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -31,7 +31,7 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     cfg.clk_rst_vif.wait_clks(20);
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -21,7 +21,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck); // check OUT response

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -21,7 +21,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck); // check OUT response

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -21,7 +21,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck); // check OUT response

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_length_out_transaction_vseq.sv
@@ -8,9 +8,9 @@ class usbdev_max_length_out_transaction_vseq extends usbdev_random_length_out_tr
 
   `uvm_object_new
 
-  task body();
+  task pre_start();
+    super.pre_start();
     num_of_bytes = 64;
-    rand_or_not = 0;
-    super.body();
+    rand_or_not = 1'b0;
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_min_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_min_length_out_transaction_vseq.sv
@@ -8,9 +8,9 @@ class usbdev_min_length_out_transaction_vseq extends usbdev_random_length_out_tr
 
   `uvm_object_new
 
-  task body();
+  task pre_start();
+    super.pre_start();
     num_of_bytes = 0;
-    rand_or_not = 0;
-    super.body();
+    rand_or_not = 1'b0;
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -26,7 +26,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check first transaction accuracy
@@ -51,7 +51,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData1, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData1, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check second transaction accuracy

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -26,7 +26,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check first transaction accuracy
@@ -51,7 +51,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData1, num_of_bytes);
+    call_data_seq(PidTypeData1);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check second transaction accuracy

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -26,7 +26,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check first transaction accuracy
@@ -51,7 +51,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData1, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData1, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check second transaction accuracy

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -10,7 +10,6 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
 
   usb20_item     item;
   RSP            rsp_item;
-  bit      [6:0] num_of_bytes;
   bit            pkt_received;
   uvm_reg_data_t read_rxfifo;
   uvm_reg_data_t intr_state;
@@ -23,7 +22,7 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     get_response(rsp_item);
     $cast(item, rsp_item);
     get_out_response_from_device(item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -10,13 +10,14 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
 
   usb20_item     item;
   RSP            rsp_item;
-  bit            rand_or_not = 1;
   bit      [6:0] num_of_bytes;
   bit            pkt_received;
   uvm_reg_data_t read_rxfifo;
   uvm_reg_data_t intr_state;
 
   task body();
+    rand_or_not = 1'b1;
+
     // Configure transaction
     configure_trans();
     // Out token packet followed by a data packet

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -23,7 +23,7 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     get_response(rsp_item);
     $cast(item, rsp_item);
     get_out_response_from_device(item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -23,7 +23,7 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     get_response(rsp_item);
     $cast(item, rsp_item);
     get_out_response_from_device(item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -25,7 +25,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -25,7 +25,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -25,7 +25,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -14,7 +14,7 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet of random bytes
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PktTypeData, PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -14,7 +14,7 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet of random bytes
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, rand_or_not, num_of_bytes);
+    call_data_seq(PidTypeData0, num_of_bytes);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -14,7 +14,7 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet of random bytes
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, num_of_bytes);
+    call_data_seq(PidTypeData0);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -36,7 +36,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     // Setup token packet followed by a data packet of 8 bytes
     call_token_sequence(PidTypeSetupToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_sequence(PktTypeData, PidTypeData0);
+    call_data_sequence(PidTypeData0);
     cfg.clk_rst_vif.wait_clks(20);
     // read rx_fifo register to check rcvd buffer id, endpoint number and type setup/out
     csr_rd(.ptr(ral.rxfifo), .value(rx_fifo_read));
@@ -62,10 +62,10 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
       end
   endtask
 
-  task call_data_sequence(input pkt_type_e pkt_type, input pid_type_e pid_type);
+  task call_data_sequence(input pid_type_e pid_type);
     RSP rsp_item;
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
-    m_data_pkt.m_pkt_type = pkt_type;
+    m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;
     m_data_pkt.m_bmRT = bmRequestType3;
     m_data_pkt.m_bR = bRequestGET_DESCRIPTOR;


### PR DESCRIPTION
This is analoguous to #21816. Remove some unneeded arguments and sort out some slightly confusing subclass usage. It should all end up a bit clearer now.