### PR TITLE
[bazel] Rename the cloud_kms token label

### DIFF
--- a/signing/tokens/BUILD
+++ b/signing/tokens/BUILD
@@ -23,8 +23,27 @@ signing_tool(
     tool = "//sw/host/hsmtool",
 )
 
+# TODO(lowrisc#22428): Remove this target once everyone has started using `cloud_kms_sival`.
 signing_tool(
     name = "cloud_kms",
+    data = [
+        "earlgrey_z1_sival.yaml",
+        "@cloud_kms_hsm//:libkmsp11",
+    ],
+    deprecation = "Please use the token `//signing/tokens:cloud_kms_sival`.",
+    env = {
+        # The Cloud KMS PKCS11 provider needs to know where the user's home
+        # is in order to load the gclould credentials.
+        "HOME": ENV["HOME"],
+        "HSMTOOL_MODULE": "$(location @cloud_kms_hsm//:libkmsp11)",
+        "KMS_PKCS11_CONFIG": "$(location earlgrey_z1_sival.yaml)",
+    },
+    location = "token",
+    tool = "//sw/host/hsmtool",
+)
+
+signing_tool(
+    name = "cloud_kms_sival",
     data = [
         "earlgrey_z1_sival.yaml",
         "@cloud_kms_hsm//:libkmsp11",

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -20,6 +20,8 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw310",
         "//hw/top_earlgrey:sim_dv",
         "//hw/top_earlgrey:sim_verilator",
+        # For some reason, this target makes englishbreakfast builds fail.
+        #"//hw/top_earlgrey:silicon_owner_sival_rom_ext",
     ],
     deps = [
         ":hello_world_lib",
@@ -43,7 +45,6 @@ cc_library(
         "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing/test_framework:check",
-        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
         "//sw/device/lib/testing/test_framework:ottf_start",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
     ],


### PR DESCRIPTION
1. Rename the `cloud_kms` token label to `cloud_kms_sival` and deprecate the old name.
2. Fix the `hello_world` demo to build as a sival ROM_EXT target.

This partially addresses #22428.
