### PR TITLE
[usbdev] Diagnostic and performance counters

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -884,6 +884,8 @@
                   '''
           }
         ]
+        tags: [// 'rdy', 'pend' and 'sending' bits interact with each other.
+               "excl:CsrNonInitTests:CsrExclWrite"]
       }
     }
     { multireg: {

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -1301,6 +1301,450 @@
         }
       ]
     }
+    { name: "count_ign_avsetup",
+      desc: "Count of SETUP packets ignored because there was no buffer available.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of SETUP packets ignored because there was no buffer in the Av SETUP FIFO.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_drop_avout",
+      desc: "Count of OUT packets dropped/NAKed because there was no buffer available.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of OUT packets that could not be accepted because there was no buffer in the
+                Av OUT FIFO. Non-Isochronous OUT packets have been NAKed.
+                Isochronous OUT packets were ignored.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true",
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_drop_rx",
+      desc: "Count of SETUP/OUT packets ignored, dropped or NAKed because the RX FIFO was full.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of SETUP/OUT packets ignored, dropped or NAKed because the RX FIFO was full.
+                SETUP packets have been ignored, Isochronous OUT packets have been dropped, and
+                non-Isochronous OUT packets have been NAKed.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_datatog_out",
+      desc: "Count of OUT transactions that were ACKnowledged and dropped as apparent retries.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of OUT transactions for which the USB device acknowledged the OUT packet
+                and dropped it internally, which is the correct response to a packet transmitted
+                with an incorrect Data Toggle.
+
+                The expectation is that this packet is a retry of the previous packet transmission
+                and that the handshake response was not received intact by the USB host, indicating
+                unreliable communications.
+
+                This counter may be enabled for a specific set of endpoints in the event that
+                there there is another cause of the Data Toggle synchronization failure.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_timeout_in",
+      desc: "Count of IN transactions that did not receive a handshake response from the USB host.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of IN transactions for which the USB host did not respond with a handshake,
+                and the transactions timed out. This indicates that the host did not receive it
+                and decode it as a valid packet, suggesting that communication is unreliable.
+
+                Isochronous IN transactions are excluded from this count because there is no
+                handshake response to Isochronous packet transfers.
+
+                This counter may be enabled for a specific set of endpoints in the event that
+                particular pipes are unable to accept more data at the host.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_nak_in",
+      desc: "Count of rejected IN transactions; NAK received from host.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of IN transactions rejected by the host responding with a NAK handshake.
+                This counter may be enabled for a specific set of endpoints in the event that
+                particular pipes are unable to accept more data at the host.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_nodata_in0",
+      desc: "Count of IN transactions for which no packet data was available.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of IN transactions that were attempted when there was no packet available
+                in the corresponding 'configin' register(s). This is not necessarily an error
+                condition, and the counter primarily offers some visibility into when the IN
+                traffic is underusing the available bus bandwidth.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_nodata_in1",
+      desc: "Count of IN transactions for which no packet data was available.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of IN transactions that were attempted when there was no packet available
+                in the corresponding 'configin' register(s).
+                This secondary register allows some partitioning of endpoints among the two
+                counters, for more targeted measurement, eg. endpoints may be grouped according to
+                the expected bandwidth usage, or Isochronous vs. non-Isochronous transfers.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_crc5_out",
+      desc: "Count of CRC5 errors detected on token packets from the host.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of CRC5 errors detected on token packets sent by the host. CRC5 errors on
+                token packets received from the host indicate very unreliable communication and
+                possibly a substantial frequency mismatch between the host and the device.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "30",
+          name: "enable",
+          desc: "Write 1 to enable the counter, 0 to disable.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_crc16_out",
+      desc: "Count of CRC16 errors detected on SETUP/OUT transactions from the host.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of SETUP/OUT DATA packets that were ignored, dropped or NAKed because a
+                CRC16 error was detected.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "30",
+          name: "enable",
+          desc: "Write 1 to enable the counter, 0 to disable.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_bitstuff",
+      desc: "Count of Bit Stuffing errors detected on SETUP/OUT transactions from the host.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of SETUP/OUT packets that were ignored, dropped or NAKed because a
+                Bit Stuffing error was detected.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "30",
+          name: "enable",
+          desc: "Write 1 to enable the counter, 0 to disable.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_pid_invalid",
+      desc: "Count of OUT transactions rejected because of Invalid Packet IDentifiers.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "15:0",
+          name: "count",
+          desc: '''
+                Number of Invalid PIDs detected on packets from the host. Invalid PIDs may
+                indicate very unreliable communication and/or a substantial frequency mismatch
+                between the host and the device.
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "30",
+          name: "enable",
+          desc: "Write 1 to enable the counter, 0 to disable.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
     { window: {
         name: "buffer",
         items: "512",
@@ -1309,9 +1753,9 @@
         unusual: "false"
         swaccess: "rw",
         desc: '''
-              2 kB packet buffer. Divided into 32 64-byte buffers.
+              2 KiB packet buffer. Divided into thirty two 64-byte buffers.
 
-              The packet buffer is used for sending and receiveing packets.
+              The packet buffer is used for sending and receiving packets.
               '''
       },
     },

--- a/hw/ip/usbdev/doc/registers.md
+++ b/hw/ip/usbdev/doc/registers.md
@@ -3,48 +3,60 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/usbdev/data/usbdev.hjson -->
 ## Summary
 
