### PR TITLE
[aes, csrng] Reduce area of unmasked AES core inside CSRNG

### DIFF
--- a/hw/ip/aes/pre_sca/prolead/aes_cipher_core_config.set
+++ b/hw/ip/aes/pre_sca/prolead/aes_cipher_core_config.set
@@ -68,11 +68,13 @@ no
 no_of_groups
 2
 
-% The lowest 128 bits are used for the initial state shares. The upper 128 bits of share 0 are used
-% for prd_clearing_i. The latter bits are random but change only once per encryption (simulation),
+% The lowest 128 bits are used for the initial state shares. For the clearing,
+% - the upper 512 bits (prd_clearing_key_i), and
+% - the lower 256 bits of these 512 bits (prd_clearing_state_i)
+% of share 0 are used. All these bits are random but change only once per encryption (simulation),
 % i.e., we shouldn't use the `no_of_always_random_inputs` argument for that.
-256'h$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
-256'h$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$00000000000000000000000000000000
+640'h$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+640'h$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$00000000000000000000000000000000
 
 % name of the clock signal
 clock_signal_name
@@ -86,253 +88,289 @@ no_of_always_random_inputs
 
 % number of primary inputs during the initialization
 no_of_initial_inputs
-18
+21
 
 % number of clock cycles to initiate the run (start of encryption)
 no_of_initial_clock_cycles
 12
 
 %1 - First clock cycle with inactive reset.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b011
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b0
-[2:0]       key_len_i           3'b000
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b011
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b0
+[2:0]       key_len_i            3'b000
 
 %2 - Reset the DUT.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b0
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b011
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b0
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b0
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b011
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b0
+[2:0]       key_len_i            3'b001
 
 %3 - Perform an initial reseed of the internal masking PRNG to put it into a random state.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b011
-[2:0]       crypt_i             3'b100
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b011
+[2:0]       crypt_i              3'b100
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %4 - De-assert in_valid_i. The DUT is busy reseeding the internal masking PRNG.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b100
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b100
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %5 - Wait for initial reseed of the masking PRNG to finish.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b100
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b100
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %6 - Wait for initial reseed of the masking PRNG to finish.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b100
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b100
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %7 - Wait for initial reseed of the masking PRNG to finish.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b100
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b100
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %8 - Wait for initial reseed of the masking PRNG to finish.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b100
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b100
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %9 - Wait for initial reseed of the masking PRNG to finish.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b100
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b100
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %10 - Wait for initial reseed of the masking PRNG to finish.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b100
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b100
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %11 - Start encryption.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b011
-[2:0]       crypt_i             3'b011
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b011
+[2:0]       crypt_i              3'b011
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 %12 - De-assert in_valid_i. The DUT is already busy performing the encryption.
 % De-asserting in_valid_i helps to avoid restarting the encryption after finishing in case the
 % simulation isn't stopped.
-            key_clear_i         1'b0
-            data_out_clear_i    1'b0
-            alert_fatal_i       1'b0
-            force_masks_i       1'b0
-            entropy_ack_i       1'b1
-[2:0]       out_ready_i         3'b011
-            cfg_valid_i         1'b1
-[1:0]       op_i                2'b01
-[127:0]     state_init_i        group_in0[127:0]
-[255:128]   state_init_i        group_in1[127:0]
-[127:0]     prd_clearing_i      group_in0[255:128]
-[511:0]     key_init_i          512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-            rst_ni              1'b1
-[2:0]       in_valid_i          3'b100
-[2:0]       crypt_i             3'b011
-[2:0]       dec_key_gen_i       3'b100
-            prng_reseed_i       1'b1
-[2:0]       key_len_i           3'b001
+            key_clear_i          1'b0
+            data_out_clear_i     1'b0
+            alert_fatal_i        1'b0
+            force_masks_i        1'b0
+            entropy_ack_i        1'b1
+[2:0]       out_ready_i          3'b011
+            cfg_valid_i          1'b1
+[1:0]       op_i                 2'b01
+[127:0]     state_init_i         group_in0[127:0]
+[255:128]   state_init_i         group_in1[127:0]
+[255:0]     prd_clearing_key_i   group_in0[383:128]
+[511:256]   prd_clearing_key_i   group_in0[639:384]
+[127:0]     prd_clearing_state_i group_in0[255:128]
+[255:128]   prd_clearing_state_i group_in0[511:384]
+[511:0]     key_init_i           512'h00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+            rst_ni               1'b1
+[2:0]       in_valid_i           3'b100
+[2:0]       crypt_i              3'b011
+[2:0]       dec_key_gen_i        3'b100
+            prng_reseed_i        1'b1
+[2:0]       key_len_i            3'b001
 
 % the condition to check to terminate the simulation (e.g., done signal is high) or a number of
 % clock cycles, e.g., ClockCycles 5.

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -10,8 +10,9 @@
 
 module aes_cipher_control import aes_pkg::*;
 #(
