### PR TITLE
[rv_dm,dv] Connect rst_lc_ni in tb.sv

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.sv
@@ -35,6 +35,10 @@ class rv_dm_env extends cip_base_env #(
     if (!uvm_config_db#(virtual rv_dm_if)::get(this, "", "rv_dm_vif", cfg.rv_dm_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get rv_dm_vif from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "",
+                                                 "clk_lc_rst_vif", cfg.clk_lc_rst_vif)) begin
+      `uvm_fatal(`gfn, "failed to get clk_lc_rst_vif from uvm_config_db")
+    end
 
     // create components
     m_tl_sba_agent = tl_agent::type_id::create("m_tl_sba_agent", this);

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -9,6 +9,10 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
   rand jtag_agent_cfg m_jtag_agent_cfg;
   rand tl_agent_cfg   m_tl_sba_agent_cfg;
 
+  // A handle to a clock interface for the LC domain. We don't actually use the clock itself, but
+  // use the unsynchronised reset signal.
+  virtual clk_rst_if clk_lc_rst_vif;
+
   // The JTAG DMI register model.
   rand jtag_dmi_reg_block jtag_dmi_ral;
 


### PR DESCRIPTION
This PR depends on #22591 (no real impact, but they are touching related lines and rebasing is annoying!). The second commit is the only one that's special to this PR and can reviewed on its own. The other PR should be merged first.

The commit that's unique to this PR just makes an extra clock/reset interface to drive the signals and wires it up to the block.