-| Name                                         | Offset   |   Length | Description                                                                |
-|:---------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------|
-| usbdev.[`INTR_STATE`](#intr_state)           | 0x0      |        4 | Interrupt State Register                                                   |
-| usbdev.[`INTR_ENABLE`](#intr_enable)         | 0x4      |        4 | Interrupt Enable Register                                                  |
-| usbdev.[`INTR_TEST`](#intr_test)             | 0x8      |        4 | Interrupt Test Register                                                    |
-| usbdev.[`ALERT_TEST`](#alert_test)           | 0xc      |        4 | Alert Test Register                                                        |
-| usbdev.[`usbctrl`](#usbctrl)                 | 0x10     |        4 | USB Control                                                                |
-| usbdev.[`ep_out_enable`](#ep_out_enable)     | 0x14     |        4 | Enable an endpoint to respond to transactions in the downstream direction. |
-| usbdev.[`ep_in_enable`](#ep_in_enable)       | 0x18     |        4 | Enable an endpoint to respond to transactions in the upstream direction.   |
-| usbdev.[`usbstat`](#usbstat)                 | 0x1c     |        4 | USB Status                                                                 |
-| usbdev.[`avoutbuffer`](#avoutbuffer)         | 0x20     |        4 | Available OUT Buffer FIFO                                                  |
-| usbdev.[`avsetupbuffer`](#avsetupbuffer)     | 0x24     |        4 | Available SETUP Buffer FIFO                                                |
-| usbdev.[`rxfifo`](#rxfifo)                   | 0x28     |        4 | Received Buffer FIFO                                                       |
-| usbdev.[`rxenable_setup`](#rxenable_setup)   | 0x2c     |        4 | Receive SETUP transaction enable                                           |
-| usbdev.[`rxenable_out`](#rxenable_out)       | 0x30     |        4 | Receive OUT transaction enable                                             |
-| usbdev.[`set_nak_out`](#set_nak_out)         | 0x34     |        4 | Set NAK after OUT transactions                                             |
-| usbdev.[`in_sent`](#in_sent)                 | 0x38     |        4 | IN Transaction Sent                                                        |
-| usbdev.[`out_stall`](#out_stall)             | 0x3c     |        4 | OUT Endpoint STALL control                                                 |
-| usbdev.[`in_stall`](#in_stall)               | 0x40     |        4 | IN Endpoint STALL control                                                  |
-| usbdev.[`configin_0`](#configin)             | 0x44     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_1`](#configin)             | 0x48     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_2`](#configin)             | 0x4c     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_3`](#configin)             | 0x50     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_4`](#configin)             | 0x54     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_5`](#configin)             | 0x58     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_6`](#configin)             | 0x5c     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_7`](#configin)             | 0x60     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_8`](#configin)             | 0x64     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_9`](#configin)             | 0x68     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_10`](#configin)            | 0x6c     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`configin_11`](#configin)            | 0x70     |        4 | Configure IN Transaction                                                   |
-| usbdev.[`out_iso`](#out_iso)                 | 0x74     |        4 | OUT Endpoint isochronous setting                                           |
-| usbdev.[`in_iso`](#in_iso)                   | 0x78     |        4 | IN Endpoint isochronous setting                                            |
-| usbdev.[`out_data_toggle`](#out_data_toggle) | 0x7c     |        4 | OUT Endpoints Data Toggles                                                 |
-| usbdev.[`in_data_toggle`](#in_data_toggle)   | 0x80     |        4 | IN Endpoints Data Toggles                                                  |
-| usbdev.[`phy_pins_sense`](#phy_pins_sense)   | 0x84     |        4 | USB PHY pins sense.                                                        |
-| usbdev.[`phy_pins_drive`](#phy_pins_drive)   | 0x88     |        4 | USB PHY pins drive.                                                        |
-| usbdev.[`phy_config`](#phy_config)           | 0x8c     |        4 | USB PHY Configuration                                                      |
-| usbdev.[`wake_control`](#wake_control)       | 0x90     |        4 | USB wake module control for suspend / resume                               |
-| usbdev.[`wake_events`](#wake_events)         | 0x94     |        4 | USB wake module events and debug                                           |
-| usbdev.[`fifo_ctrl`](#fifo_ctrl)             | 0x98     |        4 | FIFO control register                                                      |
-| usbdev.[`buffer`](#buffer)                   | 0x800    |     2048 | 2 kB packet buffer. Divided into 32 64-byte buffers.                       |
+| Name                                             | Offset   |   Length | Description                                                                           |
+|:-------------------------------------------------|:---------|---------:|:--------------------------------------------------------------------------------------|
+| usbdev.[`INTR_STATE`](#intr_state)               | 0x0      |        4 | Interrupt State Register                                                              |
+| usbdev.[`INTR_ENABLE`](#intr_enable)             | 0x4      |        4 | Interrupt Enable Register                                                             |
+| usbdev.[`INTR_TEST`](#intr_test)                 | 0x8      |        4 | Interrupt Test Register                                                               |
+| usbdev.[`ALERT_TEST`](#alert_test)               | 0xc      |        4 | Alert Test Register                                                                   |
+| usbdev.[`usbctrl`](#usbctrl)                     | 0x10     |        4 | USB Control                                                                           |
+| usbdev.[`ep_out_enable`](#ep_out_enable)         | 0x14     |        4 | Enable an endpoint to respond to transactions in the downstream direction.            |
+| usbdev.[`ep_in_enable`](#ep_in_enable)           | 0x18     |        4 | Enable an endpoint to respond to transactions in the upstream direction.              |
+| usbdev.[`usbstat`](#usbstat)                     | 0x1c     |        4 | USB Status                                                                            |
+| usbdev.[`avoutbuffer`](#avoutbuffer)             | 0x20     |        4 | Available OUT Buffer FIFO                                                             |
+| usbdev.[`avsetupbuffer`](#avsetupbuffer)         | 0x24     |        4 | Available SETUP Buffer FIFO                                                           |
+| usbdev.[`rxfifo`](#rxfifo)                       | 0x28     |        4 | Received Buffer FIFO                                                                  |
+| usbdev.[`rxenable_setup`](#rxenable_setup)       | 0x2c     |        4 | Receive SETUP transaction enable                                                      |
+| usbdev.[`rxenable_out`](#rxenable_out)           | 0x30     |        4 | Receive OUT transaction enable                                                        |
+| usbdev.[`set_nak_out`](#set_nak_out)             | 0x34     |        4 | Set NAK after OUT transactions                                                        |
+| usbdev.[`in_sent`](#in_sent)                     | 0x38     |        4 | IN Transaction Sent                                                                   |
+| usbdev.[`out_stall`](#out_stall)                 | 0x3c     |        4 | OUT Endpoint STALL control                                                            |
+| usbdev.[`in_stall`](#in_stall)                   | 0x40     |        4 | IN Endpoint STALL control                                                             |
+| usbdev.[`configin_0`](#configin)                 | 0x44     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_1`](#configin)                 | 0x48     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_2`](#configin)                 | 0x4c     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_3`](#configin)                 | 0x50     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_4`](#configin)                 | 0x54     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_5`](#configin)                 | 0x58     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_6`](#configin)                 | 0x5c     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_7`](#configin)                 | 0x60     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_8`](#configin)                 | 0x64     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_9`](#configin)                 | 0x68     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_10`](#configin)                | 0x6c     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`configin_11`](#configin)                | 0x70     |        4 | Configure IN Transaction                                                              |
+| usbdev.[`out_iso`](#out_iso)                     | 0x74     |        4 | OUT Endpoint isochronous setting                                                      |
+| usbdev.[`in_iso`](#in_iso)                       | 0x78     |        4 | IN Endpoint isochronous setting                                                       |
+| usbdev.[`out_data_toggle`](#out_data_toggle)     | 0x7c     |        4 | OUT Endpoints Data Toggles                                                            |
+| usbdev.[`in_data_toggle`](#in_data_toggle)       | 0x80     |        4 | IN Endpoints Data Toggles                                                             |
+| usbdev.[`phy_pins_sense`](#phy_pins_sense)       | 0x84     |        4 | USB PHY pins sense.                                                                   |
+| usbdev.[`phy_pins_drive`](#phy_pins_drive)       | 0x88     |        4 | USB PHY pins drive.                                                                   |
+| usbdev.[`phy_config`](#phy_config)               | 0x8c     |        4 | USB PHY Configuration                                                                 |
+| usbdev.[`wake_control`](#wake_control)           | 0x90     |        4 | USB wake module control for suspend / resume                                          |
+| usbdev.[`wake_events`](#wake_events)             | 0x94     |        4 | USB wake module events and debug                                                      |
+| usbdev.[`fifo_ctrl`](#fifo_ctrl)                 | 0x98     |        4 | FIFO control register                                                                 |
+| usbdev.[`count_ign_avsetup`](#count_ign_avsetup) | 0x9c     |        4 | Count of SETUP packets ignored because there was no buffer available.                 |
+| usbdev.[`count_drop_avout`](#count_drop_avout)   | 0xa0     |        4 | Count of OUT packets dropped/NAKed because there was no buffer available.             |
+| usbdev.[`count_drop_rx`](#count_drop_rx)         | 0xa4     |        4 | Count of SETUP/OUT packets ignored, dropped or NAKed because the RX FIFO was full.    |
+| usbdev.[`count_datatog_out`](#count_datatog_out) | 0xa8     |        4 | Count of OUT transactions that were ACKnowledged and dropped as apparent retries.     |
+| usbdev.[`count_timeout_in`](#count_timeout_in)   | 0xac     |        4 | Count of IN transactions that did not receive a handshake response from the USB host. |
+| usbdev.[`count_nak_in`](#count_nak_in)           | 0xb0     |        4 | Count of rejected IN transactions; NAK received from host.                            |
+| usbdev.[`count_nodata_in0`](#count_nodata_in0)   | 0xb4     |        4 | Count of IN transactions for which no packet data was available.                      |
+| usbdev.[`count_nodata_in1`](#count_nodata_in1)   | 0xb8     |        4 | Count of IN transactions for which no packet data was available.                      |
+| usbdev.[`count_crc5_out`](#count_crc5_out)       | 0xbc     |        4 | Count of CRC5 errors detected on token packets from the host.                         |
+| usbdev.[`count_crc16_out`](#count_crc16_out)     | 0xc0     |        4 | Count of CRC16 errors detected on SETUP/OUT transactions from the host.               |
+| usbdev.[`count_bitstuff`](#count_bitstuff)       | 0xc4     |        4 | Count of Bit Stuffing errors detected on SETUP/OUT transactions from the host.        |
+| usbdev.[`count_pid_invalid`](#count_pid_invalid) | 0xc8     |        4 | Count of OUT transactions rejected because of Invalid Packet IDentifiers.             |
+| usbdev.[`buffer`](#buffer)                       | 0x800    |     2048 | 2 KiB packet buffer. Divided into thirty two 64-byte buffers.                         |
 
 ## INTR_STATE
 Interrupt State Register
@@ -1364,10 +1376,298 @@ FIFO control register
 |   1    |   wo   |   0x0   | avsetup_rst | Software reset of the Available SETUP Buffer FIFO. This must be used only when the USB device is not connected to the USB. |
 |   0    |   wo   |   0x0   | avout_rst   | Software reset of the Available OUT Buffer FIFO. This must be used only when the USB device is not connected to the USB.   |
 
-## buffer
-2 kB packet buffer. Divided into 32 64-byte buffers.
+## count_ign_avsetup
+Count of SETUP packets ignored because there was no buffer available.
+- Offset: `0x9c`
+- Reset default: `0x0`
+- Reset mask: `0x8fffffff`
 
-The packet buffer is used for sending and receiveing packets.
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"name": "endpoints", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name      | Description                                                                       |
+|:------:|:------:|:-------:|:----------|:----------------------------------------------------------------------------------|
+|   31   |   wo   |   0x0   | rst       | Write 1 to reset the counter.                                                     |
+| 30:28  |        |         |           | Reserved                                                                          |
+| 27:16  |   rw   |   0x0   | endpoints | Set of endpoints for which this counter is enabled.                               |
+|  15:0  |   ro   |   0x0   | count     | Number of SETUP packets ignored because there was no buffer in the Av SETUP FIFO. |
+
+## count_drop_avout
+Count of OUT packets dropped/NAKed because there was no buffer available.
+- Offset: `0xa0`
+- Reset default: `0x0`
+- Reset mask: `0x8fffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"name": "endpoints", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name      | Description                                                                                                                                                                         |
+|:------:|:------:|:-------:|:----------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   31   |   wo   |   0x0   | rst       | Write 1 to reset the counter.                                                                                                                                                       |
+| 30:28  |        |         |           | Reserved                                                                                                                                                                            |
+| 27:16  |   rw   |   0x0   | endpoints | Set of endpoints for which this counter is enabled.                                                                                                                                 |
+|  15:0  |   ro   |   0x0   | count     | Number of OUT packets that could not be accepted because there was no buffer in the Av OUT FIFO. Non-Isochronous OUT packets have been NAKed. Isochronous OUT packets were ignored. |
+
+## count_drop_rx
+Count of SETUP/OUT packets ignored, dropped or NAKed because the RX FIFO was full.
+- Offset: `0xa4`
+- Reset default: `0x0`
+- Reset mask: `0x8fffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"name": "endpoints", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name      | Description                                                                                                                                                                                                      |
+|:------:|:------:|:-------:|:----------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   31   |   wo   |   0x0   | rst       | Write 1 to reset the counter.                                                                                                                                                                                    |
+| 30:28  |        |         |           | Reserved                                                                                                                                                                                                         |
+| 27:16  |   rw   |   0x0   | endpoints | Set of endpoints for which this counter is enabled.                                                                                                                                                              |
+|  15:0  |   ro   |   0x0   | count     | Number of SETUP/OUT packets ignored, dropped or NAKed because the RX FIFO was full. SETUP packets have been ignored, Isochronous OUT packets have been dropped, and non-Isochronous OUT packets have been NAKed. |
+
+## count_datatog_out
+Count of OUT transactions that were ACKnowledged and dropped as apparent retries.
+- Offset: `0xa8`
+- Reset default: `0x0`
+- Reset mask: `0x8fffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"name": "endpoints", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                                       |
+|:------:|:------:|:-------:|:-------------------------------------------|
+|   31   |   wo   |   0x0   | [rst](#count_datatog_out--rst)             |
+| 30:28  |        |         | Reserved                                   |
+| 27:16  |   rw   |   0x0   | [endpoints](#count_datatog_out--endpoints) |
+|  15:0  |   ro   |   0x0   | [count](#count_datatog_out--count)         |
+
+### count_datatog_out . rst
+Write 1 to reset the counter.
+
+### count_datatog_out . endpoints
+Set of endpoints for which this counter is enabled.
+
+### count_datatog_out . count
+Number of OUT transactions for which the USB device acknowledged the OUT packet
+and dropped it internally, which is the correct response to a packet transmitted
+with an incorrect Data Toggle.
+
+The expectation is that this packet is a retry of the previous packet transmission
+and that the handshake response was not received intact by the USB host, indicating
+unreliable communications.
+
+This counter may be enabled for a specific set of endpoints in the event that
+there there is another cause of the Data Toggle synchronization failure.
+
+## count_timeout_in
+Count of IN transactions that did not receive a handshake response from the USB host.
+- Offset: `0xac`
+- Reset default: `0x0`
+- Reset mask: `0x8fffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"name": "endpoints", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                                      |
+|:------:|:------:|:-------:|:------------------------------------------|
+|   31   |   wo   |   0x0   | [rst](#count_timeout_in--rst)             |
+| 30:28  |        |         | Reserved                                  |
+| 27:16  |   rw   |   0x0   | [endpoints](#count_timeout_in--endpoints) |
+|  15:0  |   ro   |   0x0   | [count](#count_timeout_in--count)         |
+
+### count_timeout_in . rst
+Write 1 to reset the counter.
+
+### count_timeout_in . endpoints
+Set of endpoints for which this counter is enabled.
+
+### count_timeout_in . count
+Number of IN transactions for which the USB host did not respond with a handshake,
+and the transactions timed out. This indicates that the host did not receive it
+and decode it as a valid packet, suggesting that communication is unreliable.
+
+Isochronous IN transactions are excluded from this count because there is no
+handshake response to Isochronous packet transfers.
+
+This counter may be enabled for a specific set of endpoints in the event that
+particular pipes are unable to accept more data at the host.
+
+## count_nak_in
+Count of rejected IN transactions; NAK received from host.
+- Offset: `0xb0`
+- Reset default: `0x0`
+- Reset mask: `0x8fffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"name": "endpoints", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name      | Description                                                                                                                                                                                                                |
+|:------:|:------:|:-------:|:----------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   31   |   wo   |   0x0   | rst       | Write 1 to reset the counter.                                                                                                                                                                                              |
+| 30:28  |        |         |           | Reserved                                                                                                                                                                                                                   |
+| 27:16  |   rw   |   0x0   | endpoints | Set of endpoints for which this counter is enabled.                                                                                                                                                                        |
+|  15:0  |   ro   |   0x0   | count     | Number of IN transactions rejected by the host responding with a NAK handshake. This counter may be enabled for a specific set of endpoints in the event that particular pipes are unable to accept more data at the host. |
+
+## count_nodata_in0
+Count of IN transactions for which no packet data was available.
+- Offset: `0xb4`
+- Reset default: `0x0`
+- Reset mask: `0x8fffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"name": "endpoints", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                                      |
+|:------:|:------:|:-------:|:------------------------------------------|
+|   31   |   wo   |   0x0   | [rst](#count_nodata_in0--rst)             |
+| 30:28  |        |         | Reserved                                  |
+| 27:16  |   rw   |   0x0   | [endpoints](#count_nodata_in0--endpoints) |
+|  15:0  |   ro   |   0x0   | [count](#count_nodata_in0--count)         |
+
+### count_nodata_in0 . rst
+Write 1 to reset the counter.
+
+### count_nodata_in0 . endpoints
+Set of endpoints for which this counter is enabled.
+
+### count_nodata_in0 . count
+Number of IN transactions that were attempted when there was no packet available
+in the corresponding 'configin' register(s). This is not necessarily an error
+condition, and the counter primarily offers some visibility into when the IN
+traffic is underusing the available bus bandwidth.
+
+## count_nodata_in1
+Count of IN transactions for which no packet data was available.
+- Offset: `0xb8`
+- Reset default: `0x0`
+- Reset mask: `0x8fffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"name": "endpoints", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                                      |
+|:------:|:------:|:-------:|:------------------------------------------|
+|   31   |   wo   |   0x0   | [rst](#count_nodata_in1--rst)             |
+| 30:28  |        |         | Reserved                                  |
+| 27:16  |   rw   |   0x0   | [endpoints](#count_nodata_in1--endpoints) |
+|  15:0  |   ro   |   0x0   | [count](#count_nodata_in1--count)         |
+
+### count_nodata_in1 . rst
+Write 1 to reset the counter.
+
+### count_nodata_in1 . endpoints
+Set of endpoints for which this counter is enabled.
+
+### count_nodata_in1 . count
+Number of IN transactions that were attempted when there was no packet available
+in the corresponding 'configin' register(s).
+This secondary register allows some partitioning of endpoints among the two
+counters, for more targeted measurement, eg. endpoints may be grouped according to
+the expected bandwidth usage, or Isochronous vs. non-Isochronous transfers.
+
+## count_crc5_out
+Count of CRC5 errors detected on token packets from the host.
+- Offset: `0xbc`
+- Reset default: `0x0`
+- Reset mask: `0xc000ffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"bits": 14}, {"name": "enable", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                                                                                                 |
+|:------:|:------:|:-------:|:-------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   31   |   wo   |   0x0   | rst    | Write 1 to reset the counter.                                                                                                                                                                                                               |
+|   30   |   rw   |   0x0   | enable | Write 1 to enable the counter, 0 to disable.                                                                                                                                                                                                |
+| 29:16  |        |         |        | Reserved                                                                                                                                                                                                                                    |
+|  15:0  |   ro   |   0x0   | count  | Number of CRC5 errors detected on token packets sent by the host. CRC5 errors on token packets received from the host indicate very unreliable communication and possibly a substantial frequency mismatch between the host and the device. |
+
+## count_crc16_out
+Count of CRC16 errors detected on SETUP/OUT transactions from the host.
+- Offset: `0xc0`
+- Reset default: `0x0`
+- Reset mask: `0xc000ffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"bits": 14}, {"name": "enable", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                              |
+|:------:|:------:|:-------:|:-------|:---------------------------------------------------------------------------------------------------------|
+|   31   |   wo   |   0x0   | rst    | Write 1 to reset the counter.                                                                            |
+|   30   |   rw   |   0x0   | enable | Write 1 to enable the counter, 0 to disable.                                                             |
+| 29:16  |        |         |        | Reserved                                                                                                 |
+|  15:0  |   ro   |   0x0   | count  | Number of SETUP/OUT DATA packets that were ignored, dropped or NAKed because a CRC16 error was detected. |
+
+## count_bitstuff
+Count of Bit Stuffing errors detected on SETUP/OUT transactions from the host.
+- Offset: `0xc4`
+- Reset default: `0x0`
+- Reset mask: `0xc000ffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"bits": 14}, {"name": "enable", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                |
+|:------:|:------:|:-------:|:-------|:-----------------------------------------------------------------------------------------------------------|
+|   31   |   wo   |   0x0   | rst    | Write 1 to reset the counter.                                                                              |
+|   30   |   rw   |   0x0   | enable | Write 1 to enable the counter, 0 to disable.                                                               |
+| 29:16  |        |         |        | Reserved                                                                                                   |
+|  15:0  |   ro   |   0x0   | count  | Number of SETUP/OUT packets that were ignored, dropped or NAKed because a Bit Stuffing error was detected. |
+
+## count_pid_invalid
+Count of OUT transactions rejected because of Invalid Packet IDentifiers.
+- Offset: `0xc8`
+- Reset default: `0x0`
+- Reset mask: `0xc000ffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "count", "bits": 16, "attr": ["ro"], "rotate": 0}, {"bits": 14}, {"name": "enable", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "rst", "bits": 1, "attr": ["wo"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                                                |
+|:------:|:------:|:-------:|:-------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   31   |   wo   |   0x0   | rst    | Write 1 to reset the counter.                                                                                                                                                              |
+|   30   |   rw   |   0x0   | enable | Write 1 to enable the counter, 0 to disable.                                                                                                                                               |
+| 29:16  |        |         |        | Reserved                                                                                                                                                                                   |
+|  15:0  |   ro   |   0x0   | count  | Number of Invalid PIDs detected on packets from the host. Invalid PIDs may indicate very unreliable communication and/or a substantial frequency mismatch between the host and the device. |
+
+## buffer
+2 KiB packet buffer. Divided into thirty two 64-byte buffers.
+
+The packet buffer is used for sending and receiving packets.
 
 - Word Aligned Offset Range: `0x800`to`0xffc`
 - Size (words): `512`

--- a/hw/ip/usbdev/rtl/usb_fs_nb_in_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_in_pe.sv
@@ -85,7 +85,14 @@ module usb_fs_nb_in_pe #(
   // Data payload to send if any
   output logic              tx_data_avail_o,
   input  logic              tx_data_get_i,
-  output logic [7:0]        tx_data_o
+  output logic [7:0]        tx_data_o,
+
+  ////////////////////
+  // event counters
+  ////////////////////
+  output logic              event_timeout_in_o,
+  output logic              event_nak_in_o,
+  output logic              event_nodata_in_o
 );
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -114,7 +121,7 @@ module usb_fs_nb_in_pe #(
   logic [NumInEps-1:0] data_toggle_q, data_toggle_d;
 
   // endpoint data buffer
-  logic       token_received, setup_token_received, in_token_received, ack_received;
+  logic       token_received, setup_token_received, in_token_received, ack_received, nak_received;
   logic       more_data_to_send;
   logic       ep_in_hw, ep_active;
   logic [3:0] in_ep_current_d;
@@ -143,6 +150,11 @@ module usb_fs_nb_in_pe #(
     rx_pkt_end_i &&
     rx_pkt_valid_i &&
     rx_pid == UsbPidAck;
+
+  assign nak_received =
+    rx_pkt_end_i &&
+    rx_pkt_valid_i &&
+    rx_pid == UsbPidNak;
 
   // Is the specified endpoint actually implemented in hardware?
   assign ep_in_hw = {1'b0, rx_endp_i} < NumInEps;
@@ -267,9 +279,11 @@ module usb_fs_nb_in_pe #(
           in_xact_state_next = StIdle;
           in_xact_end = 1'b1;
         end else if (in_token_received) begin
+          // Handshake response is missing.
           in_xact_state_next = ep_active ? StRcvdIn : StIdle;
           rollback_in_xact = 1'b1;
         end else if (rx_pkt_end_i) begin
+          // Includes NAK
           in_xact_state_next = StIdle;
           rollback_in_xact = 1'b1;
         end else begin
@@ -381,6 +395,24 @@ module usb_fs_nb_in_pe #(
       end
     end
   end
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Count non-Isochronous IN transactions not receiving a handshake response.
+  ////////////////////////////////////////////////////////////////////////////////
+  assign event_timeout_in_o = (in_xact_state == StWaitAckStart ||
+                              (in_xact_state == StWaitAck && in_token_received)) & rollback_in_xact;
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Count IN transactions that are actively NAKed by the host.
+  ////////////////////////////////////////////////////////////////////////////////
+  assign event_nak_in_o = (in_xact_state == StWaitAck) && nak_received;
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Count the number of IN requests for which data is not available, including
+  // endpoints which are supported but not presently enabled/configured.
+  // (These may be ignored using the event counter configuration if required.)
+  ////////////////////////////////////////////////////////////////////////////////
+  assign event_nodata_in_o = in_starting & (ep_in_hw ? !in_ep_has_data_i[in_ep_index_d] : 1'b0);
 
   ////////////////
   // Assertions //

--- a/hw/ip/usbdev/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_pe.sv
@@ -96,7 +96,8 @@ module usb_fs_nb_pe #(
   output logic                   rx_j_det_o,
 
   // RX errors
-  output logic                   rx_crc_err_o,
+  output logic                   rx_crc5_err_o,
+  output logic                   rx_crc16_err_o,
   output logic                   rx_pid_err_o,
   output logic                   rx_bitstuff_err_o,
 
@@ -114,7 +115,13 @@ module usb_fs_nb_pe #(
   output logic                   usb_se0_o,
   output logic                   usb_dp_o,
   output logic                   usb_dn_o,
-  output logic                   usb_oe_o
+  output logic                   usb_oe_o,
+
+  // event counters
+  output logic                   event_datatog_out_o,
+  output logic                   event_timeout_in_o,
+  output logic                   event_nak_in_o,
+  output logic                   event_nodata_in_o
 );
 
   import usb_consts_pkg::*;
@@ -207,7 +214,12 @@ module usb_fs_nb_pe #(
     .tx_pid_o              (in_tx_pid),
     .tx_data_avail_o       (tx_data_avail),
     .tx_data_get_i         (tx_data_get),
-    .tx_data_o             (tx_data)
+    .tx_data_o             (tx_data),
+
+    // event counters
+    .event_timeout_in_o    (event_timeout_in_o),
+    .event_nak_in_o        (event_nak_in_o),
+    .event_nodata_in_o     (event_nodata_in_o)
   );
 
   usb_fs_nb_out_pe #(
@@ -253,7 +265,10 @@ module usb_fs_nb_pe #(
     // tx path
     .tx_pkt_start_o         (out_tx_pkt_start),
     .tx_pkt_end_i           (tx_pkt_end),
-    .tx_pid_o               (out_tx_pid)
+    .tx_pid_o               (out_tx_pid),
+
+    // event counters
+    .event_datatog_out_o    (event_datatog_out_o)
   );
 
   usb_fs_rx u_usb_fs_rx (
@@ -280,7 +295,8 @@ module usb_fs_nb_pe #(
     .valid_packet_o         (rx_pkt_valid),
     .rx_idle_det_o          (rx_idle_det_o),
     .rx_j_det_o             (rx_j_det_o),
-    .crc_error_o            (rx_crc_err_o),
+    .crc5_error_o           (rx_crc5_err_o),
+    .crc16_error_o          (rx_crc16_err_o),
     .pid_error_o            (rx_pid_err_o),
     .bitstuff_error_o       (rx_bitstuff_err_o)
   );

--- a/hw/ip/usbdev/rtl/usb_fs_rx.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_rx.sv
@@ -51,7 +51,8 @@ module usb_fs_rx (
   output logic rx_j_det_o,
 
   // Error detection
-  output logic crc_error_o,
+  output logic crc5_error_o,
+  output logic crc16_error_o,
   output logic pid_error_o,
   output logic bitstuff_error_o
 );
@@ -528,8 +529,8 @@ module usb_fs_rx (
   );
 
   // Detect CRC errors
-  assign crc_error_o = ((pkt_is_data && !crc16_valid) ||
-    (pkt_is_token && !crc5_valid)) && packet_end;
+  assign crc5_error_o  = pkt_is_token & packet_end & !crc5_valid;
+  assign crc16_error_o = pkt_is_data & packet_end & !crc16_valid;
 
   // Detect PID errors
   assign pid_error_o = !pid_valid && packet_end;

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -1260,6 +1260,155 @@ module usbdev
   assign hw2reg.wake_events.bus_reset.de = 1'b1;
   assign hw2reg.wake_events.bus_reset.d = usb_aon_bus_reset_i;
 
+  /////////////////////////////////////
+  // Diagnostic/performance counters //
+  /////////////////////////////////////
+
+  // Counters use 'rst_n' and remain at zero in Stubbed implementation
+  usbdev_counter #(.NEndpoints(NEndpoints)) u_ctr_ign_avsetup(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_n),
+    .reset_i      (reg2hw.count_ign_avsetup.rst.qe & reg2hw.count_ign_avsetup.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (4'h0),
+    .endp_qe_i    (reg2hw.count_ign_avsetup.endpoints.qe),
+    .endpoints_i  (reg2hw.count_ign_avsetup.endpoints.q),
+    .endpoints_o  (hw2reg.count_ign_avsetup.endpoints.d),
+    .count_o      (hw2reg.count_ign_avsetup.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(NEndpoints)) u_ctr_drop_avout(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_drop_avout.rst.qe & reg2hw.count_drop_avout.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (4'h0),
+    .endp_qe_i    (reg2hw.count_drop_avout.endpoints.qe),
+    .endpoints_i  (reg2hw.count_drop_avout.endpoints.q),
+    .endpoints_o  (hw2reg.count_drop_avout.endpoints.d),
+    .count_o      (hw2reg.count_drop_avout.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(NEndpoints)) u_ctr_drop_rx(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_drop_rx.rst.qe & reg2hw.count_drop_rx.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (4'h0),
+    .endp_qe_i    (reg2hw.count_drop_rx.endpoints.qe),
+    .endpoints_i  (reg2hw.count_drop_rx.endpoints.q),
+    .endpoints_o  (hw2reg.count_drop_rx.endpoints.d),
+    .count_o      (hw2reg.count_drop_rx.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(NEndpoints)) u_ctr_datatag_out(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_datatog_out.rst.qe & reg2hw.count_datatog_out.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (4'h0),
+    .endp_qe_i    (reg2hw.count_datatog_out.endpoints.qe),
+    .endpoints_i  (reg2hw.count_datatog_out.endpoints.q),
+    .endpoints_o  (hw2reg.count_datatog_out.endpoints.d),
+    .count_o      (hw2reg.count_datatog_out.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(NEndpoints)) u_ctr_timeout_in(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_timeout_in.rst.qe & reg2hw.count_timeout_in.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (4'h0),
+    .endp_qe_i    (reg2hw.count_timeout_in.endpoints.qe),
+    .endpoints_i  (reg2hw.count_timeout_in.endpoints.q),
+    .endpoints_o  (hw2reg.count_timeout_in.endpoints.d),
+    .count_o      (hw2reg.count_timeout_in.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(NEndpoints)) u_ctr_nak_in(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_nak_in.rst.qe & reg2hw.count_nak_in.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (4'h0),
+    .endp_qe_i    (reg2hw.count_nak_in.endpoints.qe),
+    .endpoints_i  (reg2hw.count_nak_in.endpoints.q),
+    .endpoints_o  (hw2reg.count_nak_in.endpoints.d),
+    .count_o      (hw2reg.count_nak_in.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(NEndpoints)) u_ctr_nodata_in0(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_nodata_in0.rst.qe & reg2hw.count_nodata_in0.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (4'h0),
+    .endp_qe_i    (reg2hw.count_nodata_in0.endpoints.qe),
+    .endpoints_i  (reg2hw.count_nodata_in0.endpoints.q),
+    .endpoints_o  (hw2reg.count_nodata_in0.endpoints.d),
+    .count_o      (hw2reg.count_nodata_in0.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(NEndpoints)) u_ctr_nodata_in1(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_nodata_in1.rst.qe & reg2hw.count_nodata_in1.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (4'h0),
+    .endp_qe_i    (reg2hw.count_nodata_in1.endpoints.qe),
+    .endpoints_i  (reg2hw.count_nodata_in1.endpoints.q),
+    .endpoints_o  (hw2reg.count_nodata_in1.endpoints.d),
+    .count_o      (hw2reg.count_nodata_in1.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(1)) u_ctr_crc5_out(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_crc5_out.rst.qe & reg2hw.count_crc5_out.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (1'b0),
+    .endp_qe_i    (reg2hw.count_crc5_out.enable.qe),
+    .endpoints_i  (reg2hw.count_crc5_out.enable.q),
+    .endpoints_o  (hw2reg.count_crc5_out.enable.d),
+    .count_o      (hw2reg.count_crc5_out.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(1)) u_ctr_crc16_out(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_crc16_out.rst.qe & reg2hw.count_crc16_out.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (1'b0),
+    .endp_qe_i    (reg2hw.count_crc16_out.enable.qe),
+    .endpoints_i  (reg2hw.count_crc16_out.enable.q),
+    .endpoints_o  (hw2reg.count_crc16_out.enable.d),
+    .count_o      (hw2reg.count_crc16_out.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(1)) u_ctr_bitstuff(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_bitstuff.rst.qe & reg2hw.count_bitstuff.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (1'b0),
+    .endp_qe_i    (reg2hw.count_bitstuff.enable.qe),
+    .endpoints_i  (reg2hw.count_bitstuff.enable.q),
+    .endpoints_o  (hw2reg.count_bitstuff.enable.d),
+    .count_o      (hw2reg.count_bitstuff.count.d)
+  );
+
+  usbdev_counter #(.NEndpoints(1)) u_ctr_pid_invalid(
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .reset_i      (reg2hw.count_pid_invalid.rst.qe & reg2hw.count_pid_invalid.rst.q),
+    .event_i      (1'b0),
+    .ep_i         (1'b0),
+    .endp_qe_i    (reg2hw.count_pid_invalid.enable.qe),
+    .endpoints_i  (reg2hw.count_pid_invalid.enable.q),
+    .endpoints_o  (hw2reg.count_pid_invalid.enable.d),
+    .count_o      (hw2reg.count_pid_invalid.count.d)
+  );
+
   /////////////////////////////////
   // Xprop assertions on outputs //
   /////////////////////////////////

--- a/hw/ip/usbdev/rtl/usbdev_counter.sv
+++ b/hw/ip/usbdev/rtl/usbdev_counter.sv
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// USB device event counter
+//
+// At every rising edge of 'event_i' the counter samples the current endpoint as indicated by
+// 'ep_i' and increments the count if the endpoint in question is enabled at that moment.
+//
+// This means the set of endpoints for which events are counted may be changed over time by
+// software, whilst the USB device is active, multiplexing a single counter amongst multiple
+// sets of endpoints.
+//
+// The counter value saturates at its maximum and may be reset by software at any point.
+
+module usbdev_counter
+#(
+  parameter int unsigned NEndpoints = 12, // Number of endpoints supported.
+  localparam int unsigned EpW = prim_util_pkg::vbits(NEndpoints) // derived parameter
+) (
+  input  logic                  clk_i,
+  input  logic                  rst_ni,
+
+  input  logic                  reset_i, // Software reset
+  input  logic                  event_i, // Event pulse
+  input  logic [EpW-1:0]        ep_i, // Endpoint on which event occurred.
+  input  logic                  endp_qe_i,  // SW write to the endpoint enables.
+  input  logic [NEndpoints-1:0] endpoints_i, // Per-endpoint enable/disable.
+  output logic [NEndpoints-1:0] endpoints_o, // Current enables
+  output logic [15:0]           count_o // Current value of counter.
+);
+
+// Current per-endpoint enables.
+logic [NEndpoints-1:0] endpoints;
+always_ff @(posedge clk_i or negedge rst_ni) begin
+  if (!rst_ni) endpoints <= '0;
+  else if (endp_qe_i) endpoints <= endpoints_i;
+end
+
+// Respond to events on this endpoint?
+logic ep_enabled;
+if (NEndpoints > 1) begin : gen_multi
+  assign ep_enabled = (ep_i < EpW'(NEndpoints)) ? endpoints[ep_i] : 1'b0;
+end else begin : gen_single
+  logic unused_ep;
+  assign unused_ep = ^ep_i;  // Endpoint number not required
+  assign ep_enabled = endpoints[0];
+end
+
+// Saturating event counter.
+logic [15:0] count;
+logic event_q;
+
+always_ff @(posedge clk_i or negedge rst_ni) begin
+  if (!rst_ni) begin
+    count   <= 16'b0;
+    event_q <= 1'b0;
+  end else if (reset_i) begin
+    count   <= 16'b0;
+    // Do not modify 'event_q' here because the event input may still be asserted.
+  end else begin
+    // Positive-edge triggered, saturating count of events.
+    if ((event_i & ~event_q) & ep_enabled) count <= count + ~&count;
+    // Retain previous state of event input signal.
+    event_q <= event_i;
+  end
+end
+
+assign endpoints_o = endpoints;
+assign count_o = count;
+
+endmodule

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -409,6 +409,138 @@ package usbdev_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_ign_avsetup_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_drop_avout_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_drop_rx_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_datatog_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_timeout_in_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_nak_in_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_nodata_in0_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_nodata_in1_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } enable;
+  } usbdev_reg2hw_count_crc5_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } enable;
+  } usbdev_reg2hw_count_crc16_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } enable;
+  } usbdev_reg2hw_count_bitstuff_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } enable;
+  } usbdev_reg2hw_count_pid_invalid_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
       logic        de;
     } pkt_received;
@@ -639,50 +771,182 @@ package usbdev_reg_pkg;
     } bus_not_idle;
   } usbdev_hw2reg_wake_events_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_ign_avsetup_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_drop_avout_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_drop_rx_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_datatog_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_timeout_in_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_nak_in_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_nodata_in0_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_nodata_in1_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic        d;
+    } enable;
+  } usbdev_hw2reg_count_crc5_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic        d;
+    } enable;
+  } usbdev_hw2reg_count_crc16_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic        d;
+    } enable;
+  } usbdev_hw2reg_count_bitstuff_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] d;
+    } count;
+    struct packed {
+      logic        d;
+    } enable;
+  } usbdev_hw2reg_count_pid_invalid_reg_t;
+
   // Register -> HW type
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [481:464]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [463:446]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [445:410]
-    usbdev_reg2hw_alert_test_reg_t alert_test; // [409:408]
-    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [407:398]
-    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [397:386]
-    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [385:374]
-    usbdev_reg2hw_avoutbuffer_reg_t avoutbuffer; // [373:368]
-    usbdev_reg2hw_avsetupbuffer_reg_t avsetupbuffer; // [367:362]
-    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [361:341]
-    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [340:329]
-    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [328:317]
-    usbdev_reg2hw_set_nak_out_mreg_t [11:0] set_nak_out; // [316:305]
-    usbdev_reg2hw_in_sent_mreg_t [11:0] in_sent; // [304:293]
-    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [292:281]
-    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [280:269]
-    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [268:101]
-    usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [100:89]
-    usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [88:77]
-    usbdev_reg2hw_out_data_toggle_reg_t out_data_toggle; // [76:51]
-    usbdev_reg2hw_in_data_toggle_reg_t in_data_toggle; // [50:25]
-    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [24:16]
-    usbdev_reg2hw_phy_config_reg_t phy_config; // [15:10]
-    usbdev_reg2hw_wake_control_reg_t wake_control; // [9:6]
-    usbdev_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [5:0]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [617:600]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [599:582]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [581:546]
+    usbdev_reg2hw_alert_test_reg_t alert_test; // [545:544]
+    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [543:534]
+    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [533:522]
+    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [521:510]
+    usbdev_reg2hw_avoutbuffer_reg_t avoutbuffer; // [509:504]
+    usbdev_reg2hw_avsetupbuffer_reg_t avsetupbuffer; // [503:498]
+    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [497:477]
+    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [476:465]
+    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [464:453]
+    usbdev_reg2hw_set_nak_out_mreg_t [11:0] set_nak_out; // [452:441]
+    usbdev_reg2hw_in_sent_mreg_t [11:0] in_sent; // [440:429]
+    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [428:417]
+    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [416:405]
+    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [404:237]
+    usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [236:225]
+    usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [224:213]
+    usbdev_reg2hw_out_data_toggle_reg_t out_data_toggle; // [212:187]
+    usbdev_reg2hw_in_data_toggle_reg_t in_data_toggle; // [186:161]
+    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [160:152]
+    usbdev_reg2hw_phy_config_reg_t phy_config; // [151:146]
+    usbdev_reg2hw_wake_control_reg_t wake_control; // [145:142]
+    usbdev_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [141:136]
+    usbdev_reg2hw_count_ign_avsetup_reg_t count_ign_avsetup; // [135:121]
+    usbdev_reg2hw_count_drop_avout_reg_t count_drop_avout; // [120:106]
+    usbdev_reg2hw_count_drop_rx_reg_t count_drop_rx; // [105:91]
+    usbdev_reg2hw_count_datatog_out_reg_t count_datatog_out; // [90:76]
+    usbdev_reg2hw_count_timeout_in_reg_t count_timeout_in; // [75:61]
+    usbdev_reg2hw_count_nak_in_reg_t count_nak_in; // [60:46]
+    usbdev_reg2hw_count_nodata_in0_reg_t count_nodata_in0; // [45:31]
+    usbdev_reg2hw_count_nodata_in1_reg_t count_nodata_in1; // [30:16]
+    usbdev_reg2hw_count_crc5_out_reg_t count_crc5_out; // [15:12]
+    usbdev_reg2hw_count_crc16_out_reg_t count_crc16_out; // [11:8]
+    usbdev_reg2hw_count_bitstuff_reg_t count_bitstuff; // [7:4]
+    usbdev_reg2hw_count_pid_invalid_reg_t count_pid_invalid; // [3:0]
   } usbdev_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [323:288]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [287:280]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [279:250]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [249:233]
-    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [232:209]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [208:185]
-    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [184:161]
-    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [160:137]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [136:65]
-    usbdev_hw2reg_out_data_toggle_reg_t out_data_toggle; // [64:41]
-    usbdev_hw2reg_in_data_toggle_reg_t in_data_toggle; // [40:17]
-    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [16:8]
-    usbdev_hw2reg_wake_events_reg_t wake_events; // [7:0]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [615:580]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [579:572]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [571:542]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [541:525]
+    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [524:501]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [500:477]
+    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [476:453]
+    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [452:429]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [428:357]
+    usbdev_hw2reg_out_data_toggle_reg_t out_data_toggle; // [356:333]
+    usbdev_hw2reg_in_data_toggle_reg_t in_data_toggle; // [332:309]
+    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [308:300]
+    usbdev_hw2reg_wake_events_reg_t wake_events; // [299:292]
+    usbdev_hw2reg_count_ign_avsetup_reg_t count_ign_avsetup; // [291:264]
+    usbdev_hw2reg_count_drop_avout_reg_t count_drop_avout; // [263:236]
+    usbdev_hw2reg_count_drop_rx_reg_t count_drop_rx; // [235:208]
+    usbdev_hw2reg_count_datatog_out_reg_t count_datatog_out; // [207:180]
+    usbdev_hw2reg_count_timeout_in_reg_t count_timeout_in; // [179:152]
+    usbdev_hw2reg_count_nak_in_reg_t count_nak_in; // [151:124]
+    usbdev_hw2reg_count_nodata_in0_reg_t count_nodata_in0; // [123:96]
+    usbdev_hw2reg_count_nodata_in1_reg_t count_nodata_in1; // [95:68]
+    usbdev_hw2reg_count_crc5_out_reg_t count_crc5_out; // [67:51]
+    usbdev_hw2reg_count_crc16_out_reg_t count_crc16_out; // [50:34]
+    usbdev_hw2reg_count_bitstuff_reg_t count_bitstuff; // [33:17]
+    usbdev_hw2reg_count_pid_invalid_reg_t count_pid_invalid; // [16:0]
   } usbdev_hw2reg_t;
 
   // Register offsets
@@ -725,6 +989,18 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_CONTROL_OFFSET = 12'h 90;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_EVENTS_OFFSET = 12'h 94;
   parameter logic [BlockAw-1:0] USBDEV_FIFO_CTRL_OFFSET = 12'h 98;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_IGN_AVSETUP_OFFSET = 12'h 9c;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_DROP_AVOUT_OFFSET = 12'h a0;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_DROP_RX_OFFSET = 12'h a4;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_DATATOG_OUT_OFFSET = 12'h a8;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_TIMEOUT_IN_OFFSET = 12'h ac;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_NAK_IN_OFFSET = 12'h b0;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_NODATA_IN0_OFFSET = 12'h b4;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_NODATA_IN1_OFFSET = 12'h b8;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_CRC5_OUT_OFFSET = 12'h bc;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_CRC16_OUT_OFFSET = 12'h c0;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_BITSTUFF_OFFSET = 12'h c4;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_PID_INVALID_OFFSET = 12'h c8;
 
   // Reset values for hwext registers and their fields
   parameter logic [17:0] USBDEV_INTR_TEST_RESVAL = 18'h 0;
@@ -757,6 +1033,54 @@ package usbdev_reg_pkg;
   parameter logic [1:0] USBDEV_WAKE_CONTROL_RESVAL = 2'h 0;
   parameter logic [0:0] USBDEV_WAKE_CONTROL_SUSPEND_REQ_RESVAL = 1'h 0;
   parameter logic [0:0] USBDEV_WAKE_CONTROL_WAKE_ACK_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_IGN_AVSETUP_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_IGN_AVSETUP_COUNT_RESVAL = 16'h 0;
+  parameter logic [11:0] USBDEV_COUNT_IGN_AVSETUP_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_IGN_AVSETUP_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_DROP_AVOUT_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_DROP_AVOUT_COUNT_RESVAL = 16'h 0;
+  parameter logic [11:0] USBDEV_COUNT_DROP_AVOUT_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_DROP_AVOUT_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_DROP_RX_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_DROP_RX_COUNT_RESVAL = 16'h 0;
+  parameter logic [11:0] USBDEV_COUNT_DROP_RX_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_DROP_RX_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_DATATOG_OUT_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_DATATOG_OUT_COUNT_RESVAL = 16'h 0;
+  parameter logic [11:0] USBDEV_COUNT_DATATOG_OUT_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_DATATOG_OUT_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_TIMEOUT_IN_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_TIMEOUT_IN_COUNT_RESVAL = 16'h 0;
+  parameter logic [11:0] USBDEV_COUNT_TIMEOUT_IN_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_TIMEOUT_IN_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_NAK_IN_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_NAK_IN_COUNT_RESVAL = 16'h 0;
+  parameter logic [11:0] USBDEV_COUNT_NAK_IN_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_NAK_IN_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_NODATA_IN0_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_NODATA_IN0_COUNT_RESVAL = 16'h 0;
+  parameter logic [11:0] USBDEV_COUNT_NODATA_IN0_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_NODATA_IN0_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_NODATA_IN1_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_NODATA_IN1_COUNT_RESVAL = 16'h 0;
+  parameter logic [11:0] USBDEV_COUNT_NODATA_IN1_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_NODATA_IN1_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_CRC5_OUT_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_CRC5_OUT_COUNT_RESVAL = 16'h 0;
+  parameter logic [0:0] USBDEV_COUNT_CRC5_OUT_ENABLE_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_CRC5_OUT_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_CRC16_OUT_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_CRC16_OUT_COUNT_RESVAL = 16'h 0;
+  parameter logic [0:0] USBDEV_COUNT_CRC16_OUT_ENABLE_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_CRC16_OUT_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_BITSTUFF_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_BITSTUFF_COUNT_RESVAL = 16'h 0;
+  parameter logic [0:0] USBDEV_COUNT_BITSTUFF_ENABLE_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_BITSTUFF_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_PID_INVALID_RESVAL = 32'h 0;
+  parameter logic [15:0] USBDEV_COUNT_PID_INVALID_COUNT_RESVAL = 16'h 0;
+  parameter logic [0:0] USBDEV_COUNT_PID_INVALID_ENABLE_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_PID_INVALID_RST_RESVAL = 1'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] USBDEV_BUFFER_OFFSET = 12'h 800;
@@ -803,11 +1127,23 @@ package usbdev_reg_pkg;
     USBDEV_PHY_CONFIG,
     USBDEV_WAKE_CONTROL,
     USBDEV_WAKE_EVENTS,
-    USBDEV_FIFO_CTRL
+    USBDEV_FIFO_CTRL,
+    USBDEV_COUNT_IGN_AVSETUP,
+    USBDEV_COUNT_DROP_AVOUT,
+    USBDEV_COUNT_DROP_RX,
+    USBDEV_COUNT_DATATOG_OUT,
+    USBDEV_COUNT_TIMEOUT_IN,
+    USBDEV_COUNT_NAK_IN,
+    USBDEV_COUNT_NODATA_IN0,
+    USBDEV_COUNT_NODATA_IN1,
+    USBDEV_COUNT_CRC5_OUT,
+    USBDEV_COUNT_CRC16_OUT,
+    USBDEV_COUNT_BITSTUFF,
+    USBDEV_COUNT_PID_INVALID
   } usbdev_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] USBDEV_PERMIT [39] = '{
+  parameter logic [3:0] USBDEV_PERMIT [51] = '{
     4'b 0111, // index[ 0] USBDEV_INTR_STATE
     4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
     4'b 0111, // index[ 2] USBDEV_INTR_TEST
@@ -846,7 +1182,19 @@ package usbdev_reg_pkg;
     4'b 0001, // index[35] USBDEV_PHY_CONFIG
     4'b 0001, // index[36] USBDEV_WAKE_CONTROL
     4'b 0011, // index[37] USBDEV_WAKE_EVENTS
-    4'b 0001  // index[38] USBDEV_FIFO_CTRL
+    4'b 0001, // index[38] USBDEV_FIFO_CTRL
+    4'b 1111, // index[39] USBDEV_COUNT_IGN_AVSETUP
+    4'b 1111, // index[40] USBDEV_COUNT_DROP_AVOUT
+    4'b 1111, // index[41] USBDEV_COUNT_DROP_RX
+    4'b 1111, // index[42] USBDEV_COUNT_DATATOG_OUT
+    4'b 1111, // index[43] USBDEV_COUNT_TIMEOUT_IN
+    4'b 1111, // index[44] USBDEV_COUNT_NAK_IN
+    4'b 1111, // index[45] USBDEV_COUNT_NODATA_IN0
+    4'b 1111, // index[46] USBDEV_COUNT_NODATA_IN1
+    4'b 1111, // index[47] USBDEV_COUNT_CRC5_OUT
+    4'b 1111, // index[48] USBDEV_COUNT_CRC16_OUT
+    4'b 1111, // index[49] USBDEV_COUNT_BITSTUFF
+    4'b 1111  // index[50] USBDEV_COUNT_PID_INVALID
   };
 
 endpackage

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -59,9 +59,9 @@ module usbdev_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [38:0] reg_we_check;
+  logic [50:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(39)
+    .OneHotWidth(51)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -733,6 +733,78 @@ module usbdev_reg_top (
   logic fifo_ctrl_avout_rst_wd;
   logic fifo_ctrl_avsetup_rst_wd;
   logic fifo_ctrl_rx_rst_wd;
+  logic count_ign_avsetup_re;
+  logic count_ign_avsetup_we;
+  logic [15:0] count_ign_avsetup_count_qs;
+  logic [11:0] count_ign_avsetup_endpoints_qs;
+  logic [11:0] count_ign_avsetup_endpoints_wd;
+  logic count_ign_avsetup_rst_wd;
+  logic count_drop_avout_re;
+  logic count_drop_avout_we;
+  logic [15:0] count_drop_avout_count_qs;
+  logic [11:0] count_drop_avout_endpoints_qs;
+  logic [11:0] count_drop_avout_endpoints_wd;
+  logic count_drop_avout_rst_wd;
+  logic count_drop_rx_re;
+  logic count_drop_rx_we;
+  logic [15:0] count_drop_rx_count_qs;
+  logic [11:0] count_drop_rx_endpoints_qs;
+  logic [11:0] count_drop_rx_endpoints_wd;
+  logic count_drop_rx_rst_wd;
+  logic count_datatog_out_re;
+  logic count_datatog_out_we;
+  logic [15:0] count_datatog_out_count_qs;
+  logic [11:0] count_datatog_out_endpoints_qs;
+  logic [11:0] count_datatog_out_endpoints_wd;
+  logic count_datatog_out_rst_wd;
+  logic count_timeout_in_re;
+  logic count_timeout_in_we;
+  logic [15:0] count_timeout_in_count_qs;
+  logic [11:0] count_timeout_in_endpoints_qs;
+  logic [11:0] count_timeout_in_endpoints_wd;
+  logic count_timeout_in_rst_wd;
+  logic count_nak_in_re;
+  logic count_nak_in_we;
+  logic [15:0] count_nak_in_count_qs;
+  logic [11:0] count_nak_in_endpoints_qs;
+  logic [11:0] count_nak_in_endpoints_wd;
+  logic count_nak_in_rst_wd;
+  logic count_nodata_in0_re;
+  logic count_nodata_in0_we;
+  logic [15:0] count_nodata_in0_count_qs;
+  logic [11:0] count_nodata_in0_endpoints_qs;
+  logic [11:0] count_nodata_in0_endpoints_wd;
+  logic count_nodata_in0_rst_wd;
+  logic count_nodata_in1_re;
+  logic count_nodata_in1_we;
+  logic [15:0] count_nodata_in1_count_qs;
+  logic [11:0] count_nodata_in1_endpoints_qs;
+  logic [11:0] count_nodata_in1_endpoints_wd;
+  logic count_nodata_in1_rst_wd;
+  logic count_crc5_out_re;
+  logic count_crc5_out_we;
+  logic [15:0] count_crc5_out_count_qs;
+  logic count_crc5_out_enable_qs;
+  logic count_crc5_out_enable_wd;
+  logic count_crc5_out_rst_wd;
+  logic count_crc16_out_re;
+  logic count_crc16_out_we;
+  logic [15:0] count_crc16_out_count_qs;
+  logic count_crc16_out_enable_qs;
+  logic count_crc16_out_enable_wd;
+  logic count_crc16_out_rst_wd;
+  logic count_bitstuff_re;
+  logic count_bitstuff_we;
+  logic [15:0] count_bitstuff_count_qs;
+  logic count_bitstuff_enable_qs;
+  logic count_bitstuff_enable_wd;
+  logic count_bitstuff_rst_wd;
+  logic count_pid_invalid_re;
+  logic count_pid_invalid_we;
+  logic [15:0] count_pid_invalid_count_qs;
+  logic count_pid_invalid_enable_qs;
+  logic count_pid_invalid_enable_wd;
+  logic count_pid_invalid_rst_wd;
   // Define register CDC handling.
   // CDC handling is done on a per-reg instead of per-field boundary.
 
@@ -8293,8 +8365,668 @@ module usbdev_reg_top (
   assign reg2hw.fifo_ctrl.rx_rst.qe = fifo_ctrl_qe;
 
 
+  // R[count_ign_avsetup]: V(True)
+  logic count_ign_avsetup_qe;
+  logic [2:0] count_ign_avsetup_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_ign_avsetup_flds_we;
+  assign unused_count_ign_avsetup_flds_we = ^(count_ign_avsetup_flds_we & 3'h1);
+  assign count_ign_avsetup_qe = &(count_ign_avsetup_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_ign_avsetup_count (
+    .re     (count_ign_avsetup_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_ign_avsetup.count.d),
+    .qre    (),
+    .qe     (count_ign_avsetup_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_ign_avsetup_count_qs)
+  );
 
-  logic [38:0] addr_hit;
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_ign_avsetup_endpoints (
+    .re     (count_ign_avsetup_re),
+    .we     (count_ign_avsetup_we),
+    .wd     (count_ign_avsetup_endpoints_wd),
+    .d      (hw2reg.count_ign_avsetup.endpoints.d),
+    .qre    (),
+    .qe     (count_ign_avsetup_flds_we[1]),
+    .q      (reg2hw.count_ign_avsetup.endpoints.q),
+    .ds     (),
+    .qs     (count_ign_avsetup_endpoints_qs)
+  );
+  assign reg2hw.count_ign_avsetup.endpoints.qe = count_ign_avsetup_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_ign_avsetup_rst (
+    .re     (1'b0),
+    .we     (count_ign_avsetup_we),
+    .wd     (count_ign_avsetup_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_ign_avsetup_flds_we[2]),
+    .q      (reg2hw.count_ign_avsetup.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_ign_avsetup.rst.qe = count_ign_avsetup_qe;
+
+
+  // R[count_drop_avout]: V(True)
+  logic count_drop_avout_qe;
+  logic [2:0] count_drop_avout_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_drop_avout_flds_we;
+  assign unused_count_drop_avout_flds_we = ^(count_drop_avout_flds_we & 3'h1);
+  assign count_drop_avout_qe = &(count_drop_avout_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_drop_avout_count (
+    .re     (count_drop_avout_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_drop_avout.count.d),
+    .qre    (),
+    .qe     (count_drop_avout_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_drop_avout_count_qs)
+  );
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_drop_avout_endpoints (
+    .re     (count_drop_avout_re),
+    .we     (count_drop_avout_we),
+    .wd     (count_drop_avout_endpoints_wd),
+    .d      (hw2reg.count_drop_avout.endpoints.d),
+    .qre    (),
+    .qe     (count_drop_avout_flds_we[1]),
+    .q      (reg2hw.count_drop_avout.endpoints.q),
+    .ds     (),
+    .qs     (count_drop_avout_endpoints_qs)
+  );
+  assign reg2hw.count_drop_avout.endpoints.qe = count_drop_avout_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_drop_avout_rst (
+    .re     (1'b0),
+    .we     (count_drop_avout_we),
+    .wd     (count_drop_avout_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_drop_avout_flds_we[2]),
+    .q      (reg2hw.count_drop_avout.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_drop_avout.rst.qe = count_drop_avout_qe;
+
+
+  // R[count_drop_rx]: V(True)
+  logic count_drop_rx_qe;
+  logic [2:0] count_drop_rx_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_drop_rx_flds_we;
+  assign unused_count_drop_rx_flds_we = ^(count_drop_rx_flds_we & 3'h1);
+  assign count_drop_rx_qe = &(count_drop_rx_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_drop_rx_count (
+    .re     (count_drop_rx_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_drop_rx.count.d),
+    .qre    (),
+    .qe     (count_drop_rx_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_drop_rx_count_qs)
+  );
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_drop_rx_endpoints (
+    .re     (count_drop_rx_re),
+    .we     (count_drop_rx_we),
+    .wd     (count_drop_rx_endpoints_wd),
+    .d      (hw2reg.count_drop_rx.endpoints.d),
+    .qre    (),
+    .qe     (count_drop_rx_flds_we[1]),
+    .q      (reg2hw.count_drop_rx.endpoints.q),
+    .ds     (),
+    .qs     (count_drop_rx_endpoints_qs)
+  );
+  assign reg2hw.count_drop_rx.endpoints.qe = count_drop_rx_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_drop_rx_rst (
+    .re     (1'b0),
+    .we     (count_drop_rx_we),
+    .wd     (count_drop_rx_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_drop_rx_flds_we[2]),
+    .q      (reg2hw.count_drop_rx.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_drop_rx.rst.qe = count_drop_rx_qe;
+
+
+  // R[count_datatog_out]: V(True)
+  logic count_datatog_out_qe;
+  logic [2:0] count_datatog_out_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_datatog_out_flds_we;
+  assign unused_count_datatog_out_flds_we = ^(count_datatog_out_flds_we & 3'h1);
+  assign count_datatog_out_qe = &(count_datatog_out_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_datatog_out_count (
+    .re     (count_datatog_out_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_datatog_out.count.d),
+    .qre    (),
+    .qe     (count_datatog_out_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_datatog_out_count_qs)
+  );
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_datatog_out_endpoints (
+    .re     (count_datatog_out_re),
+    .we     (count_datatog_out_we),
+    .wd     (count_datatog_out_endpoints_wd),
+    .d      (hw2reg.count_datatog_out.endpoints.d),
+    .qre    (),
+    .qe     (count_datatog_out_flds_we[1]),
+    .q      (reg2hw.count_datatog_out.endpoints.q),
+    .ds     (),
+    .qs     (count_datatog_out_endpoints_qs)
+  );
+  assign reg2hw.count_datatog_out.endpoints.qe = count_datatog_out_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_datatog_out_rst (
+    .re     (1'b0),
+    .we     (count_datatog_out_we),
+    .wd     (count_datatog_out_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_datatog_out_flds_we[2]),
+    .q      (reg2hw.count_datatog_out.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_datatog_out.rst.qe = count_datatog_out_qe;
+
+
+  // R[count_timeout_in]: V(True)
+  logic count_timeout_in_qe;
+  logic [2:0] count_timeout_in_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_timeout_in_flds_we;
+  assign unused_count_timeout_in_flds_we = ^(count_timeout_in_flds_we & 3'h1);
+  assign count_timeout_in_qe = &(count_timeout_in_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_timeout_in_count (
+    .re     (count_timeout_in_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_timeout_in.count.d),
+    .qre    (),
+    .qe     (count_timeout_in_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_timeout_in_count_qs)
+  );
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_timeout_in_endpoints (
+    .re     (count_timeout_in_re),
+    .we     (count_timeout_in_we),
+    .wd     (count_timeout_in_endpoints_wd),
+    .d      (hw2reg.count_timeout_in.endpoints.d),
+    .qre    (),
+    .qe     (count_timeout_in_flds_we[1]),
+    .q      (reg2hw.count_timeout_in.endpoints.q),
+    .ds     (),
+    .qs     (count_timeout_in_endpoints_qs)
+  );
+  assign reg2hw.count_timeout_in.endpoints.qe = count_timeout_in_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_timeout_in_rst (
+    .re     (1'b0),
+    .we     (count_timeout_in_we),
+    .wd     (count_timeout_in_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_timeout_in_flds_we[2]),
+    .q      (reg2hw.count_timeout_in.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_timeout_in.rst.qe = count_timeout_in_qe;
+
+
+  // R[count_nak_in]: V(True)
+  logic count_nak_in_qe;
+  logic [2:0] count_nak_in_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_nak_in_flds_we;
+  assign unused_count_nak_in_flds_we = ^(count_nak_in_flds_we & 3'h1);
+  assign count_nak_in_qe = &(count_nak_in_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_nak_in_count (
+    .re     (count_nak_in_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_nak_in.count.d),
+    .qre    (),
+    .qe     (count_nak_in_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_nak_in_count_qs)
+  );
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_nak_in_endpoints (
+    .re     (count_nak_in_re),
+    .we     (count_nak_in_we),
+    .wd     (count_nak_in_endpoints_wd),
+    .d      (hw2reg.count_nak_in.endpoints.d),
+    .qre    (),
+    .qe     (count_nak_in_flds_we[1]),
+    .q      (reg2hw.count_nak_in.endpoints.q),
+    .ds     (),
+    .qs     (count_nak_in_endpoints_qs)
+  );
+  assign reg2hw.count_nak_in.endpoints.qe = count_nak_in_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_nak_in_rst (
+    .re     (1'b0),
+    .we     (count_nak_in_we),
+    .wd     (count_nak_in_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_nak_in_flds_we[2]),
+    .q      (reg2hw.count_nak_in.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_nak_in.rst.qe = count_nak_in_qe;
+
+
+  // R[count_nodata_in0]: V(True)
+  logic count_nodata_in0_qe;
+  logic [2:0] count_nodata_in0_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_nodata_in0_flds_we;
+  assign unused_count_nodata_in0_flds_we = ^(count_nodata_in0_flds_we & 3'h1);
+  assign count_nodata_in0_qe = &(count_nodata_in0_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_nodata_in0_count (
+    .re     (count_nodata_in0_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_nodata_in0.count.d),
+    .qre    (),
+    .qe     (count_nodata_in0_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_nodata_in0_count_qs)
+  );
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_nodata_in0_endpoints (
+    .re     (count_nodata_in0_re),
+    .we     (count_nodata_in0_we),
+    .wd     (count_nodata_in0_endpoints_wd),
+    .d      (hw2reg.count_nodata_in0.endpoints.d),
+    .qre    (),
+    .qe     (count_nodata_in0_flds_we[1]),
+    .q      (reg2hw.count_nodata_in0.endpoints.q),
+    .ds     (),
+    .qs     (count_nodata_in0_endpoints_qs)
+  );
+  assign reg2hw.count_nodata_in0.endpoints.qe = count_nodata_in0_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_nodata_in0_rst (
+    .re     (1'b0),
+    .we     (count_nodata_in0_we),
+    .wd     (count_nodata_in0_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_nodata_in0_flds_we[2]),
+    .q      (reg2hw.count_nodata_in0.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_nodata_in0.rst.qe = count_nodata_in0_qe;
+
+
+  // R[count_nodata_in1]: V(True)
+  logic count_nodata_in1_qe;
+  logic [2:0] count_nodata_in1_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_nodata_in1_flds_we;
+  assign unused_count_nodata_in1_flds_we = ^(count_nodata_in1_flds_we & 3'h1);
+  assign count_nodata_in1_qe = &(count_nodata_in1_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_nodata_in1_count (
+    .re     (count_nodata_in1_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_nodata_in1.count.d),
+    .qre    (),
+    .qe     (count_nodata_in1_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_nodata_in1_count_qs)
+  );
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_nodata_in1_endpoints (
+    .re     (count_nodata_in1_re),
+    .we     (count_nodata_in1_we),
+    .wd     (count_nodata_in1_endpoints_wd),
+    .d      (hw2reg.count_nodata_in1.endpoints.d),
+    .qre    (),
+    .qe     (count_nodata_in1_flds_we[1]),
+    .q      (reg2hw.count_nodata_in1.endpoints.q),
+    .ds     (),
+    .qs     (count_nodata_in1_endpoints_qs)
+  );
+  assign reg2hw.count_nodata_in1.endpoints.qe = count_nodata_in1_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_nodata_in1_rst (
+    .re     (1'b0),
+    .we     (count_nodata_in1_we),
+    .wd     (count_nodata_in1_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_nodata_in1_flds_we[2]),
+    .q      (reg2hw.count_nodata_in1.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_nodata_in1.rst.qe = count_nodata_in1_qe;
+
+
+  // R[count_crc5_out]: V(True)
+  logic count_crc5_out_qe;
+  logic [2:0] count_crc5_out_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_crc5_out_flds_we;
+  assign unused_count_crc5_out_flds_we = ^(count_crc5_out_flds_we & 3'h1);
+  assign count_crc5_out_qe = &(count_crc5_out_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_crc5_out_count (
+    .re     (count_crc5_out_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_crc5_out.count.d),
+    .qre    (),
+    .qe     (count_crc5_out_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_crc5_out_count_qs)
+  );
+
+  //   F[enable]: 30:30
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_crc5_out_enable (
+    .re     (count_crc5_out_re),
+    .we     (count_crc5_out_we),
+    .wd     (count_crc5_out_enable_wd),
+    .d      (hw2reg.count_crc5_out.enable.d),
+    .qre    (),
+    .qe     (count_crc5_out_flds_we[1]),
+    .q      (reg2hw.count_crc5_out.enable.q),
+    .ds     (),
+    .qs     (count_crc5_out_enable_qs)
+  );
+  assign reg2hw.count_crc5_out.enable.qe = count_crc5_out_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_crc5_out_rst (
+    .re     (1'b0),
+    .we     (count_crc5_out_we),
+    .wd     (count_crc5_out_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_crc5_out_flds_we[2]),
+    .q      (reg2hw.count_crc5_out.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_crc5_out.rst.qe = count_crc5_out_qe;
+
+
+  // R[count_crc16_out]: V(True)
+  logic count_crc16_out_qe;
+  logic [2:0] count_crc16_out_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_crc16_out_flds_we;
+  assign unused_count_crc16_out_flds_we = ^(count_crc16_out_flds_we & 3'h1);
+  assign count_crc16_out_qe = &(count_crc16_out_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_crc16_out_count (
+    .re     (count_crc16_out_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_crc16_out.count.d),
+    .qre    (),
+    .qe     (count_crc16_out_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_crc16_out_count_qs)
+  );
+
+  //   F[enable]: 30:30
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_crc16_out_enable (
+    .re     (count_crc16_out_re),
+    .we     (count_crc16_out_we),
+    .wd     (count_crc16_out_enable_wd),
+    .d      (hw2reg.count_crc16_out.enable.d),
+    .qre    (),
+    .qe     (count_crc16_out_flds_we[1]),
+    .q      (reg2hw.count_crc16_out.enable.q),
+    .ds     (),
+    .qs     (count_crc16_out_enable_qs)
+  );
+  assign reg2hw.count_crc16_out.enable.qe = count_crc16_out_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_crc16_out_rst (
+    .re     (1'b0),
+    .we     (count_crc16_out_we),
+    .wd     (count_crc16_out_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_crc16_out_flds_we[2]),
+    .q      (reg2hw.count_crc16_out.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_crc16_out.rst.qe = count_crc16_out_qe;
+
+
+  // R[count_bitstuff]: V(True)
+  logic count_bitstuff_qe;
+  logic [2:0] count_bitstuff_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_bitstuff_flds_we;
+  assign unused_count_bitstuff_flds_we = ^(count_bitstuff_flds_we & 3'h1);
+  assign count_bitstuff_qe = &(count_bitstuff_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_bitstuff_count (
+    .re     (count_bitstuff_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_bitstuff.count.d),
+    .qre    (),
+    .qe     (count_bitstuff_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_bitstuff_count_qs)
+  );
+
+  //   F[enable]: 30:30
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_bitstuff_enable (
+    .re     (count_bitstuff_re),
+    .we     (count_bitstuff_we),
+    .wd     (count_bitstuff_enable_wd),
+    .d      (hw2reg.count_bitstuff.enable.d),
+    .qre    (),
+    .qe     (count_bitstuff_flds_we[1]),
+    .q      (reg2hw.count_bitstuff.enable.q),
+    .ds     (),
+    .qs     (count_bitstuff_enable_qs)
+  );
+  assign reg2hw.count_bitstuff.enable.qe = count_bitstuff_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_bitstuff_rst (
+    .re     (1'b0),
+    .we     (count_bitstuff_we),
+    .wd     (count_bitstuff_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_bitstuff_flds_we[2]),
+    .q      (reg2hw.count_bitstuff.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_bitstuff.rst.qe = count_bitstuff_qe;
+
+
+  // R[count_pid_invalid]: V(True)
+  logic count_pid_invalid_qe;
+  logic [2:0] count_pid_invalid_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_pid_invalid_flds_we;
+  assign unused_count_pid_invalid_flds_we = ^(count_pid_invalid_flds_we & 3'h1);
+  assign count_pid_invalid_qe = &(count_pid_invalid_flds_we | 3'h1);
+  //   F[count]: 15:0
+  prim_subreg_ext #(
+    .DW    (16)
+  ) u_count_pid_invalid_count (
+    .re     (count_pid_invalid_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_pid_invalid.count.d),
+    .qre    (),
+    .qe     (count_pid_invalid_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_pid_invalid_count_qs)
+  );
+
+  //   F[enable]: 30:30
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_pid_invalid_enable (
+    .re     (count_pid_invalid_re),
+    .we     (count_pid_invalid_we),
+    .wd     (count_pid_invalid_enable_wd),
+    .d      (hw2reg.count_pid_invalid.enable.d),
+    .qre    (),
+    .qe     (count_pid_invalid_flds_we[1]),
+    .q      (reg2hw.count_pid_invalid.enable.q),
+    .ds     (),
+    .qs     (count_pid_invalid_enable_qs)
+  );
+  assign reg2hw.count_pid_invalid.enable.qe = count_pid_invalid_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_pid_invalid_rst (
+    .re     (1'b0),
+    .we     (count_pid_invalid_we),
+    .wd     (count_pid_invalid_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_pid_invalid_flds_we[2]),
+    .q      (reg2hw.count_pid_invalid.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_pid_invalid.rst.qe = count_pid_invalid_qe;
+
+
+
+  logic [50:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == USBDEV_INTR_STATE_OFFSET);
@@ -8336,6 +9068,18 @@ module usbdev_reg_top (
     addr_hit[36] = (reg_addr == USBDEV_WAKE_CONTROL_OFFSET);
     addr_hit[37] = (reg_addr == USBDEV_WAKE_EVENTS_OFFSET);
     addr_hit[38] = (reg_addr == USBDEV_FIFO_CTRL_OFFSET);
+    addr_hit[39] = (reg_addr == USBDEV_COUNT_IGN_AVSETUP_OFFSET);
+    addr_hit[40] = (reg_addr == USBDEV_COUNT_DROP_AVOUT_OFFSET);
+    addr_hit[41] = (reg_addr == USBDEV_COUNT_DROP_RX_OFFSET);
+    addr_hit[42] = (reg_addr == USBDEV_COUNT_DATATOG_OUT_OFFSET);
+    addr_hit[43] = (reg_addr == USBDEV_COUNT_TIMEOUT_IN_OFFSET);
+    addr_hit[44] = (reg_addr == USBDEV_COUNT_NAK_IN_OFFSET);
+    addr_hit[45] = (reg_addr == USBDEV_COUNT_NODATA_IN0_OFFSET);
+    addr_hit[46] = (reg_addr == USBDEV_COUNT_NODATA_IN1_OFFSET);
+    addr_hit[47] = (reg_addr == USBDEV_COUNT_CRC5_OUT_OFFSET);
+    addr_hit[48] = (reg_addr == USBDEV_COUNT_CRC16_OUT_OFFSET);
+    addr_hit[49] = (reg_addr == USBDEV_COUNT_BITSTUFF_OFFSET);
+    addr_hit[50] = (reg_addr == USBDEV_COUNT_PID_INVALID_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -8381,7 +9125,19 @@ module usbdev_reg_top (
                (addr_hit[35] & (|(USBDEV_PERMIT[35] & ~reg_be))) |
                (addr_hit[36] & (|(USBDEV_PERMIT[36] & ~reg_be))) |
                (addr_hit[37] & (|(USBDEV_PERMIT[37] & ~reg_be))) |
-               (addr_hit[38] & (|(USBDEV_PERMIT[38] & ~reg_be)))));
+               (addr_hit[38] & (|(USBDEV_PERMIT[38] & ~reg_be))) |
+               (addr_hit[39] & (|(USBDEV_PERMIT[39] & ~reg_be))) |
+               (addr_hit[40] & (|(USBDEV_PERMIT[40] & ~reg_be))) |
+               (addr_hit[41] & (|(USBDEV_PERMIT[41] & ~reg_be))) |
+               (addr_hit[42] & (|(USBDEV_PERMIT[42] & ~reg_be))) |
+               (addr_hit[43] & (|(USBDEV_PERMIT[43] & ~reg_be))) |
+               (addr_hit[44] & (|(USBDEV_PERMIT[44] & ~reg_be))) |
+               (addr_hit[45] & (|(USBDEV_PERMIT[45] & ~reg_be))) |
+               (addr_hit[46] & (|(USBDEV_PERMIT[46] & ~reg_be))) |
+               (addr_hit[47] & (|(USBDEV_PERMIT[47] & ~reg_be))) |
+               (addr_hit[48] & (|(USBDEV_PERMIT[48] & ~reg_be))) |
+               (addr_hit[49] & (|(USBDEV_PERMIT[49] & ~reg_be))) |
+               (addr_hit[50] & (|(USBDEV_PERMIT[50] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -8941,6 +9697,78 @@ module usbdev_reg_top (
   assign fifo_ctrl_avsetup_rst_wd = reg_wdata[1];
 
   assign fifo_ctrl_rx_rst_wd = reg_wdata[2];
+  assign count_ign_avsetup_re = addr_hit[39] & reg_re & !reg_error;
+  assign count_ign_avsetup_we = addr_hit[39] & reg_we & !reg_error;
+
+  assign count_ign_avsetup_endpoints_wd = reg_wdata[27:16];
+
+  assign count_ign_avsetup_rst_wd = reg_wdata[31];
+  assign count_drop_avout_re = addr_hit[40] & reg_re & !reg_error;
+  assign count_drop_avout_we = addr_hit[40] & reg_we & !reg_error;
+
+  assign count_drop_avout_endpoints_wd = reg_wdata[27:16];
+
+  assign count_drop_avout_rst_wd = reg_wdata[31];
+  assign count_drop_rx_re = addr_hit[41] & reg_re & !reg_error;
+  assign count_drop_rx_we = addr_hit[41] & reg_we & !reg_error;
+
+  assign count_drop_rx_endpoints_wd = reg_wdata[27:16];
+
+  assign count_drop_rx_rst_wd = reg_wdata[31];
+  assign count_datatog_out_re = addr_hit[42] & reg_re & !reg_error;
+  assign count_datatog_out_we = addr_hit[42] & reg_we & !reg_error;
+
+  assign count_datatog_out_endpoints_wd = reg_wdata[27:16];
+
+  assign count_datatog_out_rst_wd = reg_wdata[31];
+  assign count_timeout_in_re = addr_hit[43] & reg_re & !reg_error;
+  assign count_timeout_in_we = addr_hit[43] & reg_we & !reg_error;
+
+  assign count_timeout_in_endpoints_wd = reg_wdata[27:16];
+
+  assign count_timeout_in_rst_wd = reg_wdata[31];
+  assign count_nak_in_re = addr_hit[44] & reg_re & !reg_error;
+  assign count_nak_in_we = addr_hit[44] & reg_we & !reg_error;
+
+  assign count_nak_in_endpoints_wd = reg_wdata[27:16];
+
+  assign count_nak_in_rst_wd = reg_wdata[31];
+  assign count_nodata_in0_re = addr_hit[45] & reg_re & !reg_error;
+  assign count_nodata_in0_we = addr_hit[45] & reg_we & !reg_error;
+
+  assign count_nodata_in0_endpoints_wd = reg_wdata[27:16];
+
+  assign count_nodata_in0_rst_wd = reg_wdata[31];
+  assign count_nodata_in1_re = addr_hit[46] & reg_re & !reg_error;
+  assign count_nodata_in1_we = addr_hit[46] & reg_we & !reg_error;
+
+  assign count_nodata_in1_endpoints_wd = reg_wdata[27:16];
+
+  assign count_nodata_in1_rst_wd = reg_wdata[31];
+  assign count_crc5_out_re = addr_hit[47] & reg_re & !reg_error;
+  assign count_crc5_out_we = addr_hit[47] & reg_we & !reg_error;
+
+  assign count_crc5_out_enable_wd = reg_wdata[30];
+
+  assign count_crc5_out_rst_wd = reg_wdata[31];
+  assign count_crc16_out_re = addr_hit[48] & reg_re & !reg_error;
+  assign count_crc16_out_we = addr_hit[48] & reg_we & !reg_error;
+
+  assign count_crc16_out_enable_wd = reg_wdata[30];
+
+  assign count_crc16_out_rst_wd = reg_wdata[31];
+  assign count_bitstuff_re = addr_hit[49] & reg_re & !reg_error;
+  assign count_bitstuff_we = addr_hit[49] & reg_we & !reg_error;
+
+  assign count_bitstuff_enable_wd = reg_wdata[30];
+
+  assign count_bitstuff_rst_wd = reg_wdata[31];
+  assign count_pid_invalid_re = addr_hit[50] & reg_re & !reg_error;
+  assign count_pid_invalid_we = addr_hit[50] & reg_we & !reg_error;
+
+  assign count_pid_invalid_enable_wd = reg_wdata[30];
+
+  assign count_pid_invalid_rst_wd = reg_wdata[31];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -8984,6 +9812,18 @@ module usbdev_reg_top (
     reg_we_check[36] = wake_control_we;
     reg_we_check[37] = 1'b0;
     reg_we_check[38] = fifo_ctrl_we;
+    reg_we_check[39] = count_ign_avsetup_we;
+    reg_we_check[40] = count_drop_avout_we;
+    reg_we_check[41] = count_drop_rx_we;
+    reg_we_check[42] = count_datatog_out_we;
+    reg_we_check[43] = count_timeout_in_we;
+    reg_we_check[44] = count_nak_in_we;
+    reg_we_check[45] = count_nodata_in0_we;
+    reg_we_check[46] = count_nodata_in1_we;
+    reg_we_check[47] = count_crc5_out_we;
+    reg_we_check[48] = count_crc16_out_we;
+    reg_we_check[49] = count_bitstuff_we;
+    reg_we_check[50] = count_pid_invalid_we;
   end
 
   // Read data return
@@ -9390,6 +10230,78 @@ module usbdev_reg_top (
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
+      end
+
+      addr_hit[39]: begin
+        reg_rdata_next[15:0] = count_ign_avsetup_count_qs;
+        reg_rdata_next[27:16] = count_ign_avsetup_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[40]: begin
+        reg_rdata_next[15:0] = count_drop_avout_count_qs;
+        reg_rdata_next[27:16] = count_drop_avout_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[41]: begin
+        reg_rdata_next[15:0] = count_drop_rx_count_qs;
+        reg_rdata_next[27:16] = count_drop_rx_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[42]: begin
+        reg_rdata_next[15:0] = count_datatog_out_count_qs;
+        reg_rdata_next[27:16] = count_datatog_out_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[43]: begin
+        reg_rdata_next[15:0] = count_timeout_in_count_qs;
+        reg_rdata_next[27:16] = count_timeout_in_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[44]: begin
+        reg_rdata_next[15:0] = count_nak_in_count_qs;
+        reg_rdata_next[27:16] = count_nak_in_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[45]: begin
+        reg_rdata_next[15:0] = count_nodata_in0_count_qs;
+        reg_rdata_next[27:16] = count_nodata_in0_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[46]: begin
+        reg_rdata_next[15:0] = count_nodata_in1_count_qs;
+        reg_rdata_next[27:16] = count_nodata_in1_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[47]: begin
+        reg_rdata_next[15:0] = count_crc5_out_count_qs;
+        reg_rdata_next[30] = count_crc5_out_enable_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[48]: begin
+        reg_rdata_next[15:0] = count_crc16_out_count_qs;
+        reg_rdata_next[30] = count_crc16_out_enable_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[49]: begin
+        reg_rdata_next[15:0] = count_bitstuff_count_qs;
+        reg_rdata_next[30] = count_bitstuff_enable_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[50]: begin
+        reg_rdata_next[15:0] = count_pid_invalid_count_qs;
+        reg_rdata_next[30] = count_pid_invalid_enable_qs;
+        reg_rdata_next[31] = '0;
       end
 
       default: begin

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -20,6 +20,7 @@ filesets:
       - rtl/usbdev_usbif.sv
       - rtl/usbdev_linkstate.sv
       - rtl/usbdev_iomux.sv
+      - rtl/usbdev_counter.sv
       - rtl/usbdev_aon_wake.sv
       - rtl/usbdev.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This ~~draft~~ PR proposes a specification for a set of diagnostic/performance monitoring event counters as discussed in #13316.

These would be purely passive monitors/counters that do not modify the behavior of the existing logic.

- Many of the counters may be enabled/disabled on a per-endpoint basis, given software more fine-grained control of the events that it wishes to monitor.
- All counters saturate at their maximum values and remain there until reset (IP block reset or software reset via bit 31 of the counter register itself).
- An explicit enable is provided for those event counters that cannot be enabled/disabled on a per-endpoint basis, where per-endpoint counting is not meaningful/useful.
- CRC5 errors and CRC16 errors are separated, because when there is a significant frequency delta between the host and the device, it is anticipated that Invalid PID and CRC5 errors may be observed. When the delta is smaller, longer packets will be required in order to demonstrate communication problems; CRC16 errors may be observed on long packets whilst Invalid PID and CRC5 errors are not observed.
- Counting of timed out IN transactions is performed, separately from host NAK responses to IN traffic.
- Counting of attempted OUT transactions with mismatched Data Toggles are counted; these are taken, according to the specification, to be retransmissions of earlier packets, but there may be causes other than a missed handshake response leading to a resend.
- The register fields have been specified to permit the endpoint set to be changed over time, whilst the counters are operating, allowing them to be switched among multiple endpoints/pipes.

~~This PR has been created to discuss whether the set of event counters is appropriate, and whether implementation should proceed.~~ These are not considered an essential feature for production Si, although verification/testing of frequency tracking is limited at this stage, not being open sourced.