### PR TITLE
Cherrypick to master: [opentitanlib] ECDSA/RSA/SPX raw key helper functions

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -216,6 +216,7 @@ rust_library(
         "src/util/printer.rs",
         "src/util/raw_tty.rs",
         "src/util/rom_detect.rs",
+        "src/util/serde.rs",
         "src/util/status.rs",
         "src/util/testing.rs",
         "src/util/unknown.rs",

--- a/sw/host/opentitanlib/src/crypto/ecdsa.rs
+++ b/sw/host/opentitanlib/src/crypto/ecdsa.rs
@@ -2,17 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{anyhow, ensure, Context, Result};
 use ecdsa::elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey};
 use ecdsa::elliptic_curve::pkcs8::{DecodePublicKey, EncodePublicKey};
 use ecdsa::signature::hazmat::PrehashVerifier;
 use p256::ecdsa::{Signature, SigningKey, VerifyingKey};
 use rand::rngs::OsRng;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_annotate::Annotate;
+use std::io::{Read, Write};
 use std::path::Path;
+use std::str::FromStr;
 
-use crate::crypto::sha256::Sha256Digest;
+use super::Error;
+use crate::crypto::sha256::{sha256, Sha256Digest};
 
 pub struct EcdsaPrivateKey {
     pub key: SigningKey,
@@ -20,16 +23,6 @@ pub struct EcdsaPrivateKey {
 
 pub struct EcdsaPublicKey {
     pub key: VerifyingKey,
-}
-
-#[derive(Debug, Serialize, Annotate)]
-pub struct EcdsaRawPublicKey {
-    #[serde(with = "serde_bytes")]
-    #[annotate(format = hexstr)]
-    pub x: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    #[annotate(format = hexstr)]
-    pub y: Vec<u8>,
 }
 
 impl Default for EcdsaPrivateKey {
@@ -61,10 +54,89 @@ impl EcdsaPrivateKey {
         }
     }
 
-    pub fn sign(&self, digest: &Sha256Digest) -> Result<Vec<u8>> {
+    pub fn sign(&self, digest: &Sha256Digest) -> Result<EcdsaRawSignature> {
         let (sig, _) = self.key.sign_prehash_recoverable(&digest.to_be_bytes())?;
-        let bytes = sig.to_bytes().as_slice().to_vec();
-        Ok(bytes)
+        let bytes = sig.to_bytes();
+        let half = bytes.len() / 2;
+        // The signature bytes are (R || S).  Since opentitan is a little-endian
+        // machine, we want to reverse the byte order of each component of the
+        // signature.
+        let mut r = Vec::new();
+        r.extend(bytes[..half].iter().rev());
+        let mut s = Vec::new();
+        s.extend(bytes[half..].iter().rev());
+        Ok(EcdsaRawSignature { r, s })
+    }
+
+    pub fn digest_and_sign(&self, data: &[u8]) -> Result<EcdsaRawSignature> {
+        let digest = sha256(data);
+        self.sign(&digest)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Annotate)]
+pub struct EcdsaRawSignature {
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub r: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub s: Vec<u8>,
+}
+
+impl Default for EcdsaRawSignature {
+    fn default() -> Self {
+        Self {
+            r: vec![0u8; 32],
+            s: vec![0u8; 32],
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for EcdsaRawSignature {
+    type Error = Error;
+    fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
+        if value.len() != 64 {
+            return Err(Error::InvalidSignature(anyhow!(
+                "bad length: {}",
+                value.len()
+            )));
+        }
+        let mut value = std::io::Cursor::new(value);
+        EcdsaRawSignature::read(&mut value).map_err(Error::InvalidSignature)
+    }
+}
+
+impl EcdsaRawSignature {
+    pub fn read(src: &mut impl Read) -> Result<Self> {
+        let mut sig = Self::default();
+        src.read_exact(&mut sig.r)?;
+        src.read_exact(&mut sig.s)?;
+        Ok(sig)
+    }
+
+    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+        ensure!(
+            self.r.len() == 32,
+            Error::InvalidSignature(anyhow!("bad r length: {}", self.r.len()))
+        );
+        ensure!(
+            self.s.len() == 32,
+            Error::InvalidSignature(anyhow!("bad s length: {}", self.s.len()))
+        );
+        dest.write_all(&self.r)?;
+        dest.write_all(&self.s)?;
+        Ok(())
+    }
+
+    pub fn to_vec(&self) -> Result<Vec<u8>> {
+        let mut sig = Vec::new();
+        self.write(&mut sig)?;
+        Ok(sig)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.r.iter().all(|&v| v == 0) && self.s.iter().all(|&v| v == 0)
     }
 }
 
@@ -79,17 +151,82 @@ impl EcdsaPublicKey {
         Ok(Self { key })
     }
 
-    pub fn to_raw(&self) -> EcdsaRawPublicKey {
-        let point = self.key.to_encoded_point(false);
-        EcdsaRawPublicKey {
-            x: point.x().unwrap().as_slice().to_vec(),
-            y: point.y().unwrap().as_slice().to_vec(),
+    pub fn verify(&self, digest: &Sha256Digest, signature: &EcdsaRawSignature) -> Result<()> {
+        let mut bytes = signature.to_vec()?;
+        let half = bytes.len() / 2;
+        // The signature bytes are (R || S).  Since opentitan is a little-endian
+        // machine, we expect the input signature to have R and S in
+        // little-endian order.  Reverse the bytes back to big-endian ordering.
+        bytes[..half].reverse();
+        bytes[half..].reverse();
+        let signature = Signature::from_slice(&bytes)?;
+        self.key.verify_prehash(&digest.to_be_bytes(), &signature)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Annotate)]
+pub struct EcdsaRawPublicKey {
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub x: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub y: Vec<u8>,
+}
+
+impl Default for EcdsaRawPublicKey {
+    fn default() -> Self {
+        Self {
+            x: vec![0u8; 32],
+            y: vec![0u8; 32],
         }
     }
+}
 
-    pub fn verify(&self, digest: &Sha256Digest, signature: &[u8]) -> Result<()> {
-        let signature = Signature::from_slice(signature)?;
-        self.key.verify_prehash(&digest.to_be_bytes(), &signature)?;
+impl TryFrom<&EcdsaPublicKey> for EcdsaRawPublicKey {
+    type Error = Error;
+    fn try_from(v: &EcdsaPublicKey) -> Result<Self, Self::Error> {
+        let point = v.key.to_encoded_point(false);
+        // Since opentitan is a little-endian machine, we reverse the byte
+        // order of the X and Y values.
+        let mut x = point.x().unwrap().as_slice().to_vec();
+        let mut y = point.y().unwrap().as_slice().to_vec();
+        x.reverse();
+        y.reverse();
+        Ok(EcdsaRawPublicKey { x, y })
+    }
+}
+
+impl FromStr for EcdsaRawPublicKey {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let key = EcdsaPublicKey::load(s)
+            .with_context(|| format!("Failed to load {s}"))
+            .map_err(Error::Other)?;
+        EcdsaRawPublicKey::try_from(&key)
+    }
+}
+
+impl EcdsaRawPublicKey {
+    pub const SIZE: usize = 32 + 32;
+    pub fn read(src: &mut impl Read) -> Result<Self> {
+        let mut key = Self::default();
+        src.read_exact(&mut key.x)?;
+        src.read_exact(&mut key.y)?;
+        Ok(key)
+    }
+    pub fn write(&self, dest: &mut impl Write) -> Result<()> {
+        ensure!(
+            self.x.len() == 32,
+            Error::InvalidPublicKey(anyhow!("bad x length: {}", self.x.len()))
+        );
+        ensure!(
+            self.y.len() == 32,
+            Error::InvalidPublicKey(anyhow!("bad y length: {}", self.y.len()))
+        );
+        dest.write_all(&self.x)?;
+        dest.write_all(&self.y)?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/crypto/mod.rs
+++ b/sw/host/opentitanlib/src/crypto/mod.rs
@@ -2,7 +2,46 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::PathBuf;
+use thiserror::Error;
+
 pub mod ecdsa;
 pub mod rsa;
 pub mod sha256;
 pub mod spx;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Invalid public key: {0:?}")]
+    InvalidPublicKey(#[source] anyhow::Error),
+    #[error("Invalid DER file: {der}")]
+    InvalidDerFile {
+        der: PathBuf,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Read failed: {file}")]
+    ReadFailed {
+        file: PathBuf,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Write failed: {file}")]
+    WriteFailed {
+        file: PathBuf,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("Generate failed")]
+    GenerateFailed(#[source] anyhow::Error),
+    #[error("Invalid signature")]
+    InvalidSignature(#[source] anyhow::Error),
+    #[error("Sign failed")]
+    SignFailed(#[source] anyhow::Error),
+    #[error("Verification failed")]
+    VerifyFailed(#[source] anyhow::Error),
+    #[error("Failed to compute key component")]
+    KeyComponentComputeFailed,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -12,6 +12,7 @@ pub mod present;
 pub mod printer;
 pub mod raw_tty;
 pub mod rom_detect;
+pub mod serde;
 pub mod status;
 pub mod testing;
 pub mod unknown;

--- a/sw/host/opentitanlib/src/util/serde.rs
+++ b/sw/host/opentitanlib/src/util/serde.rs
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+use std::marker::PhantomData;
+use std::str::FromStr;
+
+use serde::de::{self, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize a type T from either a string or struct by forwarding
+/// string forms to `FromStr`.
+///
+/// The use-case for this is to allow specifying key material in ownership
+/// configuration files either directly or by filename:
+/// ```
+/// key: {
+///   Ecdsa: "some/path/to/key.pub.der"
+/// }
+///
+/// key: {
+///   Ecdsa: {
+///     x: "...",
+///     y: "..."
+///   }
+/// }
+/// ```
+
+// This function was taken nearly verbatim from the serde documentation.
+// The example in the serde documentation constrains the `FromStr` error
+// type to `Void`; we constrain to any type implementing std::error::Error.
+pub fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + FromStr,
+    <T as FromStr>::Err: std::error::Error,
+    D: Deserializer<'de>,
+{
+    // This is a Visitor that forwards string types to T's `FromStr` impl and
+    // forwards map types to T's `Deserialize` impl. The `PhantomData` is to
+    // keep the compiler from complaining about T being an unused generic type
+    // parameter. We need T in order to know the Value type for the Visitor
+    // impl.
+    struct StringOrStruct<T>(PhantomData<fn() -> T>);
+
+    impl<'de, T> Visitor<'de> for StringOrStruct<T>
+    where
+        T: Deserialize<'de> + FromStr,
+        <T as FromStr>::Err: std::error::Error,
+    {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<T, E>
+        where
+            E: de::Error,
+        {
+            FromStr::from_str(value).map_err(|e| E::custom(format!("{e:?}")))
+        }
+
+        fn visit_map<M>(self, map: M) -> Result<T, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+    deserializer.deserialize_any(StringOrStruct(PhantomData))
+}


### PR DESCRIPTION
1. Add a `Raw` struct type for each of the key types that is both serde serializable and convertible to/from binary form.
2. Add `TryFrom` conversions between the native key types and the `Raw` structs.
3. Implement `FromStr` conversions that load the Raw key material from a file.
4. Add a serde helper to allow serde deserialization to use the `FromStr` trait to initialize structs based either on their `FromStr` conversion or a json key-value map.

Signed-off-by: Chris Frantz <cfrantz@google.com>
(cherry picked from commit 96f12253f261048c2ce426c35164324caeefac03)