### PR TITLE
[fpv,alert_handler] Carefully waive some coverage requirements in prim FPV

### DIFF
--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -6,10 +6,12 @@
   import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_formal_cfg.hjson"]
   stopats: []
   task: ""
+  after_load: ""
 
   // Optional vars that need to exported to the env
   exports: [
-    {STOPATS: "'{stopats}'"},
-    {TASK:    '{task}'},
+    {STOPATS:    "'{stopats}'"},
+    {TASK:       '{task}'},
+    {AFTER_LOAD: '{after_load}'},
   ]
 }

--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -11,6 +11,9 @@
 # STOPATS: string to indicate the name of the signal to insert `stopat`.
 # TASK: string to collect and prove a subset of assertions that contains these string.
 # FPV_DEFINES: string to add additional macro defines during anaylze phase.
+# AFTER_LOAD: string with the path to a TCL file that should be sourced after the design and test
+#             bench have been loaded. If there is no such file, the variable should be undefined or
+#             the string should be empty.
 
 # clear previous settings
 clear -all
@@ -62,6 +65,14 @@ set stopat [regexp -all -inline {[^\s\']+} $env(STOPATS)]
 if {$stopat ne ""} {
   stopat -env $stopat
 }
+
+if {[info exists ::env(AFTER_LOAD)]} {
+    if {$env(AFTER_LOAD) != ""} {
+        puts "Running prefix TCL command from $env(AFTER_LOAD)"
+        source $env(AFTER_LOAD)
+    }
+}
+
 
 #-------------------------------------------------------------------------
 # specify clock(s) and reset(s)

--- a/hw/ip_templates/alert_handler/fpv/tb/esc_after_load.tcl.tpl
+++ b/hw/ip_templates/alert_handler/fpv/tb/esc_after_load.tcl.tpl
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The UpCntIncrStable_A and DnCntIncrStable_A assertions are vacuous
+# in this test because we can never get to the situation where the
+# counter would saturate: it only be set to 1 and incremented, but it
+# is reasonably wide (EscCntDw=${esc_cnt_dw}).
+cover -disable -regexp ".*\.g_check_incr\.UpCntIncrStable_A:precondition1"
+cover -disable -regexp ".*\.g_check_incr\.DnCntIncrStable_A:precondition1"

--- a/hw/ip_templates/alert_handler/fpv/tb/ping_after_load.tcl
+++ b/hw/ip_templates/alert_handler/fpv/tb/ping_after_load.tcl
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# In the ping timer, there is a counter called u_prim_count_esc_cnt. The FSM that drives this uses
+# the prim_count to count through the N_ESC_SEV senders and then clears it back to zero. As a
+# result, it never tries to increment the counter at maximum value (N_ESC_SEV-1), so we will never
+# see the precondition for the *CntIncrStable_A assertions. Waive the cover property for each
+# assertion.
+cover -disable -regexp ".*\.u_prim_count_esc_cnt\..*\.UpCntIncrStable_A:precondition1"
+cover -disable -regexp ".*\.u_prim_count_esc_cnt\..*\.DnCntIncrStable_A:precondition1"
+
+# In the ping timer, there is also a counter called u_prim_count_cnt. This counts down from the
+# value supplied in ping_timeout_cyc_i (this happens to be constrained in
+# alert_handler_ping_timer_assert_fpv.sv to be less than 8). When it gets to zero, we set the
+# timer_expired flag, which disables the decrement. As such, we are never asked to decrement when
+# equal to zero. Waive the cover property for each of the assertions that checks this.
+cover -disable -regexp ".*\.u_prim_count_cnt\..*\.UpCntDecrStable_A:precondition1"
+cover -disable -regexp ".*\.u_prim_count_cnt\..*\.DnCntDecrStable_A:precondition1"

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
@@ -32,6 +32,7 @@
               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
               rel_path: "hw/top_earlgrey/ip_autogen/alert_handler/alert_handler/ping_timer/{sub_flow}/{tool}"
               cov: true
+              after_load: "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/fpv/tb/ping_after_load.tcl"
              }
              {
                name: prim_alert_rxtx_fpv

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
@@ -23,6 +23,7 @@
               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
               rel_path: "hw/top_earlgrey/ip_autogen/alert_handler/alert_handler_esc_timer/{sub_flow}/{tool}"
               cov: true
+              after_load: "{proj_root}/hw/top_earlgrey/ip_autogen/alert_handler/fpv/tb/esc_after_load.tcl"
              }
              {
               name: alert_handler_ping_timer_fpv

--- a/hw/top_earlgrey/ip_autogen/alert_handler/fpv/tb/esc_after_load.tcl
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/fpv/tb/esc_after_load.tcl
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The UpCntIncrStable_A and DnCntIncrStable_A assertions are vacuous
+# in this test because we can never get to the situation where the
+# counter would saturate: it only be set to 1 and incremented, but it
+# is reasonably wide (EscCntDw=32).
+cover -disable -regexp ".*\.g_check_incr\.UpCntIncrStable_A:precondition1"
+cover -disable -regexp ".*\.g_check_incr\.DnCntIncrStable_A:precondition1"

--- a/hw/top_earlgrey/ip_autogen/alert_handler/fpv/tb/ping_after_load.tcl
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/fpv/tb/ping_after_load.tcl
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# In the ping timer, there is a counter called u_prim_count_esc_cnt. The FSM that drives this uses
+# the prim_count to count through the N_ESC_SEV senders and then clears it back to zero. As a
+# result, it never tries to increment the counter at maximum value (N_ESC_SEV-1), so we will never
+# see the precondition for the *CntIncrStable_A assertions. Waive the cover property for each
+# assertion.
+cover -disable -regexp ".*\.u_prim_count_esc_cnt\..*\.UpCntIncrStable_A:precondition1"
+cover -disable -regexp ".*\.u_prim_count_esc_cnt\..*\.DnCntIncrStable_A:precondition1"
+
+# In the ping timer, there is also a counter called u_prim_count_cnt. This counts down from the
+# value supplied in ping_timeout_cyc_i (this happens to be constrained in
+# alert_handler_ping_timer_assert_fpv.sv to be less than 8). When it gets to zero, we set the
+# timer_expired flag, which disables the decrement. As such, we are never asked to decrement when
+# equal to zero. Waive the cover property for each of the assertions that checks this.
+cover -disable -regexp ".*\.u_prim_count_cnt\..*\.UpCntDecrStable_A:precondition1"
+cover -disable -regexp ".*\.u_prim_count_cnt\..*\.DnCntDecrStable_A:precondition1"


### PR DESCRIPTION
There are careful comments in the respective commits' commit messages (and in the code they add: most of which is comments to explain it!).

The second group of cover properties that is waived in the final commit actually points to some unnecessary RTL(!). I'll file a separate PR to reflect that.