### PR TITLE
[usbdev,dv] adds usbdev_in_iso_seq name in testplan

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -314,7 +314,7 @@
               without awaiting a handshake packet from the host.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_in_iso"]
     }
     {
       name: pkt_received


### PR DESCRIPTION
Adds in_iso sequence name in tesplan for regression run.