### PR TITLE
[pinmux/doc]: Fix the description for the keeper_en register

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -453,7 +453,7 @@
                     },
                     { bits: "4",
                       name: "keeper_en",
-                      desc: "Enable pull-up or pull-down resistor."
+                      desc: "Enable keeper termination. This weakly drives the previous pad output value when output is disabled, similar to a verilog `trireg`."
                     },
                     { bits: "5",
                       name: "schmitt_en",
@@ -548,7 +548,7 @@
                     },
                     { bits: "4",
                       name: "keeper_en",
-                      desc: "Enable pull-up or pull-down resistor."
+                      desc: "Enable keeper termination. This weakly drives the previous pad output value when output is disabled, similar to a verilog `trireg`."
                     },
                     { bits: "5",
                       name: "schmitt_en",

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -596,7 +596,7 @@
                     },
                     { bits: "4",
                       name: "keeper_en",
-                      desc: "Enable pull-up or pull-down resistor."
+                      desc: "Enable keeper termination. This weakly drives the previous pad output value when output is disabled, similar to a verilog `trireg`."
                     },
                     { bits: "5",
                       name: "schmitt_en",
@@ -691,7 +691,7 @@
                     },
                     { bits: "4",
                       name: "keeper_en",
-                      desc: "Enable pull-up or pull-down resistor."
+                      desc: "Enable keeper termination. This weakly drives the previous pad output value when output is disabled, similar to a verilog `trireg`."
                     },
                     { bits: "5",
                       name: "schmitt_en",

--- a/hw/ip/pinmux/doc/registers.md
+++ b/hw/ip/pinmux/doc/registers.md
@@ -1055,7 +1055,7 @@ Enable open drain.
 Enable the schmitt trigger.
 
 ### MIO_PAD_ATTR . keeper_en
-Enable pull-up or pull-down resistor.
+Enable keeper termination. This weakly drives the previous pad output value when output is disabled, similar to a verilog `trireg`.
 
 ### MIO_PAD_ATTR . pull_select
 Pull select (0: pull-down, 1: pull-up).
@@ -1176,7 +1176,7 @@ Enable open drain.
 Enable the schmitt trigger.
 
 ### DIO_PAD_ATTR . keeper_en
-Enable pull-up or pull-down resistor.
+Enable keeper termination. This weakly drives the previous pad output value when output is disabled, similar to a verilog `trireg`.
 
 ### DIO_PAD_ATTR . pull_select
 Pull select (0: pull-down, 1: pull-up).

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -592,7 +592,7 @@
                     },
                     { bits: "4",
                       name: "keeper_en",
-                      desc: "Enable pull-up or pull-down resistor."
+                      desc: "Enable keeper termination. This weakly drives the previous pad output value when output is disabled, similar to a verilog `trireg`."
                     },
                     { bits: "5",
                       name: "schmitt_en",
@@ -687,7 +687,7 @@
                     },
                     { bits: "4",
                       name: "keeper_en",
-                      desc: "Enable pull-up or pull-down resistor."
+                      desc: "Enable keeper termination. This weakly drives the previous pad output value when output is disabled, similar to a verilog `trireg`."
                     },
                     { bits: "5",
                       name: "schmitt_en",


### PR DESCRIPTION
It previously copied the pull_en description, which is incorrect. I consulted with hweng on what a correct description would be.

Cc: @moidx @msfschaffner 