### PR TITLE
 [cherry-pick] #22250 to `earlgrey_es_sival` branch 

### DIFF
--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -7,7 +7,6 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/memory.h"
-#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
@@ -19,6 +18,7 @@
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
 
 #include "otp_ctrl_regs.h"  // Generated.
@@ -114,8 +114,8 @@ static void curr_tbs_signature_le_to_be_convert(void) {
  * Helper function to compute measurements of various OTP partitions that are to
  * be included in attestation certificates.
  */
-static status_t measure_otp_partition(otp_partition_t partition,
-                                      hmac_digest_t *measurement) {
+static void measure_otp_partition(otp_partition_t partition,
+                                  hmac_digest_t *measurement) {
   // Compute the digest.
   otp_dai_read(partition, /*address=*/0, otp_state,
                kOtpPartitions[partition].size / sizeof(uint32_t));
@@ -128,34 +128,31 @@ static status_t measure_otp_partition(otp_partition_t partition,
     uint64_t expected_digest = otp_partition_digest_read(partition);
     uint32_t digest_hi = expected_digest >> 32;
     uint32_t digest_lo = expected_digest & UINT32_MAX;
-    TRY_CHECK(digest_hi == measurement->digest[1]);
-    TRY_CHECK(digest_lo == measurement->digest[0]);
+    HARDENED_CHECK_EQ(digest_hi, measurement->digest[1]);
+    HARDENED_CHECK_EQ(digest_lo, measurement->digest[0]);
   }
-
-  return OK_STATUS();
 }
 
-status_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
-                             hmac_digest_t *uds_pubkey_id, uint8_t *tbs_cert,
-                             size_t *tbs_cert_size) {
+rom_error_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
+                                hmac_digest_t *uds_pubkey_id, uint8_t *tbs_cert,
+                                size_t *tbs_cert_size) {
   // Measure OTP partitions.
   hmac_digest_t otp_creator_sw_cfg_measurement = {.digest = {0}};
   hmac_digest_t otp_owner_sw_cfg_measurement = {.digest = {0}};
   hmac_digest_t otp_hw_cfg_measurement = {.digest = {0}};
-  TRY(measure_otp_partition(kOtpPartitionCreatorSwCfg,
-                            &otp_creator_sw_cfg_measurement));
-  TRY(measure_otp_partition(kOtpPartitionOwnerSwCfg,
-                            &otp_owner_sw_cfg_measurement));
-  TRY(measure_otp_partition(kOtpPartitionHwCfg, &otp_hw_cfg_measurement));
+  measure_otp_partition(kOtpPartitionCreatorSwCfg,
+                        &otp_creator_sw_cfg_measurement);
+  measure_otp_partition(kOtpPartitionOwnerSwCfg, &otp_owner_sw_cfg_measurement);
+  measure_otp_partition(kOtpPartitionHwCfg, &otp_hw_cfg_measurement);
 
   // Generate the UDS key.
-  TRY(keymgr_state_check(kKeymgrStateInit));
+  HARDENED_RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateInit));
   keymgr_advance_state();
-  TRY(keymgr_state_check(kKeymgrStateCreatorRootKey));
-  TRY(otbn_boot_attestation_keygen(kUdsAttestationKeySeed,
-                                   kUdsKeymgrDiversifier, &curr_pubkey));
-  TRY(otbn_boot_attestation_key_save(kUdsAttestationKeySeed,
-                                     kUdsKeymgrDiversifier));
+  HARDENED_RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateCreatorRootKey));
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_keygen(
+      kUdsAttestationKeySeed, kUdsKeymgrDiversifier, &curr_pubkey));
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kUdsAttestationKeySeed, kUdsKeymgrDiversifier));
   curr_pubkey_le_to_be_convert();
 
   // Generate the key ID.
@@ -181,16 +178,17 @@ status_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
       .creator_pub_key_ec_y = (unsigned char *)curr_pubkey_be.y,
       .creator_pub_key_ec_y_size = kAttestationPublicKeyCoordBytes,
   };
-  TRY(uds_build_tbs(&uds_cert_tbs_params, tbs_cert, tbs_cert_size));
+  HARDENED_RETURN_IF_ERROR(
+      uds_build_tbs(&uds_cert_tbs_params, tbs_cert, tbs_cert_size));
 
-  return OK_STATUS();
+  return kErrorOk;
 }
 
