### PR TITLE
[dv] spi-monitor collect_trans unused phase reference removed

### DIFF
--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -33,11 +33,11 @@ class spi_monitor extends dv_base_monitor#(
   endfunction
 
   virtual task run_phase(uvm_phase phase);
-    forever collect_trans(phase);
+    forever collect_trans();
   endtask
 
   // collect transactions
-  virtual protected task collect_trans(uvm_phase phase);
+  virtual protected task collect_trans();
     bit flash_opcode_received;
 
     wait (cfg.en_monitor);


### PR DESCRIPTION
Spi-monitor collect_trans task was receiving the UVM_PHASE handle as a dead task parameter since it was doing nothing with it