### PR TITLE
[uart,dv] Correct uart time unit mishaps & typos

### DIFF
--- a/hw/dv/sv/uart_agent/uart_agent_cfg.sv
+++ b/hw/dv/sv/uart_agent/uart_agent_cfg.sv
@@ -62,7 +62,7 @@ class uart_agent_cfg extends dv_base_agent_cfg;
 
   function void set_baud_rate(baud_rate_e b);
     baud_rate = b;
-    vif.uart_clk_period_ns = (get_baud_rate_period_ns(b) * 1ns);
+    vif.uart_clk_period = (get_baud_rate_period_ns(b) * 1ns);
   endfunction
 
   function void set_parity(bit en_parity, bit odd_parity);

--- a/hw/dv/sv/uart_agent/uart_driver.sv
+++ b/hw/dv/sv/uart_agent/uart_driver.sv
@@ -19,8 +19,7 @@ class uart_driver extends dv_base_driver #(uart_item, uart_agent_cfg);
 
   // Sets the value of rx after randomly glitching for 10% of uart clk
   task set_rx(input bit val);
-    uint glitch_ns = uint'(cfg.vif.uart_clk_period_ns * cfg.get_uart_period_glitch_pct() / 100
-                           / 1ns);
+    uint glitch_ns = uint'(cfg.vif.uart_clk_period * cfg.get_uart_period_glitch_pct() / 100 / 1ns);
     repeat (glitch_ns) begin
       if (!cfg.under_reset) begin
         cfg.vif.uart_rx <= $urandom_range(0, 1);

--- a/hw/dv/sv/uart_agent/uart_if.sv
+++ b/hw/dv/sv/uart_agent/uart_if.sv
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-interface uart_if #(realtime UartDefaultClkPeriodNs = 104166.667ns) ();
+interface uart_if #(realtime UartDefaultClkPeriod = 104166.667ns) ();
   wire uart_tx;
   logic uart_rx;
 
   // generate local clk
-  realtime uart_clk_period_ns = UartDefaultClkPeriodNs;
+  realtime uart_clk_period = UartDefaultClkPeriod;
   bit   uart_tx_clk = 1'b1;
   int   uart_tx_clk_pulses = 0;
   bit   uart_rx_clk = 1'b1;

--- a/hw/dv/sv/uart_agent/uart_logger.sv
+++ b/hw/dv/sv/uart_agent/uart_logger.sv
@@ -44,7 +44,7 @@ class uart_logger extends uvm_component;
         log_item_fifo.get(item);
         char = string'(item.data);
         `uvm_info(`gfn, $sformatf("received char: %0s", char), UVM_DEBUG)
-        // Continue concatenating chars into the log string untl lf or cr is encountered.
+        // Continue concatenating chars into the log string until lf or cr is encountered.
         if (item.data inside {lf, cr}) begin
           print_log(log);
           log_analysis_port.write(log);

--- a/hw/dv/sv/uart_agent/uart_monitor.sv
+++ b/hw/dv/sv/uart_agent/uart_monitor.sv
@@ -138,14 +138,14 @@ class uart_monitor extends dv_base_monitor#(
   task drive_tx_clk();
     forever begin
       if (cfg.vif.uart_tx_clk_pulses > 0) begin
-        #(cfg.vif.uart_clk_period_ns / 2);
+        #(cfg.vif.uart_clk_period / 2);
         cfg.vif.uart_tx_clk = ~cfg.vif.uart_tx_clk;
         // last cycle only use half period as design and agent aren't using same clock. If agent
         // freq is slower and design continues sending tx item, the freq diff will be accumulated.
         // Ending current item after latch STOP bit to allow agent to re-establish clock to sample
         // the START bit of next item
-        if (cfg.vif.uart_tx_clk_pulses == 1) #(cfg.vif.uart_clk_period_ns / 4);
-        else                                 #(cfg.vif.uart_clk_period_ns / 2);
+        if (cfg.vif.uart_tx_clk_pulses == 1) #(cfg.vif.uart_clk_period / 4);
+        else                                 #(cfg.vif.uart_clk_period / 2);
         cfg.vif.uart_tx_clk = ~cfg.vif.uart_tx_clk;
         cfg.vif.uart_tx_clk_pulses--;
       end else begin
@@ -157,9 +157,9 @@ class uart_monitor extends dv_base_monitor#(
   task drive_rx_clk();
     forever begin
       if (cfg.vif.uart_rx_clk_pulses > 0) begin
-        #(cfg.vif.uart_clk_period_ns / 2);
+        #(cfg.vif.uart_clk_period / 2);
         cfg.vif.uart_rx_clk = ~cfg.vif.uart_rx_clk;
-        #(cfg.vif.uart_clk_period_ns / 2);
+        #(cfg.vif.uart_clk_period / 2);
         cfg.vif.uart_rx_clk = ~cfg.vif.uart_rx_clk;
         cfg.vif.uart_rx_clk_pulses--;
       end else begin
