### PR TITLE
[dvsim] Be more explicit about seeds when running tests

### DIFF
--- a/hw/dv/tools/dvsim/common_modes.hjson
+++ b/hw/dv/tools/dvsim/common_modes.hjson
@@ -69,7 +69,7 @@
     {
       name: build_seed
       is_sim_mode: 1
-      build_opts: ["+define+BUILD_SEED={seed}"]
+      build_opts: ["+define+BUILD_SEED={long_seed}"]
     }
   ]
 

--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -33,7 +33,7 @@
                "-image image",
                // UVM DPI
                "-sv_lib {DSIM_HOME}/lib/libuvm_dpi.so",
-               "-sv_seed {seed}",
+               "-sv_seed {short_seed}",
                // tell DSim to write line-buffered stdout (lines will be written in proper order)
                "-linebuf",
                "+UVM_TESTNAME={uvm_test}",

--- a/hw/dv/tools/dvsim/questa.hjson
+++ b/hw/dv/tools/dvsim/questa.hjson
@@ -17,7 +17,7 @@
               ]
 
   run_opts:   [ "-outdir {build_dir}/qrun.out",
-                "-sv_seed {seed}",
+                "-sv_seed {short_seed}",
                 // dv_macros.svh has a macro printing null using %0d
                 // format specifier, Questa throws an error on this
                 // we demote this error in Questa

--- a/hw/dv/tools/dvsim/riviera.hjson
+++ b/hw/dv/tools/dvsim/riviera.hjson
@@ -13,7 +13,7 @@
                "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
               ]
 
-  run_opts:   ["-sv_seed={seed}",
+  run_opts:   ["-sv_seed={short_seed}",
                "-c",
                "{tb}",
                "-lib {sv_flist_gen_dir}/work",

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -113,7 +113,7 @@
 
   run_opts:   ["-licqueue",
                "-ucli -do {run_script}",
-               "+ntb_random_seed={svseed}",
+               "+ntb_random_seed={short_seed}",
                // Disable the display of the SystemVerilog assert and cover statement summary
                // at the end of simulation. This summary is list of assertions that started but
                // did not finish because the simulation terminated, or assertions that did not
@@ -134,7 +134,7 @@
 
   // Individual test specific coverage data - this will be deleted if the test fails
   // so that coverage from failiing tests is not included in the final report.
-  cov_db_test_dir_name: "{run_dir_name}.{svseed}"
+  cov_db_test_dir_name: "{run_dir_name}.{seed}"
   cov_db_test_dir: "{cov_db_dir}/snps/coverage/db/testdata/{cov_db_test_dir_name}"
 
   // Merging coverage.

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -68,7 +68,7 @@
                "-64bit -xmlibdirname {build_db_dir}",
                // Use the same snapshot name set during the build step.
                "-r {tb}",
-               "+SVSEED={svseed}",
+               "+SVSEED={short_seed}",
                "{uvm_testname_plusarg}",
                "{uvm_testseq_plusarg}",
                // Ignore "IEEE 1800-2009 SystemVerilog simulation semantics" warning
@@ -129,7 +129,7 @@
 
   // Individual test specific coverage data - this will be deleted if the test fails
   // so that coverage from failiing tests is not included in the final report.
-  cov_db_test_dir_name: "{run_dir_name}.{svseed}"
+  cov_db_test_dir_name: "{run_dir_name}.{seed}"
   cov_db_test_dir:      "{cov_db_dir}/{cov_db_test_dir_name}"
 
   // Merging coverage.

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -44,7 +44,7 @@
     // defined in `hw/dv/tools/dvsim/common_modes.hjson` for more details.
     {
       name: build_seed
-      pre_build_cmds: ["cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}"]
+      pre_build_cmds: ["cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {long_seed}"]
       is_sim_mode: 1
     }
   ]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -181,13 +181,13 @@
         //        -o hw/top_earlgrey --rnd_cnst_seed {seed}
         // ''',
         // Generate LC encoding
-        "cd {proj_root} && ./util/design/gen-lc-state-enc.py --seed {seed}",
+        "cd {proj_root} && ./util/design/gen-lc-state-enc.py --seed {long_seed}",
         // Generate OTP memory map and scrambling constants keys.
-        "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}",
+        "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {long_seed}",
         // Use eval_cmd to save build_seed in a file and reuse that file during run phase.
         // Create the build directory first because eval_cmd runs before actual build phase command
         // execution.
-        '''{eval_cmd} mkdir -p {build_dir}; echo {seed} > {build_seed_file_path}; \
+        '''{eval_cmd} mkdir -p {build_dir}; echo {long_seed} > {build_seed_file_path}; \
            echo "echo create file {build_seed_file_path}"
         '''
       ]
@@ -233,7 +233,7 @@
   gen_otp_images_cfg_dir: "{proj_root}/hw/ip/otp_ctrl/data"
   gen_otp_images_cmd: "{proj_root}/util/design/gen-otp-img.py"
   gen_otp_images_cmd_opts: ["--quiet",
-                            "--img-seed {seed}",
+                            "--img-seed {long_seed}",
                             // Only provide `--otp-seed` argument if the file to store build_seed
                             // is found. Set this option at the end of the list to avoid `eval_cmd`
                             // take other options as eval_cmd.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -44,7 +44,8 @@ class SimCfg(FlowCfg):
 
     # TODO: Find a way to set these in sim cfg instead
     ignored_wildcards = [
-        "build_mode", "index", "test", "seed", "svseed", "uvm_test", "uvm_test_seq",
+        "build_mode", "index", "test", "seed", "short_seed", "long_seed",
+        "uvm_test", "uvm_test_seq",
         "cov_db_dirs", "sw_images", "sw_build_device", "sw_build_cmd",
         "sw_build_opts"
     ]


### PR DESCRIPTION
This should avoid ugly paths all over the place and tests that are hard to reproduce. We still get the long build seeds that were the motivation for the 256 bit constants that we had before.

The base seeds are now all 16 bit values, so should be a bit more convenient to type on the command line. But the build seeds should be much longer (256 bits) if needed.