### PR TITLE
[cherrypick] Adds keymgr side load tests based on cryptolib test cases.

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -66,6 +66,9 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: [
+        "//sw/device/tests/crypto:aes_functest",
+      ]
     }
     {
       name: chip_sw_aes_interrupt_encryption
@@ -253,6 +256,10 @@
       si_stage: SV3
       lc_states: ["PROD", "DEV"]
       tests: ["chip_sw_keymgr_sideload_aes"]
+      bazel: [
+        "//sw/device/tests/crypto:aes_sideload_functest",
+        "//sw/device/tests/crypto:aes_kwp_sideload_functest",
+      ]
     }
     {
       name: chip_sw_aes_masking_off

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -110,7 +110,10 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_sideload_aes"]
-      bazel: []
+      bazel: [
+        "//sw/device/tests/crypto:aes_sideload_functest",
+        "//sw/device/tests/crypto:aes_kwp_sideload_functest",
+      ]
     }
     {
       name: chip_sw_keymgr_sideload_otbn
@@ -126,7 +129,10 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_sideload_otbn"]
-      bazel: []
+      bazel: [
+        "//sw/device/tests/crypto:ecdh_p256_sideload_functest",
+        "//sw/device/tests/crypto:ecdsa_p256_sideload_functest",
+      ]
     }
     {
       name: chip_sw_keymgr_derive_attestation

--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -144,7 +144,11 @@
       stage: V2
       si_stage: SV2
       tests: []
-      bazel: ["//sw/device/tests:keymgr_sideload_otbn_simple_test"]
+      bazel: [
+        "//sw/device/tests:keymgr_sideload_otbn_simple_test",
+        "//sw/device/tests/crypto:ecdh_p256_sideload_functest",
+        "//sw/device/tests/crypto:ecdsa_p256_sideload_functest",
+      ]
       lc_states: ["PROD"]
       features: [
         "OTBN.KEYMGR",

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -116,6 +116,23 @@ status_t keymgr_testutils_flash_init(
     const keymgr_testutils_secret_t *owner_secret);
 
 /**
+ * Wrapper function to `keymgr_testutils_startup()`.
+ *
+ * This function checks the state of the key manager before attempting to
+ * initialize its dependencies and state.
+ *
+ * The function will return an error if the keymgr is disabled or in invalid
+ * state.
+ *
+ * @param keymgr A key manager handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
+ * @param[out] keymgr_state The state of the keymgr after startup.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_testutils_try_startup(dif_keymgr_t *keymgr, dif_kmac_t *kmac,
+                                      dif_keymgr_state_t *keymgr_state);
+
+/**
  * Programs flash, restarts, and advances keymgr to CreatorRootKey state.
  *
  * This procedure essentially gets the keymgr into the first state where it can

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -2,11 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
 load("//rules:autogen.bzl", "autogen_cryptotest_header")
 load(
     "//rules/opentitan:defs.bzl",
-    "EARLGREY_TEST_ENVS",
     "cw310_params",
+    "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
+    "EARLGREY_TEST_ENVS",
     "opentitan_test",
     "verilator_params",
 )
@@ -18,10 +23,15 @@ load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
+CRYPTOTEST_EXEC_ENVS = dicts.add(
+    EARLGREY_TEST_ENVS,
+    EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+)
+
 opentitan_test(
     name = "aes_functest",
     srcs = ["aes_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -36,7 +46,7 @@ opentitan_test(
 opentitan_test(
     name = "aes_kwp_kat_functest",
     srcs = ["aes_kwp_kat_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -50,7 +60,7 @@ opentitan_test(
 opentitan_test(
     name = "aes_kwp_functest",
     srcs = ["aes_kwp_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -90,14 +100,7 @@ opentitan_test(
 opentitan_test(
     name = "aes_sideload_functest",
     srcs = ["aes_sideload_functest.c"],
-    broken = cw310_params(tags = ["broken"]),
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        },
-    ),
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -9,10 +9,11 @@ load(
 load("//rules:autogen.bzl", "autogen_cryptotest_header")
 load(
     "//rules/opentitan:defs.bzl",
-    "cw310_params",
     "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "EARLGREY_TEST_ENVS",
+    "cw310_params",
     "opentitan_test",
+    "silicon_params",
     "verilator_params",
 )
 load(
@@ -76,14 +77,7 @@ opentitan_test(
 opentitan_test(
     name = "aes_kwp_sideload_functest",
     srcs = ["aes_kwp_sideload_functest.c"],
-    broken = cw310_params(tags = ["broken"]),
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        },
-    ),
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -127,7 +121,7 @@ cc_library(
 opentitan_test(
     name = "aes_gcm_functest",
     srcs = ["aes_gcm_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -204,7 +198,7 @@ opentitan_test(
 opentitan_test(
     name = "ecdh_p256_functest",
     srcs = ["ecdh_p256_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -236,14 +230,7 @@ opentitan_test(
 opentitan_test(
     name = "ecdh_p256_sideload_functest",
     srcs = ["ecdh_p256_sideload_functest.c"],
-    broken = cw310_params(tags = ["broken"]),
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        },
-    ),
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -262,13 +249,16 @@ opentitan_test(
 opentitan_test(
     name = "ecdsa_p256_functest",
     srcs = ["ecdsa_p256_functest.c"],
-    exec_env = {
-        # Test is too large for ROM, so excluding rom_with_fake_keys.
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            # Test is too large for ROM, so excluding rom_with_fake_keys.
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+        },
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -287,13 +277,16 @@ opentitan_test(
 opentitan_test(
     name = "ecdsa_p384_functest",
     srcs = ["ecdsa_p384_functest.c"],
-    exec_env = {
-        # Test is too large for ROM, so excluding rom_with_fake_keys.
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            # Test is too large for ROM, so excluding rom_with_fake_keys.
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+        },
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -312,14 +305,7 @@ opentitan_test(
 opentitan_test(
     name = "ecdsa_p256_sideload_functest",
     srcs = ["ecdsa_p256_sideload_functest.c"],
-    broken = cw310_params(tags = ["broken"]),
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        },
-    ),
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -360,7 +346,7 @@ autogen_cryptotest_header(
 opentitan_test(
     name = "kmac_functest_hardcoded",
     srcs = ["kmac_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -469,7 +455,7 @@ opentitan_test(
 opentitan_test(
     name = "ecdsa_p256_verify_functest_hardcoded",
     srcs = ["ecdsa_p256_verify_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -486,7 +472,7 @@ opentitan_test(
 opentitan_test(
     name = "rsa_2048_encryption_functest",
     srcs = ["rsa_2048_encryption_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -502,7 +488,7 @@ opentitan_test(
 opentitan_test(
     name = "rsa_3072_encryption_functest",
     srcs = ["rsa_3072_encryption_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -518,7 +504,7 @@ opentitan_test(
 opentitan_test(
     name = "rsa_4096_encryption_functest",
     srcs = ["rsa_4096_encryption_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -534,7 +520,7 @@ opentitan_test(
 opentitan_test(
     name = "rsa_2048_key_from_cofactor_functest",
     srcs = ["rsa_2048_key_from_cofactor_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -555,10 +541,10 @@ opentitan_test(
         timeout = "long",
     ),
     # This test is too slow for Verilator/DV, so target FPGA only.
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    verilator = verilator_params(
+        timeout = "eternal",
+    ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
@@ -573,7 +559,7 @@ opentitan_test(
 opentitan_test(
     name = "rsa_2048_signature_functest",
     srcs = ["rsa_2048_signature_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -594,10 +580,14 @@ opentitan_test(
         timeout = "long",
     ),
     # This test is too slow for Verilator/DV, so target FPGA only.
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+    ),
+    verilator = verilator_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
@@ -612,9 +602,10 @@ opentitan_test(
 opentitan_test(
     name = "rsa_3072_signature_functest",
     srcs = ["rsa_3072_signature_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
@@ -633,10 +624,14 @@ opentitan_test(
         timeout = "long",
     ),
     # This test is too slow for Verilator/DV, so target FPGA only.
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-    },
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    silicon = silicon_params(
+        timeout = "long",
+    ),
+    verilator = verilator_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:rsa",
@@ -651,9 +646,10 @@ opentitan_test(
 opentitan_test(
     name = "rsa_4096_signature_functest",
     srcs = ["rsa_4096_signature_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
@@ -680,10 +676,13 @@ opentitan_test(
     ),
     # The test vectors don't fit in the flash allocated for ROM_EXT stage, so
     # we have to restrict the environments to run with the test_rom.
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+        },
+    ),
     verilator = verilator_params(
         timeout = "eternal",
     ),
@@ -708,7 +707,7 @@ autogen_cryptotest_header(
 opentitan_test(
     name = "rsa_3072_verify_functest_hardcoded",
     srcs = ["rsa_3072_verify_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -726,7 +725,7 @@ opentitan_test(
 opentitan_test(
     name = "sha384_functest",
     srcs = ["sha384_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -740,7 +739,7 @@ opentitan_test(
 opentitan_test(
     name = "sha512_functest",
     srcs = ["sha512_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -755,7 +754,7 @@ opentitan_test(
 opentitan_test(
     name = "symmetric_keygen_functest",
     srcs = ["symmetric_keygen_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/crypto/impl:drbg",
@@ -782,7 +781,7 @@ py_binary(
 opentitan_test(
     name = "hkdf_functest",
     srcs = ["hkdf_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -798,7 +797,7 @@ opentitan_test(
 opentitan_test(
     name = "hmac_sha256_functest",
     srcs = ["hmac_sha256_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -813,7 +812,7 @@ opentitan_test(
 opentitan_test(
     name = "hmac_sha384_functest",
     srcs = ["hmac_sha384_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -827,7 +826,7 @@ opentitan_test(
 opentitan_test(
     name = "hmac_sha512_functest",
     srcs = ["hmac_sha512_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -874,7 +873,7 @@ py_binary(
 opentitan_test(
     name = "sha256_functest",
     srcs = ["sha256_functest.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -889,9 +888,12 @@ opentitan_test(
 opentitan_test(
     name = "otcrypto_hash_test",
     srcs = ["otcrypto_hash_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        },
+    ),
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:status",
@@ -904,9 +906,12 @@ opentitan_test(
 opentitan_test(
     name = "otcrypto_export_test",
     srcs = ["otcrypto_export_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        },
+    ),
     deps = [
         "//sw/device/lib/crypto:crypto_exported_for_test",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -918,5 +923,46 @@ filegroup(
     srcs = [
         "ecdsa_p256_verify_testvectors.h.tpl",
         "rsa_3072_verify_testvectors.h.tpl",
+    ],
+)
+
+test_suite(
+    name = "cryptolib_test_suite",
+    tests = [
+        ":aes_functest",
+        ":aes_gcm_functest",
+        ":aes_gcm_timing_test",
+        ":aes_kwp_functest",
+        ":aes_kwp_kat_functest",
+        ":aes_kwp_sideload_functest",
+        ":aes_sideload_functest",
+        ":drbg_functest",
+        ":ecdh_p256_functest",
+        ":ecdh_p256_sideload_functest",
+        ":ecdsa_p256_functest",
+        ":ecdsa_p256_sideload_functest",
+        ":ecdsa_p256_verify_functest_hardcoded",
+        ":hkdf_functest",
+        ":hmac_sha256_functest",
+        ":hmac_sha384_functest",
+        ":hmac_sha512_functest",
+        ":otcrypto_export_test",
+        ":otcrypto_hash_test",
+        ":rsa_2048_encryption_functest",
+        ":rsa_2048_key_from_cofactor_functest",
+        ":rsa_2048_keygen_functest",
+        ":rsa_2048_signature_functest",
+        ":rsa_3072_encryption_functest",
+        ":rsa_3072_keygen_functest",
+        ":rsa_3072_signature_functest",
+        ":rsa_3072_verify_functest_hardcoded",
+        ":rsa_3072_verify_functest_wycheproof",
+        ":rsa_4096_encryption_functest",
+        ":rsa_4096_keygen_functest",
+        ":rsa_4096_signature_functest",
+        ":sha256_functest",
+        ":sha384_functest",
+        ":sha512_functest",
+        ":symmetric_keygen_functest",
     ],
 )

--- a/sw/device/tests/crypto/aes_kwp_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_sideload_functest.c
@@ -15,7 +15,7 @@
 #define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
 
 // Key version data for testing.
-static const uint32_t kKeyVersion = 0x9;
+static const uint32_t kKeyVersion = 0x0;
 
 // Key salt for testing.
 static const uint32_t kKeySalt[7] = {
@@ -125,9 +125,17 @@ status_t test_setup(void) {
   // the expected setup in production.
   dif_keymgr_t keymgr;
   dif_kmac_t kmac;
-  TRY(keymgr_testutils_startup(&keymgr, &kmac));
-  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  dif_keymgr_state_t keymgr_state;
+  TRY(keymgr_testutils_try_startup(&keymgr, &kmac, &keymgr_state));
+
+  if (keymgr_state == kDifKeymgrStateInitialized) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
+  }
+
+  if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  }
+
   TRY(keymgr_testutils_check_state(&keymgr, kDifKeymgrStateOwnerRootKey));
 
   // Initialize entropy complex for cryptolib, which the key manager uses to

--- a/sw/device/tests/crypto/aes_kwp_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_kwp_sideload_functest.c
@@ -128,11 +128,10 @@ status_t test_setup(void) {
   dif_keymgr_state_t keymgr_state;
   TRY(keymgr_testutils_try_startup(&keymgr, &kmac, &keymgr_state));
 
-  if (keymgr_state == kDifKeymgrStateInitialized) {
+  if (keymgr_state == kDifKeymgrStateCreatorRootKey) {
     TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  }
-
-  if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  } else if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
     TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
   }
 

--- a/sw/device/tests/crypto/aes_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_sideload_functest.c
@@ -145,11 +145,10 @@ status_t test_setup(void) {
   dif_keymgr_state_t keymgr_state;
   TRY(keymgr_testutils_try_startup(&keymgr, &kmac, &keymgr_state));
 
-  if (keymgr_state == kDifKeymgrStateInitialized) {
+  if (keymgr_state == kDifKeymgrStateCreatorRootKey) {
     TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  }
-
-  if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  } else if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
     TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
   }
 

--- a/sw/device/tests/crypto/aes_sideload_functest.c
+++ b/sw/device/tests/crypto/aes_sideload_functest.c
@@ -19,7 +19,7 @@
 #define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
 
 // Key version data for testing.
-static const uint32_t kKeyVersion = 0x9;
+static const uint32_t kKeyVersion = 0x0;
 
 // Two distinct key salts for testing.
 static const uint32_t kKeySalt1[7] = {
@@ -142,9 +142,17 @@ status_t test_setup(void) {
   // the expected setup in production.
   dif_keymgr_t keymgr;
   dif_kmac_t kmac;
-  TRY(keymgr_testutils_startup(&keymgr, &kmac));
-  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  dif_keymgr_state_t keymgr_state;
+  TRY(keymgr_testutils_try_startup(&keymgr, &kmac, &keymgr_state));
+
+  if (keymgr_state == kDifKeymgrStateInitialized) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
+  }
+
+  if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  }
+
   TRY(keymgr_testutils_check_state(&keymgr, kDifKeymgrStateOwnerRootKey));
 
   // Initialize entropy complex for cryptolib, which the key manager uses to

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -36,8 +36,8 @@ static const otcrypto_ecc_curve_t kCurveP256 = {
 };
 
 // Versions for private keys A and B.
-static const uint32_t kPrivateKeyAVersion = 0xa;
-static const uint32_t kPrivateKeyBVersion = 0xb;
+static const uint32_t kPrivateKeyAVersion = 0;
+static const uint32_t kPrivateKeyBVersion = 0;
 
 // Salt for private keys A and B.
 static const uint32_t kPrivateKeyASalt[7] = {0xdeadbeef, 0xdeadbeef, 0xdeadbeef,
@@ -164,9 +164,17 @@ static status_t test_setup(void) {
   // the expected setup in production.
   dif_keymgr_t keymgr;
   dif_kmac_t kmac;
-  TRY(keymgr_testutils_startup(&keymgr, &kmac));
-  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  dif_keymgr_state_t keymgr_state;
+  TRY(keymgr_testutils_try_startup(&keymgr, &kmac, &keymgr_state));
+
+  if (keymgr_state == kDifKeymgrStateInitialized) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
+  }
+
+  if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  }
+
   TRY(keymgr_testutils_check_state(&keymgr, kDifKeymgrStateOwnerRootKey));
 
   // Initialize entropy complex for cryptolib, which the key manager uses to

--- a/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdh_p256_sideload_functest.c
@@ -167,11 +167,10 @@ static status_t test_setup(void) {
   dif_keymgr_state_t keymgr_state;
   TRY(keymgr_testutils_try_startup(&keymgr, &kmac, &keymgr_state));
 
-  if (keymgr_state == kDifKeymgrStateInitialized) {
+  if (keymgr_state == kDifKeymgrStateCreatorRootKey) {
     TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  }
-
-  if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  } else if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
     TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
   }
 

--- a/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
+++ b/sw/device/tests/crypto/ecdsa_p256_sideload_functest.c
@@ -118,11 +118,10 @@ static status_t test_setup(void) {
   dif_keymgr_state_t keymgr_state;
   TRY(keymgr_testutils_try_startup(&keymgr, &kmac, &keymgr_state));
 
-  if (keymgr_state == kDifKeymgrStateInitialized) {
+  if (keymgr_state == kDifKeymgrStateCreatorRootKey) {
     TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerIntParams));
-  }
-
-  if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
+    TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
+  } else if (keymgr_state == kDifKeymgrStateOwnerIntermediateKey) {
     TRY(keymgr_testutils_advance_state(&keymgr, &kOwnerRootKeyParams));
   }
 

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -147,3 +147,16 @@ test_suite(
         "//sw/device/tests/pmod:i2c_host_fram_test",
     ],
 )
+
+test_suite(
+    name = "regression_test_suite",
+    tests = [
+        # Silicon validation test suites.
+        ":sv1_tests",
+        ":sv2_tests",
+        ":sv3_tests",
+
+        # Crypto test suites.
+        "//sw/device/tests/crypto:cryptolib_test_suite",
+    ],
+)


### PR DESCRIPTION
Manual cherry-pick of https://github.com/lowRISC/opentitan/pull/22215

## Test cases (porting to master)

- https://github.com/lowRISC/opentitan/issues/19984
- https://github.com/lowRISC/opentitan/issues/21502
- https://github.com/lowRISC/opentitan/issues/19981
- https://github.com/lowRISC/opentitan/issues/21503