### PR TITLE
[lint,verible] Waive Verible's always-comb rule for AST blocks

### DIFF
--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -77,6 +77,10 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
+    files:
+      - lint/ast.vbl
+    file_type: veribleLintWaiver
+
 
 parameters:
   SYNTHESIS:

--- a/hw/top_earlgrey/ip/ast/lint/ast.vbl
+++ b/hw/top_earlgrey/ip/ast/lint/ast.vbl
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verible waiver file for AST
+
+# Waive the always-comb rule in the various "pgd" modules. The rule is checking
+# that we don't use always @*, and suggests we use always_comb instead.
+# Unfortunately, the code in question doesn't really translate to always_comb.
+# And we don't really care about the linting rule: the code is just supposed to
+# be a behavioural model of some analog code that isn't really part of the OT
+# opensource repo. Waive the warning.
+waive --rule=always-comb --location="vcc_pgd.sv"
+waive --rule=always-comb --location="vio_pgd.sv"
+waive --rule=always-comb --location="vcaon_pgd.sv"
+waive --rule=always-comb --location="vcmain_pgd.sv"


### PR DESCRIPTION
This waiver is described properly in the code. The reason to bother is that the rule failure is breaking CI at the moment. Eek!