### PR TITLE
[sival] Mark `i2c_target_test_fpga_cw310_sival` as broken

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -35,6 +35,7 @@ load(
     "rsa_key_for_lc_state",
     "silicon_params",
     "verilator_params",
+    new_cw310_params = "cw310_params",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -4842,6 +4843,7 @@ opentitan_test(
     srcs = [
         "i2c_target_test.c",
     ],
+    broken = new_cw310_params(tags = ["broken"]),
     cw310 = cw310_params(
         test_cmd = """
             --bootstrap="{firmware}"
@@ -4851,7 +4853,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": "broken",
         },
     ),
     deps = [


### PR DESCRIPTION
I've seen this test failing in multiple PRs now that don't touch any of I2C. I think it's most likely broken.

Examples of where it failed CI:
- https://github.com/lowRISC/opentitan/pull/22599
- https://github.com/lowRISC/opentitan/pull/22588
- https://github.com/lowRISC/opentitan/pull/22621