### PR TITLE
[usbdev,dv] Remove usb20_if uses from usbdev block-level DV

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent.sv
@@ -15,10 +15,6 @@ class usb20_agent extends dv_base_agent #(
 
 function void build_phase(uvm_phase phase);
   super.build_phase(phase);
-  // get usb20_if handle
-  if (!uvm_config_db#(virtual usb20_if)::get(this, "", "vif", cfg.vif)) begin
-    `uvm_fatal(`gfn, "failed to get usb20_if handle from uvm_config_db")
-  end
   // get usb20_block_if handle
   if (!uvm_config_db#(virtual usb20_block_if)::get(this, "", "bif", cfg.bif)) begin
     `uvm_fatal(`gfn, "failed to get usb20_block_if handle from uvm_config_db")

--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -5,7 +5,6 @@
 class usb20_agent_cfg extends dv_base_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
-  virtual usb20_if vif;
   virtual usb20_block_if bif;
   virtual clk_rst_if clk_rst_if_i;
 

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -45,8 +45,6 @@ module tb;
   clk_rst_if usb_clk_rst_if(.clk(usb_clk), .rst_n(usb_rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   tl_if tl_if(.clk(usb_clk), .rst_n(usb_rst_n));
-  usb20_if usb20_if(.clk_i(usb_clk), .rst_ni(usb_rst_n), .usb_vbus(usb_vbus),
-  .usb_p(usb_p), .usb_n(usb_n));
   usb20_block_if usb20_block_if(.clk_i(usb_clk), .rst_ni(usb_rst_n),
   .usb_vbus(usb_vbus), .usb_p(usb_p), .usb_n(usb_n));
  `DV_ALERT_IF_CONNECT(usb_clk, usb_rst_n)
@@ -149,7 +147,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "aon_clk_rst_vif", aon_clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
-    uvm_config_db#(virtual usb20_if)::set(null, "*.env.m_usb20_agent*", "vif", usb20_if);
     uvm_config_db#(virtual usb20_block_if)::set(null, "*.env.m_usb20_agent*","bif",usb20_block_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
There's a slightly complicated situation where we currently have two USB interfaces (usb20_if and usb20_block_if).

At the moment, usb20_if is used at chip-level (interfacing over DPI with a USB reference model) and usb20_block_if is used at block level.

Keeping them separate avoids block-level DV engineers who can't run chip-level tests breaking chip-level sims. This is a slightly silly situation and the right eventual solution would probably be to merge the two interfaces again.

But a short-term cleanup is to remove the chip-level-only interface from the block-level testbench.