### PR TITLE
[i2c,rtl] Halt controller FSM when unexp. NAK is seen

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent.core
+++ b/hw/dv/sv/i2c_agent/i2c_agent.core
@@ -23,6 +23,7 @@ filesets:
       - seq_lib/i2c_base_seq.sv: {is_include_file: true}
       - seq_lib/i2c_device_response_seq.sv: {is_include_file: true}
       - seq_lib/i2c_target_base_seq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_may_nack_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -17,7 +17,7 @@ package i2c_agent_pkg;
 
   // Bus/Transaction types for the agent driver
   typedef enum logic [3:0] {
-    None, DevAck, RdData, WrData,
+    None, DevAck, DevNack, RdData, WrData,
     HostStart, HostRStart, HostData, HostAck,
     HostNAck, HostStop, HostDataNoWaitForACK,
     HostWait

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -169,6 +169,9 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
           cfg.vif.device_send_ack(cfg.timing_cfg, !cfg.stretch_after_ack);
         join
       end
+      DevNack: begin
+        cfg.vif.device_send_nack(cfg.timing_cfg);
+      end
       RdData: begin
         `uvm_info(`gfn, $sformatf("Send readback data %0x", req.rdata), UVM_MEDIUM)
         cfg.timing_cfg.tStretchHostClock = gen_num_stretch_host_clks(cfg.timing_cfg);

