### PR TITLE
[rom_ctrl,lc_ctrl,dv] Specialise scratch_path/rel_path for variants

### DIFF
--- a/hw/ip/lc_ctrl/dv/lc_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_base_sim_cfg.hjson
@@ -57,6 +57,15 @@
       name: tl_dbw
       value: 8
     }
+    // Override the default scratch directory and rel_path to take variant into account
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
+    }
+    {
+      name: rel_path
+      value: "hw/ip/{name}_{variant}/dv"
+    }
   ]
 
   // Default UVM test and seq class name.

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -46,6 +46,18 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  overrides: [
+    // Override the default scratch directory and rel_path to take variant into account
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{name}_{variant}-{flow}-{tool}"
+    }
+    {
+      name: rel_path
+      value: "hw/ip/{name}_{variant}/dv"
+    }
+  ]
+
   // Add ROM_CTRL specific exclusion files.
   vcs_cov_excl_files: ["{proj_root}/hw/ip/rom_ctrl/dv/cov/rom_ctrl_cov_unr_excl.el",
                        "{proj_root}/hw/ip/rom_ctrl/dv/cov/rom_ctrl_cov_excl.el"]


### PR DESCRIPTION
Without this change, there is a problem where we have two different variants of each block that are both getting built for nightly tests and both variants write results to the same place. This fix nicks the equivalent code from the aes block (which has to solve the same problem).

Fixes #22122.