### PR TITLE
[spi_device,dv] Lower the reseed count for spi_device_ram_cfg

### DIFF
--- a/hw/ip/spi_device/dv/base_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/base_sim_cfg.hjson
@@ -72,7 +72,7 @@
     {
       name: "spi_device_ram_cfg"
       uvm_test_seq: "spi_device_ram_cfg_vseq"
-      reseed: 20
+      reseed: 1
     }
 
     {


### PR DESCRIPTION
This test randomises a configuration many times and then checks that the randomised values make it to the RAM itself. That's reasonable, but there's not really any benefit from running it several times. Cut down to avoid the wasted work.