### PR TITLE
[ci] Disable flaky Bazel tags step

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,13 +144,13 @@ jobs:
   - template: ci/install-package-dependencies.yml
   # Bazel test suites are a common cause of problematic tags. Check test suites
   # before checking for other tag issues.
-  # #21973: Disabled until Verilator tags are fixed in our build tree.
-  #- bash:  ci/scripts/check_bazel_test_suites.py
-  #  displayName: Check Bazel test suites (Experimental)
-  #  continueOnError: True
-  - bash: ci/scripts/check-bazel-tags.sh
-    displayName: Check Bazel Tags (Experimental)
+  - bash:  ci/scripts/check_bazel_test_suites.py
+    displayName: Check Bazel test suites (Experimental)
     continueOnError: True
+  # #21973: Disabled until Verilator tags are fixed in our build tree.
+  #- bash: ci/scripts/check-bazel-tags.sh
+  #  displayName: Check Bazel Tags (Experimental)
+  #  continueOnError: True
   - bash: ci/scripts/check-bazel-banned-rules.sh
     displayName: Check for banned rules
   - bash:  ci/scripts/check_bazel_target_names.py


### PR DESCRIPTION
Embarrassingly I disabled the wrong step in #21974. This PR re-enables that step and disables the intended one.