### PR TITLE
Make .core files pass FuseSoC 2 schema validator

### DIFF
--- a/hw/ip/adc_ctrl/adc_ctrl.core
+++ b/hw/ip/adc_ctrl/adc_ctrl.core
@@ -28,18 +28,12 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-      # - lint/adc_ctrl.vlt
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-      # - lint/adc_ctrl.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/i2c/i2c_pkg.core
+++ b/hw/ip/i2c/i2c_pkg.core
@@ -7,7 +7,6 @@ description: "I2C Package"
 
 filesets:
   files_rtl:
-    depend:
     files:
       - rtl/i2c_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/prim_and2.core
+++ b/hw/ip/prim/prim_and2.core
@@ -16,7 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_blanker.core
+++ b/hw/ip/prim/prim_blanker.core
@@ -17,15 +17,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim/prim_buf.core
+++ b/hw/ip/prim/prim_buf.core
@@ -16,7 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_clock_buf.core
+++ b/hw/ip/prim/prim_clock_buf.core
@@ -16,8 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_clock_div.core
+++ b/hw/ip/prim/prim_clock_div.core
@@ -15,8 +15,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_clock_gating.core
+++ b/hw/ip/prim/prim_clock_gating.core
@@ -16,8 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_clock_inv.core
+++ b/hw/ip/prim/prim_clock_inv.core
@@ -16,8 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_clock_mux2.core
+++ b/hw/ip/prim/prim_clock_mux2.core
@@ -16,8 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_flash.core
+++ b/hw/ip/prim/prim_flash.core
@@ -21,8 +21,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_flop.core
+++ b/hw/ip/prim/prim_flop.core
@@ -16,7 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_flop_2sync.core
+++ b/hw/ip/prim/prim_flop_2sync.core
@@ -21,7 +21,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_flop_en.core
+++ b/hw/ip/prim/prim_flop_en.core
@@ -15,7 +15,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_lc_and_hardened.core
+++ b/hw/ip/prim/prim_lc_and_hardened.core
@@ -19,16 +19,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      # - lint/prim_lc_and_hardened.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim/prim_lc_combine.core
+++ b/hw/ip/prim/prim_lc_combine.core
@@ -17,16 +17,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      # - lint/prim_lc_combine.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim/prim_lc_dec.core
+++ b/hw/ip/prim/prim_lc_dec.core
@@ -18,16 +18,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      # - lint/prim_lc_sync.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim/prim_lc_or_hardened.core
+++ b/hw/ip/prim/prim_lc_or_hardened.core
@@ -19,16 +19,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      # - lint/prim_lc_or_hardened.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim/prim_lc_sender.core
+++ b/hw/ip/prim/prim_lc_sender.core
@@ -19,8 +19,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_lc_sync.core
+++ b/hw/ip/prim/prim_lc_sync.core
@@ -20,15 +20,12 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      # - lint/prim_lc_sync.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim/prim_lfsr.core
+++ b/hw/ip/prim/prim_lfsr.core
@@ -18,8 +18,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_msb_extend.core
+++ b/hw/ip/prim/prim_msb_extend.core
@@ -22,7 +22,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim/prim_mubi.core
+++ b/hw/ip/prim/prim_mubi.core
@@ -36,8 +36,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_otp.core
+++ b/hw/ip/prim/prim_otp.core
@@ -19,8 +19,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_otp_pkg.core
+++ b/hw/ip/prim/prim_otp_pkg.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim/prim_pad_attr.core
+++ b/hw/ip/prim/prim_pad_attr.core
@@ -17,8 +17,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_pad_wrapper.core
+++ b/hw/ip/prim/prim_pad_wrapper.core
@@ -17,7 +17,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_pad_wrapper_pkg.core
+++ b/hw/ip/prim/prim_pad_wrapper_pkg.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim/prim_ram_1p.core
+++ b/hw/ip/prim/prim_ram_1p.core
@@ -17,8 +17,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_ram_1p_adv.core
+++ b/hw/ip/prim/prim_ram_1p_adv.core
@@ -19,8 +19,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_ram_1p_pkg.core
+++ b/hw/ip/prim/prim_ram_1p_pkg.core
@@ -7,7 +7,6 @@ name: "lowrisc:prim:ram_1p_pkg"
 description: "Ram 1p package"
 filesets:
   files_rtl:
-    depend:
     files:
       - rtl/prim_ram_1p_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/prim_ram_1r1w.core
