### PR TITLE
[sival] Add `sram_ctrl_lc_escalation` test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -124,9 +124,10 @@
       features: ["SRAM_CTRL.LOCK_ON_ERROR"]
       stage: V2
       si_stage: SV3
-      lc_states: ["PROD"]
+      lc_states: ["RMA"]
       tests: ["chip_sw_all_escalation_resets",
               "chip_sw_data_integrity_escalation"]
+      bazel: ["//sw/device/tests:sram_ctrl_lc_escalation"]
     }
 
     {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5669,3 +5669,34 @@ opentitan_test(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+opentitan_test(
+    name = "sram_ctrl_lc_escalation_test",
+    srcs = ["sram_ctrl_lc_escalation_test.c"],
+    cw310 = cw310_params(
+        timeout = "moderate",
+        needs_jtag = True,
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_rma_manuf_personalized",
+        test_cmd = " ".join([
+            "--bootstrap=\"{firmware}\"",
+            "--firmware-elf=\"{firmware:elf}\"",
+        ]),
+        test_harness = "//sw/host/tests/chip/sram_ctrl:sram_ctrl_lc_escalation",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+    },
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:sram_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_utils",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)

--- a/sw/device/tests/sram_ctrl_lc_escalation_test.c
+++ b/sw/device/tests/sram_ctrl_lc_escalation_test.c
@@ -1,0 +1,157 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * This test checks that SRAMs become inaccessible when an alert is escalated.
+ *
+ * The device side of this test:
+ *
+ * 1. Writes to and reads back data from both main and retention SRAM.
+ * 2. Configures the alert handlers to lock up the SRAMs for the LC bus
+ *    bus integrity alert.
+ * 3. Forces that alert.
+ *
+ * This level of escalation also locks up ibex, so we cannot check the SRAMs
+ * from within this test. Instead, a test bench must try to access the SRAMs
+ * through the debug module.
+ */
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_sram_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ottf_utils.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sram_ctrl_regs.h"  // Generated.
+
+static const uint32_t kStatusRegMask = kDifSramCtrlStatusBusIntegErr |
+                                       kDifSramCtrlStatusInitErr |
+                                       kDifSramCtrlStatusEscalated;
+
+enum {
+  kCommandTimeoutMicros = 1 * 1000 * 1000,
+};
+
+static dif_alert_handler_t alert_handler;
+static dif_lc_ctrl_t lc_ctrl;
+static dif_sram_ctrl_t sram_ctrl_main;
+static dif_sram_ctrl_t sram_ctrl_ret;
+
+// Buffer to allow the compiler to allocate a safe area in Main SRAM where
+// we can do the write/read test without the risk of clobbering data
+// used by the program.
+OT_SECTION(".data")
+static volatile uint32_t sram_buffer_main;
+
+enum test_phase {
+  kTestPhaseCfg,
+  kTestPhaseEscalate,
+};
+static volatile uint8_t test_phase = kTestPhaseCfg;
+
+static volatile uintptr_t sram_buffer_addr_main;
+static volatile uintptr_t sram_buffer_addr_ret;
+
+/// Write and read back a word of data to check SRAM is responsive.
+static bool write_read_data(mmio_region_t sram_region, uint32_t data) {
+  mmio_region_write32(sram_region, 0, data);
+  uint32_t read_data = mmio_region_read32(sram_region, 0);
+
+  return read_data == data;
+}
+
+status_t configure_srams(void) {
+  uint32_t base_addr;
+  base_addr = TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR;
+  TRY(dif_sram_ctrl_init(mmio_region_from_addr(base_addr), &sram_ctrl_main));
+  base_addr = TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR;
+  TRY(dif_sram_ctrl_init(mmio_region_from_addr(base_addr), &sram_ctrl_ret));
+
+  dif_sram_ctrl_status_bitfield_t status_main;
+  dif_sram_ctrl_status_bitfield_t status_ret;
+
+  // Check Status registers
+  CHECK_DIF_OK(dif_sram_ctrl_get_status(&sram_ctrl_ret, &status_ret));
+  CHECK_DIF_OK(dif_sram_ctrl_get_status(&sram_ctrl_main, &status_main));
+
+  CHECK((status_main & kStatusRegMask) == 0x0,
+        "SRAM main status error bits set, status = %08x.", status_main);
+  CHECK((status_ret & kStatusRegMask) == 0x0,
+        "SRAM ret status error bits set, status = %08x.", status_ret);
+
+  return OK_STATUS();
+}
+
+status_t configure_alert_handler(void) {
+  TRY(dif_alert_handler_init(
+      mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR),
+      &alert_handler));
+
+  dif_alert_handler_escalation_phase_t esc_phases[] = {{
+      .phase = kDifAlertHandlerClassStatePhase0,
+      .signal = 1,  // This level causes ibex and SRAMs to lock up.
+      .duration_cycles = UINT32_MAX,
+  }};
+
+  dif_alert_handler_class_config_t class_config = {
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = 0,
+      .irq_deadline_cycles = 1000,
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase1,
+  };
+
+  TRY(dif_alert_handler_configure_alert(
+      &alert_handler, kTopEarlgreyAlertIdLcCtrlFatalBusIntegError,
+      kDifAlertHandlerClassA, kDifToggleEnabled, kDifToggleEnabled));
+  TRY(dif_alert_handler_configure_class(&alert_handler, kDifAlertHandlerClassA,
+                                        class_config, kDifToggleEnabled,
+                                        kDifToggleEnabled));
+
+  return OK_STATUS();
+}
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc_ctrl));
+
+  CHECK_STATUS_OK(configure_alert_handler());
+  CHECK_STATUS_OK(configure_srams());
+
+  // Read and Write to/from SRAMs. Main SRAM will use the address of the
+  // buffer that has been allocated. Ret SRAM can start at the owner section.
+  sram_buffer_addr_main = (uintptr_t)&sram_buffer_main;
+  sram_buffer_addr_ret = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR +
+                         offsetof(retention_sram_t, owner);
+
+  mmio_region_t sram_region_main = mmio_region_from_addr(sram_buffer_addr_main);
+  mmio_region_t sram_region_ret = mmio_region_from_addr(sram_buffer_addr_ret);
+
+  // Write and read-back some data to both SRAMs to confirm they're responding.
+  CHECK(write_read_data(sram_region_main, 0x6b4abfae),
+        "main SRAM was not written to/read from correctly");
+  CHECK(write_read_data(sram_region_ret, 0x6b4abfae),
+        "retention SRAM was not written to/read from correctly");
+
+  OTTF_WAIT_FOR(test_phase == kTestPhaseEscalate, kCommandTimeoutMicros);
+
+  // Trigger an alert in the lifecycle controller.
+  CHECK_DIF_OK(
+      dif_lc_ctrl_alert_force(&lc_ctrl, kDifLcCtrlAlertFatalBusIntegError));
+
+  // Ibex should have also locked up because of the alert so we don't expect
+  // to continue executing.
+  LOG_ERROR("Did not expect to execute after alert fired");
+  return false;
+}

