### PR TITLE
[dv,usbdev] DV sequence for packet buffer memory

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -821,13 +821,33 @@
             Verify that the device times out transactions when a host packet is 18 bit times
             after the preceding one in the same transaction.
 
-            - Generate a host packet 18 bit times than the preceding packet in the same
+            - Generate a host packet 18 bit times after the preceding packet in the same
               transaction.
             - Verify that the device time out the transaction when a host packet is 18 bit times
               after the preceding one in the same transaction.
             '''
       stage: V2
       tests: []
+    }
+    {
+      name: packet_buffer
+      desc: '''
+            Exercise all buffers within the packet buffer memory, performing reads and writes of
+            packet buffer data from both sides (CSR and USB) simultaneously.
+
+            - Randomly choose between IN and OUT packet transfer on the USB side.
+            - Randomly choose between buffer read and buffer write on the CSR side.
+            - Ensure, however, that the CSR side and the USB side never access the same buffer
+              simultaneously; this is guaranteed by the contract that exists between hardware and
+              software.
+            - Check all transferred data on both sides.
+            - Ensure that it is possible for individual read and write accesses to occur at the
+              packet buffer memory from both sides within the same cycle.
+              Since the packet buffer memory is now a Single Port RAM implementation, this requires
+              the CSR-side access to be delayed until the USB side is idle.
+            '''
+      stage: V2
+      tests: ["usbdev_pkt_buffer"]
     }
     {
       name: nak_to_out_trans_when_avbuffer_empty_rxfifo_full

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_buffer_vseq.sv
@@ -1,0 +1,188 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// USBDEV packet buffer test sequence
+//
+// Employing randomization, sufficient transactions and coverage:
+//
+// - read and write the entire packet buffer memory from the CSR side
+// - read and write from/to every buffer on the USB side
+// - produce temporal collisions between the CSR side and the USB side;
+//   - The DUT does not need to handle simultaneous access to the same packet
+//     buffer from both sides because the software is responsible for ensuring
+//     that this does not happen.
+//   - It does, however, need to handle simultaneous accesses to the packet
+//     buffer memory because all of the buffers are stored within a single
+//     RAM.
+
+class usbdev_pkt_buffer_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_pkt_buffer_vseq)
+
+  `uvm_object_new
+
+  // Large number of transactions to try to cover all packet buffers and increase the chance of
+  // simultaneous packet buffer accesses from CSR and USB sides.
+  constraint num_trans_c { num_trans inside {[256:1024]}; }
+
+  // Amount of valid/defined data in each of the packet buffers; zero initialized and the
+  // values increase as the sequence advances.
+  int unsigned valid_len[NumBuffers];
+
+  // Expected contents of each packet buffer.
+  byte unsigned exp_data[NumBuffers][$];
+
+  // We need to track the OUT side Data Toggle(s) otherwise packets will be rejected;
+  bit exp_out_toggle[NEndpoints];
+  // Similarly for the IN side; these both default to zeros.
+  bit exp_in_toggle[NEndpoints];
+
+  // OUT component (host -> device) of the USB side of the test.
+  task usb_side_out(int unsigned usb_buf);
+    // Expected data content of packet
+    byte unsigned pkt_data[];
+    int unsigned usb_len;
+    usb20_item response;
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(usb_len, usb_len inside {[0:MaxPktSizeByte]};)
+    `uvm_info(`gfn, $sformatf("USB sending an OUT packet of 0x%x byte(s) to buffer 0x%x",
+                              usb_len, usb_buf), UVM_MEDIUM)
+    // Supply the buffer
+    csr_wr(.ptr(ral.avoutbuffer), .value(usb_buf));
+
+    // If we have just completed an IN transaction with a handshake response we must ensure at
+    // least 2 bit intervals of Idle before the OUT transaction here.
+    //
+    // TODO: this should probably be checked and enforced in the usb20_driver rather than in the
+    //       vseqs where it will be susceptible to oversight.
+    inter_packet_delay();
+
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_data_seq(exp_out_toggle[endp] ? PidTypeData1 : PidTypeData0, 0, usb_len);
+    cfg.clk_rst_vif.wait_clks(20);
+
+    // Check that the packet was accepted (ACKnowledged) by the USB device.
+    get_response(m_response_item);
+    $cast(response, m_response_item);
+    `DV_CHECK_EQ(response.m_pkt_type, PktTypeHandshake);
+    `DV_CHECK_EQ(response.m_pid_type, PidTypeAck);
+
+    // Given that the packet has been accepted, we must flip the OUT Data Toggle.
+    exp_out_toggle[endp] ^= 1;
+
+    // Check the contents of the packet buffer memory against the OUT packet that was sent.
+    check_rx_packet(endp, 1'b0, usb_buf, m_data_pkt.data);
+
+    // This is now the expected content of the packet buffer
+    valid_len[usb_buf] = pkt_data.size();
+    exp_data[usb_buf]  = pkt_data;
+  endtask
+
+  // IN component (device -> host) of the USB side of the test.
+  task usb_side_in(int unsigned usb_buf);
+    byte unsigned pkt_data[];
+    int unsigned usb_len;
+    usb20_item response;
+    data_pkt in_data;
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(usb_len, usb_len inside {[0:valid_len[usb_buf]]};)
+    `uvm_info(`gfn, $sformatf("USB retrieving an IN packet of 0x%x byte(s) from buffer 0x%x",
+                              usb_len, usb_buf), UVM_MEDIUM)
+
+    // Pick up the portion of the packet that we intended to retrieve from the USB device.
+    if (usb_len > 0) pkt_data = exp_data[usb_buf][0:usb_len-1];
+
+    // Present the IN packet for collection.
+    ral.configin[endp].size.set(usb_len);
+    ral.configin[endp].buffer.set(usb_buf);
+    ral.configin[endp].rdy.set(1'b0);
+    csr_update(ral.configin[endp]);
+    // Now set the RDY bit
+    ral.configin[endp].rdy.set(1'b1);
+    csr_update(ral.configin[endp]);
+
+    // Token pkt followed by handshake pkt
+    call_token_seq(PidTypeInToken);
+    get_response(m_response_item);
+    $cast(response, m_response_item);
+    `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);
+    $cast(in_data, response);
+    check_tx_packet(in_data, exp_in_toggle[endp] ? PidTypeData1 : PidTypeData0, pkt_data);
+    cfg.clk_rst_vif.wait_clks(20);
+    call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+
+    // Flip the IN side Data Toggle in anticipation of the next packet transfer.
+    exp_in_toggle[endp] ^= 1;
+  endtask
+
+  // USB side of test.
+  task usb_side(int unsigned usb_buf);
+    // Decide on the direction of USB traffic.
+    bit usb_wr;
+    `DV_CHECK_STD_RANDOMIZE_FATAL(usb_wr)
+
+    // Choose a new endpoint
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(endp, endp inside {[0:NEndpoints-1]};)
+
+    // Initiate writing of the buffer
+    if (usb_wr) begin
+      usb_side_out(usb_buf);
+    end else begin
+      usb_side_in(usb_buf);
+    end
+  endtask
+
+  // CSR side of test.
+  task csr_side(int unsigned csr_buf);
+    // Decide on the direction of CSR traffic.
+    bit csr_wr;
+    `DV_CHECK_STD_RANDOMIZE_FATAL(csr_wr)
+    if (csr_wr) begin
+      // Generate some random data, write it to the packet buffer and update our expectation.
+      byte unsigned pkt[];
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(pkt, pkt.size() inside {[0:MaxPktSizeByte]};)
+      valid_len[csr_buf] = pkt.size();
+      exp_data[csr_buf] = pkt;
+      `uvm_info(`gfn, $sformatf("CSR side writing 0x%x byte(s) to buffer 0x%x",
+                                pkt.size(), csr_buf), UVM_MEDIUM)
+      write_buffer(csr_buf, exp_data[csr_buf]);
+    end else begin
+      `uvm_info(`gfn, $sformatf("CSR checking 0x%x byte(s) in buffer 0x%x",
+                                valid_len[csr_buf], csr_buf), UVM_MEDIUM)
+      // Read and check the contents of this packet buffer against the captured expectations.
+      read_check_buffer(csr_buf, exp_data[csr_buf]);
+    end
+  endtask
+
+  task body;
+    // Enable all endpoints for both IN and OUT traffic.
+    configure_out_all();
+    configure_in_all();
+
+    // Ensure all packet buffer expectations are defined but empty.
+    for (int unsigned b = 0; b < NumBuffers; b++) begin
+      exp_data[b].delete();
+    end
+
+    // Do not proceed further until the device has exited the Bus Reset signaling of the
+    // usb20_driver module.
+    wait_for_link_state({LinkActive, LinkActiveNoSOF}, 10 * 1000 * 48);  // 10ms timeout, at 48MHz
+
+    for (int unsigned txn = 0; txn < num_trans; txn++) begin
+      int unsigned csr_buf;
+      int unsigned usb_buf;
+      // Choose a random buffer and direction for the CSR side access.
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(csr_buf, csr_buf inside {[0:NumBuffers-1]};)
+      // Choose a random packet buffer and direction for the USB side, ensuring that it does not
+      // access the same buffer as the CSR side.
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(usb_buf,
+                                         usb_buf inside {[0:NumBuffers-1]}; usb_buf != csr_buf;)
+      fork
+        csr_side(csr_buf);
+        usb_side(usb_buf);
+      join
+    end
+  endtask
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -17,6 +17,7 @@
 `include "usbdev_out_stall_vseq.sv"
 `include "usbdev_out_trans_nak_vseq.sv"
 `include "usbdev_phy_pins_sense_vseq.sv"
+`include "usbdev_pkt_buffer_vseq.sv"
 `include "usbdev_pkt_received_vseq.sv"
 `include "usbdev_pkt_sent_vseq.sv"
 `include "usbdev_random_length_out_transaction_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -31,6 +31,7 @@ filesets:
       - seq_lib/usbdev_pkt_received_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_av_buffer_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_setup_trans_ignored_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_pkt_buffer_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_pkt_sent_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_nak_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
@@ -21,6 +21,10 @@ package usbdev_env_pkg;
 
   // parameters
 
+  // Number of Endpoints (in each direction) supported by the USB device
+  parameter uint NEndpoints       = usbdev_reg_pkg::NEndpoints;
+  // Maximum supported packet size, in bytes.
+  parameter uint MaxPktSizeByte   = 64;
   // Number of packet buffers available within the USB device
   parameter uint NumBuffers       = 32;
   // FIFO Depths; number of entries
@@ -67,6 +71,21 @@ package usbdev_env_pkg;
     DATA_PKT = 2'b11,
     HANDSHAKE_PKT = 2'b10
   } usbdev_pkt_type_e;
+
+  // Link State
+  // TODO: make this available in a DUT package file and import here.
+  typedef enum logic [2:0] {
+    // No power and/or no pull-up connected state
+    LinkDisconnected = 0,
+    // Powered / connected states
+    LinkPowered = 1,
+    LinkPoweredSuspended = 2,
+    // Active states
+    LinkActiveNoSOF = 5,
+    LinkActive = 3,
+    LinkSuspended = 4,
+    LinkResuming = 6
+  } usbdev_link_state_e;
 
   // functions
 

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -98,6 +98,10 @@
       uvm_test_seq: usbdev_out_trans_nak_vseq
     }
     {
+      name: usbdev_pkt_buffer
+      uvm_test_seq: usbdev_pkt_buffer_vseq
+    }
+    {
       name: usbdev_pkt_received
       uvm_test_seq: usbdev_pkt_received_vseq
     }


### PR DESCRIPTION
This PR adds a DV test sequence for exercising the packet buffer memory:

- Randomized IN and OUT transactions of random length/content, to randomized buffers and randomized endpoints.
- CSR-side randomized packet buffer reads/writes, ensuring no collision with USB-side access.
- Checking of all data transfers, in both directions and on both CSR and USB sides.
- Aim to induce access collisions (same cycle, don't need to worry about same address); CSR side should be stalled because the packet buffer is implemented using a Single Port RAM now.
- CSR-side access to the packet buffer memory only worked if the scoreboard/UVM was capable of predicting the memory contents; this is not the case when the DUT hardware may write to the packet buffer memory at any moment.
- usbdev_scoreboard is therefore updated to avoid predictions, making writing possible and relying upon the vseq itself to check the returned read data.
- Constraint on 4n packet length is eliminated, and the usbdev_base_vseq tasks 'write_buffer' and 'read_check_buffer' should now be as generic as required for any test sequence.

The changes in the 'usbdev_base_vseq' are more forward-thinking and some of the functionality is not yet required, but as the testing moves to being more thorough, covering more endpoints etc. these tasks should prove useful in the base sequences.

Note that some of the constants used within the DV environment should be lifted from the DUT package/constants in the RTL but presently non-essential changes to the RTL are to be discouraged.