### PR TITLE
[alert_handler,rtl] Slightly simplify decrementing counter

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -239,7 +239,7 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     .set_i(cnt_set),
     .set_cnt_i(cnt_setval),
     .incr_en_i(1'b0),
-    .decr_en_i(!timer_expired), // we are counting down here.
+    .decr_en_i(1'b1), // we are counting down here.
     .step_i(PING_CNT_DW'(1'b1)),
     .commit_i(1'b1),
     .cnt_o(cnt),

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -239,7 +239,7 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     .set_i(cnt_set),
     .set_cnt_i(cnt_setval),
     .incr_en_i(1'b0),
-    .decr_en_i(!timer_expired), // we are counting down here.
+    .decr_en_i(1'b1), // we are counting down here.
     .step_i(PING_CNT_DW'(1'b1)),
     .commit_i(1'b1),
     .cnt_o(cnt),


### PR DESCRIPTION
The FSM in the ping timer uses a prim_count to count down from a timeout value (ping_timeout_cyc_i) to zero. It then avoids telling the prim_count module to decrement further.

But the prim_count saturates at zero already, so that check isn't actually needed.

(Spotted by debugging why an FPV property about decrementing when equal to zero was unreachable)

Note that the FPV property in question has its coverage property waived in PR #22797. If both PRs land, the second one to land should be amended to drop the waiver.