### PR TITLE
[csrng,sival] Fix `csrng_edn_concurrency`

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -928,20 +928,16 @@ opentitan_test(
 opentitan_test(
     name = "csrng_edn_concurrency_test",
     srcs = ["csrng_edn_concurrency_test.c"],
-    broken = cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_proda_rom_ext": "silicon_owner",
+            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
+            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
+            "//hw/top_earlgrey:silicon_owner_proda_rom_ext": None,
         },
-    ),
-    silicon_owner = silicon_params(
-        tags = ["broken"],
     ),
     verilator = verilator_params(timeout = "eternal"),
     deps = [

--- a/sw/device/tests/csrng_edn_concurrency_test.c
+++ b/sw/device/tests/csrng_edn_concurrency_test.c
@@ -297,6 +297,9 @@ static void main_task(void *task_parameters) {
     for (size_t i = 0; i < kTestTaskIdCount; ++i) {
       task_done[i] = false;
     }
+    // Clear any recoverable alert that could have been triggered before or
+    // during setup.
+    CHECK_DIF_OK(dif_csrng_clear_recoverable_alerts(&csrng));
     // Signal the other tasks to start test execution.
     execution_state_update(kTestStateRun);
     // This is required to ensure the aggregation of task_done entries is equal


### PR DESCRIPTION
The problem is that recoverable alert (`ACMD_FLAG0_FIELD_ALERT`) is triggered *before* the test, but the test does not clear it before starting. This is problem triggered in the ROM_EXT or the ROM, and it happens on both master and es_sival.