### PR TITLE
[ownership] Fix merge skew

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/ecdsa_functest.c
+++ b/sw/device/silicon_creator/lib/ownership/ecdsa_functest.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/silicon_creator/lib/ownership/ecdsa.h"
-#include "sw/device/silicon_creator/lib/ownership/keys/fake/ownership_no_owner_recovery_ecdsa_p256.h"
+#include "sw/device/silicon_creator/lib/ownership/keys/fake/no_owner_recovery_ecdsa_p256.h"
 
 // From: http://www.abrahamlincolnonline.org/lincoln/speeches/gettysburg.htm
 static const char kGettysburgPrelude[] =
@@ -51,7 +51,7 @@ static const char kGettysburgSignature[] =
 // clang-format on
 
 static const owner_key_t kNoOwnerRecoveryKey = {
-    .key = OWNERSHIP_NO_OWNER_RECOVERY_ECDSA_P256,
+    .key = NO_OWNER_RECOVERY_ECDSA_P256,
 };
 
 void __assert_func(const char *file, int line, const char *func,

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -38,7 +38,6 @@ rom_error_t owner_block_parse(const owner_block_t *block,
   uint32_t offset = 0;
   while (remain) {
     const tlv_header_t *item = (const tlv_header_t *)(block->data + offset);
-    printf("Found tag: %08x %08x\n", item->tag, item->length);
     if (item->tag == kTlvTagNotPresent || item->length == kTlvTagNotPresent) {
       break;
     }
@@ -86,12 +85,12 @@ rom_error_t owner_block_flash_apply(const owner_flash_config_t *flash,
                                     uint32_t primary_side) {
   if ((hardened_bool_t)flash == kHardenedBoolFalse)
     return kErrorOk;
-  uint32_t start = config_side == kBootDataSlotA   ? 0
-                   : config_side == kBootDataSlotB ? kFlashBankSize
-                                                   : 0xFFFFFFFF;
-  uint32_t end = config_side == kBootDataSlotA   ? kFlashBankSize
-                 : config_side == kBootDataSlotB ? 2 * kFlashBankSize
-                                                 : 0;
+  uint32_t start = config_side == kBootSlotA   ? 0
+                   : config_side == kBootSlotB ? kFlashBankSize
+                                               : 0xFFFFFFFF;
+  uint32_t end = config_side == kBootSlotA   ? kFlashBankSize
+                 : config_side == kBootSlotB ? 2 * kFlashBankSize
+                                             : 0;
   size_t len = (flash->header.length - sizeof(owner_flash_config_t)) /
                sizeof(owner_flash_region_t);
   if (len >= 8) {

--- a/sw/device/silicon_creator/lib/ownership/owner_block_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/owner_block_unittest.cc
@@ -227,8 +227,7 @@ const owner_flash_info_config_t info_config = {
 };
 
 TEST_F(OwnerBlockTest, FlashConfigApplyBad) {
-  rom_error_t error =
-      owner_block_flash_apply(&bad_flash_config, kBootDataSlotA, 0);
+  rom_error_t error = owner_block_flash_apply(&bad_flash_config, kBootSlotA, 0);
   EXPECT_EQ(error, kErrorOwnershipFlashConfigLenth);
 }
 
@@ -257,7 +256,7 @@ TEST_F(OwnerBlockTest, FlashConfigApplySideA) {
                                  kMultiBitBool4True)));
 
   rom_error_t error =
-      owner_block_flash_apply(&simple_flash_config, kBootDataSlotA, 0);
+      owner_block_flash_apply(&simple_flash_config, kBootSlotA, 0);
   EXPECT_EQ(error, kErrorOk);
 }
 
@@ -287,8 +286,8 @@ TEST_F(OwnerBlockTest, FlashConfigApplySideAPrimary) {
                         FlashCfg(kMultiBitBool4False, kMultiBitBool4False,
                                  kMultiBitBool4True)));
 
-  rom_error_t error = owner_block_flash_apply(&simple_flash_config,
-                                              kBootDataSlotA, kBootDataSlotA);
+  rom_error_t error =
+      owner_block_flash_apply(&simple_flash_config, kBootSlotA, kBootSlotA);
   EXPECT_EQ(error, kErrorOk);
 }
 
@@ -317,7 +316,7 @@ TEST_F(OwnerBlockTest, FlashConfigApplySideB) {
                                  kMultiBitBool4True)));
 
   rom_error_t error =
-      owner_block_flash_apply(&simple_flash_config, kBootDataSlotB, 0);
+      owner_block_flash_apply(&simple_flash_config, kBootSlotB, 0);
   EXPECT_EQ(error, kErrorOk);
 }
 


### PR DESCRIPTION
The symbol `kBootDataSlot...` got replaced by `kBootSlot...`.