### PR TITLE
[uart,doc] uart watermark documentation update

### DIFF
--- a/hw/ip/uart/doc/theory_of_operation.md
+++ b/hw/ip/uart/doc/theory_of_operation.md
@@ -169,15 +169,9 @@ and unexpected event interrupts.
 If the TX FIFO level becomes smaller than the TX water mark level (configurable via [`FIFO_CTRL.RXILVL`](registers.md#fifo_ctrl) and [`FIFO_CTRL.TXILVL`](registers.md#fifo_ctrl)), the `tx_watermark` interrupt is raised to inform SW.
 If the RX FIFO level becomes greater than or equal to RX water mark level (configurable via [`FIFO_CTRL.RXILVL`](registers.md#fifo_ctrl) and [`FIFO_CTRL.TXILVL`](registers.md#fifo_ctrl)), the `rx_watermark` interrupt is raised to inform SW.
 
-Note that the watermark interrupts are edge triggered events.
-This means the interrupt only triggers when the condition transitions from untrue->true.
-This is especially important in the tx_watermark case.
-When the TX FIFO is empty, it by default satisfies all the watermark conditions.
-In order for the interrupt to trigger then, it is required that software initiates a write burst that is greater than the programmed watermark value.
-
-For example, assume TX watermark is programmed to be less than 4 bytes, and software programs one byte at a time, waits for it to finish transmitting, before supplying the next byte.
-Under these conditions, the TX watermark interrupt will never trigger because the size of the FIFO never exceeds the watermark level.
-
+Note that the watermark interrupts are level-based status interrupts.
+They will stay asserted for as long as the FIFO levels are in violation of the configured level and cannot be cleared by writing to the status register.
+This also means that the `tx_watermark` starts off in an asserted state (resets high).
 
 #### tx_empty
 If TX FIFO becomes empty as part of transmit, the interrupt `tx_empty` is asserted.


### PR DESCRIPTION
Update the uart "Theory of Operation" documentation to reflect the switch to status-type interrupts for these watermark interrupts.