### PR TITLE
[manuf] improve reliability of `personalize_functest`  and reactivate in CI

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -268,7 +268,6 @@ opentitan_test(
         needs_jtag = True,
         otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_dev_manuf_individualized",
         tags = [
-            "broken",  # https://github.com/lowRISC/opentitan/issues/19086
             "lc_dev",
             "manuf",
         ],

--- a/sw/device/silicon_creator/manuf/lib/personalize_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize_functest.c
@@ -118,8 +118,8 @@ bool test_main(void) {
       // the RMA unlock token, to arrive over the console.
       LOG_INFO("Ready to receive host ECC pubkey ...");
       ecc_p256_public_key_t host_ecc_pk;
-      CHECK_STATUS_OK(
-          ujson_deserialize_ecc_p256_public_key_t(&uj, &host_ecc_pk));
+      CHECK_STATUS_OK(UJSON_WITH_CRC(ujson_deserialize_ecc_p256_public_key_t,
+                                     &uj, &host_ecc_pk));
 
       // Perform OTP and flash info writes.
       LOG_INFO("Provisioning OTP SECRET2 flash info pages 1, 2, & 4 ...");

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -278,7 +278,7 @@ opentitan_test(
         binaries = _FT_PROVISIONING_BINARIES,
         changes_otp = True,
         data = FT_PERSONALIZE_KEYS,
-        interface = "hyper310",
+        interface = "teacup",
         needs_jtag = True,
         test_cmd = _FT_PROVISIONING_CMD_ARGS,
         test_harness = _FT_PROVISIONING_HARNESS,

--- a/sw/host/opentitanlib/src/test_utils/lc.rs
+++ b/sw/host/opentitanlib/src/test_utils/lc.rs
@@ -7,8 +7,9 @@ use std::time::Duration;
 use anyhow::Result;
 
 use crate::app::TransportWrapper;
-use crate::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
+use crate::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
 use crate::io::jtag::{JtagParams, JtagTap};
+use crate::test_utils::lc_transition::wait_for_status;
 
 pub fn read_lc_state(
     transport: &TransportWrapper,
@@ -22,6 +23,12 @@ pub fn read_lc_state(
     transport.pin_strapping("ROM_BOOTSTRAP")?.apply()?;
     transport.reset_target(reset_delay, true)?;
     let mut jtag = jtag_params.create(transport)?.connect(JtagTap::LcTap)?;
+    // We must wait for the lc_ctrl to initialize before the LC state is exposed.
+    wait_for_status(
+        &mut *jtag,
+        Duration::from_secs(1),
+        LcCtrlStatus::INITIALIZED,
+    )?;
     let raw_lc_state = jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?;
     jtag.disconnect()?;
     transport.pin_strapping("PINMUX_TAP_LC")?.remove()?;

--- a/sw/host/tests/manuf/personalize_functest/src/main.rs
+++ b/sw/host/tests/manuf/personalize_functest/src/main.rs
@@ -86,7 +86,7 @@ fn rma_unlock_token_export(opts: &Opts, transport: &TransportWrapper) -> Result<
     )?;
 
     // Send the host ECC public key to the device over the console.
-    host_pk.send(&*uart)?;
+    host_pk.send_with_crc(&*uart)?;
 
     // Wait for output data to be transimitted over the console.
     let _ = UartConsole::wait_for(&*uart, r"Exporting RMA unlock token ...", opts.timeout)?;


### PR DESCRIPTION
This makes several reliability improvements to the perso functest and reactivates it in CI. This fixes #19086.