### PR TITLE
Backport 22701 to master

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -124,7 +124,7 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: []
+      tests: ["//sw/device/tests:i2c_target_test", "//sw/device/tests/pmod:i2c_host_clock_stretching_test"]
     }
     {
       name: chip_sw_i2c_nack

--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -21,6 +21,7 @@ extern "C" {
     value(_, I2cStartTransferWriteSlow) \
     value(_, I2cStartTransferRead) \
     value(_, I2cStartTransferWriteRead) \
+    value(_, I2cTestConfig) \
     value(_, MemRead) \
     value(_, MemRead32) \
     value(_, MemWrite) \

--- a/sw/device/lib/testing/json/i2c_target.h
+++ b/sw/device/lib/testing/json/i2c_target.h
@@ -30,6 +30,11 @@ UJSON_SERDE_STRUCT(I2cTargetAddress, i2c_target_address_t, STRUCT_I2C_TARGET_ADD
     field(data, uint8_t, 256)
 UJSON_SERDE_STRUCT(I2cTransferStart, i2c_transfer_start_t, STRUCT_I2C_TRANSFER_START);
 
+// Should be used to set parameters for i2c tests.
+#define STRUCT_I2C_TEST_CONFIG(field, string) \
+    field(clock_stretching_delay_millis, uint32_t)
+UJSON_SERDE_STRUCT(I2cTestConfig, i2c_test_config_t, STRUCT_I2C_TEST_CONFIG);
+
 #undef MODULE_ID
 
 // clang-format on

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -47,6 +47,7 @@ static dif_rv_plic_t plic;
 static dif_i2c_t i2c;
 
 static uint8_t i2c_instance_under_test = 0;
+static uint32_t i2c_clock_stretching_delay_micros = 0;
 
 static plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
                                   .hart_id = kTopEarlgreyPlicTargetIbex0};
@@ -207,6 +208,7 @@ static status_t recv_write_transfer(dif_i2c_t *i2c, i2c_transfer_start_t *txn,
 static status_t start_read_transaction(ujson_t *uj, dif_i2c_t *i2c) {
   i2c_transfer_start_t txn;
   TRY(UJSON_WITH_CRC(ujson_deserialize_i2c_transfer_start_t, uj, &txn));
+  busy_spin_micros(i2c_clock_stretching_delay_micros);
   TRY(i2c_testutils_target_read(i2c, txn.length, txn.data));
   ibex_timeout_t deadline = ibex_timeout_init(kTestTimeout);
   TRY(wait_for_acq_fifo(i2c, 2, &deadline));
@@ -325,6 +327,13 @@ static status_t command_processor(ujson_t *uj) {
         // at 100 KHz, forcing the peripheral to stretch the clock.
         RESP_ERR(uj, start_write_transaction(uj, &i2c, kTransactionDelay));
         break;
+      case kTestCommandI2cTestConfig: {
+        i2c_test_config_t config;
+        TRY(ujson_deserialize_i2c_test_config_t(uj, &config));
+        i2c_clock_stretching_delay_micros =
+            config.clock_stretching_delay_millis * 1000;
+        RESP_ERR(uj, RESP_OK_STATUS(uj));
+      } break;
       default:
         LOG_ERROR("Unrecognized command: %d", command);
         RESP_ERR(uj, INVALID_ARGUMENT());

--- a/sw/host/opentitanlib/src/test_utils/i2c_target.rs
+++ b/sw/host/opentitanlib/src/test_utils/i2c_target.rs
@@ -74,3 +74,12 @@ impl I2cTransferStart {
         Self::recv(uart, Duration::from_secs(300), false)
     }
 }
+
+impl I2cTestConfig {
+    pub fn write(&self, uart: &dyn Uart) -> Result<()> {
+        TestCommand::I2cTestConfig.send(uart)?;
+        self.send(uart)?;
+        Status::recv(uart, Duration::from_secs(300), false)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is a manual backport PR of #22701 to master.
The automatic backport failed because the master branch has new CRC functions for ujson.