### PR TITLE
[ot_certs] Add a DICE TCB info unit test and mark extension as critical

### DIFF
--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -88,6 +88,8 @@ rust_test_suite(
         ":ot_certs",
         "@crate_index//:anyhow",
         "@crate_index//:base64ct",
+        "@crate_index//:num-bigint-dig",
+        "@crate_index//:num-traits",
     ],
 )
 

--- a/sw/host/ot_certs/src/asn1/dice_tcb.rs
+++ b/sw/host/ot_certs/src/asn1/dice_tcb.rs
@@ -140,7 +140,8 @@ impl DiceTcbInfoExtension {
 
     // Push a DICE TCB Info X509 extension.
     pub fn push_extension<B: Builder>(&self, builder: &mut B) -> Result<()> {
-        X509::push_extension(builder, &Oid::DiceTcbInfo, false, |builder| {
+        // Per the DICE specification, the DiceTcbInfo extension SHOULD be marked critical.
+        X509::push_extension(builder, &Oid::DiceTcbInfo, true, |builder| {
             self.push_extension_raw(builder)
         })
     }

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -110,7 +110,7 @@ pub struct DiceTcbInfoExtension {
     /// TCB firmware IDs.
     pub fw_ids: Option<Vec<FirmwareId>>,
     /// TCB flags.
-    pub flags: Option<Flags>,
+    pub flags: Option<DiceTcbInfoFlags>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Hash, strum::Display, Serialize)]
@@ -320,7 +320,7 @@ pub enum EcCurve {
 /// Flags that can be set for a certificate.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct Flags {
+pub struct DiceTcbInfoFlags {
     pub not_configured: Value<bool>,
     pub not_secure: Value<bool>,
     pub recovery: Value<bool>,
@@ -562,7 +562,7 @@ mod tests {
                         digest: Value::variable("ownership_manifest_hash"),
                     },
                 ])),
-                flags: Some(Flags {
+                flags: Some(DiceTcbInfoFlags {
                     not_configured: Value::Literal(true),
                     not_secure: Value::Literal(false),
                     recovery: Value::Literal(true),

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::template::{
     BasicConstraints, Certificate, CertificateExtension, Conversion, DiceTcbInfoExtension,
-    EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, Flags, Signature,
+    DiceTcbInfoFlags, EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, Signature,
     SubjectPublicKeyInfo, Template, Value, Variable, VariableType,
 };
 
@@ -436,9 +436,9 @@ impl Subst for FirmwareId {
     }
 }
 
-impl Subst for Flags {
-    fn subst(&self, data: &SubstData) -> Result<Flags> {
-        Ok(Flags {
+impl Subst for DiceTcbInfoFlags {
+    fn subst(&self, data: &SubstData) -> Result<DiceTcbInfoFlags> {
+        Ok(DiceTcbInfoFlags {
             not_configured: self
                 .not_configured
                 .subst(data)

--- a/sw/host/ot_certs/src/x509.rs
+++ b/sw/host/ot_certs/src/x509.rs
@@ -24,7 +24,7 @@ use crate::template::{
     Value,
 };
 
-mod extension;
+pub mod extension;
 
 fn curve_from_ecgroup(group: &EcGroupRef) -> Result<EcCurve> {
     let Some(name) = group.curve_name() else {

--- a/sw/host/ot_certs/src/x509/extension.rs
+++ b/sw/host/ot_certs/src/x509/extension.rs
@@ -229,8 +229,8 @@ impl<'a> asn1::SimpleAsn1Readable<'a> for DiceTcbInfoFlags {
 }
 
 /// Try to parse an X509 extension as a DICE TCB info extension.
-pub fn parse_dice_tcb_info_extension(ext: &X509ExtensionRef) -> Result<DiceTcbInfoExtension> {
-    asn1::parse_single::<DiceTcbInfo>(ext.data.as_slice())
+pub fn parse_dice_tcb_info_extension(ext: &[u8]) -> Result<DiceTcbInfoExtension> {
+    asn1::parse_single::<DiceTcbInfo>(ext)
         .context("cannot parse DICE extension")?
         .to_dice_extension()
 }
@@ -265,7 +265,7 @@ pub fn parse_extension(ext: &X509ExtensionRef) -> Result<CertificateExtension> {
     // The openssl library does not provide a way to compare between two Asn1Object so compare the raw DER.
     Ok(match ext.object.to_owned().as_slice() {
         obj if obj == dice_oid.as_slice() => {
-            CertificateExtension::DiceTcbInfo(parse_dice_tcb_info_extension(ext)?)
+            CertificateExtension::DiceTcbInfo(parse_dice_tcb_info_extension(ext.data.as_slice())?)
         }
         _ => bail!("unknown extension type {}", ext.object,),
     })

--- a/sw/host/ot_certs/src/x509/extension.rs
+++ b/sw/host/ot_certs/src/x509/extension.rs
@@ -11,8 +11,8 @@ use openssl::x509::X509;
 
 use crate::asn1::Oid;
 use crate::template::{
-    BasicConstraints, CertificateExtension, DiceTcbInfoExtension, FirmwareId, Flags, HashAlgorithm,
-    Value,
+    BasicConstraints, CertificateExtension, DiceTcbInfoExtension, DiceTcbInfoFlags, FirmwareId,
+    HashAlgorithm, Value,
 };
 
 /// X509 extension reference.
@@ -136,7 +136,7 @@ struct DiceTcbInfo<'a> {
     #[implicit(6)]
     pub fwids: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
     #[implicit(7)]
-    pub flags: Option<Flags>,
+    pub flags: Option<DiceTcbInfoFlags>,
     #[implicit(8)]
     pub vendor_info: Option<&'a [u8]>,
     #[implicit(9)]
@@ -209,7 +209,7 @@ impl DiceTcbInfo<'_> {
     }
 }
 
-impl<'a> asn1::SimpleAsn1Readable<'a> for Flags {
+impl<'a> asn1::SimpleAsn1Readable<'a> for DiceTcbInfoFlags {
     const TAG: asn1::Tag = asn1::OwnedBitString::TAG;
     fn parse_data(_data: &'a [u8]) -> asn1::ParseResult<Self> {
         let result = asn1::OwnedBitString::parse_data(_data)?;
@@ -218,7 +218,7 @@ impl<'a> asn1::SimpleAsn1Readable<'a> for Flags {
             // We expect 4 bits.
             asn1::ParseResult::Err(asn1::ParseError::new(asn1::ParseErrorKind::InvalidLength))
         } else {
-            Ok(Flags {
+            Ok(DiceTcbInfoFlags {
                 not_configured: Value::Literal(bs.has_bit_set(0)),
                 not_secure: Value::Literal(bs.has_bit_set(1)),
                 recovery: Value::Literal(bs.has_bit_set(2)),

--- a/sw/host/ot_certs/tests/dice_tcb_info.rs
+++ b/sw/host/ot_certs/tests/dice_tcb_info.rs
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Context, Result};
+use base64ct::Encoding;
+use num_bigint_dig::BigUint;
+use num_traits::cast::FromPrimitive;
+use num_traits::Num;
+
+use ot_certs::asn1::der::Der;
+use ot_certs::template::{
+    DiceTcbInfoExtension, DiceTcbInfoFlags, FirmwareId, HashAlgorithm, Value,
+};
+use ot_certs::x509::extension::parse_dice_tcb_info_extension;
+
+fn check_dice_tcb_info(dice_tcb_info: DiceTcbInfoExtension) -> Result<()> {
+    // Generate the DER for this DICE TCB Info.
+    let der = Der::generate(|builder| dice_tcb_info.push_extension_raw(builder))?;
+    // Parse DER back.
+    let parsed_tcb =
+        parse_dice_tcb_info_extension(&der).context("could not parse DICE TCB Info der")?;
+    // Check that it matches the original one.
+    if parsed_tcb != dice_tcb_info {
+        println!("expected: {dice_tcb_info:#?}");
+        println!("got: {parsed_tcb:#?}");
+        println!("DER: {}", base64ct::Base64::encode_string(&der));
+        bail!("parsed DICE TCB does not match the expected one");
+    }
+    Ok(())
+}
+
+#[test]
+fn main() -> Result<()> {
+    // For each optional field, we exercise one case where it is set
+    // and one case where it is not set.
+    check_dice_tcb_info(DiceTcbInfoExtension {
+        model: Some(Value::Literal("Model".into())),
+        vendor: None,
+        version: Some(Value::Literal("Version".into())),
+        svn: None,
+        layer: Some(Value::Literal(BigUint::from_u32(42).unwrap())),
+        fw_ids: None,
+        flags: Some(DiceTcbInfoFlags {
+            not_configured: Value::Literal(true),
+            not_secure: Value::Literal(true),
+            recovery: Value::Literal(false),
+            debug: Value::Literal(true),
+        }),
+    })?;
+
+    check_dice_tcb_info(DiceTcbInfoExtension {
+        model: None,
+        vendor: Some(Value::Literal("Vendor".into())),
+        version: None,
+        svn: Some(Value::Literal(BigUint::from_str_radix(
+            "89485897489778474678876487678657",
+            10,
+        )?)),
+        layer: None,
+        fw_ids: Some(vec![
+            FirmwareId {
+                hash_algorithm: HashAlgorithm::Sha256,
+                digest: Value::Literal(vec![
+                    0x46, 0x56, 0x44, 0xd9, 0x35, 0x38, 0x57, 0x83, 0x65, 0x83, 0x57, 0x58, 0x37,
+                    0x58, 0xc5, 0x93, 0x58, 0x3b, 0x65, 0x37,
+                ]),
+            },
+            FirmwareId {
+                hash_algorithm: HashAlgorithm::Sha256,
+                digest: Value::Literal(vec![
+                    0x00, 0x9e, 0x98, 0x09, 0xf8, 0x59, 0x78, 0x32, 0x75, 0x92, 0x85, 0x7a, 0x09,
+                    0x3f, 0x53, 0x90, 0x78, 0x62, 0x65, 0x89,
+                ]),
+            },
+        ]),
+        flags: None,
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR makes a few changes:
- mark DICE TCB info extension as **CRITICAL**, as recommended per the spec @timothytrippel 
- shuffle around some code so that the DICE TCB Info generation and parsing can be used on their own
- add a unit test to exercise the DICE TCB info specifically, without using any of the X509 stuff