### PR TITLE
[rom_ext] Improve `boot_log` reporting

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.h
+++ b/sw/device/silicon_creator/lib/boot_data.h
@@ -84,10 +84,15 @@ typedef struct boot_data {
    */
   uint32_t ownership_state;
   /**
+   * Number of ownership transfers this chip has had.
+   */
+  uint32_t ownership_transfers;
+
+  /**
    * Padding for future enhancements and to make the size of `boot_data_t` a
    * power of two.
    */
-  uint32_t padding[5];
+  uint32_t padding[4];
 } boot_data_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_data_t, digest, 0);
@@ -101,7 +106,8 @@ OT_ASSERT_MEMBER_OFFSET(boot_data_t, primary_bl0_slot, 60);
 OT_ASSERT_MEMBER_OFFSET(boot_data_t, next_owner, 64);
 OT_ASSERT_MEMBER_OFFSET(boot_data_t, nonce, 96);
 OT_ASSERT_MEMBER_OFFSET(boot_data_t, ownership_state, 104);
-OT_ASSERT_MEMBER_OFFSET(boot_data_t, padding, 108);
+OT_ASSERT_MEMBER_OFFSET(boot_data_t, ownership_transfers, 108);
+OT_ASSERT_MEMBER_OFFSET(boot_data_t, padding, 112);
 OT_ASSERT_SIZE(boot_data_t, 128);
 
 enum {

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -43,8 +43,10 @@ typedef struct boot_log {
   uint32_t bl0_slot;
   /** Chip ownership state. */
   uint32_t ownership_state;
+  /** Number of ownership transfers this chip has had. */
+  uint32_t ownership_transfers;
   /** Pad to 128 bytes. */
-  uint32_t reserved[13];
+  uint32_t reserved[12];
 } boot_log_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, digest, 0);
