### PR TITLE
[opentitantool] Better way of clearing HyperDebug UART buffers

### DIFF
--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -17,7 +17,7 @@ pub enum TransportError {
     NoMatch,
     #[error("Found no USB device")]
     NoDevice,
-    #[error("Found multiple USB devices, use --serial")]
+    #[error("Found multiple USB devices, use --usb-serial")]
     MultipleDevices,
     #[error("USB error: {0}")]
     UsbGenericError(String),

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -377,6 +377,10 @@ impl<T: Flavor> Hyperdebug<T> {
             // Return cached value.
             return Ok(capabilities);
         }
+        self.inner
+            .usb_device
+            .borrow_mut()
+            .claim_interface(cmsis_interface.interface)?;
         let cmd = [
             Self::CMSIS_DAP_CUSTOM_COMMAND_GOOGLE_INFO,
             Self::GOOGLE_INFO_CAPABILITIES,
@@ -400,6 +404,10 @@ impl<T: Flavor> Hyperdebug<T> {
         );
         let capabilities = u16::from_le_bytes([resp[2], resp[3]]);
         self.cmsis_google_capabilities.set(Some(capabilities));
+        self.inner
+            .usb_device
+            .borrow_mut()
+            .release_interface(cmsis_interface.interface)?;
         Ok(capabilities)
     }
 }

--- a/sw/host/opentitanlib/src/util/usb.rs
+++ b/sw/host/opentitanlib/src/util/usb.rs
@@ -130,6 +130,10 @@ impl UsbBackend {
         self.handle.claim_interface(iface).context("USB error")
     }
 
+    pub fn release_interface(&mut self, iface: u8) -> Result<()> {
+        self.handle.release_interface(iface).context("USB error")
+    }
+
     pub fn kernel_driver_active(&self, iface: u8) -> Result<bool> {
         self.handle.kernel_driver_active(iface).context("USB error")
     }

--- a/sw/host/opentitanlib/src/util/usb.rs
+++ b/sw/host/opentitanlib/src/util/usb.rs
@@ -130,6 +130,18 @@ impl UsbBackend {
         self.handle.claim_interface(iface).context("USB error")
     }
 
+    pub fn kernel_driver_active(&self, iface: u8) -> Result<bool> {
+        self.handle.kernel_driver_active(iface).context("USB error")
+    }
+
+    pub fn detach_kernel_driver(&mut self, iface: u8) -> Result<()> {
+        self.handle.detach_kernel_driver(iface).context("USB error")
+    }
+
+    pub fn attach_kernel_driver(&mut self, iface: u8) -> Result<()> {
+        self.handle.attach_kernel_driver(iface).context("USB error")
+    }
+
     //
     // Enumerating interfaces of the USB device.  The methods below leak rusb data structures,
     // and may have to be refactored, when we convert UsbDevice into a trait, and want to

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240411_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "43fd0425856765bbe11fc344fb797f8c08eb5d733bc244c6385a2cb272f5a5fd",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240501_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "add2552c940603af0f810f94e4d397ec60f8184722a08e386dcbb91b8e01fe37",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
Rather than repeatedly reading until timeout, use a new USB control request to make HyperDebug drop any UART data buffered in its memory.

We still need to repeatedly read, though, since data could also be buffered in the host operating system or libraries.

Also this PR contains a few more cleanups and improvements to the HyperDebug backend driver.

Includes below HyperDebug firmware change and others:
https://chromium-review.googlesource.com/c/chromiumos/platform/ec/+/5468408
