### PR TITLE
[prim_sha2/hmac,rtl/dv] HMAC/SHA-2 secure wiping fix

### DIFF
--- a/hw/ip/hmac/README.md
+++ b/hw/ip/hmac/README.md
@@ -17,7 +17,7 @@ See that document for integration overview within the broader OpenTitan top leve
 
 - HMAC supporting multiple digest sizes: SHA-2 256/384/512 hashing algorithm
 - HMAC-SHA-2 and unkeyed SHA-2 dual mode
-- Configurable key length 256/384/512/1024-bit secret key for HMAC mode
+- Configurable key length 128/256/384/512/1024-bit secret key for HMAC mode
 - 32 x 32-bit message buffer
 
 ## Description
@@ -25,7 +25,7 @@ See that document for integration overview within the broader OpenTitan top leve
 [sha256-spec]: https://csrc.nist.gov/publications/detail/fips/180/4/final
 
 The HMAC module is a [SHA-2][sha256-spec] hash-based authentication code generator to check the integrity of an incoming message and a signature signed with the same secret key.
-It supports SHA-2 256/384/512 and 256/384/512/1024-bit keys in HMAC mode, so long as the key length does not exceed the block size of the configured SHA-2 mode, i.e., 1024-bit keys are not supported for SHA-2 256 where the block size is 512-bit.
+It supports SHA-2 256/384/512 and 128/256/384/512/1024-bit keys in HMAC mode, so long as the key length does not exceed the block size of the configured SHA-2 mode, i.e., 1024-bit keys are not supported for SHA-2 256 where the block size is 512-bit.
 It generates a different authentication code with the same message if the secret key is different.
 
 This HMAC implementation is not hardened against side channel or fault injection attacks.
