### PR TITLE
[i2c] Bump version to 2.0.0, set to D1/V0

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -20,10 +20,10 @@
   sw_checklist:       "/sw/device/lib/dif/dif_i2c",
   revisions: [
     {
-      version:            "1.1.0",
+      version:            "2.0.0",
       life_stage:         "L1",
-      design_stage:       "D2S",
-      verification_stage: "V2",
+      design_stage:       "D1",
+      verification_stage: "V0",
       dif_stage:          "S2",
       notes:              ""
     }


### PR DESCRIPTION
Since i2c was versioned at 1.1.0 (in 0a8d1b27eba), we made multiple changes that change the HW and SW interfaces of this HW IP block in a backward-incompatible way. `git diff 0a8d1b27eba..<this commit>^ -- hw/ip/i2c/data/i2c.hjson` gives a good overview:
```diff
diff --git a/hw/ip/i2c/data/i2c.hjson b/hw/ip/i2c/data/i2c.hjson
index 9e62d5095f..f316e58936 100644
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -40,13 +40,16 @@
   // INTERRUPT pins
   interrupt_list: [
     { name: "fmt_threshold"
-      desc: "host mode interrupt: raised when the FMT FIFO depth is less than the low threshold."
+      desc: "host mode interrupt: asserted whilst the FMT FIFO level is below the low threshold. This is a level status interrupt."
+      type: "status"
     }
     { name: "rx_threshold"
-      desc: "host mode interrupt: raised if the RX FIFO is greater than the high threshold."
+      desc: "host mode interrupt: asserted whilst the RX FIFO level is above the high threshold. This is a level status interrupt."
+      type: "status"
     }
-    { name: "fmt_overflow"
-      desc: "host mode interrupt: raised if the FMT FIFO has overflowed."
+    { name: "acq_threshold"
+      desc: "target mode interrupt: asserted whilst the ACQ FIFO level is above the high threshold. This is a level status interrupt."
+      type: "status"
     }
     { name: "rx_overflow"
       desc: "host mode interrupt: raised if the RX FIFO has overflowed."
@@ -74,14 +77,15 @@
       '''
     }
     { name: "tx_stretch"
-      desc: "target mode interrupt: raised if the target is stretching clocks for a read command.  This is a level status interrupt."
+      desc: "target mode interrupt: raised if the target is stretching clocks for a read command. This is a level status interrupt."
       type: "status"
     }
-    { name: "tx_overflow"
-      desc: "target mode interrupt: raised if TX FIFO has overflowed."
+    { name: "tx_threshold"
+      desc: "target mode interrupt: asserted whilst the TX FIFO level is below the low threshold. This is a level status interrupt."
+      type: "status"
     }
     { name: "acq_full"
-      desc: "target mode interrupt: raised if ACQ FIFO becomes full.  This is a level status interrupt."
+      desc: "target mode interrupt: raised if ACQ FIFO becomes full. This is a level status interrupt."
       type: "status"
     }
     { name: "unexp_stop"
@@ -100,10 +104,21 @@
   ],
   param_list: [
     { name: "FifoDepth",
-      desc: "Depth of FMT, RX, TX, and ACQ FIFOs",
+      desc: '''
+            Depth of FMT, RX, and TX FIFOs.
+            The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
+            ''',
       type: "int",
       default: "64",
     }
+    { name: "AcqFifoDepth",
+      desc: '''
+            Depth of ACQ FIFO.
+            The maximum supported value is 2^12-1, although much lower values are recommended to keep area requirements reasonable.
+            ''',
+      type: int
+      default: "268",
+    }
   ],
   features: [
     { name: "I2C.MODE.HOST",
@@ -209,27 +224,27 @@
       ]
     }
     { name:     "STATUS"
-      desc:     "I2C Live Status Register"
+      desc:     "I2C Live Status Register for Host and Target modes"
       swaccess: "ro"
       hwaccess: "hwo"
       hwext:    "true"
       fields: [
         { bits: "0"
           name: "FMTFULL"
-          desc: "FMT FIFO is full"
+          desc: "Host mode FMT FIFO is full"
         }
         { bits: "1"
           name: "RXFULL"
-          desc: "RX FIFO is full"
+          desc: "Host mode RX FIFO is full"
         }
         { bits: "2"
           name: "FMTEMPTY"
-          desc: "FMT FIFO is empty"
+          desc: "Host mode FMT FIFO is empty"
           resval: "1"
         }
         { bits: "5"
           name: "RXEMPTY"
-          desc: "RX FIFO is empty"
+          desc: "Host mode RX FIFO is empty"
           resval: "1"
         }
         { bits: "3"
@@ -244,20 +259,20 @@
         }
         { bits: "6"
           name: "TXFULL"
-          desc: "TX FIFO is full"
+          desc: "Target mode TX FIFO is full"
         }
         { bits: "7"
           name: "ACQFULL"
-          desc: "ACQ FIFO is full"
+          desc: "Target mode receive FIFO is full"
         }
         { bits: "8"
           name: "TXEMPTY"
-          desc: "TX FIFO is empty"
+          desc: "Target mode TX FIFO is empty"
           resval: "1"
         }
         { bits: "9"
           name: "ACQEMPTY"
-          desc: "ACQ FIFO is empty"
+          desc: "Target mode receive FIFO is empty"
           resval: "1"
         }
       ]
@@ -277,7 +292,7 @@
              "excl:CsrAllTests:CsrExclCheck"]
     }
     { name: "FDATA"
-      desc: "I2C Format Data"
+      desc: "I2C Host Format Data"
       swaccess: "wo"
       hwaccess: "hro"
       hwqe: "true"
@@ -324,58 +339,6 @@
           name: "FMTRST"
           desc: "FMT fifo reset. Write 1 to the register resets FMT_FIFO. Read returns 0"
         }
-        { bits: "4:2"
-          name: "RXILVL"
-          desc: '''Trigger level for RX interrupts. If the FIFO depth exceeds
-                this setting, it raises rx_threshold interrupt.
-                '''
-          enum: [
-            { value: "0",
-              name: "rxlvl1",
-              desc: "1 character"
-            },
-            { value: "1",
-              name: "rxlvl4",
-              desc: "4 characters"
-            },
-            { value: "2",
-              name: "rxlvl8",
-              desc: "8 characters"
-            },
-            { value: "3",
-              name: "rxlvl16",
-              desc: "16 characters"
-            },
-            { value: "4",
-              name: "rxlvl30",
-              desc: "30 characters"
-            },
-          ]
-        }
-        { bits: "6:5"
-          name: "FMTILVL"
-          desc: '''Trigger level for FMT interrupts. If the FIFO depth falls below
-                this setting, it raises fmt_threshold interrupt.
-                '''
-          enum: [
-            { value: "0",
-              name: "fmtlvl1"
-              desc: "1 character"
-            },
-            { value: "1",
-              name: "fmtlvl4",
-              desc: "4 characters"
-            },
-            { value: "2",
-              name: "fmtlvl8",
-              desc: "8 characters"
-            },
-            { value: "3",
-              name: "fmtlvl16",
-              desc: "16 characters"
-            }
-          ]
-        }
         { bits: "7"
           swaccess: "wo"
           name: "ACQRST"
@@ -388,25 +351,81 @@
         }
       ]
     }
-    { name: "FIFO_STATUS"
-      desc: "I2C FIFO status register"
+    {
+      name: "HOST_FIFO_CONFIG"
+      desc: "Host mode FIFO configuration"
+      swaccess: "rw"
+      hwaccess: "hro"
+      hwqe: "true"
+      fields: [
+        { bits: "11:0"
+          name: "RX_THRESH"
+          desc: '''Threshold level for RX interrupts. Whilst the level of data in the RX FIFO
+                is above this setting, the rx_threshold interrupt will be asserted.
+                '''
+          resval: "0"
+        }
+        { bits: "27:16"
+          name: "FMT_THRESH"
+          desc: '''Threshold level for FMT interrupts. Whilst the number of used entries in the
+                FMT FIFO is below this setting, the fmt_threshold interrupt will be asserted.
+                '''
+          resval: "0"
+        }
+      ]
+    }
+    {
+      name: "TARGET_FIFO_CONFIG"
+      desc: "Target mode FIFO configuration"
+      swaccess: "rw"
+      hwaccess: "hro"
+      hwqe: "true"
+      fields: [
+        { bits: "11:0"
+          name: "TX_THRESH"
+          desc: '''Threshold level for TX interrupts. Whilst the number of used entries in the
+                TX FIFO is below this setting, the tx_threshold interrupt will be asserted.
+                '''
+          resval: "0"
+        }
+        { bits: "27:16"
+          name: "ACQ_THRESH"
+          desc: '''Threshold level for ACQ interrupts. Whilst the level of data in the ACQ FIFO
+                is above this setting, the acq_threshold interrupt will be asserted.
+                '''
+          resval: "0"
+        }
+      ]
+    }
+    { name: "HOST_FIFO_STATUS"
+      desc: "Host mode FIFO status register"
       swaccess: "ro"
       hwaccess: "hwo"
       hwext: "true"
       fields: [
-        { bits: "6:0"
+        { bits: "11:0"
           name: "FMTLVL"
           desc: "Current fill level of FMT fifo"
         }
-        { bits: "22:16"
+        { bits: "27:16"
           name: "RXLVL"
           desc: "Current fill level of RX fifo"
         }
-        { bits: "14:8"
+      ]
+      tags: [// Updated by the hw. Exclude from write-checks.
+             "excl:CsrNonInitTests:CsrExclWriteCheck"]
+    }
+    { name: "TARGET_FIFO_STATUS"
+      desc: "Target mode FIFO status register"
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwext: "true"
+      fields: [
+        { bits: "11:0"
           name: "TXLVL"
           desc: "Current fill level of TX fifo"
         }
-        { bits: "30:24"
+        { bits: "27:16"
           name: "ACQLVL"
           desc: "Current fill level of ACQ fifo"
         }
@@ -551,7 +570,10 @@
       ]
     }
     { name: "TIMEOUT_CTRL"
-      desc: "I2C clock stretching timeout control"
+      desc: '''
+            I2C clock stretching timeout control.
+            This is used in I2C host mode to detect whether a connected target is stretching for too long.
+            '''
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
@@ -599,7 +621,7 @@
           name: "ABYTE"
           desc: "Address for accepted transaction or acquired byte"
         }
-        { bits: "9:8"
+        { bits: "10:8"
           name: "SIGNAL"
           desc: "Host issued a START before transmitting ABYTE, a STOP or a RESTART after the preceeding ABYTE"
           enum: [
@@ -619,6 +641,14 @@
               name: "RESTART",
               desc: "ABYTE contains junk, START with address will follow"
             },
+            { value: "4",
+              name: "NACK",
+              desc: "ABYTE contains either the address or data that was NACK'ed"
+            },
+            { value: "5",
+              name: "NACKSTART",
+              desc: "ABYTE contains the I2C address which was ACK'ed, but the block will continue and NACK the next data byte that was received: this only happens for writes"
+            },
           ]
         }
       ]
@@ -643,5 +673,35 @@
         { bits: "31:0" }
       ]
     }
+    { name: "TARGET_TIMEOUT_CTRL"
+      desc: '''
+            I2C target internal stretching timeout control.
+            When the target has stretched beyond this time it will send a NACK.
+            '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "30:0"
+          name: "VAL"
+          desc: "Clock stretching timeout value (in units of input clock frequency)"
+        }
+        { bits: "31"
+          name: "EN"
+          desc: "Enable timeout feature and send NACK once the timeout has been reached"
+        }
+      ]
+    }
+    { name: "TARGET_NACK_COUNT"
+      desc: '''
+            Number of times the I2C target has NACK'ed a new transaction since the last read of this register.
+            Reading this register clears it.
+            This is useful because when the ACQ FIFO is full the software know that a NACK has occurred, but without this register would not know how many transactions it missed.
+            '''
+      swaccess: "rc"
+      hwaccess: "hrw"
+      fields: [
+        { bits: "31:0" }
+      ]
+    }
   ]
 }
```


Thus we need to give I2C a major version bump and reset its D and V stages.

Issues #20971 and #22108 track signing i2c off at D2(S) and V2(S) again, respectively.