--- a/hw/dv/sv/i2c_agent/i2c_if.sv
+++ b/hw/dv/sv/i2c_agent/i2c_if.sv
@@ -182,8 +182,10 @@ interface i2c_if(
     join
   endtask: wait_for_host_ack_or_nack
 
+  // TODO(#21887) Re-strengthen checks
+
   task automatic wait_for_device_ack(ref timing_cfg_t tc, input bit ack_bit = 1'b1);
-    @(negedge sda_o && scl_o);
+    // @(negedge sda_o && scl_o);
     wait_for_dly(tc.tSetupBit);
     forever begin
       @(posedge scl_i);
@@ -247,6 +249,10 @@ interface i2c_if(
   task automatic device_send_ack(ref timing_cfg_t tc, input bit can_stretch);
     device_send_bit(tc, 1'b0, can_stretch); // special case for ack bit
   endtask: device_send_ack
+
+  task automatic device_send_nack(ref timing_cfg_t tc);
+    device_send_bit(tc, 1'b1, 1'b0); // special case for nack bit
+  endtask: device_send_nack
 
   // when the I2C module is in transmit mode, `scl_interference` interrupt
   // will be asserted if the IP identifies that some other device (host or target) on the bus

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_seq_list.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_seq_list.sv
@@ -5,3 +5,4 @@
 `include "i2c_base_seq.sv"
 `include "i2c_device_response_seq.sv"
 `include "i2c_target_base_seq.sv"
+`include "i2c_target_may_nack_seq.sv"

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_target_may_nack_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_target_may_nack_seq.sv
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// I2C Agent sequence which behaves as an I2C TARGET.
+//
+// - Receives seq_items from req_analysis_fifo which are sent onto the driver.
+// - If the item is requesting to drive an ACK, 50/50 to change this to a NACK instead.
+//
+class i2c_target_may_nack_seq extends i2c_base_seq;
+  `uvm_object_utils(i2c_target_may_nack_seq)
+  `uvm_object_new
+
+  virtual task body();
+    case (cfg.if_mode)
+      Device: send_device_mode_txn();
+      Host:    `uvm_fatal(`gfn, "This sequence is for the agent in TARGET-Mode only!")
+      default: `uvm_fatal(`gfn, "Invalid cfg.if_mode!")
+    endcase
+  endtask : body
+
+  virtual task send_device_mode_txn();
+    bit [7:0] rdata;
+    forever begin
+      p_sequencer.req_analysis_fifo.get(req);
+      // If it's a read type response, create randomized return data
+      if (req.drv_type == RdData) begin
+        `DV_CHECK_STD_RANDOMIZE_FATAL(rdata)
+        req.rdata = rdata;
+      end
+      // Convert some of the 'DevAck' items from the monitor into NACKs
+      if (req.drv_type == DevAck) begin
+        if ($urandom_range(0, 1)) begin
+          `uvm_info(`gfn, "Converting an ACK to a NACK!", UVM_LOW)
+          req.drv_type = DevNack;
+        end
+      end
+      start_item(req);
+      finish_item(req);
+    end
+  endtask
+
+endclass : i2c_target_may_nack_seq

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -204,7 +204,8 @@
     { name: "CTRL"
       desc: "I2C Control Register"
       swaccess: "rw"
-      hwaccess: "hro"
+      hwaccess: "hrw"
+      hwqe:     "true",
       fields: [
         { bits: "0"
           resval: "0"
@@ -283,6 +284,13 @@
           name: "ACQEMPTY"
           desc: "Target mode receive FIFO is empty"
           resval: "1"
+        }
+        { bits: "10"
+          name: "HOST_DISABLED_NACK_TIMEOUT"
+          desc: '''
+                A Host-Mode active transaction has been ended by the !!HOST_NACK_HANDLER_TIMEOUT mechanism.
+                This bit is cleared when !!CTRL.ENABLEHOST is set by software to start a new transaction.
+                '''
         }
       ]
       tags: [// Updated by the hw. Exclude from write-checks.
@@ -726,6 +734,38 @@
       hwaccess: "hrw"
       fields: [
         { bits: "7:0" }
+      ]
+    }
+    { name: "HOST_NACK_HANDLER_TIMEOUT"
+      desc: '''
+            Timeout in Host-Mode for an unhandled NACK before hardware automatically ends the transaction.
+            (in units of input clock frequency)
+
+            In Host-Mode during an active Controller-Transmitter transfer, if the Target NACKs a byte
+            the 'nak' interrupt is asserted and the Byte-Formatted Programming Mode FSM halts awaiting
+            software intervention. Software must acknowledge the interrupt (CIP 'Event-Type') to allow
+            the state machine to continue, typically after clearing out the FMTFIFO to start a new transfer.
+            While halted, the active transaction is not ended (no STOP (P) condition is created), and the
+            block releases both SCL and SDA.
+
+            This timeout can be used to automatically disable the block if software does not handle the
+            'nak' interrupt in a timely manner. If the timeout expires, (!!CTRL.HOSTMODE) will be disabled
+            which creates a STOP (P) condition on the bus ending the active transaction. Additionally, the
+            !!STATUS.HOST_DISABLED_NACK_TIMEOUT bit is set to alert software.
+
+            The enable bit must be set for this feature to operate.
+            '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "30:0"
+          name: "VAL"
+          desc: "Unhandled NAK timeout value (in units of input clock frequency)"
+        }
+        { bits: "31"
+          name: "EN"
+          desc: "Timeout enable"
+        }
       ]
     }
   ]

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -683,7 +683,14 @@
       ]
     }
     { name: "HOST_TIMEOUT_CTRL"
-      desc: "I2C host clock generation timeout value (in units of input clock frequency)"
+      desc: '''
+            I2C host clock generation timeout value (in units of input clock frequency).
+
+            In an active transaction in Target-Mode, if the Controller ceases to send SCL pulses
+            for this number of cycles then the "host_timeout" interrupt will be asserted.
+
+            Set this CSR to 0 to disable this behaviour.
+            '''
       swaccess: "rw"
       hwaccess: "hro"
       fields: [

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -3,35 +3,36 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/i2c/data/i2c.hjson -->
 ## Summary
 
-| Name                                              | Offset   |   Length | Description                                                                                        |
-|:--------------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------------------------------|
-| i2c.[`INTR_STATE`](#intr_state)                   | 0x0      |        4 | Interrupt State Register                                                                           |
-| i2c.[`INTR_ENABLE`](#intr_enable)                 | 0x4      |        4 | Interrupt Enable Register                                                                          |
-| i2c.[`INTR_TEST`](#intr_test)                     | 0x8      |        4 | Interrupt Test Register                                                                            |
-| i2c.[`ALERT_TEST`](#alert_test)                   | 0xc      |        4 | Alert Test Register                                                                                |
-| i2c.[`CTRL`](#ctrl)                               | 0x10     |        4 | I2C Control Register                                                                               |
-| i2c.[`STATUS`](#status)                           | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                                 |
-| i2c.[`RDATA`](#rdata)                             | 0x18     |        4 | I2C Read Data                                                                                      |
-| i2c.[`FDATA`](#fdata)                             | 0x1c     |        4 | I2C Host Format Data                                                                               |
-| i2c.[`FIFO_CTRL`](#fifo_ctrl)                     | 0x20     |        4 | I2C FIFO control register                                                                          |
-| i2c.[`HOST_FIFO_CONFIG`](#host_fifo_config)       | 0x24     |        4 | Host mode FIFO configuration                                                                       |
-| i2c.[`TARGET_FIFO_CONFIG`](#target_fifo_config)   | 0x28     |        4 | Target mode FIFO configuration                                                                     |
-| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)       | 0x2c     |        4 | Host mode FIFO status register                                                                     |
-| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status)   | 0x30     |        4 | Target mode FIFO status register                                                                   |
-| i2c.[`OVRD`](#ovrd)                               | 0x34     |        4 | I2C Override Control Register                                                                      |
-| i2c.[`VAL`](#val)                                 | 0x38     |        4 | Oversampled RX values                                                                              |
-| i2c.[`TIMING0`](#timing0)                         | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
-| i2c.[`TIMING1`](#timing1)                         | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
-| i2c.[`TIMING2`](#timing2)                         | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
-| i2c.[`TIMING3`](#timing3)                         | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).               |
-| i2c.[`TIMING4`](#timing4)                         | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).               |
-| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)               | 0x50     |        4 | I2C clock stretching timeout control.                                                              |
-| i2c.[`TARGET_ID`](#target_id)                     | 0x54     |        4 | I2C target address and mask pairs                                                                  |
-| i2c.[`ACQDATA`](#acqdata)                         | 0x58     |        4 | I2C target acquired data                                                                           |
-| i2c.[`TXDATA`](#txdata)                           | 0x5c     |        4 | I2C target transmit data                                                                           |
-| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)     | 0x60     |        4 | I2C host clock generation timeout value (in units of input clock frequency)                        |
-| i2c.[`TARGET_TIMEOUT_CTRL`](#target_timeout_ctrl) | 0x64     |        4 | I2C target internal stretching timeout control.                                                    |
-| i2c.[`TARGET_NACK_COUNT`](#target_nack_count)     | 0x68     |        4 | Number of times the I2C target has NACK'ed a new transaction since the last read of this register. |
+| Name                                                          | Offset   |   Length | Description                                                                                        |
+|:--------------------------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------------------------------|
+| i2c.[`INTR_STATE`](#intr_state)                               | 0x0      |        4 | Interrupt State Register                                                                           |
+| i2c.[`INTR_ENABLE`](#intr_enable)                             | 0x4      |        4 | Interrupt Enable Register                                                                          |
+| i2c.[`INTR_TEST`](#intr_test)                                 | 0x8      |        4 | Interrupt Test Register                                                                            |
+| i2c.[`ALERT_TEST`](#alert_test)                               | 0xc      |        4 | Alert Test Register                                                                                |
+| i2c.[`CTRL`](#ctrl)                                           | 0x10     |        4 | I2C Control Register                                                                               |
+| i2c.[`STATUS`](#status)                                       | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                                 |
+| i2c.[`RDATA`](#rdata)                                         | 0x18     |        4 | I2C Read Data                                                                                      |
+| i2c.[`FDATA`](#fdata)                                         | 0x1c     |        4 | I2C Host Format Data                                                                               |
+| i2c.[`FIFO_CTRL`](#fifo_ctrl)                                 | 0x20     |        4 | I2C FIFO control register                                                                          |
+| i2c.[`HOST_FIFO_CONFIG`](#host_fifo_config)                   | 0x24     |        4 | Host mode FIFO configuration                                                                       |
+| i2c.[`TARGET_FIFO_CONFIG`](#target_fifo_config)               | 0x28     |        4 | Target mode FIFO configuration                                                                     |
+| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)                   | 0x2c     |        4 | Host mode FIFO status register                                                                     |
+| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status)               | 0x30     |        4 | Target mode FIFO status register                                                                   |
+| i2c.[`OVRD`](#ovrd)                                           | 0x34     |        4 | I2C Override Control Register                                                                      |
+| i2c.[`VAL`](#val)                                             | 0x38     |        4 | Oversampled RX values                                                                              |
+| i2c.[`TIMING0`](#timing0)                                     | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
+| i2c.[`TIMING1`](#timing1)                                     | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
+| i2c.[`TIMING2`](#timing2)                                     | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
+| i2c.[`TIMING3`](#timing3)                                     | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).               |
+| i2c.[`TIMING4`](#timing4)                                     | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).               |
+| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)                           | 0x50     |        4 | I2C clock stretching timeout control.                                                              |
+| i2c.[`TARGET_ID`](#target_id)                                 | 0x54     |        4 | I2C target address and mask pairs                                                                  |
+| i2c.[`ACQDATA`](#acqdata)                                     | 0x58     |        4 | I2C target acquired data                                                                           |
+| i2c.[`TXDATA`](#txdata)                                       | 0x5c     |        4 | I2C target transmit data                                                                           |
+| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)                 | 0x60     |        4 | I2C host clock generation timeout value (in units of input clock frequency).                       |
+| i2c.[`TARGET_TIMEOUT_CTRL`](#target_timeout_ctrl)             | 0x64     |        4 | I2C target internal stretching timeout control.                                                    |
+| i2c.[`TARGET_NACK_COUNT`](#target_nack_count)                 | 0x68     |        4 | Number of times the I2C target has NACK'ed a new transaction since the last read of this register. |
+| i2c.[`HOST_NACK_HANDLER_TIMEOUT`](#host_nack_handler_timeout) | 0x6c     |        4 | Timeout in Host-Mode for an unhandled NACK before hardware automatically ends the transaction.     |
 
 ## INTR_STATE
 Interrupt State Register
@@ -166,27 +167,28 @@ I2C Control Register
 I2C Live Status Register for Host and Target modes
 - Offset: `0x14`
 - Reset default: `0x33c`
-- Reset mask: `0x3ff`
+- Reset mask: `0x7ff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "FMTFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "RXFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "FMTEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "HOSTIDLE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TARGETIDLE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "RXEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TXFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ACQFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TXEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ACQEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 22}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "FMTFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "RXFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "FMTEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "HOSTIDLE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TARGETIDLE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "RXEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TXFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ACQFULL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TXEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ACQEMPTY", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "HOST_DISABLED_NACK_TIMEOUT", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 21}], "config": {"lanes": 1, "fontsize": 10, "vspace": 280}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name       | Description                                                        |
-|:------:|:------:|:-------:|:-----------|:-------------------------------------------------------------------|
-| 31:10  |        |         |            | Reserved                                                           |
-|   9    |   ro   |   0x1   | ACQEMPTY   | Target mode receive FIFO is empty                                  |
-|   8    |   ro   |   0x1   | TXEMPTY    | Target mode TX FIFO is empty                                       |
-|   7    |   ro   |    x    | ACQFULL    | Target mode receive FIFO is full                                   |
-|   6    |   ro   |    x    | TXFULL     | Target mode TX FIFO is full                                        |
-|   5    |   ro   |   0x1   | RXEMPTY    | Host mode RX FIFO is empty                                         |
-|   4    |   ro   |   0x1   | TARGETIDLE | Target functionality is idle. No Target transaction is in progress |
-|   3    |   ro   |   0x1   | HOSTIDLE   | Host functionality is idle. No Host transaction is in progress     |
-|   2    |   ro   |   0x1   | FMTEMPTY   | Host mode FMT FIFO is empty                                        |
-|   1    |   ro   |    x    | RXFULL     | Host mode RX FIFO is full                                          |
-|   0    |   ro   |    x    | FMTFULL    | Host mode FMT FIFO is full                                         |
+|  Bits  |  Type  |  Reset  | Name                       | Description                                                                                                                                                                                                                  |
+|:------:|:------:|:-------:|:---------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:11  |        |         |                            | Reserved                                                                                                                                                                                                                     |
+|   10   |   ro   |    x    | HOST_DISABLED_NACK_TIMEOUT | A Host-Mode active transaction has been ended by the [`HOST_NACK_HANDLER_TIMEOUT`](#host_nack_handler_timeout) mechanism. This bit is cleared when [`CTRL.ENABLEHOST`](#ctrl) is set by software to start a new transaction. |
+|   9    |   ro   |   0x1   | ACQEMPTY                   | Target mode receive FIFO is empty                                                                                                                                                                                            |
+|   8    |   ro   |   0x1   | TXEMPTY                    | Target mode TX FIFO is empty                                                                                                                                                                                                 |
+|   7    |   ro   |    x    | ACQFULL                    | Target mode receive FIFO is full                                                                                                                                                                                             |
+|   6    |   ro   |    x    | TXFULL                     | Target mode TX FIFO is full                                                                                                                                                                                                  |
+|   5    |   ro   |   0x1   | RXEMPTY                    | Host mode RX FIFO is empty                                                                                                                                                                                                   |
+|   4    |   ro   |   0x1   | TARGETIDLE                 | Target functionality is idle. No Target transaction is in progress                                                                                                                                                           |
+|   3    |   ro   |   0x1   | HOSTIDLE                   | Host functionality is idle. No Host transaction is in progress                                                                                                                                                               |
+|   2    |   ro   |   0x1   | FMTEMPTY                   | Host mode FMT FIFO is empty                                                                                                                                                                                                  |
+|   1    |   ro   |    x    | RXFULL                     | Host mode RX FIFO is full                                                                                                                                                                                                    |
+|   0    |   ro   |    x    | FMTFULL                    | Host mode FMT FIFO is full                                                                                                                                                                                                   |
 
 ## RDATA
 I2C Read Data
@@ -543,7 +545,12 @@ I2C target transmit data
 |  7:0   |   wo   |   0x0   | TXDATA |               |
 
 ## HOST_TIMEOUT_CTRL
-I2C host clock generation timeout value (in units of input clock frequency)
+I2C host clock generation timeout value (in units of input clock frequency).
+
+In an active transaction in Target-Mode, if the Controller ceases to send SCL pulses
+for this number of cycles then the "host_timeout" interrupt will be asserted.
+
+Set this CSR to 0 to disable this behaviour.
 - Offset: `0x60`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -595,6 +602,38 @@ When it reaches its maximum value it will stay at that value.
 |:------:|:------:|:-------:|:------------------|:--------------|
 |  31:8  |        |         |                   | Reserved      |
 |  7:0   |   rc   |   0x0   | TARGET_NACK_COUNT |               |
+
+## HOST_NACK_HANDLER_TIMEOUT
+Timeout in Host-Mode for an unhandled NACK before hardware automatically ends the transaction.
+(in units of input clock frequency)
+
+In Host-Mode during an active Controller-Transmitter transfer, if the Target NACKs a byte
+the 'nak' interrupt is asserted and the Byte-Formatted Programming Mode FSM halts awaiting
+software intervention. Software must acknowledge the interrupt (CIP 'Event-Type') to allow
+the state machine to continue, typically after clearing out the FMTFIFO to start a new transfer.
+While halted, the active transaction is not ended (no STOP (P) condition is created), and the
+block releases both SCL and SDA.
+
+This timeout can be used to automatically disable the block if software does not handle the
+'nak' interrupt in a timely manner. If the timeout expires, ([`CTRL.HOSTMODE`](#ctrl)) will be disabled
+which creates a STOP (P) condition on the bus ending the active transaction. Additionally, the
+[`STATUS.HOST_DISABLED_NACK_TIMEOUT`](#status) bit is set to alert software.
+
+The enable bit must be set for this feature to operate.
+- Offset: `0x6c`
+- Reset default: `0x0`
+- Reset mask: `0xffffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "VAL", "bits": 31, "attr": ["rw"], "rotate": 0}, {"name": "EN", "bits": 1, "attr": ["rw"], "rotate": -90}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name   | Description                                                     |
+|:------:|:------:|:-------:|:-------|:----------------------------------------------------------------|
+|   31   |   rw   |   0x0   | EN     | Timeout enable                                                  |
+|  30:0  |   rw   |   0x0   | VAL    | Unhandled NAK timeout value (in units of input clock frequency) |
 
 
 <!-- END CMDGEN -->

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -52,6 +52,7 @@ filesets:
       - seq_lib/i2c_target_hrst_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_mode_toggle_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_glitch_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_host_may_nack_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -462,7 +462,10 @@ class i2c_base_vseq extends cip_base_vseq #(
     print_format_flag(item, msg, do_print);
   endtask : program_format_flag
 
-  // read interrupts and randomly clear interrupts if set
+  // Read and clear interrupts
+  //
+  // - Clear all interrupts that are active
+  // - Add a delay of 'clear_intr_dly' cycles before the W1C operation
   virtual task process_interrupts();
     bit [TL_DW-1:0] intr_state, intr_clear;
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -466,6 +466,7 @@ class i2c_base_vseq extends cip_base_vseq #(
   //
   // - Clear all interrupts that are active
   // - Add a delay of 'clear_intr_dly' cycles before the W1C operation
+  // - If 'nak' irq is active, add an extra delay of 1000 cycles
   virtual task process_interrupts();
     bit [TL_DW-1:0] intr_state, intr_clear;
 
@@ -489,6 +490,11 @@ class i2c_base_vseq extends cip_base_vseq #(
     end
     if (bit'(get_field_val(ral.intr_state.tx_stretch, intr_clear))) begin
       `uvm_info(`gfn, "\n  clearing tx_stretch", UVM_DEBUG)
+    end
+    if (bit'(get_field_val(ral.intr_state.nak, intr_clear))) begin
+      // Add a longer delay to mimic a software handler clearing the NAK condition
+      cfg.clk_rst_vif.wait_clks(1_000);
+      `uvm_info(`gfn, "Clearing 'NAK' interrupt, allowing FSM to continue...", UVM_DEBUG)
     end
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_intr_dly)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_may_nack_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_may_nack_vseq.sv
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class i2c_host_may_nack_vseq extends i2c_rx_tx_vseq;
+  `uvm_object_utils(i2c_host_may_nack_vseq)
+  `uvm_object_new
+
+  virtual task i2c_init(if_mode_e mode = Host);
+    super.i2c_init();
+    // Mask some interrupts that are just noise for this test.
+    ral.intr_enable.fmt_threshold.set(1'b0);
+    ral.intr_enable.tx_threshold.set(1'b0);
+    ral.intr_enable.sda_interference.set(1'b0);
+    ral.intr_enable.scl_interference.set(1'b0);
+    ral.intr_enable.sda_unstable.set(1'b0);
+    ral.intr_enable.stretch_timeout.set(1'b0);
+    csr_update(ral.intr_enable);
+
+    // Enable the 'nak' timeout feature, but with a longer timeout than our handler latency.
+    ral.host_nack_handler_timeout.en.set(1'b1);
+    ral.host_nack_handler_timeout.val.set(30'd5000);
+    csr_update(ral.host_nack_handler_timeout);
+  endtask
+
+  // Override the base vseq method to configure an agent which may sometime NACK
+  virtual task agent_init(if_mode_e mode = Device);
+    i2c_target_may_nack_seq may_nack_seq;
+
+    case (mode)
+      Device: begin
+        `uvm_create_obj(i2c_target_may_nack_seq, may_nack_seq)
+        fork may_nack_seq.start(p_sequencer.i2c_sequencer_h); join_none
+      end
+      Host:    `uvm_fatal(`gfn, "This vseq requires the agent to be in TARGET-Mode!")
+      default: `uvm_fatal(`gfn, "Invalid 'if_mode'!")
+    endcase
+  endtask : agent_init
+
+endclass : i2c_host_may_nack_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -34,3 +34,4 @@
 `include "i2c_target_hrst_vseq.sv"
 `include "i2c_host_mode_toggle_vseq.sv"
 `include "i2c_glitch_vseq.sv"
+`include "i2c_host_may_nack_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -235,6 +235,10 @@
       uvm_test_seq: "i2c_host_mode_toggle_vseq"
       run_timeout_mins: 10
     }
+    {
+      name: "i2c_host_may_nack"
+      uvm_test_seq: "i2c_host_may_nack_vseq"
+    }
   ]
 
   // List of regressions.
@@ -249,7 +253,7 @@
               "i2c_host_fifo_watermark", "i2c_host_fifo_overflow", "i2c_host_fifo_reset_fmt",
               "i2c_host_rx_oversample",  "i2c_host_stretch_timeout",
               "i2c_host_fifo_fmt_empty", "i2c_host_fifo_reset_rx", "i2c_host_stretch_timeout",
-              "i2c_host_fifo_full",
+              "i2c_host_fifo_full", "i2c_host_may_nack",
               "i2c_host_error_intr"]
     }
     {

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -510,7 +510,7 @@ module i2c_fsm import i2c_pkg::*;
     AcquireByte,
     // Target function sends ack to external host
     AcquireAckWait, AcquireAckSetup, AcquireAckPulse, AcquireAckHold,
-    // Target function sends not ackowledge to external host
+    // Target function sends not acknowledge to external host
     NackWait, NackSetup, NackPulse, NackHold,
     // Target function clock stretch handling.
     StretchAddr,

--- a/hw/ip/i2c/rtl/i2c_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_fsm.sv
@@ -189,7 +189,12 @@ module i2c_fsm import i2c_pkg::*;
         tNoDelay    : tcount_d = 20'h00001;
         default     : tcount_d = 20'h00001;
       endcase
-    end else if (host_enable_i || target_enable_i) begin
+    end else if (
+      host_enable_i ||
+      target_enable_i ||
+      // If we disable Host-Mode mid-txn, keep counting until the end of
+      // byte, at which point we create a STOP condition then return to Idle.
+      (!host_idle_o && !host_enable_i)) begin
       tcount_d = tcount_q - 1'b1;
     end
   end

--- a/hw/ip/i2c/rtl/i2c_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_pkg.sv
@@ -23,7 +23,7 @@ package i2c_pkg;
     // 2. We received too many bytes in a write request and had to NACK a data
     // byte. The NACK'ed data byte is still in the data field for inspection.
     AcqNack      = 3'b100,
-    // AcqNackStart menas that we got a write request to our address, we sent
+    // AcqNackStart means that we got a write request to our address, we sent
     // an ACK to back to the host so that we can be compatible with SMBus, but
     // now we must unconditionally NACK the next byte. We cannot record that
     // NACK'ed byte because there is no space in the ACQ FIFO. The OpenTitan

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -185,12 +185,15 @@ package i2c_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        qe;
     } llpbk;
     struct packed {
       logic        q;
+      logic        qe;
     } enabletarget;
     struct packed {
       logic        q;
+      logic        qe;
     } enablehost;
   } i2c_reg2hw_ctrl_reg_t;
 
@@ -387,6 +390,15 @@ package i2c_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic [30:0] q;
+    } val;
+  } i2c_reg2hw_host_nack_handler_timeout_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
       logic        de;
     } fmt_threshold;
