### PR TITLE
Cherrypick to master: [rust] Upgrade to serde-annotate v0.0.11

### DIFF
--- a/sw/host/hsmtool/BUILD
+++ b/sw/host/hsmtool/BUILD
@@ -47,9 +47,6 @@ rust_library(
         "src/util/signing.rs",
     ],
     crate_name = "hsmtool",
-    proc_macro_deps = [
-        "@lowrisc_serde_annotate//annotate_derive:annotate_derive",
-    ],
     deps = [
         "@crate_index//:anyhow",
         "@crate_index//:clap",
@@ -71,7 +68,7 @@ rust_library(
         "@crate_index//:strum",
         "@crate_index//:thiserror",
         "@crate_index//:typetag",
-        "@lowrisc_serde_annotate//:serde_annotate",
+        "@lowrisc_serde_annotate//serde_annotate",
     ],
 )
 

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -254,7 +254,6 @@ rust_library(
     }),
     proc_macro_deps = [
         "//sw/host/opentitanlib/opentitantool_derive",
-        "@lowrisc_serde_annotate//annotate_derive:annotate_derive",
     ],
     rustc_env = {
         "e2e_command": "$(location :e2e_command)",
@@ -319,7 +318,7 @@ rust_library(
         "@crate_index//:thiserror",
         "@crate_index//:typetag",
         "@crate_index//:zerocopy",
-        "@lowrisc_serde_annotate//:serde_annotate",
+        "@lowrisc_serde_annotate//serde_annotate",
     ],
 )
 

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -66,7 +66,7 @@ rust_binary(
         "@crate_index//:serde_json",
         "@crate_index//:shellwords",
         "@crate_index//:thiserror",
-        "@lowrisc_serde_annotate//:serde_annotate",
+        "@lowrisc_serde_annotate//serde_annotate",
     ],
 )
 

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -103,7 +103,7 @@ def rust_repos(rules_rust = None, serde_annotate = None):
     http_archive_or_local(
         name = "lowrisc_serde_annotate",
         local = serde_annotate,
-        sha256 = "fa44e96f541934f8d971a8a3a08d5925dc8b04991938c6eada129804c82f7137",
-        strip_prefix = "serde-annotate-0.0.9",
-        url = "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.9.tar.gz",
+        sha256 = "7d6db7c811469f3abd6b58745bd2b8ebb7596a68974739da51bc8b6568c8002a",
+        strip_prefix = "serde-annotate-0.0.11",
+        url = "https://github.com/lowRISC/serde-annotate/archive/refs/tags/v0.0.11.tar.gz",
     )


### PR DESCRIPTION
- v0.0.10 fixed a bug in deserializing enums.
- v0.0.11 re-organizes the serde-annotate project workspace.  The dependency label changes reflect the new structure.

Signed-off-by: Chris Frantz <cfrantz@google.com>
(cherry picked from commit 383a9198febad71e8bf5f3814f3ad3ea91002e8f)