### PR TITLE
[ast] Revert dependency on top-specific rstmgr_pkg

### DIFF
--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -24,7 +24,7 @@ filesets:
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:ip_interfaces:alert_handler_reg
-      - lowrisc:opentitan:top_earlgrey_rstmgr_pkg
+      - lowrisc:ip_interfaces:rstmgr_pkg
       - lowrisc:systems:clkmgr_pkg
     files:
       - rtl/ast_reg_pkg.sv


### PR DESCRIPTION
ast is used in the englishbreakfast build, so it must depend on the virtual rstmgr_pkg.