### PR TITLE
[manuf] redundant flash info fields

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -83,27 +83,6 @@ const flash_info_field_t kFlashInfoFieldCdi1AttestationKeySeed = {
     .byte_offset = (2 * kAttestationSeedBytes),
 };
 
-const flash_info_field_t kFlashInfoFieldUdsCertificate = {
-    .partition = 0,
-    .bank = 1,
-    .page = 6,
-    .byte_offset = 0,
-};
-
-const flash_info_field_t kFlashInfoFieldCdi0Certificate = {
-    .partition = 0,
-    .bank = 1,
-    .page = 8,
-    .byte_offset = 0,
-};
-
-const flash_info_field_t kFlashInfoFieldCdi1Certificate = {
-    .partition = 0,
-    .bank = 1,
-    .page = 9,
-    .byte_offset = 0,
-};
-
 status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
                                      flash_info_field_t field,
                                      uint32_t *data_out, size_t num_words) {

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -44,9 +44,6 @@ extern const flash_info_field_t kFlashInfoFieldWaferAuthSecret;
 extern const flash_info_field_t kFlashInfoFieldUdsAttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldCdi0AttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldCdi1AttestationKeySeed;
-extern const flash_info_field_t kFlashInfoFieldUdsCertificate;
-extern const flash_info_field_t kFlashInfoFieldCdi0Certificate;
-extern const flash_info_field_t kFlashInfoFieldCdi1Certificate;
 
 /**
  * Reads info flash page field.

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -238,7 +238,6 @@ opentitan_binary(
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:kmac",
-        "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
         "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_a0_sku_sival_bringup",
         "//sw/device/silicon_creator/manuf/lib:personalize",
     ],

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -28,7 +28,6 @@
 #include "sw/device/silicon_creator/lib/drivers/kmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
-#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 #include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
 #include "sw/device/silicon_creator/manuf/lib/personalize.h"
 
@@ -238,8 +237,7 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
                             &dice_certs.cdi_0_certificate_size));
   TRY(flash_ctrl_info_write(
       &kFlashCtrlInfoPageCdi0Certificate,
-      kFlashInfoFieldCdi0Certificate.byte_offset,
-      dice_certs.cdi_0_certificate_size / sizeof(uint32_t),
+      /*offset=*/0, dice_certs.cdi_0_certificate_size / sizeof(uint32_t),
       dice_certs.cdi_0_certificate));
   LOG_INFO("Generated CDI_0 certificate.");
 
@@ -254,8 +252,7 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
                             &dice_certs.cdi_1_certificate_size));
   TRY(flash_ctrl_info_write(
       &kFlashCtrlInfoPageCdi1Certificate,
-      kFlashInfoFieldCdi1Certificate.byte_offset,
-      dice_certs.cdi_1_certificate_size / sizeof(uint32_t),
+      /*offset=*/0, dice_certs.cdi_1_certificate_size / sizeof(uint32_t),
       dice_certs.cdi_1_certificate));
   LOG_INFO("Generated CDI_1 certificate.");
 
@@ -270,8 +267,7 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
   // Write the endorsed UDS certificate to flash and ack to host.
   TRY(flash_ctrl_info_write(
       &kFlashCtrlInfoPageUdsCertificate,
-      kFlashInfoFieldUdsCertificate.byte_offset,
-      endorsed_certs.uds_certificate_size / sizeof(uint32_t),
+      /*offset=*/0, endorsed_certs.uds_certificate_size / sizeof(uint32_t),
       endorsed_certs.uds_certificate));
   LOG_INFO("Imported DICE UDS certificate.");
 


### PR DESCRIPTION
The certificate flash info pages/fields are contained in the silicon_creator flash_ctrl driver. This removes duplicate information.