### PR TITLE
[i2c] Reduce counter sizes to save area

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -547,13 +547,19 @@
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
-        { bits: "15:0"
+        { bits: "12:0"
           name: "THIGH"
-          desc: "The actual time to hold SCL high in a given pulse: in host mode, when there is no stretching this value is 3 cycles longer as tracked in issue #18962"
+          desc: '''
+                The actual time to hold SCL high in a given pulse.
+                This field is sized to have a range of at least Standard Mode's 4.0 us max with a core clock at 1 GHz.
+                '''
         }
-        { bits: "31:16"
+        { bits: "28:16"
           name: "TLOW"
-          desc: "The actual time to hold SCL low between any two SCL pulses"
+          desc: '''
+                The actual time to hold SCL low between any two SCL pulses.
+                This field is sized to have a range of at least Standard Mode's 4.7 us max with a core clock at 1 GHz.
+                '''
         }
       ]
     }
@@ -565,13 +571,19 @@
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
-        { bits: "15:0"
+        { bits: "9:0"
           name: "T_R"
-          desc: "The nominal rise time to anticipate for the bus (depends on capacitance)"
+          desc: '''
+                The nominal rise time to anticipate for the bus (depends on capacitance).
+                This field is sized to have a range of at least Standard Mode's 1000 ns max with a core clock at 1 GHz.
+                '''
         }
-        { bits: "31:16"
+        { bits: "24:16"
           name: "T_F"
-          desc: "The nominal fall time to anticipate for the bus (influences SDA hold times): this is currently counted twice in host mode as tracked in issue #18958"
+          desc: '''
+                The nominal fall time to anticipate for the bus (influences SDA hold times).
+                This field is sized to have a range of at least Standard Mode's 300 ns max with a core clock at 1 GHz.
+                '''
         }
       ]
     }
@@ -583,13 +595,19 @@
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
-        { bits: "15:0"
+        { bits: "12:0"
           name: "TSU_STA"
-          desc: "Actual setup time for repeated start signals"
+          desc: '''
+                Actual setup time for repeated start signals.
+                This field is sized to have a range of at least Standard Mode's 4.7 us max with a core clock at 1 GHz.
+                '''
         }
-        { bits: "31:16"
+        { bits: "28:16"
           name: "THD_STA"
-          desc: "Actual hold time for start signals"
+          desc: '''
+                Actual hold time for start signals.
+                This field is sized to have a range of at least Standard Mode's 4.0 us max with a core clock at 1 GHz.
+                '''
         }
       ]
     }
