### PR TITLE
[ci] Avoid fusesoc builds in CI

### DIFF
--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -28,7 +28,7 @@ fi
 mkdir -p "${BIT_CACHE_DIR}"
 cp -rt "${BIT_CACHE_DIR}" "${BIT_SRC_DIR}"/*
 
-export BITSTREAM="--offline --list ci_bitstreams"
+export BITSTREAM="--offline --list --unavailable=@//hw/bitstream/unavailable ci_bitstreams"
 
 # We will lose serial access when we reboot, but if tests fail we should reboot
 # in case we've crashed the UART handler on the CW310's SAM3U

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -136,6 +136,7 @@ bitstream_splice(
 # Create manifest fragments for all the cached bitstreams
 bitstream_fragment_from_manifest(
     name = "chip_earlgrey_cw310_cached_fragment",
+    testonly = True,
     srcs = [
         "@bitstreams//:chip_earlgrey_cw310_bitstream",
         "@bitstreams//:chip_earlgrey_cw310_otp_mmi",
@@ -158,6 +159,7 @@ pkg_tar(
 
 bitstream_fragment_from_manifest(
     name = "chip_earlgrey_cw310_hyperdebug_cached_fragment",
+    testonly = True,
     srcs = [
         "@bitstreams//:chip_earlgrey_cw310_hyperdebug_bitstream",
         "@bitstreams//:chip_earlgrey_cw310_hyperdebug_otp_mmi",
@@ -180,6 +182,7 @@ pkg_tar(
 
 bitstream_fragment_from_manifest(
     name = "chip_earlgrey_cw340_cached_fragment",
+    testonly = True,
     srcs = [
         "@bitstreams//:chip_earlgrey_cw340_bitstream",
         "@bitstreams//:chip_earlgrey_cw340_otp_mmi",

--- a/hw/bitstream/unavailable/BUILD
+++ b/hw/bitstream/unavailable/BUILD
@@ -1,0 +1,36 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The targets in this files are designed so that bazel will not complain
+# about missing bitstreams targets but if you actually try to use them
+# then an error will be thrown. This is useful for offline builds to
+# load bitstreams from the cache but avoid Vivado builds in case of mistake.
+
+load("//rules:bitstreams.bzl", "unavailable_bitstream")
+
+package(default_visibility = ["//visibility:public"])
+
+# Note: all of the targets are tagged with "manual" to prevent them from being
+# matched by bazel wildcards like "//...".  In order to build the bitstream,
+# you need to ask for it directly or by dependency via another rule, such as
+# a functest.
+unavailable_bitstream(
+    name = "fpga_cw310_test_rom",
+    rom_mmi = "rom_mmi",
+    otp_mmi = "otp_mmi",
+)
+
+# Standalone CW310 image for use with hyperdebug.
+unavailable_bitstream(
+    name = "fpga_cw310_test_rom_hyp",
+    rom_mmi = "rom_mmi_hyp",
+    otp_mmi = "otp_mmi_hyp",
+)
+
+# CW340 bitstream
+unavailable_bitstream(
+    name = "fpga_cw340_test_rom",
+    rom_mmi = "fpga_cw340_rom_mmi",
+    otp_mmi = "fpga_cw340_otp_mmi",
+)


### PR DESCRIPTION
See individual commits. Essentially this adds a new switch to the workspace bitstream cache so that required but unavailable bitstream can use a configurable package. In CI, we can then used a newly created "fake" unavailable bitstream that errors out if used.

NOTE: I have left a few debugging statements on purpose to double-check with what happens in CI. Will remove them afterwards.