### PR TITLE
[edn] Increase version number, revert verification stage to V1

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -17,10 +17,10 @@
   dv_doc:             "../doc/dv",
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_edn",
-  version:            "1.0.0",
+  version:            "2.0.0",
   life_stage:         "L1",
   design_stage:       "D2S",
-  verification_stage: "V2S",
+  verification_stage: "V1",
   dif_stage:          "S2",
   clocking: [{clock: "clk_i", reset: "rst_ni"}],
   bus_interfaces: [

--- a/hw/ip/edn/doc/checklist.md
+++ b/hw/ip/edn/doc/checklist.md
@@ -41,7 +41,7 @@ Type          | Item                      | Resolution  | Note/Collaterals
 Documentation | [NEW_FEATURES][]          | Done        |
 Documentation | [BLOCK_DIAGRAM][]         | Done        |
 Documentation | [DOC_INTERFACE][]         | Done        |
-Documentation | [DOC_INTEGRATION_GUIDE][] | Waived      | This checklist item has been added retrospectively.
+Documentation | [DOC_INTEGRATION_GUIDE][] | N/A         |
 Documentation | [MISSING_FUNC][]          | Done        |
 Documentation | [FEATURE_FROZEN][]        | Done        |
 RTL           | [FEATURE_COMPLETE][]      | Done        |
@@ -188,8 +188,8 @@ Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |
 Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | N/A         |
 Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | N/A         |
 Tests         | [SIM_FW_SIMULATED][]                    | N/A         |
-Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Done        |
-Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        |
+Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | In progress |
+Coverage      | [SIM_CODE_COVERAGE_V2][]                | In progress |
 Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        |
 Coverage      | [FPV_CODE_COVERAGE_V2][]                | N/A         |
 Coverage      | [FPV_COI_COVERAGE_V2][]                 | N/A         |
@@ -227,7 +227,7 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
 Tests         | [FPV_SEC_CM_VERIFIED][]                 | Done        |
 Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | In progress |
 Review        | [SEC_CM_DV_REVIEWED][]                  | Done        | Reviewed on 11/11/2022
 
 [SEC_CM_TESTPLAN_COMPLETED]:          ../../../../doc/project_governance/checklist/README.md#sec_cm_testplan_completed


### PR DESCRIPTION
Since ES tapeout, a couple of API breaking changes had to be implemented. The DV side was mostly updated in sync but there are two reasons why we cannot meet V2S currently:
- The edn_disable_auto_req_mode test has a pass rate below 90%. See lowRISC/OpenTitan#20818.
- The FSM coverage dropped to around 82%. See lowRISC/OpenTitan#22352.