### PR TITLE
[crypto] Fix outdated cryptolib docstrings.

### DIFF
--- a/sw/device/lib/crypto/include/ecc.h
+++ b/sw/device/lib/crypto/include/ecc.h
@@ -90,10 +90,11 @@ typedef struct otcrypto_ecc_curve {
  * including populating the key configuration and allocating space for the
  * keyblob. The caller should indicate the length of the allocated keyblob;
  * this function will return an error if the keyblob length does not match
- * expectations. For hardware-backed keys, the keyblob length is 0 and the
- * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
- * should be twice the length of the key. The value in the `checksum` field of
- * the blinded key struct will be populated by the key generation function.
+ * expectations. If the key is hardware-backed, the caller should pass a fully
+ * populated private key handle as returned by `otcrypto_hw_backed_key`. For
+ * non-hardware-backed keys, the keyblob should be twice the length of the key.
+ * The value in the `checksum` field of the blinded key struct will be
+ * populated by the key generation function.
  *
  * The `domain_parameter` field of the `elliptic_curve` is required only for a
  * custom curve. For named curves this field is ignored and can be set to
@@ -177,10 +178,11 @@ otcrypto_status_t otcrypto_ecdsa_verify(
  * including populating the key configuration and allocating space for the
  * keyblob. The caller should indicate the length of the allocated keyblob;
  * this function will return an error if the keyblob length does not match
- * expectations. For hardware-backed keys, the keyblob length is 0 and the
- * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
- * should be twice the length of the key. The value in the `checksum` field of
- * the blinded key struct will be populated by the key generation function.
+ * expectations. If the key is hardware-backed, the caller should pass a fully
+ * populated private key handle as returned by `otcrypto_hw_backed_key`. For
+ * non-hardware-backed keys, the keyblob should be twice the length of the key.
+ * The value in the `checksum` field of the blinded key struct will be
+ * populated by the key generation function.
  *
  * @param elliptic_curve Pointer to the elliptic curve to be used.
  * @param[out] private_key Pointer to the blinded private key (d) struct.
@@ -223,10 +225,11 @@ otcrypto_status_t otcrypto_ecdh(const otcrypto_blinded_key_t *private_key,
  * including populating the key configuration and allocating space for the
  * keyblob. The caller should indicate the length of the allocated keyblob;
  * this function will return an error if the keyblob length does not match
- * expectations. For hardware-backed keys, the keyblob length is 0 and the
- * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
- * should be twice the length of the key. The value in the `checksum` field of
- * the blinded key struct will be populated by the key generation function.
+ * expectations. If the key is hardware-backed, the caller should pass a fully
+ * populated private key handle as returned by `otcrypto_hw_backed_key`. For
+ * non-hardware-backed keys, the keyblob should be twice the length of the key.
+ * The value in the `checksum` field of the blinded key struct will be
+ * populated by the key generation function.
  *
  * @param[out] private_key Pointer to the blinded private key struct.
  * @param[out] public_key Pointer to the unblinded public key struct.
@@ -281,10 +284,11 @@ otcrypto_status_t otcrypto_ed25519_verify(
  * including populating the key configuration and allocating space for the
  * keyblob. The caller should indicate the length of the allocated keyblob;
  * this function will return an error if the keyblob length does not match
- * expectations. For hardware-backed keys, the keyblob length is 0 and the
- * keyblob pointer may be `NULL`. For non-hardware-backed keys, the keyblob
- * should be twice the length of the key. The value in the `checksum` field of
- * the blinded key struct will be populated by the key generation function.
+ * expectations. If the key is hardware-backed, the caller should pass a fully
+ * populated private key handle as returned by `otcrypto_hw_backed_key`. For
+ * non-hardware-backed keys, the keyblob should be twice the length of the key.
+ * The value in the `checksum` field of the blinded key struct will be
+ * populated by the key generation function.
  *
  * @param[out] private_key Pointer to the blinded private key struct.
  * @param[out] public_key Pointer to the unblinded public key struct.

--- a/sw/device/lib/crypto/include/kdf.h
+++ b/sw/device/lib/crypto/include/kdf.h
@@ -31,10 +31,11 @@ extern "C" {
  * allocating space for the keyblob. The caller should indicate the length of
  * the allocated keyblob; this function will return an error if the keyblob
  * length does not match expectations. For hardware-backed keys, the keyblob
- * length is 0 and the keyblob pointer may be `NULL`. For non-hardware-backed
- * keys, the keyblob should be twice the length of the key. The value in the
- * `checksum` field of the blinded key struct will be populated by this
- * function.
+ * expectations. If the key is hardware-backed, the caller should pass a fully
+ * populated private key handle such as the kind returned by
+ * `otcrypto_hw_backed_key`. For non-hardware-backed keys, the keyblob should
+ * be twice the length of the key. The value in the `checksum` field of the
+ * blinded key struct will be populated by this function.
  *
  * @param key_derivation_key Blinded key derivation key.
  * @param kdf_label Label string according to SP 800-108r1.


### PR DESCRIPTION
These comments refer to the old method of representing hardware-backed keys (which used a field in the key configuration instead of the keyblob). This was changed in https://github.com/lowRISC/opentitan/pull/19714

Instead, adds guidance that directs callers to `otcrypto_hw_backed_key` for initializing these keys.

Thanks to @vsukhoml for finding this mistake! See https://github.com/lowRISC/opentitan/issues/21936#issuecomment-1989531303