### PR TITLE
[dv] Add sim_dv_rom_with_fake_keys exec env

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -83,7 +83,7 @@ ifneq (${sw_images},)
 		index=`echo $$sw_image | cut -d: -f 3`; \
 		flags=(`echo $$sw_image | cut -d: -f 4- --output-delimiter " "`); \
 		bazel_label="`echo $$sw_image | cut -d: -f 1-2`"; \
-		if [[ $${index} != 4 && $${index} != 5 ]]; then \
+		if [[ $${index} != 0 && $${index} != 4 && $${index} != 5 ]]; then \
 			bazel_label="$${bazel_label}_$${sw_build_device}"; \
 			bazel_cquery="labels(data, $${bazel_label}) union labels(srcs, $${bazel_label})"; \
 		else \

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -560,3 +560,13 @@ sim_dv(
     exec_env = "sim_dv",
     rom = "//sw/device/lib/testing/test_rom:test_rom",
 )
+
+sim_dv(
+    name = "sim_dv_rom_with_fake_keys",
+    testonly = True,
+    base = ":sim_dv_base",
+    exec_env = "sim_dv",
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
+    rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "test_key_0"},
+)

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -816,9 +816,12 @@
     {
       name: chip_sw_uart_smoketest_signed
       uvm_test_seq: chip_sw_uart_smoke_vseq
-      sw_images: ["//sw/device/tests:uart_smoketest_signed:1:signed:fake_rsa_test_key_0"]
+      sw_images: [
+        "//sw/device/tests:uart_smoketest:1:new_rules",
+        "//hw/ip/otp_ctrl/data:img_rma:4",
+      ]
       en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
+      run_opts: ["+sw_test_timeout_ns=20000000", "+use_otp_image=OtpTypeCustom"]
       run_timeout_mins: 180
     }
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -345,7 +345,8 @@
     }
     {
       name: sw_test_mode_rom_with_fake_keys
-      sw_images: ["//sw/device/silicon_creator/rom:rom_with_fake_keys:0"]
+      sw_build_device: sim_dv_rom_with_fake_keys
+      sw_images: ["//sw/device/silicon_creator/rom:rom_with_fake_keys_sim_dv:0:new_rules"]
       en_run_modes: ["sw_test_mode_common"]
     }
     {
@@ -376,7 +377,7 @@
       en_run_modes: ["sw_test_mode_common"]
       // The tests using this mode only require the ROM init check to succeed.
       // The example_test_from_rom test is sufficient.
-      sw_images: ["//sw/device/tests:example_test_from_rom:0:test_in_rom:new_rules"]
+      sw_images: ["//sw/device/tests:example_test_from_rom_sim_dv:0:test_in_rom:new_rules"]
       run_opts: ["+create_jtag_riscv_map=1"]
       reseed: 5
     }
@@ -439,7 +440,7 @@
     {
       name: chip_sw_example_rom
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests:example_test_from_rom:0:test_in_rom:new_rules"]
+      sw_images: ["//sw/device/tests:example_test_from_rom_sim_dv:0:test_in_rom:new_rules"]
       en_run_modes: ["sw_test_mode_common"]
     }
     {
@@ -774,14 +775,14 @@
     {
       name: chip_sw_flash_init
       uvm_test_seq: chip_sw_flash_init_vseq
-      sw_images: ["//sw/device/tests/sim_dv:flash_init_test:0:test_in_rom:new_rules"]
+      sw_images: ["//sw/device/tests/sim_dv:flash_init_test_sim_dv:0:test_in_rom:new_rules"]
       en_run_modes: ["sw_test_mode_common"]
       run_opts: ["+sw_test_timeout_ns=25_000_000"]
     }
     {
       name: chip_sw_flash_rma_unlocked
       uvm_test_seq: chip_sw_flash_rma_unlocked_vseq
-      sw_images: ["//sw/device/tests/sim_dv:flash_rma_unlocked_test:0:test_in_rom:new_rules"]
+      sw_images: ["//sw/device/tests/sim_dv:flash_rma_unlocked_test_sim_dv:0:test_in_rom:new_rules"]
       en_run_modes: ["sw_test_mode_common"]
       run_opts: ["+flash_program_latency=5", "+sw_test_timeout_ns=150_000_000"]
       run_timeout_mins: 200
@@ -2041,7 +2042,7 @@
     {
       name: chip_sw_flash_init_reduced_freq
       uvm_test_seq: chip_sw_flash_init_vseq
-      sw_images: ["//sw/device/tests/sim_dv:flash_init_test:0:test_in_rom:new_rules"]
+      sw_images: ["//sw/device/tests/sim_dv:flash_init_test_sim_dv:0:test_in_rom:new_rules"]
       en_run_modes: ["sw_test_mode_common"]
       run_opts: ["+sw_test_timeout_ns=25_000_000", "+cal_sys_clk_70mhz=1"]
     }

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -425,6 +425,9 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
           if ("test_in_rom" inside {sw_image_flags[i]} &&
               !("new_rules" inside {sw_image_flags[i]})) begin
             sw_images[i] = $sformatf("%0s_rom_prog_%0s", sw_images[i], sw_build_device);
+          // If Rom type is new_rules, use the target directly.
+          end else if ("new_rules" inside {sw_image_flags[i]}) begin
+            sw_images[i] = $sformatf("%0s", sw_images[i]);
           // If Rom type but not test_in_rom, no need to tweak name further.
           end else begin
             sw_images[i] = $sformatf("%0s_%0s", sw_images[i], sw_build_device);

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3608,6 +3608,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         EARLGREY_CW340_TEST_ENVS,
         {
+            "//hw/top_earlgrey:sim_dv_rom_with_fake_keys": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),


### PR DESCRIPTION
Because execution environments only describe how to sign the last stage and provide direct opentitan_binary() targets with signing and key info embedded for all prior stages, require specifying the target for the ROM directly (and for test_in_rom images).

Add a uart_smoketest target that is signed for DV.

For some reason, the OTP image provided by DV tooling is different from the OTP images associated with the execution environment for the sim_dv_rom_with_fake_keys target, causing
`kErrorSigverifyBadAuthPartition` errors. Provide a "custom" OTP from //hw/ip/otp_ctrl/data:img_rma instead, so the key digests and validity match.

Now we get `kErrorBootPolicyBadIdentifier`, even though the ROM and images in the scratch directory appear to have the expected values. However, when ROM reads the image, it comes back erased (0xffffffff). What now...?