### PR TITLE
[dice,manuf] refactor keymgr config and cranking in DICE lib

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice.h
+++ b/sw/device/silicon_creator/lib/cert/dice.h
@@ -7,10 +7,10 @@
 
 #include <stdint.h>
 
-#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
 
 enum {
   /**
@@ -40,9 +40,10 @@ enum {
  *                          computed size of the certificate).
  * @return The result of the operation.
  */
-status_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
-                             hmac_digest_t *uds_pubkey_id, uint8_t *cert,
-                             size_t *cert_size);
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
+                                hmac_digest_t *uds_pubkey_id, uint8_t *cert,
+                                size_t *cert_size);
 
 /**
  * Generates the CDI_0 attestation keypair and X.509 certificate.
@@ -58,10 +59,11 @@ status_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
  *                          computed size of the certificate).
  * @return The result of the operation.
  */
-status_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
-                               hmac_digest_t *uds_pubkey_id,
-                               hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
-                               size_t *cert_size);
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
+                                  hmac_digest_t *uds_pubkey_id,
+                                  hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
+                                  size_t *cert_size);
 
 /**
  * Generates the CDI_1 attestation keypair and X.509 certificate.
@@ -76,8 +78,9 @@ status_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
  *                          computed size of the certificate).
  * @return The result of the operation.
  */
-status_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
-                               hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
-                               size_t *cert_size);
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
+                                  hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
+                                  size_t *cert_size);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_H_

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -269,3 +269,27 @@ rom_error_t sc_keymgr_sideload_clear_otbn(void) {
 
   return kErrorOk;
 }
