### PR TITLE
[dice] add measurements of addition PROD OTP partitions to UDS cert

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -100,7 +100,7 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
  */
 // clang-format off
 #define STRUCT_MANUF_DICE_CERTS(field, string) \
-    field(uds_tbs_certificate, uint8_t, 569) \
+    field(uds_tbs_certificate, uint8_t, 714) \
     field(uds_tbs_certificate_size, size_t) \
     field(cdi_0_certificate, uint8_t, 582) \
     field(cdi_0_certificate_size, size_t) \
@@ -116,7 +116,7 @@ UJSON_SERDE_STRUCT(ManufDiceCerts, \
  */
 // clang-format off
 #define STRUCT_MANUF_ENDORSED_CERTS(field, string) \
-    field(uds_certificate, uint8_t, 660) \
+    field(uds_certificate, uint8_t, 805) \
     field(uds_certificate_size, size_t)
 UJSON_SERDE_STRUCT(ManufEndorsedCerts, \
                    manuf_endorsed_certs_t, \

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -64,6 +64,7 @@ cc_library(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/json:provisioning_data",
+        "//sw/device/lib/testing/test_framework:check",
         "//sw/device/silicon_creator/lib:attestation",
         "//sw/device/silicon_creator/lib:attestation_key_diversifiers",
         "//sw/device/silicon_creator/lib:otbn_boot_services",

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -60,6 +60,7 @@ cc_library(
     hdrs = ["dice.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/json:provisioning_data",
@@ -72,6 +73,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/otbn/crypto:boot",
     ],
 )

--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -131,12 +131,20 @@ status_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
   // TODO(#19455): check against digests present in the OTP digest field.
   hmac_digest_t otp_creator_sw_cfg_measurement = {.digest = {0}};
   hmac_digest_t otp_owner_sw_cfg_measurement = {.digest = {0}};
+  hmac_digest_t otp_rot_creator_auth_codesign_measurement = {.digest = {0}};
+  hmac_digest_t otp_rot_creator_auth_state_measurement = {.digest = {0}};
   hmac_digest_t otp_hw_cfg0_measurement = {.digest = {0}};
+  hmac_digest_t otp_hw_cfg1_measurement = {.digest = {0}};
   TRY(measure_otp_partition(kOtpPartitionCreatorSwCfg,
                             &otp_creator_sw_cfg_measurement));
   TRY(measure_otp_partition(kOtpPartitionOwnerSwCfg,
                             &otp_owner_sw_cfg_measurement));
+  TRY(measure_otp_partition(kOtpPartitionRotCreatorAuthCodesign,
+                            &otp_rot_creator_auth_codesign_measurement));
+  TRY(measure_otp_partition(kOtpPartitionRotCreatorAuthState,
+                            &otp_rot_creator_auth_state_measurement));
   TRY(measure_otp_partition(kOtpPartitionHwCfg0, &otp_hw_cfg0_measurement));
+  TRY(measure_otp_partition(kOtpPartitionHwCfg1, &otp_hw_cfg1_measurement));
 
   // Generate the UDS key.
   TRY(sc_keymgr_state_check(kScKeymgrStateInit));
@@ -153,15 +161,22 @@ status_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
 
   // Generate the TBS certificate.
   uds_tbs_values_t uds_cert_tbs_params = {
-      // TODO(#19455): add measurements of new (A1) OTP partitions.
       .otp_creator_sw_cfg_hash =
           (unsigned char *)otp_creator_sw_cfg_measurement.digest,
       .otp_creator_sw_cfg_hash_size = kHmacDigestNumBytes,
       .otp_owner_sw_cfg_hash =
           (unsigned char *)otp_owner_sw_cfg_measurement.digest,
       .otp_owner_sw_cfg_hash_size = kHmacDigestNumBytes,
+      .otp_rot_creator_auth_codesign_hash =
+          (unsigned char *)otp_rot_creator_auth_codesign_measurement.digest,
+      .otp_rot_creator_auth_codesign_hash_size = kHmacDigestNumBytes,
+      .otp_rot_creator_auth_state_hash =
+          (unsigned char *)otp_rot_creator_auth_state_measurement.digest,
+      .otp_rot_creator_auth_state_hash_size = kHmacDigestNumBytes,
       .otp_hw_cfg0_hash = (unsigned char *)otp_hw_cfg0_measurement.digest,
       .otp_hw_cfg0_hash_size = kHmacDigestNumBytes,
+      .otp_hw_cfg1_hash = (unsigned char *)otp_hw_cfg1_measurement.digest,
+      .otp_hw_cfg1_hash_size = kHmacDigestNumBytes,
       .debug_flag = is_debug_exposed(),
       .creator_pub_key_id = (unsigned char *)uds_pubkey_id->digest,
       .creator_pub_key_id_size = kCertKeyIdSizeInBytes,

--- a/sw/device/silicon_creator/lib/cert/uds.hjson
+++ b/sw/device/silicon_creator/lib/cert/uds.hjson
@@ -62,7 +62,7 @@
         // Debug (whether LC state exposes JTAG access or not).
         debug_flag: {
             type: "boolean",
-        }
+        },
         // Certificate signature: the result of signing with ECDSA
         // are two integers named "r" and "s"
         cert_signature_r: {
@@ -72,7 +72,7 @@
         cert_signature_s: {
             type: "integer",
             size: 32,
-        },
+        }
     },
 
     certificate: {

--- a/sw/device/silicon_creator/lib/cert/uds.hjson
+++ b/sw/device/silicon_creator/lib/cert/uds.hjson
@@ -39,8 +39,23 @@
             type: "byte-array",
             size: 32,
         },
+        // Hash of the rot_creator_auth_codesign OTP partition (SHA256).
+        otp_rot_creator_auth_codesign_hash: {
+            type: "byte-array",
+            size: 32,
+        },
+        // Hash of the rot_creator_auth_state OTP partition (SHA256).
+        otp_rot_creator_auth_state_hash: {
+            type: "byte-array",
+            size: 32,
+        },
         // Hash of the hw_cfg0 OTP partition (SHA256).
         otp_hw_cfg0_hash: {
+            type: "byte-array",
+            size: 32,
+        },
+        // Hash of the hw_cfg1 OTP partition (SHA256).
+        otp_hw_cfg1_hash: {
             type: "byte-array",
             size: 32,
         },
@@ -86,7 +101,10 @@
         fw_ids: [
             { hash_algorithm: "sha256", digest: { var: "otp_creator_sw_cfg_hash" } },
             { hash_algorithm: "sha256", digest: { var: "otp_owner_sw_cfg_hash" } },
+            { hash_algorithm: "sha256", digest: { var: "otp_rot_creator_auth_codesign_hash" } },
+            { hash_algorithm: "sha256", digest: { var: "otp_rot_creator_auth_state_hash" } },
             { hash_algorithm: "sha256", digest: { var: "otp_hw_cfg0_hash" } },
+            { hash_algorithm: "sha256", digest: { var: "otp_hw_cfg1_hash" } },
         ],
         flags: {
             not_configured: false,

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -15,9 +15,13 @@ extern "C" {
 
 enum {
   /**
-   * Size of a SHA-256 digest in words.
+   * Size of a SHA-256 digest in bytes.
    */
-  kHmacDigestNumWords = 8,
+  kHmacDigestNumBytes = 32,
+  /**
+   * Size of a SHA-256 digest in 32-bit words.
+   */
+  kHmacDigestNumWords = kHmacDigestNumBytes / sizeof(uint32_t),
 };
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -27,31 +27,37 @@ const otp_partition_info_t kOtpPartitions[] = {
         .start_addr = OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET,
         .size = OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
                 OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE,
+        .digest_addr = OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_REG_OFFSET,
         .align_mask = 0x3},
     [kOtpPartitionOwnerSwCfg] = {
         .start_addr = OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET,
         .size = OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
                 OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE,
+        .digest_addr = OTP_CTRL_OWNER_SW_CFG_DIGEST_0_REG_OFFSET,
         .align_mask = 0x3},
     [kOtpPartitionRotCreatorAuthCodesign] = {
         .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_OFFSET,
         .size = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
                 OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE,
+        .digest_addr = OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_DIGEST_0_REG_OFFSET,
         .align_mask = 0x3},
     [kOtpPartitionRotCreatorAuthState] = {
         .start_addr = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_OFFSET,
         .size = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
                 OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE,
+        .digest_addr = OTP_CTRL_ROT_CREATOR_AUTH_STATE_DIGEST_0_REG_OFFSET,
         .align_mask = 0x3},
     [kOtpPartitionHwCfg0] = {
         .start_addr = OTP_CTRL_PARAM_HW_CFG0_OFFSET,
         .size = OTP_CTRL_PARAM_HW_CFG0_SIZE -
                 OTP_CTRL_PARAM_HW_CFG0_DIGEST_SIZE,
+        .digest_addr = OTP_CTRL_HW_CFG0_DIGEST_0_REG_OFFSET,
         .align_mask = 0x3},
     [kOtpPartitionHwCfg1] = {
         .start_addr = OTP_CTRL_PARAM_HW_CFG1_OFFSET,
         .size = OTP_CTRL_PARAM_HW_CFG1_SIZE -
                 OTP_CTRL_PARAM_HW_CFG1_DIGEST_SIZE,
+        .digest_addr = OTP_CTRL_HW_CFG1_DIGEST_0_REG_OFFSET,
         .align_mask = 0x3},
 };
 // clang-format on
@@ -77,6 +83,14 @@ void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
   }
   HARDENED_CHECK_EQ(i, num_words);
   HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+}
+
+uint64_t otp_partition_digest_read(otp_partition_t partition) {
+  uint32_t reg_offset = kBase + kOtpPartitions[partition].digest_addr;
+  uint64_t value = sec_mmio_read32(reg_offset + sizeof(uint32_t));
+  value <<= 32;
+  value |= sec_mmio_read32(reg_offset);
+  return value;
 }
 
 static void wait_for_dai_idle(void) {

--- a/sw/device/silicon_creator/lib/drivers/otp.h
+++ b/sw/device/silicon_creator/lib/drivers/otp.h
@@ -45,6 +45,10 @@ typedef struct otp_partition_info {
    */
   size_t size;
   /**
+   * The absolute OTP address at which this partition's digest starts.
+   */
+  uint32_t digest_addr;
+  /**
    * The alignment mask for this partition.
    *
    * A valid address for this partition must be such that
@@ -99,6 +103,14 @@ uint64_t otp_read64(uint32_t address);
  * @param num_words The number of 32-bit words to read from OTP.
  */
 void otp_read(uint32_t address, uint32_t *data, size_t num_words);
+
+/**
+ * Read a partition's 64-bit digest from the corresponding CSRs.
+ *
+ * @param partition The OTP partition whose digest should be read.
+ * @return The 64-bit digest value.
+ */
+uint64_t otp_partition_digest_read(otp_partition_t partition);
 
 /**
  * Perform a blocking 32-bit read from the Direct Access Interface (DAI).

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -89,6 +89,53 @@ TEST_F(OtpReadTest, ReadLenN) {
   EXPECT_THAT(arr, ElementsAreArray(expected));
 }
 
+struct DigestReadTestCase {
+  otp_partition_t partition;
+  uint32_t digest_offest;
+};
+
+class OtpPartitionDigestTest
+    : public OtpTest,
+      public testing::WithParamInterface<DigestReadTestCase> {};
+
+TEST_P(OtpPartitionDigestTest, ReadDigest) {
+  EXPECT_SEC_READ32(base_ + GetParam().digest_offest + sizeof(uint32_t),
+                    0x12345678);
+  EXPECT_SEC_READ32(base_ + GetParam().digest_offest, 0x87654321);
+  EXPECT_EQ(otp_partition_digest_read(GetParam().partition),
+            0x1234567887654321);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ReadPartitionDigests, OtpPartitionDigestTest,
+    testing::Values(
+        DigestReadTestCase{
+            .partition = kOtpPartitionCreatorSwCfg,
+            .digest_offest = OTP_CTRL_CREATOR_SW_CFG_DIGEST_0_REG_OFFSET,
+        },
+        DigestReadTestCase{
+            .partition = kOtpPartitionOwnerSwCfg,
+            .digest_offest = OTP_CTRL_OWNER_SW_CFG_DIGEST_0_REG_OFFSET,
+        },
+        DigestReadTestCase{
+            .partition = kOtpPartitionRotCreatorAuthCodesign,
+            .digest_offest =
+                OTP_CTRL_ROT_CREATOR_AUTH_CODESIGN_DIGEST_0_REG_OFFSET,
+        },
+        DigestReadTestCase{
+            .partition = kOtpPartitionRotCreatorAuthState,
+            .digest_offest =
+                OTP_CTRL_ROT_CREATOR_AUTH_STATE_DIGEST_0_REG_OFFSET,
+        },
+        DigestReadTestCase{
+            .partition = kOtpPartitionHwCfg0,
+            .digest_offest = OTP_CTRL_HW_CFG0_DIGEST_0_REG_OFFSET,
+        },
+        DigestReadTestCase{
+            .partition = kOtpPartitionHwCfg1,
+            .digest_offest = OTP_CTRL_HW_CFG1_DIGEST_0_REG_OFFSET,
+        }));
+
 class OtpDaiReadTest : public OtpReadTest,
                        public testing::WithParamInterface<int> {};
 

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -105,10 +105,11 @@ static status_t lock_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
 
   // Get the least significant 64 bits of the digest. We will use this as the
   // digest to lock the OTP partition. The complete digest will be used in the
-  // attestation key / certificate generation.
-  uint64_t partition_digest_lowest_64bits = digest[1];
+  // attestation key / certificate generation. Note: cryptolib generates the
+  // digest in big-endian format so we must rearrange the bytes.
+  uint64_t partition_digest_lowest_64bits = __builtin_bswap32(digest[6]);
   partition_digest_lowest_64bits =
-      (partition_digest_lowest_64bits << 32) | digest[0];
+      (partition_digest_lowest_64bits << 32) | __builtin_bswap32(digest[7]);
 
   TRY(otp_ctrl_testutils_lock_partition(
       otp_ctrl, partition, /*digest=*/partition_digest_lowest_64bits));

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -74,23 +74,30 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
 
   switch (partition) {
     case kDifOtpCtrlPartitionVendorTest: {
-      uint32_t vendor_test_32bit_array[OTP_CTRL_PARAM_VENDOR_TEST_SIZE /
-                                       sizeof(uint32_t)];
+      uint32_t
+          vendor_test_32bit_array[(OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
+                                   OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE) /
+                                  sizeof(uint32_t)];
 
       TRY(otp_ctrl_testutils_dai_read32_array(
           otp_ctrl, kDifOtpCtrlPartitionVendorTest, 0, vendor_test_32bit_array,
-          OTP_CTRL_PARAM_VENDOR_TEST_SIZE / sizeof(uint32_t)));
+          (OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
+           OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE) /
+              sizeof(uint32_t)));
       otcrypto_const_byte_buf_t input = {
           .data = (unsigned char *)vendor_test_32bit_array,
-          .len = OTP_CTRL_PARAM_VENDOR_TEST_SIZE,
+          .len = OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
+                 OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE,
       };
       TRY(otcrypto_hash(input, digest));
     } break;
     case kDifOtpCtrlPartitionCreatorSwCfg: {
       otcrypto_const_byte_buf_t input = {
           .data = (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
-                                    OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET),
-          .len = OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE,
+                                    OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
+                                    OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET),
+          .len = OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE -
+                 OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_SIZE,
       };
       TRY(otcrypto_hash(input, digest));
     } break;
@@ -98,8 +105,9 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
       otcrypto_const_byte_buf_t input = {
           .data = (unsigned char *)(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +
                                     OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET +
-                                    OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE),
-          .len = OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE,
+                                    OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET),
+          .len = OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
+                 OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE,
       };
       TRY(otcrypto_hash(input, digest));
     } break;

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -34,11 +34,11 @@
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
-static_assert(kUdsMaxTbsSizeBytes == 569,
+static_assert(kUdsMaxTbsSizeBytes == 714,
               "The `uds_tbs_certificate` buffer size in the "
               "`manuf_dice_certs_t` struct should match the value of "
               "`kUdsMaxTbsSizeBytes`.");
-static_assert(kUdsMaxCertSizeBytes == 660,
+static_assert(kUdsMaxCertSizeBytes == 805,
               "The `uds_tbs_certificate` buffer size in the "
               "`manuf_dice_certs_t` struct should match the value of "
               "`kUdsMaxTbsSizeBytes`.");


### PR DESCRIPTION
The Earlgrey PROD chip has additional OTP partitions (e.g., for first stage secure boot keys) that contribute to the overall TCB of the device. Hence, this adds their measurements to the UDS cert. This partially addresses #19455.

Note: this depends on #22060, only review the last 4 commits.