### PR TITLE
[i2c] Clean up target mode transaction boundaries and NACK handling

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -645,31 +645,62 @@
         }
         { bits: "10:8"
           name: "SIGNAL"
-          desc: "Host issued a START before transmitting ABYTE, a STOP or a RESTART after the preceeding ABYTE"
+          desc: '''
+                Indicates any control symbols associated with the ABYTE.
+
+                For the STOP symbol, a stretch timeout will cause a NACK_STOP to appear in the ACQ FIFO.
+                If the ACQ FIFO doesn't have enough space to record a START and a STOP, the transaction will be dropped entirely on a stretch timeout.
+                In that case, the START byte will not appear (neither as START nor NACK_START), but a standalone NACK_STOP may, if there was space.
+                Software can discard any standalone NACK_STOP that appears.
+
+                See the associated values for more information about the contents.
+                '''
           enum: [
             { value: "0",
               name: "NONE",
-              desc: "ABYTE contains ordinary data byte as received"
+              desc: "ABYTE contains an ordinary data byte that was received and ACK'd."
             },
             { value: "1",
               name: "START",
-              desc: "ABYTE contains the 8-bit I2C address (R/W in lsb)"
+              desc: '''
+                    A START condition preceded the ABYTE to start a new transaction.
+                    ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.
+                    '''
             },
             { value: "2",
               name: "STOP",
-              desc: "ABYTE contains junk"
+              desc: '''
+                    A STOP condition was received for a transaction including a transfer that addressed this Target.
+                    No transfers addressing this Target in that transaction were NACK'd.
+                    ABYTE contains no data.
+                    '''
             },
             { value: "3",
               name: "RESTART",
-              desc: "ABYTE contains junk, START with address will follow"
+              desc: '''
+                    A repeated START condition preceded the ABYTE, extending the current transaction with a new transfer.
+                    ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.
+                    '''
             },
             { value: "4",
               name: "NACK",
-              desc: "ABYTE contains either the address or data that was NACK'ed"
+              desc: '''ABYTE contains an ordinary data byte that was received and NACK'd.'''
             },
             { value: "5",
-              name: "NACKSTART",
-              desc: "ABYTE contains the I2C address which was ACK'ed, but the block will continue and NACK the next data byte that was received: this only happens for writes"
+              name: "NACK_START",
+              desc: '''
+                    A START condition preceded the ABYTE (including repeated START) that was part of a NACK'd transer.
+                    The ABYTE contains the matching I2C address and command bit.
+                    The ABYTE was ACK'd, but the rest of the transaction was NACK'ed.
+                    '''
+            },
+            { value: "6",
+              name: "NACK_STOP",
+              desc: '''
+                    A STOP condition was received for a transaction including a transfer that addressed this Target.
+                    A transfer addressing this Target was NACK'd.
+                    ABYTE contains no data.
+                    '''
             },
           ]
         }
@@ -705,7 +736,7 @@
     { name: "TARGET_TIMEOUT_CTRL"
       desc: '''
             I2C target internal stretching timeout control.
-            When the target has stretched beyond this time it will send a NACK.
+            When the target has stretched beyond this time it will send a NACK for incoming data bytes or release SDA for outgoing data bytes.
             '''
       swaccess: "rw"
       hwaccess: "hro"

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
@@ -49,7 +49,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
     // Target function clock stretch handling.
     StretchAddr,
     StretchTx, StretchTxSetup,
-    StretchAcqFull
+    StretchAcqFull, StretchAcqSetup
   } state_e;
 
   // initialize the states in which glitch is to be introduced
@@ -57,12 +57,16 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
   // WaitForStop -> Idle and WaitForStop -> AcquireStart
   // TransmitAckPulse -> Idle and TransmitAckPulse -> AcquireStart
   // AcquireByte -> Idle and AcquireByte -> AcquireStart
