### PR TITLE
[prim,rtl] Avoid unnecessary check in prim_esc_receiver.sv

### DIFF
--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -97,7 +97,7 @@ module prim_esc_receiver
   logic timeout_cnt_set, timeout_cnt_en;
   logic [TimeoutCntDw-1:0] timeout_cnt;
   assign timeout_cnt_set = (ping_en && !(&timeout_cnt));
-  assign timeout_cnt_en = ((timeout_cnt > '0) && !(&timeout_cnt));
+  assign timeout_cnt_en = (timeout_cnt > '0);
 
   prim_count #(
     .Width(TimeoutCntDw),


### PR DESCRIPTION
The code in prim_esc_receiver tells the instantiated prim_count to increment the counter unless the value is '1. But prim_count is already designed to saturate, so there's no need to condition incr_en_i like this.

Found by an unreachable cover property when running FPV tests.