### PR TITLE
[top/pinmux] Enable Schmitt trigger for POR and JTAG Clk/Rst

### DIFF
--- a/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
@@ -407,8 +407,12 @@ module pinmux_strap_sampling
 
       // Also reset all corresponding pad attributes to the default ('0) when JTAG is enabled.
       // This disables functional pad features that may have been set, e.g., pull-up/pull-down.
-      assign attr_padring_o[k] = (jtag_en) ? '0 : attr_core_i[k];
-
+      // Do enable schmitt trigger on JTAG clock and JTAG reset for better signal integrity.
+      if (k == TargetCfg.tck_idx  || k == TargetCfg.trst_idx) begin : gen_schmitt_en
+        assign attr_padring_o[k] = (jtag_en) ? '{schmitt_en: 1'b1, default: '0} : attr_core_i[k];
+      end else begin : gen_no_schmitt
+        assign attr_padring_o[k] = (jtag_en) ? '0 : attr_core_i[k];
+      end
     end else begin : gen_other_inputs
       assign attr_padring_o[k] = attr_core_i[k];
       assign in_core_o[k]      = in_padring_i[k];

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -1028,8 +1028,9 @@ module chip_earlgrey_asic #(
   assign manual_out_otp_ext_volt = 1'b0;
   assign manual_oe_otp_ext_volt = 1'b0;
 
+  // Enable schmitt trigger on POR for better signal integrity.
+  assign manual_attr_por_n = '{schmitt_en: 1'b1, default: '0};
   // These pad attributes currently tied off permanently (these are all input-only pads).
-  assign manual_attr_por_n = '0;
   assign manual_attr_cc1 = '0;
   assign manual_attr_cc2 = '0;
   assign manual_attr_flash_test_mode0 = '0;

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -895,8 +895,9 @@ module chip_${top["name"]}_${target["name"]} #(
   assign manual_out_otp_ext_volt = 1'b0;
   assign manual_oe_otp_ext_volt = 1'b0;
 
+  // Enable schmitt trigger on POR for better signal integrity.
+  assign manual_attr_por_n = '{schmitt_en: 1'b1, default: '0};
   // These pad attributes currently tied off permanently (these are all input-only pads).
-  assign manual_attr_por_n = '0;
   assign manual_attr_cc1 = '0;
   assign manual_attr_cc2 = '0;
   assign manual_attr_flash_test_mode0 = '0;


### PR DESCRIPTION
This hardwires the schmitt trigger enable to 1 for the JTAG Clk/Rst and POR signals for improved signal integrity.