### PR TITLE
[sival] Disable uart_tx_rx test in CI

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5105,7 +5105,8 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/uart:uart_tx_rx",
     ),
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        # FIXME has some flaky behaviour.
+        "//hw/top_earlgrey:fpga_cw310_sival": "broken",
         # FIXME broken in sival ROM_EXT, change this line when fixed. See #21706.
         "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         "//hw/top_earlgrey:silicon_creator": None,


### PR DESCRIPTION
This test has had some flaky behaviour with the UART communication between the FPGA and HyperDebug. I haven't yet debugged the cause, so disabling until it's fixed.