### PR TITLE
[i2c] Consolidate transaction boundary tracking in a bus monitor

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -807,7 +807,7 @@
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
-        { bits: "31:0" }
+        { bits: "19:0" }
       ]
     }
     { name: "TARGET_TIMEOUT_CTRL"

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -272,6 +272,25 @@
                 If it is 0, the decision to ACK or NACK is made only from stretching timeouts and !!CTRL.NACK_ADDR_AFTER_TIMEOUT.
                 '''
         }
+        { bits: "5"
+          resval: "0"
+          name: "MULTI_CONTROLLER_MONITOR_EN"
+          desc: '''
+                Enable the bus monitor in multi-controller mode.
+
+                If a 0->1 transition happens while !!CTRL.ENABLEHOST and !!CTRL.ENABLETARGET are both 0, the bus monitor will enable and begin in the "bus busy" state.
+                To transition to a bus free state, !!HOST_TIMEOUT_CTRL must be nonzero, so the bus monitor may count out idle cycles to confirm the freedom to transmit.
+                In addition, the bus monitor will track whether the bus is free based on the enabled timeouts and detected Stop symbols.
+                For multi-controller mode, ensure !!CTRL.MULTI_CONTROLLER_MONITOR_EN becomes 1 no later than !!CTRL.ENABLEHOST or !!CTRL.ENABLETARGET.
+                This bit can be set at the same time as either or both of the other two, though.
+
+                Note that if !!CTRL.MULTI_CONTROLLER_MONITOR_EN is set after !!CTRL.ENABLEHOST or !!CTRL.ENABLETARGET, the bus monitor will begin in the "bus free" state instead.
+                This would violate the proper protocol for a controller to join a multi-controller environment.
+                However, if this controller is known to be the first to join, this ordering will enable skipping the idle wait.
+
+                When 0, the bus monitor will report that the bus is always free, so the controller FSM is never blocked from transmitting.
+                '''
+        }
       ]
     }
     { name:     "STATUS"
@@ -808,8 +827,8 @@
             { value: "6",
               name: "NACK_STOP",
               desc: '''
-                    A STOP condition was received for a transaction including a transfer that addressed this Target.
-                    A transfer addressing this Target was NACK'd.
+                    A transaction including a transfer that addressed this Target was ended, but the transaction ended abnormally and/or the transfer was NACK'd.
+                    The end can be due to a STOP condition or unexpected events, such as a bus timeout (if enabled).
                     ABYTE contains no data.
                     '''
             },
@@ -836,6 +855,7 @@
             In an active transaction in Target-Mode, if the Controller ceases to send SCL pulses
             for this number of cycles then the "host_timeout" interrupt will be asserted.
 
+            In multi-controller monitoring mode, !!HOST_TIMEOUT_CTRL is required to be nonzero to transition out of the initial busy state.
             Set this CSR to 0 to disable this behaviour.
             '''
       swaccess: "rw"

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -691,7 +691,10 @@
         }
         { bits: "13:7"
           name: "MASK0"
-          desc: "I2C target mask number 0"
+          desc: '''
+                I2C target mask number 0.
+                At least one bit in MASK0 must be set to 1 for ADDRESS0 to be used.
+                '''
         }
         { bits: "20:14"
           name: "ADDRESS1"
@@ -699,7 +702,10 @@
         }
         { bits: "27:21"
           name: "MASK1"
-          desc: "I2C target mask number 1"
+          desc: '''
+                I2C target mask number 1.
+                At least one bit in MASK1 must be set to 1 for ADDRESS1 to be used.
+                '''
         }
       ]
     }

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -896,6 +896,9 @@
       fields: [
         { bits: "7:0" }
       ]
