### PR TITLE
[sival] Test plan updates

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -82,6 +82,7 @@
             - Re-enable data transfer and ensure data correctness.
             '''
       stage: V3
+      si_stage: NA
       tests: []
     }
     {
@@ -92,6 +93,7 @@
             - Ensure the CSR `wake_debug` returns correctly value.
             '''
       stage: V3
+      si_stage: NA
       tests: []
     }
 
@@ -116,6 +118,8 @@
             - Follow a similar testing procedure for DIOs.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
     }
     {
@@ -133,6 +137,8 @@
             Cross-references the `chip_pin_mux` test.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
     }
     {
@@ -154,6 +160,8 @@
             covered in other tests such as chip_sw_sleep_pwm_pulses.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_sleep_pin_mio_dio_val"]
     }
     {
@@ -170,6 +178,8 @@
             those detectors. Also, randomize and test all wakeup modes and enable debounce filter.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_sleep_pin_wake"]
     }
     {
@@ -189,6 +199,8 @@
               chip is back in active power.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_sleep_pin_retention"]
     }
     {
@@ -211,6 +223,8 @@
             host (SV testbench) performs these stimulus / checks.
             '''
       stage: V2
+      si_stage: SV2
+      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "RMA"]
       tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma",
               "chip_tap_straps_testunlock0"]
     }
@@ -245,6 +259,7 @@
       ]
       stage: V2
       si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_pattgen_ios"]
     }
 
@@ -282,6 +297,7 @@
       ]
       stage: V2
       si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_sleep_pwm_pulses"]
     }
 
@@ -305,6 +321,7 @@
             - Check the alert up to the NMI phase and make sure that the alert cause is from Ibex.
             '''
       stage: V2
+      si_stage: NA
       tests: ["chip_sw_data_integrity_escalation"]
     }
     {
@@ -320,6 +337,7 @@
             - Check the alert up to the NMI phase and make sure that the alert cause is from Ibex.
             '''
       stage: V2
+      si_stage: NA
       tests: ["chip_sw_data_integrity_escalation"]
     }
 
@@ -338,6 +356,7 @@
             regwen is enabled, and errors are not cleared.
             '''
       stage: V2
+      si_stage: NA
       tests: ["chip_sw_ast_clk_outputs"]
     }
     {
@@ -355,6 +374,8 @@
             Repeat 1-4 to check it is ok.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_ast_clk_rst_inputs"]
     }
     {
@@ -364,6 +385,8 @@
             X-ref with chip_sw_clkmgr_jitter
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_clkmgr_jitter",
               "chip_sw_flash_ctrl_ops_jitter_en",
               "chip_sw_flash_ctrl_access_jitter_en",
@@ -391,6 +414,8 @@
               open source is effectively short-circuited.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_usb_ast_clk_calib"]
     }
     {
@@ -400,6 +425,7 @@
              X-ref'ed with `chip_sensor_ctrl_ast_alerts`.
              '''
       stage: V2
+      si_stage: NA
       tests: ["chip_sw_sensor_ctrl_alert"]
     }
 
@@ -416,6 +442,8 @@
                as either recoverable or fatal.
              '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup",
               "chip_sw_sensor_ctrl_alert"]
     }
@@ -428,6 +456,8 @@
                from a sensor_ctrl register.
             '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_sensor_ctrl_status"]
     }
     {
@@ -437,6 +467,8 @@
                AST. X-ref'ed chip_sw_pwrmgr_sleep_all_wake_ups.
              '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup"]
     }
 
@@ -458,6 +490,7 @@
             5. Enable concurrent threads in tests
             '''
       stage: V1
+      si_stage: NA
       tests: ["chip_sw_example_rom",
               "chip_sw_example_flash",
               "chip_sw_uart_smoketest_signed",
@@ -475,6 +508,7 @@
             '''
       stage: V2
       si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_aes_smoketest",
               "chip_sw_aon_timer_smoketest",
               "chip_sw_clkmgr_smoketest",
@@ -527,6 +561,7 @@
             as well.
             '''
       stage: V2
+      si_stage: NA
       tests: ["rom_keymgr_functest"]
     }
     {
@@ -545,6 +580,8 @@
       name: chip_sw_coremark
       desc: '''Run the coremark benchmark on the full chip.'''
       stage: V3
+      si_stage: SV4
+      lc_states: ["PROD"]
       tests: ["chip_sw_coremark"]
     }
     {
@@ -561,6 +598,7 @@
              For detail, refer to chip_spi_device_flash_mode
              '''
       stage: V2
+      si_stage: NA
       tests: ["chip_sw_uart_tx_rx_bootstrap"]
     }
     {
@@ -571,6 +609,7 @@
              In reality this can be any rom based test, which requires secure boot.
              '''
       stage: V2
+      si_stage: NA
       tests: ["rom_e2e_smoke"]
     }
     {
@@ -596,6 +635,7 @@
              - Check AST init done equal to 0 via sensor_ctrl.
              '''
       stage: V2
+      si_stage: NA
       tests: ["rom_raw_unlock"]
     }
     {
@@ -648,6 +688,8 @@
       in #14095 for more details on how to approach the implementation.
       '''
       stage: V3
+      si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_power_virus"]
     }
     {
@@ -676,6 +718,8 @@
         - Check whether PWM should be active
       '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_power_idle_load"]
     }
     {
@@ -703,6 +747,8 @@
       in #14095 for more details on how to approach the implementation.
       '''
       stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_power_sleep_load"]
     }
 
@@ -720,6 +766,7 @@
       X-ref'ed with manuf_ft_exit_token from manufacturing test plan.
       '''
       stage: V2
+      si_stage: NA
       tests: ["chip_sw_exit_test_unlocked_bootstrap"]
     }
 
@@ -744,6 +791,7 @@
       X-ref'ed with manuf_ft_sku_individualization from manufacturing test plan.
       '''
       stage: V2
+      si_stage: NA
       tests: ["chip_sw_inject_scramble_seed"]
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
@@ -27,6 +27,7 @@
       features:["ADC_CTRL.MODE.LOW_POWER"]
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
     }
     {
@@ -51,6 +52,7 @@
       features:["ADC_CTRL.MODE.LOW_POWER"]
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
     }
     {
@@ -59,6 +61,7 @@
       features:["ADC_CTRL.MODE.NORMAL"]
       stage: V3
       si_stage: SV2
+      lc_states: ["PROD"]
       tests: []
     }
     {
@@ -67,6 +70,7 @@
       features:["ADC_CTRL.ONESHOT", "ADC_CTRL.MODE.NORMAL"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -251,7 +251,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD", "DEV"]
       tests: ["chip_sw_keymgr_sideload_aes"]
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -21,7 +21,7 @@
                  "ALERT_HANDLER.ALERT.ESCALATE"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_alert_test"]
       bazel: ["//sw/device/tests/autogen:alert_test"]
     }
@@ -41,7 +41,7 @@
                  "ALERT_HANDLER.ESCALATION.PHASES"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_escalation"]
       otp_mutate: true
       host_support: true
@@ -65,7 +65,7 @@
                  "ALERT_HANDLER.ESCALATION.PHASES"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       otp_mutate: false
     }
@@ -83,7 +83,7 @@
                  "ALERT_HANDLER.ESCALATION.TIMEOUT"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
     }
     {
@@ -119,7 +119,7 @@
       features: ["ALERT_HANDLER.ALERT.INTERRUPT"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_plic_all_irqs"]
       bazel: ["//sw/device/tests/autogen:plic_all_irqs_test_0"]
     }
@@ -152,7 +152,7 @@
       features: ["ALERT_HANDLER.CRASH_DUMP"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_rstmgr_alert_info"]
       bazel: ["//sw/device/tests:rstmgr_alert_info_test"]
     }
@@ -167,7 +167,7 @@
       features: ["ALERT_HANDLER.PING_TIMER"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_ping_timeout"]
       bazel: ["//sw/device/tests:alert_handler_ping_timeout_test"]
     }
@@ -188,7 +188,7 @@
       features: ["ALERT_HANDLER.PING_TIMER"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_lpg_sleep_mode_alerts"]
     }
     {
@@ -212,7 +212,7 @@
       features: ["ALERT_HANDLER.PING_TIMER"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_lpg_sleep_mode_pings"]
       bazel: ["//sw/device/tests:alert_handler_lpg_sleep_mode_pings_test"]
     }
@@ -226,7 +226,7 @@
       features: ["ALERT_HANDLER.PING_TIMER"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_lpg_clkoff"]
       bazel: ["//sw/device/tests:alert_handler_lpg_clkoff_test"]
     }
@@ -240,7 +240,7 @@
       features: ["ALERT_HANDLER.PING_TIMER"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_lpg_reset_toggle"]
       bazel: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test"]
    }
@@ -298,7 +298,7 @@
       features: ["ALERT_HANDLER.PING_TIMER"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_reverse_ping_in_deep_sleep"]
       bazel: ["//sw/device/tests:alert_handler_reverse_ping_in_deep_sleep_test"]
     }

--- a/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
@@ -16,7 +16,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["AON_TIMER.WAKEUP.INTERRUPT"]
       tests: ["chip_sw_aon_timer_irq"]
       bazel: ["//sw/device/tests:aon_timer_irq_test"]
@@ -38,7 +38,7 @@
             '''
       stage: V2
       si_stage: SV2
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["AON_TIMER.WAKEUP.WAKEUP_CONFIG", "AON_TIMER.WAKEUP.WAKEUP_REQUEST"]
       tests: ["chip_sw_pwrmgr_smoketest"]
       bazel: ["//sw/device/tests:pwrmgr_smoketest"]
@@ -53,7 +53,7 @@
             '''
       stage: V2
       si_stage: SV2
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["AON_TIMER.WATCHDOG.INTERRUPT"]
       tests: ["chip_sw_aon_timer_irq"]
       bazel: ["//sw/device/tests:aon_timer_irq_test"]
@@ -71,7 +71,7 @@
             '''
       stage: V2
       si_stage: SV2
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["AON_TIMER.WATCHDOG.BITE", "AON_TIMER.WATCHDOG.BARK"]
       tests: ["chip_sw_aon_timer_wdog_bite_reset"]
       bazel: ["//sw/device/tests:aon_timer_wdog_bite_reset_test"]
@@ -89,7 +89,7 @@
             '''
       stage: V2
       si_stage: SV2
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["AON_TIMER.WATCHDOG.BITE", "AON_TIMER.WATCHDOG.BARK"]
       tests: ["chip_sw_aon_timer_wdog_bite_reset"]
       bazel: ["//sw/device/tests:aon_timer_wdog_bite_reset_test"]
@@ -109,7 +109,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["AON_TIMER.WATCHDOG.BITE", "AON_TIMER.WATCHDOG.PAUSE"]
       tests: ["chip_sw_aon_timer_sleep_wdog_sleep_pause"]
       bazel: ["//sw/device/tests:aon_timer_sleep_wdog_sleep_pause_test"]
@@ -130,7 +130,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["AON_TIMER.WATCHDOG.DISABLE_BY_LC_CTRL"]
       tests: ["chip_sw_aon_timer_wdog_lc_escalate"]
       bazel: ["//sw/device/tests:aon_timer_wdog_lc_escalate_test"]

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -18,10 +18,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "CLKMGR.HINT.AES",
         "CLKMGR.HINT.HMAC",
@@ -57,10 +54,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "CLKMGR.HINT.AES",
         "CLKMGR.HINT.HMAC",
@@ -93,10 +87,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "CLKMGR.ENABLE.IO",
         "CLKMGR.ENABLE.IO_DIV2",
@@ -176,7 +167,7 @@
             with the right frequency after calibration. There are a few such tests already.
             '''
       stage: V2
-      si_stage: NA
+      si_stage: SV3
       lc_states: [
         "DEV",
       ]
@@ -225,10 +216,7 @@
             '''
       stage: V3
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "CLKMGR.JITTER.REGWEN",
         "CLKMGR.JITTER.ENABLE",
@@ -282,7 +270,6 @@
         "chip_sw_flash_init_reduced_freq",
         "chip_sw_csrng_edn_concurrency_reduced_freq",
       ]
-      bazel: []
     }
     {
       name: chip_sw_clkmgr_deep_sleep_frequency
@@ -294,10 +281,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "CLKMGR.MEAS_CTRL.REGWEN",
         "CLKMGR.MEAS_CTRL.IO",
@@ -322,10 +306,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "CLKMGR.MEAS_CTRL.REGWEN",
         "CLKMGR.MEAS_CTRL.IO",
@@ -350,6 +331,7 @@
             '''
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       features: [
         "CLKMGR.MEAS_CTRL.REGWEN",
         "CLKMGR.MEAS_CTRL.IO",
@@ -375,7 +357,6 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_all_escalation_resets"]
-      bazel: []
     }
     {
       name: chip_sw_clkmgr_alert_handler_clock_enables
@@ -389,12 +370,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "DEV",
-        "PROD",
-        "PROD_END",
-        "RMA",
-      ]
+      lc_states: ["PROD"]
       features: ["CLKMGR.ALERT_HANDLER.CLOCK_STATUS"]
       tests: ["chip_sw_alert_handler_lpg_clkoff"]
       bazel: ["//sw/device/tests:alert_handler_lpg_clkoff_test"]

--- a/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
@@ -17,6 +17,7 @@
             '''
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_edn_entropy_reqs",
               "chip_sw_csrng_edn_concurrency",
               "chip_sw_entropy_src_ast_rng_req",]
@@ -68,7 +69,6 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      bazel: []
       tests: ["chip_sw_edn_boot_mode"]
       bazel: ["//sw/device/tests:edn_boot_mode"]
     },
@@ -97,7 +97,6 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      bazel: []
       tests: ["chip_sw_edn_auto_mode"]
       bazel: ["//sw/device/tests:edn_auto_mode"]
     },
@@ -124,7 +123,6 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      bazel: []
       tests: ["chip_sw_edn_sw_mode"]
       bazel: ["//sw/device/tests:edn_sw_mode"]
     },
@@ -167,7 +165,6 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      bazel: []
       tests: ["chip_sw_edn_kat"]
       bazel: ["//sw/device/tests:edn_kat"]
     },

--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -23,7 +23,7 @@
       features: ["ENTROPY_SRC.FW_OV.EXTRACT_AND_INSERT"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "PROD"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_entropy_src_ast_rng_req"]
       bazel: ["//sw/device/tests:entropy_src_ast_rng_req_test"]
     },
@@ -71,7 +71,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "PROD"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_entropy_src_kat_test"]
       bazel: ["//sw/device/tests:entropy_src_kat_test"]
     },
@@ -175,7 +175,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "PROD"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     },
@@ -209,7 +209,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "PROD"]
+      lc_states: ["PROD"]
       tests: []
       bazel: ["//sw/device/tests:entropy_src_fw_observe_many_contiguous_test"]
     },
@@ -249,7 +249,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "PROD"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     },

--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -24,7 +24,7 @@
                  "FLASH_CTRL.INFO.CREATOR_PARTITION", "FLASH_CTRL.INFO.OWNER_PARTITION"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_init"]
       bazel: ["//sw/device/tests:flash_ctrl_test"]
     }
@@ -37,7 +37,7 @@
       features: ["FLASH_CTRL.OP.HOST_READ"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_ctrl_access",
               "chip_sw_flash_ctrl_access_jitter_en"]
       bazel: ["//sw/device/tests:flash_ctrl_ops_test"]
@@ -53,7 +53,7 @@
       features: ["FLASH_CTRL.OP.PROTOCOL_CTRL"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_ctrl_ops", "chip_sw_flash_ctrl_ops_jitter_en"]
       bazel: ["//sw/device/tests:flash_ctrl_ops_test"]
     }
@@ -69,7 +69,7 @@
       features: ["FLASH_CTRL.MEM_PROTECTION"]
       stage: V3
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_ctrl_mem_protection"]
       bazel: ["//sw/device/tests:flash_ctrl_mem_protection_test"]
     }
@@ -92,7 +92,7 @@
       features: ["FLASH_CTRL.RMA"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_rma_unlocked"]
     }
     {
@@ -110,7 +110,7 @@
       features: ["FLASH_CTRL.INIT.SCRAMBLING_KEYS", "FLASH_CTRL.OP.PROTOCOL_CTRL"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_init"]
       bazel: ["//sw/device/tests:flash_ctrl_test"]
     }
@@ -125,7 +125,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_ctrl_idle_low_power"]
       bazel: ["//sw/device/tests:flash_ctrl_idle_low_power_test"]
     }
@@ -139,7 +139,7 @@
       features: ["FLASH_CTRL.INIT.ROOT_SEEDS", "FLASH_CTRL.INFO.CREATOR_PARTITION", "FLASH_CTRL.INFO.OWNER_PARTITION"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_key_derivation"]
     }
     {
@@ -153,7 +153,7 @@
       features: ["FLASH_CTRL.INFO.CREATOR_PARTITION"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
       bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states",
               "//sw/device/tests:flash_ctrl_info_access_lc_states_personalized"]
@@ -166,7 +166,7 @@
       features: ["FLASH_CTRL.RMA"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["RMA"]
       tests: ["chip_sw_flash_rma_unlocked"]
       bazel: ["//sw/device/tests:flash_ctrl_rma_test"]
     }
@@ -189,7 +189,7 @@
       name: chip_sw_flash_lc_iso_part_sw_rd_en
       desc: '''Verify the lc_iso_part_sw_rd_en signal from LC ctrl.
 
-            - Transition from DEV to PROD to ESCALATION/SCRAP state via OTP and verify
+            - Transition from DEV or PROD to ESCALATION/SCRAP state via OTP and verify
               that this LC signal transitions from 0 to 1 and back to 0. Verify that the SW
               accessibility of the corresponding partition depending on the signal value.
             '''
@@ -245,7 +245,7 @@
             '''
       features: ["FLASH_CTRL.ESCALATION"]
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_all_escalation_resets"]
     }
     {
@@ -257,7 +257,7 @@
             - Verify that this region can be read / written to by the SW in any LC state.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_prim_tl_access"]
     }
     {
@@ -270,6 +270,7 @@
             '''
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_ctrl_clock_freqs"]
       bazel: ["//sw/device/tests:flash_ctrl_clock_freqs_test"]
     }
@@ -283,7 +284,7 @@
             the internal status should be clean and should not send out more alerts.
             '''
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_flash_crash_alert"]
     }
     {
@@ -307,6 +308,7 @@
             '''
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_flash_crash_alert"]
       bazel: ["//sw/device/tests:flash_ctrl_write_clear_test"]
     }

--- a/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
@@ -16,6 +16,7 @@
       features: ["GPIO.OUT.MASK"]
       stage: V1
       si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_gpio"]
       bazel: ["//sw/device/tests:gpio_pinmux_test"]
     }
@@ -29,6 +30,7 @@
       features: ["GPIO.IN.INTR_CTRL", "GPIO.IN.FILTER"]
       stage: V1
       si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_gpio"]
       bazel: ["//sw/device/tests:gpio_pinmux_test"]
     }
@@ -43,6 +45,7 @@
       features: ["GPIO.IN.INTR_CTRL", "GPIO.IN.FILTER"]
       stage: V1
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_gpio"]
       bazel: ["//sw/device/tests:gpio_intr_test"]
     }

--- a/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
@@ -15,7 +15,7 @@
             '''
       stage: V2
       si_stage: SV2
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_hmac_enc",
               "chip_sw_hmac_enc_jitter_en"]
       bazel: ["//sw/device/tests:hmac_enc_test"]
