### PR TITLE
[top_darjeeling/dv] Increase timeout of some SW tests

### DIFF
--- a/hw/top_darjeeling/dv/chip_sim_cfg.hjson
+++ b/hw/top_darjeeling/dv/chip_sim_cfg.hjson
@@ -817,6 +817,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:rstmgr_cpu_info_test:6"]
       en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=20_000_000"]
     }
     {
       name: chip_sw_pwrmgr_full_aon_reset
@@ -933,7 +934,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:aon_timer_wdog_bite_reset_test:6"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=18_000_000"]
+      run_opts: ["+sw_test_timeout_ns=30_000_000"]
     }
     {
       name: chip_sw_pwrmgr_wdog_reset
@@ -1317,7 +1318,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:sensor_ctrl_wakeup_test:6"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=8_000_000"]
+      run_opts: ["+sw_test_timeout_ns=12_000_000"]
     }
     {
       name: chip_sw_coremark


### PR DESCRIPTION
As Darjeeling has a second rom_ctrl, the post-reset sequence takes more time.

With the increased timeouts, all affected tests pass 100% (even with a 5x reseed multiplier).