### PR TITLE
[pentest] Return alerts as array

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/ibex_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/ibex_fi.c
@@ -180,9 +180,7 @@ status_t handle_ibex_fi_address_translation(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -254,9 +252,7 @@ status_t handle_ibex_fi_address_translation_config(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -294,9 +290,7 @@ status_t handle_ibex_fi_char_csr_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -336,9 +330,7 @@ status_t handle_ibex_fi_char_csr_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -409,9 +401,7 @@ status_t handle_ibex_fi_char_flash_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -477,9 +467,7 @@ status_t handle_ibex_fi_char_flash_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -530,9 +518,7 @@ status_t handle_ibex_fi_char_sram_static(ujson_t *uj) {
 
   // Send res & ERR_STATUS to host.
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_faulty_addresses_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -579,9 +565,7 @@ status_t handle_ibex_fi_char_sram_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -624,9 +608,7 @@ status_t handle_ibex_fi_char_sram_write(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -751,9 +733,7 @@ status_t handle_ibex_fi_char_unconditional_branch(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = result;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -787,9 +767,7 @@ status_t handle_ibex_fi_char_conditional_branch(ujson_t *uj) {
   uj_output.result1 = branch_if_;
   uj_output.result2 = branch_else;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_mult_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -820,9 +798,7 @@ status_t handle_ibex_fi_char_mem_op_loop(ujson_t *uj) {
   uj_output.loop_counter1 = loop_counter1;
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -857,9 +833,7 @@ status_t handle_ibex_fi_char_unrolled_mem_op_loop(ujson_t *uj) {
   ibex_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -894,9 +868,7 @@ status_t handle_ibex_fi_char_reg_op_loop(ujson_t *uj) {
   uj_output.loop_counter1 = loop_counter1;
   uj_output.loop_counter2 = loop_counter2;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_mirrored_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -933,9 +905,7 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   ibex_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -987,9 +957,7 @@ status_t handle_ibex_fi_char_register_file(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }
@@ -1038,9 +1006,7 @@ status_t handle_ibex_fi_char_register_file_read(ujson_t *uj) {
   ibex_fi_test_result_t uj_output;
   uj_output.result = res;
   uj_output.err_status = codes;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_ibex_fi_test_result_t, uj, &uj_output);
   return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/otbn_fi.c
@@ -281,9 +281,7 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -335,9 +333,7 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -391,9 +387,7 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -445,9 +439,7 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
   uj_output.err_status = err_bits;
-  uj_output.alerts_1 = reg_alerts.alerts_1;
-  uj_output.alerts_2 = reg_alerts.alerts_2;
-  uj_output.alerts_3 = reg_alerts.alerts_3;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }

--- a/sw/device/tests/penetrationtests/firmware/sca_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/sca_lib.c
@@ -25,9 +25,7 @@ sca_registered_alerts_t sca_get_triggered_alerts(void) {
   bool is_cause;
 
   sca_registered_alerts_t registered;
-  registered.alerts_1 = 0;
-  registered.alerts_2 = 0;
-  registered.alerts_3 = 0;
+  memset(registered.alerts, 0, sizeof(registered.alerts));
 
   // Loop over all alert_cause regs
   for (size_t alert = 0; alert < ALERT_HANDLER_PARAM_N_ALERTS; alert++) {
@@ -35,11 +33,11 @@ sca_registered_alerts_t sca_get_triggered_alerts(void) {
         dif_alert_handler_alert_is_cause(&alert_handler, alert, &is_cause));
     if (is_cause) {
       if (alert < 32) {
-        registered.alerts_1 |= (1 << alert);
+        registered.alerts[0] |= (1 << alert);
       } else if (alert < 64) {
-        registered.alerts_2 |= (1 << (alert - 32));
+        registered.alerts[1] |= (1 << (alert - 32));
       } else {
-        registered.alerts_3 |= (1 << (alert - 64));
+        registered.alerts[2] |= (1 << (alert - 64));
       }
     }
   }

--- a/sw/device/tests/penetrationtests/firmware/sca_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/sca_lib.h
@@ -8,9 +8,7 @@
 #include "sw/device/lib/ujson/ujson.h"
 
 typedef struct sca_registered_alerts {
-  uint32_t alerts_1;
-  uint32_t alerts_2;
-  uint32_t alerts_3;
+  uint32_t alerts[3];
 } sca_registered_alerts_t;
 
 /**

--- a/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
@@ -35,43 +35,33 @@ UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
 #define IBEXFI_TEST_RESULT(field, string) \
     field(result, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts_1, uint32_t) \
-    field(alerts_2, uint32_t) \
-    field(alerts_3, uint32_t)
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiTestResult, ibex_fi_test_result_t, IBEXFI_TEST_RESULT);
 
 #define IBEXFI_TEST_RESULT_MULT(field, string) \
     field(result1, uint32_t) \
     field(result2, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts_1, uint32_t) \
-    field(alerts_2, uint32_t) \
-    field(alerts_3, uint32_t)
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiTestResultMult, ibex_fi_test_result_mult_t, IBEXFI_TEST_RESULT_MULT);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts_1, uint32_t) \
-    field(alerts_2, uint32_t) \
-    field(alerts_3, uint32_t)
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterOutput, ibex_fi_loop_counter_t, IBEXFI_LOOP_COUNTER_OUTPUT);
 
 #define IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT(field, string) \
     field(loop_counter1, uint32_t) \
     field(loop_counter2, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts_1, uint32_t) \
-    field(alerts_2, uint32_t) \
-    field(alerts_3, uint32_t)
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterMirroredOutput, ibex_fi_loop_counter_mirrored_t, IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT);
 
 #define IBEXFI_FAULTY_ADDRESSES(field, string) \
     field(err_status, uint32_t) \
     field(addresses, uint32_t, 8) \
-    field(alerts_1, uint32_t) \
-    field(alerts_2, uint32_t) \
-    field(alerts_3, uint32_t)
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiFaultyAddresses, ibex_fi_faulty_addresses_t, IBEXFI_FAULTY_ADDRESSES);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
@@ -25,9 +25,7 @@ UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND);
 #define OTBNFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
     field(err_status, uint32_t) \
-    field(alerts_1, uint32_t) \
-    field(alerts_2, uint32_t) \
-    field(alerts_3, uint32_t)
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(OtbnFiLoopCounterOutput, otbn_fi_loop_counter_t, OTBNFI_LOOP_COUNTER_OUTPUT);
 
 #define OTBNFI_RESULT_OUTPUT(field, string) \


### PR DESCRIPTION
As for the pen. testing evaluating an array instead of individual variables for the triggered alerts is easier, this commit switches the format of how the alerts are returned to the host.