### PR TITLE
[hmac] Coding style and minor fixes

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -6,12 +6,9 @@
   human_name:         "HMAC Accelerator",
   one_line_desc:      "Accelerator for SHA-2 256/384/512-based keyed HMAC and the hash function",
   one_paragraph_desc: '''
-  HMAC Accelerator is a keyed hash based message authentication code generator using
-  [SHA-256/384/512][nist-fips-180-4] to check the integrity of an incoming message and optionally
-  a signature signed with the same secret key. This HMAC implementation is not hardened against
-  side-channel analysis (SCA) or fault injection (FI) attacks; it is meant purely for
-  hashing acceleration. If hardened MAC operations are required, either the KMAC Accelerator
-  or a software implementation should be used.
+  HMAC Accelerator is a keyed hash based message authentication code generator using [SHA-2 256/384/512][nist-fips-180-4] to check the integrity of an incoming message and optionally a signature signed with the same secret key.
+  This HMAC implementation is not hardened against side-channel analysis (SCA) or fault injection (FI) attacks; it is meant purely for hashing acceleration.
+  If hardened MAC operations are required, either the KMAC Accelerator or a software implementation should be used.
 
   [nist-fips-180-4]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
   '''
@@ -104,8 +101,13 @@
   features: [
     {
       name: "HMAC.MODE.SHA2",
-      desc: '''SHA2 hashing algorithm supporting the following security strength configurations:
-            SHA-2 256/384/512. Compliant with NIST FIPS 180-4.
+      desc: '''SHA-2 hashing algorithm supporting the following security strength configurations: SHA-2 256/384/512. Compliant with NIST FIPS 180-4.
+            '''
+    }
+    {
+      name: "HMAC.MODE.HMAC",
+      desc: '''Keyed-Hash Message Authentication Code (HMAC) supporting the following security strength configurations: HMAC/SHA-2 256/384/512.
+      Compliant with NIST FIPS 198-1 which will be superseded by NIST SP 800-224.
             '''
     }
     {
@@ -145,56 +147,7 @@
     }
     {
       name: "HMAC.KEY_LENGTH.KEY_1024",
-      desc: '''HMAC based on SHA-2 384/SHA-2 512 using 1024-bit key. If configured with SHA-2 256,
-            KEY_LENGTH defaults to Key_512.
-            '''
-    }
-    {
-      name: "HMAC.DIGEST_SIZE.SHA2-256",
-      desc: '''SHA2-256 hashing algorithm for SHA-2 and keyed HMAC.
-            '''
-    }
-    {
-      name: "HMAC.DIGEST_SIZE.SHA2-384",
-      desc: '''SHA2-384 hashing algorithm for SHA-2 and keyed HMAC.
-            '''
-    }
-    {
-      name: "HMAC.DIGEST_SIZE.SHA2-512",
-      desc: '''SHA2-512 hashing algorithm or SHA-2 and keyed HMAC.
-            '''
-    }
-    {
-      name: "HMAC.KEY_LENGTH.Key_128",
-      desc: '''HMAC based on any digest size using 128-bit key.
-            '''
-    }
-    {
-      name: "HMAC.KEY_LENGTH.Key_256",
-      desc: '''HMAC based on any digest size using 256-bit key.
-            '''
-    }
-    {
-      name: "HMAC.KEY_LENGTH.Key_384",
-      desc: '''HMAC based on any digest size using 384-bit key.
-            '''
-    }
-    {
-      name: "HMAC.KEY_LENGTH.Key_512",
-      desc: '''HMAC based on any digest size using 512-bit key.
-            '''
-    }
-    {
-      name: "HMAC.KEY_LENGTH.Key_1024",
-      desc: '''HMAC based on SHA-384/SHA-512 using 1024-bit key. If configured with SHA-256,
-            KEY_LENGTH defaults to Key_512.
-            '''
-    }
-    {
-      name: "HMAC.MODE.HMAC",
-      desc: '''Keyed-Hash Message Authentication Code (HMAC) supporting the following security
-            strength configurations: HMAC/SHA-2 256/384/512. Compliant with NIST FIPS 198-1
-            which will be superseded by NIST SP 800-224.
+      desc: '''HMAC based on SHA-2 384/SHA-2 512 using 1024-bit key.
             '''
     }
     {
@@ -221,8 +174,7 @@
       desc: '''HMAC Configuration register.
 
             The register is updated when the engine is in Idle.
-            If the software updates the register while the engine computes the hash,
-            the updated value is discarded.
+            If the software updates the register while the engine computes the hash, the updated value is discarded.
             ''',
       hwext:    "true",
       hwqe:     "true",
@@ -240,9 +192,10 @@
         }
         { bits: "1",
           name: "sha_en",
-          desc: '''SHA256 enable. If 0, SHA engine won't initiate compression,
-                this is used to stop operation of the SHA engine until configuration
-                has been done. When the SHA engine is disabled the digest is cleared.'''
+          desc: '''SHA-2 enable.
+
+                 If 0, the SHA engine will not initiate compression, this is used to stop operation of the SHA-2 engine until configuration has been done.
+                 When the SHA-2 engine is disabled the digest is cleared.'''
           tags: [// don't enable hmac and sha data paths - we will do that in functional tests
                  "excl:CsrNonInitTests:CsrExclWrite"]
         }
@@ -250,18 +203,11 @@
           name: "endian_swap",
           desc: '''Endian swap.
 
-                If 0, each value will be added to the message in little-endian
-                byte order. The value is written to MSG_FIFO same to the SW writes.
-
-                If 1, then each individual multi-byte value, regardless of its
-                alignment, written to !!MSG_FIFO will be added to the message
-                in big-endian byte order.
-
-                A message written to !!MSG_FIFO one byte at a time will not be
-                affected by this setting.
-
-                From a hardware perspective byte swaps are performed on a TL-UL
-                word granularity.
+                If 0, each value will be added to the message in little-endian byte order.
+                The value is written to MSG_FIFO same to the SW writes.
+                If 1, then each individual multi-byte value, regardless of its alignment, written to !!MSG_FIFO will be added to the message in big-endian byte order.
+                A message written to !!MSG_FIFO one byte at a time will not be affected by this setting.
+                From a hardware perspective byte swaps are performed on a TL-UL word granularity.
                 ''',
           resval: "0",
         }
