### PR TITLE
[spi_device,dv] Generalise description of mem_cfg testpoint

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -41,9 +41,13 @@
     }
     {
       name: mem_cfg
-      desc: '''Test cfg_i connectivity between spi_device and prim_ram_2p.
+      desc: '''Test cfg_i connectivity between spi_device and the backing RAM.
 
-               Randomly set dut.ram_cfg_i and check this value is propagated to prim_mem_2p.'''
+
+               Randomly set dut.ram_cfg_i and check this value is propagated to the memory itself.
+               For the 1r1w implementation, where the RAM is split into ingress and egress portions,
+               check that the configuration makes it to both sides.'''
+
       stage: V2
       tests: ["spi_device_ram_cfg"]
     }


### PR DESCRIPTION
This testpoint was written when we only had the two-port implementation. It makes sense in the 1r1w configuration too. Generalise the text a bit so that it is sensible either way.

Fixes #21863.