### PR TITLE
[tock] Update the Tock kernel.

### DIFF
--- a/sw/device/silicon_owner/tock/apps/single_app_layout.ld
+++ b/sw/device/silicon_owner/tock/apps/single_app_layout.ld
@@ -9,7 +9,7 @@ TBF_HEADER_SIZE = 0x80;
 FLASH_START = 0x20040000;
 FLASH_LENGTH = 32M;
 
-RAM_START = 0x10005000;
+RAM_START = 0x10006000;
 RAM_LENGTH = 512K;
 
 /* TODO(cfrantz): Fix the ld_library rule to allow include paths and avoid  */

--- a/sw/device/silicon_owner/tock/kernel/layout.ld
+++ b/sw/device/silicon_owner/tock/kernel/layout.ld
@@ -14,10 +14,27 @@ MEMORY
    * and 0x2009_0000 to 0x2010_0000 is for flash storage.
    */
   prog  (rx)  : ORIGIN = 0x20040000, LENGTH = 0x60000
-  ram   (!rx) : ORIGIN = 0x10000000, LENGTH = 0x20000
+  fs    (r)   : ORIGIN = 0x200a0000, LENGTH = 0x60000
+  /* The first 0x650 bytes of RAM are reserved for the boot
+   * ROM, so we have to ignore that space.
+   * See https://github.com/lowRISC/opentitan/blob/master/sw/device/silicon_creator/lib/base/static_critical.ld
+   * for details
+   */
+  ram   (!rx) : ORIGIN = 0x10000650, LENGTH = 0x20000 - 0x650
 }
 
 SECTIONS {
+    /* Export the start & end of SRAM and flash as symbols for setting
+     * up the ePMP. Flash includes rom, prog and flash storage, such
+     * that we can use a single NAPOT region. The .text section will
+     * be made executable by a separate PMP region.
+     */
+    _sflash = ORIGIN(rom);
+    _eflash = ORIGIN(fs) + LENGTH(fs);
+
+    _ssram  = ORIGIN(ram) - 0x650;
+    _esram  = ORIGIN(ram) + LENGTH(ram);
+
     .manifest ORIGIN(rom):
     {
         _manifest = .;

--- a/sw/device/silicon_owner/tock/upstream_kernel/layout.ld
+++ b/sw/device/silicon_owner/tock/upstream_kernel/layout.ld
@@ -14,10 +14,27 @@ MEMORY
    * and 0x2009_0000 to 0x2010_0000 is for flash storage.
    */
   prog  (rx)  : ORIGIN = 0x20040000, LENGTH = 0x60000
-  ram   (!rx) : ORIGIN = 0x10000000, LENGTH = 0x20000
+  fs    (r)   : ORIGIN = 0x200a0000, LENGTH = 0x60000
+  /* The first 0x650 bytes of RAM are reserved for the boot
+   * ROM, so we have to ignore that space.
+   * See https://github.com/lowRISC/opentitan/blob/master/sw/device/silicon_creator/lib/base/static_critical.ld
+   * for details
+   */
+  ram   (!rx) : ORIGIN = 0x10000650, LENGTH = 0x20000 - 0x650
 }
 
 SECTIONS {
+    /* Export the start & end of SRAM and flash as symbols for setting
+     * up the ePMP. Flash includes rom, prog and flash storage, such
+     * that we can use a single NAPOT region. The .text section will
+     * be made executable by a separate PMP region.
+     */
+    _sflash = ORIGIN(rom);
+    _eflash = ORIGIN(fs) + LENGTH(fs);
+
+    _ssram  = ORIGIN(ram) - 0x650;
+    _esram  = ORIGIN(ram) + LENGTH(ram);
+
     .manifest ORIGIN(rom):
     {
         _manifest = .;

--- a/third_party/tock/repos.bzl
+++ b/third_party/tock/repos.bzl
@@ -40,9 +40,9 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
     bare_repository(
         name = "tock",
         local = tock,
-        strip_prefix = "tock-4d3a4c73372103acc95e0c016660a6943eec67dc",
-        url = "https://github.com/tock/tock/archive/4d3a4c73372103acc95e0c016660a6943eec67dc.tar.gz",
-        sha256 = "e72c26bf90ccc1fe3cfd143ee8fcec8423f5e59ae3f0773495181837798f237f",
+        strip_prefix = "tock-81602d4894bb5bb9e5157b5ea2876a902996ba1d",
+        url = "https://github.com/tock/tock/archive/81602d4894bb5bb9e5157b5ea2876a902996ba1d.tar.gz",
+        sha256 = "69d1fa4789909cb3206bfd9e1b3453f9cf1b1211ec989b7b753b2917cc653306",
         additional_files_content = {
             "BUILD": """exports_files(glob(["**"]))""",
             "arch/riscv/BUILD": crate_build(


### PR DESCRIPTION
This updates Tock past the [PMP rewrite](https://github.com/tock/tock/pull/3597), which should help with running Tock on ES hardware.