### PR TITLE
[dv,flash_ctrl] Port missing fix from ip/flash_ctrl/dv

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -755,7 +755,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       tl_addr[OTFHostId] = 1;
       overflow = end_addr[OTFHostId];
     end
-    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow:% x",
+    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow: %x",
                                        addr, end_addr, overflow), UVM_HIGH)
     rd_entry.bank = bank;
     tl_addr[OTFBankId] = bank;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -755,7 +755,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       tl_addr[OTFHostId] = 1;
       overflow = end_addr[OTFHostId];
     end
-    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow:% x",
+    `uvm_info("direct_read", $sformatf("addr: %x end_addr: %x overflow: %x",
                                        addr, end_addr, overflow), UVM_HIGH)
     rd_entry.bank = bank;
     tl_addr[OTFBankId] = bank;


### PR DESCRIPTION
This change was done for hw/ip/flash_ctrl only, so it must be done in hw/ip_templates/flash_ctrl as well.

Part of #8440