### PR TITLE
[entropy_src,rtl] Factor sfifo errors into fatal alert

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -983,7 +983,9 @@ module entropy_src_core import entropy_src_pkg::*; #(
   end : gen_err_code_test_bit
 
   // alert - send all interrupt sources to the alert for the fatal case
-  assign fatal_alert_o = event_es_fatal_err;
+  assign fatal_alert_o = (event_es_fatal_err |
+                          sfifo_distr_int_err | sfifo_esrng_int_err |
+                          sfifo_observe_int_err | sfifo_esfinal_int_err);
 
   // alert test
   assign recov_alert_test_o = {


### PR DESCRIPTION
These signals come from:

- u_prim_fifo_sync_distr (the distribution FIFO)
- u_prim_fifo_sync_esrng (the RNG bus input FIFO)
- u_prim_fifo_sync_observe
- u_prim_fifo_sync_esfinal

when one sees an internal error. We want any of these errors to be transformed into a fatal alert.