### PR TITLE
[reggen,fpv] Fix array sizes in fpv_csr.sv.tpl... again!

### DIFF
--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -49,8 +49,8 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
 
   # This is the width of hro_idx, which indexes into regwen, access_policy and
   # exp_vals. Each of those arrays has an index for each HRO register plus an
-  # extra index that represents "non-HRO registers".
-  hro_idx_width = (num_hro_regs + 1).bit_length()
+  # extra index (with value num_hro_regs) that represents "non-HRO registers".
+  hro_idx_width = num_hro_regs.bit_length()
 %>\
 
 `ifdef UVM


### PR DESCRIPTION
The previous change was mostly right, except for an off-by-one which didn't get triggered with the HRO register count I was testing with. If num_hro_regs = N, they will have indices 0, 1, ..., N-1. Then we'll throw in an extra index for non-HRO registers, with value N.

To represent an arbitrary one of these indices, we need $clog2(N) bits. My code was wrong and used $clog2(N+1) (because there are N+1 entries in the array).

It turns out that I was testing with a value of N where those two calculations give the same result. But it doesn't work with N=3 (the situation I have now).

Note in the PR: The previous (wrong) code was in PR #22408