### PR TITLE
[usbdev,dv] Remove usb_d[pn]_i from usb20_block_if

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_block_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_block_if.sv
@@ -10,8 +10,6 @@ interface usb20_block_if (
   inout wire usb_n
 );
   // Data Inputs pins
-  logic usb_dp_i;
-  logic usb_dn_i;
   logic usb_rx_d_i;
   // Data Outputs pins
   logic usb_dp_o;
@@ -33,8 +31,6 @@ interface usb20_block_if (
   logic usb_clk;             // signal used to divide clock or send J/K symbols for 4 clock cycles
 
   assign usb_sense_i = usb_vbus;
-  assign usb_dp_i = usb_p;
-  assign usb_dn_i = usb_n;
   assign usb_p = usb_dp_en_o ? usb_dp_o : drive_p;
   assign usb_n = usb_dn_en_o ? usb_dn_o : drive_n;
 

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -65,8 +65,8 @@ module tb;
     .alert_tx_o           (alert_tx   ),
 
     // USB Interface
-    .cio_usb_dp_i           (usb20_block_if.usb_dp_i     ),
-    .cio_usb_dn_i           (usb20_block_if.usb_dn_i     ),
+    .cio_usb_dp_i           (usb20_block_if.usb_p        ),
+    .cio_usb_dn_i           (usb20_block_if.usb_n        ),
     .usb_rx_d_i             (usb20_block_if.usb_rx_d_i   ),
     .cio_usb_dp_o           (usb20_block_if.usb_dp_o     ),
     .cio_usb_dp_en_o        (usb20_block_if.usb_dp_en_o  ),


### PR DESCRIPTION
The names here look a bit mad (the "_i" signals in the interface get assigned to) and they aren't really doing anything.

Short-circuit the assignment in tb.sv and remove the unused signals.