@@ -269,17 +215,13 @@
           name: "digest_swap",
           desc: '''Digest register byte swap.
 
-                If 1 the value contained in each digest output register is
-                converted to big-endian byte order.
-                This setting does not affect the order of the digest output
-                registers, !!DIGEST_0 still contains the first 4 bytes of
-                the digest.
+                If 1 the value contained in each digest output register is converted to big-endian byte order.
+                This setting does not affect the order of the digest output registers, !!DIGEST_0 still contains the first 4 bytes of the digest.
                 ''',
           resval: "0",
           tags: [
-            // Don't enable/disable digest swap in automated CSR tests because it will have side
-            // effects on the DIGEST_* CSRs that the automated tests don't know of.  This field is
-            // covered in functional tests instead.
+            // Don't enable/disable digest swap in automated CSR tests because it will have side effects on the DIGEST_* CSRs that the automated tests don't know of.
+            // This field is covered in functional tests instead.
             "excl:CsrAllTests:CsrExclWrite"
           ]
         }
@@ -289,8 +231,7 @@
           desc: '''Digest size configuration.
 
                 This is a 4-bit one-hot encoded field to select digest size for either HMAC or SHA-2.
-                Invalid values, i.e., values with multiple bits set and value 4'b0000 are
-                mapped in HMAC to SHA2_NONE (4'b0001).
+                Invalid values, i.e., values with multiple bits set and value 4'b0000 are mapped in HMAC to SHA2_NONE (4'b0001).
                 '''
           enum: [
             { value: "1",
@@ -326,11 +267,9 @@
           resval: "0x02",
           desc: '''Key length configuration.
 
-                This is a 5-bit one-hot encoded field to configure the key length for HMAC. The HMAC
-                supports key lengths of 128-bit, 256-bit, 384-bit, 512-bit and 1024-bit, but will
-                to block size if key length is greater than block size, i.e. max of 1024 bits
-                for digest size SHA-2 384/512 and respectively 512 bits for SHA-2 256. The value of
-                this register is irrelevant when only SHA-2 (not keyed HMAC) is configured.
+                This is a 5-bit one-hot encoded field to configure the key length for HMAC.
+                The HMAC supports key lengths of 128-bit, 256-bit, 384-bit, 512-bit and 1024-bit, but will to block size if key length is greater than block size, i.e. max of 1024 bits for digest size SHA-2 384/512 and respectively 512 bits for SHA-2 256.
+                The value of this register is irrelevant when only SHA-2 (not keyed HMAC) is configured.
                 '''
           enum: [
             { value: "1",
@@ -382,34 +321,27 @@
       fields: [
         { bits: "0",
           name: "hash_start",
-          desc: '''If writes 1 into this field, SHA-2 or HMAC begins its operation.
-
-                CPU must configure relative information first, such as the digest size, secret key
-                and the key length.
+          desc: '''If 1 is written into this field, SHA-2 or HMAC begins its operation.
+                CPU must configure relative information first, such as the digest size, secret key and the key length.
                 ''',
         }
         { bits: "1",
           name: "hash_process",
-          desc: '''If writes 1 into this field, SHA-2 or HMAC calculates the digest or signing
-                based on currently received message.
+          desc: '''If 1 is written to this field, SHA-2 or HMAC calculates the digest or signing based on currently received message.
                 '''
         }
         { bits: "2",
           name: "hash_stop",
           desc: '''
-                When 1 is written to this field, SHA or HMAC will afterwards set the `hmac_done`
-                interrupt as soon as the current block has been hashed. The hash can then be read
-                from the registers !!DIGEST_0 to !!DIGEST_7. Together with the message length in
-                !!MSG_LENGTH_LOWER and !!MSG_LENGTH_UPPER, this forms the information that has to be
-                saved before switching context.
+                When 1 is written to this field, SHA or HMAC will afterwards set the `hmac_done` interrupt as soon as the current block has been hashed.
+                The hash can then be read from the registers !!DIGEST_0 to !!DIGEST_7.
+                Together with the message length in !!MSG_LENGTH_LOWER and !!MSG_LENGTH_UPPER, this forms the information that has to be saved before switching context.
                 '''
         }
         { bits: "3",
           name: "hash_continue",
           desc: '''
-                When 1 is written to this field, SHA or HMAC will continue hashing based on the
-                current hash in the digest registers and the message length, which both have to be
-                restored to switch context.
+                When 1 is written to this field, SHA or HMAC will continue hashing based on the current hash in the digest registers and the message length, which both have to be restored to switch context.
                 '''
         }
       ],
@@ -453,11 +385,10 @@
     { name: "WIPE_SECRET",
       desc: '''Clear internal secret registers.
 
-            If CPU writes value into the register, the value is used to clear the internal
-            variables such as secret key, internal state machine, or hash value. The clear
-            secret operation uses XORs with the provided value as one of the operands. It is
-            recommended to use a value extracted from an entropy source. A value equal to 0
-            will leave all internal values unchanged.
+            If CPU writes value into the register, the value is used to clear the internal variables such as secret key, internal state machine, or hash value.
+            The clear secret operation uses XORs with the provided value as one of the operands.
+            It is recommended to use a value extracted from an entropy source.
+            A value equal to 0 will leave all internal values unchanged.
             ''',
       swaccess: "wo",
       hwaccess: "hro",
@@ -476,14 +407,12 @@
         name: "KEY",
         desc: '''HMAC Secret Key
 
-              HMAC using SHA-256/384/512 assumes any hashed secret key length up to the block size,
-              thus capped at 1024-bit. !!key_length determines how many of these registers are
-              relevant for the HMAC operation. Order of the secret key is:
+              HMAC using SHA-2 256/384/512 assumes any hashed secret key length up to the block size, thus capped at 1024-bit.
+              !!key_length determines how many of these registers are relevant for the HMAC operation. Order of the secret key is:
               key[1023:0] = {KEY0, KEY1, KEY2, ... , KEY31};
 
               The registers are allowed to be updated only when the engine is in Idle state.
-              If the engine computes the hash, it discards any attempts to update the secret keys
-              and report an error.
+              If the engine computes the hash, it discards any attempts to update the secret keys and report an error.
               ''',
         count: "NumKeyWords",
         cname: "HMAC",
@@ -501,11 +430,9 @@
         desc: '''Digest output.
 
               If HMAC is disabled, the register shows result of SHA-2 256/384/512.
-              Order of the digest is:
-              digest[511:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST15}. For SHA-2 256
-              256-bit digest = {DIGEST0, DIGEST1, DIGEST2, DIGEST3, DIGEST4, DIGEST5, DIGEST6,
-              DIGEST7} and {DIGEST8 - DIGEST15} are all-zero. For SHA-2 384, {DIGEST12-DIGEST15} are
-              truncated and are all-zero.
+              Order of the 512-bit digest[511:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST15}.
+              For SHA-2 256 order of the 256-bit digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, DIGEST3, DIGEST4, DIGEST5, DIGEST6, DIGEST7} and {DIGEST8 - DIGEST15} are all-zero.
+              For SHA-2 384, {DIGEST12-DIGEST15} are truncated and are all-zero.
 
               The digest gets cleared when `CFG.sha_en` transitions from 1 to 0.
               When `CFG.sha_en` is 0, these registers can be written by software.
@@ -529,7 +456,7 @@
       desc: '''Received Message Length calculated by the HMAC in bits [31:0]
 
             Message is byte granularity.
-            lower 3bits [2:0] are ignored.
+            Lower 3 bits [2:0] are ignored.
 
             When `CFG.sha_en` is 0, this register can be written by software.
             ''',
@@ -545,10 +472,8 @@
       desc: '''Received Message Length calculated by the HMAC in bits [63:32]
 
             When `CFG.sha_en` is 0, this register can be written by software.
-            For SHA-2-2 256 computations, message length is 64-bit
-            {MSG_LENGTH_UPPER, MSG_LENGTH_LOWER}, and for SHA-2 384/512,
-            message length is extended to 128-bit in line with [nist-fips-180-4] where the
-            upper 64 bits get zero-padded: {32'b0, 32'b0, MSG_LENGTH_UPPER, MSG_LENGTH_LOWER}.
+            For SHA-2-2 256 computations, message length is 64-bit {MSG_LENGTH_UPPER, MSG_LENGTH_LOWER}.f
+            For SHA-2 384/512 message length is extended to 128-bit in line with [nist-fips-180-4] where the upper 64 bits get zero-padded: {32'b0, 32'b0, MSG_LENGTH_UPPER, MSG_LENGTH_LOWER}.
             ''',
       swaccess: "rw",
       hwaccess: "hrw",

--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -108,7 +108,7 @@
     }
   ]
 
-  // TODO: probably need to extend cfg_cg to include digest_size and key_length or another cg
+  // TODO (issue #22102): need to extend cfg_cg to include digest_size and key_length or add another cg
   covergroups: [
     {
       name: cfg_cg

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -158,8 +158,7 @@ Alert Test Register
 HMAC Configuration register.
 
 The register is updated when the engine is in Idle.
-If the software updates the register while the engine computes the hash,
-the updated value is discarded.
+If the software updates the register while the engine computes the hash, the updated value is discarded.
 - Offset: `0x10`
 - Reset default: `0x210`
 - Reset mask: `0x1fff`
@@ -183,11 +182,9 @@ the updated value is discarded.
 ### CFG . key_length
 Key length configuration.
 
-This is a 5-bit one-hot encoded field to configure the key length for HMAC. The HMAC
-supports key lengths of 128-bit, 256-bit, 384-bit, 512-bit and 1024-bit, but will
-to block size if key length is greater than block size, i.e. max of 1024 bits
-for digest size SHA-2 384/512 and respectively 512 bits for SHA-2 256. The value of
-this register is irrelevant when only SHA-2 (not keyed HMAC) is configured.
+This is a 5-bit one-hot encoded field to configure the key length for HMAC.
+The HMAC supports key lengths of 128-bit, 256-bit, 384-bit, 512-bit and 1024-bit, but will to block size if key length is greater than block size, i.e. max of 1024 bits for digest size SHA-2 384/512 and respectively 512 bits for SHA-2 256.
+The value of this register is irrelevant when only SHA-2 (not keyed HMAC) is configured.
 
 | Value   | Name     | Description                                                                                          |
 |:--------|:---------|:-----------------------------------------------------------------------------------------------------|
@@ -203,8 +200,7 @@ Other values are reserved.
 Digest size configuration.
 
 This is a 4-bit one-hot encoded field to select digest size for either HMAC or SHA-2.
-Invalid values, i.e., values with multiple bits set and value 4'b0000 are
-mapped in HMAC to SHA2_NONE (4'b0001).
+Invalid values, i.e., values with multiple bits set and value 4'b0000 are mapped in HMAC to SHA2_NONE (4'b0001).
 
 | Value   | Name      | Description                                                                      |
 |:--------|:----------|:---------------------------------------------------------------------------------|
@@ -218,32 +214,23 @@ Other values are reserved.
 ### CFG . digest_swap
 Digest register byte swap.
 
-If 1 the value contained in each digest output register is
-converted to big-endian byte order.
-This setting does not affect the order of the digest output
-registers, [`DIGEST_0`](#digest_0) still contains the first 4 bytes of
-the digest.
+If 1 the value contained in each digest output register is converted to big-endian byte order.
+This setting does not affect the order of the digest output registers, [`DIGEST_0`](#digest_0) still contains the first 4 bytes of the digest.
 
 ### CFG . endian_swap
 Endian swap.
 
-If 0, each value will be added to the message in little-endian
-byte order. The value is written to MSG_FIFO same to the SW writes.
-
-If 1, then each individual multi-byte value, regardless of its
-alignment, written to [`MSG_FIFO`](#msg_fifo) will be added to the message
-in big-endian byte order.
-
-A message written to [`MSG_FIFO`](#msg_fifo) one byte at a time will not be
-affected by this setting.
-
-From a hardware perspective byte swaps are performed on a TL-UL
-word granularity.
+If 0, each value will be added to the message in little-endian byte order.
+The value is written to MSG_FIFO same to the SW writes.
+If 1, then each individual multi-byte value, regardless of its alignment, written to [`MSG_FIFO`](#msg_fifo) will be added to the message in big-endian byte order.
+A message written to [`MSG_FIFO`](#msg_fifo) one byte at a time will not be affected by this setting.
+From a hardware perspective byte swaps are performed on a TL-UL word granularity.
 
 ### CFG . sha_en
-SHA256 enable. If 0, SHA engine won't initiate compression,
-this is used to stop operation of the SHA engine until configuration
-has been done. When the SHA engine is disabled the digest is cleared.
+SHA-2 enable.
+
+ If 0, the SHA engine will not initiate compression, this is used to stop operation of the SHA-2 engine until configuration has been done.
+ When the SHA-2 engine is disabled the digest is cleared.
 
 ### CFG . hmac_en
 HMAC datapath enable.
@@ -271,26 +258,19 @@ HMAC command register
 |   0    | r0w1c  |    x    | [hash_start](#cmd--hash_start)       |
 
 ### CMD . hash_continue
-When 1 is written to this field, SHA or HMAC will continue hashing based on the
-current hash in the digest registers and the message length, which both have to be
-restored to switch context.
+When 1 is written to this field, SHA or HMAC will continue hashing based on the current hash in the digest registers and the message length, which both have to be restored to switch context.
 
 ### CMD . hash_stop
-When 1 is written to this field, SHA or HMAC will afterwards set the `hmac_done`
-interrupt as soon as the current block has been hashed. The hash can then be read
-from the registers [`DIGEST_0`](#digest_0) to [`DIGEST_7.`](#digest_7) Together with the message length in
-[`MSG_LENGTH_LOWER`](#msg_length_lower) and [`MSG_LENGTH_UPPER`](#msg_length_upper), this forms the information that has to be
-saved before switching context.
+When 1 is written to this field, SHA or HMAC will afterwards set the `hmac_done` interrupt as soon as the current block has been hashed.
+The hash can then be read from the registers [`DIGEST_0`](#digest_0) to [`DIGEST_7.`](#digest_7)
+Together with the message length in [`MSG_LENGTH_LOWER`](#msg_length_lower) and [`MSG_LENGTH_UPPER`](#msg_length_upper), this forms the information that has to be saved before switching context.
 
 ### CMD . hash_process
-If writes 1 into this field, SHA-2 or HMAC calculates the digest or signing
-based on currently received message.
+If 1 is written to this field, SHA-2 or HMAC calculates the digest or signing based on currently received message.
 
 ### CMD . hash_start
-If writes 1 into this field, SHA-2 or HMAC begins its operation.
-
-CPU must configure relative information first, such as the digest size, secret key
-and the key length.
+If 1 is written into this field, SHA-2 or HMAC begins its operation.
+CPU must configure relative information first, such as the digest size, secret key and the key length.
 
 ## STATUS
 HMAC Status register
@@ -331,11 +311,10 @@ HMAC Error Code
 ## WIPE_SECRET
 Clear internal secret registers.
 
-If CPU writes value into the register, the value is used to clear the internal
-variables such as secret key, internal state machine, or hash value. The clear
-secret operation uses XORs with the provided value as one of the operands. It is
-recommended to use a value extracted from an entropy source. A value equal to 0
-will leave all internal values unchanged.
+If CPU writes value into the register, the value is used to clear the internal variables such as secret key, internal state machine, or hash value.
+The clear secret operation uses XORs with the provided value as one of the operands.
+It is recommended to use a value extracted from an entropy source.
+A value equal to 0 will leave all internal values unchanged.
 - Offset: `0x20`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
@@ -353,14 +332,12 @@ will leave all internal values unchanged.
 ## KEY
 HMAC Secret Key
 
-HMAC using SHA-256/384/512 assumes any hashed secret key length up to the block size,
-thus capped at 1024-bit. [`key_length`](#key_length) determines how many of these registers are
-relevant for the HMAC operation. Order of the secret key is:
+HMAC using SHA-2 256/384/512 assumes any hashed secret key length up to the block size, thus capped at 1024-bit.
+[`key_length`](#key_length) determines how many of these registers are relevant for the HMAC operation. Order of the secret key is:
 key[1023:0] = {KEY0, KEY1, KEY2, ... , KEY31};
 
 The registers are allowed to be updated only when the engine is in Idle state.
-If the engine computes the hash, it discards any attempts to update the secret keys
-and report an error.
+If the engine computes the hash, it discards any attempts to update the secret keys and report an error.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -416,11 +393,9 @@ and report an error.
 Digest output.
 
 If HMAC is disabled, the register shows result of SHA-2 256/384/512.
-Order of the digest is:
-digest[511:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST15}. For SHA-2 256
-256-bit digest = {DIGEST0, DIGEST1, DIGEST2, DIGEST3, DIGEST4, DIGEST5, DIGEST6,
-DIGEST7} and {DIGEST8 - DIGEST15} are all-zero. For SHA-2 384, {DIGEST12-DIGEST15} are
-truncated and are all-zero.
+Order of the 512-bit digest[511:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST15}.
+For SHA-2 256 order of the 256-bit digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, DIGEST3, DIGEST4, DIGEST5, DIGEST6, DIGEST7} and {DIGEST8 - DIGEST15} are all-zero.
+For SHA-2 384, {DIGEST12-DIGEST15} are truncated and are all-zero.
 
 The digest gets cleared when `CFG.sha_en` transitions from 1 to 0.
 When `CFG.sha_en` is 0, these registers can be written by software.
@@ -463,7 +438,7 @@ When `CFG.sha_en` is 0, these registers can be written by software.
 Received Message Length calculated by the HMAC in bits [31:0]
 
 Message is byte granularity.
-lower 3bits [2:0] are ignored.
+Lower 3 bits [2:0] are ignored.
 
 When `CFG.sha_en` is 0, this register can be written by software.
 - Offset: `0xe4`
@@ -484,10 +459,8 @@ When `CFG.sha_en` is 0, this register can be written by software.
 Received Message Length calculated by the HMAC in bits [63:32]
 
 When `CFG.sha_en` is 0, this register can be written by software.
-For SHA-2-2 256 computations, message length is 64-bit
-{MSG_LENGTH_UPPER, MSG_LENGTH_LOWER}, and for SHA-2 384/512,
-message length is extended to 128-bit in line with [nist-fips-180-4] where the
-upper 64 bits get zero-padded: {32'b0, 32'b0, MSG_LENGTH_UPPER, MSG_LENGTH_LOWER}.
+For SHA-2-2 256 computations, message length is 64-bit {MSG_LENGTH_UPPER, MSG_LENGTH_LOWER}.f
+For SHA-2 384/512 message length is extended to 128-bit in line with [nist-fips-180-4] where the upper 64 bits get zero-padded: {32'b0, 32'b0, MSG_LENGTH_UPPER, MSG_LENGTH_LOWER}.
 - Offset: `0xe8`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`

--- a/hw/ip/hmac/lint/hmac.vlt
+++ b/hw/ip/hmac/lint/hmac.vlt
@@ -6,10 +6,10 @@
 
 `verilator_config
 
-// The wipe_secret and wipe_v inputs to hmac_core and sha2_pad are not
+// The wipe_secret_i and wipe_v_i inputs to hmac_core and sha2_pad are not
 // currently used, but we're keeping them attached for future use.
-lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_secret'"
-lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_v'"
+lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_secret_i'"
+lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_v_i'"
 
 // 1 bit adder to optimize the count ones logic
 lint_off -rule WIDTH -file "*/rtl/hmac.sv" -match "*RHS's SEL generates 1 bits*"

--- a/hw/ip/hmac/rtl/hmac_core.sv
+++ b/hw/ip/hmac/rtl/hmac_core.sv
@@ -8,42 +8,42 @@ module hmac_core import prim_sha2_pkg::*; (
   input clk_i,
   input rst_ni,
 
-  input [1023:0]      secret_key, // {word0, word1, ..., word7}
-  input               wipe_secret,
-  input [31:0]        wipe_v,
-  input               hmac_en,
-  input digest_mode_e digest_size,
-  input key_length_e  key_length,
+  input [1023:0]      secret_key_i, // {word0, word1, ..., word7}
+  input               wipe_secret_i,
+  input [31:0]        wipe_v_i,
+  input               hmac_en_i,
+  input digest_mode_e digest_size_i,
+  input key_length_e  key_length_i,
 
-  input        reg_hash_start,
-  input        reg_hash_continue,
-  input        reg_hash_process,
-  output logic hash_done,
-  output logic sha_hash_start,
-  output logic sha_hash_continue,
-  output logic sha_hash_process,
-  input        sha_hash_done,
+  input        reg_hash_start_i,
+  input        reg_hash_continue_i,
+  input        reg_hash_process_i,
+  output logic hash_done_o,
+  output logic sha_hash_start_o,
+  output logic sha_hash_continue_o,
+  output logic sha_hash_process_o,
+  input        sha_hash_done_i,
 
   // fifo
-  output logic        sha_rvalid,
-  output sha_fifo32_t sha_rdata,
-  input               sha_rready,
+  output logic        sha_rvalid_o,
+  output sha_fifo32_t sha_rdata_o,
+  input               sha_rready_i,
 
-  input               fifo_rvalid,
-  input  sha_fifo32_t fifo_rdata,
-  output logic        fifo_rready,
+  input               fifo_rvalid_i,
+  input  sha_fifo32_t fifo_rdata_i,
+  output logic        fifo_rready_o,
 
   // fifo control (select and fifo write data)
-  output logic       fifo_wsel,      // 0: from reg, 1: from digest
-  output logic       fifo_wvalid,
+  output logic       fifo_wsel_o,      // 0: from reg, 1: from digest
+  output logic       fifo_wvalid_o,
   // 0: digest[0][upper], 1:digest[0][lower] .. 14: digest[7][upper], 15: digest[7][lower]
-  output logic [3:0] fifo_wdata_sel,
-  input              fifo_wready,
+  output logic [3:0] fifo_wdata_sel_o,
+  input              fifo_wready_i,
 
-  input  [127:0] message_length,
-  output [127:0] sha_message_length,
+  input  [63:0] message_length_i,
+  output [63:0] sha_message_length_o,
 
-  output logic idle
+  output logic idle_o
 );
 
   localparam int unsigned BlockSizeSHA256     = 512;
@@ -54,8 +54,8 @@ module hmac_core import prim_sha2_pkg::*; (
 
   localparam int unsigned HashWordBitsSHA256  = $clog2($bits(sha_word32_t));
 
-  localparam bit [127:0] BlockSizeSHA256in128  = 128'(BlockSizeSHA256);
-  localparam bit [127:0] BlockSizeSHA512in128  = 128'(BlockSizeSHA512);
+  localparam bit [63:0] BlockSizeSHA256in64  = 64'(BlockSizeSHA256);
+  localparam bit [63:0] BlockSizeSHA512in64  = 64'(BlockSizeSHA512);
 
   localparam bit [BlockSizeBitsSHA256:0] BlockSizeBSBSHA256 =
                                                             BlockSizeSHA256[BlockSizeBitsSHA256:0];
@@ -72,7 +72,7 @@ module hmac_core import prim_sha2_pkg::*; (
   logic [BlockSizeSHA256-1:0] o_pad_256;
   logic [BlockSizeSHA512-1:0] o_pad_512;
 
-  logic [127:0] txcount; // works for both digest lengths
+  logic [63:0] txcount, txcount_d; // works for both digest lengths
 
   logic [BlockSizeBitsSHA512-HashWordBitsSHA256-1:0] pad_index_512;
   logic [BlockSizeBitsSHA256-HashWordBitsSHA256-1:0] pad_index_256;
@@ -120,161 +120,168 @@ module hmac_core import prim_sha2_pkg::*; (
 
   logic reg_hash_process_flag;
 
-  assign sha_hash_start    = (hmac_en) ? hash_start                       : reg_hash_start ;
-  assign sha_hash_continue = (hmac_en) ? hash_continue                    : reg_hash_continue ;
-  assign sha_hash_process  = (hmac_en) ? reg_hash_process | hash_process  : reg_hash_process ;
-  assign hash_done         = (hmac_en) ? hmac_hash_done                   : sha_hash_done  ;
+  assign sha_hash_start_o    = (hmac_en_i) ? hash_start    : reg_hash_start_i;
+  assign sha_hash_continue_o = (hmac_en_i) ? hash_continue : reg_hash_continue_i;
+
+  assign sha_hash_process_o  = (hmac_en_i) ? reg_hash_process_i | hash_process : reg_hash_process_i;
+  assign hash_done_o         = (hmac_en_i) ? hmac_hash_done                    : sha_hash_done_i;
 
   assign pad_index_512 = txcount[BlockSizeBitsSHA512-1:HashWordBitsSHA256];
   assign pad_index_256 = txcount[BlockSizeBitsSHA256-1:HashWordBitsSHA256];
 
-  // defaults key length to block size if supplied key length is larger than block size
+  // this defaults key length to block size if supplied key length is larger than block size
   always_comb begin : adjust_key_pad_length
-    unique case (key_length)
+    unique case (key_length_i)
       Key_128: begin
-        i_pad_256 = {secret_key[1023:896],
+        i_pad_256 = {secret_key_i[1023:896],
                     {(BlockSizeSHA256-128){1'b0}}} ^ {(BlockSizeSHA256/8){8'h36}};
-        i_pad_512 = {secret_key[1023:896],
+        i_pad_512 = {secret_key_i[1023:896],
                     {(BlockSizeSHA512-128){1'b0}}} ^ {(BlockSizeSHA512/8){8'h36}};
-        o_pad_256 = {secret_key[1023:896],
+        o_pad_256 = {secret_key_i[1023:896],
                     {(BlockSizeSHA256-128){1'b0}}} ^ {(BlockSizeSHA256/8){8'h5c}};
-        o_pad_512 = {secret_key[1023:896],
+        o_pad_512 = {secret_key_i[1023:896],
                     {(BlockSizeSHA512-128){1'b0}}} ^ {(BlockSizeSHA512/8){8'h5c}};
       end
       Key_256: begin
-        i_pad_256 = {secret_key[1023:768],
+        i_pad_256 = {secret_key_i[1023:768],
                     {(BlockSizeSHA256-256){1'b0}}} ^ {(BlockSizeSHA256/8){8'h36}};
-        i_pad_512 = {secret_key[1023:768],
+        i_pad_512 = {secret_key_i[1023:768],
                     {(BlockSizeSHA512-256){1'b0}}} ^ {(BlockSizeSHA512/8){8'h36}};
-        o_pad_256 = {secret_key[1023:768],
+        o_pad_256 = {secret_key_i[1023:768],
                     {(BlockSizeSHA256-256){1'b0}}} ^ {(BlockSizeSHA256/8){8'h5c}};
-        o_pad_512 = {secret_key[1023:768],
+        o_pad_512 = {secret_key_i[1023:768],
                     {(BlockSizeSHA512-256){1'b0}}} ^ {(BlockSizeSHA512/8){8'h5c}};
       end
       Key_384: begin
-        i_pad_256 = {secret_key[1023:640],
+        i_pad_256 = {secret_key_i[1023:640],
                     {(BlockSizeSHA256-384){1'b0}}} ^ {(BlockSizeSHA256/8){8'h36}};
-        i_pad_512 = {secret_key[1023:640],
+        i_pad_512 = {secret_key_i[1023:640],
                     {(BlockSizeSHA512-384){1'b0}}} ^ {(BlockSizeSHA512/8){8'h36}};
-        o_pad_256 = {secret_key[1023:640],
+        o_pad_256 = {secret_key_i[1023:640],
                     {(BlockSizeSHA256-384){1'b0}}} ^ {(BlockSizeSHA256/8){8'h5c}};
-        o_pad_512 = {secret_key[1023:640],
+        o_pad_512 = {secret_key_i[1023:640],
                     {(BlockSizeSHA512-384){1'b0}}} ^ {(BlockSizeSHA512/8){8'h5c}};
       end
       Key_512: begin
-        i_pad_256 = secret_key[1023:512] ^ {(BlockSizeSHA256/8){8'h36}};
-        i_pad_512 = {secret_key[1023:512],
+        i_pad_256 = secret_key_i[1023:512] ^ {(BlockSizeSHA256/8){8'h36}};
+        i_pad_512 = {secret_key_i[1023:512],
                     {(BlockSizeSHA512-512){1'b0}}} ^ {(BlockSizeSHA512/8){8'h36}};
-        o_pad_256 = secret_key[1023:512] ^ {(BlockSizeSHA256/8){8'h5c}};
-        o_pad_512 = {secret_key[1023:512],
+        o_pad_256 = secret_key_i[1023:512] ^ {(BlockSizeSHA256/8){8'h5c}};
+        o_pad_512 = {secret_key_i[1023:512],
                     {(BlockSizeSHA512-512){1'b0}}} ^ {(BlockSizeSHA512/8){8'h5c}};
       end
       Key_1024: begin
         // cap key to 512-bit for SHA-256
-        i_pad_256 = secret_key[1023:512] ^ {(BlockSizeSHA256/8){8'h36}};
-        i_pad_512 = secret_key[1023:0]   ^ {(BlockSizeSHA512/8){8'h36}};
+        i_pad_256 = secret_key_i[1023:512] ^ {(BlockSizeSHA256/8){8'h36}};
+        i_pad_512 = secret_key_i[1023:0]   ^ {(BlockSizeSHA512/8){8'h36}};
         // cap key to 512-bit for SHA-256
-        o_pad_256 = secret_key[1023:512] ^ {(BlockSizeSHA256/8){8'h5c}};
-        o_pad_512 = secret_key[1023:0]   ^ {(BlockSizeSHA512/8){8'h5c}};
+        o_pad_256 = secret_key_i[1023:512] ^ {(BlockSizeSHA256/8){8'h5c}};
+        o_pad_512 = secret_key_i[1023:0]   ^ {(BlockSizeSHA512/8){8'h5c}};
       end
-      default: begin // TODO: in case of unsupported lengths, default to 256-bit key or flag error?
-        i_pad_256 = {secret_key[1023:768],
+      default: begin // TODO (issue  #22312)
+        i_pad_256 = {secret_key_i[1023:768],
                     {(BlockSizeSHA256-256){1'b0}}} ^ {(BlockSizeSHA256/8){8'h36}};
-        i_pad_512 = {secret_key[1023:768],
+        i_pad_512 = {secret_key_i[1023:768],
                     {(BlockSizeSHA512-256){1'b0}}} ^ {(BlockSizeSHA512/8){8'h36}};
-        o_pad_256 = {secret_key[1023:768],
+        o_pad_256 = {secret_key_i[1023:768],
                     {(BlockSizeSHA256-256){1'b0}}} ^ {(BlockSizeSHA256/8){8'h5c}};
-        o_pad_512 = {secret_key[1023:768],
+        o_pad_512 = {secret_key_i[1023:768],
                     {(BlockSizeSHA512-256){1'b0}}} ^ {(BlockSizeSHA512/8){8'h5c}};
       end
     endcase
   end
 
-  assign fifo_rready  = (hmac_en) ? (st_q == StMsg) & sha_rready : sha_rready ;
+  assign fifo_rready_o = (hmac_en_i) ? (st_q == StMsg) & sha_rready_i : sha_rready_i ;
   // sha_rvalid is controlled by State Machine below.
-  assign sha_rvalid = (!hmac_en) ? fifo_rvalid : hmac_sha_rvalid ;
-  assign sha_rdata =
-    (!hmac_en)    ? fifo_rdata                                                             :
-    (sel_rdata == SelIPad && digest_size == SHA2_256)
+  assign sha_rvalid_o  = (!hmac_en_i) ? fifo_rvalid_i : hmac_sha_rvalid ;
+  assign sha_rdata_o =
+    (!hmac_en_i)    ? fifo_rdata_i                                                             :
+    (sel_rdata == SelIPad && digest_size_i == SHA2_256)
                   ? '{data: i_pad_256[(BlockSizeSHA256-1)-32*pad_index_256-:32], mask: '1} :
-    (sel_rdata == SelIPad && ((digest_size == SHA2_384) || (digest_size == SHA2_512)))
+    (sel_rdata == SelIPad && ((digest_size_i == SHA2_384) || (digest_size_i == SHA2_512)))
                   ? '{data: i_pad_512[(BlockSizeSHA512-1)-32*pad_index_512-:32], mask: '1} :
-    (sel_rdata == SelOPad && digest_size == SHA2_256)
+    (sel_rdata == SelOPad && digest_size_i == SHA2_256)
                   ? '{data: o_pad_256[(BlockSizeSHA256-1)-32*pad_index_256-:32], mask: '1} :
-    (sel_rdata == SelOPad && ((digest_size == SHA2_384) || (digest_size == SHA2_512)))
+    (sel_rdata == SelOPad && ((digest_size_i == SHA2_384) || (digest_size_i == SHA2_512)))
                   ? '{data: o_pad_512[(BlockSizeSHA512-1)-32*pad_index_512-:32], mask: '1} :
-    (sel_rdata == SelFifo) ? fifo_rdata                                                    :
+    (sel_rdata == SelFifo) ? fifo_rdata_i                                                    :
                   '{default: '0};
 
-  logic [127:0] sha_msg_len;
+  logic [63:0] sha_msg_len;
 
   always_comb begin: assign_sha_message_length
     sha_msg_len = '0;
-    if (!hmac_en) begin
-      sha_msg_len = message_length;
+    if (!hmac_en_i) begin
+      sha_msg_len = message_length_i;
     // HASH = (o_pad || HASH_INTERMEDIATE (i_pad || msg))
     // message length for HASH_INTERMEDIATE = block size (i_pad) + message length
     end else if (sel_msglen == SelIPadMsg) begin
-      if (digest_size == SHA2_256) begin
-        sha_msg_len = message_length + BlockSizeSHA256in128;
-      end else if ((digest_size == SHA2_384) || (digest_size == SHA2_512)) begin
-        sha_msg_len = message_length + BlockSizeSHA512in128;
+      if (digest_size_i == SHA2_256) begin
+        sha_msg_len = message_length_i + BlockSizeSHA256in64;
+      end else if ((digest_size_i == SHA2_384) || (digest_size_i == SHA2_512)) begin
+        sha_msg_len = message_length_i + BlockSizeSHA512in64;
       end
     end else if (sel_msglen == SelOPadMsg) begin
     // message length for HASH = block size (o_pad) + HASH_INTERMEDIATE digest length
-      if (digest_size == SHA2_256) begin
-        sha_msg_len = BlockSizeSHA256in128 + 128'd256;
-      end else if (digest_size == SHA2_384) begin
-        sha_msg_len = BlockSizeSHA512in128 + 128'd384;
-      end else if (digest_size == SHA2_512) begin
-        sha_msg_len = BlockSizeSHA512in128 + 128'd512;
+      if (digest_size_i == SHA2_256) begin
+        sha_msg_len = BlockSizeSHA256in64 + 64'd256;
+      end else if (digest_size_i == SHA2_384) begin
+        sha_msg_len = BlockSizeSHA512in64 + 64'd384;
+      end else if (digest_size_i == SHA2_512) begin
+        sha_msg_len = BlockSizeSHA512in64 + 64'd512;
       end
     end else
       sha_msg_len = '0;
   end
 
-  assign sha_message_length = sha_msg_len;
+  assign sha_message_length_o = sha_msg_len;
 
-  assign txcnt_eq_blksz = (digest_size == SHA2_256) ?
-                                      (txcount[BlockSizeBitsSHA256:0] == BlockSizeBSBSHA256) :
-                          ((digest_size == SHA2_384) || (digest_size == SHA2_512)) ?
-                                      (txcount[BlockSizeBitsSHA512:0] == BlockSizeBSBSHA512) :
-                                      '0;
+  always_comb begin
+    unique case (digest_size_i)
+      SHA2_256: txcnt_eq_blksz = (txcount[BlockSizeBitsSHA256:0] == BlockSizeBSBSHA256);
+      SHA2_384: txcnt_eq_blksz = (txcount[BlockSizeBitsSHA512:0] == BlockSizeBSBSHA512);
+      SHA2_512: txcnt_eq_blksz = (txcount[BlockSizeBitsSHA512:0] == BlockSizeBSBSHA512);
+      default : txcnt_eq_blksz = '0;
+    endcase
+  end
 
-  assign inc_txcount = sha_rready && sha_rvalid;
+  assign inc_txcount = sha_rready_i && sha_rvalid_o;
 
   // txcount
   //    Looks like txcount can be removed entirely here in hmac_core
   //    In the first round (InnerPaddedKey), it can just watch process and hash_done
   //    In the second round, it only needs count 256 bits for hash digest to trigger
   //    hash_process to SHA2
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      txcount <= '0;
-    end else if (clr_txcount) begin
-      txcount <= '0;
+  always_comb begin
+    txcount_d = txcount;
+    if (clr_txcount) begin
+      txcount_d = '0;
     end else if (load_txcount) begin
       // When loading, add block size to the message length because the SW-visible message length
       // does not include the block containing the key xor'ed with the inner pad.
-      if (digest_size == SHA2_256) begin
-        txcount <= message_length + BlockSizeSHA256in128;
-      end else if ((digest_size == SHA2_384) || (digest_size == SHA2_512)) begin
-        txcount <= message_length + BlockSizeSHA512in128;
-      end else begin
-        txcount <= message_length + '0;
-      end
+      unique case (digest_size_i)
+        SHA2_256: txcount_d = message_length_i + BlockSizeSHA256in64;
+        SHA2_384: txcount_d = message_length_i + BlockSizeSHA512in64;
+        SHA2_512: txcount_d = message_length_i + BlockSizeSHA512in64;
+        default : txcount_d = message_length_i + '0;
+      endcase
     end else if (inc_txcount) begin
-      txcount[63:5] <= txcount[63:5] + 1'b1; // increment by 32 (data word size)
+      txcount_d[63:5] = txcount[63:5] + 1'b1; // increment by 32 (data word size)
     end
   end
 
-  // reg_hash_process trigger logic
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) txcount <= '0;
+    else         txcount <= txcount_d;
+  end
+
+  // reg_hash_process_i trigger logic
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       reg_hash_process_flag <= 1'b0;
-    end else if (reg_hash_process) begin
+    end else if (reg_hash_process_i) begin
       reg_hash_process_flag <= 1'b1;
-    end else if (hmac_hash_done || reg_hash_start || reg_hash_continue) begin
+    end else if (hmac_hash_done || reg_hash_start_i || reg_hash_continue_i) begin
       reg_hash_process_flag <= 1'b0;
     end
   end
@@ -289,11 +296,11 @@ module hmac_core import prim_sha2_pkg::*; (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      fifo_wdata_sel <= 3'h 0;
+      fifo_wdata_sel_o <= 3'h 0;
     end else if (clr_fifo_wdata_sel) begin
-      fifo_wdata_sel <= 3'h 0;
-    end else if (fifo_wsel && fifo_wvalid) begin
-      fifo_wdata_sel <= fifo_wdata_sel + 1'b1; // increment by 1
+      fifo_wdata_sel_o <= 3'h 0;
+    end else if (fifo_wsel_o && fifo_wvalid_o) begin
+      fifo_wdata_sel_o <= fifo_wdata_sel_o + 1'b1; // increment by 1
     end
   end
 
@@ -305,29 +312,23 @@ module hmac_core import prim_sha2_pkg::*; (
   end
 
   always_comb begin : next_state
-    hmac_hash_done  = 1'b0;
-    hmac_sha_rvalid = 1'b0;
-
-    clr_txcount  = 1'b0;
-    load_txcount = 1'b0;
-
-    update_round = 1'b0;
-    round_d      = Inner;
-
-    fifo_wsel    = 1'b0;   // from register
-    fifo_wvalid  = 1'b0;
-
+    hmac_hash_done     = 1'b0;
+    hmac_sha_rvalid    = 1'b0;
+    clr_txcount        = 1'b0;
+    load_txcount       = 1'b0;
+    update_round       = 1'b0;
+    round_d            = Inner;
+    fifo_wsel_o        = 1'b0;   // from register
+    fifo_wvalid_o      = 1'b0;
     clr_fifo_wdata_sel = 1'b1;
-
-    sel_rdata = SelFifo;
-
-    hash_start    = 1'b0;
-    hash_continue = 1'b0;
-    hash_process  = 1'b0;
+    sel_rdata          = SelFifo;
+    hash_start         = 1'b0;
+    hash_continue      = 1'b0;
+    hash_process       = 1'b0;
 
     unique case (st_q)
       StIdle: begin
-        if (hmac_en && reg_hash_start) begin
+        if (hmac_en_i && reg_hash_start_i) begin
           st_d = StIPad;
 
           clr_txcount  = 1'b1;
@@ -354,29 +355,29 @@ module hmac_core import prim_sha2_pkg::*; (
       end
 
       StMsg: begin
-        sel_rdata = SelFifo;
-        fifo_wsel = (round_q == Outer);
+        sel_rdata   = SelFifo;
+        fifo_wsel_o = (round_q == Outer);
 
-        if (round_q == Inner && reg_hash_continue) begin
+        if (round_q == Inner && reg_hash_continue_i) begin
           load_txcount  = 1'b1;
           hash_continue = 1'b1;
         end
 
         if ( (((round_q == Inner) && reg_hash_process_flag) || (round_q == Outer))
-            && (txcount >= sha_message_length)) begin
+            && (txcount >= sha_message_length_o)) begin
           st_d    = StWaitResp;
           hmac_sha_rvalid = 1'b0; // block
           hash_process = (round_q == Outer);
         end else begin
           st_d            = StMsg;
-          hmac_sha_rvalid = fifo_rvalid;
+          hmac_sha_rvalid = fifo_rvalid_i;
         end
       end
 
       StWaitResp: begin
         hmac_sha_rvalid = 1'b0;
 
-        if (sha_hash_done) begin
+        if (sha_hash_done_i) begin
           if (round_q == Outer) begin
             st_d = StDone;
           end else begin // round_q == Inner
@@ -389,13 +390,13 @@ module hmac_core import prim_sha2_pkg::*; (
 
       StPushToMsgFifo: begin
         hmac_sha_rvalid    = 1'b0;
-        fifo_wsel          = 1'b1;
-        fifo_wvalid        = 1'b1;
+        fifo_wsel_o        = 1'b1;
+        fifo_wvalid_o      = 1'b1;
         clr_fifo_wdata_sel = 1'b0;
 
-        if (fifo_wready && (((fifo_wdata_sel == 4'd7)  && (digest_size == SHA2_256)) ||
-                            ((fifo_wdata_sel == 4'd15) && (digest_size == SHA2_512)) ||
-                            ((fifo_wdata_sel == 4'd11) && (digest_size == SHA2_384)))) begin
+        if (fifo_wready_i && (((fifo_wdata_sel_o == 4'd7)  && (digest_size_i == SHA2_256)) ||
+                             ((fifo_wdata_sel_o == 4'd15) && (digest_size_i == SHA2_512)) ||
+                             ((fifo_wdata_sel_o == 4'd11) && (digest_size_i == SHA2_384)))) begin
 
           st_d = StOPad;
 
@@ -410,8 +411,8 @@ module hmac_core import prim_sha2_pkg::*; (
       end
 
       StOPad: begin
-        sel_rdata = SelOPad;
-        fifo_wsel = 1'b1; // Remained HMAC select to indicate HMAC is in second stage
+        sel_rdata   = SelOPad;
+        fifo_wsel_o = 1'b1; // Remained HMAC select to indicate HMAC is in second stage
 
         if (txcnt_eq_blksz) begin
           st_d = StMsg;
@@ -439,6 +440,6 @@ module hmac_core import prim_sha2_pkg::*; (
   end
 
   // Idle: Idle in HMAC_CORE only represents the idle status when hmac mode is
-  // set. If hmac_en is 0, this logic sends the idle signal always.
-  assign idle = (st_q == StIdle) && !(reg_hash_start || reg_hash_continue);
+  // set. If hmac_en_i is 0, this logic sends the idle signal always.
+  assign idle_o = (st_q == StIdle) && !(reg_hash_start_i || reg_hash_continue_i);
 endmodule

--- a/hw/ip/prim/rtl/prim_sha2.sv
+++ b/hw/ip/prim/rtl/prim_sha2.sv
@@ -33,7 +33,7 @@ module prim_sha2 import prim_sha2_pkg::*;
   input               hash_process_i,
   output logic        hash_done_o,
 
-  input  [127:0]            message_length_i, // bits but byte based
+  input  [63:0]             message_length_i, // bits but byte based
   input  sha_word64_t [7:0] digest_i,
   input  logic [7:0]        digest_we_i,
   output sha_word64_t [7:0] digest_o, // tie off unused port slice when MultimodeEn = 0
@@ -141,10 +141,10 @@ module prim_sha2 import prim_sha2_pkg::*;
 
     // compute digest
     always_comb begin : compute_digest_multimode
-      digest_d          = digest_q;
+      digest_d = digest_q;
       if (wipe_secret_i) begin
         for (int i = 0 ; i < 8 ; i++) begin
-          digest_d[i]       = digest_q[i] ^ wipe_v_i;
+          digest_d[i] = digest_q[i] ^ wipe_v_i;
         end
       end else if (hash_start_i) begin
         for (int i = 0 ; i < 8 ; i++) begin
@@ -484,7 +484,7 @@ module prim_sha2 import prim_sha2_pkg::*;
     .digest_mode_i,
     .hash_process_i,
     .hash_done_i (hash_done_o),
-    .message_length_i,
+    .message_length_i ({64'b0, message_length_i}), // 128-bit message length per NIST-FIPS-180-4
     .msg_feed_complete_o (msg_feed_complete)
   );
 


### PR DESCRIPTION
This PR fixes existing coding style issues in the HMAC RTL from earlier to bring it closer to the current coding style guide. It also adds minor styling fixes for the issues raised in the reviews for the wider digest PR https://github.com/lowRISC/opentitan/pull/21604, and fixes the I/O port suffixes in `hmac_core.sv` per the coding style per this issue https://github.com/lowRISC/opentitan/issues/21666.  Once the RTL is finalized and coverage is improved via the extended testplan for the new features, we will need to run the UNR analysis anyway again, and the UNR exclusions list will thus be updated with the changed I/O port names.