### PR TITLE
[otbn, rtl] Squash call stack read data to 0 when stack is empty

### DIFF
--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -89,7 +89,7 @@ module otbn_rf_base
   logic rd_stack_b;
 
   logic                     stack_full;
-  logic [BaseIntgWidth-1:0] stack_data_intg;
+  logic [BaseIntgWidth-1:0] stack_data_intg, stack_data_intg_raw;
   logic                     stack_data_valid;
 
   logic state_reset;
@@ -158,7 +158,7 @@ module otbn_rf_base
 
     .pop_i         (pop_stack),
     .commit_i      (1'b1),
-    .top_data_o    (stack_data_intg),
+    .top_data_o    (stack_data_intg_raw),
     .top_valid_o   (stack_data_valid),
 
     .stack_wr_idx_o(),
@@ -169,6 +169,11 @@ module otbn_rf_base
     .next_top_data_o (),
     .next_top_valid_o()
   );
+
+  // Squash call stack read data to 0 (which means invalid ECC with the encoding we use) when
+  // there's nothing on the call stack. OTBN will raise an error when we read from an empty call
+  // stack but this prevents X propagation and exposing any previous, now invalid, stack values.
+  assign stack_data_intg = stack_data_valid ? stack_data_intg_raw : '0;
 
   if (RegFile == RegFileFF) begin : gen_rf_base_ff
     otbn_rf_base_ff #(


### PR DESCRIPTION
Previous to this change we were seeing X prop issues where a branch happened using a call stack as one or both of the compare operands when the stack was empty. Whilst OTBN raises an error due to the use of the empty stack the branch result goes to X (as the comparison inputs are X) which produces Xs on the imem request interface.

With this change output from the stack gets squashed to 0 when its empty.

Draft PR for as I don't think this is an essential fix. When running a regression I'm seeing some new failures though I think they were hidden behind previous X check failures (overall pass rate is similar). Further investigation should be done before merging this.