### PR TITLE
[sival] Add entropy_src_fw_override_test to test plan

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -281,7 +281,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:entropy_src_fw_override_test"]
     },
   ]
 }


### PR DESCRIPTION
I missed this when adding the test originally.