### PR TITLE
[entropy] reduce reseed interval in cryptolib

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -259,7 +259,7 @@ static const entropy_complex_config_t
                                 .id = kEntropyDrbgOpGenerate,
                                 .disable_trng_input = kHardenedBoolFalse,
                                 .seed_material = NULL,
-                                .generate_len = 8,
+                                .generate_len = 32,
                             },
                         .reseed =
                             {
@@ -284,7 +284,7 @@ static const entropy_complex_config_t
                             {
                                 .id = kEntropyDrbgOpGenerate,
                                 .seed_material = NULL,
-                                .generate_len = 1,
+                                .generate_len = 4,
                             },
                         .reseed =
                             {


### PR DESCRIPTION
This reduces the reseed interval for EDN0 and 1 which was causing OTBN program execution to appear to hang in the `ft_personalize` binary during an attestation key generation operation.

Specifically, when working on #22714, I noticed that OTBN execution would hang during the UDS attestation (ECC P256) key generation. It would not error out, rather it would just hang, causing `//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_provision_fpga_cw310_sival` to timeout eventually. (After attaching a JTAG/OpenOCD/GDB setup, I was able to determine the location of the hang.)

A few things we noticed were:
1. [moving the loading of the OTBN Boot Services program to before the entropy complex was reconfigured for keymgr operations](https://github.com/lowRISC/opentitan/pull/22714/commits/9deb11db10bdce8b5764e2691471a7a2d52f3873) inside the `ft_personalize` binary made the problem go away, and
2. making the modification made in this PR also made the problem go away.

As result, the thought is that entropy requests are getting dropped somewhere in the pipeline of FIFOs between entropy_src --> CSRNG --> EDN. This should probably be investigated further via waveforms. If we increase the reseed intervals (opposite of what is done in this PR) we may be able to trigger some DV testcases to fail. Alternatively, I could try to create a failing DV testcase based on parts of the `ft_personalize` test mentioned above.

CC: @vogelpi 