### PR TITLE
[bazel] And KeyInfo provider and associated rules.

### DIFF
--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -10,24 +10,38 @@ KeyInfo = provider(
     Used to capture all required information about a key.
     """,
     fields = {
-        "key_info": "Info associated with the key.",
+        "id": "Identifier used by the consumers of the provider to determine the key algorithm.",
+        "config": "The config of the key. Specific to the key algorithm.",
+        "method": "Mechanism used to access the key. Can be local or hsmtool.",
+        "pub_key": "Public key `file`.",
+        "private_key": "Private key `file`. May be None when method is set to hsmtool.",
+        "type": "The type of the key. Can be TestKey, DevKey or ProdKey.",
     },
 )
 
-def _key_sphincs_plus(ctx):
-    key_obj = {
-        "id": "sphincs_plus",
-        "config": ctx.attr.config,
-        "method": ctx.attr.method,
-        "pub_key": ctx.file.pub_key.path,
-        "type": ctx.attr.type,
-    }
-    if ctx.attr.private_key:
-        key_obj["private_key"] = ctx.file.private_key.path
-    return [KeyInfo(key_info = key_obj)]
+def _build_key_info_handler(id):
+    """Return a handler that creates a KeyInfo provider.
+
+    Args:
+        id: Identifier used by the consumers of the provider to determine the key algorithm.
+    Returns:
+        A handler that creates a KeyInfo provider.
+    """
+
+    def key_info_handler(ctx):
+        return [KeyInfo(
+            id = id,
+            config = ctx.attr.config,
+            method = ctx.attr.method,
+            pub_key = ctx.file.pub_key,
+            private_key = ctx.file.private_key,
+            type = ctx.attr.type,
+        )]
+
+    return key_info_handler
 
 key_sphincs_plus = rule(
-    implementation = _key_sphincs_plus,
+    implementation = _build_key_info_handler("sphincs_plus"),
     attrs = {
         "pub_key": attr.label(
             allow_single_file = [".pem"],
@@ -54,21 +68,8 @@ key_sphincs_plus = rule(
     },
 )
 
-def _key_ecdsa(ctx):
-    key_obj = {
-        "id": "ecdsa",
-        "config": ctx.attr.config,
-        "method": ctx.attr.method,
-        "pub_key": ctx.file.pub_key.path,
-        "type": ctx.attr.type,
-    }
-    if ctx.attr.private_key:
-        key_obj["private_key"] = ctx.file.private_key.path
-
-    return [KeyInfo(key_info = key_obj)]
-
 key_ecdsa = rule(
-    implementation = _key_ecdsa,
+    implementation = _build_key_info_handler("ecdsa"),
     attrs = {
         "pub_key": attr.label(
             allow_single_file = [".der"],

--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -1,7 +1,99 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
 load("//rules:opentitan.bzl", "key_allowed_in_lc_state")
+
+KeyInfo = provider(
+    """Key Information.
+
+    Used to capture all required information about a key.
+    """,
+    fields = {
+        "key_info": "Info associated with the key.",
+    },
+)
+
+def _key_sphincs_plus(ctx):
+    key_obj = {
+        "id": "sphincs_plus",
+        "config": ctx.attr.config,
+        "method": ctx.attr.method,
+        "pub_key": ctx.file.pub_key.path,
+        "type": ctx.attr.type,
+    }
+    if ctx.attr.private_key:
+        key_obj["private_key"] = ctx.file.private_key.path
+    return [KeyInfo(key_info = key_obj)]
+
+key_sphincs_plus = rule(
+    implementation = _key_sphincs_plus,
+    attrs = {
+        "pub_key": attr.label(
+            allow_single_file = [".pem"],
+            doc = "Public key in pem format.",
+        ),
+        "private_key": attr.label(
+            allow_single_file = [".pem"],
+            doc = "Private key in pem format.",
+        ),
+        "type": attr.string(
+            default = "TestKey",
+            doc = "The type of the key. Can be TestKey, DevKey or ProdKey.",
+            values = ["TestKey", "DevKey", "ProdKey"],
+        ),
+        "config": attr.string(
+            default = "Shake128s",
+            doc = "The config of the key. Can be Shake128s or Shake128sQ20.",
+            values = ["Shake128s", "Shake128sQ20"],
+        ),
+        "method": attr.string(
+            doc = "Mechanism used to access the key. Can be local or hsmtool.",
+            values = ["local", "hsmtool"],
+        ),
+    },
+)
+
+def _key_ecdsa(ctx):
+    key_obj = {
+        "id": "ecdsa",
+        "config": ctx.attr.config,
+        "method": ctx.attr.method,
+        "pub_key": ctx.file.pub_key.path,
+        "type": ctx.attr.type,
+    }
+    if ctx.attr.private_key:
+        key_obj["private_key"] = ctx.file.private_key.path
+
+    return [KeyInfo(key_info = key_obj)]
+
+key_ecdsa = rule(
+    implementation = _key_ecdsa,
+    attrs = {
+        "pub_key": attr.label(
+            allow_single_file = [".der"],
+            doc = "Public key in DER format.",
+        ),
+        "private_key": attr.label(
+            allow_single_file = [".der"],
+            doc = "Private key in DER format.",
+        ),
+        "type": attr.string(
+            default = "TestKey",
+            doc = "The type of the key. Can be TestKey, DevKey or ProdKey.",
+            values = ["TestKey", "DevKey", "ProdKey"],
+        ),
+        "config": attr.string(
+            default = "EcdsaP256",
+            doc = "The config of the key. Only EcdsaP256 is supported at the moment.",
+            values = ["EcdsaP256"],
+        ),
+        "method": attr.string(
+            doc = "Mechanism used to access the key. Can be local or hsmtool.",
+            values = ["local", "hsmtool"],
+        ),
+    },
+)
 
 def rsa_key_for_lc_state(key_structs, hw_lc_state):
     """Return a dictionary containing a single key that can be used in the given

--- a/sw/device/silicon_creator/rom/keys/fake/spx/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/spx/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules/opentitan:keyutils.bzl", "key_sphincs_plus")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -45,9 +47,27 @@ filegroup(
     srcs = ["test_key_0_spx.pem"],
 )
 
