### PR TITLE
[i2c,dv] Remove +3 correction for coerced period in host_perf_vseq

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_perf_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_perf_vseq.sv
@@ -169,9 +169,7 @@ class i2c_host_perf_vseq extends i2c_rx_tx_vseq;
     thigh.rand_mode(0);
     // Coerce value after quantization. Actual frequency is different from the
     // randomized setting, due to the granularity of the dividers.
-    // TODO(#18492): Remove round-trip latency of 3 cycles when appropriate fixes
-    // go into the RTL.
-    coerced_scl_period = t_r + t_f + thigh + tlow + 3;
+    coerced_scl_period = t_r + t_f + thigh + tlow;
     coerced_scl_frequency = 10**9/(coerced_scl_period*cfg.clk_rst_vif.clk_period_ps);
   endfunction
 


### PR DESCRIPTION
This is no longer necessary now that #21813 has been merged. However, due to the 'PERFTHRESHOLD = 0.80' fudge-factor in comparing the exp/obs SCL period in this vseq, the check still passed.
This perf check should be made more stringent in the future.