### PR TITLE
[rom] remove 64k ROM_EXT code size restriction

### DIFF
--- a/sw/device/silicon_creator/rom/boot_policy.c
+++ b/sw/device/silicon_creator/rom/boot_policy.c
@@ -30,8 +30,7 @@ rom_error_t boot_policy_manifest_check(const manifest_t *manifest,
   if (manifest->identifier != CHIP_ROM_EXT_IDENTIFIER) {
     return kErrorBootPolicyBadIdentifier;
   }
-  if (manifest->length < CHIP_ROM_EXT_SIZE_MIN ||
-      manifest->length > CHIP_ROM_EXT_SIZE_MAX) {
+  if (manifest->length < CHIP_ROM_EXT_SIZE_MIN) {
     return kErrorBootPolicyBadLength;
   }
   RETURN_IF_ERROR(manifest_check(manifest));

--- a/sw/device/silicon_creator/rom/boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom/boot_policy_unittest.cc
@@ -56,10 +56,6 @@ TEST_F(BootPolicyTest, ManifestCheckBadLength) {
   manifest.length = CHIP_ROM_EXT_SIZE_MIN - 1;
   EXPECT_EQ(boot_policy_manifest_check(&manifest, &boot_data),
             kErrorBootPolicyBadLength);
-
-  manifest.length = CHIP_ROM_EXT_SIZE_MAX + 1;
-  EXPECT_EQ(boot_policy_manifest_check(&manifest, &boot_data),
-            kErrorBootPolicyBadLength);
 }
 
 TEST_F(BootPolicyTest, ManifestCheckBadManifest) {

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -578,6 +578,25 @@
     }
 
     {
+      name: rom_e2e_boot_policy_big_image
+      desc: '''Verify that ROM can boot flash images that are larger than the ROM_EXT slot.
+
+            Provisioning flash images may take up more space than the dedicated ROM_EXT slot,
+            and potentially, up to the size of the entire slot A/B (since there is no need to
+            have multiple boot stages for provisioning firmware).
+
+            - Write image of size `CHIP_ROM_EXT_SIZE_MAX` + 1 or greater to `slot_a`.
+              - The other slot remains empty (since it could be consumed by the single image).
+              - Image should be less than (`CHIP_ROM_EXT_SIZE_MAX` + `CHIP_BL0_SIZE_MAX` + 1).
+            - Verify that the chip boots the image successfully.
+            - Repeat for all life cycle states: TEST, DEV, PROD, PROD_END, and RMA.
+            '''
+      tags: ["rom", "no_dv", "fpga", "silicon"]
+      stage: V2
+      tests: []
+    }
+
+    {
       name: rom_e2e_boot_policy_valid
       desc: '''Verify that ROM chooses the slot with the valid signature.
 

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -561,7 +561,7 @@
             | :---------------------------------: | :-------------------------------: |
             | `identitfier = 0`                   | `kErrorBootPolicyBadIdentifier`   |
             | `length < CHIP_ROM_EXT_SIZE_MIN`    | `kErrorBootPolicyBadLength`       |
-            | `length > CHIP_ROM_EXT_SIZE_MAX`    | `kErrorBootPolicyBadLength`       |
+            | `length > CHIP_ROM_EXT_SIZE_MAX`    | No Error; image should boot.      |
             | `code_start = code_end`             | `kErrorManifestBadCodeRegion`     |
             | `code_start < CHIP_MANIFEST_SIZE`   | `kErrorManifestBadCodeRegion`     |
             | `code_end > length`                 | `kErrorManifestBadCodeRegion`     |

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
@@ -3,12 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules/opentitan:defs.bzl",
-    "cw310_params",
-    "opentitan_test",
-    "verilator_params",
-)
-load(
     "//rules:const.bzl",
     "CONST",
     "get_lc_items",
@@ -16,14 +10,13 @@ load(
     "hex_digits",
 )
 load(
-    "//rules:opentitan.bzl",
-    "RSA_ONLY_KEY_STRUCTS",
-    "opentitan_flash_binary",
-    "opentitan_multislot_flash_binary",
-)
-load(
     "//rules:manifest.bzl",
     "manifest",
+)
+load(
+    "//rules:opentitan_test.bzl",
+    "OTTF_SUCCESS_MSG",
+    "ROM_BOOT_FAILURE_MSG",
 )
 load(
     "//rules:otp.bzl",
@@ -35,6 +28,11 @@ load(
 load(
     "//rules:rom_e2e.bzl",
     "maybe_skip_in_ci",
+)
+load(
+    "//rules/opentitan:defs.bzl",
+    "cw310_params",
+    "opentitan_test",
 )
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
@@ -67,10 +65,12 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
         "name": "too_large",
         "manifest": {
             "identifier": hex(CONST.ROM_EXT),
+            # Note: we expect this image to boot successfully, so we must set the `address_translation` field to ensure the ROM does not error out an a bad field here.
+            "address_translation": hex(CONST.HARDENED_FALSE),
             "length": hex(CONST.ROM_EXT_SIZE_MAX + 1),
         },
-        "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.BAD_LENGTH)),
-        "exit_failure": msg_template_bfv_all_except(CONST.BFV.BOOT_POLICY.BAD_LENGTH),
+        "exit_success": OTTF_SUCCESS_MSG,
+        "exit_failure": ROM_BOOT_FAILURE_MSG,
     },
     {
         "name": "empty_code",

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_big_image/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_big_image/BUILD
@@ -1,0 +1,67 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules:const.bzl",
+    "get_lc_items",
+)
+load(
+    "//rules:rom_e2e.bzl",
+    "maybe_skip_in_ci",
+)
+load(
+    "//rules/opentitan:defs.bzl",
+    "cw310_params",
+    "opentitan_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+BOOT_POLICY_BIG_IMAGE_CASES = [
+    {
+        "suffix": "bigger_than_64k",
+        "array_size": 65000,
+    },
+]
+
+[
+    opentitan_test(
+        name = "boot_policy_big_image_{}_{}".format(
+            lc_state,
+            t["suffix"],
+        ),
+        srcs = ["resizable_test.c"],
+        cw310 = cw310_params(
+            otp = "//hw/ip/otp_ctrl/data:img_{}".format(lc_state),
+            tags = maybe_skip_in_ci(lc_state_val),
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+        local_defines = ["ARRAY_SIZE={}".format(t["array_size"])],
+        # Use the prod key because it is valid in every LC state.
+        rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+        deps = [
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/rom:boot_policy_ptrs",
+        ],
+    )
+    for lc_state, lc_state_val in get_lc_items()
+    for t in BOOT_POLICY_BIG_IMAGE_CASES
+]
+
+test_suite(
+    name = "boot_policy_big_image",
+    tags = ["manual"],
+    tests = [
+        "boot_policy_big_image_{}_{}".format(
+            lc_state,
+            t["suffix"],
+        )
+        for lc_state, _ in get_lc_items()
+        for t in BOOT_POLICY_BIG_IMAGE_CASES
+    ],
+)

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_big_image/resizable_test.c
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_big_image/resizable_test.c
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+#include "sw/device/silicon_creator/rom/boot_policy_ptrs.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+#ifdef ARRAY_SIZE
+static const unsigned char arr[ARRAY_SIZE] = {1, 2, 3};
+#endif
+
+bool test_main(void) {
+#ifdef ARRAY_SIZE
+  for (size_t i = 0; i < ARRAY_SIZE; i += (ARRAY_SIZE / 4)) {
+    LOG_INFO("arr[%d] = %d", i, arr[i]);
+  }
+#endif
+
+  // Check image of the expected size.
+  const manifest_t *manifest = boot_policy_manifest_a_get();
+  LOG_INFO("Image Length (bytes) = %d", manifest->length);
+  CHECK(manifest->length > CHIP_ROM_EXT_SIZE_MAX);
+  CHECK(manifest->length <= (CHIP_ROM_EXT_SIZE_MAX + CHIP_BL0_SIZE_MAX));
+  return true;
+}

--- a/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_entry/src/main.rs
@@ -412,8 +412,8 @@ fn test_bootstrap_phase1_erase(
     // Remove strapping so that chip fails to boot instead of going into bootstrap.
     transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
-    // `kErrorBootPolicyBadLength` (0242500d) is defined in `error.h`.
-    console.exit_success = Some(Regex::new("BFV:0242500d")?);
+    // `kErrorManifestBadVersionMajor` (054d410d) is defined in `error.h`.
+    console.exit_success = Some(Regex::new("BFV:054d410d")?);
     let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
     if result != ExitStatus::ExitSuccess {
         bail!("FAIL: {:?}", result);
@@ -426,8 +426,8 @@ fn test_bootstrap_phase1_erase(
     uart.clear_rx_buffer()?;
     transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
-    // `kErrorBootPolicyBadIdentifier` (0142500d) is defined in `error.h`.
-    console.exit_success = Some(Regex::new("BFV:0142500d")?);
+    // `kErrorManifestBadVersionMajor` (054d410d) is defined in `error.h`.
+    console.exit_success = Some(Regex::new("BFV:054d410d")?);
     let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
     if result != ExitStatus::ExitSuccess {
         bail!("FAIL: {:?}", result);
@@ -454,8 +454,8 @@ fn test_bootstrap_phase1_read(opts: &Opts, transport: &TransportWrapper) -> Resu
     // Remove strapping so that chip fails to boot instead of going into bootstrap.
     transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
     transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
-    // `kErrorBootPolicyBadLength` (0242500d) is defined in `error.h`.
-    console.exit_success = Some(Regex::new("0242500d")?);
+    // `kErrorManifestBadVersionMajor` (054d410d) is defined in `error.h`.
+    console.exit_success = Some(Regex::new("BFV:054d410d")?);
     let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
     if result != ExitStatus::ExitSuccess {
         bail!("FAIL: {:?}", result);
@@ -518,8 +518,8 @@ fn test_bootstrap_phase2_page_program(opts: &Opts, transport: &TransportWrapper)
 
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
-        // `kErrorBootPolicyBadLength` (0242500d) is defined in `error.h`.
-        exit_success: Some(Regex::new("BFV:0242500d\r\n")?),
+        // `kErrorManifestBadVersionMajor` (054d410d) is defined in `error.h`.
+        exit_success: Some(Regex::new("BFV:054d410d\r\n")?),
         ..Default::default()
     };
     // Remove strapping so that chip fails to boot instead of going into bootstrap.
@@ -592,8 +592,8 @@ fn test_bootstrap_phase2_read(opts: &Opts, transport: &TransportWrapper) -> Resu
 
     let mut console = UartConsole {
         timeout: Some(Duration::new(1, 0)),
-        // `kErrorBootPolicyBadLength` (0242500d) is defined in `error.h`.
-        exit_success: Some(Regex::new("BFV:0242500d\r\n")?),
+        // `kErrorManifestBadVersionMajor` (054d410d) is defined in `error.h`.
+        exit_success: Some(Regex::new("BFV:054d410d\r\n")?),
         ..Default::default()
     };
     // Remove strapping so that chip fails to boot instead of going into bootstrap.


### PR DESCRIPTION
This fixes #21553.

Note, this simply removes the restriction. Additional changes will be required to truly support dynamic ROM_EXT / Owner slot sizes (if that is deemed desirable in the future).