### PR TITLE
[ownership] Miscellaneous preparation

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -168,6 +168,24 @@ cc_library(
 )
 
 cc_library(
+    name = "hexstr",
+    srcs = ["hexstr.c"],
+    hdrs = ["hexstr.h"],
+    deps = [
+        "//sw/device/lib/base:status",
+    ],
+)
+
+cc_test(
+    name = "hexstr_unittest",
+    srcs = ["hexstr_unittest.cc"],
+    deps = [
+        ":hexstr",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "hmac_testutils",
     srcs = ["hmac_testutils.c"],
     hdrs = ["hmac_testutils.h"],

--- a/sw/device/lib/testing/hexstr.c
+++ b/sw/device/lib/testing/hexstr.c
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/hexstr.h"
+
+static const char hex[] = "0123456789abcdef";
+
+status_t hexstr_encode(char *dst, size_t dst_size, const void *src,
+                       size_t src_size) {
+  const uint8_t *data = (const uint8_t *)src;
+  for (; src_size > 0; --src_size, ++data) {
+    if (dst_size < 3) {
+      return INVALID_ARGUMENT();
+    }
+    *dst++ = hex[*data >> 4];
+    *dst++ = hex[*data & 15];
+    dst_size -= 2;
+  }
+  *dst = '\0';
+  return OK_STATUS();
+}
+
+static status_t decode_nibble(char ch) {
+  if (ch == 0) {
+    // Unexpected end of string.
+    return INVALID_ARGUMENT();
+  }
+  int nibble = (ch >= '0' && ch <= '9')   ? ch - '0'
+               : (ch >= 'A' && ch <= 'F') ? ch - 'A' + 10
+               : (ch >= 'a' && ch <= 'f') ? ch - 'a' + 10
+                                          : -1;
+  if (nibble == -1) {
+    // Not a valid hex digit.
+    return INVALID_ARGUMENT();
+  }
+  return OK_STATUS(nibble);
+}
+
+status_t hexstr_decode(void *dst, size_t dst_size, const char *src) {
+  uint8_t *data = (uint8_t *)dst;
+  while (*src) {
+    if (dst_size == 0) {
+      // Dest buffer too short.
+      return INVALID_ARGUMENT();
+    }
+    // Decode two hex digits the destination byte.
+    uint8_t nibble = (uint8_t)TRY(decode_nibble(*src++));
+    *data = (uint8_t)(nibble << 4);
+    nibble = (uint8_t)TRY(decode_nibble(*src++));
+    *data |= nibble;
+
+    ++data;
+    --dst_size;
+  }
+  return OK_STATUS();
+}

--- a/sw/device/lib/testing/hexstr.h
+++ b/sw/device/lib/testing/hexstr.h
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_HEXSTR_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_HEXSTR_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/status.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Encode binary data as a hexadecimal string.
+ *
+ * @param dst The destination string buffer.
+ * @param dst_size The maximum size of the destination buffer (including the nul
+ *                 terminator).
+ * @param src The source data to encode.
+ * @param src_size The size of the source data.
+ * @return status_t Success or error code.
+ */
+status_t hexstr_encode(char *dst, size_t dst_size, const void *src,
+                       size_t src_size);
+
+/**
+ * Decode binary data from a hexadecimal string.
+ *
+ * @param dst The destination binary buffer.
+ * @param dst_size The size of the destination buffer.
+ * @param src The source string to decode.
+ * @return status_t Success or error code.
+ */
+status_t hexstr_decode(void *dst, size_t dst_size, const char *src);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_HEXSTR_H_

--- a/sw/device/lib/testing/hexstr_unittest.cc
+++ b/sw/device/lib/testing/hexstr_unittest.cc
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/hexstr.h"
+
+#include <stdint.h>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(HexStr, Encode) {
+  uint32_t value = 0x01020304;
+  char buf[9];
+
+  status_t result = hexstr_encode(buf, sizeof(buf), &value, sizeof(value));
+  EXPECT_TRUE(status_ok(result));
+  EXPECT_EQ(std::string(buf), "04030201");
+}
+
+TEST(HexStr, EncodeShortBuf) {
+  uint32_t value = 0x01020304;
+  // Buf is too short - it omits space for the nul terminator.
+  char buf[8];
+
+  status_t result = hexstr_encode(buf, sizeof(buf), &value, sizeof(value));
+  EXPECT_FALSE(status_ok(result));
+}
+
+TEST(HexStr, Decode) {
+  char str[] = "11223344";
+  uint32_t value = 0;
+
+  status_t result = hexstr_decode(&value, sizeof(value), str);
+  EXPECT_TRUE(status_ok(result));
+  EXPECT_EQ(value, 0x44332211);
+}
+
+TEST(HexStr, DecodeShortBuf) {
+  char str[] = "1122334455667788";
+  // 32-bit int is too small to hold the decoded value.
+  uint32_t value = 0;
+
+  status_t result = hexstr_decode(&value, sizeof(value), str);
+  EXPECT_FALSE(status_ok(result));
+}
+
+TEST(HexStr, DecodeShortInput) {
+  // The input is an odd length.
+  char str[] = "1122334";
+  uint32_t value = 0;
+
+  status_t result = hexstr_decode(&value, sizeof(value), str);
+  EXPECT_FALSE(status_ok(result));
+}
+
+TEST(HexStr, DecodeIllegalInput) {
+  // The contains in invalid character.
+  char str[] = "1122334x";
+  uint32_t value = 0;
+
+  status_t result = hexstr_decode(&value, sizeof(value), str);
+  EXPECT_FALSE(status_ok(result));
+}
+
+}  // namespace

