### PR TITLE
[pentest] Add FI Ibex tests

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -175,8 +175,10 @@ cc_library(
     deps = [
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",
         "//sw/device/sca/lib:sca",

--- a/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/ibex_fi.h
@@ -8,6 +8,12 @@
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/ujson/ujson.h"
 
+status_t handle_ibex_fi_char_flash_read(ujson_t *uj);
+status_t handle_ibex_fi_char_flash_write(ujson_t *uj);
+status_t handle_ibex_fi_char_sram_read(ujson_t *uj);
+status_t handle_ibex_fi_char_sram_write(ujson_t *uj);
+status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj);
+status_t handle_ibex_fi_char_conditional_branch(ujson_t *uj);
 status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj);
 status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj);
 status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj);

--- a/sw/device/tests/crypto/cryptotest/firmware/status.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/status.h
@@ -12,4 +12,11 @@
     }                                \
   } while (false)
 
+#define UJSON_CHECK_STATUS_OK(status) \
+  do {                                \
+    if (status.value != 0) {          \
+      return ABORTED();               \
+    }                                 \
+  } while (false)
+
 #endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_STATUS_H_

--- a/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h
@@ -18,13 +18,25 @@ extern "C" {
     value(_, CharUnrolledMemOpLoop) \
     value(_, CharMemOpLoop) \
     value(_, CharRegisterFile) \
-    value(_, CharRegisterFileRead)
+    value(_, CharRegisterFileRead) \
+    value(_, CharCondBranch) \
+    value(_, CharUncondBranch) \
+    value(_, CharSramWrite) \
+    value(_, CharSramRead) \
+    value(_, CharFlashWrite) \
+    value(_, CharFlashRead)
 UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
 
 #define IBEXFI_TEST_RESULT(field, string) \
     field(result, uint32_t) \
     field(err_status, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiTestResult, ibex_fi_test_result_t, IBEXFI_TEST_RESULT);
+
+#define IBEXFI_TEST_RESULT_MULT(field, string) \
+    field(result1, uint32_t) \
+    field(result2, uint32_t) \
+    field(err_status, uint32_t)
+UJSON_SERDE_STRUCT(IbexFiTestResultMult, ibex_fi_test_result_mult_t, IBEXFI_TEST_RESULT_MULT);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \


### PR DESCRIPTION
This commit adds the following FI penetrationt test that can be used to characterize Ibex:
- ibex.char.flash_read
- ibex.char.flash_write
- ibex.char.sram_read
- ibex.char.sram_write
- ibex.char.unconditional_branch
- ibex.char.conditional_branch