### PR TITLE
Add a bazel rule to start a jtag server

### DIFF
--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -397,6 +397,16 @@ cd $REPO_TOP
     -f util/openocd/target/lowrisc-earlgrey.cfg
 ```
 
+#### Bazel-managed OpenOCD startup
+Bazel can configure and execute an OpenOCD process for you.
+Bazel will set the appropriate configuration straps for the chip, issue a reset and then start OpenOCD.
+This is currently supported for CW310 and Silicon environments:
+
+```
+bazel run //hw/top_earlgrey:jtag_server \
+    --//hw/top_earlgrey:jtag_env=//hw/top_earlgrey:fpga_cw310
+```
+
 Example OpenOCD output:
 ```console
 Open On-Chip Debugger 0.11.0

--- a/doc/getting_started/using_openocd.md
+++ b/doc/getting_started/using_openocd.md
@@ -20,3 +20,6 @@ Currently, we only expose OpenTitan's default JTAG adapter config as `//third_pa
 # Get the path of the OpenOCD binary:
 ./bazelisk.sh outquery //third_party/openocd:openocd_bin
 ```
+
+See also the [Bazel-managed OpenOCD
+startup](setup_fpga.md#bazel-managed-openocd-startup) section of the FPGA guide.

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -14,6 +14,7 @@ load(
     "sim_dv",
     "sim_verilator",
 )
+load("//rules/opentitan:jtag.bzl", "jtag_server")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -41,6 +42,29 @@ filegroup(
     ],
 )
 
+label_flag(
+    name = "jtag_env",
+    build_setting_default = ":silicon_creator",
+)
+
+jtag_server(
+    name = "jtag_server",
+    testonly = True,
+    chip_setup = [
+        "gpio write TAP_STRAP0 false",
+        "gpio write TAP_STRAP1 true",
+        "gpio apply RMA_BOOTSTRAP",
+        "gpio apply RESET",
+        "no-op --delay 50ms",
+        "gpio remove RESET",
+    ],
+    exec_env = ":jtag_env",
+    openocd_chip_config = "//util/openocd/target:lowrisc-earlgrey.cfg",
+    openocd_commands = [
+        "adapter speed 500; transport select jtag; reset_config trst_only",
+    ],
+)
+
 ###########################################################################
 # FPGA CW310 Environments
 ###########################################################################
@@ -53,6 +77,7 @@ fpga_cw310(
         "//sw/device/lib/arch:fpga_cw310",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    openocd_adapter_config = "//third_party/openocd:jtag_olimex_cfg",
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
     test_cmd = "testing-not-supported",
 )
@@ -71,7 +96,6 @@ fpga_cw310(
     base = ":fpga_cw310",
     base_bitstream = "//hw/bitstream:bitstream",
     exec_env = "fpga_cw310_test_rom",
-    openocd_adapter_config = "//third_party/openocd:jtag_olimex_cfg",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
     otp_mmi = "//hw/bitstream:otp_mmi",
     param = {
@@ -141,6 +165,7 @@ fpga_cw310(
     base_bitstream = "//hw/bitstream/hyperdebug:bitstream",
     exec_env = "fpga_hyper310_rom_with_fake_keys",
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    openocd_adapter_config = "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
     otp_mmi = "//hw/bitstream/hyperdebug:otp_mmi",
     param = {
@@ -338,6 +363,7 @@ silicon(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    openocd_adapter_config = "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
     param = {
         "interface": "teacup",
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
@@ -371,6 +397,7 @@ silicon(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
     manifest = "//sw/device/silicon_owner:manifest_standard",
+    openocd_adapter_config = "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
     param = {
         "interface": "teacup",
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,

--- a/rules/opentitan/jtag.bzl
+++ b/rules/opentitan/jtag.bzl
@@ -1,0 +1,80 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
+load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_override")
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+_COMMAND = """#!/bin/bash
+
+{opentitantool} --rcfile= --interface={interface} {setup} no-op
+
+{openocd} \
+    -f {adapter_config} \
+    {openocd_commands} \
+    -f {chip_config} \
+"""
+
+def _jtag_server(ctx):
+    exec_env = ctx.attr.exec_env[ExecEnvInfo]
+    adapter_config = get_fallback(ctx, "attr.openocd_adapter_config", exec_env)
+    adapter_config = adapter_config.files.to_list()
+    if len(adapter_config) != 1:
+        fail("Expected only one file for openocd_adapter_config")
+    adapter_config = adapter_config[0]
+
+    setup = ["--exec={}".format(shell.quote(s)) for s in ctx.attr.chip_setup]
+    commands = ["-c {}".format(shell.quote(c)) for c in ctx.attr.openocd_commands]
+
+    file = ctx.actions.declare_file("{}.sh".format(ctx.attr.name))
+    script = _COMMAND.format(
+        opentitantool = exec_env._opentitantool.executable.short_path,
+        interface = exec_env.param["interface"],
+        setup = " ".join(setup),
+        openocd = exec_env.openocd.files_to_run.executable.short_path,
+        adapter_config = adapter_config.short_path,
+        openocd_commands = " ".join(commands),
+        chip_config = ctx.file.openocd_chip_config.short_path,
+    )
+    ctx.actions.write(
+        output = file,
+        content = script,
+        is_executable = True,
+    )
+
+    return DefaultInfo(
+        executable = file,
+        runfiles = ctx.runfiles(files = [
+            exec_env._opentitantool.executable,
+            exec_env.openocd.files_to_run.executable,
+            adapter_config,
+            ctx.file.openocd_chip_config,
+        ]),
+    )
+
+jtag_server = rule(
+    implementation = _jtag_server,
+    attrs = {
+        "exec_env": attr.label(
+            providers = [ExecEnvInfo],
+            doc = "List of exeuction environments for this target.",
+        ),
+        "chip_setup": attr.string_list(
+            doc = "OpenTitanTool commands to configure the chip for JTAG",
+        ),
+        "openocd_adapter_config": attr.label(
+            allow_single_file = True,
+            doc = "OpenOCD adapter configuration override",
+        ),
+        "openocd_chip_config": attr.label(
+            allow_single_file = True,
+            doc = "OpenOCD chip configuration override",
+        ),
+        "openocd_commands": attr.string_list(
+            doc = "OpenOCD commands to execute",
+        ),
+    },
+    executable = True,
+    doc = "Configure a chip for jtag and spawn an OpenOCD server process",
+)


### PR DESCRIPTION
Add a bazel rule to configure the chip for jtag and start an OpenOCD instance as a jtag server:

```
bazel run //hw/top_earlgrey:jtag_server
```
