### PR TITLE
[rom] Add ECDSA fake keys to OTP auth partition.

### DIFF
--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/dev_key_0_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/dev_key_0_ecdsa_p256.h
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_DEV_KEY_0_ECDSA_P256_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_DEV_KEY_0_ECDSA_P256_H_
+
+#define DEV_KEY_0_ECDSA_P256                                                \
+  {                                                                         \
+    0xc11c931c, 0x4f7ed1a3, 0x8a01ceb0, 0x8ce15738, 0xa742ec25, 0xb9e7bf8a, \
+        0x65a85787, 0xd0b7ee13, 0x2fbccaaf, 0xba9eb917, 0x40529329,         \
+        0xb1dfa2cc, 0xf7a103fd, 0xc9dbc64b, 0x70df4ad0, 0xce8c4b5b,         \
+  }
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_DEV_KEY_0_ECDSA_P256_H_

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/prod_key_0_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/prod_key_0_ecdsa_p256.h
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_0_ECDSA_P256_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_0_ECDSA_P256_H_
+
+#define PROD_KEY_0_ECDSA_P256                                               \
+  {                                                                         \
+    0x9bf2dafd, 0x38daf96b, 0x0fa3a5a4, 0x28a525c1, 0x0eeeff00, 0x923499d9, \
+        0xe6557b33, 0x8277988c, 0x1ddda9bd, 0x0e3cd209, 0xef6d9014,         \
+        0x611a0325, 0x734ebd05, 0x0a5b3c2e, 0x866f12e0, 0x7e571d04,         \
+  }
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_0_ECDSA_P256_H_

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/prod_key_1_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/prod_key_1_ecdsa_p256.h
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_1_ECDSA_P256_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_1_ECDSA_P256_H_
+
+#define PROD_KEY_1_ECDSA_P256                                               \
+  {                                                                         \
+    0x423e545e, 0xd80fe551, 0xad9f2278, 0x2fccd456, 0x204d2420, 0xec711f34, \
+        0xe2838f6c, 0xfbf0b76a, 0xac4d7547, 0xddd1167a, 0x2e8abaf1,         \
+        0xf120582d, 0xd3ea06e1, 0x87f974e6, 0xb1c79bbb, 0xb70fd07d,         \
+  }
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_PROD_KEY_1_ECDSA_P256_H_

--- a/sw/device/silicon_creator/rom/keys/fake/ecdsa/test_key_0_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/keys/fake/ecdsa/test_key_0_ecdsa_p256.h
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_TEST_KEY_0_ECDSA_P256_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_TEST_KEY_0_ECDSA_P256_H_
+
+#define TEST_KEY_0_ECDSA_P256                                               \
+  {                                                                         \
+    0xee07109a, 0x0bba6de3, 0x7bfccca8, 0xe9e0f480, 0x845024cf, 0x5bcb453d, \
+        0x6937e237, 0x2e66e6cb, 0xd8e17e50, 0x444da9de, 0x3c413ac2,         \
+        0x012abb22, 0xf773fc51, 0xa5d7eb1d, 0xbb56aeb4, 0xdeb1e092,         \
+  }
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_KEYS_FAKE_ECDSA_TEST_KEY_0_ECDSA_P256_H_

--- a/sw/device/silicon_creator/rom/keys/fake/otp/BUILD
+++ b/sw/device/silicon_creator/rom/keys/fake/otp/BUILD
@@ -18,6 +18,22 @@ otp_json_rot_keys(
         otp_partition(
             name = "ROT_CREATOR_AUTH_CODESIGN",
             items = {
+                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256
+                "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE0": otp_hex(CONST.SIGVERIFY.KEY_TYPE.TEST),
+                "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY0": "0xdeb1e092bb56aeb4a5d7eb1df773fc51012abb223c413ac2444da9ded8e17e502e66e6cb6937e2375bcb453d845024cfe9e0f4807bfccca80bba6de3ee07109a",
+
+                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:dev_key_0_ecdsa_p256
+                "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE1": otp_hex(CONST.SIGVERIFY.KEY_TYPE.DEV),
+                "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY1": "0xce8c4b5b70df4ad0c9dbc64bf7a103fdb1dfa2cc40529329ba9eb9172fbccaafd0b7ee1365a85787b9e7bf8aa742ec258ce157388a01ceb04f7ed1a3c11c931c",
+
+                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256
+                "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE2": otp_hex(CONST.SIGVERIFY.KEY_TYPE.PROD),
+                "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY2": "0x7e571d04866f12e00a5b3c2e734ebd05611a0325ef6d90140e3cd2091ddda9bd8277988ce6557b33923499d90eeeff0028a525c10fa3a5a438daf96b9bf2dafd",
+
+                # //sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_1_ecdsa_p256
+                "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE3": otp_hex(CONST.SIGVERIFY.KEY_TYPE.PROD),
+                "ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY3": "0xb70fd07db1c79bbb87f974e6d3ea06e1f120582d2e8abaf1ddd1167aac4d7547fbf0b76ae2838f6cec711f34204d24202fccd456ad9f2278d80fe551423e545e",
+
                 # //sw/device/silicon_creator/rom/keys/fake/spx:test_key_0_spx
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY_TYPE0": otp_hex(CONST.SIGVERIFY.KEY_TYPE.TEST),
                 "ROT_CREATOR_AUTH_CODESIGN_SPX_KEY0": "0x2a4994a9b25e107c5f1df0065a37ff358d45a8a94b4938e4f48a5bbe8dbf6ee6",
@@ -42,10 +58,10 @@ otp_json_rot_keys(
         otp_partition(
             name = "ROT_CREATOR_AUTH_STATE",
             items = {
-                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY0": otp_hex(CONST.SIGVERIFY.KEY_STATE.BLANK),
-                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY1": otp_hex(CONST.SIGVERIFY.KEY_STATE.BLANK),
-                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY2": otp_hex(CONST.SIGVERIFY.KEY_STATE.BLANK),
-                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY3": otp_hex(CONST.SIGVERIFY.KEY_STATE.BLANK),
+                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY0": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
+                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY1": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
+                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY2": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
+                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY3": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
                 "ROT_CREATOR_AUTH_STATE_SPX_KEY0": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
                 "ROT_CREATOR_AUTH_STATE_SPX_KEY1": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
                 "ROT_CREATOR_AUTH_STATE_SPX_KEY2": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),


### PR DESCRIPTION
Adds ECDSA keys to fake auth partition. Also adds header version of the public keys to simplify auditing of key values.

This change is part of https://github.com/lowRISC/opentitan/issues/21204.