### PR TITLE
[edn/dv] Correct prediction of sw_cmd_reg_rdy for auto mode Instantiate

### DIFF
--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -664,7 +664,8 @@ class edn_scoreboard extends cip_base_scoreboard #(
 
       // Each time a handshake happens in SW mode, the cmd_reg_rdy signal goes high.
       // In auto mode the signal also goes high but only for the initial instantiate command.
-      if ((!auto_mode || (!instantiated && clen_cntr)) && !boot_mode && predict_sts) begin
+      if ((!auto_mode || (!instantiated && clen_cntr) || (instantiated && inst_ack_outstanding))
+          && !boot_mode && predict_sts) begin
         sw_cmd_sts[sw_cmd_reg_rdy] = 1'b1;
       end
     end


### PR DESCRIPTION
The sw_cmd_reg_rdy also goes high after the last additional data word and low again after receiving the ACK from CSRNG. Previously, the scoreboard expected this bit not to go high again after the last additional data word causing around 20 - 40% of edn_disable_auto_req_mode tests to fail.