### PR TITLE
[python] Fix FuseSoC version

### DIFF
--- a/python-requirements.in
+++ b/python-requirements.in
@@ -61,7 +61,7 @@ types-tabulate==0.8.11
 anytree==2.8.0
 
 # Development version with OT-specific changes
-https://github.com/lowRISC/fusesoc/archive/refs/tags/ot-0.5.zip
+https://github.com/lowRISC/fusesoc/archive/refs/tags/ot-0.5.dev0.zip
 
 # Development version with OT-specific changes
 https://github.com/lowRISC/edalize/archive/refs/tags/v0.4.0.zip

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -186,8 +186,8 @@ enlighten==1.10.2 \
 flake8==5.0.4 \
     --hash=sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db \
     --hash=sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248
-fusesoc @ https://github.com/lowRISC/fusesoc/archive/refs/tags/ot-0.5.zip \
-    --hash=sha256:2b9e29adc09b61e00c8f6246274a937a0f13fe940f1362f12788a6246b3cc4c7
+fusesoc @ https://github.com/lowRISC/fusesoc/archive/refs/tags/ot-0.5.dev0.zip \
+    --hash=sha256:6d1d9b202748d160bc6da70ea8cf7a700ca80e1e7e4a78cbc1ec039bde595c65
 gitdb==4.0.10 \
     --hash=sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a \
     --hash=sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7


### PR DESCRIPTION
Prior to this commit, the FuseSoC version downloaded when running

    pip install -r python-requirements.txt

would identify itself as **version `0.4.dev0`** to Pip as well as in `fusesoc --version`.  This is problematic in at least two ways:

1. Because Pip gets told that it downloaded version 0.4, it can prefer to use a locally cached archive (and I've seen it doing that!) that is *really* version 0.4, causing the update to become a NOP even though the user thinks they just updated FuseSoC.

2. Users have no way of distinguishing between versions 0.4 and 0.5 from the command line, which makes debugging issues that got fixed in version 0.5 difficult.

To work around this problem, the PR lowRISC/fusesoc#6 changed `fallback_version`, from which our FuseSoC gets its version, to `0.5.dev0`, and this version was subsequently tagged as such.  This commit now updates our Python requirements to load the fixed version.

Run `pip install -r python-requirements.txt` after this commit has landed to update FuseSoC to version `0.5.dev0` for good.