@@ -451,6 +463,21 @@ package i2c_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        d;
+      logic        de;
+    } enablehost;
+    struct packed {
+      logic        d;
+      logic        de;
+    } enabletarget;
+    struct packed {
+      logic        d;
+      logic        de;
+    } llpbk;
+  } i2c_hw2reg_ctrl_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
     } fmtfull;
     struct packed {
       logic        d;
@@ -479,6 +506,9 @@ package i2c_reg_pkg;
     struct packed {
       logic        d;
     } acqempty;
+    struct packed {
+      logic        d;
+    } host_disabled_nack_timeout;
   } i2c_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -528,35 +558,37 @@ package i2c_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [471:457]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [456:442]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [441:412]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [411:410]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [409:407]
-    i2c_reg2hw_rdata_reg_t rdata; // [406:398]
-    i2c_reg2hw_fdata_reg_t fdata; // [397:379]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [378:371]
-    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [370:345]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [344:317]
-    i2c_reg2hw_ovrd_reg_t ovrd; // [316:314]
-    i2c_reg2hw_timing0_reg_t timing0; // [313:282]
-    i2c_reg2hw_timing1_reg_t timing1; // [281:250]
-    i2c_reg2hw_timing2_reg_t timing2; // [249:218]
-    i2c_reg2hw_timing3_reg_t timing3; // [217:186]
-    i2c_reg2hw_timing4_reg_t timing4; // [185:154]
-    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [153:122]
-    i2c_reg2hw_target_id_reg_t target_id; // [121:94]
-    i2c_reg2hw_acqdata_reg_t acqdata; // [93:81]
-    i2c_reg2hw_txdata_reg_t txdata; // [80:72]
-    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [71:40]
-    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [39:8]
-    i2c_reg2hw_target_nack_count_reg_t target_nack_count; // [7:0]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [506:492]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [491:477]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [476:447]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [446:445]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [444:439]
+    i2c_reg2hw_rdata_reg_t rdata; // [438:430]
+    i2c_reg2hw_fdata_reg_t fdata; // [429:411]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [410:403]
+    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [402:377]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [376:349]
+    i2c_reg2hw_ovrd_reg_t ovrd; // [348:346]
+    i2c_reg2hw_timing0_reg_t timing0; // [345:314]
+    i2c_reg2hw_timing1_reg_t timing1; // [313:282]
+    i2c_reg2hw_timing2_reg_t timing2; // [281:250]
+    i2c_reg2hw_timing3_reg_t timing3; // [249:218]
+    i2c_reg2hw_timing4_reg_t timing4; // [217:186]
+    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [185:154]
+    i2c_reg2hw_target_id_reg_t target_id; // [153:126]
+    i2c_reg2hw_acqdata_reg_t acqdata; // [125:113]
+    i2c_reg2hw_txdata_reg_t txdata; // [112:104]
+    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [103:72]
+    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [71:40]
+    i2c_reg2hw_target_nack_count_reg_t target_nack_count; // [39:32]
+    i2c_reg2hw_host_nack_handler_timeout_reg_t host_nack_handler_timeout; // [31:0]
   } i2c_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    i2c_hw2reg_intr_state_reg_t intr_state; // [147:118]