--- a/sw/host/tests/chip/sram_ctrl/BUILD
+++ b/sw/host/tests/chip/sram_ctrl/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "sram_ctrl_lc_escalation",
+    srcs = [
+        "src/sram_ctrl_lc_escalation.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:anyhow",
+        "//third_party/rust/crates:clap",
+        "//third_party/rust/crates:humantime",
+        "//third_party/rust/crates:log",
+        "//third_party/rust/crates:object",
+    ],
+)

--- a/sw/host/tests/chip/sram_ctrl/src/sram_ctrl_lc_escalation.rs
+++ b/sw/host/tests/chip/sram_ctrl/src/sram_ctrl_lc_escalation.rs
@@ -1,0 +1,143 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This is the test harness for the `sram_ctrl_lc_escalation` test which
+//! checks that SRAMs can no longer be accessed after an alert is escalated.
+//!
+//! We have to check SRAM access over the debugger and not from within Ibex
+//! because the core also locks up on escalation.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{ensure, Context, Result};
+use clap::Parser;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::jtag::{Jtag, JtagTap};
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::mem::{MemRead32Req, MemWriteReq};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+
+    /// Path to the ELF file being tested on the device.
+    #[arg(long)]
+    firmware_elf: PathBuf,
+}
+
+/// Addresses of symbols in the ELF file that we will access.
+///
+/// Note that the `main` and `ret` addresses point to variables holding the
+/// main and retention SRAM addresses and not those addresses directly.
+#[derive(Debug, Clone, Copy)]
+struct Addresses {
+    test_phase: u32,
+    main: u32,
+    ret: u32,
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let elf_file = fs::read(&opts.firmware_elf).context("failed to read ELF")?;
+    let object = object::File::parse(elf_file.as_ref()).context("failed to parse ELF")?;
+
+    let addresses = Addresses {
+        test_phase: test_utils::object::symbol_addr(&object, "test_phase")?,
+        main: test_utils::object::symbol_addr(&object, "sram_buffer_addr_main")?,
+        ret: test_utils::object::symbol_addr(&object, "sram_buffer_addr_ret")?,
+    };
+
+    let transport = opts.init.init_target()?;
+    let uart_console = transport.uart("console")?;
+
+    execute_test!(lc_escalation, &opts, &transport, &*uart_console, addresses);
+
+    Ok(())
+}
+
+/// Send and receive data with a device's UART.
+fn lc_escalation(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    console: &dyn Uart,
+    addresses: Addresses,
+) -> Result<()> {
+    UartConsole::wait_for(console, r"waiting for commands", opts.timeout)?;
+
+    // Get the addresses of main and retention SRAM that we can access.
+    let main_addr = MemRead32Req::execute(console, addresses.main)?;
+    let ret_addr = MemRead32Req::execute(console, addresses.ret)?;
+
+    // Enable JTAG debugging.
+    transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::RiscvTap)?;
+
+    // Test that we can write to and read back the SRAMs over the debugger.
+    write_read(&mut *jtag, main_addr, 0xaaaa_aaaa)?;
+    write_read(&mut *jtag, ret_addr, 0xbbbb_bbbb)?;
+
+    // Let the device side of the test escalate an alert and lock up.
+    MemWriteReq::execute(console, addresses.test_phase, &[1])?;
+
+    log::info!("-------------------------------");
+    log::info!("EXPECTING JTAG ACCESSES TO FAIL");
+    log::info!("-------------------------------");
+
+    // Check that we can no longer access the SRAMs after escalation.
+    // These operations should time out.
+    ensure!(
+        write_read(&mut *jtag, main_addr, 0xcccc_cccc).is_err(),
+        "expected main SRAM access to fail"
+    );
+    ensure!(
+        write_read(&mut *jtag, ret_addr, 0xdddd_dddd).is_err(),
+        "expected retention SRAM access to fail"
+    );
+
+    // Reset the chip and try again - the SRAMs should now be unlocked.
+    jtag.disconnect()?;
+    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+    let mut jtag = opts
+        .init
+        .jtag_params
+        .create(transport)?
+        .connect(JtagTap::RiscvTap)?;
+
+    log::info!("----------------------------------");
+    log::info!("EXPECTING JTAG ACCESSES TO SUCCEED");
+    log::info!("----------------------------------");
+
+    write_read(&mut *jtag, main_addr, 0xeeee_eeee)?;
+    write_read(&mut *jtag, ret_addr, 0xffff_ffff)?;
+
+    Ok(())
+}
+
+// Write to and read back a word from the given address over the debugger.
+fn write_read(jtag: &mut dyn Jtag, addr: u32, data: u32) -> Result<()> {
+    let mut buf = 0;
+    jtag.write_memory32(addr, &[data])?;
+    jtag.read_memory32(addr, std::slice::from_mut(&mut buf))?;
+
+    assert_eq!(buf, data);
+    Ok(())
+}


### PR DESCRIPTION
This test:

1. Reads and writes to main and retention SRAMs from ibex and through the debug module.
2. Triggers a lifecycle controller bus integrity error alert which is configured to escalate to locking the SRAMs.
3. Tries to read and write the SRAMs through the debug module again which should fail.
4. Resets the chip.
5. Tries to read and write the SRAMs again which should pass.

We can't check that the SRAMs lock up from within ibex because ibex also locks up at the same escalation level.

Instead, I have moved the test from the PROD to RMA lifecycle state and tried to access the SRAMs through the debug module.

There's a chance for a false positive with this test where actually the debug module (or something else) locks up / breaks during the escalation and not the SRAMs. I can't think of any way around that, though.