### PR TITLE
[otbn,dv] Drop verification stage to V1

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -35,7 +35,7 @@
           version:            "1.0.0",
           life_stage:         "L1",
           design_stage:       "D2S",
-          verification_stage: "V2S",
+          verification_stage: "V1",
           dif_stage:          "S2",
           commit_id:          "a6b908283fccba3f8b6b44052c6ad87276dc21e8",
           notes:              ""


### PR DESCRIPTION
This will represent the version of OTBN going into PROD. We've just had a V1 review meeting (which was, honestly, a bit of a formality), but we think there will be some proper work to do before we can claim to be back at the V2 stage.