@@ -601,15 +619,21 @@
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
-        { bits: "15:0"
+        { bits: "8:0"
           name: "TSU_DAT"
-          desc: "Actual setup time for data (or ack) bits"
+          desc: '''
+                Actual setup time for data (or ack) bits.
+                This field is sized to have a range of at least Standard Mode's 250 ns max with a core clock at 1 GHz.
+                '''
         }
-        { bits: "31:16"
+        { bits: "28:16"
           name: "THD_DAT"
           desc: '''
-                Actual hold time for data (or ack) bits
+                Actual hold time for data (or ack) bits.
                 (Note, where required, the parameters TVD_DAT is taken to be THD_DAT+T_F)
+                This field is sized to have a range that accommodates Standard Mode's 3.45 us max for TVD_DAT with a core clock at 1 GHz.
+                However, this field is generally expected to represent a time substantially shorter than that.
+                It should be long enough to cover the maximum round-trip latency from output pins, through pads and voltage transitions on the board, and back to the input pins, but it should not be substantially greater.
                 '''
         }
       ]
@@ -622,13 +646,19 @@
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
-        { bits: "15:0"
+        { bits: "12:0"
           name: "TSU_STO"
-          desc: "Actual setup time for stop signals"
+          desc: '''
+                Actual setup time for stop signals.
+                This field is sized to have a range of at least Standard Mode's 4.0 us max with a core clock at 1 GHz.
+                '''
         }
-        { bits: "31:16"
+        { bits: "28:16"
           name: "T_BUF"
-          desc: "Actual time between each STOP signal and the following START signal"
+          desc: '''
+                Actual time between each STOP signal and the following START signal.
+                This field is sized to have a range of at least Standard Mode's 4.7 us max with a core clock at 1 GHz.
+                '''
         }
       ]
     }

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -404,90 +404,111 @@ All values are expressed in units of the input clock period.
 These must be greater than 2 in order for the change in SCL to propagate to the input of the FSM so that acknowledgements are detected correctly.
 - Offset: `0x3c`
 - Reset default: `0x0`
-- Reset mask: `0xffffffff`
+- Reset mask: `0x1fff1fff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "THIGH", "bits": 16, "attr": ["rw"], "rotate": 0}, {"name": "TLOW", "bits": 16, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "THIGH", "bits": 13, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "TLOW", "bits": 13, "attr": ["rw"], "rotate": 0}, {"bits": 3}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                           |
-|:------:|:------:|:-------:|:-------|:------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 31:16  |   rw   |   0x0   | TLOW   | The actual time to hold SCL low between any two SCL pulses                                                                                            |
-|  15:0  |   rw   |   0x0   | THIGH  | The actual time to hold SCL high in a given pulse: in host mode, when there is no stretching this value is 3 cycles longer as tracked in issue #18962 |
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                        |
+|:------:|:------:|:-------:|:-------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:29  |        |         |        | Reserved                                                                                                                                                           |
+| 28:16  |   rw   |   0x0   | TLOW   | The actual time to hold SCL low between any two SCL pulses. This field is sized to have a range of at least Standard Mode's 4.7 us max with a core clock at 1 GHz. |
+| 15:13  |        |         |        | Reserved                                                                                                                                                           |
+|  12:0  |   rw   |   0x0   | THIGH  | The actual time to hold SCL high in a given pulse. This field is sized to have a range of at least Standard Mode's 4.0 us max with a core clock at 1 GHz.          |
 
 ## TIMING1
 Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
 All values are expressed in units of the input clock period.
 - Offset: `0x40`
 - Reset default: `0x0`
-- Reset mask: `0xffffffff`
+- Reset mask: `0x1ff03ff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "T_R", "bits": 16, "attr": ["rw"], "rotate": 0}, {"name": "T_F", "bits": 16, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "T_R", "bits": 10, "attr": ["rw"], "rotate": 0}, {"bits": 6}, {"name": "T_F", "bits": 9, "attr": ["rw"], "rotate": 0}, {"bits": 7}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                          |
-|:------:|:------:|:-------:|:-------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 31:16  |   rw   |   0x0   | T_F    | The nominal fall time to anticipate for the bus (influences SDA hold times): this is currently counted twice in host mode as tracked in issue #18958 |
-|  15:0  |   rw   |   0x0   | T_R    | The nominal rise time to anticipate for the bus (depends on capacitance)                                                                             |
+|  Bits  |  Type  |  Reset  | Name   | Description                                                                                                                                                                         |
+|:------:|:------:|:-------:|:-------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:25  |        |         |        | Reserved                                                                                                                                                                            |
+| 24:16  |   rw   |   0x0   | T_F    | The nominal fall time to anticipate for the bus (influences SDA hold times). This field is sized to have a range of at least Standard Mode's 300 ns max with a core clock at 1 GHz. |
+| 15:10  |        |         |        | Reserved                                                                                                                                                                            |
+|  9:0   |   rw   |   0x0   | T_R    | The nominal rise time to anticipate for the bus (depends on capacitance). This field is sized to have a range of at least Standard Mode's 1000 ns max with a core clock at 1 GHz.   |
 
 ## TIMING2
 Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).
 All values are expressed in units of the input clock period.
 - Offset: `0x44`
 - Reset default: `0x0`
