### PR TITLE
[dv,usbdev] Initial coverage for usbdev

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -14,11 +14,13 @@ package usb20_agent_pkg;
 
   // usb20_item enums
   typedef enum bit [2:0] {PktTypeSoF, PktTypeToken, PktTypeData, PktTypeHandshake} pkt_type_e;
+  // TODO: these are presently nibble-swapped relative to the specification.
   typedef enum bit [7:0] {PidTypeOutToken = 8'b0001_1110, PidTypeInToken = 8'b1001_0110,
       PidTypeSofToken = 8'b0101_1010, PidTypeSetupToken = 8'b1101_0010,
       PidTypeData0 = 8'b0011_1100, PidTypeData1 = 8'b1011_0100, PidTypeData2 = 8'b0111_1000,
       PidTypeMData = 8'b1111_0000, PidTypeAck = 8'b0010_1101, PidTypeNak = 8'b1010_0101,
-      PidTypeStall = 8'b1110_0001, PidTypeNyet = 8'b0110_1001} pid_type_e;
+      PidTypeStall = 8'b1110_0001, PidTypeNyet = 8'b0110_1001, PidTypePre = 8'b1100_0011,
+      PidTypeSplit = 8'b1000_0111, PidTypePing = 8'b0100_1011} pid_type_e;
 
   typedef enum byte {bmRequestType0 = 8'b0_00_00000, bmRequestType1 = 8'b0_00_00001,
       bmRequestType2 = 8'b0_00_00010, bmRequestType3 = 8'b1_00_00000,

--- a/hw/ip/usbdev/dv/env/usbdev_env_cov.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cov.sv
@@ -2,20 +2,247 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Covergoups that are dependent on run-time parameters that may be available
- * only in build_phase can be defined here
- * Covergroups may also be wrapped inside helper classes if needed.
- */
-
 class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
   `uvm_component_utils(usbdev_env_cov)
 
-  // the base class provides the following handles for use:
-  // usbdev_env_cfg: cfg
+  // Have observed all PIDs about which we care; a number of the available PIDs are ignored
+  // by the USB device because they related only to High Speed operation and/or hubs.
+  covergroup pids_cg with function sample(pid_type_e pid);
+    cp_pid: coverpoint pid {
+      bins sof   = {PidTypeSofToken};
+      bins setup = {PidTypeSetupToken};
+      bins out   = {PidTypeOutToken};
+      bins in    = {PidTypeInToken};
+      bins data0 = {PidTypeData0};
+      bins data1 = {PidTypeData1};
+      bins ack   = {PidTypeAck};
+      bins nak   = {PidTypeNak};
+      // Not directly relevant to USBDEV function, but we must appropriately ignore it and the
+      // ensuing Low Speed traffic.
+      bins pre   = {PidTypePre};
+    }
+  endgroup
 
-  // covergroups
-  // [add covergroups here]
+  // Have observed all significant/extreme frame numbers being reported via CSRs; this just
+  // ensures that all bits have been decoded and presented; the frame number has no significance
+  // to USBDEV but it's important to software.
+  covergroup framenum_rx_cg with function sample(bit [10:0] frame);
+    cp_frame: coverpoint frame {
+      bins zero = {0};
+      bins one  = {1};
+      bins range_2_to_15 = {[2:15]};
+      bins range_16_to_127 = {[16:127]};
+      bins range_128_to_1023 = {[128:1023]};
+      bins range_1024_to_2046 = {[1024:2046]};
+      bins max  = {2047};
+    }
+  endgroup
+
+  // CRC16 values on packets in each direction, because CRC16 is subject to bit stuffing
+  covergroup crc16_cg with function sample(bit dir_in, bit [15:0] crc16);
+    cp_crc16: coverpoint crc16 {
+      // Contrive a packet that results in all 1s.
+      bins all_ones = {65535};
+      // At least one of these shall have been encountered, because the presence of six consecutive
+      // ones necessitates bit stuffing.
+      bins six_ones = {63, 126, 252, 504, 1008, 2016, 4032, 8064, 16128, 32256};
+    }
+    cp_dir: coverpoint dir_in;
+
+    cr_crc16_X_dir: cross
+      cp_crc16,
+      cp_dir;
+  endgroup
+
+  // CRC5 in Token packets is subject to bit stuffing too, so check some potentially problematic
+  // cases.
+  covergroup crc5_cg with function sample(bit dir_in, bit [4:0] crc5);
+    cp_crc5: coverpoint crc5 {
+      bins trailing_zero = {15};
+      bins leading_zero = {30};
+      bins all_ones = {31};
+    }
+    cp_dir: coverpoint dir_in;
+
+    cr_crc5_X_dir: cross
+      cp_crc5,
+      cp_dir;
+  endgroup
+
+  // Check that all Device Address bits are decoded and usable and that those problematic
+  // combinations with endpoint values that demand bit stuffing within the token packet
+  // have been observed.
+  covergroup address_cg with function sample(bit [6:0] address, bit [4:0] endp);
+    // In the address field, which is 7 bits, there could be three 1 bits from the
+    // OUT PID: LSB 1000_0111 MSB
+    // So the problem addresses would be xxxx111b and 1111110b
+    // Endpoint numbers such 0111 and 0011 are more likely to cause issues
+    cp_address: coverpoint address {
+      bins zero = {0};  // The default address, used before the device has been configured.
+      bins one  = {1};
+      bins seven = {7};
+      bins range_2_to_14 = {[2:14]};
+      bins fifteen = {15};
+      bins range_16_to_126 = {[16:126]};
+      bins range_127 = {127};
+    }
+    cp_endp: coverpoint endp {
+      bins three = {3};
+      bins seven = {7};
+    }
+
+    cr_address_X_endp: cross
+      cp_address,
+      cp_endp;
+  endgroup
+
+  // Receipt of SETUP, OUT and PRE packets with different OUT endpoint configurations
+  covergroup ep_out_cfg_cg with function sample(pid_type_e pid, bit out_enable, bit rxenable_setup,
+                                                bit rxenable_out, bit set_nak_out, bit out_stall,
+                                                bit out_iso);
+    cp_pid: coverpoint pid {
+      bins pkt_types[] = {PidTypeSetupToken, PidTypeOutToken};
+      // The USB device shall ignore all packets commencing with a Pre PID because these are
+      // Low Speed traffic intended for other devices on the bus.
+      bins ignore_pre[] = {PidTypePre};
+    }
+
+    // Each endpoint has a lot of configuration options and whilst not all permutations are
+    // entirely meaningful, there is a risk that some internal logic within the USB device may
+    // not be fully qualified with all of the relevant configuration bits.
+    //
+    // OUT side configuration bits (Host sending data to Device).
+    cp_out_enable:     coverpoint out_enable;
+    cp_rxenable_setup: coverpoint rxenable_setup;
+    cp_rxenable_out:   coverpoint rxenable_out;
+    cp_set_nak_out:    coverpoint set_nak_out;
+    cp_out_iso:        coverpoint out_iso;
+    cp_out_stall:      coverpoint out_stall;
+
+    cr_pid_x_epconfig: cross
+      cp_pid,
+      cp_out_enable,
+      cp_rxenable_setup,
+      cp_rxenable_out,
+      cp_set_nak_out,
+      cp_out_iso,
+      cp_out_stall;
+  endgroup
+
+  // Receipt of IN and PRE packets with different IN endpoint configurations
+  covergroup ep_in_cfg_cg with function sample(pid_type_e pid,
+                                               bit in_enable, bit in_stall, bit in_iso);
+    cp_pid: coverpoint pid {
+      bins pkt_types[] = {PidTypeInToken};
+      // The USB device shall ignore all packets commencing with a Pre PID because these are
+      // Low Speed traffic intended for other devices on the bus.
+      bins ignore_pre[] = {PidTypePre};
+    }
+
+    // IN side configuration bits (Host retrieving data from Device).
+    cp_in_enable:      coverpoint in_enable;
+    cp_in_iso:         coverpoint in_iso;
+    cp_in_stall:       coverpoint in_stall;
+
+    cr_pid_x_epconfig: cross
+      cp_pid,
+      cp_in_enable,
+      cp_in_iso,
+      cp_in_stall;
+  endgroup
+
+  // Received SETUP/OUT packets within FIFO levels of interest
+  covergroup fifo_lvl_cg with function sample(pid_type_e pid, bit [2:0] avsetup_lvl,
+                                              bit [3:0] avout_lvl, bit [3:0] rx_lvl);
+    // Buffer is plucked from AV SETUP or AV OUT FIFO according to PID.
+    cp_avsetup: coverpoint avsetup_lvl {
+      bins empty = {0};
+      bins solo  = {1};
+      bins full  = {AvSetupFIFODepth};
+    }
+    cp_avout: coverpoint avout_lvl {
+      bins empty = {0};
+      bins solo  = {1};
+      bins full  = {AvOutFIFODepth};
+    }
+    // Buffer is placed in RX FIFO, if there is space available.
+    cp_rx: coverpoint rx_lvl {
+      bins empty = {0};
+      bins solo  = {RxFIFODepth-1};  // Single slot available, should be reserved for SETUP
+      bins full  = {RxFIFODepth};
+    }
+    cp_pid: coverpoint pid {
+      bins setup = {PidTypeSetupToken};
+      bins out   = {PidTypeOutToken};
+    }
+
+    cr_fifo_X_pid: cross
+      cp_avsetup,
+      cp_avout,
+      cp_rx,
+      cp_pid;
+  endgroup
+
+  // Length of DATA packets in each direction
+  covergroup data_pkt_cg with function sample(bit dir_in, bit [6:0] pkt_len);
+    // Packets are read/written from/to memory as 32-bit quantities.
+    cp_pkt_len: coverpoint pkt_len {
+      // Zero-length packets have special significance to Message Pipes, and are _not_ zero
+      // bytes on the wire.
+      bins zero  = {0};
+      // Awkward lengths are those which fall just shy, align with, or just exceed word boundaries.
+      bins one   = {1};
+      bins three = {3};
+      bins four  = {4};
+      bins five  = {5};
+      // Plus those where the additional bytes of the CRC16 cause the total byte count to near or
+      // exceed 64.
+      bins sixty_one   = {61};
+      bins sixty_two   = {62};
+      bins sixty_three = {63};
+      bins sixty_four  = {64};
+    }
+    // Directions
+    cp_dir: coverpoint dir_in;
+
+    cr_pktlen_X_dir: cross
+      cp_pkt_len,
+      cp_dir;
+  endgroup
+
+  // Both DATA0 and DATA1 for each endpoint, and in each direction (Data Toggles),
+  // as well as both ACK and NAK (rollback and retry transaction in Packet Engines).
+  covergroup data_tog_endp_cg with function sample(pid_type_e pid, bit dir_in, bit [3:0] endp);
+    cp_pid: coverpoint pid {
+      bins data0 = {PidTypeData0};
+      bins data1 = {PidTypeData1};
+      bins ack = {PidTypeAck};
+      bins nak = {PidTypeNak};
+    }
+    cp_dir: coverpoint dir_in;  // 'dir_in' is set to indicate IN
+    cp_endp: coverpoint endp;
+
+    cr_pid_X_dir_X_endp: cross
+      cp_pid,
+      cp_dir,
+      cp_endp;
+  endgroup
+
+  // All of SETUP, IN, and OUT for each endpoint
+  covergroup pid_type_endp_cfg with function sample(pid_type_e pid, bit [3:0] endp);
+    cp_pid: coverpoint pid {
+      bins pkt_types[] = {PidTypeSetupToken, PidTypeOutToken, PidTypeInToken};
+    }
+    cp_endp: coverpoint endp {
+      bins endpoints[] = {[0:11]};
+      // Device should ignore all packets to unimplemented endpoints.
+      bins invalid_ep[] = {[12:15]};
+    }
+
+    cr_pid_X_endp: cross
+      cp_pid,
+      cp_endp;
+  endgroup
 
   function new(string name, uvm_component parent);
     super.new(name, parent);


### PR DESCRIPTION
Initial set of covergroups and coverpoints for usbdev DV.
Disclaimer: coverage DV is very unfamiliar at this point, and none of the DV code collects samples presently.
