### PR TITLE
[crypto-lib/csrng] Remove wait for idle in csrng_send_app_cmd

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -339,7 +339,6 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
     return OUT_OF_RANGE();
   }
 
-  HARDENED_TRY(csrng_fsm_idle_wait());
   uint32_t cmd_reg_addr;
   uint32_t sts_reg_addr;
   uint32_t rdy_bit_offset;


### PR DESCRIPTION
This PR removes the wait for idle in csrng_send_app_cmd().
For further information check out the commit message.

This PR depends on #22114.

Fixes [#19568](https://github.com/lowRISC/opentitan/issues/19568).