### PR TITLE
[pentest] Cherry-pick Fix bugs in AES SCA

### DIFF
--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -186,7 +186,7 @@ static void aes_key_mask_and_config(const uint8_t *key, size_t key_len) {
     key_shares.share0[i] = *((uint32_t *)key + i) ^ key_shares.share1[i];
   }
   // Provide random shares for unused key bits.
-  for (size_t i = key_len; i < kAesKeyLengthMax / 4; ++i) {
+  for (size_t i = key_len / 4; i < kAesKeyLengthMax / 4; ++i) {
     key_shares.share1[i] =
         sca_non_linear_layer(sca_next_lfsr(1, kScaLfsrMasking));
     key_shares.share0[i] =

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -354,7 +354,7 @@ void sca_seed_lfsr(uint32_t seed, sca_lfsr_context_t context) {
     sca_lfsr_state_masking = seed;
   }
   if (context == kScaLfsrOrder) {
-    sca_lfsr_state_masking = seed;
+    sca_lfsr_state_order = seed;
   }
 }
 

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -146,12 +146,16 @@ cc_library(
 cc_library(
     name = "aes_sca",
     srcs = ["aes_sca.c"],
-    hdrs = ["aes_sca.h"],
+    hdrs = [
+        "aes_sca.h",
+        "status.h",
+    ],
     deps = [
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aes_testutils",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:aes",

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
@@ -168,7 +168,7 @@ static aes_sca_error_t aes_key_mask_and_config(const uint8_t *key,
     key_shares.share0[i] = *((uint32_t *)key + i) ^ key_shares.share1[i];
   }
   // Provide random shares for unused key bits.
-  for (size_t i = key_len; i < kAesKeyLengthMax / 4; ++i) {
+  for (size_t i = key_len / 4; i < kAesKeyLengthMax / 4; ++i) {
     key_shares.share1[i] =
         sca_non_linear_layer(sca_next_lfsr(1, kScaLfsrMasking));
     key_shares.share0[i] =

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
@@ -15,7 +15,12 @@
 #include "sw/device/sca/lib/prng.h"
 #include "sw/device/sca/lib/sca.h"
 #include "sw/device/tests/crypto/cryptotest/firmware/sca_lib.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/status.h"
 #include "sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h"
+
+#if !OT_IS_ENGLISH_BREAKFAST
+#include "sw/device/lib/testing/aes_testutils.h"
+#endif
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -778,6 +783,17 @@ status_t handle_aes_sca_seed_lfsr(ujson_t *uj) {
     transaction.force_masks = false;
   }
   sca_seed_lfsr(seed_local, kScaLfsrMasking);
+
+#if !OT_IS_ENGLISH_BREAKFAST
+  if (transaction.force_masks) {
+    LOG_INFO("Disabling masks.");
+    status_t res = aes_testutils_masking_prng_zero_output_seed();
+    if (res.value != 0) {
+      return ABORTED();
+    }
+    UJSON_CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerPrngReseed));
+  }
+#endif
 
   return OK_STATUS(0);
 }


### PR DESCRIPTION
This PR manually cherry-picks "Fix bugs in AES SCA" #21784 as the automatic cherry-pick failed due to a merge conflict.