### PR TITLE
[i2c] Add target FSM responses to timeouts and read commands

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -291,6 +291,19 @@
                 When 0, the bus monitor will report that the bus is always free, so the controller FSM is never blocked from transmitting.
                 '''
         }
+        { bits: "6"
+          resval: "0"
+          name: "TX_STRETCH_CTRL_EN"
+          desc: '''
+                If set to 1, this bit causes a read transfer addressed to this target to set the corresponding bit in !!TARGET_EVENTS.
+
+                While !!TARGET_EVENTS.TX_PENDING is 1, subsequent read transactions will stretch the clock, even if there is data in the TX FIFO.
+
+                If enabled, this function allows software to confirm the data in the TX FIFO should be released for the current read.
+                This may be useful for cases where the TX FIFO has data that does not apply to the current transfer.
+                For example, the transaction could've targeted an alternate function via another address.
+                '''
+        }
       ]
     }
     { name:     "STATUS"
@@ -459,14 +472,6 @@
           name: "TX_THRESH"
           desc: '''Threshold level for TX interrupts. Whilst the number of used entries in the
                 TX FIFO is below this setting, the tx_threshold interrupt will be asserted.
-                '''
-          resval: "0"
-        }
-        { bits: "15"
-          name: "TXRST_ON_COND"
-          desc: '''If set, automatically reset the TX FIFO (TXRST) upon seeing a RSTART/STOP condition
-                during an active transaction in Target Mode. This may be useful if the remaining data
-                in the TX FIFO becomes no longer applicable to the next transaction.
                 '''
           resval: "0"
         }
@@ -778,7 +783,7 @@
           desc: '''
                 Indicates any control symbols associated with the ABYTE.
 
-                For the STOP symbol, a stretch timeout will cause a NACK_STOP to appear in the ACQ FIFO.
+                For the STOP symbol, a stretch timeout or other unexpected events will cause a NACK_STOP to appear in the ACQ FIFO.
                 If the ACQ FIFO doesn't have enough space to record a START and a STOP, the transaction will be dropped entirely on a stretch timeout.
                 In that case, the START byte will not appear (neither as START nor NACK_START), but a standalone NACK_STOP may, if there was space.
                 Software can discard any standalone NACK_STOP that appears.
@@ -830,6 +835,9 @@
                     A transaction including a transfer that addressed this Target was ended, but the transaction ended abnormally and/or the transfer was NACK'd.
                     The end can be due to a STOP condition or unexpected events, such as a bus timeout (if enabled).
                     ABYTE contains no data.
+
+                    NACKing can occur for multiple reasons, including a stretch timeout or a SW-directed NACK.
+                    This signal is a bucket for all these error-type terminations.
                     '''
             },
           ]
@@ -1009,6 +1017,35 @@
         { bits: "2"
           name: "BUS_TIMEOUT"
           desc: "A Host-Mode active transaction has terminated due to a bus timeout activated by !!TIMEOUT_CTRL."
+        }
+      ]
+    }
+    { name: "TARGET_EVENTS"
+      desc: '''
+            Latched events that can cause the target module to stretch the clock at the beginning of a read transfer.
+
+            These events cause TX FIFO-related stretching even when the TX FIFO has data available.
+            Any bits that are set must be written (with a 1) to clear the tx_stretch interrupt.
+
+            This CSR serves as a gate to prevent the Target module from responding to a read command with unrelated, leftover data.
+            '''
+      swaccess: "rw1c"
+      hwaccess: "hrw"
+      fields: [
+        { bits: "0"
+          name: "TX_PENDING"
+          desc: '''
+                A new Target-Mode read transfer has arrived that addressed this target.
+
+                This bit is used by software to confirm the release of the contents in the TX FIFO.
+                If the contents do not apply, software should first reset the TX FIFO, then load it with the correct data, then clear this bit.
+
+                Optionally enabled by !!CTRL.TX_STRETCH_CTRL_EN.
+                '''
+        }
+        { bits: "1"
+          name: "BUS_TIMEOUT"
+          desc: "A Target-Mode read transfer has terminated due to a bus timeout activated by !!TIMEOUT_CTRL."
         }
       ]
     }

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -549,19 +549,22 @@
       tests: []
     }
     {
-      name: target_mode_txrst_on_cond
+      name: target_mode_tx_stretch_ctrl
       desc: '''
-            Test that the TXRST_ON_COND feature resets the TXFIFO at the appropriate time
+            Test that the TX_STRETCH_CTRL feature prevents the TX
 
             Stimulus
               - Configure DUT/Agent to Target/Host mode respectively.
-              - Randomly enable TXRST_ON_COND feature
+              - Randomly enable TX_STRETCH_CTRL feature and write data into the TX FIFO prior to the
+                transfer start.
               - Stimulate transactions, including transactions with multiple transfers
                 interspersed by RSTART conditions.
 
             Checking
