### PR TITLE
[dv] Fix stale autogened file

### DIFF
--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -163,6 +163,7 @@
       uvm_test_seq: flash_ctrl_full_mem_access_vseq
       run_opts: ["+test_timeout_ns=500_000_000_000"]
       reseed: 5
+      run_timeout_mins: 180
     }
     {
       name: flash_ctrl_error_prog_type


### PR DESCRIPTION
Fixes In-depth Lint error on master:
```
Auto-generated tops not up-to-date. Regenerate with 'make -k -C hw top'.
```