+++ b/hw/ip/prim/prim_ram_1r1w.core
@@ -17,8 +17,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_ram_2p.core
+++ b/hw/ip/prim/prim_ram_2p.core
@@ -17,8 +17,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_ram_2p_pkg.core
+++ b/hw/ip/prim/prim_ram_2p_pkg.core
@@ -7,7 +7,6 @@ name: "lowrisc:prim:ram_2p_pkg"
 description: "Ram 2p package"
 filesets:
   files_rtl:
-    depend:
     files:
       - rtl/prim_ram_2p_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/prim_rom.core
+++ b/hw/ip/prim/prim_rom.core
@@ -17,8 +17,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim/prim_rom_pkg.core
+++ b/hw/ip/prim/prim_rom_pkg.core
@@ -7,7 +7,6 @@ name: "lowrisc:prim:rom_pkg"
 description: "Rom package"
 filesets:
   files_rtl:
-    depend:
     files:
       - rtl/prim_rom_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/prim_rst_sync.core
+++ b/hw/ip/prim/prim_rst_sync.core
@@ -22,7 +22,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_secded.core
+++ b/hw/ip/prim/prim_secded.core
@@ -51,8 +51,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      # - lint/prim_secded.vlt
     file_type: vlt
 
   files_ascentlint_waiver:
@@ -75,4 +73,3 @@ targets:
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
-

--- a/hw/ip/prim/prim_usb_diff_rx.core
+++ b/hw/ip/prim/prim_usb_diff_rx.core
@@ -16,7 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_xnor2.core
+++ b/hw/ip/prim/prim_xnor2.core
@@ -16,7 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_xor2.core
+++ b/hw/ip/prim/prim_xor2.core
@@ -16,7 +16,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/ip/prim/prim_xoshiro256pp.core
+++ b/hw/ip/prim/prim_xoshiro256pp.core
@@ -25,8 +25,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_and2.core
+++ b/hw/ip/prim_generic/prim_generic_and2.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_buf.core
+++ b/hw/ip/prim_generic/prim_generic_buf.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_clock_inv.core
+++ b/hw/ip/prim_generic/prim_generic_clock_inv.core
@@ -18,17 +18,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      # - lint/prim_generic_clock_inv.vlt
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      # - lint/prim_generic_clock_inv.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_flop.core
+++ b/hw/ip/prim_generic/prim_generic_flop.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_flop_en.core
+++ b/hw/ip/prim_generic/prim_generic_flop_en.core
@@ -17,15 +17,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_pad_attr.core
+++ b/hw/ip/prim_generic/prim_generic_pad_attr.core
@@ -18,17 +18,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      #- lint/prim_generic_pad_attr.vlt
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      #- lint/prim_generic_pad_attr.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
+++ b/hw/ip/prim_generic/prim_generic_usb_diff_rx.core
@@ -15,9 +15,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      #- lint/prim_generic_usb_diff_rx.vlt
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_xnor2.core
+++ b/hw/ip/prim_generic/prim_generic_xnor2.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_generic/prim_generic_xor2.core
+++ b/hw/ip/prim_generic/prim_generic_xor2.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_xilinx/prim_xilinx_and2.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_and2.core
@@ -15,14 +15,12 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim_xilinx/prim_xilinx_flop.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_flop.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_xilinx/prim_xilinx_flop_en.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_flop_en.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_xilinx/prim_xilinx_pad_attr.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_pad_attr.core
@@ -18,17 +18,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      #- lint/prim_xilinx_pad_attr.vlt
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      #- lint/prim_xilinx_pad_attr.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_xilinx/prim_xilinx_xor2.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_xor2.core
@@ -15,15 +15,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_and2.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_and2.core
@@ -15,14 +15,12 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_clock_div.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_clock_div.core
@@ -20,7 +20,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: waiver
 
 targets:

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_flop.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_flop.core
@@ -15,14 +15,12 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_flop_en.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_flop_en.core
@@ -15,14 +15,12 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_pad_attr.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_pad_attr.core
@@ -18,17 +18,11 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      #- lint/prim_xilinx_ultrascale_pad_attr.vlt
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      #- lint/prim_xilinx_ultrascale_pad_attr.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_xor2.core
+++ b/hw/ip/prim_xilinx_ultrascale/prim_xilinx_ultrascale_xor2.core
@@ -15,14 +15,12 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/rv_dm/jtag_pkg.core
+++ b/hw/ip/rv_dm/jtag_pkg.core
@@ -7,7 +7,6 @@ description: "JTAG package with interface types"
 
 filesets:
   files_rtl:
