### PR TITLE
[rom_e2e,dv] disable ROM self hash test in DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -901,20 +901,21 @@
     }
 
     // ROM self hash test.
-    {
-      name: rom_e2e_self_hash
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/presigned_images:rom_e2e_self_hash:1:signed:ot_flash_binary"
-        "//sw/device/silicon_creator/rom/e2e/sigverify_mod_exp:otp_img_sigverify_mod_exp_rma_otbn:4",
-      ]
-      en_run_modes: ["sw_test_mode_rom_with_real_keys"]
-      run_opts: [
-        "+sw_test_timeout_ns=200_000_000",
-        "+use_otp_image=OtpTypeCustom",
-      ]
-      run_timeout_mins: 480
-    }
+    // TODO(#19199): reactivate this test before PROD tapeout, when doing a ROM release.
+    // {
+    //   name: rom_e2e_self_hash
+    //   uvm_test_seq: chip_sw_base_vseq
+    //   sw_images: [
+    //     "//sw/device/silicon_creator/rom/e2e/presigned_images:rom_e2e_self_hash:1:signed:ot_flash_binary"
+    //     "//sw/device/silicon_creator/rom/e2e/sigverify_mod_exp:otp_img_sigverify_mod_exp_rma_otbn:4",
+    //   ]
+    //   en_run_modes: ["sw_test_mode_rom_with_real_keys"]
+    //   run_opts: [
+    //     "+sw_test_timeout_ns=200_000_000",
+    //     "+use_otp_image=OtpTypeCustom",
+    //   ]
+    //   run_timeout_mins: 480
+    // }
     // This test is commented out in the open-source, but can be uncommented by
     // back-end designers after they integrate the functional model of the ROM
     // macro into the netlist.


### PR DESCRIPTION
The ROM E2E self hash test was disabled on FPGA in #17177. The test should also have been disabled in DV. #19199 tracks reenabling the test when the ROM is released for the Earlgrey PROD backend integration.