### PR TITLE
[ci] Disable experimental bazel tags step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,9 +144,10 @@ jobs:
   - template: ci/install-package-dependencies.yml
   # Bazel test suites are a common cause of problematic tags. Check test suites
   # before checking for other tag issues.
-  - bash:  ci/scripts/check_bazel_test_suites.py
-    displayName: Check Bazel test suites (Experimental)
-    continueOnError: True
+  # #21973: Disabled until Verilator tags are fixed in our build tree.
+  #- bash:  ci/scripts/check_bazel_test_suites.py
+  #  displayName: Check Bazel test suites (Experimental)
+  #  continueOnError: True
   - bash: ci/scripts/check-bazel-tags.sh
     displayName: Check Bazel Tags (Experimental)
     continueOnError: True


### PR DESCRIPTION
We're not getting much value out of this CI step at the moment because it has been failing for a long time. Disabling until somebody can fix it. Arguably this is sweeping it under the rug and may delay it getting fixed even more, but because we've been ignoring its warnings we could miss other more interesting failures.

See https://github.com/lowRISC/opentitan/issues/21973.