### PR TITLE
[ast/lint] Fix Verible linting errors

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
@@ -33,11 +33,11 @@ end
 
 always_comb begin
   if ( init_start ) begin
-    vcaon_pok_o <= 1'b0;
+    vcaon_pok_o = 1'b0;
   end else if ( !init_start && gen_supp_a ) begin
-    vcaon_pok_o <= #(ast_bhv_pkg::VCAON_POK_RDLY) gen_supp_a;
+    vcaon_pok_o = #(ast_bhv_pkg::VCAON_POK_RDLY) gen_supp_a;
   end else if ( !init_start && !gen_supp_a ) begin
-    vcaon_pok_o <= #(ast_bhv_pkg::VCAON_POK_FDLY) gen_supp_a;
+    vcaon_pok_o = #(ast_bhv_pkg::VCAON_POK_FDLY) gen_supp_a;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
@@ -33,13 +33,13 @@ end
 
 always_comb (* xprop_off *) begin
   if ( init_start ) begin
-    vcc_pok_o <= 1'b0;
+    vcc_pok_o = 1'b0;
   end
   if ( !init_start && gen_supp_a ) begin
-    vcc_pok_o <= #(ast_bhv_pkg::VCC_POK_RDLY) gen_supp_a;
+    vcc_pok_o = #(ast_bhv_pkg::VCC_POK_RDLY) gen_supp_a;
   end
   if ( !init_start && !gen_supp_a ) begin
-    vcc_pok_o <= #(ast_bhv_pkg::VCC_POK_FDLY) gen_supp_a;
+    vcc_pok_o = #(ast_bhv_pkg::VCC_POK_FDLY) gen_supp_a;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
@@ -33,11 +33,11 @@ end
 
 always_comb begin
   if ( init_start ) begin
-    vcmain_pok_o <= 1'b0;
+    vcmain_pok_o = 1'b0;
   end else if ( !init_start && gen_supp_a ) begin
-    vcmain_pok_o <= #(ast_bhv_pkg::VCMAIN_POK_RDLY) gen_supp_a;
+    vcmain_pok_o = #(ast_bhv_pkg::VCMAIN_POK_RDLY) gen_supp_a;
   end else if ( !init_start && !gen_supp_a ) begin
-    vcmain_pok_o <= #(ast_bhv_pkg::VCMAIN_POK_FDLY) gen_supp_a;
+    vcmain_pok_o = #(ast_bhv_pkg::VCMAIN_POK_FDLY) gen_supp_a;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
@@ -33,13 +33,13 @@ end
 
 always_comb (* xprop_off *) begin
   if ( init_start ) begin
-    vio_pok_o <= 1'b0;
+    vio_pok_o = 1'b0;
   end
   if ( !init_start && gen_supp_a ) begin
-    vio_pok_o <= #(ast_bhv_pkg::VIO_POK_RDLY) gen_supp_a;
+    vio_pok_o = #(ast_bhv_pkg::VIO_POK_RDLY) gen_supp_a;
   end
   if ( !init_start && !gen_supp_a ) begin
-    vio_pok_o <= #(ast_bhv_pkg::VIO_POK_FDLY) gen_supp_a;
+    vio_pok_o = #(ast_bhv_pkg::VIO_POK_FDLY) gen_supp_a;
   end
 end
 `else


### PR DESCRIPTION
This should fix the Verible linting issue we're currently seeing in CI.

@meisnere FYI - this is now needed since `always_comb` should only contain blocking assingments.