### PR TITLE
[ci] Update GitHub actions

### DIFF
--- a/.github/workflows/pr_change_check.yml
+++ b/.github/workflows/pr_change_check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Determine changed files
         run: |

--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       verible_config: hw/lint/tools/veriblelint/lowrisc-styleguide.rules.verible_lint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Because `pull_request_target` runs at the PR's base, we need to
           # checkout the head of the PR before running the lint.

--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -45,7 +45,7 @@ jobs:
           cat "verible_waiver"
           echo "::endgroup::"
       - name: Run Verible linter action
-        uses: chipsalliance/verible-linter-action@main
+        uses: chipsalliance/verible-linter-action@v2
         with:
           verible_version: "v0.0-3430-g060bde0f"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Very minor PR which updates the deprecated `actions/checkout@v3` to `@v4` in preparation for Node 16 being removed from the runners.

It also fixes the verible lint action version to v2 as opposed to `main` for some stability.