### PR TITLE
[rom e2e] Upgrade sigverify_spx tests

### DIFF
--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -39,6 +39,8 @@ load(
     "@lowrisc_opentitan//rules/opentitan:keyutils.bzl",
     _rsa_key_by_name = "rsa_key_by_name",
     _rsa_key_for_lc_state = "rsa_key_for_lc_state",
+    _spx_key_by_name = "spx_key_by_name",
+    _spx_key_for_lc_state = "spx_key_for_lc_state",
 )
 
 """Rules to build OpenTitan for the RISC-V target"""
@@ -66,6 +68,9 @@ dv_params = _dv_params
 
 rsa_key_for_lc_state = _rsa_key_for_lc_state
 rsa_key_by_name = _rsa_key_by_name
+
+spx_key_for_lc_state = _spx_key_for_lc_state
+spx_key_by_name = _spx_key_by_name
 
 # The default set of test environments for Earlgrey.
 EARLGREY_TEST_ENVS = {

--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -24,3 +24,25 @@ def rsa_key_by_name(key_structs, nickname):
     return {
         keys[0].rsa.label: keys[0].rsa.name,
     }
+
+def spx_key_for_lc_state(key_structs, hw_lc_state):
+    """Return a dictionary containing a single key that can be used in the given
+    LC state. The format of the dictionary is compatible with opentitan_test.
+    """
+    keys = [k for k in key_structs if (k.spx != None and key_allowed_in_lc_state(k.spx, hw_lc_state))]
+    if len(keys) == 0:
+        fail("There are no SPX keys compatible with HW LC state {} in key structs".format(hw_lc_state))
+    return {
+        keys[0].spx.label: keys[0].spx.name,
+    }
+
+def spx_key_by_name(key_structs, nickname):
+    """Return a dictionary containing a single key that matches the name given.
+    The format of the dictionary is compatible with opentitan_test.
+    """
+    keys = [k for k in key_structs if (k.spx != None and k.spx.name == nickname)]
+    if len(keys) == 0:
+        fail("There are no SPX keys compatible with name {} in key structs".format(nickname))
+    return {
+        keys[0].spx.label: keys[0].spx.name,
+    }

--- a/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules:opentitan_test.bzl",
+    "//rules/opentitan:defs.bzl",
     "cw310_params",
-    "opentitan_functest",
+    "opentitan_test",
+    "rsa_key_for_lc_state",
+    "spx_key_for_lc_state",
 )
 load(
     "//rules:const.bzl",
@@ -16,7 +18,6 @@ load(
 load(
     "//rules:opentitan.bzl",
     "RSA_SPX_KEY_STRUCTS",
-    "get_key_structs_for_lc_state",
     "opentitan_flash_binary",
 )
 load(
@@ -194,11 +195,12 @@ opentitan_flash_binary(
 ]
 
 [
-    opentitan_functest(
+    opentitan_test(
         name = "sigverify_spx_{}_{}".format(
             lc_state,
             t["name"],
         ),
+        srcs = ["sigverify_spx_test.c"],
         cw310 = cw310_params(
             bitstream = ":bitstream_sigverify_spx_{}_{}".format(
                 lc_state,
@@ -207,9 +209,25 @@ opentitan_flash_binary(
             exit_success = t["exit_success"][lc_state],
             tags = maybe_skip_in_ci(lc_state_val),
         ),
-        key_struct = get_key_structs_for_lc_state(lc_state_val)[0],
-        ot_flash_binary = ":empty_test_sigverify_spx",
-        targets = ["cw310_rom_with_fake_keys"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+        rsa_key = rsa_key_for_lc_state(
+            RSA_SPX_KEY_STRUCTS,
+            lc_state_val,
+        ),
+        spx_key = spx_key_for_lc_state(
+            RSA_SPX_KEY_STRUCTS,
+            lc_state_val,
+        ),
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+            "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+            "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+        ],
     )
     for lc_state, lc_state_val in get_lc_items()
     for t in SIGVERIFY_SPX_CASES

--- a/sw/device/silicon_creator/rom/e2e/sigverify_spx/sigverify_spx_test.c
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_spx/sigverify_spx_test.c
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+#include "sw/device/silicon_creator/lib/sigverify/spx_verify.h"
+
+#include "otp_ctrl_regs.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  LOG_INFO(
+      "spx_en=0x%08x, spx_en_otp=0x%08x, spx_key_en=0x%08x%08x",
+      sigverify_spx_verify_enabled(lifecycle_state_get()),
+      otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_EN_OFFSET),
+      otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_KEY_EN_OFFSET +
+                 sizeof(uint32_t)),
+      otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_SIGVERIFY_SPX_KEY_EN_OFFSET));
+  return true;
+}


### PR DESCRIPTION
1. Upgrades the `rom_e2e_sigverify_spx` test suite to use the new `opentitan_test` Bazel macro.
2. Add SPX utils to keyutils.bzl

Part of #20090