-  parameter bit         SecMasking  = 0,
-  parameter sbox_impl_e SecSBoxImpl = SBoxImplDom
+  parameter bit         CiphOpFwdOnly = 0,
+  parameter bit         SecMasking    = 0,
+  parameter sbox_impl_e SecSBoxImpl   = SBoxImplDom
 ) (
   input  logic                    clk_i,
   input  logic                    rst_ni,
@@ -369,8 +370,8 @@ module aes_cipher_control import aes_pkg::*;
   end
 
   // Use separate signal for key expand operation, forward round.
-  assign key_expand_op_o    = (dec_key_gen_d == SP2V_HIGH ||
-                               dec_key_gen_q == SP2V_HIGH) ? CIPH_FWD : op_i;
+  assign key_expand_op_o    = (dec_key_gen_d == SP2V_HIGH  ||
+                               dec_key_gen_q == SP2V_HIGH) || CiphOpFwdOnly ? CIPH_FWD : op_i;
   assign key_expand_round_o = rnd_ctr;
 
   // Let the main controller know whate we are doing.

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -57,15 +57,11 @@ module csrng_block_encrypt import csrng_pkg::*; #(
   logic [BlkLen-1:0]    cipher_data_out;
   logic                 aes_cipher_core_enable;
 
-  logic [aes_pkg::WidthPRDClearing-1:0] prd_clearing [NumShares];
-
   logic [3:0][3:0][7:0] state_init[NumShares];
 
   logic [7:0][31:0]     key_init[NumShares];
   logic [3:0][3:0][7:0] state_done[NumShares];
   logic [3:0][3:0][7:0] state_out;
-
-  assign     prd_clearing[0] = '0;
 
   assign     state_init[0] = aes_pkg::aes_transpose({<<8{block_encrypt_v_i}});
 
@@ -102,35 +98,40 @@ module csrng_block_encrypt import csrng_pkg::*; #(
     .clk_i              (clk_i),
     .rst_ni             (rst_ni),
 
-    .cfg_valid_i        ( 1'b1                       ),
-    .in_valid_i         ( cipher_in_valid            ),
-    .in_ready_o         ( cipher_in_ready            ),
-    .out_valid_o        ( cipher_out_valid           ),
-    .out_ready_i        ( cipher_out_ready           ),
-    .op_i               ( aes_pkg::CIPH_FWD          ),
-    .key_len_i          ( aes_pkg::AES_256           ),
-    .crypt_i            ( aes_pkg::SP2V_HIGH         ), // Enable
-    .crypt_o            ( cipher_crypt_busy          ),
-    .alert_fatal_i      ( 1'b0                       ),
-    .alert_o            ( block_encrypt_aes_cipher_sm_err_o),
-    .dec_key_gen_i      ( aes_pkg::SP2V_LOW          ), // Disable
-    .dec_key_gen_o      (                            ),
-    .prng_reseed_i      ( 1'b0                       ), // Disable
-    .prng_reseed_o      (                            ),
-    .key_clear_i        ( 1'b0                       ), // Disable
-    .key_clear_o        (                            ),
-    .data_out_clear_i   ( 1'b0                       ), // Disable
-    .data_out_clear_o   (                            ),
-    .prd_clearing_i     ( prd_clearing               ),
-    .force_masks_i      ( 1'b0                       ),
-    .data_in_mask_o     (                            ),
-    .entropy_req_o      (                            ),
-    .entropy_ack_i      ( 1'b0                       ),
-    .entropy_i          ( '0                         ),
+    .cfg_valid_i          ( 1'b1                       ),
+    .in_valid_i           ( cipher_in_valid            ),
+    .in_ready_o           ( cipher_in_ready            ),
+    .out_valid_o          ( cipher_out_valid           ),
+    .out_ready_i          ( cipher_out_ready           ),
+    .op_i                 ( aes_pkg::CIPH_FWD          ),
+    .key_len_i            ( aes_pkg::AES_256           ),
+    .crypt_i              ( aes_pkg::SP2V_HIGH         ), // Enable
+    .crypt_o              ( cipher_crypt_busy          ),
+    .alert_fatal_i        ( 1'b0                       ),
+    .alert_o              ( block_encrypt_aes_cipher_sm_err_o),
+    .dec_key_gen_i        ( aes_pkg::SP2V_LOW          ), // Disable
+    .dec_key_gen_o        (                            ),
+    .prng_reseed_i        ( 1'b0                       ), // Disable
+    .prng_reseed_o        (                            ),
+    .key_clear_i          ( 1'b0                       ), // Disable
+    .key_clear_o          (                            ),
+    .data_out_clear_i     ( 1'b0                       ), // Disable
+    .data_out_clear_o     (                            ),
+    .prd_clearing_state_i ( state_init                 ), // Providing this value allows synthesis
+                                                          // to perform optimizations. We don't
+                                                          // care about SCA leakage in this context.
+    .prd_clearing_key_i   ( key_init                   ), // This input is not used. Providing this
+                                                          // value allows synthesis to perform
+                                                          // optimizations.
+    .force_masks_i        ( 1'b0                       ),
+    .data_in_mask_o       (                            ),
+    .entropy_req_o        (                            ),
+    .entropy_ack_i        ( 1'b0                       ),
+    .entropy_i            ( '0                         ),
 
-    .state_init_i       ( state_init                 ),
-    .key_init_i         ( key_init                   ),
-    .state_o            ( state_done                 )
+    .state_init_i         ( state_init                 ),
+    .key_init_i           ( key_init                   ),
+    .state_o              ( state_done                 )
   );
 
 

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -94,9 +94,10 @@ module csrng_block_encrypt import csrng_pkg::*; #(
   // SEC_CM: AES_CIPHER.DATA_REG.LOCAL_ESC
 
   aes_cipher_core #(
-    .AES192Enable ( 1'b0 ),  // AES192Enable disabled
-    .SecMasking   ( 1'b0 ),  // Masking disable
-    .SecSBoxImpl  ( SBoxImpl )
+    .AES192Enable  ( 1'b0 ),  // AES192Enable disabled
+    .CiphOpFwdOnly ( 1'b1 ),  // Forward operation only
+    .SecMasking    ( 1'b0 ),  // Masking disable
+    .SecSBoxImpl   ( SBoxImpl )
   ) u_aes_cipher_core   (
     .clk_i              (clk_i),
     .rst_ni             (rst_ni),


### PR DESCRIPTION
This PR contains mainly two changes:
1. A new compile-time parameter is added to the AES cipher core to only implement the forward operation of the cipher. Enabling this parameter inside CSRNG allows to completely trim away unused data paths only relevant for the inverse operation. Previously some logic wasn't optimized out due to synthesis optimization barriers placed around the control FSM (synthesis was no longer able to infer that some mux control signals never take on certain values). This allows optimizing away 256 FFs, one 256-bit 2-input mux, one 128-bit 2-input mux and some more inputs on other existing 256-bit and 128-bit muxes.
2. The generation of the PRD signals for register clearing are moved to the outside of the cipher core. This allows connecting the initial state and key inputs inside CSRNG (where we don't care about SCA leakage and never clear the key registers).

These two changes allow saving around 4 kGE inside CSRNG.