### PR TITLE
[pentest] Configure alert handler for FI

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -280,6 +280,12 @@ cc_library(
     hdrs = ["sca_lib.h"],
     deps = [
         "//sw/device/lib/base:csr",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/testing:alert_handler_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.c
@@ -31,6 +31,9 @@ extern uint32_t increment_100x1(uint32_t start_value);
 static str_fn_t increment_100x10_remapped = (str_fn_t)increment_100x10;
 static str_fn_t increment_100x1_remapped = (str_fn_t)increment_100x1;
 
+// Interface to Ibex.
+static dif_rv_core_ibex_t rv_core_ibex;
+
 // Make sure that this function does not get optimized by the compiler.
 uint32_t increment_counter(uint32_t counter) __attribute__((optnone)) {
   uint32_t return_value = counter + 1;
@@ -102,11 +105,8 @@ OT_SECTION(".data")
 static volatile uint32_t sram_main_buffer[32];
 
 status_t handle_ibex_fi_address_translation(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // Create translation descriptions.
   dif_rv_core_ibex_addr_translation_mapping_t increment_100x10_mapping = {
@@ -157,6 +157,9 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   asm volatile(NOP100);
   result_expected = increment_100x10_remapped(0);
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
+
   uint32_t result_target = increment_100x1_remapped(0);
   // Compare values
   uint32_t res = 0;
@@ -176,16 +179,14 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // Address translation configuration.
   dif_rv_core_ibex_addr_translation_mapping_t mapping1 = {
@@ -214,6 +215,8 @@ status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
       kDifRvCoreIbexAddrTranslationDBus, mapping2));
   asm volatile(NOP1000);
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read back address translation configuration.
   dif_rv_core_ibex_addr_translation_mapping_t mapping1_read_back;
@@ -248,16 +251,14 @@ status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   sca_set_trigger_high();
@@ -267,6 +268,8 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   }
   asm volatile(NOP10);
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   uint32_t res_values;
   // Read values from CSRs.
@@ -286,16 +289,14 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // Write reference value into CSR.
   CSR_WRITE(CSR_REG_MSCRATCH, ref_values[0]);
@@ -309,6 +310,8 @@ status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   }
   asm volatile(NOP10);
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Compare against reference values.
   uint32_t res = 0;
@@ -326,16 +329,14 @@ status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_flash_read(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // Configure the data flash.
   // Flash configuration.
@@ -380,6 +381,8 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) {
         mmio_region_read32(flash_bank_1, i * (ptrdiff_t)sizeof(uint32_t));
   }
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Compare against reference values.
   uint32_t res = 0;
@@ -397,16 +400,15 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
+
   // Configure the data flash.
   // Flash configuration.
   dif_flash_ctrl_region_properties_t region_properties = {
@@ -442,6 +444,8 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
       &flash, (uint32_t)flash_bank_1_addr, /*partition_id=*/0, input_page,
       kDifFlashCtrlPartitionTypeData, FLASH_UINT32_WORDS_PER_PAGE));
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read back and compare against reference values.
   uint32_t res_values[32];
@@ -462,16 +466,14 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // Get address of buffer located in SRAM.
   uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
@@ -492,6 +494,8 @@ status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
                                        i * (ptrdiff_t)sizeof(uint32_t));
   }
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Compare against reference values.
   uint32_t res = 0;
@@ -509,16 +513,14 @@ status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // Get address of buffer located in SRAM.
   uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
@@ -532,6 +534,8 @@ status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
                         ref_values[i]);
   }
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read back and compare against reference values.
   uint32_t res_values[32];
