### PR TITLE
[spi_host,rtl] Revert "[spi_host,rtl] Use sd_en_o[0] to only drive sd_o[0] during TX (std_mode)"

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -564,7 +564,7 @@ module spi_host_fsm
     end else begin
       unique case (speed_o)
         Standard: begin
-          sd_en_o[0]   = cmd_wr_en_q;
+          sd_en_o[0]   = 1'b1;
           sd_en_o[1]   = 1'b0;
           sd_en_o[3:2] = 2'b00;
         end


### PR DESCRIPTION
The original change cause the `chip_sw_spi_host_tx_rx` test to fail and thus causes failing CI checks on `master`.
For now, revert the commit.

A proper fix is being worked on.
See https://github.com/lowRISC/opentitan/pull/21338#issuecomment-1984908004 for details.