### PR TITLE
fix rust format violations.

### DIFF
--- a/sw/device/silicon_owner/tock/kernel/src/main.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/main.rs
@@ -65,7 +65,9 @@ static mut PLATFORM: Option<&'static EarlGrey> = None;
 #[cfg(test)]
 static mut MAIN_CAP: Option<&dyn kernel::capabilities::MainLoopCapability> = None;
 // Test access to alarm
-static mut ALARM: Option<&'static MuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>> = None;
+static mut ALARM: Option<
+    &'static MuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
+> = None;
 // Test access to TicKV
 static mut TICKV: Option<
     &capsules_extra::tickv::TicKVSystem<
@@ -94,7 +96,9 @@ static mut RSA_HARDWARE: Option<&lowrisc::rsa::OtbnRsa<'static>> = None;
 #[cfg(test)]
 static mut SHA256SOFT: Option<&capsules_extra::sha256::Sha256Software<'static>> = None;
 
-static mut CHIP: Option<&'static earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig>> = None;
+static mut CHIP: Option<
+    &'static earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig>,
+> = None;
 static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
 
 // How should the kernel respond when a process faults.
@@ -174,8 +178,9 @@ struct EarlGrey {
     >,
     syscall_filter: &'static TbfHeaderFilterDefaultAllow,
     scheduler: &'static PrioritySched,
-    scheduler_timer:
-        &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>>,
+    scheduler_timer: &'static VirtualSchedulerTimer<
+        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
+    >,
     watchdog: &'static lowrisc::aon_timer::AonTimer,
 }
 
@@ -202,16 +207,23 @@ impl SyscallDriverLookup for EarlGrey {
     }
 }
 
-impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripherals<'static, ChipConfig>, ChipConfig>>
-    for EarlGrey
+impl
+    KernelResources<
+        earlgrey::chip::EarlGrey<
+            'static,
+            EarlGreyDefaultPeripherals<'static, ChipConfig>,
+            ChipConfig,
+        >,
+    > for EarlGrey
 {
     type SyscallDriverLookup = Self;
     type SyscallFilter = TbfHeaderFilterDefaultAllow;
     type ProcessFault = ();
     type CredentialsCheckingPolicy = ();
     type Scheduler = PrioritySched;
-    type SchedulerTimer =
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>>;
+    type SchedulerTimer = VirtualSchedulerTimer<
+        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
+    >;
     type WatchDog = lowrisc::aon_timer::AonTimer;
     type ContextSwitchCallback = ();
 
@@ -244,7 +256,11 @@ impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripheral
 unsafe fn setup() -> (
     &'static kernel::Kernel,
     &'static EarlGrey,
-    &'static earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripherals<'static, ChipConfig>, ChipConfig>,
+    &'static earlgrey::chip::EarlGrey<
+        'static,
+        EarlGreyDefaultPeripherals<'static, ChipConfig>,
+        ChipConfig,
+    >,
     &'static EarlGreyDefaultPeripherals<'static, ChipConfig>,
 ) {
     // Ibex-specific handler
@@ -270,11 +286,9 @@ unsafe fn setup() -> (
     );
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(
-        &peripherals.uart0,
-        ChipConfig::UART_BAUDRATE,
-    )
-    .finalize(components::uart_mux_component_static!());
+    let uart_mux =
+        components::console::UartMuxComponent::new(&peripherals.uart0, ChipConfig::UART_BAUDRATE)
+            .finalize(components::uart_mux_component_static!());
 
     // LEDs
     // Start with half on and half off
@@ -307,7 +321,10 @@ unsafe fn setup() -> (
     )
     .finalize(components::gpio_component_static!(earlgrey::gpio::GpioPin));
 
-    let hardware_alarm = static_init!(earlgrey::timer::RvTimer<ChipConfig>, earlgrey::timer::RvTimer::new());
+    let hardware_alarm = static_init!(
+        earlgrey::timer::RvTimer<ChipConfig>,
+        earlgrey::timer::RvTimer::new()
+    );
     hardware_alarm.setup();
 
     // Create a shared virtualization mux layer on top of a single hardware
@@ -346,14 +363,14 @@ unsafe fn setup() -> (
     hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
 
     let scheduler_timer = static_init!(
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>>,
+        VirtualSchedulerTimer<
+            VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static, ChipConfig>>,
+        >,
         VirtualSchedulerTimer::new(scheduler_timer_virtual_alarm)
     );
 
     let chip = static_init!(
-        earlgrey::chip::EarlGrey<
-            EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig
-        >,
+        earlgrey::chip::EarlGrey<EarlGreyDefaultPeripherals<ChipConfig>, ChipConfig>,
         earlgrey::chip::EarlGrey::new(peripherals, hardware_alarm)
     );
     CHIP = Some(chip);

--- a/sw/host/tests/chip/i2c_target/src/smbus_arp.rs
+++ b/sw/host/tests/chip/i2c_target/src/smbus_arp.rs
@@ -183,7 +183,9 @@ fn test_smbus_arp_sequence(
     if write_scratch(&i2c, 0x57u8, !MESSAGE_REG, &msg_to_dut).is_err() {
         log::info!("Got an expected error");
     } else {
-        return Err(I2cError::Generic("Expected NACK, but transaction accepted".to_string()).into());
+        return Err(
+            I2cError::Generic("Expected NACK, but transaction accepted".to_string()).into(),
+        );
     }
     log::info!("Write scratch");
     if let Err(x) = write_scratch(&i2c, 0x57u8, MESSAGE_REG, &msg_to_dut) {

--- a/sw/host/tests/chip/rv_dm/src/control_status.rs
+++ b/sw/host/tests/chip/rv_dm/src/control_status.rs
@@ -49,7 +49,10 @@ fn test_control_status(opts: &Opts, transport: &TransportWrapper) -> Result<()> 
     dmi.dmi_write(consts::DMCONTROL, dmcontrol)?;
     // Since this target only supports 1 hart, the WARL behavior of this register is such that no
     // bits should be set at this point, except for dmactive.
-    assert_eq!(dmi.dmi_read(consts::DMCONTROL)?, consts::DMCONTROL_DMACTIVE_MASK);
+    assert_eq!(
+        dmi.dmi_read(consts::DMCONTROL)?,
+        consts::DMCONTROL_DMACTIVE_MASK
+    );
 
     let mut hart = dmi.select_hart(0)?;
     assert!(hart.state()?.running);

--- a/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ec_rst_l.rs
+++ b/sw/host/tests/chip/sysrst_ctrl/sysrst_ctrl_ec_rst_l.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, Context, ensure, Result};
+use anyhow::{bail, ensure, Context, Result};
 use clap::Parser;
 use once_cell::sync::Lazy;
 use std::time::Duration;
@@ -105,9 +105,16 @@ fn chip_sw_sysrst_ctrl_input(params: &Params) -> Result<()> {
     // the entire time.
     let events = gpio_mon.read(false)?;
     let mut events_iter = events.iter();
-    let first_event = events_iter.next().context("Expected at least one GPIO event during reset")?;
-    let second_event = events_iter.next().context("Expected at least two GPIO events during reset")?;
-    ensure!(events_iter.next().is_none(), "Unexpected third GPIO event during reset");
+    let first_event = events_iter
+        .next()
+        .context("Expected at least one GPIO event during reset")?;
+    let second_event = events_iter
+        .next()
+        .context("Expected at least two GPIO events during reset")?;
+    ensure!(
+        events_iter.next().is_none(),
+        "Unexpected third GPIO event during reset"
+    );
     match (first_event, second_event) {
         (
             &MonitoringEvent {
@@ -167,9 +174,16 @@ fn chip_sw_sysrst_ctrl_input(params: &Params) -> Result<()> {
     let events = gpio_mon.read(false)?;
     // We expect to see EC_RST go low and then high.
     let mut events_iter = events.iter();
-    let first_event = events_iter.next().context("Expected at least one GPIO event during reset")?;
-    let second_event = events_iter.next().context("Expected at least two GPIO events during reset")?;
-    ensure!(events_iter.next().is_none(), "Unexpected third GPIO event during reset");
+    let first_event = events_iter
+        .next()
+        .context("Expected at least one GPIO event during reset")?;
+    let second_event = events_iter
+        .next()
+        .context("Expected at least two GPIO events during reset")?;
+    ensure!(
+        events_iter.next().is_none(),
+        "Unexpected third GPIO event during reset"
+    );
     match (first_event, second_event) {
         (
             &MonitoringEvent {


### PR DESCRIPTION
This patch is a result of running

$ touch sw/device/silicon_owner/tock/kernel/src/tests.rs $ basel run //quality:rustfmt_fix
$ rm sw/device/silicon_owner/tock/kernel/src/tests.rs

The first line is necessary to address the issue where rustfmt fails to process sw/device/silicon_owner/tock/kernel/src/main.rs due to the missing test module.