### PR TITLE
[usbdev] Reduce timeout interval

### DIFF
--- a/hw/ip/usbdev/rtl/usb_fs_nb_in_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_in_pe.sv
@@ -16,10 +16,10 @@ module usb_fs_nb_in_pe #(
   parameter logic [4:0] NumInEps = 12,
   parameter int unsigned MaxInPktSizeByte = 32,
   // Targeting 17 bit times for the timeout. The counter runs on the 48 MHz
-  // clock, the SOP delay to rx_pkt_start_i is 3 bit times, and the EOP delay
-  // to tx_pkt_end_i is essentially 0. This timeout originates from Section
+  // clock, the SOP delay to rx_pkt_start_i is 1.5 bit times (synchronizer flops and K detection),
+  // and the EOP delay to tx_pkt_end_i is essentially 0. This timeout originates from Section
   // 7.1.19.1 of the USB 2.0 specification.
-  parameter int unsigned AckTimeoutCnt = (17 + 3) * 4,
+  parameter int unsigned AckTimeoutCnt = ((17 * 4) + 6) - 1,  // -1 because [N-1:0] counted
   localparam int unsigned InEpW = $clog2(NumInEps), // derived parameter
   localparam int unsigned PktW = $clog2(MaxInPktSizeByte), // derived parameter
   localparam int unsigned AckTimeoutCntW = $clog2(AckTimeoutCnt) // derived parameter


### PR DESCRIPTION
Time out in the event of a missing handshake response from the host was tardy. Must time out after 16-18 bit intervals (7.1.19.1) and the calculation anticipated a longer delay in the receipt of 'rx_pkt_start_i' signaling.

This PR reduces the time out to 17 bit intervals plus the 1.5 bit intervals for the SOP be seen within the IN packet engine.

Fixes #22437, from observations in simulation.