### PR TITLE
[silicon_creator] add OTP DAI read functions to driver lib

### DIFF
--- a/sw/device/silicon_creator/lib/base/sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.h
@@ -32,7 +32,7 @@ extern "C" {
  * - Perform a number (N) of calls to `sec_mmio_write32()`.
  * - Increment the expected number of writes by N with
  *   `SEC_MMIO_WRITE_INCREMENT()`. This is done using a separate function call
- *   to be able to detect skip instruciton faults on `sec_mmio_write32()`
+ *   to be able to detect skip instruction faults on `sec_mmio_write32()`
  *   calls.
  *
  * Register reads

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -469,6 +469,7 @@ dual_cc_library(
             "//sw/device/lib/base:hardened",
             "//sw/device/lib/base:macros",
             "//sw/device/silicon_creator/lib/base:sec_mmio",
+            "//sw/device/lib/base:abs_mmio",
         ],
     ),
 )

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -25,21 +25,33 @@ enum {
 const otp_partition_info_t kOtpPartitions[] = {
     [kOtpPartitionCreatorSwCfg] = {
         .start_addr = OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET,
+        .size = OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
+                OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE,
         .align_mask = 0x3},
     [kOtpPartitionOwnerSwCfg] = {
         .start_addr = OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET,
+        .size = OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
+                OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE,
         .align_mask = 0x3},
     [kOtpPartitionRotCreatorAuthCodesign] = {
         .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET,
+        .size = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
+                OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE,
         .align_mask = 0x3},
     [kOtpPartitionRotCreatorAuthState] = {
         .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET,
+        .size = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
+                OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE,
         .align_mask = 0x3},
     [kOtpPartitionHwCfg0] = {
         .start_addr = OTP_CTRL_PARAM_HW_CFG0_OFFSET,
+        .size = OTP_CTRL_PARAM_HW_CFG0_SIZE -
+                OTP_CTRL_PARAM_HW_CFG0_DIGEST_SIZE,
         .align_mask = 0x3},
     [kOtpPartitionHwCfg1] = {
         .start_addr = OTP_CTRL_PARAM_HW_CFG1_OFFSET,
+        .size = OTP_CTRL_PARAM_HW_CFG1_SIZE -
+                OTP_CTRL_PARAM_HW_CFG1_DIGEST_SIZE,
         .align_mask = 0x3},
 };
 // clang-format on
@@ -71,7 +83,7 @@ static void wait_for_dai_idle(void) {
   uint32_t status = 0;
   bool idle = false;
   do {
-    status = sec_mmio_read32(kBase + OTP_CTRL_STATUS_REG_OFFSET);
+    status = abs_mmio_read32(kBase + OTP_CTRL_STATUS_REG_OFFSET);
     idle = bitfield_bit32_read(status, OTP_CTRL_STATUS_DAI_IDLE_BIT);
   } while (!idle);
 }

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -6,6 +6,7 @@
 
 #include <stddef.h>
 
+#include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
@@ -14,7 +15,34 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otp_ctrl_regs.h"  // Generated.
 
-enum { kBase = TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR };
+enum {
+  kBase = TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR,
+};
+
+// This is generates too many lines with different formatting variants, so
+// We opt to just disable formatting.
+// clang-format off
+const otp_partition_info_t kOtpPartitions[] = {
+    [kOtpPartitionCreatorSwCfg] = {
+        .start_addr = OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET,
+        .align_mask = 0x3},
+    [kOtpPartitionOwnerSwCfg] = {
+        .start_addr = OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET,
+        .align_mask = 0x3},
+    [kOtpPartitionRotCreatorAuthCodesign] = {
+        .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET,
+        .align_mask = 0x3},
+    [kOtpPartitionRotCreatorAuthState] = {
+        .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET,
+        .align_mask = 0x3},
+    [kOtpPartitionHwCfg0] = {
+        .start_addr = OTP_CTRL_PARAM_HW_CFG0_OFFSET,
+        .align_mask = 0x3},
+    [kOtpPartitionHwCfg1] = {
+        .start_addr = OTP_CTRL_PARAM_HW_CFG1_OFFSET,
+        .align_mask = 0x3},
+};
+// clang-format on
 
 uint32_t otp_read32(uint32_t address) {
   return sec_mmio_read32(kBase + OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + address);
@@ -48,29 +76,46 @@ static void wait_for_dai_idle(void) {
   } while (!idle);
 }
 
-static void dai_read_blocking(uint32_t address) {
+static void dai_read_blocking(otp_partition_t partition,
+                              uint32_t relative_address) {
   wait_for_dai_idle();
-  sec_mmio_write32(kBase + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, address);
+  HARDENED_CHECK_EQ(relative_address & kOtpPartitions[partition].align_mask, 0);
+  sec_mmio_write32(kBase + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+                   kOtpPartitions[partition].start_addr + relative_address);
   uint32_t cmd =
       bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true);
-  sec_mmio_write32(kBase + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, cmd);
+  abs_mmio_write32(kBase + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, cmd);
   wait_for_dai_idle();
 }
 
-uint32_t otp_dai_read32(uint32_t address) {
-  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioDaiRead32, 2);
-  dai_read_blocking(address);
+uint32_t otp_dai_read32(otp_partition_t partition, uint32_t relative_address) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioDaiRead32, 1);
+  dai_read_blocking(partition, relative_address);
   return sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET);
 }
 
