### PR TITLE
[cryptotest] Fix license header in wycheproof ed25519 test vector parser

### DIFF
--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright lowRISC contributors.
+# Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Fixes the license header in Ed25519 test vector parser to comply with the changes to `//quality:license_check` in #20823.