### PR TITLE
[prim,fpv] Fix width of FPV variable in prim_arbiter_ppc.sv

### DIFF
--- a/hw/ip/prim/rtl/prim_arbiter_ppc.sv
+++ b/hw/ip/prim/rtl/prim_arbiter_ppc.sv
@@ -177,7 +177,7 @@ end
 // FPV-only assertions with symbolic variables
 `ifdef FPV_ON
   // symbolic variables
-  int unsigned k;
+  bit [IdxW-1:0] k;
   bit ReadyIsStable;
   bit ReqsAreStable;
 


### PR DESCRIPTION
A minor cleanup that avoids some tool warnings. Fortunately, it turns out that we had a width parameter floating around already so it was really easy to use!