### PR TITLE
[rv_dm,dv] Expose new ports in rv_dm_if

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_if.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_if.sv
@@ -6,8 +6,13 @@ interface rv_dm_if(input logic clk, input logic rst_n);
 
   import rv_dm_env_pkg::*;
 
-  // DUT inputs.
+  // "Enable" inputs
   lc_ctrl_pkg::lc_tx_t    lc_hw_debug_en;
+  lc_ctrl_pkg::lc_tx_t    pinmux_hw_debug_en;
+  lc_ctrl_pkg::lc_tx_t    lc_dft_en;
+  prim_mubi_pkg::mubi8_t  otp_dis_rv_dm_late_debug;
+
+  // Other DUT inputs.
   prim_mubi_pkg::mubi4_t  scanmode;
   logic                   scan_rst_n;
   logic [NUM_HARTS-1:0]   unavailable;
@@ -22,6 +27,9 @@ interface rv_dm_if(input logic clk, input logic rst_n);
 
   clocking cb @(posedge clk);
     output lc_hw_debug_en;
+    output pinmux_hw_debug_en;
+    output lc_dft_en;
+    output otp_dis_rv_dm_late_debug;
     output scanmode;
     output scan_rst_n;
     output unavailable;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -52,6 +52,13 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     cfg.rv_dm_vif.scanmode <= scanmode;
     cfg.rv_dm_vif.unavailable <= unavailable;
 
+    // TODO(#23096): We're currently wiring all the enable signals to match lc_hw_debug_en and
+    //               hard-coding the late debug enable flag to be true. These eventually need to be
+    //               separately controlled.
+    cfg.rv_dm_vif.pinmux_hw_debug_en       <= lc_hw_debug_en;
+    cfg.rv_dm_vif.lc_dft_en                <= lc_hw_debug_en;
+    cfg.rv_dm_vif.otp_dis_rv_dm_late_debug <= prim_mubi_pkg::MuBi8True;
+
     super.pre_start();
   endtask
 

--- a/hw/ip/rv_dm/dv/tb.sv
+++ b/hw/ip/rv_dm/dv/tb.sv
@@ -29,42 +29,39 @@ module tb;
 
   // dut
   rv_dm #(
-    .IdcodeValue          (rv_dm_env_pkg::RV_DM_JTAG_IDCODE)
+    .IdcodeValue (rv_dm_env_pkg::RV_DM_JTAG_IDCODE)
   ) dut (
-    .clk_i                (clk  ),
-    .rst_ni               (rst_n),
-    .clk_lc_i             (clk_lc  ),
-    .rst_lc_ni            (rst_lc_n),
-    // the differing behavior of lc_hw_debug_en_i and pinmux_hw_debug_en_i
-    // will be tested at the top-level. for the purposes of this TB we connect
-    // both signals to the same life cycle signal.
-    .lc_hw_debug_en_i     (rv_dm_if.lc_hw_debug_en),
-    .pinmux_hw_debug_en_i (rv_dm_if.lc_hw_debug_en),
-    // TODO: this needs to be hooked up to the interface properly so that all combinations
-    // of access control combinations can be tested.
-    .lc_dft_en_i          (rv_dm_if.lc_hw_debug_en),
-    .otp_dis_rv_dm_late_debug_i(prim_mubi_pkg::MuBi8True),
-    .scanmode_i           (rv_dm_if.scanmode      ),
-    .scan_rst_ni          (rv_dm_if.scan_rst_n    ),
-    .ndmreset_req_o       (rv_dm_if.ndmreset_req  ),
-    .dmactive_o           (rv_dm_if.dmactive      ),
-    .debug_req_o          (rv_dm_if.debug_req     ),
-    .unavailable_i        (rv_dm_if.unavailable   ),
+    .clk_i                     (clk  ),
+    .rst_ni                    (rst_n),
+    .clk_lc_i                  (clk_lc  ),
+    .rst_lc_ni                 (rst_lc_n),
 
-    .regs_tl_d_i          (regs_tl_if.h2d),
-    .regs_tl_d_o          (regs_tl_if.d2h),
+    .lc_hw_debug_en_i          (rv_dm_if.lc_hw_debug_en           ),
+    .pinmux_hw_debug_en_i      (rv_dm_if.pinmux_hw_debug_en       ),
+    .lc_dft_en_i               (rv_dm_if.lc_dft_en                ),
+    .otp_dis_rv_dm_late_debug_i(rv_dm_if.otp_dis_rv_dm_late_debug ),
 
-    .mem_tl_d_i           (mem_tl_if.h2d),
-    .mem_tl_d_o           (mem_tl_if.d2h),
+    .scanmode_i                (rv_dm_if.scanmode      ),
+    .scan_rst_ni               (rv_dm_if.scan_rst_n    ),
+    .ndmreset_req_o            (rv_dm_if.ndmreset_req  ),
+    .dmactive_o                (rv_dm_if.dmactive      ),
+    .debug_req_o               (rv_dm_if.debug_req     ),
+    .unavailable_i             (rv_dm_if.unavailable   ),
 
-    .sba_tl_h_o           (sba_tl_if.h2d),
-    .sba_tl_h_i           (sba_tl_if.d2h),
+    .regs_tl_d_i               (regs_tl_if.h2d),
+    .regs_tl_d_o               (regs_tl_if.d2h),
 
-    .alert_rx_i           (alert_rx ),
-    .alert_tx_o           (alert_tx ),
+    .mem_tl_d_i                (mem_tl_if.h2d),
+    .mem_tl_d_o                (mem_tl_if.d2h),
 
-    .jtag_i               ({jtag_if.tck, jtag_if.tms, jtag_if.trst_n, jtag_if.tdi}),
-    .jtag_o               ({jtag_if.tdo, jtag_tdo_oe})
+    .sba_tl_h_o                (sba_tl_if.h2d),
+    .sba_tl_h_i                (sba_tl_if.d2h),
+
+    .alert_rx_i                (alert_rx ),
+    .alert_tx_o                (alert_tx ),
+
+    .jtag_i                    ({jtag_if.tck, jtag_if.tms, jtag_if.trst_n, jtag_if.tdi}),
+    .jtag_o                    ({jtag_if.tdo, jtag_tdo_oe})
   );
 
   initial begin


### PR DESCRIPTION
This builds on top of #22594 (which should be reviewed and merged first). Only the final commit is unique to this PR. Its commit message is:

*[rv_dm,dv] Expose new ports in rv_dm_if*

This change shouldn't cause any change to behaviour, but it's
connecting up the ports separately in tb.sv so that they can be
controlled by vseqs.

The logic that wires everything together (and the TODO comment) have
now been moved to the base vseq.
