### PR TITLE
[fpv] Minor tidy-ups to SecCm FPV code

### DIFF
--- a/hw/ip/prim/rtl/prim_assert_sec_cm.svh
+++ b/hw/ip/prim/rtl/prim_assert_sec_cm.svh
@@ -9,24 +9,35 @@
 
 `define _SEC_CM_ALERT_MAX_CYC 30
 
-// Helper macros
-`define ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_, MAX_CYCLES_, ERR_NAME_) \
-  `ASSERT(FpvSecCm``NAME_``, \
-          $rose(PRIM_HIER_.ERR_NAME_) && !(GATE_) \
-          |-> ##[0:MAX_CYCLES_] (ALERT_.alert_p)) \
-  `ifdef INC_ASSERT \
-  assign PRIM_HIER_.unused_assert_connected = 1'b1; \
-  `endif \
-  `ASSUME_FPV(``NAME_``TriggerAfterAlertInit_S, $stable(rst_ni) == 0 |-> \
-              PRIM_HIER_.ERR_NAME_ == 0 [*10])
-
+// When a named error signal rises, expect to see an associated error in at most MAX_CYCLES_ cycles.
+//
+// The NAME_ argument gets included in the name of the generated assertion, following an FpSecCm
+// prefix. The error signal should be at PRIM_HIER_.ERR_NAME_ and the posedge is ignored if GATE_ is
+// true.
+//
+// This macro drives a magic "unused_assert_connected" signal, which is used for a static check to
+// ensure the assertions are in place.
 `define ASSERT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_, MAX_CYCLES_, ERR_NAME_, CLK_, RST_) \
-  `ASSERT(FpvSecCm``NAME_``, \
-          $rose(PRIM_HIER_.ERR_NAME_) && !(GATE_) \
-          |-> ##[0:MAX_CYCLES_] (ERR_), CLK_, RST_) \
-  `ifdef INC_ASSERT \
-  assign PRIM_HIER_.unused_assert_connected = 1'b1; \
+  `ASSERT(FpvSecCm``NAME_``,                                                                         \
+          $rose(PRIM_HIER_.ERR_NAME_) && !(GATE_) |-> ##[0:MAX_CYCLES_] (ERR_),                      \
+          CLK_, RST_)                                                                                \
+  `ifdef INC_ASSERT                                                                                  \
+    assign PRIM_HIER_.unused_assert_connected = 1'b1;                                                \
   `endif
+
+// When an error signal rises, expect to see the associated alert in at most MAX_CYCLE_ cycles.
+//
+// The NAME_, PRIM_HIER_, GATE_, MAX_CYCLES_ and ERR_NAME_ arguments are the same as for
+// `ASSERT_ERROR_TRIGGER_ERR. The ALERT_ argument is the name of the alert that we expect to be
+// asserted.
+//
+// This macro adds an assumption that says the named error signal will stay low for the first 10
+// cycles after reset.
+`define ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_, MAX_CYCLES_, ERR_NAME_)    \
+  `ASSERT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, (ALERT_.alert_p), GATE_, MAX_CYCLES_, ERR_NAME_, \
+                            `ASSERT_DEFAULT_CLK, `ASSERT_DEFAULT_RST)                           \
+  `ASSUME_FPV(``NAME_``TriggerAfterAlertInit_S,                                                 \
+              $stable(rst_ni) == 0 |-> PRIM_HIER_.ERR_NAME_ == 0 [*10])
 
 // macros for security countermeasures that will trigger alert
 `define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \

--- a/hw/ip/prim/rtl/prim_assert_sec_cm.svh
+++ b/hw/ip/prim/rtl/prim_assert_sec_cm.svh
@@ -39,7 +39,12 @@
   `ASSUME_FPV(``NAME_``TriggerAfterAlertInit_S,                                            \
               $stable(rst_ni) == 0 |-> HIER_.ERR_NAME_ == 0 [*10])
 
-// macros for security countermeasures that will trigger alert
+////////////////////////////////////////////////////////////////////////////////
+//
+// Assertions for CMs that trigger alerts
+//
+////////////////////////////////////////////////////////////////////////////////
+
 `define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
   `ASSERT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
 
@@ -56,7 +61,12 @@
   `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(NAME_, \
     REG_TOP_HIER_.u_prim_reg_we_check.u_prim_onehot_check, ALERT_, GATE_, MAX_CYCLES_)
 
