### PR TITLE
[uart,dv] Import generic testplan for stress_all_with_reset

### DIFF
--- a/hw/ip/uart/data/uart_testplan.hjson
+++ b/hw/ip/uart/data/uart_testplan.hjson
@@ -7,6 +7,7 @@
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "uart_sec_cm_testplan.hjson"]
   testpoints: [
     {
@@ -195,12 +196,6 @@
             - Randomly add reset between each sequence'''
       stage: V2
       tests: ["uart_stress_all"]
-    }
-    {
-      name: stress_all_with_reset
-      desc: '''Have random reset in parallel with stress_all and tl_errors sequences'''
-      stage: V2
-      tests: ["uart_stress_all_with_rand_reset"]
     }
   ]
 


### PR DESCRIPTION
This mirrors most of the other blocks in the design. One consequence is that the testpoint moves to V3, but we probably believe that's a better place for it to live anyway.