### PR TITLE
[ci] Correctly ignore manual tests when filtering

### DIFF
--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -69,11 +69,11 @@ then
             )
             except
             `# Remove all test suites depending on a test tagged cw310_sival_rom_ext`
-            `# but ignore those marked as broken`
+            `# but ignore those marked as broken or manual`
             rdeps(
                 //...
                 except
-                attr(\"tags\",\"broken\", //...),
+                attr(\"tags\",\"broken|manual\", //...),
                 `# Find all tests tagged cw310_sival_rom_ext`
                 attr(\"tags\",\"cw310_sival_rom_ext\", //...),
                 1
@@ -103,11 +103,11 @@ then
             )
             except
             `# Remove all test suites depending on a test tagged cw310_sival[_rom_ext]`
-            `# but ignore those marked as broken`
+            `# but ignore those marked as broken or manual`
             rdeps(
                 //...
                 except
-                attr(\"tags\",\"broken\", //...),
+                attr(\"tags\",\"broken|manual\", //...),
                 `# Find all tests tagged cw310_sival_rom_ext`
                 attr(\"tags\",\"cw310_sival\", //...),
                 1


### PR DESCRIPTION
Follow-up on #21757 where I forgot to add the manual tag in two places.

When looking at ROM or SiVal tests to determine if they should be run, ignore siblings tests marked as broken OR manual. Otherwise we may end up ignoring a test because of a sibling marked as manual that won't run either!