### PR TITLE
[csrng/rtl] Propagate csrng errors to edn through cmd sts signal

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
@@ -15,13 +15,13 @@ class csrng_agent_cfg extends dv_base_agent_cfg;
 
   `uvm_object_new
 
-  uint   min_cmd_ack_dly, max_cmd_ack_dly,
-         min_genbits_dly, max_genbits_dly,
-         min_genbits_rdy_dly, max_genbits_rdy_dly,
-         min_cmd_rdy_dly, max_cmd_rdy_dly,
-         reseed_cnt, generate_cnt, generate_between_reseeds_cnt;
-  bit    cmd_zero_delays;
-  bit    under_reset;
-  bit    rsp_sts_err;
+  uint              min_cmd_ack_dly, max_cmd_ack_dly,
+                    min_genbits_dly, max_genbits_dly,
+                    min_genbits_rdy_dly, max_genbits_rdy_dly,
+                    min_cmd_rdy_dly, max_cmd_rdy_dly,
+                    reseed_cnt, generate_cnt, generate_between_reseeds_cnt;
+  bit               cmd_zero_delays;
+  bit               under_reset;
+  csrng_cmd_sts_e   rsp_sts_err;
 
 endclass

--- a/hw/dv/sv/csrng_agent/csrng_device_driver.sv
+++ b/hw/dv/sv/csrng_agent/csrng_device_driver.sv
@@ -16,7 +16,7 @@ class csrng_device_driver extends csrng_driver;
 
   virtual task reset_signals();
     cfg.vif.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
-    cfg.vif.cmd_rsp_int.csrng_rsp_sts <= 1'b0;
+    cfg.vif.cmd_rsp_int.csrng_rsp_sts <= CMD_STS_SUCCESS;
   endtask
 
   // drive trans received from sequencer
@@ -35,7 +35,7 @@ class csrng_device_driver extends csrng_driver;
           cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= cfg.rsp_sts_err;
           @(cfg.vif.device_cb);
           cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_ack <= 1'b0;
-          cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= 1'b0;,
+          cfg.vif.device_cb.cmd_rsp_int.csrng_rsp_sts <= CMD_STS_SUCCESS;,
           wait (cfg.under_reset == 1);)
 
       // Write ack bit again in case the race condition with `reset_signals`.

--- a/hw/dv/sv/csrng_agent/csrng_if.sv
+++ b/hw/dv/sv/csrng_agent/csrng_if.sv
@@ -30,7 +30,8 @@ interface csrng_if (input clk, input rst_n);
   assign cmd_push_if.valid     = (if_mode == dv_utils_pkg::Device) ? cmd_req.csrng_req_valid : 'z;
   assign cmd_push_if.h_data    = (if_mode == dv_utils_pkg::Device) ? cmd_req.csrng_req_bus : 'z;
   assign cmd_rsp.csrng_rsp_ack = (if_mode == dv_utils_pkg::Device) ? cmd_rsp_int.csrng_rsp_ack : 'z;
-  assign cmd_rsp.csrng_rsp_sts = (if_mode == dv_utils_pkg::Device) ? cmd_rsp_int.csrng_rsp_sts : 'z;
+  assign cmd_rsp.csrng_rsp_sts = (if_mode == dv_utils_pkg::Device) ?
+                                 cmd_rsp_int.csrng_rsp_sts : CMD_STS_UNDRIVEN;
 
   assign genbits_push_if.ready = (if_mode == dv_utils_pkg::Device) ? cmd_req.genbits_ready : 'z;
   assign cmd_rsp.genbits_valid = (if_mode == dv_utils_pkg::Device) ? genbits_push_if.valid : 'z;

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -325,20 +325,45 @@
       tags: [// Internal HW can modify status register
                  "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
-        { bits: "0",
-          name: "CMD_RDY",
-          desc: '''This bit indicates when the command interface is ready to accept commands.
-                '''
-          resval: "1"
-        }
         { bits: "1",
+          name: "CMD_RDY",
+          desc: '''
+                This bit indicates when the command interface is ready to accept commands.
+                Before starting to write a new command to !!SW_CMD_REQ, this field needs to be polled.
+                0b0: CSRNG is not ready to accept commands or the last command hasn't been acked yet.
+                0b1: CSRNG is ready to accept the next command.
+                '''
+          resval: "0"
+        }
+        { bits: "2",
+          name: "CMD_ACK",
+          desc: '''
+                This one bit field indicates when a SW command has been acknowledged by the CSRNG.
+                It is set to low each time a new command is written to !!CMD_REQ.
+                The field is set to high once a SW command request has been acknowledged by the CSRNG.
+                0b0: The last SW command has not been acknowledged yet.
+                0b1: The last SW command has been acknowledged.
+                '''
+          resval: "0"
+        }
+        { bits: "4:3",
           name: "CMD_STS",
           desc: '''
-                This one bit field is the status code returned with the application command ack.
+                This field represents the status code returned with the application command ack.
                 It is updated each time a command ack is asserted on the internal application
                 interface for software use.
-                0b0: Request completed successfully
-                0b1: Request completed with an error
+                To check whether a command was succesful, wait for !!INTR_STATE.CS_CMD_REQ_DONE or
+                !!SW_CMD_STS.CMD_ACK to be high and then check the value of this field.
+                0x0: Request completed successfully.
+                0x1: Request completed with an invalid application command error.
+                     This error indicates that the issued application command doesn't represent a valid operation.
+                     If this error appears, the main state machine will hang and the entropy complex has to be restarted.
+                0x2: Request completed with an invalid state parameter error.
+                     This error indicates that the state wasn't zeroized properly after an uninstantiate command.
+                     In this case the entropy complex should be restarted to properly zeroize the state.
+                0x3: Request completed with an invalid counter drbg generation command error.
+                     This error indicates that CSRNG entropy was generated for a command that is not a generate command.
+                     In this case the entropy should not be considered as valid.
                 '''
           resval: "0"
         }

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -27,10 +27,10 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   output logic [CmdFifoWidth-1:0]    cmd_arb_bus_o,
   // Ack from core.
   input logic                        cmd_ack_i,
-  input logic                        cmd_ack_sts_i,
+  input csrng_cmd_sts_e              cmd_ack_sts_i,
   // Ack to app i/f.
   output logic                       cmd_stage_ack_o,
-  output logic                       cmd_stage_ack_sts_o,
+  output csrng_cmd_sts_e             cmd_stage_ack_sts_o,
   // Genbits from core.
   input logic                        genbits_vld_i,
   input logic [127:0]                genbits_bus_i,
@@ -85,7 +85,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
 
   // Flops.
   logic                    cmd_ack_q, cmd_ack_d;
-  logic                    cmd_ack_sts_q, cmd_ack_sts_d;
+  csrng_cmd_sts_e          cmd_ack_sts_q, cmd_ack_sts_d;
   logic [3:0]              cmd_len_q, cmd_len_d;
   logic                    cmd_gen_flag_q, cmd_gen_flag_d;
   logic [11:0]             cmd_gen_cmd_q, cmd_gen_cmd_d;
@@ -96,7 +96,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
       cmd_ack_q       <= '0;
-      cmd_ack_sts_q   <= '0;
+      cmd_ack_sts_q   <= CMD_STS_SUCCESS;
       cmd_len_q       <= '0;
       cmd_gen_flag_q  <= '0;
       cmd_gen_cmd_q   <= '0;
@@ -413,7 +413,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   assign cmd_stage_ack_o = cmd_ack_q;
 
   assign cmd_ack_sts_d =
-         (!cs_enable_i) ? '0 :
+         (!cs_enable_i) ? CMD_STS_SUCCESS :
          cmd_final_ack ? cmd_ack_sts_i :
          cmd_ack_sts_q;
 

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -106,7 +106,7 @@ module csrng_core import csrng_pkg::*; #(
   logic [KeyLen-1:0]           state_db_wr_key;
   logic [BlkLen-1:0]           state_db_wr_v;
   logic [CtrLen-1:0]           state_db_wr_rc;
-  logic                        state_db_wr_sts;
+  csrng_cmd_sts_e              state_db_wr_sts;
   logic                        state_db_wr_fips;
   logic [Cmd-1:0]              state_db_wr_ccmd;
 
@@ -125,7 +125,7 @@ module csrng_core import csrng_pkg::*; #(
 
   logic                        cmd_result_wr_req;
   logic                        cmd_result_ack;
-  logic                        cmd_result_ack_sts;
+  csrng_cmd_sts_e              cmd_result_ack_sts;
   logic [Cmd-1:0]              cmd_result_ccmd;
   logic                        cmd_result_ack_rdy;
   logic [StateId-1:0]          cmd_result_inst_id;
@@ -137,11 +137,11 @@ module csrng_core import csrng_pkg::*; #(
   logic [CtrLen-1:0]           cmd_result_rc;
 
   logic                        state_db_sts_ack;
-  logic                        state_db_sts_sts;
+  csrng_cmd_sts_e              state_db_sts_sts;
   logic [StateId-1:0]          state_db_sts_id;
 
   logic                        gen_result_wr_req;
-  logic                        gen_result_ack_sts;
+  csrng_cmd_sts_e              gen_result_ack_sts;
   logic                        gen_result_ack_rdy;
   logic [Cmd-1:0]              gen_result_ccmd;
   logic [StateId-1:0]          gen_result_inst_id;
@@ -303,54 +303,54 @@ module csrng_core import csrng_pkg::*; #(
   logic                        ctr_drbg_upd_v_ctr_err;
   logic                        ctr_drbg_gen_v_ctr_err;
 
-  logic [NApps-1:0]          cmd_stage_vld;
-  logic [StateId-1:0]        cmd_stage_shid[NApps];
-  logic [AppCmdWidth-1:0]    cmd_stage_bus[NApps];
-  logic [NApps-1:0]          cmd_stage_rdy;
-  logic [NApps-1:0]          cmd_arb_req;
-  logic [NApps-1:0]          cmd_arb_gnt;
-  logic [$clog2(NApps)-1:0]  cmd_arb_idx;
-  logic [NApps-1:0]          cmd_arb_sop;
-  logic [NApps-1:0]          cmd_arb_mop;
-  logic [NApps-1:0]          cmd_arb_eop;
-  logic [AppCmdWidth-1:0]    cmd_arb_bus[NApps];
-  logic [NApps-1:0]          cmd_core_ack;
-  logic [NApps-1:0]          cmd_core_ack_sts;
-  logic [NApps-1:0]          cmd_stage_ack;
-  logic [NApps-1:0]          cmd_stage_ack_sts;
-  logic [NApps-1:0]          genbits_core_vld;
-  logic [GenBitsWidth-1:0]   genbits_core_bus[NApps];
-  logic [NApps-1:0]          genbits_core_fips;
-  logic [NApps-1:0]          genbits_stage_vld;
-  logic [NApps-1:0]          genbits_stage_fips;
-  logic [GenBitsWidth-1:0]   genbits_stage_bus[NApps];
-  logic [NApps-1:0]          genbits_stage_rdy;
-  logic                      genbits_stage_vldo_sw;
-  logic                      genbits_stage_bus_rd_sw;
-  logic [31:0]               genbits_stage_bus_sw;
-  logic                      genbits_stage_fips_sw;
+  logic [NApps-1:0]            cmd_stage_vld;
+  logic [StateId-1:0]          cmd_stage_shid[NApps];
+  logic [AppCmdWidth-1:0]      cmd_stage_bus[NApps];
+  logic [NApps-1:0]            cmd_stage_rdy;
+  logic [NApps-1:0]            cmd_arb_req;
+  logic [NApps-1:0]            cmd_arb_gnt;
+  logic [$clog2(NApps)-1:0]    cmd_arb_idx;
+  logic [NApps-1:0]            cmd_arb_sop;
+  logic [NApps-1:0]            cmd_arb_mop;
+  logic [NApps-1:0]            cmd_arb_eop;
+  logic [AppCmdWidth-1:0]      cmd_arb_bus[NApps];
+  logic [NApps-1:0]            cmd_core_ack;
+  csrng_cmd_sts_e [NApps-1:0]  cmd_core_ack_sts;
+  logic [NApps-1:0]            cmd_stage_ack;
+  csrng_cmd_sts_e [NApps-1:0]  cmd_stage_ack_sts;
+  logic [NApps-1:0]            genbits_core_vld;
+  logic [GenBitsWidth-1:0]     genbits_core_bus[NApps];
+  logic [NApps-1:0]            genbits_core_fips;
+  logic [NApps-1:0]            genbits_stage_vld;
+  logic [NApps-1:0]            genbits_stage_fips;
+  logic [GenBitsWidth-1:0]     genbits_stage_bus[NApps];
+  logic [NApps-1:0]            genbits_stage_rdy;
+  logic                        genbits_stage_vldo_sw;
+  logic                        genbits_stage_bus_rd_sw;
+  logic [31:0]                 genbits_stage_bus_sw;
+  logic                        genbits_stage_fips_sw;
 
-  logic [15:0]               hw_exception_sts;
-  logic [LcHwDebugCopies-1:0]lc_hw_debug_on_fo;
-  logic                      state_db_is_dump_en;
-  logic                      state_db_reg_rd_sel;
-  logic                      state_db_reg_rd_id_pulse;
-  logic [StateId-1:0]        state_db_reg_rd_id;
-  logic [31:0]               state_db_reg_rd_val;
+  logic [15:0]                 hw_exception_sts;
+  logic [LcHwDebugCopies-1:0]  lc_hw_debug_on_fo;
+  logic                        state_db_is_dump_en;
+  logic                        state_db_reg_rd_sel;
+  logic                        state_db_reg_rd_id_pulse;
+  logic [StateId-1:0]          state_db_reg_rd_id;
+  logic [31:0]                 state_db_reg_rd_val;
 
-  logic [30:0]               err_code_test_bit;
-  logic                      ctr_drbg_upd_es_ack;
-  logic                      ctr_drbg_gen_es_ack;
-  logic                      block_encrypt_quiet;
+  logic [30:0]                 err_code_test_bit;
+  logic                        ctr_drbg_upd_es_ack;
+  logic                        ctr_drbg_gen_es_ack;
+  logic                        block_encrypt_quiet;
 
-  logic                      cs_rdata_capt_vld;
-  logic                      cs_bus_cmp_alert;
-  logic                      cmd_rdy;
-  logic [1:0]                efuse_sw_app_enable;
+  logic                        cs_rdata_capt_vld;
+  logic                        cs_bus_cmp_alert;
+  logic                        cmd_rdy;
+  logic [1:0]                  efuse_sw_app_enable;
 
-  logic                      unused_err_code_test_bit;
-  logic                      unused_reg2hw_genbits;
-  logic                      unused_int_state_val;
+  logic                        unused_err_code_test_bit;
+  logic                        unused_reg2hw_genbits;
+  logic                        unused_int_state_val;
 
   prim_mubi_pkg::mubi8_t [1:0] en_csrng_sw_app_read;
   prim_mubi_pkg::mubi4_t [CsEnableCopies-1:0] mubi_cs_enable_fanout;
@@ -372,6 +372,7 @@ module csrng_core import csrng_pkg::*; #(
   logic [63:0]               cs_rdata_capt_q, cs_rdata_capt_d;
   logic                      cs_rdata_capt_vld_q, cs_rdata_capt_vld_d;
   logic                      sw_rdy_sts_q, sw_rdy_sts_d;
+  logic                      sw_sts_ack_q, sw_sts_ack_d;
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
@@ -390,6 +391,7 @@ module csrng_core import csrng_pkg::*; #(
       cs_rdata_capt_q         <= '0;
       cs_rdata_capt_vld_q     <= '0;
       sw_rdy_sts_q            <= '0;
+      sw_sts_ack_q            <= '0;
     end else begin
       acmd_q                  <= acmd_d;
       shid_q                  <= shid_d;
@@ -406,6 +408,7 @@ module csrng_core import csrng_pkg::*; #(
       cs_rdata_capt_q         <= cs_rdata_capt_d;
       cs_rdata_capt_vld_q     <= cs_rdata_capt_vld_d;
       sw_rdy_sts_q            <= sw_rdy_sts_d;
+      sw_sts_ack_q            <= sw_sts_ack_d;
     end
 
   //--------------------------------------------
@@ -870,14 +873,23 @@ module csrng_core import csrng_pkg::*; #(
   assign hw2reg.sw_cmd_sts.cmd_rdy.d = cmd_rdy;
   assign cmd_rdy = !cmd_stage_vld[NApps-1] && sw_rdy_sts_q;
   assign sw_rdy_sts_d =
-         !cs_enable_fo[28] ? 1'b1 :
+         !cs_enable_fo[28] ? 1'b0 :
          cmd_stage_vld[NApps-1] ? 1'b0 :
          cmd_stage_rdy[NApps-1] ? 1'b1 :
          sw_rdy_sts_q;
-
+  // cmd sts ack
+  assign hw2reg.sw_cmd_sts.cmd_ack.de = 1'b1;
+  assign hw2reg.sw_cmd_sts.cmd_ack.d = sw_sts_ack_d;
+  assign sw_sts_ack_d =
+         !cs_enable_fo[28] ? 1'b0 :
+         cmd_stage_vld[NApps-1] ? 1'b0 :
+         cmd_stage_ack[NApps-1] ? 1'b1 :
+         sw_sts_ack_q;
   // cmd ack sts
-  assign hw2reg.sw_cmd_sts.cmd_sts.de = cmd_stage_ack[NApps-1];
-  assign hw2reg.sw_cmd_sts.cmd_sts.d = cmd_stage_ack_sts[NApps-1];
+  assign hw2reg.sw_cmd_sts.cmd_sts.de = (cs_main_sm_alert && (shid_q == StateId'(NApps-1))) ||
+      cmd_stage_ack[NApps-1];
+  assign hw2reg.sw_cmd_sts.cmd_sts.d = (cs_main_sm_alert && (shid_q == StateId'(NApps-1))) ?
+      CMD_STS_INVALID_ACMD : cmd_stage_ack_sts[NApps-1];
   // genbits
   assign hw2reg.genbits_vld.genbits_vld.d = genbits_stage_vldo_sw;
   assign hw2reg.genbits_vld.genbits_fips.d = genbits_stage_fips_sw;
@@ -963,8 +975,10 @@ module csrng_core import csrng_pkg::*; #(
     assign cmd_stage_bus[hai] = csrng_cmd_i[hai].csrng_req_bus;
     assign csrng_cmd_o[hai].csrng_req_ready = cmd_stage_rdy[hai];
     // cmd ack
-    assign csrng_cmd_o[hai].csrng_rsp_ack = cmd_stage_ack[hai];
-    assign csrng_cmd_o[hai].csrng_rsp_sts = cmd_stage_ack_sts[hai];
+    assign csrng_cmd_o[hai].csrng_rsp_ack = (cs_main_sm_alert && (shid_q == StateId'(hai))) ||
+        cmd_stage_ack[hai];
+    assign csrng_cmd_o[hai].csrng_rsp_sts = (cs_main_sm_alert && (shid_q == StateId'(hai))) ?
+        CMD_STS_INVALID_ACMD : cmd_stage_ack_sts[hai];
     // genbits
     assign csrng_cmd_o[hai].genbits_valid = genbits_stage_vld[hai];
     assign csrng_cmd_o[hai].genbits_fips = genbits_stage_fips[hai];

--- a/hw/ip/csrng/rtl/csrng_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_pkg.sv
@@ -14,6 +14,7 @@ package csrng_pkg;
   parameter int unsigned FIPS_GENBITS_BUS_WIDTH = entropy_src_pkg::FIPS_BUS_WIDTH +
                          GENBITS_BUS_WIDTH;
   parameter int unsigned MainSmStateWidth = 8;
+  parameter int unsigned CSRNG_CMD_STS_WIDTH = 2;
 
   // instantiation interface
   typedef struct packed {
@@ -22,17 +23,25 @@ package csrng_pkg;
     logic                       genbits_ready;
   } csrng_req_t;
 
+  typedef enum logic [CSRNG_CMD_STS_WIDTH-1:0] {
+    CMD_STS_SUCCESS              = 2'h0,
+    CMD_STS_INVALID_ACMD         = 2'h1,
+    CMD_STS_INVALID_STATE_PARAM  = 2'h2,
+    CMD_STS_INVALID_GEN_CMD      = 2'h3,
+    CMD_STS_UNDRIVEN             = 'z
+  } csrng_cmd_sts_e;
+
   typedef struct packed {
     logic                         csrng_req_ready;
     logic                         csrng_rsp_ack;
-    logic                         csrng_rsp_sts;
+    csrng_cmd_sts_e               csrng_rsp_sts;
     logic                         genbits_valid;
     logic                         genbits_fips;
     logic [GENBITS_BUS_WIDTH-1:0] genbits_bus;
   } csrng_rsp_t;
 
   parameter csrng_req_t CSRNG_REQ_DEFAULT = '{default: '0};
-  parameter csrng_rsp_t CSRNG_RSP_DEFAULT = '{default: '0};
+  parameter csrng_rsp_t CSRNG_RSP_DEFAULT = '0;
 
   typedef enum logic [2:0] {
     INV  = 3'h0,
@@ -76,7 +85,7 @@ package csrng_pkg;
   // Minimum Hamming weight: 1
   // Maximum Hamming weight: 7
   //
-  typedef    enum logic [MainSmStateWidth-1:0] {
+  typedef enum logic [MainSmStateWidth-1:0] {
     MainSmIdle          = 8'b01001110, // idle
     MainSmParseCmd      = 8'b10111011, // parse the cmd
     MainSmInstantPrep   = 8'b11000001, // instantiate prep

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -140,6 +140,10 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } cmd_ack;
+    struct packed {
+      logic [1:0]  d;
+      logic        de;
     } cmd_sts;
   } csrng_hw2reg_sw_cmd_sts_reg_t;
 
@@ -320,8 +324,8 @@ package csrng_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [167:160]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [159:156]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [170:163]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [162:156]
     csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [155:154]
     csrng_hw2reg_genbits_reg_t genbits; // [153:122]
     csrng_hw2reg_int_state_val_reg_t int_state_val; // [121:90]

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -160,7 +160,8 @@ module csrng_reg_top (
   logic cmd_req_we;
   logic [31:0] cmd_req_wd;
   logic sw_cmd_sts_cmd_rdy_qs;
-  logic sw_cmd_sts_cmd_sts_qs;
+  logic sw_cmd_sts_cmd_ack_qs;
+  logic [1:0] sw_cmd_sts_cmd_sts_qs;
   logic genbits_vld_re;
   logic genbits_vld_genbits_vld_qs;
   logic genbits_vld_genbits_fips_qs;
@@ -700,11 +701,11 @@ module csrng_reg_top (
 
 
   // R[sw_cmd_sts]: V(False)
-  //   F[cmd_rdy]: 0:0
+  //   F[cmd_rdy]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1),
+    .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_sw_cmd_sts_cmd_rdy (
     .clk_i   (clk_i),
@@ -727,11 +728,38 @@ module csrng_reg_top (
     .qs     (sw_cmd_sts_cmd_rdy_qs)
   );
 
-  //   F[cmd_sts]: 1:1
+  //   F[cmd_ack]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_sw_cmd_sts_cmd_ack (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.sw_cmd_sts.cmd_ack.de),
+    .d      (hw2reg.sw_cmd_sts.cmd_ack.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (sw_cmd_sts_cmd_ack_qs)
+  );
+
+  //   F[cmd_sts]: 4:3
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (2'h0),
     .Mubi    (1'b0)
   ) u_sw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
@@ -2012,8 +2040,9 @@ module csrng_reg_top (
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[0] = sw_cmd_sts_cmd_rdy_qs;
-        reg_rdata_next[1] = sw_cmd_sts_cmd_sts_qs;
+        reg_rdata_next[1] = sw_cmd_sts_cmd_rdy_qs;
+        reg_rdata_next[2] = sw_cmd_sts_cmd_ack_qs;
+        reg_rdata_next[4:3] = sw_cmd_sts_cmd_sts_qs;
       end
 
       addr_hit[8]: begin

--- a/hw/ip/csrng/rtl/csrng_state_db.sv
+++ b/hw/ip/csrng/rtl/csrng_state_db.sv
@@ -37,7 +37,7 @@ module csrng_state_db import csrng_pkg::*; #(
   input logic [KeyLen-1:0]   state_db_wr_key_i,
   input logic [BlkLen-1:0]   state_db_wr_v_i,
   input logic [CtrLen-1:0]   state_db_wr_res_ctr_i,
-  input logic                state_db_wr_sts_i,
+  input csrng_cmd_sts_e      state_db_wr_sts_i,
   // status interface
   input logic                state_db_is_dump_en_i,
   input logic                state_db_reg_rd_sel_i,
@@ -45,14 +45,14 @@ module csrng_state_db import csrng_pkg::*; #(
   input logic [StateId-1:0]  state_db_reg_rd_id_i,
   output logic [31:0]        state_db_reg_rd_val_o,
   output logic               state_db_sts_ack_o,
-  output logic               state_db_sts_sts_o,
+  output csrng_cmd_sts_e     state_db_sts_sts_o,
   output logic [StateId-1:0] state_db_sts_id_o
 );
 
   localparam int InternalStateWidth = 2+KeyLen+BlkLen+CtrLen;
   localparam int RegInternalStateWidth = 30+InternalStateWidth;
   localparam int RegW = 32;
-  localparam int StateWidth = 1+1+KeyLen+BlkLen+CtrLen+StateId+1;
+  localparam int StateWidth = 1+1+KeyLen+BlkLen+CtrLen+StateId+CSRNG_CMD_STS_WIDTH;
 
   logic [StateId-1:0]              state_db_id;
   logic [KeyLen-1:0]               state_db_key;
@@ -60,7 +60,7 @@ module csrng_state_db import csrng_pkg::*; #(
   logic [CtrLen-1:0]               state_db_rc;
   logic                            state_db_fips;
   logic                            state_db_inst_st;
-  logic                            state_db_sts;
+  csrng_cmd_sts_e                  state_db_sts;
   logic                            state_db_write;
   logic                            instance_status;
   logic [NApps-1:0]                int_st_out_sel;
@@ -74,7 +74,7 @@ module csrng_state_db import csrng_pkg::*; #(
 
   // flops
   logic                            state_db_sts_ack_q, state_db_sts_ack_d;
-  logic                            state_db_sts_sts_q, state_db_sts_sts_d;
+  csrng_cmd_sts_e                  state_db_sts_sts_q, state_db_sts_sts_d;
   logic [StateId-1:0]              state_db_sts_id_q, state_db_sts_id_d;
   logic [StateId-1:0]              reg_rd_ptr_q, reg_rd_ptr_d;
   logic [StateId-1:0]              int_st_dump_id_q, int_st_dump_id_d;
@@ -82,7 +82,7 @@ module csrng_state_db import csrng_pkg::*; #(
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
       state_db_sts_ack_q   <= '0;
-      state_db_sts_sts_q   <= '0;
+      state_db_sts_sts_q   <= CMD_STS_SUCCESS;
       state_db_sts_id_q    <= '0;
       reg_rd_ptr_q         <= '0;
       int_st_dump_id_q     <= '0;

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -329,18 +329,6 @@
           resval: "0"
         }
         { bits: "2",
-          name: "CMD_STS",
-          desc: '''
-                This one bit field represents the status code returned with the CSRNG application command ack.
-                It is updated each time a SW command is acknowledged by CSRNG.
-                To check whether a command was succesful, wait for !!INTR_STATE.EDN_CMD_REQ_DONE or
-                !!SW_CMD_STS.CMD_ACK to be high and then check the value of this field.
-                0b0: Request completed successfully.
-                0b1: Request completed with an error.
-                '''
-          resval: "0"
-        }
-        { bits: "3",
           name: "CMD_ACK",
           desc: '''
                 This one bit field indicates when a SW command has been acknowledged by the CSRNG.
@@ -348,6 +336,17 @@
                 The field is set to high once a SW command request has been acknowledged by the CSRNG.
                 0b0: The last SW command has not been acknowledged yet.
                 0b1: The last SW command has been acknowledged.
+                '''
+          resval: "0"
+        }
+        { bits: "4:3",
+          name: "CMD_STS",
+          desc: '''
+                This field represents the status code returned with the CSRNG application command ack.
+                It is updated each time a SW command is acknowledged by CSRNG.
+                To check whether a command was successful, wait for !!INTR_STATE.EDN_CMD_REQ_DONE or
+                !!SW_CMD_STS.CMD_ACK to be high and then check the value of this field.
+                A description of the command status types can be found [here](../../csrng/doc/registers.md#sw_cmd_sts--cmd_sts).
                 '''
           resval: "0"
         }
@@ -379,17 +378,16 @@
                 '''
           resval: "0"
         }
-        { bits: "2",
-          name: "CMD_STS",
+        { bits: "5:2",
+          name: "CMD_TYPE",
           desc: '''
-                This one bit field represents the status code returned with the CSRNG application command ack.
-                It is updated each time a HW command is acknowledged by CSRNG.
-                0b0: Request completed successfully.
-                0b1: Request completed with an error.
+                This field contains the application command type of the hardware controlled command issued last.
+                The application command selects one of five operations to perform.
+                A description of the application command types can be found [here](../../csrng/doc/theory_of_operation.md#command-description).
                 '''
           resval: "0"
         }
-        { bits: "3",
+        { bits: "6",
           name: "CMD_ACK",
           desc: '''
                 This one bit field indicates when a HW command has been acknowledged by the CSRNG.
@@ -400,12 +398,12 @@
                 '''
           resval: "0"
         }
-        { bits: "7:4",
-          name: "CMD_TYPE",
+        { bits: "8:7",
+          name: "CMD_STS",
           desc: '''
-                This field contains the application command type of the hardware controlled command issued last.
-                The application command selects one of five operations to perform.
-                A description of the application command types can be found [here](https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#command-description).
+                This field represents the status code returned with the CSRNG application command ack.
+                It is updated each time a HW command is acknowledged by CSRNG.
+                A description of the command status types can be found [here](../../csrng/doc/registers.md#sw_cmd_sts--cmd_sts).
                 '''
           resval: "0"
         }

--- a/hw/ip/edn/doc/registers.md
+++ b/hw/ip/edn/doc/registers.md
@@ -1,3 +1,6 @@
+# Registers
+
+<!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/edn/data/edn.hjson -->
 ## Summary
 
 | Name                                                                | Offset   |   Length | Description                                                  |
@@ -224,21 +227,28 @@ in the CSRNG documentation.
 EDN software command status register
 - Offset: `0x24`
 - Reset default: `0x0`
-- Reset mask: `0xf`
+- Reset mask: `0x1f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "CMD_REG_RDY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_RDY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_STS", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_ACK", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "CMD_REG_RDY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_RDY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_ACK", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_STS", "bits": 2, "attr": ["ro"], "rotate": -90}, {"bits": 27}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                    |
 |:------:|:------:|:-------:|:----------------------------------------|
