### PR TITLE
[prim,tlul,rtl] Explicitly cast a "1" to specific number of bits

### DIFF
--- a/hw/ip/prim/rtl/prim_packer_fifo.sv
+++ b/hw/ip/prim/rtl/prim_packer_fifo.sv
@@ -66,6 +66,7 @@ module prim_packer_fifo #(
 
   localparam int unsigned   WidthRatio = MaxW / MinW;
   localparam bit [DepthW:0] FullDepth = WidthRatio[DepthW:0];
+  localparam bit [DepthW:0] DepthOne = 1;
 
   // signals
   logic  load_data;
@@ -103,7 +104,7 @@ module prim_packer_fifo #(
     assign load_data = wvalid_i && wready_o;
 
     assign depth_d =  clear_status ? '0 :
-           load_data ? depth_q+1 :
+           load_data ? (depth_q + DepthOne):
            depth_q;
 
     assign data_d = clear_data ? '0 :
@@ -140,11 +141,11 @@ module prim_packer_fifo #(
 
     assign depth_d =  clear_status ? '0 :
            load_data ? max_value :
-           pull_data ? depth_q-1 :
+           pull_data ? (depth_q - DepthOne) :
            depth_q;
 
     assign ptr_d =  clear_status ? '0 :
-           pull_data ? ptr_q+1 :
+           pull_data ? (ptr_q + DepthOne) :
            ptr_q;
 
     assign data_d = clear_data ? '0 :

--- a/hw/ip/tlul/rtl/tlul_err.sv
+++ b/hw/ip/tlul/rtl/tlul_err.sv
@@ -48,9 +48,10 @@ module tlul_err import tlul_pkg::*; (
   logic mask_chk;       // inactive lane a_mask check
   logic fulldata_chk;   // PutFullData should have size match to mask
 
+  localparam bit [MW-1:0] MaskOne = 1;
   logic [MW-1:0] mask;
 
-  assign mask = (1 << tl_i.a_address[SubAW-1:0]);
+  assign mask = MaskOne << tl_i.a_address[SubAW-1:0];
 
   always_comb begin
     addr_sz_chk  = 1'b0;


### PR DESCRIPTION
This avoids a warning from Jasper (and, I suspect, some lint tools). The problem is that "1" is a 32-bit value, so "1 << xyz" is also a 32-bit value and the tool warns when we try to put it in something with fewer bits bits.

Explicitly making a "one" that's the right width seems to avoid the warnings and is obviously equivalent.