### PR TITLE
[pentest] Configure extclk

### DIFF
--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -208,6 +208,22 @@ cc_library(
 )
 
 cc_library(
+    name = "extclk_sca_fi",
+    srcs = ["extclk_sca_fi.c"],
+    hdrs = ["extclk_sca_fi.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:multibits",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:extclk_sca_fi_commands",
+    ],
+)
+
+cc_library(
     name = "kmac_sca",
     srcs = ["kmac_sca.c"],
     hdrs = [
@@ -325,6 +341,7 @@ FIRMWARE_DEPS = [
     ":drbg",
     ":ecdh",
     ":ecdsa",
+    ":extclk_sca_fi",
     ":hash",
     ":hmac",
     ":ibex_fi",

--- a/sw/device/tests/crypto/cryptotest/firmware/extclk_sca_fi.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/extclk_sca_fi.c
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/tests/crypto/cryptotest/firmware/extclk_sca_fi.h"
+
+#include "sw/device/lib/base/multibits.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/extclk_sca_fi_commands.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_clkmgr_t clkmgr;
+
+status_t handle_extclk_sca_fi_configure(ujson_t *uj) {
+  cryptotest_extclk_sca_fi_cfg_t uj_data;
+  TRY(ujson_deserialize_cryptotest_extclk_sca_fi_cfg_t(uj, &uj_data));
+
+  TRY(dif_clkmgr_init(mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
+                      &clkmgr));
+
+  multi_bit_bool_t is_low_speed = kMultiBitBool4True;
+  if (uj_data.hi_speed_sel) {
+    is_low_speed = kMultiBitBool4False;
+  }
+
+  if (uj_data.sel) {
+    // Enable external clock.
+    TRY(dif_clkmgr_external_clock_set_enabled(&clkmgr, is_low_speed));
+  } else {
+    // Disable external clock.
+    TRY(dif_clkmgr_external_clock_set_disabled(&clkmgr));
+  }
+  // Check CLKMGR_EXTCLK_STATUS_REG_OFFSET register. Blocks if clock does not
+  // switch.
+  TRY(dif_clkmgr_wait_for_ext_clk_switch(&clkmgr));
+
+  return OK_STATUS();
+}
+
+status_t handle_extclk_sca_fi(ujson_t *uj) {
+  extclk_sca_fi_subcommand_t cmd;
+  TRY(ujson_deserialize_extclk_sca_fi_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kExtClkScaFiSubcommandConfigure:
+      return handle_extclk_sca_fi_configure(uj);
+    default:
+      LOG_ERROR("Unrecognized EXTCLK SCA FI subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/extclk_sca_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/extclk_sca_fi.h
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EXTCLK_SCA_FI_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EXTCLK_SCA_FI_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+/**
+ * Extclk configure command handler.
+ *
+ * Allows to configure the external clock.
+ * The uJSON data contains:
+ *  - sel: External clock on or off.
+ *  - hi_speed_sel: Nominal or low-speed external clock.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_extclk_sca_fi_configure(ujson_t *uj);
+
+/**
+ * EXTCLK SCA FI command handler.
+ *
+ * Command handler for the EXTCLK SCA FI command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_extclk_sca_fi(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EXTCLK_SCA_FI_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -17,6 +17,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/drbg_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdh_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdsa_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/extclk_sca_fi_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hmac_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
@@ -34,6 +35,7 @@
 #include "drbg.h"
 #include "ecdh.h"
 #include "ecdsa.h"
+#include "extclk_sca_fi.h"
 #include "hash.h"
 #include "hmac.h"
 #include "ibex_fi.h"
@@ -75,6 +77,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandAesSca:
         RESP_ERR(uj, handle_aes_sca(uj));
+        break;
+      case kCryptotestCommandExtClkScaFi:
+        RESP_ERR(uj, handle_extclk_sca_fi(uj));
         break;
       case kCryptotestCommandIbexFi:
         RESP_ERR(uj, handle_ibex_fi(uj));

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -14,6 +14,7 @@ cc_library(
         ":drbg_commands",
         ":ecdh_commands",
         ":ecdsa_commands",
+        ":extclk_sca_fi_commands",
         ":hash_commands",
         ":hmac_commands",
         ":ibex_fi_commands",
@@ -116,6 +117,13 @@ cc_library(
     name = "prng_sca_commands",
     srcs = ["prng_sca_commands.c"],
     hdrs = ["prng_sca_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "extclk_sca_fi_commands",
+    srcs = ["extclk_sca_fi_commands.c"],
+    hdrs = ["extclk_sca_fi_commands.h"],
     deps = ["//sw/device/lib/ujson"],
 )
 

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -20,6 +20,7 @@ extern "C" {
     value(_, Hmac) \
     value(_, Kmac) \
     value(_, AesSca) \
+    value(_, ExtClkScaFi) \
     value(_, IbexFi) \
     value(_, IbexSca) \
     value(_, KmacSca) \

--- a/sw/device/tests/crypto/cryptotest/json/extclk_sca_fi_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/extclk_sca_fi_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "extclk_sca_fi_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/extclk_sca_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/extclk_sca_fi_commands.h
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EXTCLK_SCA_FI_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EXTCLK_SCA_FI_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+// EXTCLK SCA FI arguments
+
+#define EXTCLK_SCA_FI_SUBCOMMAND(_, value) \
+    value(_, Configure)
+UJSON_SERDE_ENUM(ExtClkScaFiSubcommand, extclk_sca_fi_subcommand_t, EXTCLK_SCA_FI_SUBCOMMAND);
+
+#define EXTCLK_SCA_FI_CFG(field, string) \
+    field(sel, bool) \
+    field(hi_speed_sel, bool)
+UJSON_SERDE_STRUCT(CryptotestExtClkScaFiCfg, cryptotest_extclk_sca_fi_cfg_t, EXTCLK_SCA_FI_CFG);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EXTCLK_SCA_FI_COMMANDS_H_


### PR DESCRIPTION
This commit adds uJSON command handlers allowing to configure the external clock for the penetration testing.