-- Reset mask: `0xffffffff`
+- Reset mask: `0x1fff1fff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "TSU_STA", "bits": 16, "attr": ["rw"], "rotate": 0}, {"name": "THD_STA", "bits": 16, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "TSU_STA", "bits": 13, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "THD_STA", "bits": 13, "attr": ["rw"], "rotate": 0}, {"bits": 3}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name    | Description                                  |
-|:------:|:------:|:-------:|:--------|:---------------------------------------------|
-| 31:16  |   rw   |   0x0   | THD_STA | Actual hold time for start signals           |
-|  15:0  |   rw   |   0x0   | TSU_STA | Actual setup time for repeated start signals |
+|  Bits  |  Type  |  Reset  | Name    | Description                                                                                                                                          |
+|:------:|:------:|:-------:|:--------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:29  |        |         |         | Reserved                                                                                                                                             |
+| 28:16  |   rw   |   0x0   | THD_STA | Actual hold time for start signals. This field is sized to have a range of at least Standard Mode's 4.0 us max with a core clock at 1 GHz.           |
+| 15:13  |        |         |         | Reserved                                                                                                                                             |
+|  12:0  |   rw   |   0x0   | TSU_STA | Actual setup time for repeated start signals. This field is sized to have a range of at least Standard Mode's 4.7 us max with a core clock at 1 GHz. |
 
 ## TIMING3
 Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
 All values are expressed in units of the input clock period.
 - Offset: `0x48`
 - Reset default: `0x0`
-- Reset mask: `0xffffffff`
+- Reset mask: `0x1fff01ff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "TSU_DAT", "bits": 16, "attr": ["rw"], "rotate": 0}, {"name": "THD_DAT", "bits": 16, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "TSU_DAT", "bits": 9, "attr": ["rw"], "rotate": 0}, {"bits": 7}, {"name": "THD_DAT", "bits": 13, "attr": ["rw"], "rotate": 0}, {"bits": 3}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name    | Description                                                                                                       |
-|:------:|:------:|:-------:|:--------|:------------------------------------------------------------------------------------------------------------------|
-| 31:16  |   rw   |   0x0   | THD_DAT | Actual hold time for data (or ack) bits (Note, where required, the parameters TVD_DAT is taken to be THD_DAT+T_F) |
-|  15:0  |   rw   |   0x0   | TSU_DAT | Actual setup time for data (or ack) bits                                                                          |
+|  Bits  |  Type  |  Reset  | Name                         |
+|:------:|:------:|:-------:|:-----------------------------|
+| 31:29  |        |         | Reserved                     |
+| 28:16  |   rw   |   0x0   | [THD_DAT](#timing3--thd_dat) |
+|  15:9  |        |         | Reserved                     |
+|  8:0   |   rw   |   0x0   | [TSU_DAT](#timing3--tsu_dat) |
+
+### TIMING3 . THD_DAT
+Actual hold time for data (or ack) bits.
+(Note, where required, the parameters TVD_DAT is taken to be THD_DAT+T_F)
+This field is sized to have a range that accommodates Standard Mode's 3.45 us max for TVD_DAT with a core clock at 1 GHz.
+However, this field is generally expected to represent a time substantially shorter than that.
+It should be long enough to cover the maximum round-trip latency from output pins, through pads and voltage transitions on the board, and back to the input pins, but it should not be substantially greater.
+
+### TIMING3 . TSU_DAT
+Actual setup time for data (or ack) bits.
+This field is sized to have a range of at least Standard Mode's 250 ns max with a core clock at 1 GHz.
 
 ## TIMING4
 Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).
 All values are expressed in units of the input clock period.
 - Offset: `0x4c`
 - Reset default: `0x0`
-- Reset mask: `0xffffffff`
+- Reset mask: `0x1fff1fff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "TSU_STO", "bits": 16, "attr": ["rw"], "rotate": 0}, {"name": "T_BUF", "bits": 16, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "TSU_STO", "bits": 13, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "T_BUF", "bits": 13, "attr": ["rw"], "rotate": 0}, {"bits": 3}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name    | Description                                                         |
-|:------:|:------:|:-------:|:--------|:--------------------------------------------------------------------|
-| 31:16  |   rw   |   0x0   | T_BUF   | Actual time between each STOP signal and the following START signal |
-|  15:0  |   rw   |   0x0   | TSU_STO | Actual setup time for stop signals                                  |
+|  Bits  |  Type  |  Reset  | Name    | Description                                                                                                                                                                 |
+|:------:|:------:|:-------:|:--------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:29  |        |         |         | Reserved                                                                                                                                                                    |
+| 28:16  |   rw   |   0x0   | T_BUF   | Actual time between each STOP signal and the following START signal. This field is sized to have a range of at least Standard Mode's 4.7 us max with a core clock at 1 GHz. |
+| 15:13  |        |         |         | Reserved                                                                                                                                                                    |
+|  12:0  |   rw   |   0x0   | TSU_STO | Actual setup time for stop signals. This field is sized to have a range of at least Standard Mode's 4.0 us max with a core clock at 1 GHz.                                  |
 
 ## TIMEOUT_CTRL
 I2C clock stretching timeout control.

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -45,16 +45,16 @@ module i2c_core import i2c_pkg::*;
   // Maximum number of bits required to represent the level/depth of any FIFO.
   localparam int unsigned MaxFifoDepthW = 12;
 
-  logic [15:0] thigh;
-  logic [15:0] tlow;
-  logic [15:0] t_r;
-  logic [15:0] t_f;
-  logic [15:0] thd_sta;
-  logic [15:0] tsu_sta;
-  logic [15:0] tsu_sto;
-  logic [15:0] tsu_dat;
-  logic [15:0] thd_dat;
-  logic [15:0] t_buf;
+  logic [12:0] thigh;
+  logic [12:0] tlow;
+  logic [12:0] t_r;
+  logic [12:0] t_f;
+  logic [12:0] thd_sta;
+  logic [12:0] tsu_sta;
+  logic [12:0] tsu_sto;
+  logic [12:0] tsu_dat;
+  logic [12:0] thd_dat;
+  logic [12:0] t_buf;
   logic [30:0] stretch_timeout;
   logic        timeout_enable;
   logic [31:0] host_timeout;
@@ -252,11 +252,11 @@ module i2c_core import i2c_pkg::*;
 
   assign thigh                        = reg2hw.timing0.thigh.q;
   assign tlow                         = reg2hw.timing0.tlow.q;
-  assign t_r                          = reg2hw.timing1.t_r.q;
-  assign t_f                          = reg2hw.timing1.t_f.q;
+  assign t_r                          = 13'(reg2hw.timing1.t_r.q);
+  assign t_f                          = 13'(reg2hw.timing1.t_f.q);
   assign tsu_sta                      = reg2hw.timing2.tsu_sta.q;
   assign thd_sta                      = reg2hw.timing2.thd_sta.q;
-  assign tsu_dat                      = reg2hw.timing3.tsu_dat.q;
+  assign tsu_dat                      = 13'(reg2hw.timing3.tsu_dat.q);
   assign thd_dat                      = reg2hw.timing3.thd_dat.q;
   assign tsu_sto                      = reg2hw.timing4.tsu_sto.q;
   assign t_buf                        = reg2hw.timing4.t_buf.q;
@@ -456,7 +456,6 @@ module i2c_core import i2c_pkg::*;
     .thd_sta_i                      (thd_sta),
     .tsu_sta_i                      (tsu_sta),
     .tsu_sto_i                      (tsu_sto),
-    .tsu_dat_i                      (tsu_dat),
     .thd_dat_i                      (thd_dat),
     .t_buf_i                        (t_buf),
     .stretch_timeout_i              (stretch_timeout),

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -291,46 +291,46 @@ package i2c_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [15:0] q;
+      logic [12:0] q;
     } tlow;
     struct packed {
-      logic [15:0] q;
+      logic [12:0] q;
     } thigh;
   } i2c_reg2hw_timing0_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [15:0] q;
+      logic [8:0]  q;
     } t_f;
     struct packed {
-      logic [15:0] q;
+      logic [9:0] q;
     } t_r;
   } i2c_reg2hw_timing1_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [15:0] q;
+      logic [12:0] q;
     } thd_sta;
     struct packed {
-      logic [15:0] q;
+      logic [12:0] q;
     } tsu_sta;
   } i2c_reg2hw_timing2_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [15:0] q;
+      logic [12:0] q;
     } thd_dat;
     struct packed {
-      logic [15:0] q;
+      logic [8:0]  q;
     } tsu_dat;
   } i2c_reg2hw_timing3_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [15:0] q;
+      logic [12:0] q;
     } t_buf;
     struct packed {
-      logic [15:0] q;
+      logic [12:0] q;
     } tsu_sto;
   } i2c_reg2hw_timing4_reg_t;
 
@@ -587,22 +587,22 @@ package i2c_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [519:505]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [504:490]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [489:460]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [459:458]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [457:453]
-    i2c_reg2hw_rdata_reg_t rdata; // [452:444]
-    i2c_reg2hw_fdata_reg_t fdata; // [443:425]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [424:417]
-    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [416:391]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [390:363]
-    i2c_reg2hw_ovrd_reg_t ovrd; // [362:360]
-    i2c_reg2hw_timing0_reg_t timing0; // [359:328]
-    i2c_reg2hw_timing1_reg_t timing1; // [327:296]
-    i2c_reg2hw_timing2_reg_t timing2; // [295:264]
-    i2c_reg2hw_timing3_reg_t timing3; // [263:232]
-    i2c_reg2hw_timing4_reg_t timing4; // [231:200]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [478:464]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [463:449]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [448:419]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [418:417]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [416:412]
+    i2c_reg2hw_rdata_reg_t rdata; // [411:403]
+    i2c_reg2hw_fdata_reg_t fdata; // [402:384]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [383:376]
+    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [375:350]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [349:322]
+    i2c_reg2hw_ovrd_reg_t ovrd; // [321:319]
+    i2c_reg2hw_timing0_reg_t timing0; // [318:293]
+    i2c_reg2hw_timing1_reg_t timing1; // [292:274]
+    i2c_reg2hw_timing2_reg_t timing2; // [273:248]
+    i2c_reg2hw_timing3_reg_t timing3; // [247:226]
+    i2c_reg2hw_timing4_reg_t timing4; // [225:200]
     i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [199:168]
     i2c_reg2hw_target_id_reg_t target_id; // [167:140]
     i2c_reg2hw_acqdata_reg_t acqdata; // [139:127]

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -260,30 +260,30 @@ module i2c_reg_top (
   logic [15:0] val_scl_rx_qs;
   logic [15:0] val_sda_rx_qs;
   logic timing0_we;
-  logic [15:0] timing0_thigh_qs;
-  logic [15:0] timing0_thigh_wd;
-  logic [15:0] timing0_tlow_qs;
-  logic [15:0] timing0_tlow_wd;
+  logic [12:0] timing0_thigh_qs;
+  logic [12:0] timing0_thigh_wd;
+  logic [12:0] timing0_tlow_qs;
+  logic [12:0] timing0_tlow_wd;
   logic timing1_we;
-  logic [15:0] timing1_t_r_qs;
-  logic [15:0] timing1_t_r_wd;
-  logic [15:0] timing1_t_f_qs;
-  logic [15:0] timing1_t_f_wd;
+  logic [9:0] timing1_t_r_qs;
+  logic [9:0] timing1_t_r_wd;
+  logic [8:0] timing1_t_f_qs;
+  logic [8:0] timing1_t_f_wd;
   logic timing2_we;
-  logic [15:0] timing2_tsu_sta_qs;
-  logic [15:0] timing2_tsu_sta_wd;
-  logic [15:0] timing2_thd_sta_qs;
-  logic [15:0] timing2_thd_sta_wd;
+  logic [12:0] timing2_tsu_sta_qs;
+  logic [12:0] timing2_tsu_sta_wd;
+  logic [12:0] timing2_thd_sta_qs;
+  logic [12:0] timing2_thd_sta_wd;
   logic timing3_we;
-  logic [15:0] timing3_tsu_dat_qs;
-  logic [15:0] timing3_tsu_dat_wd;
-  logic [15:0] timing3_thd_dat_qs;
-  logic [15:0] timing3_thd_dat_wd;
+  logic [8:0] timing3_tsu_dat_qs;
+  logic [8:0] timing3_tsu_dat_wd;
+  logic [12:0] timing3_thd_dat_qs;
+  logic [12:0] timing3_thd_dat_wd;
   logic timing4_we;
-  logic [15:0] timing4_tsu_sto_qs;
-  logic [15:0] timing4_tsu_sto_wd;
-  logic [15:0] timing4_t_buf_qs;
-  logic [15:0] timing4_t_buf_wd;
+  logic [12:0] timing4_tsu_sto_qs;
+  logic [12:0] timing4_tsu_sto_wd;
+  logic [12:0] timing4_t_buf_qs;
+  logic [12:0] timing4_t_buf_wd;
   logic timeout_ctrl_we;
   logic [30:0] timeout_ctrl_val_qs;
   logic [30:0] timeout_ctrl_val_wd;
@@ -2384,11 +2384,11 @@ module i2c_reg_top (
 
 
   // R[timing0]: V(False)
-  //   F[thigh]: 15:0
+  //   F[thigh]: 12:0
   prim_subreg #(
-    .DW      (16),
+    .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (13'h0),
     .Mubi    (1'b0)
   ) u_timing0_thigh (
     .clk_i   (clk_i),
@@ -2411,11 +2411,11 @@ module i2c_reg_top (
     .qs     (timing0_thigh_qs)
   );
 
-  //   F[tlow]: 31:16
+  //   F[tlow]: 28:16
   prim_subreg #(
-    .DW      (16),
+    .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (13'h0),
     .Mubi    (1'b0)
   ) u_timing0_tlow (
     .clk_i   (clk_i),
@@ -2440,11 +2440,11 @@ module i2c_reg_top (
 
 
   // R[timing1]: V(False)
-  //   F[t_r]: 15:0
+  //   F[t_r]: 9:0
   prim_subreg #(
-    .DW      (16),
+    .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (10'h0),
     .Mubi    (1'b0)
   ) u_timing1_t_r (
     .clk_i   (clk_i),
@@ -2467,11 +2467,11 @@ module i2c_reg_top (
     .qs     (timing1_t_r_qs)
   );
 
-  //   F[t_f]: 31:16
+  //   F[t_f]: 24:16
   prim_subreg #(
-    .DW      (16),
+    .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (9'h0),
     .Mubi    (1'b0)
   ) u_timing1_t_f (
     .clk_i   (clk_i),
@@ -2496,11 +2496,11 @@ module i2c_reg_top (
 
 
   // R[timing2]: V(False)
-  //   F[tsu_sta]: 15:0
+  //   F[tsu_sta]: 12:0
   prim_subreg #(
-    .DW      (16),
+    .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (13'h0),
     .Mubi    (1'b0)
   ) u_timing2_tsu_sta (
     .clk_i   (clk_i),
@@ -2523,11 +2523,11 @@ module i2c_reg_top (
     .qs     (timing2_tsu_sta_qs)
   );
 
-  //   F[thd_sta]: 31:16
+  //   F[thd_sta]: 28:16
   prim_subreg #(
-    .DW      (16),
+    .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (13'h0),
     .Mubi    (1'b0)
   ) u_timing2_thd_sta (
     .clk_i   (clk_i),
@@ -2552,11 +2552,11 @@ module i2c_reg_top (
 
 
   // R[timing3]: V(False)
-  //   F[tsu_dat]: 15:0
+  //   F[tsu_dat]: 8:0
   prim_subreg #(
-    .DW      (16),
+    .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (9'h0),
     .Mubi    (1'b0)
   ) u_timing3_tsu_dat (
     .clk_i   (clk_i),
@@ -2579,11 +2579,11 @@ module i2c_reg_top (
     .qs     (timing3_tsu_dat_qs)
   );
 
-  //   F[thd_dat]: 31:16
+  //   F[thd_dat]: 28:16
   prim_subreg #(
-    .DW      (16),
+    .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (13'h0),
     .Mubi    (1'b0)
   ) u_timing3_thd_dat (
     .clk_i   (clk_i),
@@ -2608,11 +2608,11 @@ module i2c_reg_top (
 
 
   // R[timing4]: V(False)
-  //   F[tsu_sto]: 15:0
+  //   F[tsu_sto]: 12:0
   prim_subreg #(
-    .DW      (16),
+    .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (13'h0),
     .Mubi    (1'b0)
   ) u_timing4_tsu_sto (
     .clk_i   (clk_i),
@@ -2635,11 +2635,11 @@ module i2c_reg_top (
     .qs     (timing4_tsu_sto_qs)
   );
 
-  //   F[t_buf]: 31:16
+  //   F[t_buf]: 28:16
   prim_subreg #(
-    .DW      (16),
+    .DW      (13),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0),
+    .RESVAL  (13'h0),
     .Mubi    (1'b0)
   ) u_timing4_t_buf (
     .clk_i   (clk_i),
@@ -3395,29 +3395,29 @@ module i2c_reg_top (
   assign val_re = addr_hit[14] & reg_re & !reg_error;
   assign timing0_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign timing0_thigh_wd = reg_wdata[15:0];
+  assign timing0_thigh_wd = reg_wdata[12:0];
 
-  assign timing0_tlow_wd = reg_wdata[31:16];
+  assign timing0_tlow_wd = reg_wdata[28:16];
   assign timing1_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign timing1_t_r_wd = reg_wdata[15:0];
+  assign timing1_t_r_wd = reg_wdata[9:0];
 
-  assign timing1_t_f_wd = reg_wdata[31:16];
+  assign timing1_t_f_wd = reg_wdata[24:16];
   assign timing2_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign timing2_tsu_sta_wd = reg_wdata[15:0];
+  assign timing2_tsu_sta_wd = reg_wdata[12:0];
 
-  assign timing2_thd_sta_wd = reg_wdata[31:16];
+  assign timing2_thd_sta_wd = reg_wdata[28:16];
   assign timing3_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign timing3_tsu_dat_wd = reg_wdata[15:0];
+  assign timing3_tsu_dat_wd = reg_wdata[8:0];
 
-  assign timing3_thd_dat_wd = reg_wdata[31:16];
+  assign timing3_thd_dat_wd = reg_wdata[28:16];
   assign timing4_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign timing4_tsu_sto_wd = reg_wdata[15:0];
+  assign timing4_tsu_sto_wd = reg_wdata[12:0];
 
-  assign timing4_t_buf_wd = reg_wdata[31:16];
+  assign timing4_t_buf_wd = reg_wdata[28:16];
   assign timeout_ctrl_we = addr_hit[20] & reg_we & !reg_error;
 
   assign timeout_ctrl_val_wd = reg_wdata[30:0];
@@ -3638,28 +3638,28 @@ module i2c_reg_top (
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[15:0] = timing0_thigh_qs;
-        reg_rdata_next[31:16] = timing0_tlow_qs;
+        reg_rdata_next[12:0] = timing0_thigh_qs;
+        reg_rdata_next[28:16] = timing0_tlow_qs;
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[15:0] = timing1_t_r_qs;
-        reg_rdata_next[31:16] = timing1_t_f_qs;
+        reg_rdata_next[9:0] = timing1_t_r_qs;
+        reg_rdata_next[24:16] = timing1_t_f_qs;
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[15:0] = timing2_tsu_sta_qs;
-        reg_rdata_next[31:16] = timing2_thd_sta_qs;
+        reg_rdata_next[12:0] = timing2_tsu_sta_qs;
+        reg_rdata_next[28:16] = timing2_thd_sta_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[15:0] = timing3_tsu_dat_qs;
-        reg_rdata_next[31:16] = timing3_thd_dat_qs;
+        reg_rdata_next[8:0] = timing3_tsu_dat_qs;
+        reg_rdata_next[28:16] = timing3_thd_dat_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[15:0] = timing4_tsu_sto_qs;
-        reg_rdata_next[31:16] = timing4_t_buf_qs;
+        reg_rdata_next[12:0] = timing4_tsu_sto_qs;
+        reg_rdata_next[28:16] = timing4_t_buf_qs;
       end
 
       addr_hit[20]: begin


### PR DESCRIPTION
Reduce counter sizes to only the widths needed to support Standard mode at a 1 GHz core clock.

In the FPGA implementation, this saves 44 flops (~4%) and over 100 LUTs (~6.6%). The granularity of the FPGA area is large, so the size of the savings can be misleading, but compared to what we had prior to the FSM split, this brings us to +29 flops, -59 LUTs for the whole chain of commits.

This builds on #22551. Only the last commit is new.