### PR TITLE
[sival,ci] Mark drbg_functest as broken

### DIFF
--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -185,6 +185,9 @@ opentitan_test(
 opentitan_test(
     name = "drbg_functest",
     srcs = ["drbg_functest.c"],
+    cw310 = cw310_params(
+        tags = ["broken"],  # https://github.com/lowRISC/opentitan/issues/19568
+    ),
     exec_env = EARLGREY_TEST_ENVS,
     verilator = verilator_params(
         timeout = "eternal",


### PR DESCRIPTION
This test is broken on the ES due to the impossibility to safely issue a CSRNG command. See #19568. Mark as broken to avoid CI failures.

NOTE: this has been fixed on master.