### PR TITLE
[opentitantool] Updated HyperDebug firmware

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -481,7 +481,7 @@ impl Bus for HyperdebugI2cBus {
             TransportError::UnsupportedOperation
         );
         ensure!(self.mode.get() == Mode::Device, I2cError::NotInDeviceMode);
-        if data.len() > 256 {
+        if data.len() > 1024 {
             bail!(TransportError::CommunicationError(
                 "Data exceeds maximum length".to_string()
             ))

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240209_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "03c58b220828fc88c9a23ec1b6e93f210354687a5dccd9b957aaaf45f75f82f0",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240411_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "43fd0425856765bbe11fc344fb797f8c08eb5d733bc244c6385a2cb272f5a5fd",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Updated HyperDebug firmware fixing several bugs and adding small features.

Changes since release 20240209_01:
- 653223750e board/hyperdebug: New flag for controlling I2C STOP condition
- 1d59513c9e board/hyperdebug: Support long I2C transcripts
- 63c132ee45 board/hyperdebug: Inline i2c_xfer() function
- 810b1b5719 board/hyperdebug: Handle cases of I2C interference
- f68e8ebe35 board/hyperdebug: Allow controlling drive speed
- 7358863899 board/hyperdebug: Bugfix to custom JTAG pins
- 9e38f8fdf6 board/hyperdebug: Better recording of bitbanged pins
- 2a324ce387 board/hyperdebug: Reset OCTOSPI between transactions
 