### PR TITLE
[ot_certs] Add support for pushing boolean and make basic constraints configurable

### DIFF
--- a/sw/device/silicon_creator/lib/cert/asn1.c
+++ b/sw/device/silicon_creator/lib/cert/asn1.c
@@ -123,11 +123,11 @@ rom_error_t asn1_finish_tag(asn1_tag_t *tag) {
   return kErrorOk;
 }
 
-rom_error_t asn1_push_bool(asn1_state_t *state, bool value) {
-  asn1_tag_t tag;
-  RETURN_IF_ERROR(asn1_start_tag(state, &tag, kAsn1TagNumberBoolean));
+rom_error_t asn1_push_bool(asn1_state_t *state, uint8_t tag, bool value) {
+  asn1_tag_t tag_st;
+  RETURN_IF_ERROR(asn1_start_tag(state, &tag_st, tag));
   RETURN_IF_ERROR(asn1_push_byte(state, value ? 0xff : 0));
-  return asn1_finish_tag(&tag);
+  return asn1_finish_tag(&tag_st);
 }
 
 rom_error_t asn1_push_int32(asn1_state_t *state, uint8_t tag, int32_t value) {

--- a/sw/device/silicon_creator/lib/cert/asn1.h
+++ b/sw/device/silicon_creator/lib/cert/asn1.h
@@ -163,9 +163,10 @@ rom_error_t asn1_finish_tag(asn1_tag_t *tag);
  * acceptable per the specification).
  *
  * @param state Pointer to the state initialized by asn1_start.
+ * @param tag Identifier octet of the tag.
  * @param value Boolean value.
  */
-rom_error_t asn1_push_bool(asn1_state_t *state, bool value);
+rom_error_t asn1_push_bool(asn1_state_t *state, uint8_t tag, bool value);
 
 /**
  * Push a tagged integer into the buffer.

--- a/sw/device/silicon_creator/lib/cert/asn1_unittest.cc
+++ b/sw/device/silicon_creator/lib/cert/asn1_unittest.cc
@@ -98,14 +98,14 @@ TEST(Asn1, PushBoolean) {
   asn1_state_t state;
   uint8_t buf[16];
   EXPECT_EQ(asn1_start(&state, buf, sizeof(buf)), kErrorOk);
-  EXPECT_EQ(asn1_push_bool(&state, true), kErrorOk);
-  EXPECT_EQ(asn1_push_bool(&state, false), kErrorOk);
+  EXPECT_EQ(asn1_push_bool(&state, kAsn1TagNumberBoolean, true), kErrorOk);
+  EXPECT_EQ(asn1_push_bool(&state, kAsn1TagClassContext | 42, false), kErrorOk);
   size_t out_size;
   EXPECT_EQ(asn1_finish(&state, &out_size), kErrorOk);
   const std::array<uint8_t, 6> kExpectedResult = {
       // Identifier octet (universal, boolean), length, content (can be any
       // nonzero value, the library uses 0xff).
-      0x01, 0x01, 0xff, 0x01, 0x01, 0x00,
+      0x01, 0x01, 0xff, 0xaa, 0x01, 0x00,
   };
   EXPECT_EQ_CONST_ARRAY(buf, out_size, kExpectedResult);
 }

--- a/sw/device/silicon_creator/lib/cert/cdi_0.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_0.hjson
@@ -75,6 +75,10 @@
         },
         authority_key_identifier: { var: "creator_pub_key_id" },
         subject_key_identifier: { var: "owner_intermediate_pub_key_id" },
+        // From the Open Profile for DICE specification:
+        // https://pigweed.googlesource.com/open-dice/+/refs/heads/main/docs/specification.md#certificate-details
+        // The standard extensions are fixed by the specification.
+        basic_constraints: { ca: true },
         extensions: [
             {
                 type: "dice_tcb_info",

--- a/sw/device/silicon_creator/lib/cert/cdi_1.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_1.hjson
@@ -80,6 +80,10 @@
         },
         authority_key_identifier: { var: "owner_intermediate_pub_key_id" },
         subject_key_identifier: { var: "owner_pub_key_id" },
+        // From the Open Profile for DICE specification:
+        // https://pigweed.googlesource.com/open-dice/+/refs/heads/main/docs/specification.md#certificate-details
+        // The standard extensions are fixed by the specification.
+        basic_constraints: { ca: true },
         extensions: [
             {
                 type: "dice_tcb_info",

--- a/sw/device/silicon_creator/lib/cert/uds.hjson
+++ b/sw/device/silicon_creator/lib/cert/uds.hjson
@@ -101,6 +101,10 @@
         },
         authority_key_identifier: { var: "auth_key_key_id" },
         subject_key_identifier: { var: "creator_pub_key_id" },
+        // From the Open Profile for DICE specification:
+        // https://pigweed.googlesource.com/open-dice/+/refs/heads/main/docs/specification.md#certificate-details
+        // The standard extensions are fixed by the specification.
+        basic_constraints: { ca: true },
         extensions: [
             {
                 type: "dice_tcb_info",

--- a/sw/host/ot_certs/src/asn1/builder.rs
+++ b/sw/host/ot_certs/src/asn1/builder.rs
@@ -30,7 +30,7 @@ pub trait Builder {
     fn push_byte(&mut self, val: u8) -> Result<()>;
 
     /// Push a tagged boolean into the ASN1 output.
-    fn push_boolean(&mut self, val: bool) -> Result<()>;
+    fn push_boolean(&mut self, tag: &Tag, val: &Value<bool>) -> Result<()>;
 
     /// Push a tagged integer into the ASN1 output. The name hint can be used by
     /// the implementation for documentation purpose, or completely ignored.

--- a/sw/host/ot_certs/src/asn1/x509.rs
+++ b/sw/host/ot_certs/src/asn1/x509.rs
@@ -222,7 +222,7 @@ impl X509 {
         // The standard extensions are fixed by the specification.
         Self::push_extension(builder, &Oid::BasicConstraints, true, |builder| {
             builder.push_seq(Some("basic_constraints".into()), |builder| {
-                builder.push_boolean(true)
+                builder.push_boolean(&Tag::Boolean, &Value::Literal(true))
             })
         })
     }
@@ -321,7 +321,7 @@ impl X509 {
         //         }
         builder.push_seq(concat_suffix(&Some(oid.to_string()), "ext"), |builder| {
             builder.push_oid(oid)?;
-            builder.push_boolean(critical)?;
+            builder.push_boolean(&Tag::Boolean, &Value::Literal(critical))?;
             builder.push_octet_string(concat_suffix(&Some(oid.to_string()), "ext_value"), gen)
         })
     }

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -73,10 +73,17 @@ pub struct Certificate {
     pub authority_key_identifier: Value<Vec<u8>>,
     /// X509 certificate's public key identifier.
     pub subject_key_identifier: Value<Vec<u8>>,
+    // X509 basic constraints extension, optional.
+    pub basic_constraints: Option<BasicConstraints>,
     /// X509 certificate extensions.
     pub extensions: Vec<CertificateExtension>,
     /// X509 certificate's signature.
     pub signature: Signature,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct BasicConstraints {
+    pub ca: Value<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -538,6 +545,7 @@ mod tests {
             }),
             authority_key_identifier: Value::variable("signing_pub_key_id"),
             subject_key_identifier: Value::variable("owner_pub_key_id"),
+            basic_constraints: None,
             extensions: vec![CertificateExtension::DiceTcbInfo(DiceTcbInfoExtension {
                 vendor: Some(Value::literal("OpenTitan")),
                 model: Some(Value::literal("ROM_EXT")),

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -13,9 +13,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::template::{
-    Certificate, CertificateExtension, Conversion, DiceTcbInfoExtension, EcPublicKey,
-    EcPublicKeyInfo, EcdsaSignature, FirmwareId, Flags, Signature, SubjectPublicKeyInfo, Template,
-    Value, Variable, VariableType,
+    BasicConstraints, Certificate, CertificateExtension, Conversion, DiceTcbInfoExtension,
+    EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, Flags, Signature,
+    SubjectPublicKeyInfo, Template, Value, Variable, VariableType,
 };
 
 /// Substitution value: this is the raw value loaded from a hjson/json file
@@ -358,6 +358,10 @@ impl Subst for Certificate {
                 .subject_key_identifier
                 .subst(data)
                 .context("cannot substitute subject key id")?,
+            basic_constraints: self
+                .basic_constraints
+                .subst(data)
+                .context("cannot substitute basic constraints")?,
             extensions: self
                 .extensions
                 .iter()
@@ -368,6 +372,14 @@ impl Subst for Certificate {
                 .signature
                 .subst(data)
                 .context("cannot substitute signature")?,
+        })
+    }
+}
+
+impl Subst for BasicConstraints {
+    fn subst(&self, data: &SubstData) -> Result<BasicConstraints> {
+        Ok(BasicConstraints {
+            ca: self.ca.subst(data)?,
         })
     }
 }

--- a/sw/host/ot_certs/tests/example.hjson
+++ b/sw/host/ot_certs/tests/example.hjson
@@ -32,6 +32,9 @@
         },
         authority_key_identifier: "94589abcd8744445ef329bc4186a11ff9a74bc4d",
         subject_key_identifier: "04897afec876db876d4efbc6a3dd9f164965dfac",
+        basic_constraints: {
+            ca: true,
+        }
         extensions: [
             {
                 type: "dice_tcb_info",

--- a/sw/host/ot_certs/tests/example_data.json
+++ b/sw/host/ot_certs/tests/example_data.json
@@ -20,5 +20,6 @@
     "recovery": "false",
     "debug": "true",
     "cert_signature_r": "0",
-    "cert_signature_s": "0"
+    "cert_signature_s": "0",
+    "basic_constraints_ca": true
 }

--- a/sw/host/ot_certs/tests/generic.hjson
+++ b/sw/host/ot_certs/tests/generic.hjson
@@ -89,6 +89,9 @@
         debug: {
             type: "boolean",
         }
+        basic_constraints_ca: {
+            type: "boolean",
+        }
     },
 
     certificate: {
@@ -112,6 +115,9 @@
         },
         authority_key_identifier: { var: "auth_key_id" },
         subject_key_identifier: { var: "pub_key_id" },
+        basic_constraints: {
+            ca: { var: "basic_constraints_ca" }
+        }
         extensions: [
             {
                 type: "dice_tcb_info",


### PR DESCRIPTION
The first commit modifies `push_boolean` to accept a variable, this wasn't the case before because it was not needed. The second commit uses this new feature to make basic constraints configurable. This is also a good test for the new feature.