### PR TITLE
[bazel,ci] Add `rom_ext`, `sival`, and `sival_rom_ext` exec envs for CW340

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -690,6 +690,48 @@ jobs:
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 
+- job: execute_sival_rom_ext_fpga_tests_cw340
+  displayName: CW340 SiVal ROM_EXT Tests
+  pool:
+    name: $(fpga_pool)
+    demands: BOARD -equals cw340
+  timeoutInMinutes: 45
+  dependsOn:
+    - chip_earlgrey_cw340
+    - sw_build
+  condition: succeeded( 'chip_earlgrey_cw340', 'sw_build' )
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw340
+        - sw_build
+  - template: ci/load-bazel-cache-write-creds.yml
+  # We run the update command twice to workaround an issue with udev on the container,
+  # where rusb cannot dynamically update its device list in CI (udev is not completely
+  # functional). If the device is in normal mode, the first thing that opentitantool
+  # does is to switch it to DFU mode and wait until it reconnects. This reconnection is
+  # never detected. But if we run the tool another time, the device list is queried again
+  # and opentitantool can finish the update. The device will now reboot in normal mode
+  # and work for the hyperdebug job.
+  - bash: |
+      ci/bazelisk.sh run \
+        //sw/host/opentitantool:opentitantool -- \
+        --interface=hyperdebug_dfu transport update-firmware \
+      || ci/bazelisk.sh run \
+        //sw/host/opentitantool:opentitantool -- \
+        --interface=hyperdebug_dfu transport update-firmware || true
+    displayName: "Update the hyperdebug firmware"
+  - bash: |
+      set -e
+      . util/build_consts.sh
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/scripts/run-fpga-tests.sh cw340 cw340_sival_rom_ext || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+    displayName: Execute tests
+  - template: ci/publish-bazel-test-results.yml
+
 - job: execute_fpga_manuf_tests_cw310
   displayName: CW310 Manufacturing Tests
   pool:

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -331,6 +331,66 @@ fpga_cw340(
     """,
 )
 
+fpga_cw340(
+    name = "fpga_cw340_rom_ext",
+    testonly = True,
+    base = ":fpga_cw340_rom_with_fake_keys",
+    exec_env = "fpga_cw340_rom_ext",
+    libs = [
+        "//sw/device/lib/arch:boot_stage_owner",
+        "//sw/device/lib/arch:fpga_cw340",
+    ],
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+    manifest = "//sw/device/silicon_owner:manifest_standard",
+    otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
+    param = {
+        "interface": "hyper340",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+        "assemble": "{rom_ext}@0 {firmware}@0x10000",
+    },
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0": "test_key_0"},
+)
+
+# FPGA configuration used to emulate silicon targets. This rule can be used by
+# targets that require executing at the `rom_ext` stage level in flash, as well
+# as SRAM programs. Use the `fpga_cw340_sival_rom_ext` execution environment to
+# emulate silicon targets containing a `rom_ext` stage.
+# See sw/device/tests/doc/sival/devguide.md for more details.
+fpga_cw340(
+    name = "fpga_cw340_sival",
+    testonly = True,
+    base = ":fpga_cw340_rom_with_fake_keys",
+    exec_env = "fpga_cw340_sival",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+
+    # PROD keys are allowed to run across all life cycle stages. This prod key
+    # is used to enable execution across life cycle stages with a single
+    # binary.
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    tags = ["cw340_sival"],
+)
+
+# FPGA configuration used to emulate silicon targets containing a `rom_ext`
+# stage.
+# See `fpga_cw340_sival` for more details.
+# Also, see sw/device/tests/doc/sival/devguide.md.
+fpga_cw340(
+    name = "fpga_cw340_sival_rom_ext",
+    testonly = True,
+    base = ":fpga_cw340_rom_ext",
+    exec_env = "fpga_cw340_sival_rom_ext",
+    libs = [
+        "//sw/device/lib/arch:boot_stage_owner",
+        "//sw/device/lib/arch:fpga_cw340",
+    ],
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
+    tags = ["cw340_sival_rom_ext"],
+)
+
 ###########################################################################
 # Silicon Environments
 ###########################################################################

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -86,6 +86,15 @@ EARLGREY_SILICON_OWNER_ROM_EXT_ENVS = {
     "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
 }
 
+# All CW340 test environments for Earlgrey.
+EARLGREY_CW340_TEST_ENVS = {
+    "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+    "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+    "//hw/top_earlgrey:fpga_cw340_sival": None,
+    "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+    "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+}
+
 # Messages we expect for possible test outcomes.
 OTTF_SUCCESS_MSG = r"PASS.*\n"
 OTTF_FAILURE_MSG = r"(FAIL|FAULT).*\n"

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -270,6 +270,7 @@ opentitan_binary(
     name = "rom_ext_slot_a",
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
@@ -292,6 +293,7 @@ opentitan_binary(
     name = "rom_ext_slot_b",
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
@@ -314,6 +316,7 @@ opentitan_binary(
     name = "rom_ext_slot_virtual",
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
@@ -342,6 +345,7 @@ opentitan_binary(
     name = "rom_ext_slot_a_bad_address_translation",
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
     ],

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -25,6 +25,7 @@ load(
 )
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_CW340_TEST_ENVS",
     "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "EARLGREY_TEST_ENVS",
     "cw310_params",
@@ -3604,10 +3605,9 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:fpga_cw340_test_rom": None,
-            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
         },
     ),
     deps = [


### PR DESCRIPTION
This PR adds three new execution environments:

* `fpga_cw340_rom_ext`
* `fpga_cw340_sival`
* `fpga_cw340_sival_rom_ext`

The `uart_smoketest` is given all CW340 environments for testing purposes. The plan is to later add some select CW340 environments to the `EARLGREY_TEST_ENVS` variable used by most tests.

This PR also adds a CI job for the `cw340_sival_rom_ext` execution environment which currently will only execute `uart_smoketest`. In the future we may want another CI job for `cw340_sival` but that isn't necessary right now.