### PR TITLE
[rom_ext] Initialize ownership 

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -97,6 +97,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:chip_info",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/drivers:hmac",
+        "//sw/device/silicon_creator/lib/ownership:datatypes",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -543,6 +543,7 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
 
   HARDENED_RETURN_IF_ERROR(res);
 
+  memset(boot_data, 0, sizeof(*boot_data));
   boot_data->is_valid = kBootDataValidEntry;
   boot_data->identifier = kBootDataIdentifier;
   boot_data->version = kBootDataVersion2;

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -12,6 +12,7 @@
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/nonce.h"
+#include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,8 +40,10 @@ typedef struct boot_log {
   nonce_t rom_ext_nonce;
   /** Which BL0 slot booted. */
   uint32_t bl0_slot;
+  /** Chip ownership state. */
+  uint32_t ownership_state;
   /** Pad to 128 bytes. */
-  uint32_t reserved[15];
+  uint32_t reserved[14];
 } boot_log_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, digest, 0);
@@ -52,7 +55,8 @@ OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_minor, 50);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_size, 52);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_nonce, 56);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_slot, 64);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 68);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, ownership_state, 68);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 72);
 
 enum {
   /**

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -247,6 +247,8 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/lib/drivers:uart",
+        "//sw/device/silicon_creator/lib/ownership",
+        "//sw/device/silicon_creator/lib/ownership:ownership_unlock",
         "//sw/device/silicon_creator/lib/sigverify",
         "//sw/otbn/crypto:boot",
     ],
@@ -283,6 +285,7 @@ opentitan_binary(
         ":rom_ext",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake",
         "//sw/device/silicon_creator/rom_ext/keys/fake",
     ],
 )
@@ -305,6 +308,7 @@ opentitan_binary(
         ":rom_ext",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake",
         "//sw/device/silicon_creator/rom_ext/keys/fake",
     ],
 )
@@ -327,6 +331,7 @@ opentitan_binary(
         ":rom_ext",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake",
         "//sw/device/silicon_creator/rom_ext/keys/fake",
     ],
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -103,3 +103,40 @@ opentitan_test(
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
     ],
 )
+
+opentitan_test(
+    name = "boot_svc_ownership_unlock_test",
+    srcs = [
+        "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
+    ],
+    cw310 = cw310_params(
+        data = [
+            "//sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key",
+        ],
+        exit_failure = "(PASS|FAIL|FAULT).*\n",
+        # This test requires serial break support which is not available in CI yet.
+        tags = ["broken"],
+        test_cmd = """
+            --exec="transport init"
+            --exec="fpga clear-bitstream"
+            --exec="fpga load-bitstream {bitstream}"
+            --exec="bootstrap --clear-uart=true {firmware}"
+            --exec="console --non-interactive --exit-success='ownership_state = LockedNone\r\n' --exit-failure='{exit_failure}'"
+            --exec="rescue boot-svc ownership-unlock \
+                    --mode Any \
+                    --nonce 0 \
+                    --sign $(location //sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key)"
+            --exec="console --non-interactive --exit-success='ownership_state = UnlockedAny\r\n' --exit-failure='{exit_failure}'"
+            no-op
+        """,
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
@@ -20,10 +20,23 @@ status_t boot_log_print(boot_log_t *boot_log) {
            (boot_log->rom_ext_slot == kRomExtBootSlotA)   ? "A"
            : (boot_log->rom_ext_slot == kRomExtBootSlotB) ? "B"
                                                           : "error");
+  LOG_INFO("boot_log rom_ext_version = %d.%d", boot_log->rom_ext_major,
+           boot_log->rom_ext_minor);
+  LOG_INFO("boot_log rom_ext_size = 0x%08x", boot_log->rom_ext_size);
+  LOG_INFO("boot_log rom_ext_nonce = %08x%08x",
+           boot_log->rom_ext_nonce.value[1], boot_log->rom_ext_nonce.value[0]);
   LOG_INFO("boot_log bl0_slot = %s", (boot_log->bl0_slot == kBl0BootSlotA) ? "A"
                                      : (boot_log->bl0_slot == kBl0BootSlotB)
                                          ? "B"
                                          : "error");
+  ownership_state_t os = boot_log->ownership_state;
+  LOG_INFO("boot_log ownership_state = %s",
+           os == kOwnershipStateLockedOwner        ? "LockedOwner"
+           : os == kOwnershipStateLockedUpdate     ? "LockedUpdate"
+           : os == kOwnershipStateUnlockedAny      ? "UnlockedAny"
+           : os == kOwnershipStateUnlockedEndorsed ? "UnlockedEndorsed"
+                                                   : "LockedNone");
+
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -37,6 +37,8 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/lib/manifest_def.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+#include "sw/device/silicon_creator/lib/ownership/ownership.h"
+#include "sw/device/silicon_creator/lib/ownership/ownership_unlock.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
 #include "sw/device/silicon_creator/rom_ext/rescue.h"
@@ -131,7 +133,7 @@ void rom_ext_check_rom_expectations(void) {
 }
 
 OT_WARN_UNUSED_RESULT
-static rom_error_t rom_ext_init(void) {
+static rom_error_t rom_ext_init(boot_data_t *boot_data) {
   sec_mmio_next_stage_init();
   lc_state = lifecycle_state_get();
   pinmux_init();
@@ -145,6 +147,9 @@ static rom_error_t rom_ext_init(void) {
 
   // Check that the retention RAM is initialized.
   HARDENED_RETURN_IF_ERROR(retention_sram_check_version());
+
+  // Get the boot_data record
+  HARDENED_RETURN_IF_ERROR(boot_data_read(lc_state, boot_data));
 
   return kErrorOk;
 }
@@ -461,7 +466,6 @@ static rom_error_t boot_svc_next_boot_bl0_slot_handler(
 
   boot_svc_next_boot_bl0_slot_res_init(error,
                                        &boot_svc_msg->next_boot_bl0_slot_res);
-  retention_sram_get()->creator.boot_svc_msg = *boot_svc_msg;
   // We always return OK here because we've logged any error status in the boot
   // services response message and we want the boot flow to continue.
   return kErrorOk;
@@ -541,47 +545,50 @@ static rom_error_t boot_svc_min_sec_ver_handler(boot_svc_msg_t *boot_svc_msg,
 }
 
 OT_WARN_UNUSED_RESULT
-static rom_error_t rom_ext_try_boot(void) {
-  boot_data_t boot_data;
-  HARDENED_RETURN_IF_ERROR(boot_data_read(lc_state, &boot_data));
-
-  boot_svc_msg_t boot_svc_msg = retention_sram_get()->creator.boot_svc_msg;
-  if (boot_svc_msg.header.identifier == kBootSvcIdentifier) {
-    HARDENED_RETURN_IF_ERROR(boot_svc_header_check(&boot_svc_msg.header));
-    uint32_t msg_type = boot_svc_msg.header.type;
+static rom_error_t handle_boot_svc(boot_data_t *boot_data) {
+  boot_svc_msg_t *boot_svc_msg = &retention_sram_get()->creator.boot_svc_msg;
+  // TODO(lowRISC#22387): Examine the boot_svc code paths for boot loops.
+  if (boot_svc_msg->header.identifier == kBootSvcIdentifier) {
+    HARDENED_RETURN_IF_ERROR(boot_svc_header_check(&boot_svc_msg->header));
+    uint32_t msg_type = boot_svc_msg->header.type;
     switch (launder32(msg_type)) {
       case kBootSvcEmptyType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcEmptyType);
         break;
       case kBootSvcNextBl0SlotReqType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcNextBl0SlotReqType);
-        HARDENED_RETURN_IF_ERROR(
-            boot_svc_next_boot_bl0_slot_handler(&boot_svc_msg, &boot_data));
-        break;
+        return boot_svc_next_boot_bl0_slot_handler(boot_svc_msg, boot_data);
       case kBootSvcPrimaryBl0SlotReqType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcPrimaryBl0SlotReqType);
-        HARDENED_RETURN_IF_ERROR(
-            boot_svc_primary_boot_bl0_slot_handler(&boot_svc_msg, &boot_data));
-        break;
+        return boot_svc_primary_boot_bl0_slot_handler(boot_svc_msg, boot_data);
       case kBootSvcMinBl0SecVerReqType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcMinBl0SecVerReqType);
-        HARDENED_RETURN_IF_ERROR(
-            boot_svc_min_sec_ver_handler(&boot_svc_msg, &boot_data));
-        break;
+        return boot_svc_min_sec_ver_handler(boot_svc_msg, boot_data);
+      case kBootSvcOwnershipUnlockReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcOwnershipUnlockReqType);
+        return ownership_unlock_handler(boot_svc_msg, boot_data);
       case kBootSvcNextBl0SlotResType:
+      case kBootSvcPrimaryBl0SlotResType:
+      case kBootSvcMinBl0SecVerResType:
+      case kBootSvcOwnershipUnlockResType:
         // For response messages left in ret-ram we do nothing.
         break;
       default:
-        HARDENED_TRAP();
+          // For messages with an unknown msg_type, we do nothing.
+          ;
     }
   }
+  return kErrorOk;
+}
 
+OT_WARN_UNUSED_RESULT
+static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data) {
   rom_ext_boot_policy_manifests_t manifests =
-      rom_ext_boot_policy_manifests_get(&boot_data);
+      rom_ext_boot_policy_manifests_get(boot_data);
   rom_error_t error = kErrorRomExtBootFailed;
   rom_error_t slot[2] = {0, 0};
   for (size_t i = 0; i < ARRAYSIZE(manifests.ordered); ++i) {
-    error = rom_ext_verify(manifests.ordered[i], &boot_data);
+    error = rom_ext_verify(manifests.ordered[i], boot_data);
     slot[i] = error;
     if (error != kErrorOk) {
       continue;
@@ -616,22 +623,54 @@ static rom_error_t rom_ext_try_boot(void) {
   return error;
 }
 
-void rom_ext_main(void) {
-  rom_ext_check_rom_expectations();
-  SHUTDOWN_IF_ERROR(rom_ext_init());
+static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
+  HARDENED_RETURN_IF_ERROR(rom_ext_init(boot_data));
   dbg_printf("Starting ROM_EXT\r\n");
 
-  boot_log_t *boot_log = &retention_sram_get()->creator.boot_log;
+  // Initialize the boot_log in retention RAM.
   const chip_info_t *rom_chip_info = (const chip_info_t *)_chip_info_start;
   boot_log_check_or_init(boot_log, rom_ext_current_slot(), rom_chip_info);
+  boot_log->rom_ext_nonce = boot_data->nonce;
+  boot_log->ownership_state = boot_data->ownership_state;
 
+  // Initialize the chip ownership state.
+  HARDENED_RETURN_IF_ERROR(ownership_init());
+
+  // Handle any pending boot_svc commands.
   rom_error_t error;
+  error = handle_boot_svc(boot_data);
+  if (error == kErrorWriteBootdataThenReboot) {
+    // Boot services reports errors by writing a status code into the reply
+    // messages.  Regardless of whether a boot service request produced an
+    // error, we want to continue booting unless the error specifically asks
+    // for a reboot.
+    return error;
+  }
+
+  // Re-sync the boot_log entries that could be changed by boot services.
+  boot_log->rom_ext_nonce = boot_data->nonce;
+  boot_log->ownership_state = boot_data->ownership_state;
+  boot_log_digest_update(boot_log);
+
   if (uart_break_detect(kRescueDetectTime) == kHardenedBoolTrue) {
     dbg_printf("rescue: remember to clear break\r\n");
     uart_enable_receiver();
     error = rescue_protocol();
   } else {
-    error = rom_ext_try_boot();
+    error = rom_ext_try_next_stage(boot_data);
+  }
+  return error;
+}
+
+void rom_ext_main(void) {
+  rom_ext_check_rom_expectations();
+  boot_data_t boot_data;
+  boot_log_t *boot_log = &retention_sram_get()->creator.boot_log;
+
+  rom_error_t error = rom_ext_start(&boot_data, boot_log);
+  if (error == kErrorWriteBootdataThenReboot) {
+    HARDENED_CHECK_EQ(error, kErrorWriteBootdataThenReboot);
+    error = boot_data_write(&boot_data);
   }
   shutdown_finalize(error);
 }

--- a/sw/host/opentitanlib/src/rescue/serial.rs
+++ b/sw/host/opentitanlib/src/rescue/serial.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use crate::app::TransportWrapper;
 use crate::chip::boot_log::BootLog;
-use crate::chip::boot_svc::{BootDataSlot, BootSvc, NextBootBl0};
+use crate::chip::boot_svc::{BootDataSlot, BootSvc, NextBootBl0, OwnershipUnlockRequest};
 use crate::io::uart::Uart;
 use crate::rescue::xmodem::Xmodem;
 use crate::rescue::RescueError;
@@ -114,6 +114,12 @@ impl RescueSerial {
 
     pub fn set_primary_bl0_slot(&self, slot: BootDataSlot) -> Result<()> {
         let message = BootSvc::primary_bl0_slot(slot);
+        let data = message.to_bytes()?;
+        self.set_boot_svc_raw(&data)
+    }
+
+    pub fn ownership_unlock(&self, unlock: OwnershipUnlockRequest) -> Result<()> {
+        let message = BootSvc::ownership_unlock(unlock);
         let data = message.to_bytes()?;
         self.set_boot_svc_raw(&data)
     }

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -25,6 +25,7 @@ rust_binary(
         "src/command/load_bitstream.rs",
         "src/command/mod.rs",
         "src/command/otp.rs",
+        "src/command/ownership.rs",
         "src/command/rescue.rs",
         "src/command/reset_sam3x.rs",
         "src/command/rsa.rs",

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -16,6 +16,7 @@ pub mod image;
 pub mod lc;
 pub mod load_bitstream;
 pub mod otp;
+pub mod ownership;
 pub mod rescue;
 pub mod reset_sam3x;
 pub mod rsa;

--- a/sw/host/opentitantool/src/command/ownership.rs
+++ b/sw/host/opentitantool/src/command/ownership.rs
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use serde_annotate::Annotate;
+use std::any::Any;
+use std::fs::{File, OpenOptions};
+use std::path::PathBuf;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::chip::helper::OwnershipUnlockParams;
+
+#[derive(Debug, Args)]
+pub struct OwnershipUnlockCommand {
+    #[command(flatten)]
+    params: OwnershipUnlockParams,
+    #[arg(short, long, help = "A file containing a binary unlock request")]
+    input: Option<PathBuf>,
+    #[arg(
+        value_name = "FILE",
+        help = "A file to write out a binary unlock request"
+    )]
+    output: Option<PathBuf>,
+}
+
+impl CommandDispatch for OwnershipUnlockCommand {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        let unlock = self
+            .params
+            .apply_to(self.input.as_ref().map(File::open).transpose()?.as_mut())?;
+        if let Some(output) = &self.output {
+            let mut f = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(output)?;
+            unlock.write(&mut f)?;
+        }
+        Ok(Some(Box::new(unlock)))
+    }
+}
+
+#[derive(Debug, Subcommand, CommandDispatch)]
+pub enum OwnershipCommand {
+    Unlock(OwnershipUnlockCommand),
+}

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -48,6 +48,8 @@ enum RootCommandHierarchy {
     #[command(subcommand)]
     Otp(command::otp::Otp),
     #[command(subcommand)]
+    Ownership(command::ownership::OwnershipCommand),
+    #[command(subcommand)]
     Rescue(command::rescue::RescueCommand),
     #[command(subcommand)]
     Rsa(command::rsa::Rsa),


### PR DESCRIPTION
1. Initialize ownership during ROM_EXT init.
2. Process the OwnershipUnlock message in boot services.
3. Update the serial rescue implementation to encode and send the
   ownership unlock command.
4. Add a top-level `ownership` command for creating the ownership unlock
   command.
5. Add a rescue command to send the ownership unlock command.
6. Add a test for the OwnershipUnlock command.