### PR TITLE
Replace struct/command identifiers with "FourCC" codes.

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -92,6 +92,7 @@ cc_library(
     srcs = ["boot_log.c"],
     hdrs = ["boot_log.h"],
     deps = [
+        ":boot_data",
         ":nonce",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:chip_info",

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -552,7 +552,7 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
       otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_MIN_SEC_VER_ROM_EXT_OFFSET);
   boot_data->min_security_version_bl0 =
       otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_MIN_SEC_VER_BL0_OFFSET);
-  boot_data->primary_bl0_slot = kBootDataSlotA;
+  boot_data->primary_bl0_slot = kBootSlotA;
   // We cannot use a constant digest since some fields are read from the OTP
   // and we check the digest of the cached boot data entry in rom.c
   boot_data_digest_compute(boot_data, &boot_data->digest);
@@ -576,7 +576,7 @@ static rom_error_t boot_data_as_v2(boot_data_t *boot_data) {
   switch (launder32(boot_data->version)) {
     case kBootDataVersion1:
       HARDENED_CHECK_EQ(boot_data->version, kBootDataVersion1);
-      boot_data->primary_bl0_slot = kBootDataSlotA;
+      boot_data->primary_bl0_slot = kBootSlotA;
       boot_data->version = kBootDataVersion2;
       boot_data_digest_compute(boot_data, &boot_data->digest);
       return kErrorOk;

--- a/sw/device/silicon_creator/lib/boot_data.h
+++ b/sw/device/silicon_creator/lib/boot_data.h
@@ -156,20 +156,15 @@ static_assert(kBootDataValidEntry ==
                   ((uint64_t)kFlashCtrlErasedWord << 32 | kFlashCtrlErasedWord),
               "kBootDataValidEntry words must be kFlashCtrlErasedWord");
 
-/*
- * Encoding generated with
- * $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 32 \
- *     -s 3436204326 --language=c
- *
- * Minimum Hamming distance: 12
- * Maximum Hamming distance: 12
- * Minimum Hamming weight: 15
- * Maximum Hamming weight: 15
+/**
+ * Constants referring to EFLASH slots A and B.
  */
-enum {
-  kBootDataSlotA = 0x9cdc8d50,
-  kBootDataSlotB = 0xcd598a4a,
-};
+typedef enum boot_slot {
+  /** Slot A: `AA__`. */
+  kBootSlotA = 0x5f5f4141,
+  /** Slot B: `__BB`. */
+  kBootSlotB = 0x42425f5f,
+} boot_slot_t;
 
 /**
  * Reads the boot data stored in the flash info partition.

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -29,15 +29,23 @@ static const flash_ctrl_info_page_t *kPages[2] = {
  * Boot data entry used in tests.
  */
 boot_data_t kTestBootData = (boot_data_t){
-    .digest = {{0x8ee18396, 0xbc21d5de, 0x288c27bb, 0x7388061c, 0xe7382e8a,
-                0x8af122bc, 0xd851f67a, 0xdcc440a2}},
+    .digest = {{
+        0x44e757cb,
+        0x19899a04,
+        0xf872d77f,
+        0x58361229,
+        0x48d748f1,
+        0xfcafabf1,
+        0x4fbc4153,
+        0x0f05e1c9,
+    }},
     .identifier = kBootDataIdentifier,
     .version = kBootDataVersion2,
     .is_valid = kBootDataValidEntry,
     // `kBootDataDefaultCounterVal` + 1 for consistency.
     .counter = kBootDataDefaultCounterVal + 1,
     .min_security_version_rom_ext = 0,
-    .primary_bl0_slot = kBootDataSlotA,
+    .primary_bl0_slot = kBootSlotA,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/boot_data_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_data_unittest.cc
@@ -37,7 +37,7 @@ constexpr boot_data_t kValidEntry0 = {
     .counter = kBootDataDefaultCounterVal,
     .min_security_version_rom_ext = 0,
     .min_security_version_bl0 = 0,
-    .primary_bl0_slot = kBootDataSlotA,
+    .primary_bl0_slot = kBootSlotA,
 };
 
 /**
@@ -52,7 +52,7 @@ constexpr boot_data_t kValidEntry1 = {
     .counter = kBootDataDefaultCounterVal + 1,
     .min_security_version_rom_ext = 0,
     .min_security_version_bl0 = 0,
-    .primary_bl0_slot = kBootDataSlotA,
+    .primary_bl0_slot = kBootSlotA,
 };
 
 /**
@@ -81,7 +81,7 @@ constexpr boot_data_t kDefaultEntry = {
     .counter = kBootDataDefaultCounterVal,
     .min_security_version_rom_ext = 0x01234567,
     .min_security_version_bl0 = 0x89abcdef,
-    .primary_bl0_slot = kBootDataSlotA,
+    .primary_bl0_slot = kBootSlotA,
 };
 
 namespace boot_data_unittest {

--- a/sw/device/silicon_creator/lib/boot_log.c
+++ b/sw/device/silicon_creator/lib/boot_log.c
@@ -83,7 +83,7 @@ void boot_log_check_or_init(boot_log_t *boot_log, uint32_t rom_ext_slot,
   boot_log->chip_version.scm_revision_high =
       info->scm_revision.scm_revision_high;
   boot_log->rom_ext_slot = rom_ext_slot;
-  boot_log->bl0_slot = kBootLogUninitialized;
+  boot_log->bl0_slot = 0;  // Unknown: no BL0 slot selected yet.
   for (size_t i = 0; i < ARRAYSIZE(boot_log->reserved); ++i) {
     boot_log->reserved[i] = 0;
   }

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/chip_info.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -28,7 +29,7 @@ typedef struct boot_log {
   uint32_t identifier;
   /** Chip version (from the ROM). */
   chip_info_scm_revision_t chip_version;
-  /** Which ROM_EXT slot booted. */
+  /** Which ROM_EXT slot booted (boot_slot_t). */
   uint32_t rom_ext_slot;
   /** ROM_EXT major version number. */
   uint16_t rom_ext_major;
@@ -38,7 +39,7 @@ typedef struct boot_log {
   uint32_t rom_ext_size;
   /** ROM_EXT nonce for challenge/response boot_svc commands. */
   nonce_t rom_ext_nonce;
-  /** Which BL0 slot booted. */
+  /** Which BL0 slot booted (boot_slot_t). */
   uint32_t bl0_slot;
   /** Chip ownership state. */
   uint32_t ownership_state;
@@ -63,28 +64,6 @@ enum {
    * Boot log identifier value (ASCII "BLOG").
    */
   kBootLogIdentifier = 0x474f4c42,
-
-  /**
-   * Boot Slot designators
-   *
-   * Encoding generated with:
-   * $ ./util/design/sparse-fsm-encode.py -d 6 -m 5 -n 32 \
-   *     -s 2335952935 --language=c
-   *
-   * Minimum Hamming distance: 12
-   * Maximum Hamming distance: 21
-   * Minimum Hamming weight: 18
-   * Maximum Hamming weight: 22
-   */
-  kRomExtBootSlotA = 0x5abf68ea,
-  kRomExtBootSlotB = 0x53ebdf83,
-  kBl0BootSlotA = 0xb851f57e,
-  kBl0BootSlotB = 0x17cfb6bf,
-
-  /**
-   * Indicates an unpopulated field in the boot log.
-   */
-  kBootLogUninitialized = 0xe67f0d52,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -32,9 +32,9 @@ typedef struct boot_log {
   /** Which ROM_EXT slot booted (boot_slot_t). */
   uint32_t rom_ext_slot;
   /** ROM_EXT major version number. */
-  uint16_t rom_ext_major;
+  uint32_t rom_ext_major;
   /** ROM_EXT minor version number. */
-  uint16_t rom_ext_minor;
+  uint32_t rom_ext_minor;
   /** ROM_EXT size in flash. */
   uint32_t rom_ext_size;
   /** ROM_EXT nonce for challenge/response boot_svc commands. */
@@ -44,7 +44,7 @@ typedef struct boot_log {
   /** Chip ownership state. */
   uint32_t ownership_state;
   /** Pad to 128 bytes. */
-  uint32_t reserved[14];
+  uint32_t reserved[13];
 } boot_log_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, digest, 0);
@@ -52,12 +52,12 @@ OT_ASSERT_MEMBER_OFFSET(boot_log_t, identifier, 32);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, chip_version, 36);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_slot, 44);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_major, 48);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_minor, 50);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_size, 52);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_nonce, 56);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_slot, 64);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, ownership_state, 68);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 72);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_minor, 52);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_size, 56);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_nonce, 60);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_slot, 68);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, ownership_state, 72);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 76);
 
 enum {
   /**

--- a/sw/device/silicon_creator/lib/boot_log_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_log_unittest.cc
@@ -51,8 +51,8 @@ class BootLogTest : public rom_test::RomTest {
       .scm_revision_high = 0xcafecafe,
   };
 
-  uint32_t expected_rom_ext_slot = kRomExtBootSlotA;
-  uint32_t expected_bl0_slot = kBl0BootSlotB;
+  uint32_t expected_rom_ext_slot = kBootSlotA;
+  uint32_t expected_bl0_slot = kBootSlotB;
 
   boot_log_t boot_log = {
       .digest = expected_digest,

--- a/sw/device/silicon_creator/lib/boot_svc/BUILD
+++ b/sw/device/silicon_creator/lib/boot_svc/BUILD
@@ -133,6 +133,7 @@ cc_library(
     deps = [
         ":boot_svc_header",
         "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:chip",
     ],

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h
@@ -15,7 +15,8 @@ extern "C" {
 #endif  // __cplusplus
 
 enum {
-  kBootSvcEmptyType = 0xb4594546,
+  /** Empty boot services request: `EMPT`. */
+  kBootSvcEmptyType = 0x54504d45,
   kBootSvcEmptyPayloadWordCount =
       CHIP_BOOT_SVC_MSG_PAYLOAD_SIZE_MAX / sizeof(uint32_t),
 };

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_header_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_header_unittest.cc
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_header.h"
 