@@ -57,7 +59,8 @@ OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_size, 56);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_nonce, 60);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_slot, 68);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, ownership_state, 72);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 76);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, ownership_transfers, 76);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 80);
 
 enum {
   /**

--- a/sw/device/silicon_creator/lib/drivers/ibex.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex.c
@@ -52,6 +52,17 @@ void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
   icache_invalidate();
 }
 
+uint32_t ibex_addr_remap_get(uint32_t index) {
+  HARDENED_CHECK_LT(index, 2);
+  index *= sizeof(uint32_t);
+  if (abs_mmio_read32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET + index)) {
+    return abs_mmio_read32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET +
+                           index);
+  } else {
+    return 0;
+  }
+}
+
 void ibex_addr_remap_lockdown(uint32_t index) {
   HARDENED_CHECK_LT(index, 2);
   index *= sizeof(uint32_t);

--- a/sw/device/silicon_creator/lib/drivers/ibex.h
+++ b/sw/device/silicon_creator/lib/drivers/ibex.h
@@ -86,6 +86,16 @@ void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
                            size_t size);
 
 /**
+ * Get the remap target address.
+ *
+ * Returns zero if the remap window is not in use.
+ *
+ * @param index Which window to lock (0 or 1).
+ * @return The remap target address.
+ */
+uint32_t ibex_addr_remap_get(uint32_t index);
+
+/**
  * Lock the remap windows so they cannot be reprogrammed.
  * This function locks the given the IBUS and DBUS windows simultaneously.
  *

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -20,25 +20,69 @@ filegroup(
 )
 
 _POSITIONS = {
-    "slot_a": {
+    "owner_slot_a": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
         "manifest": "//sw/device/silicon_owner:manifest_standard",
-        "offset": "0x10000",
+        "owner_offset": "0x10000",
+        "success": "bl0_slot = AA__\r\n",
     },
-    "slot_b": {
+    "owner_slot_b": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
         "manifest": "//sw/device/silicon_owner:manifest_standard",
-        "offset": "0x90000",
+        "owner_offset": "0x90000",
+        "success": "bl0_slot = __BB\r\n",
     },
-    "virtual_a": {
+    "owner_virtual_a": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         "manifest": "//sw/device/silicon_owner:manifest_virtual",
-        "offset": "0x10000",
+        "owner_offset": "0x10000",
+        "success": "bl0_slot = AA__\r\n",
     },
-    "virtual_b": {
+    "owner_virtual_b": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         "manifest": "//sw/device/silicon_owner:manifest_virtual",
-        "offset": "0x90000",
+        "owner_offset": "0x90000",
+        "success": "bl0_slot = __BB\r\n",
+    },
+    "romext_slot_a": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext_offset": "0",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        "manifest": "//sw/device/silicon_owner:manifest_standard",
+        "owner_offset": "0x10000",
+        "success": "rom_ext_slot = AA__\r\n",
+    },
+    "romext_slot_b": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b",
+        "romext_offset": "0x80000",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        "manifest": "//sw/device/silicon_owner:manifest_standard",
+        "owner_offset": "0x10000",
+        "success": "rom_ext_slot = __BB\r\n",
+    },
+    "romext_virtual_a": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual",
+        "romext_offset": "0",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        "manifest": "//sw/device/silicon_owner:manifest_standard",
+        "owner_offset": "0x10000",
+        "success": "rom_ext_slot = AA__\r\n",
+    },
+    "romext_virtual_b": {
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual",
+        "romext_offset": "0x80000",
+        "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        "manifest": "//sw/device/silicon_owner:manifest_standard",
+        "owner_offset": "0x10000",
+        "success": "rom_ext_slot = __BB\r\n",
     },
 }
 
@@ -47,8 +91,13 @@ _POSITIONS = {
         name = "position_{}".format(name),
         srcs = [":boot_test"],
         cw310 = cw310_params(
-            assemble = "{rom_ext}@0 {firmware}@{offset}",
-            offset = position["offset"],
+            assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
+            binaries = {
+                position["romext"]: "romext",
+            },
+            exit_success = position["success"],
+            owner_offset = position["owner_offset"],
+            romext_offset = position["romext_offset"],
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_ext": None,

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
@@ -25,6 +25,7 @@ status_t boot_log_print(boot_log_t *boot_log) {
            boot_log->rom_ext_nonce.value[1], boot_log->rom_ext_nonce.value[0]);
   LOG_INFO("boot_log bl0_slot = %C", boot_log->bl0_slot);
   LOG_INFO("boot_log ownership_state = %C", boot_log->ownership_state);
+  LOG_INFO("boot_log ownership_transfers = %u", boot_log->ownership_transfers);
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -121,26 +121,40 @@ static rom_error_t rom_ext_irq_error(void) {
 
 OT_WARN_UNUSED_RESULT
 static uint32_t rom_ext_current_slot(void) {
-  uint32_t pc = 0;
-  asm("auipc %[pc], 0;" : [pc] "=r"(pc));
+  uint32_t pc = ibex_addr_remap_get(0);
+  if (pc == 0) {
+    // If the remap window has address zero, we're running from flash and we can
+    // simply read the program counter.
+    asm("auipc %[pc], 0;" : [pc] "=r"(pc));
+  }
 
   const uint32_t kFlashSlotA = TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR;
   const uint32_t kFlashSlotB =
       kFlashSlotA + TOP_EARLGREY_FLASH_CTRL_MEM_SIZE_BYTES / 2;
   const uint32_t kFlashSlotEnd =
       kFlashSlotA + TOP_EARLGREY_FLASH_CTRL_MEM_SIZE_BYTES;
+  uint32_t side = 0;
   if (pc >= kFlashSlotA && pc < kFlashSlotB) {
     // Running in Slot A.
-    return kBootSlotA;
+    side = kBootSlotA;
   } else if (pc >= kFlashSlotB && pc < kFlashSlotEnd) {
     // Running in Slot B.
-    return kBootSlotB;
+    side = kBootSlotB;
   } else {
-    // Running elsewhere (ie: the remap window).
-    // TODO: read the remap register configuration to determine the execution
-    // slot.
-    return 0;
+    // Not running in flash: impossible.
+    HARDENED_TRAP();
   }
+  return side;
+}
+
+const manifest_t *rom_ext_manifest(void) {
+  uint32_t pc = 0;
+  asm("auipc %[pc], 0;" : [pc] "=r"(pc));
+  const uint32_t kFlashHalf = TOP_EARLGREY_FLASH_CTRL_MEM_SIZE_BYTES / 2;
+  // Align the PC to the current flash side.  The ROM_EXT must be the first
+  // entity in each flash side, so this alignment is the manifest address.
+  pc &= ~(kFlashHalf - 1);
+  return (const manifest_t *)pc;
 }
 
 void rom_ext_check_rom_expectations(void) {
@@ -696,13 +710,19 @@ static rom_error_t rom_ext_try_next_stage(boot_data_t *boot_data) {
 
 static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   HARDENED_RETURN_IF_ERROR(rom_ext_init(boot_data));
-  dbg_printf("Starting ROM_EXT\r\n");
+  const manifest_t *self = rom_ext_manifest();
+  dbg_printf("Starting ROM_EXT %u.%u\r\n", self->version_major,
+             self->version_minor);
 
   // Initialize the boot_log in retention RAM.
   const chip_info_t *rom_chip_info = (const chip_info_t *)_chip_info_start;
   boot_log_check_or_init(boot_log, rom_ext_current_slot(), rom_chip_info);
+  boot_log->rom_ext_major = self->version_major;
+  boot_log->rom_ext_minor = self->version_minor;
+  boot_log->rom_ext_size = CHIP_ROM_EXT_SIZE_MAX;
   boot_log->rom_ext_nonce = boot_data->nonce;
   boot_log->ownership_state = boot_data->ownership_state;
+  boot_log->ownership_transfers = boot_data->ownership_transfers;
 
   // Initialize the chip ownership state.
   HARDENED_RETURN_IF_ERROR(ownership_init());


### PR DESCRIPTION
1. Add an `ownership_transfers` member which will report the total number of ownership transfers the chip has had.
2. Use the remap window to detect in which flash slot the ROM_EXT is running.
3. Test all variations of owner slots and ROM_EXT slots.