### PR TITLE
[flash_ctrl/dv] Carry over timeout increase to legacy DV file

### DIFF
--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -163,6 +163,7 @@
       uvm_test_seq: flash_ctrl_full_mem_access_vseq
       run_opts: ["+test_timeout_ns=500_000_000_000"]
       reseed: 5
+      run_timeout_mins: 180
     }
     {
       name: flash_ctrl_error_prog_type


### PR DESCRIPTION
Due to the Ipgen migration, we unfortunately have two copies of this file in the tree at the moment. Hence, this change needs to be carried over.