-    i2c_hw2reg_status_reg_t status; // [117:108]
+    i2c_hw2reg_intr_state_reg_t intr_state; // [154:125]
+    i2c_hw2reg_ctrl_reg_t ctrl; // [124:119]
+    i2c_hw2reg_status_reg_t status; // [118:108]
     i2c_hw2reg_rdata_reg_t rdata; // [107:100]
     i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [99:76]
     i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [75:52]
@@ -593,6 +625,7 @@ package i2c_reg_pkg;
   parameter logic [BlockAw-1:0] I2C_HOST_TIMEOUT_CTRL_OFFSET = 7'h 60;
   parameter logic [BlockAw-1:0] I2C_TARGET_TIMEOUT_CTRL_OFFSET = 7'h 64;
   parameter logic [BlockAw-1:0] I2C_TARGET_NACK_COUNT_OFFSET = 7'h 68;
+  parameter logic [BlockAw-1:0] I2C_HOST_NACK_HANDLER_TIMEOUT_OFFSET = 7'h 6c;
 
   // Reset values for hwext registers and their fields
   parameter logic [14:0] I2C_INTR_TEST_RESVAL = 15'h 0;
@@ -613,7 +646,7 @@ package i2c_reg_pkg;
   parameter logic [0:0] I2C_INTR_TEST_HOST_TIMEOUT_RESVAL = 1'h 0;
   parameter logic [0:0] I2C_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] I2C_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
