### PR TITLE
[dv] Add run_timeout_mins to flash_ctrl config

### DIFF
--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -163,6 +163,7 @@
       uvm_test_seq: flash_ctrl_full_mem_access_vseq
       run_opts: ["+test_timeout_ns=500_000_000_000"]
       reseed: 5
+      run_timeout_mins: 180
     }
     {
       name: flash_ctrl_error_prog_type


### PR DESCRIPTION
https://github.com/lowRISC/opentitan/pull/21828 added this to the template but did not regenerate the flash_ctrl config. This PR fixes CI.

Generated with `make -k -C hw top`.