### PR TITLE
Fix entropy src edn reqs

### DIFF
--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -206,7 +206,7 @@ def opentitan_test(
             kind = kind,
             deps = deps,
             copts = copts,
-            defines = defines,
+            defines = defines + getattr(tparam, "defines", []),
             local_defines = local_defines,
             includes = includes,
             linker_script = linker_script,

--- a/rules/opentitan/fpga_cw310.bzl
+++ b/rules/opentitan/fpga_cw310.bzl
@@ -228,6 +228,7 @@ def cw310_params(
         needs_jtag = False,
         test_cmd = "",
         data = [],
+        defines = [],
         **kwargs):
     """A macro to create CW310 parameters for OpenTitan tests.
 
@@ -277,4 +278,5 @@ def cw310_params(
         param = kwargs,
         post_test_cmd = post_test_cmd,
         post_test_harness = post_test_harness,
+        defines = defines,
     )

--- a/rules/opentitan/silicon.bzl
+++ b/rules/opentitan/silicon.bzl
@@ -140,6 +140,7 @@ def silicon_params(
         needs_jtag = False,
         test_cmd = "",
         data = [],
+        defines = [],
         **kwargs):
     """A macro to create Silicon parameters for OpenTitan tests.
 
@@ -175,4 +176,5 @@ def silicon_params(
         """ if needs_jtag else "") + test_cmd,
         data = data,
         param = kwargs,
+        defines = defines,
     )

--- a/rules/opentitan/sim_dv.bzl
+++ b/rules/opentitan/sim_dv.bzl
@@ -175,6 +175,7 @@ def dv_params(
         otp = None,
         test_cmd = "",
         data = [],
+        defines = [],
         **kwargs):
     """A macro to create dv parameters for OpenTitan tests.
 
@@ -206,4 +207,5 @@ def dv_params(
         test_cmd = test_cmd,
         data = data,
         param = kwargs,
+        defines = defines,
     )

--- a/rules/opentitan/sim_verilator.bzl
+++ b/rules/opentitan/sim_verilator.bzl
@@ -168,6 +168,7 @@ def verilator_params(
         otp = None,
         test_cmd = "",
         data = [],
+        defines = [],
         **kwargs):
     """A macro to create verilator parameters for OpenTitan tests.
 
@@ -199,4 +200,5 @@ def verilator_params(
         test_cmd = test_cmd,
         data = data,
         param = kwargs,
+        defines = defines,
     )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1323,21 +1323,21 @@ opentitan_test(
 opentitan_test(
     name = "entropy_src_edn_reqs_test",
     srcs = ["entropy_src_edn_reqs_test.c"],
-    broken = cw310_params(tags = ["broken"]),
+    # The SiVal ROM_EXT locks down the OTP and prevents reads by using the ePMP
+    # and the key manager state is different, so the test needs to behave differently.
+    cw310_sival = cw310_params(defines = ["SIVAL_ROM_EXT"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_proda_rom_ext": "silicon_owner",
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_sival",
+            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
+            "//hw/top_earlgrey:silicon_owner_proda_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "cw310_sival",
         },
     ),
-    silicon_owner = silicon_params(
-        tags = ["broken"],
-    ),
+    # See cw310_sival.
+    silicon_sival = silicon_params(defines = ["SIVAL_ROM_EXT"]),
     verilator = verilator_params(timeout = "long"),
     deps = [
         ":otbn_randomness_impl",


### PR DESCRIPTION
The first commit enables `opentitan_test` to take per-exec-env defines.
The second commit fixes the test, the test has two problems in SiVal:
- the SiVal ROM_EXT blocks direct access to the OTP registers so the
  OTP test triggers an exception. Disable this test in SiVal as it
  simply cannot be done.
- the SiVal ROM_EXT cranks the key manage to the owner state whereas
  the ROM does not touch the key manager. Change the test to expect
  a different state in SiVal.