### PR TITLE
[sival] Re-enable UART Baud test and disable high Bauds

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5274,7 +5274,6 @@ opentitan_binary(
 opentitan_test(
     name = "uart_baud_rate_test",
     srcs = ["uart_baud_rate_test.c"],
-    broken = cw310_params(tags = ["broken"]),
     cw310 = cw310_params(
         test_cmd = " ".join([
             "--bootstrap=\"{firmware}\"",
@@ -5283,8 +5282,7 @@ opentitan_test(
         test_harness = "//sw/host/tests/chip/uart:uart_baud_rate",
     ),
     exec_env = dicts.add(
-        # FIXME broken in sival ROM_EXT, change this line when fixed. See #21706.
-        {"//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken"},
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     silicon = silicon_params(

--- a/sw/device/tests/uart_baud_rate_test.c
+++ b/sw/device/tests/uart_baud_rate_test.c
@@ -24,16 +24,11 @@ static const uint32_t kBaseAddrs[4] = {
     TOP_EARLGREY_UART2_BASE_ADDR,
     TOP_EARLGREY_UART3_BASE_ADDR,
 };
-static uint32_t kBauds[7] = {
-    9600, 115200, 230400, 128000, 256000, 1000000, 1500000,
-};
+static const uint32_t kBauds[9] = {4800,   9600,   19200,  38400, 57600,
+                                   115200, 230400, 128000, 256000};
 
 enum {
   kTestTimeoutMillis = 500000,
-  // Number of Bauds to test from `kBauds`.
-  kBaudCountSilicon = 7,
-  // The two highest Bauds won't work at the clock speed we run the FPGAs at.
-  kBaudCountFpga = 5,
 };
 
 typedef enum test_phase {
@@ -112,12 +107,9 @@ bool test_main(void) {
   CHECK_STATUS_OK(
       uart_testutils_select_pinmux(&pinmux, uart_idx, kUartPinmuxChannelDut));
 
-  size_t baud_count =
-      kDeviceType == kDeviceSilicon ? kBaudCountSilicon : kBaudCountFpga;
-
   // Check every baud rate is sent and received okay.
   status_t result = OK_STATUS();
-  for (size_t baud_idx = 0; baud_idx < baud_count; ++baud_idx) {
+  for (size_t baud_idx = 0; baud_idx < ARRAYSIZE(kBauds); ++baud_idx) {
     baud_rate = kBauds[baud_idx];
     EXECUTE_TEST(result, test_uart_baud);
   }

--- a/sw/device/tests/uart_baud_rate_test.c
+++ b/sw/device/tests/uart_baud_rate_test.c
@@ -53,24 +53,24 @@ OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 static status_t test_uart_baud(void) {
   test_phase = kTestPhaseCfg;
 
-  CHECK_DIF_OK(dif_uart_configure(
-      &uart, (dif_uart_config_t){
-                 .baudrate = (uint32_t)baud_rate,
-                 .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
-                 .parity_enable = kDifToggleDisabled,
-                 .parity = kDifUartParityEven,
-                 .tx_enable = kDifToggleEnabled,
-                 .rx_enable = kDifToggleEnabled,
-             }));
+  TRY(dif_uart_configure(&uart,
+                         (dif_uart_config_t){
+                             .baudrate = (uint32_t)baud_rate,
+                             .clk_freq_hz = (uint32_t)kClockFreqPeripheralHz,
+                             .parity_enable = kDifToggleDisabled,
+                             .parity = kDifUartParityEven,
+                             .tx_enable = kDifToggleEnabled,
+                             .rx_enable = kDifToggleEnabled,
+                         }));
 
-  CHECK_DIF_OK(dif_uart_fifo_reset(&uart, kDifUartDatapathAll));
+  TRY(dif_uart_fifo_reset(&uart, kDifUartDatapathAll));
 
   LOG_INFO("Configured UART%d with Baud rate %d", uart_idx, baud_rate);
 
   OTTF_WAIT_FOR(test_phase == kTestPhaseSend, kTestTimeoutMillis);
 
   LOG_INFO("Sending data...");
-  CHECK_DIF_OK(dif_uart_bytes_send(&uart, kSendData, sizeof(kSendData), NULL));
+  TRY(dif_uart_bytes_send(&uart, kSendData, sizeof(kSendData), NULL));
   LOG_INFO("Data sent");
 
   OTTF_WAIT_FOR(test_phase == kTestPhaseRecv, kTestTimeoutMillis);
@@ -78,9 +78,9 @@ static status_t test_uart_baud(void) {
   LOG_INFO("Receiving data...");
   uint8_t data[sizeof(kSendData)] = {0};
   for (size_t i = 0; i < sizeof(data); ++i) {
-    CHECK_DIF_OK(dif_uart_byte_receive_polled(&uart, &data[i]));
+    TRY(dif_uart_byte_receive_polled(&uart, &data[i]));
   }
-  CHECK_ARRAYS_EQ(data, kSendData, sizeof(kSendData));
+  TRY_CHECK_ARRAYS_EQ(data, kSendData, sizeof(kSendData));
 
   test_phase = kTestPhaseDone;
 

--- a/sw/host/tests/chip/uart/src/uart_baud_rate.rs
+++ b/sw/host/tests/chip/uart/src/uart_baud_rate.rs
@@ -85,6 +85,12 @@ fn main() -> Result<()> {
         );
     }
 
+    // Reset baud rate to the default.
+    // HyperDebug doesn't seem to clear this properly between tests.
+    let uart = transport.uart("dut")?;
+    uart.set_baudrate(115200)?;
+    uart.clear_rx_buffer()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
This test was disabled in CI due to problems with the HyperDebug which appear to be fixed now.

This PR also removes the two highest Baud rates (1MBd and 1.5MBd) since they're too high for us to test. Previously they were only enabled in Silicon (where the clock was thought to run fast enough) but it seems it's either not fast enough or HyperDebug doesn't go that fast.

Open question: should I change the test plan to only require the lower Baud rates? @rswarbrick is this an acceptible change to the test?