### PR TITLE
[bazel] Add support for ecdsa keys to opentitan_test.

### DIFF
--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -37,6 +37,7 @@ load(
 )
 load(
     "@lowrisc_opentitan//rules/opentitan:keyutils.bzl",
+    _ecdsa_key_for_lc_state = "ecdsa_key_for_lc_state",
     _rsa_key_by_name = "rsa_key_by_name",
     _rsa_key_for_lc_state = "rsa_key_for_lc_state",
     _spx_key_by_name = "spx_key_by_name",
@@ -65,6 +66,8 @@ verilator_params = _verilator_params
 
 sim_dv = _sim_dv
 dv_params = _dv_params
+
+ecdsa_key_for_lc_state = _ecdsa_key_for_lc_state
 
 rsa_key_for_lc_state = _rsa_key_for_lc_state
 rsa_key_by_name = _rsa_key_by_name
@@ -155,6 +158,7 @@ def opentitan_test(
         includes = [],
         linkopts = [],
         linker_script = None,
+        ecdsa_key = None,
         rsa_key = None,
         spx_key = None,
         manifest = None,
@@ -178,6 +182,7 @@ def opentitan_test(
       local_defines: Compiler defines for this test.
       includes: Additional compiler include dirs for this test.
       linker_script: Linker script for this test.
+      ecdsa_key: ECDSA key to sign the binary for this test.
       rsa_key: RSA key to sign the binary for this test.
       spx_key: SPX key to sign the binary for this test.
       manifest: manifest used during signing for this test.
@@ -241,6 +246,7 @@ def opentitan_test(
             test_cmd = tparam.test_cmd,
             param = tparam.param,
             data = tparam.data,
+            ecdsa_key = ecdsa_key,
             rsa_key = rsa_key,
             spx_key = spx_key,
             manifest = manifest,

--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -82,6 +82,17 @@ key_ecdsa = rule(
     },
 )
 
+def ecdsa_key_for_lc_state(key_structs, hw_lc_state):
+    """Return a dictionary containing a single key that can be used in the given
+    LC state. The format of the dictionary is compatible with opentitan_test.
+    """
+    keys = [k for k in key_structs if (k.ecdsa != None and key_allowed_in_lc_state(k.ecdsa, hw_lc_state))]
+    if len(keys) == 0:
+        fail("There are no ECDSA keys compatible with HW LC state {} in key structs".format(hw_lc_state))
+    return {
+        keys[0].ecdsa.label: keys[0].ecdsa.name,
+    }
+
 def rsa_key_for_lc_state(key_structs, hw_lc_state):
     """Return a dictionary containing a single key that can be used in the given
     LC state. The format of the dictionary is compatible with opentitan_test.


### PR DESCRIPTION
1. Update opentitan_test macro to support ecdsa_keys.
2. Add `ecdsa_key_for_lc_state()` to keyutils.bzl. This is helpful in providing a mechanism to generate a key set dependency for opentitan_test and opentitan_binary targets.
