### PR TITLE
[uart] Correct timeout comment units

### DIFF
--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -88,7 +88,7 @@
     {
       name: uart_intr
       uvm_test_seq: uart_intr_vseq
-      // 3ms
+      // 3s
       run_opts: ["+test_timeout_ns=3000000000"]
     }
 


### PR DESCRIPTION
The timeout value and corresponding comment seem to be saying different things. Let's update the comment to reflext the value, as doing it the other way around results is many more test failures.