### PR TITLE
Prepare for LTO

### DIFF
--- a/sw/device/silicon_creator/lib/base/static_critical_boot_measurements.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_boot_measurements.c
@@ -10,4 +10,4 @@
 // This is placed at a fixed location in memory within the .static_critical
 // section. It will be populated by the ROM before the jump to ROM_EXT.
 OT_SET_BSS_SECTION(".static_critical.boot_measurements",
-                   boot_measurements_t boot_measurements;)
+                   OT_USED boot_measurements_t boot_measurements;)

--- a/sw/device/silicon_creator/lib/base/static_critical_epmp_state.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_epmp_state.c
@@ -9,4 +9,5 @@
 //
 // This is placed at a fixed location in memory within the .static_critical
 // section. It will be populated by the ROM before the jump to ROM_EXT.
-OT_SET_BSS_SECTION(".static_critical.epmp_state", epmp_state_t epmp_state;)
+OT_SET_BSS_SECTION(".static_critical.epmp_state",
+                   OT_USED epmp_state_t epmp_state;)

--- a/sw/device/silicon_creator/lib/base/static_critical_sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_sec_mmio.c
@@ -10,4 +10,4 @@
 // This is placed at a fixed location in memory within the .static_critical
 // section. It will be populated by the ROM before the jump to ROM_EXT.
 OT_SET_BSS_SECTION(".static_critical.sec_mmio_ctx",
-                   sec_mmio_ctx_t sec_mmio_ctx;)
+                   OT_USED sec_mmio_ctx_t sec_mmio_ctx;)

--- a/sw/device/silicon_creator/lib/manifest_def.c
+++ b/sw/device/silicon_creator/lib/manifest_def.c
@@ -23,8 +23,7 @@ extern char _manifest_entry_point[];
  * binary by `opentitantool` (overriding the implicitly specified initial value
  * of zero).
  */
-OT_SECTION(".manifest")
-static manifest_t kManifest_ = {
+OT_USED OT_SECTION(".manifest") static manifest_t kManifest_ = {
     .manifest_version =
         (manifest_version_t){
             .minor = kManifestVersionMinor1,

--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -15,7 +15,7 @@ def crt_repos(local = None):
         maybe(
             http_archive,
             name = "crt",
-            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.10.tar.gz",
-            strip_prefix = "crt-0.4.10",
-            sha256 = "655a7cd56d22485a96e9ffca8dd2b4b8b3134099407899300354367ce708ed32",
+            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.11.tar.gz",
+            strip_prefix = "crt-0.4.11",
+            sha256 = "ee52d825fbaf654d76fe689cac7345a3a652c7f779912b46226adb9aee92b9ab",
         )


### PR DESCRIPTION
Update the CRT to a version that includes the LTO feature.
Adds `OT_USED` to variables that would seem unreferenced and thus could be discarded by LTO.