### PR TITLE
[rv_plic,fpv] Fix index widths

### DIFF
--- a/hw/ip_templates/rv_plic/fpv/vip/rv_plic_assert_fpv.sv.tpl
+++ b/hw/ip_templates/rv_plic/fpv/vip/rv_plic_assert_fpv.sv.tpl
@@ -27,14 +27,17 @@ module ${module_instance_name}_assert_fpv #(parameter int NumSrc = 1,
   input [PRIOW-1:0]  threshold [NumTarget]
 );
 
+  localparam int SrcIdxWidth = NumSrc > 1 ? $clog2(NumSrc - 1) : 1;
+  localparam int TgtIdxWidth = NumTarget > 1 ? $clog2(NumTarget - 1) : 1;
+
   logic claim_reg, claimed;
   logic max_priority;
   logic irq;
   logic [$clog2(NumSrc)-1:0] i_high_prio;
 
   // symbolic variables
-  int unsigned src_sel;
-  int unsigned tgt_sel;
+  bit [SrcIdxWidth-1:0] src_sel;
+  bit [TgtIdxWidth-1:0] tgt_sel;
 
   `ASSUME_FPV(IsrcRange_M, src_sel >  0 && src_sel < NumSrc, clk_i, !rst_ni)
   `ASSUME_FPV(ItgtRange_M, tgt_sel >= 0 && tgt_sel < NumTarget, clk_i, !rst_ni)

--- a/hw/top_earlgrey/ip_autogen/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
@@ -27,14 +27,17 @@ module rv_plic_assert_fpv #(parameter int NumSrc = 1,
   input [PRIOW-1:0]  threshold [NumTarget]
 );
 
+  localparam int SrcIdxWidth = NumSrc > 1 ? $clog2(NumSrc - 1) : 1;
+  localparam int TgtIdxWidth = NumTarget > 1 ? $clog2(NumTarget - 1) : 1;
+
   logic claim_reg, claimed;
   logic max_priority;
   logic irq;
   logic [$clog2(NumSrc)-1:0] i_high_prio;
 
   // symbolic variables
-  int unsigned src_sel;
-  int unsigned tgt_sel;
+  bit [SrcIdxWidth-1:0] src_sel;
+  bit [TgtIdxWidth-1:0] tgt_sel;
 
   `ASSUME_FPV(IsrcRange_M, src_sel >  0 && src_sel < NumSrc, clk_i, !rst_ni)
   `ASSUME_FPV(ItgtRange_M, tgt_sel >= 0 && tgt_sel < NumTarget, clk_i, !rst_ni)


### PR DESCRIPTION
No functional change really, but it silences some warnings that come out of Jasper at build time (because the type of the index is a 32-bit variable and it reasonably worries that this might mean we're going to to an out-of-bounds access).