### PR TITLE
[RV_DM]remove progbuf_exception testpoint entry

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -525,7 +525,7 @@
             - Verify that jtag_dmi_ral.abstractcs.cmderr is set to 3.
             '''
       stage: V1
-      tests: []
+      tests: ["rv_dm_cmderr_exception"]
     }
     {
       name: rom_read_access

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -157,7 +157,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     uvm_reg_data_t rdata;
     repeat ($urandom_range(1, 10)) begin
       data = $urandom;
-      csr_wr(.ptr(tl_mem_ral.halted), .value(0));
+      request_halt();
       cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
       csr_wr(.ptr(jtag_dmi_ral.command), .value(command));
       csr_wr(.ptr(ptr), .value(data));
@@ -173,7 +173,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     uvm_reg_data_t rdata;
     repeat ($urandom_range(1, 10)) begin
       data = $urandom;
-      csr_wr(.ptr(tl_mem_ral.halted), .value(0));
+      request_halt();
       cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
       csr_wr(.ptr(jtag_dmi_ral.command), .value(command));
       csr_rd(.ptr(ptr), .value(data));

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_exception_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_exception_vseq.sv
@@ -16,8 +16,9 @@ class rv_dm_cmderr_exception_vseq extends rv_dm_base_vseq;
   }
 
   task body();
-    //Verify that the cmderr should set to 3, if an excepton occurred while executing the command.
-    write_chk(.ptr(tl_mem_ral.exception), .cmderr(3), .command(32'h00231000));
+    // Verify that the cmderr should be AbstractCmdErrException,
+    // if an excepton occurred while executing the command.
+    write_chk(.ptr(tl_mem_ral.exception), .cmderr(AbstractCmdErrException), .command(32'h00231000));
   endtask : body
 
 endclass : rv_dm_cmderr_exception_vseq


### PR DESCRIPTION
This commit is to remove rv_dm_progbuf_exception testpoint entry as this functionality is already covered in rv_dm_cmderr_exception vseq. So this testpoint is no longer needed.