### PR TITLE
[usbdev,dv] Remove num_of_bytes from base vseq

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -23,7 +23,6 @@ bit [4:0] setup_buffer_id = 5'd1;
 bit [4:0] out_buffer_id = 5'd7;
 // Current IN buffer number
 bit [4:0] in_buffer_id = 5'd13;
-bit      [6:0] num_of_bytes;
 
 constraint endpoint_c {
   endp inside {[0:11]};
@@ -265,7 +264,7 @@ virtual task configure_setup_trans();
   csr_update(ral.avsetupbuffer);
 endtask
 
-virtual task configure_in_trans(bit [4:0] buffer_id);
+virtual task configure_in_trans(bit [4:0] buffer_id, bit [6:0] num_of_bytes);
   // Enable Endp IN
   csr_wr(.ptr(ral.ep_in_enable[0].enable[endp]),  .value(1'b1));
   csr_update(ral.ep_in_enable[0]);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -21,7 +21,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(num_of_bytes));
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck); // check OUT response
@@ -31,9 +31,8 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // Make sure buffer is availabe for next trans
     ral.avoutbuffer.buffer.set(out_buffer_id + 1);
     csr_update(ral.avoutbuffer);
-    num_of_bytes = m_data_pkt.data.size();
     // Note: data should have been written into the current OUT buffer by the above transaction
-    configure_in_trans(out_buffer_id);  // register configurations for IN Trans.
+    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
     // Token pkt followed by handshake pkt
     call_token_seq(PidTypeInToken);
     get_response(m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_length_out_transaction_vseq.sv
@@ -10,7 +10,7 @@ class usbdev_max_length_out_transaction_vseq extends usbdev_random_length_out_tr
 
   task pre_start();
     super.pre_start();
-    num_of_bytes = 64;
     randomize_length = 1'b0;
+    num_of_bytes = 64;
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_min_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_min_length_out_transaction_vseq.sv
@@ -10,7 +10,8 @@ class usbdev_min_length_out_transaction_vseq extends usbdev_random_length_out_tr
 
   task pre_start();
     super.pre_start();
-    num_of_bytes = 0;
+
     randomize_length = 1'b0;
+    num_of_bytes = 0;
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -26,7 +26,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(num_of_bytes));
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check first transaction accuracy
@@ -51,7 +51,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData1, .randomize_length(1'b1), .num_of_bytes(num_of_bytes));
+    call_data_seq(PidTypeData1, .randomize_length(1'b1), .num_of_bytes(0));
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check second transaction accuracy

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(num_of_bytes));
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(num_of_bytes));
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -10,7 +10,6 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
 
   usb20_item     item;
   RSP            rsp_item;
-  bit      [6:0] num_of_bytes;
   bit            pkt_received;
   uvm_reg_data_t read_rxfifo;
   uvm_reg_data_t intr_state;
@@ -21,7 +20,7 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(num_of_bytes));
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(rsp_item);
     $cast(item, rsp_item);
     get_out_response_from_device(item, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -25,7 +25,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(num_of_bytes));
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
@@ -38,9 +38,8 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // IN TRANS
     // --------------------------------
     // Configure in transaction
-    num_of_bytes = m_data_pkt.data.size();
     // Note: data should have been written into the current OUT buffer by the above transaction
-    configure_in_trans(out_buffer_id);
+    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
     // Token pkt followed by handshake pkt
     call_token_seq(PidTypeInToken);
     // Get response from DUT

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -8,8 +8,11 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
 
   `uvm_object_new
 
-  // Subclasses with a fixed length transaction should set this to zero
-  bit randomize_length = 1'b1;
+  // Subclasses with a fixed length transaction should set this to zero and should set num_of_bytes
+  // to the length that they want. The default is to set randomize_length to 1. num_of_bytes will
+  // then be ignored.
+  bit       randomize_length = 1'b1;
+  bit [6:0] num_of_bytes = 0;
 
   task body();
     // Configure out transaction


### PR DESCRIPTION
It turns out that we almost never need the sequence to have an opinion about num_of_bytes. The only time it matters is when we send an OUT packet to populate a buffer and then try to read the data back out again with an IN packet.

In those situations, we pick up the correct num_of_bytes value for configuring the IN packet by looking at the data packet that we just sent (see usbdev_pkt_sent_vseq for an example).