### PR TITLE
[usbdev] Lighter diagnostic and performance counters

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -1303,6 +1303,273 @@
         }
       ]
     }
+    { name: "count_out",
+      desc: "Counter for OUT side USB events.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "7:0",
+          name: "count",
+          desc: "Number of events counted.",
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "12",
+          name: "datatog_out",
+          desc: '''
+                Count the OUT transactions for which the USB device acknowledged the OUT packet
+                and dropped it internally, which is the correct response to a packet transmitted
+                with an incorrect Data Toggle.
+
+                The expectation is that this packet is a retry of the previous packet transmission
+                and that the handshake response was not received intact by the USB host, indicating
+                unreliable communications.
+
+                Other causes of Data Toggle synchronization failure may result in data loss.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "13",
+          name: "drop_rx",
+          desc: '''
+                Count the SETUP/OUT packets ignored, dropped or NAKed because the RX FIFO was full.
+                SETUP packets have been ignored, Isochronous OUT packets have been dropped, and
+                non-Isochronous OUT packets have been NAKed.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "14",
+          name: "drop_avout",
+          desc: '''
+                Count the OUT packets that could not be accepted because there was no buffer in the
+                Av OUT FIFO. Non-Isochronous OUT packets have been NAKed.
+                Isochronous OUT packets were ignored.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "15",
+          name: "ign_avsetup",
+          desc: '''
+                Count the SETUP packets that were ignored because there was no buffer in the
+                Av SETUP FIFO.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of OUT endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_in",
+      desc: "Counter for IN side USB events.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "7:0",
+          name: "count",
+          desc: "Number of events counted.",
+          swaccess: "ro",
+          hwaccess: "hwo",
+        }
+        {
+          bits: "13",
+          name: "nodata",
+          desc: '''
+                Count the IN transactions that were attempted when there was no packet available
+                in the corresponding 'configin' register(s). This is not necessarily an error
+                condition, and the counter primarily offers some visibility into when the IN
+                traffic is underusing the available bus bandwidth.
+                It is of particular utility to Isochronous IN endpoints.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "14",
+          name: "nak",
+          desc: '''
+                Count the IN transactions rejected by the host responding with a NAK handshake.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "15",
+          name: "timeout",
+          desc: '''
+                Count the IN transactions for which the USB host did not respond with a handshake,
+                and the transactions timed out. This indicates that the host did not receive it
+                and decode it as a valid packet, suggesting that communication is unreliable.
+
+                Isochronous IN transactions are excluded from this count because there is no
+                handshake response to Isochronous packet transfers.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_nodata_in",
+      desc: '''
+            Count of IN transactions for which no packet data was available.
+
+            This secondary register allows some partitioning of endpoints among the two
+            counters, for more targeted measurement, eg. endpoints may be grouped according to
+            the expected bandwidth usage, or Isochronous vs. non-Isochronous transfers.
+            '''
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "7:0",
+          name: "count",
+          desc: '''
+                Number of IN transactions that were attempted when there was no packet available
+                in the corresponding 'configin' register(s).
+                '''
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27:16"
+          name: "endpoints",
+          desc: "Set of endpoints for which this counter is enabled.",
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
+    { name: "count_errors",
+      desc: "Count of error conditions detected on token packets from the host.",
+      resval: "0",
+      hwext: "true",
+      fields: [
+        {
+          bits: "7:0",
+          name: "count",
+          desc: "Number of events counted.",
+          swaccess: "ro",
+          hwaccess: "hwo"
+        }
+        {
+          bits: "27",
+          name: "pid_invalid",
+          desc: '''
+                Number of Invalid PIDs detected on packets from the host. Invalid PIDs may
+                indicate very unreliable communication and/or a substantial frequency mismatch
+                between the host and the device.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "28",
+          name: "bitstuff",
+          desc: '''
+                Number of SETUP/OUT packets that were ignored, dropped or NAKed because a
+                Bit Stuffing error was detected.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "29",
+          name: "crc16",
+          desc: '''
+                Count SETUP/OUT DATA packets that were ignored, dropped or NAKed because a
+                CRC16 error was detected.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "30",
+          name: "crc5",
+          desc: '''
+                Count CRC5 errors detected on token packets sent by the host. CRC5 errors on
+                token packets received from the host indicate very unreliable communication and
+                possibly a substantial frequency mismatch between the host and the device.
+                '''
+          swaccess: "rw",
+          hwaccess: "hrw",
+          hwqe: "true"
+        }
+        {
+          bits: "31",
+          name: "rst",
+          desc: "Write 1 to reset the counter.",
+          swaccess: "wo",
+          hwaccess: "hro",
+          hwqe: "true",
+          tags: [// Prevent interaction with the count field.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
+        }
+      ]
+    }
     { window: {
         name: "buffer",
         items: "512",
@@ -1311,9 +1578,9 @@
         unusual: "false"
         swaccess: "rw",
         desc: '''
-              2 kB packet buffer. Divided into 32 64-byte buffers.
+              2 KiB packet buffer. Divided into thirty two 64-byte buffers.
 
-              The packet buffer is used for sending and receiveing packets.
+              The packet buffer is used for sending and receiving packets.
               '''
       },
     },

--- a/hw/ip/usbdev/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_pe.sv
@@ -96,7 +96,8 @@ module usb_fs_nb_pe #(
   output logic                   rx_j_det_o,
 
   // RX errors
