### PR TITLE
[bazel] Revert "Remove opentitan_functest UART smoketest"

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -17,6 +17,12 @@ load(
     "RSA_ONLY_KEY_STRUCTS",
 )
 load(
+    "//rules:opentitan_test.bzl",
+    "ROM_BOOT_FAILURE_MSG",
+    "opentitan_functest",
+    dv_params_functest = "dv_params",
+)
+load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
     "otp_image",
@@ -3597,6 +3603,27 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+# Used by DVSIM test-points to test signed binaries.
+# Please do not remove until those tests are updated to use `uart_smoketest`.
+opentitan_functest(
+    name = "uart_smoketest_signed",
+    srcs = ["uart_smoketest.c"],
+    dv = dv_params_functest(
+        rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
+    ),
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    signed = True,
+    targets = ["dv"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
 


### PR DESCRIPTION
This reverts commit 2cfed61d65eb9a7e0055af6fcfcff5697d28361c.

The Bazel target was removed because it was assumed to only be there for CW340 use, but it was also used by some DVSIM tests.

Re-adding until we work out how DVSIM can use the `opentitan_test` version.

See https://github.com/lowRISC/opentitan/issues/22733