### PR TITLE
[pentest] Configure additional alerts for FI

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -162,6 +162,7 @@ cc_library(
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/ujson",
     ],
 )
 

--- a/sw/device/tests/penetrationtests/firmware/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/ibex_fi.c
@@ -106,7 +106,7 @@ static volatile uint32_t sram_main_buffer[32];
 
 status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Create translation descriptions.
   dif_rv_core_ibex_addr_translation_mapping_t increment_100x10_mapping = {
@@ -179,14 +179,16 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Address translation configuration.
   dif_rv_core_ibex_addr_translation_mapping_t mapping1 = {
@@ -251,14 +253,16 @@ status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   sca_set_trigger_high();
@@ -289,14 +293,16 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Write reference value into CSR.
   CSR_WRITE(CSR_REG_MSCRATCH, ref_values[0]);
@@ -329,14 +335,16 @@ status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_flash_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Configure the data flash.
   // Flash configuration.
@@ -400,14 +408,16 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Configure the data flash.
   // Flash configuration.
@@ -466,14 +476,16 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Get address of buffer located in SRAM.
   uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
@@ -513,14 +525,16 @@ status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Get address of buffer located in SRAM.
   uintptr_t sram_main_buffer_addr = (uintptr_t)&sram_main_buffer;
@@ -556,14 +570,16 @@ status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t result = 0;
@@ -681,14 +697,16 @@ status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = result;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_conditional_branch(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t branch_if_ = 1;
@@ -715,14 +733,16 @@ status_t handle_ibex_fi_char_conditional_branch(ujson_t *uj) {
   uj_output.result1 = branch_if_;
   uj_output.result2 = branch_else;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t loop_counter1 = 0;
@@ -746,14 +766,16 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   uj_output.loop_counter1 = loop_counter1;
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -781,14 +803,16 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   ibex_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t loop_counter1 = 0;
@@ -816,14 +840,16 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   uj_output.loop_counter1 = loop_counter1;
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // FI code target.
   uint32_t loop_counter = 0;
@@ -853,14 +879,16 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   ibex_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   uint32_t res_values[7];
   // Initialize temporary registers with reference values.
@@ -905,14 +933,16 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
 
 status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   uint32_t res_values[3];
   // Initialize temporary registers with reference values.
@@ -954,7 +984,9 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -985,6 +1017,7 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
   TRY(dif_rv_core_ibex_init(
       mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
       &rv_core_ibex));
+
   return OK_STATUS();
 }
 

--- a/sw/device/tests/penetrationtests/firmware/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/otbn_fi.c
@@ -249,7 +249,7 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
  */
 status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_dmem_op_loop);
@@ -281,7 +281,9 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -301,7 +303,7 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
  */
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_reg_op_loop);
@@ -333,7 +335,9 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -355,7 +359,7 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
  */
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_dmem_op_loop);
@@ -387,7 +391,9 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -407,7 +413,7 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
  */
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
-  uint32_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
 
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_reg_op_loop);
@@ -439,7 +445,9 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
-  uj_output.alerts = reg_alerts;
+  uj_output.alerts_1 = reg_alerts.alerts_1;
+  uj_output.alerts_2 = reg_alerts.alerts_2;
+  uj_output.alerts_3 = reg_alerts.alerts_3;
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }

--- a/sw/device/tests/penetrationtests/firmware/sca_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/sca_lib.h
@@ -5,8 +5,38 @@
 #ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_SCA_LIB_H_
 #define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_SCA_LIB_H_
 
-uint32_t sca_get_triggered_alerts(void);
+#include "sw/device/lib/ujson/ujson.h"
+
+typedef struct sca_registered_alerts {
+  uint32_t alerts_1;
+  uint32_t alerts_2;
+  uint32_t alerts_3;
+} sca_registered_alerts_t;
+
+/**
+ * Returns the registered alerts.
+ *
+ * If a fault injection triggered an alert, this function returns the alert ID
+ * back to the host. Afterwards, the alert is cleared.
+ *
+ * @return A struct containing which of the alerts were triggered during the
+ * test.
+ */
+sca_registered_alerts_t sca_get_triggered_alerts(void);
+
+/**
+ * Configures the alert handler for FI.
+ *
+ * Register all alerts and let them escalate to Phase0 only.
+ */
 void sca_configure_alert_handler(void);
+
+/**
+ * Configures CPU for SCA and FI penetration tests.
+ *
+ * This function disables the iCache and the dummy instructions using the
+ * CPU Control and Status Register (cpuctrlsts).
+ */
 void sca_configure_cpu(void);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_SCA_LIB_H_

--- a/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
@@ -34,27 +34,35 @@ UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
 #define IBEXFI_TEST_RESULT(field, string) \
     field(result, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t)
+    field(alerts_1, uint32_t) \
+    field(alerts_2, uint32_t) \
+    field(alerts_3, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiTestResult, ibex_fi_test_result_t, IBEXFI_TEST_RESULT);
 
 #define IBEXFI_TEST_RESULT_MULT(field, string) \
     field(result1, uint32_t) \
     field(result2, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t)
+    field(alerts_1, uint32_t) \
+    field(alerts_2, uint32_t) \
+    field(alerts_3, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiTestResultMult, ibex_fi_test_result_mult_t, IBEXFI_TEST_RESULT_MULT);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t)
+    field(alerts_1, uint32_t) \
+    field(alerts_2, uint32_t) \
+    field(alerts_3, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterOutput, ibex_fi_loop_counter_t, IBEXFI_LOOP_COUNTER_OUTPUT);
 
 #define IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT(field, string) \
     field(loop_counter1, uint32_t) \
     field(loop_counter2, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t)
+    field(alerts_1, uint32_t) \
+    field(alerts_2, uint32_t) \
+    field(alerts_3, uint32_t)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterMirroredOutput, ibex_fi_loop_counter_mirrored_t, IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
@@ -25,7 +25,9 @@ UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND);
 #define OTBNFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts, uint32_t)
+    field(alerts_1, uint32_t) \
+    field(alerts_2, uint32_t) \
+    field(alerts_3, uint32_t)
 UJSON_SERDE_STRUCT(OtbnFiLoopCounterOutput, otbn_fi_loop_counter_t, OTBNFI_LOOP_COUNTER_OUTPUT);
 
 #define OTBNFI_RESULT_OUTPUT(field, string) \


### PR DESCRIPTION
This commit adds additional alerts to the alert handler configuration and fixes a bug in the configuration of the alert handler. Previously random alerts were triggered, now, only the alerts are reported that were triggered by a FI attack.