-  output logic                   rx_crc_err_o,
+  output logic                   rx_crc5_err_o,
+  output logic                   rx_crc16_err_o,
   output logic                   rx_pid_err_o,
   output logic                   rx_bitstuff_err_o,
 
@@ -114,7 +115,13 @@ module usb_fs_nb_pe #(
   output logic                   usb_se0_o,
   output logic                   usb_dp_o,
   output logic                   usb_dn_o,
-  output logic                   usb_oe_o
+  output logic                   usb_oe_o,
+
+  // event counters
+  output logic                   event_datatog_out_o,
+  output logic                   event_timeout_in_o,
+  output logic                   event_nak_in_o,
+  output logic                   event_nodata_in_o
 );
 
   import usb_consts_pkg::*;
@@ -207,7 +214,12 @@ module usb_fs_nb_pe #(
     .tx_pid_o              (in_tx_pid),
     .tx_data_avail_o       (tx_data_avail),
     .tx_data_get_i         (tx_data_get),
-    .tx_data_o             (tx_data)
+    .tx_data_o             (tx_data),
+
+    // event counters
+    .event_timeout_in_o    (event_timeout_in_o),
+    .event_nak_in_o        (event_nak_in_o),
+    .event_nodata_in_o     (event_nodata_in_o)
   );
 
   usb_fs_nb_out_pe #(
@@ -253,7 +265,10 @@ module usb_fs_nb_pe #(
     // tx path
     .tx_pkt_start_o         (out_tx_pkt_start),
     .tx_pkt_end_i           (tx_pkt_end),
-    .tx_pid_o               (out_tx_pid)
+    .tx_pid_o               (out_tx_pid),
+
+    // event counters
+    .event_datatog_out_o    (event_datatog_out_o)
   );
 
   usb_fs_rx u_usb_fs_rx (
@@ -280,7 +295,8 @@ module usb_fs_nb_pe #(
     .valid_packet_o         (rx_pkt_valid),
     .rx_idle_det_o          (rx_idle_det_o),
     .rx_j_det_o             (rx_j_det_o),
-    .crc_error_o            (rx_crc_err_o),
+    .crc5_error_o           (rx_crc5_err_o),
+    .crc16_error_o          (rx_crc16_err_o),
     .pid_error_o            (rx_pid_err_o),
     .bitstuff_error_o       (rx_bitstuff_err_o)
   );

--- a/hw/ip/usbdev/rtl/usb_fs_rx.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_rx.sv
@@ -51,7 +51,8 @@ module usb_fs_rx (
   output logic rx_j_det_o,
 
   // Error detection
-  output logic crc_error_o,
+  output logic crc5_error_o,
+  output logic crc16_error_o,
   output logic pid_error_o,
   output logic bitstuff_error_o
 );
@@ -528,8 +529,8 @@ module usb_fs_rx (
   );
 
   // Detect CRC errors
-  assign crc_error_o = ((pkt_is_data && !crc16_valid) ||
-    (pkt_is_token && !crc5_valid)) && packet_end;
+  assign crc5_error_o  = pkt_is_token & packet_end & !crc5_valid;
+  assign crc16_error_o = pkt_is_data & packet_end & !crc16_valid;
 
   // Detect PID errors
   assign pid_error_o = !pid_valid && packet_end;

--- a/hw/ip/usbdev/rtl/usbdev_counter.sv
+++ b/hw/ip/usbdev/rtl/usbdev_counter.sv
@@ -1,0 +1,88 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// USB device event counter
+//
+// At every rising edge within 'event_i' the counter samples the current endpoint as indicated by
+// 'ep_i' and increments the count if the endpoint in question is enabled at that moment.
+//
+// This means the set of endpoints for which events are counted may be changed over time by
+// software, whilst the USB device is active, multiplexing a single counter amongst multiple
+// sets of endpoints.
+//
+// The counter value saturates at its maximum and may be reset by software at any point.
+
+module usbdev_counter
+#(
+  parameter int unsigned NEndpoints = 12, // Number of endpoints supported.
+  parameter int unsigned NEvents = 1,  // Number of events being counted.
+  parameter int unsigned Width = 8,  // Counter width, in bits.
+
+  localparam int unsigned EpW = prim_util_pkg::vbits(NEndpoints) // derived parameter
+) (
+  input  logic                  clk_i,
+  input  logic                  rst_ni,
+
+  input  logic                  reset_i, // Software reset
+  input  logic [NEvents-1:0]    event_i, // Event pulse
+  input  logic [EpW-1:0]        ep_i, // Endpoint on which event occurred.
+  // Set of events being counted.
+  input  logic                  ev_qe_i, // SW write to the event enables.
+  input  logic [NEvents-1:0]    ev_i, // Per-event enable/disable.
+  output logic [NEvents-1:0]    ev_o, // Current event enables.
+  // Endpoints being monitored.
+  input  logic                  endp_qe_i,  // SW write to the endpoint enables.
+  input  logic [NEndpoints-1:0] endpoints_i, // Per-endpoint enable/disable.
+  output logic [NEndpoints-1:0] endpoints_o, // Current endpoint enables.
+  output logic [Width-1:0]      count_o // Current value of counter.
+);
+
+  // Current per-endpoint and per-event enables.
+  logic [NEndpoints-1:0] endpoints;
+  logic [NEvents-1:0] ev_enables;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      endpoints  <= NEndpoints'(0);
+      ev_enables <= NEvents'(0);
+    end else begin
+      // Software writes to set the current enables.
+      if (endp_qe_i) endpoints  <= endpoints_i;
+      if (ev_qe_i)   ev_enables <= ev_i;
+    end
+  end
+
+  // Respond to events on this endpoint?
+  logic ep_enabled;
+  if (NEndpoints > 1) begin : gen_multi
+    assign ep_enabled = (ep_i < EpW'(NEndpoints)) ? endpoints[ep_i] : 1'b0;
+  end else begin : gen_single
+    logic unused_ep;
+    assign unused_ep = ^ep_i;  // Endpoint number not required
+    assign ep_enabled = endpoints[0];
+  end
+
+  // Saturating event counter.
+  logic [Width-1:0] count;
+  logic [NEvents-1:0] event_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      count   <= Width'(0);
+      event_q <= NEvents'(0);
+    end else if (reset_i) begin
+      count   <= Width'(0);
+      // Do not modify 'event_q' here because the event inputs may still be asserted.
+    end else begin
+      // Positive-edge triggered, saturating count of events.
+      if (|(ev_enables & event_i & ~event_q) & ep_enabled) count <= count + ~&count;
+      // Retain previous state of event input signals.
+      event_q <= event_i;
+    end
+  end
+
+  assign ev_o = ev_enables;
+  assign endpoints_o = endpoints;
+  assign count_o = count;
+
+endmodule

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -409,6 +409,90 @@ package usbdev_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } ign_avsetup;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } drop_avout;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } drop_rx;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } datatog_out;
+  } usbdev_reg2hw_count_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } timeout;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } nak;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } nodata;
+  } usbdev_reg2hw_count_in_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic [11:0] q;
+      logic        qe;
+    } endpoints;
+  } usbdev_reg2hw_count_nodata_in_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } rst;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } crc5;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } crc16;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } bitstuff;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } pid_invalid;
+  } usbdev_reg2hw_count_errors_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
       logic        de;
     } pkt_received;
