### PR TITLE
[uart] Reduce TX FIFO depth from 128B to 32B

### DIFF
--- a/hw/ip/uart/README.md
+++ b/hw/ip/uart/README.md
@@ -20,7 +20,7 @@ top level system.
 - 2-pin full duplex external interface
 - 8-bit data word, optional even or odd parity bit per byte
 - 1 stop bit
-- 32 x 8b RX buffer
+- 128 x 8b RX buffer
 - 32 x 8b TX buffer
 - Programmable baud rate
 - Interrupt for transmit empty, receive overflow, frame error, parity error, break error, receive

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -119,6 +119,23 @@
       desc: "End-to-end bus integrity scheme."
     }
   ]
+  param_list: [
+    // Note that the watermark CSRs further below need to be adjusted when
+    // making changes to these FIFO depths. The RTL and DV are written in
+    // a parametric way and will adjust automatically.
+    { name:    "RxFifoDepth",
+      desc:    "Number of bytes in the RX FIFO.",
+      type:    "int",
+      default: "128",
+      local:   "true",
+    }
+    { name:    "TxFifoDepth",
+      desc:    "Number of bytes in the TX FIFO.",
+      type:    "int",
+      default: "32",
+      local:   "true",
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "CTRL",
@@ -344,14 +361,6 @@
             { value: "4",
               name: "txlvl16",
               desc: "16 characters"
-            },
-            { value: "5",
-              name: "txlvl32",
-              desc: "32 characters"
-            },
-            { value: "6",
-              name: "txlvl64",
-              desc: "64 characters"
             },
           ]
         }

--- a/hw/ip/uart/doc/registers.md
+++ b/hw/ip/uart/doc/registers.md
@@ -266,8 +266,6 @@ raises tx_watermark interrupt.
 | 0x2     | txlvl4  | 4 characters  |
 | 0x3     | txlvl8  | 8 characters  |
 | 0x4     | txlvl16 | 16 characters |
-| 0x5     | txlvl32 | 32 characters |
-| 0x6     | txlvl64 | 64 characters |
 
 Other values are reserved.
 

--- a/hw/ip/uart/dv/README.md
+++ b/hw/ip/uart/dv/README.md
@@ -39,10 +39,7 @@ The following utilities provide generic helper tasks and functions to perform ac
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
-`uart_env_pkg`. Some of them in use are:
-```systemverilog
-parameter uint UART_FIFO_DEPTH    = 32;
-```
+`uart_env_pkg`.
 
 ### TL_agent
 UART instantiates (already handled in CIP base env) [tl_agent](../../../dv/sv/tl_agent/README.md)
@@ -75,7 +72,8 @@ To ensure high quality constrained random stimulus, it is necessary to develop a
 The following covergroups have been developed to prove that the test intent has been adequately met:
 * common covergroup for interrupts `hw/dv/sv/cip_lib/cip_base_env_cov.sv`: Cover interrupt value, interrupt enable, intr_test, interrupt pin
 * uart_cg in uart_agent_cov `hw/dv/sv/uart_agent/uart_agent_cov.sv`:       Cover direction, uart data, en_parity, odd_parity and baud rate
-* fifo_level_cg `hw/ip/uart/dv/env/uart_env_cov.sv`:                       Cover all fifo level with fifo reset for both TX and RX
+* rx_fifo_level_cg `hw/ip/uart/dv/env/uart_env_cov.sv`:                    Cover all fifo level with fifo reset for RX
+* tx_fifo_level_cg `hw/ip/uart/dv/env/uart_env_cov.sv`:                    Cover all fifo level with fifo reset for TX
 * tx_watermark_cg / rx_watermark_cg `hw/ip/uart/dv/env/uart_env_cov.sv`: Cover TX/RX watermark interrupt triggered for all watermark levels
 * rx_break_err_cg `hw/ip/uart/dv/env/uart_env_cov.sv`: Cover break interrupt triggered for all break levels
 * rx_timeout_cg `hw/ip/uart/dv/env/uart_env_cov.sv`: Cover timeout interrupt with small ( < 20), medium (20 - 50) and large (50 - 100) timeout values

