### PR TITLE
[dv,usbdev] DV simplifications

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -14,13 +14,21 @@ package usb20_agent_pkg;
 
   // usb20_item enums
   typedef enum bit [2:0] {PktTypeSoF, PktTypeToken, PktTypeData, PktTypeHandshake} pkt_type_e;
-  // TODO: these are presently nibble-swapped relative to the specification.
-  typedef enum bit [7:0] {PidTypeOutToken = 8'b0001_1110, PidTypeInToken = 8'b1001_0110,
-      PidTypeSofToken = 8'b0101_1010, PidTypeSetupToken = 8'b1101_0010,
-      PidTypeData0 = 8'b0011_1100, PidTypeData1 = 8'b1011_0100, PidTypeData2 = 8'b0111_1000,
-      PidTypeMData = 8'b1111_0000, PidTypeAck = 8'b0010_1101, PidTypeNak = 8'b1010_0101,
-      PidTypeStall = 8'b1110_0001, PidTypeNyet = 8'b0110_1001, PidTypePre = 8'b1100_0011,
-      PidTypeSplit = 8'b1000_0111, PidTypePing = 8'b0100_1011} pid_type_e;
+  // Packet IDentifiers; the 4 LSBs identify the Packet type, and are reflected in inverted
+  //   form as the 4 MSBs to provide some internal error checking.
+  typedef enum bit [7:0] {
+      // Token PIDs
+      PidTypeOutToken = 8'b1110_0001, PidTypeInToken    = 8'b0110_1001,
+      PidTypeSofToken = 8'b1010_0101, PidTypeSetupToken = 8'b0010_1101,
+      // Data PIDs
+      PidTypeData0 = 8'b1100_0011, PidTypeData1 = 8'b0100_1011,
+      PidTypeData2 = 8'b1000_0111, PidTypeMData = 8'b0000_1111,
+      // Handshake PIDs
+      PidTypeAck   = 8'b1101_0010, PidTypeNak  = 8'b0101_1010,
+      PidTypeStall = 8'b0001_1110, PidTypeNyet = 8'b1001_0110,
+      // Special PIDs
+      PidTypePre   = 8'b0011_1100, PidTypeSplit = 8'b0111_1000,
+      PidTypePing  = 8'b1011_0100} pid_type_e;
 
   typedef enum byte {bmRequestType0 = 8'b0_00_00000, bmRequestType1 = 8'b0_00_00001,
       bmRequestType2 = 8'b0_00_00010, bmRequestType3 = 8'b1_00_00000,

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -55,8 +55,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     token_pkt pkt;
     $cast(pkt, req_item.clone());
     pkt.print();
-    // Modified each field of the packet to start with the Least Significant Bit (LSB)
-    pkt.m_pid_type = pid_type_e'({<<4{pkt.m_pid_type}});
+    // Modify each field of the packet to start with the Least Significant Bit (LSB)
     pkt.m_pid_type = pid_type_e'({<<{pkt.m_pid_type}});
     pkt.address = {<<{pkt.address}};
     pkt.endpoint = {<<{pkt.endpoint}};
@@ -88,8 +87,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     data_pkt pkt;
     $cast(pkt, req_item.clone());
     pkt.print();
-    // Modified each field of the packet to start with the Least Significant Bit (LSB)
-    pkt.m_pid_type = pid_type_e'({<<4{pkt.m_pid_type}});
+    // Modify each field of the packet to start with the Least Significant Bit (LSB)
     pkt.m_pid_type = pid_type_e'({<<{pkt.m_pid_type}});
     pkt.data = {<<8{pkt.data}};
     pkt.data = {<<{pkt.data}};
@@ -123,7 +121,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     // Protect sender from modifications to the request item.
     handshake_pkt pkt;
     $cast(pkt, req_item.clone());
-    pkt.m_pid_type = pid_type_e'({<<4{pkt.m_pid_type}});
+    // Modify each field of the packet to start with the Least Significant Bit (LSB)
     pkt.m_pid_type = pid_type_e'({<<{pkt.m_pid_type}});
     void'(pkt.pack(driver_handshake_pkt));
     `uvm_info(`gfn, $sformatf("Driver Handshake_Packet = %p", driver_handshake_pkt), UVM_DEBUG)
@@ -147,8 +145,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     sof_pkt pkt;
     $cast(pkt, req_item.clone());
     pkt.print();
-    // Modified each field of the packet to start with the Least Significant Bit (LSB)
-    pkt.m_pid_type = pid_type_e'({<<4{pkt.m_pid_type}});
+    // Modify each field of the packet to start with the Least Significant Bit (LSB)
     pkt.m_pid_type = pid_type_e'({<<{pkt.m_pid_type}});
     pkt.framecnt = {<<{pkt.framecnt}};
     pkt.crc5 = {<<{pkt.crc5}};
@@ -351,8 +348,6 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     for (int i = 0 ; i < 8; i++) begin
       received_pid[i] = decoded_received_pkt[i + 8];
     end
-    // TODO: this contortion seems confusing and unnecessary
-    received_pid = {<<4{received_pid}};
 
     // Capture the Packet IDentifier and Packet Type
     rsp_item.m_pid_type = pid_type_e'(received_pid);

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -75,7 +75,6 @@ class usb20_monitor extends dv_base_monitor #(
     for (int i = 0; i < 8; i++) begin
     packet_type[i] = bit_destuffed[i + 8];
     end
-    packet_type = {<<4{packet_type}};
     `uvm_info(`gfn, $sformatf(".......Packet PID = %b ", packet_type), UVM_DEBUG)
     case (packet_type)
       PidTypeOutToken: token_packet();

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -19,8 +19,6 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
   endtask
 
   task body();
