### PR TITLE
[sram_program] Rename `sram_main` to `test_main`

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv
@@ -97,7 +97,7 @@ class chip_sw_rom_e2e_jtag_inject_vseq extends chip_sw_base_vseq;
       `DV_CHECK(result)
       sram_program_gp = BUS_AW'(addr);
       result = dv_utils_pkg::sw_symbol_get_addr_size(.elf_file(elf_file),
-          .symbol("sram_main"), .does_not_exist_ok(0), .addr(addr), .size(size));
+          .symbol("test_main"), .does_not_exist_ok(0), .addr(addr), .size(size));
       `DV_CHECK(result)
       sram_program_start = BUS_AW'(addr);
     end
@@ -119,8 +119,8 @@ class chip_sw_rom_e2e_jtag_inject_vseq extends chip_sw_base_vseq;
     `uvm_info(`gfn, "Invalidate the icache", UVM_LOW)
     cfg.debugger.call(.symbol("icache_invalidate"));
 
-    `uvm_info(`gfn, "Call sram_main (it writes the PASS pattern to the DV monitor)", UVM_LOW)
-    cfg.debugger.call(.symbol("sram_main"), .noreturn_function(1));
+    `uvm_info(`gfn, "Call test_main (it writes the PASS pattern to the DV monitor)", UVM_LOW)
+    cfg.debugger.call(.symbol("test_main"), .noreturn_function(1));
   endtask
 
 endclass

--- a/sw/device/examples/sram_program/sram_program.c
+++ b/sw/device/examples/sram_program/sram_program.c
@@ -24,7 +24,7 @@ enum {
              TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES,
 };
 
