### PR TITLE
[bazel] Remove opentitantest references from build files

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -483,7 +483,6 @@
       si_stage: NA
       tests: ["chip_sw_example_rom",
               "chip_sw_example_flash",
-              "chip_sw_uart_smoketest_signed",
               "chip_sw_example_manufacturer",
               "chip_sw_example_concurrency"
               ]
@@ -553,18 +552,6 @@
       stage: V2
       si_stage: NA
       tests: ["rom_keymgr_functest"]
-    }
-    {
-      name: chip_sw_signed
-      desc: '''Run some chip-level tests with ROM.
-
-            In addition to ROM E2E tests, we select at least one (or a few)
-            tests defined in this file to sign, and run via ROM instead of
-            test ROM. We need to ensure our test infrastructure and ROM can
-            boot and run one (or a few) of the same tests our test ROM can.
-            '''
-      stage: V2
-      tests: ["chip_sw_uart_smoketest_signed"]
     }
     {
       name: chip_sw_coremark

--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -812,16 +812,6 @@
     //   run_timeout_mins: 480
     // }
 
-    // Signed chip-level tests to be run with ROM, instead of test ROM.
-    {
-      name: chip_sw_uart_smoketest_signed
-      uvm_test_seq: chip_sw_uart_smoke_vseq
-      sw_images: ["//sw/device/tests:uart_smoketest_signed:1:signed:fake_rsa_test_key_0"]
-      en_run_modes: ["sw_test_mode_rom_with_fake_keys"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
-      run_timeout_mins: 180
-    }
-
     // ROM func tests to be run with test ROM.
     {
       name: rom_keymgr_functest
@@ -836,10 +826,6 @@
     {
       name: rom_functests
       tests: ["rom_keymgr_functest"]
-    }
-    {
-      name: signed
-      tests: ["chip_sw_uart_smoketest_signed"]
     }
     {
       name: rom_e2e_boot_policy_valid

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -179,8 +179,8 @@ opentitan_binary(
     ],
 )
 
-# Create the legacy ROM target names so that existing opentitan_functest and
-# splicing rules can find the rom VMEM files.
+# Create the legacy ROM target names so that existing splicing rules can find
+# the rom VMEM files.
 legacy_rom_targets(
     testonly = True,
     suffixes = _ROM_DEVICES,
@@ -210,8 +210,8 @@ opentitan_binary(
     ],
 )
 
-# Create the legacy ROM target names so that existing opentitan_functest and
-# splicing rules can find the rom VMEM files.
+# Create the legacy ROM target names so that existing splicing rules can find
+# the rom VMEM files.
 legacy_rom_targets(
     suffixes = _ROM_DEVICES,
     target = "rom_with_real_keys",

--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -101,7 +101,7 @@ opentitan_test(
     name = "e2e_bootstrap_disabled",
     cw310 = cw310_params(
         # Since the bitstream disables bootstrap, there is no firmware to
-        # load into the chip.  However, opentitan_functest wants to build a
+        # load into the chip.  However, opentitan_test wants to build a
         # binary target.  We'll build an unsigned do-nothing binary.
         binaries = {
             "//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware",

--- a/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
@@ -4,13 +4,8 @@
 
 load(
     "//rules/opentitan:defs.bzl",
-    "opentitan_test",
-    new_cw310_params = "cw310_params",
-)
-load(
-    "//rules:opentitan_test.bzl",
     "cw310_params",
-    "opentitan_functest",
+    "opentitan_test",
 )
 load(
     "//rules:const.bzl",
@@ -21,7 +16,6 @@ load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
     "otp_image",
-    "otp_json",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -45,7 +39,7 @@ package(default_visibility = ["//visibility:public"])
     opentitan_test(
         name = "sram_program_fpga_cw310_test_otp_{}".format(lc_state),
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-        cw310 = new_cw310_params(
+        cw310 = cw310_params(
             binaries = {
                 "//sw/device/examples/sram_program:sram_program": "sram_program",
             },
@@ -92,7 +86,7 @@ test_suite(
     opentitan_test(
         name = "openocd_asm_interrupt_handler_otp_" + lc_state,
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-        cw310 = new_cw310_params(
+        cw310 = cw310_params(
             logging = "debug",
             needs_jtag = True,
             otp = ":img_{}_exec_disabled".format(lc_state),
@@ -133,7 +127,7 @@ test_suite(
     opentitan_test(
         name = "openocd_shutdown_execution_asm_" + lc_state,
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-        cw310 = new_cw310_params(
+        cw310 = cw310_params(
             logging = "debug",
             needs_jtag = True,
             otp = ":img_{}_exec_disabled".format(lc_state),
@@ -174,7 +168,7 @@ test_suite(
     opentitan_test(
         name = "openocd_asm_watchdog_bark_" + lc_state,
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-        cw310 = new_cw310_params(
+        cw310 = cw310_params(
             logging = "debug",
             needs_jtag = True,
             otp = ":img_{}_exec_disabled".format(lc_state),
@@ -216,7 +210,7 @@ test_suite(
     opentitan_test(
         name = "openocd_asm_watchdog_bite_" + lc_state,
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-        cw310 = new_cw310_params(
+        cw310 = cw310_params(
             logging = "debug",
             needs_jtag = True,
             otp = ":img_{}_exec_disabled".format(lc_state),
@@ -263,7 +257,7 @@ LC_STATES_DEBUG_DISALLOWED = [
     opentitan_test(
         name = "openocd_debug_test_otp_" + lc_state,
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
-        cw310 = new_cw310_params(
+        cw310 = cw310_params(
             timeout = "moderate",
             logging = "debug",
             needs_jtag = True,

--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -1,13 +1,6 @@
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-
-load(
-    "//rules:opentitan_test.bzl",
-    "cw310_params",
-    "dv_params",
-    "opentitan_functest",
-)
 load(
     "//rules:opentitan.bzl",
     "opentitan_flash_binary",
@@ -16,7 +9,6 @@ load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
     "otp_image",
-    "otp_json",
 )
 load(
     "//rules:splice.bzl",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -17,12 +17,6 @@ load(
     "RSA_ONLY_KEY_STRUCTS",
 )
 load(
-    "//rules:opentitan_test.bzl",
-    "ROM_BOOT_FAILURE_MSG",
-    "opentitan_functest",
-    dv_params_functest = "dv_params",
-)
-load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
     "otp_image",
@@ -49,7 +43,7 @@ package(default_visibility = ["//visibility:public"])
 # TODO(lowRISC:opentitan#13180): this is a temporary solution to enable writing
 # manufacturer specific tests in the `manufacturer_test_hooks` repository that
 # use open source test code. Specifically, this enables defining an
-# `opentitan_functest` in the `manufacturer_test_hooks` repository without the
+# `opentitan_test` in the `manufacturer_test_hooks` repository without the
 # need to specify the corresponding test hooks that should be used with the test
 # on the command line.
 exports_files(glob([
@@ -1421,7 +1415,7 @@ opentitan_test(
         "//hw/top_earlgrey:sim_verilator": None,
     },
     # This test is designed to run and complete entirely in the ROM boot stage.
-    # Setting the `test_in_rom` flag makes the `opentitan_functest` rule aware
+    # Setting the `test_in_rom` flag makes the `opentitan_test` rule aware
     # of this, and instructs it to load the test image into ROM (rather than
     # loading the default test ROM, or any other ROM that may be specified via
     # DV or Verilator params).
@@ -3609,27 +3603,6 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
-    ],
-)
-
-# Used by DVSIM test-points to test signed binaries.
-# Please do not remove until those tests are updated to use `uart_smoketest`.
-opentitan_functest(
-    name = "uart_smoketest_signed",
-    srcs = ["uart_smoketest.c"],
-    dv = dv_params_functest(
-        rom = "//sw/device/silicon_creator/rom:rom_with_fake_keys",
-    ),
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
-    signed = True,
-    targets = ["dv"],
-    deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/arch:device",
-        "//sw/device/lib/base:mmio",
-        "//sw/device/lib/dif:uart",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
 


### PR DESCRIPTION
1. Remove unused `opentitan_functest` references from BUILD files.
2. Remove `uart_smoketest_signed` as this is equivalent to the `rom_e2e_smoketest`.