### PR TITLE
[pentest] Add SRAM Write Static test

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/ibex_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/ibex_fi.h
@@ -170,6 +170,25 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj);
 status_t handle_ibex_fi_char_sram_read(ujson_t *uj);
 
 /**
+ * ibex.fi.char.sram_write_static command handler.
+ *
+ * This FI penetration tests executes the following instructions:
+ * - Set the trigger.
+ * - Add 10 NOPs to delay the trigger
+ * - Write 64 static values into SRAM.
+ * - Unset the trigger.
+ * - Read back values and compare.
+ * - Return the values over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_ibex_fi_char_sram_write_static(ujson_t *uj);
+
+/**
  * ibex.fi.char.sram_write command handler.
  *
  * This FI penetration tests executes the following instructions:

--- a/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
@@ -22,6 +22,7 @@ extern "C" {
     value(_, CharCondBranch) \
     value(_, CharUncondBranch) \
     value(_, CharSramWrite) \
+    value(_, CharSramWriteStatic) \
     value(_, CharSramRead) \
     value(_, CharSramStatic) \
     value(_, CharFlashWrite) \


### PR DESCRIPTION
This commit adds the ibex.fi.char.sram_write_static FI test to the codebase. The aim of this test is to fault one of the 64 consecutive SW instructions used to write a static value into SRAM. The host code is located in lowRISC/ot-sca#359