-void sram_main(void) {
+bool test_main(void) {
   if (kDeviceType != kDeviceSimDV) {
     // Configure the pinmux.
     CHECK_DIF_OK(dif_pinmux_init(
@@ -57,6 +57,7 @@ void sram_main(void) {
   if (kDeviceType == kDeviceSimDV) {
     test_status_set(kTestStatusPassed);
   }
+  return true;
 }
 
 // Reference functions that the debugger may wish to call. This prevents the

--- a/sw/device/examples/sram_program/sram_program.ld
+++ b/sw/device/examples/sram_program/sram_program.ld
@@ -26,7 +26,7 @@ _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
  */
 _dv_log_offset = 0x10000;
 
-ENTRY(sram_main);
+ENTRY(test_main);
 
 SECTIONS {
   /**
@@ -47,8 +47,8 @@ SECTIONS {
     /* Place the entry point of the SRAM program to the start of the main SRAM
      * so that we don't have to maintain a separate offset from the start of
      * the RAM to the entry point. */
-    ASSERT(DEFINED(sram_main), "SRAM programs must define `sram_main()`");
-    KEEP(*(.text.sram_main))
+    ASSERT(DEFINED(test_main), "SRAM programs must define `test_main()`");
+    KEEP(*(.text.test_main))
     . = ALIGN(4);
 
     /* Place all input `.rodata`, `.data`, `.text`, and `.bss` sections in the

--- a/sw/device/silicon_creator/manuf/lib/sram_start.S
+++ b/sw/device/silicon_creator/manuf/lib/sram_start.S
@@ -179,7 +179,7 @@ sram_start:
   li a0, 0  // Do not run in verbose mode.
   call ast_program_config
   // Jump into the C program entry point.
-  call sram_main
+  call test_main
 
   // Notify the host that we are done.
   li  sp, SRAM_MAGIC_SP_EXECUTION_DONE

--- a/sw/device/silicon_creator/manuf/lib/sram_start_no_ast_init.S
+++ b/sw/device/silicon_creator/manuf/lib/sram_start_no_ast_init.S
@@ -176,7 +176,7 @@ sram_start:
   sw t0, EDN_CTRL_REG_OFFSET(a0)
 
   // Jump into the C program entry point.
-  call sram_main
+  call test_main
 
   // Notify the host that we are done.
   li  sp, SRAM_MAGIC_SP_EXECUTION_DONE

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/sram_cp_provision.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/sram_cp_provision.c
@@ -167,7 +167,7 @@ static status_t provision(ujson_t *uj) {
   return OK_STATUS();
 }
 
-bool sram_main(void) {
+bool test_main(void) {
   // Initialize AST, DIF handles, pinmux, and UART.
   manually_init_ast(ast_cfg_data);
   CHECK_STATUS_OK(peripheral_handles_init());

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/sram_cp_provision_functest.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/sram_cp_provision_functest.c
@@ -83,7 +83,7 @@ static status_t check_device_id_and_manuf_state(
   return OK_STATUS();
 }
 
-bool sram_main(void) {
+bool test_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
   pinmux_testutils_init(&pinmux);
   ottf_console_init();

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/sram_ft_individualize.c
@@ -97,7 +97,7 @@ static status_t provision(ujson_t *uj) {
   return OK_STATUS();
 }
 
-bool sram_main(void) {
+bool test_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
   pinmux_testutils_init(&pinmux);
   ottf_console_init();

--- a/sw/device/silicon_creator/manuf/tests/sram_device_info_flash_wr_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_device_info_flash_wr_functest.c
@@ -49,7 +49,7 @@ static status_t peripheral_handles_init(void) {
   return OK_STATUS();
 }
 
-bool sram_main(void) {
+bool test_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
 
   // Initialize UART (for console, since we do not have the OTTF).

--- a/sw/device/silicon_creator/manuf/tests/sram_empty_functest.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_empty_functest.c
@@ -20,7 +20,7 @@ OTTF_DEFINE_TEST_CONFIG();
 static dif_uart_t uart;
 static dif_pinmux_t pinmux;
 
-void sram_main(void) {
+bool test_main(void) {
   // Initialize UART console.
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
@@ -44,4 +44,5 @@ void sram_main(void) {
   LOG_INFO("Hello OpenTitan! We are executing from SRAM.");
 
   // Make sure that the function returns so that the CRT can notify the host.
+  return true;
 }

--- a/sw/device/silicon_creator/manuf/tests/sram_exec_test.c
+++ b/sw/device/silicon_creator/manuf/tests/sram_exec_test.c
@@ -122,7 +122,7 @@ static status_t provisioning_device_id_end(void) {
   return OK_STATUS();
 }
 
-void sram_main(void) {
+bool test_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
   // Initialize UART console.
   pinmux_testutils_init(&pinmux);
@@ -144,4 +144,5 @@ void sram_main(void) {
   CHECK_STATUS_OK(provisioning_device_id_end());
 
   test_status_set(kTestStatusPassed);
+  return true;
 }

--- a/sw/device/tests/flash_ctrl_rma_test.c
+++ b/sw/device/tests/flash_ctrl_rma_test.c
@@ -99,7 +99,7 @@ static status_t read_and_check_info(bool match) {
   return OK_STATUS();
 }
 
-bool sram_main(void) {
+bool test_main(void) {
   // Initialize dif handles and pinmux
   CHECK_DIF_OK(dif_pinmux_init(
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));

--- a/sw/device/tests/rv_core_ibex_epmp_test.S
+++ b/sw/device/tests/rv_core_ibex_epmp_test.S
@@ -51,6 +51,7 @@ kIAmBecomeUserEnd:
   .global finish_test
   .type finish_test, @function
 finish_test:
+  li  a0, 0
   li  sp, SRAM_MAGIC_SP_EXECUTION_DONE
   ebreak
   .size finish_test, .-finish_test

--- a/sw/device/tests/rv_core_ibex_epmp_test.c
+++ b/sw/device/tests/rv_core_ibex_epmp_test.c
@@ -294,7 +294,7 @@ static void setup_uart(void) {
  *
  * *Control flow passed from `sram_start`.*
  */
-void sram_main(void) {
+bool test_main(void) {
   setup_uart();
 
   // Must set up the Machine Mode Area Correctly

--- a/sw/device/tests/rv_core_ibex_isa_test.S
+++ b/sw/device/tests/rv_core_ibex_isa_test.S
@@ -5,14 +5,15 @@
 /**
  * Checks the given value is equal to zero or a second given value.
  * If they are not equal,
- * a0 is set to a unique value and returns early from sram_main.
+ * a1 is set to a unique value and returns early from test_main.
  *
  * @param actual The value to check.
  * @param[opt] expected The value to check against. Defaults to zero.
  */
 .macro check actual, expected=zero
   beq \actual, \expected, 1f
-  li a0, \@+1
+  li a0, 0
+  li a1, \@+1
   jr s1
   1:
 .endm
@@ -22,14 +23,15 @@
 /**
  * Runs every instruction that is available to the ibex.
  *
- * @param[out] a0 error code, will be non-zero if a check fails.
+ * @param[out] a0 test status, will be zero if a check fails.
+ * @param[out] a1 error code, set if `a0` is zero.
  */
   .balign 4
-  .global sram_main
-  .type sram_main, @function
-sram_main:
+  .global test_main
+  .type test_main, @function
+test_main:
   mv s1, ra
-  li a0, -1
+  li a1, -1
 
   jal smoke_branch
   jal smoke_auipc
@@ -53,7 +55,7 @@ sram_main:
   la t0, smoke_c
   c.jalr t0
 
-  mv a0, zero
+  li a0, 1
   jr s1
 
 /**

--- a/sw/device/tests/rv_core_ibex_mem_test.c
+++ b/sw/device/tests/rv_core_ibex_mem_test.c
@@ -155,7 +155,7 @@ static void setup_flash(void) {
 /**
  * The entry point of the SRAM test.
  */
-void sram_main(void) {
+bool test_main(void) {
   setup_uart();
 
   LOG_INFO("Testing Load from ROM Location.");
@@ -207,4 +207,5 @@ void sram_main(void) {
   flash_test_gadget();
 
   test_status_set(kTestStatusPassed);
+  return true;
 }

--- a/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
+++ b/sw/host/opentitanlib/src/test_utils/load_sram_program.rs
@@ -106,7 +106,9 @@ pub enum ExecutionResult {
     /// (Jump only) Execution is ongoing.
     Executing,
     /// (JumpAndWait only) Execution successfully stopped.
-    ExecutionDone,
+    ///
+    /// The content of register `a0` is returned.
+    ExecutionDone(u32),
     /// (JumpAndWait only) Execution did not finish it time or an error occurred.
     ExecutionError(ExecutionError),
 }
@@ -420,7 +422,10 @@ pub fn execute_sram_program(
             // the stack pointer to a certain value.
             let sp = jtag.read_riscv_reg(&RiscvReg::Gpr(RiscvGpr::SP))?;
             match sp {
-                SRAM_MAGIC_SP_EXECUTION_DONE => Ok(ExecutionResult::ExecutionDone),
+                SRAM_MAGIC_SP_EXECUTION_DONE => {
+                    let a0 = jtag.read_riscv_reg(&RiscvReg::Gpr(RiscvGpr::A0))?;
+                    Ok(ExecutionResult::ExecutionDone(a0))
+                }
                 SRAM_MAGIC_SP_CRC_ERROR => {
                     Ok(ExecutionResult::ExecutionError(ExecutionError::CrcMismatch))
                 }

--- a/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
+++ b/sw/host/tests/manuf/manuf_cp_device_info_flash_wr/src/main.rs
@@ -58,7 +58,7 @@ fn manuf_cp_device_info_flash_wr(opts: &Opts, transport: &TransportWrapper) -> R
         .sram_program
         .load_and_execute(&mut *jtag, ExecutionMode::JumpAndWait(opts.timeout))?
     {
-        ExecutionResult::ExecutionDone => {
+        ExecutionResult::ExecutionDone(_) => {
             log::info!("SRAM program loaded and executed successfully.")
         }
         res => log::info!("SRAM program execution failed: {:?}.", res),

--- a/sw/host/tests/manuf/manuf_sram_program_crc_check/src/main.rs
+++ b/sw/host/tests/manuf/manuf_sram_program_crc_check/src/main.rs
@@ -65,7 +65,7 @@ fn test_sram_load(opts: &Opts, transport: &TransportWrapper, corrupt: bool) -> R
         ExecutionMode::JumpAndWait(Duration::from_secs(5)),
     )?;
     match exec_res {
-        ExecutionResult::ExecutionDone => {
+        ExecutionResult::ExecutionDone(_) => {
             if corrupt {
                 bail!("SRAM program finished successfully but expected a CRC failure")
             } else {


### PR DESCRIPTION
This makes it easier to use the a test as both sram main and a normal test.

The rv_core_ibex_isa_test currently uses a0 for returning error code, which I have changed it to a1 so that a0 is used as `bool test_main` return code.

This is a preparatory PR to run some rv_core_ibex SRAM program tests as normal tests when LC state is PROD.