### PR TITLE
[rv_core_ibex,rtl] Reduce number of performance counters

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7466,7 +7466,7 @@
         PMPEnable: "1"
         PMPGranularity: "0"
         PMPNumRegions: "16"
-        MHPMCounterNum: "10"
+        MHPMCounterNum: "2"
         MHPMCounterWidth: "32"
         RV32E: "0"
         RV32M: ibex_pkg::RV32MSingleCycle
@@ -7606,7 +7606,7 @@
           name: MHPMCounterNum
           desc: "Number of the MHPM counter "
           type: int unsigned
-          default: "10"
+          default: "2"
           expose: "true"
           name_top: RvCoreIbexMHPMCounterNum
         }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -768,7 +768,7 @@
       param_decl: {PMPEnable: "1",
                    PMPGranularity: "0",
                    PMPNumRegions: "16",
-                   MHPMCounterNum: "10",
+                   MHPMCounterNum: "2",
                    MHPMCounterWidth: "32",
                    RV32E: "0",
                    RV32M: "ibex_pkg::RV32MSingleCycle",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -100,7 +100,7 @@ module top_earlgrey #(
   parameter bit RvCoreIbexPMPEnable = 1,
   parameter int unsigned RvCoreIbexPMPGranularity = 0,
   parameter int unsigned RvCoreIbexPMPNumRegions = 16,
-  parameter int unsigned RvCoreIbexMHPMCounterNum = 10,
+  parameter int unsigned RvCoreIbexMHPMCounterNum = 2,
   parameter int unsigned RvCoreIbexMHPMCounterWidth = 32,
   parameter bit RvCoreIbexRV32E = 0,
   parameter ibex_pkg::rv32m_e RvCoreIbexRV32M = ibex_pkg::RV32MSingleCycle,


### PR DESCRIPTION
On top of the RV32I mandatory counters this just leaves the counters for data memory and instruction memory waits. The others are counting different types of instructions being executed so are purely a property of the architectural behaviour of the program so could be found another way (e.g. via simulation) where the wait counters cannot be easily modelled.

This will drop 8 * 32 * 2 (counters are duplicated due to lockstep) = 512 flops out of the design along with associated logic for incrementers and reduce inputs on muxes in the Ibex CSR block.

For reference the details on performance counters in Ibex can be found here: https://ibex-core.readthedocs.io/en/latest/03_reference/performance_counters.html

With this change only events 0-4 from that documentation will have counters.

Before merging we need to confirm this is acceptable for software

@msfschaffner @andreaskurth @vogelpi @jesultra @cfrantz  PTAL