-// macros for security countermeasures that will trigger other errors
+////////////////////////////////////////////////////////////////////////////////
+//
+// Assertions for CMs that trigger some other form of error
+//
+////////////////////////////////////////////////////////////////////////////////
+
 `define ASSERT_PRIM_FSM_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = 2, CLK_ = clk_i, RST_ = !rst_ni) \
   `ASSERT_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_, MAX_CYCLES_, unused_err_o, CLK_, RST_)
 

--- a/hw/ip/prim/rtl/prim_assert_sec_cm.svh
+++ b/hw/ip/prim/rtl/prim_assert_sec_cm.svh
@@ -12,62 +12,62 @@
 // When a named error signal rises, expect to see an associated error in at most MAX_CYCLES_ cycles.
 //
 // The NAME_ argument gets included in the name of the generated assertion, following an FpSecCm
-// prefix. The error signal should be at PRIM_HIER_.ERR_NAME_ and the posedge is ignored if GATE_ is
+// prefix. The error signal should be at HIER_.ERR_NAME_ and the posedge is ignored if GATE_ is
 // true.
 //
 // This macro drives a magic "unused_assert_connected" signal, which is used for a static check to
 // ensure the assertions are in place.
-`define ASSERT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_, MAX_CYCLES_, ERR_NAME_, CLK_, RST_) \
-  `ASSERT(FpvSecCm``NAME_``,                                                                         \
-          $rose(PRIM_HIER_.ERR_NAME_) && !(GATE_) |-> ##[0:MAX_CYCLES_] (ERR_),                      \
-          CLK_, RST_)                                                                                \
-  `ifdef INC_ASSERT                                                                                  \
-    assign PRIM_HIER_.unused_assert_connected = 1'b1;                                                \
+`define ASSERT_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_, MAX_CYCLES_, ERR_NAME_, CLK_, RST_) \
+  `ASSERT(FpvSecCm``NAME_``,                                                                    \
+          $rose(HIER_.ERR_NAME_) && !(GATE_) |-> ##[0:MAX_CYCLES_] (ERR_),                      \
+          CLK_, RST_)                                                                           \
+  `ifdef INC_ASSERT                                                                             \
+    assign HIER_.unused_assert_connected = 1'b1;                                                \
   `endif
 
 // When an error signal rises, expect to see the associated alert in at most MAX_CYCLE_ cycles.
 //
-// The NAME_, PRIM_HIER_, GATE_, MAX_CYCLES_ and ERR_NAME_ arguments are the same as for
+// The NAME_, HIER_, GATE_, MAX_CYCLES_ and ERR_NAME_ arguments are the same as for
 // `ASSERT_ERROR_TRIGGER_ERR. The ALERT_ argument is the name of the alert that we expect to be
 // asserted.
 //
 // This macro adds an assumption that says the named error signal will stay low for the first 10
 // cycles after reset.
-`define ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_, MAX_CYCLES_, ERR_NAME_)    \
-  `ASSERT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, (ALERT_.alert_p), GATE_, MAX_CYCLES_, ERR_NAME_, \
-                            `ASSERT_DEFAULT_CLK, `ASSERT_DEFAULT_RST)                           \
-  `ASSUME_FPV(``NAME_``TriggerAfterAlertInit_S,                                                 \
-              $stable(rst_ni) == 0 |-> PRIM_HIER_.ERR_NAME_ == 0 [*10])
+`define ASSERT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, ERR_NAME_)    \
+  `ASSERT_ERROR_TRIGGER_ERR(NAME_, HIER_, (ALERT_.alert_p), GATE_, MAX_CYCLES_, ERR_NAME_, \
+                            `ASSERT_DEFAULT_CLK, `ASSERT_DEFAULT_RST)                      \
+  `ASSUME_FPV(``NAME_``TriggerAfterAlertInit_S,                                            \
+              $stable(rst_ni) == 0 |-> HIER_.ERR_NAME_ == 0 [*10])
 
 // macros for security countermeasures that will trigger alert
