### PR TITLE
[cryptotest] Fix AES-GCM schema and test vector parser

### DIFF
--- a/sw/host/cryptotest/testvectors/data/schemas/aes_gcm_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/aes_gcm_schema.json
@@ -53,6 +53,10 @@
         "description": "AES intermediate value",
         "$ref": "#/$defs/byte_array"
       },
+      "tag": {
+        "description": "Authentication Tag",
+        "$ref": "#/$defs/byte_array"
+      },
       "ciphertext": {
         "description": "Ciphertext",
         "$ref": "#/$defs/byte_array"


### PR DESCRIPTION
Fix 1:
Currently, there are no FAIL cases in the GCM encryption test vectors. However, for decryption test vectors, if a test vector lacks a Plaintext (PT) field, the result of that particular test vector will be marked as FAIL.

In the initial PR, we accidentally marked the expected result as PASS if
there is no Plaintext (PT) field in the test vector, regardless it's
operation mode.

Fix 2:
In this PR, we include the missing auth tag from the test vectors into
the schema and parser.