### PR TITLE
[boot_svc] Add unlock and activate ownership commands]

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -119,6 +119,8 @@ cc_library(
         ":boot_svc_header",
         ":boot_svc_min_bl0_sec_ver",
         ":boot_svc_next_boot_bl0_slot",
+        ":boot_svc_ownership_activate",
+        ":boot_svc_ownership_unlock",
         ":boot_svc_primary_bl0_slot",
         "//sw/device/lib/base:macros",
     ],
@@ -141,6 +143,56 @@ cc_test(
     srcs = ["boot_svc_next_boot_bl0_slot_unittest.cc"],
     deps = [
         ":boot_svc_next_boot_bl0_slot",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "boot_svc_ownership_unlock",
+    srcs = ["boot_svc_ownership_unlock.c"],
+    hdrs = ["boot_svc_ownership_unlock.h"],
+    deps = [
+        ":boot_svc_header",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:nonce",
+        "//sw/device/silicon_creator/lib/base:chip",
+        "//sw/device/silicon_creator/lib/ownership:datatypes",
+    ],
+)
+
+cc_test(
+    name = "boot_svc_ownership_unlock_unittest",
+    srcs = ["boot_svc_ownership_unlock_unittest.cc"],
+    deps = [
+        ":boot_svc_ownership_unlock",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "boot_svc_ownership_activate",
+    srcs = ["boot_svc_ownership_activate.c"],
+    hdrs = ["boot_svc_ownership_activate.h"],
+    deps = [
+        ":boot_svc_header",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:nonce",
+        "//sw/device/silicon_creator/lib/base:chip",
+        "//sw/device/silicon_creator/lib/ownership:datatypes",
+    ],
+)
+
+cc_test(
+    name = "boot_svc_ownership_activate_unittest",
+    srcs = ["boot_svc_ownership_activate_unittest.cc"],
+    deps = [
+        ":boot_svc_ownership_activate",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h
@@ -10,6 +10,8 @@
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.h"
 
 #ifdef __cplusplus
@@ -43,7 +45,17 @@ extern "C" {
    * Set Primary BL0 Slot request and response.
    */ \
   X(boot_svc_primary_bl0_slot_req_t, primary_bl0_slot_req) \
-  X(boot_svc_primary_bl0_slot_res_t, primary_bl0_slot_res)
+  X(boot_svc_primary_bl0_slot_res_t, primary_bl0_slot_res) \
+  /**
+   * Ownership Activate
+   */ \
+  X(boot_svc_ownership_activate_req_t, ownership_activate_req) \
+  X(boot_svc_ownership_activate_res_t, ownership_activate_res) \
+  /**
+   * Ownership Unlock
+   */ \
+  X(boot_svc_ownership_unlock_req_t, ownership_unlock_req) \
+  X(boot_svc_ownership_unlock_res_t, ownership_unlock_res)
 // clang-format on
 
 /**

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.c
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+void boot_svc_ownership_activate_req_init(
+    uint32_t primary_bl0_slot, uint32_t erase_previous, nonce_t nonce,
+    const owner_signature_t *signature,
+    boot_svc_ownership_activate_req_t *msg) {
+  msg->primary_bl0_slot = primary_bl0_slot;
+  msg->erase_previous = erase_previous;
+  memset(msg->reserved, 0, sizeof(msg->reserved));
+  msg->nonce = nonce;
+  msg->signature = *signature;
+  boot_svc_header_finalize(kBootSvcOwnershipActivateReqType,
+                           sizeof(boot_svc_ownership_activate_req_t),
+                           &msg->header);
+}
+
+void boot_svc_ownership_activate_res_init(
+    rom_error_t status, boot_svc_ownership_activate_res_t *msg) {
+  msg->status = status;
+  boot_svc_header_finalize(kBootSvcOwnershipActivateResType,
+                           sizeof(boot_svc_ownership_activate_res_t),
+                           &msg->header);
+}

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_OWNERSHIP_ACTIVATE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_OWNERSHIP_ACTIVATE_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/nonce.h"
+#include "sw/device/silicon_creator/lib/ownership/datatypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  // ASCII: AORQ.
+  kBootSvcOwnershipActivateReqType = 0x51524f41,
+  // ASCII: AORS.
+  kBootSvcOwnershipActivateResType = 0x53524f41,
+};
+
+/**
+ * An Ownership Activate request.
+ */
+typedef struct boot_svc_ownership_activate_req {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * Which side of the flash is primary after activation.
+   */
+  uint32_t primary_bl0_slot;
+  /**
+   * Erase previous owner's flash (hardened_bool_t).
+   */
+  uint32_t erase_previous;
+  /**
+   * Reserved for future use.
+   */
+  uint32_t reserved[33];
+  /**
+   * The current ownership nonce.
+   */
+  nonce_t nonce;
+  /**
+   * Signature over [primary_bl0_slot..nonce]
+   */
+  owner_signature_t signature;
+
+} boot_svc_ownership_activate_req_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, primary_bl0_slot,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, erase_previous,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 4);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, reserved,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 8);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, nonce,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 140);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, signature,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 148);
+OT_ASSERT_SIZE(boot_svc_ownership_activate_req_t, 256);
+
+/**
+ * An Ownership Activate response.
+ */
+typedef struct boot_svc_ownership_activate_res {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * Response status from the ROM_EXT.
+   */
+  rom_error_t status;
+} boot_svc_ownership_activate_res_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_res_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_res_t, status,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_SIZE(boot_svc_ownership_activate_res_t, 48);
+
+/**
+ * Initialize an ownership activate request.
+ *
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_ownership_activate_req_init(
+    uint32_t primary_bl0_slot, uint32_t erase_previous, nonce_t nonce,
+    const owner_signature_t *signature, boot_svc_ownership_activate_req_t *msg);
+
+/**
+ * Initialize an ownership activate response.
+ *
+ * @param status Reponse from the ROM_EXT after receiving the request.
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_ownership_activate_res_init(
+    rom_error_t status, boot_svc_ownership_activate_res_t *msg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_OWNERSHIP_ACTIVATE_H_

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate_unittest.cc
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h"
+
+#include <string.h>
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace boot_svc_ownership_activate_unittest {
+namespace {
+using ::testing::ElementsAreArray;
+
+class BootSvcOwnershipActivateTest : public rom_test::RomTest {
+ protected:
+  rom_test::MockBootSvcHeader boot_svc_header_;
+};
+
+TEST_F(BootSvcOwnershipActivateTest, ReqInit) {
+  boot_svc_ownership_activate_req_t msg{};
+  constexpr uint32_t primary_bl0_slot = 0;
+  constexpr uint32_t erase_previous = 1;
+  constexpr nonce_t nonce = {0x55555555, 0xAAAAAAAA};
+  constexpr owner_signature_t signature = {{100, 101, 102, 103, 104, 105, 106,
+                                            107, 108, 109, 110, 111, 112, 113,
+                                            114, 115}};
+  EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcOwnershipActivateReqType,
+                                         sizeof(msg), &msg.header));
+
+  boot_svc_ownership_activate_req_init(primary_bl0_slot, erase_previous, nonce,
+                                       &signature, &msg);
+
+  EXPECT_EQ(msg.primary_bl0_slot, primary_bl0_slot);
+  EXPECT_EQ(msg.erase_previous, erase_previous);
+  EXPECT_EQ(msg.nonce.value[0], nonce.value[0]);
+  EXPECT_EQ(msg.nonce.value[1], nonce.value[1]);
+  EXPECT_EQ(memcmp(&msg.signature, &signature, sizeof(signature)), 0);
+}
+
+TEST_F(BootSvcOwnershipActivateTest, ResInit) {
+  boot_svc_ownership_activate_res_t msg{};
+  constexpr rom_error_t kStatus = kErrorOk;
+  EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcOwnershipActivateResType,
+                                         sizeof(msg), &msg.header));
+
+  boot_svc_ownership_activate_res_init(kStatus, &msg);
+
+  EXPECT_EQ(msg.status, kStatus);
+}
+
+}  // namespace
+}  // namespace boot_svc_ownership_activate_unittest

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.c
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+void boot_svc_ownership_unlock_req_init(uint32_t unlock_mode, nonce_t nonce,
+                                        const owner_key_t *next_owner_key,
+                                        const owner_signature_t *signature,
+                                        boot_svc_ownership_unlock_req_t *msg) {
+  msg->unlock_mode = unlock_mode;
+  memset(msg->reserved, 0, sizeof(msg->reserved));
+  msg->nonce = nonce;
+  msg->next_owner_key = *next_owner_key;
+  msg->signature = *signature;
+  boot_svc_header_finalize(kBootSvcOwnershipUnlockReqType,
+                           sizeof(boot_svc_ownership_unlock_req_t),
+                           &msg->header);
+}
+
+void boot_svc_ownership_unlock_res_init(rom_error_t status,
+                                        boot_svc_ownership_unlock_res_t *msg) {
+  msg->status = status;
+  boot_svc_header_finalize(kBootSvcOwnershipUnlockResType,
+                           sizeof(boot_svc_ownership_unlock_res_t),
+                           &msg->header);
+}

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
@@ -1,0 +1,123 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_OWNERSHIP_UNLOCK_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_OWNERSHIP_UNLOCK_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/nonce.h"
+#include "sw/device/silicon_creator/lib/ownership/datatypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  // ASCII: ANY
+  kBootSvcUnlockAny = 0x00594e41,
+  // ASCII: ENDO
+  kBootSvcUnlockEndorsed = 0x4f444e45,
+  // ASCII: UPD
+  kBootSvcUnlockUpdate = 0x00445055,
+  // ASCII: ABRT
+  kBootSvcUnlockAbort = 0x54524241,
+
+  // ASCII: UNRQ.
+  kBootSvcOwnershipUnlockReqType = 0x51524e55,
+  // ASCII: UNRS.
+  kBootSvcOwnershipUnlockResType = 0x53524e55,
+};
+
+/**
+ * An ownership unlock request.
+ */
+typedef struct boot_svc_ownership_unlock_req {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * Unlock mode: Any, Endorsed, Update or Abort.
+   */
+  uint32_t unlock_mode;
+  /**
+   * Reserved for future use.
+   */
+  uint32_t reserved[18];
+  /**
+   * The current ownership nonce.
+   */
+  nonce_t nonce;
+  /**
+   * The public key of the next owner (for endorsed mode).
+   */
+  owner_key_t next_owner_key;
+  /**
+   * Signature over [unlock_mode..next_owner_key]
+   */
+  owner_signature_t signature;
+
+} boot_svc_ownership_unlock_req_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, unlock_mode,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, reserved,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 4);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, nonce,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 76);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, next_owner_key,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 84);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, signature,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 148);
+OT_ASSERT_SIZE(boot_svc_ownership_unlock_req_t, 256);
+
+/**
+ * An ownership unlock response.
+ */
+typedef struct boot_svc_ownership_unlock_res {
+  /**
+   * Boot services message header.
+   */
+  boot_svc_header_t header;
+  /**
+   * Response status from the ROM_EXT.
+   */
+  rom_error_t status;
+} boot_svc_ownership_unlock_res_t;
+
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_res_t, header, 0);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_res_t, status,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE);
+OT_ASSERT_SIZE(boot_svc_ownership_unlock_res_t, 48);
+
+/**
+ * Initialize an ownership unlock request.
+ *
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_ownership_unlock_req_init(uint32_t unlock_mode, nonce_t nonce,
+                                        const owner_key_t *next_owner_key,
+                                        const owner_signature_t *signature,
+                                        boot_svc_ownership_unlock_req_t *msg);
+
+/**
+ * Initialize an ownership unlock response.
+ *
+ * @param status Reponse from the ROM_EXT after receiving the request.
+ * @param[out] msg Output buffer for the message.
+ */
+void boot_svc_ownership_unlock_res_init(rom_error_t status,
+                                        boot_svc_ownership_unlock_res_t *msg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_SVC_BOOT_SVC_OWNERSHIP_UNLOCK_H_

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock_unittest.cc
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h"
+
+#include <string.h>
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace boot_svc_ownership_unlock_unittest {
+namespace {
+using ::testing::ElementsAreArray;
+
+class BootSvcOwnershipUnlockTest : public rom_test::RomTest {
+ protected:
+  rom_test::MockBootSvcHeader boot_svc_header_;
+};
+
+TEST_F(BootSvcOwnershipUnlockTest, ReqInit) {
+  boot_svc_ownership_unlock_req_t msg{};
+  constexpr uint32_t unlock_mode = kBootSvcUnlockAny;
+  constexpr nonce_t nonce = {0x55555555, 0xAAAAAAAA};
+  constexpr owner_key_t next_owner_key = {
+      {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}};
+  constexpr owner_signature_t signature = {{100, 101, 102, 103, 104, 105, 106,
+                                            107, 108, 109, 110, 111, 112, 113,
+                                            114, 115}};
+  EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcOwnershipUnlockReqType,
+                                         sizeof(msg), &msg.header));
+
+  boot_svc_ownership_unlock_req_init(unlock_mode, nonce, &next_owner_key,
+                                     &signature, &msg);
+
+  EXPECT_EQ(msg.unlock_mode, unlock_mode);
+  EXPECT_EQ(msg.nonce.value[0], nonce.value[0]);
+  EXPECT_EQ(msg.nonce.value[1], nonce.value[1]);
+  EXPECT_EQ(
+      memcmp(&msg.next_owner_key, &next_owner_key, sizeof(next_owner_key)), 0);
+  EXPECT_EQ(memcmp(&msg.signature, &signature, sizeof(signature)), 0);
+}
+
+TEST_F(BootSvcOwnershipUnlockTest, ResInit) {
+  boot_svc_ownership_unlock_res_t msg{};
+  constexpr rom_error_t kStatus = kErrorOk;
+  EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcOwnershipUnlockResType,
+                                         sizeof(msg), &msg.header));
+
+  boot_svc_ownership_unlock_res_init(kStatus, &msg);
+
+  EXPECT_EQ(msg.status, kStatus);
+}
+
+}  // namespace
+}  // namespace boot_svc_ownership_unlock_unittest

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "datatypes",
+    hdrs = ["datatypes.h"],
+)

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_DATATYPES_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_DATATYPES_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * An owner_key can be either a ECDSA P256 or SPX+ key.  The type of the key
+ * material will be determined by a separate field on the owner block
+ */
+typedef struct owner_key {
+  uint32_t key[16];
+} owner_key_t;
+
+/**
+ * An owner_signature is an ECDSA P256 signature.
+ */
+typedef struct owner_signature {
+  uint32_t signature[16];
+} owner_signature_t;
+
+/**
+ * The owner digest is a SHA256 digest.
+ *
+ * TODO(cfrantz): Unify this type with hmac_digest_t.
+ */
+typedef struct owner_digest {
+  uint32_t digest[8];
+} owner_digest_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_DATATYPES_H_


### PR DESCRIPTION
Add boot_svc command structures for the unlock and activate ownership commands.