@@ -38,7 +38,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_hmac_enc_idle"]
       bazel: []
     }
@@ -54,7 +54,7 @@
       features: ["HMAC.MODE.SHA2"]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -70,7 +70,7 @@
       features: ["HMAC.MODE.HMAC"]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -89,7 +89,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -107,7 +107,7 @@
       features: ["HMAC.SECURE_WIPE"]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -126,7 +126,7 @@
       features: []
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -25,6 +25,7 @@
       features: ["I2C.MODE.HOST", "I2C.OPERATION.READ", "I2C.OPERATION.WRITE"]
       stage: V2
       si_stage: SV2
+      lc_states: ["PROD"]
       bazel: ["//sw/device/tests/pmod:i2c_host_eeprom_test"]
       tests: ["chip_sw_i2c_host_tx_rx",
               "chip_sw_i2c_host_tx_rx_idx1",
@@ -49,6 +50,7 @@
       features: ["I2C.MODE.TARGET", "I2C.OPERATION.READ", "I2C.OPERATION.WRITE"]
       stage: V2
       si_stage: SV2
+      lc_states: ["PROD"]
       bazel: ["//sw/device/tests:i2c_target_test"]
       tests: ["chip_sw_i2c_device_tx_rx"]
     }
@@ -75,6 +77,7 @@
       features: ["I2C.MODE.HOST", "I2C.MODE.TARGET", "I2C.SPEED.STANDARD", "I2C.SPEED.FAST", "I2C.SPEED.FASTPLUS"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       bazel: ["//sw/device/tests/pmod:i2c_host_fram_test"]
       tests: []
     }