@@ -639,50 +723,124 @@ package usbdev_reg_pkg;
     } bus_not_idle;
   } usbdev_hw2reg_wake_events_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  d;
+    } count;
+    struct packed {
+      logic        d;
+    } datatog_out;
+    struct packed {
+      logic        d;
+    } drop_rx;
+    struct packed {
+      logic        d;
+    } drop_avout;
+    struct packed {
+      logic        d;
+    } ign_avsetup;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_out_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  d;
+    } count;
+    struct packed {
+      logic        d;
+    } nodata;
+    struct packed {
+      logic        d;
+    } nak;
+    struct packed {
+      logic        d;
+    } timeout;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_in_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  d;
+    } count;
+    struct packed {
+      logic [11:0] d;
+    } endpoints;
+  } usbdev_hw2reg_count_nodata_in_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  d;
+    } count;
+    struct packed {
+      logic        d;
+    } pid_invalid;
+    struct packed {
+      logic        d;
+    } bitstuff;
+    struct packed {
+      logic        d;
+    } crc16;
+    struct packed {
+      logic        d;
+    } crc5;
+  } usbdev_hw2reg_count_errors_reg_t;
+
   // Register -> HW type
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [481:464]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [463:446]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [445:410]
-    usbdev_reg2hw_alert_test_reg_t alert_test; // [409:408]
-    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [407:398]
-    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [397:386]
-    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [385:374]
-    usbdev_reg2hw_avoutbuffer_reg_t avoutbuffer; // [373:368]
-    usbdev_reg2hw_avsetupbuffer_reg_t avsetupbuffer; // [367:362]
-    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [361:341]
-    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [340:329]
-    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [328:317]
-    usbdev_reg2hw_set_nak_out_mreg_t [11:0] set_nak_out; // [316:305]
-    usbdev_reg2hw_in_sent_mreg_t [11:0] in_sent; // [304:293]
-    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [292:281]
-    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [280:269]
-    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [268:101]
-    usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [100:89]
-    usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [88:77]
-    usbdev_reg2hw_out_data_toggle_reg_t out_data_toggle; // [76:51]
-    usbdev_reg2hw_in_data_toggle_reg_t in_data_toggle; // [50:25]
-    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [24:16]
-    usbdev_reg2hw_phy_config_reg_t phy_config; // [15:10]
-    usbdev_reg2hw_wake_control_reg_t wake_control; // [9:6]
-    usbdev_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [5:0]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [550:533]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [532:515]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [514:479]
+    usbdev_reg2hw_alert_test_reg_t alert_test; // [478:477]
+    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [476:467]
+    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [466:455]
+    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [454:443]
+    usbdev_reg2hw_avoutbuffer_reg_t avoutbuffer; // [442:437]
+    usbdev_reg2hw_avsetupbuffer_reg_t avsetupbuffer; // [436:431]
+    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [430:410]
+    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [409:398]
+    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [397:386]
+    usbdev_reg2hw_set_nak_out_mreg_t [11:0] set_nak_out; // [385:374]
+    usbdev_reg2hw_in_sent_mreg_t [11:0] in_sent; // [373:362]
+    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [361:350]
+    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [349:338]
+    usbdev_reg2hw_configin_mreg_t [11:0] configin; // [337:170]
+    usbdev_reg2hw_out_iso_mreg_t [11:0] out_iso; // [169:158]
+    usbdev_reg2hw_in_iso_mreg_t [11:0] in_iso; // [157:146]
+    usbdev_reg2hw_out_data_toggle_reg_t out_data_toggle; // [145:120]
+    usbdev_reg2hw_in_data_toggle_reg_t in_data_toggle; // [119:94]
+    usbdev_reg2hw_phy_pins_drive_reg_t phy_pins_drive; // [93:85]
+    usbdev_reg2hw_phy_config_reg_t phy_config; // [84:79]
+    usbdev_reg2hw_wake_control_reg_t wake_control; // [78:75]
+    usbdev_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [74:69]
+    usbdev_reg2hw_count_out_reg_t count_out; // [68:46]
+    usbdev_reg2hw_count_in_reg_t count_in; // [45:25]
+    usbdev_reg2hw_count_nodata_in_reg_t count_nodata_in; // [24:10]
+    usbdev_reg2hw_count_errors_reg_t count_errors; // [9:0]
   } usbdev_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [323:288]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [287:280]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [279:250]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [249:233]
