### PR TITLE
[tock] Update Tock and the nightly Rust toolchain.

### DIFF
--- a/sw/host/opentitanlib/src/lib.rs
+++ b/sw/host/opentitanlib/src/lib.rs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Stabilised in Rust 1.74, can be removed when we upgrade.
-#![feature(io_error_other)]
 // Used for serde_annotate.
 #![feature(min_specialization)]
 

--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -13,7 +13,7 @@ def rust_deps():
         # upstream `rules_rust`.
         #include_rustc_srcs = False,
         edition = "2021",
-        versions = ["1.71.1", "nightly/2023-07-30"],
+        versions = ["1.71.1", "nightly/2024-01-01"],
         extra_target_triples = [
             "riscv32imc-unknown-none-elf",
         ],

--- a/third_party/tock/repos.bzl
+++ b/third_party/tock/repos.bzl
@@ -40,9 +40,9 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
     bare_repository(
         name = "tock",
         local = tock,
-        strip_prefix = "tock-d0042ffb83330d6d874471e0b06cc26591844ece",
-        url = "https://github.com/tock/tock/archive/d0042ffb83330d6d874471e0b06cc26591844ece.tar.gz",
-        sha256 = "cea19af8e364f991e93c8062e776aded3b4a61127d336a3a2eab1b4d6e523549",
+        strip_prefix = "tock-4d3a4c73372103acc95e0c016660a6943eec67dc",
+        url = "https://github.com/tock/tock/archive/4d3a4c73372103acc95e0c016660a6943eec67dc.tar.gz",
+        sha256 = "e72c26bf90ccc1fe3cfd143ee8fcec8423f5e59ae3f0773495181837798f237f",
         additional_files_content = {
             "BUILD": """exports_files(glob(["**"]))""",
             "arch/riscv/BUILD": crate_build(


### PR DESCRIPTION
This updates Tock to https://github.com/tock/tock/pull/3748, which updates Tock's Rust toolchain to `2024-01-01`.