--- a/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
@@ -139,7 +139,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
     if (ral.ctrl.tx.get_mirrored_value()) begin
       // use a very big timeout as it takes long time to flush all the items
       csr_spinwait(.ptr(ral.status.txidle), .exp_data(1'b1),
-                   .timeout_ns(UART_FIFO_DEPTH * 1_250_000),
+                   .timeout_ns(TxFifoDepth * 1_250_000),
                    .spinwait_delay_ns($urandom_range(0, 1000)));
     end
   endtask

--- a/hw/ip/uart/dv/env/seq_lib/uart_fifo_full_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_fifo_full_vseq.sv
@@ -25,20 +25,37 @@ class uart_fifo_full_vseq extends uart_tx_rx_vseq;
     };
   }
 
-  constraint dly_to_next_trans_c {
-    dly_to_next_trans dist {
-      0           :/ UART_FIFO_DEPTH - 2,  // more back2back transaction
+  constraint dly_to_next_rx_trans_c {
+    dly_to_next_rx_trans dist {
+      0           :/ RxFifoDepth - 2,  // more back2back transaction
       [1:100]     :/ 5,
       [100:10000] :/ 2
     };
   }
 
-  constraint wait_for_idle_c {
-    // ratio of wait/not_wait depends upon UART_FIFO_DEPTH to ensure we're very likely to get a run
+  constraint dly_to_next_tx_trans_c {
+    dly_to_next_tx_trans dist {
+      0           :/ TxFifoDepth - 2,  // more back2back transaction
+      [1:100]     :/ 5,
+      [100:10000] :/ 2
+    };
+  }
+
+  constraint wait_for_rx_idle_c {
+    // ratio of wait/not_wait depends upon RxFifoDepth to ensure we're very likely to get a run
     // of transactions to fill the FIFO
-    wait_for_idle dist {
+    wait_for_rx_idle dist {
       1       :/ 1,
-      0       :/ UART_FIFO_DEPTH + 10
+      0       :/ RxFifoDepth + 10
+    };
+  }
+
+  constraint wait_for_tx_idle_c {
+    // ratio of wait/not_wait depends upon TxFifoDepth to ensure we're very likely to get a run
+    // of transactions to fill the FIFO
+    wait_for_tx_idle dist {
+      1       :/ 1,
+      0       :/ TxFifoDepth + 10
     };
   }
 

--- a/hw/ip/uart/dv/env/seq_lib/uart_long_xfer_wo_dly_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_long_xfer_wo_dly_vseq.sv
@@ -25,12 +25,20 @@ class uart_long_xfer_wo_dly_vseq extends uart_fifo_full_vseq;
     dly_to_access_fifo < 100;
   }
 
-  constraint dly_to_next_trans_c {
-    dly_to_next_trans == 0;
+  constraint dly_to_next_rx_trans_c {
+    dly_to_next_rx_trans == 0;
   }
 
-  constraint wait_for_idle_c {
-    wait_for_idle == 0;
+  constraint dly_to_next_tx_trans_c {
+    dly_to_next_tx_trans == 0;
+  }
+
+  constraint wait_for_rx_idle_c {
+    wait_for_rx_idle == 0;
+  }
+
+  constraint wait_for_tx_idle_c {
+    wait_for_tx_idle == 0;
   }
 
   constraint weight_to_skip_rx_read_c {

--- a/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
@@ -39,8 +39,8 @@ class uart_loopback_vseq extends uart_tx_rx_vseq;
     csr_update(ral.ctrl);
 
     `DV_CHECK_STD_RANDOMIZE_FATAL(tx_byte)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_next_trans)
-    cfg.clk_rst_vif.wait_clks(dly_to_next_trans);
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_next_tx_trans)
+    cfg.clk_rst_vif.wait_clks(dly_to_next_tx_trans);
 
     // drive tx data and expect to receive it rx fifo
     send_tx_byte(tx_byte);
@@ -74,9 +74,9 @@ class uart_loopback_vseq extends uart_tx_rx_vseq;
           // drive RX with random data and random delay
           repeat ($urandom_range(100, 1000)) begin
             cfg.m_uart_agent_cfg.vif.uart_rx = $urandom_range(0, 1);
-            `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(dly_to_next_trans,
-                                                  dly_to_next_trans > 0;)
-            #(dly_to_next_trans * 1ns);
+            `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(dly_to_next_rx_trans,
+                                                  dly_to_next_rx_trans > 0;)
+            #(dly_to_next_rx_trans * 1ns);
           end
           // RX has same value as TX without any synchronizer in the data path
           forever begin

--- a/hw/ip/uart/dv/env/seq_lib/uart_perf_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_perf_vseq.sv
@@ -12,12 +12,20 @@ class uart_perf_vseq extends uart_fifo_full_vseq;
     dly_to_access_fifo == 0;
   }
 
-  constraint dly_to_next_trans_c {
-    dly_to_next_trans == 0;
+  constraint dly_to_next_rx_trans_c {
+    dly_to_next_rx_trans == 0;
   }
 
-  constraint wait_for_idle_c {
-    wait_for_idle == 0;
+  constraint dly_to_next_tx_trans_c {
+    dly_to_next_tx_trans == 0;
+  }
+
+  constraint wait_for_rx_idle_c {
+    wait_for_rx_idle == 0;
+  }
+
+  constraint wait_for_tx_idle_c {
+    wait_for_tx_idle == 0;
   }
 
   constraint dly_to_rx_read_c {

--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_ovrd_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_ovrd_vseq.sv
@@ -22,14 +22,14 @@ class uart_tx_ovrd_vseq extends uart_smoke_vseq;
     repeat ($urandom_range(1, 5)) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(en_ovrd)
       `DV_CHECK_STD_RANDOMIZE_FATAL(txval)
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_next_trans)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_next_tx_trans)
 
       if (en_ovrd) exp = txval;
       else         exp = 1;
       csr_wr(.ptr(ral.ovrd), .value({txval, en_ovrd}));
       cfg.clk_rst_vif.wait_clks(1);
       if (!cfg.under_reset) `DV_CHECK_EQ(cfg.m_uart_agent_cfg.vif.uart_tx, exp)
-      cfg.clk_rst_vif.wait_clks(dly_to_next_trans);
+      cfg.clk_rst_vif.wait_clks(dly_to_next_tx_trans);
     end
     // disable ovrd
     csr_wr(.ptr(ral.ovrd), .value(0));

--- a/hw/ip/uart/dv/env/uart_env_cov.sv
+++ b/hw/ip/uart/dv/env/uart_env_cov.sv
@@ -5,13 +5,23 @@
 class uart_env_cov extends cip_base_env_cov #(.CFG_T(uart_env_cfg));
   `uvm_component_utils(uart_env_cov)
 
-  covergroup fifo_level_cg with function sample(uart_dir_e dir, int lvl, bit rst);
-    cp_dir: coverpoint dir;
+  import uart_reg_pkg::RxFifoDepth;
+  import uart_reg_pkg::TxFifoDepth;
+
+  covergroup rx_fifo_level_cg with function sample(int lvl, bit rst);
     cp_lvl: coverpoint lvl {
-      bins all_levels[] = {[0:UART_FIFO_DEPTH]};
+      bins all_levels[] = {[0:RxFifoDepth]};
     }
     cp_rst: coverpoint rst;
-    cross cp_dir, cp_lvl, cp_rst;
+    cross cp_lvl, cp_rst;
+  endgroup
+
+  covergroup tx_fifo_level_cg with function sample(int lvl, bit rst);
+    cp_lvl: coverpoint lvl {
+      bins all_levels[] = {[0:TxFifoDepth]};
+    }
+    cp_rst: coverpoint rst;
+    cross cp_lvl, cp_rst;
   endgroup
 
   // Cover all combinations of 2 different clocks
@@ -29,13 +39,13 @@ class uart_env_cov extends cip_base_env_cov #(.CFG_T(uart_env_cfg));
 
   covergroup tx_watermark_cg with function sample(int watermark_lvl);
     cp_watermark_lvl: coverpoint watermark_lvl {
-      bins all_levels[] = {[0:MAX_WATERMARK_LVL-1]};
+      bins all_levels[] = {[0:MAX_TX_WATERMARK_LVL-1]};
     }
   endgroup
 
   covergroup rx_watermark_cg with function sample(int watermark_lvl);
     cp_watermark_lvl: coverpoint watermark_lvl {
-      bins all_levels[] = {[0:MAX_WATERMARK_LVL]};
+      bins all_levels[] = {[0:MAX_RX_WATERMARK_LVL]};
     }
   endgroup
 
@@ -63,7 +73,8 @@ class uart_env_cov extends cip_base_env_cov #(.CFG_T(uart_env_cfg));
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    fifo_level_cg = new();
+    rx_fifo_level_cg = new();
+    tx_fifo_level_cg = new();
     baud_rate_w_core_clk_cg = new();
     tx_watermark_cg = new();
     rx_watermark_cg = new();

--- a/hw/ip/uart/dv/uart_sim_cfg.hjson
+++ b/hw/ip/uart/dv/uart_sim_cfg.hjson
@@ -74,7 +74,7 @@
 
     {
       name: uart_fifo_reset
-      // need more seeds to cover uart_env_cov::fifo_level_cg
+      // need more seeds to cover uart_env_cov::rx_fifo_level_cg and uart_env_cov::tx_fifo_level_cg
       reseed: 300
       uvm_test_seq: uart_fifo_reset_vseq
     }

--- a/hw/ip/uart/lint/uart.waiver
+++ b/hw/ip/uart/lint/uart.waiver
@@ -35,3 +35,6 @@ waive -rules RESET_MUX    -location {uart_core.sv} -regexp {Asynchronous reset '
 
 waive -rules UNREACHABLE -location {uart_core.sv} -msg {'break_st_q' is assigned to a non-x value within the default branch of a fully specified case statement} \
       -comment "This is fine, lint tool doesn't seem to recognize the if-statements in the case-items."
+
+waive -rules INVALID_COMPARE  -location {uart_core.sv} -msg {Comparison 'uart_fifo_rxilvl > (RxFifoDepthW - 1)' with '(RxFifoDepthW - 1)'=7 can never be true} \
+      -comment "This comparison is added for generality so that the module works even with differen FIFO depths."

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -7,6 +7,8 @@
 package uart_reg_pkg;
 
   // Param list
+  parameter int RxFifoDepth = 128;
+  parameter int TxFifoDepth = 32;
   parameter int NumAlerts = 1;
 
   // Address widths within the block

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -221,12 +221,6 @@ dif_result_t dif_uart_watermark_tx_set(const dif_uart_t *uart,
     case kDifUartWatermarkByte16:
       value = UART_FIFO_CTRL_TXILVL_VALUE_TXLVL16;
       break;
-    case kDifUartWatermarkByte32:
-      value = UART_FIFO_CTRL_TXILVL_VALUE_TXLVL32;
-      break;
-    case kDifUartWatermarkByte64:
-      value = UART_FIFO_CTRL_TXILVL_VALUE_TXLVL64;
-      break;
     default:
       // The minimal TX watermark is 1 byte, maximal 16 bytes.
       return kDifError;

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -195,9 +195,9 @@ TEST_F(WatermarkTxSetTest, Success) {
   EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
                 {
                     {UART_FIFO_CTRL_TXILVL_OFFSET, UART_FIFO_CTRL_TXILVL_MASK,
-                     UART_FIFO_CTRL_TXILVL_VALUE_TXLVL64},
+                     UART_FIFO_CTRL_TXILVL_VALUE_TXLVL16},
                 });
-  EXPECT_DIF_OK(dif_uart_watermark_tx_set(&uart_, kDifUartWatermarkByte64));
+  EXPECT_DIF_OK(dif_uart_watermark_tx_set(&uart_, kDifUartWatermarkByte16));
 }
 
 class SetEnableTest : public UartTest {};


### PR DESCRIPTION
The UART FIFOs had been increased from 32B to 128B for Earlgrey ES, predominantly due to the fact that there was a requirement for 128B deep RX FIFOs. Such a requirement does however not exist for the TX FIFO and it can be just 32B deep.

Since the design only supported a homogeneous arrangement, both RX and TX FIFOs had been set to the same depth. This patch reworks that and makes both depths individually configurable.