-              - Ensure that the TXFIFO is automatically reset when the TXRST_ON_COND feature is enabled
-                each time a Sr/P condition is observed during an active transaction.
+              - Ensure that the TARGET_EVENTS.TX_PENDING bit goes high for new reads when the
+                TX_STRETCH_CTRL feature is enabled.
+              - Ensure that the target holds SCL low and does not continue the transfer until the
+                TARGET_EVENTS.TX_PENDING bit has cleared.
             '''
       stage: V2
       tests: []
@@ -651,8 +654,6 @@
             Cross rx_overflow with RXRST
             Cross acq_overflow with ACQRST
             Cross tx_threshold with TXRST
-            Cover the TXRST_ON_COND bit in TARGET_FIFO_CONFIG
-            Cross TXRST_ON_COND with Sr/P bus conditions
             '''
     }
     {

--- a/hw/ip/i2c/doc/registers.md
+++ b/hw/ip/i2c/doc/registers.md
@@ -3,39 +3,40 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/i2c/data/i2c.hjson -->
 ## Summary
 
-| Name                                                          | Offset   |   Length | Description                                                                                        |
-|:--------------------------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------------------------------|
-| i2c.[`INTR_STATE`](#intr_state)                               | 0x0      |        4 | Interrupt State Register                                                                           |
-| i2c.[`INTR_ENABLE`](#intr_enable)                             | 0x4      |        4 | Interrupt Enable Register                                                                          |
-| i2c.[`INTR_TEST`](#intr_test)                                 | 0x8      |        4 | Interrupt Test Register                                                                            |
-| i2c.[`ALERT_TEST`](#alert_test)                               | 0xc      |        4 | Alert Test Register                                                                                |
-| i2c.[`CTRL`](#ctrl)                                           | 0x10     |        4 | I2C Control Register                                                                               |
-| i2c.[`STATUS`](#status)                                       | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                                 |
-| i2c.[`RDATA`](#rdata)                                         | 0x18     |        4 | I2C Read Data                                                                                      |
-| i2c.[`FDATA`](#fdata)                                         | 0x1c     |        4 | I2C Host Format Data                                                                               |
-| i2c.[`FIFO_CTRL`](#fifo_ctrl)                                 | 0x20     |        4 | I2C FIFO control register                                                                          |
-| i2c.[`HOST_FIFO_CONFIG`](#host_fifo_config)                   | 0x24     |        4 | Host mode FIFO configuration                                                                       |
-| i2c.[`TARGET_FIFO_CONFIG`](#target_fifo_config)               | 0x28     |        4 | Target mode FIFO configuration                                                                     |
-| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)                   | 0x2c     |        4 | Host mode FIFO status register                                                                     |
-| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status)               | 0x30     |        4 | Target mode FIFO status register                                                                   |
-| i2c.[`OVRD`](#ovrd)                                           | 0x34     |        4 | I2C Override Control Register                                                                      |
-| i2c.[`VAL`](#val)                                             | 0x38     |        4 | Oversampled RX values                                                                              |
-| i2c.[`TIMING0`](#timing0)                                     | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
-| i2c.[`TIMING1`](#timing1)                                     | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
-| i2c.[`TIMING2`](#timing2)                                     | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                |
-| i2c.[`TIMING3`](#timing3)                                     | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).               |
-| i2c.[`TIMING4`](#timing4)                                     | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).               |
-| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)                           | 0x50     |        4 | I2C clock stretching and bus timeout control.                                                      |
-| i2c.[`TARGET_ID`](#target_id)                                 | 0x54     |        4 | I2C target address and mask pairs                                                                  |
-| i2c.[`ACQDATA`](#acqdata)                                     | 0x58     |        4 | I2C target acquired data                                                                           |
-| i2c.[`TXDATA`](#txdata)                                       | 0x5c     |        4 | I2C target transmit data                                                                           |
-| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)                 | 0x60     |        4 | I2C host clock generation timeout value (in units of input clock frequency).                       |
-| i2c.[`TARGET_TIMEOUT_CTRL`](#target_timeout_ctrl)             | 0x64     |        4 | I2C target internal stretching timeout control.                                                    |
-| i2c.[`TARGET_NACK_COUNT`](#target_nack_count)                 | 0x68     |        4 | Number of times the I2C target has NACK'ed a new transaction since the last read of this register. |
-| i2c.[`TARGET_ACK_CTRL`](#target_ack_ctrl)                     | 0x6c     |        4 | Controls for mid-transfer (N)ACK phase handling                                                    |
-| i2c.[`ACQ_FIFO_NEXT_DATA`](#acq_fifo_next_data)               | 0x70     |        4 | The data byte pending to be written to the ACQ FIFO.                                               |
-| i2c.[`HOST_NACK_HANDLER_TIMEOUT`](#host_nack_handler_timeout) | 0x74     |        4 | Timeout in Host-Mode for an unhandled NACK before hardware automatically ends the transaction.     |
-| i2c.[`CONTROLLER_EVENTS`](#controller_events)                 | 0x78     |        4 | Latched events that explain why the controller halted.                                             |
+| Name                                                          | Offset   |   Length | Description                                                                                               |
+|:--------------------------------------------------------------|:---------|---------:|:----------------------------------------------------------------------------------------------------------|
+| i2c.[`INTR_STATE`](#intr_state)                               | 0x0      |        4 | Interrupt State Register                                                                                  |
+| i2c.[`INTR_ENABLE`](#intr_enable)                             | 0x4      |        4 | Interrupt Enable Register                                                                                 |
+| i2c.[`INTR_TEST`](#intr_test)                                 | 0x8      |        4 | Interrupt Test Register                                                                                   |
+| i2c.[`ALERT_TEST`](#alert_test)                               | 0xc      |        4 | Alert Test Register                                                                                       |
+| i2c.[`CTRL`](#ctrl)                                           | 0x10     |        4 | I2C Control Register                                                                                      |
+| i2c.[`STATUS`](#status)                                       | 0x14     |        4 | I2C Live Status Register for Host and Target modes                                                        |
+| i2c.[`RDATA`](#rdata)                                         | 0x18     |        4 | I2C Read Data                                                                                             |
+| i2c.[`FDATA`](#fdata)                                         | 0x1c     |        4 | I2C Host Format Data                                                                                      |
+| i2c.[`FIFO_CTRL`](#fifo_ctrl)                                 | 0x20     |        4 | I2C FIFO control register                                                                                 |
+| i2c.[`HOST_FIFO_CONFIG`](#host_fifo_config)                   | 0x24     |        4 | Host mode FIFO configuration                                                                              |
+| i2c.[`TARGET_FIFO_CONFIG`](#target_fifo_config)               | 0x28     |        4 | Target mode FIFO configuration                                                                            |
+| i2c.[`HOST_FIFO_STATUS`](#host_fifo_status)                   | 0x2c     |        4 | Host mode FIFO status register                                                                            |
+| i2c.[`TARGET_FIFO_STATUS`](#target_fifo_status)               | 0x30     |        4 | Target mode FIFO status register                                                                          |
+| i2c.[`OVRD`](#ovrd)                                           | 0x34     |        4 | I2C Override Control Register                                                                             |
+| i2c.[`VAL`](#val)                                             | 0x38     |        4 | Oversampled RX values                                                                                     |
+| i2c.[`TIMING0`](#timing0)                                     | 0x3c     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                       |
+| i2c.[`TIMING1`](#timing1)                                     | 0x40     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                       |
+| i2c.[`TIMING2`](#timing2)                                     | 0x44     |        4 | Detailed I2C Timings (directly corresponding to table 10 in the I2C Specification).                       |
+| i2c.[`TIMING3`](#timing3)                                     | 0x48     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).                      |
+| i2c.[`TIMING4`](#timing4)                                     | 0x4c     |        4 | Detailed I2C Timings (directly corresponding to table 10, in the I2C Specification).                      |
+| i2c.[`TIMEOUT_CTRL`](#timeout_ctrl)                           | 0x50     |        4 | I2C clock stretching and bus timeout control.                                                             |
+| i2c.[`TARGET_ID`](#target_id)                                 | 0x54     |        4 | I2C target address and mask pairs                                                                         |
+| i2c.[`ACQDATA`](#acqdata)                                     | 0x58     |        4 | I2C target acquired data                                                                                  |
+| i2c.[`TXDATA`](#txdata)                                       | 0x5c     |        4 | I2C target transmit data                                                                                  |
+| i2c.[`HOST_TIMEOUT_CTRL`](#host_timeout_ctrl)                 | 0x60     |        4 | I2C host clock generation timeout value (in units of input clock frequency).                              |
+| i2c.[`TARGET_TIMEOUT_CTRL`](#target_timeout_ctrl)             | 0x64     |        4 | I2C target internal stretching timeout control.                                                           |
+| i2c.[`TARGET_NACK_COUNT`](#target_nack_count)                 | 0x68     |        4 | Number of times the I2C target has NACK'ed a new transaction since the last read of this register.        |
+| i2c.[`TARGET_ACK_CTRL`](#target_ack_ctrl)                     | 0x6c     |        4 | Controls for mid-transfer (N)ACK phase handling                                                           |
+| i2c.[`ACQ_FIFO_NEXT_DATA`](#acq_fifo_next_data)               | 0x70     |        4 | The data byte pending to be written to the ACQ FIFO.                                                      |
+| i2c.[`HOST_NACK_HANDLER_TIMEOUT`](#host_nack_handler_timeout) | 0x74     |        4 | Timeout in Host-Mode for an unhandled NACK before hardware automatically ends the transaction.            |
+| i2c.[`CONTROLLER_EVENTS`](#controller_events)                 | 0x78     |        4 | Latched events that explain why the controller halted.                                                    |
+| i2c.[`TARGET_EVENTS`](#target_events)                         | 0x7c     |        4 | Latched events that can cause the target module to stretch the clock at the beginning of a read transfer. |
 
 ## INTR_STATE
 Interrupt State Register
@@ -151,23 +152,33 @@ Alert Test Register
 I2C Control Register
 - Offset: `0x10`
 - Reset default: `0x0`
-- Reset mask: `0x3f`
+- Reset mask: `0x7f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "ENABLEHOST", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ENABLETARGET", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "LLPBK", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "NACK_ADDR_AFTER_TIMEOUT", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ACK_CTRL_EN", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "MULTI_CONTROLLER_MONITOR_EN", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 290}}
+{"reg": [{"name": "ENABLEHOST", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ENABLETARGET", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "LLPBK", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "NACK_ADDR_AFTER_TIMEOUT", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ACK_CTRL_EN", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "MULTI_CONTROLLER_MONITOR_EN", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "TX_STRETCH_CTRL_EN", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 25}], "config": {"lanes": 1, "fontsize": 10, "vspace": 290}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                                              |
 |:------:|:------:|:-------:|:------------------------------------------------------------------|
-|  31:6  |        |         | Reserved                                                          |
+|  31:7  |        |         | Reserved                                                          |
+|   6    |   rw   |   0x0   | [TX_STRETCH_CTRL_EN](#ctrl--tx_stretch_ctrl_en)                   |
 |   5    |   rw   |   0x0   | [MULTI_CONTROLLER_MONITOR_EN](#ctrl--multi_controller_monitor_en) |
 |   4    |   rw   |   0x0   | [ACK_CTRL_EN](#ctrl--ack_ctrl_en)                                 |
 |   3    |   rw   |   0x0   | [NACK_ADDR_AFTER_TIMEOUT](#ctrl--nack_addr_after_timeout)         |
 |   2    |   rw   |   0x0   | [LLPBK](#ctrl--llpbk)                                             |
 |   1    |   rw   |   0x0   | [ENABLETARGET](#ctrl--enabletarget)                               |
 |   0    |   rw   |   0x0   | [ENABLEHOST](#ctrl--enablehost)                                   |
+
+### CTRL . TX_STRETCH_CTRL_EN
+If set to 1, this bit causes a read transfer addressed to this target to set the corresponding bit in [`TARGET_EVENTS.`](#target_events)
+
+While [`TARGET_EVENTS.TX_PENDING`](#target_events) is 1, subsequent read transactions will stretch the clock, even if there is data in the TX FIFO.
+
+If enabled, this function allows software to confirm the data in the TX FIFO should be released for the current read.
+This may be useful for cases where the TX FIFO has data that does not apply to the current transfer.
+For example, the transaction could've targeted an alternate function via another address.
 
 ### CTRL . MULTI_CONTROLLER_MONITOR_EN
 Enable the bus monitor in multi-controller mode.
@@ -324,21 +335,20 @@ Host mode FIFO configuration
 Target mode FIFO configuration
 - Offset: `0x28`
 - Reset default: `0x0`
-- Reset mask: `0xfff8fff`
+- Reset mask: `0xfff0fff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "TX_THRESH", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 3}, {"name": "TXRST_ON_COND", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ACQ_THRESH", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}], "config": {"lanes": 1, "fontsize": 10, "vspace": 150}}
+{"reg": [{"name": "TX_THRESH", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}, {"name": "ACQ_THRESH", "bits": 12, "attr": ["rw"], "rotate": 0}, {"bits": 4}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name          | Description                                                                                                                                                                                                                                    |
-|:------:|:------:|:-------:|:--------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 31:28  |        |         |               | Reserved                                                                                                                                                                                                                                       |
-| 27:16  |   rw   |   0x0   | ACQ_THRESH    | Threshold level for ACQ interrupts. Whilst the level of data in the ACQ FIFO is above this setting, the acq_threshold interrupt will be asserted.                                                                                              |
-|   15   |   rw   |   0x0   | TXRST_ON_COND | If set, automatically reset the TX FIFO (TXRST) upon seeing a RSTART/STOP condition during an active transaction in Target Mode. This may be useful if the remaining data in the TX FIFO becomes no longer applicable to the next transaction. |
-| 14:12  |        |         |               | Reserved                                                                                                                                                                                                                                       |
-|  11:0  |   rw   |   0x0   | TX_THRESH     | Threshold level for TX interrupts. Whilst the number of used entries in the TX FIFO is below this setting, the tx_threshold interrupt will be asserted.                                                                                        |
+|  Bits  |  Type  |  Reset  | Name       | Description                                                                                                                                             |
+|:------:|:------:|:-------:|:-----------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 31:28  |        |         |            | Reserved                                                                                                                                                |
+| 27:16  |   rw   |   0x0   | ACQ_THRESH | Threshold level for ACQ interrupts. Whilst the level of data in the ACQ FIFO is above this setting, the acq_threshold interrupt will be asserted.       |
+| 15:12  |        |         |            | Reserved                                                                                                                                                |
+|  11:0  |   rw   |   0x0   | TX_THRESH  | Threshold level for TX interrupts. Whilst the number of used entries in the TX FIFO is below this setting, the tx_threshold interrupt will be asserted. |
 
 ## HOST_FIFO_STATUS
 Host mode FIFO status register
@@ -612,22 +622,22 @@ I2C target acquired data
 ### ACQDATA . SIGNAL
 Indicates any control symbols associated with the ABYTE.
 
-For the STOP symbol, a stretch timeout will cause a NACK_STOP to appear in the ACQ FIFO.
+For the STOP symbol, a stretch timeout or other unexpected events will cause a NACK_STOP to appear in the ACQ FIFO.
 If the ACQ FIFO doesn't have enough space to record a START and a STOP, the transaction will be dropped entirely on a stretch timeout.
 In that case, the START byte will not appear (neither as START nor NACK_START), but a standalone NACK_STOP may, if there was space.
 Software can discard any standalone NACK_STOP that appears.
 
 See the associated values for more information about the contents.
 
-| Value   | Name       | Description                                                                                                                                                                                                                                                            |
-|:--------|:-----------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0x0     | NONE       | ABYTE contains an ordinary data byte that was received and ACK'd.                                                                                                                                                                                                      |
-| 0x1     | START      | A START condition preceded the ABYTE to start a new transaction. ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.                                                                                                |
-| 0x2     | STOP       | A STOP condition was received for a transaction including a transfer that addressed this Target. No transfers addressing this Target in that transaction were NACK'd. ABYTE contains no data.                                                                          |
-| 0x3     | RESTART    | A repeated START condition preceded the ABYTE, extending the current transaction with a new transfer. ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.                                                           |
-| 0x4     | NACK       | ABYTE contains an ordinary data byte that was received and NACK'd.                                                                                                                                                                                                     |
-| 0x5     | NACK_START | A START condition preceded the ABYTE (including repeated START) that was part of a NACK'd transer. The ABYTE contains the matching I2C address and command bit. The ABYTE was ACK'd, but the rest of the transaction was NACK'ed.                                      |
-| 0x6     | NACK_STOP  | A transaction including a transfer that addressed this Target was ended, but the transaction ended abnormally and/or the transfer was NACK'd. The end can be due to a STOP condition or unexpected events, such as a bus timeout (if enabled). ABYTE contains no data. |
+| Value   | Name       | Description                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|:--------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0x0     | NONE       | ABYTE contains an ordinary data byte that was received and ACK'd.                                                                                                                                                                                                                                                                                                                                                                |
+| 0x1     | START      | A START condition preceded the ABYTE to start a new transaction. ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.                                                                                                                                                                                                                                                          |
+| 0x2     | STOP       | A STOP condition was received for a transaction including a transfer that addressed this Target. No transfers addressing this Target in that transaction were NACK'd. ABYTE contains no data.                                                                                                                                                                                                                                    |
+| 0x3     | RESTART    | A repeated START condition preceded the ABYTE, extending the current transaction with a new transfer. ABYTE contains the 7-bit I2C address plus R/W command bit in the order received on the bus, MSB first.                                                                                                                                                                                                                     |
+| 0x4     | NACK       | ABYTE contains an ordinary data byte that was received and NACK'd.                                                                                                                                                                                                                                                                                                                                                               |
+| 0x5     | NACK_START | A START condition preceded the ABYTE (including repeated START) that was part of a NACK'd transer. The ABYTE contains the matching I2C address and command bit. The ABYTE was ACK'd, but the rest of the transaction was NACK'ed.                                                                                                                                                                                                |
+| 0x6     | NACK_STOP  | A transaction including a transfer that addressed this Target was ended, but the transaction ended abnormally and/or the transfer was NACK'd. The end can be due to a STOP condition or unexpected events, such as a bus timeout (if enabled). ABYTE contains no data. NACKing can occur for multiple reasons, including a stretch timeout or a SW-directed NACK. This signal is a bucket for all these error-type terminations. |
 
 Other values are reserved.
 
@@ -828,6 +838,40 @@ Any bits that are set must be written (with a 1) to clear the CONTROLLER_HALT in
 |   2    |  rw1c  |   0x0   | BUS_TIMEOUT            | A Host-Mode active transaction has terminated due to a bus timeout activated by [`TIMEOUT_CTRL.`](#timeout_ctrl)          |
 |   1    |  rw1c  |   0x0   | UNHANDLED_NACK_TIMEOUT | A Host-Mode active transaction has been ended by the [`HOST_NACK_HANDLER_TIMEOUT`](#host_nack_handler_timeout) mechanism. |
 |   0    |  rw1c  |   0x0   | NACK                   | Received an unexpected NACK                                                                                               |
+
+## TARGET_EVENTS
+Latched events that can cause the target module to stretch the clock at the beginning of a read transfer.
+
+These events cause TX FIFO-related stretching even when the TX FIFO has data available.
+Any bits that are set must be written (with a 1) to clear the tx_stretch interrupt.
+
+This CSR serves as a gate to prevent the Target module from responding to a read command with unrelated, leftover data.
+- Offset: `0x7c`
+- Reset default: `0x0`
+- Reset mask: `0x3`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "TX_PENDING", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "BUS_TIMEOUT", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                                       |
+|:------:|:------:|:-------:|:-------------------------------------------|
+|  31:2  |        |         | Reserved                                   |
+|   1    |  rw1c  |   0x0   | [BUS_TIMEOUT](#target_events--bus_timeout) |
+|   0    |  rw1c  |   0x0   | [TX_PENDING](#target_events--tx_pending)   |
+
+### TARGET_EVENTS . BUS_TIMEOUT
+A Target-Mode read transfer has terminated due to a bus timeout activated by [`TIMEOUT_CTRL.`](#timeout_ctrl)
+
+### TARGET_EVENTS . TX_PENDING
+A new Target-Mode read transfer has arrived that addressed this target.
+
+This bit is used by software to confirm the release of the contents in the TX FIFO.
+If the contents do not apply, software should first reset the TX FIFO, then load it with the correct data, then clear this bit.
+
+Optionally enabled by [`CTRL.TX_STRETCH_CTRL_EN.`](#ctrl)
 
 
 <!-- END CMDGEN -->

--- a/hw/ip/i2c/rtl/i2c_reg_pkg.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_pkg.sv
@@ -185,6 +185,9 @@ package i2c_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } tx_stretch_ctrl_en;
+    struct packed {
+      logic        q;
     } multi_controller_monitor_en;
     struct packed {
       logic        q;
@@ -270,10 +273,6 @@ package i2c_reg_pkg;
       logic [11:0] q;
       logic        qe;
     } acq_thresh;
-    struct packed {
-      logic        q;
-      logic        qe;
-    } txrst_on_cond;
     struct packed {
       logic [11:0] q;
       logic        qe;
@@ -428,6 +427,15 @@ package i2c_reg_pkg;
       logic        q;
     } nack;
   } i2c_reg2hw_controller_events_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } bus_timeout;
+    struct packed {
+      logic        q;
+    } tx_pending;
+  } i2c_reg2hw_target_events_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -598,49 +606,62 @@ package i2c_reg_pkg;
     } bus_timeout;
   } i2c_hw2reg_controller_events_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } tx_pending;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bus_timeout;
+  } i2c_hw2reg_target_events_reg_t;
+
   // Register -> HW type
   typedef struct packed {
-    i2c_reg2hw_intr_state_reg_t intr_state; // [468:454]
-    i2c_reg2hw_intr_enable_reg_t intr_enable; // [453:439]
-    i2c_reg2hw_intr_test_reg_t intr_test; // [438:409]
-    i2c_reg2hw_alert_test_reg_t alert_test; // [408:407]
-    i2c_reg2hw_ctrl_reg_t ctrl; // [406:401]
+    i2c_reg2hw_intr_state_reg_t intr_state; // [469:455]
+    i2c_reg2hw_intr_enable_reg_t intr_enable; // [454:440]
+    i2c_reg2hw_intr_test_reg_t intr_test; // [439:410]
+    i2c_reg2hw_alert_test_reg_t alert_test; // [409:408]
+    i2c_reg2hw_ctrl_reg_t ctrl; // [407:401]
     i2c_reg2hw_rdata_reg_t rdata; // [400:392]
     i2c_reg2hw_fdata_reg_t fdata; // [391:373]
     i2c_reg2hw_fifo_ctrl_reg_t fifo_ctrl; // [372:365]
     i2c_reg2hw_host_fifo_config_reg_t host_fifo_config; // [364:339]
-    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [338:311]
-    i2c_reg2hw_ovrd_reg_t ovrd; // [310:308]
-    i2c_reg2hw_timing0_reg_t timing0; // [307:282]
-    i2c_reg2hw_timing1_reg_t timing1; // [281:263]
-    i2c_reg2hw_timing2_reg_t timing2; // [262:237]
-    i2c_reg2hw_timing3_reg_t timing3; // [236:215]
-    i2c_reg2hw_timing4_reg_t timing4; // [214:189]
-    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [188:157]
-    i2c_reg2hw_target_id_reg_t target_id; // [156:129]
-    i2c_reg2hw_acqdata_reg_t acqdata; // [128:116]
-    i2c_reg2hw_txdata_reg_t txdata; // [115:107]
-    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [106:87]
-    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [86:55]
-    i2c_reg2hw_target_nack_count_reg_t target_nack_count; // [54:47]
-    i2c_reg2hw_target_ack_ctrl_reg_t target_ack_ctrl; // [46:35]
-    i2c_reg2hw_host_nack_handler_timeout_reg_t host_nack_handler_timeout; // [34:3]
-    i2c_reg2hw_controller_events_reg_t controller_events; // [2:0]
+    i2c_reg2hw_target_fifo_config_reg_t target_fifo_config; // [338:313]
+    i2c_reg2hw_ovrd_reg_t ovrd; // [312:310]
+    i2c_reg2hw_timing0_reg_t timing0; // [309:284]
+    i2c_reg2hw_timing1_reg_t timing1; // [283:265]
+    i2c_reg2hw_timing2_reg_t timing2; // [264:239]
+    i2c_reg2hw_timing3_reg_t timing3; // [238:217]
+    i2c_reg2hw_timing4_reg_t timing4; // [216:191]
+    i2c_reg2hw_timeout_ctrl_reg_t timeout_ctrl; // [190:159]
+    i2c_reg2hw_target_id_reg_t target_id; // [158:131]
+    i2c_reg2hw_acqdata_reg_t acqdata; // [130:118]
+    i2c_reg2hw_txdata_reg_t txdata; // [117:109]
+    i2c_reg2hw_host_timeout_ctrl_reg_t host_timeout_ctrl; // [108:89]
+    i2c_reg2hw_target_timeout_ctrl_reg_t target_timeout_ctrl; // [88:57]
+    i2c_reg2hw_target_nack_count_reg_t target_nack_count; // [56:49]
+    i2c_reg2hw_target_ack_ctrl_reg_t target_ack_ctrl; // [48:37]
+    i2c_reg2hw_host_nack_handler_timeout_reg_t host_nack_handler_timeout; // [36:5]
+    i2c_reg2hw_controller_events_reg_t controller_events; // [4:2]
+    i2c_reg2hw_target_events_reg_t target_events; // [1:0]
   } i2c_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    i2c_hw2reg_intr_state_reg_t intr_state; // [171:142]
-    i2c_hw2reg_status_reg_t status; // [141:131]
-    i2c_hw2reg_rdata_reg_t rdata; // [130:123]
-    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [122:99]
-    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [98:75]
-    i2c_hw2reg_val_reg_t val; // [74:43]
-    i2c_hw2reg_acqdata_reg_t acqdata; // [42:32]
-    i2c_hw2reg_target_nack_count_reg_t target_nack_count; // [31:23]
-    i2c_hw2reg_target_ack_ctrl_reg_t target_ack_ctrl; // [22:14]
-    i2c_hw2reg_acq_fifo_next_data_reg_t acq_fifo_next_data; // [13:6]
-    i2c_hw2reg_controller_events_reg_t controller_events; // [5:0]
+    i2c_hw2reg_intr_state_reg_t intr_state; // [175:146]
+    i2c_hw2reg_status_reg_t status; // [145:135]
+    i2c_hw2reg_rdata_reg_t rdata; // [134:127]
+    i2c_hw2reg_host_fifo_status_reg_t host_fifo_status; // [126:103]
+    i2c_hw2reg_target_fifo_status_reg_t target_fifo_status; // [102:79]
+    i2c_hw2reg_val_reg_t val; // [78:47]
+    i2c_hw2reg_acqdata_reg_t acqdata; // [46:36]
+    i2c_hw2reg_target_nack_count_reg_t target_nack_count; // [35:27]
+    i2c_hw2reg_target_ack_ctrl_reg_t target_ack_ctrl; // [26:18]
+    i2c_hw2reg_acq_fifo_next_data_reg_t acq_fifo_next_data; // [17:10]
+    i2c_hw2reg_controller_events_reg_t controller_events; // [9:4]
+    i2c_hw2reg_target_events_reg_t target_events; // [3:0]
   } i2c_hw2reg_t;
 
   // Register offsets
@@ -675,6 +696,7 @@ package i2c_reg_pkg;
   parameter logic [BlockAw-1:0] I2C_ACQ_FIFO_NEXT_DATA_OFFSET = 7'h 70;
   parameter logic [BlockAw-1:0] I2C_HOST_NACK_HANDLER_TIMEOUT_OFFSET = 7'h 74;
   parameter logic [BlockAw-1:0] I2C_CONTROLLER_EVENTS_OFFSET = 7'h 78;
+  parameter logic [BlockAw-1:0] I2C_TARGET_EVENTS_OFFSET = 7'h 7c;
 
   // Reset values for hwext registers and their fields
   parameter logic [14:0] I2C_INTR_TEST_RESVAL = 15'h 0;
@@ -742,11 +764,12 @@ package i2c_reg_pkg;
     I2C_TARGET_ACK_CTRL,
     I2C_ACQ_FIFO_NEXT_DATA,
     I2C_HOST_NACK_HANDLER_TIMEOUT,
-    I2C_CONTROLLER_EVENTS
+    I2C_CONTROLLER_EVENTS,
+    I2C_TARGET_EVENTS
   } i2c_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] I2C_PERMIT [31] = '{
+  parameter logic [3:0] I2C_PERMIT [32] = '{
     4'b 0011, // index[ 0] I2C_INTR_STATE
     4'b 0011, // index[ 1] I2C_INTR_ENABLE
     4'b 0011, // index[ 2] I2C_INTR_TEST
@@ -777,7 +800,8 @@ package i2c_reg_pkg;
     4'b 1111, // index[27] I2C_TARGET_ACK_CTRL
     4'b 0001, // index[28] I2C_ACQ_FIFO_NEXT_DATA
     4'b 1111, // index[29] I2C_HOST_NACK_HANDLER_TIMEOUT
-    4'b 0001  // index[30] I2C_CONTROLLER_EVENTS
+    4'b 0001, // index[30] I2C_CONTROLLER_EVENTS
+    4'b 0001  // index[31] I2C_TARGET_EVENTS
   };
 
 endpackage

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -52,9 +52,9 @@ module i2c_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [30:0] reg_we_check;
+  logic [31:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(31)
+    .OneHotWidth(32)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -207,6 +207,8 @@ module i2c_reg_top (
   logic ctrl_ack_ctrl_en_wd;
   logic ctrl_multi_controller_monitor_en_qs;
   logic ctrl_multi_controller_monitor_en_wd;
+  logic ctrl_tx_stretch_ctrl_en_qs;
+  logic ctrl_tx_stretch_ctrl_en_wd;
   logic status_re;
   logic status_fmtfull_qs;
   logic status_rxfull_qs;
@@ -241,8 +243,6 @@ module i2c_reg_top (
   logic target_fifo_config_we;
   logic [11:0] target_fifo_config_tx_thresh_qs;
   logic [11:0] target_fifo_config_tx_thresh_wd;
-  logic target_fifo_config_txrst_on_cond_qs;
-  logic target_fifo_config_txrst_on_cond_wd;
   logic [11:0] target_fifo_config_acq_thresh_qs;
   logic [11:0] target_fifo_config_acq_thresh_wd;
   logic host_fifo_status_re;
@@ -337,6 +337,11 @@ module i2c_reg_top (
   logic controller_events_unhandled_nack_timeout_wd;
   logic controller_events_bus_timeout_qs;
   logic controller_events_bus_timeout_wd;
+  logic target_events_we;
+  logic target_events_tx_pending_qs;
+  logic target_events_tx_pending_wd;
+  logic target_events_bus_timeout_qs;
+  logic target_events_bus_timeout_wd;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1581,6 +1586,33 @@ module i2c_reg_top (
     .qs     (ctrl_multi_controller_monitor_en_qs)
   );
 
+  //   F[tx_stretch_ctrl_en]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ctrl_tx_stretch_ctrl_en (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ctrl_we),
+    .wd     (ctrl_tx_stretch_ctrl_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ctrl.tx_stretch_ctrl_en.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ctrl_tx_stretch_ctrl_en_qs)
+  );
+
 
   // R[status]: V(True)
   //   F[fmtfull]: 0:0
@@ -2142,7 +2174,7 @@ module i2c_reg_top (
 
   // R[target_fifo_config]: V(False)
   logic target_fifo_config_qe;
-  logic [2:0] target_fifo_config_flds_we;
+  logic [1:0] target_fifo_config_flds_we;
   prim_flop #(
     .Width(1),
     .ResetValue(0)
@@ -2180,34 +2212,6 @@ module i2c_reg_top (
   );
   assign reg2hw.target_fifo_config.tx_thresh.qe = target_fifo_config_qe;
 
-  //   F[txrst_on_cond]: 15:15
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_target_fifo_config_txrst_on_cond (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (target_fifo_config_we),
-    .wd     (target_fifo_config_txrst_on_cond_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (target_fifo_config_flds_we[1]),
-    .q      (reg2hw.target_fifo_config.txrst_on_cond.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (target_fifo_config_txrst_on_cond_qs)
-  );
-  assign reg2hw.target_fifo_config.txrst_on_cond.qe = target_fifo_config_qe;
-
   //   F[acq_thresh]: 27:16
   prim_subreg #(
     .DW      (12),
@@ -2227,7 +2231,7 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (target_fifo_config_flds_we[2]),
+    .qe     (target_fifo_config_flds_we[1]),
     .q      (reg2hw.target_fifo_config.acq_thresh.q),
     .ds     (),
 
@@ -3265,8 +3269,64 @@ module i2c_reg_top (
   );
 
 
+  // R[target_events]: V(False)
+  //   F[tx_pending]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_target_events_tx_pending (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
 
-  logic [30:0] addr_hit;
+    // from register interface
+    .we     (target_events_we),
+    .wd     (target_events_tx_pending_wd),
+
+    // from internal hardware
+    .de     (hw2reg.target_events.tx_pending.de),
+    .d      (hw2reg.target_events.tx_pending.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.target_events.tx_pending.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (target_events_tx_pending_qs)
+  );
+
+  //   F[bus_timeout]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_target_events_bus_timeout (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (target_events_we),
+    .wd     (target_events_bus_timeout_wd),
+
+    // from internal hardware
+    .de     (hw2reg.target_events.bus_timeout.de),
+    .d      (hw2reg.target_events.bus_timeout.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.target_events.bus_timeout.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (target_events_bus_timeout_qs)
+  );
+
+
+
+  logic [31:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == I2C_INTR_STATE_OFFSET);
@@ -3300,6 +3360,7 @@ module i2c_reg_top (
     addr_hit[28] = (reg_addr == I2C_ACQ_FIFO_NEXT_DATA_OFFSET);
     addr_hit[29] = (reg_addr == I2C_HOST_NACK_HANDLER_TIMEOUT_OFFSET);
     addr_hit[30] = (reg_addr == I2C_CONTROLLER_EVENTS_OFFSET);
+    addr_hit[31] = (reg_addr == I2C_TARGET_EVENTS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -3337,7 +3398,8 @@ module i2c_reg_top (
                (addr_hit[27] & (|(I2C_PERMIT[27] & ~reg_be))) |
                (addr_hit[28] & (|(I2C_PERMIT[28] & ~reg_be))) |
                (addr_hit[29] & (|(I2C_PERMIT[29] & ~reg_be))) |
-               (addr_hit[30] & (|(I2C_PERMIT[30] & ~reg_be)))));
+               (addr_hit[30] & (|(I2C_PERMIT[30] & ~reg_be))) |
+               (addr_hit[31] & (|(I2C_PERMIT[31] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -3436,6 +3498,8 @@ module i2c_reg_top (
   assign ctrl_ack_ctrl_en_wd = reg_wdata[4];
 
   assign ctrl_multi_controller_monitor_en_wd = reg_wdata[5];
+
+  assign ctrl_tx_stretch_ctrl_en_wd = reg_wdata[6];
   assign status_re = addr_hit[5] & reg_re & !reg_error;
   assign rdata_re = addr_hit[6] & reg_re & !reg_error;
   assign fdata_we = addr_hit[7] & reg_we & !reg_error;
@@ -3468,8 +3532,6 @@ module i2c_reg_top (
   assign target_fifo_config_we = addr_hit[10] & reg_we & !reg_error;
 
   assign target_fifo_config_tx_thresh_wd = reg_wdata[11:0];
-
-  assign target_fifo_config_txrst_on_cond_wd = reg_wdata[15];
 
   assign target_fifo_config_acq_thresh_wd = reg_wdata[27:16];
   assign host_fifo_status_re = addr_hit[11] & reg_re & !reg_error;
@@ -3557,6 +3619,11 @@ module i2c_reg_top (
   assign controller_events_unhandled_nack_timeout_wd = reg_wdata[1];
 
   assign controller_events_bus_timeout_wd = reg_wdata[2];
+  assign target_events_we = addr_hit[31] & reg_we & !reg_error;
+
+  assign target_events_tx_pending_wd = reg_wdata[0];
+
+  assign target_events_bus_timeout_wd = reg_wdata[1];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
@@ -3592,6 +3659,7 @@ module i2c_reg_top (
     reg_we_check[28] = 1'b0;
     reg_we_check[29] = host_nack_handler_timeout_we;
     reg_we_check[30] = controller_events_we;
+    reg_we_check[31] = target_events_we;
   end
 
   // Read data return
@@ -3663,6 +3731,7 @@ module i2c_reg_top (
         reg_rdata_next[3] = ctrl_nack_addr_after_timeout_qs;
         reg_rdata_next[4] = ctrl_ack_ctrl_en_qs;
         reg_rdata_next[5] = ctrl_multi_controller_monitor_en_qs;
+        reg_rdata_next[6] = ctrl_tx_stretch_ctrl_en_qs;
       end
 
       addr_hit[5]: begin
@@ -3706,7 +3775,6 @@ module i2c_reg_top (
 
       addr_hit[10]: begin
         reg_rdata_next[11:0] = target_fifo_config_tx_thresh_qs;
-        reg_rdata_next[15] = target_fifo_config_txrst_on_cond_qs;
         reg_rdata_next[27:16] = target_fifo_config_acq_thresh_qs;
       end
 
@@ -3809,6 +3877,11 @@ module i2c_reg_top (
         reg_rdata_next[0] = controller_events_nack_qs;
         reg_rdata_next[1] = controller_events_unhandled_nack_timeout_qs;
         reg_rdata_next[2] = controller_events_bus_timeout_qs;
+      end
+
+      addr_hit[31]: begin
+        reg_rdata_next[0] = target_events_tx_pending_qs;
+        reg_rdata_next[1] = target_events_bus_timeout_qs;
       end
 
       default: begin

--- a/hw/ip/i2c/rtl/i2c_target_fsm.sv
+++ b/hw/ip/i2c/rtl/i2c_target_fsm.sv
@@ -148,7 +148,7 @@ module i2c_target_fsm import i2c_pkg::*;
       stretch_active_cnt <= '0;
     end else if (actively_stretching) begin
       stretch_active_cnt <= stretch_active_cnt + 1'b1;
-    end else begin
+    end else if (start_detect_i && target_idle_o) begin
       stretch_active_cnt <= '0;
     end
   end

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -403,6 +403,37 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_i2c_clear_controller_halt_events(
     const dif_i2c_t *i2c, dif_i2c_controller_halt_events_t events);
 
+typedef struct dif_i2c_target_tx_halt_events {
+  /** Received a new read transfer, and TX stretch controls were enabled. */
+  bool tx_pending;
+  /** The bus timed out during a read transfer. */
+  bool bus_timeout;
+} dif_i2c_target_tx_halt_events_t;
+
+/**
+ * Get the events that are contributing or would contribute to the target
+ * halting and stretching the clock on a read.
+ *
+ * @param i2c handle,
+ * @param[out] events The events causing the target FSM to stretch on reads.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_get_target_tx_halt_events(
+    const dif_i2c_t *i2c, dif_i2c_target_tx_halt_events_t *events);
+
+/**
+ * Clear the selected events that are contributing or would contribute to the
+ * target halting and stretching the clock on a read.
+ *
+ * @param i2c handle,
+ * @param events The events to clear.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_clear_target_tx_halt_events(
+    const dif_i2c_t *i2c, dif_i2c_target_tx_halt_events_t events);
+
 /**
  * Computes timing parameters for an I2C host and stores them in `config`.
  *
@@ -580,6 +611,19 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_i2c_multi_controller_monitor_set_enabled(const dif_i2c_t *i2c,
                                                           dif_toggle_t state);
 
+/**
+ * Enables or disables the target FSM's stretch control for the start of read
+ * transactions.
+ *
+ * This function should be called prior to enabling the target.
+ *
+ * @param i2c An I2C handle.
+ * @param state The new toggle state for the device functionality.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_target_tx_stretch_ctrl_set_enabled(const dif_i2c_t *i2c,
+                                                        dif_toggle_t state);
 /**
  * Enables or disables the "override mode". In override mode, software is able
  * to directly control the driven values of the SCL and SDA lines using


### PR DESCRIPTION
Change target FSM's stretch timeout to count across an entire transaction, for SMBus support.

Add a CSR to report fault events that occurred during a read, and gate
the next read (stretch clock at the first bit) until the event latch is
cleared. This is for reads to this IP's target module.

The gate helps prevent stale data from emerging from the FIFO.

Also roll in some of the functionality the TXRST_ON_COND CSR was meant
to provide, and make this a catch-all gate for releasing the TX FIFO on
a read instead. The prior mechanism had some corner cases that produced
races with software, such as software being able to inadvertently write
a new (yet stale) byte of data after the clear yet before being notified
that the command completed. The separate gating CSR helps avoid such
races by not allowing software's normal write path to bypass event
handling.