+
+rom_error_t sc_keymgr_owner_int_advance(keymgr_binding_value_t *sealing_binding,
+                                        keymgr_binding_value_t *attest_binding,
+                                        uint32_t max_key_version) {
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(kScKeymgrStateCreatorRootKey));
+  sc_keymgr_sw_binding_set(sealing_binding, attest_binding);
+  sc_keymgr_owner_int_max_ver_set(max_key_version);
+  sc_keymgr_advance_state();
+  HARDENED_RETURN_IF_ERROR(
+      sc_keymgr_state_check(kScKeymgrStateOwnerIntermediateKey));
+  return kErrorOk;
+}
+
+rom_error_t sc_keymgr_owner_advance(keymgr_binding_value_t *sealing_binding,
+                                    keymgr_binding_value_t *attest_binding,
+                                    uint32_t max_key_version) {
+  HARDENED_RETURN_IF_ERROR(
+      sc_keymgr_state_check(kScKeymgrStateOwnerIntermediateKey));
+  sc_keymgr_sw_binding_set(sealing_binding, attest_binding);
+  sc_keymgr_owner_max_ver_set(max_key_version);
+  sc_keymgr_advance_state();
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(kScKeymgrStateOwnerKey));
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -208,6 +208,42 @@ rom_error_t sc_keymgr_generate_attestation_key_otbn(
 OT_WARN_UNUSED_RESULT
 rom_error_t sc_keymgr_sideload_clear_otbn(void);
 
+/**
+ * Sets the binding registers and advances the keymgr to the
+ * `OwnerIntermediateKey` (CDI_0) key stage.
+ *
+ * Preconditions: keymgr has been initialized and cranked to the
+ * `CreatorRootKey` stage.
+ *
+ * @param attest_binding The attestation binding value to use.
+ * @param sealing_binding The sealing binding value to use.
+ * @param max_key_version Maximum key version associated with the Silicon Owner
+ *                        Intermediate key manager stage.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_owner_int_advance(keymgr_binding_value_t *attest_binding,
+                                        keymgr_binding_value_t *sealing_binding,
+                                        uint32_t max_key_version);
+
+/**
+ * Sets the binding registers and advances the keymgr to the `OwnerKey` (CDI_1)
+ * key stage.
+ *
+ * Preconditions: keymgr has been initialized and cranked to the
+ * `OwnerIntermediateKey` stage.
+ *
+ * @param attest_binding The attestation binding value to use.
+ * @param sealing_binding The sealing binding value to use.
+ * @param max_key_version Maximum key version associated with the Silicon Owner
+ *                        key manager stage.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_owner_advance(keymgr_binding_value_t *attest_binding,
+                                    keymgr_binding_value_t *sealing_binding,
+                                    uint32_t max_key_version);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -59,6 +59,63 @@ class KeymgrTest : public rom_test::RomTest {
     EXPECT_ABS_WRITE32(base_ + KEYMGR_SALT_7_REG_OFFSET,
                        diversification.salt[7]);
   }
+  void ExpectSwBindingUnlockWait(void) {
+    EXPECT_ABS_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
+    EXPECT_SEC_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
+  }
+  void ExpectSwBindingValueSet(
+      const keymgr_binding_value_t *binding_value_sealing,
+      const keymgr_binding_value_t *binding_value_attestation) {
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
+                       binding_value_sealing->data[0]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_1_REG_OFFSET,
+                       binding_value_sealing->data[1]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_2_REG_OFFSET,
+                       binding_value_sealing->data[2]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_3_REG_OFFSET,
+                       binding_value_sealing->data[3]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET,
+                       binding_value_sealing->data[4]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET,
+                       binding_value_sealing->data[5]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET,
+                       binding_value_sealing->data[6]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET,
+                       binding_value_sealing->data[7]);
+
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET,
+                       binding_value_attestation->data[0]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_1_REG_OFFSET,
+                       binding_value_attestation->data[1]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_2_REG_OFFSET,
+                       binding_value_attestation->data[2]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_3_REG_OFFSET,
+                       binding_value_attestation->data[3]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_4_REG_OFFSET,
+                       binding_value_attestation->data[4]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_5_REG_OFFSET,
+                       binding_value_attestation->data[5]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_6_REG_OFFSET,
+                       binding_value_attestation->data[6]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_7_REG_OFFSET,
+                       binding_value_attestation->data[7]);
+
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  }
+  void ExpectAdvanceState(void) {
+    EXPECT_ABS_WRITE32_SHADOWED(
+        base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,
+        {
+            {KEYMGR_CONTROL_SHADOWED_DEST_SEL_OFFSET,
+             KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE},
+            {KEYMGR_CONTROL_SHADOWED_OPERATION_OFFSET,
+             KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE},
+        });
+    EXPECT_ABS_WRITE32(base_ + KEYMGR_START_REG_OFFSET,
+                       {
+                           {KEYMGR_START_EN_BIT, true},
+                       });
+  }
   void ExpectWaitUntilDone(size_t busy_cycles, uint32_t end_status) {
     for (size_t i = 0; i < busy_cycles; i++) {
       EXPECT_ABS_READ32(base_ + KEYMGR_OP_STATUS_REG_OFFSET,
@@ -87,48 +144,14 @@ TEST_F(KeymgrTest, EntropyReseedIntervalSet) {
 }
 
 TEST_F(KeymgrTest, SwBindingValuesSet) {
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[0]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_1_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[1]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_2_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[2]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_3_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[3]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[4]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[5]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[6]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[7]);
-
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[0]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_1_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[1]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_2_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[2]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_3_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[3]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_4_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[4]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_5_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[5]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_6_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[6]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_7_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[7]);
-
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  ExpectSwBindingValueSet(&cfg_.binding_value_sealing,
+                          &cfg_.binding_value_attestation);
   sc_keymgr_sw_binding_set(&cfg_.binding_value_sealing,
                            &cfg_.binding_value_attestation);
 }
 
 TEST_F(KeymgrTest, SwBindingUnlockWait) {
-  EXPECT_ABS_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
-  EXPECT_SEC_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
+  ExpectSwBindingUnlockWait();
   sc_keymgr_sw_binding_unlock_wait();
 }
 
@@ -155,18 +178,7 @@ TEST_F(KeymgrTest, SetOwnerMaxVerKey) {
 }
 
 TEST_F(KeymgrTest, AdvanceState) {
-  EXPECT_ABS_WRITE32_SHADOWED(
-      base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,
-      {
-          {KEYMGR_CONTROL_SHADOWED_DEST_SEL_OFFSET,
-           KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE},
-          {KEYMGR_CONTROL_SHADOWED_OPERATION_OFFSET,
-           KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE},
-      });
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_START_REG_OFFSET,
-                     {
-                         {KEYMGR_START_EN_BIT, true},
-                     });
+  ExpectAdvanceState();
   sc_keymgr_advance_state();
 }
 
@@ -324,6 +336,45 @@ TEST_F(KeymgrTest, SideloadClearOtbnReadbackMismatch) {
                     });
 
   EXPECT_EQ(sc_keymgr_sideload_clear_otbn(), kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrTest, OwnerIntAdvance) {
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
+                    /*err_code=*/0u);
+  ExpectSwBindingValueSet(&cfg_.binding_value_sealing,
+                          &cfg_.binding_value_attestation);
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + KEYMGR_MAX_OWNER_INT_KEY_VER_SHADOWED_REG_OFFSET,
+      cfg_.max_key_ver);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET, 0);
+  ExpectAdvanceState();
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY,
+                    /*err_code=*/0u);
+  EXPECT_EQ(sc_keymgr_owner_int_advance(&cfg_.binding_value_sealing,
+                                        &cfg_.binding_value_attestation,
+                                        cfg_.max_key_ver),
+            kErrorOk);
+}
+
+TEST_F(KeymgrTest, OwnerAdvance) {
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY,
+                    /*err_code=*/0u);
+  ExpectSwBindingValueSet(&cfg_.binding_value_sealing,
+                          &cfg_.binding_value_attestation);
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET, cfg_.max_key_ver);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_OWNER_KEY_VER_REGWEN_REG_OFFSET, 0);
+  ExpectAdvanceState();
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_KEY,
+                    /*err_code=*/0u);
+  EXPECT_EQ(sc_keymgr_owner_advance(&cfg_.binding_value_sealing,
+                                    &cfg_.binding_value_attestation,
+                                    cfg_.max_key_ver),
+            kErrorOk);
 }
 
 }  // namespace


### PR DESCRIPTION
This refactors the keymgr configuration and cranking in the DICE lib / FT person binary to decouple keymgr state operations from attestation key and cert generation. This is preparation for enabling #21583.