### PR TITLE
Sival update testplans

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -299,6 +299,7 @@
       si_stage: SV2
       lc_states: ["PROD"]
       tests: ["chip_sw_sleep_pwm_pulses"]
+      bazel: ["//sw/device/tests:sleep_pwm_pulses_test"]
     }
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -427,6 +428,7 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_sensor_ctrl_alert"]
+      bazel: ["//sw/device/tests:sensor_ctrl_alert_test"]
     }
 
     // SENSOR_CTRL tests:
@@ -446,6 +448,7 @@
       lc_states: ["PROD"]
       tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup",
               "chip_sw_sensor_ctrl_alert"]
+      bazel: ["//sw/device/tests:sensor_ctrl_alert_test", "//sw/device/tests:sensor_ctrl_wakeup_test"]
     }
     {
       name: chip_sw_sensor_ctrl_ast_status
@@ -691,6 +694,7 @@
       si_stage: SV2
       lc_states: ["PROD"]
       tests: ["chip_sw_power_virus"]
+      bazel: ["//sw/device/tests:power_virus_systemtest"]
     }
     {
       name: chip_sw_power_idle_load
@@ -721,6 +725,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_power_idle_load"]
+      bazel: ["//sw/device/tests:chip_power_idle_load"]
     }
     {
       name: chip_sw_power_sleep_load

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -258,6 +258,7 @@
       tests: ["chip_sw_keymgr_sideload_aes"]
       bazel: [
         "//sw/device/tests/crypto:aes_sideload_functest",
+        "//sw/device/tests/crypto:keymgr_sideload_aes_test",
         "//sw/device/tests/crypto:aes_kwp_sideload_functest",
       ]
     }

--- a/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
@@ -41,7 +41,7 @@
       lc_states: ["PROD"]
       features: ["AON_TIMER.WAKEUP.WAKEUP_CONFIG", "AON_TIMER.WAKEUP.WAKEUP_REQUEST"]
       tests: ["chip_sw_pwrmgr_smoketest"]
-      bazel: ["//sw/device/tests:pwrmgr_smoketest"]
+      bazel: ["//sw/device/tests:pwrmgr_smoketest", "//sw/device/tests:aon_timer_smoketest"]
     }
     {
       name: chip_sw_aon_timer_wdog_bark_irq

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -202,7 +202,7 @@
         "chip_sw_sram_ctrl_scrambled_access_jitter_en",
         "chip_sw_edn_entropy_reqs_jitter",
       ]
