### PR TITLE
[dv,usbdev] Fixes for usbdev DV sequences

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -65,7 +65,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     m_token_pkt.address = {<<{m_token_pkt.address}};
     m_token_pkt.endpoint = {<<{m_token_pkt.endpoint}};
     m_token_pkt.crc5 = {<<{m_token_pkt.crc5}};
-    m_token_pkt.pack(driver_token_pkt);
+    void'(m_token_pkt.pack(driver_token_pkt));
     // to make complete packet need to attach SYNC at start of packet
     comp_token_pkt = new[driver_token_pkt.size() + 8];
     for (int i = 0; i < 8; i++) begin
@@ -96,7 +96,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     m_data_pkt.data = {<<8{m_data_pkt.data}};
     m_data_pkt.data = {<<{m_data_pkt.data}};
     m_data_pkt.crc16 = {<<{m_data_pkt.crc16}};
-    m_data_pkt.pack(driver_data_pkt);
+    void'(m_data_pkt.pack(driver_data_pkt));
     `uvm_info(`gfn, $sformatf("Driver Data_Packet = %p", driver_data_pkt), UVM_DEBUG)
     // To make complete packet need to attach SYNC at start of packet
     comp_data_pkt = new[driver_data_pkt.size() + 8];
@@ -125,7 +125,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     $cast(m_handshake_pkt, seq_item);
     m_handshake_pkt.m_pid_type = pid_type_e'({<<4{m_handshake_pkt.m_pid_type}});
     m_handshake_pkt.m_pid_type = pid_type_e'({<<{m_handshake_pkt.m_pid_type}});
-    m_handshake_pkt.pack(driver_handshake_pkt);
+    void'(m_handshake_pkt.pack(driver_handshake_pkt));
     `uvm_info(`gfn, $sformatf("Driver Handshake_Packet = %p", driver_handshake_pkt), UVM_DEBUG)
     // To make complete packet need to attach SYNC at start of packet
     comp_handshake_pkt = new[driver_handshake_pkt.size() + 8];
@@ -150,7 +150,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     m_sof_pkt.m_pid_type = pid_type_e'({<<{m_sof_pkt.m_pid_type}});
     m_sof_pkt.framecnt = {<<{m_sof_pkt.framecnt}};
     m_sof_pkt.crc5 = {<<{m_sof_pkt.crc5}};
-    m_sof_pkt.pack(driver_sof_pkt);
+    void'(m_sof_pkt.pack(driver_sof_pkt));
     // to make complete packet need to attach SYNC at start of packet
     comp_sof_pkt = new[driver_sof_pkt.size() + 8];
     for (int i = 0; i < 8; i++) begin

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -37,8 +37,7 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
     ral.rxenable_out[0].out[endp].set(1'b1);
     csr_update(ral.rxenable_out[0]);
     // Set buffer
-    ral.avoutbuffer.buffer.set(out_buffer_id);
-    csr_update(ral.avoutbuffer);
+    csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id));
   endtask
 
   task check_trans_accuracy();

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -277,9 +277,8 @@ virtual task configure_out_trans();
   // Enable rx out
   ral.rxenable_out[0].out[endp].set(1'b1);
   csr_update(ral.rxenable_out[0]);
-  // Set buffer
-  ral.avoutbuffer.buffer.set(out_buffer_id);
-  csr_update(ral.avoutbuffer);
+  // Put buffer in Available OUT Buffer _FIFO_, so use csr_wr _not_ csr_update
+  csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id));
 endtask
 
 virtual task configure_setup_trans();
