### PR TITLE
[sram_ctrl] Mubi encoding for write enable

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -302,6 +302,15 @@
                   ''',
             resval: 0,
           }
+          { bits: "6"
+            name: "SRAM_WE_ERROR"
+            desc: '''
+                  This bit is set to 1 if a faulty SRAM WE multi-bit signal is detected.
+                  This error triggers a fatal_error alert.
+                  This condition is terminal.
+                  ''',
+            resval: 0,
+          }
         ]
       }
       { name: "EXEC_REGWEN",

--- a/hw/ip/sram_ctrl/doc/registers.md
+++ b/hw/ip/sram_ctrl/doc/registers.md
@@ -1,6 +1,3 @@
-# Registers
-
-<!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/sram_ctrl/data/sram_ctrl.hjson -->
 ## Summary of the **`regs`** interface's registers
 
 | Name                                            | Offset   |   Length | Description                                  |
@@ -34,23 +31,29 @@ Alert Test Register
 SRAM status register.
 - Offset: `0x4`
 - Reset default: `0x0`
-- Reset mask: `0x3f`
+- Reset mask: `0x7f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "BUS_INTEG_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "INIT_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ESCALATED", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SCR_KEY_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SCR_KEY_SEED_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "INIT_DONE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 200}}
+{"reg": [{"name": "BUS_INTEG_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "INIT_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ESCALATED", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SCR_KEY_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SCR_KEY_SEED_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "INIT_DONE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SRAM_WE_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 25}], "config": {"lanes": 1, "fontsize": 10, "vspace": 200}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                              |
 |:------:|:------:|:-------:|:--------------------------------------------------|
-|  31:6  |        |         | Reserved                                          |
+|  31:7  |        |         | Reserved                                          |
+|   6    |   ro   |   0x0   | [SRAM_WE_ERROR](#status--sram_we_error)           |
 |   5    |   ro   |   0x0   | [INIT_DONE](#status--init_done)                   |
 |   4    |   ro   |   0x0   | [SCR_KEY_SEED_VALID](#status--scr_key_seed_valid) |
 |   3    |   ro   |   0x0   | [SCR_KEY_VALID](#status--scr_key_valid)           |
 |   2    |   ro   |   0x0   | [ESCALATED](#status--escalated)                   |
 |   1    |   ro   |   0x0   | [INIT_ERROR](#status--init_error)                 |
 |   0    |   ro   |   0x0   | [BUS_INTEG_ERROR](#status--bus_integ_error)       |
+
+### STATUS . SRAM_WE_ERROR
+This bit is set to 1 if a faulty SRAM WE multi-bit signal is detected.
+This error triggers a fatal_error alert.
+This condition is terminal.
 
 ### STATUS . INIT_DONE
 Set to 1 if the hardware initialization triggered via [`CTRL.INIT`](#ctrl) has completed.
@@ -202,4 +205,3 @@ kMultiBitBool4True indicates that a valid scrambling key has been obtained from 
 Write kMultiBitBool4True to clear.
 
 This interface does not expose any registers.
-<!-- END CMDGEN -->

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -25,6 +25,9 @@ package sram_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } sram_we_error;
+    struct packed {
+      logic        q;
     } init_done;
     struct packed {
       logic        q;
@@ -80,6 +83,10 @@ package sram_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } init_done;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sram_we_error;
   } sram_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -89,15 +96,15 @@ package sram_ctrl_reg_pkg;
 
   // Register -> HW type for regs interface
   typedef struct packed {
-    sram_ctrl_reg2hw_alert_test_reg_t alert_test; // [14:13]
-    sram_ctrl_reg2hw_status_reg_t status; // [12:8]
+    sram_ctrl_reg2hw_alert_test_reg_t alert_test; // [15:14]
+    sram_ctrl_reg2hw_status_reg_t status; // [13:8]
     sram_ctrl_reg2hw_exec_reg_t exec; // [7:4]
     sram_ctrl_reg2hw_ctrl_reg_t ctrl; // [3:0]
   } sram_ctrl_regs_reg2hw_t;
 
   // HW -> register type for regs interface
   typedef struct packed {
-    sram_ctrl_hw2reg_status_reg_t status; // [16:5]
+    sram_ctrl_hw2reg_status_reg_t status; // [18:5]
     sram_ctrl_hw2reg_scr_key_rotated_reg_t scr_key_rotated; // [4:0]
   } sram_ctrl_regs_hw2reg_t;
 

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -129,6 +129,7 @@ module sram_ctrl_regs_reg_top (
   logic status_scr_key_valid_qs;
   logic status_scr_key_seed_valid_qs;
   logic status_init_done_qs;
+  logic status_sram_we_error_qs;
   logic exec_regwen_we;
   logic exec_regwen_qs;
   logic exec_regwen_wd;
@@ -327,6 +328,33 @@ module sram_ctrl_regs_reg_top (
 
     // to register interface (read)
     .qs     (status_init_done_qs)
+  );
+
+  //   F[sram_we_error]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_status_sram_we_error (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.status.sram_we_error.de),
+    .d      (hw2reg.status.sram_we_error.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.status.sram_we_error.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (status_sram_we_error_qs)
   );
 
 
@@ -593,6 +621,7 @@ module sram_ctrl_regs_reg_top (
         reg_rdata_next[3] = status_scr_key_valid_qs;
         reg_rdata_next[4] = status_scr_key_seed_valid_qs;
         reg_rdata_next[5] = status_init_done_qs;
+        reg_rdata_next[6] = status_sram_we_error_qs;
       end
 
       addr_hit[2]: begin

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -576,7 +576,7 @@ module ibex_top import ibex_pkg::*; #(
           .req_i       (ic_tag_req[way]),
 
           .gnt_o       (),
-          .write_i     (ic_tag_write),
+          .write_i     (prim_mubi_pkg::mubi4_bool_to_mubi(ic_tag_write)),
           .addr_i      (ic_tag_addr),
           .wdata_i     (ic_tag_wdata),
           .wmask_i     ({TagSizeECC{1'b1}}),
@@ -608,7 +608,7 @@ module ibex_top import ibex_pkg::*; #(
           .req_i       (ic_data_req[way]),
 
           .gnt_o       (),
-          .write_i     (ic_data_write),
+          .write_i     (prim_mubi_pkg::mubi4_bool_to_mubi(ic_data_write)),
           .addr_i      (ic_data_addr),
           .wdata_i     (ic_data_wdata),
           .wmask_i     ({LineSizeECC{1'b1}}),


### PR DESCRIPTION
This commit hardens the write enable signal used in the SRAM logic against fault attacks by encoding it with a mubi.

The encoded WE signal is generated in the tlul_adapter_sram, passed through sram_ctrl, and forwarded to the prim_ram_1p_scr module. In this module, a integrity check is conducted, triggering an error on failure.