-status_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
-                               hmac_digest_t *uds_pubkey_id,
-                               hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
-                               size_t *cert_size) {
-  TRY(keymgr_state_check(kKeymgrStateCreatorRootKey));
+rom_error_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
+                                  hmac_digest_t *uds_pubkey_id,
+                                  hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
+                                  size_t *cert_size) {
+  HARDENED_RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateCreatorRootKey));
 
   // Set attestation binding to the ROM_EXT measurement.
   memcpy(attestation_binding_value.data, inputs->rom_ext_measurement,
@@ -203,9 +201,10 @@ status_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
 
   // Generate the CDI_0 key.
   keymgr_advance_state();
-  TRY(keymgr_state_check(kKeymgrStateOwnerIntermediateKey));
-  TRY(otbn_boot_attestation_keygen(kCdi0AttestationKeySeed,
-                                   kCdi0KeymgrDiversifier, &curr_pubkey));
+  HARDENED_RETURN_IF_ERROR(
+      keymgr_state_check(kKeymgrStateOwnerIntermediateKey));
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_keygen(
+      kCdi0AttestationKeySeed, kCdi0KeymgrDiversifier, &curr_pubkey));
   curr_pubkey_le_to_be_convert();
 
   // Generate the key ID.
@@ -226,31 +225,35 @@ status_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
       .owner_intermediate_pub_key_ec_y = (unsigned char *)curr_pubkey_be.y,
       .owner_intermediate_pub_key_ec_y_size = kAttestationPublicKeyCoordBytes,
   };
-  TRY(cdi_0_build_tbs(&cdi_0_cert_tbs_params, cdi_0_cert_params.tbs,
-                      &cdi_0_cert_params.tbs_size));
+  HARDENED_RETURN_IF_ERROR(cdi_0_build_tbs(&cdi_0_cert_tbs_params,
+                                           cdi_0_cert_params.tbs,
+                                           &cdi_0_cert_params.tbs_size));
 
   // Sign the TBS and generate the certificate.
   hmac_digest_t tbs_digest;
   hmac_sha256(cdi_0_cert_params.tbs, cdi_0_cert_params.tbs_size, &tbs_digest);
-  TRY(otbn_boot_attestation_endorse(&tbs_digest, &curr_tbs_signature));
+  HARDENED_RETURN_IF_ERROR(
+      otbn_boot_attestation_endorse(&tbs_digest, &curr_tbs_signature));
   curr_tbs_signature_le_to_be_convert();
   cdi_0_cert_params.cert_signature_r = (unsigned char *)curr_tbs_signature_be.r;
   cdi_0_cert_params.cert_signature_r_size = kAttestationSignatureBytes / 2;
   cdi_0_cert_params.cert_signature_s = (unsigned char *)curr_tbs_signature_be.s;
   cdi_0_cert_params.cert_signature_s_size = kAttestationSignatureBytes / 2;
-  TRY(cdi_0_build_cert(&cdi_0_cert_params, cert, cert_size));
+  HARDENED_RETURN_IF_ERROR(
+      cdi_0_build_cert(&cdi_0_cert_params, cert, cert_size));
 
   // Save the CDI_0 private key to OTBN DMEM so it can endorse the next stage.
-  TRY(otbn_boot_attestation_key_save(kCdi0AttestationKeySeed,
-                                     kCdi0KeymgrDiversifier));
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kCdi0AttestationKeySeed, kCdi0KeymgrDiversifier));
 
-  return OK_STATUS();
+  return kErrorOk;
 }
 
-status_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
-                               hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
-                               size_t *cert_size) {
-  TRY(keymgr_state_check(kKeymgrStateOwnerIntermediateKey));
+rom_error_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
+                                  hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
+                                  size_t *cert_size) {
+  HARDENED_RETURN_IF_ERROR(
+      keymgr_state_check(kKeymgrStateOwnerIntermediateKey));
 
   // Set attestation binding to combination of Owner firmware and Ownership
   // Manifest measurements.
@@ -272,9 +275,9 @@ status_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
 
   // Generate the CDI_1 key.
   keymgr_advance_state();
-  TRY(keymgr_state_check(kKeymgrStateOwnerKey));
-  TRY(otbn_boot_attestation_keygen(kCdi1AttestationKeySeed,
-                                   kCdi1KeymgrDiversifier, &curr_pubkey));
+  HARDENED_RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateOwnerKey));
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_keygen(
+      kCdi1AttestationKeySeed, kCdi1KeymgrDiversifier, &curr_pubkey));
   curr_pubkey_le_to_be_convert();
 
   // Generate the key ID.
