### PR TITLE
[siva] Add cryptotest targets to chip_kmac_testplan.

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -131,7 +131,9 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: [
+        "//sw/device/tests/crypto/cryptotest:hash_kat",
+      ]
     }
     {
       name: chip_sw_kmac_shake_stress
@@ -151,7 +153,9 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: [
+        "//sw/device/tests/crypto/cryptotest:hash_kat",
+      ]
     }
     {
       name: chip_sw_kmac_cshake_stress
@@ -171,7 +175,9 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: [
+        "//sw/device/tests/crypto/cryptotest:hash_kat",
+      ]
     }
     {
       name: chip_sw_kmac_kmac_stress
@@ -191,7 +197,9 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: [
+        "//sw/device/tests/crypto/cryptotest:kmac_kat",
+      ]
     }
     {
       name: chip_sw_kmac_kmac_key_sideload


### PR DESCRIPTION
Adds cryptotest targets to KMAC stress chip test points.


## Sival Test Issues

* https://github.com/lowRISC/opentitan/issues/21406
* https://github.com/lowRISC/opentitan/issues/21407
* https://github.com/lowRISC/opentitan/issues/21408
* https://github.com/lowRISC/opentitan/issues/21409