+      tags: [// Updated by the hw. Exclude from init and write-checks.
+             // Without actual I2C traffic, read from this CSR returns Xs.
+             "excl:CsrAllTests:CsrExclCheck"]
     }
     { name: "HOST_NACK_HANDLER_TIMEOUT"
       desc: '''

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -664,19 +664,53 @@
     }
     { name: "TIMEOUT_CTRL"
       desc: '''
-            I2C clock stretching timeout control.
-            This is used in I2C host mode to detect whether a connected target is stretching for too long.
+            I2C clock stretching and bus timeout control.
+            The behavior of this feature depends on the value of TIMEOUT_CTRL.BUS_TIMEOUT_EN.
+            If the bus timeout is disabled, this is used in I2C controller mode to detect whether a connected target is stretching a single low time beyond the timeout value.
+            When the bus timeout feature is disabled, this feature is more informative and doesn't do more than assert the "stretch_timeout" interrupt.
+
+            If the bus timeout feature is enabled, it is used to detect whether the clock has been held low for too long instead, inclusive of the controller's clock low time.
+            In an SMBus context, the VAL programmed should be tTIMEOUT:MIN, and EN and BUS_TIMEOUT_EN should be 1.
             '''
       swaccess: "rw"
       hwaccess: "hro"
       fields: [
-        { bits: "30:0"
+        { bits: "29:0"
           name: "VAL"
           desc: "Clock stretching timeout value (in units of input clock frequency)"
         }
+        { bits: "30"
+          name: "MODE"
+          desc: '''
+                Selects the timeout mode, between a stretch timeout and a bus timeout.
+
+                Between the two modes, the primary difference is how much of the clock low period is counted.
+                For a stretch timeout, only the time that another device holds the clock low will be counted.
+                For a bus timeout, the entire clock low time is counted, consistent with the SMBus tTIMEOUT type.
+
+                !!TIMEOUT_CTRL.EN must be 1 for either of these features to be enabled.
+                '''
+          enum: [
+            { value: "0",
+              name: "STRETCH_TIMEOUT",
+              desc: '''
+                    The timeout is a target stretch timeout.
+                    The counter will track how long the clock has been stretched by another device while the controller is active.
+                    '''
+            },
+            { value: "1",
+              name: "BUS_TIMEOUT",
+              desc: '''
+                    The timeout is a clock low timeout.
+                    The counter will track how long the clock low period is, inclusive of the controller's ordinary low count.
+                    A timeout will set !!CONTROLLER_EVENTS.BUS_TIMEOUT and cause a "controller_halt" interrupt.
+                    '''
+            },
+          ],
+        }
         { bits: "31"
           name: "EN"
-          desc: "Enable timeout feature"
+          desc: "Enable stretch timeout or bus timeout feature"
         }
       ]
     }
@@ -951,6 +985,10 @@
         { bits: "1"
           name: "UNHANDLED_NACK_TIMEOUT"
           desc: "A Host-Mode active transaction has been ended by the !!HOST_NACK_HANDLER_TIMEOUT mechanism."
+        }
+        { bits: "2"
+          name: "BUS_TIMEOUT"
+          desc: "A Host-Mode active transaction has terminated due to a bus timeout activated by !!TIMEOUT_CTRL."
         }
       ]
     }

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -617,17 +617,18 @@ for this number of cycles then the "host_timeout" interrupt will be asserted.
 Set this CSR to 0 to disable this behaviour.
 - Offset: `0x60`
 - Reset default: `0x0`
-- Reset mask: `0xffffffff`
+- Reset mask: `0xfffff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "HOST_TIMEOUT_CTRL", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+{"reg": [{"name": "HOST_TIMEOUT_CTRL", "bits": 20, "attr": ["rw"], "rotate": 0}, {"bits": 12}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name              | Description   |
 |:------:|:------:|:-------:|:------------------|:--------------|
-|  31:0  |   rw   |   0x0   | HOST_TIMEOUT_CTRL |               |
+| 31:20  |        |         |                   | Reserved      |
+|  19:0  |   rw   |   0x0   | HOST_TIMEOUT_CTRL |               |
 
 ## TARGET_TIMEOUT_CTRL
 I2C target internal stretching timeout control.

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -540,13 +540,13 @@ I2C target address and mask pairs
 {"reg": [{"name": "ADDRESS0", "bits": 7, "attr": ["rw"], "rotate": 0}, {"name": "MASK0", "bits": 7, "attr": ["rw"], "rotate": 0}, {"name": "ADDRESS1", "bits": 7, "attr": ["rw"], "rotate": 0}, {"name": "MASK1", "bits": 7, "attr": ["rw"], "rotate": 0}, {"bits": 4}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name     | Description                 |
-|:------:|:------:|:-------:|:---------|:----------------------------|
-| 31:28  |        |         |          | Reserved                    |
-| 27:21  |   rw   |   0x0   | MASK1    | I2C target mask number 1    |
-| 20:14  |   rw   |   0x0   | ADDRESS1 | I2C target address number 1 |
-|  13:7  |   rw   |   0x0   | MASK0    | I2C target mask number 0    |
-|  6:0   |   rw   |   0x0   | ADDRESS0 | I2C target address number 0 |
+|  Bits  |  Type  |  Reset  | Name     | Description                                                                                   |
+|:------:|:------:|:-------:|:---------|:----------------------------------------------------------------------------------------------|
+| 31:28  |        |         |          | Reserved                                                                                      |
+| 27:21  |   rw   |   0x0   | MASK1    | I2C target mask number 1. At least one bit in MASK1 must be set to 1 for ADDRESS1 to be used. |
+| 20:14  |   rw   |   0x0   | ADDRESS1 | I2C target address number 1                                                                   |
+|  13:7  |   rw   |   0x0   | MASK0    | I2C target mask number 0. At least one bit in MASK0 must be set to 1 for ADDRESS0 to be used. |
+|  6:0   |   rw   |   0x0   | ADDRESS0 | I2C target address number 0                                                                   |
 
 ## ACQDATA
 I2C target acquired data

--- a/hw/ip/i2c/doc/theory_of_operation.md
+++ b/hw/ip/i2c/doc/theory_of_operation.md
@@ -119,6 +119,10 @@ In other words, address matching is performed only for bits where the mask is "1
 Thus, with the masks set to all ones (0x7F), the target device will respond to either of the two assigned unique addresses and no other.
 If the mask and the assigned address both have zeros in a particular bit position, that bit will be a match regardless of the value of that bit received from the host.
 Note that if, in any bit position, the mask has zero and the assigned address has one, no transaction can match and such mask/address pair is effectively disabled.
+
+Finally, in the special case where the mask is all zeroes (0x00), then that corresponding entry is ignored and will not match.
+If the user wishes to have the target respond to *all* addresses, then this can be achieved by setting mask0 and mask1 to 0x01 and setting address0 to 0x00 and address1 to 0x01.
+
 The assigned address and mask pairs are set in registers [`TARGET_ID.ADDRESS0`](registers.md#target_id), [`TARGET_ID.MASK0`](registers.md#target_id), [`TARGET_ID.ADDRESS1`](registers.md#target_id), and [`TARGET_ID.MASK1`](registers.md#target_id).
 
 ### Acquired Formatted Data

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_glitch_vseq.sv
@@ -20,9 +20,9 @@ class i2c_glitch_vseq extends i2c_target_smoke_vseq;
   uint scl_period;
 
   // Variable used to detect start internally
-  string start_detected_path = "tb.dut.i2c_core.u_i2c_target_fsm.start_det";
+  string start_detected_path = "tb.dut.i2c_core.u_i2c_bus_monitor.start_det";
   // Variable used to detect Stop internally
-  string stop_detected_path = "tb.dut.i2c_core.u_i2c_target_fsm.stop_det";
+  string stop_detected_path = "tb.dut.i2c_core.u_i2c_bus_monitor.stop_det";
   // Internal FSM variable
   string fsm_state_path = "tb.dut.i2c_core.u_i2c_target_fsm.state_q";
 

--- a/hw/ip/i2c/i2c.core
+++ b/hw/ip/i2c/i2c.core
@@ -19,6 +19,7 @@ filesets:
       - rtl/i2c_fifo_sync_sram_adapter.sv
       - rtl/i2c_fifos.sv
       - rtl/i2c_core.sv
+      - rtl/i2c_bus_monitor.sv
       - rtl/i2c_controller_fsm.sv
       - rtl/i2c_target_fsm.sv
       - rtl/i2c.sv

--- a/hw/ip/i2c/rtl/i2c_bus_monitor.sv
+++ b/hw/ip/i2c/rtl/i2c_bus_monitor.sv
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Description: I2C bus collision detector module
+// Description: I2C bus idle and timeout monitoring, plus Start/Stop
+// detection.
 
 module i2c_bus_monitor import i2c_pkg::*;
 (
@@ -15,14 +16,17 @@ module i2c_bus_monitor import i2c_pkg::*;
   input                            controller_enable_i,
   input                            target_enable_i,
   input                            target_idle_i,
-  input [12:0]                     thd_dat_i,
-  input [12:0]                     t_buf_i,
-  input [19:0]                     bus_timeout_i,
+  input [12:0]                     thd_dat_i,              // Data hold time(< 200 ns, < thd_sta)
+  input [12:0]                     t_buf_i,                // Bus free time (< 5 us)
+  input [29:0]                     bus_active_timeout_i,   // SCL held low  (~25 ms)
+  input                            bus_active_timeout_en_i,
+  input [19:0]                     bus_inactive_timeout_i, // SCL held high (~50 us)
 
   output                           bus_free_o,
   output                           start_detect_o,
   output                           stop_detect_o,
 
+  output                           event_bus_active_timeout_o,
   output                           event_host_timeout_o
 
 );
@@ -106,35 +110,48 @@ module i2c_bus_monitor import i2c_pkg::*;
   assign stop_detect_o = stop_det;
 
   //
-  // Bus inactive logic
+  // Bus timeout logic
   //
 
   // Detection of bus in a released state.
   logic bus_idling;
   assign bus_idling = scl_i && (sda_i == sda_i_q);
 
-  // At a 1 GHz core clock, 20 bits for the idle threshold yields a range of
-  // over 1 ms. Meanwhile, SMBus specs require an idle timeout at just 50 us.
-  logic [19:0] bus_inactive_cnt, bus_inactive_cnt_sel;
-  logic bus_inactive_cnt_load, bus_inactive_cnt_dec;
+  logic [29:0] bus_release_cnt, bus_release_cnt_sel;
+  logic bus_release_cnt_load, bus_release_cnt_dec;
 
-  // bus_idle_timeout is only high for the case where the bus inactive counter
-  // reaches zero for bus idling, not the wait after a Stop condition.
-  logic bus_idle_timeout;
+  // bus_inactive_timeout_det is only high for the case where the bus release
+  // counter reaches zero for bus idling, not the wait after a Stop condition.
+  logic bus_inactive_timeout_det;
 
-  logic bus_timeout_en;
-  assign bus_timeout_en = (bus_timeout_i > '0);
+  logic bus_inactive_timeout_en;
+  assign bus_inactive_timeout_en = (bus_inactive_timeout_i > '0);
 
-  // Bus inactive counter.
-  // Together with the FSM below, this counter detects a bus idle timeout and
-  // the end of the bus free time following a Stop condition.
+  // bus_active_timeout latches high when SCL has been held low for too long.
+  // This can be done intentionally or unintentionally, as the response for
+  // target devices should be to abort the current transaction and release any
+  // hold on the bus. Note that the bus doesn't immediately transition to
+  // "free" status, since the controller can continue holding SCL low for some
+  // time.
+  logic bus_active_timeout_det_d, bus_active_timeout_det_q;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      bus_active_timeout_det_q <= 1'b0;
+    end else begin
+      bus_active_timeout_det_q <= bus_active_timeout_det_d;
+    end
+  end
+
+  // Bus release counter.
+  // Together with the FSM below, this counter detects bus timeouts and the end
+  // of the bus free time following a Stop condition.
   always_ff @ (posedge clk_i or negedge rst_ni) begin : bus_idle
     if (!rst_ni) begin
-      bus_inactive_cnt <= '0;
-    end else if (bus_inactive_cnt_load) begin
-      bus_inactive_cnt <= bus_inactive_cnt_sel;
-    end else if (bus_inactive_cnt_dec && (bus_inactive_cnt != '0)) begin
-      bus_inactive_cnt <= bus_inactive_cnt - 1'b1;
+      bus_release_cnt <= '0;
+    end else if (bus_release_cnt_load) begin
+      bus_release_cnt <= bus_release_cnt_sel;
+    end else if (bus_release_cnt_dec && (bus_release_cnt != '0)) begin
+      bus_release_cnt <= bus_release_cnt - 1'b1;
     end
   end
 
@@ -153,47 +170,68 @@ module i2c_bus_monitor import i2c_pkg::*;
 
   always_comb begin
     state_d = state_q;
-    bus_inactive_cnt_load = 1'b0;
-    bus_inactive_cnt_sel = t_buf_i;
-    bus_inactive_cnt_dec = 1'b0;
-    bus_idle_timeout = 1'b0;
+    bus_release_cnt_load = 1'b0;
+    bus_release_cnt_sel = 30'(t_buf_i);
+    bus_release_cnt_dec = 1'b0;
+    bus_inactive_timeout_det = 1'b0;
+    bus_active_timeout_det_d = bus_active_timeout_det_q;
 
     unique case (state_q)
       StBusFree: begin
+        bus_active_timeout_det_d = 1'b0;
+
         if (!scl_i || !sda_i) begin
           state_d = StBusBusyLow;
+          bus_release_cnt_load = 1'b1;
+          bus_release_cnt_sel = bus_active_timeout_i;
         end
       end
 
       StBusBusyLow: begin
+        bus_release_cnt_dec = !scl_i;
+
         if (stop_det) begin
           state_d = StBusBusyStop;
-          bus_inactive_cnt_load = 1'b1;
-          bus_inactive_cnt_sel = t_buf_i;
-        end else if (bus_idling && bus_timeout_en) begin
+          bus_release_cnt_load = 1'b1;
+          bus_release_cnt_sel = 30'(t_buf_i);
+        end else if (bus_idling && bus_inactive_timeout_en) begin
           state_d = StBusBusyHigh;
-          bus_inactive_cnt_load = 1'b1;
-          bus_inactive_cnt_sel = bus_timeout_i;
+          bus_release_cnt_load = 1'b1;
+          bus_release_cnt_sel = 30'(bus_inactive_timeout_i);
+        end else if (scl_i) begin
+          bus_release_cnt_load = 1'b1;
+          bus_release_cnt_sel = bus_active_timeout_i;
+          if (bus_active_timeout_det_q) begin
+            // SCL was released due to the bus timeout, so go to BusFree.
+            state_d = StBusFree;
+          end
+        end else if (bus_release_cnt == 30'd1) begin
+          // The active timeout occurs when SCL has been held continuously low
+          // for too long. Both the controller and target should respond to
+          // this timeout and release the bus. We don't consider the bus free
+          // yet, though: SCL must be released first.
+          bus_active_timeout_det_d = bus_active_timeout_en_i;
         end
       end
 
       StBusBusyHigh: begin
-        bus_inactive_cnt_dec = 1'b1;
+        bus_release_cnt_dec = 1'b1;
 
         if (stop_det) begin
           state_d = StBusBusyStop;
-          bus_inactive_cnt_load = 1'b1;
-          bus_inactive_cnt_sel = t_buf_i;
+          bus_release_cnt_load = 1'b1;
+          bus_release_cnt_sel = 30'(t_buf_i);
         end else if (!bus_idling) begin
           state_d = StBusBusyLow;
-        end else if (bus_inactive_cnt == 20'd1) begin
+          bus_release_cnt_load = 1'b1;
+          bus_release_cnt_sel = bus_active_timeout_i;
+        end else if (bus_release_cnt == 30'd1) begin
           // The host_timeout interrupt occurs regardless of which value of
           // SDA was present, but only transition to StBusFree if we entered
           // this state with SDA high. If SDA is low, a change to SCL will
-          // cause a transition back to StBusBusyLow. If it SDA changes from
-          // low-to-high, we get a Stop condition and transition to
-          // StBusBusyStop.
-          bus_idle_timeout = 1'b1;
+          // cause a transition back to StBusBusyLow. If SDA changes from low
+          // to high, we get a Stop condition and transition to StBusBusyStop.
+          bus_inactive_timeout_det = 1'b1;
           if (sda_i) begin
             state_d = StBusFree;
           end
@@ -201,11 +239,11 @@ module i2c_bus_monitor import i2c_pkg::*;
       end
 
       StBusBusyStop: begin
-        bus_inactive_cnt_dec = 1'b1;
+        bus_release_cnt_dec = 1'b1;
 
         if (!scl_i || !sda_i) begin
           state_d = StBusBusyLow;
-        end else if (bus_inactive_cnt == 20'd1) begin
+        end else if (bus_release_cnt == 30'd1) begin
           state_d = StBusFree;
         end
       end
@@ -225,6 +263,7 @@ module i2c_bus_monitor import i2c_pkg::*;
   end
 
   assign bus_free_o = (state_q == StBusFree);
-  assign event_host_timeout_o = !target_idle_i && bus_idle_timeout;
+  assign event_bus_active_timeout_o = bus_active_timeout_det_d && !bus_active_timeout_det_q;
+  assign event_host_timeout_o = !target_idle_i && bus_inactive_timeout_det;
 
 endmodule

--- a/hw/ip/i2c/rtl/i2c_bus_monitor.sv
+++ b/hw/ip/i2c/rtl/i2c_bus_monitor.sv
@@ -14,6 +14,7 @@ module i2c_bus_monitor import i2c_pkg::*;
   input                            sda_i,
 
   input                            controller_enable_i,
+  input                            multi_controller_enable_i,
   input                            target_enable_i,
   input                            target_idle_i,
   input [12:0]                     thd_dat_i,              // Data hold time(< 200 ns, < thd_sta)
@@ -22,7 +23,7 @@ module i2c_bus_monitor import i2c_pkg::*;
   input                            bus_active_timeout_en_i,
   input [19:0]                     bus_inactive_timeout_i, // SCL held high (~50 us)
 
-  output                           bus_free_o,
+  output logic                     bus_free_o,
   output                           start_detect_o,
   output                           stop_detect_o,
 
@@ -32,8 +33,16 @@ module i2c_bus_monitor import i2c_pkg::*;
 );
 
   // Only activate this monitor if at least one of the modules is enabled.
-  logic monitor_enable;
-  assign monitor_enable = controller_enable_i | target_enable_i;
+  logic monitor_enable, monitor_enable_q;
+  assign monitor_enable = controller_enable_i | target_enable_i | multi_controller_enable_i;
+
+  always_ff @ (posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      monitor_enable_q <= 1'b0;
+    end else begin
+      monitor_enable_q <= monitor_enable;
+    end
+  end
 
   // SDA and SCL at the previous clock edge
   logic scl_i_q, sda_i_q;
@@ -148,6 +157,14 @@ module i2c_bus_monitor import i2c_pkg::*;
   always_ff @ (posedge clk_i or negedge rst_ni) begin : bus_idle
     if (!rst_ni) begin
       bus_release_cnt <= '0;
+    end else if (monitor_enable && !monitor_enable_q) begin
+      // The rising edge of monitor enable resets the counter for
+      // multi-controller mode.
+      if (multi_controller_enable_i) begin
+        // For the multi-controller case, wait until the bus isn't busy before
+        // transmitting.
+        bus_release_cnt <= 30'(bus_inactive_timeout_i);
+      end
     end else if (bus_release_cnt_load) begin
       bus_release_cnt <= bus_release_cnt_sel;
     end else if (bus_release_cnt_dec && (bus_release_cnt != '0)) begin
@@ -231,7 +248,7 @@ module i2c_bus_monitor import i2c_pkg::*;
           // this state with SDA high. If SDA is low, a change to SCL will
           // cause a transition back to StBusBusyLow. If SDA changes from low
           // to high, we get a Stop condition and transition to StBusBusyStop.
-          bus_inactive_timeout_det = 1'b1;
+          bus_inactive_timeout_det = bus_inactive_timeout_en;
           if (sda_i) begin
             state_d = StBusFree;
           end
@@ -257,12 +274,32 @@ module i2c_bus_monitor import i2c_pkg::*;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       state_q <= StBusFree;
+    end else if (!monitor_enable) begin
+      state_q <= StBusFree;
+    end else if (monitor_enable && !monitor_enable_q) begin
+      if (multi_controller_enable_i) begin
+        // For the multi-controller case, wait until the bus isn't busy before
+        // transmitting.
+        state_q <= StBusBusyHigh;
+      end else begin
+        state_q <= StBusFree;
+      end
     end else begin
       state_q <= state_d;
     end
   end
 
-  assign bus_free_o = (state_q == StBusFree);
+  always_comb begin
+    if (multi_controller_enable_i) begin
+      bus_free_o = (state_q == StBusFree);
+    end else begin
+      // For single-controller cases, the bus is only "busy" while waiting for the "bus free" time
+      // after a Stop condition. In other words, that is the only time our controller can't
+      // continue to the next transaction.
+      bus_free_o = (state_q != StBusBusyStop);
+    end
+  end
+
   assign event_bus_active_timeout_o = bus_active_timeout_det_d && !bus_active_timeout_det_q;
   assign event_host_timeout_o = !target_idle_i && bus_inactive_timeout_det;
 

--- a/hw/ip/i2c/rtl/i2c_bus_monitor.sv
+++ b/hw/ip/i2c/rtl/i2c_bus_monitor.sv
@@ -1,0 +1,230 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Description: I2C bus collision detector module
+
+module i2c_bus_monitor import i2c_pkg::*;
+(
+  input                            clk_i,
+  input                            rst_ni,
+
+  input                            scl_i,
+  input                            sda_i,
+
+  input                            controller_enable_i,
+  input                            target_enable_i,
+  input                            target_idle_i,
+  input [12:0]                     thd_dat_i,
+  input [12:0]                     t_buf_i,
+  input [19:0]                     bus_timeout_i,
+
+  output                           bus_free_o,
+  output                           start_detect_o,
+  output                           stop_detect_o,
+
+  output                           event_host_timeout_o
+
+);
+
+  // Only activate this monitor if at least one of the modules is enabled.
+  logic monitor_enable;
+  assign monitor_enable = controller_enable_i | target_enable_i;
+
+  // SDA and SCL at the previous clock edge
+  logic scl_i_q, sda_i_q;
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : bus_prev
+    if (!rst_ni) begin
+      scl_i_q <= 1'b1;
+      sda_i_q <= 1'b1;
+    end else begin
+      scl_i_q <= scl_i;
+      sda_i_q <= sda_i;
+    end
+  end
+
+  // Start and Stop detection
+  //
+  // To resolve ambiguity with early SDA arrival, reject control symbols when
+  // SCL goes low too soon. The hold time for ordinary data/ACK bits is too
+  // short to reliably see SCL change before SDA. Use the hold time for
+  // control signals to ensure a Start or Stop symbol was actually received.
+  // Requirements: thd_dat + 1 < thd_sta
+  //   The extra (+1) here is to account for a late SDA arrival due to CDC
+  //   skew.
+  //
+  // Note that this counter combines Start and Stop detection into one
+  // counter. A controller-only reset scenario could end up with a Stop
+  // following shortly after a Start, with the requisite setup time not
+  // observed.
+  logic        start_det_trigger, start_det_pending;
+  logic        start_det;     // indicates start or repeated start is detected on the bus
+  logic        stop_det_trigger, stop_det_pending;
+  logic        stop_det;      // indicates stop is detected on the bus
+
+  // Stop / Start detection counter
+  logic [13:0] ctrl_det_count;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      ctrl_det_count <= '0;
+    end else if (start_det_trigger || stop_det_trigger) begin
+      ctrl_det_count <= 14'd1;
+    end else if (start_det_pending || stop_det_pending) begin
+      ctrl_det_count <= ctrl_det_count + 1'b1;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      start_det_pending <= 1'b0;
+    end else if (start_det_trigger) begin
+      start_det_pending <= 1'b1;
+    end else if (!monitor_enable || !scl_i || start_det || stop_det_trigger) begin
+      start_det_pending <= 1'b0;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      stop_det_pending <= 1'b0;
+    end else if (stop_det_trigger) begin
+      stop_det_pending <= 1'b1;
+    end else if (!monitor_enable || !scl_i || stop_det || start_det_trigger) begin
+      stop_det_pending <= 1'b0;
+    end
+  end
+
+  // (Repeated) Start condition detection by target
+  assign start_det_trigger = monitor_enable && (scl_i_q && scl_i) & (sda_i_q && !sda_i);
+  assign start_det = monitor_enable && start_det_pending && (ctrl_det_count >= 14'(thd_dat_i));
+  assign start_detect_o = start_det;
+
+  // Stop condition detection by target
+  assign stop_det_trigger = monitor_enable && (scl_i_q && scl_i) & (!sda_i_q && sda_i);
+  assign stop_det = monitor_enable && stop_det_pending && (ctrl_det_count >= 14'(thd_dat_i));
+  assign stop_detect_o = stop_det;
+
+  //
+  // Bus inactive logic
+  //
+
+  // Detection of bus in a released state.
+  logic bus_idling;
+  assign bus_idling = scl_i && (sda_i == sda_i_q);
+
+  // At a 1 GHz core clock, 20 bits for the idle threshold yields a range of
+  // over 1 ms. Meanwhile, SMBus specs require an idle timeout at just 50 us.
+  logic [19:0] bus_inactive_cnt, bus_inactive_cnt_sel;
+  logic bus_inactive_cnt_load, bus_inactive_cnt_dec;
+
+  // bus_idle_timeout is only high for the case where the bus inactive counter
+  // reaches zero for bus idling, not the wait after a Stop condition.
+  logic bus_idle_timeout;
+
+  logic bus_timeout_en;
+  assign bus_timeout_en = (bus_timeout_i > '0);
+
+  // Bus inactive counter.
+  // Together with the FSM below, this counter detects a bus idle timeout and
+  // the end of the bus free time following a Stop condition.
+  always_ff @ (posedge clk_i or negedge rst_ni) begin : bus_idle
+    if (!rst_ni) begin
+      bus_inactive_cnt <= '0;
+    end else if (bus_inactive_cnt_load) begin
+      bus_inactive_cnt <= bus_inactive_cnt_sel;
+    end else if (bus_inactive_cnt_dec && (bus_inactive_cnt != '0)) begin
+      bus_inactive_cnt <= bus_inactive_cnt - 1'b1;
+    end
+  end
+
+  typedef enum logic [1:0] {
+    // Bus is currently free. Can transmit.
+    StBusFree,
+    // Bus is busy and not held with SCL high.
+    StBusBusyLow,
+    // Bus is currently busy, but SCL is held high.
+    StBusBusyHigh,
+    // Bus is currently busy, but saw a Stop. Count down to Bus Free.
+    StBusBusyStop
+  } bus_state_e;
+
+  bus_state_e state_q, state_d;
+
+  always_comb begin
+    state_d = state_q;
+    bus_inactive_cnt_load = 1'b0;
+    bus_inactive_cnt_sel = t_buf_i;
+    bus_inactive_cnt_dec = 1'b0;
+    bus_idle_timeout = 1'b0;
+
+    unique case (state_q)
+      StBusFree: begin
+        if (!scl_i || !sda_i) begin
+          state_d = StBusBusyLow;
+        end
+      end
+
+      StBusBusyLow: begin
+        if (stop_det) begin
+          state_d = StBusBusyStop;
+          bus_inactive_cnt_load = 1'b1;
+          bus_inactive_cnt_sel = t_buf_i;
+        end else if (bus_idling && bus_timeout_en) begin
+          state_d = StBusBusyHigh;
+          bus_inactive_cnt_load = 1'b1;
+          bus_inactive_cnt_sel = bus_timeout_i;
+        end
+      end
+
+      StBusBusyHigh: begin
+        bus_inactive_cnt_dec = 1'b1;
+
+        if (stop_det) begin
+          state_d = StBusBusyStop;
+          bus_inactive_cnt_load = 1'b1;
+          bus_inactive_cnt_sel = t_buf_i;
+        end else if (!bus_idling) begin
+          state_d = StBusBusyLow;
+        end else if (bus_inactive_cnt == 20'd1) begin
+          // The host_timeout interrupt occurs regardless of which value of
+          // SDA was present, but only transition to StBusFree if we entered
+          // this state with SDA high. If SDA is low, a change to SCL will
+          // cause a transition back to StBusBusyLow. If it SDA changes from
+          // low-to-high, we get a Stop condition and transition to
+          // StBusBusyStop.
+          bus_idle_timeout = 1'b1;
+          if (sda_i) begin
+            state_d = StBusFree;
+          end
+        end
+      end
+
+      StBusBusyStop: begin
+        bus_inactive_cnt_dec = 1'b1;
+
+        if (!scl_i || !sda_i) begin
+          state_d = StBusBusyLow;
+        end else if (bus_inactive_cnt == 20'd1) begin
+          state_d = StBusFree;
+        end
+      end
+
+      default: begin
+        state_d = StBusFree;
+      end
+    endcase
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q <= StBusFree;
+    end else begin
+      state_q <= state_d;
+    end
+  end
+
+  assign bus_free_o = (state_q == StBusFree);
+  assign event_host_timeout_o = !target_idle_i && bus_idle_timeout;
+
+endmodule

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -435,6 +435,7 @@ module i2c_core import i2c_pkg::*;
     .sda_i                          (sda_sync),
 
     .controller_enable_i            (host_enable),
+    .multi_controller_enable_i      (reg2hw.ctrl.multi_controller_monitor_en.q),
     .target_enable_i                (target_enable),
     .target_idle_i                  (target_idle),
     .thd_dat_i                      (thd_dat),

--- a/hw/ip/i2c/rtl/i2c_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_pkg.sv
@@ -32,6 +32,11 @@ package i2c_pkg;
     AcqNackStop  = 3'b110
   } i2c_acq_byte_id_e;
 
+  typedef enum logic {
+    StretchTimeoutMode = 1'b0,
+    BusTimeoutMode     = 1'b1
+  } i2c_timeout_mode_e;
+
   // Width of each entry in the FMT FIFO with enough space for an 8-bit data
   // byte and 5 flags.
   parameter int unsigned FMT_FIFO_WIDTH = 8 + 5;

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -375,7 +375,7 @@ package i2c_reg_pkg;
   } i2c_reg2hw_txdata_reg_t;
 
   typedef struct packed {
-    logic [31:0] q;
+    logic [19:0] q;
   } i2c_reg2hw_host_timeout_ctrl_reg_t;
 
   typedef struct packed {
@@ -587,27 +587,27 @@ package i2c_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [478:464]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [463:449]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [448:419]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [418:417]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [416:412]
-    i2c_reg2hw_rdata_reg_t rdata; // [411:403]
-    i2c_reg2hw_fdata_reg_t fdata; // [402:384]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [383:376]
-    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [375:350]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [349:322]
-    i2c_reg2hw_ovrd_reg_t ovrd; // [321:319]
-    i2c_reg2hw_timing0_reg_t timing0; // [318:293]
-    i2c_reg2hw_timing1_reg_t timing1; // [292:274]
-    i2c_reg2hw_timing2_reg_t timing2; // [273:248]
-    i2c_reg2hw_timing3_reg_t timing3; // [247:226]
-    i2c_reg2hw_timing4_reg_t timing4; // [225:200]
-    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [199:168]
-    i2c_reg2hw_target_id_reg_t target_id; // [167:140]
-    i2c_reg2hw_acqdata_reg_t acqdata; // [139:127]
-    i2c_reg2hw_txdata_reg_t txdata; // [126:118]
-    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [117:86]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [466:452]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [451:437]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [436:407]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [406:405]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [404:400]
+    i2c_reg2hw_rdata_reg_t rdata; // [399:391]
+    i2c_reg2hw_fdata_reg_t fdata; // [390:372]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [371:364]
+    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [363:338]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [337:310]
+    i2c_reg2hw_ovrd_reg_t ovrd; // [309:307]
+    i2c_reg2hw_timing0_reg_t timing0; // [306:281]
+    i2c_reg2hw_timing1_reg_t timing1; // [280:262]
+    i2c_reg2hw_timing2_reg_t timing2; // [261:236]
+    i2c_reg2hw_timing3_reg_t timing3; // [235:214]
+    i2c_reg2hw_timing4_reg_t timing4; // [213:188]
+    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [187:156]
+    i2c_reg2hw_target_id_reg_t target_id; // [155:128]
+    i2c_reg2hw_acqdata_reg_t acqdata; // [127:115]
+    i2c_reg2hw_txdata_reg_t txdata; // [114:106]
+    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [105:86]
     i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [85:54]
     i2c_reg2hw_target_nack_count_reg_t target_nack_count; // [53:46]
     i2c_reg2hw_target_ack_ctrl_reg_t target_ack_ctrl; // [45:34]
@@ -758,7 +758,7 @@ package i2c_reg_pkg;
     4'b 1111, // index[21] I2C_TARGET_ID
     4'b 0011, // index[22] I2C_ACQDATA
     4'b 0001, // index[23] I2C_TXDATA
-    4'b 1111, // index[24] I2C_HOST_TIMEOUT_CTRL
+    4'b 0111, // index[24] I2C_HOST_TIMEOUT_CTRL
     4'b 1111, // index[25] I2C_TARGET_TIMEOUT_CTRL
     4'b 0001, // index[26] I2C_TARGET_NACK_COUNT
     4'b 1111, // index[27] I2C_TARGET_ACK_CTRL

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -339,7 +339,10 @@ package i2c_reg_pkg;
       logic        q;
     } en;
     struct packed {
-      logic [30:0] q;
+      logic        q;
+    } mode;
+    struct packed {
+      logic [29:0] q;
     } val;
   } i2c_reg2hw_timeout_ctrl_reg_t;
 
@@ -412,6 +415,9 @@ package i2c_reg_pkg;
   } i2c_reg2hw_host_nack_handler_timeout_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        q;
+    } bus_timeout;
     struct packed {
       logic        q;
     } unhandled_nack_timeout;
@@ -583,51 +589,55 @@ package i2c_reg_pkg;
       logic        d;
       logic        de;
     } unhandled_nack_timeout;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bus_timeout;
   } i2c_hw2reg_controller_events_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [466:452]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [451:437]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [436:407]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [406:405]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [404:400]
-    i2c_reg2hw_rdata_reg_t rdata; // [399:391]
-    i2c_reg2hw_fdata_reg_t fdata; // [390:372]
-    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [371:364]
-    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [363:338]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [337:310]
-    i2c_reg2hw_ovrd_reg_t ovrd; // [309:307]
-    i2c_reg2hw_timing0_reg_t timing0; // [306:281]
-    i2c_reg2hw_timing1_reg_t timing1; // [280:262]
-    i2c_reg2hw_timing2_reg_t timing2; // [261:236]
-    i2c_reg2hw_timing3_reg_t timing3; // [235:214]
-    i2c_reg2hw_timing4_reg_t timing4; // [213:188]
-    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [187:156]
-    i2c_reg2hw_target_id_reg_t target_id; // [155:128]
-    i2c_reg2hw_acqdata_reg_t acqdata; // [127:115]
-    i2c_reg2hw_txdata_reg_t txdata; // [114:106]
-    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [105:86]
-    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [85:54]
-    i2c_reg2hw_target_nack_count_reg_t target_nack_count; // [53:46]
-    i2c_reg2hw_target_ack_ctrl_reg_t target_ack_ctrl; // [45:34]
-    i2c_reg2hw_host_nack_handler_timeout_reg_t host_nack_handler_timeout; // [33:2]
-    i2c_reg2hw_controller_events_reg_t controller_events; // [1:0]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [467:453]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [452:438]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [437:408]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [407:406]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [405:401]
+    i2c_reg2hw_rdata_reg_t rdata; // [400:392]
+    i2c_reg2hw_fdata_reg_t fdata; // [391:373]
+    i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [372:365]
+    i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [364:339]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [338:311]
+    i2c_reg2hw_ovrd_reg_t ovrd; // [310:308]
+    i2c_reg2hw_timing0_reg_t timing0; // [307:282]
+    i2c_reg2hw_timing1_reg_t timing1; // [281:263]
+    i2c_reg2hw_timing2_reg_t timing2; // [262:237]
+    i2c_reg2hw_timing3_reg_t timing3; // [236:215]
+    i2c_reg2hw_timing4_reg_t timing4; // [214:189]
+    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [188:157]
+    i2c_reg2hw_target_id_reg_t target_id; // [156:129]
+    i2c_reg2hw_acqdata_reg_t acqdata; // [128:116]
+    i2c_reg2hw_txdata_reg_t txdata; // [115:107]
+    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [106:87]
+    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [86:55]
+    i2c_reg2hw_target_nack_count_reg_t target_nack_count; // [54:47]
+    i2c_reg2hw_target_ack_ctrl_reg_t target_ack_ctrl; // [46:35]
+    i2c_reg2hw_host_nack_handler_timeout_reg_t host_nack_handler_timeout; // [34:3]
+    i2c_reg2hw_controller_events_reg_t controller_events; // [2:0]
   } i2c_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    i2c_hw2reg_intr_state_reg_t intr_state; // [169:140]
-    i2c_hw2reg_status_reg_t status; // [139:129]
-    i2c_hw2reg_rdata_reg_t rdata; // [128:121]
-    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [120:97]
-    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [96:73]
-    i2c_hw2reg_val_reg_t val; // [72:41]
-    i2c_hw2reg_acqdata_reg_t acqdata; // [40:30]
-    i2c_hw2reg_target_nack_count_reg_t target_nack_count; // [29:21]
-    i2c_hw2reg_target_ack_ctrl_reg_t target_ack_ctrl; // [20:12]
-    i2c_hw2reg_acq_fifo_next_data_reg_t acq_fifo_next_data; // [11:4]
-    i2c_hw2reg_controller_events_reg_t controller_events; // [3:0]
+    i2c_hw2reg_intr_state_reg_t intr_state; // [171:142]
+    i2c_hw2reg_status_reg_t status; // [141:131]
+    i2c_hw2reg_rdata_reg_t rdata; // [130:123]
+    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [122:99]
+    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [98:75]
+    i2c_hw2reg_val_reg_t val; // [74:43]
+    i2c_hw2reg_acqdata_reg_t acqdata; // [42:32]
+    i2c_hw2reg_target_nack_count_reg_t target_nack_count; // [31:23]
+    i2c_hw2reg_target_ack_ctrl_reg_t target_ack_ctrl; // [22:14]
+    i2c_hw2reg_acq_fifo_next_data_reg_t acq_fifo_next_data; // [13:6]
+    i2c_hw2reg_controller_events_reg_t controller_events; // [5:0]
   } i2c_hw2reg_t;
 
   // Register offsets

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -185,6 +185,9 @@ package i2c_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } multi_controller_monitor_en;
+    struct packed {
+      logic        q;
     } ack_ctrl_en;
     struct packed {
       logic        q;
@@ -597,11 +600,11 @@ package i2c_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [467:453]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [452:438]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [437:408]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [407:406]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [405:401]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [468:454]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [453:439]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [438:409]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [408:407]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [406:401]
     i2c_reg2hw_rdata_reg_t rdata; // [400:392]
     i2c_reg2hw_fdata_reg_t fdata; // [391:373]
     i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [372:365]

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -304,8 +304,8 @@ module i2c_reg_top (
   logic txdata_we;
   logic [7:0] txdata_wd;
   logic host_timeout_ctrl_we;
-  logic [31:0] host_timeout_ctrl_qs;
-  logic [31:0] host_timeout_ctrl_wd;
+  logic [19:0] host_timeout_ctrl_qs;
+  logic [19:0] host_timeout_ctrl_wd;
   logic target_timeout_ctrl_we;
   logic [30:0] target_timeout_ctrl_val_qs;
   logic [30:0] target_timeout_ctrl_val_wd;
@@ -2903,9 +2903,9 @@ module i2c_reg_top (
 
   // R[host_timeout_ctrl]: V(False)
   prim_subreg #(
-    .DW      (32),
+    .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0),
+    .RESVAL  (20'h0),
     .Mubi    (1'b0)
   ) u_host_timeout_ctrl (
     .clk_i   (clk_i),
@@ -3438,7 +3438,7 @@ module i2c_reg_top (
   assign txdata_wd = reg_wdata[7:0];
   assign host_timeout_ctrl_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign host_timeout_ctrl_wd = reg_wdata[31:0];
+  assign host_timeout_ctrl_wd = reg_wdata[19:0];
   assign target_timeout_ctrl_we = addr_hit[25] & reg_we & !reg_error;
 
   assign target_timeout_ctrl_val_wd = reg_wdata[30:0];
@@ -3684,7 +3684,7 @@ module i2c_reg_top (
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[31:0] = host_timeout_ctrl_qs;
+        reg_rdata_next[19:0] = host_timeout_ctrl_qs;
       end
 
       addr_hit[25]: begin

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -205,6 +205,8 @@ module i2c_reg_top (
   logic ctrl_nack_addr_after_timeout_wd;
   logic ctrl_ack_ctrl_en_qs;
   logic ctrl_ack_ctrl_en_wd;
+  logic ctrl_multi_controller_monitor_en_qs;
+  logic ctrl_multi_controller_monitor_en_wd;
   logic status_re;
   logic status_fmtfull_qs;
   logic status_rxfull_qs;
@@ -1550,6 +1552,33 @@ module i2c_reg_top (
 
     // to register interface (read)
     .qs     (ctrl_ack_ctrl_en_qs)
+  );
+
+  //   F[multi_controller_monitor_en]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ctrl_multi_controller_monitor_en (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ctrl_we),
+    .wd     (ctrl_multi_controller_monitor_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ctrl.multi_controller_monitor_en.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ctrl_multi_controller_monitor_en_qs)
   );
 
 
@@ -3405,6 +3434,8 @@ module i2c_reg_top (
   assign ctrl_nack_addr_after_timeout_wd = reg_wdata[3];
 
   assign ctrl_ack_ctrl_en_wd = reg_wdata[4];
+
+  assign ctrl_multi_controller_monitor_en_wd = reg_wdata[5];
   assign status_re = addr_hit[5] & reg_re & !reg_error;
   assign rdata_re = addr_hit[6] & reg_re & !reg_error;
   assign fdata_we = addr_hit[7] & reg_we & !reg_error;
@@ -3631,6 +3662,7 @@ module i2c_reg_top (
         reg_rdata_next[2] = ctrl_llpbk_qs;
         reg_rdata_next[3] = ctrl_nack_addr_after_timeout_qs;
         reg_rdata_next[4] = ctrl_ack_ctrl_en_qs;
+        reg_rdata_next[5] = ctrl_multi_controller_monitor_en_qs;
       end
 
       addr_hit[5]: begin

--- a/hw/ip/i2c/rtl/i2c_target_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_target_fsm.sv
@@ -301,8 +301,10 @@ module i2c_target_fsm import i2c_pkg::*;
   end
 
   // Deserializer for a byte read from the bus on the target side
-  assign address0_match = ((input_byte[7:1] & target_mask0_i) == target_address0_i);
-  assign address1_match = ((input_byte[7:1] & target_mask1_i) == target_address1_i);
+  assign address0_match = ((input_byte[7:1] & target_mask0_i) == target_address0_i) &&
+                          (target_mask0_i != '0);
+  assign address1_match = ((input_byte[7:1] & target_mask1_i) == target_address1_i) &&
+                          (target_mask1_i != '0);
   assign address_match = (address0_match || address1_match);
 
   // Shift data in on positive SCL edge

--- a/sw/device/tests/i2c_target_smbus_arp_test.c
+++ b/sw/device/tests/i2c_target_smbus_arp_test.c
@@ -297,11 +297,11 @@ static status_t test_init(void) {
   TRY(i2c_testutils_select_pinmux(&pinmux, 0, I2cPinmuxPlatformIdHyper310));
   TRY(i2c_testutils_set_speed(&i2c, kDifI2cSpeedStandard));
 
-  // 20 ms stretch timeout. The upper limit of support is ~1 GHz for the IP, so
-  // OK to make the frequency a uint32_t.
-  uint32_t kStretchCycles = ((uint32_t)kClockFreqPeripheralHz / (1000 / 20));
-  TRY(dif_i2c_enable_clock_stretching_timeout(&i2c, kDifToggleEnabled,
-                                              kStretchCycles));
+  // 25 ms bus timeout. The upper limit of support is ~1 GHz for the IP, so OK
+  // to make the frequency a uint32_t.
+  uint32_t kBusTimeoutCycles = ((uint32_t)kClockFreqPeripheralHz / (1000 / 25));
+  TRY(dif_i2c_enable_clock_timeout(&i2c, kDifI2cSclTimeoutBus,
+                                   kBusTimeoutCycles));
 
   // 50 us bus idle timeout.
   uint32_t kIdleCycles = ((uint32_t)kClockFreqPeripheralHz / (1000000 / 50));
@@ -319,6 +319,7 @@ static status_t test_init(void) {
   TRY(dif_i2c_set_target_watermarks(&i2c, /*tx_level=*/0,
                                     I2C_PARAM_ACQ_FIFO_DEPTH));
   TRY(dif_i2c_set_device_id(&i2c, &kSmbusArpId, NULL));
+  TRY(dif_i2c_multi_controller_monitor_set_enabled(&i2c, kDifToggleEnabled));
   TRY(dif_i2c_device_set_enabled(&i2c, kDifToggleEnabled));
 
   // Enable all I2C interrupts.

--- a/sw/device/tests/pmod/i2c_host_clock_stretching_test.c
+++ b/sw/device/tests/pmod/i2c_host_clock_stretching_test.c
@@ -130,7 +130,7 @@ static status_t rx_stretch_timeout(void) {
   }
 
   uint32_t cycles = (kTimeoutMillis - 1) * 100;
-  TRY(dif_i2c_enable_clock_stretching_timeout(&i2c, kDifToggleEnabled, cycles));
+  TRY(dif_i2c_enable_clock_timeout(&i2c, kDifI2cSclTimeoutStretch, cycles));
 
   uint8_t reg = kProductIdReg;
   TRY(i2c_testutils_write(&i2c, kDeviceAddr, 1, &reg, true));

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -162,15 +162,15 @@ def gen_cdefine_register(outstr: TextIO,
                         dname + '_FIELD', [],
                         '((bitfield_field32_t) {{ .mask = {dname}_MASK, .index = {dname}_OFFSET }})'
                         .format(dname=dname), existing_defines))
-            if field.enum is not None:
-                for enum in field.enum:
-                    ename = as_define(enum.name)
-                    value = hex(enum.value)
-                    genout(
-                        outstr,
-                        gen_define(
-                            defname + '_' + as_define(field.name) +
-                            '_VALUE_' + ename, [], value, existing_defines))
+        if field.enum is not None:
+            for enum in field.enum:
+                ename = as_define(enum.name)
+                value = hex(enum.value)
+                genout(
+                    outstr,
+                    gen_define(
+                        defname + '_' + as_define(field.name) +
+                        '_VALUE_' + ename, [], value, existing_defines))
     genout(outstr, '\n')
     return
 


### PR DESCRIPTION
Prepare for multi-controller functionality by creating a bus monitor that tracks transaction boundaries, detects Start and Stop symbols, and provides clock timeout functions. Move "bus free" detection to the bus monitor, and block the controller FSM from beginning transmissions unless the bus monitor gives the OK.

Add an optional SMBus bus timeout, which checks if SCL is held low for too long, and make it mux with the target stretch timeout, since it doesn't make much sense for them to both be active. In the general bus timeout case, it doesn't matter which entity is pulling SCL low. In the target stretch timeout case, the controller's contribution to SCL low time is ignored.

Add a control bit for selecting between single-controller and multi-controller monitoring mode. For the single-controller case, the bus monitor starts with the bus assumed to be free, and it only blocks the controller FSM from transmitting during the t_buf window after a Stop condition. For the multi-controller case, the bus monitor begins in a bus busy state, and the controller FSM must wait for at least the idle timeout (which _must_ be set in HOST_TIMEOUT_CTRL) before it is allowed to transmit.

Remove the "SDA is low in Idle" check from the SDA interference interrupt. There are various single-controller scenarios where this may trigger uselessly, and it isn't compatible with multi-controller scenarios.

Finally, fix a couple miscellaneous issues for DV:
- Eliminate ACQ_FIFO_NEXT_DATA from auto CSR checks (needs i2c traffic)
- Prevent address matching when the mask is 0