### PR TITLE
[ci] Fix verible lint action version

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -45,7 +45,7 @@ jobs:
           cat "verible_waiver"
           echo "::endgroup::"
       - name: Run Verible linter action
-        uses: chipsalliance/verible-linter-action@v2
+        uses: chipsalliance/verible-linter-action@v2.0
         with:
           verible_version: "v0.0-3430-g060bde0f"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the CI that was broken by #22257

Unlike other actions, the tag is called v2.0 and not v2. See https://github.com/chipsalliance/verible-linter-action/tags for tags.

I've checked the fix on my own fork here: https://github.com/jwnrt/opentitan/pull/13