### PR TITLE
[usbdev,dv] Move covergroup descriptions to testplan

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -1113,4 +1113,82 @@
       tests: ["usbdev_fifo_rst"]
     }
   ]
+
+  covergroups: [
+    {
+      name: pids_cg
+      desc: '''
+        Observe all PIDs about which we care; a number of the available PIDs are ignored by the USB
+        device because they related only to High Speed operation and/or hubs.
+      '''
+    }
+    {
+      name: framenum_rx_cg
+      desc: '''
+        Observe all significant/extreme frame numbers being reported via CSRs; this just ensures
+        that all bits have been decoded and presented; the frame number has no significance to
+        USBDEV but it's important to software.
+      '''
+    }
+    {
+      name: crc16_cg
+      desc: '''
+        CRC16 values on packets in each direction, because CRC16 is subject to bit stuffing.
+      '''
+    }
+    {
+      name: crc5_cg
+      desc: '''
+        Check some potentially problematic cases for bit stuffing with CRC5 in Token packets.
+      '''
+    }
+    {
+      name: address_cg
+      desc: '''
+        Check that all Device Address bits are decoded and usable and that those problematic
+        combinations with endpoint values that demand bit stuffing within the token packet have
+        been observed.
+      '''
+    }
+    {
+      name: ep_out_cfg_cg
+      desc: '''
+        Receipt of SETUP, OUT and PRE packets with different OUT endpoint configurations
+      '''
+    }
+    {
+      name: ep_in_cfg_cg
+      desc: '''
+        Receipt of IN and PRE packets with different IN endpoint configurations
+      '''
+    }
+    {
+      name: fifo_lvl_cg
+      desc: '''
+        Received SETUP/OUT packets with FIFO levels of interest
+      '''
+    }
+    {
+      name: data_pkt_cg
+      desc: '''
+        Length of DATA packets in each direction
+      '''
+    }
+    {
+      name: data_tog_endp_cg
+      desc: '''
+        Both DATA0 and DATA1 for each endpoint, and in each direction (Data Toggles), as well as
+        both ACK and NAK (rollback and retry transaction in Packet Engines).
+      '''
+    }
+    {
+      name: pid_type_endp_cg
+      desc: '''
+        All of SETUP, IN, and OUT for each endpoint
+      '''
+    }
+
+
+  ]
+
 }

--- a/hw/ip/usbdev/dv/env/usbdev_env_cov.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cov.sv
@@ -5,8 +5,6 @@
 class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
   `uvm_component_utils(usbdev_env_cov)
 
-  // Have observed all PIDs about which we care; a number of the available PIDs are ignored
-  // by the USB device because they related only to High Speed operation and/or hubs.
   covergroup pids_cg with function sample(pid_type_e pid);
     cp_pid: coverpoint pid {
       bins sof   = {PidTypeSofToken};
@@ -23,9 +21,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
     }
   endgroup
 
-  // Have observed all significant/extreme frame numbers being reported via CSRs; this just
-  // ensures that all bits have been decoded and presented; the frame number has no significance
-  // to USBDEV but it's important to software.
   covergroup framenum_rx_cg with function sample(bit [10:0] frame);
     cp_frame: coverpoint frame {
       bins zero = {0};
@@ -38,7 +33,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
     }
   endgroup
 
-  // CRC16 values on packets in each direction, because CRC16 is subject to bit stuffing
   covergroup crc16_cg with function sample(bit dir_in, bit [15:0] crc16);
     cp_crc16: coverpoint crc16 {
       // Contrive a packet that results in all 1s.
@@ -54,8 +48,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       cp_dir;
   endgroup
 
-  // CRC5 in Token packets is subject to bit stuffing too, so check some potentially problematic
-  // cases.
   covergroup crc5_cg with function sample(bit dir_in, bit [4:0] crc5);
     cp_crc5: coverpoint crc5 {
       bins trailing_zero = {15};
@@ -69,9 +61,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       cp_dir;
   endgroup
 
-  // Check that all Device Address bits are decoded and usable and that those problematic
-  // combinations with endpoint values that demand bit stuffing within the token packet
-  // have been observed.
   covergroup address_cg with function sample(bit [6:0] address, bit [4:0] endp);
     // In the address field, which is 7 bits, there could be three 1 bits from the
     // OUT PID: LSB 1000_0111 MSB
@@ -96,7 +85,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       cp_endp;
   endgroup
 
-  // Receipt of SETUP, OUT and PRE packets with different OUT endpoint configurations
   covergroup ep_out_cfg_cg with function sample(pid_type_e pid, bit out_enable, bit rxenable_setup,
                                                 bit rxenable_out, bit set_nak_out, bit out_stall,
                                                 bit out_iso);
@@ -129,7 +117,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       cp_out_stall;
   endgroup
 
-  // Receipt of IN and PRE packets with different IN endpoint configurations
   covergroup ep_in_cfg_cg with function sample(pid_type_e pid,
                                                bit in_enable, bit in_stall, bit in_iso);
     cp_pid: coverpoint pid {
@@ -151,7 +138,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       cp_in_stall;
   endgroup
 
-  // Received SETUP/OUT packets within FIFO levels of interest
   covergroup fifo_lvl_cg with function sample(pid_type_e pid, bit [2:0] avsetup_lvl,
                                               bit [3:0] avout_lvl, bit [3:0] rx_lvl);
     // Buffer is plucked from AV SETUP or AV OUT FIFO according to PID.
@@ -183,7 +169,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       cp_pid;
   endgroup
 
-  // Length of DATA packets in each direction
   covergroup data_pkt_cg with function sample(bit dir_in, bit [6:0] pkt_len);
     // Packets are read/written from/to memory as 32-bit quantities.
     cp_pkt_len: coverpoint pkt_len {
@@ -210,8 +195,6 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       cp_dir;
   endgroup
 
-  // Both DATA0 and DATA1 for each endpoint, and in each direction (Data Toggles),
-  // as well as both ACK and NAK (rollback and retry transaction in Packet Engines).
   covergroup data_tog_endp_cg with function sample(pid_type_e pid, bit dir_in, bit [3:0] endp);
     cp_pid: coverpoint pid {
       bins data0 = {PidTypeData0};
@@ -228,8 +211,7 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       cp_endp;
   endgroup
 
-  // All of SETUP, IN, and OUT for each endpoint
-  covergroup pid_type_endp_cfg with function sample(pid_type_e pid, bit [3:0] endp);
+  covergroup pid_type_endp_cg with function sample(pid_type_e pid, bit [3:0] endp);
     cp_pid: coverpoint pid {
       bins pkt_types[] = {PidTypeSetupToken, PidTypeOutToken, PidTypeInToken};
     }


### PR DESCRIPTION
This is a pretty mechanical change: it is basically copying the list of covergroups from usbdev_env_cov.sv into usbdev_testplan.hjson. I've taken the long comment above each covergroup and turned it into the description of the covergroup in the testplan.

The only nontrivial change is to a covergroup name (pid_type_end_cg), which had a stray "f".

@alees24: Would you mind glancing over this? I *think* it should be equivalent to the text you wrote, but want to make sure I'm not mangling anything.

Closes #22194.