### PR TITLE
[sw] Fix params for parity test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5538,7 +5538,7 @@ opentitan_test(
 opentitan_test(
     name = "uart_parity_test",
     srcs = ["uart_parity_test.c"],
-    cw310 = new_cw310_params(
+    cw310 = cw310_params(
         test_cmd = " ".join([
             "--bootstrap=\"{firmware}\"",
             "--firmware-elf=\"{firmware:elf}\"",


### PR DESCRIPTION
This PR fixes a merge skew caused by the renaming of `new_cw310_params` to `cw310_params`.

Relevant PRs: #21845 #22078 