### PR TITLE
[rom] Update manifest extension getters.

### DIFF
--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -26,8 +26,8 @@ extern manifest_digest_region_t manifest_digest_region_get(
     const manifest_t *manifest);
 extern epmp_region_t manifest_code_region_get(const manifest_t *manifest);
 extern uintptr_t manifest_entry_point_get(const manifest_t *manifest);
-extern rom_error_t manifest_get_ext_spx_key(
+extern rom_error_t manifest_ext_get_spx_key(
     const manifest_t *manifest, const manifest_ext_spx_key_t **spx_key);
-extern rom_error_t manifest_get_ext_spx_signature(
+extern rom_error_t manifest_ext_get_spx_signature(
     const manifest_t *manifest,
     const manifest_ext_spx_signature_t **spx_signature);

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -581,7 +581,7 @@ inline uintptr_t manifest_entry_point_get(const manifest_t *manifest) {
  */
 MANIFEST_EXTENSIONS(DEFINE_GETTER)
 
-#else   // defined(OT_PLATFORM_RV32) || defined(MANIFEST_UNIT_TEST_)
+#else  // defined(OT_PLATFORM_RV32) || defined(MANIFEST_UNIT_TEST_)
 /**
  * Declarations for the functions above that should be defined in tests.
  */
@@ -589,11 +589,14 @@ rom_error_t manifest_check(const manifest_t *manifest);
 manifest_digest_region_t manifest_digest_region_get(const manifest_t *manifest);
 epmp_region_t manifest_code_region_get(const manifest_t *manifest);
 uintptr_t manifest_entry_point_get(const manifest_t *manifest);
-rom_error_t manifest_get_ext_spx_key(const manifest_t *manifest,
+
+// Manifest extension getters.
+rom_error_t manifest_ext_get_spx_key(const manifest_t *manifest,
                                      const manifest_ext_spx_key_t **spx_key);
-rom_error_t manifest_get_ext_spx_signature(
+rom_error_t manifest_ext_get_spx_signature(
     const manifest_t *manifest,
     const manifest_ext_spx_signature_t **spx_signature);
+
 #endif  // defined(OT_PLATFORM_RV32) || defined(MANIFEST_UNIT_TEST_)
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix naming bug in manifest extension getters. The extern declaration of the functions were not matching the naming generated by the manifest extension macros.