### PR TITLE
[ast] fixing always_comb lint errors

### DIFF
--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -24,7 +24,7 @@ filesets:
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:ip_interfaces:alert_handler_reg
-      - lowrisc:ip_interfaces:rstmgr_pkg
+      - lowrisc:opentitan:top_earlgrey_rstmgr_pkg
       - lowrisc:systems:clkmgr_pkg
     files:
       - rtl/ast_reg_pkg.sv

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -685,7 +685,7 @@ rng #(
 // Alerts (Always ON)
 ///////////////////////////////////////
 ast_pkg::ast_dif_t as_alert_src;
-ast_pkg::ast_dif_t cg_alert_src;
+ast_pkg::ast_dif_t cgc_alert_src;
 ast_pkg::ast_dif_t gd_alert_src;
 ast_pkg::ast_dif_t ts_alert_hi_src;
 ast_pkg::ast_dif_t ts_alert_lo_src;
@@ -712,7 +712,7 @@ ast_alert u_alert_as (
 ast_alert u_alert_cg (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
-  .alert_src_i ( cg_alert_src ),
+  .alert_src_i ( cgc_alert_src ),
   .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::CgSel] ),
   .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::CgSel] ),
   .alert_req_o ( alert_req_o.alerts[ast_pkg::CgSel] )
@@ -820,7 +820,7 @@ ast_alert u_alert_ot5 (
 // Alerts Open-Source Selection
 ////////////////////////////////////////
 assign as_alert_src    = '{p: 1'b0, n: 1'b1};
-assign cg_alert_src    = '{p: 1'b0, n: 1'b1};
+assign cgc_alert_src   = '{p: 1'b0, n: 1'b1};
 assign gd_alert_src    = '{p: 1'b0, n: 1'b1};
 assign ts_alert_hi_src = '{p: 1'b0, n: 1'b1};
 assign ts_alert_lo_src = '{p: 1'b0, n: 1'b1};

--- a/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
@@ -31,7 +31,7 @@ initial begin
   init_start = 1'b0;
 end
 
-always @( * ) begin
+always_comb begin
   if ( init_start ) begin
     vcaon_pok_o <= 1'b0;
   end else if ( !init_start && gen_supp_a ) begin

--- a/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
@@ -31,7 +31,7 @@ initial begin
   init_start = 1'b0;
 end
 
-always (* xprop_off *) @( * ) begin
+always_comb (* xprop_off *) begin
   if ( init_start ) begin
     vcc_pok_o <= 1'b0;
   end

--- a/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
@@ -31,7 +31,7 @@ initial begin
   init_start = 1'b0;
 end
 
-always @( * ) begin
+always_comb begin
   if ( init_start ) begin
     vcmain_pok_o <= 1'b0;
   end else if ( !init_start && gen_supp_a ) begin

--- a/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
@@ -31,7 +31,7 @@ initial begin
   init_start = 1'b0;
 end
 
-always (* xprop_off *) @( * ) begin
+always_comb (* xprop_off *) begin
   if ( init_start ) begin
     vio_pok_o <= 1'b0;
   end


### PR DESCRIPTION
This PR should fix #22037

Added some other minor changes:
spaces, rename of wire, rstmgr pgk location