### PR TITLE
Make check_tool_requirements compatible with newer FuseSoC

### DIFF
--- a/check_tool_requirements.core
+++ b/check_tool_requirements.core
@@ -8,8 +8,8 @@ description: "Check tool requirements"
 filesets:
   files_check_tool_requirements:
     files:
-      - ./util/check_tool_requirements.py : { copyto: util/check_tool_requirements.py }
-      - ./tool_requirements.py : { copyto: tool_requirements.py }
+      - util/check_tool_requirements.py : { copyto: util/check_tool_requirements.py }
+      - tool_requirements.py : { copyto: tool_requirements.py }
 
 scripts:
   check_tool_requirements_verible:


### PR DESCRIPTION
Newer versions of FuseSoC (at least 2.4) fails to export files that start with ./ in the filename.