@@ -94,6 +97,7 @@
       features: ["I2C.MODE.HOST", "I2C.OVERRIDE"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
     }
     {
@@ -119,6 +123,7 @@
       features: ["I2C.MODE.HOST", "I2C.PROTOCOL.CLOCKSTRETCHING"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
     }
     {
@@ -138,6 +143,7 @@
       features: ["I2C.MODE.HOST", "I2C.PROTOCOL.NACK"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
       bazel: ["//sw/device/tests/pmod:i2c_host_eeprom_test"]
     }
@@ -157,6 +163,7 @@
       features: ["I2C.MODE.TARGET", "I2C.PROTOCOL.REPEATEDSTART"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -38,6 +38,7 @@
             '''
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: [
         "chip_sw_keymgr_key_derivation",
         "chip_sw_keymgr_key_derivation_jitter_en",
@@ -94,7 +95,7 @@
       features: ["KEYMGR.SIDELOAD.KMAC"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_sideload_kmac"]
       bazel: []
     }
@@ -107,7 +108,7 @@
       features: ["KEYMGR.SIDELOAD.AES"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_sideload_aes"]
       bazel: []
     }
@@ -123,7 +124,7 @@
       features: ["KEYMGR.SIDELOAD.OTBN"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_sideload_otbn"]
       bazel: []
     }
@@ -159,7 +160,7 @@
             ]
             stage: V3
             si_stage: SV2
-            lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+            lc_states: ["PROD"]
             tests: []
             bazel: []
     }
@@ -183,7 +184,7 @@
             ]
             stage: V3
             si_stage: SV3
-            lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+            lc_states: ["PROD"]
             tests: []
             bazel: []
     }

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -19,7 +19,7 @@
         "chip_sw_kmac_mode_kmac",
         "chip_sw_kmac_mode_kmac_jitter_en",
       ]
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       bazel: ["//sw/device/tests:kmac_mode_kmac_test"]
     }
     {
@@ -94,6 +94,7 @@
             '''
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_kmac_entropy"]
     }
     {
@@ -128,7 +129,7 @@
       features: ["KMAC.MODE.SHA3"]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -148,7 +149,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -168,7 +169,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -188,7 +189,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -214,7 +215,7 @@
       features: ["KMAC.KEY.SIDELOAD"]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -233,7 +234,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -257,7 +258,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -285,7 +286,7 @@
       features: []
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }

--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -22,7 +22,7 @@
       si_stage: SV3
       tests: []
       bazel: ["//sw/device/tests:otbn_isa_test"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "OTBN.ISA",
         "OTBN.SECUREWIPE"
@@ -42,7 +42,7 @@
       tests: ["chip_sw_otbn_ecdsa_op_irq",
               "chip_sw_otbn_ecdsa_op_irq_jitter_en"]
       bazel: ["//sw/device/tests:otbn_ecdsa_op_irq_test"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "OTBN.ISA"
       ]
@@ -61,7 +61,7 @@
       si_stage: SV3
       tests: ["chip_sw_otbn_randomness"]
       bazel: ["//sw/device/tests:otbn_randomness_test"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "OTBN.RANDOM"
       ]
@@ -76,7 +76,7 @@
       si_stage: SV3
       tests:  ["chip_sw_otbn_randomness"]
       bazel: ["//sw/device/tests:otbn_randomness_test"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "OTBN.RANDOM"
       ]
@@ -100,7 +100,7 @@
       si_stage: SV3
       tests: ["chip_sw_otbn_randomness"]
       bazel: ["//sw/device/tests:otbn_randomness_test"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: []
     }
     {
@@ -126,7 +126,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_otbn_mem_scramble"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "OTBN.MEM_SCRAMBLE",
         "OTBN.SECUREWIPE"
@@ -145,7 +145,7 @@
       si_stage: SV2
       tests: []
       bazel: ["//sw/device/tests:keymgr_sideload_otbn_simple_test"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "OTBN.KEYMGR",
       ]

--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -17,7 +17,7 @@
             '''
       features: ["OTP_CTRL.INIT"]
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
@@ -41,7 +41,7 @@
       features: ["OTP_CTRL.KEY_DERIVATION", "OTP_CTRL.PARTITION.SECRET1"]
       stage: V2
       si_stage: SV1
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: [// Verifies both, main and retention SRAM scrambling.
               "chip_sw_sram_ctrl_scrambled_access",
               "chip_sw_flash_init",
@@ -62,6 +62,7 @@
       features: ["OTP_CTRL.ENTROPY_READ"]
       stage: V2
       si_stage: SV1
+      lc_states: ["PROD"]
       tests: ["chip_sw_sram_ctrl_scrambled_access",
               "chip_sw_flash_init",
               "chip_sw_keymgr_key_derivation",
@@ -87,6 +88,7 @@
                  "OTP_CTRL.PARTITION.LIFE_CYCLE", "OTP_CTRL.PARTITION.SECRET2"]
       stage: V2
       si_stage: SV1
+      lc_states: ["PROD"]
       tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
@@ -125,6 +127,8 @@
       stage: V2
       si_stage: SV1
       tests: ["chip_sw_lc_ctrl_otp_hw_cfg0"]
+      lc_states: ["PROD"]
+      bazel: ["//sw/device/tests:lc_ctrl_otp_hw_cfg_test"]
     }
     {
       name: chip_sw_otp_ctrl_lc_signals
@@ -147,7 +151,7 @@
             '''
       features: ["OTP_CTRL.PARTITION.SECRET2"]
       stage: V2
-      si_stage: None
+      si_stage: NA
       tests: [
         // lc_dft_en_i
         "chip_prim_tl_access",
@@ -197,7 +201,7 @@
                  "OTP_CTRL.PARTITIONS_FEATURE.READ_LOCK",
                  "OTP_CTRL.PARTITIONS_FEATURE.WRITE_LOCK"]
       stage: V3
-      si_stage: None
+      si_stage: NA
       tests: ["chip_sw_otp_ctrl_vendor_test_csr_access"]
     }
     {
@@ -242,7 +246,7 @@
       features: ["OTP_CTRL.PARTITIONS_FEATURE.READ_LOCK", "OTP_CTRL.PARTITIONS_FEATURE.WRITE_LOCK",
                  "OTP_CTRL.ERROR_HANDLING.RECOVERABLE"]
       stage: V3
-      si_stage: None
+      si_stage: NA
       tests: []
     }
     {
@@ -257,7 +261,7 @@
       '''
       features: ["OTP_CTRL.BACKGROUND_CHECK.CHECK_TIMEOUT"]
       stage: V3
-      si_stage: None
+      si_stage: NA
       tests: []
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -16,12 +16,8 @@
             when they start.
             '''
       stage: V2
-      si_stage: NA
-      lc_states: [
-        "RAW",
-        "TEST_LOCKED",
-        "TEST_UNLOCKED1",
-      ]
+      si_stage: SV1
+      lc_states: ["PROD"]
       features: ["PWRMGR.RESET.POR_REQUEST"]
       tests: ["chip_sw_pwrmgr_full_aon_reset"]
     }
@@ -49,10 +45,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "PWRMGR.LOW_POWER.SYSRST_CTRL_AON_WKUP_REQ_WAKEUP_ENABLE",
         "PWRMGR.LOW_POWER.SYSRST_CTRL_AON_WKUP_REQ_WAKEUP_REQUEST",
@@ -101,10 +94,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "PWRMGR.LOW_POWER.DISABLE_POWER",
         "PWRMGR.LOW_POWER.ENTRY",
@@ -125,10 +115,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "PWRMGR.LOW_POWER.ENTRY",
         "PWRMGR.RESET.POR_REQUEST",
@@ -220,7 +207,8 @@
             SiVal: No need to run this, run chip_sw_pwrmgr_random_sleep_all_reset_reqs instead.
             '''
       stage: V2
-      si_stage: NA
+      si_stage: SV3
+      lc_states: ["PROD"]
       features: [
         "PWRMGR.LOW_POWER.ENTRY",
         "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
@@ -245,12 +233,7 @@
             '''
       stage: V2
       si_stage: SV2
-      lc_states: [
-        "TEST_UNLOCKED1",
-        "DEV",
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
         "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
@@ -286,7 +269,6 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_main_power_glitch_reset"]
-      bazel: []
     }
     {
       name: chip_sw_pwrmgr_random_sleep_power_glitch_reset
@@ -309,7 +291,6 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_random_sleep_power_glitch_reset"]
-      bazel: []
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_power_glitch_reset
@@ -329,7 +310,6 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_deep_sleep_power_glitch_reset"]
-      bazel: []
     }
     {
       name: chip_sw_pwrmgr_sleep_power_glitch_reset
@@ -344,7 +324,6 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_sleep_power_glitch_reset"]
-      bazel: []
     }
     {
       name: chip_sw_pwrmgr_random_sleep_all_reset_reqs
@@ -364,10 +343,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "PWRMGR.LOW_POWER.ENTRY",
         "PWRMGR.LOW_POWER.DISABLE_POWER"
@@ -397,6 +373,7 @@
             '''
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: [
         "chip_sw_pwrmgr_sysrst_ctrl_reset",
         "chip_sw_pwrmgr_all_reset_reqs",
@@ -411,7 +388,6 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_b2b_sleep_reset_req"]
-      bazel: []
     }
     {
       name: chip_sw_pwrmgr_sleep_disabled
@@ -424,10 +400,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: ["PWRMGR.LOW_POWER.ENTRY"]
       tests: ["chip_sw_pwrmgr_sleep_disabled"]
       bazel: ["//sw/device/tests:pwrmgr_sleep_disabled_test"]
@@ -444,10 +417,7 @@
             '''
       stage: V3
       si_stage: SV3
-      lc_states: [
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: ["PWRMGR.CLOCK_CONTROL.USB_WHEN_ACTIVE"]
       tests: ["chip_sw_pwrmgr_usb_clk_disabled_when_active"]
       bazel: ["//sw/device/tests:pwrmgr_usb_clk_disabled_when_active_test"]
@@ -465,12 +435,7 @@
             '''
       stage: V3
       si_stage: SV3
-      lc_states: [
-        "TEST_UNLOCKED1",
-        "DEV",
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_ENABLE",
         "PWRMGR.RESET.AON_TIMER_AON_AON_TIMER_RST_REQ_REQUEST",
@@ -496,13 +461,8 @@
             '''
       stage: V2
       si_stage: NA
-      lc_states: [
-        "TEST_UNLOCKED1",
-        "DEV",
-      ]
       features: ["PWRMGR.RESET.ESCALATION_REQUEST"]
       tests: ["chip_sw_all_escalation_resets"]
-      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -14,7 +14,7 @@
       stage: V2
       si_stage: SV1
       bazel:["//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test"]
-      lc_states: ["TEST_UNLOCKED0", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {
@@ -75,6 +75,7 @@
       features: ["ROM_CTRL.DIGESTS", "ROM_CTRL.EXP_DIGESTS"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
@@ -28,13 +28,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "TEST_UNLOCKED",
-        "DEV",
-        "PROD",
-        "PROD_END",
-        "RMA",
-      ]
+      lc_states: ["PROD"]
       features: [
         "RSTMGR.RESET_INFO.CAPTURE",
         "RSTMGR.RESET_INFO.CLEAR"
@@ -70,11 +64,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "TEST_UNLOCKED",
-        "DEV",
-        "RMA",
-      ]
+      lc_states: ["PROD"]
       features: [
         "RSTMGR.RESET_INFO.CAPTURE",
         "RSTMGR.RESET_INFO.CLEAR",
@@ -97,12 +87,7 @@
             '''
       stage: V2
       si_stage: SV2
-      lc_states: [
-        "TEST_UNLOCKED",
-        "DEV",
-        "PROD",
-        "PROD_END",
-      ]
+      lc_states: ["PROD"]
       features: [
         "RSTMGR.CPU_INFO.CAPTURE",
         "RSTMGR.CPU_INFO.ENABLE",
@@ -125,13 +110,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "TEST_UNLOCKED",
-        "DEV",
-        "PROD",
-        "PROD_END",
-        "RMA",
-      ]
+      lc_states: ["PROD"]
       features: ["RSTMGR.SW_RST.CHIP_RESET"]
       tests: ["chip_sw_rstmgr_sw_req"]
       bazel: [
@@ -155,13 +134,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "TEST_UNLOCKED",
-        "DEV",
-        "PROD",
-        "PROD_END",
-        "RMA",
-      ]
+      lc_states: ["PROD"]
       features: [
         "RSTMGR.ALERT_INFO.CAPTURE",
         "RSTMGR.ALERT_INFO.ENABLE",
@@ -187,13 +160,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "TEST_UNLOCKED",
-        "DEV",
-        "PROD",
-        "PROD_END",
-        "RMA",
-      ]
+      lc_states: ["PROD"]
       features: [
         "RSTMGR.SW_RST.I2C2_ENABLE",
         "RSTMGR.SW_RST.I2C2_REQUEST",
@@ -229,13 +196,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "TEST_UNLOCKED",
-        "DEV",
-        "PROD",
-        "PROD_END",
-        "RMA",
-      ]
+      lc_states: ["PROD"]
       features: [
         "RSTMGR.RESET_INFO.CAPTURE",
         "RSTMGR.ALERT_INFO.CAPTURE",
@@ -256,13 +217,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: [
-        "TEST_UNLOCKED0",
-        "DEV",
-        "PROD",
-        "PROD_END",
-        "RMA",
-      ]
+      lc_states: ["PROD"]
       features: ["RSTMGR.ALERT_HANDLER.RESET_STATUS"]
       tests: ["chip_sw_alert_handler_lpg_reset_toggle"]
       bazel: ["//sw/device/tests:alert_handler_lpg_reset_toggle_test"]

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -22,7 +22,7 @@
       si_stage: SV2
       tests: ["chip_sw_rv_core_ibex_nmi_irq"]
       bazel: ["//sw/device/tests:rv_core_ibex_nmi_irq_test"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "RV_CORE_IBEX.CPU.INTERRUPTS"
       ]
@@ -43,7 +43,7 @@
       stage: V2
       si_stage: SV1
       tests: ["chip_sw_rv_core_ibex_rnd"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "RV_CORE_IBEX.RND"
       ]
@@ -65,7 +65,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_rv_core_ibex_address_translation"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "RV_CORE_IBEX.ADDRESS_TRANSLATION"
       ]
@@ -87,7 +87,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_rv_core_ibex_icache_invalidate"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+      lc_states: ["PROD"]
       features: [
         "RV_CORE_IBEX.CPU.ICACHE"
       ]
@@ -106,7 +106,7 @@
        si_stage: SV1
        tests: ["chip_sw_rstmgr_cpu_info"]
        bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
-       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+       lc_states: ["PROD"]
        features: [
          "RV_CORE_IBEX.CRASH_DUMP"
        ]
@@ -124,7 +124,7 @@
        si_stage: SV1
        tests: ["chip_sw_rstmgr_cpu_info"]
        bazel: ["//sw/device/tests:rstmgr_cpu_info_test"]
-       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+       lc_states: ["PROD"]
        features: [
          "RV_CORE_IBEX.CRASH_DUMP"
        ]
@@ -143,7 +143,7 @@
        si_stage: SV1
        tests: []
        bazel: ["//sw/device/tests:rv_core_ibex_isa_test_functest"]
-       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+       lc_states: ["PROD"]
        features: [
          "RV_CORE_IBEX.CPU.ISA"
        ]
@@ -202,7 +202,7 @@
        stage: V2
        si_stage: SV1
        tests: []
-       lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+       lc_states: ["PROD"]
        features: [
          "RV_CORE_IBEX.CPU.ICACHE",
          "RV_CORE_IBEX.CPU.MEMORY"
@@ -233,7 +233,7 @@
              - ECC error in the register file
             '''
       stage: V3
-      si_stage: None
+      si_stage: NA
       tests: []
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -23,7 +23,7 @@
       si_stage: SV3
       tests: ["chip_jtag_csr_rw"]
       bazel: ["//sw/device/tests:rv_dm_csr_rw"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -54,7 +54,7 @@
       si_stage: SV3
       tests: ["chip_jtag_mem_access"]
       bazel: ["//sw/device/tests:rv_dm_mem_access"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -77,7 +77,7 @@
       si_stage: SV3
       tests: ["rom_e2e_jtag_debug_test_unlocked0", "rom_e2e_jtag_debug_dev",
               "rom_e2e_jtag_debug_rma"]
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -101,7 +101,7 @@
       si_stage: SV2
       tests: ["chip_rv_dm_ndm_reset_req"]
       bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -133,7 +133,7 @@
       si_stage: SV3
       tests: ["chip_sw_rv_dm_ndm_reset_req_when_cpu_halted"]
       bazel: ["//sw/device/tests:rv_dm_ndm_reset_req_when_cpu_halted"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -154,7 +154,7 @@
       si_stage: SV3
       tests: ["chip_sw_rv_dm_access_after_wakeup"]
       bazel: ["//sw/device/tests:rv_dm_access_after_wakeup"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -172,7 +172,7 @@
       si_stage: SV3
       tests: ["chip_sw_rv_dm_access_after_escalation_reset"]
       bazel: ["//sw/device/tests:rv_dm_access_after_hw_reset"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -191,7 +191,7 @@
       si_stage: SV2
       tests: ["chip_tap_straps_rma"]
       bazel: ["//sw/device/tests:rv_dm_jtag_tap_sel"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -244,7 +244,7 @@
       si_stage: SV3
       tests: []
       bazel: ["//sw/device/tests:rv_dm_jtag"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -263,7 +263,7 @@
       si_stage: SV3
       tests: []
       bazel: ["//sw/device/tests:rv_dm_dtm"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",
@@ -294,7 +294,7 @@
       si_stage: SV3
       tests: []
       bazel: ["//sw/device/tests:rv_dm_control_status"],
-      lc_states: ["TEST_UNLOCKED", "DEV", "RMA"]
+      lc_states: ["DEV"]
       host_support: "true"
       features: [
         "RV_DM.JTAG.FSM",

--- a/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_plic_testplan.hjson
@@ -18,6 +18,7 @@
             '''
       stage: V2
       si_stage: SV2
+      lc_states: ["PROD"]
       features: ["RV_PLIC.PRIORITY", "RV_PLIC.ENABLE"]
       tests: [
         "chip_plic_all_irqs_0",
@@ -40,6 +41,7 @@
             '''
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       features: ["RV_PLIC.PRIORITY", "RV_PLIC.ENABLE"]
       tests: ["chip_sw_plic_sw_irq"]
       bazel: ["//sw/device/tests:plic_sw_irq_test"],

--- a/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
@@ -15,7 +15,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT",
                  "RV_TIMER.COUNTER"]
       tests: ["chip_sw_rv_timer_irq"]
@@ -35,7 +35,7 @@
             '''
       stage: V3
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE"]
       tests: ["chip_sw_rv_timer_systick_test"]
       bazel: ["//sw/device/tests:rv_timer_systick_test"]
@@ -54,7 +54,7 @@
             '''
       stage: V3
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "RMA"]
+      lc_states: ["PROD"]
       features: ["RV_TIMER.ENABLE", "RV_TIMER.CONFIG", "RV_TIMER.COMPARE", "RV_TIMER.INTERRUPT",
                  "RV_TIMER.COUNTER", "RV_TIMER.RISCV_CSRS_INTEGRATION"]
       tests: ["chip_sw_rv_timer_systick_test"]

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -74,15 +74,13 @@
               model.
             '''
       stage: V3
-      si_stage: None
-      lc_states: [ "PROD" ]
+      si_stage: NA
       features: [
         "SPI_DEVICE.MODE.PASSTHROUGH",
         "SPI_DEVICE.HW.LANES",
         "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
       ]
       tests: []
-      bazel: []
     }
     {
       name: chip_sw_spi_device_pass_through_collision

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -28,6 +28,7 @@
       ]
       stage: V2
       si_stage: SV2
+      lc_states: ["PROD"]
       tests: ["chip_sw_spi_host_tx_rx"]
       bazel: [
         "//sw/device/tests:spi_host_winbond_flash_test",
@@ -51,6 +52,7 @@
       ]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
     }
     {
@@ -69,6 +71,7 @@
       ]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
     }
     {
@@ -93,6 +96,7 @@
       ]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
     }
   ]

--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -26,6 +26,7 @@
       features: ["SRAM_CTRL.SCRAMBLED"]
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_sram_ctrl_scrambled_access",
               "chip_sw_sram_ctrl_scrambled_access_jitter_en"]
     }
@@ -50,6 +51,7 @@
       features: []
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: [
         "chip_sw_sleep_sram_ret_contents_no_scramble",
         "chip_sw_sleep_sram_ret_contents_scramble",
@@ -102,6 +104,7 @@
       features: ["SRAM_CTRL.FETCH_ALLOW"]
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_sram_ctrl_execution_main"]
       bazel: ["//sw/device/tests:sram_ctrl_execution_test"]
     }
@@ -120,6 +123,7 @@
       features: ["SRAM_CTRL.LOCK_ON_ERROR"]
       stage: V2
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: ["chip_sw_all_escalation_resets",
               "chip_sw_data_integrity_escalation"]
     }
@@ -139,6 +143,7 @@
       features: ["SRAM_CTRL.MEMSET"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
       bazel: ["//sw/device/tests:sram_ctrl_memset_test"]
     }
@@ -156,6 +161,7 @@
       features: ["SRAM_CTRL.SUBWORD_ACCESS"]
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       tests: []
       bazel: ["//sw/device/tests:sram_ctrl_subword_access_test"]
     }

--- a/hw/top_earlgrey/data/ip/chip_sysrst_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sysrst_ctrl_testplan.hjson
@@ -26,7 +26,7 @@
       features: ["SYSRST_CTRL.COMBO_DETECT"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_pwrmgr_sysrst_ctrl_reset", "chip_sw_sysrst_ctrl_reset"]
       bazel: ["//sw/device/tests:sysrst_ctrl_reset_test"]
     }
@@ -41,7 +41,7 @@
       features: ["SYSRST_CTRL.PIN_INPUT_VALUE_ACCESS"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_inputs"]
       bazel: ["//sw/device/tests:sysrst_ctrl_inputs_test"]
     }
@@ -64,7 +64,7 @@
             '''
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_outputs"]
       bazel: ["//sw/device/tests:sysrst_ctrl_outputs_test"]
     }
@@ -86,7 +86,7 @@
       features: ["SYSRST_CTRL.INPUT_TRIGGERED_INTERRUPT"]
       stage: V2
       si_stage: SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_in_irq"]
       bazel: ["//sw/device/tests:sysrst_ctrl_in_irq_test"]
     }
@@ -112,7 +112,7 @@
       features: ["SYSRST_CTRL.ULTRA_LOW_POWER_WAKEUP"]
       stage: V2
       si_stage:SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_reset"]
       bazel: ["//sw/device/tests:sysrst_ctrl_reset_test"]
     }
@@ -140,7 +140,7 @@
       features: ["SYSRST_CTRL.ULTRA_LOW_POWER_RESET"]
       stage: V2
       si_stage:SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_reset"]
       bazel: ["//sw/device/tests:sysrst_ctrl_reset_test"]
     }
@@ -158,7 +158,7 @@
       features: ["SYSRST_CTRL.EC_RESET_POR"]
       stage: V2
       si_stage:SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_ec_rst_l"]
       bazel: ["//sw/device/tests:sysrst_ctrl_ec_rst_l_test"]
     }
@@ -171,7 +171,7 @@
       features: ["SYSRST_CTRL.FLASH_WP_POR"]
       stage: V2
       si_stage:SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_sysrst_ctrl_ec_rst_l"]
       bazel: ["//sw/device/tests:sysrst_ctrl_ec_rst_l_test"]
     }
@@ -192,7 +192,7 @@
       features: ["SYSRST_CTRL.ULTRA_LOW_POWER_WAKEUP"]
       stage: V2
       si_stage:SV3
-      lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: [
         "chip_sw_adc_ctrl_sleep_debug_cable_wakeup",
         "chip_sw_sysrst_ctrl_ulp_z3_wakeup"

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -18,6 +18,7 @@
             '''
       stage: V1
       si_stage: SV2
+      lc_states: ["PROD"]
       features: ["UART.FIFO_INTERRUPTS"]
       tests: ["chip_sw_uart_tx_rx"]
       tags: ["gls"]
@@ -35,6 +36,7 @@
             '''
       stage: V1
       si_stage: SV3
+      lc_states: ["PROD"]
       features: ["UART.FIFO_INTERRUPTS"]
       tests: ["chip_sw_uart_tx_rx", "chip_sw_uart_tx_rx_idx1", "chip_sw_uart_tx_rx_idx2",
               "chip_sw_uart_tx_rx_idx3"]
@@ -49,6 +51,7 @@
             '''
       stage: V1
       si_stage: SV3
+      lc_states: ["PROD"]
       features: ["UART.BAUD_RATE_CONTROL"]
       tests: ["chip_sw_uart_rand_baudrate"]
       bazel: ["//sw/device/tests:uart_baud_rate_test"]
@@ -71,9 +74,8 @@
 
             '''
       stage: V1
-      si_stage: SV3
+      si_stage: NA
       features: []
-      lc_states: ["RMA"]
       tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
     }
     {
@@ -88,6 +90,7 @@
             '''
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       features: ["UART.PARITY"]
       tests: []
     }
@@ -101,9 +104,10 @@
             '''
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       features: ["UART.LINE_LOOPBACK"]
       tests: []
-	  bazel: ["//sw/device/tests:uart_loopback_test"]
+      bazel: ["//sw/device/tests:uart_loopback_test"]
     },
     {
       name: chip_sw_uart_system_loopback
@@ -115,9 +119,10 @@
             '''
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       features: ["UART.SYSTEM_LOOPBACK"]
       tests: []
-	  bazel: ["//sw/device/tests:uart_loopback_test"]
+      bazel: ["//sw/device/tests:uart_loopback_test"]
     },
     {
       name: chip_sw_uart_line_break
@@ -133,6 +138,7 @@
             '''
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       features: ["UART.LINE_BREAK"]
       tests: []
     },
@@ -150,6 +156,7 @@
             '''
       stage: V3
       si_stage: SV3
+      lc_states: ["PROD"]
       features: ["UART.FIFO_INTERRUPTS"]
       tests: ["chip_sw_uart_tx_rx"]
       bazel: ["//sw/device/tests:uart_tx_rx_test"]

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -17,7 +17,7 @@
       features: ["USBDEV.BUFFER.MEMORY"]
       stage: V2
       si_stage: SV2
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -32,7 +32,7 @@
       features: ["USBDEV.CONN.VBUS"]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_vbus"]
       bazel: ["//sw/device/tests:usbdev_vbus_test"]
     }
@@ -57,7 +57,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_pullup"]
       bazel: ["//sw/device/tests:usbdev_pullup_test"]
     }
@@ -82,7 +82,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_aon_pullup"]
       bazel: ["//sw/device/tests:usbdev_aon_pullup_test"]
     }
@@ -108,7 +108,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -136,7 +136,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_setuprx"]
       bazel: ["//sw/device/tests:usbdev_setuprx_test"]
     }
@@ -161,7 +161,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_config_host"]
       bazel: ["//sw/device/tests:usbdev_config_host_test"]
     }
@@ -188,7 +188,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_pincfg"]
       bazel: ["//sw/device/tests:usbdev_pincfg_test"]
     }
@@ -216,7 +216,7 @@
       ]
       stage: V2
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_dpi"]
       bazel: []
     }
@@ -244,7 +244,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_stream"]
       bazel: []
     }
@@ -273,7 +273,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -301,7 +301,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -331,7 +331,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }
@@ -362,7 +362,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: ["//sw/device/tests:usbdev_aon_wake_reset"]
     }
@@ -395,7 +395,7 @@
       ]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: ["//sw/device/tests:usbdev_aon_wake_disconnect"]
     }
@@ -414,7 +414,7 @@
       features: ["USBDEV.POWER.TOGGLE_RESTORE"]
       stage: V3
       si_stage: SV3
-      lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
+      lc_states: ["PROD"]
       tests: []
       bazel: []
     }


### PR DESCRIPTION
1. Explicitly set sival stage as `NA` for test cases we are not planning to run in SiVal.
2. Reduce the number of test permutations by only running test cases in `PROD` state whenever applicable.
3. Explicitly add missing `lc_states` attribute to test cases having the `si_state` attribute set to a value different than `NA`.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>
(cherry picked from commit a1952062bc8c4c75bcc945c447371218e5ce45ac)