### PR TITLE
[bazel,ci] Temporarily disable i2c_host_eeprom_test in CI

### DIFF
--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -285,6 +285,7 @@ opentitan_test(
         tags = [
             "manual",
             "pmod",
+            "skip_in_ci",
         ],  # Requires the PMOD::BoB.
     ),
     exec_env = {


### PR DESCRIPTION
Test is currently broken

Re-enablement tracked in https://github.com/lowRISC/opentitan/issues/22347