### PR TITLE
[rom] sigverify ECDSA P256

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -126,6 +126,31 @@ opentitan_test(
 )
 
 cc_library(
+    name = "ecdsa_p256_verify",
+    srcs = ["ecdsa_p256_verify.c"],
+    hdrs = ["ecdsa_p256_verify.h"],
+    deps = [
+        ":ecdsa_p256_key",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:otbn_boot_services",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+    ],
+)
+
+opentitan_test(
+    name = "ecdsa_p256_verify_functest",
+    srcs = ["ecdsa_p256_verify_functest.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+    },
+    deps = [
+        ":ecdsa_p256_verify",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+cc_library(
     name = "rsa_verify",
     srcs = ["rsa_verify.c"],
     hdrs = ["rsa_verify.h"],

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.c
@@ -1,0 +1,148 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h"
+
+#include "sw/device/silicon_creator/lib/attestation.h"
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+
+#include "otp_ctrl_regs.h"
+
+enum {
+  kP256SignatureWords = kP256PublicKeyWords,
+  kP256SignatureCordWords = kP256SignatureWords / 2,
+};
+
+/*
+ * Shares for producing the `kSigverifyEcdsaSuccess` value in
+ * `sigverify_encoded_message_check)`. First 7 shares are generated using the
+ * `sparse-fsm-encode` script while the last share is `kSigverifySpxSuccess ^
+ * kSigverifyFlashExec ^ kShares[0] ^ ... ^ kShares[6]` ==
+ * `kSigverifyEcdsaSuccess`.
+ *
+ * It follows that:
+ *
+ * `kSigverifyFlashExec = kSigverifyEcdsaSuccess ^ kSigverifySpxSuccess`
+ *
+ * Where `kSigverifyFlashExec` is the value to write to the flash_ctrl to enable
+ * code execution.
+ *
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 7 -n 32 \
+ *     -s 3118901143 --language=c
+ *
+ * Minimum Hamming distance: 9
+ * Maximum Hamming distance: 25
+ * Minimum Hamming weight: 14
+ * Maximum Hamming weight: 23
+ */
+static const uint32_t kSigverifyShares[kP256SignatureCordWords] = {
+    0xaf28073b, 0x5eb7dcfb, 0x177240b5, 0xa8469df3,
+    0x2e92e9c0, 0x83ed133b, 0x0c9e99f0, 0xc04cd16d,
+};
+
+/**
+ * Checks the encoded message and produces the value to write to the flash_ctrl.
+ *
+ * @param recovered_r Recovered r parameter, little-endian.
+ * @param signature Provided signature, little-endian.
+ * @param[out] flash_exec Value to write to the flash_ctrl EXEC register.
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+static rom_error_t sigverify_encoded_message_check(
+    sigverify_ecdsa_p256_buffer_t *recovered_r,
+    const sigverify_ecdsa_p256_buffer_t *signature, uint32_t *flash_exec) {
+  // The algorithm below uses shares, i.e. trivial secret sharing, to check an
+  // encoded message and produce two values: `flash_exec` and `result`.
+  // `flash_exec` is the value to write to the flash_ctrl EXEC register to
+  // unlock flash execution and `result` is the return value. We produce
+  // `result` in addition to `flash_exec` to avoid having the unlock value in
+  // registers or memory just for checking the result of signature verification.
+  // The algorithm consists of two steps:
+  //
+  // 1. First, we xor each word of `recovered_r` with the corresponding expected
+  // value and share (`kSigverifyShares[i]`). At the end of this step,
+  // `recovered_r` becomes `kSigverifyShares` if it's correct and garbage
+  // otherwise.
+  //
+  // 2. Next, we produce `flash_exec` and `result`. `flash_exec` is produced by
+  // xor'ing all words of `recovered_r` with each other. If `recovered_r` is
+  // correct, `flash_exec` will be `kSigverifyEcdsaSuccess` due to the way
+  // `kSigverifyShares` is defined. To make sure that we don't produce this
+  // value otherwise, we compare each word of `recovered_r` with the
+  // corresponding expected value and set `flash_exec` to `UINT32_MAX` at each
+  // iteration if there is a mismatch. Finally, we produce the return value
+  // `result` from `flash_exec` by xor'ing parts of it together. Note that the
+  // hardware constant `kSigverifyEcdsaSuccess` is chosen such that this
+  // operation results in `kErrorOk`.
+
+  // Step 1: Process `recovered_r` so that it becomes `kSigverifyShares` if it's
+  // correct, garbage otherwise.
+  uint32_t *recovered_r_ptr = recovered_r->data;
+  size_t i = 0;
+  for (size_t j = 0; launder32(j) < kP256SignatureCordWords; ++j, ++i) {
+    recovered_r_ptr[i] ^= signature->data[j] ^ kSigverifyShares[i];
+  }
+  HARDENED_CHECK_EQ(i, kP256SignatureCordWords);
+
+  // Step 2: Reduce `recovered_r` to produce the value to write to flash_ctrl
+  // EXEC register (`flash_exec`) and the return value (`result`).
+  uint32_t flash_exec_ecdsa = 0;
+  uint32_t diff = 0;
+  for (i = 0; launder32(i) < kP256SignatureCordWords; ++i) {
+    // Following three statements set `diff` to `UINT32_MAX` if `recovered_r[i]`
+    // is incorrect, no change otherwise.
+    diff |= recovered_r_ptr[i] ^ kSigverifyShares[i];
+    diff |= ~diff + 1;          // Set upper bits to 1 if not 0, no change o/w.
+    diff |= ~(diff >> 31) + 1;  // Set to all 1s if MSB is set, no change o/w.
+
+    flash_exec_ecdsa ^= recovered_r_ptr[i];
+    // Set `flash_exec_ecdsa` to `UINT32_MAX` if `recovered_r` is incorrect.
+    flash_exec_ecdsa |= diff;
+  }
+  HARDENED_CHECK_EQ(i, kP256SignatureCordWords);
+
+  // Note: `kSigverifyEcdsaSuccess` is defined such that the following operation
+  // produces `kErrorOk`.
+  rom_error_t result = sigverify_ecdsa_p256_success_to_ok(flash_exec_ecdsa);
+  *flash_exec ^= flash_exec_ecdsa;
+  if (launder32(result) == kErrorOk) {
+    HARDENED_CHECK_EQ(result, kErrorOk);
+    return result;
+  }
+
+  return kErrorSigverifyBadEcdsaSignature;
+}
+
+rom_error_t sigverify_ecdsa_p256_verify(
+    const sigverify_ecdsa_p256_buffer_t *signature,
+    const sigverify_ecdsa_p256_buffer_t *key, const hmac_digest_t *act_digest,
+    uint32_t *flash_exec) {
+  // TODO(#22134): Unify key and signature structures.
+  static_assert(
+      sizeof(sigverify_ecdsa_p256_buffer_t) == sizeof(attestation_public_key_t),
+      "Size of sigverify_ecdsa_p256_buffer_t and attestation_public_key_t must "
+      "match");
+  static_assert(
+      sizeof(sigverify_ecdsa_p256_buffer_t) == sizeof(attestation_signature_t),
+      "Size of sigverify_ecdsa_p256_buffer_t and attestation_signature_t must "
+      "match");
+
+  sigverify_ecdsa_p256_buffer_t recovered_r;
+  rom_error_t error =
+      otbn_boot_sigverify((const attestation_public_key_t *)key,
+                          (const attestation_signature_t *)signature,
+                          act_digest, (uint32_t *)&recovered_r);
+  if (launder32(error) != kErrorOk) {
+    *flash_exec ^= UINT32_MAX;
+    return error;
+  }
+  HARDENED_CHECK_EQ(error, kErrorOk);
+  return sigverify_encoded_message_check(&recovered_r, signature, flash_exec);
+}
+
+// Extern declarations for the inline functions in the header.
+extern uint32_t sigverify_ecdsa_p256_success_to_ok(uint32_t v);

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_ECDSA_P256_VERIFY_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_ECDSA_P256_VERIFY_H_
+
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /**
+   * A non-trivial constant chosen such that `kSigverifySpxSuccess ^
+   * kSigverifyEcdsaSuccess = kSigverifyFlashExec`. The derivation of this value
+   * is documented in ecda_p256_verify.c (see `kSigverifyShares` definition).
+   */
+  kSigverifyEcdsaSuccess = 0x2f06b4e0,
+};
+
+/**
+ * Verifies an ECDSA-P256 signature.
+ *
+ * @param signature The signature to verify, little endian.
+ * @param key The public key to use for verification, little endian.
+ * @param act_digest The actual digest of the signed message.
+ * @param[out] flash_exec The partial value to write to the flash_ctrl EXEC
+ * register.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sigverify_ecdsa_p256_verify(
+    const sigverify_ecdsa_p256_buffer_t *signature,
+    const sigverify_ecdsa_p256_buffer_t *key, const hmac_digest_t *act_digest,
+    uint32_t *flash_exec);
+
+/**
+ * Transforms `kSigverifyEcdsaSuccess` into `kErrorOk`.
+ *
+ * Callers should transform the result to a suitable error value if it is not
+ * `kErrorOk` for ease of debugging.
+ *
+ * @param v A value.
+ * @return `kErrorOk` if `v` is `kSigverifyEcdsaSuccess`.
+ */
+OT_WARN_UNUSED_RESULT
+inline uint32_t sigverify_ecdsa_p256_success_to_ok(uint32_t v) {
+  return (v << 22 ^ v << 19 ^ v << 3) >> 21;
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_ECDSA_P256_VERIFY_H_

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify_functest.c
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Message value for signature generation/verification tests.
+const char kTestMessage[] = "Test message.";
+const size_t kTestMessageLen = sizeof(kTestMessage) - 1;
+
+// Digest of the test message above.
+hmac_digest_t digest;
+
+// Valid ECDSA-P256 public key.
+static const sigverify_ecdsa_p256_buffer_t kEcdsaKey = {
+    .data = {0x1ceb402b, 0x9dc600d1, 0x182ec21b, 0x5ede3640, 0x3566bdac,
+             0x1debf94b, 0x1a286a75, 0x8904d749, 0x63eab6dc, 0x0c53bf99,
+             0x086d3ee7, 0x1076efa6, 0x8dd8ece2, 0xbfececf0, 0x9b94e34d,
+             0x59b12f3c},
+};
+
+// Valid ECDSA-P256 signature for `kTestMessage`.
+static const sigverify_ecdsa_p256_buffer_t kEcdsaSignature = {
+    .data = {0x4811545a, 0x088d927b, 0x5d8624b5, 0x2ef1f329, 0x184ba14a,
+             0xf655eede, 0xaaed0d54, 0xa20e1ac7, 0x729b945d, 0x181dc116,
+             0x1025dba4, 0xb99828a0, 0xe7225df3, 0x0e200e9b, 0x785690b4,
+             0xf47efe98},
+};
+
+static const sigverify_ecdsa_p256_buffer_t kEcdsaSignatureBad = {
+    .data = {0x481154ff, 0x088d92ff, 0x5d8624b5, 0x2ef1f329, 0x184ba14a,
+             0xf655eede, 0xaaed0d54, 0xa20e1ac7, 0x729b945d, 0x181dc116,
+             0x1025dba4, 0xb99828a0, 0xe7225df3, 0x0e200e9b, 0x785690b4,
+             0xf47efe98},
+};
+
+rom_error_t ecdsa_p256_verify_ok_test(void) {
+  uint32_t flash_exec = 0;
+  rom_error_t result = sigverify_ecdsa_p256_verify(&kEcdsaSignature, &kEcdsaKey,
+                                                   &digest, &flash_exec);
+  CHECK(flash_exec == kSigverifyEcdsaSuccess);
+  return result;
+}
+
+rom_error_t ecdsa_p256_verify_negative_test(void) {
+  uint32_t flash_exec = 0;
+  // Signature verification should fail when using the wrong signature.
+  if (sigverify_ecdsa_p256_verify(&kEcdsaSignature, &kEcdsaSignatureBad,
+                                  &digest, &flash_exec) == kErrorOk) {
+    return kErrorUnknown;
+  }
+  CHECK(flash_exec == UINT32_MAX);
+  return kErrorOk;
+}
+
+bool test_main(void) {
+  CHECK(otbn_boot_app_load() == kErrorOk);
+
+  status_t result = OK_STATUS();
+  hmac_sha256(kTestMessage, kTestMessageLen, &digest);
+
+  EXECUTE_TEST(result, ecdsa_p256_verify_ok_test);
+  EXECUTE_TEST(result, ecdsa_p256_verify_negative_test);
+  return status_ok(result);
+}


### PR DESCRIPTION
Introduce `sigverify_p256_verify()` function. The function uses the otbn_boot_services OTBN kernel to provide signature verification of the next code partition. The signature comparison method is adapted from the sigverify RSA implementation.

The magic constant generated by `sigverify_ecdsa_p256_verify()` is the same value generated by `sigverify_rsa_verify()`. This is so that we can migrate from RSA --> ECDSA via incremental changes.

This change is part of [#21204](https://github.com/lowRISC/opentitan/issues/21204).