### PR TITLE
[cryptotest] Add generator for random ECDSA test vectors

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -41,6 +41,23 @@ ECDSA_TESTVECTOR_TARGETS = [
 ] + [
     "//sw/host/cryptotest/testvectors/data:nist_cavp_ecdsa_fips_186_4_sig_ver_json",
     "//sw/host/cryptotest/testvectors/data:nist_cavp_ecdsa_fips_186_4_sign_json",
+] + [
+    "//sw/host/cryptotest/testvectors/data:random_ecdsa_{}".format(random_target)
+    for random_target in [
+        "p256_sha256",
+        "p256_sha384",
+        "p256_sha512",
+        "p256_sha3_256",
+        "p256_sha3_384",
+        "p256_sha3_512",
+        # TODO uncomment when cryptolib supports ECDSA with P-384
+        # "p384_sha256",
+        # "p384_sha384",
+        # "p384_sha512",
+        # "p384_sha3_256",
+        # "p384_sha3_384",
+        # "p384_sha3_512",
+    ]
 ]
 
 ECDSA_TESTVECTOR_ARGS = " ".join([

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -135,6 +135,49 @@ run_binary(
     tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_ed25519_parser",
 )
 
+# Number of tests per configuration (e.g. Verify P-256 SHA-256)
+ECDSA_RANDOM_COUNT = 128
+
+[
+    run_binary(
+        name = cryptotest_name,
+        srcs = [
+            "//sw/host/cryptotest/testvectors/data/schemas:ecdsa_schema",
+        ],
+        outs = [":{}.json".format(cryptotest_name)],
+        args = [
+            "--dst",
+            "$(location :{}.json)".format(cryptotest_name),
+            "--schema",
+            "$(location //sw/host/cryptotest/testvectors/data/schemas:ecdsa_schema)",
+            "--count",
+            str(ECDSA_RANDOM_COUNT),
+            "--curve",
+            curve,
+            "--hash_alg",
+            hash_alg,
+        ],
+        # Do not cache these results in CI, so every run generates a new set of
+        # random test vectors.
+        tags = ["no-cache"],
+        tool = "//sw/host/cryptotest/testvectors/parsers:random_ecdsa_generator",
+    )
+    for cryptotest_name, curve, hash_alg in [
+        ("random_ecdsa_p256_sha256", "p256", "sha-256"),
+        ("random_ecdsa_p256_sha384", "p256", "sha-384"),
+        ("random_ecdsa_p256_sha512", "p256", "sha-512"),
+        ("random_ecdsa_p256_sha3_256", "p256", "sha3-256"),
+        ("random_ecdsa_p256_sha3_384", "p256", "sha3-384"),
+        ("random_ecdsa_p256_sha3_512", "p256", "sha3-512"),
+        ("random_ecdsa_p384_sha256", "p384", "sha-256"),
+        ("random_ecdsa_p384_sha384", "p384", "sha-384"),
+        ("random_ecdsa_p384_sha512", "p384", "sha-512"),
+        ("random_ecdsa_p384_sha3_256", "p384", "sha3-256"),
+        ("random_ecdsa_p384_sha3_384", "p384", "sha3-384"),
+        ("random_ecdsa_p384_sha3_512", "p384", "sha3-512"),
+    ]
+]
+
 [
     run_binary(
         name = "nist_cavp_{}_{}_{}_json".format(

--- a/sw/host/cryptotest/testvectors/data/schemas/ecdsa_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ecdsa_schema.json
@@ -59,6 +59,10 @@
         "description": "Qy",
         "type": "string"
       },
+      "d": {
+        "description": "Private value d",
+        "type": "string"
+      },
       "r": {
         "description": "r parameter",
         "type": "string"

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -88,6 +88,16 @@ py_binary(
 )
 
 py_binary(
+    name = "random_ecdsa_generator",
+    srcs = ["random_ecdsa_generator.py"],
+    deps = [
+        ":cryptotest_util",
+        requirement("jsonschema"),
+        requirement("pycryptodome"),
+    ],
+)
+
+py_binary(
     name = "nist_cavp_hash_parser",
     srcs = ["nist_cavp_hash_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
+++ b/sw/host/cryptotest/testvectors/parsers/cryptotest_util.py
@@ -2,6 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import random
+from typing import Callable
+
+
 def parse_rsp(file_path: str, persists: list[str] = []) -> dict:
     """Parser for NIST `.rsp` files.
 
@@ -117,3 +121,14 @@ def str_to_byte_array(s: str) -> list:
     for i in range(0, len(s), 2):
         byte_array.append(int(s[i:i + 2], 16))
     return byte_array
+
+
+def rng() -> Callable[[int], bytes]:
+    """
+    Initializes the `random` module for generating random test vectors.
+    """
+    seed = random.randrange(0, 2 ** 32)
+    # Log random seed for reproducability in CI runs
+    print(f"RANDOM SEED = {seed}")
+    random.seed(seed)
+    return random.randbytes

--- a/sw/host/cryptotest/testvectors/parsers/random_ecdsa_generator.py
+++ b/sw/host/cryptotest/testvectors/parsers/random_ecdsa_generator.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import logging
+import math
+import sys
+
+import jsonschema
+from Crypto.Hash import SHA256, SHA384, SHA512, SHA3_256, SHA3_384, SHA3_512
+from Crypto.PublicKey import ECC
+from Crypto.Signature import DSS
+from cryptotest_util import rng
+
+MESSAGE_LENGTH = 512
+
+
+def generate_test_vectors(args):
+    test_vectors = []
+    random = rng()
+    # Parse tests within the group
+    for count in range(args.count):
+        # Generate random ECC key pair
+        key_pair = ECC.generate(curve=args.curve, randfunc=random)
+        public = key_pair.pointQ
+        msg = random(MESSAGE_LENGTH)
+        signature = []
+        # Sign digest of message using private key
+        if args.hash_alg == "sha-256":
+            digest = SHA256.new(msg)
+        elif args.hash_alg == "sha-384":
+            digest = SHA384.new(msg)
+        elif args.hash_alg == "sha-512":
+            digest = SHA512.new(msg)
+        elif args.hash_alg == "sha3-256":
+            digest = SHA3_256.new(msg)
+        elif args.hash_alg == "sha3-384":
+            digest = SHA3_384.new(msg)
+        elif args.hash_alg == "sha3-512":
+            digest = SHA3_512.new(msg)
+        else:
+            raise ValueError("Unsupported hash algorithm " + args.hash_alg)
+        signer = DSS.new(key_pair, 'fips-186-3', randfunc=random)
+        signature = signer.sign(digest)
+
+        signature = list(signature)
+
+        verify_result = True
+        # Decide whether to flip a bit in the signature, creating a
+        # negative test.
+        if random(1)[0] % 2 == 0:
+            if len(signature) == 0:
+                # To change an empty signature, make it a single random byte
+                signature = list(random(1))
+            else:
+                # Flip a random bit in the signature
+                idx = int.from_bytes(random(4), "big") % (len(signature) * 8)
+                signature[math.floor(idx / 8)] ^= 1 << (idx % 8)
+                verify_result = False
+
+        r = signature[:int(len(signature) / 2)]
+        s = signature[int(len(signature) / 2):]
+
+        d = hex(int(key_pair.d))[2:]
+
+        # Create sign test vector (currently only SHA-2 is supported)
+        if args.hash_alg.startswith("sha-"):
+            test_vectors.append({
+                "vendor": "random",
+                "test_case_id": count,
+                "algorithm": "ecdsa",
+                "operation": "sign",
+                "curve": args.curve,
+                "hash_alg": args.hash_alg,
+                "message": list(msg),
+                # The [2:] removes the '0x' at the beginning of hex strings
+                "qx": hex(int(public.x))[2:],
+                "qy": hex(int(public.y))[2:],
+                "d": d,
+                "result": True,
+            })
+
+        # Create verify test vector
+        test_vectors.append({
+            "vendor": "random",
+            "test_case_id": count,
+            "algorithm": "ecdsa",
+            "operation": "verify",
+            "curve": args.curve,
+            "hash_alg": args.hash_alg,
+            "message": list(msg),
+            # The [2:] removes the '0x' at the beginning of hex strings
+            "qx": hex(int(public.x))[2:],
+            "qy": hex(int(public.y))[2:],
+            "r": bytes(r).hex(),
+            "s": bytes(s).hex(),
+            "result": verify_result,
+        })
+
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dst',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help='Write output to this file.')
+    parser.add_argument('--schema', type=str, help='Testvector schema file')
+    parser.add_argument('--count', type=int, help='Number of test vectors to generate')
+    parser.add_argument('--curve', type=str, help='Elliptic curve [p256, p384]')
+    parser.add_argument('--hash_alg',
+                        type=str,
+                        help='Hash algorithm \
+                        [sha-256, sha-384, sha-512, sha3-256, sha3-384, sha3-512]')
+    args = parser.parse_args()
+
+    testvecs = generate_test_vectors(args)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    logging.info(f"Created {len(testvecs)} tests")
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Adds a generator for random ECDSA tests. Per the crypto testplan, the randomness is sourced using a seed generated using python's internal randomness source. This seed is printed to `stderr` to allow for reproducible results in CI.

This PR also includes a few small changes to the ECDSA test harness to allow the random tests to work properly. The changes have been regression-tested against the existing test vectors.

~Dependent on #21713~