### PR TITLE
[opentitanlib] ECDSA/RSA/SPX raw key helper functions

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -212,6 +212,7 @@ rust_library(
         "src/util/printer.rs",
         "src/util/raw_tty.rs",
         "src/util/rom_detect.rs",
+        "src/util/serde.rs",
         "src/util/status.rs",
         "src/util/testing.rs",
         "src/util/unknown.rs",

--- a/sw/host/opentitanlib/src/chip/boot_svc.rs
+++ b/sw/host/opentitanlib/src/chip/boot_svc.rs
@@ -515,7 +515,7 @@ impl OwnershipUnlockRequest {
     }
 
     pub fn set_next_owner_key(&mut self, key: &EcdsaPublicKey) -> Result<()> {
-        self.next_owner_key = key.to_raw();
+        self.next_owner_key = EcdsaRawPublicKey::try_from(key)?;
         Ok(())
     }
 

--- a/sw/host/opentitanlib/src/chip/helper.rs
+++ b/sw/host/opentitanlib/src/chip/helper.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chip::boot_svc::{OwnershipUnlockRequest, UnlockMode};
-use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawSignature};
+use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawPublicKey, EcdsaRawSignature};
 use crate::util::parse_int::ParseInt;
 use anyhow::Result;
 use clap::Args;
