### PR TITLE
[i2c,rtl] NACK after timing out on a stretch

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -570,7 +570,10 @@
       ]
     }
     { name: "TIMEOUT_CTRL"
-      desc: "I2C clock stretching timeout control"
+      desc: '''
+            I2C clock stretching timeout control.
+            This is used in I2C host mode to detect whether a connected target is stretching for too long.
+            '''
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
@@ -660,6 +663,24 @@
       hwaccess: "hro"
       fields: [
         { bits: "31:0" }
+      ]
+    }
+    { name: "TARGET_TIMEOUT_CTRL"
+      desc: '''
+            I2C target internal stretching timeout control.
+            When the target has stretched beyond this time it will send a NACK.
+            '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "30:0"
+          name: "VAL"
+          desc: "Clock stretching timeout value (in units of input clock frequency)"
+        }
+        { bits: "31"
+          name: "EN"
+          desc: "Enable timeout feature and send NACK once the timeout has been reached"
+        }
       ]
     }
   ]

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -621,7 +621,7 @@
           name: "ABYTE"
           desc: "Address for accepted transaction or acquired byte"
         }
-        { bits: "9:8"
+        { bits: "10:8"
           name: "SIGNAL"
           desc: "Host issued a START before transmitting ABYTE, a STOP or a RESTART after the preceeding ABYTE"
           enum: [
@@ -640,6 +640,14 @@
             { value: "3",
               name: "RESTART",
               desc: "ABYTE contains junk, START with address will follow"
+            },
+            { value: "4",
+              name: "NACK",
+              desc: "ABYTE contains either the address or data that was NACK'ed"
+            },
+            { value: "5",
+              name: "NACKSTART",
+              desc: "ABYTE contains the I2C address which was ACK'ed, but the block will continue and NACK the next data byte that was received: this only happens for writes"
             },
           ]
         }

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -691,5 +691,17 @@
         }
       ]
     }
+    { name: "TARGET_NACK_COUNT"
+      desc: '''
+            Number of times the I2C target has NACK'ed a new transaction since the last read of this register.
+            Reading this register clears it.
+            This is useful because when the ACQ FIFO is full the software know that a NACK has occurred, but without this register would not know how many transactions it missed.
+            '''
+      swaccess: "rc"
+      hwaccess: "hrw"
+      fields: [
+        { bits: "31:0" }
+      ]
+    }
   ]
 }

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -492,30 +492,33 @@ I2C target address and mask pairs
 I2C target acquired data
 - Offset: `0x58`
 - Reset default: `0x0`
-- Reset mask: `0x3ff`
+- Reset mask: `0x7ff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "ABYTE", "bits": 8, "attr": ["ro"], "rotate": 0}, {"name": "SIGNAL", "bits": 2, "attr": ["ro"], "rotate": -90}, {"bits": 22}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "ABYTE", "bits": 8, "attr": ["ro"], "rotate": 0}, {"name": "SIGNAL", "bits": 3, "attr": ["ro"], "rotate": -90}, {"bits": 21}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                       |
 |:------:|:------:|:-------:|:---------------------------|
-| 31:10  |        |         | Reserved                   |
-|  9:8   |   ro   |    x    | [SIGNAL](#acqdata--signal) |
+| 31:11  |        |         | Reserved                   |
+|  10:8  |   ro   |    x    | [SIGNAL](#acqdata--signal) |
 |  7:0   |   ro   |    x    | [ABYTE](#acqdata--abyte)   |
 
 ### ACQDATA . SIGNAL
 Host issued a START before transmitting ABYTE, a STOP or a RESTART after the preceeding ABYTE
 
-| Value   | Name    | Description                                         |
-|:--------|:--------|:----------------------------------------------------|
-| 0x0     | NONE    | ABYTE contains ordinary data byte as received       |
-| 0x1     | START   | ABYTE contains the 8-bit I2C address (R/W in lsb)   |
-| 0x2     | STOP    | ABYTE contains junk                                 |
-| 0x3     | RESTART | ABYTE contains junk, START with address will follow |
+| Value   | Name      | Description                                                                                                                                              |
+|:--------|:----------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0x0     | NONE      | ABYTE contains ordinary data byte as received                                                                                                            |
+| 0x1     | START     | ABYTE contains the 8-bit I2C address (R/W in lsb)                                                                                                        |
+| 0x2     | STOP      | ABYTE contains junk                                                                                                                                      |
+| 0x3     | RESTART   | ABYTE contains junk, START with address will follow                                                                                                      |
+| 0x4     | NACK      | ABYTE contains either the address or data that was NACK'ed                                                                                               |
+| 0x5     | NACKSTART | ABYTE contains the I2C address which was ACK'ed, but the block will continue and NACK the next data byte that was received: this only happens for writes |
 
+Other values are reserved.
 
 ### ACQDATA . ABYTE
 Address for accepted transaction or acquired byte
@@ -570,5 +573,6 @@ When the target has stretched beyond this time it will send a NACK.
 |:------:|:------:|:-------:|:-------|:-----------------------------------------------------------------------|
 |   31   |   rw   |   0x0   | EN     | Enable timeout feature and send NACK once the timeout has been reached |
 |  30:0  |   rw   |   0x0   | VAL    | Clock stretching timeout value (in units of input clock frequency)     |
+
 
 <!-- END CMDGEN -->

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -3,34 +3,35 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/i2c/data/i2c.hjson -->
 ## Summary
 
-| Name                                              | Offset   |   Length | Description                                                                          |
-|:--------------------------------------------------|:---------|---------:|:-------------------------------------------------------------------------------------|
-| i2c.[`INTR_STATE`](#intr_state)                   | 0x0      |        4 | Interrupt State Register                                                             |
-| i2c.[`INTR_ENABLE`](#intr_enable)                 | 0x4      |        4 | Interrupt Enable Register                                                            |
-| i2c.[`INTR_TEST`](#intr_test)                     | 0x8      |        4 | Interrupt Test Register                                                              |
-| i2c.[`ALERT_TEST`](#alert_test)                   | 0xc      |        4 | Alert Test Register                                                                  |
-| i2c.[`CTRL`](#ctrl)                               | 0x10     |        4 | I2C Control Register                                                                 |
-| i2c.[`STATUS`](#status)                           | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                   |
-| i2c.[`RDATA`](#rdata)                             | 0x18     |        4 | I2C Read Data                                                                        |
-| i2c.[`FDATA`](#fdata)                             | 0x1c     |        4 | I2C Host Format Data                                                                 |
-| i2c.[`FIFO_CTRL`](#fifo_ctrl)                     | 0x20     |        4 | I2C FIFO control register                                                            |
-| i2c.[`HOST_FIFO_CONFIG`](#host_fifo_config)       | 0x24     |        4 | Host mode FIFO configuration                                                         |
-| i2c.[`TARGET_FIFO_CONFIG`](#target_fifo_config)   | 0x28     |        4 | Target mode FIFO configuration                                                       |
-| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)       | 0x2c     |        4 | Host mode FIFO status register                                                       |
-| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status)   | 0x30     |        4 | Target mode FIFO status register                                                     |
-| i2c.[`OVRD`](#ovrd)                               | 0x34     |        4 | I2C Override Control Register                                                        |
-| i2c.[`VAL`](#val)                                 | 0x38     |        4 | Oversampled RX values                                                                |
-| i2c.[`TIMING0`](#timing0)                         | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING1`](#timing1)                         | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING2`](#timing2)                         | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING3`](#timing3)                         | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
-| i2c.[`TIMING4`](#timing4)                         | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
-| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)               | 0x50     |        4 | I2C clock stretching timeout control.                                                |
-| i2c.[`TARGET_ID`](#target_id)                     | 0x54     |        4 | I2C target address and mask pairs                                                    |
-| i2c.[`ACQDATA`](#acqdata)                         | 0x58     |        4 | I2C target acquired data                                                             |
-| i2c.[`TXDATA`](#txdata)                           | 0x5c     |        4 | I2C target transmit data                                                             |
-| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)     | 0x60     |        4 | I2C host clock generation timeout value (in units of input clock frequency)          |
-| i2c.[`TARGET_TIMEOUT_CTRL`](#target_timeout_ctrl) | 0x64     |        4 | I2C target internal stretching timeout control.                                      |
+| Name                                              | Offset   |   Length | Description                                                                                        |
+|:--------------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------------------------------|
+| i2c.[`INTR_STATE`](#intr_state)                   | 0x0      |        4 | Interrupt State Register                                                                           |
+| i2c.[`INTR_ENABLE`](#intr_enable)                 | 0x4      |        4 | Interrupt Enable Register                                                                          |
+| i2c.[`INTR_TEST`](#intr_test)                     | 0x8      |        4 | Interrupt Test Register                                                                            |
+| i2c.[`ALERT_TEST`](#alert_test)                   | 0xc      |        4 | Alert Test Register                                                                                |
+| i2c.[`CTRL`](#ctrl)                               | 0x10     |        4 | I2C Control Register                                                                               |
+| i2c.[`STATUS`](#status)                           | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                                 |
+| i2c.[`RDATA`](#rdata)                             | 0x18     |        4 | I2C Read Data                                                                                      |
+| i2c.[`FDATA`](#fdata)                             | 0x1c     |        4 | I2C Host Format Data                                                                               |
+| i2c.[`FIFO_CTRL`](#fifo_ctrl)                     | 0x20     |        4 | I2C FIFO control register                                                                          |
+| i2c.[`HOST_FIFO_CONFIG`](#host_fifo_config)       | 0x24     |        4 | Host mode FIFO configuration                                                                       |
+| i2c.[`TARGET_FIFO_CONFIG`](#target_fifo_config)   | 0x28     |        4 | Target mode FIFO configuration                                                                     |
+| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)       | 0x2c     |        4 | Host mode FIFO status register                                                                     |
+| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status)   | 0x30     |        4 | Target mode FIFO status register                                                                   |
+| i2c.[`OVRD`](#ovrd)                               | 0x34     |        4 | I2C Override Control Register                                                                      |
+| i2c.[`VAL`](#val)                                 | 0x38     |        4 | Oversampled RX values                                                                              |
+| i2c.[`TIMING0`](#timing0)                         | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
+| i2c.[`TIMING1`](#timing1)                         | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
+| i2c.[`TIMING2`](#timing2)                         | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
+| i2c.[`TIMING3`](#timing3)                         | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).               |
+| i2c.[`TIMING4`](#timing4)                         | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).               |
+| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)               | 0x50     |        4 | I2C clock stretching timeout control.                                                              |
+| i2c.[`TARGET_ID`](#target_id)                     | 0x54     |        4 | I2C target address and mask pairs                                                                  |
+| i2c.[`ACQDATA`](#acqdata)                         | 0x58     |        4 | I2C target acquired data                                                                           |
+| i2c.[`TXDATA`](#txdata)                           | 0x5c     |        4 | I2C target transmit data                                                                           |
+| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)     | 0x60     |        4 | I2C host clock generation timeout value (in units of input clock frequency)                        |
+| i2c.[`TARGET_TIMEOUT_CTRL`](#target_timeout_ctrl) | 0x64     |        4 | I2C target internal stretching timeout control.                                                    |
+| i2c.[`TARGET_NACK_COUNT`](#target_nack_count)     | 0x68     |        4 | Number of times the I2C target has NACK'ed a new transaction since the last read of this register. |
 
 ## INTR_STATE
 Interrupt State Register
@@ -573,6 +574,24 @@ When the target has stretched beyond this time it will send a NACK.
 |:------:|:------:|:-------:|:-------|:-----------------------------------------------------------------------|
 |   31   |   rw   |   0x0   | EN     | Enable timeout feature and send NACK once the timeout has been reached |
 |  30:0  |   rw   |   0x0   | VAL    | Clock stretching timeout value (in units of input clock frequency)     |
+
+## TARGET_NACK_COUNT
+Number of times the I2C target has NACK'ed a new transaction since the last read of this register.
+Reading this register clears it.
+This is useful because when the ACQ FIFO is full the software know that a NACK has occurred, but without this register would not know how many transactions it missed.
+- Offset: `0x68`
+- Reset default: `0x0`
+- Reset mask: `0xffffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "TARGET_NACK_COUNT", "bits": 32, "attr": ["rc"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name              | Description   |
+|:------:|:------:|:-------:|:------------------|:--------------|
+|  31:0  |   rc   |   0x0   | TARGET_NACK_COUNT |               |
 
 
 <!-- END CMDGEN -->

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -3,33 +3,34 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/i2c/data/i2c.hjson -->
 ## Summary
 
-| Name                                            | Offset   |   Length | Description                                                                          |
-|:------------------------------------------------|:---------|---------:|:-------------------------------------------------------------------------------------|
-| i2c.[`INTR_STATE`](#intr_state)                 | 0x0      |        4 | Interrupt State Register                                                             |
-| i2c.[`INTR_ENABLE`](#intr_enable)               | 0x4      |        4 | Interrupt Enable Register                                                            |
-| i2c.[`INTR_TEST`](#intr_test)                   | 0x8      |        4 | Interrupt Test Register                                                              |
-| i2c.[`ALERT_TEST`](#alert_test)                 | 0xc      |        4 | Alert Test Register                                                                  |
-| i2c.[`CTRL`](#ctrl)                             | 0x10     |        4 | I2C Control Register                                                                 |
-| i2c.[`STATUS`](#status)                         | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                   |
-| i2c.[`RDATA`](#rdata)                           | 0x18     |        4 | I2C Read Data                                                                        |
-| i2c.[`FDATA`](#fdata)                           | 0x1c     |        4 | I2C Host Format Data                                                                 |
-| i2c.[`FIFO_CTRL`](#fifo_ctrl)                   | 0x20     |        4 | I2C FIFO control register                                                            |
-| i2c.[`HOST_FIFO_CONFIG`](#host_fifo_config)     | 0x24     |        4 | Host mode FIFO configuration                                                         |
-| i2c.[`TARGET_FIFO_CONFIG`](#target_fifo_config) | 0x28     |        4 | Target mode FIFO configuration                                                       |
-| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)     | 0x2c     |        4 | Host mode FIFO status register                                                       |
-| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status) | 0x30     |        4 | Target mode FIFO status register                                                     |
-| i2c.[`OVRD`](#ovrd)                             | 0x34     |        4 | I2C Override Control Register                                                        |
-| i2c.[`VAL`](#val)                               | 0x38     |        4 | Oversampled RX values                                                                |
-| i2c.[`TIMING0`](#timing0)                       | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING1`](#timing1)                       | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING2`](#timing2)                       | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
-| i2c.[`TIMING3`](#timing3)                       | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
-| i2c.[`TIMING4`](#timing4)                       | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
-| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)             | 0x50     |        4 | I2C clock stretching timeout control                                                 |
-| i2c.[`TARGET_ID`](#target_id)                   | 0x54     |        4 | I2C target address and mask pairs                                                    |
-| i2c.[`ACQDATA`](#acqdata)                       | 0x58     |        4 | I2C target acquired data                                                             |
-| i2c.[`TXDATA`](#txdata)                         | 0x5c     |        4 | I2C target transmit data                                                             |
-| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)   | 0x60     |        4 | I2C host clock generation timeout value (in units of input clock frequency)          |
+| Name                                              | Offset   |   Length | Description                                                                          |
+|:--------------------------------------------------|:---------|---------:|:-------------------------------------------------------------------------------------|
+| i2c.[`INTR_STATE`](#intr_state)                   | 0x0      |        4 | Interrupt State Register                                                             |
+| i2c.[`INTR_ENABLE`](#intr_enable)                 | 0x4      |        4 | Interrupt Enable Register                                                            |
+| i2c.[`INTR_TEST`](#intr_test)                     | 0x8      |        4 | Interrupt Test Register                                                              |
+| i2c.[`ALERT_TEST`](#alert_test)                   | 0xc      |        4 | Alert Test Register                                                                  |
+| i2c.[`CTRL`](#ctrl)                               | 0x10     |        4 | I2C Control Register                                                                 |
+| i2c.[`STATUS`](#status)                           | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                   |
+| i2c.[`RDATA`](#rdata)                             | 0x18     |        4 | I2C Read Data                                                                        |
+| i2c.[`FDATA`](#fdata)                             | 0x1c     |        4 | I2C Host Format Data                                                                 |
+| i2c.[`FIFO_CTRL`](#fifo_ctrl)                     | 0x20     |        4 | I2C FIFO control register                                                            |
+| i2c.[`HOST_FIFO_CONFIG`](#host_fifo_config)       | 0x24     |        4 | Host mode FIFO configuration                                                         |
+| i2c.[`TARGET_FIFO_CONFIG`](#target_fifo_config)   | 0x28     |        4 | Target mode FIFO configuration                                                       |
+| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)       | 0x2c     |        4 | Host mode FIFO status register                                                       |
+| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status)   | 0x30     |        4 | Target mode FIFO status register                                                     |
+| i2c.[`OVRD`](#ovrd)                               | 0x34     |        4 | I2C Override Control Register                                                        |
+| i2c.[`VAL`](#val)                                 | 0x38     |        4 | Oversampled RX values                                                                |
+| i2c.[`TIMING0`](#timing0)                         | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
+| i2c.[`TIMING1`](#timing1)                         | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
+| i2c.[`TIMING2`](#timing2)                         | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).  |
+| i2c.[`TIMING3`](#timing3)                         | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
+| i2c.[`TIMING4`](#timing4)                         | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification). |
+| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)               | 0x50     |        4 | I2C clock stretching timeout control.                                                |
+| i2c.[`TARGET_ID`](#target_id)                     | 0x54     |        4 | I2C target address and mask pairs                                                    |
+| i2c.[`ACQDATA`](#acqdata)                         | 0x58     |        4 | I2C target acquired data                                                             |
+| i2c.[`TXDATA`](#txdata)                           | 0x5c     |        4 | I2C target transmit data                                                             |
+| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)     | 0x60     |        4 | I2C host clock generation timeout value (in units of input clock frequency)          |
+| i2c.[`TARGET_TIMEOUT_CTRL`](#target_timeout_ctrl) | 0x64     |        4 | I2C target internal stretching timeout control.                                      |
 
 ## INTR_STATE
 Interrupt State Register
@@ -450,7 +451,8 @@ All values are expressed in units of the input clock period.
 |  15:0  |   rw   |   0x0   | TSU_STO | Actual setup time for stop signals                                  |
 
 ## TIMEOUT_CTRL
-I2C clock stretching timeout control
+I2C clock stretching timeout control.
+This is used in I2C host mode to detect whether a connected target is stretching for too long.
 - Offset: `0x50`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -551,5 +553,22 @@ I2C host clock generation timeout value (in units of input clock frequency)
 |:------:|:------:|:-------:|:------------------|:--------------|
 |  31:0  |   rw   |   0x0   | HOST_TIMEOUT_CTRL |               |
 
+## TARGET_TIMEOUT_CTRL
+I2C target internal stretching timeout control.
+When the target has stretched beyond this time it will send a NACK.
+- Offset: `0x64`
+- Reset default: `0x0`
+- Reset mask: `0xffffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "VAL", "bits": 31, "attr": ["rw"], "rotate": 0}, {"name": "EN", "bits": 1, "attr": ["rw"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                                                            |
+|:------:|:------:|:-------:|:-------|:-----------------------------------------------------------------------|
+|   31   |   rw   |   0x0   | EN     | Enable timeout feature and send NACK once the timeout has been reached |
+|  30:0  |   rw   |   0x0   | VAL    | Clock stretching timeout value (in units of input clock frequency)     |
 
 <!-- END CMDGEN -->

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -61,6 +61,8 @@ module i2c_core import i2c_pkg::*;
   logic [30:0] stretch_timeout;
   logic        timeout_enable;
   logic [31:0] host_timeout;
+  logic [30:0] nack_timeout;
+  logic        nack_timeout_en;
 
   logic scl_sync;
   logic sda_sync;
@@ -228,6 +230,8 @@ module i2c_core import i2c_pkg::*;
   assign stretch_timeout = reg2hw.timeout_ctrl.val.q;
   assign timeout_enable  = reg2hw.timeout_ctrl.en.q;
   assign host_timeout    = reg2hw.host_timeout_ctrl.q;
+  assign nack_timeout    = reg2hw.target_timeout_ctrl.val.q;
+  assign nack_timeout_en = reg2hw.target_timeout_ctrl.en.q;
 
   assign i2c_fifo_rxrst      = reg2hw.fifo_ctrl.rxrst.q & reg2hw.fifo_ctrl.rxrst.qe;
   assign i2c_fifo_fmtrst     = reg2hw.fifo_ctrl.fmtrst.q & reg2hw.fifo_ctrl.fmtrst.qe;
@@ -459,6 +463,8 @@ module i2c_core import i2c_pkg::*;
     .stretch_timeout_i       (stretch_timeout),
     .timeout_enable_i        (timeout_enable),
     .host_timeout_i          (host_timeout),
+    .nack_timeout_i          (nack_timeout),
+    .nack_timeout_en_i       (nack_timeout_en),
     .target_address0_i       (target_address0),
     .target_mask0_i          (target_mask0),
     .target_address1_i       (target_address1),

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -76,6 +76,7 @@ module i2c_core import i2c_pkg::*;
   logic event_stretch_timeout;
   logic event_sda_unstable;
   logic event_cmd_complete;
+  logic event_target_nack;
   logic event_tx_stretch;
   logic event_unexp_stop;
   logic event_host_timeout;
@@ -187,6 +188,9 @@ module i2c_core import i2c_pkg::*;
   assign hw2reg.target_fifo_status.acqlvl.d = MaxFifoDepthW'(acq_fifo_depth);
   assign hw2reg.acqdata.abyte.d = acq_fifo_rdata[7:0];
   assign hw2reg.acqdata.signal.d = acq_fifo_rdata[AcqFifoWidth-1:8];
+  // Add one to the target NACK count if this target has sent a NACK.
+  assign hw2reg.target_nack_count.de = event_target_nack;
+  assign hw2reg.target_nack_count.d = reg2hw.target_nack_count.q + 1;
 
   assign override = reg2hw.ovrd.txovrden;
 
@@ -469,6 +473,7 @@ module i2c_core import i2c_pkg::*;
     .target_mask0_i          (target_mask0),
     .target_address1_i       (target_address1),
     .target_mask1_i          (target_mask1),
+    .event_target_nack_o     (event_target_nack),
     .event_nak_o             (event_nak),
     .event_scl_interference_o(event_scl_interference),
     .event_sda_interference_o(event_sda_interference),

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -73,6 +73,7 @@ module i2c_fsm import i2c_pkg::*;
   input logic [6:0] target_address1_i,
   input logic [6:0] target_mask1_i,
 
+  output logic event_target_nack_o,      // this target sent a NACK (this is used to keep count)
   output logic event_nak_o,              // target didn't Ack when expected
   output logic event_scl_interference_o, // other device forcing SCL low
   output logic event_sda_interference_o, // other device forcing SDA low
@@ -518,6 +519,7 @@ module i2c_fsm import i2c_pkg::*;
     event_scl_interference_o = 1'b0;
     event_sda_unstable_o = 1'b0;
     event_cmd_complete_o = 1'b0;
+    event_target_nack_o = 1'b0;
     rw_bit = rw_bit_q;
     stretch_en = 1'b0;
     expect_stop = 1'b0;
@@ -832,6 +834,7 @@ module i2c_fsm import i2c_pkg::*;
           // complete notification from a restart or a stop. We must notify
           // software that it needs to start processing the ACQ FIFO.
           event_cmd_complete_o = 1'b1;
+          event_target_nack_o = 1'b1;
         end
       end
       // StretchAddr: target stretches the clock if matching address cannot be
@@ -881,6 +884,7 @@ module i2c_fsm import i2c_pkg::*;
         event_scl_interference_o = 1'b0;
         event_sda_unstable_o = 1'b0;
         event_cmd_complete_o = 1'b0;
+        event_target_nack_o = 1'b0;
         actively_stretching = 1'b0;
       end
     endcase // unique case (state_q)

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -8,6 +8,7 @@ module i2c_fsm import i2c_pkg::*;
 #(
   parameter int FifoDepth = 64,
   parameter int AcqFifoDepth = 64,
+  parameter int unsigned AcqFifoWidth = 10,
   localparam int FifoDepthWidth = $clog2(FifoDepth+1),
   localparam int AcqFifoDepthWidth = $clog2(AcqFifoDepth+1)
 ) (
@@ -43,10 +44,10 @@ module i2c_fsm import i2c_pkg::*;
   input [7:0]                tx_fifo_rdata_i,  // byte in tx_fifo to be sent to host
 
   output logic                    acq_fifo_wvalid_o, // high if there is valid data in acq_fifo
-  output logic [9:0]              acq_fifo_wdata_o,  // byte and signal in acq_fifo read from target
+  output logic [AcqFifoWidth-1:0] acq_fifo_wdata_o,  // byte and signal in acq_fifo read from target
   input [AcqFifoDepthWidth-1:0]   acq_fifo_depth_i,  // fill level of acq_fifo
   output logic                    acq_fifo_wready_o, // local version of ready
-  input [9:0]                     acq_fifo_rdata_i,  // only used for assertion
+  input [AcqFifoWidth-1:0]        acq_fifo_rdata_i,  // only used for assertion
 
   output logic       host_idle_o,      // indicates the host is idle
   output logic       target_idle_o,    // indicates the target is idle
@@ -467,7 +468,7 @@ module i2c_fsm import i2c_pkg::*;
     rx_fifo_wdata_o = 8'h00;
     tx_fifo_rready_o = 1'b0;
     acq_fifo_wvalid_o = 1'b0;
-    acq_fifo_wdata_o = 10'b0;
+    acq_fifo_wdata_o = AcqFifoWidth'(0);
     event_nak_o = 1'b0;
     event_scl_interference_o = 1'b0;
     event_sda_unstable_o = 1'b0;
@@ -786,7 +787,7 @@ module i2c_fsm import i2c_pkg::*;
         rx_fifo_wdata_o = 8'h00;
         tx_fifo_rready_o = 1'b0;
         acq_fifo_wvalid_o = 1'b0;
-        acq_fifo_wdata_o = 10'b0;
+        acq_fifo_wdata_o = AcqFifoWidth'(0);
         event_nak_o = 1'b0;
         event_scl_interference_o = 1'b0;
         event_sda_unstable_o = 1'b0;

--- a/hw/ip/i2c/rtl/i2c_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_pkg.sv
@@ -5,13 +5,19 @@
 // i2c package
 //
 package i2c_pkg;
-  parameter int unsigned I2C_ACQ_BYTE_ID_WIDTH = 2;
+  parameter int unsigned I2C_ACQ_BYTE_ID_WIDTH = 3;
 
+  // TODO(#22028) encode this more efficiently in the ACQ FIFO. Each entry in the
+  // ACQ FIFO does not need to contain both an 8 bit data field and a 3 bit
+  // identifier. We should have the ACQ FIFO be 9 bits wide where the MSB
+  // indicates whether it is a data byte or a control byte. This way we can
+  // add more values to this enum without having to widen the ACQ FIFO width.
   typedef enum logic [I2C_ACQ_BYTE_ID_WIDTH-1:0] {
-    AcqData = 2'b00,
-    AcqStart = 2'b01,
-    AcqStop = 2'b10,
-    AcqRestart = 2'b11
+    AcqData      = 3'b000,
+    AcqStart     = 3'b001,
+    AcqStop      = 3'b010,
+    AcqRestart   = 3'b011,
+    AcqNack      = 3'b100
   } i2c_acq_byte_id_e;
 
 endpackage : i2c_pkg

--- a/hw/ip/i2c/rtl/i2c_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_pkg.sv
@@ -5,7 +5,9 @@
 // i2c package
 //
 package i2c_pkg;
-  typedef enum logic [1:0] {
+  parameter int unsigned I2C_ACQ_BYTE_ID_WIDTH = 2;
+
+  typedef enum logic [I2C_ACQ_BYTE_ID_WIDTH-1:0] {
     AcqData = 2'b00,
     AcqStart = 2'b01,
     AcqStop = 2'b10,

--- a/hw/ip/i2c/rtl/i2c_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_pkg.sv
@@ -17,7 +17,20 @@ package i2c_pkg;
     AcqStart     = 3'b001,
     AcqStop      = 3'b010,
     AcqRestart   = 3'b011,
-    AcqNack      = 3'b100
+    // AcqNack means one of two things:
+    // 1. We received a read request to our address, but had to NACK the
+    // address because our ACQ FIFO is full.
+    // 2. We received too many bytes in a write request and had to NACK a data
+    // byte. The NACK'ed data byte is still in the data field for inspection.
+    AcqNack      = 3'b100,
+    // AcqNackStart menas that we got a write request to our address, we sent
+    // an ACK to back to the host so that we can be compatible with SMBus, but
+    // now we must unconditionally NACK the next byte. We cannot record that
+    // NACK'ed byte because there is no space in the ACQ FIFO. The OpenTitan
+    // software must know this distinction from a normal AcqNack because the
+    // state machine must still continue through the AcquireByte and Nack*
+    // states.
+    AcqNackStart = 3'b101
   } i2c_acq_byte_id_e;
 
 endpackage : i2c_pkg

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -378,6 +378,10 @@ package i2c_reg_pkg;
   } i2c_reg2hw_target_timeout_ctrl_reg_t;
 
   typedef struct packed {
+    logic [31:0] q;
+  } i2c_reg2hw_target_nack_count_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -513,41 +517,48 @@ package i2c_reg_pkg;
     } signal;
   } i2c_hw2reg_acqdata_reg_t;
 
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } i2c_hw2reg_target_nack_count_reg_t;
+
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [461:447]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [446:432]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [431:402]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [401:400]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [399:397]
-    i2c_reg2hw_rdata_reg_t rdata; // [396:388]
-    i2c_reg2hw_fdata_reg_t fdata; // [387:369]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [368:361]
-    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [360:335]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [334:309]
-    i2c_reg2hw_ovrd_reg_t ovrd; // [308:306]
-    i2c_reg2hw_timing0_reg_t timing0; // [305:274]
-    i2c_reg2hw_timing1_reg_t timing1; // [273:242]
-    i2c_reg2hw_timing2_reg_t timing2; // [241:210]
-    i2c_reg2hw_timing3_reg_t timing3; // [209:178]
-    i2c_reg2hw_timing4_reg_t timing4; // [177:146]
-    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [145:114]
-    i2c_reg2hw_target_id_reg_t target_id; // [113:86]
-    i2c_reg2hw_acqdata_reg_t acqdata; // [85:73]
-    i2c_reg2hw_txdata_reg_t txdata; // [72:64]
-    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [63:32]
-    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [31:0]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [493:479]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [478:464]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [463:434]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [433:432]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [431:429]
+    i2c_reg2hw_rdata_reg_t rdata; // [428:420]
+    i2c_reg2hw_fdata_reg_t fdata; // [419:401]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [400:393]
+    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [392:367]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [366:341]
+    i2c_reg2hw_ovrd_reg_t ovrd; // [340:338]
+    i2c_reg2hw_timing0_reg_t timing0; // [337:306]
+    i2c_reg2hw_timing1_reg_t timing1; // [305:274]
+    i2c_reg2hw_timing2_reg_t timing2; // [273:242]
+    i2c_reg2hw_timing3_reg_t timing3; // [241:210]
+    i2c_reg2hw_timing4_reg_t timing4; // [209:178]
+    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [177:146]
+    i2c_reg2hw_target_id_reg_t target_id; // [145:118]
+    i2c_reg2hw_acqdata_reg_t acqdata; // [117:105]
+    i2c_reg2hw_txdata_reg_t txdata; // [104:96]
+    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [95:64]
+    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [63:32]
+    i2c_reg2hw_target_nack_count_reg_t target_nack_count; // [31:0]
   } i2c_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    i2c_hw2reg_intr_state_reg_t intr_state; // [138:109]
-    i2c_hw2reg_status_reg_t status; // [108:99]
-    i2c_hw2reg_rdata_reg_t rdata; // [98:91]
-    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [90:67]
-    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [66:43]
-    i2c_hw2reg_val_reg_t val; // [42:11]
-    i2c_hw2reg_acqdata_reg_t acqdata; // [10:0]
+    i2c_hw2reg_intr_state_reg_t intr_state; // [171:142]
+    i2c_hw2reg_status_reg_t status; // [141:132]
+    i2c_hw2reg_rdata_reg_t rdata; // [131:124]
+    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [123:100]
+    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [99:76]
+    i2c_hw2reg_val_reg_t val; // [75:44]
+    i2c_hw2reg_acqdata_reg_t acqdata; // [43:33]
+    i2c_hw2reg_target_nack_count_reg_t target_nack_count; // [32:0]
   } i2c_hw2reg_t;
 
   // Register offsets
@@ -577,6 +588,7 @@ package i2c_reg_pkg;
   parameter logic [BlockAw-1:0] I2C_TXDATA_OFFSET = 7'h 5c;
   parameter logic [BlockAw-1:0] I2C_HOST_TIMEOUT_CTRL_OFFSET = 7'h 60;
   parameter logic [BlockAw-1:0] I2C_TARGET_TIMEOUT_CTRL_OFFSET = 7'h 64;
+  parameter logic [BlockAw-1:0] I2C_TARGET_NACK_COUNT_OFFSET = 7'h 68;
 
   // Reset values for hwext registers and their fields
   parameter logic [14:0] I2C_INTR_TEST_RESVAL = 15'h 0;
@@ -637,11 +649,12 @@ package i2c_reg_pkg;
     I2C_ACQDATA,
     I2C_TXDATA,
     I2C_HOST_TIMEOUT_CTRL,
-    I2C_TARGET_TIMEOUT_CTRL
+    I2C_TARGET_TIMEOUT_CTRL,
+    I2C_TARGET_NACK_COUNT
   } i2c_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] I2C_PERMIT [26] = '{
+  parameter logic [3:0] I2C_PERMIT [27] = '{
     4'b 0011, // index[ 0] I2C_INTR_STATE
     4'b 0011, // index[ 1] I2C_INTR_ENABLE
     4'b 0011, // index[ 2] I2C_INTR_TEST
@@ -667,7 +680,8 @@ package i2c_reg_pkg;
     4'b 0011, // index[22] I2C_ACQDATA
     4'b 0001, // index[23] I2C_TXDATA
     4'b 1111, // index[24] I2C_HOST_TIMEOUT_CTRL
-    4'b 1111  // index[25] I2C_TARGET_TIMEOUT_CTRL
+    4'b 1111, // index[25] I2C_TARGET_TIMEOUT_CTRL
+    4'b 1111  // index[26] I2C_TARGET_NACK_COUNT
   };
 
 endpackage

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -370,6 +370,15 @@ package i2c_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic [30:0] q;
+    } val;
+  } i2c_reg2hw_target_timeout_ctrl_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
       logic        de;
     } fmt_threshold;
@@ -506,27 +515,28 @@ package i2c_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [428:414]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [413:399]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [398:369]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [368:367]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [366:364]
-    i2c_reg2hw_rdata_reg_t rdata; // [363:355]
-    i2c_reg2hw_fdata_reg_t fdata; // [354:336]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [335:328]
-    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [327:302]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [301:276]
-    i2c_reg2hw_ovrd_reg_t ovrd; // [275:273]
-    i2c_reg2hw_timing0_reg_t timing0; // [272:241]
-    i2c_reg2hw_timing1_reg_t timing1; // [240:209]
-    i2c_reg2hw_timing2_reg_t timing2; // [208:177]
-    i2c_reg2hw_timing3_reg_t timing3; // [176:145]
-    i2c_reg2hw_timing4_reg_t timing4; // [144:113]
-    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [112:81]
-    i2c_reg2hw_target_id_reg_t target_id; // [80:53]
-    i2c_reg2hw_acqdata_reg_t acqdata; // [52:41]
-    i2c_reg2hw_txdata_reg_t txdata; // [40:32]
-    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [31:0]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [460:446]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [445:431]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [430:401]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [400:399]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [398:396]
+    i2c_reg2hw_rdata_reg_t rdata; // [395:387]
+    i2c_reg2hw_fdata_reg_t fdata; // [386:368]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [367:360]
+    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [359:334]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [333:308]
+    i2c_reg2hw_ovrd_reg_t ovrd; // [307:305]
+    i2c_reg2hw_timing0_reg_t timing0; // [304:273]
+    i2c_reg2hw_timing1_reg_t timing1; // [272:241]
+    i2c_reg2hw_timing2_reg_t timing2; // [240:209]
+    i2c_reg2hw_timing3_reg_t timing3; // [208:177]
+    i2c_reg2hw_timing4_reg_t timing4; // [176:145]
+    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [144:113]
+    i2c_reg2hw_target_id_reg_t target_id; // [112:85]
+    i2c_reg2hw_acqdata_reg_t acqdata; // [84:73]
+    i2c_reg2hw_txdata_reg_t txdata; // [72:64]
+    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [63:32]
+    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [31:0]
   } i2c_reg2hw_t;
 
   // HW -> register type
@@ -566,6 +576,7 @@ package i2c_reg_pkg;
   parameter logic [BlockAw-1:0] I2C_ACQDATA_OFFSET = 7'h 58;
   parameter logic [BlockAw-1:0] I2C_TXDATA_OFFSET = 7'h 5c;
   parameter logic [BlockAw-1:0] I2C_HOST_TIMEOUT_CTRL_OFFSET = 7'h 60;
+  parameter logic [BlockAw-1:0] I2C_TARGET_TIMEOUT_CTRL_OFFSET = 7'h 64;
 
   // Reset values for hwext registers and their fields
   parameter logic [14:0] I2C_INTR_TEST_RESVAL = 15'h 0;
@@ -625,11 +636,12 @@ package i2c_reg_pkg;
     I2C_TARGET_ID,
     I2C_ACQDATA,
     I2C_TXDATA,
-    I2C_HOST_TIMEOUT_CTRL
+    I2C_HOST_TIMEOUT_CTRL,
+    I2C_TARGET_TIMEOUT_CTRL
   } i2c_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] I2C_PERMIT [25] = '{
+  parameter logic [3:0] I2C_PERMIT [26] = '{
     4'b 0011, // index[ 0] I2C_INTR_STATE
     4'b 0011, // index[ 1] I2C_INTR_ENABLE
     4'b 0011, // index[ 2] I2C_INTR_TEST
@@ -654,7 +666,8 @@ package i2c_reg_pkg;
     4'b 1111, // index[21] I2C_TARGET_ID
     4'b 0011, // index[22] I2C_ACQDATA
     4'b 0001, // index[23] I2C_TXDATA
-    4'b 1111  // index[24] I2C_HOST_TIMEOUT_CTRL
+    4'b 1111, // index[24] I2C_HOST_TIMEOUT_CTRL
+    4'b 1111  // index[25] I2C_TARGET_TIMEOUT_CTRL
   };
 
 endpackage

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -350,7 +350,7 @@ package i2c_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [1:0]  q;
+      logic [2:0]  q;
       logic        re;
     } signal;
     struct packed {
@@ -509,31 +509,31 @@ package i2c_reg_pkg;
       logic [7:0]  d;
     } abyte;
     struct packed {
-      logic [1:0]  d;
+      logic [2:0]  d;
     } signal;
   } i2c_hw2reg_acqdata_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [460:446]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [445:431]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [430:401]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [400:399]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [398:396]
-    i2c_reg2hw_rdata_reg_t rdata; // [395:387]
-    i2c_reg2hw_fdata_reg_t fdata; // [386:368]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [367:360]
-    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [359:334]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [333:308]
-    i2c_reg2hw_ovrd_reg_t ovrd; // [307:305]
-    i2c_reg2hw_timing0_reg_t timing0; // [304:273]
-    i2c_reg2hw_timing1_reg_t timing1; // [272:241]
-    i2c_reg2hw_timing2_reg_t timing2; // [240:209]
-    i2c_reg2hw_timing3_reg_t timing3; // [208:177]
-    i2c_reg2hw_timing4_reg_t timing4; // [176:145]
-    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [144:113]
-    i2c_reg2hw_target_id_reg_t target_id; // [112:85]
-    i2c_reg2hw_acqdata_reg_t acqdata; // [84:73]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [461:447]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [446:432]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [431:402]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [401:400]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [399:397]
+    i2c_reg2hw_rdata_reg_t rdata; // [396:388]
+    i2c_reg2hw_fdata_reg_t fdata; // [387:369]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [368:361]
+    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [360:335]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [334:309]
+    i2c_reg2hw_ovrd_reg_t ovrd; // [308:306]
+    i2c_reg2hw_timing0_reg_t timing0; // [305:274]
+    i2c_reg2hw_timing1_reg_t timing1; // [273:242]
+    i2c_reg2hw_timing2_reg_t timing2; // [241:210]
+    i2c_reg2hw_timing3_reg_t timing3; // [209:178]
+    i2c_reg2hw_timing4_reg_t timing4; // [177:146]
+    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [145:114]
+    i2c_reg2hw_target_id_reg_t target_id; // [113:86]
+    i2c_reg2hw_acqdata_reg_t acqdata; // [85:73]
     i2c_reg2hw_txdata_reg_t txdata; // [72:64]
     i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [63:32]
     i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [31:0]
@@ -541,13 +541,13 @@ package i2c_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    i2c_hw2reg_intr_state_reg_t intr_state; // [137:108]
-    i2c_hw2reg_status_reg_t status; // [107:98]
-    i2c_hw2reg_rdata_reg_t rdata; // [97:90]
-    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [89:66]
-    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [65:42]
-    i2c_hw2reg_val_reg_t val; // [41:10]
-    i2c_hw2reg_acqdata_reg_t acqdata; // [9:0]
+    i2c_hw2reg_intr_state_reg_t intr_state; // [138:109]
+    i2c_hw2reg_status_reg_t status; // [108:99]
+    i2c_hw2reg_rdata_reg_t rdata; // [98:91]
+    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [90:67]
+    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [66:43]
+    i2c_hw2reg_val_reg_t val; // [42:11]
+    i2c_hw2reg_acqdata_reg_t acqdata; // [10:0]
   } i2c_hw2reg_t;
 
   // Register offsets
@@ -608,7 +608,7 @@ package i2c_reg_pkg;
   parameter logic [27:0] I2C_HOST_FIFO_STATUS_RESVAL = 28'h 0;
   parameter logic [27:0] I2C_TARGET_FIFO_STATUS_RESVAL = 28'h 0;
   parameter logic [31:0] I2C_VAL_RESVAL = 32'h 0;
-  parameter logic [9:0] I2C_ACQDATA_RESVAL = 10'h 0;
+  parameter logic [10:0] I2C_ACQDATA_RESVAL = 11'h 0;
 
   // Register index
   typedef enum int {

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -294,7 +294,7 @@ module i2c_reg_top (
   logic [6:0] target_id_mask1_wd;
   logic acqdata_re;
   logic [7:0] acqdata_abyte_qs;
-  logic [1:0] acqdata_signal_qs;
+  logic [2:0] acqdata_signal_qs;
   logic txdata_we;
   logic [7:0] txdata_wd;
   logic host_timeout_ctrl_we;
@@ -2722,9 +2722,9 @@ module i2c_reg_top (
     .qs     (acqdata_abyte_qs)
   );
 
-  //   F[signal]: 9:8
+  //   F[signal]: 10:8
   prim_subreg_ext #(
-    .DW    (2)
+    .DW    (3)
   ) u_acqdata_signal (
     .re     (acqdata_re),
     .we     (1'b0),
@@ -3317,7 +3317,7 @@ module i2c_reg_top (
 
       addr_hit[22]: begin
         reg_rdata_next[7:0] = acqdata_abyte_qs;
-        reg_rdata_next[9:8] = acqdata_signal_qs;
+        reg_rdata_next[10:8] = acqdata_signal_qs;
       end
 
       addr_hit[23]: begin


### PR DESCRIPTION
This is a change to our I2C target. It essentially adds another timeout control register that can be set in the target that keeps track of how long it has been stretching for and otherwise NACK. The first 6 commits have no functional changes, so you can focus your reviews on the latter 10 commits (some of these have just auto-generated changes which are labelled accordingly).

There are many design parameters here and you can read a more detailed discussion in the issue: https://github.com/lowRISC/opentitan/issues/15227 But here's my take on a few of these:

### When to stretch
There are two options here, stretch before the ACK or stretch afterwards. After discussion with @andreaskurth and @a-will we decided to stretch after the ACK to be closer to the current design and to align with I2C high-speed mode.

### Do we NACK an address?
To be compatible with SMBus, @andreaskurth suggested we should not NACK an address and instead NACK subsequent data bytes. This works fine for writes because the host sends bytes after the address and the acknowledge is in the control of the target. However, for reads we still need to NACK the address because after a read request the acknowledge is in control of the host.

### How to communicate a NACK to the OpenTitan software
We need to NACK when the ACQ FIFO is full, but there also needs to be a way to report this incident to OpenTitan software. I've chosen to reserve an extra spot in the ACQ FIFO so that we can always send an `AcqNack` in there. I've also added a `AckNackStart` for the case when we have actually acknowledged an address when our ACQ FIFO is full but will unconditionally NACK the next data byte. This means the state machine needs to continue for a little while so that is why `AcqNackStart` needs to be different from `AcqNack`. The subsequent NACK'ed data byte will not be put in the ACQ FIFO so we cannot put a `AcqNack` entry in there anymore that is why `AckNackStart` needs to be different from `AcqStart`.

Another request by @hcallahan-lowrisc was that we still record the byte that was NACK'ed in the ACQ FIFO. This is done automaticaly at the moment through the concatenation of `{AcqNack, input_byte}`. However, this may not be possible in the future if we compress the entries in the ACQ FIFO.

### NACK'ing subsequent bytes
At the moment, I go directly to idle after sending a NACK and do not explicitly NACK any subsequent bytes. @andreaskurth mentioned that in idle mode the pull-up on SDA will essentially act as a NACK.

### Draft status
I've marked this PR as draft because I've only done limited testing on this. Some tests are passing, but I have not investigated the failures. Let's first converge on the functionality and then we can do more thorough testing.

Closes: https://github.com/lowRISC/opentitan/issues/15227