-|  31:4  |        |         | Reserved                                |
-|   3    |   ro   |   0x0   | [CMD_ACK](#sw_cmd_sts--cmd_ack)         |
-|   2    |   ro   |   0x0   | [CMD_STS](#sw_cmd_sts--cmd_sts)         |
+|  31:5  |        |         | Reserved                                |
+|  4:3   |   ro   |   0x0   | [CMD_STS](#sw_cmd_sts--cmd_sts)         |
+|   2    |   ro   |   0x0   | [CMD_ACK](#sw_cmd_sts--cmd_ack)         |
 |   1    |   ro   |   0x0   | [CMD_RDY](#sw_cmd_sts--cmd_rdy)         |
 |   0    |   ro   |   0x0   | [CMD_REG_RDY](#sw_cmd_sts--cmd_reg_rdy) |
+
+### SW_CMD_STS . CMD_STS
+This field represents the status code returned with the CSRNG application command ack.
+It is updated each time a SW command is acknowledged by CSRNG.
+To check whether a command was successful, wait for [`INTR_STATE.EDN_CMD_REQ_DONE`](#intr_state) or
+[`SW_CMD_STS.CMD_ACK`](#sw_cmd_sts) to be high and then check the value of this field.
+A description of the command status types can be found [here](../../csrng/doc/registers.md#sw_cmd_sts--cmd_sts).
 
 ### SW_CMD_STS . CMD_ACK
 This one bit field indicates when a SW command has been acknowledged by the CSRNG.
@@ -246,14 +256,6 @@ It is set to low each time a new command is written to [`SW_CMD_REQ.`](#sw_cmd_r
 The field is set to high once a SW command request has been acknowledged by the CSRNG.
 0b0: The last SW command has not been acknowledged yet.
 0b1: The last SW command has been acknowledged.
-
-### SW_CMD_STS . CMD_STS
-This one bit field represents the status code returned with the CSRNG application command ack.
-It is updated each time a SW command is acknowledged by CSRNG.
-To check whether a command was succesful, wait for [`INTR_STATE.EDN_CMD_REQ_DONE`](#intr_state) or
-[`SW_CMD_STS.CMD_ACK`](#sw_cmd_sts) to be high and then check the value of this field.
-0b0: Request completed successfully.
-0b1: Request completed with an error.
 
 ### SW_CMD_STS . CMD_RDY
 This bit indicates when the EDN is ready to accept the next command.
@@ -271,27 +273,27 @@ This bit has to be polled before each word of a command is written to [`SW_CMD_R
 EDN hardware command status register
 - Offset: `0x28`
 - Reset default: `0x0`
-- Reset mask: `0xff`
+- Reset mask: `0x1ff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "BOOT_MODE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "AUTO_MODE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_STS", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_ACK", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_TYPE", "bits": 4, "attr": ["ro"], "rotate": -90}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
+{"reg": [{"name": "BOOT_MODE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "AUTO_MODE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_TYPE", "bits": 4, "attr": ["ro"], "rotate": -90}, {"name": "CMD_ACK", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "CMD_STS", "bits": 2, "attr": ["ro"], "rotate": -90}, {"bits": 23}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                |
 |:------:|:------:|:-------:|:------------------------------------|
-|  31:8  |        |         | Reserved                            |
-|  7:4   |   ro   |   0x0   | [CMD_TYPE](#hw_cmd_sts--cmd_type)   |
-|   3    |   ro   |   0x0   | [CMD_ACK](#hw_cmd_sts--cmd_ack)     |
-|   2    |   ro   |   0x0   | [CMD_STS](#hw_cmd_sts--cmd_sts)     |
+|  31:9  |        |         | Reserved                            |
+|  8:7   |   ro   |   0x0   | [CMD_STS](#hw_cmd_sts--cmd_sts)     |
+|   6    |   ro   |   0x0   | [CMD_ACK](#hw_cmd_sts--cmd_ack)     |
+|  5:2   |   ro   |   0x0   | [CMD_TYPE](#hw_cmd_sts--cmd_type)   |
 |   1    |   ro   |   0x0   | [AUTO_MODE](#hw_cmd_sts--auto_mode) |
 |   0    |   ro   |   0x0   | [BOOT_MODE](#hw_cmd_sts--boot_mode) |
 
-### HW_CMD_STS . CMD_TYPE
-This field contains the application command type of the hardware controlled command issued last.
-The application command selects one of five operations to perform.
-A description of the application command types can be found [here](https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#command-description).
+### HW_CMD_STS . CMD_STS
+This field represents the status code returned with the CSRNG application command ack.
+It is updated each time a HW command is acknowledged by CSRNG.
+A description of the command status types can be found [here](../../csrng/doc/registers.md#sw_cmd_sts--cmd_sts).
 
 ### HW_CMD_STS . CMD_ACK
 This one bit field indicates when a HW command has been acknowledged by the CSRNG.
@@ -300,11 +302,10 @@ The field is set to high once a HW command request has been acknowledged by the 
 0b0: The last HW command has not been acknowledged yet.
 0b1: The last HW command has been acknowledged.
 
-### HW_CMD_STS . CMD_STS
-This one bit field represents the status code returned with the CSRNG application command ack.
-It is updated each time a HW command is acknowledged by CSRNG.
-0b0: Request completed successfully.
-0b1: Request completed with an error.
+### HW_CMD_STS . CMD_TYPE
+This field contains the application command type of the hardware controlled command issued last.
+The application command selects one of five operations to perform.
+A description of the application command types can be found [here](../../csrng/doc/theory_of_operation.md#command-description).
 
 ### HW_CMD_STS . AUTO_MODE
 This one bit field indicates whether the EDN is in the hardware controlled part of auto mode.
@@ -532,3 +533,6 @@ Main state machine state observation register
 |:------:|:------:|:-------:|:--------------|:---------------------------------------------------------------------------------------------------------------|
 |  31:9  |        |         |               | Reserved                                                                                                       |
 |  8:0   |   ro   |  0xc1   | MAIN_SM_STATE | This is the state of the EDN main state machine. See the RTL file `edn_main_sm` for the meaning of the values. |
+
+
+<!-- END CMDGEN -->

--- a/hw/ip/edn/dv/cov/edn_cov_if.sv
+++ b/hw/ip/edn/dv/cov/edn_cov_if.sv
@@ -238,7 +238,8 @@ interface edn_cov_if (
   endgroup : edn_cs_cmd_response_cg
 
   covergroup edn_sw_cmd_sts_cg with function sample(bit cmd_rdy, bit cmd_reg_rdy,
-                                                    bit cmd_sts, bit cmd_ack);
+                                                    csrng_pkg::csrng_cmd_sts_e cmd_sts,
+                                                    bit cmd_ack);
     option.name         = "edn_sw_cmd_sts_cg";
     option.per_instance = 1;
 
@@ -252,10 +253,7 @@ interface edn_cov_if (
       bins not_ready = { 1'b0 };
     }
 
-    cp_cmd_sts_cg: coverpoint cmd_sts {
-      bins error   = { 1'b1 };
-      bins success = { 1'b0 };
-    }
+    cp_cmd_sts_cg: coverpoint cmd_sts;
 
     cp_cmd_ack_cg: coverpoint cmd_ack {
       bins ack    = { 1'b1 };
@@ -264,8 +262,8 @@ interface edn_cov_if (
   endgroup : edn_sw_cmd_sts_cg
 
   covergroup edn_hw_cmd_sts_cg with function sample(bit boot_mode, bit auto_mode,
-                                                    bit cmd_sts, bit cmd_ack,
-                                                    csrng_pkg::acmd_e acmd);
+                                                    csrng_pkg::csrng_cmd_sts_e cmd_sts,
+                                                    bit cmd_ack, csrng_pkg::acmd_e acmd);
     option.name         = "edn_hw_cmd_sts_cg";
     option.per_instance = 1;
 
@@ -279,10 +277,7 @@ interface edn_cov_if (
       bins not_auto_mode = { 1'b0 };
     }
 
-    cp_cmd_sts: coverpoint cmd_sts {
-      bins error   = { 1'b1 };
-      bins success = { 1'b0 };
-    }
+    cp_cmd_sts: coverpoint cmd_sts;
 
     cp_cmd_ack: coverpoint cmd_ack {
       bins ack    = { 1'b1 };
@@ -368,13 +363,14 @@ interface edn_cov_if (
   endfunction : cg_cs_cmd_response_sample
 
   function automatic void cg_edn_sw_cmd_sts_sample(bit cmd_rdy, bit cmd_reg_rdy,
-                                                   bit cmd_sts, bit cmd_ack);
+                                                   csrng_pkg::csrng_cmd_sts_e cmd_sts,
+                                                   bit cmd_ack);
     edn_sw_cmd_sts_cg_inst.sample(cmd_rdy, cmd_reg_rdy, cmd_sts, cmd_ack);
   endfunction : cg_edn_sw_cmd_sts_sample
 
   function automatic void cg_edn_hw_cmd_sts_sample(bit boot_mode, bit auto_mode,
-                                                   bit cmd_sts, bit cmd_ack,
-                                                   csrng_pkg::acmd_e acmd);
+                                                   csrng_pkg::csrng_cmd_sts_e cmd_sts,
+                                                   bit cmd_ack, csrng_pkg::acmd_e acmd);
     edn_hw_cmd_sts_cg_inst.sample(boot_mode, auto_mode, cmd_sts, cmd_ack, acmd);
   endfunction : cg_edn_hw_cmd_sts_sample
 

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -46,11 +46,12 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   rand bit       force_disable;
   rand bit [csrng_pkg::CSRNG_CMD_WIDTH - 1:0]   boot_ins_cmd, boot_gen_cmd;
 
-  rand fatal_err_e      which_fatal_err;
-  rand err_code_e       which_err_code;
-  rand which_fifo_e     which_fifo;
-  rand which_fifo_err_e which_fifo_err;
-  rand invalid_mubi_e   which_invalid_mubi;
+  rand fatal_err_e                    which_fatal_err;
+  rand err_code_e                     which_err_code;
+  rand which_fifo_e                   which_fifo;
+  rand which_fifo_err_e               which_fifo_err;
+  rand invalid_mubi_e                 which_invalid_mubi;
+  rand csrng_pkg::csrng_cmd_sts_e     which_cmd_sts_err;
 
   // Constraints
   constraint glen_auto_mode_c {glen_auto_mode dist {
@@ -84,6 +85,9 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
     edn_cntr_err    :/ 5
     // All other error codes will implicitly get a weight of 1.
   };}
+
+  // CMD_STS_SUCCESS is not an error so ignore it.
+  constraint which_cmd_sts_err_c {{which_cmd_sts_err != csrng_pkg::CMD_STS_SUCCESS};}
 
   // Functions
   function void post_randomize();

--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -26,6 +26,8 @@ package edn_env_pkg;
   parameter uint     MAX_NUM_ENDPOINTS = 7;
   parameter string   LIST_OF_ALERTS[]  = {"recov_alert","fatal_alert"};
   parameter uint     NUM_ALERTS        = 2;
+  parameter uint     CMD_STS_SIZE      = 2;
+  parameter uint     CMD_TYPE_SIZE     = 4;
 
   // types
   typedef enum int {
@@ -127,17 +129,17 @@ package edn_env_pkg;
 
   typedef enum int {
     sw_cmd_reg_rdy = 0,
-    sw_cmd_rdy  = 1,
-    sw_cmd_sts = 2,
-    sw_cmd_ack = 3
+    sw_cmd_rdy     = 1,
+    sw_cmd_ack     = 2,
+    sw_cmd_sts     = 3
   } sw_cmd_sts_e;
 
   typedef enum int {
     hw_cmd_boot_mode = 0,
     hw_cmd_auto_mode = 1,
-    hw_cmd_sts = 2,
-    hw_cmd_ack = 3,
-    hw_cmd_type = 4
+    hw_cmd_type      = 2,
+    hw_cmd_ack       = 6,
+    hw_cmd_sts       = 7
   } hw_cmd_sts_e;
 
   // package sources

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -239,7 +239,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
             backdoor_disable_fifo_clr = 1'b0;
             reset_happened = 1'b0;
             sw_cmd_sts[sw_cmd_ack] = 1'b0;
-            sw_cmd_sts[sw_cmd_sts] = 1'b0;
+            sw_cmd_sts[sw_cmd_sts+:CMD_STS_SIZE-1] = csrng_pkg::CMD_STS_SUCCESS;
             sw_cmd_sts[sw_cmd_rdy] = !boot_mode;
             sw_cmd_sts[sw_cmd_reg_rdy] = !boot_mode;
 
@@ -314,7 +314,8 @@ class edn_scoreboard extends cip_base_scoreboard #(
                        $sformatf("reg name: %0s", csr.get_full_name()))
           if (cfg.en_cov) begin
             cov_vif.cg_edn_sw_cmd_sts_sample(item.d_data[sw_cmd_rdy], item.d_data[sw_cmd_reg_rdy],
-                                             item.d_data[sw_cmd_sts], item.d_data[sw_cmd_ack]);
+                csrng_pkg::csrng_cmd_sts_e'(item.d_data[sw_cmd_sts+:CMD_STS_SIZE]),
+                item.d_data[sw_cmd_ack]);
           end
         end
       end
@@ -656,7 +657,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
         if ((auto_mode && instantiated) || boot_mode) begin
           hw_cmd_sts = `gmv(ral.hw_cmd_sts);
           hw_cmd_sts[hw_cmd_ack] = 1'b0;
-          hw_cmd_sts[hw_cmd_type:+4] = acmd_cur;
+          hw_cmd_sts[hw_cmd_type+:CMD_TYPE_SIZE-1] = acmd_cur;
           void'(ral.hw_cmd_sts.predict(.value(hw_cmd_sts)));
         end
       end
@@ -703,7 +704,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
               csr_spinwait(.ptr(ral.sw_cmd_sts.cmd_ack),
                            .exp_data(rsp_sts.csrng_rsp_ack), .backdoor(1'b1));
               sw_cmd_sts[sw_cmd_ack] = rsp_sts.csrng_rsp_ack;
-              sw_cmd_sts[sw_cmd_sts] = rsp_sts.csrng_rsp_sts;
+              sw_cmd_sts[sw_cmd_sts+:CMD_STS_SIZE-1] = rsp_sts.csrng_rsp_sts;
               sw_cmd_sts[sw_cmd_rdy] = !auto_mode;
               sw_cmd_sts[sw_cmd_reg_rdy] = !auto_mode;,
               wait (cfg.backdoor_disable || reset_happened);
@@ -713,7 +714,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
       end else begin
         hw_cmd_sts = `gmv(ral.hw_cmd_sts);
         hw_cmd_sts[hw_cmd_ack] = rsp_sts.csrng_rsp_ack;
-        hw_cmd_sts[hw_cmd_sts] = rsp_sts.csrng_rsp_sts;
+        hw_cmd_sts[hw_cmd_sts+:CMD_STS_SIZE-1] = rsp_sts.csrng_rsp_sts;
         void'(ral.hw_cmd_sts.predict(.value(hw_cmd_sts)));
       end
     end

--- a/hw/ip/edn/dv/tests/edn_base_test.sv
+++ b/hw/ip/edn/dv/tests/edn_base_test.sv
@@ -33,7 +33,8 @@ class edn_base_test extends cip_base_test #(
     cfg.m_csrng_agent_cfg.max_genbits_dly = 32;
     cfg.m_csrng_agent_cfg.min_cmd_rdy_dly = 0;
     cfg.m_csrng_agent_cfg.max_cmd_rdy_dly = 1;
-    cfg.m_csrng_agent_cfg.rsp_sts_err     = 0; // CSRNG should not return errors
+    // CSRNG should not return errors
+    cfg.m_csrng_agent_cfg.rsp_sts_err     = csrng_pkg::CMD_STS_SUCCESS;
   endfunction
 
 endclass : edn_base_test

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -202,10 +202,10 @@ module edn_core import edn_pkg::*;
   logic [63:0]                        cs_rdata_capt_q, cs_rdata_capt_d;
   logic                               cs_rdata_capt_vld_q, cs_rdata_capt_vld_d;
   logic                               cmd_rdy_q, cmd_rdy_d;
-  logic                               csrng_cmd_sts_q, csrng_cmd_sts_d;
+  csrng_pkg::csrng_cmd_sts_e          csrng_cmd_sts_q, csrng_cmd_sts_d;
   logic                               csrng_sw_cmd_ack_q, csrng_sw_cmd_ack_d;
   logic                               csrng_hw_cmd_ack_q, csrng_hw_cmd_ack_d;
-  logic                               csrng_hw_cmd_sts_q, csrng_hw_cmd_sts_d;
+  csrng_pkg::csrng_cmd_sts_e          csrng_hw_cmd_sts_q, csrng_hw_cmd_sts_d;
   logic                               boot_mode_q, boot_mode_d,
                                       auto_mode_q, auto_mode_d;
   logic [3:0]                         cmd_type_q, cmd_type_d;
@@ -223,9 +223,9 @@ module edn_core import edn_pkg::*;
       cs_rdata_capt_q <= '0;
       cs_rdata_capt_vld_q <= '0;
       cmd_rdy_q   <= '0;
-      csrng_cmd_sts_q   <= '0;
+      csrng_cmd_sts_q   <= csrng_pkg::CMD_STS_SUCCESS;
       csrng_sw_cmd_ack_q   <= '0;
-      csrng_hw_cmd_sts_q   <= '0;
+      csrng_hw_cmd_sts_q   <= csrng_pkg::CMD_STS_SUCCESS;
       boot_mode_q   <= '0;
       auto_mode_q   <= '0;
       cmd_type_q   <= '0;
@@ -568,7 +568,7 @@ module edn_core import edn_pkg::*;
   assign hw2reg.sw_cmd_sts.cmd_sts.de = 1'b1;
   assign hw2reg.sw_cmd_sts.cmd_sts.d = csrng_cmd_sts_d;
   assign csrng_cmd_sts_d =
-         !edn_enable_fo[SwCmdSts] ? 1'b0 :
+         !edn_enable_fo[SwCmdSts] ? csrng_pkg::CMD_STS_SUCCESS :
          (csrng_cmd_i.csrng_rsp_ack && sw_cmd_valid) ? csrng_cmd_i.csrng_rsp_sts :
          csrng_cmd_sts_q;
 
@@ -601,10 +601,10 @@ module edn_core import edn_pkg::*;
   assign hw2reg.hw_cmd_sts.cmd_sts.de = 1'b1;
   assign hw2reg.hw_cmd_sts.cmd_sts.d = csrng_hw_cmd_sts_d;
   assign csrng_hw_cmd_sts_d =
-         !edn_enable_fo[HwCmdSts] ? 1'b0 :
+         !edn_enable_fo[HwCmdSts] ? csrng_pkg::CMD_STS_SUCCESS :
          sw_cmd_valid ? csrng_hw_cmd_sts_q :
-         (cs_cmd_req_vld_out_q && csrng_cmd_i.csrng_req_ready) ? 1'b0 :
-         csrng_cmd_i.csrng_rsp_ack && csrng_cmd_i.csrng_rsp_sts ? 1'b1 :
+         (cs_cmd_req_vld_out_q && csrng_cmd_i.csrng_req_ready) ? csrng_pkg::CMD_STS_SUCCESS :
+         csrng_cmd_i.csrng_rsp_ack && csrng_cmd_i.csrng_rsp_sts ? csrng_cmd_i.csrng_rsp_sts :
          csrng_hw_cmd_sts_q;
   // Set the cmd_ack signal to high whenever a hardware command is acknowledged and set it
   // to low whenever a new hardware command is issued to the CSRNG.

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -131,11 +131,11 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } cmd_sts;
-    struct packed {
-      logic        d;
-      logic        de;
     } cmd_ack;
+    struct packed {
+      logic [1:0]  d;
+      logic        de;
+    } cmd_sts;
   } edn_hw2reg_sw_cmd_sts_reg_t;
 
   typedef struct packed {
@@ -148,17 +148,17 @@ package edn_reg_pkg;
       logic        de;
     } auto_mode;
     struct packed {
-      logic        d;
+      logic [3:0]  d;
       logic        de;
-    } cmd_sts;
+    } cmd_type;
     struct packed {
       logic        d;
       logic        de;
     } cmd_ack;
     struct packed {
-      logic [3:0]  d;
+      logic [1:0]  d;
       logic        de;
-    } cmd_type;
+    } cmd_sts;
   } edn_hw2reg_hw_cmd_sts_reg_t;
 
   typedef struct packed {
@@ -246,9 +246,9 @@ package edn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    edn_hw2reg_intr_state_reg_t intr_state; // [62:59]
-    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [58:51]
-    edn_hw2reg_hw_cmd_sts_reg_t hw_cmd_sts; // [50:38]
+    edn_hw2reg_intr_state_reg_t intr_state; // [64:61]
+    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [60:52]
+    edn_hw2reg_hw_cmd_sts_reg_t hw_cmd_sts; // [51:38]
     edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [37:26]
     edn_hw2reg_err_code_reg_t err_code; // [25:10]
     edn_hw2reg_main_sm_state_reg_t main_sm_state; // [9:0]
@@ -319,7 +319,7 @@ package edn_reg_pkg;
     4'b 1111, // index[ 7] EDN_BOOT_GEN_CMD
     4'b 1111, // index[ 8] EDN_SW_CMD_REQ
     4'b 0001, // index[ 9] EDN_SW_CMD_STS
-    4'b 0001, // index[10] EDN_HW_CMD_STS
+    4'b 0011, // index[10] EDN_HW_CMD_STS
     4'b 1111, // index[11] EDN_RESEED_CMD
     4'b 1111, // index[12] EDN_GENERATE_CMD
     4'b 1111, // index[13] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -159,13 +159,13 @@ module edn_reg_top (
   logic [31:0] sw_cmd_req_wd;
   logic sw_cmd_sts_cmd_reg_rdy_qs;
   logic sw_cmd_sts_cmd_rdy_qs;
-  logic sw_cmd_sts_cmd_sts_qs;
   logic sw_cmd_sts_cmd_ack_qs;
+  logic [1:0] sw_cmd_sts_cmd_sts_qs;
   logic hw_cmd_sts_boot_mode_qs;
   logic hw_cmd_sts_auto_mode_qs;
-  logic hw_cmd_sts_cmd_sts_qs;
-  logic hw_cmd_sts_cmd_ack_qs;
   logic [3:0] hw_cmd_sts_cmd_type_qs;
+  logic hw_cmd_sts_cmd_ack_qs;
+  logic [1:0] hw_cmd_sts_cmd_sts_qs;
   logic reseed_cmd_we;
   logic [31:0] reseed_cmd_wd;
   logic generate_cmd_we;
@@ -658,34 +658,7 @@ module edn_reg_top (
     .qs     (sw_cmd_sts_cmd_rdy_qs)
   );
 
-  //   F[cmd_sts]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_sw_cmd_sts_cmd_sts (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.sw_cmd_sts.cmd_sts.de),
-    .d      (hw2reg.sw_cmd_sts.cmd_sts.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (sw_cmd_sts_cmd_sts_qs)
-  );
-
-  //   F[cmd_ack]: 3:3
+  //   F[cmd_ack]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -710,6 +683,33 @@ module edn_reg_top (
 
     // to register interface (read)
     .qs     (sw_cmd_sts_cmd_ack_qs)
+  );
+
+  //   F[cmd_sts]: 4:3
+  prim_subreg #(
+    .DW      (2),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (2'h0),
+    .Mubi    (1'b0)
+  ) u_sw_cmd_sts_cmd_sts (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.sw_cmd_sts.cmd_sts.de),
+    .d      (hw2reg.sw_cmd_sts.cmd_sts.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (sw_cmd_sts_cmd_sts_qs)
   );
 
 
@@ -768,13 +768,13 @@ module edn_reg_top (
     .qs     (hw_cmd_sts_auto_mode_qs)
   );
 
-  //   F[cmd_sts]: 2:2
+  //   F[cmd_type]: 5:2
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0),
+    .RESVAL  (4'h0),
     .Mubi    (1'b0)
-  ) u_hw_cmd_sts_cmd_sts (
+  ) u_hw_cmd_sts_cmd_type (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -783,8 +783,8 @@ module edn_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.hw_cmd_sts.cmd_sts.de),
-    .d      (hw2reg.hw_cmd_sts.cmd_sts.d),
+    .de     (hw2reg.hw_cmd_sts.cmd_type.de),
+    .d      (hw2reg.hw_cmd_sts.cmd_type.d),
 
     // to internal hardware
     .qe     (),
@@ -792,10 +792,10 @@ module edn_reg_top (
     .ds     (),
 
     // to register interface (read)
-    .qs     (hw_cmd_sts_cmd_sts_qs)
+    .qs     (hw_cmd_sts_cmd_type_qs)
   );
 
-  //   F[cmd_ack]: 3:3
+  //   F[cmd_ack]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -822,13 +822,13 @@ module edn_reg_top (
     .qs     (hw_cmd_sts_cmd_ack_qs)
   );
 
-  //   F[cmd_type]: 7:4
+  //   F[cmd_sts]: 8:7
   prim_subreg #(
-    .DW      (4),
+    .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (4'h0),
+    .RESVAL  (2'h0),
     .Mubi    (1'b0)
-  ) u_hw_cmd_sts_cmd_type (
+  ) u_hw_cmd_sts_cmd_sts (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -837,8 +837,8 @@ module edn_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.hw_cmd_sts.cmd_type.de),
-    .d      (hw2reg.hw_cmd_sts.cmd_type.d),
+    .de     (hw2reg.hw_cmd_sts.cmd_sts.de),
+    .d      (hw2reg.hw_cmd_sts.cmd_sts.d),
 
     // to internal hardware
     .qe     (),
@@ -846,7 +846,7 @@ module edn_reg_top (
     .ds     (),
 
     // to register interface (read)
-    .qs     (hw_cmd_sts_cmd_type_qs)
+    .qs     (hw_cmd_sts_cmd_sts_qs)
   );
 
 
@@ -1570,16 +1570,16 @@ module edn_reg_top (
       addr_hit[9]: begin
         reg_rdata_next[0] = sw_cmd_sts_cmd_reg_rdy_qs;
         reg_rdata_next[1] = sw_cmd_sts_cmd_rdy_qs;
-        reg_rdata_next[2] = sw_cmd_sts_cmd_sts_qs;
-        reg_rdata_next[3] = sw_cmd_sts_cmd_ack_qs;
+        reg_rdata_next[2] = sw_cmd_sts_cmd_ack_qs;
+        reg_rdata_next[4:3] = sw_cmd_sts_cmd_sts_qs;
       end
 
       addr_hit[10]: begin
         reg_rdata_next[0] = hw_cmd_sts_boot_mode_qs;
         reg_rdata_next[1] = hw_cmd_sts_auto_mode_qs;
-        reg_rdata_next[2] = hw_cmd_sts_cmd_sts_qs;
-        reg_rdata_next[3] = hw_cmd_sts_cmd_ack_qs;
-        reg_rdata_next[7:4] = hw_cmd_sts_cmd_type_qs;
+        reg_rdata_next[5:2] = hw_cmd_sts_cmd_type_qs;
+        reg_rdata_next[6] = hw_cmd_sts_cmd_ack_qs;
+        reg_rdata_next[8:7] = hw_cmd_sts_cmd_sts_qs;
       end
 
       addr_hit[11]: begin

--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -450,9 +450,9 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
         reg = abs_mmio_read32(kBaseCsrng + CSRNG_INTR_STATE_REG_OFFSET);
       } while (!bitfield_bit32_read(reg, CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT));
 
-      // Check the "status" bit, which will be 1 only if there was an error.
+      // Check the "status" bit, which will be 0 unless there was an error.
       reg = abs_mmio_read32(kBaseCsrng + CSRNG_SW_CMD_STS_REG_OFFSET);
-      if (bitfield_bit32_read(reg, CSRNG_SW_CMD_STS_CMD_STS_BIT)) {
+      if (bitfield_field32_read(reg, CSRNG_SW_CMD_STS_CMD_STS_FIELD)) {
         return OTCRYPTO_RECOV_ERR;
       }
     }
@@ -467,8 +467,8 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
         reg = abs_mmio_read32(sts_reg_addr);
       } while (!bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_ACK_BIT));
 
-      // Check the "status" bit, which will be 1 only if there was an error.
-      if (bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_STS_BIT)) {
+      // Check the "status" bit, which will be 0 unless there was an error.
+      if (bitfield_field32_read(reg, CSRNG_SW_CMD_STS_CMD_STS_FIELD)) {
         return OTCRYPTO_RECOV_ERR;
       }
     }
@@ -525,7 +525,7 @@ static status_t edn_ready_block(uint32_t edn_address) {
     reg = abs_mmio_read32(edn_address + EDN_SW_CMD_STS_REG_OFFSET);
   } while (!bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_RDY_BIT));
 
-  if (bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_STS_BIT)) {
+  if (bitfield_field32_read(reg, CSRNG_SW_CMD_STS_CMD_STS_FIELD)) {
     return OTCRYPTO_RECOV_ERR;
   }
   return OTCRYPTO_OK;

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -155,6 +155,30 @@ typedef enum dif_csrng_error {
 } dif_csrng_error_t;
 
 /**
+ * Enumeration of CSRNG command status errors.
+ */
+typedef enum dif_csrng_cmd_sts_error {
+  /**
+   * Indicates that the command completed successfully.
+   */
+  kDifCsrngCmdStsSuccess = 0,
+  /**
+   * Indicates that an invalid apllication command has been issued.
+   */
+  kDifCsrngCmdStsInvalidAcmd = 1,
+  /**
+   * Indicates that the state wasn't zeroized properly after an uninstantiate
+   * command due to invalid state parameters in the cmd drbg.
+   */
+  kDifCsrngCmdStsInvalidStateParams = 2,
+  /**
+   * Indicates that CSRNG entropy was generated for a command that is not a
+   * generate command.
+   */
+  kDifCsrngCmdStsInvalidCtrDrbgCmd = 3,
+} dif_csrng_cmd_sts_t;
+
+/**
  * The status of the CSRNG block at a particular moment in time.
  */
 typedef struct dif_csrng_cmd_status {
@@ -163,14 +187,9 @@ typedef struct dif_csrng_cmd_status {
    */
   dif_csrng_cmd_status_kind_t kind;
   /**
-   * A bitset of FIFOs in an unhealthy state, with bit indices given by
-   * `dif_csrng_fifo_t`.
+   * The status value CSRNG returns.
    */
-  uint32_t unhealthy_fifos;
-  /**
-   * A bitset of errors, with bit indices given by `dif_csrng_error_t`.
-   */
-  uint32_t errors;
+  dif_csrng_cmd_sts_t cmd_sts;
 } dif_csrng_cmd_status_t;
 
 /**

--- a/sw/device/lib/dif/dif_edn.c
+++ b/sw/device/lib/dif/dif_edn.c
@@ -157,26 +157,26 @@ dif_result_t dif_edn_get_status(const dif_edn_t *edn, dif_edn_status_t flag,
     return kDifBadArg;
   }
 
-  uint32_t bit;
+  uint32_t reg = mmio_region_read32(edn->base_addr, EDN_SW_CMD_STS_REG_OFFSET);
+  uint32_t field_val;
   switch (flag) {
     case kDifEdnStatusRegReady:
-      bit = EDN_SW_CMD_STS_CMD_REG_RDY_BIT;
+      *set = bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_REG_RDY_BIT);
       break;
     case kDifEdnStatusReady:
-      bit = EDN_SW_CMD_STS_CMD_RDY_BIT;
+      *set = bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_RDY_BIT);
       break;
     case kDifEdnStatusCsrngStatus:
-      bit = EDN_SW_CMD_STS_CMD_STS_BIT;
+      field_val = bitfield_field32_read(reg, EDN_SW_CMD_STS_CMD_STS_FIELD);
+      *set = field_val ? true : false;
       break;
     case kDifEdnStatusCsrngAck:
-      bit = EDN_SW_CMD_STS_CMD_ACK_BIT;
+      *set = bitfield_bit32_read(reg, EDN_SW_CMD_STS_CMD_ACK_BIT);
       break;
     default:
       return kDifBadArg;
   }
 
-  uint32_t reg = mmio_region_read32(edn->base_addr, EDN_SW_CMD_STS_REG_OFFSET);
-  *set = bitfield_bit32_read(reg, bit);
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_edn_unittest.cc
+++ b/sw/device/lib/dif/dif_edn_unittest.cc
@@ -171,8 +171,13 @@ TEST_F(SetModeTest, Auto) {
   EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET,
                 {{EDN_SW_CMD_STS_CMD_ACK_BIT, true}});
 
-  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET,
-                {{EDN_SW_CMD_STS_CMD_STS_BIT, false}});
+  uint32_t ctrl_reg = 0;
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_RDY_BIT, 1);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_REG_RDY_BIT, 1);
+  ctrl_reg =
+      bitfield_field32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_STS_FIELD, 0x0);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_ACK_BIT, 1);
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, ctrl_reg);
 
   EXPECT_DIF_OK(dif_edn_set_auto_mode(&edn_, params));
 }
@@ -188,52 +193,61 @@ class GetStatusTest : public DifEdnTest {};
 
 TEST_F(GetStatusTest, BadArgs) {
   bool flag;
+  uint32_t ctrl_reg = 0;
   EXPECT_DIF_BADARG(dif_edn_get_status(nullptr, kDifEdnStatusReady, &flag));
+
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_RDY_BIT, 1);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_REG_RDY_BIT, 1);
+  ctrl_reg =
+      bitfield_field32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_STS_FIELD, 0x0);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_ACK_BIT, 0);
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, ctrl_reg);
   EXPECT_DIF_BADARG(
       dif_edn_get_status(&edn_, static_cast<dif_edn_status_t>(-1), &flag));
+
   EXPECT_DIF_BADARG(dif_edn_get_status(&edn_, kDifEdnStatusReady, nullptr));
 }
 
 TEST_F(GetStatusTest, Ok) {
   bool flag;
+  uint32_t ctrl_reg = 0;
 
-  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET,
-                {
-                    {EDN_SW_CMD_STS_CMD_RDY_BIT, true},
-                    {EDN_SW_CMD_STS_CMD_REG_RDY_BIT, true},
-                    {EDN_SW_CMD_STS_CMD_STS_BIT, false},
-                    {EDN_SW_CMD_STS_CMD_ACK_BIT, false},
-                });
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_RDY_BIT, 1);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_REG_RDY_BIT, 1);
+  ctrl_reg =
+      bitfield_field32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_STS_FIELD, 0x0);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_ACK_BIT, 0);
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, ctrl_reg);
   EXPECT_DIF_OK(dif_edn_get_status(&edn_, kDifEdnStatusRegReady, &flag));
   EXPECT_TRUE(flag);
 
-  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET,
-                {
-                    {EDN_SW_CMD_STS_CMD_RDY_BIT, true},
-                    {EDN_SW_CMD_STS_CMD_REG_RDY_BIT, true},
-                    {EDN_SW_CMD_STS_CMD_STS_BIT, false},
-                    {EDN_SW_CMD_STS_CMD_ACK_BIT, false},
-                });
+  ctrl_reg = 0;
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_RDY_BIT, 1);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_REG_RDY_BIT, 1);
+  ctrl_reg =
+      bitfield_field32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_STS_FIELD, 0x0);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_ACK_BIT, 0);
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, ctrl_reg);
   EXPECT_DIF_OK(dif_edn_get_status(&edn_, kDifEdnStatusReady, &flag));
   EXPECT_TRUE(flag);
 
-  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET,
-                {
-                    {EDN_SW_CMD_STS_CMD_RDY_BIT, true},
-                    {EDN_SW_CMD_STS_CMD_REG_RDY_BIT, true},
-                    {EDN_SW_CMD_STS_CMD_STS_BIT, false},
-                    {EDN_SW_CMD_STS_CMD_ACK_BIT, false},
-                });
+  ctrl_reg = 0;
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_RDY_BIT, 1);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_REG_RDY_BIT, 1);
+  ctrl_reg =
+      bitfield_field32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_STS_FIELD, 0x0);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_ACK_BIT, 0);
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, ctrl_reg);
   EXPECT_DIF_OK(dif_edn_get_status(&edn_, kDifEdnStatusCsrngStatus, &flag));
   EXPECT_FALSE(flag);
 
-  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET,
-                {
-                    {EDN_SW_CMD_STS_CMD_RDY_BIT, true},
-                    {EDN_SW_CMD_STS_CMD_REG_RDY_BIT, true},
-                    {EDN_SW_CMD_STS_CMD_STS_BIT, false},
-                    {EDN_SW_CMD_STS_CMD_ACK_BIT, false},
-                });
+  ctrl_reg = 0;
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_RDY_BIT, 1);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_REG_RDY_BIT, 1);
+  ctrl_reg =
+      bitfield_field32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_STS_FIELD, 0x0);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, EDN_SW_CMD_STS_CMD_ACK_BIT, 0);
+  EXPECT_READ32(EDN_SW_CMD_STS_REG_OFFSET, ctrl_reg);
   EXPECT_DIF_OK(dif_edn_get_status(&edn_, kDifEdnStatusCsrngAck, &flag));
   EXPECT_FALSE(flag);
 }

--- a/sw/device/lib/testing/csrng_testutils.c
+++ b/sw/device/lib/testing/csrng_testutils.c
@@ -188,9 +188,7 @@ status_t csrng_testutils_fips_generate_kat(const dif_csrng_t *csrng) {
 status_t csrng_testutils_cmd_status_check(const dif_csrng_t *csrng) {
   dif_csrng_cmd_status_t status;
   TRY(dif_csrng_get_cmd_interface_status(csrng, &status));
-  TRY_CHECK(status.errors == 0);
-  TRY_CHECK(status.unhealthy_fifos == 0);
-  TRY_CHECK(status.errors != kDifCsrngCmdStatusError);
+  TRY_CHECK(status.cmd_sts == kDifCsrngCmdStsSuccess);
   return OK_STATUS();
 }
 

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -260,10 +260,10 @@ status_t entropy_testutils_error_check(const dif_entropy_src_t *entropy_src,
 
   dif_csrng_cmd_status_t status;
   TRY(dif_csrng_get_cmd_interface_status(csrng, &status));
-  if (status.errors) {
+  if (status.cmd_sts != kDifCsrngCmdStsSuccess) {
     found_error = true;
-    LOG_ERROR("csrng error status. err: 0x%x, fifo_err: 0x%x, kind: 0x%x",
-              status.errors, status.unhealthy_fifos, status.kind);
+    LOG_ERROR("csrng error status. err: 0x%x, kind: 0x%x", status.cmd_sts,
+              status.kind);
   }
 
   uint32_t fifo_errors;


### PR DESCRIPTION
This PR adds functionality to signal status errors along a command acknowledgement.
For further details have a look at the individual commit messages.

Resolves [#16516](https://github.com/lowRISC/opentitan/issues/16516)