### PR TITLE
[rv_dm,lint] Waive remaining Verilator lint warnings

### DIFF
--- a/hw/vendor/lint/pulp_riscv_dbg.vlt
+++ b/hw/vendor/lint/pulp_riscv_dbg.vlt
@@ -62,3 +62,14 @@ lint_off -rule WIDTH -file "*/src/dm_mem.sv" -match "*SUB expects 32 bits*'DataC
 // this might actually be Verilator doing something a bit strange.
 lint_off -rule WIDTH -file "*/src/dm_mem.sv" -match "*SUB expects 32*but*SEL*10 bits."
 
+// Avoid a warning about address truncation. These addresses are both derived
+// from the 64-bit dm::HaltAddress. They get assigned to something with
+// DbgAddressBits (12) bits. Both HaltAddress and DbgAddressBits come from the
+// original code (neither is a parameter that is being passed in from
+// OpenTitan)
+lint_off -rule WIDTH -file "*/src/dm_mem.sv" -match "Operator VAR 'Rom*Addr' expects 12 bits*generates 64 bits."
+
+// Avoid a warning about widths from a line that computes with "ABC / 2" rather
+// than "ABC >> 1". Verilator doesn't infer that the widths will fit in the way
+// the author expects.
+lint_off -rule WIDTH -file "*/src/dm_mem.sv" -match "Operator DIV expects 32 bits*ProgBufSize*5 bits."


### PR DESCRIPTION
The first commit is #21736: merge that first, but review the second commit here.

**For the second commit, the message is:**

This should waive the final lint warnings that come from Verilator
when building rv_dm. To see the current status, run:

```
  util/dvsim/dvsim.py hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson \
    --tool verilator --select-cfgs=rv_dm
```

Before this change, you got the following warnings:

    %Warning-WIDTHTRUNC: ../src/pulp-platform_riscv-dbg_0.1_0/pulp_riscv_dbg/src/dm_mem.sv:87:41: Operator VAR 'RomBaseAddr' expects 12 bits on the Initial value, but Initial value's VARREF 'HaltAddress' generates 64 bits.
                                                                                                : ... note: In instance 'rv_dm.u_dm_top.i_dm_mem'
       87 |   localparam logic [DbgAddressBits-1:0] RomBaseAddr   = dm::HaltAddress;
          |                                         ^~~~~~~~~~~
                         ... For warning description see https://verilator.org/warn/WIDTHTRUNC?v=5.020
                         ... Use "/* verilator lint_off WIDTHTRUNC */" and lint_on around source to disable this message.
    %Warning-WIDTHTRUNC: ../src/pulp-platform_riscv-dbg_0.1_0/pulp_riscv_dbg/src/dm_mem.sv:90:41: Operator VAR 'RomEndAddr' expects 12 bits on the Initial value, but Initial value's ADD generates 64 bits.
                                                                                                : ... note: In instance 'rv_dm.u_dm_top.i_dm_mem'
       90 |   localparam logic [DbgAddressBits-1:0] RomEndAddr    = dm::HaltAddress + 'h7FF;
          |                                         ^~~~~~~~~~
    %Warning-WIDTHEXPAND: ../src/pulp-platform_riscv-dbg_0.1_0/pulp_riscv_dbg/src/dm_mem.sv:92:59: Operator DIV expects 32 bits on the LHS, but LHS's VARREF 'ProgBufSize' generates 5 bits.
                                                                                                 : ... note: In instance 'rv_dm.u_dm_top.i_dm_mem'
       92 |   localparam int unsigned ProgBuf64Size = dm::ProgBufSize / 2;

- The first two warnings come from the same problem: `HaltAddress` is
  declared in `dm_pkg.sv` to be 64-bit variables. In `dm_mem.sv`,
  `DbgAddressBits` is a localparam equal to 12.

- The third warning comes from the fact that we want to divide (with
  floor) and do it with "/2" instead of ">> 1". Verilator sees this as
  a binary operator where the second argument (2) is interpreted as a
  32-bit value.