+  // StretchAcqSetup is also an invalid start, as a control symbol is impossible
+  // in this state.
   state_e read_states[]  = '{TransmitWait, TransmitSetup, TransmitPulse, TransmitHold, TransmitAck,
                             TransmitAckPulse, StretchTx, StretchTxSetup};
   state_e write_states[] = '{AcquireAckWait, AcquireAckSetup, AcquireAckPulse, AcquireAckHold,
                              StretchAcqFull};
   state_e addr_states[]  = '{StretchAddr, AddrAckWait, AddrAckSetup, AddrAckPulse, AddrAckHold};
-  state_e scl_high_states[]  = '{TransmitPulse, AcquireAckPulse, AddrAckPulse};
+  // AddrAckSetup is here because SCL and SDA can change simultaneously,
+  // leading to failures after the modeled CDC random insertion delay.
+  state_e scl_high_states[]  = '{TransmitPulse, AcquireAckPulse, AddrAckSetup, AddrAckPulse};
 
   // Common steps for DUT initialization
   virtual task setup();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
@@ -62,6 +62,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
   state_e write_states[] = '{AcquireAckWait, AcquireAckSetup, AcquireAckPulse, AcquireAckHold,
                              StretchAcqFull};
   state_e addr_states[]  = '{StretchAddr, AddrAckWait, AddrAckSetup, AddrAckPulse, AddrAckHold};
+  state_e scl_high_states[]  = '{TransmitPulse, AcquireAckPulse, AddrAckPulse};
 
   // Common steps for DUT initialization
   virtual task setup();
@@ -135,16 +136,17 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
     // Start sequence and inject glitch once the required state is observed
     m_i2c_target_seq.start(p_sequencer.i2c_sequencer_h);
     // Check ACQ FIFO after sequence is completed
