### PR TITLE
[cherry-pick] #22392  from `earlgrey_es_sival` branch

### DIFF
--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -47,6 +47,7 @@ rust_library(
         "@crate_index//:deser-hjson",
         "@crate_index//:heck",
         "@crate_index//:hex",
+        "@crate_index//:indexmap",
         "@crate_index//:log",
         "@crate_index//:memchr",
         "@crate_index//:num-bigint-dig",

--- a/sw/host/ot_certs/src/asn1/codegen.rs
+++ b/sw/host/ot_certs/src/asn1/codegen.rs
@@ -4,8 +4,8 @@
 
 use anyhow::{bail, ensure, Result};
 use heck::{ToSnakeCase, ToUpperCamelCase};
+use indexmap::IndexMap;
 use num_bigint_dig::BigUint;
-use std::collections::HashMap;
 
 use crate::asn1::builder::Builder;
 use crate::asn1::{Oid, Tag};
@@ -19,13 +19,13 @@ struct ConstantEntry {
 /// Constant pool for code generation.
 #[derive(Default)]
 pub struct ConstantPool {
-    constants: HashMap<Vec<u8>, ConstantEntry>,
+    constants: IndexMap<Vec<u8>, ConstantEntry>,
 }
 
 impl ConstantPool {
     pub fn new() -> ConstantPool {
         ConstantPool {
-            constants: HashMap::new(),
+            constants: IndexMap::new(),
         }
     }
 

--- a/sw/host/ot_certs/src/asn1/x509.rs
+++ b/sw/host/ot_certs/src/asn1/x509.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use indexmap::IndexMap;
 use num_bigint_dig::BigUint;
 use num_traits::FromPrimitive;
-use std::collections::HashMap;
 
 use crate::asn1::builder::{concat_suffix, Builder};
 use crate::asn1::{Oid, Tag};
@@ -169,7 +169,7 @@ impl X509 {
     pub fn push_name<B: Builder>(
         builder: &mut B,
         name_hint: Option<String>,
-        name: &HashMap<AttributeType, Value<String>>,
+        name: &IndexMap<AttributeType, Value<String>>,
     ) -> Result<()> {
         // https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.4
         // Name ::= CHOICE { -- only one possibility for now --

--- a/sw/host/ot_certs/src/codegen.rs
+++ b/sw/host/ot_certs/src/codegen.rs
@@ -7,7 +7,7 @@
 
 use anyhow::{bail, Context, Result};
 use heck::ToUpperCamelCase;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::fmt::Write;
 
 use crate::asn1::codegen::{self, ConstantPool, VariableCodegenInfo, VariableInfo};
@@ -84,8 +84,8 @@ pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
     source_h.push_str("#include \"sw/device/lib/base/status.h\"\n\n");
 
     // Partition variables between TBS and signature.
-    let mut tbs_vars = HashMap::<String, VariableType>::new();
-    let mut sig_vars = HashMap::<String, VariableType>::new();
+    let mut tbs_vars = IndexMap::<String, VariableType>::new();
+    let mut sig_vars = IndexMap::<String, VariableType>::new();
     for (var_name, var) in tmpl.variables.clone() {
         if var_appears_in_sig(&var_name, &tmpl.certificate.signature) {
             sig_vars.insert(var_name, var);
@@ -266,7 +266,7 @@ pub fn generate_cert(from_file: &str, tmpl: &Template) -> Result<Codegen> {
 // Generate a structure holding the value of the variables.
 fn generate_value_struct(
     value_struct_name: &str,
-    variables: &HashMap<String, VariableType>,
+    variables: &IndexMap<String, VariableType>,
 ) -> String {
     let mut source = String::new();
     writeln!(source, "typedef struct {value_struct_name} {{").unwrap();
@@ -280,7 +280,7 @@ fn generate_value_struct(
 
 // Generate an assignment of a structure holding the values of the variables.
 // This is used in the unittest to fill the TBS and sig structures.
-fn generate_value_struct_assignment(variables: &HashMap<String, VariableType>) -> Result<String> {
+fn generate_value_struct_assignment(variables: &IndexMap<String, VariableType>) -> Result<String> {
     let mut source = String::new();
     for (var_name, var_type) in variables {
         let (codegen, _) = c_variable_info(var_name, "", var_type);
@@ -328,7 +328,7 @@ fn generate_builder(
     fn_name: &str,
     fn_params_str: &str,
     constants: &mut ConstantPool,
-    variables: &HashMap<String, VariableType>,
+    variables: &IndexMap<String, VariableType>,
     gen: impl FnOnce(&mut codegen::Codegen) -> Result<()>,
 ) -> Result<(String, String, usize)> {
     let mut generate_fn_impl = String::new();

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -32,9 +32,9 @@
 //! ```
 
 use anyhow::Result;
+use indexmap::IndexMap;
 use num_bigint_dig::BigUint;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
 
 pub mod subst;
 pub mod testgen;
@@ -48,7 +48,7 @@ pub struct Template {
     /// Name of the certificate.
     pub name: String,
     /// Variable declarations.
-    pub variables: HashMap<String, VariableType>,
+    pub variables: IndexMap<String, VariableType>,
     /// Certificate specification.
     pub certificate: Certificate,
 }
@@ -64,9 +64,9 @@ pub struct Certificate {
     /// X509 validity's not after date. The format must be a valid ASN1 GeneralizedTime.
     pub not_after: Value<String>,
     /// X509 certificate's issuer.
-    pub issuer: HashMap<AttributeType, Value<String>>,
+    pub issuer: IndexMap<AttributeType, Value<String>>,
     /// X509 certificate's subject.
-    pub subject: HashMap<AttributeType, Value<String>>,
+    pub subject: IndexMap<AttributeType, Value<String>>,
     /// X509 certificate's public key.
     pub subject_public_key_info: SubjectPublicKeyInfo,
     /// X509 certificate's authority key identifier.
@@ -483,7 +483,7 @@ mod tests {
             }
         "#};
 
-        let variables = HashMap::from([
+        let variables = IndexMap::from([
             (
                 "owner_pub_key_ec_x".to_string(),
                 VariableType::Integer { size: 32 },
@@ -526,13 +526,13 @@ mod tests {
         // Certificate template values.
         let certificate = Certificate {
             serial_number: Value::convert("owner_pub_key_id", Conversion::BigEndian),
-            issuer: HashMap::from([(
+            issuer: IndexMap::from([(
                 AttributeType::SerialNumber,
                 Value::convert("signing_pub_key_id", Conversion::LowercaseHex),
             )]),
             not_before: Value::literal("20230101000000Z"),
             not_after: Value::literal("99991231235959Z"),
-            subject: HashMap::from([(
+            subject: IndexMap::from([(
                 AttributeType::SerialNumber,
                 Value::convert("owner_pub_key_id", Conversion::LowercaseHex),
             )]),

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -7,10 +7,10 @@
 
 use anyhow::{bail, ensure, Context, Result};
 use hex::{FromHex, ToHex};
+use indexmap::IndexMap;
 use num_bigint_dig::{BigUint, ToBigInt};
 use num_traits::Num;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 use crate::template::{
     BasicConstraints, Certificate, CertificateExtension, Conversion, DiceTcbInfoExtension,
@@ -34,13 +34,13 @@ pub enum SubstValue {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SubstData {
     #[serde(flatten)]
-    pub values: HashMap<String, SubstValue>,
+    pub values: IndexMap<String, SubstValue>,
 }
 
 impl SubstData {
     pub fn new() -> SubstData {
         SubstData {
-            values: HashMap::new(),
+            values: IndexMap::new(),
         }
     }
 
@@ -526,15 +526,15 @@ where
     }
 }
 
-impl<K, V> Subst for HashMap<K, V>
+impl<K, V> Subst for IndexMap<K, V>
 where
     K: Clone + Eq + std::hash::Hash,
     V: Subst,
 {
-    fn subst(&self, data: &SubstData) -> Result<HashMap<K, V>> {
+    fn subst(&self, data: &SubstData) -> Result<IndexMap<K, V>> {
         self.iter()
             .map(|(k, v)| Ok((k.clone(), v.subst(data)?)))
-            .collect::<Result<HashMap<K, V>>>()
+            .collect::<Result<IndexMap<K, V>>>()
     }
 }
 

--- a/sw/host/ot_certs/src/x509.rs
+++ b/sw/host/ot_certs/src/x509.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, ensure, Context, Result};
+use indexmap::IndexMap;
 use num_bigint_dig::BigUint;
-use std::collections::HashMap;
 
 use foreign_types::ForeignTypeRef;
 use openssl::asn1::{Asn1IntegerRef, Asn1OctetStringRef, Asn1StringRef, Asn1TimeRef};
@@ -102,8 +102,8 @@ fn asn1time_to_string(time: &Asn1TimeRef) -> Result<Value<String>> {
 fn asn1name_to_hashmap(
     field: &str,
     name: &X509NameRef,
-) -> Result<HashMap<AttributeType, Value<String>>> {
-    let mut res = HashMap::<AttributeType, Value<String>>::new();
+) -> Result<IndexMap<AttributeType, Value<String>>> {
+    let mut res = IndexMap::<AttributeType, Value<String>>::new();
     for entry in name.entries() {
         let attr = AttributeType::try_from(entry.object().nid())?;
         if res


### PR DESCRIPTION
#22392: [certs] make OT cert builds deterministic

Non-ordered data structures were being iterated over to produce device code that would generate OT attestation certificates. This caused builds on different machines (and on the same machine) of the same code to be different. This switches the non-deterministic data structures for a deterministic equivalent.

Signed-off-by: Tim Trippel <ttrippel@google.com>
(cherry picked from commit 39cf48bb91e55740fd0d0b8179ac903e5654d41b)