### PR TITLE
[usbdev,dv] Rename set_payload to something more specific

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -94,9 +94,9 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     m_data_pkt.m_bmRT = bmRequestType3;
     m_data_pkt.m_bR = bRequestGET_DESCRIPTOR;
     assert(m_data_pkt.randomize());
-    m_data_pkt.set_payload(m_data_pkt.m_bmRT, m_data_pkt.m_bR,
-                           8'h00, 8'h01,
-                           16'h0, 16'd18);  // Device descriptor >= 18 bytes.
+    m_data_pkt.make_device_request(m_data_pkt.m_bmRT, m_data_pkt.m_bR,
+                                   8'h00, 8'h01,
+                                   16'h0, 16'd18);  // Device descriptor >= 18 bytes.
     start_item(m_data_pkt);
     finish_item(m_data_pkt);
     get_response(rsp_item);


### PR DESCRIPTION
This PR has two commits: the first is #22292 (which should be merged first); the second builds on this. The commit message for the second commit continues with:

```
This also gives some longer comments explaining the data
formatting (because I found it hard to remember!)
```