### PR TITLE
[otbn,dv] Improve error rate in `otbn_ctrl_redun_vseq`

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_ctrl_redun_vseq.sv
@@ -134,7 +134,7 @@ class otbn_ctrl_redun_vseq extends otbn_single_vseq;
       end
       4: begin
         bit [1:0] choose_err;
-        int unsigned num_clks = $urandom_range(10, 1000);
+        int unsigned num_clks = $urandom_range(10, 100);
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(choose_err, choose_err inside {[0:2]};)
 
         report_err_type($sformatf("core error (choose_err = %0d, after %0d clocks)",


### PR DESCRIPTION
The pass rate for this vseq is not brilliant. These commits make it somewhat better (but definitely still not 100%). Before the changes, the pass rate was roughly 75%. With them, I've just run 50 seeds and got a pass rate of 94%.

A full fix for this test will be a bit fiddly. For example, the operation it chooses might be "Inject an error when OTBN is writing to a flag register". But that's going to be difficult if the randomly generated binary doesn't actually write to a flag register...

I suspect that a "full" solution will involve generating a known-good binary and then running two binaries back-to-back: a random one, followed by the binary that we know does all the operations we might want to interrupt. But that's definitely more difficult than just tweaking some wait times, so let's do the easy job first!