### PR TITLE
[i2c/rtl] Change depth of RAM for FIFOs to 464 entries

### DIFF
--- a/hw/ip/i2c/rtl/i2c_fifos.sv
+++ b/hw/ip/i2c/rtl/i2c_fifos.sv
@@ -62,7 +62,7 @@ import i2c_reg_pkg::AcqFifoDepth;
 );
 
   // RAM synthesis parameters
-  localparam int unsigned RamDepth = 472;
+  localparam int unsigned RamDepth = 464;
   `ASSERT_INIT(RamDepthSuffices_A, RamDepth >= 3 * FifoDepth + AcqFifoDepth)
   localparam int unsigned RamAw = prim_util_pkg::vbits(RamDepth);
   localparam int unsigned RamWidth = 13;


### PR DESCRIPTION
This is needed to match the SRAM macro.  The minimum depth needed by the RTL is 460 entries (which gets checked by assertions).

This resolves #22234.

CC @meisnere @OTshimeon 