### PR TITLE
[crypto] Fix a bug in ECDSA-P256.

### DIFF
--- a/sw/otbn/crypto/p256_verify.s
+++ b/sw/otbn/crypto/p256_verify.s
@@ -244,7 +244,7 @@ p256_verify:
   la        x3, p256_n
   bn.lid    x0, 0(x3)
   bn.wsrw   MOD, w0
-  bn.subm   w24, w19, w31
+  bn.addm   w24, w19, w31
 
   /* If we got here the basic validity checks passed, so set `ok` to true. */
   la       x2, ok


### PR DESCRIPTION
Fixes the failing wycheproof ECDSA tests in #22322.

When computing the recovered x coordinate, we get a value that's reduced modulo p (the coordinate field modulus) and we then need to reduce this value modulo n (the curve order). This operation is almost always a no-op, since p and n are very close together; there's roughly a 2^-130 probability of hitting this range by chance. However, the code implementing the reduction was *always* a no-op. Essentially, by using `bn.subm` instead of `bn.addm` here, the code was conditionally *adding* the modulus n if `w19 - 0` underflowed, which it never would. Instead, we need `bn.addm`, which will conditionally *subtract* the modulus n if `w19 + 0` is greater than n.