@@ -175,7 +175,7 @@ class uart_monitor extends dv_base_monitor#(
       @(cfg.vif.uart_tx_clk_pulses);
       if (cfg.vif.uart_tx_clk_pulses == 0) continue;
 
-      #(cfg.vif.uart_clk_period_ns * (50 - cfg.get_max_drift_cycle_pct()) / 100);
+      #(cfg.vif.uart_clk_period * (50 - cfg.get_max_drift_cycle_pct()) / 100);
       `DV_SPINWAIT_EXIT(
           begin
             @(cfg.vif.uart_tx_int);
@@ -183,8 +183,8 @@ class uart_monitor extends dv_base_monitor#(
                 "Expect uart_tx stable from %0d to %0d of the period, but it's changed",
                 50 - cfg.get_max_drift_cycle_pct(), 50 + cfg.get_max_drift_cycle_pct()))
           end,
-          // simplified from cfg.vif.uart_clk_period_ns * max_drift_cycle_pct * 2 / 100
-          #(cfg.vif.uart_clk_period_ns * cfg.get_max_drift_cycle_pct() / 50))
+          // simplified from cfg.vif.uart_clk_period * max_drift_cycle_pct * 2 / 100
+          #(cfg.vif.uart_clk_period * cfg.get_max_drift_cycle_pct() / 50))
     end
   endtask
 

--- a/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
@@ -69,7 +69,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
   virtual task uart_init();
     int nco = get_nco(baud_rate, cfg.clk_freq_mhz, ral.ctrl.nco.get_n_bits());
 
-    // we skip writting some CSRs at the last 1-2 uart cycles, when baud rate is 1.5Mbps, uart
+    // we skip writing some CSRs at the last 1-2 uart cycles, when baud rate is 1.5Mbps, uart
     // cycle is small, need to reduce the TL delay, so that the write doesn't happen at the
     // ignore period
     if (baud_rate == BaudRate1p5Mbps && p_sequencer.cfg.clk_freq_mhz < 48) begin
@@ -225,7 +225,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
     endcase
   endtask : rand_read_rx_byte
 
-  // read rx data from CSR rdata, but wait until it's not in igored period
+  // read rx data from CSR rdata, but wait until it's not in ignored period
   virtual task wait_ignored_period_and_read_rdata(ref bit [TL_DW-1:0] rdata);
     wait_when_in_ignored_period(.rx(1));
     csr_rd(.ptr(ral.rdata), .value(rdata));
@@ -262,7 +262,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
     `uvm_info(`gfn, "wait_for_tx_fifo_not_full is done", UVM_HIGH)
   endtask : wait_for_tx_fifo_not_full
 
-  // task to wait for rx fifo not full, will be overriden in overflow test
+  // task to wait for rx fifo not full, will be overridden in overflow test
   virtual task wait_for_rx_fifo_not_full();
     if (ral.ctrl.rx.get_mirrored_value()) begin
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_access_fifo)

--- a/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
@@ -322,7 +322,7 @@ class uart_intr_vseq extends uart_base_vseq;
   endtask
 
   task wait_for_baud_clock_cycles(uint cycles);
-    #(cfg.m_uart_agent_cfg.vif.uart_clk_period_ns * cycles);
+    #(cfg.m_uart_agent_cfg.vif.uart_clk_period * cycles);
   endtask
 
   task drive_tx_bytes(int num_bytes);

--- a/hw/ip/uart/dv/env/seq_lib/uart_rx_oversample_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_rx_oversample_vseq.sv
@@ -34,7 +34,7 @@ class uart_rx_oversample_vseq extends uart_tx_rx_vseq;
 
       find_oversampled_clk_center();
       // don't use big number here, the way TB measures cycle isn't the same as DUT
-      // need to re-sync again after cerntain cycles
+      // need to re-sync again after certain cycles
       repeat ($urandom_range(1, 3)) begin
         drive_rx_oversampled_val();
       end
@@ -43,7 +43,7 @@ class uart_rx_oversample_vseq extends uart_tx_rx_vseq;
 
     // wait for a full uart transaction time to flush out the remaining rx transaction
     uart_xfer_bits = NUM_UART_XFER_BITS_WO_PARITY + cfg.m_uart_agent_cfg.en_parity;
-    #(cfg.m_uart_agent_cfg.vif.uart_clk_period_ns * uart_xfer_bits);
+    #(cfg.m_uart_agent_cfg.vif.uart_clk_period * uart_xfer_bits);
 
     cfg.m_uart_agent_cfg.en_rx_monitor = 1;
     clear_fifos(.clear_rx_fifo(1), .clear_tx_fifo(0));
@@ -76,7 +76,7 @@ class uart_rx_oversample_vseq extends uart_tx_rx_vseq;
     // find offset to account for the fixed delay of register reading, only relevant at high baud
     fixed_delay_time = cfg.clk_rst_vif.clk_period_ps * 1ps * 3;
     // move to the center of the oversampling clk
-    #(get_oversampled_baud_clk_period_ns() * 1ns * 0.5 - fixed_delay_time);
+    #(get_oversampled_baud_clk_period()* 0.5 - fixed_delay_time);
     `uvm_info(`gfn, "at center of clock", UVM_MEDIUM)
   endtask
 
@@ -91,7 +91,7 @@ class uart_rx_oversample_vseq extends uart_tx_rx_vseq;
     // Most recent bit is bit 0
     for (int i = num_bits - 1; i >= 0; i--) begin
       cfg.m_uart_agent_cfg.vif.uart_rx = data[i];
-      #(get_oversampled_baud_clk_period_ns() * 1ns);
+      #(get_oversampled_baud_clk_period());
     end
     cfg.m_uart_agent_cfg.vif.uart_rx = 1; // back to default value
     // launch check in a parallel thread to avoid losing clock alignment in the main thread
@@ -104,8 +104,8 @@ class uart_rx_oversample_vseq extends uart_tx_rx_vseq;
     join_none
   endtask
 
-  virtual function real get_oversampled_baud_clk_period_ns();
-    return cfg.m_uart_agent_cfg.vif.uart_clk_period_ns / num_bits;
+  virtual function real get_oversampled_baud_clk_period();
+    return cfg.m_uart_agent_cfg.vif.uart_clk_period / num_bits;
   endfunction
 
 endclass : uart_rx_oversample_vseq

--- a/hw/ip/uart/dv/env/seq_lib/uart_rx_start_bit_filter_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_rx_start_bit_filter_vseq.sv
@@ -12,7 +12,7 @@ class uart_rx_start_bit_filter_vseq extends uart_smoke_vseq;
   // when start bit is detected, design will check it again after 0.5 uart clock
   // if it's not low, consider it as glitch and ignore it
   virtual task send_rx_byte(byte data);
-    uint64 uart_clk_period_ps = cfg.m_uart_agent_cfg.vif.uart_clk_period_ns * 1000;
+    uint uart_clk_period_ps = cfg.m_uart_agent_cfg.vif.uart_clk_period / 1ps;
 
     // monitor doesn't have start bit filter, need to disable it while driving filtered start bit
     cfg.m_uart_agent_cfg.en_rx_monitor = 0;

--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_ovrd_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_ovrd_vseq.sv
@@ -14,8 +14,8 @@ class uart_tx_ovrd_vseq extends uart_smoke_vseq;
     bit txval;
     bit exp;
 
-    // add 1 uart clk to make sure previous uart TX transfer is done completedly
-    #(cfg.m_uart_agent_cfg.vif.uart_clk_period_ns * 1ns);
+    // add 1 uart clk to make sure previous uart TX transfer is done completely
+    #(cfg.m_uart_agent_cfg.vif.uart_clk_period);
 
     // disable monitor as monitor can't handle this
     cfg.m_uart_agent_cfg.en_tx_monitor = 0;

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -37,7 +37,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
   uart_item rx_q[$];
 
   // it takes 3 cycles to move item from fifo to process, which delays reg status change
-  // and it also takes 3 cycles to trigger tx matermark interrupt
+  // and it also takes 3 cycles to trigger tx watermark interrupt
   parameter uint NUM_CLK_DLY_TO_UPDATE_TX_WATERMARK = 3;
 
   `uvm_component_new
@@ -115,7 +115,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
 
         if (parity_err) begin
           intr_exp[RxParityErr] = 1;
-          `uvm_info(`gfn, $sformatf("dropped uart rx item due to partiy err:\n%0s",
+          `uvm_info(`gfn, $sformatf("dropped uart rx item due to parity err:\n%0s",
                                     item.sprint()), UVM_HIGH)
         end
         if (!item.stop_bit) begin
@@ -148,7 +148,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
     intr_exp[RxWatermark] = (rx_q_size >= watermark) || status_intr_test[RxWatermark];
   endfunction
 
-  // we don't model uart cycle-acurrately, ignore checking when item is just/almost finished
+  // we don't model uart cycle-accurately, ignore checking when item is just/almost finished
   function bit is_in_ignored_period(uart_dir_e dir);
     case (dir)
       UartTx: return uart_tx_clk_pulses inside `TX_IGNORED_PERIOD;


### PR DESCRIPTION
Fix the incorrect naming and usage of time-related variables. Mostly this stems from the `_ns` suffix of `uart_clk_period_ns`, despite being assigned a `realtime` value rather than an integer number of nanosecond. Correct this by renaming to `uart_clk_period` and adjusting downstream usage as seemed most appropriate.

Also correct some comment typos in the wider uart DV code.