### PR TITLE
[usbdev] Mark V1 items done in checklist.md

### DIFF
--- a/hw/ip/usbdev/doc/checklist.md
+++ b/hw/ip/usbdev/doc/checklist.md
@@ -123,28 +123,28 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | In Progress | [USB Device DV document](../dv/README.md)
-Documentation | [TESTPLAN_COMPLETED][]                | In Progress | [USB Device Testplan](../dv/README.md#testplan)
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [USB Device DV document](../dv/README.md)
+Documentation | [TESTPLAN_COMPLETED][]                | Done        | [USB Device Testplan](../dv/README.md#testplan)
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |
 Testbench     | [SIM_RAL_MODEL_GEN_AUTOMATED][]       | Done        |
 Testbench     | [CSR_CHECK_GEN_AUTOMATED][]           | Done        |
-Testbench     | [TB_GEN_AUTOMATED][]                  | Not Started |
-Tests         | [SIM_SMOKE_TEST_PASSING][]            | Not Started |
-Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Not Started |
-Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | Not Started |
-Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Not Started |
+Testbench     | [TB_GEN_AUTOMATED][]                  | N/A         |
+Tests         | [SIM_SMOKE_TEST_PASSING][]            | Done        |
+Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Done        |
+Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | N/A         |
+Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Done        |
 Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | Done        |
 Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Done        |
-Regression    | [FPV_REGRESSION_SETUP][]              | Not Started |
+Regression    | [FPV_REGRESSION_SETUP][]              | N/A         |
 Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        |
 Code Quality  | [TB_LINT_SETUP][]                     | Done        |
-Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | Not Started |
-Review        | [DESIGN_SPEC_REVIEWED][]              | Not Started |
-Review        | [TESTPLAN_REVIEWED][]                 | Not Started |
-Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Not Started | Exception (?)
-Review        | [V2_CHECKLIST_SCOPED][]               | Not Started |
+Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | N/A         |
+Review        | [DESIGN_SPEC_REVIEWED][]              | Done        |
+Review        | [TESTPLAN_REVIEWED][]                 | Done        |
+Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done        |
+Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
 [DV_DOC_DRAFT_COMPLETED]:             ../../../../doc/project_governance/checklist/README.md#dv_doc_draft_completed
 [TESTPLAN_COMPLETED]:                 ../../../../doc/project_governance/checklist/README.md#testplan_completed


### PR DESCRIPTION
This follows several(!) V1 review meetings. The last was on March 28,
2024. The changes are as follows:

  DV_DOC_DRAFT_COMPLETED:
      The draft document is now in place. There's some more work to do in order to finish a DV document, but there's a solid draft.

  TESTPLAN_COMPLETED:
      There is a complete testplan in place, which has been reviewed and signed off.

  TB_GEN_AUTOMATED:
      We don't have TB generation for usbdev (past the usual automated CSR tests).

  SIM_SMOKE_TEST_PASSING:
      The smoke test passes with all seeds in nightly tests.

  SIM_CSR_MEM_TEST_SUITE_PASSING:
      Most CSR tests pass with all seeds in nightly tests. The usbdev_csr_bit_bash test is an exception, but still has a 40% pass rate.

  FPV_MAIN_ASSERTIONS_PROVEN:
      This block does not have FPV testing.

  SIM_ALT_TOOL_SETUP:
      Tested with both VCS and Xcelium.

  FPV_REGRESSION_SETUP
      This block does not have FPV testing.

  PRE_VERIFIED_SUB_MODULES_V1
      This block doesn't have pre-verified submodules.

  DESIGN_SPEC_REVIEWED
      This has been done.

  TESTPLAN_REVIEWED
      As above, this has been reviewed and signed off.

  STD_TEST_CATEGORIES_PLANNED:
      These standard test categories fed into the testplan as you'd hope.

  V2_CHECKLIST_SCOPED
      Done. Estimates in issue 22325.