### PR TITLE
[keymgr/sw] Add spinwait to advance state function calls

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -286,6 +286,8 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/testing/test_framework:check",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:keymgr_binding",
         "//sw/device/silicon_creator/lib/base:sec_mmio",

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -170,8 +170,10 @@ void sc_keymgr_entropy_reseed_interval_set(uint16_t entropy_reseed_interval);
  * the secure mmio `sec_mmio_check_values()` function to make sure the value of
  * the `SW_BINDING_REGWEN` register is updated in the secure mmio expectations
  * table.
+ *
+ * @return true for passing into IBEX_SPIN_FOR.
  */
-void sc_keymgr_advance_state(void);
+bool sc_keymgr_advance_state(void);
 
 /**
  * Checks the state of the key manager.

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -153,12 +153,12 @@ rom_error_t keymgr_rom_test(void) {
   sec_mmio_check_values(/*rnd_offset=*/0);
 
   // Advance keymgr to Initialized state.
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   ASSERT_OK(sc_keymgr_state_check(kScKeymgrStateInit));
   LOG_INFO("Keymgr State: Init");
 
   // Advance keymgr to CreatorRootKey state.
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   ASSERT_OK(sc_keymgr_state_check(kScKeymgrStateCreatorRootKey));
   LOG_INFO("Keymgr State: CreatorRootKey");
 
@@ -174,7 +174,7 @@ rom_error_t keymgr_rom_test(void) {
   SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioSwBindingSet +
                            kScKeymgrSecMmioOwnerIntMaxVerSet);
   sec_mmio_check_values(/*rnd_offset=*/0);
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   ASSERT_OK(sc_keymgr_state_check(kScKeymgrStateOwnerIntermediateKey));
   LOG_INFO("Keymgr State: OwnerIntermediateKey");
 
@@ -196,7 +196,7 @@ rom_error_t keymgr_rom_ext_test(void) {
   SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioSwBindingSet +
                            kScKeymgrSecMmioOwnerMaxVerSet);
   sec_mmio_check_values(/*rnd_offset=*/0);
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   ASSERT_OK(sc_keymgr_state_check(kScKeymgrStateOwnerKey));
 
   sec_mmio_check_counters(/*expected_check_count=*/7);

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -179,7 +179,7 @@ TEST_F(KeymgrTest, SetOwnerMaxVerKey) {
 
 TEST_F(KeymgrTest, AdvanceState) {
   ExpectAdvanceState();
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
 }
 
 TEST_F(KeymgrTest, CheckState) {

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -228,7 +228,7 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
 
   // Advance keymgr to Initialized state.
   TRY(sc_keymgr_state_check(kScKeymgrStateReset));
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   TRY(sc_keymgr_state_check(kScKeymgrStateInit));
 
   // Load OTBN attestation keygen program.
@@ -236,7 +236,7 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
   TRY(otbn_boot_app_load());
 
   // Generate UDS keys and (TBS) cert.
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   TRY(dice_attestation_keygen(kDiceKeyUds, &uds_pubkey_id, &curr_pubkey));
   TRY(otbn_boot_attestation_key_save(kUdsAttestationKeySeed,
                                      kUdsKeymgrDiversifier));
@@ -263,9 +263,9 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
 
   // Generate CDI_1 keys and cert.
   compute_keymgr_owner_binding(&certgen_inputs);
-  TRY(sc_keymgr_owner_advance(&sealing_binding_value,
-                              &attestation_binding_value,
-                              /*max_key_version=*/0));
+  IBEX_TRY_SPIN_FOR(sc_keymgr_owner_advance(&sealing_binding_value,
+                                            &attestation_binding_value,
+                                            /*max_key_version=*/0), 10000);
   TRY(dice_attestation_keygen(kDiceKeyCdi1, &cdi_1_pubkey_id, &curr_pubkey));
   TRY(dice_cdi_1_cert_build(&certgen_inputs, &cdi_0_pubkey_id, &cdi_1_pubkey_id,
                             &curr_pubkey, dice_certs.cdi_1_certificate,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -239,9 +239,9 @@ static rom_error_t rom_ext_attestation_keygen(const manifest_t *manifest) {
   // ROM sets the SW binding values for the first key stage (CreatorRootKey) but
   // does not initialize the key manager. Advance key manager state twice to
   // transition to the creator root key state.
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(kScKeymgrStateInit));
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(kScKeymgrStateCreatorRootKey));
 
   // Generate UDS attestation keys.
@@ -265,7 +265,7 @@ static rom_error_t rom_ext_attestation_keygen(const manifest_t *manifest) {
   sc_keymgr_owner_int_max_ver_set(rom_ext_manifest->max_key_version);
   SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioSwBindingSet +
                            kScKeymgrSecMmioOwnerIntMaxVerSet);
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   HARDENED_RETURN_IF_ERROR(
       sc_keymgr_state_check(kScKeymgrStateOwnerIntermediateKey));
 
@@ -286,7 +286,7 @@ static rom_error_t rom_ext_attestation_keygen(const manifest_t *manifest) {
   sc_keymgr_owner_max_ver_set(manifest->max_key_version);
   SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioSwBindingSet +
                            kScKeymgrSecMmioOwnerMaxVerSet);
-  sc_keymgr_advance_state();
+  IBEX_SPIN_FOR(sc_keymgr_advance_state(), 10000);
   HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(kScKeymgrStateOwnerKey));
 
   // Generate CDI_1 attestation keys.


### PR DESCRIPTION
This commit wraps sc_keymgr_advance_state in IBEX_SPIN_FORs. I noticed that the ft_personalize test started failing because certain calls complete too late. This might cause the following code to hang.

I also wrapped the sc_keymgr_owner_advance call in ft_personalize.c in an IBEX_SPIN_FOR. Otherwise this test fails for my changes in #22114.

I think there is still something off here, since if  I wrap the sc_keymgr_owner_int_advance call on line 250 in ft_personalize.c in another IBEX_SPIN_FOR, the test fails again.

This PR can be used as a starting point but I believe there's still some debugging to do here.