### PR TITLE
[dv,usbdev] Copyright message update

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_dpi_config_host_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_dpi_config_host_vseq.sv
@@ -1,4 +1,4 @@
-// Copyright lowRISC contributors.
+// Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Open PR overlapped the update to the copyright header.