### PR TITLE
[dice,manuf] decouple dice key and cert generation

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -543,6 +543,7 @@ cc_library(
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/silicon_creator/lib:attestation",

--- a/sw/device/silicon_creator/lib/dice.h
+++ b/sw/device/silicon_creator/lib/dice.h
@@ -14,26 +14,47 @@
 
 enum {
   /**
-   * Attestation measurement sizes, comprised of a SHA256 digest.
+   * DICE attestation measurement sizes, comprised of a SHA256 digest.
    */
-  kAttestMeasurementSizeInBits = 256,
-  kAttestMeasurementSizeInBytes = kAttestMeasurementSizeInBits / 8,
-  kAttestMeasurementSizeIn32BitWords =
-      kAttestMeasurementSizeInBytes / sizeof(uint32_t),
+  kDiceMeasurementSizeInBits = 256,
+  kDiceMeasurementSizeInBytes = kDiceMeasurementSizeInBits / 8,
 
   /**
-   * Certificate Key ID size.
+   * DICE key ID size (for use in DICE certificates).
    */
-  kCertKeyIdSizeInBytes = 20,
+  kDiceCertKeyIdSizeInBytes = 20,
 };
+
+/**
+ * Supported DICE attestation keys.
+ */
+typedef enum dice_key {
+  kDiceKeyUds = 0,
+  kDiceKeyCdi0 = 1,
+  kDiceKeyCdi1 = 2,
+} dice_key_t;
+
+/**
+ * Generates the requested attestation ECC keypair, returning the public key and
+ * a key ID (which is a SHA256 digest of the public key).
+ *
+ * Preconditions: keymgr has been initialized and cranked to the desired stage.
+ *
+ * @param desired_key The desired attestation key to generate.
+ * @param[out] pubkey_id The public key ID (for embedding into certificates).
+ * @param[out] pubkey The public key.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_attestation_keygen(dice_key_t desired_key,
+                                    hmac_digest_t *pubkey_id,
+                                    attestation_public_key_t *pubkey);
 
 /**
  * Generates the UDS attestation keypair and (unendorsed) X.509 certificate.
  *
- * Preconditions: keymgr has been initialized, and is ready to be cranked.
- *
  * @param inputs Pointer to the personalization input data payload.
- * @param[in,out] uds_pubkey_id Pointer to the UDS public key ID.
+ * @param uds_pubkey_id Pointer to the (current stage) UDS public key ID.
+ * @param uds_pubkey Pointer to the (current stage) public key in big endian.
  * @param[out] cert Buffer to hold the generated UDS certificate.
  * @param[in,out] cert_size Size of the UDS certificate (input value is the size
  *                          of the allocated cert_buf, output value final
@@ -42,17 +63,17 @@ enum {
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
-                                hmac_digest_t *uds_pubkey_id, uint8_t *cert,
-                                size_t *cert_size);
+                                hmac_digest_t *uds_pubkey_id,
+                                attestation_public_key_t *uds_pubkey,
+                                uint8_t *cert, size_t *cert_size);
 
 /**
  * Generates the CDI_0 attestation keypair and X.509 certificate.
  *
- * Preconditions: keymgr has been cranked to the `CreatorRootKey` stage.
- *
  * @param inputs Pointer to the personalization input data payload.
- * @param uds_pubkey_id Pointer to the UDS public key ID.
- * @param[in,out] cdi_0_pubkey_id Pointer to the CDI_0 public key ID.
+ * @param uds_pubkey_id Pointer to the (previous stage) UDS public key ID.
+ * @param cdi_0_pubkey_id Pointer to the (current stage) CDI_0 public key ID.
+ * @param cdi_0_pubkey Pointer to the (current stage) public key in big endian.
  * @param[out] cert Buffer to hold the generated CDI_0 certificate.
  * @param[in,out] cert_size Size of the CDI_0 certificate (input value is the
  *                          size of the allocated cert_buf, output value final
@@ -62,16 +83,17 @@ rom_error_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
                                   hmac_digest_t *uds_pubkey_id,
-                                  hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
-                                  size_t *cert_size);
+                                  hmac_digest_t *cdi_0_pubkey_id,
+                                  attestation_public_key_t *cdi_0_pubkey,
+                                  uint8_t *cert, size_t *cert_size);
 
 /**
  * Generates the CDI_1 attestation keypair and X.509 certificate.
  *
- * Preconditions: keymgr has been cranked to the `OwnerIntermediateKey` stage.
- *
  * @param inputs Pointer to the personalization input data payload.
- * @param cdi_0_pubkey_id Pointer the CDI_0 public key ID.
+ * @param cdi_0_pubkey_id Pointer to the (previous stage) CDI_0 public key ID.
+ * @param cdi_1_pubkey_id Pointer to the (current stage) CDI_1 public key ID.
+ * @param cdi_1_pubkey Pointer to the (current stage) public key in big endian.
  * @param[out] cert Buffer to hold the generated CDI_1 certificate.
  * @param[in,out] cert_size Size of the CDI_1 certificate (input value is the
  *                          size of the allocated cert_buf, output value final
@@ -80,7 +102,9 @@ rom_error_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
-                                  hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
-                                  size_t *cert_size);
+                                  hmac_digest_t *cdi_0_pubkey_id,
+                                  hmac_digest_t *cdi_1_pubkey_id,
+                                  attestation_public_key_t *cdi_1_pubkey,
+                                  uint8_t *cert, size_t *cert_size);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DICE_H_

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -52,6 +52,7 @@ enum module_ {
   kModuleRetRam =          MODULE_CODE('R', 'R'),
   kModuleXModem =          MODULE_CODE('X', 'M'),
   kModuleRescue =          MODULE_CODE('R', 'S'),
+  kModuleDice =            MODULE_CODE('D', 'C'),
   // clang-format on
 };
 
@@ -189,6 +190,8 @@ enum module_ {
   X(kErrorRescueReboot,               ERROR_(0, kModuleRescue, kInternal)), \
   X(kErrorRescueBadMode,              ERROR_(1, kModuleRescue, kInvalidArgument)), \
   X(kErrorRescueImageTooBig,          ERROR_(2, kModuleRescue, kFailedPrecondition)), \
+  \
+  X(kErrorDiceInvalidArgument,        ERROR_(0, kModuleDice, kInvalidArgument)), \
   \
   /* This comment prevent clang from trying to format the macro. */
 


### PR DESCRIPTION
Previously, in the `dice` lib, attestation keys and certificates were generated in the same function. This separates key gen into a separate function to enable skipping certificate generation if up-to-date certificates have already been generated, which is a ROM_EXT integration requirement.

Additionally, this optimizes the little to big endian byte order conversions for public keys and signatures by performing the swaps in place, saving on space required for the DICE lib.