### PR TITLE
[bazel] Change default environments for test targets.

### DIFF
--- a/doc/getting_started/build_sw.md
+++ b/doc/getting_started/build_sw.md
@@ -117,7 +117,7 @@ You may find it useful to use wildcards to build/test all targets in the OpenTit
 If a target (a test or build artifact) relies on optional parts of the "Getting Started" guide they should be tagged so they can be filtered out and users can `bazelisk.sh test //...` once they filter out the appropriate tags.
 We maintain or use the following tags to support this:
 * `broken` is used to tag tests that are committed but should not be expected by CI or others to pass.
-* `cw310`, `cw310_test_rom`, and `cw310_rom` are used to tag tests that depend on a correctly setup cw310 "Bergen Board" to emulate OpenTitan.
+* `cw310`, `cw310_test_rom`, and `cw310_rom_with_fake_keys` are used to tag tests that depend on a correctly setup cw310 "Bergen Board" to emulate OpenTitan.
   The `cw310` tag may be used in `--test_tag_filters` to enable concise filtering to select tests that run on this board and include or exclude them.
   Loading the bitstream is the slowest part of the test, so these tags can group tests with common bitstreams to accelerate the tests tagged `cw310_test_rom`.
 * `verilator` is used to tag tests that depend on a verilated model of OpenTitan that can take a significant time to build.
@@ -145,7 +145,8 @@ There is no way to filter out dependencies of a test\_suite such as `//sw/device
 
 On-device tests such as `//sw/device/tests:uart_smoketest` include multiple targets for different device simulation/emulation tools.
 Typically, you will only want to run one of these test targets at a time (for instance, only Verilator or only FPGA).
-Add `_sim_verilator` to the test name to run the test on Verilator only, and `_fpga_cw310_rom` or `_fpga_cw310_test_rom` to run the test on FPGA only.
+Add `_sim_verilator` to the test name to run the test on Verilator only, and `_fpga_cw310_rom_with_fake_keys` or `_fpga_cw310_test_rom` to run the test on FPGA only.
+Not all tests are available on all of these targets; in particular, tests do not always expose both `_fpga_cw310_rom_with_fake_keys` and `fpga_cw310_test_rom` options, so if one does not work then it's good to try the other.
 
 You can check which Verilator tests are available under a given directory using:
 ```console

--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -59,7 +59,7 @@ cp util/git/hooks/post-checkout .git/hooks/
 Synthesizing a design for an FPGA board is simple with Bazel.
 While Bazel is the entry point for kicking off the FPGA synthesis, under the hood, it invokes FuseSoC, the hardware package manager / build system supported by OpenTitan.
 During the build process, the boot ROM is baked into the bitstream.
-As mentioned above, we maintain two boot ROM programs, one for testing (_test ROM_), and one for production (_ROM_).
+As mentioned above, we maintain two boot ROM programs, one for faster testing (_test ROM_), and one for production (_ROM_).
 
 To build an FPGA bitstream with the _test ROM_ for the chosen board, use:
 ```sh
@@ -70,7 +70,7 @@ cd $REPO_TOP
 To build an FPGA bitstream with the _ROM_ for the chosen board, use:
 ```sh
 cd $REPO_TOP
-./bazelisk.sh build //hw/bitstream/vivado:fpga_${BOARD}_rom
+./bazelisk.sh build //hw/bitstream/vivado:fpga_${BOARD}_rom_with_fake_keys
 ```
 
 >**Note**: Building these bitstreams will require Vivado be installed on your system, with access to the proper licenses, described [here](./install_vivado/README.md).
@@ -170,7 +170,7 @@ You will then need to run this command to configure the board. You only need to 
 Check that it's working by [running the demo](#bootstrapping-the-demo-software) or a test, such as the `uart_smoketest` below.
 ```sh
 cd $REPO_TOP
-./bazelisk.sh test --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_test_rom
+./bazelisk.sh test --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_rom_with_fake_keys
 ```
 
 ### Troubleshooting
