### PR TITLE
[dv,pwrmgr] Use reset_asserted instead of setting under_reset

### DIFF
--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -89,7 +89,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
           if (|cfg.pwrmgr_vif.pwr_rst_req.rst_lc_req) begin
             // Start of d0 reset request.
             `uvm_info(`gfn, "pwrmgr start reset in reset_cip_helper", UVM_MEDIUM)
-            cfg.under_reset = 1;
+            cfg.reset_asserted();
           end
         end
       forever

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -89,7 +89,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
           if (|cfg.pwrmgr_vif.pwr_rst_req.rst_lc_req) begin
             // Start of d0 reset request.
             `uvm_info(`gfn, "pwrmgr start reset in reset_cip_helper", UVM_MEDIUM)
-            cfg.under_reset = 1;
+            cfg.reset_asserted();
           end
         end
       forever


### PR DESCRIPTION
Calling reset_asserted propagates the reset to the csr package.