### PR TITLE
[sival] Update hmac sival test targets.

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
@@ -56,7 +56,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests/crypto/cryptotest:hash_kat"]
     }
     {
       name: chip_sw_hmac_stress
@@ -72,7 +72,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests/crypto/cryptotest:hmac_kat"]
     }
     {
       name: chip_sw_hmac_endianness


### PR DESCRIPTION
Updates the test plan with the following targets:

1. chip_sw_hmac_sha2_stress: //sw/device/tests/crypto/cryptotest:hash_kat https://github.com/lowRISC/opentitan/issues/21464
2. chip_sw_hmac_stress: //sw/device/tests/crypto/cryptotest:hmac_kat https://github.com/lowRISC/opentitan/issues/21464