### PR TITLE
[uart,dv] Improve RX 'ignore period'

### DIFF
--- a/hw/dv/sv/uart_agent/uart_if.sv
+++ b/hw/dv/sv/uart_agent/uart_if.sv
@@ -12,22 +12,26 @@ interface uart_if #(realtime UartDefaultClkPeriod = 104166.667ns) ();
   int   uart_tx_clk_pulses = 0;
   bit   uart_rx_clk = 1'b1;
   int   uart_rx_clk_pulses = 0;
+  int   uart_rx_clk_x16_rem16 = 0;
 
   // UART TX from the DUT when signaled over muxed IOs can experience glitches in the same
   // time-step (a simulation artifact). Delaying by 1ps eliminates them.
   wire uart_tx_int;
   assign #1ps uart_tx_int = uart_tx;
 
+  // Sample TX data mid-bit as defined by the TX 'clock' generated in the monitor
   clocking mon_tx_cb @(negedge uart_tx_clk);
     input  #10ns uart_tx_int;
   endclocking
   modport mon_tx_mp(clocking mon_tx_cb);
 
+  // Drive RX data in time with the RX 'clock' generated in the monitor
   clocking drv_rx_cb @(posedge uart_rx_clk);
     output uart_rx;
   endclocking
   modport drv_rx_mp(clocking drv_rx_cb);
 
+  // Sample RX data mid-bit as defined by the RX 'clock' generated in the monitor
   clocking mon_rx_cb @(negedge uart_rx_clk);
     input  #10ns uart_rx;
   endclocking


### PR DESCRIPTION
Use a more targetted RX ignore window than the whole RX_IGNORED_PERIOD. RX_IGNORED_PERIOD is excessive at low baud rates and yet is insufficient at high baud rates when main-clock-based RX delays grow proportionally larger. Solves occasional failures in uart_perf.

Also add some comments written while trying to figure things out.