### PR TITLE
Disable ROM chip info stamping

### DIFF
--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -82,6 +82,12 @@ def _chip_info_src(ctx):
         stamp_files = [ctx.version_file]
         stamp_args.append("--ot_version_file")
         stamp_args.append(ctx.version_file.path)
+    else:
+        print("NOTE: stamping is disabled, the chip_info section will use a fixed version string")
+        stamp_args.append("--default_version")
+
+        # The script expects a 20-character long hash: "OpenTitanOpenTitanOT"
+        stamp_args.append("4f70656e546974616e4f70656e546974616e4f54")
 
     out_source = ctx.actions.declare_file("chip_info.c")
     ctx.actions.run(
@@ -110,7 +116,7 @@ autogen_chip_info_src = rule(
             executable = True,
             cfg = "exec",
         ),
-    } | stamp_attr(1, "//rules:stamp_flag"),
+    } | stamp_attr(-1, "//rules:stamp_flag"),
 )
 
 def autogen_chip_info(name):

--- a/util/rom_chip_info.py
+++ b/util/rom_chip_info.py
@@ -45,7 +45,7 @@ const chip_info_t kChipInfo = {{
 """
 
 
-def read_version_file(version_info_path) -> int:
+def read_version_file(version_info_path, default_version) -> int:
     """
     Search for the scm revision variable and interprets
     the contents as a big-endian hex literal. Return an error
@@ -53,7 +53,7 @@ def read_version_file(version_info_path) -> int:
     """
 
     version_info = version_file.VersionInformation(version_info_path)
-    version = version_info.scm_revision("")
+    version = version_info.scm_revision(default_version)
     return int(version, base=16)
 
 
@@ -81,11 +81,14 @@ def main():
     parser.add_argument('--ot_version_file',
                         type=Path,
                         help='Path to a file with the OpenTitan Version')
+    parser.add_argument('--default_version',
+                        type=str,
+                        help='Version to use if the version file does not indicate a version')
 
     args = parser.parse_args()
 
     # Extract version stamp from file
-    version = read_version_file(args.ot_version_file)
+    version = read_version_file(args.ot_version_file, args.default_version)
     log.info("Version: %x" % (version, ))
 
     generated_source = generate_chip_info_c_source(version)

--- a/util/rom_chip_info_test.py
+++ b/util/rom_chip_info_test.py
@@ -84,16 +84,16 @@ class TestFileOperations(unittest.TestCase):
         """Reading a properly-formatted version file produces the expected int.
         """
         version = rom_chip_info.read_version_file(
-            pathlib.Path("fake/path/version.txt"))
+            pathlib.Path("fake/path/version.txt"), None)
         self.assertEqual(version, EXAMPLE_SHA1_DIGEST)
 
     @patch("version_file.open", mock_open(read_data=''))
     def test_read_version_file_empty(self):
         """Reading an empty version file raises an exception.
         """
-        with self.assertRaisesRegex(ValueError, "invalid literal for int"):
-            rom_chip_info.read_version_file(
-                pathlib.Path("fake/path/version.txt"))
+        version = rom_chip_info.read_version_file(
+            pathlib.Path("fake/path/version.txt"), f'{EXAMPLE_SHA1_DIGEST:x}')
+        self.assertEqual(version, EXAMPLE_SHA1_DIGEST)
 
     @patch("version_file.open", mock_open(read_data='BUILD_SCM_REVISION xyz'))
     def test_read_version_file_invalid_hex(self):
@@ -101,7 +101,7 @@ class TestFileOperations(unittest.TestCase):
         """
         with self.assertRaisesRegex(ValueError, "invalid literal for int"):
             rom_chip_info.read_version_file(
-                pathlib.Path("fake/path/version.txt"))
+                pathlib.Path("fake/path/version.txt"), None)
 
     @patch("pathlib.Path.open", new_callable=mock_open)
     def test_write_source_file(self, mock_path_open):


### PR DESCRIPTION
**Context**

The ROM contains a `chip_info` structure that records the git hash at the build time. Unfortunately, this also prevents caching in CI and it provides little benefit in general since it does not record if the git hash is clean or not.

**Proposed change**

This PR disables bazel stamping by default so that the ROM chip_info will contain a **fixed** hash by default. The original behaviour can be restore by explicitley building with `--stamp`, e.g. `./bazelisk.sh --stamp ...`. The only instance that I can think of where we want this hash is probably for releases anyway.