### PR TITLE
[kmac] Abort when sideload key is invalid during operation

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -976,8 +976,10 @@
       fields: [
         { bits: "31:0",
           name: "err_code",
-          desc: '''If error interrupt occurs, this register has information of error cause.
-                Please take a look at `hw/ip/kmac/rtl/kmac_pkg.sv:err_code_e enum type.
+          desc: '''
+                If the `kmac_err` interrupt occurs, this register has information on the error cause.
+                Bits 31:24 contain the error code (please refer to `err_code_e` in `hw/ip/kmac/rtl/kmac_pkg.sv`) for the encoding, and bits 23:0 contain additional debug information.
+                This register does *not* get cleared when the `kmac_err` interrupt state gets cleared.
                 '''
           tags: [// Randomly write mem will cause this reg updated by design
                  "excl:CsrNonInitTests:CsrExclWriteCheck"]

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -557,14 +557,6 @@
                  "excl:CsrAllTests:CsrExclWrite",
                  "shadowed_reg_path:u_cfg_reg_shadowed.u_cfg_reg_shadowed_entropy_ready"]
         } // f: entropy_ready
-        { bits: "25"
-          name: err_processed
-          desc: '''When error occurs and one of the state machine stays at
-                 Error handling state, SW may process the error based on
-                 ERR_CODE, then let FSM back to the reset state
-                '''
-          tags: ["shadowed_reg_path:u_cfg_reg_shadowed.u_cfg_reg_shadowed_err_processed"]
-        } // f: err_processed
         { bits: "26"
           name: en_unsupported_modestrength
           desc: '''Enable Unsupported Mode and Strength configs.
@@ -655,6 +647,13 @@
           name: "hash_cnt_clr"
           desc: "If writes 1, it clears the hash (KMAC) counter in the entropy module"
         }
+        { bits: "10"
+          name: err_processed
+          desc: '''When error occurs and one of the state machine stays at
+                 Error handling state, SW may process the error based on
+                 ERR_CODE, then let FSM back to the reset state
+                '''
+        } // f: err_processed
       ]
     } // R: CMD
     { name: "STATUS"

--- a/hw/ip/kmac/doc/programmers_guide.md
+++ b/hw/ip/kmac/doc/programmers_guide.md
@@ -62,6 +62,18 @@ The `encode_string("KMAC")` represents `0x01 0x20 0x4b 0x4d 0x41 0x43` in byte o
 The software writes `0x4d4b2001` into [`PREFIX0`](registers.md#prefix) and `0x????4341` into [`PREFIX1`](registers.md#prefix) .
 Upper 2 bytes can vary depending on the customization input string `S`.
 
+
+## Error Handling
+
+When the KMAC HW IP encounters an error, it raises the `kmac_err` IRQ.
+SW can then read the `ERR_CODE` CSR to obtain more information about the error.
+Having handled that IRQ, SW is expected to clear the `kmac_err` bit in the `INTR_STATE` CSR before exiting the ISR.
+When SW has handled the error condition, it is expected to set the `err_processed` bit in the `CMD` CSR.
+The internal SHA3 engine then flushes its FIFOs and state, which may take a few cycles.
+The KMAC HW IP is ready for operation again as soon as the `sha3_idle` bit in the `STATUS` CSR is set; SW must not change the configuration of or send commands to the KMAC HW IP before that.
+If the error occurred while the KMAC HW IP was being used from SW (i.e., not via an HW application interface), the `kmac_done` IRQ is raised when the KMAC HW IP is ready again.
+
+
 ## KMAC/SHA3 context switching
 
 This version of KMAC/SHA3 HWIP _does not_ support the software context switching.

--- a/hw/ip/kmac/doc/registers.md
+++ b/hw/ip/kmac/doc/registers.md
@@ -183,20 +183,20 @@ If the software updates the register while the engine computes, the
 updated value will be discarded.
 - Offset: `0x14`
 - Reset default: `0x0`
-- Reset mask: `0x71b133f`
+- Reset mask: `0x51b133f`
 - Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "kmac_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "kstrength", "bits": 3, "attr": ["rw"], "rotate": -90}, {"name": "mode", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 2}, {"name": "msg_endianness", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "state_endianness", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 2}, {"name": "sideload", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 3}, {"name": "entropy_mode", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 1}, {"name": "entropy_fast_process", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "msg_mask", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 3}, {"name": "entropy_ready", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "err_processed", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "en_unsupported_modestrength", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 5}], "config": {"lanes": 1, "fontsize": 10, "vspace": 290}}
+{"reg": [{"name": "kmac_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "kstrength", "bits": 3, "attr": ["rw"], "rotate": -90}, {"name": "mode", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 2}, {"name": "msg_endianness", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "state_endianness", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 2}, {"name": "sideload", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 3}, {"name": "entropy_mode", "bits": 2, "attr": ["rw"], "rotate": -90}, {"bits": 1}, {"name": "entropy_fast_process", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "msg_mask", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 3}, {"name": "entropy_ready", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 1}, {"name": "en_unsupported_modestrength", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 5}], "config": {"lanes": 1, "fontsize": 10, "vspace": 290}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                                                      |
 |:------:|:------:|:-------:|:--------------------------------------------------------------------------|
 | 31:27  |        |         | Reserved                                                                  |
 |   26   |   rw   |   0x0   | [en_unsupported_modestrength](#cfg_shadowed--en_unsupported_modestrength) |
-|   25   |   rw   |   0x0   | [err_processed](#cfg_shadowed--err_processed)                             |
+|   25   |        |         | Reserved                                                                  |
 |   24   |   rw   |   0x0   | [entropy_ready](#cfg_shadowed--entropy_ready)                             |
 | 23:21  |        |         | Reserved                                                                  |
 |   20   |   rw   |   0x0   | [msg_mask](#cfg_shadowed--msg_mask)                                       |
@@ -221,11 +221,6 @@ Keccak Mode and Strength configurations, such as cSHAKE512.
 
 If not set, KMAC won't propagate the SW command (CmdStart) to the
 rest of the blocks (AppIntf, KMAC Core, SHA3).
-
-### CFG_SHADOWED . err_processed
-When error occurs and one of the state machine stays at
- Error handling state, SW may process the error based on
- ERR_CODE, then let FSM back to the reset state
 
 ### CFG_SHADOWED . entropy_ready
 Entropy Ready status.
@@ -345,21 +340,27 @@ control logic. It follows the sequence of
 `start` --> `process` --> {`run` if needed --> } `done`
 - Offset: `0x18`
 - Reset default: `0x0`
-- Reset mask: `0x33f`
+- Reset mask: `0x73f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "cmd", "bits": 6, "attr": ["r0w1c"], "rotate": 0}, {"bits": 2}, {"name": "entropy_req", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"name": "hash_cnt_clr", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"bits": 22}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
+{"reg": [{"name": "cmd", "bits": 6, "attr": ["r0w1c"], "rotate": 0}, {"bits": 2}, {"name": "entropy_req", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"name": "hash_cnt_clr", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"name": "err_processed", "bits": 1, "attr": ["r0w1c"], "rotate": -90}, {"bits": 21}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                               |
-|:------:|:------:|:-------:|:-----------------------------------|
-| 31:10  |        |         | Reserved                           |
-|   9    | r0w1c  |    x    | [hash_cnt_clr](#cmd--hash_cnt_clr) |
-|   8    | r0w1c  |    x    | [entropy_req](#cmd--entropy_req)   |
-|  7:6   |        |         | Reserved                           |
-|  5:0   | r0w1c  |    x    | [cmd](#cmd--cmd)                   |
+|  Bits  |  Type  |  Reset  | Name                                 |
+|:------:|:------:|:-------:|:-------------------------------------|
+| 31:11  |        |         | Reserved                             |
+|   10   | r0w1c  |    x    | [err_processed](#cmd--err_processed) |
+|   9    | r0w1c  |    x    | [hash_cnt_clr](#cmd--hash_cnt_clr)   |
+|   8    | r0w1c  |    x    | [entropy_req](#cmd--entropy_req)     |
+|  7:6   |        |         | Reserved                             |
+|  5:0   | r0w1c  |    x    | [cmd](#cmd--cmd)                     |
+
+### CMD . err_processed
+When error occurs and one of the state machine stays at
+ Error handling state, SW may process the error based on
+ ERR_CODE, then let FSM back to the reset state
 
 ### CMD . hash_cnt_clr
 If writes 1, it clears the hash (KMAC) counter in the entropy module

--- a/hw/ip/kmac/doc/registers.md
+++ b/hw/ip/kmac/doc/registers.md
@@ -763,9 +763,14 @@ KMAC/SHA3 Error Code
 {"reg": [{"name": "err_code", "bits": 32, "attr": ["ro"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name     | Description                                                                                                                                      |
-|:------:|:------:|:-------:|:---------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:0  |   ro   |   0x0   | err_code | If error interrupt occurs, this register has information of error cause. Please take a look at `hw/ip/kmac/rtl/kmac_pkg.sv:err_code_e enum type. |
+|  Bits  |  Type  |  Reset  | Name                            |
+|:------:|:------:|:-------:|:--------------------------------|
+|  31:0  |   ro   |   0x0   | [err_code](#err_code--err_code) |
+
+### ERR_CODE . err_code
+If the `kmac_err` interrupt occurs, this register has information on the error cause.
+Bits 31:24 contain the error code (please refer to `err_code_e` in `hw/ip/kmac/rtl/kmac_pkg.sv`) for the encoding, and bits 23:0 contain additional debug information.
+This register does *not* get cleared when the `kmac_err` interrupt state gets cleared.
 
 ## STATE
 Keccak State (1600 bit) memory.

--- a/hw/ip/kmac/doc/theory_of_operation.md
+++ b/hw/ip/kmac/doc/theory_of_operation.md
@@ -359,14 +359,14 @@ It asserts the entropy valid signal to complete the current hashing operation.
 If the module does not complete, or flush the pending operation, it creates the back pressure to the message FIFO.
 Then, the SW may not be able to access the KMAC IP at all, as the crossbar is stuck.
 
-The SW may move the state machine to the reset state by issuing [`CFG_SHADOWED.err_processed`](registers.md#cfg_shadowed).
+The SW may move the state machine to the reset state by issuing [`CMD.err_processed`](registers.md#cmd).
 
 #### IncorrectEntropyMode (0x05)
 
 If SW misconfigures the entropy mode and let the entropy module prepare the random data, the module reports `IncorrectEntropyMode` error.
 The state machine moves to Wait state after reporting the error.
 
-The SW may move the state machine to the reset state by issuing [`CFG_SHADOWED.err_processed`](registers.md#cfg_shadowed).
+The SW may move the state machine to the reset state by issuing [`CMD.err_processed`](registers.md#cmd).
 
 #### UnexpectedModeStrength (0x06)
 

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -438,7 +438,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
               end
               StError: begin
 
-                if (`gmv(ral.cfg_shadowed.err_processed)) begin
+                if (`gmv(ral.cmd.err_processed)) begin
                   app_st = StIdle;
                 end else begin
                   app_st = StError;

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -334,7 +334,6 @@ class kmac_base_vseq extends cip_base_vseq #(
     ral.cfg_shadowed.entropy_fast_process.set(entropy_fast_process);
     ral.cfg_shadowed.entropy_ready.set(entropy_ready);
     ral.cfg_shadowed.msg_mask.set(msg_mask);
-    ral.cfg_shadowed.err_processed.set(1'b0);
     ral.cfg_shadowed.en_unsupported_modestrength.set(en_unsupported_modestrength);
     ral.cfg_shadowed.sideload.set(reg_en_sideload);
 
@@ -396,9 +395,9 @@ class kmac_base_vseq extends cip_base_vseq #(
       cfg.clk_rst_vif.wait_clks($urandom_range(10, 50));
       // After entropy related errors, cannot set `err_processed` and `entropy_ready` together.
       // Otherwise design will ignore the `entropy_ready` field.
-      csr_wr(.ptr(ral.cfg_shadowed.err_processed), .value(1));
+      csr_wr(.ptr(ral.cmd.err_processed), .value(1));
     end else if (kmac_err_type == kmac_pkg::ErrKeyNotValid) begin
-      csr_wr(.ptr(ral.cfg_shadowed.err_processed), .value(1));
+      csr_wr(.ptr(ral.cmd.err_processed), .value(1));
     end
     `uvm_info(`gfn, "Finished checking error", UVM_HIGH)
   endtask

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_key_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_key_error_vseq.sv
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Trigger KeyNotValid error by not providing valid keymgr key during kmac transaction.
-// ICEBOX(#10704): current RTL only supports this error in app mode.
 class kmac_key_error_vseq extends kmac_app_vseq;
 
   `uvm_object_utils(kmac_key_error_vseq)

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -99,6 +99,7 @@
     {
       name: "{name}_sideload"
       uvm_test_seq: kmac_sideload_vseq
+      run_opts: ["+test_timeout_ns=1_000_000_000"]
     }
     {
       name: "{name}_burst_write"

--- a/hw/ip/kmac/lint/kmac.waiver
+++ b/hw/ip/kmac/lint/kmac.waiver
@@ -26,3 +26,6 @@ waive -rules {TAG_OVERLAP} -location {kmac_app.sv} \
 waive -rules {INTEGER} -location {kmac_entropy.sv} \
     -regexp {'i' of type int used as a non-constant value} \
     -comment "int i is compared with the storage_idx"
+
+waive -rules {CASE_SEL_EXPR} -location {kmac_app.sv} \
+    -comment "not a problem, just a suggested alternate implementation"

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -674,7 +674,6 @@ module kmac
   );
 
   // Error
-  // As of now, only SHA3 error exists. More error codes will be added.
 
   logic event_error;
   assign event_error = sha3_err.valid    | app_err.valid

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -263,6 +263,7 @@ module kmac
   logic [MaxKeyLen-1:0] sw_key_data [Share];
   key_len_e             sw_key_len;
   logic [MaxKeyLen-1:0] key_data [Share];
+  logic                 key_valid;
   key_len_e             key_len;
 
   // SHA3 Mode, Strength, KMAC enable for app interface
@@ -879,8 +880,9 @@ module kmac
     .strength_i (app_keccak_strength),
 
     // Secret key interface
-    .key_data_i (key_data),
-    .key_len_i  (key_len ),
+    .key_data_i  (key_data),
+    .key_len_i   (key_len),
+    .key_valid_i (key_valid),
 
     // Controls
     .start_i   (sha3_start          ),
@@ -1065,8 +1067,9 @@ module kmac
     .app_o,
 
     // Secret Key output to KMAC Core
-    .key_data_o (key_data),
-    .key_len_o  (key_len),
+    .key_data_o  (key_data),
+    .key_len_o   (key_len),
+    .key_valid_o (key_valid),
 
     // to MSG_FIFO
     .kmac_valid_o (mux2fifo_valid),

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -326,6 +326,8 @@ module kmac
 
   logic err_processed;
 
+  prim_mubi_pkg::mubi4_t clear_after_error;
+
   logic alert_fatal, alert_recov_operation;
   logic alert_intg_err;
 
@@ -1099,6 +1101,8 @@ module kmac
     .error_i         (sha3_err.valid),
     .err_processed_i (err_processed),
 
+    .clear_after_error_o (clear_after_error),
+
     // Command interface
     .sw_cmd_i (checked_sw_cmd),
     .cmd_o    (kmac_cmd),
@@ -1202,6 +1206,7 @@ module kmac
     .lc_escalate_en_i (lc_escalate_en[4]),
 
     .err_processed_i (err_processed),
+    .clear_after_error_i (clear_after_error),
 
     .error_o            (errchecker_err),
     .sparse_fsm_error_o (kmac_errchk_state_error)

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -565,8 +565,7 @@ module kmac
   end
 
   // Clear the error processed
-  assign err_processed = reg2hw.cfg_shadowed.err_processed.q
-                       & reg2hw.cfg_shadowed.err_processed.qe;
+  assign err_processed = reg2hw.cmd.err_processed.q & reg2hw.cmd.err_processed.qe;
 
   // Make sure the field has latch in reg_top
   `ASSERT(ErrProcessedLatched_A, $rose(err_processed) |=> !err_processed)

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -84,6 +84,8 @@ module kmac_errchk
   // Error processed indicator
   input err_processed_i,
 
+  input prim_mubi_pkg::mubi4_t clear_after_error_i,
+
   output err_t error_o,
   output logic sparse_fsm_error_o
 );
@@ -450,6 +452,11 @@ module kmac_errchk
     // if the life cycle controller triggers an escalation.
     if (lc_ctrl_pkg::lc_tx_test_true_loose(lc_escalate_en_i)) begin
       st_d = StTerminalError;
+    end
+
+    if (st_d != StTerminalError &&
+        prim_mubi_pkg::mubi4_test_true_strict(clear_after_error_i)) begin
+      st_d = StIdle;
     end
   end : next_state
   `ASSERT_KNOWN(StKnown_A, st)

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -80,10 +80,6 @@ package kmac_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
-    } err_processed;
-    struct packed {
-      logic        q;
-      logic        qe;
     } entropy_ready;
     struct packed {
       logic        q;
@@ -124,6 +120,10 @@ package kmac_reg_pkg;
   } kmac_reg2hw_cfg_shadowed_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        q;
+      logic        qe;
+    } err_processed;
     struct packed {
       logic        q;
       logic        qe;
@@ -236,8 +236,8 @@ package kmac_reg_pkg;
     kmac_reg2hw_intr_enable_reg_t intr_enable; // [1531:1529]
     kmac_reg2hw_intr_test_reg_t intr_test; // [1528:1523]
     kmac_reg2hw_alert_test_reg_t alert_test; // [1522:1519]
-    kmac_reg2hw_cfg_shadowed_reg_t cfg_shadowed; // [1518:1491]
-    kmac_reg2hw_cmd_reg_t cmd; // [1490:1480]
+    kmac_reg2hw_cfg_shadowed_reg_t cfg_shadowed; // [1518:1493]
+    kmac_reg2hw_cmd_reg_t cmd; // [1492:1480]
     kmac_reg2hw_entropy_period_reg_t entropy_period; // [1479:1454]
     kmac_reg2hw_entropy_refresh_threshold_shadowed_reg_t
         entropy_refresh_threshold_shadowed; // [1453:1444]
@@ -326,7 +326,7 @@ package kmac_reg_pkg;
   parameter logic [0:0] KMAC_ALERT_TEST_FATAL_FAULT_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] KMAC_CFG_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] KMAC_CFG_REGWEN_EN_RESVAL = 1'h 1;
-  parameter logic [9:0] KMAC_CMD_RESVAL = 10'h 0;
+  parameter logic [10:0] KMAC_CMD_RESVAL = 11'h 0;
   parameter logic [17:0] KMAC_STATUS_RESVAL = 18'h 4001;
   parameter logic [0:0] KMAC_STATUS_SHA3_IDLE_RESVAL = 1'h 1;
   parameter logic [0:0] KMAC_STATUS_FIFO_EMPTY_RESVAL = 1'h 1;

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -315,9 +315,6 @@ status_t kmac_hwip_default_configure(void) {
   // Mark entropy source as ready
   cfg_reg =
       bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_ENTROPY_READY_BIT, 1);
-  // Err not processed
-  cfg_reg =
-      bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_ERR_PROCESSED_BIT, 0);
   // Unsupported modes: disabled
   cfg_reg = bitfield_bit32_write(
       cfg_reg, KMAC_CFG_SHADOWED_EN_UNSUPPORTED_MODESTRENGTH_BIT, 0);

--- a/sw/device/lib/crypto/drivers/kmac.h
+++ b/sw/device/lib/crypto/drivers/kmac.h
@@ -83,7 +83,7 @@ status_t kmac_key_length_check(size_t key_len);
  * It touches the following fields of CSRs:
  *   CFG register:
  *     endianness, entropy_mode, fast_process, msg_mask, ent_ready,
- * err_processed, en_unsup_mode EDN refresh settings: hash threshold refresh
+ * en_unsup_mode EDN refresh settings: hash threshold refresh
  * counter entropy seed -> ignore? INTR_ENABLE: all disabled
  *
  * @return Error code.

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -144,6 +144,16 @@ dif_result_t dif_kmac_has_error_occurred(const dif_kmac_t *kmac, bool *error) {
   return kDifOk;
 }
 
+dif_result_t dif_kmac_clear_err_irq(const dif_kmac_t *kmac) {
+  if (kmac == NULL) {
+    return kDifBadArg;
+  }
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(reg, KMAC_INTR_STATE_KMAC_ERR_BIT, true);
+  mmio_region_write32(kmac->base_addr, KMAC_INTR_STATE_REG_OFFSET, reg);
+  return kDifOk;
+}
+
 dif_result_t dif_kmac_poll_status(const dif_kmac_t *kmac, uint32_t flag) {
   while (true) {
     uint32_t reg = mmio_region_read32(kmac->base_addr, KMAC_STATUS_REG_OFFSET);

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -868,11 +868,9 @@ dif_result_t dif_kmac_reset(const dif_kmac_t *kmac,
   operation_state->r = 0;
   operation_state->offset = 0;
   operation_state->squeezing = false;
-  uint32_t reg =
-      mmio_region_read32(kmac->base_addr, KMAC_CFG_SHADOWED_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, KMAC_CFG_SHADOWED_ERR_PROCESSED_BIT, 1);
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(reg, KMAC_CMD_ERR_PROCESSED_BIT, 1);
 
-  mmio_region_write32_shadowed(kmac->base_addr, KMAC_CFG_SHADOWED_REG_OFFSET,
-                               reg);
+  mmio_region_write32(kmac->base_addr, KMAC_CMD_REG_OFFSET, reg);
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -870,9 +870,16 @@ dif_result_t dif_kmac_reset(const dif_kmac_t *kmac,
   operation_state->r = 0;
   operation_state->offset = 0;
   operation_state->squeezing = false;
+  DIF_RETURN_IF_ERROR(dif_kmac_err_processed(kmac));
+  return kDifOk;
+}
+
+dif_result_t dif_kmac_err_processed(const dif_kmac_t *kmac) {
+  if (kmac == NULL) {
+    return kDifBadArg;
+  }
   uint32_t reg = 0;
   reg = bitfield_bit32_write(reg, KMAC_CMD_ERR_PROCESSED_BIT, 1);
-
   mmio_region_write32(kmac->base_addr, KMAC_CMD_REG_OFFSET, reg);
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -849,13 +849,15 @@ dif_result_t dif_kmac_get_hash_counter(const dif_kmac_t *kmac,
   return kDifOk;
 }
 
-dif_result_t dif_kmac_get_error(const dif_kmac_t *kmac,
-                                dif_kmac_error_t *error) {
-  if (kmac == NULL || error == NULL) {
+dif_result_t dif_kmac_get_error(const dif_kmac_t *kmac, dif_kmac_error_t *error,
+                                uint32_t *info) {
+  if (kmac == NULL || error == NULL || info == NULL) {
     return kDifBadArg;
   }
 
-  *error = mmio_region_read32(kmac->base_addr, KMAC_ERR_CODE_REG_OFFSET);
+  uint32_t reg = mmio_region_read32(kmac->base_addr, KMAC_ERR_CODE_REG_OFFSET);
+  *info = reg & 0xFFFFFF;
+  *error = (reg >> 24) & 0xFF;
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -736,6 +736,16 @@ dif_result_t dif_kmac_err_processed(const dif_kmac_t *kmac);
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_kmac_has_error_occurred(const dif_kmac_t *kmac, bool *error);
+
+/**
+ * Clear the `kmac_err` IRQ.
+ *
+ * @param kmac A KMAC handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_clear_err_irq(const dif_kmac_t *kmac);
+
 /**
  * Fetch the current status of the message FIFO used to buffer absorbed data.
  *

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -719,6 +719,15 @@ dif_result_t dif_kmac_reset(const dif_kmac_t *kmac,
                             dif_kmac_operation_state_t *operation_state);
 
 /**
+ * Let the KMAC HW know that SW has processed the errors the HW has flagged.
+ *
+ * @param kmac A KMAC handle
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_err_processed(const dif_kmac_t *kmac);
+
+/**
  * Fetch the current status of the message FIFO used to buffer absorbed data.
  *
  * @param kmac A KMAC handle.

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -362,39 +362,49 @@ typedef enum dif_kmac_error {
   /**
    * No error has occured.
    */
-  kDifErrorNone,
+  kDifErrorNone = 0,
 
   /**
    * The Key Manager has raised an error because the secret key is not valid.
    */
-  kDifErrorKeyNotValid,
+  kDifErrorKeyNotValid = 1,
 
   /**
    * An attempt was made to write data into the message FIFO but the KMAC unit
    * was not in the correct state to receive the data.
    */
-  kDifErrorSoftwarePushedMessageFifo,
+  kDifErrorSoftwarePushedMessageFifo = 2,
 
   /**
-   * An invalid state transition was attempted (e.g. idle -> run without
-   * intermediate process state).
+   * SW issued a command while a HW application interface was using KMAC.
    */
-  kDifErrorSoftwarePushedWrongCommand,
+  kDifErrorSoftwareIssuedCommandWhileAppInterfaceActive = 3,
 
   /**
    * The entropy wait timer has expired.
    */
-  kDifErrorEntropyWaitTimerExpired = 0x04000000,
+  kDifErrorEntropyWaitTimerExpired = 4,
 
   /**
    * Incorrect entropy mode when entropy is ready.
    */
-  kDifErrorEntropyModeIncorrect,
+  kDifErrorEntropyModeIncorrect = 5,
 
-  /**
-   * An error was encountered but the cause is unknown.
-   */
-  kDifErrorUnknownError,
+  kDifErrorUnexpectedModeStrength = 6,
+
+  kDifErrorIncorrectFunctionName = 7,
+
+  kDifErrorSoftwareCommandSequence = 8,
+
+  kDifErrorSoftwareHashingWithoutEntropyReady = 9,
+
+  kDifErrorShadowRegisterUpdate = 0xC0,
+
+  kDifErrorFatalError = 0xC1,
+
+  kDifErrorPackerIntegrity = 0xC2,
+
+  kDifErrorMsgFifoIntegrity = 0xC3,
 } dif_kmac_error_t;
 
 /**
@@ -686,11 +696,12 @@ dif_result_t dif_kmac_end(const dif_kmac_t *kmac,
  *
  * @param kmac A KMAC handle.
  * @param[out] error The current error code.
+ * @param[out] info Optional additional error information.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_kmac_get_error(const dif_kmac_t *kmac,
-                                dif_kmac_error_t *error);
+dif_result_t dif_kmac_get_error(const dif_kmac_t *kmac, dif_kmac_error_t *error,
+                                uint32_t *info);
 
 /**
  * Clear the current error code and reset the state machine to the idle state

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -728,6 +728,15 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_kmac_err_processed(const dif_kmac_t *kmac);
 
 /**
+ * Report whether the hardware currently indicates an error.
+ *
+ * @param kmac A KMAC handle.
+ * @param[out] error Whether hardware currently indicates an error.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_has_error_occurred(const dif_kmac_t *kmac, bool *error);
+/**
  * Fetch the current status of the message FIFO used to buffer absorbed data.
  *
  * @param kmac A KMAC handle.

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -143,7 +143,6 @@ class KmacTest : public testing::Test, public mock_mmio::MmioTest {
     bool entropy_fast_process = false;
     bool msg_mask = false;
     bool entropy_ready = false;
-    bool err_processed = false;
     bool enable_unsupported_mode_strength = false;
     uint16_t entropy_hash_threshold = 0;
     uint16_t entropy_wait_timer = 0;
@@ -212,7 +211,6 @@ class KmacTest : public testing::Test, public mock_mmio::MmioTest {
           config_reg_.entropy_fast_process},
          {KMAC_CFG_SHADOWED_MSG_MASK_BIT, config_reg_.msg_mask},
          {KMAC_CFG_SHADOWED_ENTROPY_READY_BIT, config_reg_.entropy_ready},
-         {KMAC_CFG_SHADOWED_ERR_PROCESSED_BIT, config_reg_.err_processed},
          {KMAC_CFG_SHADOWED_EN_UNSUPPORTED_MODESTRENGTH_BIT,
           config_reg_.enable_unsupported_mode_strength}});
   }
@@ -1007,9 +1005,7 @@ TEST_F(KmacSqueezeTest, RequestLessDataThanFixedLenError) {
 class KmacResetTest : public KmacTest {};
 
 TEST_F(KmacResetTest, Success) {
-  EXPECT_READ32(KMAC_CFG_SHADOWED_REG_OFFSET, 0);
-  EXPECT_WRITE32_SHADOWED(KMAC_CFG_SHADOWED_REG_OFFSET,
-                          {{KMAC_CFG_SHADOWED_ERR_PROCESSED_BIT, true}});
+  EXPECT_WRITE32(KMAC_CMD_REG_OFFSET, {{KMAC_CMD_ERR_PROCESSED_BIT, true}});
   EXPECT_DIF_OK(dif_kmac_reset(&kmac_, &op_state_));
   EXPECT_EQ(op_state_.squeezing, false);
   EXPECT_EQ(op_state_.append_d, false);

--- a/sw/device/lib/testing/kmac_testutils.c
+++ b/sw/device/lib/testing/kmac_testutils.c
@@ -45,24 +45,26 @@ status_t kmac_testutils_kmac(const dif_kmac_t *kmac,
   TRY(dif_kmac_customization_string_init(custom_string, custom_string_len,
                                          &kmac_custom_string));
 
-  // Start the KMAC operation.
+  // Start the KMAC operation and check that KMAC doesn't report an error.
   dif_kmac_operation_state_t operation_state;
   TRY(dif_kmac_mode_kmac_start(kmac, &operation_state, mode, output_len, key,
                                &kmac_custom_string));
+  TRY(kmac_testutils_check_error(kmac));
 
-  // Pass the entire message to KMAC ("absorb" stage).
+  // Pass the entire message to KMAC ("absorb" stage) and check that KMAC
+  // doesn't report an error.
   TRY(dif_kmac_absorb(kmac, &operation_state, message, message_len, NULL));
+  TRY(kmac_testutils_check_error(kmac));
 
-  // Get the output ("squeeze" stage).
+  // Get the output ("squeeze" stage) and check that KMAC doesn't report an
+  // error.
   TRY(dif_kmac_squeeze(kmac, &operation_state, output, output_len, NULL));
+  TRY(kmac_testutils_check_error(kmac));
 
-  // End the operation.
+  // End the operation and check that KMAC doesn't report an error.
   TRY(dif_kmac_end(kmac, &operation_state));
+  TRY(kmac_testutils_check_error(kmac));
 
-  // Double-check that there were no errors.
-  dif_kmac_error_t err;
-  TRY(dif_kmac_get_error(kmac, &err));
-  TRY_CHECK(err == kDifErrorNone);
   return OK_STATUS();
 }
 

--- a/sw/device/lib/testing/kmac_testutils.h
+++ b/sw/device/lib/testing/kmac_testutils.h
@@ -49,4 +49,13 @@ status_t kmac_testutils_kmac(const dif_kmac_t *kmac, dif_kmac_mode_kmac_t mode,
                              const char *message, const size_t message_len,
                              const size_t output_len, uint32_t *output);
 
+/**
+ * Check if the KMAC HW has flagged any errors and acknowledge them.
+ *
+ * @param kmac A KMAC DIF handle.
+ * @return Ok if there were no errors; non-Ok if there was any error.
+ */
+OT_WARN_UNUSED_RESULT
+status_t kmac_testutils_check_error(const dif_kmac_t *kmac);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_KMAC_TESTUTILS_H_

--- a/sw/device/silicon_creator/lib/drivers/kmac.c
+++ b/sw/device/silicon_creator/lib/drivers/kmac.c
@@ -197,9 +197,6 @@ static rom_error_t kmac_configure(kmac_config_t config) {
   // Set `CFG.ENTROPY_READY` bit to 1.
   cfg_reg =
       bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_ENTROPY_READY_BIT, 1);
-  // Set `CFG.ERR_PROCESSED` bit to 0.
-  cfg_reg =
-      bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_ERR_PROCESSED_BIT, 0);
   // Set `CFG.EN_UNSUPPORTED_MODESTRENGTH` bit to 0.
   cfg_reg = bitfield_bit32_write(
       cfg_reg, KMAC_CFG_SHADOWED_EN_UNSUPPORTED_MODESTRENGTH_BIT, 0);

--- a/sw/device/tests/kmac_entropy_test.c
+++ b/sw/device/tests/kmac_entropy_test.c
@@ -180,7 +180,8 @@ bool test_main(void) {
         dif_kmac_irq_is_pending(&kmac, kDifKmacIrqKmacErr, &irq_err_pending));
     if (irq_err_pending) {
       dif_kmac_error_t err_status;
-      CHECK_DIF_OK(dif_kmac_get_error(&kmac, &err_status));
+      uint32_t err_info;
+      CHECK_DIF_OK(dif_kmac_get_error(&kmac, &err_status, &err_info));
       CHECK(err_status == kDifErrorEntropyWaitTimerExpired,
             "Error other than EDN timeout occurred.");
       LOG_INFO("EDN timed out.");


### PR DESCRIPTION
The KMAC HW IP block features an option to load keys from Key Manager
via a HW key sideload interface.  Prior to this commit, KMAC would:
- when used via the SW application interface: *not check at all* if the
  sideload key is valid (issue https://github.com/lowRISC/opentitan/issues/10704, https://github.com/lowRISC/opentitan/issues/16855);
- when used via a HW application interface: check if the sideload key is
  valid *only for a single cycle* when the application interface gets
  configured (state `StAppCfg` in `kmac_app`).

This could lead to cases where KMAC would use an invalid sideload key. This PR fixes that by raising an error in these cases.

To enable that, this PR moves the `err_processed` bit from the `CFG_SHADOWED` CSR to the `CMD` CSR, and this PR fixes three problems with KMAC's error handling (some of which would only occur with the newly introduced error).

Please see the commit messages for details on the changes in this PR.

Block-level tests maintain their pass rate (tested with `-i all -rx 0.1`).

### Follow-up tasks
- [ ] DV: Cover sideload key becoming invalid during operation in all possible states (part of #16855, although we could create a new issue for clarity).
- [ ] Arch/RTL: Decide if we need a way to recover from an error if the HW application interface does not provide the last data item.