### PR TITLE
Tag `chip_pen_test` as a manually-triggered test

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -270,7 +270,10 @@ opentitan_test(
         "//hw/top_earlgrey:silicon_owner_proda_rom_ext": "silicon_owner",
     },
     silicon_owner = silicon_params(
-        tags = ["broken"],
+        tags = [
+            "broken",
+            "manual",
+        ],
     ),
     deps = FIRMWARE_DEPS,
 )


### PR DESCRIPTION
We don't want to run this test automatically as part of CI. Tag it as `manual`, to address that issue.