### PR TITLE
[i2c] Split the target and controller FSMs

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
@@ -20,31 +20,15 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
   uint scl_period;
 
   // Variable used to detect start internally
-  string start_detected_path = "tb.dut.i2c_core.u_i2c_fsm.start_det";
+  string start_detected_path = "tb.dut.i2c_core.u_i2c_target_fsm.start_det";
   // Variable used to detect Stop internally
-  string stop_detected_path = "tb.dut.i2c_core.u_i2c_fsm.stop_det";
+  string stop_detected_path = "tb.dut.i2c_core.u_i2c_target_fsm.stop_det";
   // Internal FSM variable
-  string fsm_state_path = "tb.dut.i2c_core.u_i2c_fsm.state_q";
+  string fsm_state_path = "tb.dut.i2c_core.u_i2c_target_fsm.state_q";
 
   // State definitions
   typedef enum logic [5:0] {
     Idle,
-    ///////////////////////
-    // Host function states
-    ///////////////////////
-    Active, PopFmtFifo,
-    // Host function starts a transaction
-    SetupStart, HoldStart, ClockStart,
-    // Host function stops a transaction
-    SetupStop, HoldStop, ClockStop,
-    // Host function transmits a bit to the external target
-    ClockLow, ClockPulse, HoldBit,
-    // Host function recevies an ack from the external target
-    ClockLowAck, ClockPulseAck, HoldDevAck,
-    // Host function reads a bit from the external target
-    ReadClockLow, ReadClockPulse, ReadHoldBit,
-    // Host function transmits an ack to the external target
-    HostClockLowAck, HostClockPulseAck, HostHoldBitAck,
 
     /////////////////////////
     // Target function states

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -50,6 +50,7 @@ module tb;
     .sda_io(sda)
   );
 
