### PR TITLE
[bazel] Fix ECDSA signing issues.

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -195,8 +195,8 @@ def _build_binary(ctx, exec_env, name, deps, kind):
     rsa_key = get_fallback(ctx, "attr.rsa_key", exec_env)
     spx_key = get_fallback(ctx, "attr.spx_key", exec_env)
     if (manifest or rsa_key) and kind != "ram":
-        if not (manifest and rsa_key):
-            fail("Signing requires a manifest and an rsa_key, and optionally an spx_key")
+        if not (manifest and (rsa_key or ecdsa_key)):
+            fail("Signing requires a manifest and an rsa_key or ecdsa_key, and optionally an spx_key")
         signed = sign_binary(
             ctx,
             opentitantool = exec_env._opentitantool,

--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -627,9 +627,12 @@ def sign_binary(ctx, opentitantool, **kwargs):
     if rsa_attr and key_attr:
         fail("Only one of ECDSA or RSA key should be provided")
 
-    key_attr = rsa_attr
-    rsa_key = key_from_dict(rsa_attr, "rsa_key")
+    if rsa_attr:
+        # Select RSA as the key attribute since at this point we have already
+        # determined that only one of ECDSA or RSA key should be provided.
+        key_attr = rsa_attr
 
+    rsa_key = key_from_dict(rsa_attr, "rsa_key")
     spx_key = key_from_dict(get_override(ctx, "attr.spx_key", kwargs), "spx_key")
 
     artifacts = _presigning_artifacts(


### PR DESCRIPTION
1. The `sign_binary` function was overriding the selected ecdsa key with an empty rsa object. This was due to a missing rsa attribute empty check.
2. The `_build_binary` function in cc.bzl had an unconditional rsa key check which would fail when an ecdsa was selected.

This change is part of https://github.com/lowRISC/opentitan/issues/21204.
