### PR TITLE
[usbdev,dv] usbdev resume link active seq PR

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_resume_link_active_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_resume_link_active_vseq.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_resume_link_active_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_resume_link_active_vseq)
+
+  `uvm_object_new
+
+  task body();
+    bit [2:0] powered_link_state;
+    bit       resume;
+
+    super.dut_init("HARD");
+    // Perform no operation for more than 3ms (3ms = 144,000 clk cycle at 48MHz)
+    cfg.clk_rst_vif.wait_clks(154000);
+    // Read link_state it should be in link powered state
+    csr_rd(.ptr(ral.usbstat.link_state), .value(powered_link_state));
+    `DV_CHECK_EQ(powered_link_state, 1);
+
+    // Set resume link state in usbctrl register
+    csr_wr(.ptr(ral.usbctrl.resume_link_active), .value(1'b1));
+    cfg.clk_rst_vif.wait_clks(5);
+
+    // Read link_resume interrupt
+    csr_rd(.ptr(ral.intr_state.link_resume), .value(resume));
+    // DV_CHECK on link_resume interrupt
+    `DV_CHECK_EQ(resume, 1);
+  endtask
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -20,8 +20,11 @@
 `include "usbdev_pkt_received_vseq.sv"
 `include "usbdev_pkt_sent_vseq.sv"
 `include "usbdev_random_length_out_transaction_vseq.sv"
+`include "usbdev_resume_link_active_vseq.sv"
 `include "usbdev_setup_trans_ignored_vseq.sv"
 
 // These depend on usbdev_random_length_out_transaction, so need to come after it.
 `include "usbdev_max_length_out_transaction_vseq.sv"
 `include "usbdev_min_length_out_transaction_vseq.sv"
+
+`include "usbdev_fifo_rst_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -36,6 +36,7 @@ filesets:
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_resume_link_active_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_stall_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -114,6 +114,10 @@
       uvm_test_seq: usbdev_random_length_out_transaction_vseq
     }
     {
+      name: usbdev_resume_link_active
+      uvm_test_seq: usbdev_resume_link_active_vseq
+    }
+    {
       name: usbdev_setup_trans_ignored
       uvm_test_seq: usbdev_setup_trans_ignored_vseq
     }


### PR DESCRIPTION
This PR contains usbdev_resume_link_active_vseq which implements the resume functionality of usbdev from link_powered_state.