### PR TITLE
[ci] Increase CW310 SiVal non-ROM_EXT test timeout to 75m

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -584,7 +584,7 @@ jobs:
   pool:
     name: $(fpga_pool)
     demands: BOARD -equals cw310
-  timeoutInMinutes: 45
+  timeoutInMinutes: 75
   dependsOn:
     - chip_earlgrey_cw310_hyperdebug
     - sw_build


### PR DESCRIPTION
Successful runs are taking ~40 minutes and sometimes we're getting timed out at 45 seemingly depending on the load of the CI runner.