### PR TITLE
[veriblelint] Update to v0.0-3622-g07b310a3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   #
   VERILATOR_VERSION: 4.210
   TOOLCHAIN_PATH: /opt/buildcache/riscv
-  VERIBLE_VERSION: v0.0-2135-gb534c1fe
+  VERIBLE_VERSION: v0.0-3622-g07b310a3
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20220210-1
   # This controls where builds happen, and gets picked up by build_consts.sh.

--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -23,7 +23,7 @@ variables:
   # the definitions in util/container/Dockerfile as well.
   VERILATOR_VERSION: 4.210
   TOOLCHAIN_PATH: /opt/buildcache/riscv
-  VERIBLE_VERSION: v0.0-2135-gb534c1fe
+  VERIBLE_VERSION: v0.0-3622-g07b310a3
     # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20220210-1
     # This controls where builds happen, and gets picked up by build_consts.sh.

--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -94,9 +94,8 @@ python3 -m pip install --user -r python-requirements.txt --require-hashes
 
 # Install Verible
 lsb_sr="$(lsb_release -sr)"
-lsb_sc="$(lsb_release -sc)"
-VERIBLE_BASE_URL="https://github.com/google/verible/releases/download"
-VERIBLE_TARBALL="verible-${VERIBLE_VERSION}-Ubuntu-${lsb_sr}-${lsb_sc}-x86_64.tar.gz"
+VERIBLE_BASE_URL="https://github.com/chipsalliance/verible/releases/download"
+VERIBLE_TARBALL="verible-${VERIBLE_VERSION}-linux-static-x86_64.tar.gz"
 VERIBLE_URL="${VERIBLE_BASE_URL}/${VERIBLE_VERSION}/${VERIBLE_TARBALL}"
 
 verible_tar="$TMPDIR/verible.tar.gz"

--- a/doc/getting_started/README.md
+++ b/doc/getting_started/README.md
@@ -170,20 +170,12 @@ But since this requires the Bazel build system the recommendation is to download
 
 Go to [this page](https://github.com/google/verible/releases) and download the correct binary archive for your machine.
 
-The example below is for Ubuntu 20.04:
-
-```
-export VERIBLE_VERSION={{#tool-version verible }}
-wget https://github.com/google/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz
-tar -xf verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz
-```
-
-If you are using Ubuntu 18.04 then instead use:
+The example below is for a generic linux OS:
 
 ```console
 export VERIBLE_VERSION={{#tool-version verible }}
-wget https://github.com/google/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz
-tar -xf verible-${VERIBLE_VERSION}-Ubuntu-18.04-bionic-x86_64.tar.gz
+wget https:wget https://github.com/chipsalliance/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-linux-static-x86_64.tar.gz
+tar -xf verible-${VERIBLE_VERSION}-linux-static-x86_64.tar.gz
 ```
 
 Then install Verible within 'tools' using:

--- a/release/azure-pipelines-release.yml
+++ b/release/azure-pipelines-release.yml
@@ -24,7 +24,7 @@ variables:
   # definitions in util/container/Dockerfile as well.
   VERILATOR_VERSION: 4.210
   TOOLCHAIN_PATH: /opt/buildcache/riscv
-  VERIBLE_VERSION: v0.0-2135-gb534c1fe
+  VERIBLE_VERSION: v0.0-3622-g07b310a3
     # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20220210-1
     # This controls where builds happen, and gets picked up by build_consts.sh.

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -30,7 +30,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'verible': {
-        'min_version': 'v0.0-2135-gb534c1fe',
+        'min_version': 'v0.0-3622-g07b310a3',
         'as_needed': True
     },
     'vcs': {

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -7,7 +7,7 @@
 
 # Global configuration options.
 ARG VERILATOR_VERSION=4.210
-ARG VERIBLE_VERSION=v0.0-2135-gb534c1fe
+ARG VERIBLE_VERSION=v0.0-3622-g07b310a3
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20220210-1
 # This should match the version in bazelish.sh.
@@ -147,7 +147,7 @@ RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add \
 
 # Install Verible
 RUN curl -f -Ls -o verible.tar.gz \
-        https://github.com/chipsalliance/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-Ubuntu-20.04-focal-x86_64.tar.gz \
+        https://github.com/chipsalliance/verible/releases/download/${VERIBLE_VERSION}/verible-${VERIBLE_VERSION}-linux-static-x86_64.tar.gz \
     && mkdir -p /tools/verible \
     && tar -C /tools/verible -xf verible.tar.gz --strip-components=1
 ENV PATH "/tools/verible/bin:${PATH}"


### PR DESCRIPTION
The version we have been using was quite outdated and did not catch some legacy always @(*) statements that it should have warned about.

This updates to v0.0-3622-g07b310a3, and updates the installation instructions.

We may want to consider holding off merging, though, if this causes any infrastructure issues.