### PR TITLE
[ci] Add a job to run ROM_EXT tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -642,6 +642,32 @@ jobs:
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 
+- job: execute_fpga_rom_ext_tests_cw310
+  displayName: CW310 ROM_EXT Tests
+  pool:
+    name: $(fpga_pool)
+    demands: BOARD -equals cw310
+  timeoutInMinutes: 60
+  dependsOn:
+    - chip_earlgrey_cw310
+    - sw_build
+  condition: succeeded( 'chip_earlgrey_cw310', 'sw_build' )
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw310
+        - sw_build
+  - template: ci/load-bazel-cache-write-creds.yml
+  - bash: |
+      set -e
+      . util/build_consts.sh
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/scripts/run-fpga-tests.sh cw310 fpga_cw310_rom_ext_tests || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+    displayName: Execute tests
+  - template: ci/publish-bazel-test-results.yml
 
 - job: deploy_release_artifacts
   displayName: Package & deploy release

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -84,6 +84,10 @@ then
     > "${pattern_file}"
     # We need to remove tests tagged as manual since we are not using a wildcard target.
     test_args="${test_args} --test_tag_filters=cw310_sival,-broken,-skip_in_ci,-manual"
+elif [ "${fpga_tags}" == "fpga_cw310_rom_ext_tests" ]
+then
+    test_args="${test_args} --test_tag_filters=cw310_rom_ext,-broken,-skip_in_ci"
+    echo "//sw/device/silicon_creator/rom_ext/e2e/..." > "${pattern_file}"
 else
     test_args="${test_args} --test_tag_filters=${fpga_tags},-broken,-skip_in_ci"
     echo "//..." > "${pattern_file}"

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -52,6 +52,8 @@ opentitan_test(
         binaries = {
             ":boot_test_slot_a": "slot_a",
         },
+        # This test requires serial break support which is not available in CI yet.
+        tags = ["broken"],
         test_cmd = """
             --exec="transport init"
             --exec="fpga load-bitstream {bitstream}"
@@ -78,6 +80,8 @@ opentitan_test(
             ":boot_test_slot_a": "slot_a",
             ":boot_test_slot_b": "slot_b",
         },
+        # This test requires serial break support which is not available in CI yet.
+        tags = ["broken"],
         test_cmd = """
             --exec="transport init"
             --exec="fpga load-bitstream {bitstream}"
@@ -106,6 +110,8 @@ opentitan_test(
             ":boot_test_slot_a": "slot_a",
             ":boot_test_slot_b": "slot_b",
         },
+        # This test requires serial break support which is not available in CI yet.
+        tags = ["broken"],
         test_cmd = """
             --exec="transport init"
             --exec="fpga load-bitstream {bitstream}"


### PR DESCRIPTION
Those are the tests tagged with `fpga_cw310_rom_ext` which is a different environment from the sival ROM_EXT, and which is used to test the ROM_EXT implementation.

**NOTE:** I have chosen not to limit to `//sw/device/silicon_creator/rom_ext/e2e/...` because there is also a test in `//sw/device/tests/crypto/...`. This can be changed based on feedback.