+key_sphincs_plus(
+    name = "test_key_0_spx_key",
+    config = "Shake128s",
+    method = "local",
+    private_key = "test_key_0_spx.pem",
+    pub_key = "test_key_0_spx.pub.pem",
+    type = "TestKey",
+)
+
 filegroup(
     name = "test_key_1_spx",
     srcs = ["test_key_1_spx.pem"],
+)
+
+key_sphincs_plus(
+    name = "test_key_1_spx_key",
+    config = "Shake128s",
+    method = "local",
+    private_key = "test_key_1_spx.pem",
+    pub_key = "test_key_1_spx.pub.pem",
+    type = "TestKey",
 )
 
 filegroup(
@@ -55,9 +75,27 @@ filegroup(
     srcs = ["dev_key_0_spx.pem"],
 )
 
+key_sphincs_plus(
+    name = "dev_key_0_spx_key",
+    config = "Shake128s",
+    method = "local",
+    private_key = "dev_key_0_spx.pem",
+    pub_key = "dev_key_0_spx.pub.pem",
+    type = "TestKey",
+)
+
 filegroup(
     name = "dev_key_1_spx",
     srcs = ["dev_key_1_spx.pem"],
+)
+
+key_sphincs_plus(
+    name = "dev_key_1_spx_key",
+    config = "Shake128s",
+    method = "local",
+    private_key = "dev_key_1_spx.pem",
+    pub_key = "dev_key_1_spx.pub.pem",
+    type = "TestKey",
 )
 
 filegroup(
@@ -65,12 +103,39 @@ filegroup(
     srcs = ["prod_key_0_spx.pem"],
 )
 
+key_sphincs_plus(
+    name = "prod_key_0_spx_key",
+    config = "Shake128s",
+    method = "local",
+    private_key = "prod_key_0_spx.pem",
+    pub_key = "prod_key_0_spx.pub.pem",
+    type = "TestKey",
+)
+
 filegroup(
     name = "prod_key_1_spx",
     srcs = ["prod_key_1_spx.pem"],
 )
 
+key_sphincs_plus(
+    name = "prod_key_1_spx_key",
+    config = "Shake128s",
+    method = "local",
+    private_key = "prod_key_0_spx.pem",
+    pub_key = "prod_key_0_spx.pub.pem",
+    type = "TestKey",
+)
+
 filegroup(
     name = "prod_key_2_spx",
     srcs = ["prod_key_2_spx.pem"],
+)
+
+key_sphincs_plus(
+    name = "prod_key_2_spx_key",
+    config = "Shake128s",
+    method = "local",
+    private_key = "prod_key_0_spx.pem",
+    pub_key = "prod_key_0_spx.pub.pem",
+    type = "TestKey",
 )

--- a/sw/device/silicon_creator/rom/keys/real/spx/BUILD
+++ b/sw/device/silicon_creator/rom/keys/real/spx/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules/opentitan:keyutils.bzl", "key_sphincs_plus")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -45,9 +47,25 @@ filegroup(
     srcs = ["test_key_0_spx.pub.pem"],
 )
 
+key_sphincs_plus(
+    name = "test_key_0_spx_key",
+    config = "Shake128s",
+    method = "hsmtool",
+    pub_key = "test_key_0_spx.pub.pem",
+    type = "TestKey",
+)
+
 filegroup(
     name = "test_key_1_spx",
     srcs = ["test_key_1_spx.pub.pem"],
+)
+
+key_sphincs_plus(
+    name = "test_key_1_spx_key",
+    config = "Shake128s",
+    method = "hsmtool",
+    pub_key = "test_key_1_spx.pub.pem",
+    type = "TestKey",
 )
 
 filegroup(
@@ -55,9 +73,25 @@ filegroup(
     srcs = ["dev_key_0_spx.pub.pem"],
 )
 
+key_sphincs_plus(
+    name = "dev_key_0_spx_key",
+    config = "Shake128s",
+    method = "hsmtool",
+    pub_key = "dev_key_0_spx.pub.pem",
+    type = "TestKey",
+)
+
 filegroup(
     name = "dev_key_1_spx",
     srcs = ["dev_key_1_spx.pub.pem"],
+)
+
+key_sphincs_plus(
+    name = "dev_key_1_spx_key",
+    config = "Shake128s",
+    method = "hsmtool",
+    pub_key = "dev_key_1_spx.pub.pem",
+    type = "TestKey",
 )
 
 filegroup(
@@ -65,12 +99,36 @@ filegroup(
     srcs = ["prod_key_0_spx.pub.pem"],
 )
 
+key_sphincs_plus(
+    name = "prod_key_0_spx_key",
+    config = "Shake128s",
+    method = "hsmtool",
+    pub_key = "prod_key_0_spx.pub.pem",
+    type = "TestKey",
+)
+
 filegroup(
     name = "prod_key_1_spx",
     srcs = ["prod_key_1_spx.pub.pem"],
 )
 
+key_sphincs_plus(
+    name = "prod_key_1_spx_key",
+    config = "Shake128s",
+    method = "hsmtool",
+    pub_key = "prod_key_1_spx.pub.pem",
+    type = "TestKey",
+)
+
 filegroup(
     name = "prod_key_2_spx",
     srcs = ["prod_key_2_spx.pub.pem"],
+)
+
+key_sphincs_plus(
+    name = "prod_key_2_spx_key",
+    config = "Shake128s",
+    method = "hsmtool",
+    pub_key = "prod_key_2_spx.pub.pem",
+    type = "TestKey",
 )


### PR DESCRIPTION
Introduce the following Bazel rules:

- `key_ecdsa`: Defines an ECDSA object that can be used for sign and verify operations.
- `key_sphincs_plus`: Defines a SPHINCS+ object that can be used for sign and verify operations.

This PR also introduces `key_sphincs_plus` targets for ROM SPX+ keys.