### PR TITLE
[usbdev,dv] usbdev disable endp seq

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -13,4 +13,13 @@ class usb20_agent_cfg extends dv_base_agent_cfg;
 
   `uvm_object_new
 
+  // If this is set then the driver will generate a bit stuffing error.
+  bit usb_bitstuff_error = 1'b0;
+  // This flag serves to evaluate the device's functionality,
+  // particularly regarding the recognition of a single SE0 bit as an end-of-packet,
+  // which necessitates two successive bits otherwise. Once set, it is accompanied by
+  // its respective test sequence, followed by the transmission of a single-bit SE0 as EOP.
+  bit single_bit_SE0 = 1'b0;
+  // used as a time_out signal when device timeouts.
+  bit time_out = 1'b0;
 endclass

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -75,7 +75,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     `uvm_info(`gfn, $sformatf("Complete Token_Packet = %p", comp_token_pkt), UVM_DEBUG)
     drive_pkt(comp_token_pkt);
     if (req_item.m_pid_type == PidTypeInToken) begin
-      get_dut_response(rsp_item);
+      device_response(rsp_item);
       seq_item_port.item_done(rsp_item);
       `uvm_info (`gfn, $sformatf("In drive afer In packet : \n %0s", rsp_item.sprint()), UVM_DEBUG)
     end else begin
@@ -107,13 +107,10 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     end
     `uvm_info(`gfn, $sformatf("Complete Data_Packet = %p", comp_data_pkt), UVM_DEBUG)
     drive_pkt(comp_data_pkt);
-    `uvm_info(`gfn, $sformatf("\n\nTransfer Type = %s", req_item.m_usb_transfer), UVM_HIGH)
     if (req_item.m_usb_transfer == IsoTrans) begin
       seq_item_port.item_done();
-      `uvm_info(`gfn, $sformatf("\n\nTransfer Type = %s", req_item.m_usb_transfer), UVM_HIGH)
     end else begin
-      `uvm_info(`gfn, $sformatf("\n\nTransfer Type = %s", req_item.m_usb_transfer), UVM_HIGH)
-      get_dut_response(rsp_item);
+      device_response(rsp_item);
       seq_item_port.item_done(rsp_item);
     end
   endtask
@@ -195,8 +192,12 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
   // EOP Task
   // -------------------------------
   task end_of_packet();
-    for (int j = 0; j < 2; j++) begin
-      drive_bit_interval(EOP[j], EOP[j]);
+    if (~cfg.single_bit_SE0) begin
+      for (int j = 0; j < 2; j++) begin
+        drive_bit_interval(EOP[j], EOP[j]);
+      end
+    end else begin
+       drive_bit_interval(EOP[0], EOP[0]);
     end
     `uvm_info(`gfn, "\n After EOP Idle state", UVM_DEBUG)
     drive_bit_interval(1'b1, 1'b0);
@@ -207,17 +208,20 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
   task bit_stuffing(input bit packet[], output bit bit_stuff_out[]);
     int consecutive_ones_count = 0;
     bit stuffed[$];
-    for (int i = 0; i < packet.size(); i++) begin
-      stuffed.push_back(packet[i]);
-      if (packet[i] == 1'b1) begin
-        consecutive_ones_count = consecutive_ones_count + 1;
-        if (consecutive_ones_count >= 6) begin
-          consecutive_ones_count = 0;
-          stuffed.push_back(1'b0);
-        end
-      end else consecutive_ones_count = 0;
+   if (~cfg.usb_bitstuff_error) begin
+     for (int i = 0; i < packet.size(); i++) begin
+       stuffed.push_back(packet[i]);
+       if (packet[i] == 1'b1) begin
+         consecutive_ones_count = consecutive_ones_count + 1;
+         if (consecutive_ones_count >= 6) begin
+           consecutive_ones_count = 0;
+           stuffed.push_back(1'b0);
+         end
+       end else consecutive_ones_count = 0;
     end
     bit_stuff_out = stuffed;
+   end else
+     bit_stuff_out = packet;
   endtask
 
   // Returns 1 in the event of detecting a bit stuffing error, output is
@@ -317,7 +321,37 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
 
   // Get_DUT_Response
   // -------------------------------
-  task get_dut_response(ref usb20_item rsp_item);
+  // This task verifies the device status following the transmission of an OUT packet or IN token.
+  // Upon receiving the IN token/OUT packet, the device is expected to initiate a response.
+  // This task monitors whether the device initiates the response in the form of a
+  // handshake or data packet within the specified timeout period.
+  // If no response is detected within timeout frame that is 18 bit times(from section 7.1.19.1),
+  // it send timeout response to sequence.
+  task device_response(ref usb20_item rsp_item);
+    bit timed_out = 1'b0;
+    `uvm_info(`gfn, "After drive Packet in wait to check usb_dp_en_o signal", UVM_LOW)
+    fork begin : isolation_fork
+      fork
+        begin
+          repeat (18) begin
+            repeat (4) @(posedge cfg.bif.clk_i);
+            if (cfg.bif.usb_dp_en_o) break;
+          end
+          if (!cfg.bif.usb_dp_en_o) begin
+            timed_out = 1'b1;
+            disable get_device_response;
+          end
+        end
+        get_device_response(rsp_item);
+      join
+      if (timed_out) begin
+        // this bit will indicate that device didn't repond within timeout period.
+        cfg.time_out = 1'b1;
+      end
+    end join
+  endtask
+
+  task get_device_response(ref usb20_item rsp_item);
     bit received_pkt[];
     bit nrzi_out_pkt[];
     bit decoded_received_pkt[];

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -619,7 +619,7 @@
               particular endpoint will be ignored.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_disable_endpoint"]
     }
     {
       name: out_trans_nak

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_disable_endpoint_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_disable_endpoint_vseq.sv
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_disable_endpoint_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_disable_endpoint_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Configure OUT transaction
+    configure_out_trans();
+
+    // disable EP
+    csr_wr(.ptr(ral.ep_out_enable[0].enable[endp]), .value(1'b0));
+    csr_wr(.ptr(ral.ep_in_enable[0].enable[endp]), .value(1'b0));
+
+    // Out token packet followed by a data packet
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+
+    // Get response from DUT
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+
+    // Haven't not got any response (as endpoint is disable) from DUT so it should timeout.
+    `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.time_out, 1)
+
+    // Check the pkt reception status
+    check_out_trans();
+
+    // Configure in transaction
+    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
+
+    // Token pkt followed by handshake pkt
+    call_token_seq(PidTypeInToken);
+    inter_packet_delay();
+    // Send ACK just to ensure complete IN transaction.
+    // After complete IN transaction it should be ignored (as endpoint is disable).
+    call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+
+    // Adding a delay to ensures that the status are updated following the transaction.
+    cfg.clk_rst_vif.wait_clks(4);
+
+    // Check the pkt sent status
+    check_in_trans();
+  endtask
+
+  task check_out_trans();
+    bit pkt_received;
+    // Get pkt_received interrupt status
+    csr_rd(.ptr(ral.intr_state.pkt_received), .value(pkt_received));
+    // DV_CHECK on pkt_received interrupt
+    `DV_CHECK_EQ(pkt_received, 0);
+  endtask
+
+  task check_in_trans();
+    bit pkt_sent;
+    // Get pkt_sent interrupt status
+    csr_rd(.ptr(ral.intr_state.pkt_sent), .value(pkt_sent));
+    // DV_CHECK on pkt_received interrupt
+    `DV_CHECK_EQ(pkt_sent, 0);
+  endtask
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -10,6 +10,7 @@
 `include "usbdev_av_buffer_vseq.sv"
 `include "usbdev_csr_test_vseq.sv"
 `include "usbdev_dpi_config_host_vseq.sv"
+`include "usbdev_disable_endpoint_vseq.sv"
 `include "usbdev_enable_vseq.sv"
 `include "usbdev_fifo_rst_vseq.sv"
 `include "usbdev_in_rand_trans_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -28,6 +28,7 @@ filesets:
       - seq_lib/usbdev_base_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_common_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_dpi_config_host_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_disable_endpoint_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_csr_test_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_pkt_received_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -61,6 +61,10 @@
       reseed: 1
     }
     {
+      name: usbdev_disable_endpoint
+      uvm_test_seq: usbdev_disable_endpoint_vseq
+    }
+    {
       name: usbdev_enable
       uvm_test_seq: usbdev_enable_vseq
     }


### PR DESCRIPTION
This PR includes usbdev_disable_endpoint_vseq, in which we send OUT/IN transactions when endpoints are disabled. Also, check the status of the transaction after sending it.