### PR TITLE
[dv,usbdev] Data toggle restore sequence

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -1105,9 +1105,11 @@
             - Set all of the OUT Data Toggle bits to random values.
             - Set all of the IN Data Toggle bits to random values.
             - Check that all of the OUT and IN Data Toggle bits read back as expected.
+            - Test the interaction of USB traffic with the IN and OUT Data Toggle bits, but note
+              that data toggle bits may only be toggled safely between packets.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_data_toggle_restore"]
     }
     {
       name: setup_priority

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -392,7 +392,7 @@ endtask
   endtask
 
   virtual task configure_out_trans();
-    // Enable EP0 Out
+    // Enable EP Out
     csr_wr(.ptr(ral.ep_out_enable[0].enable[endp]), .value(1'b1));
     csr_update(ral.ep_out_enable[0]);
     // Enable rx out
@@ -413,7 +413,7 @@ endtask
   endtask
 
   virtual task configure_setup_trans();
-    // Enable EP0 Out
+    // Enable EP Out
     csr_wr(.ptr(ral.ep_out_enable[0].enable[endp]), .value(1'b1));
     csr_update(ral.ep_out_enable[0]);
     // Enable rx setup

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
@@ -1,0 +1,265 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_data_toggle_restore_vseq)
+
+  `uvm_object_new
+
+  // Collect endpoint count from the DUT description.
+  localparam int unsigned NEndpoints = usbdev_reg_pkg::NEndpoints;
+
+  // Strictly, the USB host should never NAK an IN transaction (8.4.6.2), however other PIDs and
+  // transmission errors for an ACK may lead to the DUT regarding the transaction as unsuccessful,
+  // so to exercise that behavior we just emit a NAK for simplicity.
+  typedef enum {
+    InResponseNone,
+    InResponseAck,
+    InResponseNak
+  } in_response_e;
+
+  task pre_start();
+    // Disable automatic connection of the USB device to the USB; we want to exercise the
+    // data toggle restore functionality without interference from the USB host initially.
+    do_usbdev_init = 1'b0;
+
+    super.pre_start();
+  endtask
+
+  // Send an OUT packet with the specified DATAx token to the DUT and check that it
+  // receives the expected handshake response.
+  task send_out_packet(bit [3:0] ep, bit data_toggle, bit exp_ack,
+                       inout uvm_reg_data_t exp_out_data_toggles);
+    endp = ep;  // TODO: should be a parameter to tasks in base sequence.
+
+    // Set up the OUT EP and supply a randomly-chosen buffer.
+    `DV_CHECK_STD_RANDOMIZE_FATAL(out_buffer_id);
+    configure_out_trans();
+
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_data_seq(data_toggle ? PidTypeData1 : PidTypeData0, 1, 0);
+    cfg.clk_rst_vif.wait_clks(20);
+
+    // Check that the transaction received the expected response, which should either be ACK
+    // for an accepted packet (matching data toggle) or no response (packet dropped).
+    if (exp_ack) begin
+      usb20_item response;
+
+      get_response(m_response_item);
+      $cast(response, m_response_item);
+      `DV_CHECK_EQ(response.m_pkt_type, PktTypeHandshake);
+      `DV_CHECK_EQ(response.m_pid_type, PidTypeAck);
+
+      // Check the contents of the packet buffer memory against the OUT packet that was sent.
+      check_rx_packet(ep, 1'b0, out_buffer_id, m_data_pkt.data);
+
+      exp_out_data_toggles[ep] ^= 1;
+    end else begin
+      // We use the FIFO reset here to prevent the Available OUT Buffer FIFO overflowing later.
+      // Note: this functionality is not present in the engineering sample.
+      csr_wr(.ptr(ral.fifo_ctrl.avout_rst), .value(1));
+    end
+  endtask
+
+  // We'll read back the packet we sent using a random endpoint.
+  task collect_in_packet(bit [3:0] ep, in_response_e rsp, byte unsigned exp_data[],
+                         inout uvm_reg_data_t exp_in_data_toggles);
+    usb20_item response;
+    data_pkt in_data;
+
+    endp = ep; // TODO: should be a parameter to tasks in base sequence.
+
+    // Present an IN buffer for collection.
+    configure_in_trans(out_buffer_id, exp_data.size());
+
+    // Perform the IN transaction.
+    call_token_seq(PidTypeInToken);
+    get_response(m_response_item);
+    $cast(response, m_response_item);
+    `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);
+    $cast(in_data, response);
+    check_tx_packet(in_data, exp_in_data_toggles[ep] ? PidTypeData1 : PidTypeData0, exp_data);
+    cfg.clk_rst_vif.wait_clks(20);
+
+    // Respond as chosen to the DATA packet sent by the DUT.
+    case (rsp)
+      InResponseAck: begin
+        call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+        // The IN data toggle should now have flipped.
+        exp_in_data_toggles[ep] ^= 1;
+      end
+      InResponseNak: begin
+        call_handshake_sequence(PktTypeHandshake, PidTypeNak);
+      end
+      default: begin
+        // No response, nothing to do; the test may proceed to send another a packet within the
+        // timeout period of the DUT, but it should still regard the transaction as unsuccessful
+        // and not flip the data toggle.
+      end
+    endcase
+  endtask
+
+  // Check that the OUT and IN data toggles match expectations.
+  task check_toggles(input uvm_reg_data_t exp_out_data_toggles,
+                     input uvm_reg_data_t exp_in_data_toggles);
+    uvm_reg_data_t act_out_data_toggles;
+    uvm_reg_data_t act_in_data_toggles;
+
+    csr_rd(.ptr(ral.out_data_toggle), .value(act_out_data_toggles));
+    csr_rd(.ptr(ral.in_data_toggle), .value(act_in_data_toggles));
+    `DV_CHECK_EQ(act_out_data_toggles, exp_out_data_toggles);
+    `DV_CHECK_EQ(act_in_data_toggles, exp_in_data_toggles);
+  endtask
+
+  // Permute a subset of the data toggles at random and update the expectations accordingly.
+  task permute_toggles(inout uvm_reg_data_t exp_out_data_toggles,
+                       inout uvm_reg_data_t exp_in_data_toggles);
+    bit [NEndpoints-1:0] out_status;
+    bit [NEndpoints-1:0] in_status;
+    bit [NEndpoints-1:0] out_mask;
+    bit [NEndpoints-1:0] in_mask;
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(out_status)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(in_status)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(out_mask)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(in_mask)
+    `uvm_info(`gfn, $sformatf("Permuting OUT [0x%x,0x%x] and IN [0x%x,0x%x]",
+                              out_mask, out_status, in_mask, in_status), UVM_MEDIUM)
+
+    ral.out_data_toggle.mask.set(out_mask);
+    ral.out_data_toggle.status.set(out_status);
+    csr_update(.csr(ral.out_data_toggle));
+    ral.in_data_toggle.mask.set(in_mask);
+    ral.in_data_toggle.status.set(in_status);
+    csr_update(.csr(ral.in_data_toggle));
+
+    // Update expectations
+    exp_out_data_toggles = (exp_out_data_toggles & ~out_mask) | (out_status & out_mask);
+    exp_in_data_toggles  = (exp_in_data_toggles  & ~in_mask)  | (in_status  & in_mask);
+    `uvm_info(`gfn, $sformatf("Expecting OUT 0x%0x IN 0x0%0x",
+                              exp_out_data_toggles, exp_in_data_toggles), UVM_MEDIUM)
+  endtask
+
+  task body();
+    uvm_reg_data_t exp_out_data_toggles;
+    uvm_reg_data_t exp_in_data_toggles;
+    uvm_reg_data_t ep_odd_set = {((NEndpoints+1)/2){2'b10}}; // AAA
+    uvm_reg_data_t ep_even_set = ep_odd_set >> 1; // 555
+    uvm_reg_data_t ep_all = {NEndpoints{1'b1}};
+    uvm_reg_data_t rd_data;
+
+    // Basic test of Data Toggle CSR behavior without interference from the USB itself;
+    // the reception of SETUP/OUT packets would modify the OUT side Data Toggles.
+
+    ral.out_data_toggle.mask.set(ep_all);
+    ral.out_data_toggle.status.set(ep_even_set);
+    csr_update(.csr(ral.out_data_toggle));
+
+    csr_rd(.ptr(ral.out_data_toggle), .value(rd_data));
+    `DV_CHECK_EQ_FATAL(rd_data, ep_even_set)
+    `uvm_info(`gfn, "Completed basic test of OUT data toggles", UVM_MEDIUM)
+
+    ral.in_data_toggle.mask.set(ep_all);
+    ral.in_data_toggle.status.set(ep_odd_set);
+    csr_update(.csr(ral.in_data_toggle));
+
+    csr_rd(.ptr(ral.in_data_toggle), .value(rd_data));
+    `DV_CHECK_EQ_FATAL(rd_data, ep_odd_set)
+    csr_rd(.ptr(ral.out_data_toggle), .value(rd_data));
+    `DV_CHECK_EQ_FATAL(rd_data, ep_even_set)
+    `uvm_info(`gfn, "Completed basic test of IN data toggles", UVM_MEDIUM)
+
+    // Attempt to invert all of the Data Toggle bits.
+    ral.out_data_toggle.mask.set(ep_all);
+    ral.out_data_toggle.status.set(ep_all ^ ep_even_set);
+    csr_update(.csr(ral.out_data_toggle));
+
+    ral.in_data_toggle.mask.set(ep_all);
+    ral.in_data_toggle.status.set(ep_all ^ ep_odd_set);
+    csr_update(.csr(ral.in_data_toggle));
+    `uvm_info(`gfn, "Completed basic test of inverting data toggles", UVM_MEDIUM)
+
+    // Read back and check all bits.
+    check_toggles(ep_odd_set, ep_even_set);
+
+    // Try setting some random state for all of the Data Toggle bits.
+    ral.out_data_toggle.mask.set(ep_all);
+    ral.in_data_toggle.mask.set(ep_all);
+    exp_out_data_toggles = $urandom_range(0, ep_all);
+    exp_in_data_toggles  = $urandom_range(0, ep_all);
+    ral.out_data_toggle.status.set(exp_out_data_toggles);
+    ral.in_data_toggle.status.set(exp_in_data_toggles);
+    csr_update(.csr(ral.out_data_toggle));
+    csr_update(.csr(ral.in_data_toggle));
+    `uvm_info(`gfn, $sformatf("Setting OUT 0x%0x and IN 0x%0x",
+                              exp_out_data_toggles, exp_in_data_toggles), UVM_MEDIUM)
+
+    check_toggles(exp_out_data_toggles, exp_in_data_toggles);
+
+    // We shall be exercising any subset of the endpoints, so all must be capable of IN/OUT
+    // transfers, but let's just enable the specific ones that we're testing at that instant.
+    //
+    // Note 1: we can do this with the device connected only because we have control of the USB
+    //         traffic. Strictly, the DUT does not permit them to be enabled/disabled at arbitrary
+    //         times, but doing so serves to make this testing a bit more thorough.
+    csr_wr(.ptr(ral.ep_out_enable[0]), .value(0));
+    csr_wr(.ptr(ral.ep_in_enable[0]), .value(0));
+
+    // Connect the USB device to the USB
+    ral.usbctrl.enable.set(1);
+    csr_update(.csr(ral.usbctrl));
+
+    // Do not proceed further until the device has exited the Bus Reset signaling of the
+    // usb20_driver module; a Bus Reset will cause the data toggles to be reset automatically by
+    // the DUT.
+    wait_for_link_state({LinkActive, LinkActiveNoSOF}, 10 * 1000 * 48);  // 10ms timeout, at 48MHz
+
+    // A Bus Reset should have occurred above, which resets all of the Data Toggle bits to zero.
+    exp_out_data_toggles = 0;
+    exp_in_data_toggles  = 0;
+
+    // Randomized interaction of Data Toggle CSR access and USB-side IN/OUT packet transfers.
+    for (int unsigned txn = 0; txn < num_trans; txn++) begin
+      bit out_provoke_mismatch;
+      in_response_e in_rsp;
+      bit [3:0] ep_out;
+      bit [3:0] ep_in;
+
+      // Randomly modify the data toggles and update our expectations.
+      permute_toggles(exp_out_data_toggles, exp_in_data_toggles);
+
+      // Select an IN endpoint and an OUT endpoint to test.
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(ep_out, ep_out inside {[0:NEndpoints-1]};)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(ep_in,  ep_in  inside {[0:NEndpoints-1]};)
+      // Decide whether we wish to match or mismatch the expected toggle.
+      `DV_CHECK_STD_RANDOMIZE_FATAL(out_provoke_mismatch);
+      // TODO: the usb20_driver presently cannot cope with non-response from the device, so we must
+      //       not provoke a data toggle mismatch presently; lose this when usb20_driver has been
+      //       extended.
+      out_provoke_mismatch = 0;
+      // Decide upon our response to an IN DATA packet.
+      `DV_CHECK_STD_RANDOMIZE_FATAL(in_rsp);
+
+      // Send a randomized packet to the chosen OUT endpoint.
+      send_out_packet(ep_out, exp_out_data_toggles[ep_out] ^ out_provoke_mismatch,
+                      !out_provoke_mismatch, exp_out_data_toggles);
+      // Disable all OUT endpoints. See Note 1.
+      csr_wr(.ptr(ral.ep_out_enable[0]), .value(0));
+
+      // If the packet was not received and stored, we shall just retrieve a zero length packet
+      // because this always works and we're more interested in the PIDs than the content here.
+      if (out_provoke_mismatch) m_data_pkt.data.delete();
+
+      // Attempt to retrieve the packet (if accepted) via the chosen IN endpoint.
+      collect_in_packet(ep_in, in_rsp, m_data_pkt.data, exp_in_data_toggles);
+      // Disable all IN endpoints. See Note 1.
+      csr_wr(.ptr(ral.ep_in_enable[0]), .value(0));
+
+      // An OUT toggle and/or an IN toggle may have flipped; check all toggle bits.
+      check_toggles(exp_out_data_toggles, exp_in_data_toggles);
+    end
+  endtask
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -9,6 +9,7 @@
 
 `include "usbdev_av_buffer_vseq.sv"
 `include "usbdev_csr_test_vseq.sv"
+`include "usbdev_data_toggle_restore_vseq.sv"
 `include "usbdev_dpi_config_host_vseq.sv"
 `include "usbdev_enable_vseq.sv"
 `include "usbdev_fifo_rst_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/usbdev_vseq_list.sv: {is_include_file: true}
       - seq_lib/usbdev_base_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_common_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_data_toggle_restore_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_dpi_config_host_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_csr_test_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -61,6 +61,10 @@
       reseed: 1
     }
     {
+      name: usbdev_data_toggle_restore
+      uvm_test_seq: usbdev_data_toggle_restore_vseq
+    }
+    {
       name: usbdev_enable
       uvm_test_seq: usbdev_enable_vseq
     }


### PR DESCRIPTION
Add a test sequence for the additional Data Toggle restore functionality.
This sequence first performs some basic tests using the CSR interface and then brings up the USB connection and tests their interaction with the USB traffic.

Note that the data toggles may safely be changed between packets in the DV environment because the USB traffic is controlled. For active endpoints on a live system they must be modified only under very specific conditions such as halt or reset.