@@ -299,23 +302,26 @@ status_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
       .owner_pub_key_ec_y = (unsigned char *)curr_pubkey_be.y,
       .owner_pub_key_ec_y_size = kAttestationPublicKeyCoordBytes,
   };
-  TRY(cdi_1_build_tbs(&cdi_1_cert_tbs_params, cdi_1_cert_params.tbs,
-                      &cdi_1_cert_params.tbs_size));
+  HARDENED_RETURN_IF_ERROR(cdi_1_build_tbs(&cdi_1_cert_tbs_params,
+                                           cdi_1_cert_params.tbs,
+                                           &cdi_1_cert_params.tbs_size));
 
   // Sign the TBS and generate the certificate.
   hmac_digest_t tbs_digest;
   hmac_sha256(cdi_1_cert_params.tbs, cdi_1_cert_params.tbs_size, &tbs_digest);
-  TRY(otbn_boot_attestation_endorse(&tbs_digest, &curr_tbs_signature));
+  HARDENED_RETURN_IF_ERROR(
+      otbn_boot_attestation_endorse(&tbs_digest, &curr_tbs_signature));
   curr_tbs_signature_le_to_be_convert();
   cdi_1_cert_params.cert_signature_r = (unsigned char *)curr_tbs_signature_be.r;
   cdi_1_cert_params.cert_signature_r_size = kAttestationSignatureBytes / 2;
   cdi_1_cert_params.cert_signature_s = (unsigned char *)curr_tbs_signature_be.s;
   cdi_1_cert_params.cert_signature_s_size = kAttestationSignatureBytes / 2;
-  TRY(cdi_1_build_cert(&cdi_1_cert_params, cert, cert_size));
+  HARDENED_RETURN_IF_ERROR(
+      cdi_1_build_cert(&cdi_1_cert_params, cert, cert_size));
 
   // Save the CDI_1 private key to OTBN DMEM so it can endorse the next stage.
-  TRY(otbn_boot_attestation_key_save(kCdi1AttestationKeySeed,
-                                     kCdi1KeymgrDiversifier));
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kCdi1AttestationKeySeed, kCdi1KeymgrDiversifier));
 
-  return OK_STATUS();
+  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/cert/dice.h
+++ b/sw/device/silicon_creator/lib/cert/dice.h
@@ -7,10 +7,10 @@
 
 #include <stdint.h>
 
-#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
 
 enum {
   /**
@@ -40,9 +40,10 @@ enum {
  *                          computed size of the certificate).
  * @return The result of the operation.
  */
-status_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
-                             hmac_digest_t *uds_pubkey_id, uint8_t *cert,
-                             size_t *cert_size);
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
+                                hmac_digest_t *uds_pubkey_id, uint8_t *cert,
+                                size_t *cert_size);
 
 /**
  * Generates the CDI_0 attestation keypair and X.509 certificate.
@@ -58,10 +59,11 @@ status_t dice_uds_cert_build(manuf_certgen_inputs_t *inputs,
  *                          computed size of the certificate).
  * @return The result of the operation.
  */
-status_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
-                               hmac_digest_t *uds_pubkey_id,
-                               hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
-                               size_t *cert_size);
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
+                                  hmac_digest_t *uds_pubkey_id,
+                                  hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
+                                  size_t *cert_size);
 
 /**
  * Generates the CDI_1 attestation keypair and X.509 certificate.
@@ -76,8 +78,9 @@ status_t dice_cdi_0_cert_build(manuf_certgen_inputs_t *inputs,
  *                          computed size of the certificate).
  * @return The result of the operation.
  */
-status_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
-                               hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
-                               size_t *cert_size);
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_cdi_1_cert_build(manuf_certgen_inputs_t *inputs,
+                                  hmac_digest_t *cdi_0_pubkey_id, uint8_t *cert,
+                                  size_t *cert_size);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_H_

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -267,3 +267,27 @@ rom_error_t keymgr_sideload_clear_otbn(void) {
 
   return kErrorOk;
 }
