### PR TITLE
[silicon_creator] refactor OTBN boot services to enable generating TPM or DICE keys

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -491,12 +491,10 @@ cc_library(
 opentitan_test(
     name = "otbn_boot_services_functest",
     srcs = ["otbn_boot_services_functest.c"],
-    broken = cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
         },
     ),
     # This target uses OTBN pointers internally, so it cannot work host-side.

--- a/sw/device/silicon_creator/lib/dice.c
+++ b/sw/device/silicon_creator/lib/dice.c
@@ -98,20 +98,60 @@ static void curr_pubkey_le_to_be_convert(attestation_public_key_t *pubkey) {
   le_be_buf_format((unsigned char *)pubkey->y, kAttestationPublicKeyCoordBytes);
 }
 
-/**
- * Function generating a DICE or TPM certificate key pair. If successful, the
- * generated public key is saved at pubkey.
- */
-static rom_error_t common_attestation_keygen(
-    otbn_boot_attestation_key_type_t key_type,
-    const sc_keymgr_diversification_t *diversifier, attestation_key_seed_t seed,
-    sc_keymgr_state_t desired_keymgr_state, hmac_digest_t *pubkey_id,
-    attestation_public_key_t *pubkey) {
+rom_error_t dice_attestation_keygen(dice_key_t desired_key,
+                                    hmac_digest_t *pubkey_id,
+                                    attestation_public_key_t *pubkey) {
+  otbn_boot_attestation_key_type_t key_type;
+  attestation_key_seed_t otbn_ecc_keygen_seed;
+  const sc_keymgr_diversification_t *keymgr_diversifier;
+  sc_keymgr_state_t desired_keymgr_state;
+
+  switch (desired_key) {
+    case kDiceKeyUds:
+      desired_keymgr_state = kScKeymgrStateCreatorRootKey;
+      key_type = kOtbnBootAttestationKeyTypeDice;
+      keymgr_diversifier = &kUdsKeymgrDiversifier;
+      otbn_ecc_keygen_seed = kUdsAttestationKeySeed;
+      break;
+    case kDiceKeyCdi0:
+      desired_keymgr_state = kScKeymgrStateOwnerIntermediateKey;
+      key_type = kOtbnBootAttestationKeyTypeDice;
+      keymgr_diversifier = &kCdi0KeymgrDiversifier;
+      otbn_ecc_keygen_seed = kCdi0AttestationKeySeed;
+      break;
+    case kDiceKeyCdi1:
+      desired_keymgr_state = kScKeymgrStateOwnerKey;
+      key_type = kOtbnBootAttestationKeyTypeDice;
+      keymgr_diversifier = &kCdi1KeymgrDiversifier;
+      otbn_ecc_keygen_seed = kCdi1AttestationKeySeed;
+      break;
+    case kDiceKeyTpmEk:
+      desired_keymgr_state = kScKeymgrStateOwnerKey;
+      key_type = kOtbnBootAttestationKeyTypeTpm;
+      keymgr_diversifier = &kTpmEkKeymgrDiversifier;
+      otbn_ecc_keygen_seed = kTpmEkAttestationKeySeed;
+      break;
+    case kDiceKeyTpmCek:
+      desired_keymgr_state = kScKeymgrStateOwnerKey;
+      key_type = kOtbnBootAttestationKeyTypeTpm;
+      keymgr_diversifier = &kTpmCekKeymgrDiversifier;
+      otbn_ecc_keygen_seed = kTpmCekAttestationKeySeed;
+      break;
+    case kDiceKeyTpmCik:
+      desired_keymgr_state = kScKeymgrStateOwnerKey;
+      key_type = kOtbnBootAttestationKeyTypeTpm;
+      keymgr_diversifier = &kTpmCikKeymgrDiversifier;
+      otbn_ecc_keygen_seed = kTpmCikAttestationKeySeed;
+      break;
+    default:
+      return kErrorDiceInvalidKeyType;
+  };
+
   HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(desired_keymgr_state));
 
   // Generate / sideload key material into OTBN, and generate the ECC keypair.
-  HARDENED_RETURN_IF_ERROR(
-      otbn_boot_attestation_keygen(seed, key_type, *diversifier, pubkey));
+  HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_keygen(
+      otbn_ecc_keygen_seed, key_type, *keymgr_diversifier, pubkey));
 
   // Keys are represented in certificates in big endian format, but the key is
   // output from OTBN in little endian format, so we convert the key to
