### PR TITLE
[usbdev,dv] Specify num_of_bytes for call to configure_in_trans

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
@@ -8,7 +8,7 @@ class usbdev_in_stall_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    configure_in_trans(out_buffer_id);  // register configurations for IN Trans.
+    configure_in_trans(out_buffer_id, .num_of_bytes(7'd10));  // register configurations for IN Trans.
     csr_wr(.ptr(ral.in_stall[0].endpoint[endp]),  .value(1'b1)); // Stall EP IN
     // Token pkt followed by handshake pkt
     call_token_seq(PidTypeInToken);


### PR DESCRIPTION
This is in usbdev_in_stall_vseq, where we don't actually expect to transfer any data (we're going to stall!). So specify any old value: 10 is pretty arbitrary.

This fixes a silly bug that I introduced by merging #21926, which conflicts with some base sequence tidy-ups I've done in the last couple of days. Sorry!