### PR TITLE
[sival] fix GPIO tests on silicon

### DIFF
--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -140,11 +140,20 @@ const dif_pinmux_index_t kPinmuxTestutilsGpioMioOutPins[kDifGpioNumPins] = {
     kTopEarlgreyPinmuxMioOutIor12, kTopEarlgreyPinmuxMioOutIor13};
 
 uint32_t pinmux_testutils_get_testable_gpios_mask(void) {
-  if (kDeviceType == kDeviceFpgaCw310) {
-    // Only IOR6, IOR7, and IOR10 to IOR13 are available for use as GPIOs.
-    return 0xfc000000;
-  } else {
-    return 0xffffffff;
+  switch (kDeviceType) {
+    case kDeviceSimDV:
+    case kDeviceSimVerilator:
+      // All GPIOs are testable in DV.
+      return 0xffffffff;
+    case kDeviceFpgaCw310:
+      // Only IOR6, IOR7, and IOR10 to IOR13 are available for use as GPIOs.
+      return 0xfc000000;
+    case kDeviceSilicon:
+      // IOA3/6, IOB6, IOC9-12, IOR5-7 and IOR10-13.
+      return 0xfe0f0248;
+    default:
+      CHECK(false);
+      return 0;
   }
 }
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1763,6 +1763,7 @@ opentitan_test(
         {
             # Not compatible with the verilated top level.
             "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
             "//hw/top_earlgrey:sim_dv": None,
         },

--- a/sw/host/tests/chip/gpio/src/main.rs
+++ b/sw/host/tests/chip/gpio/src/main.rs
@@ -148,6 +148,80 @@ static CONFIG: Lazy<HashMap<&'static str, Config>> = Lazy::new(|| {
                 PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio28,
             },
         },
+        "teacup" => Config {
+            input: collection! {
+                // The commented lines represent multi-fuction pins.  These will
+                // be added back in when the hyperdebug firmware can set these
+                // multifunction pins into GPIO mode.
+
+                //PinmuxPeripheralIn::GpioGpio0 => PinmuxInsel::Ioa0,   // UART4
+                //PinmuxPeripheralIn::GpioGpio1 => PinmuxInsel::Ioa1,   // UART4
+                //PinmuxPeripheralIn::GpioGpio2 => PinmuxInsel::Ioa2,   // VBUS_EN_SENSE
+                PinmuxPeripheralIn::GpioGpio3 => PinmuxInsel::Ioa3,
+                //PinmuxPeripheralIn::GpioGpio4 => PinmuxInsel::Ioa4,   // UART5
+                //PinmuxPeripheralIn::GpioGpio5 => PinmuxInsel::Ioa5,   // UART5
+                PinmuxPeripheralIn::GpioGpio6 => PinmuxInsel::Ioa6,
+                //PinmuxPeripheralIn::GpioGpio7 => PinmuxInsel::Ioa7,   // I2C1
+                //PinmuxPeripheralIn::GpioGpio8 => PinmuxInsel::Ioa8,   // I2C1
+                //PinmuxPeripheralIn::GpioGpio9 => PinmuxInsel::Iob4,   // UART3
+                //PinmuxPeripheralIn::GpioGpio10 => PinmuxInsel::Iob5,  // UART3
+                PinmuxPeripheralIn::GpioGpio11 => PinmuxInsel::Iob6,
+
+                PinmuxPeripheralIn::GpioGpio12 => PinmuxInsel::Ioc0,
+                PinmuxPeripheralIn::GpioGpio13 => PinmuxInsel::Ioc1,
+                PinmuxPeripheralIn::GpioGpio14 => PinmuxInsel::Ioc2,
+
+                PinmuxPeripheralIn::GpioGpio15 => PinmuxInsel::Ioc5,
+                PinmuxPeripheralIn::GpioGpio16 => PinmuxInsel::Ioc6,
+                PinmuxPeripheralIn::GpioGpio17 => PinmuxInsel::Ioc10,
+                PinmuxPeripheralIn::GpioGpio18 => PinmuxInsel::Ioc11,
+                PinmuxPeripheralIn::GpioGpio19 => PinmuxInsel::Ioc12,
+
+                PinmuxPeripheralIn::GpioGpio20 => PinmuxInsel::Ior5,
+                PinmuxPeripheralIn::GpioGpio21 => PinmuxInsel::Ior6,
+                PinmuxPeripheralIn::GpioGpio22 => PinmuxInsel::Ior7,
+                // IOR8-9 aren't MIOs.
+                PinmuxPeripheralIn::GpioGpio25 => PinmuxInsel::Ior10,
+                PinmuxPeripheralIn::GpioGpio26 => PinmuxInsel::Ior11,
+                PinmuxPeripheralIn::GpioGpio27 => PinmuxInsel::Ior12,
+                PinmuxPeripheralIn::GpioGpio28 => PinmuxInsel::Ior13,
+
+            },
+            output: collection! {
+                // The commented lines represent multi-fuction pins.  These will
+                // be added back in when the hyperdebug firmware can set these
+                // multifunction pins into GPIO mode.
+
+                //PinmuxMioOut::Ioa0 => PinmuxOutsel::GpioGpio0,   // UART4
+                //PinmuxMioOut::Ioa1 => PinmuxOutsel::GpioGpio1,   // UART4
+                //PinmuxMioOut::Ioa2 => PinmuxOutsel::GpioGpio2,   // VBUS_EN_SENSE
+                PinmuxMioOut::Ioa3 => PinmuxOutsel::GpioGpio3,
+                //PinmuxMioOut::Ioa4 => PinmuxOutsel::GpioGpio4,   // UART5
+                //PinmuxMioOut::Ioa5 => PinmuxOutsel::GpioGpio5,   // UART5
+                PinmuxMioOut::Ioa6 => PinmuxOutsel::GpioGpio6,
+                //PinmuxMioOut::Ioa7 => PinmuxOutsel::GpioGpio7,   // I2C1
+                //PinmuxMioOut::Ioa8 => PinmuxOutsel::GpioGpio8,   // I2C1
+                //PinmuxMioOut::Iob4 => PinmuxOutsel::GpioGpio9,   // UART3
+                //PinmuxMioOut::Iob5 => PinmuxOutsel::GpioGpio10,  // UART3
+                PinmuxMioOut::Iob6 => PinmuxOutsel::GpioGpio11,
+                PinmuxMioOut::Ioc0 => PinmuxOutsel::GpioGpio12,
+                PinmuxMioOut::Ioc1 => PinmuxOutsel::GpioGpio13,
+                PinmuxMioOut::Ioc2 => PinmuxOutsel::GpioGpio14,
+                PinmuxMioOut::Ioc5 => PinmuxOutsel::GpioGpio15,
+                PinmuxMioOut::Ioc6 => PinmuxOutsel::GpioGpio16,
+                PinmuxMioOut::Ioc10 => PinmuxOutsel::GpioGpio17,
+                PinmuxMioOut::Ioc11 => PinmuxOutsel::GpioGpio18,
+                PinmuxMioOut::Ioc12 => PinmuxOutsel::GpioGpio19,
+                PinmuxMioOut::Ior5 => PinmuxOutsel::GpioGpio20,
+                PinmuxMioOut::Ior6 => PinmuxOutsel::GpioGpio21,
+                PinmuxMioOut::Ior7 => PinmuxOutsel::GpioGpio22,
+                // IOR8-9 aren't MIOs.
+                PinmuxMioOut::Ior10 => PinmuxOutsel::GpioGpio25,
+                PinmuxMioOut::Ior11 => PinmuxOutsel::GpioGpio26,
+                PinmuxMioOut::Ior12 => PinmuxOutsel::GpioGpio27,
+                PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio28,
+            },
+        },
     }
 });
 

