### PR TITLE
[flash_ctrl,rtl] Hold request when waiting for scrambling arbitration

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -755,7 +755,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       tl_addr[OTFHostId] = 1;
       overflow = end_addr[OTFHostId];
     end
-    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow:% x",
+    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow: %x",
                                        addr, end_addr, overflow), UVM_HIGH)
     rd_entry.bank = bank;
     tl_addr[OTFBankId] = bank;


### PR DESCRIPTION
After modifying the design to share the scrambling logic between Flash banks, parts of the read pipeline were (still) assuming that the shared scrambling logic would always be available immediately.

As a result of this, transactions could get lost when seeing back to back transactions on both banks. This commit fixes this issue by putting backpressure on the host request interface as follows:

Whenever de-scrambling is needed, the design now waits until the current transaction is past the mask calculation stage, i.e., it has won arbitration and the result of the GF multiplier is available before
1. Accepting the next request, and
2. Sending the next read request to the Flash primitive.

Controller requests work as is, since
- Every bank only accepts controller requests if its read pipeline is completely empty, meaning there are no back-to-back transactions.
- There might be backpressure internally due to arbitration on the scrambling interface, i.e., because of the other controller. However, the controller is not able to push the next request before the current one has won arbitration and has completed.

This is related to https://github.com/lowRISC/opentitan/issues/22089.