### PR TITLE
[silicon_creator] add function to config cert flash info pages

### DIFF
--- a/rules/certificates.bzl
+++ b/rules/certificates.bzl
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//rules:rv.bzl", "rv_rule")
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 
 def _certificate_codegen_impl(ctx):
@@ -66,7 +65,7 @@ def _certificate_codegen_impl(ctx):
 # - "sources": contains the implementation of the generator.
 # - "headers": contains the header containing the definitions and declaration.
 # All files produced by this rule will be formatted by clang-format.
-certificate_codegen = rv_rule(
+certificate_codegen = rule(
     implementation = _certificate_codegen_impl,
     attrs = {
         "template": attr.label(allow_single_file = True, doc = "path to the hjson template file"),

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -166,6 +166,8 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  */
 enum {
   kFlashCtrlSecMmioCreatorInfoPagesLockdown = 18,
+  kFlashCtrlSecMmioCertInfoPagesCreatorCfg = 6,
+  kFlashCtrlSecMmioCertInfoPagesOwnerRestrict = 3,
   kFlashCtrlSecMmioDataDefaultCfgSet = 1,
   kFlashCtrlSecMmioDataDefaultPermsSet = 1,
   kFlashCtrlSecMmioExecSet = 1,
@@ -584,6 +586,29 @@ void flash_ctrl_exec_set(uint32_t exec_val);
  * sec_mmio is being used to check expectations.
  */
 void flash_ctrl_creator_info_pages_lockdown(void);
+
+/**
+ * Configures certificate flash info pages for access by the silicon creator.
+ *
+ * Flash info pages that hold device certificates are fully accessable by the
+ * silicon creator, but are restricted to read-only access by the ROM_EXT before
+ * handing over execution to the owner boot stage.
+ *
+ * The caller is responsible for calling
+ * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPagesCreatorCfg)`
+ * when sec_mmio is being used to check expectations.
+ */
+void flash_ctrl_cert_info_pages_creator_cfg(void);
+
+/**
+ * Restricts access of certificate flash info pages to read-only for the silicon
+ * owner.
+ *
+ * The caller is responsible for calling
+ * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPagesOwnerRestrict)`
+ * when sec_mmio is being used to check expectations.
+ */
+void flash_ctrl_cert_info_pages_owner_restrict(void);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -716,6 +716,39 @@ TEST_F(FlashCtrlTest, BankErasePermsSet) {
   flash_ctrl_bank_erase_perms_set(kHardenedBoolFalse);
 }
 
+TEST_F(FlashCtrlTest, CertInfoCreatorCfg) {
+  std::array<const flash_ctrl_info_page_t *, 3> cert_pages = {
+      &kFlashCtrlInfoPageUdsCertificate,
+      &kFlashCtrlInfoPageCdi0Certificate,
+      &kFlashCtrlInfoPageCdi1Certificate,
+  };
+  for (auto page : cert_pages) {
+    auto info_page = InfoPages().at(page);
+    EXPECT_SEC_READ32(base_ + info_page.cfg_offset,
+                      FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_REG_RESVAL);
+    EXPECT_SEC_WRITE32(base_ + info_page.cfg_offset, 0x9669996);
+    EXPECT_SEC_READ32(base_ + info_page.cfg_offset, 0x9669996);
+    EXPECT_SEC_WRITE32(base_ + info_page.cfg_offset, 0x9666666);
+  }
+
+  flash_ctrl_cert_info_pages_creator_cfg();
+}
+
+TEST_F(FlashCtrlTest, CertInfoOwnerRestrict) {
+  std::array<const flash_ctrl_info_page_t *, 3> cert_pages = {
+      &kFlashCtrlInfoPageUdsCertificate,
+      &kFlashCtrlInfoPageCdi0Certificate,
+      &kFlashCtrlInfoPageCdi1Certificate,
+  };
+  for (auto page : cert_pages) {
+    auto info_page = InfoPages().at(page);
+    EXPECT_SEC_READ32(base_ + info_page.cfg_offset, 0x9666666);
+    EXPECT_SEC_WRITE32(base_ + info_page.cfg_offset, 0x9669966);
+  }
+
+  flash_ctrl_cert_info_pages_owner_restrict();
+}
+
 struct EraseVerifyCase {
   /**
    * Address.


### PR DESCRIPTION
This adds two functions to configure the certificate flash info pages in the silicon_creator (ROM_EXT and personalization) code for full access, and to restrict access to read only upon anding over execution from the ROM_EXT to the owner boot stage. This will enable sharing the flash info page configuration code between the ROM_EXT and personalization code.