### PR TITLE
[kmac] Bump version to 2.0.0

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -24,12 +24,11 @@
   sw_checklist:       "/sw/device/lib/dif/dif_kmac",
   revisions: [
     {
-      version:            "1.0.0",
+      version:            "2.0.0",
       life_stage:         "L1",
       design_stage:       "D2S",
       verification_stage: "V2S",
       dif_stage:          "S2",
-      commit_id:          "c2a8c64ccbca39707be7883dfd2f8c1100813730",
     }
   ]
   clocking: [


### PR DESCRIPTION
The SW-visible interface of the KMAC HW IP block has changed when the `fifo_empty` interrupt got its type changed to status (commit 23e491fee6b885a8c45ff5529c50fd486f00393c).  This calls for a major version bump.

Note that also as part of the PRNG reworking in https://github.com/lowRISC/opentitan/pull/21624 the CSRs changed, which is another reason for this major version bump.

This closes #20978.