### PR TITLE
[dv,sram_ctrl] Fix a few test failures

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -286,6 +286,7 @@ virtual task run_tl_intg_err_vseq(int num_times = 1);
     end
   end
   for (int trans = 1; trans <= num_times; trans++) begin
+    if (cfg.stop_transaction_generators()) break;
     `uvm_info(`gfn, $sformatf("Running run_tl_intg_err_vseq %0d/%0d", trans, num_times),
               UVM_LOW)
     foreach (cfg.ral_models[ral_name]) begin
@@ -375,6 +376,7 @@ endtask
 
 virtual task run_passthru_mem_tl_intg_err_vseq(int num_times = 1);
   for (int trans = 1; trans <= num_times; trans++) begin
+    if (cfg.stop_transaction_generators()) break;
     `uvm_info(`gfn, $sformatf("Running run_passthru_mem_tl_intg_err_vseq %0d/%0d",
                               trans, num_times),
               UVM_LOW)

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
@@ -33,6 +33,8 @@ class sram_ctrl_lc_escalation_vseq extends sram_ctrl_multiple_keys_vseq;
 
   virtual task body();
     repeat (num_trans) begin
+      if (cfg.stop_transaction_generators()) break;
+
       if ($urandom_range(0, 1)) begin
         req_mem_init();
       end else begin

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -64,19 +64,16 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)
 
       if (access_during_key_req) begin
-        // request new key or issue mem init, in the meanwhile, do some random SRAM operations
+        // Request new key and issue mem init, in the meanwhile, do some random SRAM operations.
+        // When mem_init is requested a new key is also requested, so it is only necessary to
+        // call req_mem_init. This is important, since if only new keys are requested the
+        // scrambling will change and most memory locations will have ECC errors.
+        //
+        // The purpose of the test is to check that no memory transactions happen while either
+        // key request of memory initialization are happening, and that is met by req_mem_init
+        // since it does both.
         fork
-          begin
-            // during key or init req, sram access shouldn't be taken
-            randcase
-              1: begin
-                req_scr_key();
-              end
-              1: begin
-                req_mem_init();
-              end
-            endcase
-          end
+          req_mem_init();
           begin
             // add 2 cycles to avoid issuing key_scr/init and mem access happen at the same time,
             // as it's hard to handle this case in scb

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -54,6 +54,8 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
     m_kdi_cfg.agent_type = push_pull_agent_pkg::PullAgent;
     m_kdi_cfg.if_mode = dv_utils_pkg::Device;
     m_kdi_cfg.pull_handshake_type = push_pull_agent_pkg::TwoPhase;
+    m_kdi_cfg.device_delay_min = 30;
+    m_kdi_cfg.device_delay_max = 80;
 
     // CDC synchronization between OTP and SRAM clock domains requires that the scrambling seed data
     // should be held for at least a few cycles before it can be safely latched by the SRAM domain.


### PR DESCRIPTION
- Block a few more transaction generators to prevent failure with rand_reset.
- Set the in_init and in_key_req flags in either process_tl_access, or in the req_mem_init and req_key_scr, depending on whether the scoreboard is enabled. Setting it in both was causing retriggering of key requests.
- Avoid request for scramble key by itself in the smoke sequence since it adds no verification value and causes integrity errors.