### PR TITLE
[prim,fpv] Correct assertions for commit_i input

### DIFF
--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -183,7 +183,7 @@ module prim_count #(
 
   // Clear
   `ASSERT(ClrFwd_A,
-      rst_ni && clr_i
+      rst_ni && commit_i && clr_i
       |=>
       (cnt_o == ResetValue) &&
       (cnt_q[1] == ({Width{1'b1}} - ResetValue)),
@@ -191,7 +191,7 @@ module prim_count #(
 
   // Set
   `ASSERT(SetFwd_A,
-      rst_ni && set_i && !clr_i
+      rst_ni && commit_i && set_i && !clr_i
       |=>
       (cnt_o == $past(set_cnt_i)) &&
       (cnt_q[1] == ({Width{1'b1}} - $past(set_cnt_i))),


### PR DESCRIPTION
This PR has three commits, but only the last one is unique to this PR. The other two come from #22560 which should be merged first. The commit unique to this PR is:

*[prim,fpv] Correct assertions for commit_i input*

The ClrFwd_A assertion says "When a clear is requested, it should take
effect". But this isn't quite true because commit_i might be false,
which would mean the clear operation wouldn't take effect in cnt_q.
Strengthen the assumption to "When a clear is requested and we really
mean it ..."

Similarly for SetFwd_A.