### PR TITLE
[dv,mem_bkdr] Fix handling of multiple tiles in sram

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
@@ -57,7 +57,7 @@ class sram_ctrl_common_vseq extends sram_ctrl_base_vseq;
     bit[bus_params_pkg::BUS_DW-1:0] rdata;
     bit[tlul_pkg::DataIntgWidth+bus_params_pkg::BUS_DW-1:0] flip_bits;
 
-    rdata = cfg.mem_bkdr_util_h.sram_encrypt_read32_integ(addr, cfg.scb.key, cfg.scb.nonce);
+    rdata = cfg.mem_bkdr_util_h.sram_encrypt_read32_integ(addr, cfg.scb.key, cfg.scb.nonce, 0);
 
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bits,
         $countones(flip_bits) inside {[1:cip_base_pkg::MAX_TL_ECC_ERRORS]};)
@@ -65,7 +65,7 @@ class sram_ctrl_common_vseq extends sram_ctrl_base_vseq;
     `uvm_info(`gfn, $sformatf("Backdoor change mem (addr 0x%0h) value 0x%0h by flipping bits %0h",
                               addr, rdata, flip_bits), UVM_LOW)
 
-    cfg.mem_bkdr_util_h.sram_encrypt_write32_integ(addr, rdata, cfg.scb.key, cfg.scb.nonce,
+    cfg.mem_bkdr_util_h.sram_encrypt_write32_integ(addr, rdata, cfg.scb.key, cfg.scb.nonce, 0,
                                                    flip_bits);
   endfunction
 

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_mem_bkdr_scb.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_mem_bkdr_scb.sv
@@ -14,7 +14,7 @@ class sram_ctrl_mem_bkdr_scb extends mem_bkdr_scb;
 
   virtual function mem_data_t get_bkdr_val(mem_addr_t addr);
     // This chops the integrity bits since mem_data_t is just the data portion.
-    return mem_bkdr_util_h.sram_encrypt_read32_integ(addr, key, nonce);
+    return mem_bkdr_util_h.sram_encrypt_read32_integ(addr, key, nonce, 0);
   endfunction
 
   virtual function void update_key(otp_ctrl_pkg::sram_key_t   key,

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -215,7 +215,8 @@ class chip_sw_base_vseq extends chip_base_vseq;
     _sram_get_params(mem, num_tiles, size_bytes, is_main_ram);
 
     // calculate the scramble address
-    addr_scr = cfg.mem_bkdr_util_h[mem].get_sram_encrypt_addr(addr, nonce, $clog2(num_tiles));
+    addr_scr = cfg.mem_bkdr_util_h[mem].get_sram_encrypt_addr(
+        .addr(addr), .nonce(nonce), .extra_addr_bits($clog2(num_tiles)));
     addr_mask = size_bytes - 1;
 
     // determine which tile the scrambled address belongs
@@ -223,8 +224,9 @@ class chip_sw_base_vseq extends chip_base_vseq;
     mem = chip_mem_e'(mem + tile_idx);
 
     // calculate the scrambled data
-    data_scr = cfg.mem_bkdr_util_h[mem].get_sram_encrypt32_intg_data(addr, data, key, nonce,
-                                                                     $clog2(num_tiles));
+    data_scr = cfg.mem_bkdr_util_h[mem].get_sram_encrypt32_intg_data(
+       .addr(addr), .data(data), .key(key), .nonce(nonce), .extra_addr_bits($clog2(num_tiles)),
+       .flip_bits(flip_bits));
     cfg.mem_bkdr_util_h[mem].write39integ(addr_scr & addr_mask, data_scr ^ flip_bits);
   endfunction
 
@@ -247,7 +249,8 @@ class chip_sw_base_vseq extends chip_base_vseq;
     _sram_get_params(mem, num_tiles, size_bytes, is_main_ram);
 
     // calculate the scramble address
-    addr_scr = cfg.mem_bkdr_util_h[mem].get_sram_encrypt_addr(addr, nonce, $clog2(num_tiles));
+    addr_scr = cfg.mem_bkdr_util_h[mem].get_sram_encrypt_addr(
+        .addr(addr), .nonce(nonce), .extra_addr_bits($clog2(num_tiles)));
 
     // determine which tile the scrambled address belongs
     tile_idx = addr_scr / size_bytes;
@@ -255,7 +258,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
 
     addr_mask = size_bytes - 1;
     cfg.mem_bkdr_util_h[mem].sram_inject_integ_error(addr & addr_mask, addr_scr & addr_mask, key,
-                                                     nonce);
+                                                     nonce, $clog2(num_tiles));
   endfunction
 
   virtual task body();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
@@ -159,7 +159,7 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
         // Write the data to a known offset in the SRAM. The random byte data
         // is used little-endian.
         for (int i = 0; i < BACKDOOR_DATA_WORDS; i++) begin
-         ret_sram_bkdr_write32(offset + (i * 4), {
+          ret_sram_bkdr_write32(offset + (i * 4), {
                                 backdoor_data[(i*4)+3],
                                 backdoor_data[(i*4)+2],
                                 backdoor_data[(i*4)+1],
@@ -182,7 +182,7 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
                    "uvm_hdl_read failed for %0s", SRAM_CTRL_MAIN_SCR_KEY_VALID_PATH))
       // Wait for sram_ctrl.STATUS.SCR_KEY_VALID.
       if (scr_key_valid == 1) begin
-        `uvm_info(`gfn, $sformatf("main_backdoor_write start %x", offset), UVM_LOW)
+        `uvm_info(`gfn, $sformatf("main_backdoor_write to 0x%x", offset), UVM_LOW)
         // Write the data to a known offset in the SRAM. The random byte data
         // is used little-endian.
         for (int i = 0; i < BACKDOOR_DATA_WORDS; i++) begin

--- a/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_scrambled_access_test.c
@@ -158,7 +158,7 @@ static noreturn void main_sram_scramble(void) {
       "sw a3, 0(%[retFrame])                                         \n"
 
       // Copy the backdoor and pattern buffers from main to the retention SRAM.
-      " addi t1, a3,  %[kCopyLen]                                   \n"
+      "addi t1, a3,  %[kCopyLen]                                    \n"
       ".L_buffer_copy_loop:                                         \n"
       "  lw t0, 0(a2)                                               \n"
       "  sw t0, 0(a3)                                               \n"


### PR DESCRIPTION
Pass the number of bits selecting a tile to various sram backdoor functions. This was incompletely done in the past, which had no impact in the open-source ram configuration since it has a single tile, but causes failures in configurations with multiple tiles.