@@ -552,16 +556,14 @@ status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t result = 0;
@@ -668,6 +670,8 @@ status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   result = increment_counter(result);
   result = increment_counter(result);
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -677,16 +681,14 @@ status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = result;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_conditional_branch(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t branch_if_ = 1;
@@ -701,6 +703,8 @@ status_t handle_ibex_fi_char_conditional_branch(ujson_t *uj) {
     }
   }
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -711,16 +715,14 @@ status_t handle_ibex_fi_char_conditional_branch(ujson_t *uj) {
   uj_output.result1 = branch_if_;
   uj_output.result2 = branch_else;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t loop_counter1 = 0;
@@ -732,6 +734,8 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
     asm volatile(LWSUBISW1 : : "r"((uint32_t *)&loop_counter2));
   }
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -742,16 +746,14 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   uj_output.loop_counter1 = loop_counter1;
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -768,6 +770,8 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
   asm volatile(LWADDISW1000 : : "r"((uint32_t *)&loop_counter));
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -777,16 +781,14 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   ibex_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t loop_counter1 = 0;
@@ -802,6 +804,8 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   asm volatile("mv %0, x5" : "=r"(loop_counter1));
   asm volatile("mv %0, x6" : "=r"(loop_counter2));
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -812,16 +816,14 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   uj_output.loop_counter1 = loop_counter1;
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -840,6 +842,8 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   asm volatile(ADDI1000);
   asm volatile("mv %0, x5" : "=r"(loop_counter));
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read ERR_STATUS register.
   dif_rv_core_ibex_error_status_t codes;
@@ -849,19 +853,16 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   ibex_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   uint32_t res_values[7];
-
   // Initialize temporary registers with reference values.
   asm volatile("li x5, %0" : : "i"(ref_values[0]));
   asm volatile("li x6, %0" : : "i"(ref_values[1]));
@@ -875,6 +876,8 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   sca_set_trigger_high();
   asm volatile(NOP1000);
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Load register values.
   asm volatile("mv %0, x5" : "=r"(res_values[0]));
@@ -902,19 +905,16 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
-  // Configure Ibex to allow reading ERR_STATUS register.
-  dif_rv_core_ibex_t rv_core_ibex;
-  TRY(dif_rv_core_ibex_init(
-      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
-      &rv_core_ibex));
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
 
   uint32_t res_values[3];
-
   // Initialize temporary registers with reference values.
   asm volatile("li x5, %0" : : "i"(ref_values[0]));
   asm volatile("li x6, %0" : : "i"(ref_values[1]));
@@ -929,6 +929,8 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   asm volatile("mv x29, x6");
   asm volatile("mv x30, x7");
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Load register values.
   asm volatile("mv %0, x28" : "=r"(res_values[0]));
