### PR TITLE
[prim,fpv] Only allow unconstrained counters in prim_count FPV

### DIFF
--- a/hw/ip/prim/lint/prim_count.waiver
+++ b/hw/ip/prim/lint/prim_count.waiver
@@ -7,5 +7,5 @@
 waive -rules {PARAM_NOT_USED} -location {prim_count.sv} -regexp {.*EnableAlertTriggerSVA.*} \
       -comment "The disable parameter is used only during DV / FPV."
 
-waive -rules {IFDEF_CODE} -location {prim_count.sv} -msg {Assignment to 'fpv_force' contained within `ifndef 'FPV_SEC_CM_ON' block at} \
-      -comment "This ifdef segment is ok, since it is used to provide the tool with a symbolic variable for error injection during FPV."
+waive -rules {IFDEF_CODE} -location {prim_count.sv} -msg {Assignment to 'fpv_force' contained within `ifndef 'PrimCountFpv' block at} \
+      -comment "This ifdef segment allows us to allow error injection during prim_count FPV."

--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -57,10 +57,14 @@ module prim_count #(
   localparam logic [NumCnt-1:0][Width-1:0] ResetValues = {{Width{1'b1}} - ResetValue, // secondary
                                                           ResetValue};                // primary
 
-  logic [NumCnt-1:0][Width-1:0] cnt_d, cnt_d_committed, cnt_q, fpv_force;
+  logic [NumCnt-1:0][Width-1:0] cnt_d, cnt_d_committed, cnt_q;
 
-`ifndef FPV_SEC_CM_ON
-  // This becomes a free variable in FPV.
+  // The fpv_force signal can be used in FPV runs to make the internal counters (cnt_q) jump
+  // unexpectedly. We only want to use this mechanism when we're doing FPV on prim_count itself. In
+  // that situation, we will have the PrimCountFpv define and wish to leave fpv_force undriven so
+  // that it becomes a free variable in FPV. In any other situation, we drive the signal with zero.
+  logic [NumCnt-1:0][Width-1:0] fpv_force;
+`ifndef PrimCountFpv
   assign fpv_force = '0;
 `endif
 

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
@@ -93,7 +93,7 @@
                dut: prim_count_tb
                fusesoc_core: lowrisc:fpv:prim_count_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-               build_opts: ["-define ResetValue -1"]
+               build_opts: ["-define ResetValue -1 -define PrimCountFpv 1"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: true
                exp_fail_hjson: "{proj_root}/hw/ip/prim/fpv/prim_count_expected_failure.hjson"
@@ -103,7 +103,7 @@
                dut: prim_count_tb
                fusesoc_core: lowrisc:fpv:prim_count_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-               build_opts: ["-define ResetValue 0"]
+               build_opts: ["-define ResetValue 0 -define PrimCountFpv 1"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: true
                exp_fail_hjson: "{proj_root}/hw/ip/prim/fpv/prim_count_expected_failure.hjson"


### PR DESCRIPTION
The counters in prim_count have a magic delta signal (fpv_force), which can be used to make them jump around. This causes all manner of problems in FPV tests for other blocks that happen to include prim_count.

Tighten the ifndef line so that fpv_force is only allowed to be nonzero when we're doing FPV for prim_count on its own. This way, the outputs of the prim_count instances won't randomly jump around in blocks that want to use them.

Honestly, I suspect that the fpv_force signal isn't sufficiently constrained to be useful even in that situation. But that's probably an issue for a different commit!

This change will fix a bunch of failures in e.g. `entropy_src` SEC_CM FPV testing. I'm not sure whether it gets us to 100%, but I was seeing instant counterexamples before, and now it doesn't find any for at least 5 minutes... :-)