### PR TITLE
[dvsim] General clean-up in modes.py

### DIFF
--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -38,10 +38,7 @@ class Modes():
             setattr(self, key, mdict[key])
 
     def get_sub_modes(self):
-        sub_modes = []
-        if hasattr(self, "en_" + self.type + "_modes"):
-            sub_modes = getattr(self, "en_" + self.type + "_modes")
-        return sub_modes
+        return getattr(self, "en_" + self.type + "_modes", [])
 
     def set_sub_modes(self, sub_modes):
         setattr(self, "en_" + self.type + "_modes", sub_modes)
@@ -360,13 +357,8 @@ class Tests(RunModes):
                 Tests.item_names.append(new_test.name)
 
         # Pass 2: Process dependencies
-        build_modes = []
-        if hasattr(sim_cfg, "build_modes"):
-            build_modes = getattr(sim_cfg, "build_modes")
-
-        run_modes = []
-        if hasattr(sim_cfg, "run_modes"):
-            run_modes = getattr(sim_cfg, "run_modes")
+        build_modes = getattr(sim_cfg, "build_modes", [])
+        run_modes = getattr(sim_cfg, "run_modes", [])
 
         attrs = Tests.defaults
         for test_obj in tests_objs:
@@ -508,13 +500,8 @@ class Regressions(Modes):
                 Regressions.item_names.append(new_regression.name)
 
         # Pass 2: Process dependencies
-        build_modes = []
-        if hasattr(sim_cfg, "build_modes"):
-            build_modes = getattr(sim_cfg, "build_modes")
-
-        run_modes = []
-        if hasattr(sim_cfg, "run_modes"):
-            run_modes = getattr(sim_cfg, "run_modes")
+        build_modes = getattr(sim_cfg, "build_modes", [])
+        run_modes = getattr(sim_cfg, "run_modes", [])
 
         for regression_obj in regressions_objs:
             # Unpack the sim modes

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -4,7 +4,6 @@
 
 from copy import deepcopy
 import logging as log
-import pprint
 import sys
 
 from utils import VERBOSE
@@ -15,27 +14,6 @@ class Modes():
     Abstraction for specifying collection of options called as 'modes'. This is
     the base class which is extended for run_modes, build_modes, tests and regressions.
     """
-
-    def self_str(self):
-        '''
-        This is used to construct the string representation of the entire class object.
-        '''
-        tname = ""
-        if self.type != "":
-            tname = self.type + "_"
-        if self.mname != "":
-            tname += self.mname
-        if log.getLogger().isEnabledFor(VERBOSE):
-            return "\n<---" + tname + ":\n" + pprint.pformat(self.__dict__) + \
-                   "\n--->\n"
-        else:
-            return tname + ":" + self.name
-
-    def __str__(self):
-        return self.self_str()
-
-    def __repr__(self):
-        return self.self_str()
 
     def __init__(self, mdict):
         keys = mdict.keys()
@@ -466,8 +444,6 @@ class Regressions(Modes):
 
     # Maintain a list of tests str
     item_names = []
-
-    # TODO: define __repr__ and __str__ to print list of tests if VERBOSE
 
     def __init__(self, regdict):
         self.name = ""

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -15,7 +15,7 @@ class Modes():
     the base class which is extended for run_modes, build_modes, tests and regressions.
     """
 
-    def __init__(self, mdict):
+    def __init__(self, type_name: str, mdict):
         keys = mdict.keys()
         attrs = self.__dict__.keys()
 
@@ -27,13 +27,10 @@ class Modes():
             log.fatal("Key \"type\" is missing or invalid")
             sys.exit(1)
 
-        if not hasattr(self, "mname"):
-            self.mname = ""
-
         for key in keys:
             if key not in attrs:
                 log.error(f"Key {key} in {mdict} is invalid. Supported "
-                          f"attributes in {self.mname} are {attrs}")
+                          f"attributes for a {type_name} are {attrs}")
                 sys.exit(1)
             setattr(self, key, mdict[key])
 
@@ -60,8 +57,8 @@ class Modes():
         for attr, self_attr_val in self.__dict__.items():
             mode_attr_val = getattr(mode, attr, None)
 
-            # If sub-mode, skip the name fields - they could differ.
-            if is_sub_mode and attr in ['name', 'mname']:
+            # If sub-mode, skip the name: it could differ.
+            if is_sub_mode and attr == 'name':
                 continue
 
             # If mode's value is None, then nothing to do here.
@@ -238,8 +235,6 @@ class BuildModes(Modes):
     def __init__(self, bdict):
         self.name = ""
         self.type = "build"
-        if not hasattr(self, "mname"):
-            self.mname = "mode"
         self.is_sim_mode = 0
         self.pre_build_cmds = []
         self.post_build_cmds = []
@@ -252,7 +247,7 @@ class BuildModes(Modes):
         self.sw_images = []
         self.sw_build_opts = []
 
-        super().__init__(bdict)
+        super().__init__("build mode", bdict)
         self.en_build_modes = list(set(self.en_build_modes))
 
     @staticmethod
