### PR TITLE
[dv,usbdev] Smoke test improvements

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -69,10 +69,15 @@ class data_pkt extends usb20_item;
     data.size() <= 64;
    }
 
-  function void set_payload(byte bmRequestType, byte bRequest, byte wVH, byte wVL, byte wIH,
-                            byte wIL, byte wLH, byte wLL);
+  // Construct the Setup packet of a standard USB Device Request
+  function void set_payload(byte unsigned bmRequestType, byte unsigned bRequest,
+                            // 16-bit 'wValue' field but the bytes are used separately
+                            byte unsigned wVL, byte unsigned wVH,
+                            bit [15:0] wIndex, bit [15:0] wLength);
 
-    data = '{bmRequestType, bRequest, wVH, wVL, wIH, wIL, wLH, wLL};
+    data = '{bmRequestType, bRequest, wVL, wVH,  // 16-bit fields are sent as Little Endian
+             wIndex[7:0], wIndex[15:8],
+             wLength[7:0], wLength[15:8]};
     crc16 = generate_crc16(data);
   endfunction
 

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -14,19 +14,31 @@
     {
       name: smoke
       desc: '''
-            Smoke test of simple packet transmission in both directions over the USB.
+            Smoke test of data transfers in each direction, on both the CSR interface
+            (buffer read/write) and the USB (packet transmission/reception).
 
             - DV environment programs CSRs for suitable pin configuration, leaving the device
               unconnected by not driving the DP pullup.
-            - Program CSRs to enable SETUP packet reception and OUT traffic on Endpoint Zero.
-            - Present a buffer description in the AvBuffer, to receive the SETUP packet.
+            - Program CSRs to enable SETUP packet reception, OUT traffic and IN traffic to a chosen
+              endpoint.
+            - Present a buffer description in the AvSetup Buffer FIFO, to receive the SETUP packet.
             - Enable the interface (assert DP pull up) to indicate device presence.
             - DV host-side detects device presence.
-            - DV host-side transmits a SETUP packet to Address 0, Endpoint 0.
+            - DV host-side transmits a SETUP packet to device address 0, chosen endpoint.
             - Check that the description of the SETUP packet appears in the RxFiFo, with the
               expected 'setup' indicator, buffer ID, and a packet length of 8 bytes.
-            - Check that the SETUP packet has been received into the packet buffer memory.
+            - Check that the SETUP packet has been received into the packet buffer memory and
+              that the buffer holds the expected content.
             - DV host-side checks that ACK was received from usbdev in response to the SETUP packet.
+            - Repeat the above for a regular OUT data packet using the AvOut Buffer FIFO, using the
+              same endpoint.
+            - Populate a buffer with known randomized packet data for collection from a
+              randomly-chosen endpoint.
+            - Program CSRs to present the packet for collection by the host.
+            - DV host-side transmits an IN request to device address 0, chosen endpoint.
+            - DV host-side collect IN DATA packet, and ACKnowledges receipt.
+            - Check that the received packet matches against that data written into the buffer.
+            - Check that CSRs indicate that the packet has been sent.
             '''
       stage: V1
       tests: ["usbdev_smoke"]

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -9,19 +9,14 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
+    byte unsigned tx_data[];
     usb20_item response;
     data_pkt in_data;
 
-    super.apply_reset("HARD");
-    super.dut_init("HARD");
-    cfg.clk_rst_vif.wait_clks(200);
-    clear_all_interrupts();
-
     // Enable all endpoints for SETUP, IN and OUT
-    csr_wr(.ptr(ral.ep_out_enable[0]), .value(12'hfff));
-    csr_wr(.ptr(ral.ep_in_enable[0]), .value(12'hfff));
-    csr_wr(.ptr(ral.rxenable_out[0]), .value(12'hfff));
-    csr_wr(.ptr(ral.rxenable_setup[0]), .value(12'hfff));
+    configure_out_all();
+    configure_in_all();
+    configure_setup_all();
     csr_wr(.ptr(ral.avsetupbuffer.buffer),
            .value(setup_buffer_id));  // use csr_wr to guarantee write.
     ral.intr_enable.pkt_received.set(1'b1); // Enable pkt_received interrupt
@@ -31,8 +26,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     // SETUP token packet followed by a DATA packet of 8 bytes
     // ---------------------------------------------------------------------------------------------
     call_token_seq(PidTypeSetupToken);
-    cfg.clk_rst_vif.wait_clks(20);
-
+    inter_packet_delay();
     call_desc_sequence(PktTypeData, PidTypeData0);
     cfg.clk_rst_vif.wait_clks(20);
     // Check the contents of the packet buffer memory against the SETUP packet that was sent.
@@ -43,9 +37,8 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     // ---------------------------------------------------------------------------------------------
     csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id));  // use csr_wr to guarantee write.
     call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
-    // TODO: want to use a randomized packet length here but may be 4n contrained presently.
-    call_data_seq(PidTypeData1, 0, 64);  // Using DATA1 for second packet.
+    inter_packet_delay();
+    call_data_seq(PidTypeData1, 1, 0);  // Using DATA1 for second packet, randomized length
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check that the packet was accepted (ACKnowledged) by the USB device.
@@ -58,28 +51,32 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     check_rx_packet(endp, 1'b0, out_buffer_id, m_data_pkt.data);
 
     // ---------------------------------------------------------------------------------------------
-    // Retrieve that data packet using an IN transaction.
+    // Retrieve a data packet using an IN transaction.
     // ---------------------------------------------------------------------------------------------
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(tx_data, tx_data.size() <= MaxPktSizeByte;)
+    write_buffer(in_buffer_id, tx_data);
 
     // Declare that there is an IN packet available for collection, initially leaving the RDY bit
     // clear, to mimic the behavior of the DIF.
-    ral.configin[endp].size.set(m_data_pkt.data.size());
-    ral.configin[endp].buffer.set(out_buffer_id);
+    ral.configin[endp].size.set(tx_data.size());
+    ral.configin[endp].buffer.set(in_buffer_id);
     ral.configin[endp].rdy.set(1'b0);
     csr_update(ral.configin[endp]);
     // Now set the RDY bit
     ral.configin[endp].rdy.set(1'b1);
     csr_update(ral.configin[endp]);
 
-    // Token pkt followed by handshake pkt
+    // Send IN request and collect DATA packet in response.
     call_token_seq(PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);
     $cast(in_data, response);
-    check_tx_packet(in_data, PidTypeData1, m_data_pkt.data);
+    check_tx_packet(in_data, PidTypeData1, tx_data);
     cfg.clk_rst_vif.wait_clks(20);
+    // ACKnowledge receipt of the data packet.
     call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+    // in_sent register/interrupt assertion occurs a few cycles after the ACK has been received.
     cfg.clk_rst_vif.wait_clks(20);
     // Verify Transaction reads register status and verifies that IN transaction is successful.
     check_in_sent();
@@ -93,11 +90,13 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
     m_data_pkt.m_pkt_type = pkt_type;
     m_data_pkt.m_pid_type = pid_type;
+    // Construct a GET DESCRIPTOR request that retrieves the Device descriptor
     m_data_pkt.m_bmRT = bmRequestType3;
     m_data_pkt.m_bR = bRequestGET_DESCRIPTOR;
     assert(m_data_pkt.randomize());
-    m_data_pkt.set_payload(m_data_pkt.m_bmRT, m_data_pkt.m_bR, 8'h00, 8'h01, 8'h00, 8'h00,
-                           8'h40,8'h00);
+    m_data_pkt.set_payload(m_data_pkt.m_bmRT, m_data_pkt.m_bR,
+                           8'h00, 8'h01,
+                           16'h0, 16'd18);  // Device descriptor >= 18 bytes.
     start_item(m_data_pkt);
     finish_item(m_data_pkt);
     get_response(rsp_item);


### PR DESCRIPTION
Using the tasks now available in the base vseq, present random buffer data for IN packet collection.
Choose different endpoints at each stage of the sequence. Randomize the length of the OUT packet.
Tidy up and clarify the construction of setup packets and the inter-packet delays.