### PR TITLE
[pentest] Add EDN SCA & FI tests

### DIFF
--- a/sw/device/sca/lib/prng.c
+++ b/sw/device/sca/lib/prng.c
@@ -158,6 +158,8 @@ __attribute__((noinline)) static uint32_t genrand_int32(void) {
 
 void prng_seed(uint32_t seed) { init_by_array(&seed, 1); }
 
+uint32_t prng_rand_uint32(void) { return genrand_int32(); }
+
 uint8_t prng_rand_byte(void) {
   uint32_t rand = 0;
   do {

--- a/sw/device/sca/lib/prng.h
+++ b/sw/device/sca/lib/prng.h
@@ -34,6 +34,16 @@ extern "C" {
 void prng_seed(uint32_t seed);
 
 /**
+ * Generates a random uint32_t.
+ *
+ * The behavior of this function matches the behavior of `random.randint(0,
+ * 0xFFFFFFFF)` in python.
+ *
+ * @return A random uint32_t.
+ */
+uint32_t prng_rand_uint32(void);
+
+/**
  * Generates a random byte.
  *
  * The behavior of this function matches the behavior of `random.randint(0,

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -167,6 +167,54 @@ cc_library(
 )
 
 cc_library(
+    name = "edn_fi",
+    srcs = ["edn_fi.c"],
+    hdrs = ["edn_fi.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:csrng_shared",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:edn_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:rv_core_ibex_testutils",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/firmware:sca_lib",
+        "//sw/device/tests/crypto/cryptotest/json:edn_fi_commands",
+    ],
+)
+
+cc_library(
+    name = "edn_sca",
+    srcs = ["edn_sca.c"],
+    hdrs = ["edn_sca.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:csrng_shared",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:rv_core_ibex_testutils",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/sca/lib:prng",
+        "//sw/device/sca/lib:sca",
+        "//sw/device/tests/crypto/cryptotest/firmware:sca_lib",
+        "//sw/device/tests/crypto/cryptotest/json:edn_sca_commands",
+    ],
+)
+
+cc_library(
     name = "ibex_fi",
     srcs = [
         "ibex_fi.S",
@@ -326,6 +374,8 @@ FIRMWARE_DEPS = [
     ":drbg",
     ":ecdh",
     ":ecdsa",
+    ":edn_fi",
+    ":edn_sca",
     ":hash",
     ":hmac",
     ":ibex_fi",

--- a/sw/device/tests/crypto/cryptotest/firmware/edn_fi.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/edn_fi.c
@@ -1,0 +1,253 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_csrng_shared.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/edn_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/rv_core_ibex_testutils.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/sca_lib.h"
+#include "sw/device/tests/crypto/cryptotest/json/edn_fi_commands.h"
+
+#include "edn_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// NOP macros.
+#define NOP1 "addi x0, x0, 0\n"
+#define NOP10 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1
+
+enum {
+  kEdnKatTimeout = (10 * 1000 * 1000),
+  kEdnKatMaxClen = 12,
+  kEdnKatOutputLen = 16,
+  kEdnKatWordsPerBlock = 4,
+};
+
+static dif_rv_core_ibex_t rv_core_ibex;
+static dif_entropy_src_t entropy_src;
+static dif_csrng_t csrng;
+static dif_edn_t edn0;
+static dif_edn_t edn1;
+
+// CTR_DRBG Known-Answer-Tests (KATs).
+//
+// Test vector sourced from NIST's CAVP website:
+// https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/random-number-generators
+//
+// The number format in this docstring follows the CAVP format to simplify
+// auditing of this test case.
+//
+// Test vector: CTR_DRBG AES-256 no DF.
+//
+// - EntropyInput =
+// df5d73faa468649edda33b5cca79b0b05600419ccb7a879ddfec9db32ee494e5531b51de16a30f769262474c73bec010
+// - Nonce = EMPTY
+// - PersonalizationString = EMPTY
+//
+// Command: Instantiate
+// - Key = 8c52f901632d522774c08fad0eb2c33b98a701a1861aecf3d8a25860941709fd
+// - V   = 217b52142105250243c0b2c206b8f59e
+//
+// Command: Generate (first call):
+// - Key = 72f4af5c93258eb3eeec8c0cacea6c1d1978a4fad44312725f1ac43b167f2d52
+// - V   = e86f6d07dfb551cebad80e6bf6830ac4
+//
+// Command: Generate (second call):
+// - Key = 1a1c6e5f1cccc6974436e5fd3f015bc8e9dc0f90053b73e3c19d4dfd66d1b85a
+// - V   = 53c78ac61a0bac9d7d2e92b1e73e3392
+// - ReturnedBits =
+// d1c07cd95af8a7f11012c84ce48bb8cb87189e99d40fccb1771c619bdf82ab2280b1dc2f2581f39164f7ac0c510494b3a43c41b7db17514c87b107ae793e01c5
+
+// Seed material for the EDN KAT instantiate command.
+const dif_edn_seed_material_t kEdnKatSeedMaterialInstantiate = {
+    .len = kEdnKatMaxClen,
+    .data = {0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de, 0x2ee494e5,
+             0xdfec9db3, 0xcb7a879d, 0x5600419c, 0xca79b0b0, 0xdda33b5c,
+             0xa468649e, 0xdf5d73fa},
+};
+// Seed material for the EDN KAT reseed command.
+const dif_edn_seed_material_t kEdnKatSeedMaterialReseed = {
+    .len = kEdnKatMaxClen,
+    .data = {0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de, 0x2ee494e5,
+             0xdfec9db3, 0xcb7a879d, 0x5600419c, 0xca79b0b0, 0xdda33b5c,
+             0xa468649e, 0xdf5d73fa},
+};
+// Seed material for the EDN KAT generate command.
+const dif_edn_seed_material_t kEdnKatSeedMaterialGenerate = {
+    .len = 0,
+};
+// Expected output data for the EDN KAT.
+const uint32_t kExpectedOutput[kEdnKatOutputLen] = {
+    0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9, 0xdf82ab22, 0x771c619b,
+    0xd40fccb1, 0x87189e99, 0x510494b3, 0x64f7ac0c, 0x2581f391, 0x80b1dc2f,
+    0x793e01c5, 0x87b107ae, 0xdb17514c, 0xa43c41b7,
+};
+
+status_t handle_edn_fi_bus_ack(ujson_t *uj) {
+  // Enable entropy complex, CSRNG and EDN so Ibex can get entropy.
+  // Configure entropy in auto_mode to avoid starving the system from entropy,
+  // given that boot mode entropy has a limited number of generated bits.
+  TRY(entropy_testutils_auto_mode_init());
+
+  uint32_t ibex_rnd_data[64];
+
+  // Inject faults during generating and receiving random data.
+  // Goal is to manipulate ACK on bus to trigger that the same
+  // data chunk is transmitted multiple times.
+  sca_set_trigger_high();
+  asm volatile(NOP10);
+  for (size_t it = 0; it < 64; it++) {
+    TRY(rv_core_ibex_testutils_get_rnd_data(&rv_core_ibex, kEdnKatTimeout,
+                                            &ibex_rnd_data[it]));
+  }
+  sca_set_trigger_low();
+
+  // Check if there are any collisions.
+  size_t collisions = 0;
+  for (size_t outer = 0; outer < 64; outer++) {
+    for (size_t inner = 0; inner < 64; inner++) {
+      if (outer != inner) {
+        if (ibex_rnd_data[outer] == ibex_rnd_data[inner]) {
+          collisions++;
+        }
+      }
+    }
+  }
+
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+
+  // Send result & ERR_STATUS to host.
+  edn_fi_test_result_t uj_output;
+  uj_output.result = collisions;
+  uj_output.err_status = codes;
+  RESP_OK(ujson_serialize_edn_fi_test_result_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_edn_fi_bus_data(ujson_t *uj) {
+  dif_edn_auto_params_t edn_params =
+      edn_testutils_auto_params_build(true, /*res_itval=*/0, /*glen_val=*/0);
+  dif_edn_auto_params_t edn_kat_params;
+  edn_kat_params.instantiate_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdInstantiate, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialInstantiate.len, /*generate_len=*/0);
+  edn_kat_params.instantiate_cmd.seed_material = kEdnKatSeedMaterialInstantiate;
+  edn_kat_params.reseed_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdReseed, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialReseed.len,
+      /*generate_len=*/0);
+  edn_kat_params.reseed_cmd.seed_material = kEdnKatSeedMaterialReseed;
+  edn_kat_params.generate_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdGenerate, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialGenerate.len,
+      /*generate_len=*/
+      kEdnKatOutputLen / kEdnKatWordsPerBlock);
+
+  edn_kat_params.generate_cmd.seed_material = kEdnKatSeedMaterialGenerate;
+  edn_kat_params.reseed_interval = 32;
+
+  // Disable the entropy complex.
+  TRY(entropy_testutils_stop_all());
+  // Enable ENTROPY_SRC in FIPS mode.
+  TRY(dif_entropy_src_configure(
+      &entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));
+  // Enable CSRNG.
+  TRY(dif_csrng_configure(&csrng));
+  // Enable EDN1 in auto request mode.
+  TRY(dif_edn_set_auto_mode(&edn1, edn_params));
+  // Enable EDN0 in auto request mode.
+  TRY(dif_edn_set_auto_mode(&edn0, edn_kat_params));
+
+  uint32_t ibex_rnd_data[4];
+
+  // Inject faults during generating and receiving random data.
+  sca_set_trigger_high();
+  asm volatile(NOP10);
+  for (size_t it = 0; it < 4; it++) {
+    TRY(rv_core_ibex_testutils_get_rnd_data(&rv_core_ibex, kEdnKatTimeout,
+                                            &ibex_rnd_data[it]));
+  }
+  sca_set_trigger_low();
+
+  // Check, if received random data matches the expected data.
+  size_t next_val_pos = 0;
+  size_t hits = 0;
+  size_t it = 0;
+  while (it < 4) {
+    // If there is a hit, the next potential hit is the current position +1.
+    if (ibex_rnd_data[it] == kExpectedOutput[next_val_pos]) {
+      next_val_pos = it + 1;
+      it++;
+      hits++;
+    } else {
+      // The word has been stolen by another block. Thus, we need to
+      // increment the potential next_val_pos.
+      next_val_pos = it + 1;
+    }
+  }
+  // Read ERR_STATUS register.
+  dif_rv_core_ibex_error_status_t codes;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &codes));
+
+  // Send result & ERR_STATUS to host.
+  edn_fi_test_result_t uj_output;
+  uj_output.result = hits;
+  uj_output.err_status = codes;
+  RESP_OK(ujson_serialize_edn_fi_test_result_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_edn_fi_init(ujson_t *uj) {
+  sca_select_trigger_type(kScaTriggerTypeSw);
+  // As we are using the software defined trigger, the first argument of
+  // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
+  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4 | kScaPeripheralEntropy |
+                                     kScaPeripheralCsrng | kScaPeripheralEdn);
+
+  // Disable the instruction cache and dummy instructions for FI attacks.
+  sca_configure_cpu();
+
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // Initialize peripherals used in this FI test.
+  TRY(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  TRY(dif_csrng_init(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+                     &csrng));
+  TRY(dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
+  TRY(dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
+
+  return OK_STATUS();
+}
+
+status_t handle_edn_fi(ujson_t *uj) {
+  edn_fi_subcommand_t cmd;
+  TRY(ujson_deserialize_edn_fi_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kEdnFiSubcommandInit:
+      return handle_edn_fi_init(uj);
+    case kEdnFiSubcommandBusData:
+      return handle_edn_fi_bus_data(uj);
+    case kEdnFiSubcommandBusAck:
+      return handle_edn_fi_bus_ack(uj);
+    default:
+      LOG_ERROR("Unrecognized EDN FI subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/edn_fi.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/edn_fi.h
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EDN_FI_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EDN_FI_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+/**
+ * edn.fi.bus_ack command handler.
+ *
+ * The goal of this penetration test is to inject a fault into
+ * the ACK signal transmitted by the EDN to achieve that the
+ * same random word is transmitted multiple times.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_fi_bus_ack(ujson_t *uj);
+
+/**
+ * edn.fi.bus_data command handler.
+ *
+ * The goal of this penetration test is to inject a fault into
+ * the EDN when random data is generated and transferred to Ibex.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_fi_bus_data(ujson_t *uj);
+
+/**
+ * Initializes the trigger and configures the device for the EDN FI test.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_fi_init(ujson_t *uj);
+
+/**
+ * EDN FI command handler.
+ *
+ * Command handler for the EDN FI command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_fi(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EDN_FI_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/edn_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/edn_sca.c
@@ -1,0 +1,228 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_csrng_shared.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/rv_core_ibex_testutils.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/sca/lib/prng.h"
+#include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/crypto/cryptotest/firmware/sca_lib.h"
+#include "sw/device/tests/crypto/cryptotest/json/edn_sca_commands.h"
+
+#include "edn_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// NOP macros.
+#define NOP1 "addi x0, x0, 0\n"
+#define NOP10 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1
+
+enum {
+  kEdnKatTimeout = (10 * 1000 * 1000),
+  kEdnKatMaxClen = 12,
+  kEdnKatOutputLen = 16,
+  kEdnKatWordsPerBlock = 4,
+};
+
+static dif_rv_core_ibex_t rv_core_ibex;
+static dif_entropy_src_t entropy_src;
+static dif_csrng_t csrng;
+static dif_edn_t edn0;
+
+// Generate random values used by the test by calling the SCA PRNG.
+static void generate_random(size_t num_values, uint32_t values[]) {
+  for (size_t i = 0; i < num_values; i++) {
+    values[i] = prng_rand_uint32();
+  }
+}
+
+// Configure the EDN with the provided seed material, set the SCA trigger,
+// generate and receive random data, and unset the trigger.
+static status_t config_run_edn(uint32_t init_seed[12], uint32_t reseed[12]) {
+  // Setup seed material.
+  // Seed material for the EDN instantiate command.
+  dif_edn_seed_material_t kEdnKatSeedMaterialInstantiate = {
+      .len = kEdnKatMaxClen,
+      .data = {init_seed[0], init_seed[1], init_seed[2], init_seed[3],
+               init_seed[4], init_seed[5], init_seed[6], init_seed[7],
+               init_seed[8], init_seed[9], init_seed[10], init_seed[11]}};
+  // Seed material for the EDN reseed command.
+  dif_edn_seed_material_t kEdnKatSeedMaterialReseed = {
+      .len = kEdnKatMaxClen,
+      .data = {reseed[0], reseed[1], reseed[2], reseed[3], reseed[4], reseed[5],
+               reseed[6], reseed[7], reseed[8], reseed[9], reseed[10],
+               reseed[11]}};
+  // Seed material for the EDN generate command.
+  const dif_edn_seed_material_t kEdnKatSeedMaterialGenerate = {
+      .len = 0,
+  };
+
+  dif_edn_auto_params_t edn_params;
+  edn_params.instantiate_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdInstantiate, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialInstantiate.len, /*generate_len=*/0);
+  edn_params.instantiate_cmd.seed_material = kEdnKatSeedMaterialInstantiate;
+  edn_params.reseed_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdReseed, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialReseed.len,
+      /*generate_len=*/0);
+  edn_params.reseed_cmd.seed_material = kEdnKatSeedMaterialReseed;
+  edn_params.generate_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdGenerate, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialGenerate.len,
+      /*generate_len=*/
+      kEdnKatOutputLen / kEdnKatWordsPerBlock);
+
+  edn_params.generate_cmd.seed_material = kEdnKatSeedMaterialGenerate;
+  edn_params.reseed_interval = 32;
+
+  // Disable the entropy complex.
+  TRY(entropy_testutils_stop_all());
+  // Enable ENTROPY_SRC in FIPS mode.
+  TRY(dif_entropy_src_configure(
+      &entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));
+  // Enable CSRNG.
+  TRY(dif_csrng_configure(&csrng));
+  // Enable EDN0 in auto request mode.
+  TRY(dif_edn_set_auto_mode(&edn0, edn_params));
+
+  uint32_t ibex_rnd_data;
+
+  // Capture trace during generation and transportation of random data.
+  sca_set_trigger_high();
+  asm volatile(NOP10);
+  TRY(rv_core_ibex_testutils_get_rnd_data(&rv_core_ibex, kEdnKatTimeout,
+                                          &ibex_rnd_data));
+  sca_set_trigger_low();
+  asm volatile(NOP10);
+
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca_bus_data_batch_fvsr(ujson_t *uj) {
+  // Get seed material.
+  edn_sca_seed_batch_t uj_data;
+  TRY(ujson_deserialize_edn_sca_seed_batch_t(uj, &uj_data));
+
+  bool sample_fixed = true;
+  uint32_t last_value = 0;
+  for (size_t it = 0; it < uj_data.num_iterations; it++) {
+    if (sample_fixed) {
+      // Configure EDN with provided seed material, set trigger and start
+      // generating and fetching data.
+      TRY(config_run_edn(uj_data.init_seed, uj_data.reseed));
+      last_value = uj_data.reseed[11];
+    } else {
+      // Generate random seeds for the EDN configuration.
+      uint32_t init_seed[12];
+      uint32_t reseed[12];
+      generate_random(12, init_seed);
+      generate_random(12, reseed);
+      last_value = reseed[11];
+      // Configure EDN with random seed material, set trigger and start
+      // generating and fetching data.
+      TRY(config_run_edn(init_seed, reseed));
+    }
+    sample_fixed = prng_rand_uint32() & 0x1;
+  }
+
+  // Acknowledge test, send last reseed value back to host
+  // for verification.
+  edn_sca_result_t uj_output;
+  uj_output.result = last_value;
+  RESP_OK(ujson_serialize_edn_sca_result_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca_bus_data_batch_random(ujson_t *uj) {
+  // Get number of iterations.
+  edn_sca_batch_t uj_data;
+  TRY(ujson_deserialize_edn_sca_batch_t(uj, &uj_data));
+
+  uint32_t init_seed[12];
+  uint32_t reseed[12];
+  for (size_t it = 0; it < uj_data.num_iterations; it++) {
+    // Generate random seeds for the EDN configuration.
+    generate_random(12, init_seed);
+    generate_random(12, reseed);
+    // Configure EDN with random seed material, set trigger and start generating
+    // and fetching data.
+    TRY(config_run_edn(init_seed, reseed));
+  }
+
+  // Acknowledge test, send last random reseed value back to host
+  // for verification.
+  edn_sca_result_t uj_output;
+  uj_output.result = reseed[11];
+  RESP_OK(ujson_serialize_edn_sca_result_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca_bus_data(ujson_t *uj) {
+  // Get seed material.
+  edn_sca_seed_t uj_data;
+  TRY(ujson_deserialize_edn_sca_seed_t(uj, &uj_data));
+
+  // Configure EDN with provided seed material, set trigger and start generating
+  // and fetching data.
+  config_run_edn(uj_data.init_seed, uj_data.reseed);
+
+  // Acknowledge test.
+  edn_sca_result_t uj_output;
+  uj_output.result = 0;
+  RESP_OK(ujson_serialize_edn_sca_result_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca_init(ujson_t *uj) {
+  sca_select_trigger_type(kScaTriggerTypeSw);
+  // As we are using the software defined trigger, the first argument of
+  // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
+  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4 | kScaPeripheralEntropy |
+                                     kScaPeripheralCsrng | kScaPeripheralEdn);
+
+  // Disable the instruction cache and dummy instructions for SCA attacks.
+  sca_configure_cpu();
+
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // Initialize peripherals used in this SCA test.
+  TRY(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  TRY(dif_csrng_init(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+                     &csrng));
+  TRY(dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
+
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca(ujson_t *uj) {
+  edn_sca_subcommand_t cmd;
+  TRY(ujson_deserialize_edn_sca_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kEdnScaSubcommandInit:
+      return handle_edn_sca_init(uj);
+    case kEdnScaSubcommandBusData:
+      return handle_edn_sca_bus_data(uj);
+    case kEdnScaSubcommandBusDataBatchRandom:
+      return handle_edn_sca_bus_data_batch_random(uj);
+    case kEdnScaSubcommandBusDataBatchFvsr:
+      return handle_edn_sca_bus_data_batch_fvsr(uj);
+    default:
+      LOG_ERROR("Unrecognized EDN SCA subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/edn_sca.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/edn_sca.h
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EDN_SCA_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EDN_SCA_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+/**
+ * edn.sca.bus_data_batch_fvsr command handler.
+ *
+ * Batch version of edn.sca.bus_data with FvsR data.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca_bus_data_batch_fvsr(ujson_t *uj);
+
+/**
+ * edn.sca.bus_data_batch_random command handler.
+ *
+ * Batch version of edn.sca.bus_data with random data.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca_bus_data_batch_random(ujson_t *uj);
+
+/**
+ * edn.sca.bus_data command handler.
+ *
+ * The goal of this penetration test is to capture traces when
+ * the EDN generated random data and transfers it to Ibex.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca_bus_data(ujson_t *uj);
+
+/**
+ * Initializes the trigger and configures the device for the EDN SCA test.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca_init(ujson_t *uj);
+
+/**
+ * EDN SCA command handler.
+ *
+ * Command handler for the EDN SCA command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_EDN_SCA_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -17,6 +17,8 @@
 #include "sw/device/tests/crypto/cryptotest/json/drbg_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdh_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdsa_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/edn_fi_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/edn_sca_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hmac_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ibex_fi_commands.h"
@@ -34,6 +36,8 @@
 #include "drbg.h"
 #include "ecdh.h"
 #include "ecdsa.h"
+#include "edn_fi.h"
+#include "edn_sca.h"
 #include "hash.h"
 #include "hmac.h"
 #include "ibex_fi.h"
@@ -75,6 +79,12 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandAesSca:
         RESP_ERR(uj, handle_aes_sca(uj));
+        break;
+      case kCryptotestCommandEdnFi:
+        RESP_ERR(uj, handle_edn_fi(uj));
+        break;
+      case kCryptotestCommandEdnSca:
+        RESP_ERR(uj, handle_edn_sca(uj));
         break;
       case kCryptotestCommandIbexFi:
         RESP_ERR(uj, handle_ibex_fi(uj));

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -85,6 +85,20 @@ cc_library(
 )
 
 cc_library(
+    name = "edn_fi_commands",
+    srcs = ["edn_fi_commands.c"],
+    hdrs = ["edn_fi_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "edn_sca_commands",
+    srcs = ["edn_sca_commands.c"],
+    hdrs = ["edn_sca_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "ibex_fi_commands",
     srcs = ["ibex_fi_commands.c"],
     hdrs = ["ibex_fi_commands.h"],

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -20,6 +20,8 @@ extern "C" {
     value(_, Hmac) \
     value(_, Kmac) \
     value(_, AesSca) \
+    value(_, EdnFi) \
+    value(_, EdnSca) \
     value(_, IbexFi) \
     value(_, IbexSca) \
     value(_, KmacSca) \

--- a/sw/device/tests/crypto/cryptotest/json/edn_fi_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/edn_fi_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "edn_fi_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/edn_fi_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/edn_fi_commands.h
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EDN_FI_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EDN_FI_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define EDNFI_SUBCOMMAND(_, value) \
+    value(_, Init) \
+    value(_, BusData) \
+    value(_, BusAck)
+UJSON_SERDE_ENUM(EdnFiSubcommand, edn_fi_subcommand_t, EDNFI_SUBCOMMAND);
+
+#define EDNFI_TEST_RESULT(field, string) \
+    field(result, uint32_t) \
+    field(err_status, uint32_t)
+UJSON_SERDE_STRUCT(EdnFiTestResult, edn_fi_test_result_t, EDNFI_TEST_RESULT);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EDN_FI_COMMANDS_H_

--- a/sw/device/tests/crypto/cryptotest/json/edn_sca_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/edn_sca_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "edn_sca_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/edn_sca_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/edn_sca_commands.h
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EDN_SCA_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EDN_SCA_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define EDNSCA_SUBCOMMAND(_, value) \
+    value(_, Init) \
+    value(_, BusData) \
+    value(_, BusDataBatchRandom) \
+    value(_, BusDataBatchFvsr)
+UJSON_SERDE_ENUM(EdnScaSubcommand, edn_sca_subcommand_t, EDNSCA_SUBCOMMAND);
+
+#define EDNSCA_RESULT(field, string) \
+    field(result, uint32_t)
+UJSON_SERDE_STRUCT(EdnScaResult, edn_sca_result_t, EDNSCA_RESULT);
+
+#define EDNSCA_SEED(field, string) \
+    field(init_seed, uint32_t, 12) \
+    field(reseed, uint32_t, 12)
+UJSON_SERDE_STRUCT(EdnScaSeed, edn_sca_seed_t, EDNSCA_SEED);
+
+#define EDNSCA_SEED_BATCH(field, string) \
+    field(init_seed, uint32_t, 12) \
+    field(reseed, uint32_t, 12) \
+    field(num_iterations, uint32_t)
+UJSON_SERDE_STRUCT(EdnScaSeedBatch, edn_sca_seed_batch_t, EDNSCA_SEED_BATCH);
+
+#define EDNSCA_BATCH(field, string) \
+    field(num_iterations, uint32_t)
+UJSON_SERDE_STRUCT(EdnScaBatch, edn_sca_batch_t, EDNSCA_BATCH);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_EDN_SCA_COMMANDS_H_


### PR DESCRIPTION
This commit adds the following SCA & FI tests used to analyze EDN:
- edn.sca.bus_data
- edn.sca.bus_data_batch_random
- edn.sca.bus_data_batch_fvsr
- edn.fi.bus_data
- edn.fi.bus_ack