### PR TITLE
[opentitantool] Update hyperdebug_teacup.json to match hardware

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -100,11 +100,11 @@
     },
     {
       "name": "IOB11",
-      "alias_of": "CN9_19"
+      "alias_of": "CN9_21"
     },
     {
       "name": "IOB12",
-      "alias_of": "CN9_21"
+      "alias_of": "CN9_19"
     },
     {
       "name": "IOC0",


### PR DESCRIPTION
It seems that on the Teacup board IOB11 is routed to CN9.21 and IOB12 is routed to CN9.19, the opposite of how there were declared.  As far as I recall, the two signals were swapped at some point during Teacup design review, in order for HyperDebug I2C capabilities to match how ChromeOS intends to use the pins of OpenTitan.