### PR TITLE
[usbdev,dv] adds usbdev_phy_config_tx_osc_test_mode

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -128,7 +128,7 @@
             - Verify that the device starts transmitting the J/K pattern continuously.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_phy_config_tx_osc_test_mode"]
     }
     {
       name: phy_config_eop_single_bit_handling

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_tx_osc_test_mode_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_tx_osc_test_mode_vseq.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_phy_config_tx_osc_test_mode_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_phy_config_tx_osc_test_mode_vseq)
+
+  `uvm_object_new
+
+  task body();
+    bit [10:0] usbstat_frame;
+    // phy_config.tx_osc_mode If enabled, the device constantly transmits a J/K pattern,
+    // which is useful for testing the USB clock. In oscillator test mode,
+    // the device no longer receives SOFs.
+    csr_wr(.ptr(ral.phy_config.tx_osc_test_mode), .value(1'b1));
+    csr_wr(.ptr(ral.ep_out_enable[0].enable[endp]), .value(1'b1)); // Enable EP
+    call_sof_seq(PktTypeSoF, PidTypeSofToken);
+    csr_rd(.ptr(ral.usbstat.frame), .value(usbstat_frame));
+    // Verify that device not received SoF pkt by reading USBSTAT register field frame.
+    // it should be zero.
+    `DV_CHECK_EQ(0, usbstat_frame);
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -20,6 +20,7 @@
 `include "usbdev_out_stall_vseq.sv"
 `include "usbdev_out_trans_nak_vseq.sv"
 `include "usbdev_phy_config_usb_ref_disable_vseq.sv"
+`include "usbdev_phy_config_tx_osc_test_mode_vseq.sv"
 `include "usbdev_phy_pins_sense_vseq.sv"
 `include "usbdev_pkt_buffer_vseq.sv"
 `include "usbdev_pkt_received_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -47,6 +47,7 @@ filesets:
       - seq_lib/usbdev_out_trans_nak_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_fifo_rst_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_config_usb_ref_disable_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_phy_config_tx_osc_test_mode_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_pins_sense_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_stall_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_priority_over_nak_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -125,6 +125,10 @@
       uvm_test_seq: usbdev_phy_config_usb_ref_disable_vseq
     }
     {
+      name: usbdev_phy_config_tx_osc_test_mode
+      uvm_test_seq: usbdev_phy_config_tx_osc_test_mode_vseq
+    }
+    {
       name: usbdev_setup_stage
       uvm_test_seq: usbdev_setup_stage_vseq
     }


### PR DESCRIPTION
This pull request includes a sequence that verifies the functionality of a USB device oscillator test mode. when this mode is on device will continue to transmit J/K pattern.