### PR TITLE
[cryptolib] Add a top-level `otcrypto.h` header

### DIFF
--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -25,12 +25,34 @@ ot_static_library(
     ],
 )
 
+# This library imports the archive created by the static library rule
+# above. This can be used within the codebase to test the cryptolib
+# as built.
 cc_import(
     name = "crypto",
     static_library = ":otcrypto",
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//sw/device/lib/crypto/include:crypto_hdrs",
+    ],
+)
+
+# This library imports the archive created by the static library rule
+# above AND provides the header files as though they'd been exported
+# from the repo in the same way as the packaged headers in the
+# cryptolib.tar.xz output below.  This is used to create tests that
+# verify the exported library and header files work correctly when
+# exported.  Because we export a version of the `hardended_bool_t` and
+# `status_t` types, it can be somewhat difficult to use this target
+# within the repo (ie: you cannot use the in-repo definitions of those
+# types, nor can you directly use anything that depends on those types).
+# See //sw/device/test/crypto:otcrypto_export_test as an example.
+cc_import(
+    name = "crypto_exported_for_test",
+    static_library = ":otcrypto",
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/crypto/include:exported_headers_for_test",
     ],
 )
 

--- a/sw/device/lib/crypto/include/BUILD
+++ b/sw/device/lib/crypto/include/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "kdf.h",
         "key_transport.h",
         "mac.h",
+        "otcrypto.h",
         "rsa.h",
     ],
     defines = ["OTCRYPTO_IN_REPO=1"],
@@ -39,6 +40,28 @@ cc_library(
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:status",
     ],
+)
+
+# Create a library that makes the headers available as though we've been
+# exported from the repo (ie: OTCRYPTO_IN_REPO is not set).
+cc_library(
+    name = "exported_headers_for_test",
+    hdrs = [
+        "aes.h",
+        "datatypes.h",
+        "drbg.h",
+        "ecc.h",
+        "hash.h",
+        "kdf.h",
+        "key_transport.h",
+        "mac.h",
+        "otcrypto.h",
+        "rsa.h",
+        "//sw/device/lib/crypto/include/freestanding:absl_status.h",
+        "//sw/device/lib/crypto/include/freestanding:defs.h",
+        "//sw/device/lib/crypto/include/freestanding:hardened.h",
+    ],
+    includes = ["."],
 )
 
 pkg_files(

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -5,11 +5,15 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DATATYPES_H_
 #define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_DATATYPES_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef OTCRYPTO_IN_REPO
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/status.h"
 #else
 #include "freestanding/absl_status.h"
+#include "freestanding/defs.h"
 #include "freestanding/hardened.h"
 #endif
 

--- a/sw/device/lib/crypto/include/freestanding/BUILD
+++ b/sw/device/lib/crypto/include/freestanding/BUILD
@@ -6,6 +6,8 @@ package(default_visibility = ["//visibility:public"])
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
+exports_files(glob(["*.h"]))
+
 pkg_files(
     name = "package",
     srcs = glob(["*.h"]),

--- a/sw/device/lib/crypto/include/freestanding/defs.h
+++ b/sw/device/lib/crypto/include/freestanding/defs.h
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_DEFS_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_DEFS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * OpenTitan's status_t is a single 32-bit word conveying either a result code
+ * or an error code.
+ * - The otcrypto has only one result code: The `Ok` value which is
+ *   equivalent in value to kHardenedBoolTrue.
+ * - The otcrypto error codes all have the MSB set and encode an error type of
+ *   absl_status_t in the lower 5 bits.
+ *
+ *   This definition is supplied to provide the status_t definition when
+ *   otcrypto is exported out of the OpenTitan repository.
+ */
+typedef struct status {
+  int32_t value;
+} status_t;
+
+/**
+ * Attribute for functions which return errors that must be acknowledged.
+ */
+#define OT_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_FREESTANDING_DEFS_H_

--- a/sw/device/lib/crypto/include/freestanding/hardened.h
+++ b/sw/device/lib/crypto/include/freestanding/hardened.h
@@ -29,11 +29,11 @@ typedef enum hardened_bool {
   /**
    * The truthy value, expected to be used like #true.
    */
-  kHardenedBoolTrue = HARDENED_BOOL_TRUE,
+  kHardenedBoolTrue = 0x739,
   /**
    * The falsey value, expected to be used like #false.
    */
-  kHardenedBoolFalse = HARDENED_BOOL_FALSE,
+  kHardenedBoolFalse = 0x1d4,
 } hardened_bool_t;
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/include/otcrypto.h
+++ b/sw/device/lib/crypto/include/otcrypto.h
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_OTCRYPTO_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_OTCRYPTO_H_
+
+#include "aes.h"
+#include "datatypes.h"
+#include "drbg.h"
+#include "ecc.h"
+#include "hash.h"
+#include "kdf.h"
+#include "key_transport.h"
+#include "mac.h"
+#include "rsa.h"
+
+/**
+ * @file
+ * @brief Unified header file that includes the full crypto library.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_OTCRYPTO_H_

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -710,6 +710,18 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "otcrypto_export_test",
+    srcs = ["otcrypto_export_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    deps = [
+        "//sw/device/lib/crypto:crypto_exported_for_test",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 filegroup(
     name = "template_files",
     srcs = [


### PR DESCRIPTION
Add a top-level header file that includes all other cryptolib headers.