### PR TITLE
doc/theory_of_operation.md: "under" should be "over"

### DIFF
--- a/hw/ip/uart/doc/theory_of_operation.md
+++ b/hw/ip/uart/doc/theory_of_operation.md
@@ -154,10 +154,10 @@ $$ {{baud} < {{40 * f\_{pclk}} \over {2^{$bits(NCO)+4}}}} \qquad OR \qquad
 {{f\_{pclk}} > {{{2^{$bits(NCO)+4}} * {baud}} \over {40}}} $$
 
 Using rounded frequencies and common baud rates, this implies that
-care is needed for 9600 baud and below if the system clock is under
-250MHz, with 4800 baud and below if the system clock is under 125MHz,
-2400 baud and below if the system clock us under 63MHz, and 1200 baud
-and below if the system clock is under 32MHz.
+care is needed for 9600 baud and below if the system clock is over
+250MHz, with 4800 baud and below if the system clock is over 125MHz,
+2400 baud and below if the system clock is over 62MHz, and 1200 baud
+and below if the system clock is over 31MHz.
 
 
 ### Interrupts


### PR DESCRIPTION
"If the baud rate is (too low), care should be taken when the system clock frequency is (too high)." - It currently says "when the clock frequency is **under** X MHz"; should say "over".

I also changed the rounding of frequency values in that paragraph (after doing the math to make sure it's right) so that they're rounded down instead of up, which makes more sense after this change (otherwise, it would imply that 31.7 MHz is safe for 1200 baud since it's <32, but it's not - max safe frequency is 31.45).