### PR TITLE
[rules/autogen] added option for 'alias' in autogen_hjson_c_header

### DIFF
--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -24,8 +24,10 @@ def _hjson_c_header(ctx):
         "-o",
         header.path,
     ] + node + [src.path for src in ctx.files.srcs]
-
-    inputs = ctx.files.srcs + [ctx.executable._regtool]
+    
+    # `inputs = ctx.files.srcs` will create `inputs` as an unmutable list
+    # so need to unpack like this before appending the alias later
+    inputs = list(ctx.files.srcs)
 
     # add path to an alias path if it's needed
     if ctx.attr.alias:

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -25,7 +25,7 @@ def _hjson_c_header(ctx):
         header.path,
     ] + node + [src.path for src in ctx.files.srcs]
     
-    # `inputs = ctx.files.srcs` will create `inputs` as an unmutable list
+    # `inputs = ctx.files.srcs` will create `inputs` as an immutable list
     # so need to unpack like this before appending the alias later
     inputs = list(ctx.files.srcs)
 


### PR DESCRIPTION
Context: closed source OTP and FLASH use the `alias` feature to generate the wrapper (SHIM) registers. DIF SW code relies on these regiserts to successfully build, but current implementation of `autogen_hjson_c_header` does not allow execution of `regtool` with `alias`.

Suggestion:
This PR introduces an optional `alias` attribute to `//rules/autogen:autogen_hjson_c_header` rule and its implementation `_hjson_c_header`.

