### PR TITLE
Revert "[ast] fixing always_comb lint"

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
@@ -31,7 +31,7 @@ initial begin
   init_start = 1'b0;
 end
 
-always_comb begin
+always @( * ) begin
   if ( init_start ) begin
     vcaon_pok_o <= 1'b0;
   end else if ( !init_start && gen_supp_a ) begin

--- a/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
@@ -31,7 +31,7 @@ initial begin
   init_start = 1'b0;
 end
 
-always_comb (* xprop_off *) begin
+always (* xprop_off *) @( * ) begin
   if ( init_start ) begin
     vcc_pok_o <= 1'b0;
   end

--- a/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
@@ -31,7 +31,7 @@ initial begin
   init_start = 1'b0;
 end
 
-always_comb begin
+always @( * ) begin
   if ( init_start ) begin
     vcmain_pok_o <= 1'b0;
   end else if ( !init_start && gen_supp_a ) begin

--- a/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
@@ -31,7 +31,7 @@ initial begin
   init_start = 1'b0;
 end
 
-always_comb (* xprop_off *) begin
+always (* xprop_off *) @( * ) begin
   if ( init_start ) begin
     vio_pok_o <= 1'b0;
   end


### PR DESCRIPTION
This reverts commit e8bfccf76c80a082870348b4f2acfec2a27b3c17. The change here doesn't work at all (you can't put #(...) delays inside an always_comb).

Undo the change for now: we can try to fix things properly when CI is working again.