### PR TITLE
[dv,prim] Clarification of reset behavior

### DIFF
--- a/hw/ip/prim/rtl/prim_pulse_sync.sv
+++ b/hw/ip/prim/rtl/prim_pulse_sync.sv
@@ -7,6 +7,9 @@
 // cycle of its respective clock domain. Consecutive pulses need to be spaced
 // appropriately apart from each other depending on the clock frequency ratio
 // of the two clock domains.
+//
+// Also note that a reset of either the source domain or the destination domain
+// in isolation may create a pulse at the destination.
 
 module prim_pulse_sync (
   // source clock domain

--- a/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
@@ -93,7 +93,7 @@ module prim_reg_cdc_arb #(
   } state_e;
 
 
-  // Only honor the incoming destinate update request if the incoming
+  // Only honor the incoming destination update request if the incoming
   // value is actually different from what is already completed in the
   // handshake
   logic dst_update;
@@ -107,7 +107,6 @@ module prim_reg_cdc_arb #(
     req_sel_e id_q;
 
     state_e state_q, state_d;
-    // Make sure to indent the following later
     always_ff @(posedge clk_dst_i or negedge rst_dst_ni) begin
       if (!rst_dst_ni) begin
         state_q <= StIdle;

--- a/hw/ip/prim/rtl/prim_sync_reqack.sv
+++ b/hw/ip/prim/rtl/prim_sync_reqack.sv
@@ -20,8 +20,8 @@
 //   - 1 source + 2 destination + 1 destination + 2 source clock cycles until the handshake is
 //     performed in the SRC domain.
 // - Optionally, the module can also use a return-to-zero (RZ), four-phase handshake protocol.
-//   That one has lower throughput, but it is safe to partially reset either side, since the
-//   two FSMs cannot get out of sync due to persisting EVEN/ODD states. The handshake latencies
+//   That one has lower throughput, but it is safe to reset either domain in isolation, since the
+//   two FSMs cannot get out of sync due to persistent EVEN/ODD states. The handshake latencies
 //   are the same as for the NRZ protocol, but the throughput is half that of the NRZ protocol
 //   since the signals neet to return to zero first, causing two round-trips through the
 //   synchronizers instead of just one.


### PR DESCRIPTION
Clarify behavior when a single domain is reset; the auto-generated register logic appears to be robust against the spurious pulses generated by the use of 'prim_pulse_sync' and 'prim_sync_reqack' (NRZ mode) during a single-domain reset, provided that there is no in-progress transaction (register read/write from SW).

Correct a couple of typographical errors.

It is perhaps worth also noting that the `SrcAckBusyChk_A` assertion will fire if the source domain is reset after an odd number of SW accesses to the CDC register, which could perhaps be prevented by changes either to the logic (now is perhaps not the time given the chip-wide impact) or the use of more-involved assertion checking that attends to reset behavior.