### PR TITLE
[usbdev] Fixes to IN packet engine

### DIFF
--- a/hw/ip/usbdev/rtl/usb_fs_nb_in_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_in_pe.sv
@@ -170,8 +170,10 @@ module usb_fs_nb_in_pe #(
   ////////////////////////////////////////////////////////////////////////////////
   // Transaction is starting on this IN endpoint; capture the packet details.
   ////////////////////////////////////////////////////////////////////////////////
+  logic in_starting;
+  assign in_starting = (in_xact_state == StIdle || in_xact_state == StWaitAck) && in_token_received;
 
-  assign in_xact_starting_o = ep_active && in_token_received;
+  assign in_xact_starting_o = in_starting & ep_active;
   assign in_xact_start_ep_o = in_ep_current_d;
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -265,7 +267,7 @@ module usb_fs_nb_in_pe #(
           in_xact_state_next = StIdle;
           in_xact_end = 1'b1;
         end else if (in_token_received) begin
-          in_xact_state_next = StRcvdIn;
+          in_xact_state_next = ep_active ? StRcvdIn : StIdle;
           rollback_in_xact = 1'b1;
         end else if (rx_pkt_end_i) begin
           in_xact_state_next = StIdle;


### PR DESCRIPTION
This PR addresses a couple of defects in the IN packet engine:

- Handling of IN token packet reception whilst awaiting the ACK from a previous IN transaction did not check whether the endpoint is active. This aspect of the endpoint configuration is not expected to change whilst the USB device is connected, and the host should not be attempting to retrieve packets from an endpoint that is not being used. The logic should be consistent, however.

- Recent change to maintain IN buffer properties throughout the transaction (#21771) was incomplete; the logic needs qualifying with the two IN transaction states to capture the buffer properties only at the start of an IN transaction. verification effort still pending. Spotted by inspection when implementing event counters.
