### PR TITLE
[rom-a1] Root Keys in OTP - Refactor ROM key types

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/spx_key.h
+++ b/sw/device/silicon_creator/lib/sigverify/spx_key.h
@@ -54,6 +54,25 @@ enum {
 };
 
 /**
+ * SPX configuration ID.
+ *
+ * Used to identify the SPX parameter confuration used to sign/verify a message.
+ */
+typedef enum sigverify_spx_config_id {
+  /**SPHINCS+-SHAKE-128s*/
+  kSigverifySpxConfigRegular = 0,
+  /**
+   * SPHINCS+-SHAKE-128s-q20
+   *
+   * As specified in https://eprint.iacr.org/2022/1725.pdf.
+   *
+   * n  | h  | d | b  | k | w  | bitsec | sigsize
+   * 16 | 18 | 1 | 24 | 6 | 16 |   128  | 3264
+   */
+  kSigverifySpxConfigQ20 = 1,
+} sigverify_spx_config_id_t;
+
+/**
  * An SPX signature.
  */
 typedef struct sigverify_spx_signature {

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -354,6 +354,7 @@ cc_library(
         "sigverify_keys.h",
     ],
     deps = [
+        ":sigverify_key_types",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
@@ -361,6 +362,15 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:rnd",
+        "//sw/device/silicon_creator/lib/sigverify:rsa_key",
+        "//sw/device/silicon_creator/lib/sigverify:spx_key",
+    ],
+)
+
+cc_library(
+    name = "sigverify_key_types",
+    hdrs = ["sigverify_key_types.h"],
+    deps = [
         "//sw/device/silicon_creator/lib/sigverify:rsa_key",
         "//sw/device/silicon_creator/lib/sigverify:spx_key",
     ],
@@ -375,6 +385,7 @@ cc_library(
         "sigverify_keys_rsa.h",
     ],
     deps = [
+        ":sigverify_key_types",
         ":sigverify_keys",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:macros",
@@ -393,6 +404,7 @@ cc_library(
         "sigverify_keys_spx.h",
     ],
     deps = [
+        ":sigverify_key_types",
         ":sigverify_keys",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:macros",

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -371,6 +371,7 @@ cc_library(
     name = "sigverify_key_types",
     hdrs = ["sigverify_key_types.h"],
     deps = [
+        "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
         "//sw/device/silicon_creator/lib/sigverify:rsa_key",
         "//sw/device/silicon_creator/lib/sigverify:spx_key",
     ],

--- a/sw/device/silicon_creator/rom/keys/fake/rsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/rsa/BUILD
@@ -20,6 +20,7 @@ cc_library(
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/rom:sigverify_keys",
+        "//sw/device/silicon_creator/rom:sigverify_key_types",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/keys/fake/rsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/rsa/BUILD
@@ -19,8 +19,8 @@ cc_library(
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:macros",
-        "//sw/device/silicon_creator/rom:sigverify_keys",
         "//sw/device/silicon_creator/rom:sigverify_key_types",
+        "//sw/device/silicon_creator/rom:sigverify_keys",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/keys/fake/spx/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/BUILD
@@ -23,6 +23,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/sigverify",
+        "//sw/device/silicon_creator/rom:sigverify_key_types",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/keys/fake/spx/sigverify_spx_keys_fake.c
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/sigverify_spx_keys_fake.c
@@ -42,6 +42,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = TEST_KEY_0_SPX,
                 .key_type = kSigverifyKeyTypeTest,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -49,6 +50,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = TEST_KEY_1_SPX,
                 .key_type = kSigverifyKeyTypeTest,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -56,6 +58,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = DEV_KEY_0_SPX,
                 .key_type = kSigverifyKeyTypeDev,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -63,6 +66,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = DEV_KEY_1_SPX,
                 .key_type = kSigverifyKeyTypeDev,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -70,6 +74,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = PROD_KEY_0_SPX,
                 .key_type = kSigverifyKeyTypeProd,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {

--- a/sw/device/silicon_creator/rom/keys/real/rsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/real/rsa/BUILD
@@ -21,8 +21,8 @@ cc_library(
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:macros",
-        "//sw/device/silicon_creator/rom:sigverify_keys",
         "//sw/device/silicon_creator/rom:sigverify_key_types",
+        "//sw/device/silicon_creator/rom:sigverify_keys",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/keys/real/rsa/BUILD
+++ b/sw/device/silicon_creator/rom/keys/real/rsa/BUILD
@@ -22,6 +22,7 @@ cc_library(
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/rom:sigverify_keys",
+        "//sw/device/silicon_creator/rom:sigverify_key_types",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/keys/real/spx/BUILD
+++ b/sw/device/silicon_creator/rom/keys/real/spx/BUILD
@@ -23,6 +23,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/sigverify",
+        "//sw/device/silicon_creator/rom:sigverify_key_types",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/keys/real/spx/sigverify_spx_keys_real.c
+++ b/sw/device/silicon_creator/rom/keys/real/spx/sigverify_spx_keys_real.c
@@ -42,6 +42,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = TEST_KEY_0_SPX,
                 .key_type = kSigverifyKeyTypeTest,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -49,6 +50,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = TEST_KEY_1_SPX,
                 .key_type = kSigverifyKeyTypeTest,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -56,6 +58,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = DEV_KEY_0_SPX,
                 .key_type = kSigverifyKeyTypeDev,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -63,6 +66,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = DEV_KEY_1_SPX,
                 .key_type = kSigverifyKeyTypeDev,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -70,6 +74,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = PROD_KEY_0_SPX,
                 .key_type = kSigverifyKeyTypeProd,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -77,6 +82,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = PROD_KEY_1_SPX,
                 .key_type = kSigverifyKeyTypeProd,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
     {
@@ -84,6 +90,7 @@ const sigverify_rom_spx_key_t kSigverifySpxKeys[kSigverifySpxKeysCnt_] = {
             {
                 .key = PROD_KEY_2_SPX,
                 .key_type = kSigverifyKeyTypeProd,
+                .config_id = kSigverifySpxConfigRegular,
             },
     },
 };

--- a/sw/device/silicon_creator/rom/sigverify_key_types.h
+++ b/sw/device/silicon_creator/rom/sigverify_key_types.h
@@ -1,0 +1,170 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SIGVERIFY_KEY_TYPES_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SIGVERIFY_KEY_TYPES_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
+#include "sw/device/silicon_creator/lib/sigverify/spx_key.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Key types.
+ *
+ * The life cycle states in which a key can be used depend on its type.
+ *
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 3 -n 32 \
+ *     -s 1985033815 --language=c
+ *
+ * Minimum Hamming distance: 15
+ * Maximum Hamming distance: 18
+ * Minimum Hamming weight: 13
+ * Maximum Hamming weight: 16
+ */
+typedef enum sigverify_key_type {
+  /**
+   * A key used for manufacturing, testing, and RMA.
+   *
+   * Keys of this type can be used only in TEST_UNLOCKED* and RMA life cycle
+   * states.
+   */
+  kSigverifyKeyTypeTest = 0x3ff0c819,
+  /**
+   * A production key.
+   *
+   * Keys of this type can be used in all operational life cycle states, i.e.
+   * states in which CPU execution is enabled.
+   */
+  kSigverifyKeyTypeProd = 0x43a839ad,
+  /**
+   * A development key.
+   *
+   * Keys of this type can be used only in the DEV life cycle state.
+   */
+  kSigverifyKeyTypeDev = 0x7a01a471,
+} sigverify_key_type_t;
+
+/**
+ * Common initial sequence of public keys stored in ROM.
+ *
+ * OpenTitan ROM contains RSA and SPX keys whose definitions share this common
+ * initial sequence. This common initial sequence allows us to perform key
+ * lookup and validity checks in a generic manner by casting
+ * `sigverify_rom_rsa_key_t` or `sigverify_rom_spx_key_t` to this type.
+ */
+typedef struct sigverify_rom_key_header {
+  /**
+   * Type of the key.
+   */
+  sigverify_key_type_t key_type;
+  /**
+   * ID of the key.
+   */
+  uint32_t key_id;
+} sigverify_rom_key_header_t;
+
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
+OT_ASSERT_SIZE(sigverify_rom_key_header_t, 8);
+
+/**
+ * An RSA public key stored in ROM.
+ *
+ * This struct must start with the common initial sequence
+ * `sigverify_rom_key_header_t`.
+ */
+typedef struct sigverify_rom_rsa_key_entry {
+  /**
+   * Type of the key.
+   */
+  sigverify_key_type_t key_type;
+  /**
+   * An RSA public key.
+   */
+  sigverify_rsa_key_t key;
+} sigverify_rom_rsa_key_entry_t;
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key.n.data[0], 4);
+static_assert(offsetof(sigverify_rom_key_header_t, key_type) ==
+                  offsetof(sigverify_rom_rsa_key_entry_t, key_type),
+              "Invalid key_type offset.");
+static_assert(offsetof(sigverify_rom_key_header_t, key_id) ==
+                  offsetof(sigverify_rom_rsa_key_entry_t, key.n.data[0]),
+              "Invalid key_id offset.");
+
+/**
+ * Union type to inspect the common initial sequence of RSA public keys stored
+ * in ROM.
+ */
+typedef union sigverify_rom_rsa_key {
+  /**
+   * Common initial sequence.
+   */
+  sigverify_rom_key_header_t key_header;
+  /**
+   * Actual RSA public key entry.
+   */
+  sigverify_rom_rsa_key_entry_t entry;
+} sigverify_rom_rsa_key_t;
+
+static_assert(
+    sizeof(sigverify_rom_rsa_key_entry_t) == sizeof(sigverify_rom_rsa_key_t),
+    "Size of an RSA public key entry must be equal to the size of a key");
+
+/**
+ * An SPX public key stored in ROM.
+ *
+ * This struct must start with the common initial sequence
+ * `sigverify_rom_key_header_t`.
+ */
+typedef struct sigverify_rom_spx_key_entry {
+  /**
+   * Type of the key.
+   */
+  sigverify_key_type_t key_type;
+  /**
+   * An SPX public key.
+   */
+  sigverify_spx_key_t key;
+} sigverify_rom_spx_key_entry_t;
+
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key.data[0], 4);
+static_assert(offsetof(sigverify_rom_key_header_t, key_type) ==
+                  offsetof(sigverify_rom_spx_key_entry_t, key_type),
+              "Invalid key_type offset.");
+static_assert(offsetof(sigverify_rom_key_header_t, key_id) ==
+                  offsetof(sigverify_rom_spx_key_entry_t, key.data[0]),
+              "Invalid key_id offset.");
+
+/**
+ * Union type to inspect the common initial sequence of SPX public keys stored
+ * in ROM.
+ */
+typedef union sigverify_rom_spx_key {
+  /**
+   * Common initial sequence.
+   */
+  sigverify_rom_key_header_t key_header;
+  /**
+   * Actual SPX public key entry.
+   */
+  sigverify_rom_spx_key_entry_t entry;
+} sigverify_rom_spx_key_t;
+
+static_assert(
+    sizeof(sigverify_rom_spx_key_entry_t) == sizeof(sigverify_rom_spx_key_t),
+    "Size of an SPX public key entry must be equal to the size of a key");
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SIGVERIFY_KEY_TYPES_H_

--- a/sw/device/silicon_creator/rom/sigverify_key_types.h
+++ b/sw/device/silicon_creator/rom/sigverify_key_types.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 #include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
 #include "sw/device/silicon_creator/lib/sigverify/spx_key.h"
 
@@ -73,6 +74,52 @@ typedef struct sigverify_rom_key_header {
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
 OT_ASSERT_SIZE(sigverify_rom_key_header_t, 8);
+
+/**
+ * An ECDSA P256 public key stored in ROM.
+ *
+ * This struct must start with the common initial sequence
+ * `sigverify_rom_key_header_t`.
+ *
+ */
+typedef struct sigverify_rom_ecdsa_p256_key_entry {
+  /**
+   * Type of the key.
+   */
+  sigverify_key_type_t key_type;
+  /**
+   * An ECDSA P256 public key.
+   */
+  sigverify_ecdsa_p256_buffer_t key;
+} sigverify_rom_ecdsa_p256_key_entry_t;
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key_type, 0);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key.data[0], 4);
+static_assert(offsetof(sigverify_rom_key_header_t, key_type) ==
+                  offsetof(sigverify_rom_ecdsa_p256_key_entry_t, key_type),
+              "Invalid key_type offset.");
+static_assert(offsetof(sigverify_rom_key_header_t, key_id) ==
+                  offsetof(sigverify_rom_ecdsa_p256_key_entry_t, key.data[0]),
+              "Invalid key_id offset.");
+
+/**
+ * Union type to inspect the common initial sequence of ECDSA P256 public keys
+ *
+ */
+typedef union sigverify_rom_ecdsa_p256_key {
+  /**
+   * Common initial sequence.
+   */
+  sigverify_rom_key_header_t key_header;
+  /**
+   * Actual ECDSA P256 public key entry.
+   */
+  sigverify_rom_ecdsa_p256_key_entry_t entry;
+} sigverify_rom_ecdsa_p256_key_t;
+
+static_assert(sizeof(sigverify_rom_ecdsa_p256_key_entry_t) ==
+                  sizeof(sigverify_rom_ecdsa_p256_key_t),
+              "Size of an ECDSA P256 public key entry must be equal to the "
+              "size of a key");
 
 /**
  * An RSA public key stored in ROM.

--- a/sw/device/silicon_creator/rom/sigverify_key_types.h
+++ b/sw/device/silicon_creator/rom/sigverify_key_types.h
@@ -180,6 +180,10 @@ typedef struct sigverify_rom_spx_key_entry {
    * An SPX public key.
    */
   sigverify_spx_key_t key;
+  /**
+   * Parameter configuration ID for the SPX key.
+   */
+  sigverify_spx_config_id_t config_id;
 } sigverify_rom_spx_key_entry_t;
 
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key_type, 0);

--- a/sw/device/silicon_creator/rom/sigverify_keys.c
+++ b/sw/device/silicon_creator/rom/sigverify_keys.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
+#include "sw/device/silicon_creator/rom/sigverify_key_types.h"
 #include "sw/device/silicon_creator/rom/sigverify_keys_rsa.h"
 #include "sw/device/silicon_creator/rom/sigverify_keys_spx.h"
 

--- a/sw/device/silicon_creator/rom/sigverify_keys.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys.h
@@ -10,47 +10,11 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/rom/sigverify_key_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-/**
- * Key types.
- *
- * The life cycle states in which a key can be used depend on its type.
- *
- * Encoding generated with
- * $ ./util/design/sparse-fsm-encode.py -d 6 -m 3 -n 32 \
- *     -s 1985033815 --language=c
- *
- * Minimum Hamming distance: 15
- * Maximum Hamming distance: 18
- * Minimum Hamming weight: 13
- * Maximum Hamming weight: 16
- */
-typedef enum sigverify_key_type {
-  /**
-   * A key used for manufacturing, testing, and RMA.
-   *
-   * Keys of this type can be used only in TEST_UNLOCKED* and RMA life cycle
-   * states.
-   */
-  kSigverifyKeyTypeTest = 0x3ff0c819,
-  /**
-   * A production key.
-   *
-   * Keys of this type can be used in all operational life cycle states, i.e.
-   * states in which CPU execution is enabled.
-   */
-  kSigverifyKeyTypeProd = 0x43a839ad,
-  /**
-   * A development key.
-   *
-   * Keys of this type can be used only in the DEV life cycle state.
-   */
-  kSigverifyKeyTypeDev = 0x7a01a471,
-} sigverify_key_type_t;
 
 enum {
   /**
@@ -63,29 +27,6 @@ enum {
    */
   kSigverifyNumEntriesPerOtpWord = sizeof(uint32_t),
 };
-
-/**
- * Common initial sequence of public keys stored in ROM.
- *
- * OpenTitan ROM contains RSA and SPX keys whose definitions share this common
- * initial sequence. This common initial sequence allows us to perform key
- * lookup and validity checks in a generic manner by casting
- * `sigverify_rom_rsa_key_t` or `sigverify_rom_spx_key_t` to this type.
- */
-typedef struct sigverify_rom_key_header {
-  /**
-   * Type of the key.
-   */
-  sigverify_key_type_t key_type;
-  /**
-   * ID of the key.
-   */
-  uint32_t key_id;
-} sigverify_rom_key_header_t;
-
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
-OT_ASSERT_SIZE(sigverify_rom_key_header_t, 8);
 
 /**
  * Gets the ID of a public key.

--- a/sw/device/silicon_creator/rom/sigverify_keys_rsa.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys_rsa.h
@@ -10,52 +10,12 @@
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
+#include "sw/device/silicon_creator/rom/sigverify_key_types.h"
 #include "sw/device/silicon_creator/rom/sigverify_keys.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-/**
- * An RSA public key stored in ROM.
- *
- * This struct must start with the common initial sequence
- * `sigverify_rom_key_header_t`.
- */
-typedef struct sigverify_rom_rsa_key_entry {
-  /**
-   * Type of the key.
-   */
-  sigverify_key_type_t key_type;
-  /**
-   * An RSA public key.
-   */
-  sigverify_rsa_key_t key;
-} sigverify_rom_rsa_key_entry_t;
-
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key_type, 0);
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_rsa_key_entry_t, key.n.data[0], 4);
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
-
-/**
- * Union type to inspect the common initial sequence of RSA public keys stored
- * in ROM.
- */
-typedef union sigverify_rom_rsa_key {
-  /**
-   * Common initial sequence.
-   */
-  sigverify_rom_key_header_t key_header;
-  /**
-   * Actual RSA public key entry.
-   */
-  sigverify_rom_rsa_key_entry_t entry;
-} sigverify_rom_rsa_key_t;
-
-static_assert(
-    sizeof(sigverify_rom_rsa_key_entry_t) == sizeof(sigverify_rom_rsa_key_t),
-    "Size of an RSA public key entry must be equal to the size of a key");
 
 /**
  * Number of RSA public keys.

--- a/sw/device/silicon_creator/rom/sigverify_keys_spx.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys_spx.h
@@ -10,52 +10,12 @@
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify/spx_key.h"
+#include "sw/device/silicon_creator/rom/sigverify_key_types.h"
 #include "sw/device/silicon_creator/rom/sigverify_keys.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-/**
- * An SPX public key stored in ROM.
- *
- * This struct must start with the common initial sequence
- * `sigverify_rom_key_header_t`.
- */
-typedef struct sigverify_rom_spx_key_entry {
-  /**
-   * Type of the key.
-   */
-  sigverify_key_type_t key_type;
-  /**
-   * An SPX public key.
-   */
-  sigverify_spx_key_t key;
-} sigverify_rom_spx_key_entry_t;
-
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key_type, 0);
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_spx_key_entry_t, key.data[0], 4);
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_type, 0);
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_key_header_t, key_id, 4);
-
-/**
- * Union type to inspect the common initial sequence of SPX public keys stored
- * in ROM.
- */
-typedef union sigverify_rom_spx_key {
-  /**
-   * Common initial sequence.
-   */
-  sigverify_rom_key_header_t key_header;
-  /**
-   * Actual SPX public key entry.
-   */
-  sigverify_rom_spx_key_entry_t entry;
-} sigverify_rom_spx_key_t;
-
-static_assert(
-    sizeof(sigverify_rom_spx_key_entry_t) == sizeof(sigverify_rom_spx_key_t),
-    "Size of an SPX public key entry must be equal to the size of a key");
 
 /**
  * Number of SPX public keys.


### PR DESCRIPTION
1. Move key types into a separate module: We are trying to maintain the same key definitions for SPX+ after the keys are moved to OTP. This change moves key type definitions into a separate module so that they can be reused by a future sigverify otp implementation.
2. Add ECDSA key type to sigverify_key_types.
3. Introduce the `sigverify_spx_config_id_t` type to select between SPX signature parameters.

This change is part of #21204 