### PR TITLE
[usbdev,dv] add usbdev_phy_pins_sense name in testplan

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -73,7 +73,7 @@
               inputs and outputs.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_phy_pins_sense"]
     }
     {
       name: wake_events


### PR DESCRIPTION
This PR contains the addition of the usbdev_phy_pins_sense name to the test plan, so this sequence should be included in the coming regressions.