### PR TITLE
[topgen] Support if last module does not contain a parameter

### DIFF
--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -244,6 +244,12 @@ def get_pad_list(padstr):
     return pads
 
 
+def is_last_module_with_params(top, idx):
+    modules_after = top["module"][idx + 1:]
+    num_params = sum(len(m["param_list"]) for m in modules_after)
+    return num_params == 0
+
+
 # Template functions
 def ljust(x, width):
     return "{:<{width}}".format(x, width=width)

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -61,10 +61,10 @@ module top_${top["name"]} #(
     p_rhs = p_exp['default']
 %>\
     % if 12 + len(p_lhs) + 3 + len(p_rhs) + 1 < 100:
-  parameter ${p_lhs} = ${p_rhs}${"" if loop.parent.last & loop.last else ","}
+  parameter ${p_lhs} = ${p_rhs}${"" if loop.last & lib.is_last_module_with_params(top, loop.parent.index) else ","}
     % else:
   parameter ${p_lhs} =
-      ${p_rhs}${"" if loop.parent.last & loop.last else ","}
+      ${p_rhs}${"" if loop.last & lib.is_last_module_with_params(top, loop.parent.index) else ","}
     % endif
   % endfor
 % endfor


### PR DESCRIPTION
The generator for the parameter section of the top-level module only generates the last comma correctly if it is a module that has parameters. If the last module has no parameter, the generator only prints a comment for that module but a comma is already created before, causing a syntax error as shown in the following snippet:

```systemverilog
  parameter int unsigned RvCoreIbexDmExceptionAddr =
      tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0],
  parameter bit RvCoreIbexPipeLine = 0,
  // parameters for mbx0
  // parameters for mbx1
  // parameters for mbx2
) (
 ...
  ```
  
This change adds a new helper function to determine if there are any modules after the current one that have no parameters to determine if it is the last parameter.