@@ -122,69 +162,6 @@ static rom_error_t common_attestation_keygen(
   hmac_sha256(pubkey, kAttestationPublicKeyCoordBytes * 2, pubkey_id);
 
   return kErrorOk;
-}
-
-/**
- * Function preparing parameters for generating DICE attestation keys.
- */
-rom_error_t dice_attestation_keygen(dice_key_t desired_key,
-                                    hmac_digest_t *pubkey_id,
-                                    attestation_public_key_t *pubkey) {
-  attestation_key_seed_t otbn_ecc_keygen_seed;
-  const sc_keymgr_diversification_t *keymgr_diversifier;
-  sc_keymgr_state_t desired_state;
-
-  switch (desired_key) {
-    case kDiceKeyUds:
-      desired_state = kScKeymgrStateCreatorRootKey;
-      keymgr_diversifier = &kUdsKeymgrDiversifier;
-      otbn_ecc_keygen_seed = kUdsAttestationKeySeed;
-      break;
-    case kDiceKeyCdi0:
-      desired_state = kScKeymgrStateOwnerIntermediateKey;
-      keymgr_diversifier = &kCdi0KeymgrDiversifier;
-      otbn_ecc_keygen_seed = kCdi0AttestationKeySeed;
-      break;
-    case kDiceKeyCdi1:
-      desired_state = kScKeymgrStateOwnerKey;
-      keymgr_diversifier = &kCdi1KeymgrDiversifier;
-      otbn_ecc_keygen_seed = kCdi1AttestationKeySeed;
-      break;
-    default:
-      return kErrorDiceInvalidArgument;
-  };
-  return common_attestation_keygen(kOtbnBootAttestationKeyTypeDice,
-                                   keymgr_diversifier, otbn_ecc_keygen_seed,
-                                   desired_state, pubkey_id, pubkey);
-}
-
-/**
- * Function preparing parameters for generating TPM keys.
- */
-rom_error_t tpm_cert_keygen(tpm_key_t desired_key, hmac_digest_t *pubkey_id,
-                            attestation_public_key_t *pubkey) {
-  attestation_key_seed_t otbn_ecc_keygen_seed;
-  const sc_keymgr_diversification_t *keymgr_diversifier;
-
-  switch (desired_key) {
-    case kTpmKeyEk:
-      keymgr_diversifier = &kTpmEkKeymgrDiversifier;
-      otbn_ecc_keygen_seed = kTpmEkAttestationKeySeed;
-      break;
-    case kTpmKeyCek:
-      keymgr_diversifier = &kTpmCekKeymgrDiversifier;
-      otbn_ecc_keygen_seed = kTpmCekAttestationKeySeed;
-      break;
-    case kTpmKeyCik:
-      keymgr_diversifier = &kTpmCikKeymgrDiversifier;
-      otbn_ecc_keygen_seed = kTpmCikAttestationKeySeed;
-      break;
-    default:
-      return kErrorDiceInvalidArgument;
-  };
-  return common_attestation_keygen(kOtbnBootAttestationKeyTypeTpm,
-                                   keymgr_diversifier, otbn_ecc_keygen_seed,
-                                   kScKeymgrStateOwnerKey, pubkey_id, pubkey);
 }
 
 /**
@@ -371,7 +348,8 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
 
 rom_error_t dice_tpm_ek_cert_build(manuf_certgen_inputs_t *inputs,
                                    attestation_public_key_t *tpm_ek_pubkey,
-                                   hmac_digest_t *digest, uint8_t *tpm_ek_tbs,
+                                   hmac_digest_t *pubkey_id,
+                                   uint8_t *tpm_ek_tbs,
                                    size_t *tpm_ek_tbs_size) {
   tpm_ek_tbs_values_t tpm_ek_tbs_params = {
       .auth_key_key_id = inputs->auth_key_key_id,
@@ -380,7 +358,7 @@ rom_error_t dice_tpm_ek_cert_build(manuf_certgen_inputs_t *inputs,
       .tpm_ek_pub_key_ec_x_size = kAttestationPublicKeyCoordBytes,
       .tpm_ek_pub_key_ec_y = (unsigned char *)tpm_ek_pubkey->y,
       .tpm_ek_pub_key_ec_y_size = kAttestationPublicKeyCoordBytes,
-      .tpm_ek_pub_key_id = (unsigned char *)digest->digest,  // Nobody cares.
+      .tpm_ek_pub_key_id = (unsigned char *)pubkey_id->digest,
       .tpm_ek_pub_key_id_size = kDiceCertKeyIdSizeInBytes,
       .tpm_version = "0.0.1",
       .tpm_version_len = 5,
@@ -398,7 +376,8 @@ rom_error_t dice_tpm_ek_cert_build(manuf_certgen_inputs_t *inputs,
 
 rom_error_t dice_tpm_cek_cert_build(manuf_certgen_inputs_t *inputs,
                                     attestation_public_key_t *tpm_cek_pubkey,
-                                    hmac_digest_t *digest, uint8_t *tpm_cek_tbs,
+                                    hmac_digest_t *pubkey_id,
+                                    uint8_t *tpm_cek_tbs,
                                     size_t *tpm_cek_tbs_size) {
   tpm_cek_tbs_values_t tpm_cek_tbs_params = {
       .auth_key_key_id = inputs->auth_key_key_id,
@@ -407,7 +386,7 @@ rom_error_t dice_tpm_cek_cert_build(manuf_certgen_inputs_t *inputs,
       .tpm_cek_pub_key_ec_x_size = kAttestationPublicKeyCoordBytes,
       .tpm_cek_pub_key_ec_y = (unsigned char *)tpm_cek_pubkey->y,
       .tpm_cek_pub_key_ec_y_size = kAttestationPublicKeyCoordBytes,
-      .tpm_cek_pub_key_id = (unsigned char *)digest->digest,
+      .tpm_cek_pub_key_id = (unsigned char *)pubkey_id->digest,
       .tpm_cek_pub_key_id_size = kDiceCertKeyIdSizeInBytes,
   };
 
@@ -419,7 +398,8 @@ rom_error_t dice_tpm_cek_cert_build(manuf_certgen_inputs_t *inputs,
 
 rom_error_t dice_tpm_cik_cert_build(manuf_certgen_inputs_t *inputs,
                                     attestation_public_key_t *tpm_cik_pubkey,
-                                    hmac_digest_t *digest, uint8_t *tpm_cik_tbs,
+                                    hmac_digest_t *pubkey_id,
+                                    uint8_t *tpm_cik_tbs,
                                     size_t *tpm_cik_tbs_size) {
   tpm_cik_tbs_values_t tpm_cik_tbs_params = {
       .auth_key_key_id = inputs->auth_key_key_id,
@@ -428,7 +408,7 @@ rom_error_t dice_tpm_cik_cert_build(manuf_certgen_inputs_t *inputs,
       .tpm_cik_pub_key_ec_x_size = kAttestationPublicKeyCoordBytes,
       .tpm_cik_pub_key_ec_y = (unsigned char *)tpm_cik_pubkey->y,
       .tpm_cik_pub_key_ec_y_size = kAttestationPublicKeyCoordBytes,
-      .tpm_cik_pub_key_id = (unsigned char *)digest->digest,
+      .tpm_cik_pub_key_id = (unsigned char *)pubkey_id->digest,
       .tpm_cik_pub_key_id_size = kDiceCertKeyIdSizeInBytes,
   };
 

--- a/sw/device/silicon_creator/lib/dice.h
+++ b/sw/device/silicon_creator/lib/dice.h
@@ -26,12 +26,33 @@ enum {
 };
 
 /**
- * Supported DICE attestation keys.
+ * Supported DICE/TPM attestation keys.
  */
 typedef enum dice_key {
+  /**
+   * DICE UDS key.
+   */
   kDiceKeyUds = 0,
+  /**
+   * DICE CDI0 key.
+   */
   kDiceKeyCdi0 = 1,
+  /**
+   * DICE CDI1 key.
+   */
   kDiceKeyCdi1 = 2,
+  /**
+   * TPM EK key.
+   */
+  kDiceKeyTpmEk = 3,
+  /**
+   * TPM CEK key.
+   */
+  kDiceKeyTpmCek = 4,
+  /**
+   * TPM CIK key.
+   */
+  kDiceKeyTpmCik = 5,
 } dice_key_t;
 
 /**
@@ -50,17 +71,8 @@ typedef struct dice_cert_key_id_pair {
 } dice_cert_key_id_pair_t;
 
 /**
- *  Supported TPM attestation keys.
- */
-typedef enum tpm_key {
-  kTpmKeyEk = 0,
-  kTpmKeyCek = 1,
-  kTpmKeyCik = 2,
-} tpm_key_t;
-
-/**
- * Generates the requested attestation ECC keypair, returning the public key and
- * a key ID (which is a SHA256 digest of the public key).
+ * Generates the requested attestation ECC P256 keypair, returning the public
+ * key and a key ID (which is a SHA256 digest of the public key).
  *
  * Preconditions: keymgr has been initialized and cranked to the desired stage.
  *
@@ -130,20 +142,6 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
                                   dice_cert_key_id_pair_t *key_ids,
                                   attestation_public_key_t *cdi_1_pubkey,
                                   uint8_t *cert, size_t *cert_size);
-
-/**
- * Generates the requested TPM ECC keypair, returning the public key and
- * a key ID (which is a SHA256 digest of the public key).
- *
- * Preconditions: keymgr has been initialized and cranked to the desired stage.
- *
- * @param desired_key The desired attestation key to generate.
- * @param[out] pubkey_id The public key ID (for embedding into certificates).
- * @param[out] pubkey The public key.
- */
-OT_WARN_UNUSED_RESULT
-rom_error_t tpm_cert_keygen(tpm_key_t desired_key, hmac_digest_t *pubkey_id,
-                            attestation_public_key_t *pubkey);
 
 /**
  * Generates an X.509 TBS section of a TPM EK certificate.

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -203,17 +203,22 @@ static rom_error_t keymgr_wait_until_done(void) {
   return kErrorKeymgrInternal;
 }
 
-rom_error_t sc_keymgr_generate_attestation_key_otbn(
+rom_error_t sc_keymgr_generate_key_otbn(
+    sc_keymgr_key_type_t key_type,
     sc_keymgr_diversification_t diversification) {
   HARDENED_RETURN_IF_ERROR(keymgr_is_idle());
 
+  uint32_t ctrl = 0;
+
   // Select OTBN as the destination.
-  uint32_t ctrl =
-      bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,
-                             KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_OTBN);
+  ctrl = bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,
+                                KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_OTBN);
 
   // Select the attestation CDI.
-  ctrl = bitfield_bit32_write(ctrl, KEYMGR_CONTROL_SHADOWED_CDI_SEL_BIT, true);
+  if (key_type == kScKeymgrKeyTypeAttestation) {
+    ctrl =
+        bitfield_bit32_write(ctrl, KEYMGR_CONTROL_SHADOWED_CDI_SEL_BIT, true);
+  }
 
   // Select the "generate" operation.
   ctrl = bitfield_field32_write(

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -184,18 +184,27 @@ OT_WARN_UNUSED_RESULT
 rom_error_t sc_keymgr_state_check(sc_keymgr_state_t expected_state);
 
 /**
- * Derive a key manager key for the OTBN block.
+ * Keymgr output-generate key types (attestation or sealing).
+ */
+typedef enum sc_keymgr_key_type {
+  kScKeymgrKeyTypeAttestation = 0,
+  kScKeymgrKeyTypeSealing = 1,
+} sc_keymgr_key_type_t;
+
+/**
+ * Generate a key manager key and sideload to the OTBN block.
  *
  * Calls the key manager to sideload a key into the OTBN hardware block and
- * waits until the operation is complete before returning. Always uses the
- * attestation (not sealing) CDI; call this only for attestation keys.
+ * waits until the operation is complete before returning. Can sideload an
+ * attestation or sealing key based on user input.
  *
+ * @param key_type Key type: attestation or sealing.
  * @param diversification Diversification input for the key derivation.
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t sc_keymgr_generate_attestation_key_otbn(
-    const sc_keymgr_diversification_t diversification);
+rom_error_t sc_keymgr_generate_key_otbn(
+    sc_keymgr_key_type_t key_type, sc_keymgr_diversification_t diversification);
 
 /**
  * Clear OTBN's sideloaded key slot.

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -195,7 +195,7 @@ enum module_ {
   X(kErrorRescueBadMode,              ERROR_(1, kModuleRescue, kInvalidArgument)), \
   X(kErrorRescueImageTooBig,          ERROR_(2, kModuleRescue, kFailedPrecondition)), \
   \
-  X(kErrorDiceInvalidArgument,        ERROR_(0, kModuleDice, kInvalidArgument)), \
+  X(kErrorDiceInvalidKeyType,         ERROR_(0, kModuleDice, kInvalidArgument)), \
   \
   X(kErrorCertInternal,               ERROR_(0, kModuleCert, kInternal)), \
   X(kErrorCertInvalidArgument,        ERROR_(1, kModuleCert, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -125,11 +125,12 @@ rom_error_t otbn_boot_app_load(void) { return sc_otbn_load_app(kOtbnAppBoot); }
 
 rom_error_t otbn_boot_attestation_keygen(
     attestation_key_seed_t additional_seed,
+    otbn_boot_attestation_key_type_t key_type,
     sc_keymgr_diversification_t diversification,
     attestation_public_key_t *public_key) {
   // Trigger key manager to sideload the attestation key into OTBN.
-  HARDENED_RETURN_IF_ERROR(
-      sc_keymgr_generate_attestation_key_otbn(diversification));
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_generate_key_otbn(
+      (sc_keymgr_key_type_t)key_type, diversification));
 
   // Write the mode.
   uint32_t mode = kOtbnBootModeAttestationKeygen;
@@ -168,10 +169,11 @@ rom_error_t otbn_boot_attestation_keygen(
 
 rom_error_t otbn_boot_attestation_key_save(
     attestation_key_seed_t additional_seed,
+    otbn_boot_attestation_key_type_t key_type,
     sc_keymgr_diversification_t diversification) {
   // Trigger key manager to sideload the attestation key into OTBN.
-  HARDENED_RETURN_IF_ERROR(
-      sc_keymgr_generate_attestation_key_otbn(diversification));
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_generate_key_otbn(
+      (sc_keymgr_key_type_t)key_type, diversification));
 
   // Write the mode.
   uint32_t mode = kOtbnBootModeAttestationKeySave;

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -30,6 +30,14 @@ OT_WARN_UNUSED_RESULT
 rom_error_t otbn_boot_app_load(void);
 
 /**
+ * OTBN attestation key types (DICE or TPM).
+ */
+typedef enum otbn_boot_attestation_key_type {
+  kOtbnBootAttestationKeyTypeDice = kScKeymgrKeyTypeAttestation,
+  kOtbnBootAttestationKeyTypeTpm = kScKeymgrKeyTypeSealing,
+} otbn_boot_attestation_key_type_t;
+
+/**
  * Generate an attestation public key from a keymgr-derived secret.
  *
  * This routine triggers the key manager to sideload key material into OTBN,
@@ -47,6 +55,9 @@ rom_error_t otbn_boot_app_load(void);
  * `otbn_boot_app_load`.
  *
  * @param additional_seed The attestation key generation seed to load.
+ * @param key_type OTBN attestation key type to generate. "DICE" attestation
+ *                 keys are based on "attestation" keys from the keymgr; "TPM"
+ *                 attestation keys are based on "sealing keys from the keymgr.
  * @param diversification Salt and version information for key manager.
  * @param[out] public_key Attestation public key.
  * @return The result of the operation.
@@ -54,6 +65,7 @@ rom_error_t otbn_boot_app_load(void);
 OT_WARN_UNUSED_RESULT
 rom_error_t otbn_boot_attestation_keygen(
     attestation_key_seed_t additional_seed,
+    otbn_boot_attestation_key_type_t key_type,
     sc_keymgr_diversification_t diversification,
     attestation_public_key_t *public_key);
 
@@ -68,12 +80,16 @@ rom_error_t otbn_boot_attestation_keygen(
  * `otbn_boot_app_load`.
  *
  * @param additional_seed The attestation key generation seed to load.
+ * @param key_type OTBN attestation key type to generate. "DICE" attestation
+ *                 keys are based on "attestation" keys from the keymgr; "TPM"
+ *                 attestation keys are based on "sealing keys from the keymgr.
  * @param diversification Salt and version information for key manager.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t otbn_boot_attestation_key_save(
     attestation_key_seed_t additional_seed,
+    otbn_boot_attestation_key_type_t key_type,
     sc_keymgr_diversification_t diversification);
 
 /**

--- a/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
@@ -74,24 +74,34 @@ rom_error_t attestation_keygen_test(void) {
   // Check that key generations with different seeds result in different keys.
   attestation_public_key_t pk_uds;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kUdsAttestationKeySeed,
+                                               kOtbnBootAttestationKeyTypeDice,
                                                kDiversification, &pk_uds));
   attestation_public_key_t pk_cdi0;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kCdi0AttestationKeySeed,
+                                               kOtbnBootAttestationKeyTypeDice,
                                                kDiversification, &pk_cdi0));
   attestation_public_key_t pk_cdi1;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kCdi1AttestationKeySeed,
+                                               kOtbnBootAttestationKeyTypeDice,
                                                kDiversification, &pk_cdi1));
+  attestation_public_key_t pk_tpm_ek;
+  RETURN_IF_ERROR(otbn_boot_attestation_keygen(kTpmEkAttestationKeySeed,
+                                               kOtbnBootAttestationKeyTypeTpm,
+                                               kDiversification, &pk_tpm_ek));
   CHECK_ARRAYS_NE((unsigned char *)&pk_uds, (unsigned char *)&pk_cdi0,
                   sizeof(pk_uds));
   CHECK_ARRAYS_NE((unsigned char *)&pk_uds, (unsigned char *)&pk_cdi1,
                   sizeof(pk_uds));
   CHECK_ARRAYS_NE((unsigned char *)&pk_cdi0, (unsigned char *)&pk_cdi1,
                   sizeof(pk_uds));
+  CHECK_ARRAYS_NE((unsigned char *)&pk_tpm_ek, (unsigned char *)&pk_cdi1,
+                  sizeof(pk_uds));
 
   // Check that running the same key generation twice results in the same key.
   attestation_public_key_t pk_uds_again;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(
-      kUdsAttestationKeySeed, kDiversification, &pk_uds_again));
+      kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice, kDiversification,
+      &pk_uds_again));
   CHECK_ARRAYS_EQ((unsigned char *)&pk_uds_again, (unsigned char *)&pk_uds,
                   sizeof(pk_uds));
 
@@ -103,7 +113,8 @@ rom_error_t attestation_keygen_test(void) {
   diversification_modified.salt[0] ^= 1;
   attestation_public_key_t pk_uds_div;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(
-      kUdsAttestationKeySeed, diversification_modified, &pk_uds_div));
+      kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice,
+      diversification_modified, &pk_uds_div));
   CHECK_ARRAYS_NE((unsigned char *)&pk_uds_div, (unsigned char *)&pk_uds,
                   sizeof(pk_uds));
   return kErrorOk;
@@ -113,9 +124,11 @@ rom_error_t attestation_advance_and_endorse_test(void) {
   // Generate and save the a keypair.
   attestation_public_key_t pk;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kUdsAttestationKeySeed,
+                                               kOtbnBootAttestationKeyTypeDice,
                                                kDiversification, &pk));
-  RETURN_IF_ERROR(
-      otbn_boot_attestation_key_save(kUdsAttestationKeySeed, kDiversification));
+  RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice,
+      kDiversification));
 
   // Advance keymgr to the next stage.
   CHECK_STATUS_OK(
@@ -147,13 +160,15 @@ rom_error_t attestation_advance_and_endorse_test(void) {
 // N.B. This test will lock OTBN, so it needs to be the last test that runs.
 rom_error_t attestation_save_clear_key_test(void) {
   // Save and then clear a private key.
-  RETURN_IF_ERROR(
-      otbn_boot_attestation_key_save(kUdsAttestationKeySeed, kDiversification));
+  RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice,
+      kDiversification));
   RETURN_IF_ERROR(otbn_boot_attestation_key_clear());
 
   // Save the private key again and check that endorsing succeeds.
-  RETURN_IF_ERROR(
-      otbn_boot_attestation_key_save(kUdsAttestationKeySeed, kDiversification));
+  RETURN_IF_ERROR(otbn_boot_attestation_key_save(
+      kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice,
+      kDiversification));
   hmac_digest_t digest;
   hmac_sha256(kTestMessage, kTestMessageLen, &digest);
   attestation_signature_t sig;

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -233,6 +233,7 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
   sc_keymgr_advance_state();
   TRY(dice_attestation_keygen(kDiceKeyUds, &uds_pubkey_id, &curr_pubkey));
   TRY(otbn_boot_attestation_key_save(kUdsAttestationKeySeed,
+                                     kOtbnBootAttestationKeyTypeDice,
                                      kUdsKeymgrDiversifier));
   // We copy over the UDS endorsement key ID to an SHA256 digest type, since
   // this is the format of key IDs generated on-dice.

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -286,7 +286,8 @@ static rom_error_t rom_ext_attestation_keygen(
   HARDENED_RETURN_IF_ERROR(dice_attestation_keygen(kDiceKeyUds, &uds_pubkey_id,
                                                    &curr_attestation_pubkey));
   HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
-      kUdsAttestationKeySeed, kUdsKeymgrDiversifier));
+      kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice,
+      kUdsKeymgrDiversifier));
   curr_cert_valid = kHardenedBoolFalse;
   HARDENED_RETURN_IF_ERROR(cert_x509_asn1_check_serial_number(
       &kFlashCtrlInfoPageUdsCertificate, uds_pubkey_id.digest,


### PR DESCRIPTION
This fixes #22622 to enable generating TPM attestation keys off of the keymgr sealing side and DICE attestation keys off of the keymgr attestation side.

Additionally, this cleans up the DICE lib to reduce code size and align naming conventions.