### PR TITLE
[usbdev,dv] include sequence name in testplan

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -262,7 +262,7 @@
             - Verify that the device responds with the PID STALL Handshake.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_in_stall"]
     }
     {
       name: out_iso


### PR DESCRIPTION
Incorporates the sequence name into the test plan to ensure its inclusion in future regression testing.