### PR TITLE
Setup priority over stall response

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -685,7 +685,7 @@
               bits for that endpoint
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_setup_priority_over_stall_response"]
     }
     {
       name: stall_priority_over_nak

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_priority_over_stall_response_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_priority_over_stall_response_vseq.sv
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Setup priority over stall response vseq
+class usbdev_setup_priority_over_stall_response_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_setup_priority_over_stall_response_vseq)
+
+  `uvm_object_new
+
+  task body();
+    uvm_reg_data_t read_rxfifo;
+    // Configuring endpoint 0 for stalling
+    endp = 0;
+
+    // Set out_stall endpoint
+    csr_wr(ral.out_stall[0].endpoint[endp], 1'b1);
+    // Set in_stall endpoint
+    csr_wr(ral.in_stall[0].endpoint[endp], 1'b1);
+    // Configure setup transaction
+    configure_setup_trans();
+    // Out token packet followed by a data packet
+    call_token_seq(PidTypeSetupToken);
+    inter_packet_delay();
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(7'b0));
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    get_out_response_from_device(m_usb20_item, PidTypeAck);
+    // Verifies that the out and in stall endpoint
+    check_setup_priority_over_stall();
+  endtask
+
+  task check_setup_priority_over_stall();
+    uvm_reg_data_t in_stall;
+    uvm_reg_data_t out_stall;
+
+    // Read out stall endpoint
+    csr_rd(.ptr(ral.out_stall[endp]), .value(out_stall));
+    // Read in stall endpoint
+    csr_rd(.ptr(ral.in_stall[endp]), .value(in_stall));
+    // DV_CHECK on out stall endpoint
+    `DV_CHECK_EQ(out_stall, 0);
+    // DV_CHECK on in stall endpoint
+    `DV_CHECK_EQ(in_stall, 0);
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -26,6 +26,7 @@
 `include "usbdev_random_length_out_transaction_vseq.sv"
 `include "usbdev_stall_trans_vseq.sv"
 `include "usbdev_setup_trans_ignored_vseq.sv"
+`include "setup_priority_over_stall_response_vseq.sv"
 `include "usbdev_stall_priority_over_nak_vseq.sv"
 
 // These depend on usbdev_random_length_out_transaction, so need to come after it.

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -48,7 +48,14 @@ filesets:
       - seq_lib/usbdev_phy_pins_sense_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_stall_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_priority_over_nak_vseq.sv: {is_include_file: true}
+<<<<<<< HEAD
       - seq_lib/usbdev_in_iso_vseq.sv: {is_include_file: true}
+=======
+      - seq_lb/usbdev_in_iso_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_rx_pid_err_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_setup_priority_over_stall_response_vseq.sv: {is_include_file: true}
+
+>>>>>>> 4b646ba62e... [usbdev] Setup priority over stall response
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -116,6 +116,10 @@
       name: usbdev_setup_trans_ignored
       uvm_test_seq: usbdev_setup_trans_ignored_vseq
     }
+     {
+      name: usbdev_setup_proority_over_stall_response
+      uvm_test_seq: usbdev_setup_proority_over_stall_response_vseq
+    }
     {
       name: usbdev_stall_priority_over_nak
       uvm_test_seq: usbdev_stall_priority_over_nak_vseq


### PR DESCRIPTION
This Pr contains sequence that checks the setup and stalling priority.
Specific Endpoint is stalled in OUT transaction than after wards setup transaction will be sent.
instead of stalling the endpoint setup transaction will take priority.
This priority will be check using the out_stall and in_stall register.