### PR TITLE
[usbdev] Usbdev block level smoke test improvements for V1

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -202,23 +202,18 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
   // -------------------------------
   task bit_stuffing(input bit packet[], output bit bit_stuff_out[]);
     int consecutive_ones_count = 0;
+    bit stuffed[$];
     for (int i = 0; i < packet.size(); i++) begin
+      stuffed.push_back(packet[i]);
       if (packet[i] == 1'b1) begin
         consecutive_ones_count = consecutive_ones_count + 1;
-        if (consecutive_ones_count == 6) begin
-          packet = new[packet.size() + 1](packet);
-          for (int j = packet.size() ; j > i; j = j - 1) begin
-            packet[j] = packet[j - 1];
-          end
-          i = i + 1;
-          packet[i] = 1'b0;
+        if (consecutive_ones_count >= 6) begin
           consecutive_ones_count = 0;
+          stuffed.push_back(1'b0);
         end
-      end else if (packet[i] == 1'b0) begin
-        consecutive_ones_count = 0;
-      end
+      end else consecutive_ones_count = 0;
     end
-    bit_stuff_out = packet;
+    bit_stuff_out = stuffed;
   endtask
 
   // Returns 1 in the event of detecting a bit stuffing error, output is


### PR DESCRIPTION
This PR offers improvements to the testing performed by the block level smoke test for the USB device in two commits:

1. Ensure that SETUP, OUT and IN data packets are transmitted and checked at the receiver for a random endpoint, exercising both transmission and reception of packets at both the CSR side and the USB side. Crude initial implementation of full packet decoding to check the contents of IN data packets; further validation is required and in particular the calculation and checking of CRC16. Implement the removal of bit stuffed '0' bits. Introduce workaround for the sampling issues that arise from operating on a clock frequency that matches the bit rate; the DV should preferably be employing an oversampled clock and not stealing access to the USB device driver enable output; this would then permit testing of frequency and phase mismatches and operation using just the true USB signals, for example.

2. Employ a deque whilst constructing the bit stuffed output packet, which is simpler and more efficient, and addresses the out-of-bounds access in the previous implementation.

The pass rate is unaffected. It is still not 100% with either EDA tool because for some seeds each simulator finds itself stuck without simulation time advancing. It appears to be something to do with the structure of the test environment and certainly does not indicate a DUT failure.