### PR TITLE
Fix chip_sw_sensor_ctrl_ast_alerts for SiVal silicon

### DIFF
--- a/sw/device/tests/sensor_ctrl_wakeup.c
+++ b/sw/device/tests/sensor_ctrl_wakeup.c
@@ -88,6 +88,11 @@ bool test_main(void) {
   dif_pwrmgr_domain_config_t sleep_config =
       kDifPwrmgrDomainOptionMainPowerInLowPower;
 
+  // Clear any prior events before we start the test
+  for (size_t i = 0; i < sensor_ctrl_events; ++i) {
+    CHECK_DIF_OK(dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, i));
+  }
+
   for (size_t i = 0; i < sensor_ctrl_events; ++i) {
     LOG_INFO("Testing sensor_ctrl event %d", i);
 


### PR DESCRIPTION
On silicon the test would fail because there would be events being triggered before the (expected) ones being triggered by the test. This patch clears prior events, to start from a clean slate and prevent the test from failing.

I don't know if the fact that there are any prior events at all reveals an unexpected problem, and thus if this fix is sweeping that problem under the rug...? Does anyone have any insights into that?