+#include <array>
 #include <cstring>
 
 #include "gtest/gtest.h"

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_min_bl0_sec_ver.h
@@ -15,19 +15,11 @@
 extern "C" {
 #endif  // __cplusplus
 
-/*
- * Encoding generated with
- * $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 32 \
- *     -s 1625797253 --language=c
- *
- * Minimum Hamming distance: 20
- * Maximum Hamming distance: 20
- * Minimum Hamming weight: 17
- * Maximum Hamming weight: 19
- */
 enum {
-  kBootSvcMinBl0SecVerReqType = 0xdac59e6e,
-  kBootSvcMinBl0SecVerResType = 0x756385f1,
+  /** Minimum BL0 security version request: `MSEC` */
+  kBootSvcMinBl0SecVerReqType = 0x4345534d,
+  /** Minimum BL0 security version response: `CESM` */
+  kBootSvcMinBl0SecVerResType = 0x4d534543,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h
@@ -18,19 +18,6 @@ extern "C" {
 
 enum {
   /*
-   * Encoding generated with
-   * $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 32 \
-   *     -s 2121036560 --language=c
-   *
-   * Minimum Hamming distance: 14
-   * Maximum Hamming distance: 14
-   * Minimum Hamming weight: 11
-   * Maximum Hamming weight: 13
-   */
-  kBootSvcNextBootBl0SlotA = 0x08c0d499,
-  kBootSvcNextBootBl0SlotB = 0x7821e03a,
-
-  /*
    *  Encoding generated with
    *  $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 32 \
    *      -s 3290097361 --language=c

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h
@@ -17,18 +17,10 @@ extern "C" {
 #endif  // __cplusplus
 
 enum {
-  /*
-   *  Encoding generated with
-   *  $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 32 \
-   *      -s 3290097361 --language=c
-   *
-   * Minimum Hamming distance: 15
-   * Maximum Hamming distance: 15
-   * Minimum Hamming weight: 16
-   * Maximum Hamming weight: 19
-   */
-  kBootSvcNextBl0SlotReqType = 0xe1edf546,
-  kBootSvcNextBl0SlotResType = 0x657051be,
+  /** Next BL0 slot request: `NEXT`. */
+  kBootSvcNextBl0SlotReqType = 0x5458454e,
+  /** Next BL0 slot response: `TXEN`. */
+  kBootSvcNextBl0SlotResType = 0x4e455854,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot_unittest.cc
@@ -5,6 +5,7 @@
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_next_boot_bl0_slot.h"
 
 #include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/boot_svc/mock_boot_svc_header.h"
 #include "sw/device/silicon_creator/testing/rom_test.h"
 
@@ -18,7 +19,7 @@ class BootSvcNextBootBl0SlotTest : public rom_test::RomTest {
 
 TEST_F(BootSvcNextBootBl0SlotTest, ReqInit) {
   boot_svc_next_boot_bl0_slot_req_t msg{};
-  constexpr uint32_t kNextSlot = kBootSvcNextBootBl0SlotB;
+  constexpr uint32_t kNextSlot = kBootSlotB;
   EXPECT_CALL(boot_svc_header_,
               Finalize(kBootSvcNextBl0SlotReqType, sizeof(msg), &msg.header));
 

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h
@@ -19,10 +19,10 @@ extern "C" {
 #endif  // __cplusplus
 
 enum {
-  // ASCII: AORQ.
-  kBootSvcOwnershipActivateReqType = 0x51524f41,
-  // ASCII: AORS.
-  kBootSvcOwnershipActivateResType = 0x53524f41,
+  /** Ownership activate request: `ACTV`. */
+  kBootSvcOwnershipActivateReqType = 0x56544341,
+  /** Ownership activate response: `VTCA`. */
+  kBootSvcOwnershipActivateResType = 0x41435456,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
@@ -28,10 +28,10 @@ enum {
   // ASCII: ABRT
   kBootSvcUnlockAbort = 0x54524241,
 
-  // ASCII: UNRQ.
-  kBootSvcOwnershipUnlockReqType = 0x51524e55,
-  // ASCII: UNRS.
-  kBootSvcOwnershipUnlockResType = 0x53524e55,
+  /** Ownership unlock request: `UNLK`. */
+  kBootSvcOwnershipUnlockReqType = 0x4b4c4e55,
+  /** Ownership unlock response: `KLNU`. */
+  kBootSvcOwnershipUnlockResType = 0x554e4c4b,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot.h
@@ -15,19 +15,11 @@
 extern "C" {
 #endif  // __cplusplus
 
-/*
- * Encoding generated with
- * $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 32 \
- *     -s 3799858683 --language=c
- *
- * Minimum Hamming distance: 17
- * Maximum Hamming distance: 17
- * Minimum Hamming weight: 14
- * Maximum Hamming weight: 17
- */
 enum {
-  kBootSvcPrimaryBl0SlotReqType = 0x3d6c47b8,
-  kBootSvcPrimaryBl0SlotResType = 0xf2a4a609,
+  /** Primary BL0 slot request: `PRIM`. */
+  kBootSvcPrimaryBl0SlotReqType = 0x4d495250,
+  /** Primary BL0 slot response: `MIRP`. */
+  kBootSvcPrimaryBl0SlotResType = 0x5052494d,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_primary_bl0_slot_unittest.cc
@@ -19,7 +19,7 @@ class BootSvcPrimaryBl0SlotTest : public rom_test::RomTest {
 
 TEST_F(BootSvcPrimaryBl0SlotTest, ReqInit) {
   boot_svc_primary_bl0_slot_req_t msg{};
-  constexpr uint32_t kPrimarySlot = kBootDataSlotB;
+  constexpr uint32_t kPrimarySlot = kBootSlotB;
   EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcPrimaryBl0SlotReqType,
                                          sizeof(msg), &msg.header));
 
@@ -34,10 +34,10 @@ TEST_F(BootSvcPrimaryBl0SlotTest, ResInit) {
   EXPECT_CALL(boot_svc_header_, Finalize(kBootSvcPrimaryBl0SlotResType,
                                          sizeof(msg), &msg.header));
 
-  boot_svc_primary_bl0_slot_res_init(kBootDataSlotB, kStatus, &msg);
+  boot_svc_primary_bl0_slot_res_init(kBootSlotB, kStatus, &msg);
 
   EXPECT_EQ(msg.status, kStatus);
-  EXPECT_EQ(msg.primary_bl0_slot, kBootDataSlotB);
+  EXPECT_EQ(msg.primary_bl0_slot, kBootSlotB);
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.c
@@ -46,16 +46,17 @@ rom_error_t retention_sram_check_version(void) {
   retention_sram_t *rr = retention_sram_get();
   switch (rr->version) {
     case kRetentionSramVersion1:
-      // Version 1 can be in-place upgraded to version 3.
-      rr->version = kRetentionSramVersion3;
+      // Version 1 can be in-place upgraded to version 4.
+      rr->version = kRetentionSramVersion4;
+      break;
+    case kRetentionSramVersion4:
+      // Nothing to do for version 4.
       break;
     case kRetentionSramVersion3:
-      // Nothing to do for version 3.
-      break;
     case kRetentionSramVersion2:
     default:
-      // Version 2 never went into a product, so we should never see it.
-      // Other versions are not defined.
+      // Versions 2 and 3 never went into a product, so we should never see
+      // them.  Other versions are not defined.
       return kErrorRetRamBadVersion;
   }
   return kErrorOk;

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.h
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.h
@@ -142,6 +142,12 @@ enum {
    * and the a recognizable ASCII tag of `RR03`.
    */
   kRetentionSramVersion3 = 0x33305252,
+  /**
+   * Version 4 is the same layout as 3, but all identifiers and commands have
+   * been changed to use "FourCC" style values.  Version 4 is identified by
+   * the ASCII tag `RR04`.
+   */
+  kRetentionSramVersion4 = 0x34305252,
 };
 
 /**

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_next_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_next_test.c
@@ -15,8 +15,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 static status_t initialize(retention_sram_t *retram, boot_svc_retram_t *state) {
   boot_svc_msg_t msg = {0};
-  boot_svc_next_boot_bl0_slot_req_init(kBootSvcNextBootBl0SlotB,
-                                       &msg.next_boot_bl0_slot_req);
+  boot_svc_next_boot_bl0_slot_req_init(kBootSlotB, &msg.next_boot_bl0_slot_req);
   retram->creator.boot_svc_msg = msg;
   state->state = kBootSvcTestStateNextSideB;
   rstmgr_reset();
@@ -49,6 +48,7 @@ static status_t next_bl0_slot_test(void) {
 
   for (;;) {
     LOG_INFO("Test state = %d", state->state);
+    LOG_INFO("CurrentBootLog: %d:%s", state->boots, state->partition);
     switch (state->state) {
       case kBootSvcTestStateInit:
         TRY(initialize(retram, state));

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.c
@@ -29,9 +29,9 @@ status_t boot_svc_test_init(retention_sram_t *retram, boot_svc_test_t test) {
     state->test = test;
     state->state = kBootSvcTestStateInit;
   }
-  state->current_side = (boot_log->bl0_slot == kBl0BootSlotA)   ? 'A'
-                        : (boot_log->bl0_slot == kBl0BootSlotB) ? 'B'
-                                                                : 'x';
+  state->current_side = (boot_log->bl0_slot == kBootSlotA)   ? 'A'
+                        : (boot_log->bl0_slot == kBootSlotB) ? 'B'
+                                                             : 'x';
   state->partition[state->boots] = state->current_side;
   state->boots += 1;
   return OK_STATUS();

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -89,11 +89,11 @@ opentitan_test(
             # Set next slot via the rescue protocol
             --exec="rescue boot-svc set-next-bl0-slot SlotB"
             # Check for firmware execution in slot B
-            --exec="console --non-interactive --exit-success='bl0_slot = B\r\n' --exit-failure='{exit_failure}'"
+            --exec="console --non-interactive --exit-success='bl0_slot = __BB\r\n' --exit-failure='{exit_failure}'"
             # Reset and observe return to slot A.
             --exec="gpio apply RESET"
             --exec="gpio remove RESET"
-            --exec="console --non-interactive --exit-success='bl0_slot = A\r\n' --exit-failure='{exit_failure}'"
+            --exec="console --non-interactive --exit-success='bl0_slot = AA__\r\n' --exit-failure='{exit_failure}'"
             no-op
         """,
     ),
@@ -119,15 +119,15 @@ opentitan_test(
             # Set primary slot via the rescue protocol
             --exec="rescue boot-svc set-primary-bl0-slot SlotB"
             # Check for firmware execution in slot B
-            --exec="console --non-interactive --exit-success='bl0_slot = B\r\n' --exit-failure='{exit_failure}'"
+            --exec="console --non-interactive --exit-success='bl0_slot = __BB\r\n' --exit-failure='{exit_failure}'"
             # Reset and observe continued execution in slot B
             --exec="gpio apply RESET"
             --exec="gpio remove RESET"
-            --exec="console --non-interactive --exit-success='bl0_slot = B\r\n' --exit-failure='{exit_failure}'"
+            --exec="console --non-interactive --exit-success='bl0_slot = __BB\r\n' --exit-failure='{exit_failure}'"
             # Set primary slot via the rescue protocol
             --exec="rescue boot-svc set-primary-bl0-slot SlotA"
             # Check for firmware execution in slot A
-            --exec="console --non-interactive --exit-success='bl0_slot = A\r\n' --exit-failure='{exit_failure}'"
+            --exec="console --non-interactive --exit-success='bl0_slot = AA__\r\n' --exit-failure='{exit_failure}'"
             no-op
         """,
     ),

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
@@ -12,31 +12,19 @@ OTTF_DEFINE_TEST_CONFIG();
 
 status_t boot_log_print(boot_log_t *boot_log) {
   TRY(boot_log_check(boot_log));
-  LOG_INFO("boot_log identifier = %08x", boot_log->identifier);
+  LOG_INFO("boot_log identifier = %C", boot_log->identifier);
   LOG_INFO("boot_log chip_version = %08x%08x",
            boot_log->chip_version.scm_revision_high,
            boot_log->chip_version.scm_revision_low);
-  LOG_INFO("boot_log rom_ext_slot = %s",
-           (boot_log->rom_ext_slot == kRomExtBootSlotA)   ? "A"
-           : (boot_log->rom_ext_slot == kRomExtBootSlotB) ? "B"
-                                                          : "error");
+
+  LOG_INFO("boot_log rom_ext_slot = %C", boot_log->rom_ext_slot);
   LOG_INFO("boot_log rom_ext_version = %d.%d", boot_log->rom_ext_major,
            boot_log->rom_ext_minor);
   LOG_INFO("boot_log rom_ext_size = 0x%08x", boot_log->rom_ext_size);
   LOG_INFO("boot_log rom_ext_nonce = %08x%08x",
            boot_log->rom_ext_nonce.value[1], boot_log->rom_ext_nonce.value[0]);
-  LOG_INFO("boot_log bl0_slot = %s", (boot_log->bl0_slot == kBl0BootSlotA) ? "A"
-                                     : (boot_log->bl0_slot == kBl0BootSlotB)
-                                         ? "B"
-                                         : "error");
-  ownership_state_t os = boot_log->ownership_state;
-  LOG_INFO("boot_log ownership_state = %s",
-           os == kOwnershipStateLockedOwner        ? "LockedOwner"
-           : os == kOwnershipStateLockedUpdate     ? "LockedUpdate"
-           : os == kOwnershipStateUnlockedAny      ? "UnlockedAny"
-           : os == kOwnershipStateUnlockedEndorsed ? "UnlockedEndorsed"
-                                                   : "LockedNone");
-
+  LOG_INFO("boot_log bl0_slot = %C", boot_log->bl0_slot);
+  LOG_INFO("boot_log ownership_state = %C", boot_log->ownership_state);
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -112,15 +112,15 @@ static uint32_t rom_ext_current_slot(void) {
       kFlashSlotA + TOP_EARLGREY_FLASH_CTRL_MEM_SIZE_BYTES;
   if (pc >= kFlashSlotA && pc < kFlashSlotB) {
     // Running in Slot A.
-    return kRomExtBootSlotA;
+    return kBootSlotA;
   } else if (pc >= kFlashSlotB && pc < kFlashSlotEnd) {
     // Running in Slot B.
-    return kRomExtBootSlotB;
+    return kBootSlotB;
   } else {
     // Running elsewhere (ie: the remap window).
     // TODO: read the remap register configuration to determine the execution
     // slot.
-    return kBootLogUninitialized;
+    return 0;
   }
 }
 
@@ -462,13 +462,13 @@ static rom_error_t boot_svc_next_boot_bl0_slot_handler(
   // This will cause a one-time boot of the requested side.
   rom_error_t error = kErrorOk;
   switch (launder32(msg_bl0_slot)) {
-    case kBootSvcNextBootBl0SlotA:
-      HARDENED_CHECK_EQ(msg_bl0_slot, kBootSvcNextBootBl0SlotA);
-      boot_data->primary_bl0_slot = kBootDataSlotA;
+    case kBootSlotA:
+      HARDENED_CHECK_EQ(msg_bl0_slot, kBootSlotA);
+      boot_data->primary_bl0_slot = kBootSlotA;
       break;
-    case kBootSvcNextBootBl0SlotB:
-      HARDENED_CHECK_EQ(msg_bl0_slot, kBootSvcNextBootBl0SlotB);
-      boot_data->primary_bl0_slot = kBootDataSlotB;
+    case kBootSlotB:
+      HARDENED_CHECK_EQ(msg_bl0_slot, kBootSlotB);
+      boot_data->primary_bl0_slot = kBootSlotB;
       break;
     default:
       error = kErrorBootSvcBadSlot;
@@ -492,12 +492,12 @@ static rom_error_t boot_svc_primary_boot_bl0_slot_handler(
   if (launder32(active_slot) != launder32(requested_slot)) {
     HARDENED_CHECK_NE(active_slot, requested_slot);
     switch (launder32(requested_slot)) {
-      case kBootDataSlotA:
-        HARDENED_CHECK_EQ(requested_slot, kBootDataSlotA);
+      case kBootSlotA:
+        HARDENED_CHECK_EQ(requested_slot, kBootSlotA);
         boot_data->primary_bl0_slot = requested_slot;
         break;
-      case kBootDataSlotB:
-        HARDENED_CHECK_EQ(requested_slot, kBootDataSlotB);
+      case kBootSlotB:
+        HARDENED_CHECK_EQ(requested_slot, kBootSlotB);
         boot_data->primary_bl0_slot = requested_slot;
         break;
       default:
@@ -606,9 +606,9 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data) {
 
     boot_log_t *boot_log = &retention_sram_get()->creator.boot_log;
     if (manifests.ordered[i] == rom_ext_boot_policy_manifest_a_get()) {
-      boot_log->bl0_slot = kBl0BootSlotA;
+      boot_log->bl0_slot = kBootSlotA;
     } else if (manifests.ordered[i] == rom_ext_boot_policy_manifest_b_get()) {
-      boot_log->bl0_slot = kBl0BootSlotB;
+      boot_log->bl0_slot = kBootSlotB;
     } else {
       return kErrorRomExtBootFailed;
     }

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -147,6 +147,8 @@ static rom_error_t rom_ext_init(boot_data_t *boot_data) {
   HARDENED_RETURN_IF_ERROR(ast_patch(lc_state));
 
   // Check that the retention RAM is initialized.
+  // TODO(lowrisc#22387): Check if return-if-error here is a potential
+  // boot-loop.
   HARDENED_RETURN_IF_ERROR(retention_sram_check_version());
 
   // Get the boot_data record

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.c
@@ -15,13 +15,13 @@ rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(
   const manifest_t *slot_b = rom_ext_boot_policy_manifest_b_get();
   uint32_t slot = boot_data->primary_bl0_slot;
   switch (launder32(slot)) {
-    case kBootDataSlotA:
-      HARDENED_CHECK_EQ(slot, kBootDataSlotA);
+    case kBootSlotA:
+      HARDENED_CHECK_EQ(slot, kBootSlotA);
       return (rom_ext_boot_policy_manifests_t){
           .ordered = {slot_a, slot_b},
       };
-    case kBootDataSlotB:
-      HARDENED_CHECK_EQ(slot, kBootDataSlotB);
+    case kBootSlotB:
+      HARDENED_CHECK_EQ(slot, kBootSlotB);
       return (rom_ext_boot_policy_manifests_t){
           .ordered = {slot_b, slot_a},
       };

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_unittest.cc
@@ -98,15 +98,15 @@ TEST_P(ManifestOrderTest, ManifestsGet) {
       .WillOnce(Return(&manifest_b));
 
   boot_data_t boot_data{};
-  if (GetParam().primary == kBootDataSlotA) {
-    boot_data.primary_bl0_slot = kBootDataSlotA;
+  if (GetParam().primary == kBootSlotA) {
+    boot_data.primary_bl0_slot = kBootSlotA;
   } else {
-    boot_data.primary_bl0_slot = kBootDataSlotB;
+    boot_data.primary_bl0_slot = kBootSlotB;
   }
 
   rom_ext_boot_policy_manifests_t res =
       rom_ext_boot_policy_manifests_get(&boot_data);
-  if (GetParam().primary == kBootDataSlotA) {
+  if (GetParam().primary == kBootSlotA) {
     EXPECT_EQ(res.ordered[0], &manifest_a);
     EXPECT_EQ(res.ordered[1], &manifest_b);
   } else {
@@ -118,10 +118,10 @@ TEST_P(ManifestOrderTest, ManifestsGet) {
 INSTANTIATE_TEST_SUITE_P(SecurityVersionCases, ManifestOrderTest,
                          testing::Values(
                              ManifestOrderTestCase{
-                                 .primary = kBootDataSlotA,
+                                 .primary = kBootSlotA,
                              },
                              ManifestOrderTestCase{
-                                 .primary = kBootDataSlotB,
+                                 .primary = kBootSlotB,
                              }));
 }  // namespace
 }  // namespace manifest_unittest

--- a/sw/host/opentitanlib/src/chip/boot_log.rs
+++ b/sw/host/opentitanlib/src/chip/boot_log.rs
@@ -40,9 +40,9 @@ pub struct BootLog {
     /// The boot slot the ROM chose to boot the ROM_EXT.
     pub rom_ext_slot: BootSlot,
     /// The ROM_EXT major version number.
-    pub rom_ext_major: u16,
+    pub rom_ext_major: u32,
     /// The ROM_EXT minor version number.
-    pub rom_ext_minor: u16,
+    pub rom_ext_minor: u32,
     /// The ROM_EXT size in bytes.
     #[annotate(format=hex)]
     pub rom_ext_size: u32,
@@ -55,7 +55,7 @@ pub struct BootLog {
     pub ownership_state: OwnershipState,
     /// Reserved for future use.
     #[annotate(format=hex)]
-    pub reserved: [u32; 14],
+    pub reserved: [u32; 13],
 }
 
 impl TryFrom<&[u8]> for BootLog {
@@ -73,8 +73,8 @@ impl TryFrom<&[u8]> for BootLog {
         val.identifier = reader.read_u32::<LittleEndian>()?;
         val.chip_version = reader.read_u64::<LittleEndian>()?;
         val.rom_ext_slot = BootSlot(reader.read_u32::<LittleEndian>()?);
-        val.rom_ext_major = reader.read_u16::<LittleEndian>()?;
-        val.rom_ext_minor = reader.read_u16::<LittleEndian>()?;
+        val.rom_ext_major = reader.read_u32::<LittleEndian>()?;
+        val.rom_ext_minor = reader.read_u32::<LittleEndian>()?;
         val.rom_ext_size = reader.read_u32::<LittleEndian>()?;
         val.rom_ext_nonce = reader.read_u64::<LittleEndian>()?;
         val.bl0_slot = BootSlot(reader.read_u32::<LittleEndian>()?);

--- a/sw/host/opentitanlib/src/chip/boot_log.rs
+++ b/sw/host/opentitanlib/src/chip/boot_log.rs
@@ -9,18 +9,11 @@ use serde_annotate::Annotate;
 use sha2::{Digest, Sha256};
 use std::convert::TryFrom;
 
+use super::boot_svc::BootSlot;
 use super::ChipDataError;
 use crate::with_unknown;
 
 with_unknown! {
-    pub enum BootSlot: u32 [default = Self::Unknown] {
-        Unknown = 0,
-        RomExtBootSlotA = 0x5abf68ea,
-        RomExtBootSlotB = 0x53ebdf83,
-        Bl0BootSlotA = 0xb851f57e,
-        Bl0BootSlotB = 0x17cfb6bf,
-    }
-
     pub enum OwnershipState: u32 [default = Self::None] {
         None = 0,
         LockedOwner = 0x444e574f,

--- a/sw/host/opentitanlib/src/chip/boot_svc.rs
+++ b/sw/host/opentitanlib/src/chip/boot_svc.rs
@@ -16,16 +16,10 @@ use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey, EcdsaRawPublicKey, E
 use crate::with_unknown;
 
 with_unknown! {
-    pub enum NextBootBl0: u32 [default = Self::Unknown] {
+    pub enum BootSlot: u32 [default = Self::Unknown] {
         Unknown = 0,
-        SlotA = 0x08c0d499,
-        SlotB = 0x7821e03a,
-    }
-
-    pub enum BootDataSlot: u32 [default = Self::Unknown] {
-        Unknown = 0,
-        SlotA = 0x9cdc8d50,
-        SlotB = 0xcd598a4a,
+        SlotA = u32::from_le_bytes(*b"AA__"),
+        SlotB = u32::from_le_bytes(*b"__BB"),
     }
 
     /// The unlock mode for the OwnershipUnlock command.
@@ -99,7 +93,7 @@ pub struct MinBl0SecVerResponse {
 #[derive(Debug, Default, Serialize, Annotate)]
 pub struct NextBl0SlotRequest {
     /// The slot to boot.
-    pub next_bl0_slot: NextBootBl0,
+    pub next_bl0_slot: BootSlot,
 }
 
 /// Response to the set next boot slot request.
@@ -113,14 +107,14 @@ pub struct NextBl0SlotResponse {
 #[derive(Debug, Default, Serialize, Annotate)]
 pub struct PrimaryBl0SlotRequest {
     /// The slot to boot.
-    pub primary_bl0_slot: BootDataSlot,
+    pub primary_bl0_slot: BootSlot,
 }
 
 /// Response to the set primary boot slot request.
 #[derive(Debug, Default, Serialize, Annotate)]
 pub struct PrimaryBl0SlotResponse {
     /// The current primary slot.
-    pub primary_bl0_slot: BootDataSlot,
+    pub primary_bl0_slot: BootSlot,
     /// The status response to the request.
     pub status: u32,
 }
@@ -154,7 +148,7 @@ pub struct OwnershipUnlockResponse {
 #[derive(Debug, Default, Serialize, Annotate)]
 pub struct OwnershipActivateRequest {
     /// The new primary boot slot after activating ownership.
-    pub primary_bl0_slot: BootDataSlot,
+    pub primary_bl0_slot: BootSlot,
     /// Whether to erase the previous owner's data during activation.
     pub erase_previous: HardenedBool,
     /// Reserved for future use.
@@ -288,7 +282,7 @@ impl BootSvc {
         }
     }
 
-    pub fn next_boot_bl0_slot(slot: NextBootBl0) -> Self {
+    pub fn next_boot_bl0_slot(slot: BootSlot) -> Self {
         BootSvc {
             header: Header {
                 digest: [0u32; 8],
@@ -302,7 +296,7 @@ impl BootSvc {
         }
     }
 
-    pub fn primary_bl0_slot(slot: BootDataSlot) -> Self {
+    pub fn primary_bl0_slot(slot: BootSlot) -> Self {
         BootSvc {
             header: Header {
                 digest: [0u32; 8],
@@ -431,7 +425,7 @@ impl TryFrom<&[u8]> for NextBl0SlotRequest {
     fn try_from(buf: &[u8]) -> std::result::Result<Self, Self::Error> {
         let mut reader = std::io::Cursor::new(buf);
         Ok(NextBl0SlotRequest {
-            next_bl0_slot: NextBootBl0(reader.read_u32::<LittleEndian>()?),
+            next_bl0_slot: BootSlot(reader.read_u32::<LittleEndian>()?),
         })
     }
 }
@@ -465,7 +459,7 @@ impl TryFrom<&[u8]> for PrimaryBl0SlotRequest {
     fn try_from(buf: &[u8]) -> std::result::Result<Self, Self::Error> {
         let mut reader = std::io::Cursor::new(buf);
         Ok(PrimaryBl0SlotRequest {
-            primary_bl0_slot: BootDataSlot(reader.read_u32::<LittleEndian>()?),
+            primary_bl0_slot: BootSlot(reader.read_u32::<LittleEndian>()?),
         })
     }
 }
@@ -482,7 +476,7 @@ impl TryFrom<&[u8]> for PrimaryBl0SlotResponse {
     fn try_from(buf: &[u8]) -> std::result::Result<Self, Self::Error> {
         let mut reader = std::io::Cursor::new(buf);
         Ok(PrimaryBl0SlotResponse {
-            primary_bl0_slot: BootDataSlot(reader.read_u32::<LittleEndian>()?),
+            primary_bl0_slot: BootSlot(reader.read_u32::<LittleEndian>()?),
             status: reader.read_u32::<LittleEndian>()?,
         })
     }
@@ -561,7 +555,7 @@ impl TryFrom<&[u8]> for OwnershipActivateRequest {
     fn try_from(buf: &[u8]) -> std::result::Result<Self, Self::Error> {
         let mut reader = std::io::Cursor::new(buf);
         let mut val = Self::default();
-        val.primary_bl0_slot = BootDataSlot(reader.read_u32::<LittleEndian>()?);
+        val.primary_bl0_slot = BootSlot(reader.read_u32::<LittleEndian>()?);
         val.erase_previous = HardenedBool(reader.read_u32::<LittleEndian>()?);
         val.reserved.resize(Self::RESERVED_SIZE, 0);
         reader.read_exact(&mut val.reserved)?;

--- a/sw/host/opentitanlib/src/chip/boot_svc.rs
+++ b/sw/host/opentitanlib/src/chip/boot_svc.rs
@@ -37,17 +37,17 @@ with_unknown! {
 
     pub enum BootSvcKind: u32 [default = Self::Unknown] {
         Unknown = 0,
-        Empty = 0xb4594546,
-        MinBl0SecVerRequest = 0xdac59e6e,
-        MinBl0SecVerResponse = 0x756385f1,
-        NextBl0SlotRequest = 0xe1edf546,
-        NextBl0SlotResponse = 0x657051be,
-        PrimaryBl0SlotRequest = 0x3d6c47b8,
-        PrimaryBl0SlotResponse = 0xf2a4a609,
-        OwnershipUnlockRequest = 0x51524e55,
-        OwnershipUnlockResponse = 0x53524e55,
-        OwnershipActivateRequest = 0x51524f41,
-        OwnershipActivateResponse = 0x53524f41,
+        Empty = u32::from_le_bytes(*b"EMPT"),
+        MinBl0SecVerRequest = u32::from_le_bytes(*b"MSEC"),
+        MinBl0SecVerResponse = u32::from_le_bytes(*b"CESM"),
+        NextBl0SlotRequest = u32::from_le_bytes(*b"NEXT"),
+        NextBl0SlotResponse = u32::from_le_bytes(*b"TXEN"),
+        PrimaryBl0SlotRequest = u32::from_le_bytes(*b"PRIM"),
+        PrimaryBl0SlotResponse = u32::from_le_bytes(*b"MIRP"),
+        OwnershipUnlockRequest = u32::from_le_bytes(*b"UNLK"),
+        OwnershipUnlockResponse = u32::from_le_bytes(*b"LKNU"),
+        OwnershipActivateRequest = u32::from_le_bytes(*b"ACTV"),
+        OwnershipActivateResponse = u32::from_le_bytes(*b"VTCA"),
     }
 }
 

--- a/sw/host/opentitanlib/src/rescue/serial.rs
+++ b/sw/host/opentitanlib/src/rescue/serial.rs
@@ -8,9 +8,7 @@ use std::time::Duration;
 
 use crate::app::TransportWrapper;
 use crate::chip::boot_log::BootLog;
-use crate::chip::boot_svc::{
-    BootDataSlot, BootSvc, NextBootBl0, OwnershipActivateRequest, OwnershipUnlockRequest,
-};
+use crate::chip::boot_svc::{BootSlot, BootSvc, OwnershipActivateRequest, OwnershipUnlockRequest};
 use crate::io::uart::Uart;
 use crate::rescue::xmodem::Xmodem;
 use crate::rescue::RescueError;
@@ -108,13 +106,13 @@ impl RescueSerial {
         Ok(())
     }
 
-    pub fn set_next_bl0_slot(&self, slot: NextBootBl0) -> Result<()> {
+    pub fn set_next_bl0_slot(&self, slot: BootSlot) -> Result<()> {
         let message = BootSvc::next_boot_bl0_slot(slot);
         let data = message.to_bytes()?;
         self.set_boot_svc_raw(&data)
     }
 
-    pub fn set_primary_bl0_slot(&self, slot: BootDataSlot) -> Result<()> {
+    pub fn set_primary_bl0_slot(&self, slot: BootSlot) -> Result<()> {
         let message = BootSvc::primary_bl0_slot(slot);
         let data = message.to_bytes()?;
         self.set_boot_svc_raw(&data)

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
-use opentitanlib::chip::boot_svc::{BootDataSlot, NextBootBl0};
+use opentitanlib::chip::boot_svc::BootSlot;
 use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams};
 use opentitanlib::rescue::serial::RescueSerial;
 
@@ -105,7 +105,7 @@ pub struct SetNextBl0Slot {
     #[command(flatten)]
     params: UartParams,
     #[arg(default_value = "SlotA")]
-    slot: NextBootBl0,
+    slot: BootSlot,
 }
 
 impl CommandDispatch for SetNextBl0Slot {
@@ -127,7 +127,7 @@ pub struct SetPrimaryBl0Slot {
     #[command(flatten)]
     params: UartParams,
     #[arg(default_value = "SlotA")]
-    slot: BootDataSlot,
+    slot: BootSlot,
 }
 
 impl CommandDispatch for SetPrimaryBl0Slot {


### PR DESCRIPTION
Replace struct, command and slot identifiers with [FourCC](https://en.wikipedia.org/wiki/FourCC) codes.

FourCC codes are easily visible in hexdumps and can be printed by our `printf` implementation's custom `%C` specifier.

1. Consolidate all boot slot definitions into `BootSlot`.
2. Use the "FourCC" codes `AA__` and `__BB` to represent the boot slot values.  These values are easily visible in a hexdump, can be printed with our `printf`'s custom `%C` specifier and have a hamming distance of 16 bits.
3. Update the `boot_svc` request/response identifiers to FourCC codes.  The response identifiers are the request identifiers in reverse order (ie: `NEXT` -> `TXEN`).