### PR TITLE
[dv,adc_ctrl] Fix bugs in scoreboard

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -105,6 +105,7 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
     bit intr_en;
     forever begin
       @(cfg.intr_vif.pins);
+      if (cfg.clk_rst_vif.rst_n == 1'b0) continue;
       m_interrupt = cfg.intr_vif.sample_pin(ADC_CTRL_INTERRUPT_INDEX);
       // Compare against expected every change of interrupt line
       if (cfg.en_scb) begin
@@ -648,6 +649,8 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
     m_adc_ctrl_en = 0;
     m_lp_mode = 0;
     m_lp_to_np_transition = 0;
+    cfg.adc_intr_ctl = '0;
+    cfg.adc_wakeup_ctl = '0;
   endfunction
 
   // Software reset

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
@@ -102,7 +102,6 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
     ral.adc_pd_ctl.wakeup_time.set(cfg.wakeup_time);
     csr_wr(ral.adc_pd_ctl, ral.adc_pd_ctl.get());
 
-
   endtask
 
   //

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_polled_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_polled_vseq.sv
@@ -81,7 +81,6 @@ class adc_ctrl_filters_polled_vseq extends adc_ctrl_base_vseq;
       random_ramp_vseq.start(p_sequencer, this);
       `uvm_info(`gfn, random_ramp_vseq.sprint(uvm_default_line_printer), UVM_MEDIUM)
 
-
       // Send randomized ramp on all channels - falling
       `uvm_create_obj(adc_ctrl_random_ramp_vseq, random_ramp_vseq)
       random_ramp_vseq.set_sequencer(p_sequencer);
@@ -102,8 +101,7 @@ class adc_ctrl_filters_polled_vseq extends adc_ctrl_base_vseq;
       do_adc_fsm_reset();
 
       // Re-randomize configuration if enabled
-      if (!cfg.filters_fixed) `DV_CHECK_RANDOMIZE_FATAL(cfg);
-
+      if (!cfg.filters_fixed) `DV_CHECK_RANDOMIZE_FATAL(cfg)
     end
     // A short delay to allow all CDC to complete
     cfg.clk_aon_rst_vif.wait_clks($urandom_range(10, 15));


### PR DESCRIPTION
Clear the cfg.adc_*_ctl testbench variables upon reset. Skip monitor_intr_proc during reset.