### PR TITLE
[sram_ctrl] Minor alignment of init and key request behavior

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -366,7 +366,7 @@
                   before triggering a key renewal, hardware will automatically clear that status bit such that software
                   can poll its status. Note that requesting a new scrambling key takes ~200 OTP cycles, which translates
                   to ~800 CPU cycles (OTP runs at 24MHz, CPU runs at 100MHz). Note that writing 1 to this register while
-                  a key request is pending has no effect.
+                  a key request or a memory initialization request is already pending has no effect.
                   '''
           },
           { bits: "1",
@@ -376,7 +376,8 @@
                   The init mechanism uses an LFSR that is seeded with a part of the nonce supplied when requesting a scrambling key.
                   Once seeded, the memory is initialized with pseudo-random data pulled from the LFSR.
                   Note that !!CTRL.RENEW_SCR_KEY takes priority when writing 1 to both !!CTRL.RENEW_SCR_KEY and !!CTRL.INIT with the same write transaction.
-                  This means that the key request will complete first, followed by SRAM initialization.
+                  This means that the key request will complete first, followed by SRAM initialization. Note that writing 1 to this register while
+                  an init request is already pending has no effect.
                   '''
           },
         ]

--- a/hw/ip/sram_ctrl/doc/registers.md
+++ b/hw/ip/sram_ctrl/doc/registers.md
@@ -165,7 +165,8 @@ Write 1 to request memory init.
 The init mechanism uses an LFSR that is seeded with a part of the nonce supplied when requesting a scrambling key.
 Once seeded, the memory is initialized with pseudo-random data pulled from the LFSR.
 Note that [`CTRL.RENEW_SCR_KEY`](#ctrl) takes priority when writing 1 to both [`CTRL.RENEW_SCR_KEY`](#ctrl) and [`CTRL.INIT`](#ctrl) with the same write transaction.
-This means that the key request will complete first, followed by SRAM initialization.
+This means that the key request will complete first, followed by SRAM initialization. Note that writing 1 to this register while
+an init request is already pending has no effect.
 
 ### CTRL . RENEW_SCR_KEY
 Write 1 to request a new scrambling key from OTP. After writing to this register, SRAM transactions will
@@ -173,7 +174,7 @@ be blocked until [`STATUS.SCR_KEY_VALID`](#status) has been set to 1. If [`STATU
 before triggering a key renewal, hardware will automatically clear that status bit such that software
 can poll its status. Note that requesting a new scrambling key takes ~200 OTP cycles, which translates
 to ~800 CPU cycles (OTP runs at 24MHz, CPU runs at 100MHz). Note that writing 1 to this register while
-a key request is pending has no effect.
+a key request or a memory initialization request is already pending has no effect.
 
 ## SCR_KEY_ROTATED
 Clearable SRAM key request status.


### PR DESCRIPTION
Previously, it was possible to re-request a new key while a memory init was ongoing. This can result in problematic behavior since the init done indication would still be set to true afterwards, which is misleading since part of the array has then been initialized with the a different key.

This patch changes that and ignores key requests that are issued while a memory initialization is pending.

On a similar note, it was possible to re-trigger a memory initialization while one was already ongoing, causing the existing initialization to restart. This is now also changed so that initialization requests are ignored while an initialization is still pending.