### PR TITLE
[adc_ctrl] Change collated IRQ to status type

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -45,8 +45,9 @@
     }
   ],
   interrupt_list: [
-    { name: "match_done",
-      desc: "ADC match or measurement event done",
+    { name: "match_pending",
+      desc: "ADC match or measurement event has occurred",
+      type: "status"
     }
   ],
   alert_list: [

--- a/hw/ip/adc_ctrl/doc/interfaces.md
+++ b/hw/ip/adc_ctrl/doc/interfaces.md
@@ -18,9 +18,9 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## Interrupts
 
-| Interrupt Name   | Type   | Description                         |
-|:-----------------|:-------|:------------------------------------|
-| match_done       | Event  | ADC match or measurement event done |
+| Interrupt Name   | Type   | Description                                 |
+|:-----------------|:-------|:--------------------------------------------|
+| match_pending    | Status | ADC match or measurement event has occurred |
 
 ## Security Alerts
 

--- a/hw/ip/adc_ctrl/doc/registers.md
+++ b/hw/ip/adc_ctrl/doc/registers.md
@@ -47,13 +47,13 @@ Interrupt State Register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "match_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "match_pending", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name       | Description                         |
-|:------:|:------:|:-------:|:-----------|:------------------------------------|
-|  31:1  |        |         |            | Reserved                            |
-|   0    |  rw1c  |   0x0   | match_done | ADC match or measurement event done |
+|  Bits  |  Type  |  Reset  | Name          | Description                                 |
+|:------:|:------:|:-------:|:--------------|:--------------------------------------------|
+|  31:1  |        |         |               | Reserved                                    |
+|   0    |   ro   |   0x0   | match_pending | ADC match or measurement event has occurred |
 
 ## INTR_ENABLE
 Interrupt Enable Register
@@ -64,13 +64,13 @@ Interrupt Enable Register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "match_done", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "match_pending", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name       | Description                                                          |
-|:------:|:------:|:-------:|:-----------|:---------------------------------------------------------------------|
-|  31:1  |        |         |            | Reserved                                                             |
-|   0    |   rw   |   0x0   | match_done | Enable interrupt when [`INTR_STATE.match_done`](#intr_state) is set. |
+|  Bits  |  Type  |  Reset  | Name          | Description                                                             |
+|:------:|:------:|:-------:|:--------------|:------------------------------------------------------------------------|
+|  31:1  |        |         |               | Reserved                                                                |
+|   0    |   rw   |   0x0   | match_pending | Enable interrupt when [`INTR_STATE.match_pending`](#intr_state) is set. |
 
 ## INTR_TEST
 Interrupt Test Register
@@ -81,13 +81,13 @@ Interrupt Test Register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "match_done", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "match_pending", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name       | Description                                                   |
-|:------:|:------:|:-------:|:-----------|:--------------------------------------------------------------|
-|  31:1  |        |         |            | Reserved                                                      |
-|   0    |   wo   |   0x0   | match_done | Write 1 to force [`INTR_STATE.match_done`](#intr_state) to 1. |
+|  Bits  |  Type  |  Reset  | Name          | Description                                                      |
+|:------:|:------:|:-------:|:--------------|:-----------------------------------------------------------------|
+|  31:1  |        |         |               | Reserved                                                         |
+|   0    |   wo   |   0x0   | match_pending | Write 1 to force [`INTR_STATE.match_pending`](#intr_state) to 1. |
 
 ## ALERT_TEST
 Alert Test Register

--- a/hw/ip/adc_ctrl/dv/tb.sv
+++ b/hw/ip/adc_ctrl/dv/tb.sv
@@ -88,18 +88,18 @@ module tb;
 
   // dut
   adc_ctrl dut (
-    .clk_i             (clk),
-    .rst_ni            (rst_n),
-    .clk_aon_i         (clk_aon),
-    .rst_aon_ni        (rst_aon_n),
-    .tl_i              (tl_if.h2d),
-    .tl_o              (tl_if.d2h),
-    .alert_rx_i        (alert_rx),
-    .alert_tx_o        (alert_tx),
-    .adc_o             (adc_o),
-    .adc_i             (adc_i),
-    .intr_match_done_o (interrupts[ADC_CTRL_INTERRUPT_INDEX]),
-    .wkup_req_o        (wakeup_req)
+    .clk_i                (clk),
+    .rst_ni               (rst_n),
+    .clk_aon_i            (clk_aon),
+    .rst_aon_ni           (rst_aon_n),
+    .tl_i                 (tl_if.h2d),
+    .tl_o                 (tl_if.d2h),
+    .alert_rx_i           (alert_rx),
+    .alert_tx_o           (alert_tx),
+    .adc_o                (adc_o),
+    .adc_i                (adc_i),
+    .intr_match_pending_o (interrupts[ADC_CTRL_INTERRUPT_INDEX]),
+    .wkup_req_o           (wakeup_req)
   );
 
   initial begin

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
@@ -34,7 +34,7 @@ module adc_ctrl
   input  ast_pkg::adc_ast_rsp_t adc_i,
 
   // Interrupt indicates a matching or measurement is done
-  output logic intr_match_done_o,
+  output logic intr_match_pending_o,
 
   // Pwrmgr interface
   // Debug cable is detected; wake up the chip in normal sleep and deep sleep mode
@@ -90,14 +90,14 @@ module adc_ctrl
     .adc_intr_status_o(hw2reg.adc_intr_status),
     .aon_filter_status_o(hw2reg.filter_status),
     .wkup_req_o,
-    .intr_o(intr_match_done_o),
+    .intr_o(intr_match_pending_o),
     .adc_i(adc_i),
     .adc_o(adc_o),
     .aon_fsm_state_o(hw2reg.adc_fsm_state.d)
   );
 
   // All outputs should be known value after reset
-  `ASSERT_KNOWN(IntrKnown, intr_match_done_o)
+  `ASSERT_KNOWN(IntrKnown, intr_match_pending_o)
   `ASSERT_KNOWN(WakeKnown, wkup_req_o)
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready)

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -259,7 +259,7 @@ package adc_ctrl_reg_pkg;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] ADC_CTRL_INTR_TEST_RESVAL = 1'h 0;
-  parameter logic [0:0] ADC_CTRL_INTR_TEST_MATCH_DONE_RESVAL = 1'h 0;
+  parameter logic [0:0] ADC_CTRL_INTR_TEST_MATCH_PENDING_RESVAL = 1'h 0;
   parameter logic [0:0] ADC_CTRL_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] ADC_CTRL_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [4:0] ADC_CTRL_ADC_FSM_STATE_RESVAL = 5'h 0;

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -123,9 +123,7 @@ module adc_ctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic intr_state_we;
   logic intr_state_qs;
-  logic intr_state_wd;
   logic intr_enable_we;
   logic intr_enable_qs;
   logic intr_enable_wd;
@@ -1356,7 +1354,7 @@ module adc_ctrl_reg_top (
   // R[intr_state]: V(False)
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state (
@@ -1364,8 +1362,8 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.de),
@@ -4050,9 +4048,6 @@ module adc_ctrl_reg_top (
   end
 
   // Generate write-enables
-  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
-
-  assign intr_state_wd = reg_wdata[0];
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
   assign intr_enable_wd = reg_wdata[0];
@@ -4180,7 +4175,7 @@ module adc_ctrl_reg_top (
   // Assign write-enables to checker logic vector.
   always_comb begin
     reg_we_check = '0;
-    reg_we_check[0] = intr_state_we;
+    reg_we_check[0] = 1'b0;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;
     reg_we_check[3] = alert_test_we;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -14287,11 +14287,11 @@
       default_val: false
     }
     {
-      name: adc_ctrl_aon_match_done
+      name: adc_ctrl_aon_match_pending
       width: 1
       type: interrupt
       module_name: adc_ctrl_aon
-      intr_type: IntrType.Event
+      intr_type: IntrType.Status
       default_val: false
     }
     {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -489,7 +489,7 @@ module top_earlgrey #(
   logic intr_usbdev_av_setup_empty;
   logic intr_pwrmgr_aon_wakeup;
   logic intr_sysrst_ctrl_aon_event_detected;
-  logic intr_adc_ctrl_aon_match_done;
+  logic intr_adc_ctrl_aon_match_pending;
   logic intr_aon_timer_aon_wkup_timer_expired;
   logic intr_aon_timer_aon_wdog_timer_bark;
   logic intr_sensor_ctrl_aon_io_status_change;
@@ -1871,7 +1871,7 @@ module top_earlgrey #(
   ) u_adc_ctrl_aon (
 
       // Interrupt
-      .intr_match_done_o (intr_adc_ctrl_aon_match_done),
+      .intr_match_pending_o (intr_adc_ctrl_aon_match_pending),
       // [28]: fatal_fault
       .alert_tx_o  ( alert_tx[28:28] ),
       .alert_rx_i  ( alert_rx[28:28] ),
@@ -2661,7 +2661,7 @@ module top_earlgrey #(
       intr_sensor_ctrl_aon_io_status_change, // IDs [154 +: 1]
       intr_aon_timer_aon_wdog_timer_bark, // IDs [153 +: 1]
       intr_aon_timer_aon_wkup_timer_expired, // IDs [152 +: 1]
-      intr_adc_ctrl_aon_match_done, // IDs [151 +: 1]
+      intr_adc_ctrl_aon_match_pending, // IDs [151 +: 1]
       intr_sysrst_ctrl_aon_event_detected, // IDs [150 +: 1]
       intr_pwrmgr_aon_wakeup, // IDs [149 +: 1]
       intr_usbdev_av_setup_empty, // IDs [148 +: 1]

--- a/hw/top_earlgrey/sw/autogen/chip/top_earlgrey.rs
+++ b/hw/top_earlgrey/sw/autogen/chip/top_earlgrey.rs
@@ -1165,8 +1165,8 @@ pub enum PlicIrqId {
     PwrmgrAonWakeup = 149,
     /// sysrst_ctrl_aon_event_detected
     SysrstCtrlAonEventDetected = 150,
-    /// adc_ctrl_aon_match_done
-    AdcCtrlAonMatchDone = 151,
+    /// adc_ctrl_aon_match_pending
+    AdcCtrlAonMatchPending = 151,
     /// aon_timer_aon_wkup_timer_expired
     AonTimerAonWkupTimerExpired = 152,
     /// aon_timer_aon_wdog_timer_bark
@@ -1384,7 +1384,7 @@ impl TryFrom<u32> for PlicIrqId {
             148 => Ok(Self::UsbdevAvSetupEmpty),
             149 => Ok(Self::PwrmgrAonWakeup),
             150 => Ok(Self::SysrstCtrlAonEventDetected),
-            151 => Ok(Self::AdcCtrlAonMatchDone),
+            151 => Ok(Self::AdcCtrlAonMatchPending),
             152 => Ok(Self::AonTimerAonWkupTimerExpired),
             153 => Ok(Self::AonTimerAonWdogTimerBark),
             154 => Ok(Self::SensorCtrlAonIoStatusChange),
@@ -2042,7 +2042,7 @@ pub const PLIC_INTERRUPT_FOR_PERIPHERAL: [PlicPeripheral; 182] = [
     PlicPeripheral::PwrmgrAon,
     // SysrstCtrlAonEventDetected -> PlicPeripheral::SysrstCtrlAon
     PlicPeripheral::SysrstCtrlAon,
-    // AdcCtrlAonMatchDone -> PlicPeripheral::AdcCtrlAon
+    // AdcCtrlAonMatchPending -> PlicPeripheral::AdcCtrlAon
     PlicPeripheral::AdcCtrlAon,
     // AonTimerAonWkupTimerExpired -> PlicPeripheral::AonTimerAon
     PlicPeripheral::AonTimerAon,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.c
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.c
@@ -163,7 +163,7 @@ const top_earlgrey_plic_peripheral_t
   [kTopEarlgreyPlicIrqIdUsbdevAvSetupEmpty] = kTopEarlgreyPlicPeripheralUsbdev,
   [kTopEarlgreyPlicIrqIdPwrmgrAonWakeup] = kTopEarlgreyPlicPeripheralPwrmgrAon,
   [kTopEarlgreyPlicIrqIdSysrstCtrlAonEventDetected] = kTopEarlgreyPlicPeripheralSysrstCtrlAon,
-  [kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone] = kTopEarlgreyPlicPeripheralAdcCtrlAon,
+  [kTopEarlgreyPlicIrqIdAdcCtrlAonMatchPending] = kTopEarlgreyPlicPeripheralAdcCtrlAon,
   [kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired] = kTopEarlgreyPlicPeripheralAonTimerAon,
   [kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark] = kTopEarlgreyPlicPeripheralAonTimerAon,
   [kTopEarlgreyPlicIrqIdSensorCtrlAonIoStatusChange] = kTopEarlgreyPlicPeripheralSensorCtrlAon,

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1166,7 +1166,7 @@ typedef enum top_earlgrey_plic_irq_id {
   kTopEarlgreyPlicIrqIdUsbdevAvSetupEmpty = 148, /**< usbdev_av_setup_empty */
   kTopEarlgreyPlicIrqIdPwrmgrAonWakeup = 149, /**< pwrmgr_aon_wakeup */
   kTopEarlgreyPlicIrqIdSysrstCtrlAonEventDetected = 150, /**< sysrst_ctrl_aon_event_detected */
-  kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone = 151, /**< adc_ctrl_aon_match_done */
+  kTopEarlgreyPlicIrqIdAdcCtrlAonMatchPending = 151, /**< adc_ctrl_aon_match_pending */
   kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired = 152, /**< aon_timer_aon_wkup_timer_expired */
   kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark = 153, /**< aon_timer_aon_wdog_timer_bark */
   kTopEarlgreyPlicIrqIdSensorCtrlAonIoStatusChange = 154, /**< sensor_ctrl_aon_io_status_change */

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
@@ -54,8 +54,8 @@ dif_result_t dif_adc_ctrl_alert_force(const dif_adc_ctrl_t *adc_ctrl,
 static bool adc_ctrl_get_irq_bit_index(dif_adc_ctrl_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {
   switch (irq) {
-    case kDifAdcCtrlIrqMatchDone:
-      *index_out = ADC_CTRL_INTR_COMMON_MATCH_DONE_BIT;
+    case kDifAdcCtrlIrqMatchPending:
+      *index_out = ADC_CTRL_INTR_COMMON_MATCH_PENDING_BIT;
       break;
     default:
       return false;
@@ -65,14 +65,15 @@ static bool adc_ctrl_get_irq_bit_index(dif_adc_ctrl_irq_t irq,
 }
 
 static dif_irq_type_t irq_types[] = {
-    kDifIrqTypeEvent,
+    kDifIrqTypeStatus,
 };
 
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_adc_ctrl_irq_get_type(const dif_adc_ctrl_t *adc_ctrl,
                                        dif_adc_ctrl_irq_t irq,
                                        dif_irq_type_t *type) {
-  if (adc_ctrl == NULL || type == NULL || irq == kDifAdcCtrlIrqMatchDone + 1) {
+  if (adc_ctrl == NULL || type == NULL ||
+      irq == kDifAdcCtrlIrqMatchPending + 1) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
@@ -78,9 +78,9 @@ dif_result_t dif_adc_ctrl_alert_force(const dif_adc_ctrl_t *adc_ctrl,
  */
 typedef enum dif_adc_ctrl_irq {
   /**
-   * ADC match or measurement event done
+   * ADC match or measurement event has occurred
    */
-  kDifAdcCtrlIrqMatchDone = 0,
+  kDifAdcCtrlIrqMatchPending = 0,
 } dif_adc_ctrl_irq_t;
 
 /**

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -62,29 +62,29 @@ TEST_F(IrqGetTypeTest, NullArgs) {
   dif_irq_type_t type;
 
   EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_get_type(nullptr, kDifAdcCtrlIrqMatchDone, &type));
+      dif_adc_ctrl_irq_get_type(nullptr, kDifAdcCtrlIrqMatchPending, &type));
+
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_type(
+      &adc_ctrl_, kDifAdcCtrlIrqMatchPending, nullptr));
 
   EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_get_type(&adc_ctrl_, kDifAdcCtrlIrqMatchDone, nullptr));
-
-  EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_get_type(nullptr, kDifAdcCtrlIrqMatchDone, nullptr));
+      dif_adc_ctrl_irq_get_type(nullptr, kDifAdcCtrlIrqMatchPending, nullptr));
 }
 
 TEST_F(IrqGetTypeTest, BadIrq) {
   dif_irq_type_t type;
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_type(
-      &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(kDifAdcCtrlIrqMatchDone + 1),
-      &type));
+      &adc_ctrl_,
+      static_cast<dif_adc_ctrl_irq_t>(kDifAdcCtrlIrqMatchPending + 1), &type));
 }
 
 TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(
-      dif_adc_ctrl_irq_get_type(&adc_ctrl_, kDifAdcCtrlIrqMatchDone, &type));
-  EXPECT_EQ(type, kDifIrqTypeEvent);
+      dif_adc_ctrl_irq_get_type(&adc_ctrl_, kDifAdcCtrlIrqMatchPending, &type));
+  EXPECT_EQ(type, kDifIrqTypeStatus);
 }
 
 class IrqGetStateTest : public AdcCtrlTest {};
@@ -122,13 +122,13 @@ TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_is_pending(
-      nullptr, kDifAdcCtrlIrqMatchDone, &is_pending));
+      nullptr, kDifAdcCtrlIrqMatchPending, &is_pending));
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_is_pending(
-      &adc_ctrl_, kDifAdcCtrlIrqMatchDone, nullptr));
+      &adc_ctrl_, kDifAdcCtrlIrqMatchPending, nullptr));
 
-  EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_is_pending(nullptr, kDifAdcCtrlIrqMatchDone, nullptr));
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_is_pending(
+      nullptr, kDifAdcCtrlIrqMatchPending, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
@@ -144,9 +144,9 @@ TEST_F(IrqIsPendingTest, Success) {
   // Get the first IRQ state.
   irq_state = false;
   EXPECT_READ32(ADC_CTRL_INTR_STATE_REG_OFFSET,
-                {{ADC_CTRL_INTR_STATE_MATCH_DONE_BIT, true}});
-  EXPECT_DIF_OK(dif_adc_ctrl_irq_is_pending(&adc_ctrl_, kDifAdcCtrlIrqMatchDone,
-                                            &irq_state));
+                {{ADC_CTRL_INTR_STATE_MATCH_PENDING_BIT, true}});
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_is_pending(
+      &adc_ctrl_, kDifAdcCtrlIrqMatchPending, &irq_state));
   EXPECT_TRUE(irq_state);
 }
 
@@ -196,7 +196,7 @@ class IrqAcknowledgeTest : public AdcCtrlTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
   EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_acknowledge(nullptr, kDifAdcCtrlIrqMatchDone));
+      dif_adc_ctrl_irq_acknowledge(nullptr, kDifAdcCtrlIrqMatchPending));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
@@ -207,16 +207,16 @@ TEST_F(IrqAcknowledgeTest, BadIrq) {
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(ADC_CTRL_INTR_STATE_REG_OFFSET,
-                 {{ADC_CTRL_INTR_STATE_MATCH_DONE_BIT, true}});
+                 {{ADC_CTRL_INTR_STATE_MATCH_PENDING_BIT, true}});
   EXPECT_DIF_OK(
-      dif_adc_ctrl_irq_acknowledge(&adc_ctrl_, kDifAdcCtrlIrqMatchDone));
+      dif_adc_ctrl_irq_acknowledge(&adc_ctrl_, kDifAdcCtrlIrqMatchPending));
 }
 
 class IrqForceTest : public AdcCtrlTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
   EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_force(nullptr, kDifAdcCtrlIrqMatchDone, true));
+      dif_adc_ctrl_irq_force(nullptr, kDifAdcCtrlIrqMatchPending, true));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
@@ -227,9 +227,9 @@ TEST_F(IrqForceTest, BadIrq) {
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(ADC_CTRL_INTR_TEST_REG_OFFSET,
-                 {{ADC_CTRL_INTR_TEST_MATCH_DONE_BIT, true}});
+                 {{ADC_CTRL_INTR_TEST_MATCH_PENDING_BIT, true}});
   EXPECT_DIF_OK(
-      dif_adc_ctrl_irq_force(&adc_ctrl_, kDifAdcCtrlIrqMatchDone, true));
+      dif_adc_ctrl_irq_force(&adc_ctrl_, kDifAdcCtrlIrqMatchPending, true));
 }
 
 class IrqGetEnabledTest : public AdcCtrlTest {};
@@ -238,13 +238,13 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_enabled(
-      nullptr, kDifAdcCtrlIrqMatchDone, &irq_state));
+      nullptr, kDifAdcCtrlIrqMatchPending, &irq_state));
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_enabled(
-      &adc_ctrl_, kDifAdcCtrlIrqMatchDone, nullptr));
+      &adc_ctrl_, kDifAdcCtrlIrqMatchPending, nullptr));
 
-  EXPECT_DIF_BADARG(
-      dif_adc_ctrl_irq_get_enabled(nullptr, kDifAdcCtrlIrqMatchDone, nullptr));
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_enabled(
+      nullptr, kDifAdcCtrlIrqMatchPending, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
@@ -260,9 +260,9 @@ TEST_F(IrqGetEnabledTest, Success) {
   // First IRQ is enabled.
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
-                {{ADC_CTRL_INTR_ENABLE_MATCH_DONE_BIT, true}});
+                {{ADC_CTRL_INTR_ENABLE_MATCH_PENDING_BIT, true}});
   EXPECT_DIF_OK(dif_adc_ctrl_irq_get_enabled(
-      &adc_ctrl_, kDifAdcCtrlIrqMatchDone, &irq_state));
+      &adc_ctrl_, kDifAdcCtrlIrqMatchPending, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 }
 
@@ -272,7 +272,7 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
   EXPECT_DIF_BADARG(dif_adc_ctrl_irq_set_enabled(
-      nullptr, kDifAdcCtrlIrqMatchDone, irq_state));
+      nullptr, kDifAdcCtrlIrqMatchPending, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
@@ -288,9 +288,9 @@ TEST_F(IrqSetEnabledTest, Success) {
   // Enable first IRQ.
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
-                {{ADC_CTRL_INTR_ENABLE_MATCH_DONE_BIT, 0x1, true}});
+                {{ADC_CTRL_INTR_ENABLE_MATCH_PENDING_BIT, 0x1, true}});
   EXPECT_DIF_OK(dif_adc_ctrl_irq_set_enabled(
-      &adc_ctrl_, kDifAdcCtrlIrqMatchDone, irq_state));
+      &adc_ctrl_, kDifAdcCtrlIrqMatchPending, irq_state));
 }
 
 class IrqDisableAllTest : public AdcCtrlTest {};

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -38,7 +38,7 @@
 
 void isr_testutils_adc_ctrl_isr(
     plic_isr_ctx_t plic_ctx, adc_ctrl_isr_ctx_t adc_ctrl_ctx,
-    top_earlgrey_plic_peripheral_t *peripheral_serviced,
+    bool mute_status_irq, top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_adc_ctrl_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
   dif_rv_plic_irq_id_t plic_irq_id;
@@ -75,6 +75,9 @@ void isr_testutils_adc_ctrl_isr(
   CHECK_DIF_OK(dif_adc_ctrl_irq_get_type(adc_ctrl_ctx.adc_ctrl, irq, &type));
   if (type == kDifIrqTypeEvent) {
     CHECK_DIF_OK(dif_adc_ctrl_irq_acknowledge(adc_ctrl_ctx.adc_ctrl, irq));
+  } else if (mute_status_irq) {
+    CHECK_DIF_OK(dif_adc_ctrl_irq_set_enabled(adc_ctrl_ctx.adc_ctrl, irq,
+                                              kDifToggleDisabled));
   }
 
   // Complete the IRQ at the PLIC.

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -565,13 +565,14 @@ typedef struct usbdev_isr_ctx {
  *
  * @param plic_ctx A PLIC ISR context handle.
  * @param adc_ctrl_ctx A(n) adc_ctrl ISR context handle.
+ * @param mute_status_irq set to true to disable the serviced status type IRQ.
  * @param[out] peripheral_serviced Out param for the peripheral that was
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_adc_ctrl_isr(
     plic_isr_ctx_t plic_ctx, adc_ctrl_isr_ctx_t adc_ctrl_ctx,
-    top_earlgrey_plic_peripheral_t *peripheral_serviced,
+    bool mute_status_irq, top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_adc_ctrl_irq_t *irq_serviced);
 
 /**

--- a/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
+++ b/sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test.c
@@ -64,17 +64,17 @@ void ottf_external_isr(uint32_t *exc_info) {
 
   adc_ctrl_isr_ctx_t adc_ctrl_ctx = {
       .adc_ctrl = &adc_ctrl,
-      .plic_adc_ctrl_start_irq_id = kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone,
+      .plic_adc_ctrl_start_irq_id = kTopEarlgreyPlicIrqIdAdcCtrlAonMatchPending,
       .expected_irq = 0,
       .is_only_irq = true};
 
   top_earlgrey_plic_peripheral_t peripheral;
   dif_adc_ctrl_irq_t adc_ctrl_irq;
-  isr_testutils_adc_ctrl_isr(plic_ctx, adc_ctrl_ctx, &peripheral,
+  isr_testutils_adc_ctrl_isr(plic_ctx, adc_ctrl_ctx, false, &peripheral,
                              &adc_ctrl_irq);
 
   CHECK(peripheral == kTopEarlgreyPlicPeripheralAdcCtrlAon);
-  CHECK(adc_ctrl_irq == kDifAdcCtrlIrqMatchDone);
+  CHECK(adc_ctrl_irq == kDifAdcCtrlIrqMatchPending);
   interrupt_serviced = true;
 
   // Verify this interrupt was actually expected.
@@ -83,7 +83,7 @@ void ottf_external_isr(uint32_t *exc_info) {
 
 static void en_plic_irqs(dif_rv_plic_t *plic) {
   top_earlgrey_plic_irq_id_t plic_irqs[] = {
-      kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone};
+      kTopEarlgreyPlicIrqIdAdcCtrlAonMatchPending};
 
   for (uint32_t i = 0; i < ARRAYSIZE(plic_irqs); ++i) {
     CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
@@ -112,8 +112,8 @@ bool test_main(void) {
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &plic));
 
   // Enable adc interrupts.
-  CHECK_DIF_OK(dif_adc_ctrl_irq_set_enabled(&adc_ctrl, kDifAdcCtrlIrqMatchDone,
-                                            kDifToggleEnabled));
+  CHECK_DIF_OK(dif_adc_ctrl_irq_set_enabled(
+      &adc_ctrl, kDifAdcCtrlIrqMatchPending, kDifToggleEnabled));
 
   uint16_t channel0_filter0_max =
       (uint16_t)(kChannel0MaxHighByte << 8) | kChannel0MaxLowByte;

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -217,7 +217,7 @@ static void configure_adc_ctrl(const dif_adc_ctrl_t *adc_ctrl) {
 
 static void en_plic_irqs(dif_rv_plic_t *plic) {
   top_earlgrey_plic_irq_id_t plic_irqs[] = {
-      kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone};
+      kTopEarlgreyPlicIrqIdAdcCtrlAonMatchPending};
 
   for (uint32_t i = 0; i < ARRAYSIZE(plic_irqs); ++i) {
     CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
@@ -234,8 +234,8 @@ static void en_plic_irqs(dif_rv_plic_t *plic) {
 
 void adc_setup(bool first_adc_setup) {
   // Enable adc interrupts.
-  CHECK_DIF_OK(dif_adc_ctrl_irq_set_enabled(&adc_ctrl, kDifAdcCtrlIrqMatchDone,
-                                            kDifToggleEnabled));
+  CHECK_DIF_OK(dif_adc_ctrl_irq_set_enabled(
+      &adc_ctrl, kDifAdcCtrlIrqMatchPending, kDifToggleEnabled));
 
   uint16_t channel0_filter0_max =
       ((uint16_t)(kChannel0MaxHighByte << 8)) | kChannel0MaxLowByte;
@@ -332,8 +332,8 @@ void ast_enter_sleep_states_and_check_functionality(
     // Enable all the AON interrupts used in this test.
     rv_plic_testutils_irq_range_enable(
         &rv_plic, kTopEarlgreyPlicTargetIbex0,
-        kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone,
-        kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone);
+        kTopEarlgreyPlicIrqIdAdcCtrlAonMatchPending,
+        kTopEarlgreyPlicIrqIdAdcCtrlAonMatchPending);
     CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
 
     // Setup low power.
@@ -499,17 +499,17 @@ void ottf_external_isr(uint32_t *exc_info) {
 
   adc_ctrl_isr_ctx_t adc_ctrl_ctx = {
       .adc_ctrl = &adc_ctrl,
-      .plic_adc_ctrl_start_irq_id = kTopEarlgreyPlicIrqIdAdcCtrlAonMatchDone,
+      .plic_adc_ctrl_start_irq_id = kTopEarlgreyPlicIrqIdAdcCtrlAonMatchPending,
       .expected_irq = 0,
       .is_only_irq = true};
 
   top_earlgrey_plic_peripheral_t peripheral;
   dif_adc_ctrl_irq_t adc_ctrl_irq;
-  isr_testutils_adc_ctrl_isr(plic_ctx, adc_ctrl_ctx, &peripheral,
+  isr_testutils_adc_ctrl_isr(plic_ctx, adc_ctrl_ctx, false, &peripheral,
                              &adc_ctrl_irq);
 
   CHECK(peripheral == kTopEarlgreyPlicPeripheralAdcCtrlAon);
-  CHECK(adc_ctrl_irq == kDifAdcCtrlIrqMatchDone);
+  CHECK(adc_ctrl_irq == kDifAdcCtrlIrqMatchPending);
   interrupt_serviced = true;
 }
 


### PR DESCRIPTION
This fixes the `adc_ctrl` portion of #21832