-    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [232:209]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [208:185]
-    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [184:161]
-    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [160:137]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [136:65]
-    usbdev_hw2reg_out_data_toggle_reg_t out_data_toggle; // [64:41]
-    usbdev_hw2reg_in_data_toggle_reg_t in_data_toggle; // [40:17]
-    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [16:8]
-    usbdev_hw2reg_wake_events_reg_t wake_events; // [7:0]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [402:367]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [366:359]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [358:329]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [328:312]
+    usbdev_hw2reg_rxenable_out_mreg_t [11:0] rxenable_out; // [311:288]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [287:264]
+    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [263:240]
+    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [239:216]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [215:144]
+    usbdev_hw2reg_out_data_toggle_reg_t out_data_toggle; // [143:120]
+    usbdev_hw2reg_in_data_toggle_reg_t in_data_toggle; // [119:96]
+    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [95:87]
+    usbdev_hw2reg_wake_events_reg_t wake_events; // [86:79]
+    usbdev_hw2reg_count_out_reg_t count_out; // [78:55]
+    usbdev_hw2reg_count_in_reg_t count_in; // [54:32]
+    usbdev_hw2reg_count_nodata_in_reg_t count_nodata_in; // [31:12]
+    usbdev_hw2reg_count_errors_reg_t count_errors; // [11:0]
   } usbdev_hw2reg_t;
 
   // Register offsets
@@ -725,6 +883,10 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_CONTROL_OFFSET = 12'h 90;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_EVENTS_OFFSET = 12'h 94;
   parameter logic [BlockAw-1:0] USBDEV_FIFO_CTRL_OFFSET = 12'h 98;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_OUT_OFFSET = 12'h 9c;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_IN_OFFSET = 12'h a0;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_NODATA_IN_OFFSET = 12'h a4;
+  parameter logic [BlockAw-1:0] USBDEV_COUNT_ERRORS_OFFSET = 12'h a8;
 
   // Reset values for hwext registers and their fields
   parameter logic [17:0] USBDEV_INTR_TEST_RESVAL = 18'h 0;
@@ -757,6 +919,32 @@ package usbdev_reg_pkg;
   parameter logic [1:0] USBDEV_WAKE_CONTROL_RESVAL = 2'h 0;
   parameter logic [0:0] USBDEV_WAKE_CONTROL_SUSPEND_REQ_RESVAL = 1'h 0;
   parameter logic [0:0] USBDEV_WAKE_CONTROL_WAKE_ACK_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_OUT_RESVAL = 32'h 0;
+  parameter logic [7:0] USBDEV_COUNT_OUT_COUNT_RESVAL = 8'h 0;
+  parameter logic [0:0] USBDEV_COUNT_OUT_DATATOG_OUT_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_OUT_DROP_RX_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_OUT_DROP_AVOUT_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_OUT_IGN_AVSETUP_RESVAL = 1'h 0;
+  parameter logic [11:0] USBDEV_COUNT_OUT_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_OUT_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_IN_RESVAL = 32'h 0;
+  parameter logic [7:0] USBDEV_COUNT_IN_COUNT_RESVAL = 8'h 0;
+  parameter logic [0:0] USBDEV_COUNT_IN_NODATA_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_IN_NAK_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_IN_TIMEOUT_RESVAL = 1'h 0;
+  parameter logic [11:0] USBDEV_COUNT_IN_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_IN_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_NODATA_IN_RESVAL = 32'h 0;
+  parameter logic [7:0] USBDEV_COUNT_NODATA_IN_COUNT_RESVAL = 8'h 0;
+  parameter logic [11:0] USBDEV_COUNT_NODATA_IN_ENDPOINTS_RESVAL = 12'h 0;
+  parameter logic [0:0] USBDEV_COUNT_NODATA_IN_RST_RESVAL = 1'h 0;
+  parameter logic [31:0] USBDEV_COUNT_ERRORS_RESVAL = 32'h 0;
+  parameter logic [7:0] USBDEV_COUNT_ERRORS_COUNT_RESVAL = 8'h 0;
+  parameter logic [0:0] USBDEV_COUNT_ERRORS_PID_INVALID_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_ERRORS_BITSTUFF_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_ERRORS_CRC16_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_ERRORS_CRC5_RESVAL = 1'h 0;
+  parameter logic [0:0] USBDEV_COUNT_ERRORS_RST_RESVAL = 1'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] USBDEV_BUFFER_OFFSET = 12'h 800;
@@ -803,11 +991,15 @@ package usbdev_reg_pkg;
     USBDEV_PHY_CONFIG,
     USBDEV_WAKE_CONTROL,
     USBDEV_WAKE_EVENTS,
-    USBDEV_FIFO_CTRL
+    USBDEV_FIFO_CTRL,
+    USBDEV_COUNT_OUT,
+    USBDEV_COUNT_IN,
+    USBDEV_COUNT_NODATA_IN,
+    USBDEV_COUNT_ERRORS
   } usbdev_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] USBDEV_PERMIT [39] = '{