-    // Check Rstart in case of AcquireStart
-    if (state_int == AcquireStart) begin
+    // Read Start address condition
+    if (state_int != Idle) begin
+      // Check Rstart in case bus wasn't idle
       csr_rd(.ptr(ral.acqdata), .value(data));
       `uvm_info(`gfn, $sformatf("acq_data = %0h", data), UVM_MEDIUM)
       `DV_CHECK_EQ_FATAL(data[9:8], 2'b11, "RStart condition not detected")
+    end else begin
+      csr_rd(.ptr(ral.acqdata), .value(data));
+      `uvm_info(`gfn, $sformatf("acq_data = %0h", data), UVM_MEDIUM)
+      `DV_CHECK_EQ_FATAL(data[9:8], 2'b01, "Start condition not detected")
     end
-    // Read Start address condition
-    csr_rd(.ptr(ral.acqdata), .value(data));
-    `uvm_info(`gfn, $sformatf("acq_data = %0h", data), UVM_MEDIUM)
-    `DV_CHECK_EQ_FATAL(data[9:8], 2'b01, "Start condition not detected")
     `DV_CHECK_EQ_FATAL(data[7:1], addr, $sformatf("Incorrect address detected;Expected %0h", addr))
     `DV_CHECK_EQ_FATAL(data[0], 1'b0, "Incorrect RW bit detected")
     // Read Write data
@@ -165,23 +167,23 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
     bit state_detected = 0;
     // Wait for the required state to be observed
     for(int i = 0; i < wait_timeout; i++) begin
-        int temp;
-        state_e state_int;
-        `DV_CHECK_FATAL(uvm_hdl_read(state_path, temp), "Failed to read fsm_state")
-        state_int = state_e'(temp);
-        `uvm_info(`gfn, $sformatf("observed State: %s", state_int.name()), UVM_HIGH)
-        if (state_int == state_expected) begin
-          state_detected = 1;
-          break;
-        end else begin
-          cfg.clk_rst_vif.wait_clks(1);
-        end
-      end
-      if (!state_detected) begin
-        `uvm_error(`gfn, $sformatf("timed out waiting for state: %s", state_expected.name()))
+      int temp;
+      state_e state_int;
+      `DV_CHECK_FATAL(uvm_hdl_read(state_path, temp), "Failed to read fsm_state")
+      state_int = state_e'(temp);
+      `uvm_info(`gfn, $sformatf("observed State: %s", state_int.name()), UVM_HIGH)
+      if (state_int == state_expected) begin
+        state_detected = 1;
+        break;
       end else begin
-        `uvm_info(`gfn, $sformatf("observed State: %s", state_expected.name()), UVM_MEDIUM)
+        cfg.clk_rst_vif.wait_clks(1);
       end
+    end
+    if (!state_detected) begin
+      `uvm_error(`gfn, $sformatf("timed out waiting for state: %s", state_expected.name()))
+    end else begin
+      `uvm_info(`gfn, $sformatf("observed State: %s", state_expected.name()), UVM_MEDIUM)
+    end
   endtask
 
   // Task to introduce glitch by forcing internal signal
@@ -195,7 +197,10 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
     uint timeout,
     state_e state_desired = AcquireStart);
     int res;
-      // Introduce glitch by forcing internal signal
+    state_e state_start;
+    `DV_CHECK_FATAL(uvm_hdl_read(fsm_state_path, res), "Failed to read fsm_state")
+    state_start = state_e'(res);
+    // Introduce glitch by forcing internal signal
     `DV_CHECK_FATAL(uvm_hdl_force(var_path, 1'b1), "Failed to force variable")
     cfg.m_i2c_agent_cfg.driver_rst = 1;
     // Reset agent
@@ -206,6 +211,13 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
     `DV_CHECK_EQ_FATAL(state_e'(res), state_desired,
       $sformatf("FSM did not transition to %s state", state_desired.name()))
     cfg.m_i2c_agent_cfg.driver_rst = 0;
+    if (is_scl_high_state(state_start)) begin
+      // Need to set SCL low to prevent detection of a stop
+      cfg.m_i2c_agent_cfg.vif.scl_o = 1'b0;
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+    // Wait for the DUT to stop driving SDA (1 cycle latency)
+    cfg.clk_rst_vif.wait_clks(1);
     `uvm_info(`gfn, "Stop SCL from driver", UVM_MEDIUM)
     // Stop driving SCL from driver
     cfg.m_i2c_agent_cfg.host_scl_stop = 1;
@@ -297,8 +309,10 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
       endcase
       // Add data items to transaction enter StretchAddr state
       if (addr_states[i] == StretchAddr) begin
-        // one transaction for start address and another for stop condition
-        repeat(I2C_ACQ_FIFO_DEPTH - 2) begin
+        // one entry each for the last byte to ACK and STOP + one free
+        // If there isn't another free slot, the DUT will stretch on the last
+        // byte instead.
+        repeat(I2C_ACQ_FIFO_DEPTH - 3) begin
           `uvm_create_obj(i2c_item, req)
           append_data(req, m_i2c_target_seq.req_q);
         end
@@ -334,7 +348,19 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
       begin
         bit acq_fifo_empty;
         csr_rd(.ptr(ral.status.acqempty), .value(acq_fifo_empty));
-        `DV_CHECK_EQ_FATAL(acq_fifo_empty, 1'b0, "ACQ FIFO is not empty for address glitch")
+        if (addr_states[i] == StretchAddr) begin
+          `DV_CHECK_EQ_FATAL(acq_fifo_empty, 1'b0, "ACQ FIFO is empty for StretchAddr glitch")
+        end else if ((addr_states[i] == AddrAckHold) && (thd_dat == 1)) begin
+          // If thd_dat is only 1 in this state, the write to the ACQ FIFO
+          // will happen immediately.
+          `DV_CHECK_EQ_FATAL(acq_fifo_empty, 1'b0, "ACQ FIFO is empty for addressed glitch")
+        end else if (target_state == Idle) begin
+          // The ACQ FIFO always has room for the Stop, which should get
+          // written.
+          `DV_CHECK_EQ_FATAL(acq_fifo_empty, 1'b0, "ACQ FIFO is empty for address stop glitch")
+        end else begin
+          `DV_CHECK_EQ_FATAL(acq_fifo_empty, 1'b1, "ACQ FIFO is not empty for address start glitch")
+        end
       end
       `uvm_info(`gfn, $sformatf("Start target smoke after glitch in %s ", addr_states[i].name()),
         UVM_MEDIUM)
@@ -424,7 +450,7 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
     i2c_target_base_seq m_i2c_target_seq;
     // Create sequence object
     `uvm_create_obj(i2c_target_base_seq, m_i2c_target_seq)
-    // Inject glitch in address states
+    // Inject glitch in read states
     foreach(read_states[i]) begin
       bit sequence_done = 0;
       `uvm_info(`gfn,
@@ -492,5 +518,12 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
     end
     clear_fifo();
   endtask
+
+  function bit is_scl_high_state(state_e state);
+    foreach (scl_high_states[i]) begin
+      if (state == scl_high_states[i]) return 1;
+    end
+    return 0;
+  endfunction
 
 endclass : i2c_glitch_vseq

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -134,9 +134,9 @@ module i2c_core import i2c_pkg::*;
   logic [TX_FIFO_WIDTH-1:0] tx_fifo_rdata;
 
   logic                      acq_fifo_wvalid;
-  logic                      acq_fifo_wready;
   logic [ACQ_FIFO_WIDTH-1:0] acq_fifo_wdata;
   logic [AcqFifoDepthW-1:0]  acq_fifo_depth;
+  logic                      acq_fifo_full;
   logic                      acq_fifo_rvalid;
   logic                      acq_fifo_rready;
   logic [ACQ_FIFO_WIDTH-1:0] acq_fifo_rdata;
@@ -190,7 +190,7 @@ module i2c_core import i2c_pkg::*;
   assign hw2reg.val.sda_rx.d = sda_rx_val;
 
   assign hw2reg.status.txfull.d = ~tx_fifo_wready;
-  assign hw2reg.status.acqfull.d = ~acq_fifo_wready;
+  assign hw2reg.status.acqfull.d = acq_fifo_full;
   assign hw2reg.status.txempty.d = ~tx_fifo_rvalid;
   assign hw2reg.status.acqempty.d = ~acq_fifo_rvalid;
   assign hw2reg.target_fifo_status.txlvl.d = MaxFifoDepthW'(tx_fifo_depth);
@@ -482,10 +482,10 @@ module i2c_core import i2c_pkg::*;
     .tx_fifo_rready_o        (tx_fifo_rready),
     .tx_fifo_rdata_i         (tx_fifo_rdata),
 
-    .acq_fifo_wready_o              (acq_fifo_wready),
     .acq_fifo_wvalid_o              (acq_fifo_wvalid),
     .acq_fifo_wdata_o               (acq_fifo_wdata),
     .acq_fifo_rdata_i               (acq_fifo_rdata),
+    .acq_fifo_full_o                (acq_fifo_full),
     .acq_fifo_depth_i               (acq_fifo_depth),
 
     .target_idle_o                  (target_idle),
@@ -688,7 +688,7 @@ module i2c_core import i2c_pkg::*;
   ) intr_hw_acq_overflow (
     .clk_i,
     .rst_ni,
-    .event_intr_i           (~acq_fifo_wready),
+    .event_intr_i           (acq_fifo_full),
     .reg2hw_intr_enable_q_i (reg2hw.intr_enable.acq_full.q),
     .reg2hw_intr_test_q_i   (reg2hw.intr_test.acq_full.q),
     .reg2hw_intr_test_qe_i  (reg2hw.intr_test.acq_full.qe),

--- a/hw/ip/i2c/rtl/i2c_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_pkg.sv
@@ -23,14 +23,13 @@ package i2c_pkg;
     // 2. We received too many bytes in a write request and had to NACK a data
     // byte. The NACK'ed data byte is still in the data field for inspection.
     AcqNack      = 3'b100,
-    // AcqNackStart means that we got a write request to our address, we sent
-    // an ACK to back to the host so that we can be compatible with SMBus, but
-    // now we must unconditionally NACK the next byte. We cannot record that
-    // NACK'ed byte because there is no space in the ACQ FIFO. The OpenTitan
-    // software must know this distinction from a normal AcqNack because the
-    // state machine must still continue through the AcquireByte and Nack*
-    // states.
-    AcqNackStart = 3'b101
+    // AcqNackStart means that we were addressed on this item, but we timed
+    // out after stretching.
+    AcqNackStart = 3'b101,
+    // AcqNackStop means that we were addressed during the transaction, but we
+    // timed out after stretching and received the Stop to end the
+    // transaction.
+    AcqNackStop  = 3'b110
   } i2c_acq_byte_id_e;
 
   // Width of each entry in the FMT FIFO with enough space for an 8-bit data

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -205,8 +205,23 @@ typedef enum dif_i2c_signal {
    */
   kDifI2cSignalRepeat = 3,
   /**
+   * The associated data byte was NACK'd.
+   */
+  kDifI2cSignalNack = 4,
+  /**
+   * There was a stretch timeout on the associated address byte, leading to
+   * NACKing all subsequent incoming bytes for the rest of the transaction (and
+   * returning 0xFF bytes on any subsequent reads in that transaction).
+   */
+  kDifI2cSignalNackStart = 5,
+  /**
+   * A STOP signal was received to end a transaction that experienced a stretch
+   * timeout or other I/O error condition.
+   */
+  kDifI2cSignalNackStop = 6,
+  /**
    * There's no associated STOP or START signal this is just a byte that's been
-   * written to the I2C target in an ongoing transaction
+   * written to the I2C target in an ongoing transaction, and it was ACK'd.
    */
   kDifI2cSignalNone = 0,
 } dif_i2c_signal_t;

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -432,8 +432,11 @@ status_t i2c_testutils_wait_host_idle(const dif_i2c_t *i2c) {
 
 status_t i2c_testutils_wait_transaction_finish(const dif_i2c_t *i2c) {
   dif_i2c_status_t status;
+  bool controller_halted = false;
   do {
     TRY(dif_i2c_get_status(i2c, &status));
-  } while (!status.fmt_fifo_empty);
+    TRY(dif_i2c_irq_is_pending(i2c, kDifI2cIrqControllerHalt,
+                               &controller_halted));
+  } while (!status.fmt_fifo_empty || controller_halted);
   return OK_STATUS();
 }


### PR DESCRIPTION
Change recording of Start symbols to always accompany the address data,
instead of recording a separate R.Start, then Start+address. This helps
maintain certain availability invariants needed for reliable stretching
and NACK handling.

Note that a controller that chooses to do a Repeated Start and address a
*different* target is an unusual case, and it leads to a situation where
the transfer closing symbol won't appear until the Stop or a later
Repeated Start that *does* address this target. While this transaction
style is not explicitly forbidden in the I2C specification, it is not
typically supported in the wild. In any case, software should be able to
resolve this case, and a closing symbol will eventually appear.

Fix up the DV transaction generation to match the expected behavior.

Remove the extra NACK-specific states, generate ACQ FIFO entries at the
point of the NACK timeout, and go to WaitForStop to release SDA and SCL.
Return 0xFF on reads for NACK'd transactions.

Add NackStop as an ACQ FIFO value to indicate the end of transactions
that had errors (generally, NACK'd transfers).

Fix up the glitch sequence to better handle the various states.

Finally, add a StretchAcqSetup state to force the target FSM to maintain the required setup time for the ACK bit it started driving.