### PR TITLE
[prim,fpv] Use PossibleActions param in prim_esc_receiver

### DIFF
--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -103,7 +103,10 @@ module prim_esc_receiver
     .Width(TimeoutCntDw),
     // The escalation receiver behaves differently than other comportable IP. I.e., instead of
     // sending out an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
+    .EnableAlertTriggerSVA(0),
+    // Pass a parameter to disable coverage for some assertions that are unreachable because
+    // clr_i and decr_en_i are tied to zero.
+    .PossibleActions(prim_count_pkg::Set | prim_count_pkg::Incr)
   ) u_prim_count (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
This waives some cover properties in the prim_count that is instantiated with some "action" inputs hard coded to zero.