### PR TITLE
[top_darjeeling/dv] Re-enable `chip_sw_pwrmgr_smoketest`

### DIFF
--- a/hw/top_darjeeling/dv/chip_smoketests.hjson
+++ b/hw/top_darjeeling/dv/chip_smoketests.hjson
@@ -61,13 +61,13 @@
       sw_images: ["//sw/device/tests:otp_ctrl_smoketest:6"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
-    // {
-    //   name: chip_sw_pwrmgr_smoketest
-    //   uvm_test_seq: chip_sw_base_vseq
-    //   sw_images: ["//sw/device/tests:pwrmgr_smoketest:6"]
-    //   en_run_modes: ["sw_test_mode_test_rom"]
-    //   run_opts: ["+sw_test_timeout_ns=10000000"]
-    // }
+    {
+      name: chip_sw_pwrmgr_smoketest
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["//sw/device/tests:pwrmgr_smoketest:6"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=15000000"]
+    }
     {
       name: chip_sw_rv_plic_smoketest
       uvm_test_seq: chip_sw_base_vseq


### PR DESCRIPTION
The timeout of this test needs to be increased because it takes longer for both ROM controllers to confirm that they're okay than for one.

With the increased timeout, the seed that timed out before now gets a pass from SW -- but it doesn't terminate. I don't think that's a critical problem but will try to quickly fix it so the reporting is correct. Keeping PR as draft for now.