### PR TITLE
[rom] Always set ret sram version on boot

### DIFF
--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -181,9 +181,13 @@ static rom_error_t rom_init(void) {
       otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_RET_RAM_RESET_MASK_OFFSET);
   if ((reset_reasons & reset_mask) != 0) {
     retention_sram_init();
-    retention_sram_get()->version = kRetentionSramVersion3;
     retention_sram_get()->creator.last_shutdown_reason = kErrorOk;
   }
+
+  // Always store the retention RAM version so the ROM_EXT can depend on its
+  // accuracy even after scrambling.
+  retention_sram_get()->version = kRetentionSramVersion3;
+
   // Store the reset reason in retention RAM and clear the register.
   retention_sram_get()->creator.reset_reasons = reset_reasons;
   rstmgr_reason_clear(reset_reasons);

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3541,20 +3541,15 @@ opentitan_test(
 opentitan_test(
     name = "sram_ctrl_sleep_sram_ret_contents_scramble_test",
     srcs = ["sram_ctrl_sleep_sram_ret_contents_scramble_test.c"],
-    broken = cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
+            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
+            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
         },
-    ),
-    silicon_owner = silicon_params(
-        tags = ["broken"],
     ),
     verilator = verilator_params(
         timeout = "long",


### PR DESCRIPTION
This PR changes the ROM to write the retention SRAM version on every boot, not just after initialization. The version is expected by the ROM_EXT to boot, but is cleared by scrambling.

An alternative would be for the `ROM_EXT` to assume that unknown version indicate scrambling and re-populate the retention sram.

This change fixes the `sram_ctrl_sleep_sram_ret_contents_scramble_test` which ensures we can wake up from deep sleep after scrambling.

---

The previous version of this PR disabled this part of the test:

> Deep sleep requires a reset to wake up again. Resetting runs through the ROM_EXT. The ROM_EXT will not boot if the retention SRAM is scrambled.

> We therefore cannot test this part under those conditions, so I have disabled it.