### PR TITLE
[dvsim,lint] Fix bug in duplicate detection in lint parser

### DIFF
--- a/util/dvsim/LintParser.py
+++ b/util/dvsim/LintParser.py
@@ -53,7 +53,7 @@ class LintParser():
         found = {}
         for bucket, pattern in reversed(patterns):
             for m in re.finditer(pattern, log_content, flags=re.MULTILINE):
-                found[m.pos] = (bucket, m.group(0))
+                found[m.start()] = (bucket, m.group(0))
 
         # Now that we've ignored duplicate hits, flatten things out into
         # self.buckets.


### PR DESCRIPTION
The code in extract_messages tries to avoid getting multiple hits at a single location. The idea is that you might have two different buckets that both match a particular string. For example, suppose we have buckets with the following patterns:

  "This.*not.*bad"
  "This.*bad"

If the log that we're parsing contains "This is not bad", we want to find a single hit (we probably want the one for the first pattern).

The code tries to do this by storing a partial map to compute "The first pattern in the list that matches the string starting at the given location".

This should work nicely! But I had messed up the Python side of things and used m.pos instead of m.start. The pos field gives the pos argument that got passed to find() (zero here) and the result is that we find exactly one result, allocated to position zero. Oops!

Use m.start(), which gives the index of the first character that was matched. Much cleaner!

(This fixes a bug that was introduced by my 997422b5033315e6844d2382815d64814018e512 and causes the overnight lint results to be rather unhelpful)