### PR TITLE
[usbdev,dv] Sort sequences (mostly) alphabetically

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -4,19 +4,23 @@
 
 `include "usbdev_base_vseq.sv"
 `include "usbdev_common_vseq.sv"
-`include "usbdev_csr_test_vseq.sv"
+
 `include "usbdev_smoke_vseq.sv"
-`include "usbdev_pkt_received_vseq.sv"
+
 `include "usbdev_av_buffer_vseq.sv"
-`include "usbdev_setup_trans_ignored_vseq.sv"
-`include "usbdev_pkt_sent_vseq.sv"
-`include "usbdev_nak_trans_vseq.sv"
+`include "usbdev_csr_test_vseq.sv"
 `include "usbdev_enable_vseq.sv"
+`include "usbdev_fifo_rst_vseq.sv"
 `include "usbdev_in_trans_vseq.sv"
-`include "usbdev_random_length_out_transaction_vseq.sv"
-`include "usbdev_min_length_out_transaction_vseq.sv"
-`include "usbdev_max_length_out_transaction_vseq.sv"
+`include "usbdev_nak_trans_vseq.sv"
 `include "usbdev_out_stall_vseq.sv"
 `include "usbdev_out_trans_nak_vseq.sv"
-`include "usbdev_fifo_rst_vseq.sv"
 `include "usbdev_phy_pins_sense_vseq.sv"
+`include "usbdev_pkt_received_vseq.sv"
+`include "usbdev_pkt_sent_vseq.sv"
+`include "usbdev_random_length_out_transaction_vseq.sv"
+`include "usbdev_setup_trans_ignored_vseq.sv"
+
+// These depend on usbdev_random_length_out_transaction, so need to come after it.
+`include "usbdev_max_length_out_transaction_vseq.sv"
+`include "usbdev_min_length_out_transaction_vseq.sv"

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -60,49 +60,38 @@
       name: usbdev_smoke
       uvm_test_seq: usbdev_smoke_vseq
     }
-    {
-      name: usbdev_pkt_received
-      uvm_test_seq: usbdev_pkt_received_vseq
-    }
+
     {
       name: usbdev_av_buffer
       uvm_test_seq: usbdev_av_buffer_vseq
     }
     {
-      name: usbdev_setup_trans_ignored
-      uvm_test_seq: usbdev_setup_trans_ignored_vseq
-    }
-    {
-      name: usbdev_pkt_sent
-      uvm_test_seq: usbdev_pkt_sent_vseq
-    }
-    {
-      name: usbdev_nak_trans
-      uvm_test_seq: usbdev_nak_trans_vseq
+      name: usbdev_enable
+      uvm_test_seq: usbdev_enable_vseq
     }
     {
       name: usbdev_enable
       uvm_test_seq: usbdev_enable_vseq
+    }
+    {
+      name: usbdev_fifo_rst
+      uvm_test_seq: usbdev_fifo_rst_vseq
     }
     {
       name: usbdev_in_trans
       uvm_test_seq: usbdev_in_trans_vseq
     }
     {
-      name: usbdev_enable
-      uvm_test_seq: usbdev_enable_vseq
-    }
-    {
-      name: usbdev_random_length_out_trans
-      uvm_test_seq: usbdev_random_length_out_transaction_vseq
+      name: usbdev_max_length_out_transaction
+      uvm_test_seq: usbdev_max_length_out_transaction_vseq
     }
     {
       name: usbdev_min_length_out_transaction
       uvm_test_seq: usbdev_min_length_out_transaction_vseq
     }
     {
-      name: usbdev_max_length_out_transaction
-      uvm_test_seq: usbdev_max_length_out_transaction_vseq
+      name: usbdev_nak_trans
+      uvm_test_seq: usbdev_nak_trans_vseq
     }
     {
       name: usbdev_out_stall
@@ -113,8 +102,20 @@
       uvm_test_seq: usbdev_out_trans_nak_vseq
     }
     {
-      name: usbdev_fifo_rst
-      uvm_test_seq: usbdev_fifo_rst_vseq
+      name: usbdev_pkt_received
+      uvm_test_seq: usbdev_pkt_received_vseq
+    }
+    {
+      name: usbdev_pkt_sent
+      uvm_test_seq: usbdev_pkt_sent_vseq
+    }
+    {
+      name: usbdev_random_length_out_trans
+      uvm_test_seq: usbdev_random_length_out_transaction_vseq
+    }
+    {
+      name: usbdev_setup_trans_ignored
+      uvm_test_seq: usbdev_setup_trans_ignored_vseq
     }
     {
       name: usbdev_phy_pins_sense


### PR DESCRIPTION
There is no functional change here: we're just listing the sequences alphabetically in usbdev_vseq_list.sv and in usbdev_sim_cfg.hjson. This avoids an annoying situation where every PR is trying to add something at the bottom of the list and thus conflicts.

Now, we can insert a new PR at its point in the alphabetical list and should hopefully have simple merges most of the time.