### PR TITLE
[dv,usbdev] Integration of usbdpi into block level DV environment.

### DIFF
--- a/hw/dv/dpi/usbdpi/usbdpi.c
+++ b/hw/dv/dpi/usbdpi/usbdpi.c
@@ -545,7 +545,7 @@ void getDescriptor(usbdpi_ctx_t *ctx, uint8_t desc_type, uint8_t desc_idx,
           ctx->cfg_desc_len = wTotalLength;
         }
 
-        transfer_token(tr, USB_PID_ACK, ctx->dev_address, ENDPOINT_ZERO);
+        transfer_status(ctx, tr, USB_PID_ACK);
 
         transfer_send(ctx, tr);
         ctx->bus_state = kUsbControlDataInAck;
@@ -701,7 +701,7 @@ void getTestConfig(usbdpi_ctx_t *ctx, uint16_t desc_len) {
             ctx->hostSt = HS_NEXTFRAME;
             break;
         }
-        transfer_token(tr, USB_PID_ACK, ctx->dev_address, ENDPOINT_ZERO);
+        transfer_status(ctx, tr, USB_PID_ACK);
 
         transfer_send(ctx, tr);
         ctx->bus_state = kUsbControlDataInAck;
@@ -1263,7 +1263,7 @@ uint8_t usbdpi_host_to_device(void *ctx_void, const svBitVecVal *usb_d2p) {
           //
           // TODO - Set the descriptor length to the minimum because the DPI
           // model does not yet catch and report errors properly
-          ctx->cfg_desc_len = 12U;
+          ctx->cfg_desc_len = 0x12U;
           getDescriptor(ctx, USB_DESC_TYPE_DEVICE, 0U, 0x12U);
           break;
 

--- a/hw/dv/sv/usb20_agent/usb20_block_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_block_if.sv
@@ -5,7 +5,8 @@
 interface usb20_block_if (
   input clk_i,
   input rst_ni,
-  output logic usb_vbus,
+
+  output wire usb_vbus,
   inout wire usb_p,
   inout wire usb_n
 );
@@ -23,17 +24,37 @@ interface usb20_block_if (
   logic usb_dn_pullup_o ;
   logic usb_rx_enable_o;
   logic usb_tx_use_d_se0_o;
+  logic drive_vbus;          // to drive usb_vbus from driver
   logic drive_n;             // to drive usb_n from driver
   logic drive_p;             // to drive usb_n from driver
   logic usb_ref_val_o;
   logic usb_ref_pulse_o;
   logic usb_clk;             // signal used to divide clock or send J/K symbols for 4 clock cycles
 
-  assign usb_p = usb_dp_en_o ? usb_dp_o : drive_p;
-  assign usb_n = usb_dn_en_o ? usb_dn_o : drive_n;
+  // Are our drivers connected?
+  bit connected = 0;
 
-    // Weak pull down
-  assign (weak0, weak1) usb_p = 1'b0;
-  assign (weak0, weak1) usb_n = 1'b0;
+  // Is the agent active?
+  bit active = 0;
+
+  // Enable/disable the output drivers
+  function automatic void enable_driver(bit enabled);
+    connected = enabled;
+  endfunction
+
+  // Activate/deactivate the usb20_agent
+  function automatic void activate_driver(bit activated);
+    active = activated;
+  endfunction
+
+  assign usb_vbus = connected ? drive_vbus : 1'bZ;
+
+  assign usb_p = (connected & active) ? (usb_dp_en_o ? usb_dp_o : drive_p) : 1'bZ;
+  assign usb_n = (connected & active) ? (usb_dn_en_o ? usb_dn_o : drive_n) : 1'bZ;
+
+  // Weak pull down when the driver is active; pull to Idle (J) when connected but inactive to
+  // prevent unwanted 'bus reset' conditions in DUT.
+  assign (weak0, weak1) usb_p = connected ? !active : 1'bZ;
+  assign (weak0, weak1) usb_n = connected ?    1'b0 : 1'bZ;
 
 endinterface

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -277,14 +277,19 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
   // -------------------------------
   virtual task reset_signals();
     cfg.bif.usb_rx_d_i = 1'b1;
-    cfg.bif.usb_vbus = 1'b1;
+    cfg.bif.drive_vbus = 1'b1;
     cfg.bif.drive_p  = 1'b0;
     cfg.bif.drive_n = 1'b0;
     @(posedge cfg.bif.rst_ni);
-    cfg.bif.usb_vbus = 1'b0;
+    cfg.bif.drive_vbus = 1'b0;
     repeat(usb_idle_clk_cycles) @(posedge cfg.bif.usb_clk);
-    cfg.bif.usb_vbus = 1'b1;
-    bus_reset();
+    // TODO: the generation of Bus Reset on the USB shall probably want to become a sequence item,
+    // so that it my be done on demand during sequences, and to prevent it interfering with other
+    // test sequences.
+    if (cfg.bif.active) begin
+      cfg.bif.drive_vbus = 1'b1;
+      bus_reset();
+    end
   endtask
 
   // USB Bus Reset Task

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_common_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_common_vseq.sv
@@ -11,8 +11,11 @@ class usbdev_common_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task pre_start();
-    // Common test sequences do not need device init.
-    do_usbdev_init = 1'b0;
+    // Common test sequences do not need usb20_agent or device init, but we do need its interface
+    // connected to guarantee a defined bus state.
+    do_agent_connect  = 1'b1;
+    do_agent_activate = 1'b0;
+    do_usbdev_init    = 1'b0;
     super.pre_start();
   endtask
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_dpi_config_host_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_dpi_config_host_vseq.sv
@@ -1,0 +1,263 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_dpi_config_host_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_dpi_config_host_vseq)
+
+  `uvm_object_new
+
+  import usb_consts_pkg::*;
+
+  // State within the present Control Transfer
+  typedef enum {
+    // Awaiting receipt of SETUP stage
+    Ctl_AwaitSETUP,
+    // Awaiting Status Stage
+    Ctl_AwaitStatus
+  } ctl_state_e;
+
+  // Current Control Transfer
+  typedef enum {
+    Cfg_DescDev,
+    Cfg_DescCfg,
+    Cfg_DescTest
+  } cfg_state_e;
+
+  // Control Transfers thus far completed.
+  bit desc_dev_done  = 1'b0;  // GET_DESCRIPTOR for Device
+  bit desc_cfg_done  = 1'b0;  // GET_DESCRIPTOR for Configuration
+  bit addr_set_done  = 1'b0;  // SET_ADDRESS
+  bit cfg_set_done   = 1'b0;  // SET_CONFIG
+  bit desc_test_done = 1'b0;  // GET_DESCRIPTOR for vendor-specific test descriptor
+
+  // We use these ranges of buffers for reception at start up, just returning any received buffer
+  // immediately.
+  bit [4:0] setup_buf_first = 0;
+  bit [4:0] setup_buf_last  = 2;
+  bit [4:0] out_buf_first   = 8;
+  bit [4:0] out_buf_last    = 12;
+
+  // Buffer number used for transmission
+  bit [4:0] in_buf = 19;
+
+  // Device descriptor
+  byte unsigned desc_device[] = {
+    // Our standard device descriptor; see sw/device/lib/testing/usb_testutils_controlep.c
+    1, 0, 0, 0, 1, 0, 8'h50, 8'h3a, 8'h18, 8'hd1, 64, 0, 0, 0, 2, 0, 1, 18
+  };
+
+  // Configuration descriptor; may be completed by derivative sequences.
+  byte unsigned desc_config[];
+
+  // Test descriptor; may be completed by derivative sequences.
+  byte unsigned desc_test[];
+
+  // ACKnowledge packet (Status stage, so this is just a zero-length packet).
+  byte unsigned ack[];
+
+  virtual task pre_start();
+    // First of all we want to ensure that the DPI model is connected via the 'usb20_if' which
+    // models a physical USB, rather than employing the block-level DV interface.
+    cfg.m_usb20_agent_cfg.bif.enable_driver(1'b0);
+    cfg.m_usb20_agent_cfg.vif.enable_driver(1'b1);
+
+    // We want full control of the DUT configuration and communications with the DPI model.
+    do_agent_connect = 1'b0;
+    do_usbdev_init = 1'b0;
+    super.pre_start();
+  endtask
+
+  // Test for and receive a packet from the host.
+  virtual task packet_recv(output bit rx_pending, output bit rx_setup,
+                           output byte unsigned rx_data[]);
+    uvm_reg_data_t data;
+    rx_pending = 0;
+    csr_rd(.ptr(ral.intr_state), .value(data));
+    if (get_field_val(ral.intr_state.pkt_received, data)) begin
+      int unsigned rx_buf;
+      int unsigned rx_len;
+      csr_rd(.ptr(ral.rxfifo), .value(data));
+      rx_buf   = get_field_val(ral.rxfifo.buffer, data);
+      rx_len   = get_field_val(ral.rxfifo.size,   data);
+      rx_setup = get_field_val(ral.rxfifo.setup,  data);
+      read_buffer(rx_buf, rx_len, rx_data);
+      // Return the buffer to the appropriate Available Buffer FIFO.
+      if (rx_setup) begin
+        // SETUP packets used the Av SETUP FIFO.
+        csr_wr(.ptr(ral.avsetupbuffer.buffer), .value(rx_buf));
+      end else begin
+        // OUT packets used the Av OUT FIFO.
+        csr_wr(.ptr(ral.avoutbuffer.buffer), .value(rx_buf));
+      end
+      // Successfully read and returned a packet.
+      rx_pending = 1;
+    end
+  endtask
+
+  // Send a packet to the host, await response and check ACK handshake indicating reception.
+  virtual task packet_send(byte unsigned tx_data[]);
+    int timeout_clks = 1_000_000;
+    uvm_reg_data_t in_sent;
+    bit pkt_sent;
+    write_buffer(in_buf, tx_data);
+    // Present the IN packet for collection.
+    ral.configin[0].size.set(tx_data.size());
+    ral.configin[0].buffer.set(in_buf);
+    ral.configin[0].rdy.set(1'b0);
+    csr_update(ral.configin[0]);
+    // Now set the RDY bit
+    ral.configin[0].rdy.set(1'b1);
+    csr_update(ral.configin[0]);
+    // Wait until the packet is successfully retrieved and ACKed by the host.
+    do begin
+      uvm_reg_data_t intr_state;
+      timeout_clks -= 128;
+      cfg.clk_rst_vif.wait_clks(128);
+      csr_rd(ral.intr_state, intr_state);
+      pkt_sent = bit'(get_field_val(ral.intr_state.pkt_sent, intr_state));
+    end while (!pkt_sent && timeout_clks > 0);
+    `DV_CHECK_EQ(pkt_sent, 1, "IN packet not successfully collected by DPI model");
+    // Clear the SENT interrupt for all endpoints; should be just EP 0.
+    csr_rd(.ptr(ral.in_sent[0]), .value(in_sent));
+    csr_wr(.ptr(ral.in_sent[0]), .value(in_sent));
+  endtask
+
+  // Dump out the contents of a packet.
+  virtual function void packet_dump(byte unsigned pkt[]);
+    for (int unsigned i = 0; i < pkt.size(); i++) begin
+      `uvm_info(`gfn, $sformatf("%2d: 0x%02x", i, pkt[i]), UVM_MEDIUM)
+    end
+  endfunction
+
+  // Present a range of buffer IDs for use by SETUP packets.
+  virtual task setup_buffers_supply(int unsigned first, int unsigned last);
+    for (int unsigned bufnum = first; bufnum <= last; bufnum++) begin
+      csr_wr(.ptr(ral.avsetupbuffer.buffer), .value(bufnum));
+    end
+  endtask
+
+  // Present a range of buffer IDs for use by OUT packets.
+  virtual task out_buffers_supply(int unsigned first, int unsigned last);
+    for (int unsigned bufnum = first; bufnum <= last; bufnum++) begin
+      csr_wr(.ptr(ral.avoutbuffer.buffer), .value(bufnum));
+    end
+  endtask
+
+  // Set up the control endpoint to implement the Default Control Pipe
+  virtual task endpoint_ctl_setup();
+    csr_wr(.ptr(ral.ep_out_enable[0]),  .value(1));
+    csr_wr(.ptr(ral.ep_in_enable[0]),   .value(1));
+    csr_wr(.ptr(ral.rxenable_setup[0]), .value(1));
+    csr_wr(.ptr(ral.rxenable_out[0]),   .value(1));
+  endtask
+
+  // Wait until the DPI host has issued the normal Control Transfers to set the
+  // device configuration.
+  virtual task configuration_wait();
+    ctl_state_e ctl_state = Ctl_AwaitSETUP;
+    cfg_state_e cfg_state = Cfg_DescDev;
+
+    // Respond to standard Control Transfers until SET_CONFIG received
+    //
+    // Accept GET_DESCRIPTOR for Device, SET_ADDRESS and GET_DESCRIPTOR for
+    // configuration(s) in any order, before SET_CONFIG which we require but
+    // essentially ignore.
+    //
+    // If these all occur then we may regard the device as having been successfully
+    // configured by the USB host.
+    while (~&{desc_dev_done, addr_set_done, desc_cfg_done, cfg_set_done}) begin
+      byte unsigned rx_data[];
+      int unsigned rx_len;
+      bit rx_pending;
+      bit rx_setup;
+      // Await appropriate stimulus
+      case (ctl_state)
+        Ctl_AwaitSETUP: begin
+          // Collect SETUP DATA packet and decode
+          packet_recv(rx_pending, rx_setup, rx_data);
+          if (rx_pending) begin
+            `DV_CHECK(rx_setup && rx_data.size() == 8)
+            packet_dump(rx_data);
+            casez ({rx_data[1], rx_data[3]})
+              {SetupSetAddress, 8'h00}: begin
+                // USB device addresses are 7 bits.
+                byte unsigned dev_address = rx_data[2] & 8'h7f;
+                `uvm_info(`gfn, $sformatf("SET_ADDRESS %d received", dev_address), UVM_LOW)
+                packet_send(ack);
+                csr_wr(.ptr(ral.usbctrl.device_address), .value(dev_address));
+                addr_set_done = 1;
+              end
+              {SetupGetDescriptor, 8'h01}: begin
+                `uvm_info(`gfn, $sformatf("GET_DESCRIPTOR DEVICE"), UVM_LOW)
+                packet_send(desc_device);
+                ctl_state = Ctl_AwaitStatus;
+                cfg_state = Cfg_DescDev;
+              end
+              {SetupGetDescriptor, 8'h02}: begin
+                `uvm_info(`gfn, $sformatf("GET_DESCRIPTOR CONFIG"), UVM_LOW)
+                packet_send(desc_config);
+                ctl_state = Ctl_AwaitStatus;
+                cfg_state = Cfg_DescCfg;
+              end
+              {SetupSetConfiguration, 8'h00}: begin
+                `uvm_info(`gfn, $sformatf("SET_CONFIGURATION"), UVM_LOW)
+                packet_send(ack);
+                cfg_set_done = 1;
+              end
+              // TODO: we do not handle this vendor-specific Control Transfer at present,
+              // but we may do later for requesting fault injection testing etc.
+              default: begin
+                `uvm_info(`gfn, $sformatf("GET_DESCRIPTOR TEST"), UVM_LOW)
+                packet_send(desc_test);
+                ctl_state = Ctl_AwaitStatus;
+                cfg_state = Cfg_DescTest;
+              end
+            endcase
+          end
+        end
+        Ctl_AwaitStatus: begin
+          packet_recv(rx_pending, rx_setup, rx_data);
+          if (rx_pending) begin
+            `DV_CHECK(!rx_setup && !rx_data.size())
+            // Control Transfer complete
+            case (cfg_state)
+              Cfg_DescDev: begin
+                desc_dev_done = 1;
+                ctl_state = Ctl_AwaitSETUP;
+              end
+              Cfg_DescCfg: begin
+                desc_cfg_done = 1;
+                ctl_state = Ctl_AwaitSETUP;
+              end
+              default: begin
+                desc_test_done = 1;
+                ctl_state = Ctl_AwaitSETUP;
+              end
+            endcase
+          end
+        end
+        default: `uvm_fatal(`gfn, $sformatf("Invalid/unrecognised state %d", ctl_state))
+      endcase
+    end
+  endtask
+
+  virtual task body();
+    // Default Control Pipe configuration.
+    endpoint_ctl_setup();
+
+    // Populate Av FIFOs.
+    setup_buffers_supply(setup_buf_first, setup_buf_last);
+    out_buffers_supply(out_buf_first, out_buf_last);
+
+    // Enable interface
+    csr_wr(.ptr(ral.usbctrl.enable), .value(1));
+
+    // Wait for the normal device configuration sequence to complete.
+    configuration_wait();
+
+    // At this point the configuration sequence has completed.
+    `uvm_info(`gfn, $sformatf("Configuration completed"), UVM_MEDIUM)
+  endtask
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -9,6 +9,7 @@
 
 `include "usbdev_av_buffer_vseq.sv"
 `include "usbdev_csr_test_vseq.sv"
+`include "usbdev_dpi_config_host_vseq.sv"
 `include "usbdev_enable_vseq.sv"
 `include "usbdev_fifo_rst_vseq.sv"
 `include "usbdev_in_stall_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/usbdev_vseq_list.sv: {is_include_file: true}
       - seq_lib/usbdev_base_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_common_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_dpi_config_host_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_csr_test_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_pkt_received_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_packetiser.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_packetiser.sv
@@ -42,7 +42,7 @@ class usbdev_packetiser extends uvm_object;
         void'(m_hpkt.pack(handshake_pkt_arr));
       end
       default: begin
-        `uvm_fatal(`gfn, $sformatf("Special Token %x encountered", m_usb20_item.m_pid_type))
+        `uvm_fatal(`gfn, $sformatf("Special Token 0x%x encountered", m_usb20_item.m_pid_type))
       end
     endcase
   endtask

--- a/hw/ip/usbdev/dv/usbdev_sim.core
+++ b/hw/ip/usbdev/dv/usbdev_sim.core
@@ -13,6 +13,9 @@ filesets:
     depend:
       - lowrisc:dv:usbdev_test
       - lowrisc:dv:usbdev_sva
+      - lowrisc:dv:usb20_usbdpi
+      - lowrisc:dv_dpi_c:usbdpi
+      - lowrisc:dv_dpi_sv:usbdpi
     files:
       - tb/tb.sv
       - tb/Clock_Divider.sv

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -66,6 +66,12 @@
       uvm_test_seq: usbdev_av_buffer_vseq
     }
     {
+      name: usbdev_dpi_config_host
+      uvm_test_seq: usbdev_dpi_config_host_vseq
+      // Limited use of randomization presently
+      reseed: 1
+    }
+    {
       name: usbdev_enable
       uvm_test_seq: usbdev_enable_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -44,23 +44,12 @@
   uvm_test: usbdev_base_test
   uvm_test_seq: usbdev_base_vseq
 
-  // TODO: temporary fix for CSR tests - USB link reset interrupt is sticky - clearing it
-  // has no effect. Update "csr_test_mode" to add +do_clear_all_interrupts=0 switch to
-  // prevent the intr checks from being run.
-  run_modes: [
-    {
-      name: csr_tests_mode
-      run_opts: ["+do_clear_all_interrupts=0"]
-    }
-  ]
-
   // List of test specifications.
   tests: [
     {
       name: usbdev_smoke
       uvm_test_seq: usbdev_smoke_vseq
     }
-
     {
       name: usbdev_av_buffer
       uvm_test_seq: usbdev_av_buffer_vseq
@@ -128,7 +117,7 @@
       uvm_test_seq: usbdev_stall_priority_over_nak_vseq
     }
     {
-      name: phy_config_usb_ref_disable
+      name: usbdev_phy_config_usb_ref_disable
       uvm_test_seq: usbdev_phy_config_usb_ref_disable_vseq
     }
     {
@@ -140,7 +129,7 @@
       uvm_test_seq: usbdev_in_stall_vseq
     }
     {
-      name: in_iso
+      name: usbdev_in_iso
       uvm_test_seq: usbdev_in_iso_vseq
     }
   ]


### PR DESCRIPTION
This draft PR integrates the usbdpi model into block level testing for USBDEV with the following aims/advantages:

- usb20_agent may be disconnected and/or deactivated to prevent interference with CSR test, for example.
- Increase coverage within block level DV testing.
- The usbdpi connection is through a tri-stated, bidirectional signaling interface that models the two-wire physical USB with appropriate pull ups, pull downs and active drivers.
- The block level usb20_driver module may at some point drive transactions through all PHY types since it has direct connections to all USBDEV ports.
- usbdpi model is already capable of generating error conditions and invalid traffic.
- Increased opportunity for randomization within usbdpi cf chip-level simulation, because it is obviously much faster.
- Decrease the duration of development efforts on usbdpi itself because it obviously simulates a lot faster.
- The usbdpi's capable usb20_monitor.c code and symbolic decoding of the USB traffic can be made available in block level DV too. It generates a comprehensive log file (usb0.log) of everything that happens on the bus.

usbdev_dpi_config_host runs to completion (through the configuration sequence of GET_DESCRIPTOR, SET_ADDRESS, SET_CONFIG) but does not attempt to set up more than the Default Control Pipe and perform any traffic after configuration. I see no point in trying to replicate streaming tests in block level DV.

Child sequences can exercise more specific behavior such as invalid traffic, unexpected bus resets etc and/or collect coverage.

With this PR only the stress_all(_with_rand_reset) tests are failing, and that is because they have not been constructed.