### PR TITLE
[dv] fix spi_device dvsim output path

### DIFF
--- a/hw/ip/spi_device/dv/base_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/base_sim_cfg.hjson
@@ -54,6 +54,18 @@
   // Add UART specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/spi_device/dv/cov/spi_device_cov_excl.el"]
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
+    }
+    {
+      name: rel_path
+      value: "hw/ip/{name}_{variant}/dv"
+    }
+  ]
+
   // List of test specifications.
   tests: [
     {


### PR DESCRIPTION
Sicne #21812 we have two spi_device variants, which use the same output path, which cause file name
collision when parallelism is increased.

Follow other blocks by adding variant name into the output path. See #21738 as another example.