### PR TITLE
[rom_ext] add attestation keygen to ROM_EXT

### DIFF
--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -27,7 +27,7 @@ _stack_start = _stack_end - _stack_size;
  * Size of the `.static_critical` section at the bottom of the main SRAM (in
  * bytes).
  */
-_static_critical_size = 8136;
+_static_critical_size = 8168;
 
 /**
  * `.chip_info` at the top of ROM.

--- a/sw/device/silicon_creator/lib/base/boot_measurements.h
+++ b/sw/device/silicon_creator/lib/base/boot_measurements.h
@@ -28,10 +28,16 @@ typedef struct boot_measurements {
    * binding registers.
    */
   keymgr_binding_value_t rom_ext;
+  /**
+   * BL0 firmware + owner configuration block digest value calculated in
+   * ROM_EXT. Stored in a format that can be consumed by the key manager.
+   */
+  keymgr_binding_value_t bl0;
 } boot_measurements_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_measurements_t, rom_ext, 0);
-OT_ASSERT_SIZE(boot_measurements_t, 32);
+OT_ASSERT_MEMBER_OFFSET(boot_measurements_t, bl0, 32);
+OT_ASSERT_SIZE(boot_measurements_t, 64);
 
 extern boot_measurements_t boot_measurements;
 

--- a/sw/device/silicon_creator/lib/base/static_critical_version.h
+++ b/sw/device/silicon_creator/lib/base/static_critical_version.h
@@ -12,6 +12,10 @@ enum {
    * Static critical region format version 1 value.
    */
   kStaticCriticalVersion1 = 0xb86fa4b0,
+  /**
+   * Static critical region format version 2 value.
+   */
+  kStaticCriticalVersion2 = 0x8d9fc439,
 };
 
 /**

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -76,16 +76,6 @@ static keymgr_binding_value_t sealing_binding_value = {.data = {0}};
 /**
  * Certificate data.
  */
-static const flash_ctrl_perms_t kCertificateFlashInfoPerms = {
-    .read = kMultiBitBool4True,
-    .write = kMultiBitBool4True,
-    .erase = kMultiBitBool4True,
-};
-static const flash_ctrl_cfg_t kCertificateFlashInfoCfg = {
-    .scrambling = kMultiBitBool4True,
-    .ecc = kMultiBitBool4True,
-    .he = kMultiBitBool4False,
-};
 static manuf_certgen_inputs_t certgen_inputs;
 static hmac_digest_t uds_pubkey_id;
 static hmac_digest_t cdi_0_pubkey_id;
@@ -130,16 +120,7 @@ static void sw_reset(void) {
  * Configures flash info pages to store device certificates.
  */
 static status_t config_and_erase_certificate_flash_pages(void) {
-  const flash_ctrl_info_page_t *kCertFlashInfoPages[] = {
-      &kFlashCtrlInfoPageUdsCertificate,
-      &kFlashCtrlInfoPageCdi0Certificate,
-      &kFlashCtrlInfoPageCdi1Certificate,
-  };
-  for (size_t i = 0; i < ARRAYSIZE(kCertFlashInfoPages); ++i) {
-    flash_ctrl_info_cfg_set(kCertFlashInfoPages[i], kCertificateFlashInfoCfg);
-    flash_ctrl_info_perms_set(kCertFlashInfoPages[i],
-                              kCertificateFlashInfoPerms);
-  }
+  flash_ctrl_cert_info_pages_creator_cfg();
   TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageUdsCertificate,
                             kFlashCtrlEraseTypePage));
   TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageCdi0Certificate,

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -131,9 +131,10 @@ static status_t config_and_erase_certificate_flash_pages(void) {
 }
 
 /**
- * Provision OTP SECRET{1,2} partitions, enable flash scrambling, and reboot.
+ * Provision OTP SECRET{1,2} partitions, keymgr flash info pages, enable flash
+ * scrambling, and reboot.
  */
-static status_t personalize_otp_secrets(ujson_t *uj) {
+static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
   // Provision OTP Secret1 partition, and complete provisioning of OTP
   // CreatorSwCfg partition.
   if (!status_ok(manuf_personalize_device_secret1_check(&otp_ctrl))) {
@@ -296,7 +297,7 @@ bool test_main(void) {
   ujson_t uj = ujson_ottf_console();
   log_self_hash();
   CHECK_STATUS_OK(lc_ctrl_testutils_operational_state_check(&lc_ctrl));
-  CHECK_STATUS_OK(personalize_otp_secrets(&uj));
+  CHECK_STATUS_OK(personalize_otp_and_flash_secrets(&uj));
   CHECK_STATUS_OK(personalize_dice_certificates(&uj));
   return true;
 }

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -135,7 +135,7 @@ static rom_error_t rom_init(void) {
   uart_init(kUartNCOValue);
 
   // Set static_critical region format version.
-  static_critical_version = kStaticCriticalVersion1;
+  static_critical_version = kStaticCriticalVersion2;
 
   // There are no conditional checks before writing to this CSR because it is
   // expected that if relevant Ibex countermeasures are disabled, this will

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -228,6 +228,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:boot_log",
         "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib:dice",
         "//sw/device/silicon_creator/lib:manifest",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/lib:otbn_boot_services",

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -74,7 +74,7 @@ _stack_start = _stack_end - _stack_size;
  * Size of the `.static_critical` section at the bottom of the main SRAM (in
  * bytes).
  */
-_static_critical_size = 8136;
+_static_critical_size = 8168;
 
 /**
  * `.chip_info` at the top of ROM.


### PR DESCRIPTION
This partially addresses #21583 and #19588 by cranking the keymgr and generating attestation keys in the ROM_EXT.