@@ -36,7 +36,7 @@ impl OwnershipUnlockParams {
         }
         if let Some(next_owner) = &self.next_owner {
             let key = EcdsaPublicKey::load(next_owner)?;
-            unlock.next_owner_key = key.to_raw();
+            unlock.next_owner_key = EcdsaRawPublicKey::try_from(&key)?;
         }
         if let Some(signature) = &self.signature {
             let mut f = File::open(signature)?;

--- a/sw/host/opentitanlib/src/crypto/mod.rs
+++ b/sw/host/opentitanlib/src/crypto/mod.rs
@@ -2,7 +2,46 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::PathBuf;
+use thiserror::Error;
+
 pub mod ecdsa;
 pub mod rsa;
 pub mod sha256;
 pub mod spx;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Invalid public key: {0:?}")]
+    InvalidPublicKey(#[source] anyhow::Error),
+    #[error("Invalid DER file: {der}")]
+    InvalidDerFile {
+        der: PathBuf,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Read failed: {file}")]
+    ReadFailed {
+        file: PathBuf,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Write failed: {file}")]
+    WriteFailed {
+        file: PathBuf,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Generate failed")]
+    GenerateFailed(#[source] anyhow::Error),
+    #[error("Invalid signature")]
+    InvalidSignature(#[source] anyhow::Error),
+    #[error("Sign failed")]
+    SignFailed(#[source] anyhow::Error),
+    #[error("Verification failed")]
+    VerifyFailed(#[source] anyhow::Error),
+    #[error("Failed to compute key component")]
+    KeyComponentComputeFailed,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}

--- a/sw/host/opentitanlib/src/crypto/rsa.rs
+++ b/sw/host/opentitanlib/src/crypto/rsa.rs
@@ -2,21 +2,24 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use num_bigint_dig::{traits::ModInverse, BigInt, BigUint, Sign::Minus};
 use rand::rngs::OsRng;
 use rsa::pkcs1::{DecodeRsaPublicKey, EncodeRsaPublicKey};
 use rsa::pkcs1v15::Pkcs1v15Sign;
 use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey};
 use rsa::traits::PublicKeyParts;
+use serde::{Deserialize, Serialize};
+use serde_annotate::Annotate;
 use sha2::Sha256;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::ops::Deref;
 use std::ops::Shl;
 use std::path::{Path, PathBuf};
-use thiserror::Error;
+use std::str::FromStr;
 
+use super::Error;
 use crate::crypto::sha256::Sha256Digest;
 use crate::util::bigint::fixed_size_bigint;
 
@@ -31,40 +34,6 @@ fixed_size_bigint!(Exponent, EXPONENT_BIT_LEN);
 fixed_size_bigint!(Signature, at_most SIGNATURE_BIT_LEN);
 fixed_size_bigint!(RR, at_most RR_BIT_LEN);
 fixed_size_bigint!(N0Inv, at_most OTBN_BITS);
-
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Invalid public key: {0:?}")]
-    InvalidPublicKey(#[source] anyhow::Error),
-    #[error("Invalid DER file: {der}")]
-    InvalidDerFile {
-        der: PathBuf,
-        #[source]
-        source: anyhow::Error,
-    },
-    #[error("Read failed: {file}")]
-    ReadFailed {
-        file: PathBuf,
-        #[source]
-        source: anyhow::Error,
-    },
-    #[error("Write failed: {file}")]
-    WriteFailed {
-        file: PathBuf,
-        #[source]
-        source: anyhow::Error,
-    },
-    #[error("Generate failed")]
-    GenerateFailed(#[source] anyhow::Error),
-    #[error("Invalid signature")]
-    InvalidSignature(#[source] anyhow::Error),
-    #[error("Sign failed")]
-    SignFailed(#[source] anyhow::Error),
-    #[error("Verification failed")]
-    VerifyFailed(#[source] anyhow::Error),
-    #[error("Failed to compute key component")]
-    KeyComponentComputeFailed,
-}
 
 /// Ensure the components of `key` have the correct bit length.
 fn validate_key(key: &impl PublicKeyParts) -> Result<()> {
@@ -270,5 +239,66 @@ impl Deref for RsaPrivateKey {
 
     fn deref(&self) -> &Self::Target {
         &self.key
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Annotate)]
+pub struct RsaRawPublicKey {
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub modulus: Vec<u8>,
+    pub n0_inv: Vec<u8>,
+}
+
+impl Default for RsaRawPublicKey {
+    fn default() -> Self {
+        Self {
+            modulus: vec![0; 384],
+            n0_inv: vec![0; 32],
+        }
+    }
+}
+
+impl TryFrom<&RsaPublicKey> for RsaRawPublicKey {
+    type Error = Error;
+    fn try_from(v: &RsaPublicKey) -> Result<Self, Self::Error> {
+        Ok(Self {
+            modulus: v.modulus().to_le_bytes().to_vec(),
+            n0_inv: v.n0_inv().map_err(Error::Other)?.to_le_bytes().to_vec(),
+        })
+    }
+}
+
+impl FromStr for RsaRawPublicKey {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let key = RsaPublicKey::from_pkcs1_der_file(s)
+            .with_context(|| format!("Failed to load {s}"))
+            .map_err(Error::Other)?;
+        RsaRawPublicKey::try_from(&key)
+    }
+}
+
+impl RsaRawPublicKey {
+    pub const SIZE: usize = 384 + 32;
+    pub fn read(src: &mut impl Read) -> Result<Self> {
+        let mut key = Self::default();
+        src.read_exact(&mut key.modulus)?;
+        src.read_exact(&mut key.n0_inv)?;
+        Ok(key)
+    }
+
+    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+        ensure!(
+            self.modulus.len() == 384,
+            Error::InvalidPublicKey(anyhow!("bad modulus length: {}", self.modulus.len()))
+        );
+        ensure!(
+            self.n0_inv.len() == 32,
+            Error::InvalidPublicKey(anyhow!("bad n0_inv length: {}", self.n0_inv.len()))
+        );
+        dest.write_all(&self.modulus)?;
+        dest.write_all(&self.n0_inv)?;
+        Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -13,6 +13,7 @@ pub mod present;
 pub mod printer;
 pub mod raw_tty;
 pub mod rom_detect;
+pub mod serde;
 pub mod status;
 pub mod testing;
 pub mod unknown;

--- a/sw/host/opentitanlib/src/util/serde.rs
+++ b/sw/host/opentitanlib/src/util/serde.rs
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+use std::marker::PhantomData;
+use std::str::FromStr;
+
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize a type T from either a string or struct by forwarding
+/// string forms to `FromStr`.
+///
+/// The use-case for this is to allow specifying key material in ownership
+/// configuration files either directly or by filename:
+/// ```
+/// key: {
+///   Ecdsa: "some/path/to/key.pub.der"
+/// }
+///
+/// key: {
+///   Ecdsa: {
+///     x: "...",
+///     y: "..."
+///   }
+/// }
+/// ```
+
+// This function was taken nearly verbatim from the serde documentation.
+// The example in the serde documentation constrains the `FromStr` error
+// type to `Void`; we constrain to any type implementing std::error::Error.
+pub fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + FromStr,
+    <T as FromStr>::Err: std::error::Error,
+    D: Deserializer<'de>,
+{
+    // This is a Visitor that forwards string types to T's `FromStr` impl and
+    // forwards map types to T's `Deserialize` impl. The `PhantomData` is to
+    // keep the compiler from complaining about T being an unused generic type
+    // parameter. We need T in order to know the Value type for the Visitor
+    // impl.
+    struct StringOrStruct<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for StringOrStruct<T>
+    where
+        T: Deserialize<'de> + FromStr,
+        <T as FromStr>::Err: std::error::Error,
+    {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<T, E>
+        where
+            E: de::Error,
+        {
+            FromStr::from_str(value).map_err(|e| E::custom(format!("{e:?}")))
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<T, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+    deserializer.deserialize_any(StringOrStruct(PhantomData))
+}

--- a/sw/host/opentitantool/src/command/ecdsa.rs
+++ b/sw/host/opentitantool/src/command/ecdsa.rs
@@ -13,7 +13,9 @@ use std::path::{Path, PathBuf};
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
-use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawSignature};
+use opentitanlib::crypto::ecdsa::{
+    EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawPublicKey, EcdsaRawSignature,
+};
 use opentitanlib::crypto::sha256::Sha256Digest;
 use opentitanlib::util::parse_int::ParseInt;
 
@@ -42,8 +44,7 @@ impl CommandDispatch for EcdsaKeyShowCommand {
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         let key = load_pub_or_priv_key(&self.der_file)?;
-
-        Ok(Some(Box::new(key.to_raw())))
+        Ok(Some(Box::new(EcdsaRawPublicKey::try_from(&key)?)))
     }
 }
 
@@ -94,7 +95,7 @@ impl CommandDispatch for EcdsaKeyExportCommand {
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
         let key = load_pub_or_priv_key(&self.der_file)?;
-        let key = key.to_raw();
+        let key = EcdsaRawPublicKey::try_from(&key)?;
 
         let output_path = match &self.output_file {
             Some(path) => path.clone(),


### PR DESCRIPTION
1. Add a `Raw` struct type for each of the key types that is both serde serializable and convertible to/from binary form.
2. Add `TryFrom` conversions between the native key types and the `Raw` structs.
3. Implement `FromStr` conversions that load the Raw key material from a file.
4. Add a serde helper to allow serde deserialization to use the `FromStr` trait to initialize structs based either on their `FromStr` conversion or a json key-value map.