### PR TITLE
[dv,pwrmgr] Fix failures

### DIFF
--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_aborted_low_power_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_aborted_low_power_vseq.sv
@@ -59,6 +59,7 @@ class pwrmgr_aborted_low_power_vseq extends pwrmgr_base_vseq;
                 "Enabled wakeups=0x%x (wkups=%x  wkup_en=%x)", enabled_wakeups, wakeups, wakeups_en
                 ), UVM_MEDIUM)
       csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
+
       `uvm_info(`gfn, $sformatf("%0sabling wakeup capture", disable_wakeup_capture ? "Dis" : "En"),
                 UVM_MEDIUM)
       csr_wr(.ptr(ral.wake_info_capture_dis), .value(disable_wakeup_capture));
@@ -117,6 +118,7 @@ class pwrmgr_aborted_low_power_vseq extends pwrmgr_base_vseq;
       // Get ready for another round.
       cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
       set_nvms_idle();
+      cfg.slow_clk_rst_vif.wait_clks(4);
     end
     `uvm_info(`gfn, "Test done", UVM_MEDIUM)
   endtask

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -581,6 +581,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
                   low_power_hint
                   ), UVM_MEDIUM)
         csr_update(.csr(ral.control));
+        wait_for_csr_to_propagate_to_slow_domain();
       end
       // Predict the effect of the potential low power transition.
       if (low_power_hint) process_low_power_hint();
@@ -709,8 +710,10 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     if (exp_value != initial_value) begin
       // The various bits of wake_info could have different sync delays, so wait some more.
       cfg.clk_rst_vif.wait_clks(1);
-      `DV_SPINWAIT(wait(cfg.pwrmgr_vif.wake_info != initial_value);, $sformatf(
-                   "wake info wait timeout  exp:%p  init:%p", exp_value, initial_value), 15_000)
+      `DV_SPINWAIT(wait(cfg.pwrmgr_vif.wake_info == exp_value);,
+                   $sformatf("wake info wait timeout exp:%p actual:%p", exp_value,
+                             cfg.pwrmgr_vif.wake_info),
+                   15_000)
     end
   endtask : fast_check_wake_info
 

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
@@ -85,10 +85,10 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
               "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeups_en))
     `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
     csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
+
     low_power_hint = 1;
     update_control_csr();
 
-    wait_for_csr_to_propagate_to_slow_domain();
     `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
 
     // Initiate low power transition.
@@ -102,7 +102,7 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
     end
 
     // Now bring it back.
-    cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+    cfg.slow_clk_rst_vif.wait_clks(cycles_before_wakeup);
     cfg.pwrmgr_vif.update_wakeups(wakeups);
 
     wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
@@ -66,18 +66,17 @@ class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
       low_power_hint = 1'b1;
       update_control_csr();
 
-      wait_for_csr_to_propagate_to_slow_domain();
       set_nvms_idle();
 
       // This will send the wakeup and trigger low power entry so they almost coincide.
       fork
         begin
-          cfg.clk_rst_vif.wait_clks(cycles_before_transition);
+          cfg.slow_clk_rst_vif.wait_clks(cycles_before_transition);
           // Initiate low power transition.
           cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
         end
         begin
-          cfg.clk_rst_vif.wait_clks(cycles_before_early_wakeup);
+          cfg.slow_clk_rst_vif.wait_clks(cycles_before_early_wakeup);
           // Send the wakeups.
           cfg.pwrmgr_vif.update_wakeups(wakeups);
         end

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
@@ -39,16 +39,16 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
     // Enable all wakeups so any peripheral can cause a wakeup.
     wakeup_en = '1;
     csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeup_en));
+
     low_power_hint = 1'b1;
     update_control_csr();
-    wait_for_csr_to_propagate_to_slow_domain();
 
     // Initiate low power transition.
     cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
     wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
 
     // Now bring it back.
-    cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+    cfg.slow_clk_rst_vif.wait_clks(cycles_before_wakeup);
     cfg.pwrmgr_vif.update_wakeups(wakeups);
 
     wait_for_fast_fsm(FastFsmActive);

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv.tpl
@@ -81,7 +81,6 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
 
       low_power_hint = 1'b1;
       update_control_csr();
-      wait_for_csr_to_propagate_to_slow_domain();
 
       // Initiate low power transition.
       cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
@@ -38,7 +38,10 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       enabled_wakeups = wakeups_en & wakeups;
       `DV_CHECK(enabled_wakeups, $sformatf(
                 "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeups_en))
-      `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf(
+                "Enabled wakeups=0x%x, wakeups=0x%x, enables=0x%x",
+                enabled_wakeups, wakeups, wakeups_en),
+                UVM_MEDIUM)
       csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
 
       if (keep_prior_wake_info) begin
@@ -65,8 +68,6 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       low_power_hint = 1'b1;
       update_control_csr();
 
-      wait_for_csr_to_propagate_to_slow_domain();
-
       // Initiate low power transition.
       cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
       set_nvms_idle();
@@ -76,7 +77,7 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       end
 
       // Now bring it back.
-      cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+      cfg.slow_clk_rst_vif.wait_clks(cycles_before_wakeup);
       cfg.pwrmgr_vif.update_wakeups(wakeups);
       // Check wake_status prior to wakeup, or the unit requesting wakeup will have been reset.
       // This read will not work in the chip, since the processor will be asleep.

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_aborted_low_power_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_aborted_low_power_vseq.sv
@@ -59,6 +59,7 @@ class pwrmgr_aborted_low_power_vseq extends pwrmgr_base_vseq;
                 "Enabled wakeups=0x%x (wkups=%x  wkup_en=%x)", enabled_wakeups, wakeups, wakeups_en
                 ), UVM_MEDIUM)
       csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
