### PR TITLE
[dv,uart] Aid `uart_stress_all_with_rand_reset`

### DIFF
--- a/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_intr_vseq.sv
@@ -25,10 +25,12 @@ class uart_intr_vseq extends uart_base_vseq;
     // will inject parity/stop error in this case
     cfg.m_uart_agent_cfg.en_rx_checks = 0;
     for (int i = 1; i <= num_trans; i++) begin
+      if (cfg.stop_transaction_generators()) break;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       uart_init();
 
       repeat (NumUartIntr) begin
+        if (cfg.stop_transaction_generators()) break;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(uart_intr,
                                            uart_intr != NumUartIntr;)
         `uvm_info(`gfn, $sformatf("\nTesting %0s", uart_intr.name), UVM_LOW)

--- a/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_loopback_vseq.sv
@@ -20,6 +20,7 @@ class uart_loopback_vseq extends uart_tx_rx_vseq;
 
   task body();
     for (int i = 1; i <= num_trans; i++) begin
+      if (cfg.stop_transaction_generators()) break;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       uart_init();
 

--- a/hw/ip/uart/dv/env/seq_lib/uart_rx_oversample_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_rx_oversample_vseq.sv
@@ -29,6 +29,7 @@ class uart_rx_oversample_vseq extends uart_tx_rx_vseq;
     num_bits = ral.val.rx.get_n_bits();
     cfg.m_uart_agent_cfg.en_rx_monitor = 0;
     for (int i = 1; i <= num_trans; i++) begin
+      if (cfg.stop_transaction_generators()) break;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       uart_init();
 
@@ -36,6 +37,7 @@ class uart_rx_oversample_vseq extends uart_tx_rx_vseq;
       // don't use big number here, the way TB measures cycle isn't the same as DUT
       // need to re-sync again after certain cycles
       repeat ($urandom_range(1, 3)) begin
+        if (cfg.stop_transaction_generators()) break;
         drive_rx_oversampled_val();
       end
       `uvm_info(`gfn, $sformatf("finished run %0d/%0d", i, num_trans), UVM_LOW)

--- a/hw/ip/uart/dv/env/seq_lib/uart_stress_all_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_stress_all_vseq.sv
@@ -50,6 +50,7 @@ class uart_stress_all_vseq extends uart_base_vseq;
         common_vseq.common_seq_type = "intr_test";
       end
 
+      `uvm_info(`gfn, $sformatf("starting stress_all sub-sequence %s", seq_names[seq_idx]), UVM_LOW)
       uart_vseq.start(p_sequencer);
     end
   endtask : body

--- a/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_tx_rx_vseq.sv
@@ -108,6 +108,7 @@ class uart_tx_rx_vseq extends uart_base_vseq;
       begin
         // repeat test sequencing upto 50 times
         for (int i = 1; i <= num_trans; i++) begin
+          if (cfg.stop_transaction_generators()) break;
           // start each new run by randomizing dut parameters
           `DV_CHECK_RANDOMIZE_FATAL(this)
 
@@ -218,6 +219,7 @@ class uart_tx_rx_vseq extends uart_base_vseq;
           // csr read is much faster than uart transfer, use bigger delay
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_rx_read)
           cfg.clk_rst_vif.wait_clks(dly_to_rx_read);
+          wait_if_stop_transaction_generators();
           rand_read_rx_byte(weight_to_skip_rx_read);
         end
       end


### PR DESCRIPTION
Get the `uart_stress_all_with_rand_reset` test pass-rate higher by breaking out of sequence loops and increasing polling delays when we want to reset (as indicated by `cfg.stop_transaction_generators()`).

The key to getting the pass rate higher is to avoid the case where `wait_to_issue_reset()` times-out before it sees a large enough gap (defined by `CyclesWithNoAccessesThreshold`) between register accesses. The primary approach to achieving this idleness is to stop the test sequences early by breaking out of loops when they can do so cleanly. The secondary approach taken here is to increase register polling delays, which covers the cases where the test sequence would not reach a clean break point before the reset timeout. Low uart baud rates and sequences with long transactions make this additional method critical to getting the pass rate above 90%.