### PR TITLE
Increase OTBN imem size to 8 KiB

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -728,7 +728,7 @@
     // Imem size (given as `items` below) must be a power of two.
     { window: {
         name: "IMEM",
-        items: "1024", // 4 kB
+        items: "2048", // 8 kB
         swaccess: "rw",
         data-intg-passthru: "true",
         byte-write: "false",

--- a/hw/ip/otbn/doc/registers.md
+++ b/hw/ip/otbn/doc/registers.md
@@ -16,7 +16,7 @@
 | otbn.[`FATAL_ALERT_CAUSE`](#fatal_alert_cause) | 0x20     |        4 | Fatal Alert Cause Register                      |
 | otbn.[`INSN_CNT`](#insn_cnt)                   | 0x24     |        4 | Instruction Count Register                      |
 | otbn.[`LOAD_CHECKSUM`](#load_checksum)         | 0x28     |        4 | A 32-bit CRC checksum of data written to memory |
-| otbn.[`IMEM`](#imem)                           | 0x4000   |     4096 | Instruction Memory Access                       |
+| otbn.[`IMEM`](#imem)                           | 0x4000   |     8192 | Instruction Memory Access                       |
 | otbn.[`DMEM`](#dmem)                           | 0x8000   |     3072 | Data Memory Access                              |
 
 ## INTR_STATE
@@ -303,8 +303,8 @@ are ignored.
 If OTBN is busy, any access additionally triggers an
 ILLEGAL_BUS_ACCESS fatal error.
 
-- Word Aligned Offset Range: `0x4000`to`0x4ffc`
-- Size (words): `1024`
+- Word Aligned Offset Range: `0x4000`to`0x5ffc`
+- Size (words): `2048`
 - Access: `rw`
 - Byte writes are *not* supported.
 

--- a/hw/ip/otbn/doc/theory_of_operation.md
+++ b/hw/ip/otbn/doc/theory_of_operation.md
@@ -9,7 +9,7 @@
 ### Memories
 
 The OTBN processor core has access to two dedicated memories: an instruction memory (IMEM), and a data memory (DMEM).
-Each memory is 4 kiB in size.
+The IMEM is 8 KiB, the DMEM is 4 KiB.
 
 The memory layout follows the Harvard architecture.
 Both memories are byte-addressed, with addresses starting at 0.

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -19,7 +19,7 @@
 #include "sv_utils.h"
 
 OtbnMemUtil::OtbnMemUtil(const std::string &top_scope)
-    : imem_(SVScoped::join_sv_scopes(top_scope, "u_imem"), 4096 / 4, 4 / 4),
+    : imem_(SVScoped::join_sv_scopes(top_scope, "u_imem"), 8192 / 4, 4 / 4),
       dmem_(SVScoped::join_sv_scopes(top_scope, "u_dmem"), 4096 / 32, 32 / 4),
       expected_end_addr_(-1) {
   RegisterMemoryArea("imem", 0x4000, &imem_);

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -26,7 +26,7 @@
  */
 interface otbn_trace_if
 #(
-  parameter int ImemAddrWidth = 12,
+  parameter int ImemAddrWidth = 13,
   parameter int DmemAddrWidth = 12,
   parameter otbn_pkg::regfile_e RegFile = otbn_pkg::RegFileFF
 )(

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.sv
@@ -19,7 +19,9 @@ class otbn_model_agent extends dv_base_agent #(
     `DV_CHECK_FATAL(!cfg.is_active)
 
     // get otbn_model_if handle
-    if (!uvm_config_db#(virtual otbn_model_if)::get(this, "", "vif", cfg.vif)) begin
+    if (!uvm_config_db#(
+                        virtual otbn_model_if#(.ImemSizeByte(otbn_reg_pkg::OTBN_IMEM_SIZE))
+                       )::get(this, "", "vif", cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get otbn_model_if handle from uvm_config_db")
     end
   endfunction

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_cfg.sv
@@ -5,7 +5,7 @@
 class otbn_model_agent_cfg extends dv_base_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
-  virtual otbn_model_if vif;
+  virtual otbn_model_if#(.ImemSizeByte(otbn_reg_pkg::OTBN_IMEM_SIZE)) vif;
 
   `uvm_object_utils_begin(otbn_model_agent_cfg)
   `uvm_object_utils_end

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -290,7 +290,8 @@ module tb;
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(escalate_vif)::set(null, "*.env", "escalate_vif", escalate_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(virtual otbn_model_if)::set(null, "*.env.model_agent", "vif", model_if);
+    uvm_config_db#(virtual otbn_model_if#(.ImemSizeByte(ImemSizeByte)))::set(
+      null, "*.env.model_agent", "vif", model_if);
     uvm_config_db#(virtual key_sideload_if#(keymgr_pkg::otbn_key_req_t))::set(
       null, "*.env.keymgr_sideload_agent", "vif", keymgr_if);
 

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -306,7 +306,7 @@ package otbn_reg_pkg;
 
   // Window parameters
   parameter logic [BlockAw-1:0] OTBN_IMEM_OFFSET = 16'h 4000;
-  parameter int unsigned        OTBN_IMEM_SIZE   = 'h 1000;
+  parameter int unsigned        OTBN_IMEM_SIZE   = 'h 2000;
   parameter int unsigned        OTBN_IMEM_IDX    = 0;
   parameter logic [BlockAw-1:0] OTBN_DMEM_OFFSET = 16'h 8000;
   parameter int unsigned        OTBN_DMEM_SIZE   = 'h c00;

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -130,7 +130,7 @@ module otbn_reg_top (
   // Create steering logic
   always_comb begin
     reg_steer =
-        tl_i.a_address[AW-1:0] inside {[16384:20479]} ? 2'd0 :
+        tl_i.a_address[AW-1:0] inside {[16384:24575]} ? 2'd0 :
         tl_i.a_address[AW-1:0] inside {[32768:35839]} ? 2'd1 :
         // Default set to register
         2'd2;


### PR DESCRIPTION
Only to be merged if we choose to have the imem size increase.

@moidx @jadephilipoom please note with the larger imem size the branch instructions can no longer branch to any other instruction, it's limited to a 4 KiB window either side of the instruction (PC relative addressing). The jump instructions can continue to branch anywhere in imem. Hopefully this doesn't present any issues.

@rswarbrick I've seen some failures in the RIG, I believe due to this line of the `BadBranch` class:

https://github.com/lowRISC/opentitan/blob/53c6c771ed140efeefccf942ce5d875134ff3679/hw/ip/otbn/dv/rig/rig/gens/bad_branch.py#L42

This will no longer work as depending on which PC the bad branch is located at the top or bottom of memory may not be reachable. Could you look at a fix?