### PR TITLE
[csrng/rtl] Fix lint error

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -988,7 +988,7 @@ module csrng_core import csrng_pkg::*; #(
 
   // set ack status for configured instances
   for (genvar i = 0; i < NHwApps; i = i+1) begin : gen_app_if_sts
-    assign hw_exception_sts[i] = cmd_stage_ack[i] && cmd_stage_ack_sts[i];
+    assign hw_exception_sts[i] = cmd_stage_ack[i] && (cmd_stage_ack_sts[i] != CMD_STS_SUCCESS);
   end : gen_app_if_sts
 
   // set ack status to zero for un-configured instances


### PR DESCRIPTION
Previously the cmd sts signal was checked to be 1'b1 but now it is more than one bit. Now we check if it is NE zero by comparing to CMD_STS_SUCCESS.