### PR TITLE
[sw] Require mere 2-byte alignment of entry point

### DIFF
--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -481,10 +481,10 @@ inline rom_error_t manifest_check(const manifest_t *manifest) {
     return kErrorManifestBadCodeRegion;
   }
 
-  // Entry point must be inside the executable region and word aligned.
+  // Entry point must be inside the executable region and be an even address.
   if (manifest->entry_point < manifest->code_start ||
       manifest->entry_point >= manifest->code_end ||
-      (manifest->entry_point & 0x3) != 0) {
+      (manifest->entry_point & 0x1) != 0) {
     return kErrorManifestBadEntryPoint;
   }
 

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
@@ -155,7 +155,7 @@ BOOT_POLICY_BAD_MANIFEST_CASES = [
             "identifier": hex(CONST.ROM_EXT),
             "code_start": hex(CONST.MANIFEST_SIZE + 8),
             "code_end": hex(CONST.MANIFEST_SIZE + 12),
-            "entry_point": hex(CONST.MANIFEST_SIZE + 10),
+            "entry_point": hex(CONST.MANIFEST_SIZE + 11),
         },
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.MANIFEST.BAD_ENTRY_POINT)),
         "exit_failure": msg_template_bfv_all_except(CONST.BFV.MANIFEST.BAD_ENTRY_POINT),


### PR DESCRIPTION
Risc-V instructions can either be 2 bytes or 4 bytes, and can be aligned on 2-bytes boundaries.  It seems that Clang will align functions to 2 bytes.

Is there any reason to require 4-byte alignment of the entry point? Adhering to such restriction will likely require manual linker script tuning by owners.  I propose allowing any 2-byte aligned address to serve as the entry point.