### PR TITLE
[cryptotest] Add GCB-backed URLs for more NIST test vectors

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -128,6 +128,10 @@ nist_cavp_repos()
 load("//third_party/wycheproof:repos.bzl", "wycheproof_repos")
 wycheproof_repos()
 
+# SPHINCS+ Test Vectors
+load("//third_party/sphincsplus:repos.bzl", "sphincsplus_repos")
+sphincsplus_repos()
+
 # Bitstreams from https://storage.googleapis.com/opentitan-bitstreams/
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -158,3 +158,29 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
 )
+
+DRBG_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:nist_cavp_drbg_sp_800_90a_reseed_json",
+    "//sw/host/cryptotest/testvectors/data:nist_cavp_drbg_sp_800_90a_no_reseed_json",
+]
+
+DRBG_TESTVECTOR_ARGS = " ".join([
+    "--drbg-json=\"$(rootpath {})\"".format(target)
+    for target in DRBG_TESTVECTOR_TARGETS
+])
+
+opentitan_test(
+    name = "drbg_kat",
+    cw310 = cw310_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        data = DRBG_TESTVECTOR_TARGETS,
+        test_cmd = """
+                --bootstrap={firmware}
+            """ + DRBG_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/drbg_kat:harness",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    },
+)

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -212,7 +212,6 @@ opentitan_test(
         data = HMAC_TESTVECTOR_TARGETS,
         test_cmd = """
             --bootstrap={firmware}
-            --bitstream={bitstream}
         """ + HMAC_TESTVECTOR_ARGS,
         test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
     ),

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -184,3 +184,39 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     },
 )
