### PR TITLE
[keymgr] Use non-deterministic decoy values for KMAC and sideload ports

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -553,7 +553,9 @@ module keymgr
   assign invalid_data[OpGenSwOut] = ~key_vld | ~key_version_vld;
   assign invalid_data[OpGenHwOut] = ~key_vld | ~key_version_vld;
 
-  keymgr_kmac_if u_kmac_if (
+  keymgr_kmac_if #(
+    .RndCnstRandPerm(RndCnstRandPerm)
+  ) u_kmac_if (
     .clk_i,
     .rst_ni,
     .prng_en_o(data_lfsr_en),


### PR DESCRIPTION
Previously, the two shares of the masked values forwarded to KMAC and the sideload ports would be equal when not used. This is non-ideal as the effective value observed on the sideload ports and by KMAC becomes then 0 which may potentially be exploited.

This resolves lowRISC/OpenTitan#8120.