### PR TITLE
[dv,flash_ctrl] Enable random read-write tests with ecc enabled

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -192,7 +192,7 @@ class cip_base_vseq #(
                       tl_sequencer_h, tl_intg_err_type);
   endtask
 
-  // this tl_access can input req_abort_pct (pertentage to enable req abort) and output status for
+  // this tl_access can input req_abort_pct (percentage to enable req abort) and output status for
   // seq to update predicted value
   virtual task tl_access_w_abort(
       input bit [BUS_AW-1:0]  addr,

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -469,15 +469,20 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     // QW (8byte) align
     flash_op.addr[2:0] = 'h0;
 
-    `uvm_info("flash_mem_otf_read", $sformatf("is_odd:%0d size:%0d tail:%0d wd:%0d",
-                                            is_odd, size, tail, flash_op.num_words), UVM_MEDIUM)
+    `uvm_info("flash_mem_otf_read", $sformatf(
+              "addr:0x%x is_odd:%0d size:%0d tail:%0d wd:%0d", flash_op.addr, is_odd, size, tail,
+              flash_op.num_words), UVM_MEDIUM)
     for (int i = 0; i < size; i++) begin
       flash_bkdr_read_full_word(flash_op, rdata);
+      `uvm_info("flash_mem_otf_read", $sformatf("addr:0x%x data:0x%x", flash_op.addr, rdata),
+                UVM_MEDIUM)
       data.push_back(rdata);
       flash_op.addr += 8;
     end
     if (tail) begin
       flash_bkdr_read_full_word(flash_op, rdata);
+      `uvm_info("flash_mem_otf_read", $sformatf("addr:0x%x data:0x%x", flash_op.addr, rdata),
+                UVM_MEDIUM)
       data.push_back(rdata);
     end
   endfunction // flash_mem_otf_read
@@ -1159,7 +1164,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   function void update_otf_mem_read_zone(flash_dv_part_e part, int bank, addr_t addr);
     flash_otf_item item;
     int page;
-     bit [BankAddrW-1:0] mem_addr;
+    bit [BankAddrW-1:0] mem_addr;
 
     `uvm_create_obj(flash_otf_item, item)
     item.dq.push_back($urandom());

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -122,7 +122,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
                                        eg_rtl_ctrl_fifo[bank].used()),
                                        UVM_MEDIUM)
 
-    // bankdoor read from memory model
+    // backdoor read from memory model
     `uvm_create_obj(flash_otf_item, obs)
     // Host can only access data partitions.
     obs.cmd.partition = FlashPartData;
@@ -342,7 +342,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       obs.fq = {obs.fq, item.fq};
     end
 
-    `dv_info($sformatf("WDATA size: %d x 8B bank:%0d rcvd_cnt:%0d",
+    `dv_info($sformatf("WDATA size: %0d x 8B bank:%0d rcvd_cnt:%0d",
                        obs.fq.size(), bank, cfg.otf_ctrl_wr_rcvd++), UVM_MEDIUM, "process_write")
 
     compare_data(obs.fq, exp.fq, bank, $sformatf("wdata_page%0d", exp.page), exp.ecc_en);
@@ -361,7 +361,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     if (comp_off) return;
 
     foreach (obs[i]) begin
-      if(is_ecc) begin
+      if (is_ecc) begin
         if (obs[i] != exp[i]) begin
           err = 1;
           `dv_error($sformatf("%4d: obs:exp    %2x_%1x_%8x_%8x:%2x_%1x_%8x_%8x  mismatch!!", i,

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -69,6 +69,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
   bit avoid_ro_partitions; // Avoid partitions defined as read-only.
 
+  // Avoid creating flash program operations that cross program resolution boundaries of 64 byte.
+  bit avoid_prog_res_fault;
+
   bit op_readonly_on_info_partition;   // Make info  partition read-only.
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
   bit op_readonly_on_info2_partition;  // Make info2 partition read-only.
@@ -123,11 +126,14 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // States whether to wait for the flash_init to finish before starting the actual sequence.
   bit wait_init_done;
 
-  // Enable/Disable the Random Flash Inititlisation After Reset
+  // Enable/Disable the Random Flash Initialisation After Reset
   bit disable_flash_init;
 
   // Path to flash wrapper hierarchy.
   string flash_path_str;
+
+  // Restrict address to be flash word aligned
+  bit addr_flash_word_aligned;
 
   // NOTE: Make sure to keep
   // cfg.flash_ctrl_vif.rst_to_pd_time_ns < reset_width_clks_lo * clk_period_ns.
@@ -213,6 +219,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
     avoid_ro_partitions = 0;
 
+    avoid_prog_res_fault = 1;
+
     op_erase_type_bank_pc = 20;
     op_prog_type_repair_pc = 10;
     op_max_words = 512;
@@ -227,6 +235,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
     do_tran_prep_mem = 1'b1;
 
     check_mem_post_tran = 1'b1;
+
+    addr_flash_word_aligned = 1'b0;
 
     prog_timeout_ns                     = 10_000_000;   // 10ms
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
@@ -37,7 +37,7 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
     cfg.flash_ctrl_vif.lc_nvm_debug_en = (lc_nvm_debug_en)?
       lc_ctrl_pkg::On : get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
 
-    // takes dealy to propagate lc_nvm_debug_en
+    // takes delay to propagate lc_nvm_debug_en
     cfg.clk_rst_vif.wait_clks(5);
     mystr = {cfg.seq_cfg.flash_path_str, ".tck_i"};
     `DV_CHECK(uvm_hdl_read(mystr, jtag_dst_req.tck))

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -173,7 +173,6 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   data_q_t flash_rd_data;
   uvm_reg_data_t data;
-  localparam data_t ALL_ONES = {TL_DW{1'b1}};
 
   virtual task body();
     repeat (cfg.seq_cfg.max_num_trans) begin

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
@@ -10,7 +10,7 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_integrity_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
   constraint fractions_c {
        solve ctrl_num before fractions;
        if (ctrl_num == 1)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_oversize_error_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_oversize_error_vseq.sv
@@ -22,6 +22,7 @@ class flash_ctrl_oversize_error_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(cfg.otf_num_rw) begin
+          if (cfg.stop_transaction_generators()) break;
           `DV_CHECK_RANDOMIZE_FATAL(this)
           ctrl = rand_op;
           bank = rand_op.addr[OTFBankId];

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -22,7 +22,7 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
   rand bit which_copy;
 
   constraint ctrl_num_c {
-    ctrl_num dist { CTRL_TRANS_MIN := 2, [2:16] :/ 1};
+    ctrl_num dist { CtrlTransMin := 2, [2:16] :/ 1};
   }
 
   typedef struct {

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -49,7 +49,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
   // Single direct read data
   data_t flash_rd_one_data;
 
-  localparam data_t ALL_ONES = {TL_DW{1'b1}};
+  localparam data_t AllOnes = {TL_DW{1'b1}};
 
   // Configure sequence knobs to tailor it to smoke seq.
   virtual function void configure_vseq();
@@ -287,7 +287,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       `uvm_info(`gfn, $sformatf("FLASH DIRECT READ DATA: 0x%0h", flash_rd_one_data), UVM_HIGH)
       //first 5 data have init value while 6th value is overwritten by ctrl due to priority lost
       if (j < 5) begin
-        `DV_CHECK_EQ(flash_rd_one_data, ALL_ONES)
+        `DV_CHECK_EQ(flash_rd_one_data, AllOnes)
       end
       if (j == 5) begin
         `DV_CHECK_EQ(flash_rd_one_data, flash_op_data[0])

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
@@ -7,7 +7,7 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_rnd_wd_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
   constraint fractions_c {
        solve ctrl_num before fractions;
        if (ctrl_num == 1)

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
@@ -2,31 +2,81 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Generates random mix of reads and writes. Writes are somewhat delicate: when scrambling or ECC
+// are enabled we can only write full flash words (8 bytes), so the number of bus words needs to
+// be even and the starting address needs to be 8-byte aligned. This is ensured by the consraints.
+//
+// In addition, overwrites will almost surely cause ecc errors to be injected because bits cannot
+// flip from 0 to 1, so this makes sure addresses don't overlap previously written ones.
 class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_vseq)
   `uvm_object_new
+
+  // The maximum number of attempts to get an address that has not been previously written.
+  localparam int MaxProgAttempts = 16;
+
   flash_op_t ctrl;
   int num, bank;
 
-  virtual task body();
-    cfg.clk_rst_vif.wait_clks(5);
+  constraint fractions_c {
+    fractions[0] == 0;
+    fractions > 1;
+    fractions <= 16;
+  }
 
+  function void get_bank_and_num(input flash_op_t rand_op, ref int bank, ref int num);
+    bank = rand_op.addr[OTFBankId];
+    num = rand_op.partition == FlashPartData ? ctrl_num : ctrl_info_num;
+  endfunction
+
+  // Randomizes until a flash operation satisfies the constraints and its address has not
+  // previously written. It issues an error when failing.
+  protected function bit try_create_prog_op();
+    int attempts = 0;
+
+    while (attempts < MaxProgAttempts) begin
+      otf_addr_t end_addr;
+
+      // Add constraints to avoid half-word writes and to avoid readonly
+      // partitions.
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      ctrl = rand_op;
+      ctrl.num_words = fractions;
+      get_bank_and_num(ctrl, bank, num);
+      end_addr = ctrl.otf_addr + (num * fractions * 4) - 1;
+      if (!address_range_was_written(to_full_addr(ctrl.otf_addr, bank),
+                                     to_full_addr(end_addr, bank))) begin
+        return 1'b1;
+      end
+      ++attempts;
+    end
+    `DV_CHECK(0, "Too many unsuccessful attempts to create a prog_op")
+    return 1'b0;
+  endfunction : try_create_prog_op
+
+  virtual task body();
+    bit prev_addr_flash_word_aligned = cfg.seq_cfg.addr_flash_word_aligned;
+    bit prev_avoid_ro_partitions = cfg.seq_cfg.avoid_ro_partitions;
+
+    cfg.clk_rst_vif.wait_clks(5);
     fork
       begin
         repeat(cfg.otf_num_rw) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          ctrl = rand_op;
-          bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = ctrl_num;
-          end else begin
-            num = ctrl_info_num;
-          end
-          // If the partition that selected configured as read-only, skip the program
-          sync_otf_wr_ro_part();
           randcase
-            cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-            cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);
+            cfg.otf_wr_pct: begin
+              cfg.seq_cfg.addr_flash_word_aligned = 1'b1;
+              cfg.seq_cfg.avoid_ro_partitions = 1'b1;
+              `DV_CHECK(try_create_prog_op(), "Could not create a prog flash op")
+              prog_flash(ctrl, bank, num, fractions);
+              cfg.seq_cfg.addr_flash_word_aligned = prev_addr_flash_word_aligned;
+              cfg.seq_cfg.avoid_ro_partitions = prev_avoid_ro_partitions;
+            end
+            cfg.otf_rd_pct: begin
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              ctrl = rand_op;
+              get_bank_and_num(ctrl, bank, num);
+              read_flash(ctrl, bank, num, fractions);
+            end
           endcase
         end
       end
@@ -34,7 +84,7 @@ class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
         launch_host_rd();
       end
     join
-  endtask
+  endtask : body
 
   virtual task launch_host_rd();
     for (int i = 0; i < cfg.otf_num_hr; ++i) begin
@@ -44,5 +94,5 @@ class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
       #0;
     end
     csr_utils_pkg::wait_no_outstanding_access();
-  endtask
-endclass // flash_ctrl_rw_vseq
+  endtask : launch_host_rd
+endclass : flash_ctrl_rw_vseq

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -195,7 +195,7 @@
     {
       name: flash_ctrl_wo
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=0", "+otf_rd_pct=0"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=0", "+otf_rd_pct=0", "+ecc_mode=1"]
       reseed: 20
     }
     {
@@ -213,13 +213,13 @@
     {
       name: flash_ctrl_ro
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=1000", "+otf_wr_pct=0"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=1000", "+otf_wr_pct=0", "+ecc_mode=1"]
       reseed: 20
     }
     {
       name: flash_ctrl_rw
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+test_timeout_ns=5_000_000_000"]
+      run_opts: ["+scb_otf_en=1", "+test_timeout_ns=5_000_000_000", "+ecc_mode=1"]
       reseed: 20
     }
     {

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -469,15 +469,20 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     // QW (8byte) align
     flash_op.addr[2:0] = 'h0;
 
-    `uvm_info("flash_mem_otf_read", $sformatf("is_odd:%0d size:%0d tail:%0d wd:%0d",
-                                            is_odd, size, tail, flash_op.num_words), UVM_MEDIUM)
+    `uvm_info("flash_mem_otf_read", $sformatf(
+              "addr:0x%x is_odd:%0d size:%0d tail:%0d wd:%0d", flash_op.addr, is_odd, size, tail,
+              flash_op.num_words), UVM_MEDIUM)
     for (int i = 0; i < size; i++) begin
       flash_bkdr_read_full_word(flash_op, rdata);
+      `uvm_info("flash_mem_otf_read", $sformatf("addr:0x%x data:0x%x", flash_op.addr, rdata),
+                UVM_MEDIUM)
       data.push_back(rdata);
       flash_op.addr += 8;
     end
     if (tail) begin
       flash_bkdr_read_full_word(flash_op, rdata);
+      `uvm_info("flash_mem_otf_read", $sformatf("addr:0x%x data:0x%x", flash_op.addr, rdata),
+                UVM_MEDIUM)
       data.push_back(rdata);
     end
   endfunction // flash_mem_otf_read
@@ -1159,7 +1164,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   function void update_otf_mem_read_zone(flash_dv_part_e part, int bank, addr_t addr);
     flash_otf_item item;
     int page;
-     bit [BankAddrW-1:0] mem_addr;
+    bit [BankAddrW-1:0] mem_addr;
 
     `uvm_create_obj(flash_otf_item, item)
     item.dq.push_back($urandom());

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -122,7 +122,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
                                        eg_rtl_ctrl_fifo[bank].used()),
                                        UVM_MEDIUM)
 
-    // bankdoor read from memory model
+    // backdoor read from memory model
     `uvm_create_obj(flash_otf_item, obs)
     // Host can only access data partitions.
     obs.cmd.partition = FlashPartData;
@@ -342,7 +342,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       obs.fq = {obs.fq, item.fq};
     end
 
-    `dv_info($sformatf("WDATA size: %d x 8B bank:%0d rcvd_cnt:%0d",
+    `dv_info($sformatf("WDATA size: %0d x 8B bank:%0d rcvd_cnt:%0d",
                        obs.fq.size(), bank, cfg.otf_ctrl_wr_rcvd++), UVM_MEDIUM, "process_write")
 
     compare_data(obs.fq, exp.fq, bank, $sformatf("wdata_page%0d", exp.page), exp.ecc_en);
@@ -361,7 +361,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     if (comp_off) return;
 
     foreach (obs[i]) begin
-      if(is_ecc) begin
+      if (is_ecc) begin
         if (obs[i] != exp[i]) begin
           err = 1;
           `dv_error($sformatf("%4d: obs:exp    %2x_%1x_%8x_%8x:%2x_%1x_%8x_%8x  mismatch!!", i,

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -69,6 +69,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
   bit avoid_ro_partitions; // Avoid partitions defined as read-only.
 
+  // Avoid creating flash program operations that cross program resolution boundaries of 64 byte.
+  bit avoid_prog_res_fault;
+
   bit op_readonly_on_info_partition;   // Make info  partition read-only.
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
   bit op_readonly_on_info2_partition;  // Make info2 partition read-only.
@@ -123,11 +126,14 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // States whether to wait for the flash_init to finish before starting the actual sequence.
   bit wait_init_done;
 
-  // Enable/Disable the Random Flash Inititlisation After Reset
+  // Enable/Disable the Random Flash Initialisation After Reset
   bit disable_flash_init;
 
   // Path to flash wrapper hierarchy.
   string flash_path_str;
+
+  // Restrict address to be flash word aligned
+  bit addr_flash_word_aligned;
 
   // NOTE: Make sure to keep
   // cfg.flash_ctrl_vif.rst_to_pd_time_ns < reset_width_clks_lo * clk_period_ns.
@@ -213,6 +219,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
     avoid_ro_partitions = 0;
 
+    avoid_prog_res_fault = 1;
+
     op_erase_type_bank_pc = 20;
     op_prog_type_repair_pc = 10;
     op_max_words = 512;
@@ -227,6 +235,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
     do_tran_prep_mem = 1'b1;
 
     check_mem_post_tran = 1'b1;
+
+    addr_flash_word_aligned = 1'b0;
 
     prog_timeout_ns                     = 10_000_000;   // 10ms
 

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_otf_item.sv
@@ -135,8 +135,9 @@ class flash_otf_item extends uvm_object;
       return;
     end
     if (dis) begin
-    `uvm_info("wr_scr", $sformatf("size:%0d addr:%x  akey:%x  dkey:%x scr_en:%0d ecc_en:%0d",
-                              raw_fq.size(), addr, addr_key, data_key, scr_en, ecc_en), UVM_MEDIUM)
+      `uvm_info("wr_scr", $sformatf(
+                "size:%0d addr:%x  akey:%x  dkey:%x scr_en:%0d ecc_en:%0d",
+                raw_fq.size(), addr, addr_key, data_key, scr_en, ecc_en), UVM_MEDIUM)
     end
     foreach(raw_fq[i]) begin
       data = raw_fq[i][FlashDataWidth-1:0];
@@ -146,7 +147,7 @@ class flash_otf_item extends uvm_object;
           `uvm_info("icv_debug", $sformatf("before:%4b after:%4b",
                     data_with_icv[67:64], ~data_with_icv[67:64]), UVM_DEBUG)
           data_with_icv[67:64] = ~data_with_icv[67:64];
-          // if icv is all zero, use different patter for error
+          // if icv is all zero, use different pattern for error
           if (data_with_icv[67:64] == 'h0) data_with_icv[67:64] = 4'b1100;
         end
       end else begin
@@ -197,27 +198,36 @@ class flash_otf_item extends uvm_object;
     foreach (fq[i]) begin
        // erase data skip descramble
       if (fq[i] == {flash_phy_pkg::FullDataWidth{1'b1}}) begin
-         raw_fq.push_back(fq[i]);
+        raw_fq.push_back(fq[i]);
       end else begin
         if (ctrl_rd_region_q.size > 0) begin
           scr_en = (ctrl_rd_region_q[i].scramble_en == MuBi4True);
           ecc_en = (ctrl_rd_region_q[i].ecc_en == MuBi4True);
-          `uvm_info("rd_scr", $sformatf("size:%0d idx:%0d addr:%x scr_en:%0d ecc_en:%0d",
-                                        fq.size(), i, addr, scr_en, ecc_en), UVM_MEDIUM)
+          `uvm_info("rd_scr", $sformatf("size:%0d idx:%0d addr:%x data:0x%x scr_en:%0d ecc_en:%0d",
+                                        fq.size(), i, addr, fq[i], scr_en, ecc_en), UVM_MEDIUM)
         end
         if (ecc_en) begin
           dec68 = prim_secded_pkg::prim_secded_hamming_76_68_dec(fq[i]);
+          `uvm_info("rd_scr", $sformatf(
+                    "ecc dec input=0x%x, out_data=0x%x, synd=0x%x, err=0x%x", fq[i], dec68.data,
+                    dec68.syndrome, dec68.err), UVM_MEDIUM)
         end else begin
           dec68.data = fq[i][67:0];
         end
+        `uvm_info("rd_scr", $sformatf("data_scr:0x%x, err=0x%x", dec68.data, dec68.err),
+                  UVM_MEDIUM)
 
         if (scr_en) begin
           data = create_raw_data(dec68.data[63:0], addr, addr_key, data_key);
           data[67:64] = dec68.data[67:64];
+          `uvm_info("rd_scr", $sformatf(
+                    "data_plain:0x%x, intg=0x%x", data, dec68.data[67:64]), UVM_MEDIUM)
         end else begin
+          `uvm_info("rd_scr", $sformatf(
+                    "data_plain no scramble:0x%x, intg=0x%x", dec68.data, dec68.data[67:64]),
+                    UVM_MEDIUM)
           data = dec68.data;
         end
-
         // check ecc
         // chec icv
         if (ecc_en) begin

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
@@ -37,7 +37,7 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
     cfg.flash_ctrl_vif.lc_nvm_debug_en = (lc_nvm_debug_en)?
       lc_ctrl_pkg::On : get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
 
-    // takes dealy to propagate lc_nvm_debug_en
+    // takes delay to propagate lc_nvm_debug_en
     cfg.clk_rst_vif.wait_clks(5);
     mystr = {cfg.seq_cfg.flash_path_str, ".tck_i"};
     `DV_CHECK(uvm_hdl_read(mystr, jtag_dst_req.tck))

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -173,7 +173,6 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   data_q_t flash_rd_data;
   uvm_reg_data_t data;
-  localparam data_t ALL_ONES = {TL_DW{1'b1}};
 
   virtual task body();
     repeat (cfg.seq_cfg.max_num_trans) begin

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
@@ -10,7 +10,7 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_integrity_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
   constraint fractions_c {
        solve ctrl_num before fractions;
        if (ctrl_num == 1)

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -75,7 +75,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     }
   }
   constraint ctrl_num_c {
-    ctrl_num dist { CTRL_TRANS_MIN := 2, [2:31] :/ 1, CTRL_TRANS_MAX := 2};
+    ctrl_num dist { CtrlTransMin := 2, [2:31] :/ 1, CtrlTransMax := 2};
   }
   constraint fractions_c {
     fractions dist { [1:4] := 4, [5:15] := 1, 16 := 1};
@@ -110,6 +110,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
     rand_op.addr[TL_AW-1:BusAddrByteW] == 'h0;
     rand_op.addr[1:0] == 'h0;
+    cfg.seq_cfg.addr_flash_word_aligned -> rand_op.addr[2] == 1'b0;
     // If address starts from 0x4 and full prog_win size access(16),
     // transaction creates prog_win error.
     // To prevent that, make full size access always start from address[2:0] == 0.
@@ -285,6 +286,102 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end
   endfunction
 
+  // This is a helper function for prog_flash. It performs a write operation, places the data
+  // in the fifo, checks protection, and checks for program window resolution errors. If the
+  // write will proceed it creates an item with the expected results for the scoreboard.
+  local task issue_prog_request(input flash_op_t flash_op, ref shortint lcnt, input bit in_err,
+                                input bit store_prog_data);
+    flash_mp_region_cfg_t region;
+    bit expect_prog_win_error = 1'b0;
+    bit drop = 1'b0;
+    int bank = flash_op.addr[TL_AW-1:OTFBankId];
+    otf_addr_t end_addr;
+
+    `uvm_info("prog_flash", $sformatf(
+              "addr:%x, otf_addr:%x wd:%0d, ", flash_op.addr, flash_op.otf_addr,
+              flash_op.num_words), UVM_MEDIUM)
+    // Each flash_program_data[] entry : 4B
+    // {global_cnt(16bits), lcnt(16bits)}
+    for (int j = 0; j < flash_op.num_words; j++) begin
+      if (cfg.wr_rnd_data) begin
+        flash_program_data.push_back($urandom);
+      end else begin
+        flash_program_data.push_back({global_pat_cnt, lcnt++});
+      end
+    end
+    // Check permissions.
+    if (flash_op.partition == FlashPartData) begin
+      int page = cfg.addr2page(flash_op.addr);
+      region = cfg.get_region(page);
+    end else begin
+      // for region, use per bank page number
+      int page = cfg.addr2page(flash_op.otf_addr);
+      region = cfg.get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
+      drop |= check_info_part(flash_op, "prog_flash");
+    end
+    drop |= validate_flash_op(flash_op, region);
+    if (drop) begin
+      `uvm_info("prog_flash", $sformatf("op:%s is not allowed in this region %p",
+                                        flash_op.op.name, region), UVM_MEDIUM)
+    end
+
+    // Check program window resolution error.
+    end_addr = flash_op.otf_addr + flash_op.num_words * 4 - 1;
+    if (end_addr[FlashPgmResWidth + BusByteWidth ] !=
+        flash_op.otf_addr[FlashPgmResWidth + BusByteWidth]) begin
+      `uvm_info("prog_flash", $sformatf("prog_window violation, start_addr:0x%x end_addr:0x%x",
+                                        flash_op.otf_addr, end_addr), UVM_MEDIUM)
+      expect_prog_win_error = 1;
+      drop = 1;
+    end
+    if (drop) set_otf_exp_alert("recov_err");
+
+    // Start the operation.
+    if (cfg.intr_mode) begin
+      flash_ctrl_intr_write(flash_op, flash_program_data);
+    end else begin
+      flash_ctrl_start_op(flash_op);
+      if (in_err) begin
+        cfg.tlul_core_exp_cnt += flash_op.num_words;
+      end
+      flash_ctrl_write(flash_program_data, !in_err);
+
+      if (!in_err) wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
+    end
+
+    if (expect_prog_win_error) begin
+      csr_rd_check(.ptr(ral.err_code.prog_win_err), .compare_value(1));
+      drop = 1;
+    end
+
+    `uvm_info("prog_flash", $sformatf("bank:%0d addr:%x otf_addr:%x part:%s wd:%0d",
+                                      bank, flash_op.addr, flash_op.otf_addr,
+                                      flash_op.partition.name, flash_op.num_words), UVM_MEDIUM)
+    if (drop) begin
+      uvm_reg_data_t ldata;
+      csr_rd(.ptr(ral.err_code), .value(ldata), .backdoor(1));
+      `uvm_info("prog_flash", $sformatf("skip sb path due to err_code:%x", ldata), UVM_MEDIUM)
+    end else begin
+      flash_otf_item exp_item;
+      if (store_prog_data) cfg.prog_data[flash_op] = flash_program_data;
+
+      flash_otf_print_data64(flash_program_data, "wdata");
+      `uvm_create_obj(flash_otf_item, exp_item)
+
+      exp_item.cmd = flash_op;
+      exp_item.dq = flash_program_data;
+      exp_item.region = region;
+      // Scramble data
+      exp_item.scramble(otp_addr_key, otp_data_key, flash_op.otf_addr);
+
+      p_sequencer.eg_exp_ctrl_port[bank].write(exp_item);
+      flash_phy_prim_agent_pkg::print_flash_data(exp_item.fq,
+          $sformatf("fdata_%0d bank %0d", cfg.otf_ctrl_wr_sent, bank));
+    end
+    global_pat_cnt++;
+    cfg.otf_ctrl_wr_sent++;
+  endtask
+
   // Program flash in the unit of minimum resolution (4Byte)
   // If data is not aligned to 8Byte, rtl pads all F to
   // upper or lower 4Byte.
@@ -296,22 +393,17 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   virtual task prog_flash(ref flash_op_t flash_op, input int bank, int num, int wd = 16,
                   bit in_err = 0, bit store_prog_data = 0);
     data_q_t flash_data_chunk;
-    flash_otf_item exp_item;
     bit poll_fifo_status = ~in_err;
-    bit [15:0] lcnt = 0;
-    bit [flash_ctrl_pkg::BusAddrByteW-1:0] start_addr, end_addr;
+    shortint lcnt = 0;
+    otf_addr_t start_addr, end_addr;
     data_4s_t tmp_data;
-    int tail, is_odd;
-    int unit_word;
     int tot_wd;
-    int page;
     bit overflow = 0;
-    bit drop = 0;
 
-    flash_mp_region_cfg_t my_region;
-
-    is_odd = flash_op.otf_addr[2];
-    tot_wd = wd * num + is_odd;
+    `DV_CHECK_EQ(flash_op.otf_addr[2], 1'b0,
+                 "prog_flash gets unexpected address not 8 byte aligned")
+    `DV_CHECK(wd % 2 == 0, "prog_flash gets unexpected odd bus word count")
+    tot_wd = wd * num;
 
     flash_op.op = FlashOpProgram;
     flash_op.num_words = wd;
@@ -327,6 +419,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     start_addr = flash_op.otf_addr;
     // last byte address in each program
     end_addr = start_addr + (tot_wd * 4) - 1;
+    update_range_addresses_written(to_full_addr(start_addr, bank), to_full_addr(end_addr, bank));
 
     `uvm_info("prog_flash",$sformatf("begin addr:%x part:%s num:%0d wd:%0d st:%x ed:%x",
                                      flash_op.otf_addr, flash_op.partition.name, num,
@@ -344,7 +437,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end
 
     if (overflow) begin
-      bit [flash_ctrl_pkg::BusAddrByteW-1:0] tmp_addr = start_addr;
+      otf_addr_t tmp_addr = start_addr;
       if (flash_op.partition == FlashPartData) begin
         start_addr[16:0] = 'h0;
       end else begin
@@ -354,8 +447,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                                          " roll over start address to 0x%x"},
                                         tmp_addr, end_addr, flash_op.partition.name,
                                         start_addr), UVM_MEDIUM)
-      is_odd = flash_op.otf_addr[2];
-      tot_wd = wd * num + is_odd;
+      tot_wd = wd * num;
       end_addr = start_addr + (tot_wd * 4) - 1;
     end
     // Check if end_addr overflows.
@@ -364,125 +456,52 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                                        " part:%s size:%0d x %0d x 4B"},
                                       bank, flash_op.otf_addr, flash_op.partition.name,
                                       num, wd), UVM_MEDIUM)
+
     flash_op.otf_addr = start_addr;
 
     for (int i = 0; i < num; i++) begin
       flash_program_data = '{};
-      tail = 0;
-      drop = 0;
-      is_odd = flash_op.otf_addr[2];
-      end_addr = flash_op.otf_addr + ((wd + is_odd) * 4) - 1;
-      // Check resolution error
-      // Current resolution : 0x40.
-      // Check if address[6] is same for start and end addr.
-      `uvm_info("prog_flash", $sformatf("start_addr:%x  end_addr:%x",
-                                        flash_op.otf_addr, end_addr), UVM_HIGH)
-      if (flash_op.otf_addr[6] != end_addr[6]) begin
-        `uvm_info("prog_flash", $sformatf("prog_window violation, start_addr:0x%x  end_addr:0x%x",
-                                          flash_op.otf_addr, end_addr), UVM_MEDIUM)
-        // Shift start addr window
-        if (flash_op.partition == FlashPartData) begin
-          flash_op.otf_addr[BusAddrByteW-1:6] = end_addr[BusAddrByteW-1:6];
-          flash_op.otf_addr[5:0] = 0;
-        end else begin
-          flash_op.otf_addr[8:0] = 'h0;
-        end
-        end_addr = flash_op.otf_addr + (wd * 4) -1;
-        `uvm_info("prog_flash", $sformatf("change to page:%0d start_addr to 0x%x end_addr:0x%x",
-                                          cfg.addr2page(flash_op.addr),
-                                          flash_op.otf_addr,
-                                          end_addr), UVM_MEDIUM)
-        is_odd = 0;
-      end
-      unit_word = wd;
-      // Each flash_program_data[] entry : 4B
-      // {global_cnt(16bits), lcnt(16bits)}
-      for (int j = 0; j < wd; j++) begin
-        if (cfg.wr_rnd_data) begin
-           flash_program_data.push_back($urandom);
-        end else begin
-           flash_program_data.push_back({global_pat_cnt, lcnt++});
-        end
-      end
+      end_addr = flash_op.otf_addr + (wd * 4) - 1;
+
       flash_op.addr = flash_op.otf_addr;
-      // Bank : bit[19]
       flash_op.addr[TL_AW-1:OTFBankId] = bank;
 
-      if (flash_op.partition == FlashPartData) begin
-        page = cfg.addr2page(flash_op.addr);
-        my_region = cfg.get_region(page);
-      end else begin
-        // for region, use per bank page number
-        page = cfg.addr2page(flash_op.otf_addr);
-        my_region = cfg.get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
-        drop = check_info_part(flash_op, "prog_flash");
-      end
+      `DV_CHECK_EQ(flash_op.addr[2], 1'b0, "Unexpected address not 8-byte aligned for flash_prog")
+      `uvm_info("prog_flash", $sformatf("in loop tl_addr:%x start_addr:%x  end_addr:%x",
+                                        flash_op.addr, flash_op.otf_addr, end_addr), UVM_MEDIUM)
 
-      drop |= validate_flash_op(flash_op, my_region);
-      if (drop) begin
-        `uvm_info("prog_flash", $sformatf("op:%s is not allowed in this region %p",
-                                          flash_op.op.name, my_region), UVM_MEDIUM)
-        set_otf_exp_alert("recov_err");
-      end
-
-      if (cfg.intr_mode) begin
-        flash_ctrl_intr_write(flash_op, flash_program_data);
-      end else begin
-        flash_ctrl_start_op(flash_op);
-        if (in_err) begin
-          cfg.tlul_core_exp_cnt += flash_op.num_words;
+      // Check resolution error
+      // Current resolution : 0x40.
+      // If address[6] differ between start and end addr a prog_win error will be raised and the
+      // transaction will be dropped. But if cfg.seq_cfg.avoid_prog_res_fault is set this breaks
+      // off a transaction up to the window's end, issues it, and adjusts the transactions to
+      // come to start past the window's end.
+      if (end_addr[FlashPgmResWidth + BusByteWidth ] !=
+        flash_op.otf_addr[FlashPgmResWidth + BusByteWidth]) begin
+        if (cfg.seq_cfg.avoid_prog_res_fault) begin
+          flash_op_t first_op;
+          int first_wd;
+          otf_addr_t next_addr = round_to_prog_resolution(
+             flash_op.otf_addr + flash_ctrl_reg_pkg::RegBusPgmResBytes - 1);
+          first_wd = (next_addr - flash_op.otf_addr) >> 2;
+          first_op = flash_op;
+          first_op.num_words = first_wd;
+          `uvm_info("prog_flash", $sformatf(
+                    "Broke request below into one up to 0x%x with %0d bus words",
+                    next_addr, first_wd),
+                    UVM_MEDIUM)
+          print_flash_op(flash_op, UVM_MEDIUM);
+          `uvm_info("prog_flash", "Broken request:", UVM_MEDIUM)
+          print_flash_op(first_op, UVM_MEDIUM);
+          issue_prog_request(first_op, lcnt, in_err, store_prog_data);
+          flash_op.addr += first_wd * 4;
+          flash_op.otf_addr = flash_op.addr;
+          flash_op.num_words = wd - first_wd;
         end
-        flash_ctrl_write(flash_program_data, poll_fifo_status);
+      end
 
-        if (!in_err) wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
-      end
-      if (is_odd == 1) begin
-        tmp_data = {32{1'b1}};
-        flash_program_data.push_front(tmp_data);
-        unit_word++;
-      end
-      tail = unit_word % 2;
-
-      if (wd > 1 && tail == 1) begin
-        tmp_data = {32{1'b1}};
-        flash_program_data.push_back(tmp_data);
-      end
-      if (wd == 1 && is_odd == 0) begin
-        tmp_data = {32{1'b1}};
-        flash_program_data.push_back(tmp_data);
-      end
-      if (wd > 16) begin
-        csr_rd_check(.ptr(ral.err_code.prog_win_err), .compare_value(1));
-        drop = 1;
-      end
-      `uvm_info("prog_flash",$sformatf({"bank:%0d addr:%x otf_addr:%x part:%s",
-                                        " page:%0d num:%0d wd:%0d  odd:%0d tail:%0d"},
-                                        bank, flash_op.addr, flash_op.otf_addr,
-                                        flash_op.partition.name, page, num,
-                                        wd, is_odd, tail), UVM_MEDIUM)
-      if (drop) begin
-        uvm_reg_data_t ldata;
-        csr_rd(.ptr(ral.err_code), .value(ldata), .backdoor(1));
-        `uvm_info("prog_flash", $sformatf("skip sb path due to err_code:%x", ldata), UVM_MEDIUM)
-      end else begin
-        if (store_prog_data) cfg.prog_data[flash_op] = flash_program_data;
-
-        flash_otf_print_data64(flash_program_data, "wdata");
-        `uvm_create_obj(flash_otf_item, exp_item)
-
-        exp_item.cmd = flash_op;
-        exp_item.dq = flash_program_data;
-        exp_item.region = my_region;
-        // Scramble data
-        exp_item.scramble(otp_addr_key, otp_data_key, flash_op.otf_addr);
-
-        p_sequencer.eg_exp_ctrl_port[bank].write(exp_item);
-        flash_phy_prim_agent_pkg::print_flash_data(exp_item.fq,
-              $sformatf("fdata_%0d bank%0d", cfg.otf_ctrl_wr_sent, bank));
-      end
-      flash_op.otf_addr = flash_op.otf_addr + (4 * wd);
-      global_pat_cnt++;
-      cfg.otf_ctrl_wr_sent++;
+      issue_prog_request(flash_op, lcnt, in_err, store_prog_data);
+      flash_op.otf_addr += flash_op.num_words * 4;
     end // for (int i = 0; i < num; i++)
   endtask // prog_flash
 
@@ -579,6 +598,10 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         end else begin
           page = cfg.addr2page(flash_op.otf_addr);
           my_region = cfg.get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
+          `uvm_info(`gfn, $sformatf(
+                    "For addr:%x, bank:%0d, page:%0d, region scr_en:%b ecc_en:%b",
+                    flash_op.otf_addr, bank, page, my_region.scramble_en == MuBi4True,
+                    my_region.ecc_en == MuBi4True), UVM_MEDIUM)
           drop |= check_info_part(flash_op, "read_flash");
         end
         drop |= validate_flash_op(flash_op, my_region);
@@ -599,7 +622,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         exp_item.ctrl_rd_region_q.push_back(my_region);
       end
       flash_op.addr = tmp_addr;
-      // Bank id truncaded by otf_addr size
+      // Bank id truncated by otf_addr size
       flash_op.otf_addr = tmp_addr;
       // recalculate page and region based on start address
       // for the debug print
@@ -661,6 +684,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         end
       end
 
+      `uvm_info("read_flash", $sformatf("intr_mode=%b", cfg.intr_mode), UVM_MEDIUM)
       if (cfg.intr_mode) begin
         flash_ctrl_intr_read(flash_op, flash_read_data);
       end else begin
@@ -673,9 +697,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         if (overrd > 0) begin
           overread(flash_op, bank, num, overrd);
         end
-
         if (!in_err) wait_flash_op_done();
       end
+
       if (derr_is_set | cfg.ierr_created[0]) begin
         `uvm_info("read_flash", $sformatf({"bank:%0d addr: %x(otf:%x) derr_is_set:%0d",
                                           " ierr_created[0]:%0d"}, bank, flash_op.addr,
@@ -755,10 +779,10 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       tl_addr[OTFHostId] = 1;
       overflow = end_addr[OTFHostId];
     end
-    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow:% x",
+    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow: %x",
                                        addr, end_addr, overflow), UVM_HIGH)
     rd_entry.bank = bank;
-    tl_addr[OTFBankId] = bank;
+    tl_addr[TL_AW-1:OTFBankId] = bank;
     if (overflow) begin
        addr = num * 4;
     end
@@ -787,7 +811,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
 
       // Address should be per bank addr
       rd_entry.addr = tl_addr;
-      rd_entry.addr[OTFBankId] = 0;
+      rd_entry.addr[TL_AW-1:OTFBankId] = 0;
 
       // Address has to be 8byte aligned
       rd_entry.addr[2:0] = 'h0;
@@ -1088,7 +1112,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     rd_cache_t rd_entry;
 
     rd_entry.bank = bank;
-    tl_addr[OTFBankId] = bank;
+    tl_addr[TL_AW-1:OTFBankId] = bank;
     tl_addr[OTFHostId:2] = addr[OTFHostId:2];
 
     `uvm_info("direct_readback", $sformatf("bank:%0d tl_addr:0x%0h, num: %0d",
@@ -1113,7 +1137,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       exp_item.data_key = otp_data_key;
 
       rd_entry.addr = tl_addr;
-      rd_entry.addr[OTFBankId] = 0;
+      rd_entry.addr[TL_AW-1:OTFBankId] = 0;
       // Address has to be 8byte aligned
       rd_entry.addr[2:0] = 'h0;
       rd_entry.part = FlashPartData;
@@ -1200,8 +1224,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
      flash_mp_region_cfg_t my_region;
 
      flash_op.op = FlashOpErase;
-     flash_op.otf_addr[OTFBankId] = bank;
-     flash_op.addr = flash_op.otf_addr;
+     flash_op.addr[TL_AW-1:OTFBankId] = bank;
+     flash_op.otf_addr = flash_op.addr;
      flash_op.erase_type = FlashErasePage;
 
      if (cfg.ecc_mode > FlashEccEnabled) begin
@@ -1296,6 +1320,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     else host_num = $urandom_range(1,32);
     host_bank = $urandom_range(0,1);
 
+    `uvm_info(`gfn, $sformatf(
+              "send_rand_host_rd addr=0x%x bank=%0d host_num=%0d, in_err=%b",
+              host.otf_addr, host_bank, host_num, in_err), UVM_MEDIUM)
     otf_direct_read(host.otf_addr, host_bank, host_num, in_err);
   endtask // send_rand_host_rd
 
@@ -1389,7 +1416,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     repeat (iter) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
       ctrl = rand_op;
-      bank = rand_op.addr[OTFBankId];
+      bank = rand_op.addr[TL_AW-1:OTFBankId];
       if (ctrl.partition == FlashPartData) begin
         num = ctrl_num;
       end else begin
@@ -1495,6 +1522,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     obs.print("chk_mem_intg: before");
     obs.region = exp.region;
     obs.skip_err_chk = 1;
+
     // descramble needs 2 buswords
     obs.cmd.num_words = 2;
     obs.descramble(exp.addr_key, exp.data_key);

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_oversize_error_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_oversize_error_vseq.sv
@@ -22,6 +22,7 @@ class flash_ctrl_oversize_error_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(cfg.otf_num_rw) begin
+          if (cfg.stop_transaction_generators()) break;
           `DV_CHECK_RANDOMIZE_FATAL(this)
           ctrl = rand_op;
           bank = rand_op.addr[OTFBankId];

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -22,7 +22,7 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
   rand bit which_copy;
 
   constraint ctrl_num_c {
-    ctrl_num dist { CTRL_TRANS_MIN := 2, [2:16] :/ 1};
+    ctrl_num dist { CtrlTransMin := 2, [2:16] :/ 1};
   }
 
   typedef struct {

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -49,7 +49,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
   // Single direct read data
   data_t flash_rd_one_data;
 
-  localparam data_t ALL_ONES = {TL_DW{1'b1}};
+  localparam data_t AllOnes = {TL_DW{1'b1}};
 
   // Configure sequence knobs to tailor it to smoke seq.
   virtual function void configure_vseq();
@@ -287,7 +287,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       `uvm_info(`gfn, $sformatf("FLASH DIRECT READ DATA: 0x%0h", flash_rd_one_data), UVM_HIGH)
       //first 5 data have init value while 6th value is overwritten by ctrl due to priority lost
       if (j < 5) begin
-        `DV_CHECK_EQ(flash_rd_one_data, ALL_ONES)
+        `DV_CHECK_EQ(flash_rd_one_data, AllOnes)
       end
       if (j == 5) begin
         `DV_CHECK_EQ(flash_rd_one_data, flash_op_data[0])

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
@@ -7,7 +7,7 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_rnd_wd_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
   constraint fractions_c {
        solve ctrl_num before fractions;
        if (ctrl_num == 1)

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
@@ -2,31 +2,81 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Generates random mix of reads and writes. Writes are somewhat delicate: when scrambling or ECC
+// are enabled we can only write full flash words (8 bytes), so the number of bus words needs to
+// be even and the starting address needs to be 8-byte aligned. This is ensured by the consraints.
+//
+// In addition, overwrites will almost surely cause ecc errors to be injected because bits cannot
+// flip from 0 to 1, so this makes sure addresses don't overlap previously written ones.
 class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_vseq)
   `uvm_object_new
+
+  // The maximum number of attempts to get an address that has not been previously written.
+  localparam int MaxProgAttempts = 16;
+
   flash_op_t ctrl;
   int num, bank;
 
-  virtual task body();
-    cfg.clk_rst_vif.wait_clks(5);
+  constraint fractions_c {
+    fractions[0] == 0;
+    fractions > 1;
+    fractions <= 16;
+  }
 
+  function void get_bank_and_num(input flash_op_t rand_op, ref int bank, ref int num);
+    bank = rand_op.addr[OTFBankId];
+    num = rand_op.partition == FlashPartData ? ctrl_num : ctrl_info_num;
+  endfunction
+
+  // Randomizes until a flash operation satisfies the constraints and its address has not
+  // previously written. It issues an error when failing.
+  protected function bit try_create_prog_op();
+    int attempts = 0;
+
+    while (attempts < MaxProgAttempts) begin
+      otf_addr_t end_addr;
+
+      // Add constraints to avoid half-word writes and to avoid readonly
+      // partitions.
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      ctrl = rand_op;
+      ctrl.num_words = fractions;
+      get_bank_and_num(ctrl, bank, num);
+      end_addr = ctrl.otf_addr + (num * fractions * 4) - 1;
+      if (!address_range_was_written(to_full_addr(ctrl.otf_addr, bank),
+                                     to_full_addr(end_addr, bank))) begin
+        return 1'b1;
+      end
+      ++attempts;
+    end
+    `DV_CHECK(0, "Too many unsuccessful attempts to create a prog_op")
+    return 1'b0;
+  endfunction : try_create_prog_op
+
+  virtual task body();
+    bit prev_addr_flash_word_aligned = cfg.seq_cfg.addr_flash_word_aligned;
+    bit prev_avoid_ro_partitions = cfg.seq_cfg.avoid_ro_partitions;
+
+    cfg.clk_rst_vif.wait_clks(5);
     fork
       begin
         repeat(cfg.otf_num_rw) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          ctrl = rand_op;
-          bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = ctrl_num;
-          end else begin
-            num = ctrl_info_num;
-          end
-          // If the partition that selected configured as read-only, skip the program
-          sync_otf_wr_ro_part();
           randcase
-            cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-            cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);
+            cfg.otf_wr_pct: begin
+              cfg.seq_cfg.addr_flash_word_aligned = 1'b1;
+              cfg.seq_cfg.avoid_ro_partitions = 1'b1;
+              `DV_CHECK(try_create_prog_op(), "Could not create a prog flash op")
+              prog_flash(ctrl, bank, num, fractions);
+              cfg.seq_cfg.addr_flash_word_aligned = prev_addr_flash_word_aligned;
+              cfg.seq_cfg.avoid_ro_partitions = prev_avoid_ro_partitions;
+            end
+            cfg.otf_rd_pct: begin
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              ctrl = rand_op;
+              get_bank_and_num(ctrl, bank, num);
+              read_flash(ctrl, bank, num, fractions);
+            end
           endcase
         end
       end
@@ -34,7 +84,7 @@ class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
         launch_host_rd();
       end
     join
-  endtask
+  endtask : body
 
   virtual task launch_host_rd();
     for (int i = 0; i < cfg.otf_num_hr; ++i) begin
@@ -44,5 +94,5 @@ class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
       #0;
     end
     csr_utils_pkg::wait_no_outstanding_access();
-  endtask
-endclass // flash_ctrl_rw_vseq
+  endtask : launch_host_rd
+endclass : flash_ctrl_rw_vseq

--- a/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -195,7 +195,7 @@
     {
       name: flash_ctrl_wo
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=0", "+otf_rd_pct=0"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=0", "+otf_rd_pct=0", "+ecc_mode=1"]
       reseed: 20
     }
     {
@@ -213,13 +213,13 @@
     {
       name: flash_ctrl_ro
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=1000", "+otf_wr_pct=0"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=1000", "+otf_wr_pct=0", "+ecc_mode=1"]
       reseed: 20
     }
     {
       name: flash_ctrl_rw
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+test_timeout_ns=5_000_000_000"]
+      run_opts: ["+scb_otf_en=1", "+test_timeout_ns=5_000_000_000", "+ecc_mode=1"]
       reseed: 20
     }
     {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -469,15 +469,20 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     // QW (8byte) align
     flash_op.addr[2:0] = 'h0;
 
-    `uvm_info("flash_mem_otf_read", $sformatf("is_odd:%0d size:%0d tail:%0d wd:%0d",
-                                            is_odd, size, tail, flash_op.num_words), UVM_MEDIUM)
+    `uvm_info("flash_mem_otf_read", $sformatf(
+              "addr:0x%x is_odd:%0d size:%0d tail:%0d wd:%0d", flash_op.addr, is_odd, size, tail,
+              flash_op.num_words), UVM_MEDIUM)
     for (int i = 0; i < size; i++) begin
       flash_bkdr_read_full_word(flash_op, rdata);
+      `uvm_info("flash_mem_otf_read", $sformatf("addr:0x%x data:0x%x", flash_op.addr, rdata),
+                UVM_MEDIUM)
       data.push_back(rdata);
       flash_op.addr += 8;
     end
     if (tail) begin
       flash_bkdr_read_full_word(flash_op, rdata);
+      `uvm_info("flash_mem_otf_read", $sformatf("addr:0x%x data:0x%x", flash_op.addr, rdata),
+                UVM_MEDIUM)
       data.push_back(rdata);
     end
   endfunction // flash_mem_otf_read
@@ -1159,7 +1164,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   function void update_otf_mem_read_zone(flash_dv_part_e part, int bank, addr_t addr);
     flash_otf_item item;
     int page;
-     bit [BankAddrW-1:0] mem_addr;
+    bit [BankAddrW-1:0] mem_addr;
 
     `uvm_create_obj(flash_otf_item, item)
     item.dq.push_back($urandom());

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -122,7 +122,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
                                        eg_rtl_ctrl_fifo[bank].used()),
                                        UVM_MEDIUM)
 
-    // bankdoor read from memory model
+    // backdoor read from memory model
     `uvm_create_obj(flash_otf_item, obs)
     // Host can only access data partitions.
     obs.cmd.partition = FlashPartData;
@@ -342,7 +342,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
       obs.fq = {obs.fq, item.fq};
     end
 
-    `dv_info($sformatf("WDATA size: %d x 8B bank:%0d rcvd_cnt:%0d",
+    `dv_info($sformatf("WDATA size: %0d x 8B bank:%0d rcvd_cnt:%0d",
                        obs.fq.size(), bank, cfg.otf_ctrl_wr_rcvd++), UVM_MEDIUM, "process_write")
 
     compare_data(obs.fq, exp.fq, bank, $sformatf("wdata_page%0d", exp.page), exp.ecc_en);
@@ -361,7 +361,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     if (comp_off) return;
 
     foreach (obs[i]) begin
-      if(is_ecc) begin
+      if (is_ecc) begin
         if (obs[i] != exp[i]) begin
           err = 1;
           `dv_error($sformatf("%4d: obs:exp    %2x_%1x_%8x_%8x:%2x_%1x_%8x_%8x  mismatch!!", i,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -69,6 +69,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
   bit avoid_ro_partitions; // Avoid partitions defined as read-only.
 
+  // Avoid creating flash program operations that cross program resolution boundaries of 64 byte.
+  bit avoid_prog_res_fault;
+
   bit op_readonly_on_info_partition;   // Make info  partition read-only.
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
   bit op_readonly_on_info2_partition;  // Make info2 partition read-only.
@@ -123,11 +126,14 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // States whether to wait for the flash_init to finish before starting the actual sequence.
   bit wait_init_done;
 
-  // Enable/Disable the Random Flash Inititlisation After Reset
+  // Enable/Disable the Random Flash Initialisation After Reset
   bit disable_flash_init;
 
   // Path to flash wrapper hierarchy.
   string flash_path_str;
+
+  // Restrict address to be flash word aligned
+  bit addr_flash_word_aligned;
 
   // NOTE: Make sure to keep
   // cfg.flash_ctrl_vif.rst_to_pd_time_ns < reset_width_clks_lo * clk_period_ns.
@@ -213,6 +219,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
     avoid_ro_partitions = 0;
 
+    avoid_prog_res_fault = 1;
+
     op_erase_type_bank_pc = 20;
     op_prog_type_repair_pc = 10;
     op_max_words = 512;
@@ -227,6 +235,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
     do_tran_prep_mem = 1'b1;
 
     check_mem_post_tran = 1'b1;
+
+    addr_flash_word_aligned = 1'b0;
 
     prog_timeout_ns                     = 10_000_000;   // 10ms
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_otf_item.sv
@@ -135,8 +135,9 @@ class flash_otf_item extends uvm_object;
       return;
     end
     if (dis) begin
-    `uvm_info("wr_scr", $sformatf("size:%0d addr:%x  akey:%x  dkey:%x scr_en:%0d ecc_en:%0d",
-                              raw_fq.size(), addr, addr_key, data_key, scr_en, ecc_en), UVM_MEDIUM)
+      `uvm_info("wr_scr", $sformatf(
+                "size:%0d addr:%x  akey:%x  dkey:%x scr_en:%0d ecc_en:%0d",
+                raw_fq.size(), addr, addr_key, data_key, scr_en, ecc_en), UVM_MEDIUM)
     end
     foreach(raw_fq[i]) begin
       data = raw_fq[i][FlashDataWidth-1:0];
@@ -146,7 +147,7 @@ class flash_otf_item extends uvm_object;
           `uvm_info("icv_debug", $sformatf("before:%4b after:%4b",
                     data_with_icv[67:64], ~data_with_icv[67:64]), UVM_DEBUG)
           data_with_icv[67:64] = ~data_with_icv[67:64];
-          // if icv is all zero, use different patter for error
+          // if icv is all zero, use different pattern for error
           if (data_with_icv[67:64] == 'h0) data_with_icv[67:64] = 4'b1100;
         end
       end else begin
@@ -197,27 +198,36 @@ class flash_otf_item extends uvm_object;
     foreach (fq[i]) begin
        // erase data skip descramble
       if (fq[i] == {flash_phy_pkg::FullDataWidth{1'b1}}) begin
-         raw_fq.push_back(fq[i]);
+        raw_fq.push_back(fq[i]);
       end else begin
         if (ctrl_rd_region_q.size > 0) begin
           scr_en = (ctrl_rd_region_q[i].scramble_en == MuBi4True);
           ecc_en = (ctrl_rd_region_q[i].ecc_en == MuBi4True);
-          `uvm_info("rd_scr", $sformatf("size:%0d idx:%0d addr:%x scr_en:%0d ecc_en:%0d",
-                                        fq.size(), i, addr, scr_en, ecc_en), UVM_MEDIUM)
+          `uvm_info("rd_scr", $sformatf("size:%0d idx:%0d addr:%x data:0x%x scr_en:%0d ecc_en:%0d",
+                                        fq.size(), i, addr, fq[i], scr_en, ecc_en), UVM_MEDIUM)
         end
         if (ecc_en) begin
           dec68 = prim_secded_pkg::prim_secded_hamming_76_68_dec(fq[i]);
+          `uvm_info("rd_scr", $sformatf(
+                    "ecc dec input=0x%x, out_data=0x%x, synd=0x%x, err=0x%x", fq[i], dec68.data,
+                    dec68.syndrome, dec68.err), UVM_MEDIUM)
         end else begin
           dec68.data = fq[i][67:0];
         end
+        `uvm_info("rd_scr", $sformatf("data_scr:0x%x, err=0x%x", dec68.data, dec68.err),
+                  UVM_MEDIUM)
 
         if (scr_en) begin
           data = create_raw_data(dec68.data[63:0], addr, addr_key, data_key);
           data[67:64] = dec68.data[67:64];
+          `uvm_info("rd_scr", $sformatf(
+                    "data_plain:0x%x, intg=0x%x", data, dec68.data[67:64]), UVM_MEDIUM)
         end else begin
+          `uvm_info("rd_scr", $sformatf(
+                    "data_plain no scramble:0x%x, intg=0x%x", dec68.data, dec68.data[67:64]),
+                    UVM_MEDIUM)
           data = dec68.data;
         end
-
         // check ecc
         // chec icv
         if (ecc_en) begin

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_connect_vseq.sv
@@ -37,7 +37,7 @@ class flash_ctrl_connect_vseq extends flash_ctrl_base_vseq;
     cfg.flash_ctrl_vif.lc_nvm_debug_en = (lc_nvm_debug_en)?
       lc_ctrl_pkg::On : get_rand_lc_tx_val(.t_weight(0), .f_weight(1), .other_weight(4));
 
-    // takes dealy to propagate lc_nvm_debug_en
+    // takes delay to propagate lc_nvm_debug_en
     cfg.clk_rst_vif.wait_clks(5);
     mystr = {cfg.seq_cfg.flash_path_str, ".tck_i"};
     `DV_CHECK(uvm_hdl_read(mystr, jtag_dst_req.tck))

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_erase_suspend_vseq.sv
@@ -173,7 +173,6 @@ class flash_ctrl_erase_suspend_vseq extends flash_ctrl_base_vseq;
 
   data_q_t flash_rd_data;
   uvm_reg_data_t data;
-  localparam data_t ALL_ONES = {TL_DW{1'b1}};
 
   virtual task body();
     repeat (cfg.seq_cfg.max_num_trans) begin

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
@@ -10,7 +10,7 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_integrity_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
   constraint fractions_c {
        solve ctrl_num before fractions;
        if (ctrl_num == 1)

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -75,7 +75,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     }
   }
   constraint ctrl_num_c {
-    ctrl_num dist { CTRL_TRANS_MIN := 2, [2:31] :/ 1, CTRL_TRANS_MAX := 2};
+    ctrl_num dist { CtrlTransMin := 2, [2:31] :/ 1, CtrlTransMax := 2};
   }
   constraint fractions_c {
     fractions dist { [1:4] := 4, [5:15] := 1, 16 := 1};
@@ -110,6 +110,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
     rand_op.addr[TL_AW-1:BusAddrByteW] == 'h0;
     rand_op.addr[1:0] == 'h0;
+    cfg.seq_cfg.addr_flash_word_aligned -> rand_op.addr[2] == 1'b0;
     // If address starts from 0x4 and full prog_win size access(16),
     // transaction creates prog_win error.
     // To prevent that, make full size access always start from address[2:0] == 0.
@@ -285,6 +286,102 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end
   endfunction
 
+  // This is a helper function for prog_flash. It performs a write operation, places the data
+  // in the fifo, checks protection, and checks for program window resolution errors. If the
+  // write will proceed it creates an item with the expected results for the scoreboard.
+  local task issue_prog_request(input flash_op_t flash_op, ref shortint lcnt, input bit in_err,
+                                input bit store_prog_data);
+    flash_mp_region_cfg_t region;
+    bit expect_prog_win_error = 1'b0;
+    bit drop = 1'b0;
+    int bank = flash_op.addr[TL_AW-1:OTFBankId];
+    otf_addr_t end_addr;
+
+    `uvm_info("prog_flash", $sformatf(
+              "addr:%x, otf_addr:%x wd:%0d, ", flash_op.addr, flash_op.otf_addr,
+              flash_op.num_words), UVM_MEDIUM)
+    // Each flash_program_data[] entry : 4B
+    // {global_cnt(16bits), lcnt(16bits)}
+    for (int j = 0; j < flash_op.num_words; j++) begin
+      if (cfg.wr_rnd_data) begin
+        flash_program_data.push_back($urandom);
+      end else begin
+        flash_program_data.push_back({global_pat_cnt, lcnt++});
+      end
+    end
+    // Check permissions.
+    if (flash_op.partition == FlashPartData) begin
+      int page = cfg.addr2page(flash_op.addr);
+      region = cfg.get_region(page);
+    end else begin
+      // for region, use per bank page number
+      int page = cfg.addr2page(flash_op.otf_addr);
+      region = cfg.get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
+      drop |= check_info_part(flash_op, "prog_flash");
+    end
+    drop |= validate_flash_op(flash_op, region);
+    if (drop) begin
+      `uvm_info("prog_flash", $sformatf("op:%s is not allowed in this region %p",
+                                        flash_op.op.name, region), UVM_MEDIUM)
+    end
+
+    // Check program window resolution error.
+    end_addr = flash_op.otf_addr + flash_op.num_words * 4 - 1;
+    if (end_addr[FlashPgmResWidth + BusByteWidth ] !=
+        flash_op.otf_addr[FlashPgmResWidth + BusByteWidth]) begin
+      `uvm_info("prog_flash", $sformatf("prog_window violation, start_addr:0x%x end_addr:0x%x",
+                                        flash_op.otf_addr, end_addr), UVM_MEDIUM)
+      expect_prog_win_error = 1;
+      drop = 1;
+    end
+    if (drop) set_otf_exp_alert("recov_err");
+
+    // Start the operation.
+    if (cfg.intr_mode) begin
+      flash_ctrl_intr_write(flash_op, flash_program_data);
+    end else begin
+      flash_ctrl_start_op(flash_op);
+      if (in_err) begin
+        cfg.tlul_core_exp_cnt += flash_op.num_words;
+      end
+      flash_ctrl_write(flash_program_data, !in_err);
+
+      if (!in_err) wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
+    end
+
+    if (expect_prog_win_error) begin
+      csr_rd_check(.ptr(ral.err_code.prog_win_err), .compare_value(1));
+      drop = 1;
+    end
+
+    `uvm_info("prog_flash", $sformatf("bank:%0d addr:%x otf_addr:%x part:%s wd:%0d",
+                                      bank, flash_op.addr, flash_op.otf_addr,
+                                      flash_op.partition.name, flash_op.num_words), UVM_MEDIUM)
+    if (drop) begin
+      uvm_reg_data_t ldata;
+      csr_rd(.ptr(ral.err_code), .value(ldata), .backdoor(1));
+      `uvm_info("prog_flash", $sformatf("skip sb path due to err_code:%x", ldata), UVM_MEDIUM)
+    end else begin
+      flash_otf_item exp_item;
+      if (store_prog_data) cfg.prog_data[flash_op] = flash_program_data;
+
+      flash_otf_print_data64(flash_program_data, "wdata");
+      `uvm_create_obj(flash_otf_item, exp_item)
+
+      exp_item.cmd = flash_op;
+      exp_item.dq = flash_program_data;
+      exp_item.region = region;
+      // Scramble data
+      exp_item.scramble(otp_addr_key, otp_data_key, flash_op.otf_addr);
+
+      p_sequencer.eg_exp_ctrl_port[bank].write(exp_item);
+      flash_phy_prim_agent_pkg::print_flash_data(exp_item.fq,
+          $sformatf("fdata_%0d bank %0d", cfg.otf_ctrl_wr_sent, bank));
+    end
+    global_pat_cnt++;
+    cfg.otf_ctrl_wr_sent++;
+  endtask
+
   // Program flash in the unit of minimum resolution (4Byte)
   // If data is not aligned to 8Byte, rtl pads all F to
   // upper or lower 4Byte.
@@ -296,22 +393,17 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
   virtual task prog_flash(ref flash_op_t flash_op, input int bank, int num, int wd = 16,
                   bit in_err = 0, bit store_prog_data = 0);
     data_q_t flash_data_chunk;
-    flash_otf_item exp_item;
     bit poll_fifo_status = ~in_err;
-    bit [15:0] lcnt = 0;
-    bit [flash_ctrl_pkg::BusAddrByteW-1:0] start_addr, end_addr;
+    shortint lcnt = 0;
+    otf_addr_t start_addr, end_addr;
     data_4s_t tmp_data;
-    int tail, is_odd;
-    int unit_word;
     int tot_wd;
-    int page;
     bit overflow = 0;
-    bit drop = 0;
 
-    flash_mp_region_cfg_t my_region;
-
-    is_odd = flash_op.otf_addr[2];
-    tot_wd = wd * num + is_odd;
+    `DV_CHECK_EQ(flash_op.otf_addr[2], 1'b0,
+                 "prog_flash gets unexpected address not 8 byte aligned")
+    `DV_CHECK(wd % 2 == 0, "prog_flash gets unexpected odd bus word count")
+    tot_wd = wd * num;
 
     flash_op.op = FlashOpProgram;
     flash_op.num_words = wd;
@@ -327,6 +419,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     start_addr = flash_op.otf_addr;
     // last byte address in each program
     end_addr = start_addr + (tot_wd * 4) - 1;
+    update_range_addresses_written(to_full_addr(start_addr, bank), to_full_addr(end_addr, bank));
 
     `uvm_info("prog_flash",$sformatf("begin addr:%x part:%s num:%0d wd:%0d st:%x ed:%x",
                                      flash_op.otf_addr, flash_op.partition.name, num,
@@ -344,7 +437,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end
 
     if (overflow) begin
-      bit [flash_ctrl_pkg::BusAddrByteW-1:0] tmp_addr = start_addr;
+      otf_addr_t tmp_addr = start_addr;
       if (flash_op.partition == FlashPartData) begin
         start_addr[16:0] = 'h0;
       end else begin
@@ -354,8 +447,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                                          " roll over start address to 0x%x"},
                                         tmp_addr, end_addr, flash_op.partition.name,
                                         start_addr), UVM_MEDIUM)
-      is_odd = flash_op.otf_addr[2];
-      tot_wd = wd * num + is_odd;
+      tot_wd = wd * num;
       end_addr = start_addr + (tot_wd * 4) - 1;
     end
     // Check if end_addr overflows.
@@ -364,125 +456,52 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
                                        " part:%s size:%0d x %0d x 4B"},
                                       bank, flash_op.otf_addr, flash_op.partition.name,
                                       num, wd), UVM_MEDIUM)
+
     flash_op.otf_addr = start_addr;
 
     for (int i = 0; i < num; i++) begin
       flash_program_data = '{};
-      tail = 0;
-      drop = 0;
-      is_odd = flash_op.otf_addr[2];
-      end_addr = flash_op.otf_addr + ((wd + is_odd) * 4) - 1;
-      // Check resolution error
-      // Current resolution : 0x40.
-      // Check if address[6] is same for start and end addr.
-      `uvm_info("prog_flash", $sformatf("start_addr:%x  end_addr:%x",
-                                        flash_op.otf_addr, end_addr), UVM_HIGH)
-      if (flash_op.otf_addr[6] != end_addr[6]) begin
-        `uvm_info("prog_flash", $sformatf("prog_window violation, start_addr:0x%x  end_addr:0x%x",
-                                          flash_op.otf_addr, end_addr), UVM_MEDIUM)
-        // Shift start addr window
-        if (flash_op.partition == FlashPartData) begin
-          flash_op.otf_addr[BusAddrByteW-1:6] = end_addr[BusAddrByteW-1:6];
-          flash_op.otf_addr[5:0] = 0;
-        end else begin
-          flash_op.otf_addr[8:0] = 'h0;
-        end
-        end_addr = flash_op.otf_addr + (wd * 4) -1;
-        `uvm_info("prog_flash", $sformatf("change to page:%0d start_addr to 0x%x end_addr:0x%x",
-                                          cfg.addr2page(flash_op.addr),
-                                          flash_op.otf_addr,
-                                          end_addr), UVM_MEDIUM)
-        is_odd = 0;
-      end
-      unit_word = wd;
-      // Each flash_program_data[] entry : 4B
-      // {global_cnt(16bits), lcnt(16bits)}
-      for (int j = 0; j < wd; j++) begin
-        if (cfg.wr_rnd_data) begin
-           flash_program_data.push_back($urandom);
-        end else begin
-           flash_program_data.push_back({global_pat_cnt, lcnt++});
-        end
-      end
+      end_addr = flash_op.otf_addr + (wd * 4) - 1;
+
       flash_op.addr = flash_op.otf_addr;
-      // Bank : bit[19]
       flash_op.addr[TL_AW-1:OTFBankId] = bank;
 
-      if (flash_op.partition == FlashPartData) begin
-        page = cfg.addr2page(flash_op.addr);
-        my_region = cfg.get_region(page);
-      end else begin
-        // for region, use per bank page number
-        page = cfg.addr2page(flash_op.otf_addr);
-        my_region = cfg.get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
-        drop = check_info_part(flash_op, "prog_flash");
-      end
+      `DV_CHECK_EQ(flash_op.addr[2], 1'b0, "Unexpected address not 8-byte aligned for flash_prog")
+      `uvm_info("prog_flash", $sformatf("in loop tl_addr:%x start_addr:%x  end_addr:%x",
+                                        flash_op.addr, flash_op.otf_addr, end_addr), UVM_MEDIUM)
 
-      drop |= validate_flash_op(flash_op, my_region);
-      if (drop) begin
-        `uvm_info("prog_flash", $sformatf("op:%s is not allowed in this region %p",
-                                          flash_op.op.name, my_region), UVM_MEDIUM)
-        set_otf_exp_alert("recov_err");
-      end
-
-      if (cfg.intr_mode) begin
-        flash_ctrl_intr_write(flash_op, flash_program_data);
-      end else begin
-        flash_ctrl_start_op(flash_op);
-        if (in_err) begin
-          cfg.tlul_core_exp_cnt += flash_op.num_words;
+      // Check resolution error
+      // Current resolution : 0x40.
+      // If address[6] differ between start and end addr a prog_win error will be raised and the
+      // transaction will be dropped. But if cfg.seq_cfg.avoid_prog_res_fault is set this breaks
+      // off a transaction up to the window's end, issues it, and adjusts the transactions to
+      // come to start past the window's end.
+      if (end_addr[FlashPgmResWidth + BusByteWidth ] !=
+        flash_op.otf_addr[FlashPgmResWidth + BusByteWidth]) begin
+        if (cfg.seq_cfg.avoid_prog_res_fault) begin
+          flash_op_t first_op;
+          int first_wd;
+          otf_addr_t next_addr = round_to_prog_resolution(
+             flash_op.otf_addr + flash_ctrl_reg_pkg::RegBusPgmResBytes - 1);
+          first_wd = (next_addr - flash_op.otf_addr) >> 2;
+          first_op = flash_op;
+          first_op.num_words = first_wd;
+          `uvm_info("prog_flash", $sformatf(
+                    "Broke request below into one up to 0x%x with %0d bus words",
+                    next_addr, first_wd),
+                    UVM_MEDIUM)
+          print_flash_op(flash_op, UVM_MEDIUM);
+          `uvm_info("prog_flash", "Broken request:", UVM_MEDIUM)
+          print_flash_op(first_op, UVM_MEDIUM);
+          issue_prog_request(first_op, lcnt, in_err, store_prog_data);
+          flash_op.addr += first_wd * 4;
+          flash_op.otf_addr = flash_op.addr;
+          flash_op.num_words = wd - first_wd;
         end
-        flash_ctrl_write(flash_program_data, poll_fifo_status);
+      end
 
-        if (!in_err) wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
-      end
-      if (is_odd == 1) begin
-        tmp_data = {32{1'b1}};
-        flash_program_data.push_front(tmp_data);
-        unit_word++;
-      end
-      tail = unit_word % 2;
-
-      if (wd > 1 && tail == 1) begin
-        tmp_data = {32{1'b1}};
-        flash_program_data.push_back(tmp_data);
-      end
-      if (wd == 1 && is_odd == 0) begin
-        tmp_data = {32{1'b1}};
-        flash_program_data.push_back(tmp_data);
-      end
-      if (wd > 16) begin
-        csr_rd_check(.ptr(ral.err_code.prog_win_err), .compare_value(1));
-        drop = 1;
-      end
-      `uvm_info("prog_flash",$sformatf({"bank:%0d addr:%x otf_addr:%x part:%s",
-                                        " page:%0d num:%0d wd:%0d  odd:%0d tail:%0d"},
-                                        bank, flash_op.addr, flash_op.otf_addr,
-                                        flash_op.partition.name, page, num,
-                                        wd, is_odd, tail), UVM_MEDIUM)
-      if (drop) begin
-        uvm_reg_data_t ldata;
-        csr_rd(.ptr(ral.err_code), .value(ldata), .backdoor(1));
-        `uvm_info("prog_flash", $sformatf("skip sb path due to err_code:%x", ldata), UVM_MEDIUM)
-      end else begin
-        if (store_prog_data) cfg.prog_data[flash_op] = flash_program_data;
-
-        flash_otf_print_data64(flash_program_data, "wdata");
-        `uvm_create_obj(flash_otf_item, exp_item)
-
-        exp_item.cmd = flash_op;
-        exp_item.dq = flash_program_data;
-        exp_item.region = my_region;
-        // Scramble data
-        exp_item.scramble(otp_addr_key, otp_data_key, flash_op.otf_addr);
-
-        p_sequencer.eg_exp_ctrl_port[bank].write(exp_item);
-        flash_phy_prim_agent_pkg::print_flash_data(exp_item.fq,
-              $sformatf("fdata_%0d bank%0d", cfg.otf_ctrl_wr_sent, bank));
-      end
-      flash_op.otf_addr = flash_op.otf_addr + (4 * wd);
-      global_pat_cnt++;
-      cfg.otf_ctrl_wr_sent++;
+      issue_prog_request(flash_op, lcnt, in_err, store_prog_data);
+      flash_op.otf_addr += flash_op.num_words * 4;
     end // for (int i = 0; i < num; i++)
   endtask // prog_flash
 
@@ -579,6 +598,10 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         end else begin
           page = cfg.addr2page(flash_op.otf_addr);
           my_region = cfg.get_region_from_info(cfg.mp_info[bank][flash_op.partition>>1][page]);
+          `uvm_info(`gfn, $sformatf(
+                    "For addr:%x, bank:%0d, page:%0d, region scr_en:%b ecc_en:%b",
+                    flash_op.otf_addr, bank, page, my_region.scramble_en == MuBi4True,
+                    my_region.ecc_en == MuBi4True), UVM_MEDIUM)
           drop |= check_info_part(flash_op, "read_flash");
         end
         drop |= validate_flash_op(flash_op, my_region);
@@ -599,7 +622,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         exp_item.ctrl_rd_region_q.push_back(my_region);
       end
       flash_op.addr = tmp_addr;
-      // Bank id truncaded by otf_addr size
+      // Bank id truncated by otf_addr size
       flash_op.otf_addr = tmp_addr;
       // recalculate page and region based on start address
       // for the debug print
@@ -661,6 +684,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         end
       end
 
+      `uvm_info("read_flash", $sformatf("intr_mode=%b", cfg.intr_mode), UVM_MEDIUM)
       if (cfg.intr_mode) begin
         flash_ctrl_intr_read(flash_op, flash_read_data);
       end else begin
@@ -673,9 +697,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
         if (overrd > 0) begin
           overread(flash_op, bank, num, overrd);
         end
-
         if (!in_err) wait_flash_op_done();
       end
+
       if (derr_is_set | cfg.ierr_created[0]) begin
         `uvm_info("read_flash", $sformatf({"bank:%0d addr: %x(otf:%x) derr_is_set:%0d",
                                           " ierr_created[0]:%0d"}, bank, flash_op.addr,
@@ -755,10 +779,10 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       tl_addr[OTFHostId] = 1;
       overflow = end_addr[OTFHostId];
     end
-    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow:% x",
+    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow: %x",
                                        addr, end_addr, overflow), UVM_HIGH)
     rd_entry.bank = bank;
-    tl_addr[OTFBankId] = bank;
+    tl_addr[TL_AW-1:OTFBankId] = bank;
     if (overflow) begin
        addr = num * 4;
     end
@@ -787,7 +811,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
 
       // Address should be per bank addr
       rd_entry.addr = tl_addr;
-      rd_entry.addr[OTFBankId] = 0;
+      rd_entry.addr[TL_AW-1:OTFBankId] = 0;
 
       // Address has to be 8byte aligned
       rd_entry.addr[2:0] = 'h0;
@@ -1088,7 +1112,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     rd_cache_t rd_entry;
 
     rd_entry.bank = bank;
-    tl_addr[OTFBankId] = bank;
+    tl_addr[TL_AW-1:OTFBankId] = bank;
     tl_addr[OTFHostId:2] = addr[OTFHostId:2];
 
     `uvm_info("direct_readback", $sformatf("bank:%0d tl_addr:0x%0h, num: %0d",
@@ -1113,7 +1137,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       exp_item.data_key = otp_data_key;
 
       rd_entry.addr = tl_addr;
-      rd_entry.addr[OTFBankId] = 0;
+      rd_entry.addr[TL_AW-1:OTFBankId] = 0;
       // Address has to be 8byte aligned
       rd_entry.addr[2:0] = 'h0;
       rd_entry.part = FlashPartData;
@@ -1200,8 +1224,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
      flash_mp_region_cfg_t my_region;
 
      flash_op.op = FlashOpErase;
-     flash_op.otf_addr[OTFBankId] = bank;
-     flash_op.addr = flash_op.otf_addr;
+     flash_op.addr[TL_AW-1:OTFBankId] = bank;
+     flash_op.otf_addr = flash_op.addr;
      flash_op.erase_type = FlashErasePage;
 
      if (cfg.ecc_mode > FlashEccEnabled) begin
@@ -1296,6 +1320,9 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     else host_num = $urandom_range(1,32);
     host_bank = $urandom_range(0,1);
 
+    `uvm_info(`gfn, $sformatf(
+              "send_rand_host_rd addr=0x%x bank=%0d host_num=%0d, in_err=%b",
+              host.otf_addr, host_bank, host_num, in_err), UVM_MEDIUM)
     otf_direct_read(host.otf_addr, host_bank, host_num, in_err);
   endtask // send_rand_host_rd
 
@@ -1389,7 +1416,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     repeat (iter) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
       ctrl = rand_op;
-      bank = rand_op.addr[OTFBankId];
+      bank = rand_op.addr[TL_AW-1:OTFBankId];
       if (ctrl.partition == FlashPartData) begin
         num = ctrl_num;
       end else begin
@@ -1495,6 +1522,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     obs.print("chk_mem_intg: before");
     obs.region = exp.region;
     obs.skip_err_chk = 1;
+
     // descramble needs 2 buswords
     obs.cmd.num_words = 2;
     obs.descramble(exp.addr_key, exp.data_key);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_oversize_error_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_oversize_error_vseq.sv
@@ -22,6 +22,7 @@ class flash_ctrl_oversize_error_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(cfg.otf_num_rw) begin
+          if (cfg.stop_transaction_generators()) break;
           `DV_CHECK_RANDOMIZE_FATAL(this)
           ctrl = rand_op;
           bank = rand_op.addr[OTFBankId];

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -22,7 +22,7 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
   rand bit which_copy;
 
   constraint ctrl_num_c {
-    ctrl_num dist { CTRL_TRANS_MIN := 2, [2:16] :/ 1};
+    ctrl_num dist { CtrlTransMin := 2, [2:16] :/ 1};
   }
 
   typedef struct {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -49,7 +49,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
   // Single direct read data
   data_t flash_rd_one_data;
 
-  localparam data_t ALL_ONES = {TL_DW{1'b1}};
+  localparam data_t AllOnes = {TL_DW{1'b1}};
 
   // Configure sequence knobs to tailor it to smoke seq.
   virtual function void configure_vseq();
@@ -287,7 +287,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_fetch_code_vseq;
       `uvm_info(`gfn, $sformatf("FLASH DIRECT READ DATA: 0x%0h", flash_rd_one_data), UVM_HIGH)
       //first 5 data have init value while 6th value is overwritten by ctrl due to priority lost
       if (j < 5) begin
-        `DV_CHECK_EQ(flash_rd_one_data, ALL_ONES)
+        `DV_CHECK_EQ(flash_rd_one_data, AllOnes)
       end
       if (j == 5) begin
         `DV_CHECK_EQ(flash_rd_one_data, flash_op_data[0])

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
@@ -7,7 +7,7 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_rnd_wd_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CTRL_TRANS_MIN := 7, [2:31] :/ 1, CTRL_TRANS_MAX := 2}; }
+  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
   constraint fractions_c {
        solve ctrl_num before fractions;
        if (ctrl_num == 1)

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_vseq.sv
@@ -2,31 +2,81 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Generates random mix of reads and writes. Writes are somewhat delicate: when scrambling or ECC
+// are enabled we can only write full flash words (8 bytes), so the number of bus words needs to
+// be even and the starting address needs to be 8-byte aligned. This is ensured by the consraints.
+//
+// In addition, overwrites will almost surely cause ecc errors to be injected because bits cannot
+// flip from 0 to 1, so this makes sure addresses don't overlap previously written ones.
 class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_vseq)
   `uvm_object_new
+
+  // The maximum number of attempts to get an address that has not been previously written.
+  localparam int MaxProgAttempts = 16;
+
   flash_op_t ctrl;
   int num, bank;
 
-  virtual task body();
-    cfg.clk_rst_vif.wait_clks(5);
+  constraint fractions_c {
+    fractions[0] == 0;
+    fractions > 1;
+    fractions <= 16;
+  }
 
+  function void get_bank_and_num(input flash_op_t rand_op, ref int bank, ref int num);
+    bank = rand_op.addr[OTFBankId];
+    num = rand_op.partition == FlashPartData ? ctrl_num : ctrl_info_num;
+  endfunction
+
+  // Randomizes until a flash operation satisfies the constraints and its address has not
+  // previously written. It issues an error when failing.
+  protected function bit try_create_prog_op();
+    int attempts = 0;
+
+    while (attempts < MaxProgAttempts) begin
+      otf_addr_t end_addr;
+
+      // Add constraints to avoid half-word writes and to avoid readonly
+      // partitions.
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      ctrl = rand_op;
+      ctrl.num_words = fractions;
+      get_bank_and_num(ctrl, bank, num);
+      end_addr = ctrl.otf_addr + (num * fractions * 4) - 1;
+      if (!address_range_was_written(to_full_addr(ctrl.otf_addr, bank),
+                                     to_full_addr(end_addr, bank))) begin
+        return 1'b1;
+      end
+      ++attempts;
+    end
+    `DV_CHECK(0, "Too many unsuccessful attempts to create a prog_op")
+    return 1'b0;
+  endfunction : try_create_prog_op
+
+  virtual task body();
+    bit prev_addr_flash_word_aligned = cfg.seq_cfg.addr_flash_word_aligned;
+    bit prev_avoid_ro_partitions = cfg.seq_cfg.avoid_ro_partitions;
+
+    cfg.clk_rst_vif.wait_clks(5);
     fork
       begin
         repeat(cfg.otf_num_rw) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          ctrl = rand_op;
-          bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = ctrl_num;
-          end else begin
-            num = ctrl_info_num;
-          end
-          // If the partition that selected configured as read-only, skip the program
-          sync_otf_wr_ro_part();
           randcase
-            cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-            cfg.otf_rd_pct:read_flash(ctrl, bank, num, fractions);
+            cfg.otf_wr_pct: begin
+              cfg.seq_cfg.addr_flash_word_aligned = 1'b1;
+              cfg.seq_cfg.avoid_ro_partitions = 1'b1;
+              `DV_CHECK(try_create_prog_op(), "Could not create a prog flash op")
+              prog_flash(ctrl, bank, num, fractions);
+              cfg.seq_cfg.addr_flash_word_aligned = prev_addr_flash_word_aligned;
+              cfg.seq_cfg.avoid_ro_partitions = prev_avoid_ro_partitions;
+            end
+            cfg.otf_rd_pct: begin
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              ctrl = rand_op;
+              get_bank_and_num(ctrl, bank, num);
+              read_flash(ctrl, bank, num, fractions);
+            end
           endcase
         end
       end
@@ -34,7 +84,7 @@ class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
         launch_host_rd();
       end
     join
-  endtask
+  endtask : body
 
   virtual task launch_host_rd();
     for (int i = 0; i < cfg.otf_num_hr; ++i) begin
@@ -44,5 +94,5 @@ class flash_ctrl_rw_vseq extends flash_ctrl_otf_base_vseq;
       #0;
     end
     csr_utils_pkg::wait_no_outstanding_access();
-  endtask
-endclass // flash_ctrl_rw_vseq
+  endtask : launch_host_rd
+endclass : flash_ctrl_rw_vseq

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -195,7 +195,7 @@
     {
       name: flash_ctrl_wo
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=0", "+otf_rd_pct=0"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=0", "+otf_rd_pct=0", "+ecc_mode=1"]
       reseed: 20
     }
     {
@@ -213,13 +213,13 @@
     {
       name: flash_ctrl_ro
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=1000", "+otf_wr_pct=0"]
+      run_opts: ["+scb_otf_en=1", "+otf_num_rw=100", "+otf_num_hr=1000", "+otf_wr_pct=0", "+ecc_mode=1"]
       reseed: 20
     }
     {
       name: flash_ctrl_rw
       uvm_test_seq: flash_ctrl_rw_vseq
-      run_opts: ["+scb_otf_en=1", "+test_timeout_ns=5_000_000_000"]
+      run_opts: ["+scb_otf_en=1", "+test_timeout_ns=5_000_000_000", "+ecc_mode=1"]
       reseed: 20
     }
     {


### PR DESCRIPTION
We didn't have extensive testing of reads to adddresses peviously written with ECC and scrambling enabled. This PR enables ECC for flash_ctrl_rw_vseq and some others.

This requires a number of other changes:
- Writes must be done for full flash words, so the 32-bit chunks must be even and their address 8-byte aligned.
- Writes cannot overwrite contents already written or most likely some bit will not be able to flip from 0 to 1. This maintains a collection of addresses that have been already written to avoid overwrites.
- A bug is fixed for writes that span multiple program windows (aligned at 64 bytes): the dv code was replacing the sequence of writes by repeated writes to the start of the program window. Instead, this breaks any request that spills across windows in two.

Fixes #22746
Fixes #22559