@@ -271,8 +266,6 @@ class RunModes(Modes):
     def __init__(self, rdict):
         self.name = ""
         self.type = "run"
-        if not hasattr(self, "mname"):
-            self.mname = "mode"
         self.reseed = None
         self.pre_run_cmds = []
         self.post_run_cmds = []
@@ -287,7 +280,7 @@ class RunModes(Modes):
         self.sw_build_device = ""
         self.sw_build_opts = []
 
-        super().__init__(rdict)
+        super().__init__("run mode", rdict)
         self.en_run_modes = list(set(self.en_run_modes))
 
     @staticmethod
@@ -316,11 +309,6 @@ class Tests(RunModes):
         "run_timeout_mins": None,
         "run_timeout_multiplier": None
     }
-
-    def __init__(self, tdict):
-        if not hasattr(self, "mname"):
-            self.mname = "test"
-        super().__init__(tdict)
 
     @staticmethod
     def create_tests(tdicts, sim_cfg):
@@ -440,8 +428,6 @@ class Regressions(Modes):
     def __init__(self, regdict):
         self.name = ""
         self.type = ""
-        if not hasattr(self, "mname"):
-            self.mname = "regression"
 
         # The `tests` member is typically a list, but it defaults to None.
         # There are 3 possible cases after all the HJson files are parsed, when
@@ -463,7 +449,7 @@ class Regressions(Modes):
         self.post_run_cmds = []
         self.build_opts = []
         self.run_opts = []
-        super().__init__(regdict)
+        super().__init__("regression", regdict)
 
     @staticmethod
     def create_regressions(regdicts, sim_cfg, tests):

--- a/util/dvsim/Modes.py
+++ b/util/dvsim/Modes.py
@@ -40,17 +40,18 @@ class Modes():
     def set_sub_modes(self, sub_modes):
         setattr(self, "en_" + self.type + "_modes", sub_modes)
 
-    def merge_mode(self, mode):
-        '''
-        Merge a new mode with self.
-        Merge sub mode specified with 'en_*_modes with self.
-        '''
+    def merge_mode(self, mode: 'Mode') -> None:
+        '''Update this object by merging it with mode.'''
 
         sub_modes = self.get_sub_modes()
         is_sub_mode = mode.name in sub_modes
 
-        if not mode.name == self.name and not is_sub_mode:
-            return False
+        # If the mode to be merged in is not known as a sub-mode of this mode
+        # then something has gone wrong. Generate an error.
+        if mode.name != self.name and not is_sub_mode:
+            log.error(f"Cannot merge mode {self.name} with {mode.name}: "
+                      f"it is not a sub-mode and they are not equal.")
+            sys.exit(1)
 
         # Merge attributes in self with attributes in mode arg, since they are
         # the same mode but set in separate files, or a sub-mode.

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -146,11 +146,9 @@ class OneShotCfg(FlowCfg):
         '''Create deploy objects from build modes
         '''
         builds = []
-        build_map = {}
         for build in self.build_modes:
             item = CompileOneShot(build, self)
             builds.append(item)
-            build_map[build] = item
 
         self.builds = builds
         self.deploy = builds

--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 
 from Deploy import CompileOneShot
 from FlowCfg import FlowCfg
-from Modes import BuildModes, Modes
+from Modes import BuildMode, Mode
 from utils import rm_path
 
 
@@ -116,8 +116,8 @@ class OneShotCfg(FlowCfg):
 
     def _create_objects(self):
         # Create build and run modes objects
-        build_modes = Modes.create_modes(BuildModes,
-                                         getattr(self, "build_modes"))
+        build_modes = Mode.create_modes(BuildMode,
+                                        getattr(self, "build_modes"))
         setattr(self, "build_modes", build_modes)
 
         # All defined build modes are being built, h

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 from Deploy import CompileSim, CovAnalyze, CovMerge, CovReport, CovUnr, RunTest
 from FlowCfg import FlowCfg
-from Modes import BuildModes, Modes, Regressions, RunModes, Tests, find_mode
+from Modes import BuildMode, Mode, Regression, RunMode, Test, find_mode
 from results_server import ResultsServer
 from SimResults import SimResults
 from tabulate import tabulate
@@ -242,8 +242,8 @@ class SimCfg(FlowCfg):
 
     def _create_objects(self):
         # Create build and run modes objects
-        self.build_modes = Modes.create_modes(BuildModes, self.build_modes)
-        self.run_modes = Modes.create_modes(RunModes, self.run_modes)
+        self.build_modes = Mode.create_modes(BuildMode, self.build_modes)
+        self.run_modes = Mode.create_modes(RunMode, self.run_modes)
 
         # Walk through build modes enabled on the CLI and append the opts
         for en_build_mode in self.en_build_modes:
@@ -279,7 +279,7 @@ class SimCfg(FlowCfg):
                 sys.exit(1)
 
         # Create tests from given list of items
-        self.tests = Tests.create_tests(self.tests, self)
+        self.tests = Test.create_tests(self.tests, self)
 
         # Regressions
         # Parse testplan if provided.
