### PR TITLE
[dice] move keysave out of keygen function

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -543,7 +543,6 @@ cc_library(
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
-        "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/silicon_creator/lib:attestation",

--- a/sw/device/silicon_creator/lib/dice.c
+++ b/sw/device/silicon_creator/lib/dice.c
@@ -7,7 +7,6 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/memory.h"
-#include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
@@ -130,8 +129,6 @@ rom_error_t dice_attestation_keygen(dice_key_t desired_key,
   // Generate / sideload key material into OTBN, and generate the ECC keypair.
   HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_keygen(
       otbn_ecc_keygen_seed, keymgr_diversifier, pubkey));
-  HARDENED_RETURN_IF_ERROR(
-      otbn_boot_attestation_key_save(otbn_ecc_keygen_seed, keymgr_diversifier));
 
   // Keys are represented in certificates in big endian format, but the key is
   // output from OTBN in little endian format, so we convert the key to

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -228,6 +228,7 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/silicon_creator/lib:attestation_key_diversifiers",
         "//sw/device/silicon_creator/lib:dice",
         "//sw/device/silicon_creator/lib:otbn_boot_services",
         "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -16,6 +16,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/silicon_creator/lib/attestation_key_diversifiers.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
 #include "sw/device/silicon_creator/lib/cert/cdi_0.h"  // Generated.
 #include "sw/device/silicon_creator/lib/cert/cdi_1.h"  // Generated.
@@ -237,6 +238,8 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
   // Generate UDS keys and (TBS) cert.
   sc_keymgr_advance_state();
   TRY(dice_attestation_keygen(kDiceKeyUds, &uds_pubkey_id, &curr_pubkey));
+  TRY(otbn_boot_attestation_key_save(kUdsAttestationKeySeed,
+                                     kUdsKeymgrDiversifier));
   TRY(dice_uds_cert_build(&certgen_inputs, &uds_pubkey_id, &curr_pubkey,
                           dice_certs.uds_tbs_certificate,
                           &dice_certs.uds_tbs_certificate_size));


### PR DESCRIPTION
We only want to save the current stage's attestation private key to OTBN DMEM _after_ we have used the previous stage's private key to endorse our current stage's certificate. This was a slight refactoring error in #22303, since previously, we were always overwriting the prior stage's private key in OTBN DMEM before using it.