### PR TITLE
[Sival, i2c] Fix i2c tests

### DIFF
--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -148,7 +148,6 @@ fn test_write_repeated_start(
 
     log::info!("Emulating start with bit-banging");
     let gpio_bitbanging = transport.gpio_bitbanging()?;
-    let gpio_pins = transport.gpio_pins(&["IOA7", "IOA8"].map(|s| s.to_string()))?;
     let i2c_bitbang = test_utils::bitbanging::i2c::encoder::Encoder::<0, 1> {};
 
     const REFERENCE_DATA: &[u8] = b"Hello World!";


### PR DESCRIPTION
This PR fix the i2c_override test and improve the i2c_repreated_start test by changing how the hyperdebug pins are configured.