-uint64_t otp_dai_read64(uint32_t address) {
-  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioDaiRead64, 2);
-  dai_read_blocking(address);
+uint64_t otp_dai_read64(otp_partition_t partition, uint32_t relative_address) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioDaiRead64, 1);
+  dai_read_blocking(partition, relative_address);
   uint64_t value =
       sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET);
   value <<= 32;
   value |= sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET);
   return value;
+}
+
+rom_error_t otp_dai_read(otp_partition_t partition, uint32_t relative_address,
+                         uint32_t *data, size_t num_words) {
+  HARDENED_CHECK_LT(partition, ARRAYSIZE(kOtpPartitions));
+  size_t i = 0, r = num_words - 1;
+  uint32_t addr = relative_address;
+  for (; launder32(i) < num_words && launder32(r) < num_words; ++i, --r) {
+    data[i] = otp_dai_read32(partition, addr);
+    addr += sizeof(uint32_t);
+  }
+  HARDENED_CHECK_EQ(i, num_words);
+  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  return kErrorOk;
 }
 
 void otp_creator_sw_cfg_lockdown(void) {

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -6,6 +6,7 @@
 
 #include <stddef.h>
 
+#include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -36,6 +37,40 @@ void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
   }
   HARDENED_CHECK_EQ(i, num_words);
   HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+}
