### PR TITLE
[usbdev,dv] Adds usbdev out data stage sequence

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -592,7 +592,7 @@
               an ACK packet or return a NAK if it is still processing previous data.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_out_data_stage"]
     }
     {
       name: endpoint_access

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_data_stage_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_data_stage_vseq.sv
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_out_data_stage_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_out_data_stage_vseq)
+
+  `uvm_object_new
+
+  task body();
+
+    configure_out_trans();
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_control_data_sequence();
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    // Check that the USB device respond with ACK or NAK
+    case (m_usb20_item.m_pid_type)
+      PidTypeAck: get_out_response_from_device(m_usb20_item, PidTypeAck);
+      PidTypeNak: get_out_response_from_device(m_usb20_item, PidTypeNak);
+      default: `uvm_error(`gfn, "Usbdev OUT Transaction Failed")
+    endcase
+    // Check that the USB device received a packet with the expected properties.
+    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
+  endtask
+
+  // Construct and transmit a control data packet
+  task call_control_data_sequence();
+    `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
+    m_data_pkt.m_pkt_type = PktTypeData;
+    m_data_pkt.m_pid_type = PidTypeData0;
+    // Construct a GET DESCRIPTOR request that retrieves the Device descriptor
+    m_data_pkt.m_bmRT = bmRequestType3;
+    m_data_pkt.m_bR = bRequestGET_DESCRIPTOR;
+    assert(m_data_pkt.randomize());
+    m_data_pkt.make_device_request(m_data_pkt.m_bmRT, m_data_pkt.m_bR,
+                                   8'h00, 8'h01, 16'h0, 16'd18);
+    start_item(m_data_pkt);
+    finish_item(m_data_pkt);
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -16,6 +16,7 @@
 `include "usbdev_in_trans_vseq.sv"
 `include "usbdev_in_iso_vseq.sv"
 `include "usbdev_nak_trans_vseq.sv"
+`include "usbdev_out_data_stage_vseq.sv"
 `include "usbdev_out_stall_vseq.sv"
 `include "usbdev_out_trans_nak_vseq.sv"
 `include "usbdev_phy_config_usb_ref_disable_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -41,6 +41,7 @@ filesets:
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_out_data_stage_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_stall_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_trans_nak_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_fifo_rst_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -85,6 +85,10 @@
       uvm_test_seq: usbdev_nak_trans_vseq
     }
     {
+      name: out_data_stage
+      uvm_test_seq: usbdev_out_data_stage_vseq
+    }
+    {
       name: usbdev_out_stall
       uvm_test_seq: usbdev_out_stall_vseq
     }


### PR DESCRIPTION
This sequence will test the USB device functionality: OUT data stage operation. The device receives a control data OUT packet and responds with ACK or NAK. If busy, NAK is sent; otherwise, ACK is returned.