### PR TITLE
[usbdev,dv] usbdev stall_trans seq

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -671,7 +671,7 @@
             - Verify that we will get STALL response when we try to attempt OUT transactions.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_stall_trans"]
     }
     {
       name: setup_priority_over_stall_response

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_trans_vseq.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_stall_trans_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_stall_trans_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Configure out transaction
+    configure_out_trans();
+    // Set stall on endp
+    csr_wr(.ptr(ral.out_stall[0].endpoint[endp]), .value(1'b1));
+
+    // Out token packet followed by a data packet
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+
+    // Check that the DUT reponds with the PidTypeStall
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    `DV_CHECK_EQ(m_usb20_item.m_pkt_type, PktTypeHandshake);
+    `DV_CHECK_EQ(m_usb20_item.m_pid_type, PidTypeStall);
+  endtask
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -24,6 +24,7 @@
 `include "usbdev_pkt_received_vseq.sv"
 `include "usbdev_pkt_sent_vseq.sv"
 `include "usbdev_random_length_out_transaction_vseq.sv"
+`include "usbdev_stall_trans_vseq.sv"
 `include "usbdev_setup_trans_ignored_vseq.sv"
 `include "usbdev_stall_priority_over_nak_vseq.sv"
 

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -38,6 +38,7 @@ filesets:
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_stall_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -109,6 +109,10 @@
       uvm_test_seq: usbdev_random_length_out_transaction_vseq
     }
     {
+      name: usbdev_stall_trans
+      uvm_test_seq: usbdev_stall_trans_vseq
+    }
+    {
       name: usbdev_setup_trans_ignored
       uvm_test_seq: usbdev_setup_trans_ignored_vseq
     }


### PR DESCRIPTION
This PR includes the usbdev stall_tran_vseqs sequence, designed to validate the stall functionality of usbdev. Upon setting the out_stall bit for a OUT transaction, the DUT is expected to respond with PidTypeStall.

This builds on #22308. Merge that first, which should just leave the final commit from this PR.