### PR TITLE
Revert "[dv] Remove phase argument from monitor's collect_trans"

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_monitor.sv
+++ b/hw/dv/sv/dv_lib/dv_base_monitor.sv
@@ -38,12 +38,12 @@ class dv_base_monitor #(type ITEM_T = uvm_sequence_item,
 
   virtual task run_phase(uvm_phase phase);
     fork
-      collect_trans();
+      collect_trans(phase);
     join
   endtask
 
   // collect transactions forever
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     `uvm_fatal(`gfn, "this method is not supposed to be called directly!")
   endtask
 

--- a/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_monitor.sv
+++ b/hw/dv/sv/flash_phy_prim_agent/flash_phy_prim_monitor.sv
@@ -76,7 +76,7 @@ class flash_phy_prim_monitor extends dv_base_monitor #(
   endtask
 
   // collect transactions forever - already forked in dv_base_monitor::run_phase
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     `DV_SPINWAIT(wait(cfg.vif.rst_n == 1);,
                  "timeout waiting for reset deassert", 100_000)
     `uvm_info(`gfn, $sformatf("flash_phy_prim_monitor %s", (cfg.scb_otf_en)? "enabled" :

--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -25,7 +25,7 @@ class jtag_monitor extends dv_base_monitor #(
   endtask
 
   // collect transactions forever - already forked in dv_base_monitor::run_phase
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     jtag_fsm_state_e   jtag_state;
     jtag_item          item;
     int                counter;

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_monitor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_monitor.sv
@@ -36,7 +36,7 @@ class jtag_dmi_monitor #(type ITEM_T = jtag_dmi_item) extends dv_base_monitor#(
     join
   endtask
 
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     jtag_item jtag_item;
     bit dmi_selected;
 

--- a/hw/dv/sv/jtag_dmi_agent/sba_access_monitor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/sba_access_monitor.sv
@@ -74,7 +74,7 @@ class sba_access_monitor #(type ITEM_T = sba_access_item) extends dv_base_monito
     `DV_EOT_PRINT_TLM_FIFO_CONTENTS(jtag_dmi_item, jtag_dmi_fifo)
   endfunction
 
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     jtag_dmi_item dmi_item;
 
     forever begin

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_monitor.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_monitor.sv
@@ -19,7 +19,7 @@ class jtag_riscv_monitor extends dv_base_monitor #(
   endfunction
 
   // collect transactions
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     jtag_item item;
     logic [DMI_OPW-1:0] op_raw;
     jtag_op_e op;

--- a/hw/dv/sv/key_sideload_agent/key_sideload_monitor.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_monitor.sv
@@ -27,7 +27,7 @@ class key_sideload_monitor #(
   endtask
 
   // collect transactions forever - already forked in dv_base_monitor::run_phase
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     key_sideload_item#(KEY_T) prev_item;
     key_sideload_item#(KEY_T) curr_item;
     prev_item = key_sideload_item#(KEY_T)::type_id::create("prev_item");

--- a/hw/dv/sv/kmac_app_agent/kmac_app_monitor.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_monitor.sv
@@ -23,7 +23,7 @@ class kmac_app_monitor extends dv_base_monitor #(
     data_fifo = new("data_fifo", this);
   endfunction
 
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     forever fork
       begin : isolation_fork
         fork

--- a/hw/dv/sv/pattgen_agent/pattgen_monitor.sv
+++ b/hw/dv/sv/pattgen_agent/pattgen_monitor.sv
@@ -24,10 +24,10 @@ class pattgen_monitor extends dv_base_monitor #(
 
   virtual task run_phase(uvm_phase phase);
     wait(cfg.vif.rst_ni);
-    collect_trans();
+    collect_trans(phase);
   endtask : run_phase
 
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     for (uint i = 0; i < NUM_PATTGEN_CHANNELS; i++) begin
       fork
         automatic uint channel = i;

--- a/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
+++ b/hw/dv/sv/push_pull_agent/push_pull_monitor.sv
@@ -24,7 +24,7 @@ class push_pull_monitor #(parameter int HostDataWidth = 32,
     cfg.in_reset = 0;
     fork
       monitor_reset();
-      collect_trans();
+      collect_trans(phase);
       // Collect partial pull reqs for the reactive pull device agent.
       collect_pull_req();
       collect_cov();
@@ -50,7 +50,7 @@ class push_pull_monitor #(parameter int HostDataWidth = 32,
   // Collect fully-completed transactions.
   //
   // TODO : sample covergroups
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     if (cfg.agent_type == PushAgent) begin
       forever begin
         @(cfg.vif.mon_cb);

--- a/hw/dv/sv/pwm_monitor/pwm_monitor.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_monitor.sv
@@ -23,7 +23,7 @@ class pwm_monitor extends dv_base_monitor #(
   endfunction
 
   // collect transactions forever - already forked in dv_base_monitor::run_phase
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     uint count_cycles, active_cycles;
     logic pwm_prev = 0;
 

--- a/hw/dv/sv/rng_agent/rng_monitor.sv
+++ b/hw/dv/sv/rng_agent/rng_monitor.sv
@@ -25,7 +25,7 @@ class rng_monitor extends dv_base_monitor #(
   endtask
 
   // collect transactions forever - already forked in dv_base_monitor::run_phase
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
   endtask
 
 endclass

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -33,11 +33,11 @@ class spi_monitor extends dv_base_monitor#(
   endfunction
 
   virtual task run_phase(uvm_phase phase);
-    forever collect_trans();
+    forever collect_trans(phase);
   endtask
 
   // collect transactions
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     bit flash_opcode_received;
 
     wait (cfg.en_monitor);

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -45,12 +45,12 @@ class usb20_monitor extends dv_base_monitor #(
   task run_phase(uvm_phase phase);
     detect_reset();
     forever begin
-      collect_trans();
+      collect_trans(phase);
     end
   endtask
 
 //-----------------------------------------Collect Trans------------------------------------------//
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     // Idle state detected here
     while(!(cfg.bif.usb_p & ~cfg.bif.usb_n)) @(posedge cfg.bif.usb_clk);
     @(posedge cfg.bif.usb_clk);

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
@@ -11,7 +11,7 @@ class otbn_trace_monitor extends dv_base_monitor #(
   `uvm_component_utils(otbn_trace_monitor)
   `uvm_component_new
 
-  protected task collect_trans();
+  protected task collect_trans(uvm_phase phase);
     otbn_trace_item item;
     bit             item_valid = 1'b0;
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
@@ -19,7 +19,7 @@ class otbn_model_monitor extends dv_base_monitor #(
 
   `uvm_component_new
 
-  protected task collect_trans();
+  protected task collect_trans(uvm_phase phase);
     fork
       collect_status();
       collect_insns();

--- a/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/ibex_icache_core_agent/ibex_icache_core_monitor.sv
@@ -35,7 +35,7 @@ class ibex_icache_core_monitor extends dv_base_monitor #(
   endtask
 
   // collect transactions forever - already forked in dv_base_moditor::run_phase
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     ibex_icache_core_bus_item trans;
     logic                     last_inval = 0;
     logic                     last_enable = 0;

--- a/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_monitor.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/ibex_icache_mem_agent/ibex_icache_mem_monitor.sv
@@ -30,7 +30,7 @@ class ibex_icache_mem_monitor
   endtask
 
   // Collect transactions forever. Forked in dv_base_moditor::run_phase
-  protected task automatic collect_trans();
+  protected task automatic collect_trans(uvm_phase phase);
     fork
       collect_grants();
       collect_responses();

--- a/util/uvmdvgen/README.md
+++ b/util/uvmdvgen/README.md
@@ -104,7 +104,7 @@ IP. The following describes their contents in each source generated:
     This is the monitor component extended from `dv_base_monitor`. It provides
     the following items:
 
-    * `virtual protected task collect_trans()`
+    * `virtual protected task collect_trans(uvm_phase phase)`
 
         This is a shell task within which user is required to add logic to detect
         an event, sample the interface and create a transaction object and write

--- a/util/uvmdvgen/monitor.sv.tpl
+++ b/util/uvmdvgen/monitor.sv.tpl
@@ -25,7 +25,7 @@ class ${name}_monitor extends dv_base_monitor #(
   endtask
 
   // collect transactions forever - already forked in dv_base_monitor::run_phase
-  virtual protected task collect_trans();
+  virtual protected task collect_trans(uvm_phase phase);
     forever begin
       // TODO: detect event
 


### PR DESCRIPTION
This reverts commit d39c54d91dad7ef1b9dd2c617dccc2c354c0939f.

The change was reasonable, but it touched some vendored code and some unrelated CI breakage meant that I didn't spot the CI check that would have told me about it. Oops!

The easiest way to fix this properly is probably to implement the same change on the Ibex side first, so let's back out the change at this end for now.