### PR TITLE
[dv] Fix parameter types in dv_base_mubi_cov.sv

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_mubi_cov.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_mubi_cov.sv
@@ -4,9 +4,8 @@
 //
 // coverage object for a fixed width mubi
 class mubi_cov #(parameter int Width = 4,
-                parameter int ValueTrue = prim_mubi_pkg::MuBi4True,
-                parameter int ValueFalse = prim_mubi_pkg::MuBi4False
-                ) extends uvm_object;
+                 parameter int unsigned ValueTrue = prim_mubi_pkg::MuBi4True,
+                 parameter int unsigned ValueFalse = prim_mubi_pkg::MuBi4False) extends uvm_object;
   `uvm_object_param_utils(mubi_cov #(Width, ValueTrue, ValueFalse))
 
   // Collect true, false and at least N other values (N = Width)


### PR DESCRIPTION
The existing type (int) doesn't technically allow the 32-bit mubi types. The problem is that MuBi32True has its top bit set and it's value (0x96969696) isn't representable as a signed 32 bit integer.