### PR TITLE
[reggen] Reserve CIP IDs for Integrated IPs

### DIFF
--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -56,7 +56,11 @@ KNOWN_CIP_IDS = {
     32: 'alert_handler',
     33: 'rv_plic',
     34: 'ast',
-    35: 'sensor_ctrl'
+    35: 'sensor_ctrl',
+    36: 'dma',
+    37: 'mbx',
+    38: 'soc_proxy',
+    39: 'keymgr_dpe'
 }
 
 REQUIRED_ALIAS_FIELDS = {


### PR DESCRIPTION
Four HW IP modules have been created on the `integrated_dev` branch, which hasn't been reconverged with `master` yet.  This commit reserves their Comportable IP IDs on `master` to ensure we don't accidentially assign their ID to another new IP, which would make reconvergence more difficult.