### PR TITLE
[usbdev] Packet receiver refinements

### DIFF
--- a/hw/ip/usbdev/rtl/usb_fs_rx.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_rx.sv
@@ -513,6 +513,8 @@ module usb_fs_rx (
   ////////////////////////////
   // output control signals //
   ////////////////////////////
+  logic valid_token_len, valid_data_len, valid_handshake_len;
+
   logic pkt_is_token, pkt_is_data, pkt_is_handshake;
   assign pkt_is_token     = full_pid_q[2:1] == 2'b01;
   assign pkt_is_data      = full_pid_q[2:1] == 2'b11;
@@ -523,10 +525,9 @@ module usb_fs_rx (
 
 
   assign valid_packet_o = pid_valid && !bitstuff_error_q &&
-    ((pkt_is_handshake) ||
-    (pkt_is_data && crc16_valid) ||
-    (pkt_is_token && crc5_valid)
-  );
+    ((pkt_is_handshake && valid_handshake_len) ||
+     (pkt_is_data && valid_data_len && crc16_valid) ||
+     (pkt_is_token && valid_token_len && crc5_valid));
 
   // Detect CRC errors
   assign crc5_error_o  = pkt_is_token & packet_end & !crc5_valid;
@@ -581,7 +582,6 @@ module usb_fs_rx (
   /////////////////////////////////
   // deserialize and output data //
   /////////////////////////////////
-  //assign rx_data_put = dvalid && pid_complete && pkt_is_data;
   logic [8:0] rx_data_buffer_q, rx_data_buffer_d;
   logic rx_data_buffer_full;
 
@@ -601,6 +601,29 @@ module usb_fs_rx (
     end
   end
 
+  // Counting packet length in bits; we need to know whether the length is byte-aligned,
+  // and whether it's equal to 16 (token packet) or at least 16 (data packet; CRC16 required).
+  logic       rx_data_len16_q, rx_data_len16_d;
+  logic [3:0] rx_data_len_q,   rx_data_len_d;
+
+  // Valid packet length indications.
+  assign valid_token_len     = rx_data_len16_q & ~|rx_data_len_q;
+  assign valid_data_len      = rx_data_len16_q & ~|rx_data_len_q[2:0];  // Must be byte-aligned.
+  assign valid_handshake_len = ~|{rx_data_len16_q, rx_data_len_q};
+
+  always_comb begin
+    rx_data_len16_d  = rx_data_len16_q;
+    rx_data_len_d    = rx_data_len_q;
+
+    if (packet_start) begin
+      rx_data_len16_d  = 1'b0;
+      rx_data_len_d    = 4'h0;
+    end
+    if (dvalid && pid_complete) begin
+      rx_data_len16_d  = rx_data_len16_q | &rx_data_len_q;
+      rx_data_len_d    = rx_data_len_q + 4'h1;
+    end
+  end
 
   ///////////////
   // Registers //
@@ -615,6 +638,8 @@ module usb_fs_rx (
       endp_q              <= 0;
       frame_num_q         <= 0;
       rx_data_buffer_q    <= 0;
+      rx_data_len16_q     <= 0;
+      rx_data_len_q       <= 0;
     end else begin
       if (link_reset_i) begin
         full_pid_q          <= 0;
@@ -625,6 +650,8 @@ module usb_fs_rx (
         endp_q              <= 0;
         frame_num_q         <= 0;
         rx_data_buffer_q    <= 0;
+        rx_data_len16_q     <= 0;
+        rx_data_len_q       <= 0;
       end else begin
         full_pid_q          <= full_pid_d;
         crc16_q             <= crc16_d;
@@ -634,6 +661,8 @@ module usb_fs_rx (
         endp_q              <= endp_d;
         frame_num_q         <= frame_num_d;
         rx_data_buffer_q    <= rx_data_buffer_d;
+        rx_data_len16_q     <= rx_data_len16_d;
+        rx_data_len_q       <= rx_data_len_d;
       end
     end
   end

--- a/hw/ip/usbdev/rtl/usb_fs_rx.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_rx.sv
@@ -43,7 +43,9 @@ module usb_fs_rx (
   output logic rx_data_put_o,
   output logic [7:0] rx_data_o,
 
-  // Most recent packet passes PID and CRC checks
+  // Most recent packet passes PID check
+  output logic valid_pid_o,
+  // Most recent packet passes PID, length and CRC checks
   output logic valid_packet_o,
 
   // line status for the status detection (actual rx bits after clock recovery)
@@ -523,6 +525,7 @@ module usb_fs_rx (
   assign see_preamble = packet_valid_q & pid_valid & pid_complete &&
                         (usb_pid_e'(full_pid_q[4:1]) == UsbPidPre);
 
+  assign valid_pid_o = pid_valid;
 
   assign valid_packet_o = pid_valid && !bitstuff_error_q &&
     ((pkt_is_handshake && valid_handshake_len) ||

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -651,7 +651,7 @@ module usbdev
     // status
     .frame_o              (frame),
     .frame_start_o        (event_frame),
-    .sof_valid_o          (event_sof),
+    .sof_detected_o       (event_sof),
     .link_state_o         (link_state),
     .link_disconnect_o    (link_disconnect),
     .link_powered_o       (link_powered),

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -18,7 +18,7 @@ module usbdev_linkstate (
   input  logic usb_pullup_en_i,
   input  logic rx_idle_det_i,
   input  logic rx_j_det_i,
-  input  logic sof_valid_i,
+  input  logic sof_detected_i,
   input  logic resume_link_active_i, // pulse
 
   output logic link_disconnect_o,  // level
@@ -194,7 +194,7 @@ module usbdev_linkstate (
         LinkActiveNoSOF: begin
           if (ev_bus_inactive) begin
             link_state_d = LinkSuspended;
-          end else if (sof_valid_i) begin
+          end else if (sof_detected_i) begin
             link_state_d = LinkActive;
           end
         end
@@ -367,7 +367,7 @@ module usbdev_linkstate (
     if (!rst_ni) begin
       missed_sof_count <= '0;
     end else begin
-      if (sof_valid_i || !link_active_o || link_reset) begin
+      if (sof_detected_i || !link_active_o || link_reset) begin
         missed_sof_count <= '0;
       end else if (sof_missed_o && !host_lost_o) begin
         missed_sof_count <= missed_sof_count + 1;
@@ -380,7 +380,7 @@ module usbdev_linkstate (
     if (!rst_ni) begin
       missing_sof_timer <= '0;
     end else begin
-      if (sof_missed_o || sof_valid_i || !link_active_o || link_reset) begin
+      if (sof_missed_o || sof_detected_i || !link_active_o || link_reset) begin
         missing_sof_timer <= '0;
       end else if (us_tick_i) begin
         missing_sof_timer <= missing_sof_timer + 1;

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -103,8 +103,8 @@ module usbdev_usbif  #(
   // status
   output logic                     frame_start_o, // Pulses with host-generated and internal SOF
   output logic [10:0]              frame_o,
-  output logic                     sof_valid_o, // Pulses with only host-generated SOF.
-                                                // Used for clock sync.
+  output logic                     sof_detected_o, // Pulses with only host-generated SOF.
+                                                   // Used for clock sync.
   output logic [2:0]               link_state_o,
   output logic                     link_disconnect_o,
   output logic                     link_powered_o,
@@ -301,6 +301,7 @@ module usbdev_usbif  #(
                       (in_ep_get_addr[0] ? mem_rdata_i[31:24] : mem_rdata_i[23:16]) :
                       (in_ep_get_addr[0] ? mem_rdata_i[15:8]  : mem_rdata_i[7:0]);
 
+  logic            sof_valid;
   logic [10:0]     frame_index_raw;
   logic            rx_idle_det;
   logic            rx_j_det;
@@ -383,7 +384,8 @@ module usbdev_usbif  #(
     .rx_bitstuff_err_o     (rx_bitstuff_err_o),
 
     // sof interface
-    .sof_valid_o           (sof_valid_o),
+    .sof_detected_o        (sof_detected_o),
+    .sof_valid_o           (sof_valid),
     .frame_index_o         (frame_index_raw),
 
     // event counters
@@ -403,9 +405,9 @@ module usbdev_usbif  #(
 
   always_comb begin
     frame_d = frame_q;
-    if (sof_valid_o) begin
+    if (sof_valid) begin
       frame_d = frame_index_raw;
-    end else if (do_internal_sof) begin
+    end else if (sof_detected_o | do_internal_sof) begin
       frame_d = frame_q + 1;
     end
   end
@@ -429,7 +431,7 @@ module usbdev_usbif  #(
     .usb_pullup_en_i       (connect_en_i),
     .rx_idle_det_i         (rx_idle_det),
     .rx_j_det_i            (rx_j_det),
-    .sof_valid_i           (sof_valid_o),
+    .sof_detected_i        (sof_detected_o),
     .resume_link_active_i  (resume_link_active_i),
     .link_disconnect_o     (link_disconnect_o),
     .link_powered_o        (link_powered_o),


### PR DESCRIPTION
This PR proposes two alterations to the receiver side logic of the USB device:

1. As per the assertion in section `8.4.5 Handshake Packets` of the protocol specification, handshake packets that contain additional bits between the valid PID and the EOP shall cause the handshake packet to be ignored. Local modifications to the USBDPI model have demonstrated that an arbitrary number of bits may be introduced between the handshake PID and the EOP, and the handshake will still be accepted at present. Indeed the DPI model is erroneously doing this in a couple of places where it transmits 'USB_PID_ACK' as a complete token packet.

2. As per section `8.7.1 Packet Error Categories` a SOF packet that has a valid PID shall not be ignored completely; instead the presence of a CRC5 error and/or bit stuffing shall cause the Frame Number to be ignored, but the packet shall still be used for synchronization purposes. This may prove important in adjusting the USB clock frequency to match that of the USB Host.

In the first commit, it should also be noted that Data packets must be an integral number of bytes (`8.4.4 Data Packets`) and that there is presently no validity check on the packet length, including whether there is a sufficient number of bits to encode the CRC16.


Local changes to the USBDPI model to improve its error injection capabilities have shown - by waveform inspection and test failure - that additional bits may be inserted before the EOP for each of (i) token packets, (ii) data packets and (iii) handshake packets and the packet is presently still accepted. With the changes in this PR, such packets are now ignored as intended.

The change in 2 really requires additional DV effort, since block level DV presently does not emit SOF packets (excepting the nascent sequence in draft PR #22199).


Relates to #22240.