### PR TITLE
[silicon_creator] Improve `dbg_printf`

### DIFF
--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -40,6 +40,7 @@ enum {
   kHexLeLow = 'y',
   kHexLeHigh = 'Y',
   kStatusResult = 'r',
+  kFourCC = 'C',
 };
 
 // NOTE: all of the lengths of the strings below are given so that the NUL
@@ -465,6 +466,20 @@ static void process_specifier(buffer_sink_t out, format_specifier_t spec,
       }
       char value = (char)va_arg(*args, uint32_t);
       *bytes_written += out.sink(out.data, &value, 1);
+      break;
+    }
+    case kFourCC: {
+      uint32_t value = va_arg(*args, uint32_t);
+      for (size_t i = 0; i < sizeof(uint32_t); ++i, value >>= 8) {
+        uint8_t ch = (uint8_t)value;
+        if (ch >= 32 && ch < 127) {
+          *bytes_written += out.sink(out.data, (const char *)&ch, 1);
+        } else {
+          *bytes_written += out.sink(out.data, "\\x", 2);
+          *bytes_written += out.sink(out.data, &kDigitsLow[ch >> 4], 1);
+          *bytes_written += out.sink(out.data, &kDigitsLow[ch & 15], 1);
+        }
+      }
       break;
     }
     case kString: {

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -66,6 +66,7 @@ typedef struct buffer_sink {
  * - %b, which prints an unsigned binary uint32_t.
  *
  * Finally, additional nonstandard format specifiers is supported:
+ * - %C prints a 'FourCC' style uint32_t (ASCII bytes in little-endian order).
  * - %!s, which takes a size_t followed by a pointer to a buffer, and prints
  *   out that many characters from the buffer.
  * - %!x, %!X, %!y, and %!Y, which are like %!s but print out a hex dump

--- a/sw/device/silicon_creator/lib/dbg_print.c
+++ b/sw/device/silicon_creator/lib/dbg_print.c
@@ -54,14 +54,17 @@ void dbg_printf(const char *format, ...) {
         break;
       }
       case 'C': {
-        uint8_t ch = (uint8_t)va_arg(args, int);
-        if (ch >= 32 && ch < 127) {
-          uart_putchar((char)ch);
-        } else {
-          uart_putchar('\\');
-          uart_putchar('x');
-          uart_putchar(kHexTable[ch >> 4]);
-          uart_putchar(kHexTable[ch & 15]);
+        uint32_t val = va_arg(args, uint32_t);
+        for (size_t i = 0; i < sizeof(uint32_t); ++i, val >>= 8) {
+          uint8_t ch = (uint8_t)val;
+          if (ch >= 32 && ch < 127) {
+            uart_putchar((char)ch);
+          } else {
+            uart_putchar('\\');
+            uart_putchar('x');
+            uart_putchar(kHexTable[ch >> 4]);
+            uart_putchar(kHexTable[ch & 15]);
+          }
         }
         break;
       }

--- a/sw/device/silicon_creator/lib/dbg_print.h
+++ b/sw/device/silicon_creator/lib/dbg_print.h
@@ -18,14 +18,13 @@ extern "C" {
  *
  * This function only supports the format specifiers required by the
  * ROM:
- * - %c, which prints a single character.
- * - %C, which prints a printable character or a C-style hex escape.
- * - %d, which prints a signed int in decimal.
- * - %u, which prints an unsigned int in decimal.
- * - %s, which prints a nul-terminated string.
- * - %p, which prints pointer in hexadecimal.
- * - %x, which prints an `unsigned int` in hexadecimal using lowercase
- *   characters.
+ * - %c prints a single character.
+ * - %C prints a 'FourCC' style uint32_t (ASCII bytes in little-endian order).
+ * - %d prints a signed int in decimal.
+ * - %u prints an unsigned int in decimal.
+ * - %s prints a nul-terminated string.
+ * - %p prints pointer in hexadecimal.
+ * - %x prints an `unsigned int` in hexadecimal using lowercase characters.
  *
  * No modifiers are supported and the leading zeros in hexidecimal
  * values are always printed.

--- a/sw/device/silicon_creator/rom_ext/rescue.c
+++ b/sw/device/silicon_creator/rom_ext/rescue.c
@@ -57,8 +57,7 @@ rom_error_t flash_owner_block(rescue_state_t *state) {
 }
 
 static void validate_mode(uint32_t mode, rescue_state_t *state) {
-  char *m = (char *)&mode;
-  dbg_printf("\r\nmode: %C%C%C%C\r\n", m[3], m[2], m[1], m[0]);
+  dbg_printf("\r\nmode: %C\r\n", bitfield_byteswap32(mode));
   switch (mode) {
     case kRescueModeBootLog:
       dbg_printf("ok: receive boot_log via xmodem-crc\r\n");


### PR DESCRIPTION
Change the non-standard `%C` specifier to print an uint32_t in "FourCC" style (4 ASCII chars encoded into a uint32_t in little endian order).

Many rescue, boot_svc and ownership identifier words are 32-bit integer constants that are ASCII identifiers.  Adding this specifier makes printing these values much easier.