### PR TITLE
[usbdev,dv] Adds usbdev_link_in_err_vseq

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -457,7 +457,7 @@
             - Verify that the link_in_err interrupt goes high following the handshake packet sent by the host.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_link_in_err"]
     }
     {
       name: rx_crc_err

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_link_in_err_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_link_in_err_vseq)
+
+  `uvm_object_new
+
+  virtual task body();
+    bit link_error;
+    configure_out_trans();
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    inter_packet_delay();
+    // Check that link_in_err interrupt is zero.
+    csr_rd(.ptr(ral.intr_state.link_in_err), .value(link_error));
+    `DV_CHECK_EQ(0, link_error);
+    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
+    call_token_seq(PidTypeInToken);
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    get_data_pid_from_device(m_usb20_item, PidTypeData0);
+    inter_packet_delay();
+    // Send unexpected PID to USB device and device will assert link_in_err interrupt.
+    // Expected pkt is ACK but send NYET packet.
+    call_handshake_sequence(PktTypeHandshake, PidTypeNyet);
+    csr_rd(.ptr(ral.intr_state.link_in_err), .value(link_error));
+    // Check link_in_err is asserted.
+    `DV_CHECK_EQ(1, link_error);
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -15,6 +15,7 @@
 `include "usbdev_in_stall_vseq.sv"
 `include "usbdev_in_trans_vseq.sv"
 `include "usbdev_in_iso_vseq.sv"
+`include "usbdev_link_in_err_vseq.sv"
 `include "usbdev_nak_trans_vseq.sv"
 `include "usbdev_out_stall_vseq.sv"
 `include "usbdev_out_trans_nak_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -37,6 +37,7 @@ filesets:
       - seq_lib/usbdev_nak_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_link_in_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -73,6 +73,10 @@
       uvm_test_seq: usbdev_in_trans_vseq
     }
     {
+      name: link_in_err
+      uvm_test_seq: usbdev_link_in_err_vseq
+    }
+    {
       name: usbdev_max_length_out_transaction
       uvm_test_seq: usbdev_max_length_out_transaction_vseq
     }


### PR DESCRIPTION
This PR introduces a new sequence, usbdev_link_in_err. This addition focuses on USB device functionalty, particularly where packet reception at an IN endpoint is initiated but subsequently dropped due to an error condition, thus facilitating accurate error reporting via link_in_err.