### PR TITLE
[rom] Add sigverify_keys_ecdsa_p256 module

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -94,6 +94,7 @@ enum module_ {
   X(kErrorSigverifyLargeRsaSignature, ERROR_(6, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadEcdsaSignature, ERROR_(7, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadAuthPartition,  ERROR_(8, kModuleSigverify, kInvalidArgument)), \
+  X(kErrorSigverifyBadEcdsaKey,       ERROR_(9, kModuleSigverify, kInvalidArgument)), \
   \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
   \

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.c
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.c
@@ -4,5 +4,5 @@
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 
 // `extern` declarations for `inline` functions in the header.
-extern uint32_t sigverify_ecdsa_key_id_get(
+extern uint32_t sigverify_ecdsa_p256_key_id_get(
     const sigverify_ecdsa_p256_buffer_t *pub_key);

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h
@@ -37,7 +37,7 @@ typedef struct sigverify_ecdsa_p256_buffer {
  * @return ID of the key.
  */
 OT_WARN_UNUSED_RESULT
-inline uint32_t sigverify_ecdsa_key_id_get(
+inline uint32_t sigverify_ecdsa_p256_key_id_get(
     const sigverify_ecdsa_p256_buffer_t *pub_key) {
   return pub_key->data[0];
 }

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -393,6 +393,25 @@ cc_library(
 )
 
 cc_library(
+    name = "sigverify_keys_ecdsa_p256",
+    srcs = [
+        "sigverify_keys_ecdsa_p256.c",
+    ],
+    hdrs = [
+        "sigverify_keys_ecdsa_p256.h",
+    ],
+    deps = [
+        ":sigverify_key_types",
+        ":sigverify_otp_keys",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/sigverify",
+        "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
+    ],
+)
+
+cc_library(
     name = "sigverify_keys_rsa",
     srcs = [
         "sigverify_keys_rsa.c",

--- a/sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.c
+++ b/sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.c
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.h"
+
+#include "sw/device/silicon_creator/rom/sigverify_otp_keys.h"
+
+#include "otp_ctrl_regs.h"
+
+rom_error_t sigverify_ecdsa_p256_key_get(
+    const sigverify_otp_key_ctx_t *sigverify_ctx, uint32_t key_id,
+    lifecycle_state_t lc_state, const sigverify_ecdsa_p256_buffer_t **key) {
+  *key = NULL;
+  rom_error_t error = kErrorSigverifyBadEcdsaKey;
+
+  const sigverify_rom_key_header_t *rom_key = NULL;
+  error = sigverify_otp_keys_get(
+      (sigverify_otp_keys_get_params_t){
+          .key_id = key_id,
+          .lc_state = lc_state,
+          .key_array =
+              (const sigverify_rom_key_header_t *)(sigverify_ctx->keys.ecdsa),
+          .key_cnt = kSigVerifyOtpKeysEcdsaCount,
+          .key_size = sizeof(sigverify_rom_ecdsa_p256_key_t),
+          .key_states = (uint32_t *)&sigverify_ctx->states.ecdsa[0],
+      },
+      &rom_key);
+  if (error == kErrorOk) {
+    *key = &((const sigverify_rom_ecdsa_p256_key_t *)rom_key)->entry.key;
+  }
+
+  if (error != kErrorOk) {
+    return kErrorSigverifyBadEcdsaKey;
+  }
+  return error;
+}

--- a/sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.h
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SIGVERIFY_KEYS_ECDSA_P256_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SIGVERIFY_KEYS_ECDSA_P256_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+#include "sw/device/silicon_creator/rom/sigverify_key_types.h"
+#include "sw/device/silicon_creator/rom/sigverify_otp_keys.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Returns the key with the given ID.
+ *
+ * This function returns the key only if it can be used in the given life cycle
+ * state and is valid in OTP. OTP check is performed only if the device is in a
+ * non-test operational state (PROD, PROD_END, DEV, RMA).
+ *
+ * @param key_id A key ID.
+ * @param lc_state Life cycle state of the device.
+ * @param key Key with the given ID, valid only if it exists.
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sigverify_ecdsa_p256_key_get(
+    const sigverify_otp_key_ctx_t *sigverify_ctx, uint32_t key_id,
+    lifecycle_state_t lc_state, const sigverify_ecdsa_p256_buffer_t **key);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_SIGVERIFY_KEYS_ECDSA_P256_H_


### PR DESCRIPTION
This module is used to lookup keys in the ROT AUTH partition.
    
This change also updates the function name of `sigverify_ecdsa_key_id_get()` to `sigverify_ecdsa_p256_key_id_get()` to make it consistent with the module name.

This change is part of https://github.com/lowRISC/opentitan/issues/21204.

