### PR TITLE
[dv] Fix more timeout comments with wrong units

### DIFF
--- a/hw/dv/tools/dvsim/tests/stress_all_test.hjson
+++ b/hw/dv/tools/dvsim/tests/stress_all_test.hjson
@@ -10,7 +10,7 @@
     {
       name: "{name}_stress_all"
       uvm_test_seq: "{name}_stress_all_vseq"
-      // 10ms
+      // 10s
       run_opts: ["+test_timeout_ns=10000000000"]
       run_timeout_mins: 180
     }

--- a/hw/dv/tools/dvsim/tests/stress_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/stress_tests.hjson
@@ -10,7 +10,7 @@
       name: "{name}_stress_all_with_rand_reset"
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+run_stress_all_with_rand_reset",
-                 // 10ms
+                 // 10s
                  "+test_timeout_ns=10000000000",
                  "+stress_seq={name}_stress_all_vseq"]
       run_timeout_mins: 180

--- a/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
+++ b/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson
@@ -63,7 +63,7 @@
     {
       name: rv_timer_cfg_update_on_fly
       uvm_test_seq: rv_timer_cfg_update_on_fly_vseq
-      // 10ms
+      // 10s
       run_opts: ["+zero_delays=1", "+test_timeout_ns=10000000000"]
     }
 


### PR DESCRIPTION
A few more instances where the comment uses milliseconds but the value is in whole seconds.