### PR TITLE
[dv,usbdev] Fixes to DV sequences for usbdev

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -884,6 +884,8 @@
                   '''
           }
         ]
+        tags: [// 'rdy', 'pend' and 'sending' bits interact with each other.
+               "excl:CsrNonInitTests:CsrExclWrite"]
       }
     }
     { multireg: {

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -19,25 +19,38 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
   endtask
 
   task body();
+    // Expected data content of packet
+    byte unsigned exp_data[];
     uvm_reg_data_t rd_data;
+
     ral.usbctrl.enable.set(1'b1);  // Set usbdev control register enable bit.
     ral.usbctrl.device_address.set(0);
     csr_update(ral.usbctrl);
+
     configure_out_trans(); // register configurations for OUT Trans.
+
+    // Enable pkt_received interrupt
+    ral.intr_enable.pkt_received.set(1'b1);
+    csr_update(ral.intr_enable);
+
     call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
+    cfg.clk_rst_vif.wait_clks(10);
     call_data_seq(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);
-    // Verifies that usb device is enabled and received packet and sends ACK.
-    check_trans_accuracy();
+
+    recover_orig_data(m_data_pkt.data, exp_data);
+    // Check that the USB device received a packet with the expected properties.
+    check_pkt_received(endp, 0, out_buffer_id, exp_data);
   endtask
 
-  task check_trans_accuracy();
-    uvm_reg_data_t intr_state;
-    csr_rd(.ptr(ral.intr_state), .value(intr_state));
-    // DV_CHECK on pkt_received interrupt
-    `DV_CHECK_EQ(get_field_val(ral.intr_state.pkt_received, intr_state), 1)
-  endtask
+  // TODO: Presently the act of sending a data packet, destructively modifies it!
+  // Restore the data packet to its original state. This just bit-reverses each byte
+  // within the input array.
+  function recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
+    out = {<<8{in}};  // Reverse the order of the bytes
+    out = {<<{out}};  // Bit-reverse everything
+  endfunction
+
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -9,8 +9,15 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
+    // Expected data content of packet
+    byte unsigned exp_data[];
+
     // Configure transaction
     configure_out_trans();
+    // Enable pkt_received interrupt
+    ral.intr_enable.pkt_received.set(1'b1);
+    csr_update(ral.intr_enable);
+
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(10);
@@ -18,17 +25,18 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);
-    cfg.clk_rst_vif.wait_clks(10);
-    // Check transaction accuracy
-    check_trans_accuracy();
+
+    recover_orig_data(m_data_pkt.data, exp_data);
+    // Check that the USB device received a packet with the expected properties.
+    check_pkt_received(endp, 0, out_buffer_id, exp_data);
   endtask
 
-  task check_trans_accuracy();
-    uvm_reg_data_t intr_state;
-    // Read intr_state reg
-    csr_rd(.ptr(ral.intr_state), .value(intr_state));
-    // DV_CHECK on pkt_received interrupt
-    `DV_CHECK_EQ(get_field_val(ral.intr_state.pkt_received, intr_state), 1)
-  endtask
+  // TODO: Presently the act of sending a data packet, destructively modifies it!
+  // Restore the data packet to its original state. This just bit-reverses each byte
+  // within the input array.
+  function recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
+    out = {<<8{in}};  // Reverse the order of the bytes
+    out = {<<{out}};  // Bit-reverse everything
+  endfunction
 
 endclass


### PR DESCRIPTION
Some recent RTL changes shown below have not been mirrored with DV changes and thus sequences have been failing more often:

- the 'pkt_received' interrupt is now a Status type interrupt and will become deasserted when the RX FIFO entry is read.
- the 'configin' registers must now be excluded from automated CSR testing because there is an interaction among the register bits.

Additionally, since checking of the RX packet properties and content is now available within the base sequence, modify the OUT side sequences to benefit from this more extensive testing.

(Note that whilst the 'recover_orig_data' function is local to each affected sequence for now, rather than shared in the base class, this is because the function should soon be unnecessary. The action of transmitting a data packet should not cause the object to be modified in the present manner.)