### PR TITLE
[rom_ext] Relax ePMP settings.

### DIFF
--- a/sw/device/silicon_creator/lib/epmp_state.h
+++ b/sw/device/silicon_creator/lib/epmp_state.h
@@ -70,8 +70,14 @@ typedef enum epmp_perm {
   /** M mode: read/write/execute. U mode: read only. */
   kEpmpPermReadOnly = EPMP_CFG_R,
 
+  /** M mode: read/write/execute. U mode: read/write. */
+  kEpmpPermReadWrite = EPMP_CFG_R | EPMP_CFG_W,
+
   /** M mode: read/write/execute. U mode: read/execute. */
   kEpmpPermReadExecute = EPMP_CFG_R | EPMP_CFG_X,
+
+  /** M mode: read/write/execute. U mode: read/write/execute. */
+  kEpmpPermReadWriteExecute = EPMP_CFG_R | EPMP_CFG_W | EPMP_CFG_X,
 } epmp_perm_t;
 
 /**

--- a/sw/device/silicon_creator/rom_ext/doc/si_val.md
+++ b/sw/device/silicon_creator/rom_ext/doc/si_val.md
@@ -29,10 +29,10 @@ An example of how the SiVal `ROM_EXT` will configure the ePMP:
  9: 00000000 ----- ---- sz=00000000
 10: 20000400 ----- ---- sz=00000000     ; ROM_EXT code start.
 11: 20005bc8   TOR -X-R sz=000057c8     ; ROM_EXT code end.
-12: 20000000 NAPOT L--R sz=00100000     ; FLASH data (1 MB).
-13: 00010000 NAPOT LXWR sz=00001000     ; RvDM region (not PROD, RMA/DEV only).
-14: 40000000 NAPOT L-WR sz=10000000     ; MMIO region.
-15: 10000000 NAPOT L-WR sz=00020000     ; RAM region.
+12: 20000000 NAPOT ---R sz=00100000     ; FLASH data (1 MB).
+13: 00010000 NAPOT -XWR sz=00001000     ; RvDM region (not PROD, RMA/DEV only).
+14: 40000000 NAPOT --WR sz=10000000     ; MMIO region.
+15: 10000000 NAPOT --WR sz=00020000     ; RAM region.
 mseccfg = 00000002                      ; RLB=0, MMWP=1, MML=0.
 ```
 


### PR DESCRIPTION
Per discussion in the tape-out sync meeting on 2024-04-22, relax the ePMP settings:

Unlock the configuration of ePMP entries 12, 14 and 15, allowing the owner to reconfigure as needed.

As detailed in the [ePMP Proposal](file:///home/cfrantz/Downloads/Smepmp.pdf) (see section 2.2), this change will allow for CPU execution over the entire flash region, the MMIO region and main RAM because we're currently operating with MMWP=1 and MML=0.  We prevent RAM execution at the SRAM controller.
