### PR TITLE
[rom] Add ECDSA P256 support to manifest.h

### DIFF
--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -122,6 +122,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:keymgr_binding",
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
         "//sw/device/silicon_creator/lib/sigverify:rsa_key",
         "//sw/device/silicon_creator/lib/sigverify:spx_key",
     ],

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -285,6 +285,7 @@ dual_cc_library(
             ":keymgr_binding",
             "//sw/device/lib/base:macros",
             "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
             "//sw/device/silicon_creator/lib/sigverify:rsa_key",
             "//sw/device/silicon_creator/lib/sigverify:spx_key",
             "//sw/device/silicon_creator/lib/base:chip",

--- a/sw/device/silicon_creator/lib/base/chip.h
+++ b/sw/device/silicon_creator/lib/base/chip.h
@@ -21,6 +21,10 @@
 #define CHIP_MANIFEST_VERSION_MINOR_1 0x6c47
 #define CHIP_MANIFEST_VERSION_MAJOR_1 0x71c3
 
+// TODO(moidx): Update to a valid number once we figure out a manifest
+// versioning scheme.
+#define CHIP_MANIFEST_VERSION_MAJOR_2 0x0002
+
 /**
  * Number of entries in the manifest extensions table.
  */

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -13,6 +13,7 @@
 #include "sw/device/silicon_creator/lib/epmp_state.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/keymgr_binding_value.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 #include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
 #include "sw/device/silicon_creator/lib/sigverify/spx_key.h"
 
@@ -170,6 +171,7 @@ typedef struct manifest_version {
  */
 enum {
   kManifestVersionMajor1 = CHIP_MANIFEST_VERSION_MAJOR_1,
+  kManifestVersionMajor2 = CHIP_MANIFEST_VERSION_MAJOR_2,
   kManifestVersionMinor1 = CHIP_MANIFEST_VERSION_MINOR_1,
 };
 
@@ -192,11 +194,12 @@ enum {
  */
 typedef struct manifest {
   /**
-   * RSA signature of the image.
+   * The manifest only supports one of the following signatures:
    *
-   * RSASSA-PKCS1-v1_5 signature of the image generated using a 3072-bit RSA
-   * private key and the SHA-256 hash function. The signed region of an image
-   * starts immediately after this field and ends at the end of the image.
+   * - For `kManifestVersionMajor1`: `rsa_signature`.
+   * - For `kManifestVersionMajor2`: `ecdsa_signature`.
+   *
+   * Both signatures use SHA-256 as the hash function.
    *
    * On-target verification should also integrate usage constraints comparison
    * to signature verification to harden it against potential attacks. During
@@ -210,15 +213,46 @@ typedef struct manifest {
    * usage constraints read from the hardware can be obtained using
    * `manifest_digest_region_get()`.
    */
-  sigverify_rsa_buffer_t rsa_signature;
+  union {
+    /**
+     * RSA signature of the image.
+     *
+     * RSASSA-PKCS1-v1_5 signature of the image generated using a 3072-bit RSA
+     * private key and the SHA-256 hash function. The signed region of an image
+     * starts immediately after this field and ends at the end of the image.
+     */
+    sigverify_rsa_buffer_t rsa_signature;
+
+    /**
+     * ECDSA P256 signature of the image.
+     *
+     * ECDSA P256 signature of the image generated using a NIST P256 ECC key
+     * and the SHA-256 hash function. The signed region of an image starts
+     * immediately after the end of the union encapsulating this field and ends
+     * at the end of the image.
+     */
+    sigverify_ecdsa_p256_buffer_t ecdsa_signature;
+  };
   /**
    * Usage constraints.
    */
   manifest_usage_constraints_t usage_constraints;
   /**
-   * Modulus of the signer's 3072-bit RSA public key.
+   * The manifest only supports one of the following public key types:
+   *
+   * - For `kManifestVersionMajor1`: `rsa_modulus`.
+   * - For `kManifestVersionMajor2`: `ecdsa_public_key`.
    */
-  sigverify_rsa_buffer_t rsa_modulus;
+  union {
+    /**
+     * Modulus of the signer's 3072-bit RSA public key.
+     */
+    sigverify_rsa_buffer_t rsa_modulus;
+    /**
+     * Signer's ECDSA NIST P256 ECC public key.
+     */
+    sigverify_ecdsa_p256_buffer_t ecdsa_public_key;
+  };
   /**
    * Address translation (hardened boolean).
    */
@@ -300,8 +334,10 @@ typedef struct manifest {
 } manifest_t;
 
 OT_ASSERT_MEMBER_OFFSET(manifest_t, rsa_signature, 0);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, ecdsa_signature, 0);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, usage_constraints, 384);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, rsa_modulus, 432);
+OT_ASSERT_MEMBER_OFFSET(manifest_t, ecdsa_public_key, 432);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, address_translation, 816);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, identifier, 820);
 OT_ASSERT_MEMBER_OFFSET(manifest_t, manifest_version, 824);

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -20,6 +20,15 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+    name = "ecdsa_p256_key",
+    srcs = ["ecdsa_p256_key.c"],
+    hdrs = ["ecdsa_p256_key.h"],
+    deps = [
+        "//sw/device/lib/base:macros",
+    ],
+)
+
+cc_library(
     name = "rsa_key",
     srcs = ["rsa_key.c"],
     hdrs = ["rsa_key.h"],

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.c
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.c
@@ -1,0 +1,8 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+
+// `extern` declarations for `inline` functions in the header.
+extern uint32_t sigverify_ecdsa_key_id_get(
+    const sigverify_ecdsa_p256_buffer_t *pub_key);

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_ECDSA_P256_KEY_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_ECDSA_P256_KEY_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /** Number of 32-bit words in a P-256 public key. */
+  kP256PublicKeyWords = 512 / 32,
+};
+
+/**
+ * A type that holds `kP256PublicKeyWords` words.
+ *
+ * This can be used to store ECDSA P256 public keys or signatures.
+ */
+typedef struct sigverify_ecdsa_p256_buffer {
+  uint32_t data[kP256PublicKeyWords];
+} sigverify_ecdsa_p256_buffer_t;
+
+/**
+ * Gets the ID of an ECDSA public key.
+ *
+ * ID of a key is the least significant word of its key buffer.
+ * Callers must make sure that `pub_key` is valid before calling this function.
+ *
+ * @param key An ECDSA P256 public key.
+ * @return ID of the key.
+ */
+OT_WARN_UNUSED_RESULT
+inline uint32_t sigverify_ecdsa_key_id_get(
+    const sigverify_ecdsa_p256_buffer_t *pub_key) {
+  return pub_key->data[0];
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_ECDSA_P256_KEY_H_


### PR DESCRIPTION
This commit adds support for ECDSA public key and signatures to the manifest. Both signature and public key fields were converted to union types to be able to support either RSA or ECDSA.

`kManifestVersionMajor1` is associated with RSA.
`kManifestVersionMajor2` is associated with ECDSA P256.