### PR TITLE
[usbdev,dv] Avoid duplicate file when building usbdev tests

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent.core
+++ b/hw/dv/sv/usb20_agent/usb20_agent.core
@@ -10,7 +10,6 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
     files:
-      - usb20_if.sv
       - usb20_block_if.sv
       - usb20_agent_pkg.sv
       - usb20_agent_cfg.sv: {is_include_file: true}

--- a/hw/dv/sv/usb20_agent/usb20_agent.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent.sv
@@ -15,10 +15,6 @@ class usb20_agent extends dv_base_agent #(
 
 function void build_phase(uvm_phase phase);
   super.build_phase(phase);
-  // get usb20_if handle
-  if (!uvm_config_db#(virtual usb20_if)::get(this, "", "vif", cfg.vif)) begin
-    `uvm_fatal(`gfn, "failed to get usb20_if handle from uvm_config_db")
-  end
   // get usb20_block_if handle
   if (!uvm_config_db#(virtual usb20_block_if)::get(this, "", "bif", cfg.bif)) begin
     `uvm_fatal(`gfn, "failed to get usb20_block_if handle from uvm_config_db")

--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -5,7 +5,6 @@
 class usb20_agent_cfg extends dv_base_agent_cfg;
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
-  virtual usb20_if vif;
   virtual usb20_block_if bif;
   virtual clk_rst_if clk_rst_if_i;
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -105,7 +105,7 @@ endtask
     if (do_agent_connect) begin
       // Connect the USB20 agent and ensure that the USBDPI model is not connected.
       cfg.m_usb20_agent_cfg.bif.enable_driver(1'b1);
-      cfg.m_usb20_agent_cfg.vif.enable_driver(1'b0);
+      cfg.usb20_usbdpi_vif.enable_driver(1'b0);
       // Activate it as well? For common sequences we need defined inputs into the DUT to prevent
       // assertions and link-related interrupts from interfering with CSR tests, but we do not
       // want the usb20_agent to be active.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_dpi_config_host_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_dpi_config_host_vseq.sv
@@ -60,7 +60,7 @@ class usbdev_dpi_config_host_vseq extends usbdev_base_vseq;
     // First of all we want to ensure that the DPI model is connected via the 'usb20_if' which
     // models a physical USB, rather than employing the block-level DV interface.
     cfg.m_usb20_agent_cfg.bif.enable_driver(1'b0);
-    cfg.m_usb20_agent_cfg.vif.enable_driver(1'b1);
+    cfg.usb20_usbdpi_vif.enable_driver(1'b1);
 
     // We want full control of the DUT configuration and communications with the DPI model.
     do_agent_connect = 1'b0;

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:dv:usb20_agent
+      - lowrisc:dv:usb20_usbdpi
       - lowrisc:dv:dv_base_reg
     files:
       - usbdev_env_pkg.sv

--- a/hw/ip/usbdev/dv/env/usbdev_env.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env.sv
@@ -21,6 +21,10 @@ class usbdev_env extends cip_base_env #(
         cfg.aon_clk_rst_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get aon_clk_rst_if from uvm_config_db")
     end
+    // get usb20_if handle
+    if (!uvm_config_db#(virtual usb20_if)::get(this, "", "vif", cfg.usb20_usbdpi_vif)) begin
+      `uvm_fatal(`gfn, "failed to get usb20_if handle from uvm_config_db")
+    end
 
     // Use the configured USB speed for the main clock
     cfg.clk_rst_vif.set_freq_mhz(cfg.usb_clk_freq_mhz);

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -5,6 +5,7 @@
 class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
 
   virtual clk_rst_if  aon_clk_rst_vif;
+  virtual usb20_if    usb20_usbdpi_vif;
 
   // Reset kinds for USB
   string reset_kinds[] = {"HARD", "TL_IF"};

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -198,7 +198,7 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "aon_clk_rst_vif", aon_clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
-    uvm_config_db#(virtual usb20_if)::set(null, "*.env.m_usb20_agent*", "vif", usb20_if);
+    uvm_config_db#(virtual usb20_if)::set(null, "*.env", "vif", usb20_if);
     uvm_config_db#(virtual usb20_block_if)::set(null, "*.env.m_usb20_agent*","bif",usb20_block_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();


### PR DESCRIPTION
Before this change, usb20_if.sv appeared in two cores: usb20_usbdpi and usb20_agent. This causes silly warnings from EDA tools like VCS which point out that we have a spare copy of the file.

Avoid the duplication and leave a comment that explains what's going on.