### PR TITLE
[hw,prim_tlul_gate,rtl] Parametrize the number of outstanding transfers

### DIFF
--- a/hw/ip/tlul/rtl/tlul_lc_gate.sv
+++ b/hw/ip/tlul/rtl/tlul_lc_gate.sv
@@ -23,7 +23,9 @@ module tlul_lc_gate
   // By default we return a TL-UL bus error response if the bus is gated. However, in some special
   // cases we need to be able to return valid, all-zero responses instead (e.g. for the RV_DM). In
   // those cases, ReturnBlankResp can be set to 1.
-  parameter bit ReturnBlankResp = 0
+  parameter bit ReturnBlankResp = 0,
+  // The maximum number of outstanding TL-UL requests at the output
+  parameter int unsigned Outstanding = 3
 ) (
   input clk_i,
   input rst_ni,
@@ -150,7 +152,7 @@ module tlul_lc_gate
   state_e state_d, state_q;
   `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StError)
 
-  logic [1:0] outstanding_txn;
+  logic [prim_util_pkg::vbits(Outstanding+1)-1:0] outstanding_txn;
   logic a_ack;
   logic d_ack;
   assign a_ack = tl_h2d_i.a_valid & tl_d2h_o.a_ready;
@@ -260,6 +262,7 @@ module tlul_lc_gate
   );
 
   // Add assertion
-  `ASSERT(OutStandingOvfl_A, &outstanding_txn |-> ~a_ack)
+  `ASSERT(OutStandingOvfl_A, (outstanding_txn == Outstanding) |-> ~a_ack)
+  `ASSERT(SizeOutstandingTxn_A, (2 ** $bits(outstanding_txn)) - 1 >= Outstanding)
 
 endmodule : tlul_lc_gate


### PR DESCRIPTION
If the sink port takes longer to respond, the internal counter for outstanding transfers would overflow. This PR adds the ability to parametrize the counter for the number of outstanding transactions