### PR TITLE
[dv,usbdev] Reliability fixes

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -28,9 +28,6 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
   endtask
 
   task configure_trans();
-    super.apply_reset("HARD");
-    super.dut_init("HARD");
-    cfg.clk_rst_vif.wait_clks(200);
     // Enable EP0 Out
     csr_wr(.ptr(ral.ep_out_enable[0].enable[endp]), .value(1'b1));
     csr_update(ral.ep_out_enable[0]);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -13,10 +13,6 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     uvm_reg_data_t read_rxfifo;
     bit            rx_enable_out;
 
-    super.dut_init("HARD");
-    cfg.clk_rst_vif.wait_clks(20);
-    clear_all_interrupts();
-
     // Configure transaction
     configure_out_trans();
     // Set nak_out
@@ -25,7 +21,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
 
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
+    inter_packet_delay();
     call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     cfg.clk_rst_vif.wait_clks(20);
 
@@ -49,7 +45,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
 
     // Out token packet followed by a data packet
     call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
+    inter_packet_delay();
     call_data_seq(PidTypeData1, .randomize_length(1'b1), .num_of_bytes(0));
     cfg.clk_rst_vif.wait_clks(20);
 
@@ -57,7 +53,6 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_out_response_from_device(m_usb20_item, PidTypeNak);
-    cfg.clk_rst_vif.wait_clks(20);
   endtask
 
 endclass


### PR DESCRIPTION
This PR addresses a couple of reliability issues with the current usbdev DV sequences:

- The usb20_monitor suffers the same sampling/aliasing issues as the usb20_driver code when attempting to receive and decode packets on a 12MHz clock, with no ability to adjust the phase of the clock. As an interim workaround this adjusts the sampling to use the positive- or negative-edge of the clock, but a cleaner and more general solution should be implemented at some point to permit testing of frequency- and phase-differences between host and device.
- The unnecessary startup code in the usbdev_nak_trans_vseq and usbdev_av_buffer_vseq conflicted with the current Bus Reset behavior of the usb20_driver, particularly the interrupt clearing because bus resets set interrupt state bits.
