### PR TITLE
[uart] Reduce RX FIFO depth from 128B to 64B

### DIFF
--- a/hw/ip/uart/README.md
+++ b/hw/ip/uart/README.md
@@ -20,7 +20,7 @@ top level system.
 - 2-pin full duplex external interface
 - 8-bit data word, optional even or odd parity bit per byte
 - 1 stop bit
-- 128 x 8b RX buffer
+- 64 x 8b RX buffer
 - 32 x 8b TX buffer
 - Programmable baud rate
 - Interrupt for transmit empty, receive overflow, frame error, parity error, break error, receive

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -126,7 +126,7 @@
     { name:    "RxFifoDepth",
       desc:    "Number of bytes in the RX FIFO.",
       type:    "int",
-      default: "128",
+      default: "64",
       local:   "true",
     }
     { name:    "TxFifoDepth",
@@ -327,12 +327,8 @@
               desc: "32 characters"
             },
             { value: "6",
-              name: "rxlvl64",
-              desc: "64 characters"
-            },
-            { value: "7",
-              name: "rxlvl126",
-              desc: "126 characters"
+              name: "rxlvl62",
+              desc: "62 characters"
             },
           ]
         }

--- a/hw/ip/uart/doc/registers.md
+++ b/hw/ip/uart/doc/registers.md
@@ -273,17 +273,17 @@ Other values are reserved.
 Trigger level for RX interrupts. If the FIFO depth is greater than or equal to
 the setting, it raises rx_watermark interrupt.
 
-| Value   | Name     | Description    |
-|:--------|:---------|:---------------|
-| 0x0     | rxlvl1   | 1 character    |
-| 0x1     | rxlvl2   | 2 characters   |
-| 0x2     | rxlvl4   | 4 characters   |
-| 0x3     | rxlvl8   | 8 characters   |
-| 0x4     | rxlvl16  | 16 characters  |
-| 0x5     | rxlvl32  | 32 characters  |
-| 0x6     | rxlvl64  | 64 characters  |
-| 0x7     | rxlvl126 | 126 characters |
+| Value   | Name    | Description   |
+|:--------|:--------|:--------------|
+| 0x0     | rxlvl1  | 1 character   |
+| 0x1     | rxlvl2  | 2 characters  |
+| 0x2     | rxlvl4  | 4 characters  |
+| 0x3     | rxlvl8  | 8 characters  |
+| 0x4     | rxlvl16 | 16 characters |
+| 0x5     | rxlvl32 | 32 characters |
+| 0x6     | rxlvl62 | 62 characters |
 
+Other values are reserved.
 
 ### FIFO_CTRL . TXRST
 TX fifo reset. Write 1 to the register resets TX_FIFO. Read returns 0

--- a/hw/ip/uart/dv/env/uart_scoreboard.sv
+++ b/hw/ip/uart/dv/env/uart_scoreboard.sv
@@ -248,7 +248,7 @@ class uart_scoreboard extends cip_base_scoreboard #(.CFG_T(uart_env_cfg),
             if (ral.ctrl.slpbk.get_mirrored_value()) begin
               // if sys loopback is on, tx item isn't sent to uart pin but rx fifo
               uart_item tx_item = tx_q.pop_front();
-              if (rx_enabled && (rx_q.size < TxFifoDepth)) begin
+              if (rx_enabled && (rx_q.size < RxFifoDepth)) begin
                 rx_q.push_back(tx_item);
                 predict_rx_watermark_intr();
               end

--- a/hw/ip/uart/rtl/uart_reg_pkg.sv
+++ b/hw/ip/uart/rtl/uart_reg_pkg.sv
@@ -7,7 +7,7 @@
 package uart_reg_pkg;
 
   // Param list
-  parameter int RxFifoDepth = 128;
+  parameter int RxFifoDepth = 64;
   parameter int TxFifoDepth = 32;
   parameter int NumAlerts = 1;
 

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -178,11 +178,8 @@ dif_result_t dif_uart_watermark_rx_set(const dif_uart_t *uart,
     case kDifUartWatermarkByte32:
       value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL32;
       break;
-    case kDifUartWatermarkByte64:
-      value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL64;
-      break;
-    case kDifUartWatermarkByte126:
-      value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL126;
+    case kDifUartWatermarkByte62:
+      value = UART_FIFO_CTRL_RXILVL_VALUE_RXLVL62;
       break;
     default:
       return kDifError;

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -98,11 +98,7 @@ typedef enum dif_uart_watermark {
   /**
    * Indicates a sixty-four-byte watermark.
    */
-  kDifUartWatermarkByte64,
-  /**
-   * Indicates a one-hundred-twenty-six byte watermark.
-   */
-  kDifUartWatermarkByte126,
+  kDifUartWatermarkByte62,
 } dif_uart_watermark_t;
 
 /**

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -165,9 +165,9 @@ TEST_F(WatermarkRxSetTest, Success) {
   EXPECT_MASK32(UART_FIFO_CTRL_REG_OFFSET,
                 {
                     {UART_FIFO_CTRL_RXILVL_OFFSET, UART_FIFO_CTRL_RXILVL_MASK,
-                     UART_FIFO_CTRL_RXILVL_VALUE_RXLVL126},
+                     UART_FIFO_CTRL_RXILVL_VALUE_RXLVL62},
                 });
-  EXPECT_DIF_OK(dif_uart_watermark_rx_set(&uart_, kDifUartWatermarkByte126));
+  EXPECT_DIF_OK(dif_uart_watermark_rx_set(&uart_, kDifUartWatermarkByte62));
 }
 
 class WatermarkTxSetTest : public UartTest {};
@@ -177,7 +177,7 @@ TEST_F(WatermarkTxSetTest, NullArgs) {
 }
 
 TEST_F(WatermarkTxSetTest, InvalidWatermark) {
-  EXPECT_EQ(dif_uart_watermark_tx_set(&uart_, kDifUartWatermarkByte126),
+  EXPECT_EQ(dif_uart_watermark_tx_set(&uart_, kDifUartWatermarkByte62),
             kDifError);
 }
 


### PR DESCRIPTION
After more discussion with customers, it became clear that a 64B FIFO size is sufficient.