### PR TITLE
Optimize `base_log_internal_core`

### DIFF
--- a/sw/device/lib/runtime/log.c
+++ b/sw/device/lib/runtime/log.c
@@ -44,13 +44,13 @@ static const char *stringify_severity(log_severity_t severity) {
  * @param log the log data to log.
  * @param ... format parameters matching the format string.
  */
-void base_log_internal_core(log_fields_t log, ...) {
+void base_log_internal_core(const log_fields_t *log, ...) {
   size_t file_name_len =
-      (size_t)(((const char *)memchr(log.file_name, '\0', PTRDIFF_MAX)) -
-               log.file_name);
-  const char *base_name = memrchr(log.file_name, '/', file_name_len);
+      (size_t)(((const char *)memchr(log->file_name, '\0', PTRDIFF_MAX)) -
+               log->file_name);
+  const char *base_name = memrchr(log->file_name, '/', file_name_len);
   if (base_name == NULL) {
-    base_name = log.file_name;
+    base_name = log->file_name;
   } else {
     ++base_name;  // Remove the final '/'.
   }
@@ -60,13 +60,13 @@ void base_log_internal_core(log_fields_t log, ...) {
   // nothing was printed for some time.
   static uint16_t global_log_counter = 0;
 
-  base_printf("%s%05d %s:%d] ", stringify_severity(log.severity),
-              global_log_counter, base_name, log.line);
+  base_printf("%s%05d %s:%d] ", stringify_severity(log->severity),
+              global_log_counter, base_name, log->line);
   ++global_log_counter;
 
   va_list args;
   va_start(args, log);
-  base_vprintf(log.format, args);
+  base_vprintf(log->format, args);
   va_end(args);
 
   base_printf("\r\n");

--- a/sw/device/lib/runtime/log.h
+++ b/sw/device/lib/runtime/log.h
@@ -92,7 +92,7 @@ typedef struct log_fields {
 /**
  * Implementation detail.
  */
-void base_log_internal_core(log_fields_t log, ...);
+void base_log_internal_core(const log_fields_t *log, ...);
 /**
  * Implementation detail.
  */
@@ -123,9 +123,9 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
                            OT_VA_ARGS_COUNT(format, ##__VA_ARGS__), \
                            ##__VA_ARGS__); /* clang-format on */ \
     } else {                                                     \
-      log_fields_t log_fields =                                  \
+      static const log_fields_t log_fields =                     \
           LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);     \
-      base_log_internal_core(log_fields, ##__VA_ARGS__);         \
+      base_log_internal_core(&log_fields, ##__VA_ARGS__);        \
     }                                                            \
   } while (false)
 


### PR DESCRIPTION
Even though the struct `log` parameter of `base_log_internal_core` is logically constant, we were doing a `memcpy` from flash to the stack. Tweak the code to prevent that.

This saves on code size and cycles. E.g.:

```
   text	   data	    bss	    dec	    hex	filename
  19882	    132	   8176	  28190	   6e1e	old-test_rom_sim_verilator.elf
  19352	    132	   8176	  27660	   6c0c	new-test_rom_sim_verilator.elf
```