### PR TITLE
[usbdev] Fixup test name with 'usbdev_' prefix

### DIFF
--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -134,7 +134,7 @@
       uvm_test_seq: usbdev_in_stall_vseq
     }
     {
-      name: in_iso
+      name: usbdev_in_iso
       uvm_test_seq: usbdev_in_iso_vseq
     }
   ]


### PR DESCRIPTION
This caused breakage with some of our CI metrics gathering scripts, as by convention all tests start with the blockname.

This shouldn't be an issue, but it turns out there is strange underlying dvsim behaviour where if a testpoint contains no tests, it creates a 'dummy' test output with 0 total runs, but with the same name as the testpoint.
This dummy name clashes the name of the unmapped test in this case.
