### PR TITLE
[tock] Add Tock UART tests.

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -130,6 +130,26 @@ fpga_cw310(
 )
 
 fpga_cw310(
+    name = "fpga_hyper310_test_rom",
+    testonly = True,
+    args = [
+        "--rcfile=",
+        "--logging=info",
+        "--interface={interface}",
+    ],
+    base = ":fpga_cw310_test_rom",
+    base_bitstream = "//hw/bitstream/hyperdebug:bitstream",
+    exec_env = "fpga_hyper310_test_rom",
+    otp_mmi = "//hw/bitstream/hyperdebug:otp_mmi",
+    param = {
+        "interface": "hyper310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+    },
+    rom_mmi = "//hw/bitstream/hyperdebug:rom_mmi",
+)
+
+fpga_cw310(
     name = "fpga_hyper310_rom_with_fake_keys",
     testonly = True,
     args = [

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -106,6 +106,8 @@ def _parameter_name(env, pname):
             pname = "cw310"
         elif "cw340" in suffix:
             pname = "cw340"
+        elif "hyper310" in suffix:
+            pname = "hyper310"
         elif "verilator" in suffix:
             pname = "verilator"
         elif "dv" in suffix:
@@ -146,6 +148,8 @@ def opentitan_test(
         rsa_key = None,
         spx_key = None,
         manifest = None,
+        test_cmd = None,
+        test_harness = None,
         exec_env = {},
         cw310 = _cw310_params(),
         cw340 = _cw310_params(),
@@ -195,6 +199,8 @@ def opentitan_test(
         pname = _parameter_name(env, pname)
         extra_tags = _hacky_tags(env)
         tparam = test_parameters[pname]
+        cmd = tparam.test_cmd if tparam.test_cmd else test_cmd
+        harness = tparam.test_harness if tparam.test_harness else test_harness
         if pname in kwargs_unused:
             kwargs_unused.remove(pname)
         (_, suffix) = env.split(":")
@@ -218,7 +224,8 @@ def opentitan_test(
             timeout = tparam.timeout,
             local = tparam.local,
             # Override parameters in the test rule.
-            test_harness = tparam.test_harness,
+            test_harness = harness,
+            test_cmd = cmd,
             binaries = tparam.binaries,
             rom = tparam.rom,
             rom_ext = tparam.rom_ext,
@@ -226,7 +233,6 @@ def opentitan_test(
             bitstream = tparam.bitstream,
             post_test_cmd = getattr(tparam, "post_test_cmd", ""),
             post_test_harness = getattr(tparam, "post_test_harness", None),
-            test_cmd = tparam.test_cmd,
             param = tparam.param,
             data = tparam.data,
             rsa_key = rsa_key,

--- a/sw/device/silicon_owner/tock/tests/uart/BUILD
+++ b/sw/device/silicon_owner/tock/tests/uart/BUILD
@@ -1,0 +1,50 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "cw310_params", "opentitan_test")
+load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "uart",
+    srcs = [
+        "src/main.rs",
+    ],
+    # We specifically restrict our build target to the OpenTitan
+    # CPU because libtock does not support an x86_64 target.
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/silicon_owner/tock/apps:single_app_layout",
+        "@libtock",
+    ],
+)
+
+tock_elf2tab(
+    name = "tab",
+    src = ":uart",
+    arch = "rv32imc",
+)
+
+tock_image(
+    name = "image",
+    app_flash_start = 0x20040000,
+    apps = [":tab"],
+    kernel = "//sw/device/silicon_owner/tock/kernel",
+)
+
+opentitan_test(
+    name = "uart_test",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_test_rom": None,
+    },
+    hyper310 = cw310_params(
+        binaries = {":image": "firmware"},
+        test_cmd = """
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/tock/uart",
+    ),
+)

--- a/sw/device/silicon_owner/tock/tests/uart/src/main.rs
+++ b/sw/device/silicon_owner/tock/tests/uart/src/main.rs
@@ -1,0 +1,177 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+#![no_std]
+
+use core::cell::Cell;
+use core::cmp::min;
+use libtock::console::Console;
+use libtock::platform::{AllowRo, share, Subscribe, DefaultConfig, Syscalls};
+use libtock::runtime::{set_main, stack_size, TockSyscalls};
+
+#[allow(unused)]
+use libtock::low_level_debug::LowLevelDebug;
+
+set_main!(main);
+stack_size!(0x800);
+
+// Reads data from the console input. The data is read in chunks whose length is
+// given by `lens`. The newly-read data is returned. Panics upon encountering an
+// error condition.
+fn read_exact<'b>(buffer: &'b mut [u8], lens: &[usize]) -> &'b [u8] {
+    assert!(buffer.len() >= lens.iter().sum());
+    let upcall: Cell<Option<(u32, u32)>> = Cell::new(None);
+    let mut cursor = 0;
+    share::scope(|handle| {
+        TockSyscalls::subscribe::<_, _, DefaultConfig, 1, 2>(handle, &upcall).unwrap();
+        for &len in lens {
+            let bytes = share::scope(|handle| {
+                TockSyscalls::allow_rw::<DefaultConfig, 1, 1>(handle, &mut buffer[cursor..])
+                    .unwrap();
+                if let Some(error) = TockSyscalls::command(1, 2, len as u32, 0).get_failure() {
+                    panic!("{:?}", error);
+                }
+                loop {
+                    TockSyscalls::yield_wait();
+                    if let Some((_, bytes)) = upcall.take() {
+                        return bytes;
+                    }
+                }
+            });
+            assert_eq!(bytes as usize, len);
+            cursor += len;
+        }
+    });
+    &buffer[..cursor]
+}
+
+// Sends a message to the console while simultaneously reading data from the
+// console. `to_send` is sent repeatedly until a total of `tx_len` bytes have
+// been transmitted. Receives will be limited in size to `max_rx_len`; multiple
+// receives will be issued if this is less than `rx_buffer.len()`. The received
+// message will be returned.
+fn send_and_receive<'b>(to_send: &[u8], tx_len: usize, rx_buffer: &'b mut [u8], max_rx_len: u32) -> &'b [u8] {
+    let rx_upcall: Cell<Option<(u32, u32)>> = Cell::new(None);
+    let tx_upcall: Cell<Option<(u32,)>> = Cell::new(Some((0,)));
+    // rx_cursor and sent_bytes are updated when a read-write is complete, not
+    // when one is issued.
+    let mut rx_cursor = 0;
+    let mut sent_bytes = 0;
+    let rx_len = rx_buffer.len();
+    share::scope::<(
+        Subscribe<_, 1, 2>,
+        Subscribe<_, 1, 1>,
+        AllowRo<_, 1, 1>,
+    ), _, _>(|handle| {
+        let (rx_upcall_handle, tx_upcall_handle, tx_allow_handle) = handle.split();
+        TockSyscalls::subscribe::<_, _, DefaultConfig, 1, 2>(rx_upcall_handle, &rx_upcall).unwrap();
+        TockSyscalls::subscribe::<_, _, DefaultConfig, 1, 1>(tx_upcall_handle, &tx_upcall).unwrap();
+        TockSyscalls::allow_ro::<DefaultConfig, 1, 1>(tx_allow_handle, to_send).unwrap();
+        while rx_cursor < rx_len || sent_bytes < tx_len {
+            share::scope(|handle| {
+                TockSyscalls::allow_rw::<DefaultConfig, 1, 1>(handle, &mut rx_buffer[rx_cursor..]).unwrap();
+                if rx_cursor < rx_len {
+                    if let Some(error) = TockSyscalls::command(1, 2, min((rx_len - rx_cursor) as u32, max_rx_len), 0).get_failure() {
+                        panic!("{:?}", error);
+                    }
+                }
+                loop {
+                    TockSyscalls::yield_wait();
+                    if let Some((bytes,)) = tx_upcall.take() {
+                        sent_bytes += bytes as usize;
+                        if sent_bytes < tx_len {
+                            if let Some(error) = TockSyscalls::command(1, 1, min(to_send.len(), tx_len - sent_bytes) as u32, 0).get_failure() {
+                                panic!("{:?}", error);
+                            }
+                        }
+                    }
+                    if let Some((_, bytes)) = rx_upcall.take() {
+                        rx_cursor += bytes as usize;
+                        break;
+                    }
+                    if rx_cursor >= rx_len && sent_bytes >= tx_len {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    &rx_buffer[..rx_cursor]
+}
+
+fn main() {
+    let mut buffer = [0; 256];
+
+    // Test A: Send a message with all printable ASCII characters each
+    // direction. We do host->device first then device->host. The host->device
+    // message is padded to 128 bytes, which matches the hardware receive
+    // buffer.
+    assert_eq!(
+        read_exact(
+            &mut buffer,
+            &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 8]
+        ),
+        concat!(
+            r##"! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"##,
+            r##"`abcdefghijklmnopqrstuvwxyz{|}~Padding to 128 bytes looooooooong"##,
+        )
+        .as_bytes()
+    );
+    Console::write(
+        concat!(
+            r##"! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOP"##,
+            r##"QRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"##,
+            "\n",
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+
+    // Test B: The host sends a message broken into two parts, with a delay
+    // between the parts. The app should be able to receive both of these in one
+    // read operation.
+    assert_eq!(
+        read_exact(
+            &mut buffer,
+            &[15]
+        ),
+        b"Broken message.",
+    );
+
+    // Test C: Attempt to send host->device and device->host messages
+    // concurrently. host->device messages are in capital letters and
+    // device->host messages are in lowercase.
+    assert_eq!(
+        send_and_receive(
+            b"abcdefghijklmnopqrstuvwxyz",
+            26,
+            &mut buffer[..26],
+            5,
+        ),
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    );
+    assert_eq!(
+        send_and_receive(
+            &[b'a'; 25],
+            100,
+            &mut buffer[..50],
+            25,
+        ),
+        [b'A'; 50],
+    );
+    assert_eq!(
+        send_and_receive(
+            &[b'b'; 6],
+            37,
+            &mut buffer[..42],
+            42,
+        ),
+        [b'B'; 42],
+    );
+
+    // Tell the host we are done (this makes sure the final receive in Test C
+    // has completed).
+    Console::write(b"DEVICE DONE.\n").unwrap();
+}

--- a/sw/host/tests/tock/uart/BUILD
+++ b/sw/host/tests/tock/uart/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "uart",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:once_cell",
+    ],
+)

--- a/sw/host/tests/tock/uart/src/main.rs
+++ b/sw/host/tests/tock/uart/src/main.rs
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use std::str::from_utf8;
+use std::thread::sleep;
+use std::time::Duration;
+
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+}
+
+fn send_message(uart: &dyn Uart, msg: &str) -> Result<()> {
+    log::info!("Sending (len={}): {}", msg.len(), msg);
+    uart.write(msg.as_bytes())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+    let uart = transport.uart("console")?;
+    UartConsole::wait_for(
+        &*uart,
+        r"OpenTitan( \(downstream\))? initialisation complete\. Entering main loop",
+        opts.timeout,
+    )?;
+
+    // Test A: Send a message with all printable ASCII characters each
+    // direction. We do host->device first then device->host. The host->device
+    // message is padded to 128 bytes, which matches the hardware receive
+    // buffer.
+    send_message(
+        &*uart,
+        concat!(
+            r##"! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"##,
+            r##"`abcdefghijklmnopqrstuvwxyz{|}~Padding to 128 bytes looooooooong"##,
+        ),
+    )?;
+    UartConsole::wait_for(
+        &*uart,
+        concat!(
+            r##"! "#\$%&'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNO"##,
+            r##"PQRSTUVWXYZ\[\\\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}~"##,
+        ),
+        opts.timeout,
+    )?;
+
+    // Test B: Send a message broken into two parts, with a delay between the
+    // parts. The app should be able to receive both of these in one read
+    // operation.
+    send_message(&*uart, "Broken ")?;
+    sleep(Duration::from_secs(1));
+    send_message(&*uart, "message.")?;
+
+    // Test C: Attempt to send host->device and device->host messages
+    // concurrently. host->device messages are in capital letters and
+    // device->host messages are in lowercase.
+    send_message(&*uart, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")?;
+    UartConsole::wait_for(&*uart, "abcdefghijklmnopqrstuvwxyz", opts.timeout)?;
+    send_message(&*uart, from_utf8(&[b'A'; 50]).unwrap())?;
+    UartConsole::wait_for(&*uart, from_utf8(&[b'a'; 100]).unwrap(), opts.timeout)?;
+    send_message(&*uart, from_utf8(&[b'B'; 42]).unwrap())?;
+    UartConsole::wait_for(&*uart, from_utf8(&[b'b'; 37]).unwrap(), opts.timeout)?;
+
+    // Verify the device has finished the final receive of test C.
+    UartConsole::wait_for(&*uart, "DEVICE DONE.", opts.timeout)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This test the ability of a Tock app to perform console writes and reads over the UART. It is an integration tests that tests the Console syscall driver, the UART virtualizer, and the UART peripheral driver.