@@ -40,7 +40,7 @@ The `hash_done` interrupt is raised to report to software that the final digest 
 
 This module allows software to save and restore the hashing context so that different message streams can be interleaved; please check the [Programmer's Guide](doc/programmers_guide.md#saving-and-restoring-the-context) for more information.
 
-The HMAC IP can run in SHA-only mode, whose purpose is to check the correctness of the received message.
+The HMAC IP can run in SHA-2 only mode, whose purpose is to check the correctness of the received message.
 The same digest registers above are used to represent the hash result.
 SHA-2 mode does not use the given secret key.
 It generates the same result with the same message every time.
@@ -51,8 +51,9 @@ will calculate the length of the message received between **1** being written to
 
 This version does not have many defense mechanisms but is able to wipe internal variables such as the secret key, intermediate hash results H, digest and the message FIFO.
 It does not wipe the software accessible 32x32b FIFO.
-The software can wipe the variables by writing a 32-bit random value into [`WIPE_SECRET`](doc/registers.md#wipe_secret) register.
-The internal variables will be reset to the written value.
+The software can wipe the internal variables and secret key by writing a 32-bit random value into [`WIPE_SECRET`](doc/registers.md#wipe_secret) register.
+The internal variables and secret key will be reset to the written value.
+For SHA-2 384/512 modes that operate on 64-bit words, the 32-bit random value is replicated and concatenated to create the 64-bit value.
 This version of the HMAC does not have an internal pseudo-random number generator to derive the random number from the written seed number.
 
 A later update may provide an interface for external hardware IPs, such as a key manager, to update the secret key.

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -374,7 +374,7 @@
       fields: [
         { bits: "31:0",
           name: "err_code",
-          desc: '''If error interrupt occurs, this register has information of error cause.
+          desc: '''If an error interrupt occurs, this register has information of error cause.
                 Please take a look at `hw/ip/hmac/rtl/hmac_pkg.sv:err_code_e enum type.
                 '''
           tags: [// Randomly write mem will cause this reg updated by design
@@ -385,10 +385,10 @@
     { name: "WIPE_SECRET",
       desc: '''Clear internal secret registers.
 
-            If CPU writes value into the register, the value is used to clear the internal variables such as secret key, internal state machine, or hash value.
-            The clear secret operation uses XORs with the provided value as one of the operands.
+            If CPU writes a value into the register, the value is used to clear the internal variables such as the secret key, internal state machine, or hash value.
+            The clear secret operation overwrites the internal variables with the provided 32-bit value.
+            For SHA-2 384/512 that work with 64-bit words, the 32-bit value is duplicated and concatenated to generate the 64-bit value.
             It is recommended to use a value extracted from an entropy source.
-            A value equal to 0 will leave all internal values unchanged.
             ''',
       swaccess: "wo",
       hwaccess: "hro",

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -304,17 +304,17 @@ HMAC Error Code
 {"reg": [{"name": "err_code", "bits": 32, "attr": ["ro"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name     | Description                                                                                                                                      |
-|:------:|:------:|:-------:|:---------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:0  |   ro   |   0x0   | err_code | If error interrupt occurs, this register has information of error cause. Please take a look at `hw/ip/hmac/rtl/hmac_pkg.sv:err_code_e enum type. |
+|  Bits  |  Type  |  Reset  | Name     | Description                                                                                                                                         |
+|:------:|:------:|:-------:|:---------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:0  |   ro   |   0x0   | err_code | If an error interrupt occurs, this register has information of error cause. Please take a look at `hw/ip/hmac/rtl/hmac_pkg.sv:err_code_e enum type. |
 
 ## WIPE_SECRET
 Clear internal secret registers.
 
-If CPU writes value into the register, the value is used to clear the internal variables such as secret key, internal state machine, or hash value.
-The clear secret operation uses XORs with the provided value as one of the operands.
+If CPU writes a value into the register, the value is used to clear the internal variables such as the secret key, internal state machine, or hash value.
+The clear secret operation overwrites the internal variables with the provided 32-bit value.
+For SHA-2 384/512 that work with 64-bit words, the 32-bit value is duplicated and concatenated to generate the 64-bit value.
 It is recommended to use a value extracted from an entropy source.
-A value equal to 0 will leave all internal values unchanged.
 - Offset: `0x20`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`

--- a/hw/ip/hmac/lint/hmac.vlt
+++ b/hw/ip/hmac/lint/hmac.vlt
@@ -6,10 +6,5 @@
 
 `verilator_config
 
-// The wipe_secret_i and wipe_v_i inputs to hmac_core and sha2_pad are not
-// currently used, but we're keeping them attached for future use.
-lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_secret_i'"
-lint_off -rule UNUSED -file "*/rtl/hmac_core.sv" -match "Signal is not used: 'wipe_v_i'"
-
 // 1 bit adder to optimize the count ones logic
 lint_off -rule WIDTH -file "*/rtl/hmac.sv" -match "*RHS's SEL generates 1 bits*"

--- a/hw/ip/hmac/lint/hmac.waiver
+++ b/hw/ip/hmac/lint/hmac.waiver
@@ -4,9 +4,6 @@
 #
 # waiver file for HMAC
 
-waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {hmac_core.sv} -regexp {wipe_(secret|v)} \
-      -comment "Not used but remains for future use"
-
 # ARITH_CONTEXT
 waive -rules {ARITH_CONTEXT} -location {hmac.sv}  -regexp {Bitlength of arithmetic operation 'i % 2' is self-determined in this context} \
       -comment "Intended"

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -639,8 +639,6 @@ module hmac
     .clk_i,
     .rst_ni,
     .secret_key_i  (secret_key),
-    .wipe_secret_i (wipe_secret),
-    .wipe_v_i      (wipe_v),
     .hmac_en_i     (hmac_en),
     .digest_size_i (digest_size),
     .key_length_i  (key_length),

--- a/hw/ip/hmac/rtl/hmac_core.sv
+++ b/hw/ip/hmac/rtl/hmac_core.sv
@@ -9,8 +9,6 @@ module hmac_core import prim_sha2_pkg::*; (
   input rst_ni,
 
   input [1023:0]      secret_key_i, // {word0, word1, ..., word7}
-  input               wipe_secret_i,
-  input [31:0]        wipe_v_i,
   input               hmac_en_i,
   input digest_mode_e digest_size_i,
   input key_length_e  key_length_i,

--- a/hw/ip/prim/rtl/prim_sha2_32.sv
+++ b/hw/ip/prim/rtl/prim_sha2_32.sv
@@ -188,7 +188,7 @@ module prim_sha2_32 import prim_sha2_pkg::*;
       .clk_i (clk_i),
       .rst_ni (rst_ni),
       .wipe_secret_i      (wipe_secret_i),
-      .wipe_v_i           ({wipe_v_i, wipe_v_i}),
+      .wipe_v_i           (wipe_v_i),
       .fifo_rvalid_i      (word_valid),
       .fifo_rdata_i       (full_word),
       .fifo_rready_o      (sha_ready),
@@ -239,7 +239,7 @@ module prim_sha2_32 import prim_sha2_pkg::*;
       .clk_i (clk_i),
       .rst_ni (rst_ni),
       .wipe_secret_i      (wipe_secret_i),
-      .wipe_v_i           ({wipe_v_i, wipe_v_i}),
+      .wipe_v_i           (wipe_v_i),
       .fifo_rvalid_i      (fifo_rvalid_i), // feed input directly
       .fifo_rdata_i       (full_word),
       .fifo_rready_o      (sha_ready),

--- a/sw/device/tests/hmac_secure_wipe_test.c
+++ b/sw/device/tests/hmac_secure_wipe_test.c
@@ -81,9 +81,9 @@ bool test_main(void) {
   const uint32_t kSecureWipeValue = UINT32_MAX;
   CHECK_DIF_OK(dif_hmac_wipe_secret(&hmac, kSecureWipeValue, &digest));
 
-  // Secure wipe is just an XOR of kSecureWipeValue with the digest words.
+  // Secure wipe is kSecureWipeValue overwritten to the digest words.
   for (size_t i = 0; i < ARRAYSIZE(digest.digest); ++i) {
-    uint32_t expected_value = kSecureWipeValue ^ kExpectedHmacDigest.digest[i];
+    uint32_t expected_value = kSecureWipeValue;
     CHECK(digest.digest[i] == expected_value,
           "Expected digest[%d] = %x, actual = %x", i, expected_value,
           digest.digest[i]);


### PR DESCRIPTION
This PR fixes the secure wiping feature in `prim_sha2` engine such that internal variables are overwritten with the WIPE_SECRET value rather than XORed. This change makes it more secure and also consistent with how the secret key is wiped in HMAC. This change has ~~no impact on DV, given its current state (value overwritten to variables is not checked atm)~~ no impact on block-level DV - `hmac_smoke` and `hmac_wipe_secret` pass. A TLT has been updated in this PR to correspond with this change.

Once merged, this would close #22555.

