### PR TITLE
[tests] Extend timeout of various tests

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4375,6 +4375,7 @@ test_suite(
         name = "rv_dm_mem_access_{}".format(lc_state),
         srcs = ["example_test_from_flash.c"],
         cw310 = new_cw310_params(
+            timeout = "moderate",
             needs_jtag = True,
             otp = _SIVAL_OTP_IMAGE[lc_state],
             tags = [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3968,6 +3968,9 @@ opentitan_test(
 opentitan_test(
     name = "rstmgr_alert_info_test",
     srcs = ["rstmgr_alert_info_test.c"],
+    cw310 = new_cw310_params(
+        timeout = "moderate",
+    ),
     exec_env = {
         # TODO(lowrisc/opentitan#20589): Enable _sival* tests when bug is fixed
         # "//hw/top_earlgrey:fpga_cw310_sival": None,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1853,6 +1853,7 @@ opentitan_test(
     name = "gpio_intr_test",
     srcs = ["gpio_intr_test.c"],
     cw310 = new_cw310_params(
+        timeout = "moderate",
         test_cmd = """
             --bootstrap="{firmware}"
         """,

--- a/sw/device/tests/pwrmgr_sleep_resets_lib.h
+++ b/sw/device/tests/pwrmgr_sleep_resets_lib.h
@@ -32,7 +32,7 @@ typedef enum pwmgr_sleep_resets_lib_times {
   kEscalationPhase2Micros = 50,                               // 50 us
   // Allow a long wait before the reset is received, since the host needs
   // to read and parse the log message before it changes the pin values.
-  kWaitWhileActiveMicros = 80000,  // 80 ms
+  kWaitWhileActiveMicros = 500000,  // 500 ms
 } pwmgr_sleep_resets_lib_times_t;
 
 /**


### PR DESCRIPTION
The test fails occasionally while printing the last bit of info the console due to a timeout. Extend the timeout to "moderate" so this failure mode does not continue to occur.