### PR TITLE
[opentitantool] Improvements to C2D2 debugger support

### DIFF
--- a/sw/host/opentitanlib/src/app/config/h1dx_devboard_c2d2.json
+++ b/sw/host/opentitanlib/src/app/config/h1dx_devboard_c2d2.json
@@ -12,10 +12,13 @@
   ],
   "strappings": [
     {
-      "name": "RESET"
-    },
-    {
-      "name": "ROM_BOOTSTRAP"
+      "name": "RESET",
+      "pins": [
+	{
+	  "name": "RESET",
+	  "level": false
+	}
+      ]
     }
   ],
   "uarts": [

--- a/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
@@ -5,7 +5,7 @@
 use std::rc::Rc;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rusb::{Direction, Recipient, RequestType};
 use serialport::Parity;
 
@@ -97,13 +97,15 @@ impl Uart for HyperdebugUart {
 
     fn set_break(&self, enable: bool) -> Result<()> {
         let usb_handle = self.inner.usb_device.borrow();
-        usb_handle.write_control(
-            rusb::request_type(Direction::Out, RequestType::Vendor, Recipient::Interface),
-            ControlRequest::Break as u8,
-            if enable { 0xFFFF } else { 0 },
-            self.usb_interface as u16,
-            &[],
-        )?;
+        usb_handle
+            .write_control(
+                rusb::request_type(Direction::Out, RequestType::Vendor, Recipient::Interface),
+                ControlRequest::Break as u8,
+                if enable { 0xFFFF } else { 0 },
+                self.usb_interface as u16,
+                &[],
+            )
+            .context("Setting break condition")?;
         Ok(())
     }
 


### PR DESCRIPTION
The C2D2 debugger is used by ChromeOS for communicating with the security chip among other things.  It offers basically only access to the RESET signal and the two UART lines.  This is enough to perform rescue firmware updating, or other operations.

It turns out that the default configuration file for C2D2 had not been updated with proper RESET strapping, and also instead declared empty strappings, which is confusing as it leads to silent errors.

This change properly declares the RESET strapping, and removes the ROM_BOOTSTRAP strapping (as C2D2 does not have wires to enter bootstrap mode.)