### PR TITLE
[cryptotest] Add support for silicon execution environments.

### DIFF
--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -4,8 +4,8 @@
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
-    "opentitan_binary",
     "opentitan_test",
+    "silicon_params",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -22,20 +22,48 @@ testvector_args = " ".join([
     for target in testvector_targets
 ])
 
+# Defines default execution environments for cryptotest targets. All
+# opentitan_test must have the following attributes to configure
+# each execution environment:
+# - cw310
+# - silicon
+# - silicon_prodc
+CRYPTOTEST_EXEC_ENVS = {
+    "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon",
+    "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_prodc",
+}
+
 opentitan_test(
     name = "aes_kat_test",
     cw310 = cw310_params(
         timeout = "long",
-        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
         data = testvector_targets,
         test_cmd = """
             --bootstrap={firmware}
         """ + testvector_args,
         test_harness = "//sw/host/tests/crypto/aes_nist_kat:harness",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
+        data = testvector_targets,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + testvector_args,
+        test_harness = "//sw/host/tests/crypto/aes_nist_kat:harness",
+    ),
+    silicon_prodc = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_prodc_rom_ext": "firmware"},
+        data = testvector_targets,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + testvector_args,
+        test_harness = "//sw/host/tests/crypto/aes_nist_kat:harness",
+    ),
 )
 
 ECDSA_TESTVECTOR_TARGETS = [
@@ -64,16 +92,32 @@ opentitan_test(
     name = "ecdsa_kat",
     cw310 = cw310_params(
         timeout = "long",
-        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
         data = ECDSA_TESTVECTOR_TARGETS,
         test_cmd = """
             --bootstrap={firmware}
         """ + ECDSA_TESTVECTOR_ARGS,
         test_harness = "//sw/host/tests/crypto/ecdsa_kat:harness",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
+        data = ECDSA_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + ECDSA_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/ecdsa_kat:harness",
+    ),
+    silicon_prodc = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_prodc_rom_ext": "firmware"},
+        data = ECDSA_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + ECDSA_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/ecdsa_kat:harness",
+    ),
 )
 
 ECDH_TESTVECTOR_TARGETS = [
@@ -96,16 +140,32 @@ opentitan_test(
     name = "ecdh_kat",
     cw310 = cw310_params(
         timeout = "long",
-        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
         data = ECDH_TESTVECTOR_TARGETS,
         test_cmd = """
             --bootstrap={firmware}
         """ + ECDH_TESTVECTOR_ARGS,
         test_harness = "//sw/host/tests/crypto/ecdh_kat:harness",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
+        data = ECDH_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + ECDH_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/ecdh_kat:harness",
+    ),
+    silicon_prodc = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_prodc_rom_ext": "firmware"},
+        data = ECDH_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + ECDH_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/ecdh_kat:harness",
+    ),
 )
 
 HASH_TESTVECTOR_TARGETS = [
@@ -147,16 +207,32 @@ opentitan_test(
     name = "hash_kat",
     cw310 = cw310_params(
         timeout = "long",
-        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
         data = HASH_TESTVECTOR_TARGETS,
         test_cmd = """
                 --bootstrap={firmware}
             """ + HASH_TESTVECTOR_ARGS,
         test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
+        data = HASH_TESTVECTOR_TARGETS,
+        test_cmd = """
+                --bootstrap={firmware}
+            """ + HASH_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/hash_kat:harness",
+    ),
+    silicon_prodc = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_prodc_rom_ext": "firmware"},
+        data = HASH_TESTVECTOR_TARGETS,
+        test_cmd = """
+                --bootstrap={firmware}
+            """ + HASH_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/hash_kat:harness",
+    ),
 )
 
 DRBG_TESTVECTOR_TARGETS = [
@@ -173,16 +249,32 @@ opentitan_test(
     name = "drbg_kat",
     cw310 = cw310_params(
         timeout = "long",
-        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
         data = DRBG_TESTVECTOR_TARGETS,
         test_cmd = """
                 --bootstrap={firmware}
             """ + DRBG_TESTVECTOR_ARGS,
         test_harness = "//sw/host/tests/crypto/drbg_kat:harness",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
+        data = DRBG_TESTVECTOR_TARGETS,
+        test_cmd = """
+                --bootstrap={firmware}
+            """ + DRBG_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/drbg_kat:harness",
+    ),
+    silicon_prodc = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_prodc_rom_ext": "firmware"},
+        data = DRBG_TESTVECTOR_TARGETS,
+        test_cmd = """
+                --bootstrap={firmware}
+            """ + DRBG_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/drbg_kat:harness",
+    ),
 )
 
 HMAC_TESTVECTOR_TARGETS = [
@@ -208,16 +300,32 @@ opentitan_test(
     name = "hmac_kat",
     cw310 = cw310_params(
         timeout = "long",
-        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
         data = HMAC_TESTVECTOR_TARGETS,
         test_cmd = """
             --bootstrap={firmware}
         """ + HMAC_TESTVECTOR_ARGS,
         test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
+        data = HMAC_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + HMAC_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
+    ),
+    silicon_prodc = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_prodc_rom_ext": "firmware"},
+        data = HMAC_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + HMAC_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
+    ),
 )
 
 KMAC_TESTVECTOR_TARGETS = [
@@ -237,14 +345,30 @@ opentitan_test(
     name = "kmac_kat",
     cw310 = cw310_params(
         timeout = "long",
-        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware": "firmware"},
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
         data = KMAC_TESTVECTOR_TARGETS,
         test_cmd = """
             --bootstrap={firmware}
         """ + KMAC_TESTVECTOR_ARGS,
         test_harness = "//sw/host/tests/crypto/kmac_kat:harness",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
+        data = KMAC_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + KMAC_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/kmac_kat:harness",
+    ),
+    silicon_prodc = silicon_params(
+        timeout = "long",
+        binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_prodc_rom_ext": "firmware"},
+        data = KMAC_TESTVECTOR_TARGETS,
+        test_cmd = """
+            --bootstrap={firmware}
+        """ + KMAC_TESTVECTOR_ARGS,
+        test_harness = "//sw/host/tests/crypto/kmac_kat:harness",
+    ),
 )

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -316,7 +316,7 @@ FIRMWARE_DEPS = [
     "//sw/device/lib/ujson",
 
     # Include all JSON commands.
-    "//sw/device/tests/crypto/cryptotest/json",
+    "//sw/device/tests/crypto/cryptotest/json:commands",
 ]
 
 [

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 load(
     "//rules/opentitan:defs.bzl",
-    "cw310_params",
     "opentitan_binary",
     "opentitan_test",
     "silicon_params",
@@ -293,44 +292,50 @@ cc_library(
     ],
 )
 
-opentitan_binary(
-    name = "firmware",
-    testonly = True,
-    srcs = [":firmware.c"],
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310_test_rom",
-    ],
-    deps = [
-        ":aes",
-        ":aes_sca",
-        ":drbg",
-        ":ecdh",
-        ":ecdsa",
-        ":hash",
-        ":hmac",
-        ":ibex_fi",
-        ":kmac",
-        ":kmac_sca",
-        ":otbn_fi",
-        ":prng_sca",
-        ":sha3_sca",
-        ":trigger_sca",
-        "//sw/device/lib/base:csr",
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/crypto/drivers:entropy",
-        "//sw/device/lib/testing/test_framework:check",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/lib/testing/test_framework:ujson_ottf",
-        "//sw/device/lib/ujson",
-        "//sw/device/tests/crypto/cryptotest/json:aes_commands",
-        "//sw/device/tests/crypto/cryptotest/json:commands",
-        "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
-        "//sw/device/tests/crypto/cryptotest/json:ecdh_commands",
-        "//sw/device/tests/crypto/cryptotest/json:hash_commands",
-        "//sw/device/tests/crypto/cryptotest/json:hmac_commands",
-        "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
-    ],
-)
+FIRMWARE_DEPS = [
+    ":aes_sca",
+    ":aes",
+    ":drbg",
+    ":ecdh",
+    ":ecdsa",
+    ":hash",
+    ":hmac",
+    ":ibex_fi",
+    ":kmac_sca",
+    ":kmac",
+    ":otbn_fi",
+    ":prng_sca",
+    ":sha3_sca",
+    ":trigger_sca",
+    "//sw/device/lib/base:csr",
+    "//sw/device/lib/base:status",
+    "//sw/device/lib/crypto/drivers:entropy",
+    "//sw/device/lib/testing/test_framework:check",
+    "//sw/device/lib/testing/test_framework:ottf_main",
+    "//sw/device/lib/testing/test_framework:ujson_ottf",
+    "//sw/device/lib/ujson",
+
+    # Include all JSON commands.
+    "//sw/device/tests/crypto/cryptotest/json",
+]
+
+[
+    opentitan_binary(
+        name = "firmware_{}".format(exec_env),
+        testonly = True,
+        srcs = [":firmware.c"],
+        exec_env = [
+            "//hw/top_earlgrey:{}".format(exec_env),
+        ],
+        deps = FIRMWARE_DEPS,
+    )
+    for exec_env in [
+        "fpga_cw310_test_rom",
+        "silicon_owner_sival_rom_ext",
+        "silicon_owner_proda_rom_ext",
+        "silicon_owner_prodc_rom_ext",
+    ]
+]
 
 opentitan_test(
     name = "chip_pen_test",
@@ -343,36 +348,5 @@ opentitan_test(
     silicon_owner = silicon_params(
         tags = ["broken"],
     ),
-    deps = [
-        ":aes",
-        ":aes_sca",
-        ":drbg",
-        ":ecdh",
-        ":ecdsa",
-        ":hash",
-        ":hmac",
-        ":ibex_fi",
-        ":kmac",
-        ":kmac_sca",
-        ":otbn_fi",
-        ":prng_sca",
-        ":sha3_sca",
-        ":trigger_sca",
-        "//sw/device/lib/base:csr",
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/crypto/drivers:entropy",
-        "//sw/device/lib/testing/test_framework:check",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/lib/testing/test_framework:ujson_ottf",
-        "//sw/device/lib/ujson",
-        "//sw/device/tests/crypto/cryptotest/json:aes_commands",
-        "//sw/device/tests/crypto/cryptotest/json:commands",
-        "//sw/device/tests/crypto/cryptotest/json:drbg_commands",
-        "//sw/device/tests/crypto/cryptotest/json:ecdh_commands",
-        "//sw/device/tests/crypto/cryptotest/json:ecdsa_commands",
-        "//sw/device/tests/crypto/cryptotest/json:hash_commands",
-        "//sw/device/tests/crypto/cryptotest/json:hmac_commands",
-        "//sw/device/tests/crypto/cryptotest/json:ibex_fi_commands",
-        "//sw/device/tests/crypto/cryptotest/json:kmac_commands",
-    ],
+    deps = FIRMWARE_DEPS,
 )

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -8,7 +8,23 @@ cc_library(
     name = "commands",
     srcs = ["commands.c"],
     hdrs = ["commands.h"],
-    deps = ["//sw/device/lib/ujson"],
+    deps = [
+        ":aes_commands",
+        ":aes_sca_commands",
+        ":drbg_commands",
+        ":ecdh_commands",
+        ":ecdsa_commands",
+        ":hash_commands",
+        ":hmac_commands",
+        ":ibex_fi_commands",
+        ":kmac_commands",
+        ":kmac_sca_commands",
+        ":otbn_fi_commands",
+        ":prng_sca_commands",
+        ":sha3_sca_commands",
+        ":trigger_sca_commands",
+        "//sw/device/lib/ujson",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
- Update firmware target to support silicon targets
- Enable cryptotest silicon targets