### PR TITLE
[kmac] Switch PRNG stream cipher primitive from Trivium to Bivium

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -155,7 +155,7 @@
     }
     { name:    "NumSeedsEntropy",
       type:    "int",
-      default: "9",
+      default: "6",
       desc:    "Number of words for the PRNG seed used for entropy generation",
       local:   "true"
     }

--- a/hw/ip/kmac/doc/theory_of_operation.md
+++ b/hw/ip/kmac/doc/theory_of_operation.md
@@ -289,7 +289,7 @@ This section explains the entropy generator inside the KMAC HWIP.
 KMAC has an entropy generator to provide the design with pseudo-random numbers while processing the secret key block.
 The entropy is used for both remasking the DOM multipliers inside the Chi function of the Keccak core as well as for masking the message if [`CFG_SHADOWED.msg_mask`](registers.md#cfg_shadowed) is enabled.
 
-The entropy generator is constructed using a [heavily unrolled Trivium stream cipher primitive](https://eprint.iacr.org/2023/1134).
+The entropy generator is constructed using a [heavily unrolled Bivium stream cipher primitive](https://eprint.iacr.org/2023/1134).
 This allows the module to generate 800 bits of fresh, pseudo-random numbers required by the 800 DOM multipliers for remasking in every clock cycle.
 
 Depending on [`CFG_SHADOWED.entropy_mode`](registers.md#cfg_shadowed), the entropy generator fetches initial entropy from the [Entropy Distribution Network (EDN)][edn] module or software has to provide a seed by writing the [`ENTROPY_SEED`](registers.md#entropy_seed) register 9 times.

--- a/hw/ip/kmac/pre_dv/kmac_reduced_tb/rtl/kmac_reduced_tb.sv
+++ b/hw/ip/kmac/pre_dv/kmac_reduced_tb/rtl/kmac_reduced_tb.sv
@@ -226,7 +226,7 @@ module kmac_reduced_tb #(
 
       INIT_RESEED: begin
         // Perform an initial reseed of the PRNG to put it into a random state.
-        // We do one reseed operation to reseed the single Trivium primitive.
+        // We do one reseed operation to reseed the single Bivium primitive.
         entropy_refresh_req = 1'b1;
         reseed_count_increment = entropy_req_fell;
         if (reseed_count_q == 8'd1) begin

--- a/hw/ip/kmac/pre_sca/prolead/kmac_reduced_config.set
+++ b/hw/ip/kmac/pre_sca/prolead/kmac_reduced_config.set
@@ -87,7 +87,7 @@ no_of_initial_inputs
 
 % number of clock cycles to initiate the run (start of encryption)
 no_of_initial_clock_cycles
-20
+17
 
 %1 - First clock cycle with inactive reset.
             rst_ni                    1'b1
@@ -379,94 +379,7 @@ no_of_initial_clock_cycles
 [3:0]       lc_escalate_en_i          4'b1010
             err_processed_i           1'b0
 
-%11 - Perform an initial reseed of the internal PRNG to put it into a random state.
-            rst_ni                    1'b1
-[127:0]     msg_i                     group_in0[127:0]
-[255:128]   msg_i                     group_in1[127:0]
-            msg_valid_i               1'b0
-            start_i                   1'b0
-            process_i                 1'b0
-            run_i                     1'b0
-[3:0]       done_i                    4'b1001
-            entropy_ready_i           1'b0
-            entropy_refresh_req_i     1'b1
-            entropy_ack_i             1'b1
-[1:0]       mode_i                    2'b00
-[2:0]       strength_i                3'b010
-[351:0]     ns_prefix_i               352'h000000000000000000000000000000000000000000000000000000000000000000000000000043414D4B2001
-[7:0]       msg_strb_i                8'hFF
-            msg_mask_en_i             1'b1
-[1:0]       entropy_mode_i            2'b01
-            entropy_fast_process_i    1'b0
-            entropy_in_keyblock_i     1'b1
-            entropy_seed_update_i     1'b0
-[31:0]      entropy_seed_data_i       32'h00000000
-[9:0]       wait_timer_prescaler_i    10'b0000000000
-[15:0]      wait_timer_limit_i        16'hFFFF
-[9:0]       entropy_hash_threshold_i  10'b1111111111
-            entropy_hash_clr_i        1'b0
-[3:0]       lc_escalate_en_i          4'b1010
-            err_processed_i           1'b0
-
-%12 - Perform an initial reseed of the internal PRNG to put it into a random state.
-            rst_ni                    1'b1
-[127:0]     msg_i                     group_in0[127:0]
-[255:128]   msg_i                     group_in1[127:0]
-            msg_valid_i               1'b0
-            start_i                   1'b0
-            process_i                 1'b0
-            run_i                     1'b0
-[3:0]       done_i                    4'b1001
-            entropy_ready_i           1'b0
-            entropy_refresh_req_i     1'b1
-            entropy_ack_i             1'b1
-[1:0]       mode_i                    2'b00
-[2:0]       strength_i                3'b010
-[351:0]     ns_prefix_i               352'h000000000000000000000000000000000000000000000000000000000000000000000000000043414D4B2001
-[7:0]       msg_strb_i                8'hFF
-            msg_mask_en_i             1'b1
-[1:0]       entropy_mode_i            2'b01
-            entropy_fast_process_i    1'b0
-            entropy_in_keyblock_i     1'b1
-            entropy_seed_update_i     1'b0
-[31:0]      entropy_seed_data_i       32'h00000000
-[9:0]       wait_timer_prescaler_i    10'b0000000000
-[15:0]      wait_timer_limit_i        16'hFFFF
-[9:0]       entropy_hash_threshold_i  10'b1111111111
-            entropy_hash_clr_i        1'b0
-[3:0]       lc_escalate_en_i          4'b1010
-            err_processed_i           1'b0
-
-%13 - Perform an initial reseed of the internal PRNG to put it into a random state.
-            rst_ni                    1'b1
-[127:0]     msg_i                     group_in0[127:0]
-[255:128]   msg_i                     group_in1[127:0]
-            msg_valid_i               1'b0
-            start_i                   1'b0
-            process_i                 1'b0
-            run_i                     1'b0
-[3:0]       done_i                    4'b1001
-            entropy_ready_i           1'b0
-            entropy_refresh_req_i     1'b1
-            entropy_ack_i             1'b1
-[1:0]       mode_i                    2'b00
-[2:0]       strength_i                3'b010
-[351:0]     ns_prefix_i               352'h000000000000000000000000000000000000000000000000000000000000000000000000000043414D4B2001
-[7:0]       msg_strb_i                8'hFF
-            msg_mask_en_i             1'b1
-[1:0]       entropy_mode_i            2'b01
-            entropy_fast_process_i    1'b0
-            entropy_in_keyblock_i     1'b1
-            entropy_seed_update_i     1'b0
-[31:0]      entropy_seed_data_i       32'h00000000
-[9:0]       wait_timer_prescaler_i    10'b0000000000
-[15:0]      wait_timer_limit_i        16'hFFFF
-[9:0]       entropy_hash_threshold_i  10'b1111111111
-            entropy_hash_clr_i        1'b0
-[3:0]       lc_escalate_en_i          4'b1010
-            err_processed_i           1'b0
-
-%14 - Stop reseeding the internal PRNG.
+%11 - Stop reseeding the internal PRNG.
             rst_ni                    1'b1
 [127:0]     msg_i                     group_in0[127:0]
 [255:128]   msg_i                     group_in1[127:0]
@@ -495,7 +408,7 @@ no_of_initial_clock_cycles
 [3:0]       lc_escalate_en_i          4'b1010
             err_processed_i           1'b0
 
-%15 - Send the start trigger.
+%12 - Send the start trigger.
             rst_ni                    1'b1
 [127:0]     msg_i                     group_in0[127:0]
 [255:128]   msg_i                     group_in1[127:0]
@@ -524,7 +437,7 @@ no_of_initial_clock_cycles
 [3:0]       lc_escalate_en_i          4'b1010
             err_processed_i           1'b0
 
-%16 - Signal that the message is valid.
+%13 - Signal that the message is valid.
             rst_ni                    1'b1
 [127:0]     msg_i                     group_in0[127:0]
 [255:128]   msg_i                     group_in1[127:0]
@@ -553,7 +466,7 @@ no_of_initial_clock_cycles
 [3:0]       lc_escalate_en_i          4'b1010
             err_processed_i           1'b0
 
-%17 - Internal message loading.
+%14 - Internal message loading.
             rst_ni                    1'b1
 [127:0]     msg_i                     group_in0[127:0]
 [255:128]   msg_i                     group_in1[127:0]
@@ -582,7 +495,7 @@ no_of_initial_clock_cycles
 [3:0]       lc_escalate_en_i          4'b1010
             err_processed_i           1'b0
 
-%18 - Internal message loading.
+%15 - Internal message loading.
             rst_ni                    1'b1
 [127:0]     msg_i                     group_in0[127:0]
 [255:128]   msg_i                     group_in1[127:0]
@@ -611,7 +524,7 @@ no_of_initial_clock_cycles
 [3:0]       lc_escalate_en_i          4'b1010
             err_processed_i           1'b0
 
-%19 - Send the process trigger.
+%16 - Send the process trigger.
             rst_ni                    1'b1
 [127:0]     msg_i                     group_in0[127:0]
 [255:128]   msg_i                     group_in1[127:0]
@@ -640,7 +553,7 @@ no_of_initial_clock_cycles
 [3:0]       lc_escalate_en_i          4'b1010
             err_processed_i           1'b0
 
-%20 - De-assert process_i.
+%17 - De-assert process_i.
             rst_ni                    1'b1
 [127:0]     msg_i                     group_in0[127:0]
 [255:128]   msg_i                     group_in1[127:0]
@@ -681,7 +594,7 @@ end_wait_cycles
 
 % maximum number of clock cycles per run before checking the end_condition
 max_clock_cycle
-135
+132
 
 no_of_outputs
 0
@@ -690,7 +603,7 @@ no_of_outputs
 no_of_test_clock_cycles
 1
 
-15-135  % The start trigger is sent at %15 and the state_valid_o arrives at %134.
+12-132  % The start trigger is sent at %12 and the state_valid_o arrives at %131.
 
 % max number of entries in the report file with maximum leakage
 % 0 : do not generate the report file

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -352,10 +352,10 @@ module kmac_entropy
   `ASSERT_KNOWN(ModeKnown_A, mode_i)
   assign seed = (mode_q == EntropyModeSw) ? seed_data_i : entropy_data_i;
 
-  // We employ a single unrolled Trivium stream cipher primitive to generate
+  // We employ a single unrolled Bivium stream cipher primitive to generate
   // 800 bits per clock cycle.
   prim_trivium #(
-   .BiviumVariant         (0),
+   .BiviumVariant         (1),
    .OutputWidth           (EntropyOutputW),
    .StrictLockupProtection(1),
    .SeedType              (prim_trivium_pkg::SeedTypeStatePartial),

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -12,7 +12,7 @@ package kmac_reg_pkg;
   parameter int NumEntriesMsgFifo = 10;
   parameter int NumBytesMsgFifoEntry = 8;
   parameter int unsigned HashCntW = 10;
-  parameter int NumSeedsEntropy = 9;
+  parameter int NumSeedsEntropy = 6;
   parameter int NumAlerts = 2;
 
   // Address widths within the block

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -134,7 +134,7 @@ enum {
    *
    * The length is in 32-bit words.
    */
-  kDifKmacEntropySeedWords = 9,
+  kDifKmacEntropySeedWords = 6,
   /**
    * The offset of the second share within the output state register.
    */

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -656,9 +656,8 @@ class KmacConfigureTest : public KmacTest {
   dif_kmac_config_t kmac_config_ = {
       .entropy_mode = kDifKmacEntropyModeIdle,
       .entropy_fast_process = false,
-      .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe,
-                       0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
-                       0x11e1ebd1},
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
       .entropy_hash_threshold = 0x03ff,
       .entropy_wait_timer = 0xffff,
       .entropy_prescaler = 0x03ff,

--- a/sw/device/sca/kmac_serial.c
+++ b/sw/device/sca/kmac_serial.c
@@ -430,9 +430,8 @@ static void kmac_init(void) {
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
       .entropy_fast_process = kDifToggleDisabled,
-      .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe,
-                       0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
-                       0x11e1ebd1},
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
       .message_big_endian = kDifToggleDisabled,
       .output_big_endian = kDifToggleDisabled,
       .sideload = kDifToggleDisabled,

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -76,8 +76,8 @@ static dif_kmac_t kmac;
 static dif_kmac_config_t config = (dif_kmac_config_t){
     .entropy_mode = kDifKmacEntropyModeSoftware,
     .entropy_fast_process = kDifToggleDisabled,
-    .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe, 0x09596819,
-                     0x3e85a6e8, 0xb6dcdaba, 0x50dc409c, 0x11e1ebd1},
+    .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
+                     0x11e1ebd1},
     .message_big_endian = kDifToggleDisabled,
     .output_big_endian = kDifToggleDisabled,
     .sideload = kDifToggleDisabled,

--- a/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/kmac_sca.c
@@ -460,9 +460,8 @@ status_t handle_kmac_sca_init(ujson_t *uj) {
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
       .entropy_fast_process = kDifToggleDisabled,
-      .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe,
-                       0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
-                       0x11e1ebd1},
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
       .message_big_endian = kDifToggleDisabled,
       .output_big_endian = kDifToggleDisabled,
       .sideload = kDifToggleDisabled,

--- a/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/sha3_sca.c
@@ -69,8 +69,8 @@ static dif_kmac_t kmac;
 static dif_kmac_config_t config = (dif_kmac_config_t){
     .entropy_mode = kDifKmacEntropyModeSoftware,
     .entropy_fast_process = kDifToggleDisabled,
-    .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe, 0x09596819,
-                     0x3e85a6e8, 0xb6dcdaba, 0x50dc409c, 0x11e1ebd1},
+    .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
+                     0x11e1ebd1},
     .message_big_endian = kDifToggleDisabled,
     .output_big_endian = kDifToggleDisabled,
     .sideload = kDifToggleDisabled,

--- a/sw/device/tests/kmac_idle_test.c
+++ b/sw/device/tests/kmac_idle_test.c
@@ -136,9 +136,8 @@ bool test_main(void) {
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
-      .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe,
-                       0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
-                       0x11e1ebd1},
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
       .entropy_fast_process = kDifToggleEnabled,
   };
   CHECK_DIF_OK(dif_kmac_configure(&kmac, config));

--- a/sw/device/tests/kmac_mode_cshake_test.c
+++ b/sw/device/tests/kmac_mode_cshake_test.c
@@ -99,9 +99,8 @@ bool test_main(void) {
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
-      .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe,
-                       0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
-                       0x11e1ebd1},
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
       .entropy_fast_process = kDifToggleEnabled,
   };
   CHECK_DIF_OK(dif_kmac_configure(&kmac, config));

--- a/sw/device/tests/kmac_mode_kmac_test.c
+++ b/sw/device/tests/kmac_mode_kmac_test.c
@@ -200,9 +200,8 @@ bool test_main(void) {
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
-      .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe,
-                       0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
-                       0x11e1ebd1},
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
       .entropy_fast_process = kDifToggleEnabled,
   };
   CHECK_DIF_OK(dif_kmac_configure(&kmac, config));

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -294,12 +294,11 @@ bool test_main(void) {
 
   // Configure KMAC hardware using software entropy. The seed has been randomnly
   // chosen and is genrated using enerated using
-  // ./util/design/gen-lfsr-seed.py --width 288 --seed 2034386436 --prefix ""
+  // ./util/design/gen-lfsr-seed.py --width 192 --seed 2034386436 --prefix ""
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
-      .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe,
-                       0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
-                       0x11e1ebd1},
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
       .entropy_fast_process = kDifToggleEnabled,
   };
   CHECK_DIF_OK(dif_kmac_configure(&kmac, config));

--- a/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
+++ b/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
@@ -91,9 +91,8 @@ static void kmac_init(void) {
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
-      .entropy_seed = {0x5d2a3764, 0x37d3ecba, 0xe1859094, 0xb153e3fe,
-                       0x09596819, 0x3e85a6e8, 0xb6dcdaba, 0x50dc409c,
-                       0x11e1ebd1},
+      .entropy_seed = {0xb153e3fe, 0x09596819, 0x3e85a6e8, 0xb6dcdaba,
+                       0x50dc409c, 0x11e1ebd1},
       .entropy_fast_process = kDifToggleEnabled,
   };
   CHECK_DIF_OK(dif_kmac_configure(&kmac, config));


### PR DESCRIPTION
To reduce area, this PR switches the stream cipher primitive inside the PRNG of KMAC from Trivium to Bivium. It was found that the security posture of Bivium is sufficient in this application scenario. This should give us back around 10 kGE. 

Please don't merge this yet. The SCA evaluation is currently running and I will update the PR with the results.