### PR TITLE
[openocd,opentitanlib] Add Earlgrey chip tapID

### DIFF
--- a/util/openocd/target/lowrisc-earlgrey-z1-silicon.cfg
+++ b/util/openocd/target/lowrisc-earlgrey-z1-silicon.cfg
@@ -2,8 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-exports_files([
-    "lowrisc-earlgrey.cfg",
-    "lowrisc-earlgrey-lc.cfg",
-    "lowrisc-earlgrey-z1-silicon.cfg",
-])
+
+# Target configuration for the lowRISC "Earl Grey Z1" chip
+
+if { ![info exists CPUTAPID ] } {
+   set CPUTAPID 0x108c085b
+}
+
+source [find target/lowrisc-earlgrey.cfg]


### PR DESCRIPTION
Earlgrey chip has the TapID in this file and fixes errors in init.