@@ -293,7 +293,7 @@ class SimCfg(FlowCfg):
             self.testplan = Testplan(None, name=self.name)
 
         # Create regressions
-        self.regressions = Regressions.create_regressions(
+        self.regressions = Regression.create_regressions(
             self.regressions, self, self.tests)
 
     def _print_list(self):
@@ -311,7 +311,7 @@ class SimCfg(FlowCfg):
                 if isinstance(item, str):
                     mode_name = item
                 else:
-                    assert isinstance(item, Modes)
+                    assert isinstance(item, Mode)
                     mode_name = item.name
 
                 log.info(mode_name)
@@ -369,11 +369,11 @@ class SimCfg(FlowCfg):
                         f"tests in {self.flow_cfg_file}.")
 
         # Merge the global build and run opts
-        Tests.merge_global_opts(self.run_list, self.pre_build_cmds,
-                                self.post_build_cmds, self.build_opts,
-                                self.pre_run_cmds, self.post_run_cmds,
-                                self.run_opts, self.sw_images,
-                                self.sw_build_opts)
+        Test.merge_global_opts(self.run_list, self.pre_build_cmds,
+                               self.post_build_cmds, self.build_opts,
+                               self.pre_run_cmds, self.post_run_cmds,
+                               self.run_opts, self.sw_images,
+                               self.sw_build_opts)
 
         # Process reseed override and create the build_list
         build_list_names = []

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -299,12 +299,12 @@ class SimCfg(FlowCfg):
     def _print_list(self):
         for list_item in self.list_items:
             log.info("---- List of %s in %s ----", list_item, self.variant_name)
-            if hasattr(self, list_item):
-                items = getattr(self, list_item)
-                for item in items:
-                    log.info(item)
-            else:
-                log.error("Item %s does not exist!", list_item)
+            items = getattr(self, list_item, None)
+            if items is None:
+                log.error("No %s defined for %s.", list_item, self.variant_name)
+
+            for item in items:
+                log.info(item)
 
     def _create_build_and_run_list(self):
         '''Generates a list of deployable objects from the provided items.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -304,7 +304,17 @@ class SimCfg(FlowCfg):
                 log.error("No %s defined for %s.", list_item, self.variant_name)
 
             for item in items:
-                log.info(item)
+                # Convert the item into something that can be printed in the
+                # list. Some modes are specified as strings themselves (so
+                # there's no conversion needed). Others should be subclasses of
+                # Mode, which has a name field that we can use.
+                if isinstance(item, str):
+                    mode_name = item
+                else:
+                    assert isinstance(item, Modes)
+                    mode_name = item.name
+
+                log.info(mode_name)
 
     def _create_build_and_run_list(self):
         '''Generates a list of deployable objects from the provided items.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 from Deploy import CompileSim, CovAnalyze, CovMerge, CovReport, CovUnr, RunTest
 from FlowCfg import FlowCfg
-from Modes import BuildModes, Modes, Regressions, RunModes, Tests
+from Modes import BuildModes, Modes, Regressions, RunModes, Tests, find_mode
 from results_server import ResultsServer
 from SimResults import SimResults
 from tabulate import tabulate
@@ -247,7 +247,7 @@ class SimCfg(FlowCfg):
 
         # Walk through build modes enabled on the CLI and append the opts
         for en_build_mode in self.en_build_modes:
-            build_mode_obj = Modes.find_mode(en_build_mode, self.build_modes)
+            build_mode_obj = find_mode(en_build_mode, self.build_modes)
             if build_mode_obj is not None:
                 self.pre_build_cmds.extend(build_mode_obj.pre_build_cmds)
                 self.post_build_cmds.extend(build_mode_obj.post_build_cmds)
@@ -265,7 +265,7 @@ class SimCfg(FlowCfg):
 
         # Walk through run modes enabled on the CLI and append the opts
         for en_run_mode in self.en_run_modes:
-            run_mode_obj = Modes.find_mode(en_run_mode, self.run_modes)
+            run_mode_obj = find_mode(en_run_mode, self.run_modes)
             if run_mode_obj is not None:
                 self.pre_run_cmds.extend(run_mode_obj.pre_run_cmds)
                 self.post_run_cmds.extend(run_mode_obj.post_run_cmds)
@@ -476,7 +476,7 @@ class SimCfg(FlowCfg):
         # Update all tests to use the updated (uniquified) build modes.
         for test in self.run_list:
             if test.build_mode.name != build_map[test.build_mode].name:
-                test.build_mode = Modes.find_mode(
+                test.build_mode = find_mode(
                     build_map[test.build_mode].name, self.build_modes)
 
         self.runs = ([]


### PR DESCRIPTION
I spent some time looking carefully at this code back in December and it's much more complicated than we need it to be. The commits in this PR are simplifications. There are some other tidy-ups that they enable, but the PR was turning into a bit of a mammoth and I thought this was a sensible place to start!

Most of the commits here are generic tidyups. The only significant change is probably in the code that cleans up how we print `Modes` objects (see the "Strengthen typing ..." commit). This removes use of some generic "object to string" code which the following commit can delete.