### PR TITLE
[dvsim] Tweak mode find/merge to be simpler to understand

### DIFF
--- a/util/dvsim/Regression.py
+++ b/util/dvsim/Regression.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from modes import Mode, find_mode, find_and_merge_modes
+from modes import Mode, find_mode, find_mode_list
 from Test import Test
 
 import logging as log
@@ -84,11 +84,8 @@ class Regression(Mode):
 
         for regression_obj in regression_objs:
             # Unpack the sim modes
-            found_sim_mode_objs = find_and_merge_modes(
-                regression_obj, regression_obj.en_sim_modes, build_modes,
-                False)
-
-            for sim_mode_obj in found_sim_mode_objs:
+            for sim_mode_obj in find_mode_list(regression_obj.en_sim_modes,
+                                               build_modes):
                 if sim_mode_obj.is_sim_mode == 0:
                     log.error(
                         "Enabled mode \"%s\" within the regression \"%s\" is not a sim mode",
@@ -125,12 +122,11 @@ class Regression(Mode):
             # Unpack the run_modes
             # TODO: If there are other params other than run_opts throw an
             # error and exit
-            found_run_mode_objs = find_and_merge_modes(
-                regression_obj, regression_obj.en_run_modes, run_modes, False)
 
             # Only merge the pre_run_cmds, post_run_cmds & run_opts from the
             # run_modes enabled
-            for run_mode_obj in found_run_mode_objs:
+            for run_mode_obj in find_mode_list(regression_obj.en_run_modes,
+                                               run_modes):
                 # Check if run_mode_obj is also passed on the command line, in
                 # which case, skip
                 if run_mode_obj.name in sim_cfg.en_run_modes:

--- a/util/dvsim/modes.py
+++ b/util/dvsim/modes.py
@@ -207,22 +207,19 @@ def find_mode(mode_name: str, modes: List[Mode]) -> Optional[Mode]:
     return None
 
 
-def find_and_merge_modes(mode: Mode,
-                         mode_names: List[str],
-                         modes: List[Mode],
-                         merge_modes: bool = True):
-    found_mode_objs = []
+def find_mode_list(mode_names: List[str], modes: List[Mode]) -> List[Mode]:
+    '''Find modes matching a list of names.'''
+    found_list = []
     for mode_name in mode_names:
-        sub_mode = find_mode(mode_name, modes)
-        if sub_mode is not None:
-            found_mode_objs.append(sub_mode)
-            if merge_modes is True:
-                mode.merge_mode(sub_mode)
-        else:
-            log.error("Mode \"%s\" enabled within mode \"%s\" not found!",
-                      mode_name, mode.name)
+        mode = find_mode(mode_name, modes)
+        if mode is None:
+            log.error("Cannot find requested mode ({}) in list. Known names: {}"
+                      .format(mode_name, [m.name for m in modes]))
             sys.exit(1)
-    return found_mode_objs
+
+        found_list.append(mode)
+
+    return found_list
 
 
 class BuildMode(Mode):


### PR DESCRIPTION
The existing code worked through a list of desired names and found
modes with these names. If the merge_modes flag was true then it also
merged each of the hits into the object supplied as the "mode"
argument. It turns out that this merging behaviour was actually only
used at one call-site.

This commit simplifies things. We now have a function called
find_mode_list which just does the filtering operation. The merging
part of things gets moved up to the call site.
