### PR TITLE
[pentest] Return device ID to host

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -177,13 +177,16 @@ cc_library(
     deps = [
         "//sw/device/lib/base:csr",
         "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/testing:alert_handler_testutils",
         "//sw/device/lib/testing:rv_plic_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",
+        "//sw/device/tests/penetrationtests/json:sca_lib_commands",
     ],
 )
 

--- a/sw/device/tests/penetrationtests/firmware/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/aes_sca.c
@@ -907,6 +907,9 @@ status_t handle_aes_sca_init(ujson_t *uj) {
   // measurements.
   sca_configure_cpu();
 
+  // Read the device ID and return it back to the host.
+  TRY(sca_read_device_id(uj));
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/penetrationtests/firmware/hmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/hmac_sca.c
@@ -199,6 +199,9 @@ status_t handle_hmac_sca_init(ujson_t *uj) {
   // Disable the instruction cache and dummy instructions for SCA.
   sca_configure_cpu();
 
+  // Read the device ID and return it back to the host.
+  TRY(sca_read_device_id(uj));
+
   return OK_STATUS();
 }
 

--- a/sw/device/tests/penetrationtests/firmware/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/ibex_fi.c
@@ -1072,6 +1072,9 @@ status_t handle_ibex_fi_init(ujson_t *uj) {
       mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
       &rv_core_ibex));
 
+  // Read the device ID and return it back to the host.
+  TRY(sca_read_device_id(uj));
+
   return OK_STATUS();
 }
 

--- a/sw/device/tests/penetrationtests/firmware/ibex_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/ibex_sca.c
@@ -647,6 +647,9 @@ status_t handle_ibex_sca_init(ujson_t *uj) {
   // Disable the instruction cache and dummy instructions for SCA.
   sca_configure_cpu();
 
+  // Read the device ID and return it back to the host.
+  TRY(sca_read_device_id(uj));
+
   return OK_STATUS();
 }
 

--- a/sw/device/tests/penetrationtests/firmware/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/kmac_sca.c
@@ -474,6 +474,9 @@ status_t handle_kmac_sca_init(ujson_t *uj) {
   // measurements.
   sca_configure_cpu();
 
+  // Read the device ID and return it back to the host.
+  TRY(sca_read_device_id(uj));
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/penetrationtests/firmware/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/otbn_fi.c
@@ -491,6 +491,9 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   // Disable the instruction cache and dummy instructions for FI attacks.
   sca_configure_cpu();
 
+  // Read the device ID and return it back to the host.
+  TRY(sca_read_device_id(uj));
+
   return err;
 }
 

--- a/sw/device/tests/penetrationtests/firmware/sca_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/sca_lib.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_SCA_LIB_H_
 
 #include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/penetrationtests/json/sca_lib_commands.h"
 
 typedef struct sca_registered_alerts {
   uint32_t alerts_1;
@@ -30,6 +31,16 @@ sca_registered_alerts_t sca_get_triggered_alerts(void);
  * Register all alerts and let them escalate to Phase0 only.
  */
 void sca_configure_alert_handler(void);
+
+/**
+ * Reads the device ID from the LC.
+ *
+ * Can be used to categorize different SCA and FI runs.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t sca_read_device_id(ujson_t *uj);
 
 /**
  * Configures CPU for SCA and FI penetration tests.

--- a/sw/device/tests/penetrationtests/firmware/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sha3_sca.c
@@ -607,6 +607,9 @@ status_t handle_sha3_sca_init(ujson_t *uj) {
   // measurements.
   sca_configure_cpu();
 
+  // Read the device ID and return it back to the host.
+  TRY(sca_read_device_id(uj));
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/penetrationtests/json/BUILD
+++ b/sw/device/tests/penetrationtests/json/BUILD
@@ -52,6 +52,13 @@ cc_library(
 )
 
 cc_library(
+    name = "sca_lib_commands",
+    srcs = ["sca_lib_commands.c"],
+    hdrs = ["sca_lib_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "kmac_sca_commands",
     srcs = ["kmac_sca_commands.c"],
     hdrs = ["kmac_sca_commands.h"],

--- a/sw/device/tests/penetrationtests/json/sca_lib_commands.c
+++ b/sw/device/tests/penetrationtests/json/sca_lib_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "sca_lib_commands.h"

--- a/sw/device/tests/penetrationtests/json/sca_lib_commands.h
+++ b/sw/device/tests/penetrationtests/json/sca_lib_commands.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_SCA_LIB_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_SCA_LIB_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define PENETRATIONTEST_DEVICE_ID(field, string) \
+    field(device_id, uint32_t, 8)
+UJSON_SERDE_STRUCT(PenetrationtestDeviceId, penetrationtest_device_id_t, PENETRATIONTEST_DEVICE_ID);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_SCA_LIB_COMMANDS_H_


### PR DESCRIPTION
This commit extends the init function of the SCA and FI tests to read out the DEVICE_ID register in the life cycle controller. This can be used by the host to categorize test results.