### PR TITLE
[i2c,rtl] Add user toggle TXRST_ON_COND

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -388,6 +388,14 @@
                 '''
           resval: "0"
         }
+        { bits: "15"
+          name: "TXRST_ON_COND"
+          desc: '''If set, automatically reset the TX FIFO (TXRST) upon seeing a RSTART/STOP condition
+                during an active transaction in Target Mode. This may be useful if the remaining data
+                in the TX FIFO becomes no longer applicable to the next transaction.
+                '''
+          resval: "0"
+        }
         { bits: "27:16"
           name: "ACQ_THRESH"
           desc: '''Threshold level for ACQ interrupts. Whilst the level of data in the ACQ FIFO

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -271,20 +271,21 @@ Host mode FIFO configuration
 Target mode FIFO configuration
 - Offset: `0x28`
 - Reset default: `0x0`
-- Reset mask: `0xfff0fff`
+- Reset mask: `0xfff8fff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "TX_THRESH", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}, {"name": "ACQ_THRESH", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "TX_THRESH", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "TXRST_ON_COND", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ACQ_THRESH", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name       | Description                                                                                                                                             |
-|:------:|:------:|:-------:|:-----------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 31:28  |        |         |            | Reserved                                                                                                                                                |
-| 27:16  |   rw   |   0x0   | ACQ_THRESH | Threshold level for ACQ interrupts. Whilst the level of data in the ACQ FIFO is above this setting, the acq_threshold interrupt will be asserted.       |
-| 15:12  |        |         |            | Reserved                                                                                                                                                |
-|  11:0  |   rw   |   0x0   | TX_THRESH  | Threshold level for TX interrupts. Whilst the number of used entries in the TX FIFO is below this setting, the tx_threshold interrupt will be asserted. |
+|  Bits  |  Type  |  Reset  | Name          | Description                                                                                                                                                                                                                                    |
+|:------:|:------:|:-------:|:--------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:28  |        |         |               | Reserved                                                                                                                                                                                                                                       |
+| 27:16  |   rw   |   0x0   | ACQ_THRESH    | Threshold level for ACQ interrupts. Whilst the level of data in the ACQ FIFO is above this setting, the acq_threshold interrupt will be asserted.                                                                                              |
+|   15   |   rw   |   0x0   | TXRST_ON_COND | If set, automatically reset the TX FIFO (TXRST) upon seeing a RSTART/STOP condition during an active transaction in Target Mode. This may be useful if the remaining data in the TX FIFO becomes no longer applicable to the next transaction. |
+| 14:12  |        |         |               | Reserved                                                                                                                                                                                                                                       |
+|  11:0  |   rw   |   0x0   | TX_THRESH     | Threshold level for TX interrupts. Whilst the number of used entries in the TX FIFO is below this setting, the tx_threshold interrupt will be asserted.                                                                                        |
 
 ## HOST_FIFO_STATUS
 Host mode FIFO status register

--- a/hw/ip/i2c/doc/theory_of_operation.md
+++ b/hw/ip/i2c/doc/theory_of_operation.md
@@ -283,6 +283,10 @@ Firmware can configure the threshold value via the register [`TARGET_FIFO_CONFIG
 Whilst the TX FIFO level is below a designated number of entries the `tx_threshold` interrupt is asserted.
 Firmware can configure the threshold value via the register [`TARGET_FIFO_CONFIG.TX_THRESH`](registers.md#target_fifo_config).
 
+If firmware sets the bit [`TARGET_FIFO_CONFIG.TXRST_ON_COND`](registers.md#target_fifo_config), the TX FIFO will be reset whenever a RSTART or STOP condition is seen on the bus during an active Target-Mode transaction.
+This behaviour may be useful to software, as any remaining data in the TXFIFO after a Sr/P condition is probably no-longer applicable to the next transfer, so will likely have to be cleared out anyway.
+Keeping this behaviour as a toggle allows software to observe the fifo state before resetting it, which may be useful to understand how much of the previous transfer completed if that information is helpful or relevant.
+
 If ACQ FIFO becomes full, the interrupt `acq_full` is asserted.
 
 If a host ceases to send SCL pulses at any point during an ongoing transaction, the target waits for a specified time period and then asserts the interrupt `host_timeout`.

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -81,6 +81,8 @@ module i2c_core import i2c_pkg::*;
   logic event_unexp_stop;
   logic event_host_timeout;
 
+  logic target_sr_p_cond;
+
   logic [15:0] scl_rx_val;
   logic [15:0] sda_rx_val;
 
@@ -167,6 +169,7 @@ module i2c_core import i2c_pkg::*;
   logic [AcqFifoWidth-9:0] unused_acq_fifo_signal_q;
   logic        unused_alert_test_qe;
   logic        unused_alert_test_q;
+  logic        unused_txrst_on_cond_qe;
 
   assign hw2reg.status.fmtfull.d = ~fmt_fifo_wready;
   assign hw2reg.status.rxfull.d = ~rx_fifo_wready;
@@ -244,7 +247,8 @@ module i2c_core import i2c_pkg::*;
   assign i2c_fifo_rx_thresh  = reg2hw.host_fifo_config.rx_thresh.q;
   assign i2c_fifo_fmt_thresh = reg2hw.host_fifo_config.fmt_thresh.q;
 
-  assign i2c_fifo_txrst      = reg2hw.fifo_ctrl.txrst.q & reg2hw.fifo_ctrl.txrst.qe;
+  assign i2c_fifo_txrst      = (reg2hw.fifo_ctrl.txrst.q & reg2hw.fifo_ctrl.txrst.qe) ||
+                               (reg2hw.target_fifo_config.txrst_on_cond.q & target_sr_p_cond);
   assign i2c_fifo_acqrst     = reg2hw.fifo_ctrl.acqrst.q & reg2hw.fifo_ctrl.acqrst.qe;
   assign i2c_fifo_tx_thresh  = reg2hw.target_fifo_config.tx_thresh.q;
   assign i2c_fifo_acq_thresh = reg2hw.target_fifo_config.acq_thresh.q;
@@ -293,6 +297,7 @@ module i2c_core import i2c_pkg::*;
   assign unused_acq_fifo_signal_q = reg2hw.acqdata.signal.q;
   assign unused_alert_test_qe = reg2hw.alert_test.qe;
   assign unused_alert_test_q = reg2hw.alert_test.q;
+  assign unused_txrst_on_cond_qe = reg2hw.target_fifo_config.txrst_on_cond.qe;
 
   prim_fifo_sync #(
     .Width   (13),
@@ -475,6 +480,7 @@ module i2c_core import i2c_pkg::*;
     .target_mask0_i          (target_mask0),
     .target_address1_i       (target_address1),
     .target_mask1_i          (target_mask1),
+    .target_sr_p_cond_o      (target_sr_p_cond),
     .event_target_nack_o     (event_target_nack),
     .event_nak_o             (event_nak),
     .event_scl_interference_o(event_scl_interference),

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -73,6 +73,7 @@ module i2c_fsm import i2c_pkg::*;
   input logic [6:0] target_address1_i,
   input logic [6:0] target_mask1_i,
 
+  output logic target_sr_p_cond_o,       // Saw RSTART/STOP in Target-Mode.
   output logic event_target_nack_o,      // this target sent a NACK (this is used to keep count)
   output logic event_nak_o,              // target didn't Ack when expected
   output logic event_scl_interference_o, // other device forcing SCL low
@@ -1591,6 +1592,11 @@ module i2c_fsm import i2c_pkg::*;
       state_d = Idle;
     end
   end
+
+  // TARGET-Mode -> RSTART or STOP condition observed
+  // This output is used to (optionally) reset the TXFIFO, as any data populated by
+  // software is now highly-unlikely to be applicable to the next transaction.
+  assign target_sr_p_cond_o = target_enable_i && !target_idle && (stop_det | start_det);
 
   // Synchronous state transition
   always_ff @ (posedge clk_i or negedge rst_ni) begin : state_transition

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -262,6 +262,10 @@ package i2c_reg_pkg;
       logic        qe;
     } acq_thresh;
     struct packed {
+      logic        q;
+      logic        qe;
+    } txrst_on_cond;
+    struct packed {
       logic [11:0] q;
       logic        qe;
     } tx_thresh;
@@ -524,16 +528,16 @@ package i2c_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [469:455]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [454:440]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [439:410]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [409:408]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [407:405]
-    i2c_reg2hw_rdata_reg_t rdata; // [404:396]
-    i2c_reg2hw_fdata_reg_t fdata; // [395:377]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [376:369]
-    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [368:343]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [342:317]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [471:457]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [456:442]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [441:412]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [411:410]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [409:407]
+    i2c_reg2hw_rdata_reg_t rdata; // [406:398]
+    i2c_reg2hw_fdata_reg_t fdata; // [397:379]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [378:371]
+    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [370:345]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [344:317]
     i2c_reg2hw_ovrd_reg_t ovrd; // [316:314]
     i2c_reg2hw_timing0_reg_t timing0; // [313:282]
     i2c_reg2hw_timing1_reg_t timing1; // [281:250]


### PR DESCRIPTION
By setting the bit CSR.TARGET_FIFO_CONFIG.TXRST_ON_COND, the block will then automatically reset the TXFIFO (using TXRST) if it observes a STOP/RSTART condition in Target-Mode.

From the commit message:
> This behaviour may be useful to software, as any remaining data in the TXFIFO
> after a Sr/P condition is probably no-longer applicable to the next transfer, so
> will likely have to be cleared out anyway. Keeping this behaviour as a toggle
> allows software to observe the fifo state before resetting it, which may be
> useful to understand how much of the previous transfer completed if that
> information is helpful or relevant.

Reset state is disabled.

Closes #17750