--- a/sw/host/tests/chip/gpio_intr/src/main.rs
+++ b/sw/host/tests/chip/gpio_intr/src/main.rs
@@ -83,6 +83,37 @@ static CONFIG: Lazy<HashMap<&'static str, Config>> = Lazy::new(|| {
                 PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio28,
             },
         },
+        // Replication of the hyper310 config.
+        "teacup" => Config {
+            input: collection! {
+                PinmuxPeripheralIn::GpioGpio17 => PinmuxInsel::Ioc10,
+                PinmuxPeripheralIn::GpioGpio18 => PinmuxInsel::Ioc11,
+                PinmuxPeripheralIn::GpioGpio19 => PinmuxInsel::Ioc12,
+
+                PinmuxPeripheralIn::GpioGpio20 => PinmuxInsel::Ior5,
+                PinmuxPeripheralIn::GpioGpio21 => PinmuxInsel::Ior6,
+                PinmuxPeripheralIn::GpioGpio22 => PinmuxInsel::Ior7,
+
+                PinmuxPeripheralIn::GpioGpio25 => PinmuxInsel::Ior10,
+                PinmuxPeripheralIn::GpioGpio26 => PinmuxInsel::Ior11,
+                PinmuxPeripheralIn::GpioGpio27 => PinmuxInsel::Ior12,
+                PinmuxPeripheralIn::GpioGpio28 => PinmuxInsel::Ior13,
+            },
+            output: collection! {
+                PinmuxMioOut::Ioc10 => PinmuxOutsel::GpioGpio17,
+                PinmuxMioOut::Ioc11 => PinmuxOutsel::GpioGpio18,
+                PinmuxMioOut::Ioc12 => PinmuxOutsel::GpioGpio19,
+
+                PinmuxMioOut::Ior5 => PinmuxOutsel::GpioGpio20,
+                PinmuxMioOut::Ior6 => PinmuxOutsel::GpioGpio21,
+                PinmuxMioOut::Ior7 => PinmuxOutsel::GpioGpio22,
+
+                PinmuxMioOut::Ior10 => PinmuxOutsel::GpioGpio25,
+                PinmuxMioOut::Ior11 => PinmuxOutsel::GpioGpio26,
+                PinmuxMioOut::Ior12 => PinmuxOutsel::GpioGpio27,
+                PinmuxMioOut::Ior13 => PinmuxOutsel::GpioGpio28,
+            },
+        },
     }
 });
 


### PR DESCRIPTION
The current test failure is caused by:
* "teacup" interface not being recongised by test harness.
* Slight difference in pin availability compared to hyper310.