### PR TITLE
[ci] run CW340 bitstream build on slower machine

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -457,7 +457,7 @@ jobs:
   dependsOn:
     - lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyCdcChanges'], '0'))
-  pool: ci-public-eda
+  pool: ci-public
   timeoutInMinutes: 150
   steps:
   - template: ci/fpga-template.yml


### PR DESCRIPTION
CW340 bitstream build is not currently on our critical path, so run it on a slower machine to relieve bitstream builder queue pressure.