-  parameter logic [9:0] I2C_STATUS_RESVAL = 10'h 33c;
+  parameter logic [10:0] I2C_STATUS_RESVAL = 11'h 33c;
   parameter logic [0:0] I2C_STATUS_FMTEMPTY_RESVAL = 1'h 1;
   parameter logic [0:0] I2C_STATUS_HOSTIDLE_RESVAL = 1'h 1;
   parameter logic [0:0] I2C_STATUS_TARGETIDLE_RESVAL = 1'h 1;
@@ -654,11 +687,12 @@ package i2c_reg_pkg;
     I2C_TXDATA,
     I2C_HOST_TIMEOUT_CTRL,
     I2C_TARGET_TIMEOUT_CTRL,
-    I2C_TARGET_NACK_COUNT
+    I2C_TARGET_NACK_COUNT,
+    I2C_HOST_NACK_HANDLER_TIMEOUT
   } i2c_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] I2C_PERMIT [27] = '{
+  parameter logic [3:0] I2C_PERMIT [28] = '{
     4'b 0011, // index[ 0] I2C_INTR_STATE
     4'b 0011, // index[ 1] I2C_INTR_ENABLE
     4'b 0011, // index[ 2] I2C_INTR_TEST
@@ -685,7 +719,8 @@ package i2c_reg_pkg;
     4'b 0001, // index[23] I2C_TXDATA
     4'b 1111, // index[24] I2C_HOST_TIMEOUT_CTRL
     4'b 1111, // index[25] I2C_TARGET_TIMEOUT_CTRL
