### PR TITLE
[Sival, rstmgr] Fix rstmgr_alert_info_test on ROM_EXT

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -971,7 +971,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:rstmgr_alert_info_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=30_000_000", "+en_scb_tl_err_chk=0"]
+      run_opts: ["+sw_test_timeout_ns=40_000_000", "+en_scb_tl_err_chk=0"]
       run_timeout_mins: 120
     }
     {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3948,20 +3948,15 @@ opentitan_test(
 opentitan_test(
     name = "rstmgr_alert_info_test",
     srcs = ["rstmgr_alert_info_test.c"],
-    exec_env = {
-        # TODO(lowrisc/opentitan#20589): Enable _sival* tests when bug is fixed
-        # "//hw/top_earlgrey:fpga_cw310_sival": None,
-        # "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:silicon_owner_proda_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
-    silicon_owner = silicon_params(
-        tags = ["broken"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+        },
     ),
     verilator = verilator_params(
         timeout = "long",

--- a/sw/device/tests/rstmgr_alert_info_test.c
+++ b/sw/device/tests/rstmgr_alert_info_test.c
@@ -701,6 +701,11 @@ static void init_expected_cause(void) {
       .alert_info.alert_cause[kTopEarlgreyAlertIdI2c0FatalFault] = 1;
   kExpectedInfo[kRound3]
       .alert_info.alert_cause[kTopEarlgreyAlertIdSpiHost0FatalFault] = 1;
+
+  if (kDeviceType == kDeviceFpgaCw310 || kDeviceType == kDeviceFpgaCw340) {
+    kExpectedInfo[kRound3]
+        .alert_info.alert_cause[kTopEarlgreyAlertIdFlashCtrlFatalErr] = 1;
+  }
 }
 
 bool test_main(void) {


### PR DESCRIPTION
Fixes https://github.com/lowRISC/opentitan/issues/20589

The Root cause was that the ROM_EXT locks up the OTP registers with the ePMP, any attempt to write to them would generate an exception.
Therefore, we can't test the OTP alert when the test runs after the ROM_EXT.