### PR TITLE
[fpv,prim] Generalise FPV parameter that constrains what actions a prim_count is asked for

### DIFF
--- a/hw/ip/prim/lint/prim_count.vlt
+++ b/hw/ip/prim/lint/prim_count.vlt
@@ -4,6 +4,6 @@
 
 `verilator_config
 
-// This parameter is only used in DV/FPV.
+// These parameters are only used in DV/FPV.
 lint_off -rule UNUSED -file "*/rtl/prim_count.sv" -match "*EnableAlertTriggerSVA*"
-lint_off -rule UNUSED -file "*/rtl/prim_count.sv" -match "*DecrNeverTrue*"
+lint_off -rule UNUSED -file "*/rtl/prim_count.sv" -match "*PossibleActions*"

--- a/hw/ip/prim/lint/prim_count.waiver
+++ b/hw/ip/prim/lint/prim_count.waiver
@@ -6,7 +6,7 @@
 
 waive -rules {PARAM_NOT_USED} -location {prim_count.sv} -regexp {.*EnableAlertTriggerSVA.*} \
       -comment "The disable parameter is used only during DV / FPV."
-waive -rules {PARAM_NOT_USED} -location {prim_count.sv} -regexp {.*DecrNeverTrue.*} \
+waive -rules {PARAM_NOT_USED} -location {prim_count.sv} -regexp {.*PossibleActions.*} \
       -comment "The parameter is just used to control assertions in DV / FPV."
 
 waive -rules {IFDEF_CODE} -location {prim_count.sv} -msg {Assignment to 'fpv_force' contained within `ifndef 'PrimCountFpv' block at} \

--- a/hw/ip/prim/prim_count.core
+++ b/hw/ip/prim/prim_count.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:assert
     files:
+      - rtl/prim_count_pkg.sv
       - rtl/prim_count.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/prim/rtl/prim_count_pkg.sv
+++ b/hw/ip/prim/rtl/prim_count_pkg.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package prim_count_pkg;
+
+  // An enum that names the possible actions that the inputs might ask for. See the PossibleActions
+  // parameter in prim_count for how this is used.
+  typedef logic [3:0] action_mask_t;
+  typedef enum action_mask_t {Clr  = 4'h1,
+                              Set  = 4'h2,
+                              Incr = 4'h4,
+                              Decr = 4'h8} action_e;
+
+endpackage : prim_count_pkg

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -58,9 +58,11 @@ module alert_handler_esc_timer import alert_pkg::*; (
     // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
     // an alert signal, this condition is handled internally in the alert handler.
     .EnableAlertTriggerSVA(0),
-    // Pass a parameter to disable some assertions that are unreachable because decr_en_i is tied to
-    // zero.
-    .DecrNeverTrue(1)
+    // Pass a parameter to disable coverage for some assertions that are unreachable because
+    // decr_en_i is tied to zero.
+    .PossibleActions(prim_count_pkg::Clr |
+                     prim_count_pkg::Set |
+                     prim_count_pkg::Incr)
   ) u_prim_count (
     .clk_i,
     .rst_ni,

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -197,7 +197,11 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     .Width(PING_CNT_DW),
     // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
     // an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
+    .EnableAlertTriggerSVA(0),
+    // Pass a parameter to disable coverage for some assertions that are unreachable because set_i
+    // and decr_en_i are tied to zero.
+    .PossibleActions(prim_count_pkg::Clr |
+                     prim_count_pkg::Incr)
   ) u_prim_count_esc_cnt (
     .clk_i,
     .rst_ni,
@@ -231,7 +235,11 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     .Width(PING_CNT_DW),
     // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
     // an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
+    .EnableAlertTriggerSVA(0),
+    // Pass a parameter to disable coverage for some assertions that are unreachable because clr_i
+    // and incr_en_i are tied to zero.
+    .PossibleActions(prim_count_pkg::Set |
+                     prim_count_pkg::Decr)
   ) u_prim_count_cnt (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -58,9 +58,11 @@ module alert_handler_esc_timer import alert_pkg::*; (
     // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
     // an alert signal, this condition is handled internally in the alert handler.
     .EnableAlertTriggerSVA(0),
-    // Pass a parameter to disable some assertions that are unreachable because decr_en_i is tied to
-    // zero.
-    .DecrNeverTrue(1)
+    // Pass a parameter to disable coverage for some assertions that are unreachable because
+    // decr_en_i is tied to zero.
+    .PossibleActions(prim_count_pkg::Clr |
+                     prim_count_pkg::Set |
+                     prim_count_pkg::Incr)
   ) u_prim_count (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -197,7 +197,11 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     .Width(PING_CNT_DW),
     // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
     // an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
+    .EnableAlertTriggerSVA(0),
+    // Pass a parameter to disable coverage for some assertions that are unreachable because set_i
+    // and decr_en_i are tied to zero.
+    .PossibleActions(prim_count_pkg::Clr |
+                     prim_count_pkg::Incr)
   ) u_prim_count_esc_cnt (
     .clk_i,
     .rst_ni,
@@ -231,7 +235,11 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     .Width(PING_CNT_DW),
     // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
     // an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
+    .EnableAlertTriggerSVA(0),
+    // Pass a parameter to disable coverage for some assertions that are unreachable because clr_i
+    // and incr_en_i are tied to zero.
+    .PossibleActions(prim_count_pkg::Set |
+                     prim_count_pkg::Decr)
   ) u_prim_count_cnt (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This is all about avoiding some vacuous assertions that are reported in prim FPV tests. The first commit generalises a `DecrNeverTrue` parameter that I added recently and allows a user to specify exactly which actions are possible in the given instance.

The second commit uses the new `PossibleActions` parameter in the alert_handler's ping timer, where we have two different instances of `prim_count` which are used in two different ways.

The end result should be to improve the "pass rate" in the nightly prim FPV tests.