### PR TITLE
[entropy_src] Reduce depth of Observe FIFO

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -118,7 +118,7 @@
     # Selecting values different from the default values below might cause undefined behavior.
     { name:    "ObserveFifoDepth",
       type:    "int unsigned",
-      default: "64",
+      default: "32",
       desc:    '''
                 Number of 32-bit entries in the observe FIFO.
                 Note that upon changing this parameter, the bit widths of the !!OBSERVE_FIFO_THRESH and !!OBSERVE_FIFO_DEPTH registers have to be manually adjusted.
@@ -1408,12 +1408,12 @@
       hwaccess: "hro",
       regwen:   "REGWEN",
       fields: [
-        { bits: "6:0",
+        { bits: "5:0",
           desc: '''This field will set the threshold that the depth of the observe FIFO
                 will be compared with when setting the interrupt status bit.
                 Note: a value of zero is reserved and not to be used.
                 '''
-          resval: "0x20"
+          resval: "0x10"
         }
       ]
     },
@@ -1423,7 +1423,7 @@
       hwaccess: "hwo",
       hwext: "true",
       fields: [
-        { bits: "6:0",
+        { bits: "5:0",
           desc: '''This field will hold the current depth of the observe FIFO.
                 '''
         }

--- a/hw/ip/entropy_src/doc/entsrc_blk_diag.svg
+++ b/hw/ip/entropy_src/doc/entsrc_blk_diag.svg
@@ -1120,7 +1120,7 @@
                  v:horizAlign="1" /><v:tabList /><tspan
                  style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle"
                  id="tspan184287"
-                 dy="0 0 0 0 0 0 0 0">64 x 32b</tspan><v:newlineChar /></tspan><tspan
+                 dy="0 0 0 0 0 0 0 0 0">32 x 32b</tspan><v:newlineChar /></tspan><tspan
                sodipodi:role="line"
                id="tspan187058"
                x="22.733574"

--- a/hw/ip/entropy_src/doc/programmers_guide.md
+++ b/hw/ip/entropy_src/doc/programmers_guide.md
@@ -56,7 +56,7 @@ It further has to set the `FW_OV_INSERT_START` field in the [`FW_OV_SHA3_START`]
 Once all entropy bits have been written to the [`FW_OV_WR_DATA`](registers.md#fw_ov_wr_data) register, firmware can set `FW_OV_INSERT_START` to `kMultiBitBool4False` to trigger the hardware conditioning mechanism.
 
 Note that if the `FW_OV_ENTROPY_INSERT` field is set to `kMultiBitBool4True`, post-health test entropy bits do NOT continue to flow through the hardware pipeline.
-The observe FIFO will collect 2 kBit of contiguous entropy bits.
+The observe FIFO will collect 1 kBit of contiguous entropy bits.
 Any entropy bits arriving after the observe FIFO is full are being discarded.
 Firmware has to read out the entire observe FIFO to restart entropy collection.
 Only entropy bits inserted by firmware by writing the [`FW_OV_WR_DATA`](registers.md#fw_ov_wr_data) register may eventually reach the block hardware interface.

--- a/hw/ip/entropy_src/doc/registers.md
+++ b/hw/ip/entropy_src/doc/registers.md
@@ -1295,37 +1295,37 @@ In addition, the otp_en_entropy_src_fw_over input needs to be set to `kMultiBitB
 ## OBSERVE_FIFO_THRESH
 Observe FIFO threshold register
 - Offset: `0xc8`
-- Reset default: `0x20`
-- Reset mask: `0x7f`
+- Reset default: `0x10`
+- Reset mask: `0x3f`
 - Register enable: [`REGWEN`](#regwen)
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "OBSERVE_FIFO_THRESH", "bits": 7, "attr": ["rw"], "rotate": -90}, {"bits": 25}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
+{"reg": [{"name": "OBSERVE_FIFO_THRESH", "bits": 6, "attr": ["rw"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 210}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                | Description                                                                                                                                                                             |
 |:------:|:------:|:-------:|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:7  |        |         |                     | Reserved                                                                                                                                                                                |
-|  6:0   |   rw   |  0x20   | OBSERVE_FIFO_THRESH | This field will set the threshold that the depth of the observe FIFO will be compared with when setting the interrupt status bit. Note: a value of zero is reserved and not to be used. |
+|  31:6  |        |         |                     | Reserved                                                                                                                                                                                |
+|  5:0   |   rw   |  0x10   | OBSERVE_FIFO_THRESH | This field will set the threshold that the depth of the observe FIFO will be compared with when setting the interrupt status bit. Note: a value of zero is reserved and not to be used. |
 
 ## OBSERVE_FIFO_DEPTH
 Observe FIFO depth register
 - Offset: `0xcc`
 - Reset default: `0x0`
-- Reset mask: `0x7f`
+- Reset mask: `0x3f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "OBSERVE_FIFO_DEPTH", "bits": 7, "attr": ["ro"], "rotate": -90}, {"bits": 25}], "config": {"lanes": 1, "fontsize": 10, "vspace": 200}}
+{"reg": [{"name": "OBSERVE_FIFO_DEPTH", "bits": 6, "attr": ["ro"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 200}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name               | Description                                                 |
 |:------:|:------:|:-------:|:-------------------|:------------------------------------------------------------|
-|  31:7  |        |         |                    | Reserved                                                    |
-|  6:0   |   ro   |    x    | OBSERVE_FIFO_DEPTH | This field will hold the current depth of the observe FIFO. |
+|  31:6  |        |         |                    | Reserved                                                    |
+|  5:0   |   ro   |    x    | OBSERVE_FIFO_DEPTH | This field will hold the current depth of the observe FIFO. |
 
 ## DEBUG_STATUS
 Debug status register

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -7,7 +7,7 @@
 package entropy_src_reg_pkg;
 
   // Param list
-  parameter int unsigned ObserveFifoDepth = 64;
+  parameter int unsigned ObserveFifoDepth = 32;
   parameter int NumAlerts = 2;
 
   // Address widths within the block
@@ -264,7 +264,7 @@ package entropy_src_reg_pkg;
   } entropy_src_reg2hw_fw_ov_wr_data_reg_t;
 
   typedef struct packed {
-    logic [6:0]  q;
+    logic [5:0]  q;
   } entropy_src_reg2hw_observe_fifo_thresh_reg_t;
 
   typedef struct packed {
@@ -549,7 +549,7 @@ package entropy_src_reg_pkg;
   } entropy_src_hw2reg_fw_ov_rd_data_reg_t;
 
   typedef struct packed {
-    logic [6:0]  d;
+    logic [5:0]  d;
   } entropy_src_hw2reg_observe_fifo_depth_reg_t;
 
   typedef struct packed {
@@ -712,73 +712,73 @@ package entropy_src_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    entropy_src_reg2hw_intr_state_reg_t intr_state; // [552:549]
-    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [548:545]
-    entropy_src_reg2hw_intr_test_reg_t intr_test; // [544:537]
-    entropy_src_reg2hw_alert_test_reg_t alert_test; // [536:533]
-    entropy_src_reg2hw_sw_regupd_reg_t sw_regupd; // [532:532]
-    entropy_src_reg2hw_module_enable_reg_t module_enable; // [531:528]
-    entropy_src_reg2hw_conf_reg_t conf; // [527:502]
-    entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [501:494]
-    entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [493:461]
-    entropy_src_reg2hw_health_test_windows_reg_t health_test_windows; // [460:429]
-    entropy_src_reg2hw_repcnt_thresholds_reg_t repcnt_thresholds; // [428:395]
-    entropy_src_reg2hw_repcnts_thresholds_reg_t repcnts_thresholds; // [394:361]
-    entropy_src_reg2hw_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [360:327]
-    entropy_src_reg2hw_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [326:293]
-    entropy_src_reg2hw_bucket_thresholds_reg_t bucket_thresholds; // [292:259]
-    entropy_src_reg2hw_markov_hi_thresholds_reg_t markov_hi_thresholds; // [258:225]
-    entropy_src_reg2hw_markov_lo_thresholds_reg_t markov_lo_thresholds; // [224:191]
-    entropy_src_reg2hw_extht_hi_thresholds_reg_t extht_hi_thresholds; // [190:157]
-    entropy_src_reg2hw_extht_lo_thresholds_reg_t extht_lo_thresholds; // [156:123]
-    entropy_src_reg2hw_alert_threshold_reg_t alert_threshold; // [122:91]
-    entropy_src_reg2hw_fw_ov_control_reg_t fw_ov_control; // [90:83]
-    entropy_src_reg2hw_fw_ov_sha3_start_reg_t fw_ov_sha3_start; // [82:79]
-    entropy_src_reg2hw_fw_ov_rd_data_reg_t fw_ov_rd_data; // [78:46]
-    entropy_src_reg2hw_fw_ov_wr_data_reg_t fw_ov_wr_data; // [45:13]
-    entropy_src_reg2hw_observe_fifo_thresh_reg_t observe_fifo_thresh; // [12:6]
+    entropy_src_reg2hw_intr_state_reg_t intr_state; // [551:548]
+    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [547:544]
+    entropy_src_reg2hw_intr_test_reg_t intr_test; // [543:536]
+    entropy_src_reg2hw_alert_test_reg_t alert_test; // [535:532]
+    entropy_src_reg2hw_sw_regupd_reg_t sw_regupd; // [531:531]
+    entropy_src_reg2hw_module_enable_reg_t module_enable; // [530:527]
+    entropy_src_reg2hw_conf_reg_t conf; // [526:501]
+    entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [500:493]
+    entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [492:460]
+    entropy_src_reg2hw_health_test_windows_reg_t health_test_windows; // [459:428]
+    entropy_src_reg2hw_repcnt_thresholds_reg_t repcnt_thresholds; // [427:394]
+    entropy_src_reg2hw_repcnts_thresholds_reg_t repcnts_thresholds; // [393:360]
+    entropy_src_reg2hw_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [359:326]
+    entropy_src_reg2hw_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [325:292]
+    entropy_src_reg2hw_bucket_thresholds_reg_t bucket_thresholds; // [291:258]
+    entropy_src_reg2hw_markov_hi_thresholds_reg_t markov_hi_thresholds; // [257:224]
+    entropy_src_reg2hw_markov_lo_thresholds_reg_t markov_lo_thresholds; // [223:190]
+    entropy_src_reg2hw_extht_hi_thresholds_reg_t extht_hi_thresholds; // [189:156]
+    entropy_src_reg2hw_extht_lo_thresholds_reg_t extht_lo_thresholds; // [155:122]
+    entropy_src_reg2hw_alert_threshold_reg_t alert_threshold; // [121:90]
+    entropy_src_reg2hw_fw_ov_control_reg_t fw_ov_control; // [89:82]
+    entropy_src_reg2hw_fw_ov_sha3_start_reg_t fw_ov_sha3_start; // [81:78]
+    entropy_src_reg2hw_fw_ov_rd_data_reg_t fw_ov_rd_data; // [77:45]
+    entropy_src_reg2hw_fw_ov_wr_data_reg_t fw_ov_wr_data; // [44:12]
+    entropy_src_reg2hw_observe_fifo_thresh_reg_t observe_fifo_thresh; // [11:6]
     entropy_src_reg2hw_err_code_test_reg_t err_code_test; // [5:0]
   } entropy_src_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1080:1073]
-    entropy_src_hw2reg_regwen_reg_t regwen; // [1072:1071]
-    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1070:1039]
-    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1038:1007]
-    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [1006:975]
-    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [974:943]
-    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [942:911]
-    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [910:879]
-    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [878:847]
-    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [846:815]
-    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [814:783]
-    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [782:751]
-    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [750:719]
-    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [718:687]
-    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [686:655]
-    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [654:623]
-    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [622:591]
-    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [590:559]
-    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [558:527]
-    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [526:495]
-    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [494:463]
-    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [462:431]
-    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [430:399]
-    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [398:367]
-    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [366:335]
-    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [334:303]
-    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [302:271]
-    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [270:239]
-    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [238:207]
-    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [206:175]
-    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [174:159]
-    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [158:131]
-    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [130:123]
-    entropy_src_hw2reg_fw_ov_wr_fifo_full_reg_t fw_ov_wr_fifo_full; // [122:122]
-    entropy_src_hw2reg_fw_ov_rd_fifo_overflow_reg_t fw_ov_rd_fifo_overflow; // [121:120]
-    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [119:88]
-    entropy_src_hw2reg_observe_fifo_depth_reg_t observe_fifo_depth; // [87:81]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1079:1072]
+    entropy_src_hw2reg_regwen_reg_t regwen; // [1071:1070]
+    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1069:1038]
+    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1037:1006]
+    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [1005:974]
+    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [973:942]
+    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [941:910]
+    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [909:878]
+    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [877:846]
+    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [845:814]
+    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [813:782]
+    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [781:750]
+    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [749:718]
+    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [717:686]
+    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [685:654]
+    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [653:622]
+    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [621:590]
+    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [589:558]
+    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [557:526]
+    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [525:494]
+    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [493:462]
+    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [461:430]
+    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [429:398]
+    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [397:366]
+    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [365:334]
+    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [333:302]
+    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [301:270]
+    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [269:238]
+    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [237:206]
+    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [205:174]
+    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [173:158]
+    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [157:130]
+    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [129:122]
+    entropy_src_hw2reg_fw_ov_wr_fifo_full_reg_t fw_ov_wr_fifo_full; // [121:121]
+    entropy_src_hw2reg_fw_ov_rd_fifo_overflow_reg_t fw_ov_rd_fifo_overflow; // [120:119]
+    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [118:87]
+    entropy_src_hw2reg_observe_fifo_depth_reg_t observe_fifo_depth; // [86:81]
     entropy_src_hw2reg_debug_status_reg_t debug_status; // [80:70]
     entropy_src_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [69:34]
     entropy_src_hw2reg_err_code_reg_t err_code; // [33:10]
@@ -911,7 +911,7 @@ package entropy_src_reg_pkg;
   parameter logic [0:0] ENTROPY_SRC_FW_OV_WR_FIFO_FULL_RESVAL = 1'h 0;
   parameter logic [31:0] ENTROPY_SRC_FW_OV_RD_DATA_RESVAL = 32'h 0;
   parameter logic [31:0] ENTROPY_SRC_FW_OV_WR_DATA_RESVAL = 32'h 0;
-  parameter logic [6:0] ENTROPY_SRC_OBSERVE_FIFO_DEPTH_RESVAL = 7'h 0;
+  parameter logic [5:0] ENTROPY_SRC_OBSERVE_FIFO_DEPTH_RESVAL = 6'h 0;
   parameter logic [17:0] ENTROPY_SRC_DEBUG_STATUS_RESVAL = 18'h 10000;
   parameter logic [0:0] ENTROPY_SRC_DEBUG_STATUS_MAIN_SM_IDLE_RESVAL = 1'h 1;
 

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -320,10 +320,10 @@ module entropy_src_reg_top (
   logic fw_ov_wr_data_we;
   logic [31:0] fw_ov_wr_data_wd;
   logic observe_fifo_thresh_we;
-  logic [6:0] observe_fifo_thresh_qs;
-  logic [6:0] observe_fifo_thresh_wd;
+  logic [5:0] observe_fifo_thresh_qs;
+  logic [5:0] observe_fifo_thresh_wd;
   logic observe_fifo_depth_re;
-  logic [6:0] observe_fifo_depth_qs;
+  logic [5:0] observe_fifo_depth_qs;
   logic debug_status_re;
   logic [1:0] debug_status_entropy_fifo_depth_qs;
   logic [2:0] debug_status_sha3_fsm_qs;
@@ -2349,9 +2349,9 @@ module entropy_src_reg_top (
   logic observe_fifo_thresh_gated_we;
   assign observe_fifo_thresh_gated_we = observe_fifo_thresh_we & regwen_qs;
   prim_subreg #(
-    .DW      (7),
+    .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (7'h20),
+    .RESVAL  (6'h10),
     .Mubi    (1'b0)
   ) u_observe_fifo_thresh (
     .clk_i   (clk_i),
@@ -2377,7 +2377,7 @@ module entropy_src_reg_top (
 
   // R[observe_fifo_depth]: V(True)
   prim_subreg_ext #(
-    .DW    (7)
+    .DW    (6)
   ) u_observe_fifo_depth (
     .re     (observe_fifo_depth_re),
     .we     (1'b0),
@@ -3685,7 +3685,7 @@ module entropy_src_reg_top (
   assign fw_ov_wr_data_wd = reg_wdata[31:0];
   assign observe_fifo_thresh_we = addr_hit[50] & reg_we & !reg_error;
 
-  assign observe_fifo_thresh_wd = reg_wdata[6:0];
+  assign observe_fifo_thresh_wd = reg_wdata[5:0];
   assign observe_fifo_depth_re = addr_hit[51] & reg_re & !reg_error;
   assign debug_status_re = addr_hit[52] & reg_re & !reg_error;
   assign recov_alert_sts_we = addr_hit[53] & reg_we & !reg_error;
@@ -4043,11 +4043,11 @@ module entropy_src_reg_top (
       end
 
       addr_hit[50]: begin
-        reg_rdata_next[6:0] = observe_fifo_thresh_qs;
+        reg_rdata_next[5:0] = observe_fifo_thresh_qs;
       end
 
       addr_hit[51]: begin
-        reg_rdata_next[6:0] = observe_fifo_depth_qs;
+        reg_rdata_next[5:0] = observe_fifo_depth_qs;
       end
 
       addr_hit[52]: begin

--- a/sw/device/tests/entropy_src_ast_rng_req_test.c
+++ b/sw/device/tests/entropy_src_ast_rng_req_test.c
@@ -19,7 +19,7 @@ enum {
    * The size of the buffer used in firmware to process the entropy bits in
    * firmware override mode.
    */
-  kEntropyFifoBufferSize = 32,
+  kEntropyFifoBufferSize = 16,
 };
 
 static uint32_t read_fifo_depth(dif_entropy_src_t *entropy) {

--- a/sw/device/tests/entropy_src_fw_observe_many_contiguous.c
+++ b/sw/device/tests/entropy_src_fw_observe_many_contiguous.c
@@ -22,7 +22,7 @@ enum {
   /**
    * Observe FIFO threshold: half of the FIFO size.
    */
-  kEntropySrcFifoThreshold = 32,
+  kEntropySrcFifoThreshold = 16,
   /**
    * The number of contiguous samples we want to capture.
    */

--- a/sw/device/tests/entropy_src_fw_override_test.c
+++ b/sw/device/tests/entropy_src_fw_override_test.c
@@ -33,7 +33,7 @@ enum {
   /**
    * Observe FIFO threshold: half of the FIFO size.
    */
-  kEntropySrcFifoThreshold = 32,
+  kEntropySrcFifoThreshold = 16,
   /**
    * The number of contiguous samples we want to capture.
    */

--- a/sw/device/tests/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src_fw_ovr_test.c
@@ -20,7 +20,7 @@ enum {
    * The size of the buffer used in firmware to process the entropy bits in
    * firmware override mode.
    */
-  kEntropyFifoBufferSize = 32,
+  kEntropyFifoBufferSize = 16,
 };
 
 /**

--- a/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
+++ b/sw/device/tests/sim_dv/ast_clk_rst_inputs.c
@@ -68,7 +68,7 @@ enum {
    * The size of the buffer used in firmware to process the entropy bits in
    * firmware override mode.
    */
-  kEntropyFifoBufferSize = 32,
+  kEntropyFifoBufferSize = 16,
 };
 
 enum {


### PR DESCRIPTION
Halving the depth of the observe FIFO allows saving 1024 FFs. With a FIFO size of 1 kbit, it is still possible to buffer a full, contiguous 1024-sample window in single-channel mode. For the multi-channel mode, an experiment on the engineering sample showed that Ibex is fast enough in reading out the FIFO to avoid it overflowing during read out.

First block-level tests look good, I am running a full regression now. What also should be done:
- Check the affected TLTs explicitly.
- Check the documentation.

I'll continue this work later tonight.