-    // Expected data content of packet
-    byte unsigned exp_data[];
     uvm_reg_data_t rd_data;
 
     ral.usbctrl.enable.set(1'b1);  // Set usbdev control register enable bit.
@@ -40,17 +38,8 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);
 
-    recover_orig_data(m_data_pkt.data, exp_data);
     // Check that the USB device received a packet with the expected properties.
-    check_pkt_received(endp, 0, out_buffer_id, exp_data);
+    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
   endtask
-
-  // TODO: Presently the act of sending a data packet, destructively modifies it!
-  // Restore the data packet to its original state. This just bit-reverses each byte
-  // within the input array.
-  function void recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
-    out = {<<8{in}};  // Reverse the order of the bytes
-    out = {<<{out}};  // Bit-reverse everything
-  endfunction
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -9,9 +9,6 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    // Expected data content of packet
-    byte unsigned exp_data[];
-
     // Configure transaction
     configure_out_trans();
     // Enable pkt_received interrupt
@@ -26,17 +23,8 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeAck);
 
-    recover_orig_data(m_data_pkt.data, exp_data);
     // Check that the USB device received a packet with the expected properties.
-    check_pkt_received(endp, 0, out_buffer_id, exp_data);
+    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
   endtask
-
-  // TODO: Presently the act of sending a data packet, destructively modifies it!
-  // Restore the data packet to its original state. This just bit-reverses each byte
-  // within the input array.
-  function void recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
-    out = {<<8{in}};  // Reverse the order of the bytes
-    out = {<<{out}};  // Bit-reverse everything
-  endfunction
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -15,9 +15,6 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
   bit [6:0] num_of_bytes = 0;
 
   task body();
-    // Expected data content of packet
-    byte unsigned exp_data[];
-
     // Configure out transaction
     configure_out_trans();
     // Out token packet followed by a data packet of random bytes
@@ -29,17 +26,8 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
     get_out_response_from_device(m_usb20_item, PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
 
-    recover_orig_data(m_data_pkt.data, exp_data);
     // Check that the USB device received a packet with the expected properties.
-    check_pkt_received(endp, 0, out_buffer_id, exp_data);
+    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
   endtask
-
-  // TODO: Presently the act of sending a data packet, destructively modifies it!
-  // Restore the data packet to its original state. This just bit-reverses each byte
-  // within the input array.
-  function void recover_orig_data(input byte unsigned in[], output byte unsigned out[]);
-    out = {<<8{in}};  // Reverse the order of the bytes
-    out = {<<{out}};  // Bit-reverse everything
-  endfunction
 
 endclass

--- a/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
@@ -61,10 +61,11 @@ package usbdev_env_pkg;
     STALL = 2
   } usbdev_handshake_pkt_e;
 
+  // The two LSBs of the PID identify the PID Type
   typedef enum bit [1:0] {
-    TOKEN_PKT = 2'b10,
-    DATA_PKT = 2'b00,
-    HANDSHAKE_PKT = 2'b01
+    TOKEN_PKT = 2'b01,
+    DATA_PKT = 2'b11,
+    HANDSHAKE_PKT = 2'b10
   } usbdev_pkt_type_e;
 
   // functions

--- a/hw/ip/usbdev/dv/env/usbdev_packetiser.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_packetiser.sv
@@ -28,18 +28,22 @@ class usbdev_packetiser extends uvm_object;
   // Last 2 bits of pid classifies the pkt type
   // -------------------------------
   task pack_pkt(usb20_item m_usb20_item);
-    if (m_usb20_item.m_pid_type[1:0] == TOKEN_PKT) begin
-      $cast(m_tpkt, m_usb20_item.clone());
-      void'(m_tpkt.pack(token_pkt_arr));
-    end
-    else if (m_usb20_item.m_pid_type[1:0] == DATA_PKT) begin
-      $cast(m_dpkt, m_usb20_item.clone());
-      void'(m_dpkt.pack(data_pkt_arr));
-    end
-    else if (m_usb20_item.m_pid_type[1:0] == HANDSHAKE_PKT) begin
-      $cast(m_hpkt, m_usb20_item.clone());
-      void'(m_hpkt.pack(handshake_pkt_arr));
-    end
-    else;
+    case (m_usb20_item.m_pid_type[1:0])
+      TOKEN_PKT: begin
+          $cast(m_tpkt, m_usb20_item.clone());
+          void'(m_tpkt.pack(token_pkt_arr));
+        end
+      DATA_PKT: begin
+        $cast(m_dpkt, m_usb20_item.clone());
+        void'(m_dpkt.pack(data_pkt_arr));
+      end
+      HANDSHAKE_PKT: begin
+        $cast(m_hpkt, m_usb20_item.clone());
+        void'(m_hpkt.pack(handshake_pkt_arr));
+      end
+      default: begin
+        `uvm_fatal(`gfn, $sformatf("Special Token %x encountered", m_usb20_item.m_pid_type))
+      end
+    endcase
   endtask
 endclass


### PR DESCRIPTION
This PR simplifies the current DV code for the USB device by making the following changes:

- Isolates the vseq code from the internal changes that the usb20_driver makes to sequence items before they are driven onto the USB.
- Removes the unnecessary nibble swapping of the Packet IDentifier values at source and destination, allowing the 'pid_type_e' enumeration to employ the same numerical values as in the USB 2.0 protocol specification.
- Modifies the vseqs to check the received packet buffer contents against the original (randomized) data directly, rather than having to recover the original data after the act of sending it.
