### PR TITLE
[ci] Print SAM3X firmware version for FPGA jobs

### DIFF
--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -44,6 +44,9 @@ trap 'ci/bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga
 ci/bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface="$fpga" --logging debug fpga set-pll || true
 ci/bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface="$fpga" fpga clear-bitstream
 
+# Print the SAM3X firmware version. HyperDebug transports don't currently support this, so we ignore errors.
+ci/bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface="$fpga" fpga get-sam3x-fw-version || true
+
 pattern_file=$(mktemp)
 # Recognize special test set names, otherwise we interpret it as a list of tags.
 test_args=""


### PR DESCRIPTION
This PR prints the SAM3X firmware version before running FPGA tests. This is useful even for hyperdebug tests as we still program the bitstream etc through the SAM3X.