### PR TITLE
[keymgr_dpe, dv] fixes issue where exp_kmac_key for sideload keys

### DIFF
--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_if.sv
@@ -585,6 +585,7 @@ interface keymgr_dpe_if(input clk, input rst_n);
           kmac_key_exp <= '{1'b1, kmac_sideload_key_shares};
           is_kmac_key_good <= 1;
         end else begin
+          kmac_key_exp <= '0;
           kmac_key_exp.valid <= 0;
           is_kmac_key_good   <= 0;
         end

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -548,21 +548,21 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
             // check sideload keys are preserved from available to disable state
             if (cfg.keymgr_dpe_vif.aes_key_exp != cfg.keymgr_dpe_vif.aes_key) begin
                 `uvm_error(`gfn,
-                  $sformatf({"After a disable aes sideload key was not preseved",
+                  $sformatf({"After a disable aes sideload key was not preseved ",
                   "exp 'h%0h vs. act 'h%0h"},
                   cfg.keymgr_dpe_vif.aes_key_exp, cfg.keymgr_dpe_vif.aes_key))
             end
 
             if (cfg.keymgr_dpe_vif.otbn_key_exp != cfg.keymgr_dpe_vif.otbn_key) begin
                 `uvm_error(`gfn,
-                  $sformatf({"After a disable otbn sideload key was not preseved",
+                  $sformatf({"After a disable otbn sideload key was not preseved ",
                     "exp 'h%0h vs. act 'h%0h"},
                   cfg.keymgr_dpe_vif.otbn_key_exp, cfg.keymgr_dpe_vif.otbn_key))
             end
 
             if (cfg.keymgr_dpe_vif.kmac_key_exp != cfg.keymgr_dpe_vif.kmac_key) begin
                 `uvm_error(`gfn,
-                  $sformatf({"After a disable kmac sideload key was not preseved",
+                  $sformatf({"After a disable kmac sideload key was not preseved ",
                   "exp 'h%0h vs. act 'h%0h"},
                   cfg.keymgr_dpe_vif.kmac_key_exp, cfg.keymgr_dpe_vif.kmac_key))
             end
@@ -1035,9 +1035,9 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     err_code[keymgr_pkg::ErrInvalidIn] = get_hw_invalid_input() | get_sw_invalid_input();
 
     `uvm_info(`gfn, $sformatf({"op_err = %0d, rsp_err = %0d, hw_invalid = %0d, sw_invalid = %0d, ",
-              "kmac_invalid_data = %0d"},
+              "kmac_invalid_data = %0d err_code %p"},
               get_invalid_op(), is_kmac_rsp_err, get_hw_invalid_input(), get_sw_invalid_input(),
-              is_kmac_invalid_data), UVM_MEDIUM)
+              is_kmac_invalid_data, err_code), UVM_MEDIUM)
     return err_code;
   endfunction
 


### PR DESCRIPTION
When a sideload key for kmac was never generated in tests due to randomization there was no mechanism to reset the exp_kmac_key to 0 as it should be. So in some seeds after disabling keymgr_dpe and checking sideload keys a comparison was being done against the exp_kmac key and the kmac_key in rtl which was a 0. The exp_kmac key would not be properly set to 0 and a false fail was happening. This commit resets the exp_kmac key to 0 when there is no sideload key generated.