### PR TITLE
[bazel] update lowRISC misc-linters

### DIFF
--- a/third_party/lint/repos.bzl
+++ b/third_party/lint/repos.bzl
@@ -29,7 +29,7 @@ def lint_repos(lowrisc_lint = None):
     http_archive_or_local(
         name = "lowrisc_lint",
         local = lowrisc_lint,
-        sha256 = "0d07c45abdec72b464cda9626ec14955a073f5a2754fd0356de8e7cd4eee856d",
-        strip_prefix = "misc-linters-20240319_01",
-        url = "https://github.com/lowRISC/misc-linters/archive/refs/tags/20240319_01.tar.gz",
+        sha256 = "ff4e14b2a8ace83a7f6a1536c7489c29f8c2b97d345ae9bb8b2d0f68059ec265",
+        strip_prefix = "misc-linters-20240423_01",
+        url = "https://github.com/lowRISC/misc-linters/archive/refs/tags/20240423_01.tar.gz",
     )


### PR DESCRIPTION
This updates the lowRISC misc-linters dependency that was causing a CI breakage.