-`define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
-  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
+`define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
+  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
 
-`define ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
-  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
+`define ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
+  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
 
-`define ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
-  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_, MAX_CYCLES_, unused_err_o)
+`define ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
+  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, unused_err_o)
 
-`define ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
-  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
+`define ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
+  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, HIER_, ALERT_, GATE_, MAX_CYCLES_, err_o)
 
 `define ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(NAME_, REG_TOP_HIER_, ALERT_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC) \
   `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ALERT(NAME_, \
     REG_TOP_HIER_.u_prim_reg_we_check.u_prim_onehot_check, ALERT_, GATE_, MAX_CYCLES_)
 
 // macros for security countermeasures that will trigger other errors
-`define ASSERT_PRIM_FSM_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = 2, CLK_ = clk_i, RST_ = !rst_ni) \
-  `ASSERT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_, MAX_CYCLES_, unused_err_o, CLK_, RST_)
+`define ASSERT_PRIM_FSM_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = 2, CLK_ = clk_i, RST_ = !rst_ni) \
+  `ASSERT_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_, MAX_CYCLES_, unused_err_o, CLK_, RST_)
 
-`define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = 2, CLK_ = clk_i, RST_ = !rst_ni) \
-  `ASSERT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_, MAX_CYCLES_, err_o, CLK_, RST_)
+`define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = 2, CLK_ = clk_i, RST_ = !rst_ni) \
+  `ASSERT_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_, MAX_CYCLES_, err_o, CLK_, RST_)
 
-`define ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = 2, CLK_ = clk_i, RST_ = !rst_ni) \
-  `ASSERT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_, MAX_CYCLES_, err_o, CLK_, RST_)
+`define ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = 2, CLK_ = clk_i, RST_ = !rst_ni) \
+  `ASSERT_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_, MAX_CYCLES_, err_o, CLK_, RST_)
 
-`define ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC, CLK_ = clk_i, RST_ = !rst_ni) \
-  `ASSERT_ERROR_TRIGGER_ERR(NAME_, PRIM_HIER_, ERR_, GATE_, MAX_CYCLES_, err_o, CLK_, RST_)
+`define ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC, CLK_ = clk_i, RST_ = !rst_ni) \
+  `ASSERT_ERROR_TRIGGER_ERR(NAME_, HIER_, ERR_, GATE_, MAX_CYCLES_, err_o, CLK_, RST_)
 
 `define ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ERR(NAME_, REG_TOP_HIER_, ERR_, GATE_ = 0, MAX_CYCLES_ = `_SEC_CM_ALERT_MAX_CYC, CLK_ = clk_i, RST_ = !rst_ni) \
   `ASSERT_PRIM_ONEHOT_ERROR_TRIGGER_ERR(NAME_, \

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -538,7 +538,7 @@ module sram_ctrl
   // Alert assertions for redundant counters.
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntCheck_A,
       u_prim_count, alert_tx_o[0])
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ERR(LcGateFsmCheck_A,
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(LcGateFsmCheck_A,
       u_tlul_lc_gate.u_state_regs, alert_tx_o[0])
 
   // Alert assertions for reg_we onehot check.


### PR DESCRIPTION
No big change, but this makes the code a bit easier to follow. (It took me a while to understand!). Proper comments on each different commit.

The only bug fix is in the second commit ("[sram_ctrl,fpv] Fix incorrect assertion") where the assertion wasn't strong enough (and I only noticed because I was going through the code trying to understand everything).