--- a/sw/device/lib/ujson/rust/BUILD
+++ b/sw/device/lib/ujson/rust/BUILD
@@ -35,6 +35,7 @@ rust_test(
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",
+        "@crate_index//:clap",
         "@crate_index//:crc",
         "@crate_index//:serde",
         "@crate_index//:serde_json",

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -435,7 +435,9 @@ cc_library(
 
 cc_library(
     name = "nonce",
+    srcs = ["nonce.c"],
     hdrs = ["nonce.h"],
+    deps = ["//sw/device/silicon_creator/lib/drivers:rnd"],
 )
 
 cc_library(

--- a/sw/device/silicon_creator/lib/nonce.c
+++ b/sw/device/silicon_creator/lib/nonce.c
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/nonce.h"
+
+#include "sw/device/silicon_creator/lib/drivers/rnd.h"
+
+void nonce_new(nonce_t *nonce) {
+  nonce->value[0] = rnd_uint32();
+  nonce->value[1] = rnd_uint32();
+}
+
+extern bool nonce_equal(nonce_t *a, nonce_t *b);

--- a/sw/device/silicon_creator/lib/nonce.h
+++ b/sw/device/silicon_creator/lib/nonce.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_NONCE_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_NONCE_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -13,5 +14,23 @@
 typedef struct nonce {
   uint32_t value[2];
 } nonce_t;
+
+/**
+ * Generate a new nonce random nonce value.
+ *
+ * @param nonce Pointer to a nonce.
+ */
+void nonce_new(nonce_t *nonce);
+
+/**
+ * Check nonces for equality.
+ *
+ * @param a Nonce to compare.
+ * @param b Nonce to compare.
+ * @return bool true if equal, false otherwise.
+ */
+inline bool nonce_equal(nonce_t *a, nonce_t *b) {
+  return a->value[0] == b->value[0] && a->value[1] == b->value[1];
+}
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_NONCE_H_

--- a/sw/host/opentitanlib/src/util/unknown.rs
+++ b/sw/host/opentitanlib/src/util/unknown.rs
@@ -128,6 +128,28 @@ macro_rules! with_unknown {
             use serde::de::{Deserialize, Deserializer, Error, Visitor};
             use std::convert::TryFrom;
             use $crate::util::unknown::ParseError;
+            use clap::ValueEnum;
+            use clap::builder::PossibleValue;
+
+            impl ValueEnum for $Enum {
+                fn value_variants<'a>() -> &'a [Self] {
+                    const VARIANTS: &[$Enum] = &[
+                        $($Enum::$enumerator),*
+                    ];
+                    VARIANTS
+                }
+
+                fn to_possible_value(&self) -> Option<PossibleValue> {
+                    let s = match *self {
+                        $(
+                            $Enum::$enumerator => stringify!($enumerator),
+                        )*
+                        _ => return None,
+
+                    };
+                    Some(PossibleValue::new(s))
+                }
+            }
 
             impl FromStr for $Enum {
                 type Err = ParseError;

--- a/sw/host/tests/xmodem/BUILD
+++ b/sw/host/tests/xmodem/BUILD
@@ -30,6 +30,7 @@ rust_library(
         ":xmodem_testlib",
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
+        "@crate_index//:clap",
         "@crate_index//:log",
         "@crate_index//:serde",
     ],

--- a/sw/vendor/BUILD
+++ b/sw/vendor/BUILD
@@ -15,3 +15,25 @@ cc_library(
     ],
     strip_include_prefix = "cryptoc/include",
 )
+
+cc_library(
+    name = "cryptoc",
+    copts = select({
+        # The compiler configured for the riscv32 target has a very strict
+        # default configuration.
+        "@platforms//cpu:riscv32": [
+            "-Wno-error=implicit-int-conversion",
+            "-Wno-error=sign-conversion",
+        ],
+        "//conditions:default": [],
+    }),
+    srcs = glob(
+        ["cryptoc/*.c"],
+        exclude=[
+            "cryptoc/sha512.c",
+            "cryptoc/sha384.c",
+            "cryptoc/*_unittest.c",
+        ]),
+    hdrs = glob(["cryptoc/include/cryptoc/*.h"]),
+    strip_include_prefix = "cryptoc/include",
+)


### PR DESCRIPTION
Add or correct a number of utility modules to prepare for ownership code.

1. Teach `with_unknown` enums about `clap` (for opentitantool CLIs).
2. Add a build target for `cryptoc` (ECDSA verification until silicon_creator sigverify is ready).
3. Add a library for dealing with hex strings in firmware (for easier expression of test patterns).
4. Improve the `nonce` library (add `new` and `equal` functions).