@@ -952,15 +954,23 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
-status_t handle_ibex_fi_init_trigger(ujson_t *uj) {
+status_t handle_ibex_fi_init(ujson_t *uj) {
   sca_select_trigger_type(kScaTriggerTypeSw);
   // As we are using the software defined trigger, the first argument of
   // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
-  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4);
+  sca_init(kScaTriggerSourceAes,
+           kScaPeripheralIoDiv4 | kScaPeripheralEdn | kScaPeripheralCsrng |
+               kScaPeripheralEntropy | kScaPeripheralAes | kScaPeripheralHmac |
+               kScaPeripheralKmac | kScaPeripheralOtbn);
+
+  // Configure the alert handler. Alerts triggered by IP blocks are captured
+  // and reported to the test.
+  sca_configure_alert_handler();
 
   // Disable the instruction cache and dummy instructions for FI attacks.
   sca_configure_cpu();
@@ -971,6 +981,10 @@ status_t handle_ibex_fi_init_trigger(ujson_t *uj) {
       &flash, mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
   TRY(flash_ctrl_testutils_wait_for_init(&flash));
 
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
   return OK_STATUS();
 }
 
@@ -978,8 +992,8 @@ status_t handle_ibex_fi(ujson_t *uj) {
   ibex_fi_subcommand_t cmd;
   TRY(ujson_deserialize_ibex_fi_subcommand_t(uj, &cmd));
   switch (cmd) {
-    case kIbexFiSubcommandInitTrigger:
-      return handle_ibex_fi_init_trigger(uj);
+    case kIbexFiSubcommandInit:
+      return handle_ibex_fi_init(uj);
     case kIbexFiSubcommandCharUnrolledRegOpLoop:
       return handle_ibex_fi_char_unrolled_reg_op_loop(uj);
     case kIbexFiSubcommandCharRegOpLoop:

--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
@@ -282,7 +282,7 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj);
  * @param uj An initialized uJSON context.
  * @return OK or error.
  */
-status_t handle_ibex_fi_init_trigger(ujson_t *uj);
+status_t handle_ibex_fi_init(ujson_t *uj);
 
 /**
  * ibex.char.register_file command handler.

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn_fi.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn_fi.c
@@ -252,6 +252,9 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
+
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_dmem_op_loop);
   OTBN_DECLARE_SYMBOL_ADDR(otbn_char_hardware_dmem_op_loop, lc);
@@ -268,6 +271,8 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   otbn_execute();
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharHardwareDmemOpLoopLC, &loop_counter);
@@ -280,6 +285,7 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -298,6 +304,9 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
+
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_reg_op_loop);
   OTBN_DECLARE_SYMBOL_ADDR(otbn_char_hardware_reg_op_loop, lc);
@@ -314,6 +323,8 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   otbn_execute();
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharHardwareRegOpLoopLC, &loop_counter);
@@ -326,6 +337,7 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -346,6 +358,9 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
+
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_dmem_op_loop);
   OTBN_DECLARE_SYMBOL_ADDR(otbn_char_unrolled_dmem_op_loop, lc);
@@ -362,6 +377,8 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   otbn_execute();
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharUnrolledDmemOpLoopLC, &loop_counter);
@@ -374,6 +391,7 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -392,6 +410,9 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  uint32_t reg_alerts = sca_get_triggered_alerts();
+
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_reg_op_loop);
   OTBN_DECLARE_SYMBOL_ADDR(otbn_char_unrolled_reg_op_loop, lc);
@@ -408,6 +429,8 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   otbn_execute();
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharUnrolledRegOpLoopLC, &loop_counter);
@@ -420,6 +443,7 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
+  uj_output.alerts = reg_alerts;
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -444,16 +468,24 @@ status_t handle_otbn_fi_init_keymgr(ujson_t *uj) {
 }
 
 /**
- * Initializes the trigger.
+ * Initializes the OTBN FI test.
+ *
+ * Setup the trigger and alert handler. Disable dummy instructions and the
+ * iCache.
  *
  * @param uj The received uJSON data.
  */
-status_t handle_otbn_fi_init_trigger(ujson_t *uj) {
+status_t handle_otbn_fi_init(ujson_t *uj) {
   status_t err = entropy_testutils_auto_mode_init();
   sca_select_trigger_type(kScaTriggerTypeSw);
-  sca_init(kScaTriggerSourceOtbn, kScaPeripheralEntropy | kScaPeripheralIoDiv4 |
-                                      kScaPeripheralOtbn | kScaPeripheralCsrng |
-                                      kScaPeripheralEdn | kScaPeripheralKmac);
+  sca_init(kScaTriggerSourceOtbn,
+           kScaPeripheralIoDiv4 | kScaPeripheralEdn | kScaPeripheralCsrng |
+               kScaPeripheralEntropy | kScaPeripheralAes | kScaPeripheralHmac |
+               kScaPeripheralKmac | kScaPeripheralOtbn);
+
+  // Configure the alert handler. Alerts triggered by IP blocks are captured
+  // and reported to the test.
+  sca_configure_alert_handler();
 
   // Disable the instruction cache and dummy instructions for FI attacks.
   sca_configure_cpu();
@@ -472,10 +504,10 @@ status_t handle_otbn_fi(ujson_t *uj) {
   otbn_fi_subcommand_t cmd;
   TRY(ujson_deserialize_otbn_fi_subcommand_t(uj, &cmd));
   switch (cmd) {
-    case kOtbnFiSubcommandInitTrigger:
-      return handle_otbn_fi_init_trigger(uj);
     case kOtbnFiSubcommandInitKeyMgr:
       return handle_otbn_fi_init_keymgr(uj);
+    case kOtbnFiSubcommandInit:
+      return handle_otbn_fi_init(uj);
     case kOtbnFiSubcommandCharUnrolledRegOpLoop:
       return handle_otbn_fi_char_unrolled_reg_op_loop(uj);
     case kOtbnFiSubcommandCharUnrolledDmemOpLoop:

--- a/sw/device/tests/crypto/cryptotest/firmware/otbn_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/otbn_fi.h
@@ -21,7 +21,7 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj);
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj);
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj);
 status_t handle_otbn_fi_init_keymgr(ujson_t *uj);
-status_t handle_otbn_init_trigger(ujson_t *uj);
+status_t handle_otbn_init(ujson_t *uj);
 status_t handle_otbn_fi(ujson_t *uj);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_OTBN_FI_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/sca_lib.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sca_lib.c
@@ -3,7 +3,140 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+static dif_rv_plic_t plic;
+static dif_rstmgr_t rstmgr;
+static dif_alert_handler_t alert_handler;
+
+#define NUM_ALERTS 31
+
+// Manually select alerts we are interested in.
+dif_alert_handler_alert_t alerts[NUM_ALERTS] = {
+    kTopEarlgreyAlertIdSramCtrlRetAonFatalError,
+    kTopEarlgreyAlertIdFlashCtrlRecovErr,
+    kTopEarlgreyAlertIdFlashCtrlFatalStdErr,
+    kTopEarlgreyAlertIdFlashCtrlFatalErr,
+    kTopEarlgreyAlertIdFlashCtrlFatalPrimFlashAlert,
+    kTopEarlgreyAlertIdFlashCtrlRecovPrimFlashAlert,
+    kTopEarlgreyAlertIdRvDmFatalFault,
+    kTopEarlgreyAlertIdRvPlicFatalFault,
+    kTopEarlgreyAlertIdAesRecovCtrlUpdateErr,
+    kTopEarlgreyAlertIdAesFatalFault,
+    kTopEarlgreyAlertIdHmacFatalFault,
+    kTopEarlgreyAlertIdKmacRecovOperationErr,
+    kTopEarlgreyAlertIdKmacFatalFaultErr,
+    kTopEarlgreyAlertIdOtbnFatal,
+    kTopEarlgreyAlertIdOtbnRecov,
+    kTopEarlgreyAlertIdKeymgrRecovOperationErr,
+    kTopEarlgreyAlertIdKeymgrFatalFaultErr,
+    kTopEarlgreyAlertIdCsrngRecovAlert,
+    kTopEarlgreyAlertIdCsrngFatalAlert,
+    kTopEarlgreyAlertIdEntropySrcRecovAlert,
+    kTopEarlgreyAlertIdEntropySrcFatalAlert,
+    kTopEarlgreyAlertIdEdn0RecovAlert,
+    kTopEarlgreyAlertIdEdn0FatalAlert,
+    kTopEarlgreyAlertIdEdn1RecovAlert,
+    kTopEarlgreyAlertIdEdn1FatalAlert,
+    kTopEarlgreyAlertIdSramCtrlMainFatalError,
+    kTopEarlgreyAlertIdRomCtrlFatal,
+    kTopEarlgreyAlertIdRvCoreIbexFatalSwErr,
+    kTopEarlgreyAlertIdRvCoreIbexRecovSwErr,
+    kTopEarlgreyAlertIdRvCoreIbexFatalHwErr,
+    kTopEarlgreyAlertIdRvCoreIbexRecovHwErr};
+
+/**
+ * Returns the registered alerts.
+ *
+ * Checks which of the picked alerts are registered by the alert handler. If
+ * the alert was registered, set a bit mask and clear the alert register.
+ */
+uint32_t sca_get_triggered_alerts(void) {
+  uint32_t reg_alerts = 0;
+
+  for (size_t it = 0; it < NUM_ALERTS; it++) {
+    bool is_cause;
+    dif_alert_handler_alert_t is_alert = alerts[it];
+    CHECK_DIF_OK(
+        dif_alert_handler_alert_is_cause(&alert_handler, is_alert, &is_cause));
+    if (is_cause) {
+      CHECK_DIF_OK(
+          dif_alert_handler_alert_acknowledge(&alert_handler, is_alert));
+      reg_alerts |= (1 << it);
+    }
+  }
+
+  return reg_alerts;
+}
+
+/**
+ * Configures the alert handler for FI.
+ *
+ * Register the alerts we are interested in and let them escalate to Phase0
+ * only.
+ *
+ */
+void sca_configure_alert_handler(void) {
+  mmio_region_t base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_rstmgr_init(base_addr, &rstmgr));
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  CHECK_DIF_OK(dif_rv_plic_init(base_addr, &plic));
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR);
+  CHECK_DIF_OK(dif_alert_handler_init(base_addr, &alert_handler));
+
+  rv_plic_testutils_irq_range_enable(&plic, kPlicTarget,
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassa,
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassd);
+
+  // Map all alerts to AlertHandlerClassA.
+  dif_alert_handler_class_t alert_classes[NUM_ALERTS];
+  for (size_t it = 0; it < NUM_ALERTS; it++) {
+    alert_classes[it] = kDifAlertHandlerClassA;
+  }
+
+  // Only escalate to phase 0, no reset should occur.
+  dif_alert_handler_escalation_phase_t esc_phases[] = {
+      {.phase = kDifAlertHandlerClassStatePhase0,
+       .signal = 0,
+       .duration_cycles = 10000}};
+
+  // Configure alert handler.
+  dif_alert_handler_class_config_t class_config[] = {{
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = 0,
+      .irq_deadline_cycles = 10000,
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase1,
+  }};
+
+  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassA};
+  dif_alert_handler_config_t config = {
+      .alerts = alerts,
+      .alert_classes = alert_classes,
+      .alerts_len = ARRAYSIZE(alerts),
+      .classes = classes,
+      .class_configs = class_config,
+      .classes_len = ARRAYSIZE(class_config),
+      .ping_timeout = 0,
+  };
+
+  CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,
+                                                        kDifToggleEnabled));
+}
 
 /**
  * Configures Ibex for SCA and FI.

--- a/sw/device/tests/crypto/cryptotest/firmware/sca_lib.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/sca_lib.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_SCA_LIB_H_
 #define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_SCA_LIB_H_
 
+uint32_t sca_get_triggered_alerts(void);
+void sca_configure_alert_handler(void);
 void sca_configure_cpu(void);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_SCA_LIB_H_

--- a/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
@@ -12,7 +12,7 @@ extern "C" {
 // clang-format off
 
 #define IBEXFI_SUBCOMMAND(_, value) \
-    value(_, InitTrigger) \
+    value(_, Init) \
     value(_, CharUnrolledRegOpLoop) \
     value(_, CharRegOpLoop) \
     value(_, CharUnrolledMemOpLoop) \
@@ -33,24 +33,28 @@ UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
 
 #define IBEXFI_TEST_RESULT(field, string) \
     field(result, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(alerts, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiTestResult, ibex_fi_test_result_t, IBEXFI_TEST_RESULT);
 
 #define IBEXFI_TEST_RESULT_MULT(field, string) \
     field(result1, uint32_t) \
     field(result2, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(alerts, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiTestResultMult, ibex_fi_test_result_mult_t, IBEXFI_TEST_RESULT_MULT);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(alerts, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterOutput, ibex_fi_loop_counter_t, IBEXFI_LOOP_COUNTER_OUTPUT);
 
 #define IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT(field, string) \
     field(loop_counter1, uint32_t) \
     field(loop_counter2, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(alerts, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterMirroredOutput, ibex_fi_loop_counter_mirrored_t, IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT);
 
 // clang-format on

--- a/sw/device/tests/crypto/cryptotest/json/otbn_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/otbn_fi_commands.h
@@ -12,8 +12,8 @@ extern "C" {
 // clang-format off
 
 #define OTBNFI_SUBCOMMAND(_, value) \
-    value(_, InitTrigger) \
     value(_, InitKeyMgr) \
+    value(_, Init) \
     value(_, CharUnrolledRegOpLoop) \
     value(_, CharUnrolledDmemOpLoop) \
     value(_, CharHardwareRegOpLoop) \
@@ -24,7 +24,8 @@ UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND);
 
 #define OTBNFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(alerts, uint32_t)
 UJSON_SERDE_STRUCT(OtbnFiLoopCounterOutput, otbn_fi_loop_counter_t, OTBNFI_LOOP_COUNTER_OUTPUT);
 
 #define OTBNFI_RESULT_OUTPUT(field, string) \


### PR DESCRIPTION
This commit configures the alert handler to raise an interrupt that is handled by a custom ISR. This ISR registers the alert and write it back to the ot-sca host for further diagnosis.

The host code is located in https://github.com/lowRISC/ot-sca/pull/339