### PR TITLE
[usbdev] usbdev_disconnected seqeunce

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -347,7 +347,7 @@
             - Verify that the corresponding Interrupt pin goes high after the link disconnected.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_disconnected"]
     }
     {
       name: host_lost

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_disconnected_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_disconnected_vseq.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_disconnected_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_disconnected_vseq)
+
+  `uvm_object_new
+
+  task body();
+    uvm_reg_data_t rd_data;
+    bit disconnected;
+    // Enable disconnected interrupt
+    csr_wr(.ptr(ral.intr_enable.disconnected),  .value(1'b1));
+    // Clear disconnected interrupt to make sure its on reset state.
+    csr_wr(.ptr(ral.intr_state.disconnected),  .value(1'b1));
+    // send pkt to device
+    configure_out_trans();
+    call_sof_seq(PidTypeSofToken);
+    @(posedge cfg.m_usb20_agent_cfg.bif.usb_clk);
+    // Verify that the device has asserted the usb_ref_val_o signal after receiving the SoF packet.
+    `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.bif.usb_ref_val_o, 1)
+    // Check the disconnected interrupt isn't yet asserted
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrDisconnected], 0)
+    // Drive 0 on usb_vbus signal to tell device that its has been disconnected.
+    cfg.m_usb20_agent_cfg.bif.drive_vbus = 1'b0;
+    // Expect the disconnected interrupt within a short time
+    for (int i = 0; i < 10; i++) begin
+      @(posedge cfg.m_usb20_agent_cfg.bif.usb_clk);
+      if (cfg.intr_vif.pins[IntrDisconnected]) break;
+    end
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrDisconnected], 1)
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -9,6 +9,7 @@
 
 `include "usbdev_av_buffer_vseq.sv"
 `include "usbdev_csr_test_vseq.sv"
+`include "usbdev_disconnected_vseq.sv"
 `include "usbdev_dpi_config_host_vseq.sv"
 `include "usbdev_enable_vseq.sv"
 `include "usbdev_fifo_rst_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -31,6 +31,7 @@ filesets:
       - seq_lib/usbdev_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_csr_test_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_pkt_received_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_disconnected_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_av_buffer_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_setup_trans_ignored_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_pkt_buffer_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -81,6 +81,10 @@
       uvm_test_seq: usbdev_min_length_out_transaction_vseq
     }
     {
+      name: usbdev_disconnected
+      uvm_test_seq: usbdev_disconnected_vseq
+    }
+    {
       name: usbdev_nak_trans
       uvm_test_seq: usbdev_nak_trans_vseq
     }


### PR DESCRIPTION
Adds 'usbdev_disconnected' sequence to validate device functionality upon disconnection. Upon loss of usb_vbus, the device generates a disconnected interrupt.