### PR TITLE
[usbdev,dv] Get rid of get_out_response_from_device

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -9,8 +9,12 @@ class usb20_item extends uvm_sequence_item;
   brequest_e m_bR;
   usb_transfer_e m_usb_transfer;
 
-  `uvm_object_new
+  // Check the PID type of this item is the expected value. If not, raise a fatal error.
+  function void check_pid_type(pid_type_e expected);
+    `DV_CHECK_EQ_FATAL(m_pid_type, expected)
+  endfunction
 
+  `uvm_object_new
 endclass
 
 class token_pkt extends usb20_item;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
     call_data_seq(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
     get_response(rsp_item);
     $cast(item, rsp_item);
-    get_out_response_from_device(item, PidTypeAck);
+    item.check_pid_type(PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check that the USB device received a packet with the expected properties.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -170,14 +170,6 @@ endtask
     finish_item(m_data_pkt);
   endtask
 
-  virtual task get_out_response_from_device(usb20_item rsp_itm, input pid_type_e pid_type);
-    `uvm_create_on(m_handshake_pkt, p_sequencer.usb20_sequencer_h)
-    m_handshake_pkt.m_pid_type = pid_type;
-    m_usb20_item = m_handshake_pkt;
-    // DV_CHECK on device reponse
-    `DV_CHECK_EQ(m_usb20_item.m_pid_type, rsp_itm.m_pid_type);
-  endtask
-
   virtual task get_data_pid_from_device(usb20_item rsp_itm, input pid_type_e pid_type);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
     m_data_pkt.m_pid_type = pid_type;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -36,7 +36,7 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     call_data_seq(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    m_usb20_item.check_pid_type(PidTypeAck);
 
     // Check that the USB device received a packet with the expected properties.
     check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_iso_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_iso_vseq.sv
@@ -15,7 +15,7 @@ class usbdev_in_iso_vseq extends usbdev_base_vseq;
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     // check OUT response
-    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    m_usb20_item.check_pid_type(PidTypeAck);
     inter_packet_delay();
     // register configurations for IN Trans.
     configure_in_trans(out_buffer_id, m_data_pkt.data.size());

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
@@ -27,7 +27,7 @@ class usbdev_in_rand_trans_vseq extends usbdev_base_vseq;
     call_data_seq(PidTypeData0, 1'b0, num_of_bytes);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeAck); // check OUT response with ACK
+    m_usb20_item.check_pid_type(PidTypeAck);
     inter_packet_delay();
     // IN Trans configurations
     configure_in_trans(out_buffer_id, m_data_pkt.data.size());

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
@@ -16,6 +16,6 @@ class usbdev_in_stall_vseq extends usbdev_base_vseq;
     call_token_seq(PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeStall);
+    m_usb20_item.check_pid_type(PidTypeStall);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -23,7 +23,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeAck); // check OUT response
+    m_usb20_item.check_pid_type(PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
     // Read rxfifo reg
     csr_rd(.ptr(ral.rxfifo), .value(rxfifo));

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -28,7 +28,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Check first transaction accuracy
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    m_usb20_item.check_pid_type(PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Read rxenable_out
@@ -52,7 +52,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     // Check second transaction accuracy
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeNak);
+    m_usb20_item.check_pid_type(PidTypeNak);
   endtask
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -24,6 +24,6 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeStall);
+    m_usb20_item.check_pid_type(PidTypeStall);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -24,6 +24,6 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
     cfg.clk_rst_vif.wait_clks(20);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeNak);
+    m_usb20_item.check_pid_type(PidTypeNak);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pending_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pending_in_trans_vseq.sv
@@ -24,7 +24,7 @@ class usbdev_pending_in_trans_vseq extends usbdev_base_vseq;
     call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    m_usb20_item.check_pid_type(PidTypeAck);
     // Verify that after the setup transaction, the waiting IN transction is canceled
     // by checking 'rdy' and 'pend' bit of configin register.
     csr_rd(ral.configin[endp], config_in);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -21,7 +21,7 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
     call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    m_usb20_item.check_pid_type(PidTypeAck);
 
     // Check that the USB device received a packet with the expected properties.
     check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -26,7 +26,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    m_usb20_item.check_pid_type(PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Read rxfifo reg

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -23,7 +23,7 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
     call_data_seq(PidTypeData0, .randomize_length(randomize_length), .num_of_bytes(num_of_bytes));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
-    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    m_usb20_item.check_pid_type(PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check that the USB device received a packet with the expected properties.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -101,7 +101,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     finish_item(m_data_pkt);
     get_response(rsp_item);
     $cast(response, rsp_item);
-    get_out_response_from_device(response, PidTypeAck);
+    response.check_pid_type(PidTypeAck);
   endtask
 
 endclass : usbdev_smoke_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_priority_over_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_priority_over_nak_vseq.sv
@@ -23,6 +23,6 @@ class usbdev_stall_priority_over_nak_vseq extends usbdev_base_vseq;
     $cast(m_usb20_item, m_response_item);
     // Verify that the device responds with a Stall PID instead of a nak,
     // as Stall takes priority in this context.
-    get_out_response_from_device(m_usb20_item, PidTypeStall);
+    m_usb20_item.check_pid_type(PidTypeStall);
   endtask
 endclass


### PR DESCRIPTION
This task didn't actually do anything interesting! It was actually just checking that the supplied usb20_item had the PID that was provided. There were lots of other lines as well, but these had no effect.

Probably better to ditch the extra noise.