### PR TITLE
[otp_ctrl] Increase Hamming distance in OTP commands

### DIFF
--- a/hw/ip/otp_ctrl/doc/theory_of_operation.md
+++ b/hw/ip/otp_ctrl/doc/theory_of_operation.md
@@ -428,7 +428,7 @@ Parameter      | Default | Top Earlgrey  | Description
 ---------------|---------|---------------|---------------
 `Width`        | 16      | 16            | Native OTP word width.
 `Depth`        | 1024    | 1024          | Depth of OTP macro.
-`CmdWidth`     | 3       | 3             | Width of the OTP command.
+`CmdWidth`     | 7       | 7             | Width of the OTP command.
 `ErrWidth`     | 3       | 3             | Width of error code output signal.
 `PwrSeqWidth`  | 2       | 2             | Width of power sequencing signals to/from AST.
 `SizeWidth`    | 2       | 2             | Width of the size field.
@@ -459,7 +459,7 @@ Signal                  | Direction        | Type                        | Descr
 `ready_o`               | `output`         | `logic`                     | Ready signal for the command handshake.
 `valid_i`               | `input`          | `logic`                     | Valid signal for the command handshake.
 `size_i`                | `input`          | `logic [SizeWidth-1:0]`     | Number of native OTP words to transfer, minus one: `2'b00 = 1 native word` ... `2'b11 = 4 native words`.
-`cmd_i`                 | `input`          | `logic [CmdWidth-1:0]`      | OTP command: `3'b000 = read`, `3'b001 = write`, `3'b010 = read raw`, `3'b011 = write raw`,  `3'b111 = initialize`
+`cmd_i`                 | `input`          | `logic [CmdWidth-1:0]`      | OTP command: `7'b1000101 = read`, `7'b0110111 = write`, `7'b1111001 = read raw`, `7'b1100010 = write raw`,  `7'b0101100 = initialize`
 `addr_i`                | `input`          | `logic [$clog2(Depth)-1:0]` | OTP word address.
 `wdata_i`               | `input`          | `logic [IfWidth-1:0]`       | Write data for write commands.
 `valid_o`               | `output`         | `logic`                     | Valid signal for command response.

--- a/hw/ip/prim/rtl/prim_otp_pkg.sv
+++ b/hw/ip/prim/rtl/prim_otp_pkg.sv
@@ -6,16 +6,37 @@
 
 package prim_otp_pkg;
 
-  parameter int CmdWidth = 3;
+  // The command is sparsely encoded to make it more difficult to tamper with.
+  parameter int CmdWidth = 7;
   parameter int ErrWidth = 3;
 
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 4 -m 5 -n 7 \
+  //     -s 696743973 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: --
+  //  4: |||||||||||||||||||| (100.00%)
+  //  5: --
+  //  6: --
+  //  7: --
+  //
+  // Minimum Hamming distance: 4
+  // Maximum Hamming distance: 4
+  // Minimum Hamming weight: 3
+  // Maximum Hamming weight: 5
+  //
   typedef enum logic [CmdWidth-1:0] {
-    Read     = 3'b000,
-    Write    = 3'b001,
+    Read     = 7'b1000101,
+    Write    = 7'b0110111,
     // Raw commands ignore integrity
-    ReadRaw  = 3'b010,
-    WriteRaw = 3'b011,
-    Init     = 3'b111
+    ReadRaw  = 7'b1111001,
+    WriteRaw = 7'b1100010,
+    Init     = 7'b0101100
   } cmd_e;
 
   typedef enum logic [ErrWidth-1:0] {

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -54,7 +54,7 @@ module prim_generic_otp
   input                          valid_i,
   // #(Native words)-1, e.g. size == 0 for 1 native word.
   input [SizeWidth-1:0]          size_i,
-  // 000: read, 001: write, 010: read raw, 011: write raw, 111: init
+  // See prim_otp_pkg for the command encoding.
   input  cmd_e                   cmd_i,
   input [AddrWidth-1:0]          addr_i,
   input [IfWidth-1:0]            wdata_i,


### PR DESCRIPTION
This a security patch for closing out D2S for OTP_CTRL.

Fixes #21948 