-    depend:
     files:
       - rtl/jtag_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/sysrst_ctrl/sysrst_ctrl.core
+++ b/hw/ip/sysrst_ctrl/sysrst_ctrl.core
@@ -38,9 +38,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-      # - lint/sysrst_ctrl.waiver
-    file_type: waiver
 
 parameters:
   SYNTHESIS:
@@ -70,4 +67,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-

--- a/hw/ip/tlul/generic_dv/tb/xbar_macros.core
+++ b/hw/ip/tlul/generic_dv/tb/xbar_macros.core
@@ -7,7 +7,6 @@ name: "lowrisc:dv:xbar_macros:0.1"
 description: "XBAR Macros"
 filesets:
   files_dv:
-    depend:
     files:
       - xbar_macros.svh
     file_type: systemVerilogSource

--- a/hw/ip/tlul/tlul_lc_gate.core
+++ b/hw/ip/tlul/tlul_lc_gate.core
@@ -29,8 +29,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      #- lint/tlul_lc_gate.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/usbdev/usbdev_pkg.core
+++ b/hw/ip/usbdev/usbdev_pkg.core
@@ -6,7 +6,6 @@ name: "lowrisc:ip:usbdev_pkg:0.1"
 description: "Usb device package"
 filesets:
   files_rtl:
-    depend:
     files:
       - rtl/usbdev_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip_templates/clkmgr/clkmgr.core.tpl
+++ b/hw/ip_templates/clkmgr/clkmgr.core.tpl
@@ -38,8 +38,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/ip_templates/rstmgr/rstmgr.core.tpl
+++ b/hw/ip_templates/rstmgr/rstmgr.core.tpl
@@ -35,8 +35,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/top_earlgrey/chip_earlgrey_cw340.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw340.core
@@ -38,7 +38,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
     file_type: waiver
 
 parameters:

--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -11,7 +11,6 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - "!gatelevel ? (lowrisc:systems:chip_earlgrey_asic)"
       - lowrisc:ibex:ibex_tracer
-    files:
     file_type: systemVerilogSource
 
   files_dv:

--- a/hw/top_earlgrey/dv/verilator/chip_sim.core
+++ b/hw/top_earlgrey/dv/verilator/chip_sim.core
@@ -65,7 +65,7 @@ parameters:
     default: true
     description: Replace JTAG TAP with an OpenOCD direct connection
   UART_LOG_uart0:
-    datatype: string
+    datatype: str
     paramtype: plusarg
     description: Write a log of output from uart0 to the given log file. Use "-" for stdout.
   RV_CORE_IBEX_SIM_SRAM:

--- a/hw/top_earlgrey/ip/clkmgr/clkmgr.core
+++ b/hw/top_earlgrey/ip/clkmgr/clkmgr.core
@@ -32,7 +32,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl.core
+++ b/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl.core
@@ -21,7 +21,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
     file_type: vlt
 
   files_ascentlint_waiver:

--- a/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr.core
@@ -38,8 +38,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr.core
@@ -35,8 +35,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/top_earlgrey/padring.core
+++ b/hw/top_earlgrey/padring.core
@@ -20,9 +20,6 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-      # - lint/padring.vlt
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:

--- a/hw/top_earlgrey/physical_pads.core
+++ b/hw/top_earlgrey/physical_pads.core
@@ -18,18 +18,12 @@ filesets:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-      # - lint/physical_pads.vlt
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
       - lowrisc:lint:comportable
-    files:
-      # - lint/physical_pads.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:

--- a/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
@@ -65,7 +65,7 @@ parameters:
     default: true
     description: Replace JTAG TAP with an OpenOCD direct connection
   UART_LOG_uart0:
-    datatype: string
+    datatype: str
     paramtype: plusarg
     description: Write a log of output from uart0 to the given log file. Use "-" for stdout.
   RV_CORE_IBEX_SIM_SRAM:

--- a/util/design/data/prim_mubi.core.tpl
+++ b/util/design/data/prim_mubi.core.tpl
@@ -29,8 +29,6 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:


### PR DESCRIPTION
FuseSoC 2 introduced a schema for CAPI2 and a validator. These changes make all .core files syntactically compatible with FuesSoC 2