### PR TITLE
tock: comment out nonexisting test module reference

### DIFF
--- a/sw/device/silicon_owner/tock/kernel/src/main.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/main.rs
@@ -42,8 +42,6 @@ use rv32i::csr;
 
 pub mod io;
 mod otbn;
-#[cfg(test)]
-mod tests;
 
 const NUM_PROCS: usize = 4;
 


### PR DESCRIPTION
This makes it possible to run rustfmt acroll the entire tree.