### PR TITLE
[cryptotest] Fetch NIST ECDSA test vectors from lowRISC-hosted bucket

### DIFF
--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -5,12 +5,24 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def nist_cavp_repos():
+    """Load NIST CAVP test vectors
+
+    The NIST website that serves the test vectors (csrc.nist.gov) is sometimes
+    unreliable. To improve availability, the NIST test vectors are hosted in a
+    lowRISC GCS storage bucket (ot-crypto-test-vectors). To add new test
+    vectors, upload the zip file to the GCS bucket, update the manifest there
+    to indicate the original download URL, and use the public link to fetch the
+    archive instead of the NIST website.
+    """
     http_archive(
         name = "nist_cavp_ecdsa_fips_186_4",
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         strip_prefix = "186-4ecdsatestvectors",
         sha256 = "fe47cc92b4cee418236125c9ffbcd9bb01c8c34e74a4ba195d954bcb72824752",
-        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-4ecdsatestvectors.zip",
+        urls = [
+            "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-4ecdsatestvectors.zip",
+            "https://storage.googleapis.com/ot-crypto-test-vectors/nist/186-4ecdsatestvectors.zip",
+        ],
     )
     http_archive(
         name = "nist_cavp_sha2_fips_180_4",


### PR DESCRIPTION
This PR switches the URL to download the test vectors from csrc.nist.gov (which has been flaky over the past couple weeks) to a lowRISC-hosted copy of the test vectors.