### PR TITLE
[usbdev,dv] usbdev rx crc err seq

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -468,7 +468,7 @@
             - Verify that the rx_crc_err should go high following the reception of erroneous packet.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_rx_crc_err"]
     }
     {
       name: rx_pid_err

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -147,15 +147,20 @@ endtask
 
   // Construct and transmit a token packet to the USB device
   virtual task call_token_seq(input pid_type_e pid_type);
-    `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
-    m_token_pkt.m_pkt_type = PktTypeToken;
-    m_token_pkt.m_pid_type = pid_type;
-    assert(m_token_pkt.randomize() with {m_token_pkt.address inside {7'b0};
-                                         m_token_pkt.endpoint == endp;});
+    m_token_pkt = create_token_pkt(pid_type);
     m_usb20_item = m_token_pkt;
     start_item(m_token_pkt);
     finish_item(m_token_pkt);
   endtask
+
+  virtual function token_pkt create_token_pkt(pid_type_e pid_type);
+    token_pkt pkt;
+    `uvm_create_on(pkt, p_sequencer.usb20_sequencer_h)
+    pkt.m_pkt_type = PktTypeToken;
+    pkt.m_pid_type = pid_type;
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(pkt, pkt.address inside {7'b0}; pkt.endpoint == endp;)
+    return pkt;
+  endfunction
 
   // Construct and transmit a DATA packet to the USB device
   virtual task call_data_seq(input pid_type_e pid_type,

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_rx_crc_err_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_rx_crc_err_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Configure transaction
+    configure_out_trans();
+
+    // Enable rx_crc_err interrupt
+    csr_wr(.ptr(ral.intr_enable.rx_crc_err), .value(1'b1));
+
+    // Out Token packet with corrupted CRC5
+    call_token_seq(PidTypeOutToken);
+    // Adding a delay ensures that the CRC5 status is updated and triggers the
+    // interrupt to go high.
+    cfg.clk_rst_vif.wait_clks(4);
+
+    // In this check we are checking the rx crc error interrupt bit because we are sending corrupt
+    // crc and after getting corrupt crc the rx crc err bit should be high.
+    `DV_CHECK_EQ(cfg.intr_vif.sample_pin(IntrRxCrcErr), 1'b1)
+  endtask
+
+  // Override the create_token_pkt function to corrupt the crc5
+  virtual function token_pkt create_token_pkt(pid_type_e pid_type);
+    token_pkt pkt = super.create_token_pkt(pid_type);
+    pkt.crc5 = ~pkt.crc5;
+    return pkt;
+  endfunction
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -25,6 +25,7 @@
 `include "usbdev_pkt_sent_vseq.sv"
 `include "usbdev_random_length_out_transaction_vseq.sv"
 `include "usbdev_stall_trans_vseq.sv"
+`include "usbdev_rx_crc_err_vseq.sv"
 `include "usbdev_setup_trans_ignored_vseq.sv"
 `include "usbdev_stall_priority_over_nak_vseq.sv"
 `include "usbdev_setup_stage_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -40,6 +40,7 @@ filesets:
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_rx_crc_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_stall_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -113,6 +113,10 @@
       uvm_test_seq: usbdev_stall_trans_vseq
     }
     {
+      name: usbdev_rx_crc_err
+      uvm_test_seq: usbdev_rx_crc_err_vseq
+    }
+    {
       name: usbdev_setup_trans_ignored
       uvm_test_seq: usbdev_setup_trans_ignored_vseq
     }


### PR DESCRIPTION
This PR incorporates the rx_crc_err sequence, where we send a packet with a corrupted CRC and subsequently check the CRC status after sending the packet.