+  parameter logic [3:0] USBDEV_PERMIT [43] = '{
     4'b 0111, // index[ 0] USBDEV_INTR_STATE
     4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
     4'b 0111, // index[ 2] USBDEV_INTR_TEST
@@ -846,7 +1038,11 @@ package usbdev_reg_pkg;
     4'b 0001, // index[35] USBDEV_PHY_CONFIG
     4'b 0001, // index[36] USBDEV_WAKE_CONTROL
     4'b 0011, // index[37] USBDEV_WAKE_EVENTS
-    4'b 0001  // index[38] USBDEV_FIFO_CTRL
+    4'b 0001, // index[38] USBDEV_FIFO_CTRL
+    4'b 1111, // index[39] USBDEV_COUNT_OUT
+    4'b 1111, // index[40] USBDEV_COUNT_IN
+    4'b 1111, // index[41] USBDEV_COUNT_NODATA_IN
+    4'b 1111  // index[42] USBDEV_COUNT_ERRORS
   };
 
 endpackage

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -59,9 +59,9 @@ module usbdev_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [38:0] reg_we_check;
+  logic [42:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(39)
+    .OneHotWidth(43)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -733,6 +733,50 @@ module usbdev_reg_top (
   logic fifo_ctrl_avout_rst_wd;
   logic fifo_ctrl_avsetup_rst_wd;
   logic fifo_ctrl_rx_rst_wd;
+  logic count_out_re;
+  logic count_out_we;
+  logic [7:0] count_out_count_qs;
+  logic count_out_datatog_out_qs;
+  logic count_out_datatog_out_wd;
+  logic count_out_drop_rx_qs;
+  logic count_out_drop_rx_wd;
+  logic count_out_drop_avout_qs;
+  logic count_out_drop_avout_wd;
+  logic count_out_ign_avsetup_qs;
+  logic count_out_ign_avsetup_wd;
+  logic [11:0] count_out_endpoints_qs;
+  logic [11:0] count_out_endpoints_wd;
+  logic count_out_rst_wd;
+  logic count_in_re;
+  logic count_in_we;
+  logic [7:0] count_in_count_qs;
+  logic count_in_nodata_qs;
+  logic count_in_nodata_wd;
+  logic count_in_nak_qs;
+  logic count_in_nak_wd;
+  logic count_in_timeout_qs;
+  logic count_in_timeout_wd;
+  logic [11:0] count_in_endpoints_qs;
+  logic [11:0] count_in_endpoints_wd;
+  logic count_in_rst_wd;
+  logic count_nodata_in_re;
+  logic count_nodata_in_we;
+  logic [7:0] count_nodata_in_count_qs;
+  logic [11:0] count_nodata_in_endpoints_qs;
+  logic [11:0] count_nodata_in_endpoints_wd;
+  logic count_nodata_in_rst_wd;
+  logic count_errors_re;
+  logic count_errors_we;
+  logic [7:0] count_errors_count_qs;
+  logic count_errors_pid_invalid_qs;
+  logic count_errors_pid_invalid_wd;
+  logic count_errors_bitstuff_qs;
+  logic count_errors_bitstuff_wd;
+  logic count_errors_crc16_qs;
+  logic count_errors_crc16_wd;
+  logic count_errors_crc5_qs;
+  logic count_errors_crc5_wd;
+  logic count_errors_rst_wd;
   // Define register CDC handling.
   // CDC handling is done on a per-reg instead of per-field boundary.
 
@@ -8293,8 +8337,388 @@ module usbdev_reg_top (
   assign reg2hw.fifo_ctrl.rx_rst.qe = fifo_ctrl_qe;
 
 
+  // R[count_out]: V(True)
+  logic count_out_qe;
+  logic [6:0] count_out_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_out_flds_we;
+  assign unused_count_out_flds_we = ^(count_out_flds_we & 7'h1);
+  assign count_out_qe = &(count_out_flds_we | 7'h1);
+  //   F[count]: 7:0
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_count_out_count (
+    .re     (count_out_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_out.count.d),
+    .qre    (),
+    .qe     (count_out_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_out_count_qs)
+  );
 
-  logic [38:0] addr_hit;
+  //   F[datatog_out]: 12:12
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_out_datatog_out (
+    .re     (count_out_re),
+    .we     (count_out_we),
+    .wd     (count_out_datatog_out_wd),
+    .d      (hw2reg.count_out.datatog_out.d),
+    .qre    (),
+    .qe     (count_out_flds_we[1]),
+    .q      (reg2hw.count_out.datatog_out.q),
+    .ds     (),
+    .qs     (count_out_datatog_out_qs)
+  );
+  assign reg2hw.count_out.datatog_out.qe = count_out_qe;
+
+  //   F[drop_rx]: 13:13
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_out_drop_rx (
+    .re     (count_out_re),
+    .we     (count_out_we),
+    .wd     (count_out_drop_rx_wd),
+    .d      (hw2reg.count_out.drop_rx.d),
+    .qre    (),
+    .qe     (count_out_flds_we[2]),
+    .q      (reg2hw.count_out.drop_rx.q),
+    .ds     (),
+    .qs     (count_out_drop_rx_qs)
+  );
+  assign reg2hw.count_out.drop_rx.qe = count_out_qe;
+
+  //   F[drop_avout]: 14:14
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_out_drop_avout (
+    .re     (count_out_re),
+    .we     (count_out_we),
+    .wd     (count_out_drop_avout_wd),
+    .d      (hw2reg.count_out.drop_avout.d),
+    .qre    (),
+    .qe     (count_out_flds_we[3]),
+    .q      (reg2hw.count_out.drop_avout.q),
+    .ds     (),
+    .qs     (count_out_drop_avout_qs)
+  );
+  assign reg2hw.count_out.drop_avout.qe = count_out_qe;
+
+  //   F[ign_avsetup]: 15:15
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_out_ign_avsetup (
+    .re     (count_out_re),
+    .we     (count_out_we),
+    .wd     (count_out_ign_avsetup_wd),
+    .d      (hw2reg.count_out.ign_avsetup.d),
+    .qre    (),
+    .qe     (count_out_flds_we[4]),
+    .q      (reg2hw.count_out.ign_avsetup.q),
+    .ds     (),
+    .qs     (count_out_ign_avsetup_qs)
+  );
+  assign reg2hw.count_out.ign_avsetup.qe = count_out_qe;
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_out_endpoints (
+    .re     (count_out_re),
+    .we     (count_out_we),
+    .wd     (count_out_endpoints_wd),
+    .d      (hw2reg.count_out.endpoints.d),
+    .qre    (),
+    .qe     (count_out_flds_we[5]),
+    .q      (reg2hw.count_out.endpoints.q),
+    .ds     (),
+    .qs     (count_out_endpoints_qs)
+  );
+  assign reg2hw.count_out.endpoints.qe = count_out_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_out_rst (
+    .re     (1'b0),
+    .we     (count_out_we),
+    .wd     (count_out_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_out_flds_we[6]),
+    .q      (reg2hw.count_out.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_out.rst.qe = count_out_qe;
+
+
+  // R[count_in]: V(True)
+  logic count_in_qe;
+  logic [5:0] count_in_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_in_flds_we;
+  assign unused_count_in_flds_we = ^(count_in_flds_we & 6'h1);
+  assign count_in_qe = &(count_in_flds_we | 6'h1);
+  //   F[count]: 7:0
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_count_in_count (
+    .re     (count_in_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_in.count.d),
+    .qre    (),
+    .qe     (count_in_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_in_count_qs)
+  );
+
+  //   F[nodata]: 13:13
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_in_nodata (
+    .re     (count_in_re),
+    .we     (count_in_we),
+    .wd     (count_in_nodata_wd),
+    .d      (hw2reg.count_in.nodata.d),
+    .qre    (),
+    .qe     (count_in_flds_we[1]),
+    .q      (reg2hw.count_in.nodata.q),
+    .ds     (),
+    .qs     (count_in_nodata_qs)
+  );
+  assign reg2hw.count_in.nodata.qe = count_in_qe;
+
+  //   F[nak]: 14:14
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_in_nak (
+    .re     (count_in_re),
+    .we     (count_in_we),
+    .wd     (count_in_nak_wd),
+    .d      (hw2reg.count_in.nak.d),
+    .qre    (),
+    .qe     (count_in_flds_we[2]),
+    .q      (reg2hw.count_in.nak.q),
+    .ds     (),
+    .qs     (count_in_nak_qs)
+  );
+  assign reg2hw.count_in.nak.qe = count_in_qe;
+
+  //   F[timeout]: 15:15
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_in_timeout (
+    .re     (count_in_re),
+    .we     (count_in_we),
+    .wd     (count_in_timeout_wd),
+    .d      (hw2reg.count_in.timeout.d),
+    .qre    (),
+    .qe     (count_in_flds_we[3]),
+    .q      (reg2hw.count_in.timeout.q),
+    .ds     (),
+    .qs     (count_in_timeout_qs)
+  );
+  assign reg2hw.count_in.timeout.qe = count_in_qe;
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_in_endpoints (
+    .re     (count_in_re),
+    .we     (count_in_we),
+    .wd     (count_in_endpoints_wd),
+    .d      (hw2reg.count_in.endpoints.d),
+    .qre    (),
+    .qe     (count_in_flds_we[4]),
+    .q      (reg2hw.count_in.endpoints.q),
+    .ds     (),
+    .qs     (count_in_endpoints_qs)
+  );
+  assign reg2hw.count_in.endpoints.qe = count_in_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_in_rst (
+    .re     (1'b0),
+    .we     (count_in_we),
+    .wd     (count_in_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_in_flds_we[5]),
+    .q      (reg2hw.count_in.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_in.rst.qe = count_in_qe;
+
+
+  // R[count_nodata_in]: V(True)
+  logic count_nodata_in_qe;
+  logic [2:0] count_nodata_in_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_nodata_in_flds_we;
+  assign unused_count_nodata_in_flds_we = ^(count_nodata_in_flds_we & 3'h1);
+  assign count_nodata_in_qe = &(count_nodata_in_flds_we | 3'h1);
+  //   F[count]: 7:0
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_count_nodata_in_count (
+    .re     (count_nodata_in_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_nodata_in.count.d),
+    .qre    (),
+    .qe     (count_nodata_in_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_nodata_in_count_qs)
+  );
+
+  //   F[endpoints]: 27:16
+  prim_subreg_ext #(
+    .DW    (12)
+  ) u_count_nodata_in_endpoints (
+    .re     (count_nodata_in_re),
+    .we     (count_nodata_in_we),
+    .wd     (count_nodata_in_endpoints_wd),
+    .d      (hw2reg.count_nodata_in.endpoints.d),
+    .qre    (),
+    .qe     (count_nodata_in_flds_we[1]),
+    .q      (reg2hw.count_nodata_in.endpoints.q),
+    .ds     (),
+    .qs     (count_nodata_in_endpoints_qs)
+  );
+  assign reg2hw.count_nodata_in.endpoints.qe = count_nodata_in_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_nodata_in_rst (
+    .re     (1'b0),
+    .we     (count_nodata_in_we),
+    .wd     (count_nodata_in_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_nodata_in_flds_we[2]),
+    .q      (reg2hw.count_nodata_in.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_nodata_in.rst.qe = count_nodata_in_qe;
+
+
+  // R[count_errors]: V(True)
+  logic count_errors_qe;
+  logic [5:0] count_errors_flds_we;
+  // This ignores QEs that are set to constant 0 due to read-only fields.
+  logic unused_count_errors_flds_we;
+  assign unused_count_errors_flds_we = ^(count_errors_flds_we & 6'h1);
+  assign count_errors_qe = &(count_errors_flds_we | 6'h1);
+  //   F[count]: 7:0
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_count_errors_count (
+    .re     (count_errors_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.count_errors.count.d),
+    .qre    (),
+    .qe     (count_errors_flds_we[0]),
+    .q      (),
+    .ds     (),
+    .qs     (count_errors_count_qs)
+  );
+
+  //   F[pid_invalid]: 27:27
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_errors_pid_invalid (
+    .re     (count_errors_re),
+    .we     (count_errors_we),
+    .wd     (count_errors_pid_invalid_wd),
+    .d      (hw2reg.count_errors.pid_invalid.d),
+    .qre    (),
+    .qe     (count_errors_flds_we[1]),
+    .q      (reg2hw.count_errors.pid_invalid.q),
+    .ds     (),
+    .qs     (count_errors_pid_invalid_qs)
+  );
+  assign reg2hw.count_errors.pid_invalid.qe = count_errors_qe;
+
+  //   F[bitstuff]: 28:28
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_errors_bitstuff (
+    .re     (count_errors_re),
+    .we     (count_errors_we),
+    .wd     (count_errors_bitstuff_wd),
+    .d      (hw2reg.count_errors.bitstuff.d),
+    .qre    (),
+    .qe     (count_errors_flds_we[2]),
+    .q      (reg2hw.count_errors.bitstuff.q),
+    .ds     (),
+    .qs     (count_errors_bitstuff_qs)
+  );
+  assign reg2hw.count_errors.bitstuff.qe = count_errors_qe;
+
+  //   F[crc16]: 29:29
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_errors_crc16 (
+    .re     (count_errors_re),
+    .we     (count_errors_we),
+    .wd     (count_errors_crc16_wd),
+    .d      (hw2reg.count_errors.crc16.d),
+    .qre    (),
+    .qe     (count_errors_flds_we[3]),
+    .q      (reg2hw.count_errors.crc16.q),
+    .ds     (),
+    .qs     (count_errors_crc16_qs)
+  );
+  assign reg2hw.count_errors.crc16.qe = count_errors_qe;
+
+  //   F[crc5]: 30:30
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_errors_crc5 (
+    .re     (count_errors_re),
+    .we     (count_errors_we),
+    .wd     (count_errors_crc5_wd),
+    .d      (hw2reg.count_errors.crc5.d),
+    .qre    (),
+    .qe     (count_errors_flds_we[4]),
+    .q      (reg2hw.count_errors.crc5.q),
+    .ds     (),
+    .qs     (count_errors_crc5_qs)
+  );
+  assign reg2hw.count_errors.crc5.qe = count_errors_qe;
+
+  //   F[rst]: 31:31
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_count_errors_rst (
+    .re     (1'b0),
+    .we     (count_errors_we),
+    .wd     (count_errors_rst_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (count_errors_flds_we[5]),
+    .q      (reg2hw.count_errors.rst.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.count_errors.rst.qe = count_errors_qe;
+
+
+
+  logic [42:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == USBDEV_INTR_STATE_OFFSET);
@@ -8336,6 +8760,10 @@ module usbdev_reg_top (
     addr_hit[36] = (reg_addr == USBDEV_WAKE_CONTROL_OFFSET);
     addr_hit[37] = (reg_addr == USBDEV_WAKE_EVENTS_OFFSET);
     addr_hit[38] = (reg_addr == USBDEV_FIFO_CTRL_OFFSET);
+    addr_hit[39] = (reg_addr == USBDEV_COUNT_OUT_OFFSET);
+    addr_hit[40] = (reg_addr == USBDEV_COUNT_IN_OFFSET);
+    addr_hit[41] = (reg_addr == USBDEV_COUNT_NODATA_IN_OFFSET);
+    addr_hit[42] = (reg_addr == USBDEV_COUNT_ERRORS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -8381,7 +8809,11 @@ module usbdev_reg_top (
                (addr_hit[35] & (|(USBDEV_PERMIT[35] & ~reg_be))) |
                (addr_hit[36] & (|(USBDEV_PERMIT[36] & ~reg_be))) |
                (addr_hit[37] & (|(USBDEV_PERMIT[37] & ~reg_be))) |
-               (addr_hit[38] & (|(USBDEV_PERMIT[38] & ~reg_be)))));
+               (addr_hit[38] & (|(USBDEV_PERMIT[38] & ~reg_be))) |
+               (addr_hit[39] & (|(USBDEV_PERMIT[39] & ~reg_be))) |
+               (addr_hit[40] & (|(USBDEV_PERMIT[40] & ~reg_be))) |
+               (addr_hit[41] & (|(USBDEV_PERMIT[41] & ~reg_be))) |
+               (addr_hit[42] & (|(USBDEV_PERMIT[42] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -8941,6 +9373,50 @@ module usbdev_reg_top (
   assign fifo_ctrl_avsetup_rst_wd = reg_wdata[1];
 
   assign fifo_ctrl_rx_rst_wd = reg_wdata[2];
+  assign count_out_re = addr_hit[39] & reg_re & !reg_error;
+  assign count_out_we = addr_hit[39] & reg_we & !reg_error;
+
+  assign count_out_datatog_out_wd = reg_wdata[12];
+
+  assign count_out_drop_rx_wd = reg_wdata[13];
+
+  assign count_out_drop_avout_wd = reg_wdata[14];
+
+  assign count_out_ign_avsetup_wd = reg_wdata[15];
+
+  assign count_out_endpoints_wd = reg_wdata[27:16];
+
+  assign count_out_rst_wd = reg_wdata[31];
+  assign count_in_re = addr_hit[40] & reg_re & !reg_error;
+  assign count_in_we = addr_hit[40] & reg_we & !reg_error;
+
+  assign count_in_nodata_wd = reg_wdata[13];
+
+  assign count_in_nak_wd = reg_wdata[14];
+
+  assign count_in_timeout_wd = reg_wdata[15];
+
+  assign count_in_endpoints_wd = reg_wdata[27:16];
+
+  assign count_in_rst_wd = reg_wdata[31];
+  assign count_nodata_in_re = addr_hit[41] & reg_re & !reg_error;
+  assign count_nodata_in_we = addr_hit[41] & reg_we & !reg_error;
+
+  assign count_nodata_in_endpoints_wd = reg_wdata[27:16];
+
+  assign count_nodata_in_rst_wd = reg_wdata[31];
+  assign count_errors_re = addr_hit[42] & reg_re & !reg_error;
+  assign count_errors_we = addr_hit[42] & reg_we & !reg_error;
+
+  assign count_errors_pid_invalid_wd = reg_wdata[27];
+
+  assign count_errors_bitstuff_wd = reg_wdata[28];
+
+  assign count_errors_crc16_wd = reg_wdata[29];
+
+  assign count_errors_crc5_wd = reg_wdata[30];
+
+  assign count_errors_rst_wd = reg_wdata[31];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -8984,6 +9460,10 @@ module usbdev_reg_top (
     reg_we_check[36] = wake_control_we;
     reg_we_check[37] = 1'b0;
     reg_we_check[38] = fifo_ctrl_we;
+    reg_we_check[39] = count_out_we;
+    reg_we_check[40] = count_in_we;
+    reg_we_check[41] = count_nodata_in_we;
+    reg_we_check[42] = count_errors_we;
   end
 
   // Read data return
@@ -9390,6 +9870,40 @@ module usbdev_reg_top (
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
+      end
+
+      addr_hit[39]: begin
+        reg_rdata_next[7:0] = count_out_count_qs;
+        reg_rdata_next[12] = count_out_datatog_out_qs;
+        reg_rdata_next[13] = count_out_drop_rx_qs;
+        reg_rdata_next[14] = count_out_drop_avout_qs;
+        reg_rdata_next[15] = count_out_ign_avsetup_qs;
+        reg_rdata_next[27:16] = count_out_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[40]: begin
+        reg_rdata_next[7:0] = count_in_count_qs;
+        reg_rdata_next[13] = count_in_nodata_qs;
+        reg_rdata_next[14] = count_in_nak_qs;
+        reg_rdata_next[15] = count_in_timeout_qs;
+        reg_rdata_next[27:16] = count_in_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[41]: begin
+        reg_rdata_next[7:0] = count_nodata_in_count_qs;
+        reg_rdata_next[27:16] = count_nodata_in_endpoints_qs;
+        reg_rdata_next[31] = '0;
+      end
+
+      addr_hit[42]: begin
+        reg_rdata_next[7:0] = count_errors_count_qs;
+        reg_rdata_next[27] = count_errors_pid_invalid_qs;
+        reg_rdata_next[28] = count_errors_bitstuff_qs;
+        reg_rdata_next[29] = count_errors_crc16_qs;
+        reg_rdata_next[30] = count_errors_crc5_qs;
+        reg_rdata_next[31] = '0;
       end
 
       default: begin

--- a/hw/ip/usbdev/usbdev.core
+++ b/hw/ip/usbdev/usbdev.core
@@ -20,6 +20,7 @@ filesets:
       - rtl/usbdev_usbif.sv
       - rtl/usbdev_linkstate.sv
       - rtl/usbdev_iomux.sv
+      - rtl/usbdev_counter.sv
       - rtl/usbdev_aon_wake.sv
       - rtl/usbdev.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
Relating to PR #21950 if the ca. 288 flops of the original proposal causes area issues alongside all of the other changes, this PR offers a still more lightweight implementation using ca. 1/3 of those flip-flops at the expense of sacrificing separability.

- Counter widths are reduced to 8 bits as per suggestions in PR #21950; software shall be required to respond more promptly to extend the hardware counters if required.
- Events visible to usbdev hardware only are grouped into categories:
  - OUT side events
  - IN side events
  - Reception error events
- Events within a given category may be enabled/disabled individually but only a second counter collects all enables events within that category.

Associated DV Draft PR #22039 not yet updated.

Resolves #22160.