### PR TITLE
[doc] Remove opentitan_functest references.

### DIFF
--- a/doc/contributing/bazel_notes.md
+++ b/doc/contributing/bazel_notes.md
@@ -56,47 +56,29 @@ This can make them difficult to find manually, however, Bazel also provides a me
 Note, the `outquery-*` command shown below is a special command that is parsed via our `bazelisk.sh` script.
 Therefore, it cannot be run with a standalone `bazel ...` invocation.
 
-## `opentitan_{rom,flash}_binary` Artifacts
+## `opentitan_binary` Artifacts
 
-- Query the locations of all Bazel-built artifacts for all OpenTitan devices for an `opentitan_{rom,flash}_binary` macro:
+- Query the locations of all Bazel-built artifacts for all OpenTitan devices for an `opentitan_binary` macro:
   ```sh
   ./bazelisk.sh outquery-all <target>
   ```
-- Query the locations of all Bazel-built artifacts for a specific OpenTitan device for an `opentitan_{rom,flash}_binary` macro:
-  ```sh
-  ./bazelisk.sh outquery-all <target>_<device>
-  ```
-  Note: `<device>` will be in {`sim_dv`, `sim_verilator`, `fpga_cw310`}.
+
+> See [OpenTitan binary and test rules](../../rules/opentitan/README.md)) for more details on the `opentitan_binary` rule.
 
 See [Building (and Testing) Software](../getting_started/build_sw.md#device-artifacts), device software can be built for multiple OpenTitan devices and memories, using OpenTitan-specific Bazel macros.
 
-## `opentitan_functest` Artifacts
+## `opentitan_test` Artifacts
 
 As described [Building (and Testing) Software](../getting_started/build_sw.md#device-artifacts), device software can be built for multiple OpenTitan devices and memories, using OpenTitan-specific Bazel macros.
 Since running tests on multiple OpenTitan devices (whether DV or Verilator simulation, or an FPGA) involves building several software images for multiple memories, we provide a Bazel macro for this.
-This macro is called `opentitan_functest`.
+This macro is called `opentitan_test`.
 
-- List all `sh_test` targets instantiated by a `opentitan_functest`, e.g. the UART smoketest:
+- List all `sh_test` targets instantiated by a `opentitan_test`, e.g. the UART smoketest:
   ```sh
   bazel query 'labels(tests, //sw/device/tests:uart_smoketest)'
   ```
-- Query the HW and SW dependencies of a specific `opentitan_functest` for the `fpga_cw310` device, e.g. the UART smoketest:
-  ```sh
-  bazel query 'labels(data, //sw/device/tests:uart_smoketest_fpga_cw310)'
-  ```
-  or for any `opentitan_functest` target and `<device>` in {`sim_dv`, `sim_verilator`, `fpga_cw310`}
-  ```sh
-  bazel query 'labels(data, <target>_<device>)'
-  ```
-- Query the software artifacts built for the `opentitan_flash_binary` that is a dependency of an `opentitan_functest` for the `fpga_cw310` device, e.g. the UART smoketest:
-  ```sh
-  bazel query 'labels(srcs, //sw/device/tests:uart_smoketest_prog_fpga_cw310)'
-  ```
-  or for any `opentitan_functest` `<target>` and `<device>` in {`sim_dv`, `sim_verilator`, `fpga_cw310`}
-  ```sh
-  bazel query 'labels(srcs, <target>_prog_<device>)'
-  ```
-  Note: if an `opentitan_functest` target has the name `foo`, then the `opentitan_flash_binary` target that is instantiated by the `opentitan_functest` will be named `foo_prog_<device>`.
+
+> Info: See [OpenTitan binary and test rules](../../rules/opentitan/README.md)) for more details on the `opentitan_test` rule.
 
 # Building Software
 

--- a/doc/getting_started/build_sw.md
+++ b/doc/getting_started/build_sw.md
@@ -139,7 +139,7 @@ These tags can also be used to filter builds using `--build_tag_filters=-cw310,-
 `--build_tests_only` is important when matching wildcards if you aren't using
 `--build_tag_filters` to prevent `bazelisk.sh test //...` from building targets that are filtered out by `--test_tag_filters`.
 
-There is no way to filter out dependencies of a test\_suite such as `//sw/device/tests:uart_smoketest` (Which is a suite that's assembled by the `opentitan_functest` rule) from a build.
+There is no way to filter out dependencies of a test\_suite such as `//sw/device/tests:uart_smoketest` (Which is a suite that's assembled by the `opentitan_test` rule) from a build.
 
 ### Running on-device Tests
 

--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -187,16 +187,16 @@ There are two ways to load a bitstream on to the FPGA and bootstrap software int
 1. **automatically**, on single invocations of `./bazelisk.sh test ...`.
 2. **manually**, using multiple invocations of `opentitantool`, and
 Which one you use, will depend on how the build target is defined for the software you would like to test on the FPGA.
-Specifically, for software build targets defined in Bazel BUILD files using the `opentitan_functest` Bazel macro, you will use the latter (**automatic**) approach.
-Alternatively, for software build targets defined in Bazel BUILD files using the `opentitan_flash_binary` Bazel macro, you will use the former (**manual**) approach.
+Specifically, for software build targets defined in Bazel BUILD files using the `opentitan_test` Bazel macro, you will use the latter (**automatic**) approach.
+Alternatively, for software build targets defined in Bazel BUILD files using the `opentitan_binary` Bazel macro, you will use the former (**manual**) approach.
 
 See below for details on both approaches.
 
 ### Automatically loading FPGA bitstreams and bootstrapping software with Bazel
 
-A majority of on-device software tests are defined using the custom `opentitan_functest` Bazel macro, which under the hood, instantiates several Bazel [`native.sh_test` rules](https://docs.bazel.build/versions/main/be/shell.html#sh_test).
+A majority of on-device software tests are defined using the custom `opentitan_test` Bazel macro, which under the hood, instantiates several Bazel [`native.sh_test` rules](https://docs.bazel.build/versions/main/be/shell.html#sh_test).
 In doing so, this macro provides a convenient interface for developers to run software tests on OpenTitan FPGA instances with a single invocation of `./bazelisk.sh test ...`.
-For example, to run the UART smoke test (which is an `opentitan_functest` defined in `sw/device/tests/BUILD`) on FPGA hardware, and see the output in real time, use:
+For example, to run the UART smoke test (which is an `opentitan_test` defined in `sw/device/tests/BUILD`) on FPGA hardware, and see the output in real time, use:
 ```sh
 cd $REPO_TOP
 ./bazelisk.sh test --test_tag_filters=${BOARD} --test_output=streamed //sw/device/tests:uart_smoketest
@@ -230,10 +230,10 @@ Alternatively, if you would like to instruct Bazel to skip loading any bitstream
 
 ### Manually loading FPGA bitstreams and bootstrapping OpenTitan software with `opentitantool`
 
-Some on-device software targets are defined using the custom `opentitan_flash_binary` Bazel macro.
-Unlike the `opentitan_functest` macro, the `opentitan_flash_binary` macro does **not** instantiate any Bazel test rules under the hood.
+Some on-device software targets are defined using the custom `opentitan_binary` Bazel macro.
+Unlike the `opentitan_test` macro, the `opentitan_binary` macro does **not** instantiate any Bazel test rules under the hood.
 Therefore, to run such software on OpenTitan FPGA hardware, both a bitstream and the software target must be loaded manually onto the FPGA.
-Below, we describe how to accomplish this, and in doing so, we shed some light on the tasks that Bazel automates through the use of `opentitan_functest` Bazel rules.
+Below, we describe how to accomplish this, and in doing so, we shed some light on the tasks that Bazel automates through the use of `opentitan_test` Bazel rules.
 
 #### Manually loading a bitstream onto the FPGA with `opentitantool`
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -391,7 +391,7 @@
   // List of test specifications.
   //
   // If you are adding a test that has been generated from a Bazel
-  // `opentitan_functest` macro, you can specify the test using its Bazel label
+  // `opentitan_test` macro, you can specify the test using its Bazel label
   // followed by an index separated with a ':', which is used by the testbench
   // to know what type of image is it:
   // - 0 for Boot ROM,

--- a/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
@@ -82,7 +82,7 @@
   // List of test specifications.
   //
   // If you are adding a test that has been generated from a Bazel
-  // `opentitan_functest` macro, you can specify the test using its Bazel label
+  // `opentitan_test` macro, you can specify the test using its Bazel label
   // followed by an index separated with a ':', which is used by the testbench
   // to know what type of image is it:
   // - 0 for Boot ROM,

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -42,8 +42,8 @@ opentitan_binary(
     ],
 )
 
-# Create the legacy ROM target names so that existing opentitan_functest and
-# splicing rules can find the test_rom VMEM files.
+# Create the legacy ROM target names so that existing splicing rules
+# can find the test_rom VMEM files.
 legacy_rom_targets(
     suffixes = [
         "fpga_cw310",

--- a/sw/device/silicon_owner/tock/tests/basic/src/basic.rs
+++ b/sw/device/silicon_owner/tock/tests/basic/src/basic.rs
@@ -13,7 +13,7 @@ stack_size!(0x200);
 
 fn main() {
     write!(Console::writer(), "Hello world!\r\n").unwrap();
-    // opentitan_functest's default test harness looks for `PASS` or `FAIL` in
+    // opentitan_test's default test harness looks for `PASS` or `FAIL` in
     // the test output to determine the test result.
     write!(Console::writer(), "PASS!\r\n").unwrap();
 }


### PR DESCRIPTION
Remove `opentitan_functest` references from Markdown and comments in source code.

The same was done for `opentitan_{flash,rom}_binary` references.

Removed some Bazel commands that are no longer valid with `opentitan_test`.