### PR TITLE
[prim,fpv] Rephrase prim_count error assertions

### DIFF
--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -250,15 +250,11 @@ module prim_count #(
       $stable(cnt_q[1]),
       clk_i, err_o || fpv_err_present || !rst_ni)
 
-  // Error
-  `ASSERT(CntErrForward_A,
-      (cnt_q[1] + cnt_q[0]) != {Width{1'b1}}
-      |->
-      err_o)
-  `ASSERT(CntErrBackward_A,
-      err_o
-      |->
-      (cnt_q[1] + cnt_q[0]) != {Width{1'b1}})
+  // Check that count errors are reported properly in err_o
+  `ASSERT(CntErrReported_A, ((cnt_q[1] + cnt_q[0]) != {Width{1'b1}}) == err_o)
+ `ifdef PrimCountFpv
+  `COVER(CntErr_C, err_o)
+ `endif
 
   // This logic that will be assign to one, when user adds macro
   // ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT to check the error with alert, in case that prim_count


### PR DESCRIPTION
The correctness assertion is unchanged (because (A |-> B) && (B |-> A) is true if (A == B) when A and B are expressions). The change here is in the generated cover properties.

The correctness property means that we are proving there's only one cover point that is needed (let's make it "err_o" for brevity). But we will only see this happen when the counters get forced. Fortunately, we have a way of doing that (see the fpv_force variable). Only generate the cover property in that situation.

If you are a reviewer, you might reasonably wonder whether the `PrimCountFpv` situation works properly. So did I! It turns out that this has failed to compile since a change in September. I'm going to get that tidied up now.