### PR TITLE
[ascon] Fix AscentLint warning

### DIFF
--- a/hw/ip/ascon/rtl/ascon_core.sv
+++ b/hw/ip/ascon/rtl/ascon_core.sv
@@ -42,7 +42,7 @@ assign hw2reg = 'b0;
 
 // TODO
 logic d, q;
-assign d = 1'b1;
+assign d = keymgr_key_i.valid;
 
 logic unused_q;
 assign unused_q = q;


### PR DESCRIPTION
The Ascon hardware block is very much work in progress. Unfortunately, lint warnings and errors inside Ascon cause the whole AscentLint CI job to fail.