### PR TITLE
[hmac] Add testplan items for recently added features and sign off at D2S and V1

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -39,7 +39,7 @@
     {
       version:            "2.0.0",
       life_stage:         "L1",
-      design_stage:       "D1",
+      design_stage:       "D2S",
       verification_stage: "V0",
       dif_stage:          "S0",
       notes:              "",

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -40,7 +40,7 @@
       version:            "2.0.0",
       life_stage:         "L1",
       design_stage:       "D2S",
-      verification_stage: "V0",
+      verification_stage: "V1",
       dif_stage:          "S0",
       notes:              "",
     }

--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -95,6 +95,33 @@
       tests: ["hmac_wipe_secret"]
     }
     {
+      name: save_and_restore
+      desc: '''Verify save & restore, which allows SW to switch between different parallel message streams.
+
+               TODO(lowRISC/opentitan#21307)
+            '''
+      stage: V2
+      tests: []
+    }
+    {
+      name: fifo_empty_status_interrupt
+      desc: '''Verify the FIFO empty status interrupt.
+
+               TODO(lowRISC/opentitan#21815)
+            '''
+      stage: V2
+      tests: []
+    }
+    {
+      name: wide_digest_configurable_key_length
+      desc: '''Verify wider (SHA-384 and SHA-512) digests as well as configurable key lengths.
+
+               TODO(lowRISC/opentitan#22102)
+            '''
+      stage: V2
+      tests: []
+    }
+    {
       name: stress_all
       desc: "Stress_all test is a random mix of all the test above except csr tests."
       stage: V2


### PR DESCRIPTION
This PR adds testplan items for the recently added features and refers the corresponding tracking issues, then signs HMAC off at D2S and V1, based on the analysis in #20996 and #21031, respectively.

Closes #20996 (D2S signoff issue) and closes #21031 (V1 signoff issue).