### PR TITLE
[lc_ctrl,dv] Fix width of coverage binding

### DIFF
--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov.core
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov.core
@@ -15,6 +15,7 @@ filesets:
     files:
       - lc_ctrl_fsm_cov_if.sv
       - lc_ctrl_cov_bind.sv
+      - lc_tx_cov_array_if.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_bind.sv
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_bind.sv
@@ -18,7 +18,7 @@ module lc_ctrl_cov_bind;
     .rst_ni(rst_ni),
     .val(lc_clk_byp_ack_i)
   );
-  bind lc_ctrl cip_lc_tx_cov_if u_lc_flash_rma_ack_i_if (
+  bind lc_ctrl lc_tx_cov_array_if #(.Count(NumRmaAckSigs)) u_lc_flash_rma_ack_i_if (
     .rst_ni(rst_ni),
     .val(lc_flash_rma_ack_i)
   );

--- a/hw/ip/lc_ctrl/dv/cov/lc_tx_cov_array_if.sv
+++ b/hw/ip/lc_ctrl/dv/cov/lc_tx_cov_array_if.sv
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is essentially the same as cip_lc_tx_cov_if, except that it allows a bundle of lc_tx values
+// in a single port and instantiates a copy of cip_lc_tx_cov_if for each.
+
+interface lc_tx_cov_array_if #(parameter int Count = 1) (input [4*Count - 1:0] val, input rst_ni);
+  for (genvar i = 0; i < Count; i++) begin : gen_connect_lc_tx_items
+    cip_lc_tx_cov_if lc_tx_if(.val(val[4*i+3:4*i]), .rst_ni(rst_ni));
+  end
+endinterface


### PR DESCRIPTION
The existing binding expected a single object of type lc_tx_t, but the thing that it was sampling changed type with commit fa447d0cdc9: it is now NumRmaAckSigs different lc_tx_t objects.

VCS correctly complains at build time about the width mismatch. I couldn't easily see how to name the instances sensibly and "bind things in a loop", so I've used a simple approach where the generate module inside the thing that gets bound.