### PR TITLE
ot_certs: add an app for signing TBS blobs

### DIFF
--- a/sw/host/ot_certs/BUILD
+++ b/sw/host/ot_certs/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_test", "rust_test_suite")
+load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library", "rust_binary", "rust_test", "rust_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -62,6 +62,23 @@ rust_library(
         # is merged.
         "@crate_index//:openssl-sys",
         "@crate_index//:foreign-types",
+    ],
+)
+
+rust_binary(
+    name = "tbs_sign",
+    testonly = True,
+    srcs = ["src/tbs_sign.rs"],
+    deps = [
+        "//sw/host/provisioning/ft_lib:ft_lib",
+        "//sw/host/opentitanlib",
+        "//sw/host/ot_certs",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:elliptic-curve",
+        "@crate_index//:num-bigint-dig",
+        "@crate_index//:p256",
+        "@crate_index//:sha2",
     ],
 )
 

--- a/sw/host/ot_certs/src/tbs_sign.rs
+++ b/sw/host/ot_certs/src/tbs_sign.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use clap::Parser;
+use elliptic_curve::pkcs8::DecodePrivateKey;
+use elliptic_curve::SecretKey;
+use num_bigint_dig::BigUint;
+use p256::ecdsa::SigningKey;
+use p256::NistP256;
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use ot_certs::template::{EcdsaSignature, Signature, Value};
+use ot_certs::x509::generate_certificate_from_tbs;
+
+/// TBS signing command-line parameters.
+#[derive(Debug, Parser)]
+struct TbsSignInputs {
+    /// Certificate endorsement ECC (P256) private key DER file.
+    #[arg(long)]
+    signing_key: PathBuf,
+
+    /// Plain binary file containing the certificate TBS section.
+    #[arg(long)]
+    tbs: PathBuf,
+
+    /// Output file to store the signed certificate.
+    #[arg(long)]
+    signed_cert: PathBuf,
+}
+
+fn run_ft_tbs_signer(host_ecc_sk: &PathBuf, tbs: &PathBuf) -> Result<Vec<u8>> {
+    let mut file = File::open(tbs)?;
+
+    // Read the file contents into a byte vector
+    let mut tbs_bytes = Vec::new();
+    file.read_to_end(&mut tbs_bytes)?;
+
+    // Hash the TBS and convert the hash into big endian.
+    let mut hasher = Sha256::new();
+    hasher.update(&tbs_bytes);
+    let tbs_digest = hasher.finalize();
+
+    // Read the signing key data and create the proper structure.
+    let host_sk = SecretKey::<NistP256>::read_pkcs8_der_file(host_ecc_sk)?;
+    let signing_key = SigningKey::from(host_sk);
+
+    let (tbs_signature, _) = signing_key.sign_prehash_recoverable(&tbs_digest)?;
+    let (r, s) = tbs_signature.split_bytes();
+
+    // Reformat the signature.
+    let signature = Signature::EcdsaWithSha256 {
+        value: Some(EcdsaSignature {
+            r: Value::Literal(BigUint::from_bytes_be(&r)),
+            s: Value::Literal(BigUint::from_bytes_be(&s)),
+        }),
+    };
+
+    // Generate the endorsed certificate.
+    generate_certificate_from_tbs(tbs_bytes, &signature)
+}
+
+fn main() -> Result<()> {
+    let opts = TbsSignInputs::parse();
+
+    let cert = run_ft_tbs_signer(&opts.signing_key, &opts.tbs)?;
+
+    // Open or create the output file.
+    let mut file = File::create(opts.signed_cert)?;
+
+    // Write the byte vector to the file
+    file.write_all(cert.as_slice())?;
+
+    Ok(())
+}


### PR DESCRIPTION
The app accepts three command line parameters

 - file names of the signing key, a private P256 key in DER form
 - file name of the TBS blob of the certificate
 - file name to save the properly endorse certificate

This was tested in the end to end test where the TBS blobs were created by the generated code, signed with
sw/device/silicon_creator/manuf/keys/fake/cert_endorsement_key.sk.der and then the certificate chain was validated using sw/device/silicon_creator/manuf/keys/fake/fake_ca.pem as the CA.