+
+static void wait_for_dai_idle(void) {
+  uint32_t status = 0;
+  bool idle = false;
+  do {
+    status = sec_mmio_read32(kBase + OTP_CTRL_STATUS_REG_OFFSET);
+    idle = bitfield_bit32_read(status, OTP_CTRL_STATUS_DAI_IDLE_BIT);
+  } while (!idle);
+}
+
+static void dai_read_blocking(uint32_t address) {
+  wait_for_dai_idle();
+  sec_mmio_write32(kBase + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET, address);
+  uint32_t cmd =
+      bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true);
+  sec_mmio_write32(kBase + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, cmd);
+  wait_for_dai_idle();
+}
+
+uint32_t otp_dai_read32(uint32_t address) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioDaiRead32, 2);
+  dai_read_blocking(address);
+  return sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET);
+}
+
+uint64_t otp_dai_read64(uint32_t address) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioDaiRead64, 2);
+  dai_read_blocking(address);
+  uint64_t value =
+      sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET);
+  value <<= 32;
+  value |= sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET);
+  return value;
 }
 
 void otp_creator_sw_cfg_lockdown(void) {

--- a/sw/device/silicon_creator/lib/drivers/otp.h
+++ b/sw/device/silicon_creator/lib/drivers/otp.h
@@ -41,6 +41,10 @@ typedef struct otp_partition_info {
    */
   uint32_t start_addr;
   /**
+   * Size (in bytes) of the partition, excluding the digest field.
+   */
+  size_t size;
+  /**
    * The alignment mask for this partition.
    *
    * A valid address for this partition must be such that

--- a/sw/device/silicon_creator/lib/drivers/otp.h
+++ b/sw/device/silicon_creator/lib/drivers/otp.h
@@ -28,6 +28,8 @@ extern "C" {
  */
 enum {
   kOtpSecMmioCreatorSwCfgLockDown = 1,
+  kOtpSecMmioDaiRead32 = 2,
+  kOtpSecMmioDaiRead64 = 2,
 };
 
 /**
@@ -59,6 +61,30 @@ uint64_t otp_read64(uint32_t address);
  * @param num_words The number of 32-bit words to read from OTP.
  */
 void otp_read(uint32_t address, uint32_t *data, size_t num_words);
+
+/**
+ * Perform a blocking 32-bit read from the Direct Access Interface (DAI).
+ *
+ * This enables reading any readable 32-bit OTP field that is not in the memory
+ * mapped software config partitions (i.e., partitions other than the
+ * {CREATOR,OWNER}_SW_CFG partitions).
+ *
+ * @param address The address to read from offset from the start of OTP memory.
+ * @return The 32-bit value from OTP.
+ */
+uint32_t otp_dai_read32(uint32_t address);
+
+/**
+ * Perform a blocking 64-bit read from the Direct Access Interface (DAI).
+ *
+ * This enables reading any readable 64-bit OTP field that is not in the memory
+ * mapped software config partitions (i.e., partitions other than the
+ * {CREATOR,OWNER}_SW_CFG partitions).
+ *
+ * @param address The address to read from offset from the start of OTP memory.
+ * @return The 64-bit value from OTP.
+ */
+uint64_t otp_dai_read64(uint32_t address);
 
 /**
  * Disables read access to CREATOR_SW_CFG partition until next reset.

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -34,24 +34,31 @@ TEST_F(OtpTest, CreatorSwCfgLockdown) {
 
 class OtpReadTest : public OtpTest {
  protected:
-  const ptrdiff_t offset_ = OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET;
+  const ptrdiff_t mmap_window_offset_ = OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET;
+  const ptrdiff_t creator_sw_cfg_partition_offset_ =
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET;
+  const ptrdiff_t hw_cfg0_partition_offset_ = OTP_CTRL_PARAM_HW_CFG0_OFFSET;
+  void ExpectDaiIdleCheck(bool idle) {
+    EXPECT_SEC_READ32(base_ + OTP_CTRL_STATUS_REG_OFFSET,
+                      {{OTP_CTRL_STATUS_DAI_IDLE_BIT, idle}});
+  }
 };
 
 TEST_F(OtpReadTest, Read32) {
-  EXPECT_SEC_READ32(base_ + offset_, 0x00010203);
+  EXPECT_SEC_READ32(base_ + mmap_window_offset_, 0x00010203);
 
   EXPECT_EQ(otp_read32(0), 0x00010203);
 }
 
 TEST_F(OtpReadTest, Read64) {
-  EXPECT_SEC_READ32(base_ + offset_ + 8, 0x04050607);
-  EXPECT_SEC_READ32(base_ + offset_ + 4, 0x08090A0B);
+  EXPECT_SEC_READ32(base_ + mmap_window_offset_ + 8, 0x04050607);
+  EXPECT_SEC_READ32(base_ + mmap_window_offset_ + 4, 0x08090A0B);
 
   EXPECT_EQ(otp_read64(4), 0x0405060708090A0B);
 }
 
 TEST_F(OtpReadTest, ReadLen32) {
-  EXPECT_SEC_READ32(base_ + offset_, 0x08090A0B);
+  EXPECT_SEC_READ32(base_ + mmap_window_offset_, 0x08090A0B);
 
   uint32_t value = 0;
   otp_read(0, &value, 1);
@@ -59,8 +66,8 @@ TEST_F(OtpReadTest, ReadLen32) {
 }
 
 TEST_F(OtpReadTest, ReadLen64) {
-  EXPECT_SEC_READ32(base_ + offset_, 0x0C0D0E0F);
-  EXPECT_SEC_READ32(base_ + offset_ + 4, 0x08090A0B);
+  EXPECT_SEC_READ32(base_ + mmap_window_offset_, 0x0C0D0E0F);
+  EXPECT_SEC_READ32(base_ + mmap_window_offset_ + 4, 0x08090A0B);
 
   std::array<uint32_t, 2> buf;
   otp_read(0, buf.data(), 2);
@@ -69,7 +76,8 @@ TEST_F(OtpReadTest, ReadLen64) {
 
 TEST_F(OtpReadTest, ReadLenN) {
   for (int val = 0; val < 16; ++val) {
-    EXPECT_SEC_READ32(base_ + offset_ + val * sizeof(uint32_t), val);
+    EXPECT_SEC_READ32(base_ + mmap_window_offset_ + val * sizeof(uint32_t),
+                      val);
   }
 
   std::array<uint32_t, 16> arr;
@@ -78,6 +86,68 @@ TEST_F(OtpReadTest, ReadLenN) {
   std::array<uint32_t, 16> expected;
   std::iota(expected.begin(), expected.end(), 0);
   EXPECT_THAT(arr, ElementsAreArray(expected));
+}
+
+class OtpDaiReadTest : public OtpReadTest {};
+
+TEST_F(OtpDaiReadTest, Read32) {
+  ExpectDaiIdleCheck(true);
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+                     creator_sw_cfg_partition_offset_);
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
+  ExpectDaiIdleCheck(true);
+  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+                    0x00010203);
+
+  EXPECT_EQ(otp_dai_read32(creator_sw_cfg_partition_offset_), 0x00010203);
+}
+
+TEST_F(OtpDaiReadTest, Read32WithIdleWait) {
+  ExpectDaiIdleCheck(false);
+  ExpectDaiIdleCheck(true);
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+                     creator_sw_cfg_partition_offset_);
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
+  ExpectDaiIdleCheck(false);
+  ExpectDaiIdleCheck(false);
+  ExpectDaiIdleCheck(true);
+  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+                    0x00010203);
+
+  EXPECT_EQ(otp_dai_read32(creator_sw_cfg_partition_offset_), 0x00010203);
+}
+
+TEST_F(OtpDaiReadTest, Read64) {
+  ExpectDaiIdleCheck(true);
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+                     creator_sw_cfg_partition_offset_);
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
+  ExpectDaiIdleCheck(true);
+  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET,
+                    0x00010203);
+  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+                    0x00040506);
+
+  EXPECT_EQ(otp_dai_read64(creator_sw_cfg_partition_offset_),
+            0x0001020300040506);
+}
+
+TEST_F(OtpDaiReadTest, Read64WithIdleWait) {
+  ExpectDaiIdleCheck(false);
+  ExpectDaiIdleCheck(false);
+  ExpectDaiIdleCheck(true);
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+                     creator_sw_cfg_partition_offset_);
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
+  ExpectDaiIdleCheck(false);
+  ExpectDaiIdleCheck(true);
+  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET,
+                    0x00010203);
+  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+                    0x00040506);
+
+  EXPECT_EQ(otp_dai_read64(creator_sw_cfg_partition_offset_),
+            0x0001020300040506);
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -40,7 +40,7 @@ class OtpReadTest : public OtpTest {
  protected:
   const ptrdiff_t mmap_window_offset_ = OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET;
   void ExpectDaiIdleCheck(bool idle) {
-    EXPECT_SEC_READ32(base_ + OTP_CTRL_STATUS_REG_OFFSET,
+    EXPECT_ABS_READ32(base_ + OTP_CTRL_STATUS_REG_OFFSET,
                       {{OTP_CTRL_STATUS_DAI_IDLE_BIT, idle}});
   }
 };


### PR DESCRIPTION
This adds several functions to the OTP silicon_creator driver library to enable reading data from non-memory mapped, readable, partitions. This is required to enable measuring said OTP partitions for attestation key and cert generation purposes.