-      bazel: []
+      bazel: ["//sw/device/tests:clkmgr_jitter_test"]
     }
     {
       name: chip_sw_clkmgr_jitter_cycle_measurements

--- a/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
@@ -108,6 +108,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_csrng_kat_test"]
+      bazel: ["//sw/device/tests:csrng_kat_test"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -25,7 +25,11 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_entropy_src_ast_rng_req"]
-      bazel: ["//sw/device/tests:entropy_src_ast_rng_req_test"]
+      bazel: [
+        "//sw/device/tests:entropy_src_ast_rng_req_test",
+        "//sw/device/tests:entropy_src_fw_ovr_test",
+        "//sw/device/tests:entropy_src_fw_override_test"
+      ]
     },
     {
       name: chip_sw_entropy_src_csrng

--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -39,7 +39,7 @@
       lc_states: ["PROD"]
       tests: ["chip_sw_flash_ctrl_access",
               "chip_sw_flash_ctrl_access_jitter_en"]
-      bazel: ["//sw/device/tests:flash_ctrl_ops_test"]
+      bazel: ["//sw/device/tests:flash_ctrl_ops_test", "//sw/device/tests:flash_ctrl_test"]
     }
     {
       name: chip_sw_flash_ctrl_ops

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -97,7 +97,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_sideload_kmac"]
-      bazel: []
+      bazel: ["//sw/device/tests:keymgr_sideload_kmac_test"]
     }
     {
       name: chip_sw_keymgr_sideload_aes
@@ -112,6 +112,7 @@
       tests: ["chip_sw_keymgr_sideload_aes"]
       bazel: [
         "//sw/device/tests/crypto:aes_sideload_functest",
+        "//sw/device/tests:keymgr_sideload_aes_test",
         "//sw/device/tests/crypto:aes_kwp_sideload_functest",
       ]
     }

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -177,6 +177,7 @@
       tests: []
       bazel: [
         "//sw/device/tests/crypto/cryptotest:hash_kat",
+        "//sw/device/tests:kmac_mode_cshake_test",
       ]
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -40,6 +40,12 @@
       si_stage: SV3
       tests: ["chip_sw_otbn_ecdsa_op_irq",
               "chip_sw_otbn_ecdsa_op_irq_jitter_en"]
+      bazel: [
+              "//sw/device/tests:otbn_ecdsa_op_irq_test",
+              "//sw/device/tests:otbn_irq_test",
+              "//sw/device/tests:otbn_rsa_test",
+              "//sw/device/tests:otbn_smoketest"
+      ]
       lc_states: ["PROD"]
       features: [
         "OTBN.ISA"
@@ -121,6 +127,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_otbn_mem_scramble"]
+      bazel: ["//sw/device/tests:otbn_mem_scramble_test"]
       lc_states: ["PROD"]
       features: [
         "OTBN.MEM_SCRAMBLE",
@@ -143,6 +150,7 @@
         "//sw/device/tests:keymgr_sideload_otbn_simple_test",
         "//sw/device/tests/crypto:ecdh_p256_sideload_functest",
         "//sw/device/tests/crypto:ecdsa_p256_sideload_functest",
+        "//sw/device/tests:keymgr_sideload_otbn_test"
       ]
       lc_states: ["PROD"]
       features: [

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -159,6 +159,7 @@
         "SPI_DEVICE.MODE.TPM.READ_FIFO_MODE",
       ]
       tests: ["chip_sw_spi_device_tpm"]
+      bazel: ["//sw/device/tests:spi_device_tpm_tx_rx_test"]
     }
     {
       // This test is more a pinmux/padctrl test than a spi_device one. Consider reclassification.

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -97,7 +97,8 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["//sw/device/tests:spi_host_irq_test"]
+      tests: []
+      bazel: ["//sw/device/tests:spi_host_irq_test"]
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -19,7 +19,7 @@
       si_stage: SV2
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_mem_test"]
     }
     {
       name: chip_sw_usbdev_vbus
@@ -34,7 +34,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_vbus"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_vbus_test"]
     }
     {
       name: chip_sw_usbdev_pullup
@@ -59,7 +59,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_pullup"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_pullup_test"]
     }
     {
       name: chip_sw_usbdev_aon_pullup
@@ -84,7 +84,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_aon_pullup_test"]
     }
     {
       name: chip_sw_usbdev_sof
@@ -110,7 +110,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_sof_test"]
     }
     {
       name: chip_sw_usbdev_setup_rx
@@ -138,7 +138,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_setuprx"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_setuprx_test"]
     }
     {
       name: chip_sw_usbdev_config_host
@@ -163,7 +163,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_config_host_test"]
     }
     {
       name: chip_sw_usbdev_pincfg
@@ -190,7 +190,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_pincfg"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_pincfg_test"]
     }
     {
       name: chip_sw_usbdev_tx_rx
@@ -246,7 +246,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_usbdev_stream"]
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_stream_test"]
     }
     {
       name: chip_sw_usbdev_iso
@@ -275,7 +275,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_iso_test"]
     }
     {
       name: chip_sw_usbdev_mixed
@@ -303,7 +303,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_mixed_test"]
     }
     {
       name: chip_sw_usbdev_suspend_resume
@@ -333,7 +333,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_suspend_resume_test"]
     }
     {
       name: chip_sw_usbdev_aon_wake_reset
@@ -364,7 +364,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: ["//sw/device/tests:usbdev_aon_wake_reset"]
+      bazel: ["//sw/device/tests:usbdev_aon_wake_reset_test"]
     }
     {
       name: chip_sw_usbdev_aon_wake_disconnect
@@ -397,7 +397,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: ["//sw/device/tests:usbdev_aon_wake_disconnect"]
+      bazel: ["//sw/device/tests:usbdev_aon_wake_disconnect_test"]
     }
     {
       name: chip_sw_usbdev_toggle_restore
@@ -416,7 +416,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:usbdev_toggle_restore_test"]
     }
   ]
 }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -161,30 +161,6 @@ opentitan_test(
 )
 
 opentitan_test(
-    name = "aes_new_smoketest",
-    srcs = ["aes_smoketest.c"],
-    exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
-        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            "//hw/top_earlgrey:silicon_creator": None,
-        },
-    ),
-    deps = [
-        "//hw/ip/aes:model",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:memory",
-        "//sw/device/lib/base:mmio",
-        "//sw/device/lib/dif:aes",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:aes_testutils",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-    ],
-)
-
-opentitan_test(
     name = "alert_handler_ping_timeout_test",
     srcs = ["alert_handler_ping_timeout_test.c"],
     cw310 = new_cw310_params(timeout = "moderate"),


### PR DESCRIPTION
This PR adds bazel targets to the testplans which are already running on the nightlies but not linked.