+
       `uvm_info(`gfn, $sformatf("%0sabling wakeup capture", disable_wakeup_capture ? "Dis" : "En"),
                 UVM_MEDIUM)
       csr_wr(.ptr(ral.wake_info_capture_dis), .value(disable_wakeup_capture));
@@ -117,6 +118,7 @@ class pwrmgr_aborted_low_power_vseq extends pwrmgr_base_vseq;
       // Get ready for another round.
       cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
       set_nvms_idle();
+      cfg.slow_clk_rst_vif.wait_clks(4);
     end
     `uvm_info(`gfn, "Test done", UVM_MEDIUM)
   endtask

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -581,6 +581,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
                   low_power_hint
                   ), UVM_MEDIUM)
         csr_update(.csr(ral.control));
+        wait_for_csr_to_propagate_to_slow_domain();
       end
       // Predict the effect of the potential low power transition.
       if (low_power_hint) process_low_power_hint();
@@ -709,8 +710,10 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     if (exp_value != initial_value) begin
       // The various bits of wake_info could have different sync delays, so wait some more.
       cfg.clk_rst_vif.wait_clks(1);
-      `DV_SPINWAIT(wait(cfg.pwrmgr_vif.wake_info != initial_value);, $sformatf(
-                   "wake info wait timeout  exp:%p  init:%p", exp_value, initial_value), 15_000)
+      `DV_SPINWAIT(wait(cfg.pwrmgr_vif.wake_info == exp_value);,
+                   $sformatf("wake info wait timeout exp:%p actual:%p", exp_value,
+                             cfg.pwrmgr_vif.wake_info),
+                   15_000)
     end
   endtask : fast_check_wake_info
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_invalid_vseq.sv
@@ -85,10 +85,10 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
               "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeups_en))
     `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
     csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
+
     low_power_hint = 1;
     update_control_csr();
 
-    wait_for_csr_to_propagate_to_slow_domain();
     `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
 
     // Initiate low power transition.
@@ -102,7 +102,7 @@ class pwrmgr_lowpower_invalid_vseq extends pwrmgr_base_vseq;
     end
 
     // Now bring it back.
-    cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+    cfg.slow_clk_rst_vif.wait_clks(cycles_before_wakeup);
     cfg.pwrmgr_vif.update_wakeups(wakeups);
 
     wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
@@ -66,18 +66,17 @@ class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
       low_power_hint = 1'b1;
       update_control_csr();
 
-      wait_for_csr_to_propagate_to_slow_domain();
       set_nvms_idle();
 
       // This will send the wakeup and trigger low power entry so they almost coincide.
       fork
         begin
-          cfg.clk_rst_vif.wait_clks(cycles_before_transition);
+          cfg.slow_clk_rst_vif.wait_clks(cycles_before_transition);
           // Initiate low power transition.
           cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
         end
         begin
-          cfg.clk_rst_vif.wait_clks(cycles_before_early_wakeup);
+          cfg.slow_clk_rst_vif.wait_clks(cycles_before_early_wakeup);
           // Send the wakeups.
           cfg.pwrmgr_vif.update_wakeups(wakeups);
         end

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
@@ -39,16 +39,16 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
     // Enable all wakeups so any peripheral can cause a wakeup.
     wakeup_en = '1;
     csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeup_en));
+
     low_power_hint = 1'b1;
     update_control_csr();
-    wait_for_csr_to_propagate_to_slow_domain();
 
     // Initiate low power transition.
     cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
     wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
 
     // Now bring it back.
-    cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+    cfg.slow_clk_rst_vif.wait_clks(cycles_before_wakeup);
     cfg.pwrmgr_vif.update_wakeups(wakeups);
 
     wait_for_fast_fsm(FastFsmActive);

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
@@ -81,7 +81,6 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
 
       low_power_hint = 1'b1;
       update_control_csr();
-      wait_for_csr_to_propagate_to_slow_domain();
 
       // Initiate low power transition.
       cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
@@ -38,7 +38,10 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       enabled_wakeups = wakeups_en & wakeups;
       `DV_CHECK(enabled_wakeups, $sformatf(
                 "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeups_en))
-      `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf(
+                "Enabled wakeups=0x%x, wakeups=0x%x, enables=0x%x",
+                enabled_wakeups, wakeups, wakeups_en),
+                UVM_MEDIUM)
       csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
 
       if (keep_prior_wake_info) begin
@@ -65,8 +68,6 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       low_power_hint = 1'b1;
       update_control_csr();
 
-      wait_for_csr_to_propagate_to_slow_domain();
-
       // Initiate low power transition.
       cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
       set_nvms_idle();
@@ -76,7 +77,7 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       end
 
       // Now bring it back.
-      cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+      cfg.slow_clk_rst_vif.wait_clks(cycles_before_wakeup);
       cfg.pwrmgr_vif.update_wakeups(wakeups);
       // Check wake_status prior to wakeup, or the unit requesting wakeup will have been reset.
       // This read will not work in the chip, since the processor will be asleep.


### PR DESCRIPTION
- Wait for a few slow clock cycles between iterations of pwrmgr_aborted_low_power to avoid consecutive pulses in CDC due to cfg_cdc_sync being too close.
- Move wait_for_csr_to_propagate_to_slow_domain into update_control_csr to avoid missing calling it.
- Fix incorrect check in fast_check_wake_info.
- Change cycles waited before low power transition to slow clock.