+
+rom_error_t keymgr_owner_int_advance(keymgr_binding_value_t *sealing_binding,
+                                     keymgr_binding_value_t *attest_binding,
+                                     uint32_t max_key_version) {
+  HARDENED_RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateCreatorRootKey));
+  keymgr_sw_binding_set(sealing_binding, attest_binding);
+  keymgr_owner_int_max_ver_set(max_key_version);
+  keymgr_advance_state();
+  HARDENED_RETURN_IF_ERROR(
+      keymgr_state_check(kKeymgrStateOwnerIntermediateKey));
+  return kErrorOk;
+}
+
+rom_error_t keymgr_owner_advance(keymgr_binding_value_t *sealing_binding,
+                                 keymgr_binding_value_t *attest_binding,
+                                 uint32_t max_key_version) {
+  HARDENED_RETURN_IF_ERROR(
+      keymgr_state_check(kKeymgrStateOwnerIntermediateKey));
+  keymgr_sw_binding_set(sealing_binding, attest_binding);
+  keymgr_owner_max_ver_set(max_key_version);
+  keymgr_advance_state();
+  HARDENED_RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateOwnerKey));
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -208,6 +208,42 @@ rom_error_t keymgr_generate_attestation_key_otbn(
 OT_WARN_UNUSED_RESULT
 rom_error_t keymgr_sideload_clear_otbn(void);
 
+/**
+ * Sets the binding registers and advances the keymgr to the
+ * `OwnerIntermediateKey` (CDI_0) key stage.
+ *
+ * Preconditions: keymgr has been initialized and cranked to the
+ * `CreatorRootKey` stage.
+ *
+ * @param attest_binding The attestation binding value to use.
+ * @param sealing_binding The sealing binding value to use.
+ * @param max_key_version Maximum key version associated with the Silicon Owner
+ *                        Intermediate key manager stage.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t keymgr_owner_int_advance(keymgr_binding_value_t *attest_binding,
+                                     keymgr_binding_value_t *sealing_binding,
+                                     uint32_t max_key_version);
+
+/**
+ * Sets the binding registers and advances the keymgr to the `OwnerKey` (CDI_1)
+ * key stage.
+ *
+ * Preconditions: keymgr has been initialized and cranked to the
+ * `OwnerIntermediateKey` stage.
+ *
+ * @param attest_binding The attestation binding value to use.
+ * @param sealing_binding The sealing binding value to use.
+ * @param max_key_version Maximum key version associated with the Silicon Owner
+ *                        key manager stage.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t keymgr_owner_advance(keymgr_binding_value_t *attest_binding,
+                                 keymgr_binding_value_t *sealing_binding,
+                                 uint32_t max_key_version);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -59,6 +59,63 @@ class KeymgrTest : public rom_test::RomTest {
     EXPECT_ABS_WRITE32(base_ + KEYMGR_SALT_7_REG_OFFSET,
                        diversification.salt[7]);
   }
+  void ExpectSwBindingUnlockWait(void) {
+    EXPECT_ABS_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
+    EXPECT_SEC_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
+  }
+  void ExpectSwBindingValueSet(
+      const keymgr_binding_value_t *binding_value_sealing,
+      const keymgr_binding_value_t *binding_value_attestation) {
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
+                       binding_value_sealing->data[0]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_1_REG_OFFSET,
+                       binding_value_sealing->data[1]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_2_REG_OFFSET,
+                       binding_value_sealing->data[2]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_3_REG_OFFSET,
+                       binding_value_sealing->data[3]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET,
+                       binding_value_sealing->data[4]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET,
+                       binding_value_sealing->data[5]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET,
+                       binding_value_sealing->data[6]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET,
+                       binding_value_sealing->data[7]);
+
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET,
+                       binding_value_attestation->data[0]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_1_REG_OFFSET,
+                       binding_value_attestation->data[1]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_2_REG_OFFSET,
+                       binding_value_attestation->data[2]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_3_REG_OFFSET,
+                       binding_value_attestation->data[3]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_4_REG_OFFSET,
+                       binding_value_attestation->data[4]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_5_REG_OFFSET,
+                       binding_value_attestation->data[5]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_6_REG_OFFSET,
+                       binding_value_attestation->data[6]);
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_7_REG_OFFSET,
+                       binding_value_attestation->data[7]);
+
+    EXPECT_SEC_WRITE32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  }
+  void ExpectAdvanceState(void) {
+    EXPECT_ABS_WRITE32_SHADOWED(
+        base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,
+        {
+            {KEYMGR_CONTROL_SHADOWED_DEST_SEL_OFFSET,
+             KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE},
+            {KEYMGR_CONTROL_SHADOWED_OPERATION_OFFSET,
+             KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE},
+        });
+    EXPECT_ABS_WRITE32(base_ + KEYMGR_START_REG_OFFSET,
+                       {
+                           {KEYMGR_START_EN_BIT, true},
+                       });
+  }
   void ExpectWaitUntilDone(size_t busy_cycles, uint32_t end_status) {
     for (size_t i = 0; i < busy_cycles; i++) {
       EXPECT_ABS_READ32(base_ + KEYMGR_OP_STATUS_REG_OFFSET,
@@ -87,48 +144,14 @@ TEST_F(KeymgrTest, EntropyReseedIntervalSet) {
 }
 
 TEST_F(KeymgrTest, SwBindingValuesSet) {
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[0]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_1_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[1]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_2_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[2]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_3_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[3]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[4]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[5]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[6]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET,
-                     cfg_.binding_value_sealing.data[7]);
-
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[0]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_1_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[1]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_2_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[2]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_3_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[3]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_4_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[4]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_5_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[5]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_6_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[6]);
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_7_REG_OFFSET,
-                     cfg_.binding_value_attestation.data[7]);
-
-  EXPECT_SEC_WRITE32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  ExpectSwBindingValueSet(&cfg_.binding_value_sealing,
+                          &cfg_.binding_value_attestation);
   keymgr_sw_binding_set(&cfg_.binding_value_sealing,
                         &cfg_.binding_value_attestation);
 }
 
 TEST_F(KeymgrTest, SwBindingUnlockWait) {
-  EXPECT_ABS_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
-  EXPECT_SEC_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
+  ExpectSwBindingUnlockWait();
   keymgr_sw_binding_unlock_wait();
 }
 
@@ -155,18 +178,7 @@ TEST_F(KeymgrTest, SetOwnerMaxVerKey) {
 }
 
 TEST_F(KeymgrTest, AdvanceState) {
-  EXPECT_ABS_WRITE32_SHADOWED(
-      base_ + KEYMGR_CONTROL_SHADOWED_REG_OFFSET,
-      {
-          {KEYMGR_CONTROL_SHADOWED_DEST_SEL_OFFSET,
-           KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_NONE},
-          {KEYMGR_CONTROL_SHADOWED_OPERATION_OFFSET,
-           KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_ADVANCE},
-      });
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_START_REG_OFFSET,
-                     {
-                         {KEYMGR_START_EN_BIT, true},
-                     });
+  ExpectAdvanceState();
   keymgr_advance_state();
 }
 
@@ -324,6 +336,45 @@ TEST_F(KeymgrTest, SideloadClearOtbnReadbackMismatch) {
                     });
 
   EXPECT_EQ(keymgr_sideload_clear_otbn(), kErrorKeymgrInternal);
+}
+
+TEST_F(KeymgrTest, OwnerIntAdvance) {
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
+                    /*err_code=*/0u);
+  ExpectSwBindingValueSet(&cfg_.binding_value_sealing,
+                          &cfg_.binding_value_attestation);
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + KEYMGR_MAX_OWNER_INT_KEY_VER_SHADOWED_REG_OFFSET,
+      cfg_.max_key_ver);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET, 0);
+  ExpectAdvanceState();
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY,
+                    /*err_code=*/0u);
+  EXPECT_EQ(keymgr_owner_int_advance(&cfg_.binding_value_sealing,
+                                     &cfg_.binding_value_attestation,
+                                     cfg_.max_key_ver),
+            kErrorOk);
+}
+
+TEST_F(KeymgrTest, OwnerAdvance) {
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY,
+                    /*err_code=*/0u);
+  ExpectSwBindingValueSet(&cfg_.binding_value_sealing,
+                          &cfg_.binding_value_attestation);
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + KEYMGR_MAX_OWNER_KEY_VER_SHADOWED_REG_OFFSET, cfg_.max_key_ver);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_OWNER_KEY_VER_REGWEN_REG_OFFSET, 0);
+  ExpectAdvanceState();
+  ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
+                    KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_KEY,
+                    /*err_code=*/0u);
+  EXPECT_EQ(
+      keymgr_owner_advance(&cfg_.binding_value_sealing,
+                           &cfg_.binding_value_attestation, cfg_.max_key_ver),
+      kErrorOk);
 }
 
 }  // namespace


### PR DESCRIPTION
Some manual modifications were made to the cherry-picked commits to adapt them to the `earlgrey_es_sival` branch where the perso flow is still split into three separate binaries.