+  // TODO: Remove this unused interface.
   i2c_dv_if i2c_dv_if(
     .clk(clk),
     .rst_n(rst_n)
@@ -58,8 +59,6 @@ module tb;
   `ifndef I2C_HIER
     `define I2C_HIER tb.dut.i2c_core
   `endif
-
-  assign i2c_dv_if.i2c_state = `I2C_HIER.u_i2c_fsm.state_q;
 
   // Model PAD behavior
   i2c_port_conv i2c_port_conv (

--- a/hw/ip/i2c/i2c.core
+++ b/hw/ip/i2c/i2c.core
@@ -19,7 +19,8 @@ filesets:
       - rtl/i2c_fifo_sync_sram_adapter.sv
       - rtl/i2c_fifos.sv
       - rtl/i2c_core.sv
-      - rtl/i2c_fsm.sv
+      - rtl/i2c_controller_fsm.sv
+      - rtl/i2c_target_fsm.sv
       - rtl/i2c.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/i2c/rtl/i2c_controller_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_controller_fsm.sv
@@ -1,0 +1,912 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: I2C finite state machine
+
+module i2c_controller_fsm import i2c_pkg::*;
+#(
+  parameter int FifoDepth = 64,
+  localparam int FifoDepthWidth = $clog2(FifoDepth+1)
+) (
+  input        clk_i,  // clock
+  input        rst_ni, // active low reset
+
+  input        scl_i,  // serial clock input from i2c bus
+  output logic scl_o,  // serial clock output to i2c bus
+  input        sda_i,  // serial data input from i2c bus
+  output logic sda_o,  // serial data output to i2c bus
+
+  input        host_enable_i, // enable host functionality
+  output logic host_disable_o, // disable host mode
+
+  input                      fmt_fifo_rvalid_i, // indicates there is valid data in fmt_fifo
+  input [FifoDepthWidth-1:0] fmt_fifo_depth_i,  // fmt_fifo_depth
+  output logic               fmt_fifo_rready_o, // populates fmt_fifo
+  input [7:0]                fmt_byte_i,        // byte in fmt_fifo to be sent to target
+  input                      fmt_flag_start_before_i, // issue start before sending byte
+  input                      fmt_flag_stop_after_i,   // issue stop after sending byte
+  input                      fmt_flag_read_bytes_i,   // indicates byte is an number of reads
+  input                      fmt_flag_read_continue_i,// host to send Ack to final byte read
+  input                      fmt_flag_nak_ok_i,       // no Ack is expected
+  input                      unhandled_unexp_nak_i,
+
+  output logic                     rx_fifo_wvalid_o, // high if there is valid data in rx_fifo
+  output logic [RX_FIFO_WIDTH-1:0] rx_fifo_wdata_o,  // byte in rx_fifo read from target
+
+  output logic       host_idle_o,      // indicates the host is idle
+
+  input [15:0] thigh_i,    // high period of the SCL in clock units
+  input [15:0] tlow_i,     // low period of the SCL in clock units
+  input [15:0] t_r_i,      // rise time of both SDA and SCL in clock units
+  input [15:0] t_f_i,      // fall time of both SDA and SCL in clock units
+  input [15:0] thd_sta_i,  // hold time for (repeated) START in clock units
+  input [15:0] tsu_sta_i,  // setup time for repeated START in clock units
+  input [15:0] tsu_sto_i,  // setup time for STOP in clock units
+  input [15:0] tsu_dat_i,  // data setup time in clock units
+  input [15:0] thd_dat_i,  // data hold time in clock units
+  input [15:0] t_buf_i,    // bus free time between STOP and START in clock units
+  input [30:0] stretch_timeout_i,  // max time target connected to this host may stretch the clock
+  input        timeout_enable_i,   // assert if target stretches clock past max
+  input [30:0] host_nack_handler_timeout_i, // Timeout threshold for unhandled Host-Mode 'nak' irq.
+  input        host_nack_handler_timeout_en_i,
+
+  output logic event_nak_o,              // target didn't Ack when expected
+  output logic event_scl_interference_o, // other device forcing SCL low
+  output logic event_sda_interference_o, // other device forcing SDA low
+  output logic event_stretch_timeout_o,  // target stretches clock past max time
+  output logic event_sda_unstable_o,     // SDA is not constant during SCL pulse
+  output logic event_cmd_complete_o      // Command is complete
+);
+
+  // I2C bus clock timing variables
+  logic [19:0] tcount_q;      // current counter for setting delays
+  logic [19:0] tcount_d;      // next counter for setting delays
+  logic        load_tcount;   // indicates counter must be loaded
+  logic [31:0] stretch_idle_cnt; // counter for clock being stretched by target
+                                 // or clock idle by host.
+  logic [30:0] unhandled_nak_cnt; // In Host-mode, count cycles where the FSM is halted awaiting
+                                  // the nak irq to be handled by SW.
+
+  // (IP in HOST-Mode) This bit is active when the FSM is in a state where a TARGET might
+  // be trying to stretch the clock, preventing the controller FSM from continuing.
+  logic        stretch_en;
+
+  // Bit and byte counter variables
+  logic [2:0]  bit_index;     // bit being transmitted to or read from the bus
+  logic        bit_decr;      // indicates bit_index must be decremented by 1
+  logic        bit_clr;       // indicates bit_index must be reset to 7
+  logic [8:0]  byte_num;      // number of bytes to read
+  logic [8:0]  byte_index;    // byte being read from the bus
+  logic        byte_decr;     // indicates byte_index must be decremented by 1
+  logic        byte_clr;      // indicates byte_index must be reset to byte_num
+
+  // Other internal variables
+  logic        scl_d;         // scl internal
+  logic        sda_d;         // data internal
+  logic        scl_i_q;       // scl_i delayed by one clock
+  logic        sda_i_q;       // sda_i delayed by one clock
+  logic [7:0]  read_byte;     // register for reads from target
+  logic        read_byte_clr; // clear read_byte contents
+  logic        shift_data_en; // indicates data must be shifted in from the bus
+  logic        trans_started; // indicates a transaction has started
+  logic        pend_restart;  // there is a pending restart waiting to be processed
+  logic        req_restart;   // request restart
+  logic        log_start;     // indicates start is been issued
+  logic        log_stop;      // indicates stop is been issued
+
+  // Clock counter implementation
+  typedef enum logic [3:0] {
+    tSetupStart,
+    tHoldStart,
+    tSetupData,
+    tClockStart,
+    tClockLow,
+    tClockPulse,
+    tClockHigh,
+    tHoldBit,
+    tClockStop,
+    tSetupStop,
+    tHoldStop,
+    tNoDelay
+  } tcount_sel_e;
+
+  tcount_sel_e tcount_sel;
+
+  always_comb begin : counter_functions
+    tcount_d = tcount_q;
+    if (load_tcount) begin
+      unique case (tcount_sel)
+        tSetupStart : tcount_d = 20'(t_r_i) + 20'(tsu_sta_i);
+        tHoldStart  : tcount_d = 20'(t_f_i) + 20'(thd_sta_i);
+        tSetupData  : tcount_d = 20'(t_r_i) + 20'(tsu_dat_i);
+        tClockStart : tcount_d = 20'(thd_dat_i);
+        tClockLow   : tcount_d = 20'(tlow_i) - 20'(thd_dat_i);
+        tClockPulse : tcount_d = 20'(t_r_i) + 20'(thigh_i);
+        tClockHigh  : tcount_d = 20'(thigh_i);
+        tHoldBit    : tcount_d = 20'(t_f_i) + 20'(thd_dat_i);
+        tClockStop  : tcount_d = 20'(t_f_i) + 20'(tlow_i) - 20'(thd_dat_i);
+        tSetupStop  : tcount_d = 20'(t_r_i) + 20'(tsu_sto_i);
+        tHoldStop   : tcount_d = 20'(t_r_i) + 20'(t_buf_i) - 20'(tsu_sta_i);
+        tNoDelay    : tcount_d = 20'h00001;
+        default     : tcount_d = 20'h00001;
+      endcase
+    end else if (
+      host_enable_i ||
+      // If we disable Host-Mode mid-txn, keep counting until the end of
+      // byte, at which point we create a STOP condition then return to Idle.
+      (!host_idle_o && !host_enable_i)) begin
+      tcount_d = tcount_q - 1'b1;
+    end
+  end
+
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : clk_counter
+    if (!rst_ni) begin
+      tcount_q <= '1;
+    end else begin
+      tcount_q <= tcount_d;
+    end
+  end
+
+  // Clock stretching/idle detection when i2c_ctrl.
+  // When in host mode, this is a stretch count for how long an external target
+  // has stretched the clock.
+  // When in target mode, this is an idle count for how long an external host
+  // has kept the clock idle after a START indication.
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : clk_stretch
+    if (!rst_ni) begin
+      stretch_idle_cnt <= '0;
+    end else if (stretch_en && !scl_i) begin
+      // HOST-mode count of clock stretching
+      stretch_idle_cnt <= stretch_idle_cnt + 1'b1;
+    end else begin
+      stretch_idle_cnt <= '0;
+    end
+  end
+
+  // The TARGET can stretch the clock during any time that the host drives SCL to 0.
+  // However, we (the HOST) cannot know it is being stretched until we release SCL,
+  // usually trying to create the next clock pulse.
+  // There is a minimum 3-cycle round trip (1-cycle output flop, 2-cycle input synchronizer),
+  // between releasing the clock and observing the effect of releasing the clock on
+  // the inputs. However, this is really '1 + t_r + 2' as the bus also needs to slew to '1
+  // before can observe it. Even if the TARGET is not stretching the clock, we cannot
+  // confirm it until at-least this amount of time has elapsed.
+  //
+  // 'stretch_predict_cnt_expired' becomes active once we have observed (4 + t_r) cycles of
+  // delay, and if !scl_i at this point we know that the TARGET is stretching the clock.
+  // > This implementation requires 'thigh >= 4' to guarantee we don't miss stretching.
+  logic [31:0] stretch_cnt_threshold;
+  assign stretch_cnt_threshold = 32'd2 + 32'(t_r_i);
+
+  logic stretch_predict_cnt_expired;
+  always_ff @ (posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      stretch_predict_cnt_expired <= 1'b0;
+    end else begin
+      if (stretch_idle_cnt == stretch_cnt_threshold) begin
+        stretch_predict_cnt_expired <= 1'b1;
+      end else if (!stretch_en) begin
+        stretch_predict_cnt_expired <= 1'b0;
+      end
+    end
+  end
+
+  // While the FSM is halted due to an unhandled 'nak' irq in Host-Mode, this counter can
+  // be used to trigger a timeout which disables Host-Mode and creates a STOP condition to
+  // end the transaction.
+  logic unhandled_nak_cnt_expired;
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : unhandled_nak_cnt_b
+    if (!rst_ni) begin
+      unhandled_nak_cnt <= '0;
+      unhandled_nak_cnt_expired <= 1'b0;
+    end else if (unhandled_unexp_nak_i && host_enable_i && host_nack_handler_timeout_en_i) begin
+      // Increment the counter while the FSM is halted.
+      unhandled_nak_cnt <= unhandled_nak_cnt + 1'b1;
+      if (unhandled_nak_cnt > host_nack_handler_timeout_i) begin
+        unhandled_nak_cnt_expired <= 1'b1;
+      end
+    end else begin
+      unhandled_nak_cnt <= '0;
+      unhandled_nak_cnt_expired <= 1'b0;
+    end
+  end
+
+  // Bit index implementation
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : bit_counter
+    if (!rst_ni) begin
+      bit_index <= 3'd7;
+    end else if (bit_clr) begin
+      bit_index <= 3'd7;
+    end else if (bit_decr) begin
+      bit_index <= bit_index - 1'b1;
+    end else begin
+      bit_index <= bit_index;
+    end
+  end
+
+  // Deserializer for a byte read from the bus
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : read_register
+    if (!rst_ni) begin
+      read_byte <= 8'h00;
+    end else if (read_byte_clr) begin
+      read_byte <= 8'h00;
+    end else if (shift_data_en) begin
+      read_byte[7:0] <= {read_byte[6:0], sda_i};  // MSB goes in first
+    end
+  end
+
+  // Number of bytes to read
+  always_comb begin : byte_number
+    if (!fmt_flag_read_bytes_i) byte_num = 9'd0;
+    else if (fmt_byte_i == '0) byte_num = 9'd256;
+    else byte_num = 9'(fmt_byte_i);
+  end
+
+  // Byte index implementation
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : byte_counter
+    if (!rst_ni) begin
+      byte_index <= '0;
+    end else if (byte_clr) begin
+      byte_index <= byte_num;
+    end else if (byte_decr) begin
+      byte_index <= byte_index - 1'b1;
+    end else begin
+      byte_index <= byte_index;
+    end
+  end
+
+  // SDA and SCL at the previous clock edge
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : bus_prev
+    if (!rst_ni) begin
+      scl_i_q <= 1'b1;
+      sda_i_q <= 1'b1;
+    end else begin
+      scl_i_q <= scl_i;
+      sda_i_q <= sda_i;
+    end
+  end
+
+  // Registers whether a transaction start has been observed.
+  // A transaction start does not include a "restart", but rather
+  // the first start after enabling i2c, or a start observed after a
+  // stop.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      trans_started <= '0;
+    end else if (trans_started && !host_enable_i) begin
+      trans_started <= '0;
+    end else if (log_start) begin
+      trans_started <= 1'b1;
+    end else if (log_stop) begin
+      trans_started <= 1'b0;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      pend_restart <= '0;
+    end else if (pend_restart && !host_enable_i) begin
+      pend_restart <= '0;
+    end else if (req_restart) begin
+      pend_restart <= 1'b1;
+    end else if (log_start) begin
+      pend_restart <= '0;
+    end
+  end
+
+  // State definitions
+  typedef enum logic [4:0] {
+    Idle,
+    ///////////////////////
+    // Host function states
+    ///////////////////////
+    Active, PopFmtFifo,
+    // Host function starts a transaction
+    SetupStart, HoldStart, ClockStart,
+    // Host function stops a transaction
+    SetupStop, HoldStop, ClockStop,
+    // Host function transmits a bit to the external target
+    ClockLow, ClockPulse, HoldBit,
+    // Host function recevies an ack from the external target
+    ClockLowAck, ClockPulseAck, HoldDevAck,
+    // Host function reads a bit from the external target
+    ReadClockLow, ReadClockPulse, ReadHoldBit,
+    // Host function transmits an ack to the external target
+    HostClockLowAck, HostClockPulseAck, HostHoldBitAck
+  } state_e;
+
+  state_e state_q, state_d;
+
+
+  // enable sda interference detection
+  // Detects when the controller releases sda to be pulled high, but the line
+  // is unexpectedly held low by another driver.
+  logic en_sda_interf_det;
+  logic [16:0] sda_rise_cnt;
+
+  // sda_rise_latency refers to the time between
+  // changing sda_o to 1 and sampling sda_i as 1.
+  // This value is a combination of the bus rise time and the
+  // input sychronization delay
+  logic [16:0] sda_rise_latency;
+  assign sda_rise_latency = t_r_i + 16'h2;
+
+  // When detection is enabled, count through the rise time.
+  // Once rise time count is reached, hold in place until disabled.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      sda_rise_cnt <= '0;
+    end else if (!en_sda_interf_det && |sda_rise_cnt) begin
+      // When detection is disabled, 0 the count.
+      // Only 0 the count if the count is currently non-zero to avoid
+      // unnecessary toggling.
+      sda_rise_cnt <= '0;
+    end else if (en_sda_interf_det && sda_rise_cnt < sda_rise_latency) begin
+      sda_rise_cnt <= sda_rise_cnt + 1'b1;
+    end
+  end
+
+  // There are two conditions of sda interference:
+  // 1. When the host function is first enabled, but for some reason sda_i is already 0.
+  // 2. Any time the host function is trying to drive a 1 but it observes a 0 instead.
+  //
+  // When the count is reached, we are pass the rise time period.
+  // Now check for any inconsistency in the sda value.
+  assign event_sda_interference_o = (host_idle_o & host_enable_i & !sda_i) |
+                                    ((sda_rise_cnt == sda_rise_latency) & (sda_o & !sda_i));
+
+  // Outputs for each state
+  always_comb begin : state_outputs
+    host_idle_o = 1'b1;
+    sda_d = 1'b1;
+    scl_d = 1'b1;
+    fmt_fifo_rready_o = 1'b0;
+    rx_fifo_wvalid_o = 1'b0;
+    rx_fifo_wdata_o = RX_FIFO_WIDTH'(0);
+    event_nak_o = 1'b0;
+    event_scl_interference_o = 1'b0;
+    event_sda_unstable_o = 1'b0;
+    event_cmd_complete_o = 1'b0;
+    stretch_en = 1'b0;
+    unique case (state_q)
+      // Idle: initial state, SDA is released (high), SCL is released if the
+      // bus is idle. Otherwise, if no STOP condition has been sent yet,
+      // continue pulling SCL low in host mode.
+      Idle : begin
+        sda_d = 1'b1;
+        if (host_enable_i && trans_started) begin
+          host_idle_o = 1'b0;
+          scl_d = 1'b0;
+        end else begin
+          host_idle_o = 1'b1;
+          scl_d = 1'b1;
+        end
+      end
+
+      ///////////////
+      // HOST MODE //
+      ///////////////
+
+      // SetupStart: SDA and SCL are released
+      SetupStart : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b1;
+        scl_d = 1'b1;
+        if (log_start) event_cmd_complete_o = pend_restart;
+      end
+      // HoldStart: SDA is pulled low, SCL is released
+      HoldStart : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b0;
+        scl_d = 1'b1;
+      end
+      // ClockStart: SCL is pulled low, SDA stays low
+      ClockStart : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b0;
+        scl_d = 1'b0;
+      end
+      ClockLow : begin
+        host_idle_o = 1'b0;
+        if (pend_restart) begin
+          sda_d = 1'b1;
+        end else begin
+          sda_d = fmt_byte_i[bit_index];
+        end
+        scl_d = 1'b0;
+      end
+      // ClockPulse: SCL is released, SDA keeps the indexed bit value
+      ClockPulse : begin
+        host_idle_o = 1'b0;
+        sda_d = fmt_byte_i[bit_index];
+        scl_d = 1'b1;
+        stretch_en = 1'b1;
+        if (scl_i_q && !scl_i)  event_scl_interference_o = 1'b1;
+        if (sda_i_q != sda_i)   event_sda_unstable_o = 1'b1;
+      end
+      // HoldBit: SCL is pulled low
+      HoldBit : begin
+        host_idle_o = 1'b0;
+        sda_d = fmt_byte_i[bit_index];
+        scl_d = 1'b0;
+      end
+      // ClockLowAck: SCL pulled low, SDA is released
+      ClockLowAck : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b1;
+        scl_d = 1'b0;
+      end
+      // ClockPulseAck: SCL is released
+      ClockPulseAck : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b1;
+        scl_d = 1'b1;
+        if (!scl_i_q && scl_i && sda_i && !fmt_flag_nak_ok_i) event_nak_o = 1'b1;
+        stretch_en = 1'b1;
+        if (scl_i_q && !scl_i)  event_scl_interference_o = 1'b1;
+        if (sda_i_q != sda_i)   event_sda_unstable_o = 1'b1;
+      end
+      // HoldDevAck: SCL is pulled low
+      HoldDevAck : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b1;
+        scl_d = 1'b0;
+      end
+      // ReadClockLow: SCL is pulled low, SDA is released
+      ReadClockLow : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b1;
+        scl_d = 1'b0;
+      end
+      // ReadClockPulse: SCL is released, the indexed bit value is read off SDA
+      ReadClockPulse : begin
+        host_idle_o = 1'b0;
+        scl_d = 1'b1;
+        stretch_en = 1'b1;
+        if (scl_i_q && !scl_i)  event_scl_interference_o = 1'b1;
+        if (sda_i_q != sda_i)   event_sda_unstable_o = 1'b1;
+      end
+      // ReadHoldBit: SCL is pulled low
+      ReadHoldBit : begin
+        host_idle_o = 1'b0;
+        scl_d = 1'b0;
+        if (bit_index == '0 && tcount_q == 20'd1) begin
+          rx_fifo_wvalid_o = 1'b1;      // assert that rx_fifo has valid data
+          rx_fifo_wdata_o = read_byte;  // transfer read data to rx_fifo
+        end
+      end
+      // HostClockLowAck: SCL pulled low, SDA is conditional
+      HostClockLowAck : begin
+        host_idle_o = 1'b0;
+        scl_d = 1'b0;
+
+        // If it is the last byte of a read, send a NAK before the stop.
+        // Otherwise send the ack.
+        if (fmt_flag_read_continue_i) sda_d = 1'b0;
+        else if (byte_index == 9'd1) sda_d = 1'b1;
+        else sda_d = 1'b0;
+      end
+      // HostClockPulseAck: SCL is released
+      HostClockPulseAck : begin
+        host_idle_o = 1'b0;
+        if (fmt_flag_read_continue_i) sda_d = 1'b0;
+        else if (byte_index == 9'd1) sda_d = 1'b1;
+        else sda_d = 1'b0;
+        scl_d = 1'b1;
+        stretch_en = 1'b1;
+        if (scl_i_q && !scl_i)  event_scl_interference_o = 1'b1;
+        if (sda_i_q != sda_i)   event_sda_unstable_o = 1'b1;
+      end
+      // HostHoldBitAck: SCL is pulled low
+      HostHoldBitAck : begin
+        host_idle_o = 1'b0;
+        if (fmt_flag_read_continue_i) sda_d = 1'b0;
+        else if (byte_index == 9'd1) sda_d = 1'b1;
+        else sda_d = 1'b0;
+        scl_d = 1'b0;
+      end
+      // ClockStop: SCL is pulled low, SDA stays low
+      ClockStop : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b0;
+        scl_d = 1'b0;
+      end
+      // SetupStop: SDA is pulled low, SCL is released
+      SetupStop : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b0;
+        scl_d = 1'b1;
+      end
+      // HoldStop: SDA and SCL are released
+      HoldStop : begin
+        host_idle_o = 1'b0;
+        sda_d = 1'b1;
+        scl_d = 1'b1;
+        event_cmd_complete_o = 1'b1;
+      end
+      // Active: continue while keeping SCL low
+      Active : begin
+        host_idle_o = 1'b0;
+
+        // If this is a transaction start, do not drive scl low
+        // since in the next state we will drive it high to initiate
+        // the start bit.
+        // If this is a restart, continue driving the clock low.
+        scl_d = fmt_flag_start_before_i && !trans_started;
+      end
+      // PopFmtFifo: populate fmt_fifo
+      PopFmtFifo : begin
+        host_idle_o = 1'b0;
+        if (fmt_flag_stop_after_i) scl_d = 1'b1;
+        else scl_d = 1'b0;
+        fmt_fifo_rready_o = 1'b1;
+      end
+
+      // default
+      default : begin
+        host_idle_o = 1'b1;
+        sda_d = 1'b1;
+        scl_d = 1'b1;
+        fmt_fifo_rready_o = 1'b0;
+        rx_fifo_wvalid_o = 1'b0;
+        rx_fifo_wdata_o = RX_FIFO_WIDTH'(0);
+        event_nak_o = 1'b0;
+        event_scl_interference_o = 1'b0;
+        event_sda_unstable_o = 1'b0;
+        event_cmd_complete_o = 1'b0;
+      end
+    endcase // unique case (state_q)
+  end
+
+  // Conditional state transition
+  always_comb begin : state_functions
+    state_d = state_q;
+    load_tcount = 1'b0;
+    tcount_sel = tNoDelay;
+    bit_decr = 1'b0;
+    bit_clr = 1'b0;
+    byte_decr = 1'b0;
+    byte_clr = 1'b0;
+    read_byte_clr = 1'b0;
+    shift_data_en = 1'b0;
+    log_start = 1'b0;
+    log_stop = 1'b0;
+    req_restart = 1'b0;
+    en_sda_interf_det = 1'b0;
+    host_disable_o = 1'b0;
+
+    unique case (state_q)
+      // Idle: initial state, SDA and SCL are released (high)
+      Idle : begin
+        if (host_enable_i) begin
+          if (fmt_fifo_rvalid_i) state_d = Active;
+        end
+      end
+
+      ///////////////
+      // HOST MODE //
+      ///////////////
+
+      // SetupStart: SDA and SCL are released
+      SetupStart : begin
+        if (tcount_q == 20'd1) begin
+          state_d = HoldStart;
+          load_tcount = 1'b1;
+          tcount_sel = tHoldStart;
+          log_start = 1'b1;
+        end
+      end
+      // HoldStart: SDA is pulled low, SCL is released
+      HoldStart : begin
+        if (tcount_q == 20'd1) begin
+          state_d = ClockStart;
+          load_tcount = 1'b1;
+          tcount_sel = tClockStart;
+        end
+      end
+      // ClockStart: SCL is pulled low, SDA stays low
+      ClockStart : begin
+        if (tcount_q == 20'd1) begin
+          state_d = ClockLow;
+          load_tcount = 1'b1;
+          tcount_sel = tClockLow;
+        end
+      end
+      // ClockLow: SCL stays low, shift indexed bit onto SDA
+      ClockLow : begin
+        en_sda_interf_det = 1'b1;
+        if (tcount_q == 20'd1) begin
+          load_tcount = 1'b1;
+          if (pend_restart) begin
+            state_d = SetupStart;
+            tcount_sel = tSetupStart;
+          end else begin
+            state_d = ClockPulse;
+            tcount_sel = tClockPulse;
+          end
+        end
+      end
+      // ClockPulse: SCL is released, SDA keeps the indexed bit value
+      ClockPulse : begin
+        en_sda_interf_det = 1'b1;
+        if (!scl_i && stretch_predict_cnt_expired) begin
+          // Saw stretching. Remain in this state and don't count down until we see SCL high.
+          load_tcount = 1'b1;
+          tcount_sel = tClockHigh;
+        end else if (tcount_q == 20'd1) begin
+          state_d = HoldBit;
+          load_tcount = 1'b1;
+          tcount_sel = tHoldBit;
+        end
+      end
+      // HoldBit: SCL is pulled low
+      HoldBit : begin
+        en_sda_interf_det = 1'b1;
+        if (tcount_q == 20'd1) begin
+          en_sda_interf_det = 1'b0;
+          load_tcount = 1'b1;
+          tcount_sel = tClockLow;
+          if (bit_index == '0) begin
+            state_d = ClockLowAck;
+            bit_clr = 1'b1;
+          end else begin
+            state_d = ClockLow;
+            bit_decr = 1'b1;
+          end
+        end
+      end
+      // ClockLowAck: Target is allowed to drive ack back
+      // to host (dut)
+      ClockLowAck : begin
+        if (tcount_q == 20'd1) begin
+          state_d = ClockPulseAck;
+          load_tcount = 1'b1;
+          tcount_sel = tClockPulse;
+        end
+      end
+      // ClockPulseAck: SCL is released
+      ClockPulseAck : begin
+        if (!scl_i && stretch_predict_cnt_expired) begin
+          // Saw stretching. Remain in this state and don't count down until we see SCL high.
+          load_tcount = 1'b1;
+          tcount_sel = tClockHigh;
+        end else begin
+          if (unhandled_unexp_nak_i) begin
+            // If we are awaiting software to handle an unexpected NACK, halt the FSM here.
+            // The current transaction does not end, and SCL remains released so the observed
+            // bus behaviour is a very long 9th clock pulse. The next entry from the FMTFIFO
+            // is not popped until the NACK is acknowledged by software.
+            load_tcount = 1'b1;
+            tcount_sel = tClockHigh;
+            if (unhandled_nak_cnt_expired) begin
+              // If our timeout counter expires, generate a STOP condition and disable Host-Mode.
+              state_d = ClockStop;
+              load_tcount = 1'b1;
+              tcount_sel = tClockStop;
+              host_disable_o = 1'b1;
+            end
+          end else if (tcount_q == 20'd1) begin
+            state_d = HoldDevAck;
+            load_tcount = 1'b1;
+            tcount_sel = tHoldBit;
+          end
+        end
+      end
+      // HoldDevAck: SCL is pulled low
+      HoldDevAck : begin
+        if (tcount_q == 20'd1) begin
+          if (fmt_flag_stop_after_i) begin
+            state_d = ClockStop;
+            load_tcount = 1'b1;
+            tcount_sel = tClockStop;
+          end else begin
+            state_d = PopFmtFifo;
+            load_tcount = 1'b1;
+            tcount_sel = tNoDelay;
+          end
+        end
+      end
+      // ReadClockLow: SCL is pulled low, SDA is released
+      ReadClockLow : begin
+        if (tcount_q == 20'd1) begin
+          state_d = ReadClockPulse;
+          load_tcount = 1'b1;
+          tcount_sel = tClockPulse;
+        end
+      end
+      // ReadClockPulse: SCL is released, the indexed bit value is read off SDA
+      ReadClockPulse : begin
+        if (!scl_i && stretch_predict_cnt_expired) begin
+          // Saw stretching. Remain in this state and don't count down until we see SCL high.
+          load_tcount = 1'b1;
+          tcount_sel = tClockHigh;
+        end else if (tcount_q == 20'd1) begin
+          state_d = ReadHoldBit;
+          load_tcount = 1'b1;
+          tcount_sel = tHoldBit;
+          shift_data_en = 1'b1; // SDA is sampled on the final clk_i cycle of the SCL pulse.
+        end
+      end
+      // ReadHoldBit: SCL is pulled low
+      ReadHoldBit : begin
+        if (tcount_q == 20'd1) begin
+          load_tcount = 1'b1;
+          tcount_sel = tClockLow;
+          if (bit_index == '0) begin
+            state_d = HostClockLowAck;
+            bit_clr = 1'b1;
+            read_byte_clr = 1'b1;
+          end else begin
+            state_d = ReadClockLow;
+            bit_decr = 1'b1;
+          end
+        end
+      end
+      // HostClockLowAck: SCL is pulled low, SDA is conditional based on
+      // byte position
+      HostClockLowAck : begin
+        en_sda_interf_det = 1'b1;
+        if (tcount_q == 20'd1) begin
+          state_d = HostClockPulseAck;
+          load_tcount = 1'b1;
+          tcount_sel = tClockPulse;
+        end
+      end
+      // HostClockPulseAck: SCL is released
+      HostClockPulseAck : begin
+        en_sda_interf_det = 1'b1;
+        if (!scl_i && stretch_predict_cnt_expired) begin
+          // Saw stretching. Remain in this state and don't count down until we see SCL high.
+          load_tcount = 1'b1;
+          tcount_sel = tClockHigh;
+        end else if (tcount_q == 20'd1) begin
+          state_d = HostHoldBitAck;
+          load_tcount = 1'b1;
+          tcount_sel = tHoldBit;
+        end
+      end
+      // HostHoldBitAck: SCL is pulled low
+      HostHoldBitAck : begin
+        en_sda_interf_det = 1'b1;
+        if (tcount_q == 20'd1) begin
+          en_sda_interf_det = 1'b0;
+          if (byte_index == 9'd1) begin
+            if (fmt_flag_stop_after_i) begin
+              state_d = ClockStop;
+              load_tcount = 1'b1;
+              tcount_sel = tClockStop;
+            end else begin
+              state_d = PopFmtFifo;
+              load_tcount = 1'b1;
+              tcount_sel = tNoDelay;
+            end
+          end else begin
+            state_d = ReadClockLow;
+            load_tcount = 1'b1;
+            tcount_sel = tClockLow;
+            byte_decr = 1'b1;
+          end
+        end
+      end
+      // ClockStop: SCL is pulled low, SDA stays low
+      ClockStop : begin
+        if (tcount_q == 20'd1) begin
+          state_d = SetupStop;
+          load_tcount = 1'b1;
+          tcount_sel = tSetupStop;
+        end
+      end
+      // SetupStop: SDA is pulled low, SCL is released
+      SetupStop : begin
+        if (tcount_q == 20'd1) begin
+          state_d = HoldStop;
+          load_tcount = 1'b1;
+          tcount_sel = tHoldStop;
+          log_stop = 1'b1;
+        end
+      end
+      // HoldStop: SDA and SCL are released
+      HoldStop : begin
+        en_sda_interf_det = 1'b1;
+        if (tcount_q == 20'd1) begin
+          en_sda_interf_det = 1'b0;
+          if (!host_enable_i) begin
+            state_d = Idle;
+            load_tcount = 1'b1;
+            tcount_sel = tNoDelay;
+          end else begin
+            state_d = PopFmtFifo;
+            load_tcount = 1'b1;
+            tcount_sel = tNoDelay;
+          end
+        end
+      end
+      // Active: continue while keeping SCL low
+      Active : begin
+        if (fmt_flag_read_bytes_i) begin
+          byte_clr = 1'b1;
+          state_d = ReadClockLow;
+          load_tcount = 1'b1;
+          tcount_sel = tClockLow;
+        end else if (fmt_flag_start_before_i && !trans_started) begin
+          state_d = SetupStart;
+          load_tcount = 1'b1;
+          tcount_sel = tSetupStart;
+        end else begin
+          state_d = ClockLow;
+          load_tcount = 1'b1;
+          req_restart = fmt_flag_start_before_i;
+          tcount_sel = tClockLow;
+        end
+      end
+      // PopFmtFifo: populate fmt_fifo
+      PopFmtFifo : begin
+        if (!host_enable_i) begin
+          state_d = ClockStop;
+          load_tcount = 1'b1;
+          tcount_sel = tClockStop;
+        end else if (fmt_fifo_depth_i == 7'h1) begin
+          state_d = Idle;
+          load_tcount = 1'b1;
+          tcount_sel = tNoDelay;
+        end else begin
+          state_d = Active;
+          load_tcount = 1'b1;
+          tcount_sel = tNoDelay;
+        end
+      end
+
+      // default
+      default : begin
+        state_d = Idle;
+        load_tcount = 1'b0;
+        tcount_sel = tNoDelay;
+        bit_decr = 1'b0;
+        bit_clr = 1'b0;
+        byte_decr = 1'b0;
+        byte_clr = 1'b0;
+        read_byte_clr = 1'b0;
+        shift_data_en = 1'b0;
+        log_start = 1'b0;
+        log_stop = 1'b0;
+        host_disable_o = 1'b0;
+      end
+    endcase // unique case (state_q)
+  end
+
+  // Synchronous state transition
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : state_transition
+    if (!rst_ni) begin
+      state_q <= Idle;
+    end else begin
+      state_q <= state_d;
+    end
+  end
+
+  assign scl_o = scl_d;
+  assign sda_o = sda_d;
+
+  // Target stretched clock beyond timeout
+  assign event_stretch_timeout_o = stretch_en &&
+                                   (stretch_idle_cnt[30:0] > stretch_timeout_i) && timeout_enable_i;
+
+  // Make sure we never attempt to send a single cycle glitch
+  `ASSERT(SclOutputGlitch_A, $rose(scl_o) |-> ##1 scl_o)
+
+  // TODO: Handle the assertion below
+//  // I2C bus outputs
+//  always_ff @(posedge clk_i or negedge rst_ni) begin
+//    if (!rst_ni) begin
+//      scl_q <= 1'b1;
+//      sda_q <= 1'b1;
+//    end else begin
+//      scl_q <= scl_d;
+//      sda_q <= sda_d;
+//    end
+//  end
+//
+//  // Check that we don't change SCL and SDA in the same clock cycle in host mode.
+//  `ASSERT(SclSdaChangeNotSimultaneous_A, !(host_enable_i && (scl_d != scl_q) && (sda_d != sda_q)))
+
+endmodule


### PR DESCRIPTION
Split the target and controller FSMs both to simplify the code for better maintainability / readability and to lay the groundwork for multi-controller support. Note that there will likely be some increase in area for duplicated structures here, but it turns out that much of the state was already independent.

Also fix a bug where the controller-mode stretch counter would continue counting cycles even when the target had already released SCL.