-    4'b 0001  // index[26] I2C_TARGET_NACK_COUNT
+    4'b 0001, // index[26] I2C_TARGET_NACK_COUNT
+    4'b 1111  // index[27] I2C_HOST_NACK_HANDLER_TIMEOUT
   };
 
 endpackage


### PR DESCRIPTION
If the I2C bus NAKs any of our transfers when operating as a Controller-Transmitter in Byte-Formatted Programming Mode, the current behaviour is to proceed to the next FDATA entry as normal, disregarding the NAK entirely. The only side-effect of this event is the block raising the 'nak' interrupt (though this can be suppressed by the use of NAKOK in the FDATA entry).

This PR changes the behaviour so the Controller-FSM halts upon generation of the 'nak' interrupt, and proceeds once the interrupt has been acknowledged using the standard 'Event-Type' interrupt acknowledgement (W1C to INTR_STATE).
The next item in the FMTFIFO is not popped until this acknowledgement is received.
If the NAKOK bit is set for a particular Format Indicator and the bus NAKs our byte, the 'nak' interrupt is not asserted and the FSM continues to the next indicator in the fifo.

While the FSM is halted, SCL is released (we halt in the 'ClockPulseAck' state), and the bus is observed as having an elongated 9th clock period.

Two additional features are also added alongside this change.

- "HOST_NACK_HANDLER_TIMEOUT" CSR
This CSR controls a timeout mechanism where if SW does not handle a pending 'nak'
interrupt before the configured timeout elapses, the hardware will automatically
end the active transaction with a STOP condition and disable Host-Mode.

- "STATUS.HOST_DISABLED_NACK_TIMEOUT" bit
This bit is set when the block times out with the "HOST_NACK_HANDLER_TIMEOUT"
mechanism, and clears when SW re-enables Host-Mode. This is intended to inform
software that the timeout occurred.

The I2C agent / infrastructure does not currently support the generation of NAK's when operating as a Target-Receiver, so this PR also adds rudimentary support for this with a new Agent sequence, plus a test to exercise it (`i2c_host_may_nack`). The testbench currently models the SW interrupt handler latency with a fixed 1000-cycle delay. This should be expanded in the future.

TODO

- [x] Update documentation
- [ ] Check & Update TLTs

---

This new behaviour will need more comprehensive testing to achieve V2 quality. Our infrastructure to test this is currently incomplete, and will need to be expanded. I have observed some of the expected behaviour in an ad-hoc simulation, but it should not be considered fully robust until further testing is completed.

---

Closes #18917 