### PR TITLE
[aon_timer,sival] Fix aon_timer_smoketest in silicon

### DIFF
--- a/sw/device/tests/aon_timer_smoketest.c
+++ b/sw/device/tests/aon_timer_smoketest.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/aon_timer_testutils.h"
@@ -15,6 +16,10 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTTF_DEFINE_TEST_CONFIG();
+
+static dif_aon_timer_t aon;
+static dif_rv_core_ibex_t rv_core_ibex;
+static volatile bool wdog_fired = false;
 
 static void aon_timer_test_wakeup_timer(dif_aon_timer_t *aon) {
   // Test the wake-up timer functionality by setting a single cycle counter.
@@ -36,6 +41,31 @@ static void aon_timer_test_wakeup_timer(dif_aon_timer_t *aon) {
       dif_aon_timer_irq_acknowledge(aon, kDifAonTimerIrqWkupTimerExpired));
 }
 
+/**
+ * OTTF external NMI internal IRQ handler.
+ * The ROM configures the watchdog to generates a NMI at bark, so we clean the
+ * NMI.
+ */
+void ottf_external_nmi_handler(void) {
+  bool is_pending;
+  // The watchdog bark external interrupt is also connected to the NMI input
+  // of rv_core_ibex. We therefore expect the interrupt to be pending on the
+  // peripheral side.
+  CHECK_DIF_OK(dif_aon_timer_irq_is_pending(&aon, kDifAonTimerIrqWdogTimerBark,
+                                            &is_pending));
+  if (is_pending) {
+    wdog_fired = true;
+    CHECK_DIF_OK(dif_aon_timer_watchdog_stop(&aon));
+    // In order to handle the NMI we need to acknowledge the interrupt status
+    // bit at the peripheral side.
+    CHECK_DIF_OK(
+        dif_aon_timer_irq_acknowledge(&aon, kDifAonTimerIrqWdogTimerBark));
+
+    CHECK_DIF_OK(dif_rv_core_ibex_clear_nmi_state(&rv_core_ibex,
+                                                  kDifRvCoreIbexNmiSourceWdog));
+  }
+}
+
 static void aon_timer_test_watchdog_timer(dif_aon_timer_t *aon) {
   // Test the watchdog timer functionality by setting a single cycle "bark"
   // counter. Delay to compensate for AON Timer 200kHz clock (less should
@@ -44,26 +74,36 @@ static void aon_timer_test_watchdog_timer(dif_aon_timer_t *aon) {
       aon_timer_testutils_watchdog_config(aon, 1, UINT32_MAX, false));
   busy_spin_micros(100);
 
-  // Make sure that the timer has expired.
-  bool is_pending;
-  CHECK_DIF_OK(dif_aon_timer_irq_is_pending(aon, kDifAonTimerIrqWdogTimerBark,
-                                            &is_pending));
-  CHECK(is_pending);
+  dif_rv_core_ibex_nmi_state_t nmi_state;
+  CHECK_DIF_OK(dif_rv_core_ibex_get_nmi_state(&rv_core_ibex, &nmi_state));
 
-  CHECK_DIF_OK(dif_aon_timer_watchdog_stop(aon));
+  // The TestROM does not enable NMI so we need to check that the IRQ was
+  // requested.
+  if (!nmi_state.wdog_enabled) {
+    // Make sure that the timer has expired.
+    bool is_pending;
+    CHECK_DIF_OK(dif_aon_timer_irq_is_pending(aon, kDifAonTimerIrqWdogTimerBark,
+                                              &is_pending));
+    CHECK(is_pending);
 
-  CHECK_DIF_OK(
-      dif_aon_timer_irq_acknowledge(aon, kDifAonTimerIrqWdogTimerBark));
+    CHECK_DIF_OK(dif_aon_timer_watchdog_stop(aon));
+
+    CHECK_DIF_OK(
+        dif_aon_timer_irq_acknowledge(aon, kDifAonTimerIrqWdogTimerBark));
+  } else {
+    CHECK(wdog_fired);
+  }
 }
 
 bool test_main(void) {
-  dif_aon_timer_t aon;
-
   LOG_INFO("Running AON timer test");
 
   // Initialise AON Timer.
   CHECK_DIF_OK(dif_aon_timer_init(
       mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon));
+  CHECK_DIF_OK(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
 
   aon_timer_test_wakeup_timer(&aon);
   aon_timer_test_watchdog_timer(&aon);


### PR DESCRIPTION
In non-TestROM environements, the ROM enables the NMI for the watchdog which is not caught by the test. This commit makes the code handle the NMI in non-testrom.

One could say that with this change, the test becomes quite close to the aon IRQ test but it is still simpler I think.