+
+HMAC_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:wycheproof_hmac_{}.json".format(config)
+    for config in [
+        "sha256",
+        "sha384",
+        "sha512",
+        # TODO uncomment when cryptolib supports HMAC with SHA3
+        # "sha3_256",
+        # "sha3_512",
+    ]
+] + [
+    "//sw/host/cryptotest/testvectors/data:nist_cavp_hmac_fips_198_1_json",
+]
+
+HMAC_TESTVECTOR_ARGS = " ".join([
+    "--hmac-json=\"$(rootpath {})\"".format(target)
+    for target in HMAC_TESTVECTOR_TARGETS
+])
+
+opentitan_test(
+    name = "hmac_kat",
+    cw310 = cw310_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        data = HMAC_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+            --bitstream={bitstream}
+        """ + HMAC_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    },
+)

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -108,6 +108,24 @@ cc_library(
 )
 
 cc_library(
+    name = "hmac",
+    srcs = ["hmac.c"],
+    hdrs = ["hmac.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/impl:mac",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:hmac_commands",
+    ],
+)
+
+cc_library(
     name = "aes_sca",
     srcs = ["aes_sca.c"],
     hdrs = ["aes_sca.h"],
@@ -228,6 +246,7 @@ opentitan_binary(
         ":ecdh",
         ":ecdsa",
         ":hash",
+        ":hmac",
         ":ibex_fi",
         ":kmac_sca",
         ":prng_sca",
@@ -244,6 +263,7 @@ opentitan_binary(
         "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
         "//sw/device/tests/crypto/cryptotest/json:ecdh_commands",
         "//sw/device/tests/crypto/cryptotest/json:hash_commands",
+        "//sw/device/tests/crypto/cryptotest/json:hmac_commands",
         "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
     ],
 )
@@ -265,6 +285,7 @@ opentitan_test(
         ":ecdh",
         ":ecdsa",
         ":hash",
+        ":hmac",
         ":ibex_fi",
         ":kmac_sca",
         ":prng_sca",
@@ -282,6 +303,7 @@ opentitan_test(
         "//sw/device/tests/crypto/cryptotest/json:ecdh_commands",
         "//sw/device/tests/crypto/cryptotest/json:ecdsa_commands",
         "//sw/device/tests/crypto/cryptotest/json:hash_commands",
+        "//sw/device/tests/crypto/cryptotest/json:hmac_commands",
         "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
     ],
 )

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -68,6 +68,25 @@ cc_library(
 )
 
 cc_library(
+    name = "drbg",
+    srcs = ["drbg.c"],
+    hdrs = ["drbg.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl:drbg",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:keyblob",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
+    ],
+)
+
+cc_library(
     name = "hash",
     srcs = ["hash.c"],
     hdrs = ["hash.h"],
@@ -205,6 +224,7 @@ opentitan_binary(
     deps = [
         ":aes",
         ":aes_sca",
+        ":drbg",
         ":ecdh",
         ":ecdsa",
         ":hash",
@@ -221,6 +241,7 @@ opentitan_binary(
         "//sw/device/lib/ujson",
         "//sw/device/tests/crypto/cryptotest/json:aes_commands",
         "//sw/device/tests/crypto/cryptotest/json:commands",
+        "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
         "//sw/device/tests/crypto/cryptotest/json:ecdh_commands",
         "//sw/device/tests/crypto/cryptotest/json:hash_commands",
         "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
@@ -240,6 +261,7 @@ opentitan_test(
     deps = [
         ":aes",
         ":aes_sca",
+        ":drbg",
         ":ecdh",
         ":ecdsa",
         ":hash",
@@ -256,6 +278,7 @@ opentitan_test(
         "//sw/device/lib/ujson",
         "//sw/device/tests/crypto/cryptotest/json:aes_commands",
         "//sw/device/tests/crypto/cryptotest/json:commands",
+        "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
         "//sw/device/tests/crypto/cryptotest/json:ecdh_commands",
         "//sw/device/tests/crypto/cryptotest/json:ecdsa_commands",
         "//sw/device/tests/crypto/cryptotest/json:hash_commands",

--- a/sw/device/tests/crypto/cryptotest/firmware/drbg.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/drbg.c
@@ -1,0 +1,109 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/drbg.h"
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/drbg_commands.h"
+
+status_t handle_drbg(ujson_t *uj) {
+  cryptotest_drbg_input_t uj_input;
+  // Deserialize test arguments from UART
+  TRY(ujson_deserialize_cryptotest_drbg_input_t(uj, &uj_input));
+
+  // Entropy for initialization
+  uint8_t entropy_buf[kEntropySeedBytes];
+  memset(entropy_buf, 0, kEntropySeedBytes);
+  memcpy(entropy_buf, uj_input.entropy, uj_input.entropy_len);
+  otcrypto_const_byte_buf_t entropy = {
+      .len = kEntropySeedBytes,
+      .data = entropy_buf,
+  };
+
+  // Personalization string
+  uint8_t perso_string_buf[uj_input.personalization_string_len];
+  memcpy(perso_string_buf, uj_input.personalization_string,
+         uj_input.personalization_string_len);
+  otcrypto_const_byte_buf_t perso_string = {
+      .len = uj_input.personalization_string_len,
+      .data = perso_string_buf,
+  };
+
+  // Reseed entropy
+  uint8_t reseed_entropy_buf[uj_input.reseed_entropy_len];
+  memcpy(reseed_entropy_buf, uj_input.reseed_entropy,
+         uj_input.reseed_entropy_len);
+  otcrypto_const_byte_buf_t reseed_entropy = {
+      .len = uj_input.reseed_entropy_len,
+      .data = uj_input.reseed_entropy,
+  };
+
+  // Reseed additional input
+  uint8_t reseed_addl_buf[uj_input.reseed_additional_input_len];
+  memcpy(reseed_addl_buf, uj_input.reseed_additional_input,
+         uj_input.reseed_additional_input_len);
+  otcrypto_const_byte_buf_t reseed_addl = {
+      .len = uj_input.reseed_additional_input_len,
+      .data = uj_input.reseed_additional_input,
+  };
+
+  // First additional input
+  uint8_t addl_1_buf[uj_input.additional_input_1_len];
+  memcpy(addl_1_buf, uj_input.additional_input_1,
+         uj_input.additional_input_1_len);
+  otcrypto_const_byte_buf_t addl_1 = {
+      .len = uj_input.additional_input_1_len,
+      .data = uj_input.additional_input_1,
+  };
+
+  // Second additional input
+  uint8_t addl_2_buf[uj_input.additional_input_2_len];
+  memcpy(addl_2_buf, uj_input.additional_input_2,
+         uj_input.additional_input_2_len);
+  otcrypto_const_byte_buf_t addl_2 = {
+      .len = uj_input.additional_input_2_len,
+      .data = uj_input.additional_input_2,
+  };
+
+  // Buffer for random output
+  cryptotest_drbg_output_t uj_output = {
+      .output_len = uj_input.output_len,
+  };
+  size_t output_words = ceil_div(uj_output.output_len, sizeof(uint32_t));
+  otcrypto_word32_buf_t output = {
+      .len = output_words,
+      .data = (uint32_t *)uj_output.output,
+  };
+
+  // Instantiate DRBG system. We cannot use the FIPS-compliant APIs
+  // because the test vector specifies an entropy string to use.
+  TRY(otcrypto_drbg_manual_instantiate(entropy, perso_string));
+
+  // Reseed if the test says we need to
+  if (uj_input.reseed) {
+    TRY(otcrypto_drbg_manual_reseed(reseed_entropy, reseed_addl));
+  }
+
+  // Add first additional input (the test vectors require generating
+  // `output_len` bits of output here, but they may be discarded).
+  TRY(otcrypto_drbg_manual_generate(addl_1, output));
+
+  // Add second additional input and generate random output
+  TRY(otcrypto_drbg_manual_generate(addl_2, output));
+
+  // Uninstantiate the DRBG system
+  otcrypto_drbg_uninstantiate();
+
+  // Send output to host via UART
+  RESP_OK(ujson_serialize_cryptotest_drbg_output_t, uj, &uj_output);
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/drbg.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/drbg.h
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_DRBG_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_DRBG_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_drbg(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_DRBG_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -18,6 +18,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/ecdh_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdsa_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/hmac_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/kmac_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/prng_sca_commands.h"
@@ -31,6 +32,7 @@
 #include "ecdh.h"
 #include "ecdsa.h"
 #include "hash.h"
+#include "hmac.h"
 #include "ibex_fi.h"
 #include "kmac_sca.h"
 #include "prng_sca.h"
@@ -58,6 +60,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandHash:
         RESP_ERR(uj, handle_hash(uj));
+        break;
+      case kCryptotestCommandHmac:
+        RESP_ERR(uj, handle_hmac(uj));
         break;
       case kCryptotestCommandAesSca:
         RESP_ERR(uj, handle_aes_sca(uj));

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -14,6 +14,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/aes_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/drbg_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdh_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdsa_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
@@ -26,6 +27,7 @@
 // Include handlers
 #include "aes.h"
 #include "aes_sca.h"
+#include "drbg.h"
 #include "ecdh.h"
 #include "ecdsa.h"
 #include "hash.h"
@@ -44,6 +46,9 @@ status_t process_cmd(ujson_t *uj) {
     switch (cmd) {
       case kCryptotestCommandAes:
         RESP_ERR(uj, handle_aes(uj));
+        break;
+      case kCryptotestCommandDrbg:
+        RESP_ERR(uj, handle_drbg(uj));
         break;
       case kCryptotestCommandEcdsa:
         RESP_ERR(uj, handle_ecdsa(uj));

--- a/sw/device/tests/crypto/cryptotest/firmware/hmac.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/hmac.c
@@ -1,0 +1,127 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/mac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/hmac_commands.h"
+
+const int MaxKeyBytes = 192;
+const int MaxKeyWords = MaxKeyBytes / sizeof(uint32_t);
+
+const int MaxMessageBytes = 256;
+
+const int MaxTagBytes = 64;
+const int MaxTagWords = MaxTagBytes / sizeof(uint32_t);
+
+const unsigned int kOtcryptoHmacTagBytesSha256 = 32;
+const unsigned int kOtcryptoHmacTagBytesSha384 = 48;
+const unsigned int kOtcryptoHmacTagBytesSha512 = 64;
+
+// Random value for masking, as large as the longest test key. This value
+// should not affect the result.
+static const uint32_t kTestMask[48] = {
+    0xBA81767F, 0xA913C751, 0x34209992, 0x5F66021B, 0x775F4577, 0x7C02E1CE,
+    0xB4A8B698, 0x1986B902, 0x7251045B, 0x3C827C6F, 0x00909D12, 0x81ABC8F9,
+    0x62F2FCB6, 0x15B63124, 0x66F60052, 0xAD637669, 0x522779CF, 0x07E9FBA8,
+    0x1258E541, 0x860719EF, 0x1D4F5386, 0xA9B04F7C, 0x6E98A861, 0xEFADEBA6,
+    0x900E1EC8, 0xB290DBCE, 0x05946814, 0xB83A01CE, 0x4EEC86BD, 0xAE836C6C,
+    0x20182AAE, 0x4476F6F4, 0x7C4A0A31, 0x7D2809BA, 0x367B29B9, 0x42444BEA,
+    0xDFD6025C, 0x1E665207, 0x18E0895B, 0x20D435DB, 0xC509A6D6, 0x8CC19AB1,
+    0xA5D39BD2, 0xAB479AD5, 0x5786D029, 0x2E4B7CD7, 0xB77A3D76, 0xE2A09962,
+};
+
+status_t handle_hmac(ujson_t *uj) {
+  // Declare test arguments
+  cryptotest_hmac_hash_alg_t uj_hash_alg;
+  cryptotest_hmac_key_t uj_key;
+  cryptotest_hmac_message_t uj_message;
+  // Deserialize test arguments from UART
+  TRY(ujson_deserialize_cryptotest_hmac_hash_alg_t(uj, &uj_hash_alg));
+  TRY(ujson_deserialize_cryptotest_hmac_key_t(uj, &uj_key));
+  TRY(ujson_deserialize_cryptotest_hmac_message_t(uj, &uj_message));
+
+  otcrypto_key_mode_t key_mode;
+  unsigned int tag_bytes;
+  switch (uj_hash_alg) {
+    case kCryptotestHmacHashAlgSha256:
+      key_mode = kOtcryptoKeyModeHmacSha256;
+      tag_bytes = kOtcryptoHmacTagBytesSha256;
+      break;
+    case kCryptotestHmacHashAlgSha384:
+      key_mode = kOtcryptoKeyModeHmacSha384;
+      tag_bytes = kOtcryptoHmacTagBytesSha384;
+      break;
+    case kCryptotestHmacHashAlgSha512:
+      key_mode = kOtcryptoKeyModeHmacSha512;
+      tag_bytes = kOtcryptoHmacTagBytesSha512;
+      break;
+    case kCryptotestHmacHashAlgSha3_256:
+      // key_mode = kOtcryptoKeyModeHmacSha3_256;
+      // tag_bytes = kOtcryptoHmacTagBytesSha3_256;
+      // break;
+      OT_FALLTHROUGH_INTENDED;
+    case kCryptotestHmacHashAlgSha3_512:
+      // key_mode = kOtcryptoKeyModeHmacSha3_512;
+      // tag_bytes = kOtcryptoHmacTagBytesSha3_512;
+      // break;
+      OT_FALLTHROUGH_INTENDED;
+    default:
+      LOG_ERROR("Unsupported HMAC key mode: %d", uj_hash_alg);
+      return INVALID_ARGUMENT();
+  }
+  // Build the key configuration
+  otcrypto_key_config_t config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = key_mode,
+      .key_length = uj_key.key_len,
+      .hw_backed = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+  // Create buffer to store key
+  uint32_t key_buf[MaxKeyWords];
+  memcpy(key_buf, uj_key.key, uj_key.key_len);
+  // Create keyblob
+  uint32_t keyblob[keyblob_num_words(config)];
+  // Create blinded key
+  TRY(keyblob_from_key_and_mask(key_buf, kTestMask, config, keyblob));
+  otcrypto_blinded_key_t key = {
+      .config = config,
+      .keyblob_length = sizeof(keyblob),
+      .keyblob = keyblob,
+  };
+
+  // Create input message
+  uint8_t msg_buf[MaxMessageBytes];
+  memcpy(msg_buf, uj_message.message, uj_message.message_len);
+  otcrypto_const_byte_buf_t input_message = {
+      .len = uj_message.message_len,
+      .data = msg_buf,
+  };
+
+  // Create tag
+  uint32_t tag_buf[MaxTagWords];
+  otcrypto_word32_buf_t tag = {
+      .len = tag_bytes / sizeof(uint32_t),
+      .data = tag_buf,
+  };
+  otcrypto_status_t status = otcrypto_hmac(&key, input_message, &tag);
+  if (status.value != kOtcryptoStatusValueOk) {
+    return INTERNAL(status.value);
+  }
+  // Copy tag to uJSON type
+  cryptotest_hmac_tag_t uj_tag;
+  memcpy(uj_tag.tag, tag_buf, tag_bytes);
+  uj_tag.tag_len = tag_bytes;
+
+  // Send tag to host via UART
+  RESP_OK(ujson_serialize_cryptotest_hmac_tag_t, uj, &uj_tag);
+  return OK_STATUS(0);
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/hmac.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/hmac.h
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_HMAC_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_HMAC_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_hmac(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_HMAC_H_

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -19,6 +19,13 @@ cc_library(
 )
 
 cc_library(
+    name = "drbg_commands",
+    srcs = ["drbg_commands.c"],
+    hdrs = ["drbg_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "ecdsa_commands",
     srcs = ["ecdsa_commands.c"],
     hdrs = ["ecdsa_commands.h"],

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -13,6 +13,7 @@ extern "C" {
 
 #define COMMAND(_, value) \
     value(_, Aes) \
+    value(_, Drbg) \
     value(_, Ecdsa) \
     value(_, Ecdh) \
     value(_, Hash) \

--- a/sw/device/tests/crypto/cryptotest/json/drbg_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/drbg_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "drbg_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/drbg_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/drbg_commands.h
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_DRBG_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_DRBG_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DRBG_CMD_MAX_ENTROPY_BYTES 48
+#define DRBG_CMD_MAX_PERSONALIZATION_STRING_BYTES 48
+#define DRBG_CMD_MAX_ADDITIONAL_INPUT_BYTES 48
+#define DRBG_CMD_MAX_OUTPUT_BYTES 64
+
+// clang-format off
+
+#define DRBG_INPUT(field, string) \
+    field(entropy, uint8_t, DRBG_CMD_MAX_ENTROPY_BYTES) \
+    field(entropy_len, size_t) \
+    field(personalization_string, uint8_t, DRBG_CMD_MAX_PERSONALIZATION_STRING_BYTES) \
+    field(personalization_string_len, size_t) \
+    field(reseed, uint8_t) \
+    field(reseed_entropy, uint8_t, DRBG_CMD_MAX_ENTROPY_BYTES) \
+    field(reseed_entropy_len, size_t) \
+    field(reseed_additional_input, uint8_t, DRBG_CMD_MAX_ADDITIONAL_INPUT_BYTES) \
+    field(reseed_additional_input_len, size_t) \
+    field(additional_input_1, uint8_t, DRBG_CMD_MAX_ADDITIONAL_INPUT_BYTES) \
+    field(additional_input_1_len, size_t) \
+    field(additional_input_2, uint8_t, DRBG_CMD_MAX_ADDITIONAL_INPUT_BYTES) \
+    field(additional_input_2_len, size_t) \
+    field(output_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestDrbgInput, cryptotest_drbg_input_t, DRBG_INPUT);
+
+#define DRBG_OUTPUT(field, string) \
+    field(output, uint8_t, DRBG_CMD_MAX_OUTPUT_BYTES) \
+    field(output_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestDrbgOutput, cryptotest_drbg_output_t, DRBG_OUTPUT);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_DRBG_COMMANDS_H_

--- a/sw/device/tests/crypto/cryptotest/json/hmac_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/hmac_commands.h
@@ -20,6 +20,7 @@ extern "C" {
     value(_, Sha384) \
     value(_, Sha512) \
     value(_, Sha3_256) \
+    value(_, Sha3_384) \
     value(_, Sha3_512)
 UJSON_SERDE_ENUM(CryptotestHmacHashAlg, cryptotest_hmac_hash_alg_t, HMAC_HASH_ALG);
 

--- a/sw/device/tests/crypto/cryptotest/json/hmac_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/hmac_commands.h
@@ -10,7 +10,7 @@ extern "C" {
 #endif
 
 #define HMAC_CMD_MAX_MESSAGE_BYTES 256
-#define HMAC_CMD_MAX_KEY_BYTES 142
+#define HMAC_CMD_MAX_KEY_BYTES 192
 #define HMAC_CMD_MAX_TAG_BYTES 64
 
 // clang-format off

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -396,3 +396,23 @@ run_binary(
         ("verify", "Ver", "rsp"),
     ]
 ]
+
+run_binary(
+    name = "rsp_sphincsplus_shake256_128s_simple_json",
+    srcs = [
+        "//sw/host/cryptotest/testvectors/data/schemas:sphincsplus_schema.json",
+        "@sphincsplus_kat//:sphincs-shake256-128s-simple/PQCsignKAT_64.rsp",
+    ],
+    outs = [":rsp_sphincsplus_shake256_128s_simple.json"],
+    args = [
+        "--src",
+        "$(location @sphincsplus_kat//:sphincs-shake256-128s-simple/PQCsignKAT_64.rsp)",
+        "--dst",
+        "$(location :rsp_sphincsplus_shake256_128s_simple.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:sphincsplus_schema.json)",
+        "--hash_alg",
+        "shake-256",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:rsp_sphincsplus_parser",
+)

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -6,6 +6,45 @@ load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+# Strip the inner layer of the DRBG repository, which is a zip of zips
+genrule(
+    name = "nist_cavp_drbg_sp_800_90a_reseed",
+    srcs = ["@nist_cavp_drbg_sp_800_90a_root//:drbgvectors_pr_false.zip"],
+    outs = [":CTR_DRBG_RESEED.rsp"],
+    cmd = "unzip -p $(location @nist_cavp_drbg_sp_800_90a_root//:drbgvectors_pr_false.zip) CTR_DRBG.rsp > $(location :CTR_DRBG_RESEED.rsp)",
+)
+
+genrule(
+    name = "nist_cavp_drbg_sp_800_90a_no_reseed",
+    srcs = ["@nist_cavp_drbg_sp_800_90a_root//:drbgvectors_no_reseed.zip"],
+    outs = [":CTR_DRBG_NO_RESEED.rsp"],
+    cmd = "unzip -p $(location @nist_cavp_drbg_sp_800_90a_root//:drbgvectors_no_reseed.zip) CTR_DRBG.rsp > $(location :CTR_DRBG_NO_RESEED.rsp)",
+)
+
+[
+    run_binary(
+        name = "nist_cavp_drbg_sp_800_90a_{}_json".format(mode),
+        srcs = [
+            ":CTR_DRBG_{}.rsp".format(mode.upper()),
+            "//sw/host/cryptotest/testvectors/data/schemas:drbg_schema.json",
+        ],
+        outs = [":nist_cavp_drbg_sp_800_90a_{}.json".format(mode)],
+        args = [
+            "--src",
+            "$(location :CTR_DRBG_{}.rsp)".format(mode.upper()),
+            "--dst",
+            "$(location :nist_cavp_drbg_sp_800_90a_{}.json)".format(mode),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:drbg_schema.json)",
+        ] + (["--reseed"] if reseed else []),
+        tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_drbg_parser",
+    )
+    for mode, reseed in [
+        ("reseed", True),
+        ("no_reseed", False),
+    ]
+]
+
 run_binary(
     name = "nist_cavp_ecdsa_fips_186_4_sig_ver_json",
     srcs = [

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -316,3 +316,44 @@ run_binary(
         "256",
     ]
 ]
+
+[
+    run_binary(
+        name = "nist_cavp_rsa_{}_{}_json".format(
+            padding_mode,
+            operation,
+        ),
+        srcs = [
+            "@nist_cavp_rsa_fips_186_3//:Sig{}{}_186-3.{}".format(prefix, infix, suffix),
+            "//sw/host/cryptotest/testvectors/data/schemas:rsa_schema.json",
+        ],
+        outs = [":nist_rsa_{}_{}.json".format(
+            padding_mode,
+            operation,
+        )],
+        args = [
+            "--src",
+            "$(location @nist_cavp_rsa_fips_186_3//:Sig{}{}_186-3.{})".format(prefix, infix, suffix),
+            "--dst",
+            "$(location :nist_rsa_{}_{}.json)".format(
+                padding_mode,
+                operation,
+            ),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:rsa_schema.json)",
+            "--operation",
+            operation,
+            "--padding",
+            padding_mode,
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_rsa_parser",
+    )
+    for padding_mode, infix in [
+        ("pkcs1_1.5", "15"),
+        ("pss", "PSS"),
+    ]
+    for operation, prefix, suffix in [
+        ("sign", "Gen", "txt"),
+        ("verify", "Ver", "rsp"),
+    ]
+]

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -189,6 +189,24 @@ run_binary(
     ]
 ]
 
+run_binary(
+    name = "nist_cavp_hmac_fips_198_1_json",
+    srcs = [
+        "//sw/host/cryptotest/testvectors/data/schemas:hmac_schema.json",
+        "@nist_cavp_hmac_fips_198_1//:HMAC.rsp",
+    ],
+    outs = ["nist_cavp_hmac_fips_198_1.json"],
+    args = [
+        "--src",
+        "$(location @nist_cavp_hmac_fips_198_1//:HMAC.rsp)",
+        "--dst",
+        "$(location :nist_cavp_hmac_fips_198_1.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:hmac_schema.json)",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:nist_cavp_hmac_parser",
+)
+
 [
     run_binary(
         name = cryptotest_name,
@@ -212,6 +230,36 @@ run_binary(
     for src_name, mode, cryptotest_name in [
         ("kmac128_no_customization_test.json", "128", "wycheproof_kmac_128"),
         ("kmac256_no_customization_test.json", "256", "wycheproof_kmac_256"),
+    ]
+]
+
+[
+    run_binary(
+        name = cryptotest_name,
+        srcs = [
+            "@wycheproof//testvectors_v1:{}".format(src_name),
+            "//sw/host/cryptotest/testvectors/data/schemas:hmac_schema.json",
+        ],
+        outs = [":{}.json".format(cryptotest_name)],
+        args = [
+            "--src",
+            "$(location @wycheproof//testvectors_v1:{})".format(src_name),
+            "--dst",
+            "$(location :{}.json)".format(cryptotest_name),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:hmac_schema.json)",
+            "--hash",
+            hash_alg,
+        ],
+        tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_hmac_parser",
+    )
+    for src_name, hash_alg, cryptotest_name in [
+        ("hmac_sha256_test.json", "sha-256", "wycheproof_hmac_sha256"),
+        ("hmac_sha384_test.json", "sha-384", "wycheproof_hmac_sha384"),
+        ("hmac_sha512_test.json", "sha-512", "wycheproof_hmac_sha512"),
+        ("hmac_sha3_256_test.json", "sha3-256", "wycheproof_hmac_sha3_256"),
+        ("hmac_sha3_384_test.json", "sha3-384", "wycheproof_hmac_sha3_384"),
+        ("hmac_sha3_512_test.json", "sha3-512", "wycheproof_hmac_sha3_512"),
     ]
 ]
 

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -21,4 +21,5 @@ exports_files([
     "hash_schema.json",
     "hmac_schema.json",
     "kmac_schema.json",
+    "rsa_schema.json",
 ])

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -17,6 +17,7 @@ filegroup(
 exports_files([
     "aes_kw_schema.json",
     "aes_gcm_schema.json",
+    "drbg_schema.json",
     "ecdh_schema.json",
     "hash_schema.json",
     "hmac_schema.json",

--- a/sw/host/cryptotest/testvectors/data/schemas/BUILD
+++ b/sw/host/cryptotest/testvectors/data/schemas/BUILD
@@ -23,4 +23,5 @@ exports_files([
     "hmac_schema.json",
     "kmac_schema.json",
     "rsa_schema.json",
+    "sphincsplus_schema.json",
 ])

--- a/sw/host/cryptotest/testvectors/data/schemas/drbg_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/drbg_schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/hmac_schema.json",
+  "title": "Cryptotest HMAC Test Vector",
+  "description": "A list of testvectors for HMAC testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID number -- used for debugging",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be drbg",
+        "type": "string",
+        "enum": ["drbg"]
+      },
+      "entropy": {
+        "description": "Initial entropy value",
+        "$ref": "#/$defs/byte_array"
+      },
+      "personalization_string": {
+        "description": "Personalization string for instantiation",
+        "$ref": "#/$defs/byte_array"
+      },
+      "reseed": {
+        "description": "Whether the test requires reseeding",
+	"type": "boolean"
+      },
+      "reseed_entropy": {
+        "description": "Reseed entropy if reseed = True",
+        "$ref": "#/$defs/byte_array"
+      },
+      "reseed_additional_input": {
+        "description": "Additional value for reseed if reseed = True",
+        "$ref": "#/$defs/byte_array"
+      },
+      "additional_input_1": {
+        "description": "First additional value",
+        "$ref": "#/$defs/byte_array"
+      },
+      "additional_input_2": {
+        "description": "Second additional value",
+        "$ref": "#/$defs/byte_array"
+      },
+      "output": {
+        "description": "Expected random returned bits",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Whether the returned bits should match `output`",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/data/schemas/hmac_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/hmac_schema.json
@@ -35,7 +35,7 @@
       "hash_alg": {
         "description": "Hash algorithm",
         "type": "string",
-        "enum": ["sha-1", "sha-224", "sha-256", "sha-384", "sha-512"]
+        "enum": ["sha-1", "sha-224", "sha-256", "sha-384", "sha-512", "sha3-256", "sha3-384", "sha3-512"]
       },
       "key": {
         "description": "Key to use for tag generation",

--- a/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/rsa_schema.json",
+  "title": "Cryptotest RSA Signature Verification Test Vector",
+  "description": "A list of testvectors for RSA Signature Verification testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID from test vector source -- used for debugging",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be rsa",
+        "type": "string",
+        "enum": ["rsa"]
+      },
+      "operation": {
+        "description": "RSA operation",
+        "type": "string",
+        "enum": ["sign", "verify", "encrypt", "decrypt"]
+      },
+      "padding": {
+        "description": "RSA padding type",
+        "type": "string",
+        "enum": ["pkcs1_1.5", "pss", "oaep"]
+      },
+      "security_level": {
+        "description": "RSA security level",
+        "type": "integer",
+        "enum": [2048, 3072, 4096]
+      },
+      "hash_alg": {
+        "description": "Hash algorithm for message encoding",
+        "type": "string",
+        "enum": ["sha-256", "sha-384", "sha-512", "sha3-224", "sha3-256", "sha3-384", "sha3-512", "shake-128", "shake-256"]
+      },
+      "message": {
+        "description": "Un-hashed plaintext message",
+        "$ref": "#/$defs/byte_array"
+      },
+      "label": {
+        "description": "Label for OAEP encryption",
+        "$ref": "#/$defs/byte_array"
+      },
+      "n": {
+        "description": "RSA public value n",
+        "$ref": "#/$defs/byte_array"
+      },
+      "e": {
+        "description": "RSA exponent e",
+        "type": "integer"
+      },
+      "d": {
+        "description": "RSA private value d",
+        "$ref": "#/$defs/byte_array"
+      },
+      "signature": {
+        "description": "RSA signature",
+        "$ref": "#/$defs/byte_array"
+      },
+      "ciphertext": {
+        "description": "Ciphertext to decrypt",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Expected signature verification result",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/data/schemas/sphincsplus_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/sphincsplus_schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/sphincsplus_schema.json",
+  "title": "Cryptotest HMAC Test Vector",
+  "description": "A list of testvectors for SPHINCS+ testing",
+  "$defs": {
+    "byte_array": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 255
+      }
+    }
+  },
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vendor": {
+        "description": "Test vector vendor name",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case ID number (used for debugging)",
+        "type": "integer"
+      },
+      "algorithm": {
+        "description": "Should be sphincs+",
+        "type": "string",
+        "enum": ["sphincs+"]
+      },
+      "operation": {
+        "description": "SPHINCS+ operation",
+        "type": "string",
+        "enum": ["verify"]
+      },
+      "hash_alg": {
+        "description": "Hash algorithm to use",
+        "type": "string",
+        "enum": ["sha-256", "shake-256"]
+      },
+      "public": {
+        "description": "Public key bytes (big-endian)",
+        "$ref": "#/$defs/byte_array"
+      },
+      "message": {
+        "description": "Un-hashed input message",
+        "$ref": "#/$defs/byte_array"
+      },
+      "signature": {
+        "description": "Signature bytes (big-endian)",
+        "$ref": "#/$defs/byte_array"
+      },
+      "result": {
+        "description": "Whether the signature verification should succeed",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -121,3 +121,12 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "nist_cavp_rsa_parser",
+    srcs = ["nist_cavp_rsa_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -139,3 +139,12 @@ py_binary(
         requirement("jsonschema"),
     ],
 )
+
+py_binary(
+    name = "rsp_sphincsplus_parser",
+    srcs = ["rsp_sphincsplus_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -41,6 +41,15 @@ py_binary(
 )
 
 py_binary(
+    name = "nist_cavp_drbg_parser",
+    srcs = ["nist_cavp_drbg_parser.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
     name = "nist_cavp_ecdsa_parser",
     srcs = ["nist_cavp_ecdsa_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
+++ b/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
@@ -109,9 +109,9 @@ def str_to_byte_array(s: str) -> list:
     For example, str_to_byte_array("01020a0b") -> [1, 2, 10, 11]
     """
     if s.startswith("0x"):
-        s = s[1:]
+        s = s[2:]
     if len(s) % 2 != 0:
-        raise ValueError(f"String {s} has an odd number of digits; cannot convert into byte array.")
+        s = "0" + s
 
     byte_array = list()
     for i in range(0, len(s), 2):

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_drbg_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_drbg_parser.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting NIST CAVP DRBG test vectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+
+def parse_testcases(args) -> None:
+    raw_testcases = parse_rsp(args.src)
+    test_cases = list()
+
+    # NIST splits the rsp files into sections based on tag length
+    # (which implies which hash function should be used)
+    for test_vec in raw_testcases:
+        # The only configuration supported by cryptolib is AES-256
+        # without a derivation function. Exclude tests for other
+        # configs.
+        if test_vec["section_name"] != "AES-256 no df":
+            continue
+        test_case = {
+            "vendor": "nist",
+            "test_case_id": int(test_vec["COUNT"]),
+            "algorithm": "drbg",
+            "entropy": str_to_byte_array(test_vec["EntropyInput"]),
+            "personalization_string": str_to_byte_array(test_vec["PersonalizationString"]),
+            "reseed": args.reseed,
+            "additional_input_1": str_to_byte_array(test_vec["AdditionalInput"][0]),
+            "additional_input_2": str_to_byte_array(test_vec["AdditionalInput"][1]),
+            "output": str_to_byte_array(test_vec["ReturnedBits"]),
+            # All NIST DRBG vectors include the correct output in `ReturnedBits`.
+            "result": True,
+        }
+        if args.reseed:
+            test_case["reseed_entropy"] = str_to_byte_array(test_vec["EntropyInputReseed"])
+            test_case["reseed_additional_input"] = str_to_byte_array(
+                test_vec["AdditionalInputReseed"])
+
+        test_cases.append(test_case)
+
+    json_filename = f"{args.dst}"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP DRBG test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    parser.add_argument(
+        "--reseed",
+        action="store_true",
+        help = "Whether the tests require reseeding"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/host/cryptotest/testvectors/parsers/nist_cavp_rsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_cavp_rsa_parser.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting NIST CAVP RSA test vectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+SUPPORTED_SECURITY_LEVELS = [
+    2048,
+    3072,
+    4096,
+]
+
+HASH_NAME_MAPPING = {
+    "SHA256": "sha-256",
+    "SHA384": "sha-384",
+    "SHA512": "sha-512",
+}
+
+
+def parse_testcases(args) -> None:
+    # Depending on the operation, we have to notify the parser that certain
+    # variables in the rsp file are not intended to be treated as a test case
+    # on their own; instead, the values apply to all following test cases until
+    # the variable is assigned another value.
+    persists = []
+    if args.operation == "sign":
+        persists = ["n", "e", "d"]
+    elif args.operation == "verify":
+        persists = ["n", "p", "q"]
+    else:
+        raise ValueError(f"Unsupported RSA operation: {args.operation}")
+
+    raw_testcases = parse_rsp(args.src, persists=persists)
+
+    test_cases = list()
+    # NIST splits the rsp files into sections with named after (curve, hash
+    # algorithm) pairs
+    count = 0
+    for test_vec in raw_testcases:
+        count += 1
+        # Filter out unsupported configurations
+        if int(test_vec["mod"]) not in SUPPORTED_SECURITY_LEVELS:
+            continue
+        if test_vec["SHAAlg"] not in HASH_NAME_MAPPING:
+            continue
+        test_case = {
+            "vendor": "nist",
+            "test_case_id": count,
+            "algorithm": "rsa",
+            "operation": args.operation,
+            "padding": args.padding,
+            "security_level": int(test_vec["mod"]),
+            "hash_alg": HASH_NAME_MAPPING[test_vec["SHAAlg"]],
+            "message": str_to_byte_array(test_vec["Msg"]),
+            # Pad n and d with leading zero byte for compatibility
+            # with signed hexadecimal notation.
+            "n": [0] + str_to_byte_array(test_vec["n"]),
+            "e": int(test_vec["e"], 16),
+            "d": [0] + str_to_byte_array(test_vec["d"]) if "d" in test_vec else [],
+            "signature": str_to_byte_array(test_vec["S"]),
+        }
+        if args.operation == "sign":
+            # `Sign` tests always include the correct expected
+            # signature.
+            test_case["result"] = True
+        elif args.operation == "verify":
+            result_str = test_vec["Result"][:1]
+            if result_str == "P":
+                test_case["result"] = True
+            elif result_str == "F":
+                test_case["result"] = False
+            else:
+                raise ValueError(f"Unknown verification result value: {result_str}")
+
+        test_cases.append(test_case)
+
+    json_filename = f"{args.dst}"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP Digital Signatures test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    parser.add_argument(
+        "--operation",
+        type = str,
+        help = "RSA operation [sign, verify]"
+    )
+    parser.add_argument(
+        "--padding",
+        type = str,
+        help = "RSA padding type [pkcs1_1.5, pss]"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/host/cryptotest/testvectors/parsers/rsp_sphincsplus_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/rsp_sphincsplus_parser.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting SPHINCS+ RSP test vectors to JSON.
+
+"""
+
+import argparse
+import sys
+import json
+import jsonschema
+
+from cryptotest_util import parse_rsp, str_to_byte_array
+
+
+def parse_testcases(args) -> None:
+    raw_testcases = parse_rsp(args.src)
+    test_cases = list()
+
+    # The SPHINCS+ RSP files do not use named sections.
+    for test_vec in raw_testcases:
+        test_cases.append({
+            "vendor": "sphincs+",
+            "test_case_id": int(test_vec["count"]),
+            "algorithm": "sphincs+",
+            "operation": "verify",
+            "hash_alg": args.hash_alg,
+            "public": str_to_byte_array(test_vec["pk"]),
+            "message": str_to_byte_array(test_vec["msg"]),
+            # Parse the signature from `sm` by removing the message from the end.
+            "signature": str_to_byte_array(test_vec['sm'][:-len(test_vec['msg'])]),
+            "result": True,
+        })
+
+    json_filename = f"{args.dst}"
+    with open(json_filename, "w") as file:
+        json.dump(test_cases, file, indent=4)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(test_cases, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Parsing utility for NIST CAVP Digital Signatures test vectors.")
+
+    parser.add_argument(
+        "--src",
+        help="Source file to import."
+    )
+    parser.add_argument(
+        "--dst",
+        help="Destination of the output file."
+    )
+    parser.add_argument(
+        "--schema",
+        type = str,
+        help = "Test vector schema file"
+    )
+    parser.add_argument(
+        "--hash_alg",
+        type= str,
+        help = "Hash algorithm to use"
+    )
+    args = parser.parse_args()
+    parse_testcases(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -37,6 +37,11 @@ ujson_rust(
     srcs = ["//sw/device/tests/crypto/cryptotest/json:ecdsa_commands"],
 )
 
+ujson_rust(
+    name = "hmac_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:hmac_commands"],
+)
+
 rust_library(
     name = "cryptotest_commands",
     srcs = [
@@ -46,6 +51,7 @@ rust_library(
         "src/ecdh_commands.rs",
         "src/ecdsa_commands.rs",
         "src/hash_commands.rs",
+        "src/hmac_commands.rs",
         "src/lib.rs",
     ],
     compile_data = [
@@ -55,6 +61,7 @@ rust_library(
         ":drbg_commands_rust",
         ":ecdsa_commands_rust",
         ":hash_commands_rust",
+        ":hmac_commands_rust",
     ],
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
@@ -63,6 +70,7 @@ rust_library(
         "drbg_commands_loc": "$(execpath :drbg_commands_rust)",
         "ecdsa_commands_loc": "$(execpath :ecdsa_commands_rust)",
         "hash_commands_loc": "$(execpath :hash_commands_rust)",
+        "hmac_commands_loc": "$(execpath :hmac_commands_rust)",
     },
     deps = [
         "//sw/host/opentitanlib",

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -18,6 +18,11 @@ ujson_rust(
 )
 
 ujson_rust(
+    name = "drbg_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:drbg_commands"],
+)
+
+ujson_rust(
     name = "hash_commands_rust",
     srcs = ["//sw/device/tests/crypto/cryptotest/json:hash_commands"],
 )
@@ -37,6 +42,7 @@ rust_library(
     srcs = [
         "src/aes_commands.rs",
         "src/commands.rs",
+        "src/drbg_commands.rs",
         "src/ecdh_commands.rs",
         "src/ecdsa_commands.rs",
         "src/hash_commands.rs",
@@ -46,6 +52,7 @@ rust_library(
         ":commands_rust",
         ":aes_commands_rust",
         ":ecdh_commands_rust",
+        ":drbg_commands_rust",
         ":ecdsa_commands_rust",
         ":hash_commands_rust",
     ],
@@ -53,6 +60,7 @@ rust_library(
         "commands_loc": "$(execpath :commands_rust)",
         "aes_commands_loc": "$(execpath :aes_commands_rust)",
         "ecdh_commands_loc": "$(execpath :ecdh_commands_rust)",
+        "drbg_commands_loc": "$(execpath :drbg_commands_rust)",
         "ecdsa_commands_loc": "$(execpath :ecdsa_commands_rust)",
         "hash_commands_loc": "$(execpath :hash_commands_rust)",
     },

--- a/sw/host/cryptotest/ujson_lib/src/drbg_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/drbg_commands.rs
@@ -1,9 +1,4 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-pub mod aes_commands;
-pub mod commands;
-pub mod drbg_commands;
-pub mod ecdh_commands;
-pub mod ecdsa_commands;
-pub mod hash_commands;
+include!(env!("drbg_commands_loc"));

--- a/sw/host/cryptotest/ujson_lib/src/hmac_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/hmac_commands.rs
@@ -1,0 +1,4 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("hmac_commands_loc"));

--- a/sw/host/cryptotest/ujson_lib/src/lib.rs
+++ b/sw/host/cryptotest/ujson_lib/src/lib.rs
@@ -7,3 +7,4 @@ pub mod drbg_commands;
 pub mod ecdh_commands;
 pub mod ecdsa_commands;
 pub mod hash_commands;
+pub mod hmac_commands;

--- a/sw/host/tests/crypto/drbg_kat/BUILD
+++ b/sw/host/tests/crypto/drbg_kat/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -1,0 +1,162 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use std::fs;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::drbg_commands::{CryptotestDrbgInput, CryptotestDrbgOutput};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    drbg_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DrbgTestCase {
+    vendor: String,
+    test_case_id: usize,
+    entropy: Vec<u8>,
+    personalization_string: Vec<u8>,
+    reseed: bool,
+    #[serde(default)]
+    reseed_entropy: Vec<u8>,
+    #[serde(default)]
+    reseed_additional_input: Vec<u8>,
+    additional_input_1: Vec<u8>,
+    additional_input_2: Vec<u8>,
+    output: Vec<u8>,
+    result: bool,
+}
+
+fn run_drbg_testcase(
+    test_case: &DrbgTestCase,
+    opts: &Opts,
+    transport: &TransportWrapper,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "vendor: {}, test case: {}",
+        test_case.vendor,
+        test_case.test_case_id
+    );
+    let uart = transport.uart("console")?;
+
+    CryptotestCommand::Drbg.send(&*uart)?;
+
+    // Convert all inputs to little-endian
+    let mut entropy_le = Vec::from(test_case.entropy.as_slice());
+    let mut perso_string_le = Vec::from(test_case.personalization_string.as_slice());
+    let mut reseed_entropy_le = Vec::from(test_case.reseed_entropy.as_slice());
+    let mut reseed_addl_le = Vec::from(test_case.reseed_additional_input.as_slice());
+    let mut addl_1_le = Vec::from(test_case.additional_input_1.as_slice());
+    let mut addl_2_le = Vec::from(test_case.additional_input_2.as_slice());
+    entropy_le.reverse();
+    perso_string_le.reverse();
+    reseed_entropy_le.reverse();
+    reseed_addl_le.reverse();
+    addl_1_le.reverse();
+    addl_2_le.reverse();
+
+    // Send everything
+    CryptotestDrbgInput {
+        entropy: ArrayVec::try_from(entropy_le.as_slice()).unwrap(),
+        entropy_len: entropy_le.len(),
+        personalization_string: ArrayVec::try_from(perso_string_le.as_slice()).unwrap(),
+        personalization_string_len: perso_string_le.len(),
+        reseed: if test_case.reseed { 1 } else { 0 },
+        reseed_entropy: ArrayVec::try_from(reseed_entropy_le.as_slice()).unwrap(),
+        reseed_entropy_len: reseed_entropy_le.len(),
+        reseed_additional_input: ArrayVec::try_from(reseed_addl_le.as_slice()).unwrap(),
+        reseed_additional_input_len: reseed_addl_le.len(),
+        additional_input_1: ArrayVec::try_from(addl_1_le.as_slice()).unwrap(),
+        additional_input_1_len: addl_1_le.len(),
+        additional_input_2: ArrayVec::try_from(addl_2_le.as_slice()).unwrap(),
+        additional_input_2_len: addl_2_le.len(),
+        output_len: test_case.output.len(),
+    }
+    .send(&*uart)?;
+
+    // Get output
+    let drbg_output = CryptotestDrbgOutput::recv(&*uart, opts.timeout, false)?;
+    // The expected output is in a mixed-endian format (32-bit words
+    // are in little-endian order, but the bytes within the words are
+    // in big-endian order). Convert the actual output to match this
+    // format.
+    let mut output = Vec::from(&drbg_output.output[..drbg_output.output_len]);
+    let mut i = 0;
+    while i + 4 <= output.len() {
+        output[i..i + 4].reverse();
+        i += 4;
+    }
+    // Output byte length not a multiple of 4 is currently unsupported.
+    if i != output.len() {
+        panic!("Output length in bytes was not a multiple of 4.");
+    }
+    let success = test_case.output == output;
+    if test_case.result != success {
+        log::info!(
+            "FAILED test #{}: expected = {}, actual = {}",
+            test_case.test_case_id,
+            test_case.result,
+            success
+        );
+        *fail_counter += 1;
+    }
+    Ok(())
+}
+
+fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.drbg_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let drbg_tests: Vec<DrbgTestCase> = serde_json::from_str(&raw_json)?;
+
+        for drbg_test in &drbg_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_drbg_testcase(drbg_test, opts, transport, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_drbg, &opts, &transport);
+    Ok(())
+}

--- a/sw/host/tests/crypto/hmac_kat/BUILD
+++ b/sw/host/tests/crypto/hmac_kat/BUILD
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:ujson.bzl", "ujson_rust")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -1,0 +1,161 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use std::fs;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::hmac_commands::{
+    CryptotestHmacHashAlg, CryptotestHmacKey, CryptotestHmacMessage, CryptotestHmacTag,
+};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    hmac_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HmacTestCase {
+    vendor: String,
+    test_case_id: usize,
+    algorithm: String,
+    hash_alg: String,
+    key: Vec<u8>,
+    message: Vec<u8>,
+    tag: Vec<u8>,
+    result: bool,
+}
+
+const HMAC_CMD_MAX_MESSAGE_BYTES: usize = 256;
+const HMAC_CMD_MAX_KEY_BYTES: usize = 192;
+
+fn run_hmac_testcase(
+    test_case: &HmacTestCase,
+    opts: &Opts,
+    transport: &TransportWrapper,
+    fail_counter: &mut u32,
+) -> Result<()> {
+    log::info!(
+        "vendor: {}, test case: {}",
+        test_case.vendor,
+        test_case.test_case_id
+    );
+    let uart = transport.uart("console")?;
+
+    assert_eq!(test_case.algorithm.as_str(), "hmac");
+    CryptotestCommand::Hmac.send(&*uart)?;
+
+    assert!(
+        test_case.key.len() <= HMAC_CMD_MAX_KEY_BYTES,
+        "Key too long for device firmware configuration (got = {}, max = {})",
+        test_case.key.len(),
+        HMAC_CMD_MAX_KEY_BYTES,
+    );
+    assert!(
+        test_case.message.len() <= HMAC_CMD_MAX_MESSAGE_BYTES,
+        "Message too long for device firmware configuration (got = {}, max = {})",
+        test_case.message.len(),
+        HMAC_CMD_MAX_MESSAGE_BYTES,
+    );
+
+    match test_case.hash_alg.as_str() {
+        "sha-256" => CryptotestHmacHashAlg::Sha256,
+        "sha-384" => CryptotestHmacHashAlg::Sha384,
+        "sha-512" => CryptotestHmacHashAlg::Sha512,
+        "sha3-256" => CryptotestHmacHashAlg::Sha3_256,
+        "sha3-384" => CryptotestHmacHashAlg::Sha3_384,
+        "sha3-512" => CryptotestHmacHashAlg::Sha3_512,
+        _ => panic!("Unsupported HMAC hash mode"),
+    }
+    .send(&*uart)?;
+
+    CryptotestHmacKey {
+        key: ArrayVec::try_from(test_case.key.as_slice()).unwrap(),
+        key_len: test_case.key.len(),
+    }
+    .send(&*uart)?;
+
+    CryptotestHmacMessage {
+        message: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
+        message_len: test_case.message.len(),
+    }
+    .send(&*uart)?;
+
+    let hmac_tag = CryptotestHmacTag::recv(&*uart, opts.timeout, false)?;
+    let success = if test_case.tag.len() > hmac_tag.tag_len {
+        // If we got a shorter tag back then the test asks for, we can't accept the tag, even if
+        // the beginning bytes match.
+        false
+    } else {
+        // Some of the NIST test cases only specify the beginning bytes of the expected tag, so we
+        // only check up to what the test specifies.
+        test_case.tag[..] == hmac_tag.tag[..test_case.tag.len()]
+    };
+    if test_case.result != success {
+        log::info!(
+            "FAILED test #{}: expected = {}, actual = {}",
+            test_case.test_case_id,
+            test_case.result,
+            success
+        );
+    }
+    if success != test_case.result {
+        *fail_counter += 1;
+    }
+    Ok(())
+}
+
+fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut fail_counter = 0u32;
+    let test_vector_files = &opts.hmac_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let hmac_tests: Vec<HmacTestCase> = serde_json::from_str(&raw_json)?;
+
+        for hmac_test in &hmac_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_hmac_testcase(hmac_test, opts, transport, &mut fail_counter)?;
+        }
+    }
+    assert_eq!(
+        0, fail_counter,
+        "Failed {} out of {} tests.",
+        fail_counter, test_counter
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_hmac, &opts, &transport);
+    Ok(())
+}

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -15,6 +15,19 @@ def nist_cavp_repos():
     archive instead of the NIST website.
     """
     http_archive(
+        name = "nist_cavp_drbg_sp_800_90a_root",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "5f7e5658ebd5b4e6785a7b12fa32333511d2acc2f2d9c5ae1ffa16b699377769",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/drbg/drbgtestvectors.zip",
+	visibility = ["//visibility:private"],
+    )
+    http_archive(
+        name = "nist_cavp_drbg_sp_800_90a",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "8f9644adc655dd651c90b73190175b1d99164dc5a4861edab16e39862ead27ad",
+	url = "file://$(location @nist_cavp_drbg_sp_800_90a_root//:drbgvectors_no_reseed.zip)",
+    )
+    http_archive(
         name = "nist_cavp_ecdsa_fips_186_4",
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         strip_prefix = "186-4ecdsatestvectors",

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -77,3 +77,9 @@ def nist_cavp_repos():
         sha256 = "5fff092551f2d72e89a3d9362711878708f9a14b502f0dfae819649105b0ea39",
         url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/components/ecccdhtestvectors.zip",
     )
+    http_archive(
+        name = "nist_cavp_rsa_fips_186_3",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "8405aeb3572a4f98ed4b1a3ccb3f2f49e725462dd28ec4759d6a15d88855d19c",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-3rsatestvectors.zip",
+    )

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -89,3 +89,9 @@ def nist_cavp_repos():
         sha256 = "8405aeb3572a4f98ed4b1a3ccb3f2f49e725462dd28ec4759d6a15d88855d19c",
         url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-3rsatestvectors.zip",
     )
+    http_archive(
+        name = "nist_cavp_hmac_fips_198_1",
+        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
+        sha256 = "418c3837d38f249d6668146bd0090db24dd3c02d2e6797e3de33860a387ae4bd",
+        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/hmactestvectors.zip",
+    )

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -19,13 +19,6 @@ def nist_cavp_repos():
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         sha256 = "5f7e5658ebd5b4e6785a7b12fa32333511d2acc2f2d9c5ae1ffa16b699377769",
         url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/drbg/drbgtestvectors.zip",
-	visibility = ["//visibility:private"],
-    )
-    http_archive(
-        name = "nist_cavp_drbg_sp_800_90a",
-        build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
-        sha256 = "8f9644adc655dd651c90b73190175b1d99164dc5a4861edab16e39862ead27ad",
-	url = "file://$(location @nist_cavp_drbg_sp_800_90a_root//:drbgvectors_no_reseed.zip)",
     )
     http_archive(
         name = "nist_cavp_ecdsa_fips_186_4",

--- a/third_party/nist_cavp_testvectors/repos.bzl
+++ b/third_party/nist_cavp_testvectors/repos.bzl
@@ -18,7 +18,10 @@ def nist_cavp_repos():
         name = "nist_cavp_drbg_sp_800_90a_root",
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         sha256 = "5f7e5658ebd5b4e6785a7b12fa32333511d2acc2f2d9c5ae1ffa16b699377769",
-        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/drbg/drbgtestvectors.zip",
+        urls = [
+            "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/drbg/drbgtestvectors.zip",
+            "https://storage.googleapis.com/ot-crypto-test-vectors/nist/drbgtestvectors.zip",
+        ],
     )
     http_archive(
         name = "nist_cavp_ecdsa_fips_186_4",
@@ -81,17 +84,26 @@ def nist_cavp_repos():
         name = "nist_cavp_ecdh_sp_800_56a",
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         sha256 = "5fff092551f2d72e89a3d9362711878708f9a14b502f0dfae819649105b0ea39",
-        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/components/ecccdhtestvectors.zip",
+        urls = [
+            "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/components/ecccdhtestvectors.zip",
+            "https://storage.googleapis.com/ot-crypto-test-vectors/nist/ecccdhtestvectors.zip",
+        ],
     )
     http_archive(
         name = "nist_cavp_rsa_fips_186_3",
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         sha256 = "8405aeb3572a4f98ed4b1a3ccb3f2f49e725462dd28ec4759d6a15d88855d19c",
-        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-3rsatestvectors.zip",
+        urls = [
+            "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/dss/186-3rsatestvectors.zip",
+            "https://storage.googleapis.com/ot-crypto-test-vectors/nist/186-3rsatestvectors.zip",
+        ],
     )
     http_archive(
         name = "nist_cavp_hmac_fips_198_1",
         build_file = Label("//third_party/nist_cavp_testvectors:BUILD.nist_cavp_common.bazel"),
         sha256 = "418c3837d38f249d6668146bd0090db24dd3c02d2e6797e3de33860a387ae4bd",
-        url = "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/hmactestvectors.zip",
+        urls = [
+            "https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/mac/hmactestvectors.zip",
+            "https://storage.googleapis.com/ot-crypto-test-vectors/nist/hmactestvectors.zip",
+        ],
     )

--- a/third_party/sphincsplus/BUILD
+++ b/third_party/sphincsplus/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/sphincsplus/BUILD.sphincsplus_common.bazel
+++ b/third_party/sphincsplus/BUILD.sphincsplus_common.bazel
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))

--- a/third_party/sphincsplus/repos.bzl
+++ b/third_party/sphincsplus/repos.bzl
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def sphincsplus_repos():
+    http_archive(
+        name = "sphincsplus_kat",
+        build_file = Label("//third_party/sphincsplus:BUILD.sphincsplus_common.bazel"),
+        strip_prefix = "NIST-PQ-Submission-SPHINCS-20201001/KAT",
+        sha256 = "798c9ef5a851cd92e52e6c2fcc8403530a5f827bf07bf542e3dfdf98c1916338",
+        urls = [
+            # Self-hosted GCB ZIP that contains only the 128s/SHAKE256 test
+            # vectors. The original archive hosted at
+            # https://sphincs.org/data/sphincs+-round3-submission-nist.zip
+            # which includes the test vectors for all versions is not included
+            # here because the checksum differs.
+            "https://storage.googleapis.com/ot-crypto-test-vectors/sphincsplus/sphincsplus_shake256_128s_round3.zip ",
+        ],
+    )


### PR DESCRIPTION
Adds the GCB mirror URLs for the NIST test vectors for DRBG, RSA, ECDH, and HMAC.