@@ -289,9 +288,8 @@ virtual task configure_setup_trans();
   // Enable rx setup
   ral.rxenable_setup[0].setup[endp].set(1'b1);
   csr_update(ral.rxenable_setup[0]);
-  // Set buffer
-  ral.avsetupbuffer.buffer.set(setup_buffer_id);
-  csr_update(ral.avsetupbuffer);
+  // Put buffer in Available SETUP Buffer _FIFO_, so use csr_wr _not_ csr_update
+  csr_wr(.ptr(ral.avsetupbuffer.buffer), .value(setup_buffer_id));
 endtask
 
 virtual task configure_in_trans(bit [4:0] buffer_id, bit [6:0] num_of_bytes);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -48,7 +48,7 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
   // TODO: Presently the act of sending a data packet, destructively modifies it!
   // Restore the data packet to its original state. This just bit-reverses each byte
   // within the input array.
-  function recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
+  function void recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
     out = {<<8{in}};  // Reverse the order of the bytes
     out = {<<{out}};  // Bit-reverse everything
   endfunction

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_fifo_rst_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_fifo_rst_vseq.sv
@@ -52,7 +52,7 @@ class usbdev_fifo_rst_vseq extends usbdev_base_vseq;
       bit [BufW-1:0] buffer;
       // Choose a random buffer number
       buffer = $urandom_range(0, usbdev_env_pkg::NumBuffers - 1);
-      unique case (fifo)
+      case (fifo)
         AvOutFifo:   csr_wr(ral.avoutbuffer, buffer);
         AvSetupFifo: csr_wr(ral.avsetupbuffer, buffer);
         // Writing into the Rx FIFO require packet transmission from the host
@@ -84,7 +84,7 @@ class usbdev_fifo_rst_vseq extends usbdev_base_vseq;
         // TODO: Rx FIFO not yet supported.
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(fifo, fifo != RxFifo;)
         // Hit the reset
-        unique case (fifo)
+        case (fifo)
           AvOutFifo: begin
             ral.fifo_ctrl.avout_rst.set(1'b1);
             csr_update(.csr(ral.fifo_ctrl));

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_fifo_rst_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_fifo_rst_vseq.sv
@@ -53,8 +53,8 @@ class usbdev_fifo_rst_vseq extends usbdev_base_vseq;
       // Choose a random buffer number
       buffer = $urandom_range(0, usbdev_env_pkg::NumBuffers - 1);
       case (fifo)
-        AvOutFifo:   csr_wr(ral.avoutbuffer, buffer);
-        AvSetupFifo: csr_wr(ral.avsetupbuffer, buffer);
+        AvOutFifo:   csr_wr(.ptr(ral.avoutbuffer.buffer), .value(buffer));
+        AvSetupFifo: csr_wr(.ptr(ral.avsetupbuffer.buffer), .value(buffer));
         // Writing into the Rx FIFO require packet transmission from the host
         // TODO: here we need to connect the device, with some appropriate configuration of at least
         // one endpoint, and then transmit the appropriate number of packets to the OUT endpoint

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -11,8 +11,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
   virtual task body();
     uvm_reg_data_t rxfifo;
     bit in_sent;
-    super.dut_init("HARD");
-    clear_all_interrupts();
+
     ral.intr_enable.pkt_sent.set(1'b1); // Enable pkt_sent interrupt
     csr_update(ral.intr_enable);
     // For IN transaction need to do first OUT transaction
@@ -28,9 +27,6 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     cfg.clk_rst_vif.wait_clks(20);
     // Read rxfifo reg
     csr_rd(.ptr(ral.rxfifo), .value(rxfifo));
-    // Make sure buffer is availabe for next trans
-    ral.avoutbuffer.buffer.set(out_buffer_id + 1);
-    csr_update(ral.avoutbuffer);
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(out_buffer_id, m_data_pkt.data.size());
     // Token pkt followed by handshake pkt

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -45,8 +45,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Read rxfifo reg
     csr_rd(.ptr(ral.rxfifo), .value(read_rxfifo));
     // Make sure buffer is availabe for next trans
-    ral.avoutbuffer.buffer.set(out_buffer_id + 1);
-    csr_update(ral.avoutbuffer);
+    csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id + 1));
 
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -34,7 +34,7 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
   // TODO: Presently the act of sending a data packet, destructively modifies it!
   // Restore the data packet to its original state. This just bit-reverses each byte
   // within the input array.
-  function recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
+  function void recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
     out = {<<8{in}};  // Reverse the order of the bytes
     out = {<<{out}};  // Bit-reverse everything
   endfunction

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -11,9 +11,6 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
   virtual task body();
     uvm_reg_data_t read_rxfifo;
 
-     super.dut_init("HARD");
-     clear_all_interrupts();
-
     // OUT TRANS
     // -------------------------------
     // Configure out transaction

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -37,7 +37,7 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
   // TODO: Presently the act of sending a data packet, destructively modifies it!
   // Restore the data packet to its original state. This just bit-reverses each byte
   // within the input array.
-  function recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
+  function void recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
     out = {<<8{in}};  // Reverse the order of the bytes
     out = {<<{out}};  // Bit-reverse everything
   endfunction

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -94,7 +94,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
   // TODO: Presently the act of sending a data packet, destructively modifies it!
   // Restore the data packet to its original state. This just bit-reverses each byte
   // within the input array.
-  function recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
+  function void recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
     out = {<<8{in}};  // Reverse the order of the bytes
     out = {<<{out}};  // Bit-reverse everything
   endfunction

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -24,8 +24,8 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     csr_wr(.ptr(ral.ep_in_enable[0]), .value(12'hfff));
     csr_wr(.ptr(ral.rxenable_out[0]), .value(12'hfff));
     csr_wr(.ptr(ral.rxenable_setup[0]), .value(12'hfff));
-    ral.avsetupbuffer.buffer.set(setup_buffer_id); // set buffer id =1
-    csr_update(ral.avsetupbuffer);
+    csr_wr(.ptr(ral.avsetupbuffer.buffer),
+           .value(setup_buffer_id));  // use csr_wr to guarantee write.
     ral.intr_enable.pkt_received.set(1'b1); // Enable pkt_received interrupt
     csr_update(ral.intr_enable);
 
@@ -44,8 +44,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     // ---------------------------------------------------------------------------------------------
     // OUT data packet
     // ---------------------------------------------------------------------------------------------
-    ral.avoutbuffer.buffer.set(out_buffer_id);
-    csr_update(ral.avoutbuffer);
+    csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id));  // use csr_wr to guarantee write.
     call_token_seq(PidTypeOutToken);
     cfg.clk_rst_vif.wait_clks(20);
     // TODO: want to use a randomized packet length here but may be 4n contrained presently.

--- a/hw/ip/usbdev/dv/env/usbdev_packetiser.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_packetiser.sv
@@ -30,15 +30,15 @@ class usbdev_packetiser extends uvm_object;
   task pack_pkt(usb20_item m_usb20_item);
     if (m_usb20_item.m_pid_type[1:0] == TOKEN_PKT) begin
       $cast(m_tpkt, m_usb20_item.clone());
-      m_tpkt.pack(token_pkt_arr);
+      void'(m_tpkt.pack(token_pkt_arr));
     end
     else if (m_usb20_item.m_pid_type[1:0] == DATA_PKT) begin
       $cast(m_dpkt, m_usb20_item.clone());
-      m_dpkt.pack(data_pkt_arr);
+      void'(m_dpkt.pack(data_pkt_arr));
     end
     else if (m_usb20_item.m_pid_type[1:0] == HANDSHAKE_PKT) begin
       $cast(m_hpkt, m_usb20_item.clone());
-      m_hpkt.pack(handshake_pkt_arr);
+      void'(m_hpkt.pack(handshake_pkt_arr));
     end
     else;
   endtask

--- a/hw/ip/usbdev/dv/env/usbdev_pkt_manager.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_pkt_manager.sv
@@ -82,7 +82,7 @@ class token_packet extends usbdev_pkt_manager;
     this.crc5 = {<<{crc}};
 
     // Pack the token packet
-    this.pack(pack_token);
+    void'(this.pack(pack_token));
     super.push_packet(pack_token);
   endtask
 endclass
@@ -144,7 +144,7 @@ class data_packet extends usbdev_pkt_manager;
     this.crc16 = {<<{crc}};
 
     // Pack the data packet
-    this.pack(pack_data);
+    void'(this.pack(pack_data));
     super.push_packet(pack_data);
     data.delete();
   endtask
@@ -171,7 +171,7 @@ class hand_shake_packet extends usbdev_pkt_manager;
     this.pid = hpid;
 
     // Pack the handshake packet
-    this.pack(pack_handshake);
+    void'(this.pack(pack_handshake));
     super.push_packet(pack_handshake);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -82,7 +82,7 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
       if (item.m_pid_type != PidTypeSofToken) begin
         m_packetiser.pack_pkt(item);
         usbdev_expected_pkt();
-        item.pack(actual_pkt);
+        void'(item.pack(actual_pkt));
         actual_pkt_q.push_back(actual_pkt);
         for (int i = 0; i <= 7; i++) begin
           act_pid = {act_pid, actual_pkt[i]};
@@ -113,7 +113,7 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
     forever begin
       rsp_usb20_fifo.get(item);
       usbdev_expected_pkt();
-      item.pack(actual_pkt);
+      void'(item.pack(actual_pkt));
       actual_pkt_q.push_back(actual_pkt);
       for (int i = 0; i <= 7; i++) begin
         act_pid = {act_pid, actual_pkt[i]};


### PR DESCRIPTION
This PR addresses the following issues three separate issues in individual commits:

- IN side sequences were conflicting with the usb20_driver behavior by needlessly trying to clear interrupts whilst the drive is causing interrupts by performing a Bus Reset on the USB. This led to seed-dependent failures.
- Warnings in the vcs build log had become quite numerous; eliminate them to lessen the risk of losing warnings that indicate functional issues.
- Avoid the use of csr_update to write to the FIFOs because this can lead to the csr/uvm logic deciding that update is not required, and thus the write of a buffer number into the FIFO does not occur. When buffer number 0 is chosen this leads to test failures, but that is a perfectly valid buffer number and does/will get selected by randomization.
