### PR TITLE
[alert_handler,dv] Disable an assertion that breaks for FI tests

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -144,17 +144,29 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
     $assertoff(0, "tb.dut.gen_classes[2].u_esc_timer.CheckEn_A");
     $assertoff(0, "tb.dut.gen_classes[3].u_esc_timer.CheckEn_A");
 
+    // Disable the EscStateOut_A assertion while we do FI checks. This assertion checks that an FSM
+    // state matches an output signal, but this can totally fail to be true if we're forcing either
+    // side.
+    $assertoff(0, "tb.dut.gen_classes[0].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[1].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[2].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[3].u_esc_timer.EscStateOut_A");
+
     // Because the assertion contains `=>` statement.
     // Wait one clock cycle until the assertions are fully disabled.
     cfg.clk_rst_vif.wait_clks(1);
   endtask : pre_run_sec_cm_fi_vseq
 
   virtual task post_run_sec_cm_fi_vseq();
-    // Enable prim_sparse_fsm assertions.
+    // Enable all the assertions that pre_run_sec_cm_fi_vseq disabled
     $asserton(0, "tb.dut.gen_classes[0].u_esc_timer.CheckEn_A");
     $asserton(0, "tb.dut.gen_classes[1].u_esc_timer.CheckEn_A");
     $asserton(0, "tb.dut.gen_classes[2].u_esc_timer.CheckEn_A");
     $asserton(0, "tb.dut.gen_classes[3].u_esc_timer.CheckEn_A");
+    $assertoff(0, "tb.dut.gen_classes[0].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[1].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[2].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[3].u_esc_timer.EscStateOut_A");
   endtask : post_run_sec_cm_fi_vseq
 
 endclass

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -144,17 +144,29 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
     $assertoff(0, "tb.dut.gen_classes[2].u_esc_timer.CheckEn_A");
     $assertoff(0, "tb.dut.gen_classes[3].u_esc_timer.CheckEn_A");
 
+    // Disable the EscStateOut_A assertion while we do FI checks. This assertion checks that an FSM
+    // state matches an output signal, but this can totally fail to be true if we're forcing either
+    // side.
+    $assertoff(0, "tb.dut.gen_classes[0].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[1].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[2].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[3].u_esc_timer.EscStateOut_A");
+
     // Because the assertion contains `=>` statement.
     // Wait one clock cycle until the assertions are fully disabled.
     cfg.clk_rst_vif.wait_clks(1);
   endtask : pre_run_sec_cm_fi_vseq
 
   virtual task post_run_sec_cm_fi_vseq();
-    // Enable prim_sparse_fsm assertions.
+    // Enable all the assertions that pre_run_sec_cm_fi_vseq disabled
     $asserton(0, "tb.dut.gen_classes[0].u_esc_timer.CheckEn_A");
     $asserton(0, "tb.dut.gen_classes[1].u_esc_timer.CheckEn_A");
     $asserton(0, "tb.dut.gen_classes[2].u_esc_timer.CheckEn_A");
     $asserton(0, "tb.dut.gen_classes[3].u_esc_timer.CheckEn_A");
+    $assertoff(0, "tb.dut.gen_classes[0].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[1].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[2].u_esc_timer.EscStateOut_A");
+    $assertoff(0, "tb.dut.gen_classes[3].u_esc_timer.EscStateOut_A");
   endtask : post_run_sec_cm_fi_vseq
 
 endclass


### PR DESCRIPTION
This assertion was moved from an FPV file to the design itself in commit a4ad7a84c9b. The assertion is true (it's even provable!) in an FPV setting, but isn't true if you start forcing variables. Disable it for FI tests accordingly.

Fixes #22854.