### PR TITLE
[bazel] Disable `set -u` flag in bazelisk.sh

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -10,7 +10,7 @@
 # CI jobs should use ci/bazelisk.sh instead, which performs CI-friendly additional
 # setup.
 
-set -euo pipefail
+set -eo pipefail
 
 # Change to this script's directory, as it is the location of the bazel workspace.
 cd "$(dirname "$0")"


### PR DESCRIPTION
For some reason Bash 4.2 complains about `pre_cmd_args` being unset when as far as I can tell it is set. Disabling `set -u` as a workaround.

This isn't a problem with Bash 5+.