### PR TITLE
[test,ci] fix broken `spi_passthru_test` in CI by adding UJSON CRC checks

### DIFF
--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -105,7 +105,7 @@ static status_t i2c_configure_instance(dif_i2c_t *i2c, dif_pinmux_t *pinmux,
 
 static status_t configure_device_address(ujson_t *uj, dif_i2c_t *i2c) {
   i2c_target_address_t address;
-  TRY(ujson_deserialize_i2c_target_address_t(uj, &address));
+  TRY(UJSON_WITH_CRC(ujson_deserialize_i2c_target_address_t, uj, &address));
 
   TRY(dif_i2c_host_set_enabled(i2c, kDifToggleDisabled));
   TRY(dif_i2c_device_set_enabled(i2c, kDifToggleDisabled));
@@ -182,7 +182,7 @@ static status_t recv_write_transaction(dif_i2c_t *i2c, i2c_transaction_t *txn,
 
 static status_t read_transaction(ujson_t *uj, dif_i2c_t *i2c) {
   i2c_transaction_t txn;
-  TRY(ujson_deserialize_i2c_transaction_t(uj, &txn));
+  TRY(UJSON_WITH_CRC(ujson_deserialize_i2c_transaction_t, uj, &txn));
   TRY(i2c_testutils_target_read(i2c, txn.length, txn.data));
   ibex_timeout_t deadline = ibex_timeout_init(kTestTimeout);
   TRY(wait_for_acq_fifo(i2c, 2, &deadline));
@@ -257,7 +257,7 @@ static status_t command_processor(ujson_t *uj) {
   TRY(wakeup_check(uj, &i2c));
   while (true) {
     test_command_t command;
-    TRY(ujson_deserialize_test_command_t(uj, &command));
+    TRY(UJSON_WITH_CRC(ujson_deserialize_test_command_t, uj, &command));
     switch (command) {
       case kTestCommandEnterNormalSleep:
         RESP_ERR(uj, enter_sleep(uj, &i2c, true));

--- a/sw/host/opentitanlib/src/test_utils/i2c_target.rs
+++ b/sw/host/opentitanlib/src/test_utils/i2c_target.rs
@@ -15,8 +15,8 @@ include!(env!("i2c_target"));
 
 impl I2cTargetAddress {
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::I2cTargetAddress.send(uart)?;
-        self.send(uart)?;
+        TestCommand::I2cTargetAddress.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
@@ -39,8 +39,8 @@ impl I2cTransaction {
     where
         F: FnOnce() -> Result<()>,
     {
-        TestCommand::I2cReadTransaction.send(uart)?;
-        self.send(uart)?;
+        TestCommand::I2cReadTransaction.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         f()?;
         I2cRxResult::recv(uart, Duration::from_secs(300), false)
     }
@@ -49,7 +49,7 @@ impl I2cTransaction {
     where
         F: FnOnce() -> Result<()>,
     {
-        command.send(uart)?;
+        command.send_with_crc(uart)?;
         f()?;
         Self::recv(uart, Duration::from_secs(300), false)
     }

--- a/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
+++ b/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
@@ -15,8 +15,8 @@ include!(env!("spi_passthru"));
 
 impl ConfigJedecId {
     pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiConfigureJedecId.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiConfigureJedecId.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
@@ -24,13 +24,13 @@ impl ConfigJedecId {
 
 impl StatusRegister {
     pub fn read(uart: &dyn Uart) -> Result<Self> {
-        TestCommand::SpiReadStatus.send(uart)?;
+        TestCommand::SpiReadStatus.send_with_crc(uart)?;
         Self::recv(uart, Duration::from_secs(300), false)
     }
 
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiWriteStatus.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiWriteStatus.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
@@ -38,8 +38,8 @@ impl StatusRegister {
 
 impl SfdpData {
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiWriteSfdp.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiWriteSfdp.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
@@ -50,7 +50,7 @@ impl UploadInfo {
     where
         F: FnOnce() -> Result<()>,
     {
-        TestCommand::SpiWaitForUpload.send(uart)?;
+        TestCommand::SpiWaitForUpload.send_with_crc(uart)?;
         f()?;
         Self::recv(uart, Duration::from_secs(300), false)
     }
@@ -58,7 +58,7 @@ impl UploadInfo {
 
 impl SpiFlashReadId {
     pub fn execute(uart: &dyn Uart) -> Result<Self> {
-        TestCommand::SpiFlashReadId.send(uart)?;
+        TestCommand::SpiFlashReadId.send_with_crc(uart)?;
         let data = SpiFlashReadId::recv(uart, Duration::from_secs(300), false)?;
         Ok(data)
     }
@@ -66,8 +66,8 @@ impl SpiFlashReadId {
 
 impl SpiFlashReadSfdp {
     pub fn execute(&self, uart: &dyn Uart) -> Result<SfdpData> {
-        TestCommand::SpiFlashReadSfdp.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiFlashReadSfdp.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         let sfdp = SfdpData::recv(uart, Duration::from_secs(300), false)?;
         Ok(sfdp)
     }
@@ -75,8 +75,8 @@ impl SpiFlashReadSfdp {
 
 impl SpiFlashEraseSector {
     pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiFlashEraseSector.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiFlashEraseSector.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
@@ -84,8 +84,8 @@ impl SpiFlashEraseSector {
 
 impl SpiFlashWrite {
     pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiFlashWrite.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiFlashWrite.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
@@ -93,8 +93,8 @@ impl SpiFlashWrite {
 
 impl SpiPassthruSwapMap {
     pub fn apply_address_swap(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiPassthruSetAddressMap.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiPassthruSetAddressMap.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
@@ -102,14 +102,14 @@ impl SpiPassthruSwapMap {
 
 impl SpiMailboxMap {
     pub fn apply(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiMailboxMap.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiMailboxMap.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
 
     pub fn disable(uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiMailboxUnmap.send(uart)?;
+        TestCommand::SpiMailboxUnmap.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }
@@ -117,8 +117,8 @@ impl SpiMailboxMap {
 
 impl SpiMailboxWrite {
     pub fn execute(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::SpiMailboxWrite.send(uart)?;
-        self.send(uart)?;
+        TestCommand::SpiMailboxWrite.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -104,7 +104,7 @@ fn test_write_transaction_slow(
 fn test_wakeup_normal_sleep(opts: &Opts, transport: &TransportWrapper, address: u8) -> Result<()> {
     let uart = transport.uart("console")?;
     let i2c = transport.i2c(&opts.i2c)?;
-    TestCommand::EnterNormalSleep.send(&*uart)?;
+    TestCommand::EnterNormalSleep.send_with_crc(&*uart)?;
     std::thread::sleep(Duration::from_secs(2));
     let mut buf = [0u8; 8];
     log::info!("Issuing read transaction to sleeping chip. Expecting transaction error.");
@@ -123,7 +123,7 @@ fn test_wakeup_deep_sleep(
 ) -> Result<()> {
     let uart = transport.uart("console")?;
     let i2c = transport.i2c(&opts.i2c)?;
-    TestCommand::EnterDeepSleep.send(&*uart)?;
+    TestCommand::EnterDeepSleep.send_with_crc(&*uart)?;
     std::thread::sleep(Duration::from_secs(2));
     let mut buf = [0u8; 8];
     log::info!("Issuing read transaction to sleeping chip. Expecting transaction error.");


### PR DESCRIPTION
Since #22101 merged, the `spi_passthru_test` was broken due to ujson CRC's missing between Host-->Device communication. This fixes said test by adding the CRC checks.