@@ -204,7 +204,7 @@ cd $REPO_TOP
 or
 ```sh
 cd $REPO_TOP
-./bazelisk.sh test --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_test_rom
+./bazelisk.sh test --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_rom_with_fake_keys
 ```
 
 Under the hood, Bazel conveniently dispatches `opentitantool` to both:
@@ -218,14 +218,14 @@ To get a better understanding of the `opentitantool` functions Bazel invokes aut
 By default, the above invocations of `./bazelisk.sh test ...` use the pre-built (Internet downloaded) FPGA bitstream.
 To instruct bazel to load the bitstream built earlier, or to have bazel build an FPGA bitstream on the fly, and load that bitstream onto the FPGA, add the `--define bitstream=vivado` flag to either of the above Bazel commands, for example, run:
 ```sh
-./bazelisk.sh test --define bitstream=vivado --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_test_rom
+./bazelisk.sh test --define bitstream=vivado --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_rom_with_fake_keys
 ```
 
 #### Configuring Bazel to skip loading a bitstream
 
 Alternatively, if you would like to instruct Bazel to skip loading any bitstream at all, and simply use the bitstream that is already loaded, add the `--define bitstream=skip` flag, for example, run:
 ```sh
-./bazelisk.sh test --define bitstream=skip --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_test_rom
+./bazelisk.sh test --define bitstream=skip --test_output=streamed //sw/device/tests:uart_smoketest_fpga_${BOARD}_rom_with_fake_keys
 ```
 
 ### Manually loading FPGA bitstreams and bootstrapping OpenTitan software with `opentitantool`
@@ -258,7 +258,7 @@ cd $REPO_TOP
 **if you built the bitstream yourself:**
 ```sh
 cd $REPO_TOP
-./bazelisk.sh run //sw/host/opentitantool -- fpga load-bitstream $(ci/scripts/target-location.sh //hw/bitstream/vivado:fpga_${BOARD}_test_rom)
+./bazelisk.sh run //sw/host/opentitantool -- fpga load-bitstream $(ci/scripts/target-location.sh //hw/bitstream/vivado:fpga_${BOARD}_rom_with_fake_keys)
 ```
 
 Depending on the FPGA device, the flashing itself may take several seconds.
@@ -440,7 +440,7 @@ First, make sure the device software has been built with debug symbols (by defau
 For example, to build and test the UART smoke test with debug symbols, you can add `--copt=-g` flag to the `./bazelisk.sh test ...` command:
 ```sh
 cd $REPO_TOP
-./bazelisk.sh test --copt=-g --test_output=streamed //sw/device/tests:uart_smoketest_fpga_cw340_test_rom
+./bazelisk.sh test --copt=-g --test_output=streamed //sw/device/tests:uart_smoketest_fpga_cw340_rom_with_fake_keys
 ```
 
 Then a connection between OpenOCD and GDB may be established with:

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -75,7 +75,6 @@ spx_key_by_name = _spx_key_by_name
 # The default set of test environments for Earlgrey.
 EARLGREY_TEST_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-    "//hw/top_earlgrey:fpga_cw310_test_rom": None,
     "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     "//hw/top_earlgrey:sim_dv": None,
     "//hw/top_earlgrey:sim_verilator": None,


### PR DESCRIPTION
By default, `EARLGREY_TEST_ENVS` used to run tests on both test ROM and regular ROM. This results in a lot of duplicated runs on CI. This commit removes the test ROM from the defaults list, leaving only ROM. If a test has explicitly overridden this default value (and e.g. specified it only runs on test ROM), then it will be unaffected by this change.

The second commit updates documentation: since `uart_smoketest` and other targets no longer include the
`test_rom` environment, it updates the Bazel commands in the documentation to use the ROM targets instead. It also updates a few references to `_rom` targets (which no longer exist afaict, having been replaced by `_rom_with_fake_keys` targets) and clarifies that not all tests will support both test ROM and ROM.

If this works like we hope, it should mean the test ROM portion of CI is a lot shorter.