### PR TITLE
[pentest] Cherry-pick Add support for AES SCA measurements on chip

### DIFF
--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -245,7 +245,7 @@ static void aes_encrypt(const uint8_t *plaintext, size_t plaintext_len) {
   // Using the SecAesStartTriggerDelay hardware parameter, the AES unit is
   // configured to start operation 40 cycles after receiving the start trigger.
   // This allows Ibex to go to sleep in order to not disturb the capture.
-  sca_call_and_sleep(aes_manual_trigger, kIbexAesSleepCycles);
+  sca_call_and_sleep(aes_manual_trigger, kIbexAesSleepCycles, false);
 }
 
 /**

--- a/sw/device/sca/kmac_serial.c
+++ b/sw/device/sca/kmac_serial.c
@@ -480,7 +480,7 @@ static void sha3_serial_absorb(const uint8_t *msg, size_t msg_len) {
   // configured to start operation 40 cycles after receiving the START and PROC
   // commands. This allows Ibex to go to sleep in order to not disturb the
   // capture.
-  sca_call_and_sleep(kmac_msg_proc, kIbexSha3SleepCycles);
+  sca_call_and_sleep(kmac_msg_proc, kIbexSha3SleepCycles, false);
 }
 
 /**

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -309,7 +309,8 @@ void sca_set_trigger_low(void) {
   OT_DISCARD(dif_gpio_write(&gpio, trigger_bit_index, false));
 }
 
-void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles) {
+void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles,
+                        bool sw_trigger) {
   // Disable the IO_DIV4_PERI clock to reduce noise during the actual capture.
   // This also disables the UART(s) and GPIO modules required for
   // communication with the scope. Therefore, it has to be re-enabled after
@@ -328,7 +329,15 @@ void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles) {
   OT_DISCARD(dif_rv_timer_counter_set_enabled(&timer, kRvTimerHart,
                                               kDifToggleEnabled));
 
+  if (sw_trigger) {
+    sca_set_trigger_high();
+  }
+
   callee();
+
+  if (sw_trigger) {
+    sca_set_trigger_low();
+  }
 
   wait_for_interrupt();
 

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -196,8 +196,10 @@ typedef void (*sca_callee)(void);
  *
  * @param callee Function to call before putting Ibex to sleep.
  * @param sleep_cycles Number of cycles to sleep.
+ * @param sw_trigger Raise trigger before calling the target function.
  */
-void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles);
+void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles,
+                        bool sw_trigger);
 
 /**
  * Seeds the software LFSR usable e.g. for key masking.

--- a/sw/device/sca/otbn_vertical/ecc256_keygen_serial.c
+++ b/sw/device/sca/otbn_vertical/ecc256_keygen_serial.c
@@ -204,7 +204,7 @@ static void p256_run_keygen(uint32_t mode, const uint32_t *share0,
 
   // Execute program.
   sca_set_trigger_high();
-  sca_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles);
+  sca_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles, false);
   SS_CHECK_STATUS_OK(otbn_busy_wait_for_done());
   sca_set_trigger_low();
 }

--- a/sw/device/sca/otbn_vertical/ecc256_modinv_serial.c
+++ b/sw/device/sca/otbn_vertical/ecc256_modinv_serial.c
@@ -92,7 +92,7 @@ static void p256_run_modinv(uint32_t *k0, uint32_t *k1) {
 
   // Execute program.
   sca_set_trigger_high();
-  sca_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles);
+  sca_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles, false);
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
 }

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -405,9 +405,7 @@ static void sha3_serial_absorb(const uint8_t *msg, size_t msg_len) {
   // configured to start operation 40 cycles after receiving the START and PROC
   // commands. This allows Ibex to go to sleep in order to not disturb the
   // capture.
-  sca_set_trigger_high();
-  sca_call_and_sleep(kmac_msg_proc, kIbexSha3SleepCycles);
-  sca_set_trigger_low();
+  sca_call_and_sleep(kmac_msg_proc, kIbexSha3SleepCycles, true);
 }
 
 /**

--- a/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
@@ -536,7 +536,8 @@ static kmac_sca_error_t sha3_ujson_absorb(const uint8_t *msg, size_t msg_len) {
   if (fpga_mode == false) {
     // Start command. On the chip, we need to first issue a START command
     // before writing to the message FIFO.
-    sca_call_and_sleep(kmac_start_cmd, kIbexLoadHashPrefixKeySleepCycles);
+    sca_call_and_sleep(kmac_start_cmd, kIbexLoadHashPrefixKeySleepCycles,
+                       false);
   }
 
   // Write data to message FIFO.
@@ -550,11 +551,12 @@ static kmac_sca_error_t sha3_ujson_absorb(const uint8_t *msg, size_t msg_len) {
     // configured to start operation 320 cycles after receiving the START and
     // PROC commands. This allows Ibex to go to sleep in order to not disturb
     // the capture.
-    sca_call_and_sleep(kmac_start_process_cmd, kIbexSha3SleepCycles);
+    sca_call_and_sleep(kmac_start_process_cmd, kIbexSha3SleepCycles, false);
   } else {
     // On the chip, issue a PROCESS command to start operation and put Ibex
     // into sleep.
-    sca_call_and_sleep(kmac_process_cmd, kIbexLoadHashMessageSleepCycles);
+    sca_call_and_sleep(kmac_process_cmd, kIbexLoadHashMessageSleepCycles,
+                       false);
   }
 
   return kmacScaOk;

--- a/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
@@ -417,15 +417,11 @@ sha3_sca_error_t sha3_serial_absorb(const uint8_t *msg, size_t msg_len) {
     // configured to start operation 320 cycles after receiving the START and
     // PROC commands. This allows Ibex to go to sleep in order to not disturb
     // the capture.
-    sca_set_trigger_high();
-    sca_call_and_sleep(kmac_start_process_cmd, kIbexSha3SleepCycles);
-    sca_set_trigger_low();
+    sca_call_and_sleep(kmac_start_process_cmd, kIbexSha3SleepCycles, true);
   } else {
     // On the chip, issue a PROCESS command to start operation and put Ibex
     // into sleep.
-    sca_set_trigger_high();
-    sca_call_and_sleep(kmac_process_cmd, kIbexLoadHashMessageSleepCycles);
-    sca_set_trigger_low();
+    sca_call_and_sleep(kmac_process_cmd, kIbexLoadHashMessageSleepCycles, true);
   }
 
   return sha3ScaOk;

--- a/sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/aes_sca_commands.h
@@ -56,6 +56,10 @@ UJSON_SERDE_STRUCT(CryptotestAesScaLfsr, cryptotest_aes_sca_lfsr_t, AES_SCA_LFSR
     field(ciphertext, uint8_t, AESSCA_CMD_MAX_MSG_BYTES) \
     field(ciphertext_length, uint32_t)
 UJSON_SERDE_STRUCT(CryptotestAesScaCiphertext, cryptotest_aes_sca_ciphertext_t, AES_SCA_CIPHERTEXT);
+
+#define AES_SCA_FPGA_MODE(field, string) \
+    field(fpga_mode, uint8_t)
+UJSON_SERDE_STRUCT(CryptotestAesScaFpgaMode, cryptotest_aes_sca_fpga_mode_t, AES_SCA_FPGA_MODE);
 // clang-format on
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR manually cherry-picks "Add support for AES SCA measurements on chip" lowRISC/opentitan#21741 from earlgrey_es_sival to master  as the automatic cherry-pick failed due to a merge conflict.