### PR TITLE
[sival] Fix pwrmgr testplan for sival

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -20,6 +20,7 @@
       lc_states: ["PROD"]
       features: ["PWRMGR.RESET.POR_REQUEST"]
       tests: ["chip_sw_pwrmgr_full_aon_reset"]
+      bazel: ["//sw/device/tests:pwrmgr_smoketest"]
     }
     {
       name: chip_sw_pwrmgr_random_sleep_all_wake_ups

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2591,25 +2591,17 @@ opentitan_test(
 opentitan_test(
     name = "pwrmgr_random_sleep_all_reset_reqs_test",
     srcs = ["pwrmgr_random_sleep_all_reset_reqs_test.c"],
-    broken = cw310_params(tags = ["broken"]),
-    exec_env = dicts.add(
-        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw310_sival": "test_harness",
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-            "//hw/top_earlgrey:fpga_cw310_test_rom": "test_harness",
-            "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
-        },
-    ),
-    silicon = silicon_params(
+    cw310 = cw310_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
-    test_harness = cw310_params(
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        EARLGREY_TEST_ENVS,
+    ),
+    silicon = silicon_params(
         test_cmd = """
             --bootstrap={firmware}
         """,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2665,15 +2665,17 @@ opentitan_test(
     name = "pwrmgr_normal_sleep_all_reset_reqs_test",
     srcs = ["pwrmgr_normal_sleep_all_reset_reqs_test.c"],
     cw310 = cw310_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
+        test_cmd = "--bootstrap={firmware}",
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    silicon = silicon_params(
+        test_cmd = "--bootstrap={firmware}",
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",


### PR DESCRIPTION
This PR:

* Adds the `pwrmgr_smoketest` as satisfying the `external_full_reset` test point.
  * Supposedly any device test will do here, so I've just picked one.
* Removes the `broken` tag from `pwrmgr_random_sleep_all_reset_reqs_test`.
  * This test passed 100/100 runs I did so I don't think it's flaky any  more.
  * Probably fixed by https://github.com/lowRISC/opentitan/pull/22730
* Adds the sival execution environments to the `pwrmgr_normal_sleep_all_reset_reqs_test`.
  * Like above, this passed 100/100 times when I ran it on a CW310.