### PR TITLE
[tlul,doc] Fix typo in timing diagram caption

### DIFF
--- a/hw/ip/tlul/README.md
+++ b/hw/ip/tlul/README.md
@@ -440,7 +440,7 @@ the TileLink specification for more examples.
     text: 'TileLink-UL read transactions',
   },
   foot: {
-    text: 'six read transactions with various req/ready delays, error on I4 response',
+    text: 'six read transactions with various req/ready delays, error on I5 response',
     }
 }
 ```


### PR DESCRIPTION
The example in the timing diagram shows several device responses. One of these responses has the d_error signal set. On that cycle, d_source is I5 but the caption talks about an error on the I4 response. Fix the caption.

Fixes #22817.