### PR TITLE
[spi_host,dv] Fix some typing problems in spi_host DV code

### DIFF
--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -298,11 +298,10 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
         end
 
         "configopts": begin
-          string      csr_str;
-          int         csr_idx;
-
-          csr_str = csr_name.getc(csr_name.len());
-          csr_idx = csr_str.atoi();
+          // Note: CONFIGOPTS is actually a multireg, but we've only got a count of 1, which means
+          // the CSR is called "configopts" (instead of e.g. configopts0). Manufacture CSR index
+          // accordingly.
+          int csr_idx = 0;
           spi_configopts.cpol[csr_idx]     = get_field_val(ral.configopts[csr_idx].cpol,
                                                            item.a_data);
           spi_configopts.cpha[csr_idx]     = get_field_val(ral.configopts[csr_idx].cpha,

--- a/hw/ip/spi_host/dv/tb.sv
+++ b/hw/ip/spi_host/dv/tb.sv
@@ -23,6 +23,7 @@ module tb;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire [3:0]                    si_pulldown;
   wire [3:0]                    so_pulldown;
+  wire [3:0]                    sio;
 
   lc_tx_t                       scanmode_i;
   logic                         cio_sck_o;
@@ -42,7 +43,7 @@ module tb;
   clk_rst_if   clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
   tl_if        tl_if(.clk(clk), .rst_n(rst_n));
-  spi_if       spi_if(.rst_n(rst_n));
+  spi_if       spi_if(.rst_n(rst_n), .sio(sio));
   spi_passthrough_if       spi_passthrough_if(.rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT()
@@ -97,9 +98,9 @@ module tb;
   for (genvar i = 0; i < 4; i++) begin : gen_tri_state
     pullup (weak1) pd_in_i (si_pulldown[i]);
     pullup (weak1) pd_out_i (so_pulldown[i]);
-    assign spi_if.sio[i]  = (cio_sd_en_o[i]) ? cio_sd_o[i] : 'z;
-    assign (highz0, pull1) spi_if.sio[i] = !cio_sd_en_o[i];
-    assign si_pulldown[i] = spi_if.sio[i];
+    assign sio[i]  = (cio_sd_en_o[i]) ? cio_sd_o[i] : 'z;
+    assign (highz0, pull1) sio[i] = !cio_sd_en_o[i];
+    assign si_pulldown[i] = sio[i];
 
     assign spi_if.csb[i] = (i < NumCS && cio_csb_en_o[i]) ? cio_csb_o[i] : 1'b1;
   end

--- a/hw/ip/spi_host/dv/tb.sv
+++ b/hw/ip/spi_host/dv/tb.sv
@@ -102,7 +102,9 @@ module tb;
     assign (highz0, pull1) sio[i] = !cio_sd_en_o[i];
     assign si_pulldown[i] = sio[i];
 
-    assign spi_if.csb[i] = (i < NumCS && cio_csb_en_o[i]) ? cio_csb_o[i] : 1'b1;
+    if (i < NumCS) begin : gen_drive_csb
+      assign spi_if.csb[i] = cio_csb_en_o[i] ? cio_csb_o[i] : 1'b1;
+    end
   end
 
   assign interrupts[SpiHostError] = intr_error;


### PR DESCRIPTION
There's some description in commit messages. This is about trying to avoid warnings coming out when building spi_host DV code with VCS (or, I suspect, Xcelium).