### PR TITLE
[topgen] Avoid adding a comma after the last parameter in the list

### DIFF
--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -244,6 +244,14 @@ def get_pad_list(padstr):
     return pads
 
 
+def idx_of_last_module_with_params(top):
+    last = -1
+    for idx, module in enumerate(top["module"]):
+        if len(module["param_list"]):
+            last = idx
+    return last
+
+
 # Template functions
 def ljust(x, width):
     return "{:<{width}}".format(x, width=width)

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -37,6 +37,8 @@ for m in top['memory']:
   if m['type'] == 'rom':
     has_toplevel_rom = True
 
+last_modidx_with_params = lib.idx_of_last_module_with_params(top)
+
 %>\
 `include "prim_assert.sv"
 
@@ -59,12 +61,15 @@ module top_${top["name"]} #(
 
     p_lhs = f'{p_type_word}{p_exp["name_top"]}'
     p_rhs = p_exp['default']
+
+    params_follow = not loop.last or loop.parent.index < last_modidx_with_params
+    comma_char = ',' if params_follow else ''
 %>\
     % if 12 + len(p_lhs) + 3 + len(p_rhs) + 1 < 100:
-  parameter ${p_lhs} = ${p_rhs}${"" if loop.parent.last & loop.last else ","}
+  parameter ${p_lhs} = ${p_rhs}${comma_char}
     % else:
   parameter ${p_lhs} =
-      ${p_rhs}${"" if loop.parent.last & loop.last else ","}
+      ${p_rhs}${comma_char}
     % endif
   % endfor
 % endfor


### PR DESCRIPTION
The previous code added a comma after a parameter unless this was the last parameter of the module and this was the last module in the list. This works fine unless the last module in the list doesn't happen to have any parameters.

In that situation, you got something like

     ...
      parameter int unsigned RvCoreIbexDmExceptionAddr =
          tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0],
      parameter bit RvCoreIbexPipeLine = 0,
      // parameters for mbx0
      // parameters for mbx1
      // parameters for mbx2
    ) (
     ...

which is a syntax error (the parser sees something like "a, b, )").

Tweak the logic slightly so that we add a comma unless this is the last parameter in the module and this is the last module *with parameters* in the list

The diagnosis and main work was done by Robert Schilling. I just tweaked the code to make it a bit easier for me to follow.

(And I stole the idea from him! See #22130 for the work that prompted me to take a look)