### PR TITLE
[aon_timer] Sign off at D2S

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -21,7 +21,7 @@
   sw_checklist:       "/sw/device/lib/dif/dif_aon_timer",
   version:            "2.0.0",
   life_stage:         "L1",
-  design_stage:       "D2",
+  design_stage:       "D2S",
   verification_stage: "V2S",
   dif_stage:          "S2",
   clocking: [


### PR DESCRIPTION
aon_timer only has the standardized `BUS.INTEGRITY` security countermeasure, and it had been signed off at D2S before the bump to version 2.0.0.  Since aon_timer is not a security-focused block and we have not changed its security design since the previous version, we can directly sign it off at D2S again.  See #20995 for the D2 signoff analysis and PR #21908 for the version change, where going to D2S directly has been suggested post merge.