### PR TITLE
[Sival, pwrmgr] Fix flakyness on Silicon

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2544,7 +2544,12 @@ opentitan_test(
             "//hw/top_earlgrey:sim_dv": None,
         },
     ),
-    silicon = silicon_params(tags = ["broken"]),
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
+    ),
     test_harness = cw310_params(
         test_cmd = """
             --bootstrap={firmware}

--- a/sw/device/tests/pwrmgr_all_reset_reqs_test.c
+++ b/sw/device/tests/pwrmgr_all_reset_reqs_test.c
@@ -47,8 +47,6 @@ bool test_main(void) {
                                      kTopEarlgreyPlicIrqIdAlertHandlerClassa,
                                      kTopEarlgreyPlicIrqIdAlertHandlerClassd);
 
-  config_alert_handler();
-
   // Check if there was a HW reset caused by expected cases.
   dif_rstmgr_reset_info_bitfield_t rst_info;
   rst_info = rstmgr_testutils_reason_get();
@@ -104,6 +102,7 @@ bool test_main(void) {
             rst_info);
       LOG_INFO("Booting and running normal sleep followed by escalation reset");
       LOG_INFO("Let SV wait timer reset");
+      config_alert_handler();
       trigger_escalation();
       break;
     case 4:

--- a/sw/device/tests/pwrmgr_all_reset_reqs_test.c
+++ b/sw/device/tests/pwrmgr_all_reset_reqs_test.c
@@ -42,7 +42,7 @@ bool test_main(void) {
 
   init_peripherals();
 
-  // Enable all the AON interrupts used in this test.
+  // Enable all the Alert handler interrupts used in this test.
   rv_plic_testutils_irq_range_enable(plic, kPlicTarget,
                                      kTopEarlgreyPlicIrqIdAlertHandlerClassa,
                                      kTopEarlgreyPlicIrqIdAlertHandlerClassd);
@@ -109,7 +109,7 @@ bool test_main(void) {
       LOG_INFO("Last Booting");
       return true;
     default:
-      LOG_INFO("Booting for undefined case %0d", reset_case);
+      LOG_INFO("Booting for undefined case %d", reset_case);
   }
 
   return false;


### PR DESCRIPTION
The test was `pwrmgr_all_reset_reqs_test_fpga_cw310_sival_rom_ext` was flaky because occasionally an unexpected reset (0x40 = `kDifRstmgrResetInfoEscalation`) would occur and mess up with the test.
This PR moves the alert handler configuration to phase 3 of the test.