### PR TITLE
[dice] add signature vars to UDS cert HJSON description

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -116,7 +116,7 @@ UJSON_SERDE_STRUCT(ManufDiceCerts, \
  */
 // clang-format off
 #define STRUCT_MANUF_ENDORSED_CERTS(field, string) \
-    field(uds_certificate, uint8_t, 596) \
+    field(uds_certificate, uint8_t, 660) \
     field(uds_certificate_size, size_t)
 UJSON_SERDE_STRUCT(ManufEndorsedCerts, \
                    manuf_endorsed_certs_t, \

--- a/sw/device/silicon_creator/lib/cert/uds.hjson
+++ b/sw/device/silicon_creator/lib/cert/uds.hjson
@@ -48,6 +48,16 @@
         debug_flag: {
             type: "boolean",
         }
+        // Certificate signature: the result of signing with ECDSA
+        // are two integers named "r" and "s"
+        cert_signature_r: {
+            type: "integer",
+            size: 32,
+        },
+        cert_signature_s: {
+            type: "integer",
+            size: 32,
+        },
     },
 
     certificate: {
@@ -86,8 +96,10 @@
         }
         signature: {
             algorithm: "ecdsa-with-sha256",
-            // The value field is optional: since the UDS is signed offline, we don't
-            // need to be able to set the signature from the ROM.
+            value: {
+                r: { var: "cert_signature_r" },
+                s: { var: "cert_signature_s" }
+            }
         }
     }
 }

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -38,6 +38,10 @@ static_assert(kUdsMaxTbsSizeBytes == 569,
               "The `uds_tbs_certificate` buffer size in the "
               "`manuf_dice_certs_t` struct should match the value of "
               "`kUdsMaxTbsSizeBytes`.");
+static_assert(kUdsMaxCertSizeBytes == 660,
+              "The `uds_tbs_certificate` buffer size in the "
+              "`manuf_dice_certs_t` struct should match the value of "
+              "`kUdsMaxTbsSizeBytes`.");
 static_assert(kCdi0MaxCertSizeBytes == 582,
               "The `cdi_0_certificate` buffer size in the "
               "`manuf_dice_certs_t` struct should match the value of "


### PR DESCRIPTION
If we do not include the signature variables in the UDS cert HJSON description then the `kUdsMaxCertSizeBytes` constant that is automatically generated via the certificate codegen infra does not accound for the signature bytes. If these bytes are not accounted for, then the ujson struct that holds the final endorsed UDS certificate will not allocate an ArrayVec of adequate size on the host side.