### PR TITLE
[dice] add OTP measurements to UDS cert

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -60,6 +60,7 @@ cc_library(
     hdrs = ["dice.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/json:provisioning_data",
@@ -72,6 +73,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/otbn/crypto:boot",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -15,9 +15,13 @@ extern "C" {
 
 enum {
   /**
-   * Size of a SHA-256 digest in words.
+   * Size of a SHA-256 digest in bytes.
    */
-  kHmacDigestNumWords = 8,
+  kHmacDigestNumBytes = 32,
+  /**
+   * Size of a SHA-256 digest in 32-bit words.
+   */
+  kHmacDigestNumWords = kHmacDigestNumBytes / sizeof(uint32_t),
 };
 
 /**


### PR DESCRIPTION
This adds measurements of the CreatorSwCfg, OwnerSwCfg, and HwCfg0 OTP partitions to the UDS cert in the DiceTcbInfo extensions as these measurements comprise portions of the TCB. This partially addresses #19455.

Note: this depends on #22057 and #22059. Only review the last commit.