### PR TITLE
[usbev] Declare Av FIFOs as hwext

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -615,6 +615,7 @@
       desc: "Available OUT Buffer FIFO",
       swaccess: "wo",
       hwaccess: "hro",
+      hwext: "true",
       hwqe: "true",
       fields: [
         {
@@ -634,6 +635,7 @@
       desc: "Available SETUP Buffer FIFO",
       swaccess: "wo",
       hwaccess: "hro",
+      hwext: "true",
       hwqe: "true",
       fields: [
         {

--- a/hw/ip/usbdev/doc/registers.md
+++ b/hw/ip/usbdev/doc/registers.md
@@ -403,7 +403,7 @@ Available OUT Buffer FIFO
 |  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                             |
 |:------:|:------:|:-------:|:-------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
 |  31:5  |        |         |        | Reserved                                                                                                                                                |
-|  4:0   |   wo   |   0x0   | buffer | This field contains the buffer ID being passed to the USB receive engine. If the Available OUT Buffer FIFO is full, any write operations are discarded. |
+|  4:0   |   wo   |    x    | buffer | This field contains the buffer ID being passed to the USB receive engine. If the Available OUT Buffer FIFO is full, any write operations are discarded. |
 
 ## avsetupbuffer
 Available SETUP Buffer FIFO
@@ -420,7 +420,7 @@ Available SETUP Buffer FIFO
 |  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                               |
 |:------:|:------:|:-------:|:-------|:----------------------------------------------------------------------------------------------------------------------------------------------------------|
 |  31:5  |        |         |        | Reserved                                                                                                                                                  |
-|  4:0   |   wo   |   0x0   | buffer | This field contains the buffer ID being passed to the USB receive engine. If the Available SETUP Buffer FIFO is full, any write operations are discarded. |
+|  4:0   |   wo   |    x    | buffer | This field contains the buffer ID being passed to the USB receive engine. If the Available SETUP Buffer FIFO is full, any write operations are discarded. |
 
 ## rxfifo
 Received Buffer FIFO

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -750,6 +750,8 @@ package usbdev_reg_pkg;
   parameter logic [0:0] USBDEV_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [31:0] USBDEV_USBSTAT_RESVAL = 32'h 80000000;
   parameter logic [0:0] USBDEV_USBSTAT_RX_EMPTY_RESVAL = 1'h 1;
+  parameter logic [4:0] USBDEV_AVOUTBUFFER_RESVAL = 5'h 0;
+  parameter logic [4:0] USBDEV_AVSETUPBUFFER_RESVAL = 5'h 0;
   parameter logic [23:0] USBDEV_RXFIFO_RESVAL = 24'h 0;
   parameter logic [27:0] USBDEV_OUT_DATA_TOGGLE_RESVAL = 28'h 0;
   parameter logic [27:0] USBDEV_IN_DATA_TOGGLE_RESVAL = 28'h 0;

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -3013,81 +3013,41 @@ module usbdev_reg_top (
   );
 
 
-  // R[avoutbuffer]: V(False)
+  // R[avoutbuffer]: V(True)
   logic avoutbuffer_qe;
   logic [0:0] avoutbuffer_flds_we;
-  prim_flop #(
-    .Width(1),
-    .ResetValue(0)
-  ) u_avoutbuffer0_qe (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .d_i(&avoutbuffer_flds_we),
-    .q_o(avoutbuffer_qe)
-  );
-  prim_subreg #(
-    .DW      (5),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+  assign avoutbuffer_qe = &avoutbuffer_flds_we;
+  prim_subreg_ext #(
+    .DW    (5)
   ) u_avoutbuffer (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (1'b0),
     .we     (avoutbuffer_we),
     .wd     (avoutbuffer_wd),
-
-    // from internal hardware
-    .de     (1'b0),
     .d      ('0),
-
-    // to internal hardware
+    .qre    (),
     .qe     (avoutbuffer_flds_we[0]),
     .q      (reg2hw.avoutbuffer.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     ()
   );
   assign reg2hw.avoutbuffer.qe = avoutbuffer_qe;
 
 
-  // R[avsetupbuffer]: V(False)
+  // R[avsetupbuffer]: V(True)
   logic avsetupbuffer_qe;
   logic [0:0] avsetupbuffer_flds_we;
-  prim_flop #(
-    .Width(1),
-    .ResetValue(0)
-  ) u_avsetupbuffer0_qe (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .d_i(&avsetupbuffer_flds_we),
-    .q_o(avsetupbuffer_qe)
-  );
-  prim_subreg #(
-    .DW      (5),
-    .SwAccess(prim_subreg_pkg::SwAccessWO),
-    .RESVAL  (5'h0),
-    .Mubi    (1'b0)
+  assign avsetupbuffer_qe = &avsetupbuffer_flds_we;
+  prim_subreg_ext #(
+    .DW    (5)
   ) u_avsetupbuffer (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
+    .re     (1'b0),
     .we     (avsetupbuffer_we),
     .wd     (avsetupbuffer_wd),
-
-    // from internal hardware
-    .de     (1'b0),
     .d      ('0),
-
-    // to internal hardware
+    .qre    (),
     .qe     (avsetupbuffer_flds_we[0]),
     .q      (reg2hw.avsetupbuffer.q),
     .ds     (),
-
-    // to register interface (read)
     .qs     ()
   );
   assign reg2hw.avsetupbuffer.qe = avsetupbuffer_qe;


### PR DESCRIPTION
Declaring the FIFOs as hwext when they are WO from a software perspective removes the unnecessary flip-flops (and a cycle delay in the provision in the buffer). 'avsetupbuffer' recently mimicked 'avoutbuffer' and thus this apparent oversight was duplicated.

Unless I've missed something this should not change any functionality, and current block level DV tests are unaffected.