### PR TITLE
[hw,mbx,rtl] Move SOC_INTR_ADDR/DATA registers to the end

### DIFF
--- a/hw/ip/mbx/data/mbx.hjson
+++ b/hw/ip/mbx/data/mbx.hjson
@@ -336,36 +336,7 @@
       }
     ]
     soc: [
-      { name: "SOC_DOE_INTR_MSG_ADDR"
-        desc: '''
-              Utilized by the mailbox responder to send an interrupt message to the requester via a write to the configured address.
-              Defined only for FW-to-FW mailboxes.
-              '''
-        swaccess: "rw"
-        hwaccess: "hro"
-        fields: [
-          { name: "doe_intr_msg_addr"
-            desc: "Utilized by the mailbox responder to send an interrupt message to the requester via a write to the configured address."
-            bits: "31:0"
-            resval: "0x0"
-          }
-        ]
-      }
-      { name: "SOC_DOE_INTR_MSG_DATA"
-        desc: '''
-              Interrupt message data to be sent to the address configured in the DOE_INTR_MSG_ADDR register.
-              Defined only for FW-to-FW mailboxes.
-              '''
-        swaccess: "rw"
-        hwaccess: "hro"
-        fields: [
-          { name: "doe_intr_msg_data"
-            desc: "Interrupt message data to be sent to the address configured in the DOE_INTR_MSG_ADDR register."
-            bits: "31:0"
-            resval: "0x0"
-          }
-        ]
-      }
+      { skipto: "0x8" }
       { name: "SOC_CONTROL"
         desc: "DOE mailbox control register."
         hwaccess: "hrw"
@@ -481,6 +452,36 @@
           items: "1"
           swaccess: "rw"
         }
+      }
+      { name: "SOC_DOE_INTR_MSG_ADDR"
+        desc: '''
+              Utilized by the mailbox responder to send an interrupt message to the requester via a write to the configured address.
+              Defined only for FW-to-FW mailboxes.
+              '''
+        swaccess: "rw"
+        hwaccess: "hro"
+        fields: [
+          { name: "doe_intr_msg_addr"
+            desc: "Utilized by the mailbox responder to send an interrupt message to the requester via a write to the configured address."
+            bits: "31:0"
+            resval: "0x0"
+          }
+        ]
+      }
+      { name: "SOC_DOE_INTR_MSG_DATA"
+        desc: '''
+              Interrupt message data to be sent to the address configured in the DOE_INTR_MSG_ADDR register.
+              Defined only for FW-to-FW mailboxes.
+              '''
+        swaccess: "rw"
+        hwaccess: "hro"
+        fields: [
+          { name: "doe_intr_msg_data"
+            desc: "Interrupt message data to be sent to the address configured in the DOE_INTR_MSG_ADDR register."
+            bits: "31:0"
+            resval: "0x0"
+          }
+        ]
       }
     ]
   }

--- a/hw/ip/mbx/rtl/mbx_reg_pkg.sv
+++ b/hw/ip/mbx/rtl/mbx_reg_pkg.sv
@@ -287,14 +287,6 @@ package mbx_reg_pkg;
   //////////////////////////////////////////////
 
   typedef struct packed {
-    logic [31:0] q;
-  } mbx_reg2hw_soc_doe_intr_msg_addr_reg_t;
-
-  typedef struct packed {
-    logic [31:0] q;
-  } mbx_reg2hw_soc_doe_intr_msg_data_reg_t;
-
-  typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
@@ -327,6 +319,14 @@ package mbx_reg_pkg;
       logic        q;
     } ready;
   } mbx_reg2hw_soc_status_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } mbx_reg2hw_soc_doe_intr_msg_addr_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } mbx_reg2hw_soc_doe_intr_msg_data_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -368,10 +368,10 @@ package mbx_reg_pkg;
 
   // Register -> HW type for soc interface
   typedef struct packed {
-    mbx_reg2hw_soc_doe_intr_msg_addr_reg_t soc_doe_intr_msg_addr; // [75:44]
-    mbx_reg2hw_soc_doe_intr_msg_data_reg_t soc_doe_intr_msg_data; // [43:12]
-    mbx_reg2hw_soc_control_reg_t soc_control; // [11:4]
-    mbx_reg2hw_soc_status_reg_t soc_status; // [3:0]
+    mbx_reg2hw_soc_control_reg_t soc_control; // [75:68]
+    mbx_reg2hw_soc_status_reg_t soc_status; // [67:64]
+    mbx_reg2hw_soc_doe_intr_msg_addr_reg_t soc_doe_intr_msg_addr; // [63:32]
+    mbx_reg2hw_soc_doe_intr_msg_data_reg_t soc_doe_intr_msg_data; // [31:0]
   } mbx_soc_reg2hw_t;
 
   // HW -> register type for soc interface
@@ -381,10 +381,10 @@ package mbx_reg_pkg;
   } mbx_soc_hw2reg_t;
 
   // Register offsets for soc interface
-  parameter logic [SocAw-1:0] MBX_SOC_DOE_INTR_MSG_ADDR_OFFSET = 5'h 0;
-  parameter logic [SocAw-1:0] MBX_SOC_DOE_INTR_MSG_DATA_OFFSET = 5'h 4;
   parameter logic [SocAw-1:0] MBX_SOC_CONTROL_OFFSET = 5'h 8;
   parameter logic [SocAw-1:0] MBX_SOC_STATUS_OFFSET = 5'h c;
+  parameter logic [SocAw-1:0] MBX_SOC_DOE_INTR_MSG_ADDR_OFFSET = 5'h 18;
+  parameter logic [SocAw-1:0] MBX_SOC_DOE_INTR_MSG_DATA_OFFSET = 5'h 1c;
 
   // Reset values for hwext registers and their fields for soc interface
   parameter logic [31:0] MBX_SOC_CONTROL_RESVAL = 32'h 0;
@@ -403,18 +403,18 @@ package mbx_reg_pkg;
 
   // Register index for soc interface
   typedef enum int {
-    MBX_SOC_DOE_INTR_MSG_ADDR,
-    MBX_SOC_DOE_INTR_MSG_DATA,
     MBX_SOC_CONTROL,
-    MBX_SOC_STATUS
+    MBX_SOC_STATUS,
+    MBX_SOC_DOE_INTR_MSG_ADDR,
+    MBX_SOC_DOE_INTR_MSG_DATA
   } mbx_soc_id_e;
 
   // Register width information to check illegal writes for soc interface
   parameter logic [3:0] MBX_SOC_PERMIT [4] = '{
-    4'b 1111, // index[0] MBX_SOC_DOE_INTR_MSG_ADDR
-    4'b 1111, // index[1] MBX_SOC_DOE_INTR_MSG_DATA
-    4'b 1111, // index[2] MBX_SOC_CONTROL
-    4'b 1111  // index[3] MBX_SOC_STATUS
+    4'b 1111, // index[0] MBX_SOC_CONTROL
+    4'b 1111, // index[1] MBX_SOC_STATUS
+    4'b 1111, // index[2] MBX_SOC_DOE_INTR_MSG_ADDR
+    4'b 1111  // index[3] MBX_SOC_DOE_INTR_MSG_DATA
   };
 
 endpackage

--- a/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
+++ b/hw/ip/mbx/rtl/mbx_soc_reg_top.sv
@@ -176,12 +176,6 @@ module mbx_soc_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic soc_doe_intr_msg_addr_we;
-  logic [31:0] soc_doe_intr_msg_addr_qs;
-  logic [31:0] soc_doe_intr_msg_addr_wd;
-  logic soc_doe_intr_msg_data_we;
-  logic [31:0] soc_doe_intr_msg_data_qs;
-  logic [31:0] soc_doe_intr_msg_data_wd;
   logic soc_control_re;
   logic soc_control_we;
   logic soc_control_abort_wd;
@@ -197,64 +191,14 @@ module mbx_soc_reg_top (
   logic soc_status_error_qs;
   logic soc_status_doe_async_msg_status_qs;
   logic soc_status_ready_qs;
+  logic soc_doe_intr_msg_addr_we;
+  logic [31:0] soc_doe_intr_msg_addr_qs;
+  logic [31:0] soc_doe_intr_msg_addr_wd;
+  logic soc_doe_intr_msg_data_we;
+  logic [31:0] soc_doe_intr_msg_data_qs;
+  logic [31:0] soc_doe_intr_msg_data_wd;
 
   // Register instances
-  // R[soc_doe_intr_msg_addr]: V(False)
-  prim_subreg #(
-    .DW      (32),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0),
-    .Mubi    (1'b0)
-  ) u_soc_doe_intr_msg_addr (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (soc_doe_intr_msg_addr_we),
-    .wd     (soc_doe_intr_msg_addr_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.soc_doe_intr_msg_addr.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (soc_doe_intr_msg_addr_qs)
-  );
-
-
-  // R[soc_doe_intr_msg_data]: V(False)
-  prim_subreg #(
-    .DW      (32),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0),
-    .Mubi    (1'b0)
-  ) u_soc_doe_intr_msg_data (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (soc_doe_intr_msg_data_we),
-    .wd     (soc_doe_intr_msg_data_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.soc_doe_intr_msg_data.q),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (soc_doe_intr_msg_data_qs)
-  );
-
-
   // R[soc_control]: V(True)
   logic soc_control_qe;
   logic [3:0] soc_control_flds_we;
@@ -461,14 +405,70 @@ module mbx_soc_reg_top (
   );
 
 
+  // R[soc_doe_intr_msg_addr]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
+  ) u_soc_doe_intr_msg_addr (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (soc_doe_intr_msg_addr_we),
+    .wd     (soc_doe_intr_msg_addr_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.soc_doe_intr_msg_addr.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (soc_doe_intr_msg_addr_qs)
+  );
+
+
+  // R[soc_doe_intr_msg_data]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0),
+    .Mubi    (1'b0)
+  ) u_soc_doe_intr_msg_data (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (soc_doe_intr_msg_data_we),
+    .wd     (soc_doe_intr_msg_data_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.soc_doe_intr_msg_data.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (soc_doe_intr_msg_data_qs)
+  );
+
+
 
   logic [3:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[0] = (reg_addr == MBX_SOC_DOE_INTR_MSG_ADDR_OFFSET);
-    addr_hit[1] = (reg_addr == MBX_SOC_DOE_INTR_MSG_DATA_OFFSET);
-    addr_hit[2] = (reg_addr == MBX_SOC_CONTROL_OFFSET);
-    addr_hit[3] = (reg_addr == MBX_SOC_STATUS_OFFSET);
+    addr_hit[0] = (reg_addr == MBX_SOC_CONTROL_OFFSET);
+    addr_hit[1] = (reg_addr == MBX_SOC_STATUS_OFFSET);
+    addr_hit[2] = (reg_addr == MBX_SOC_DOE_INTR_MSG_ADDR_OFFSET);
+    addr_hit[3] = (reg_addr == MBX_SOC_DOE_INTR_MSG_DATA_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -483,14 +483,8 @@ module mbx_soc_reg_top (
   end
 
   // Generate write-enables
-  assign soc_doe_intr_msg_addr_we = addr_hit[0] & reg_we & !reg_error;
-
-  assign soc_doe_intr_msg_addr_wd = reg_wdata[31:0];
-  assign soc_doe_intr_msg_data_we = addr_hit[1] & reg_we & !reg_error;
-
-  assign soc_doe_intr_msg_data_wd = reg_wdata[31:0];
-  assign soc_control_re = addr_hit[2] & reg_re & !reg_error;
-  assign soc_control_we = addr_hit[2] & reg_we & !reg_error;
+  assign soc_control_re = addr_hit[0] & reg_re & !reg_error;
+  assign soc_control_we = addr_hit[0] & reg_we & !reg_error;
 
   assign soc_control_abort_wd = reg_wdata[0];
 
@@ -499,17 +493,23 @@ module mbx_soc_reg_top (
   assign soc_control_doe_async_msg_en_wd = reg_wdata[3];
 
   assign soc_control_go_wd = reg_wdata[31];
-  assign soc_status_we = addr_hit[3] & reg_we & !reg_error;
+  assign soc_status_we = addr_hit[1] & reg_we & !reg_error;
 
   assign soc_status_doe_intr_status_wd = reg_wdata[1];
+  assign soc_doe_intr_msg_addr_we = addr_hit[2] & reg_we & !reg_error;
+
+  assign soc_doe_intr_msg_addr_wd = reg_wdata[31:0];
+  assign soc_doe_intr_msg_data_we = addr_hit[3] & reg_we & !reg_error;
+
+  assign soc_doe_intr_msg_data_wd = reg_wdata[31:0];
 
   // Assign write-enables to checker logic vector.
   always_comb begin
     reg_we_check = '0;
-    reg_we_check[0] = soc_doe_intr_msg_addr_we;
-    reg_we_check[1] = soc_doe_intr_msg_data_we;
-    reg_we_check[2] = soc_control_we;
-    reg_we_check[3] = soc_status_we;
+    reg_we_check[0] = soc_control_we;
+    reg_we_check[1] = soc_status_we;
+    reg_we_check[2] = soc_doe_intr_msg_addr_we;
+    reg_we_check[3] = soc_doe_intr_msg_data_we;
   end
 
   // Read data return
@@ -517,26 +517,26 @@ module mbx_soc_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[31:0] = soc_doe_intr_msg_addr_qs;
-      end
-
-      addr_hit[1]: begin
-        reg_rdata_next[31:0] = soc_doe_intr_msg_data_qs;
-      end
-
-      addr_hit[2]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = soc_control_doe_intr_en_qs;
         reg_rdata_next[3] = soc_control_doe_async_msg_en_qs;
         reg_rdata_next[31] = '0;
       end
 
-      addr_hit[3]: begin
+      addr_hit[1]: begin
         reg_rdata_next[0] = soc_status_busy_qs;
         reg_rdata_next[1] = soc_status_doe_intr_status_qs;
         reg_rdata_next[2] = soc_status_error_qs;
         reg_rdata_next[3] = soc_status_doe_async_msg_status_qs;
         reg_rdata_next[31] = soc_status_ready_qs;
+      end
+
+      addr_hit[2]: begin
+        reg_rdata_next[31:0] = soc_doe_intr_msg_addr_qs;
+      end
+
+      addr_hit[3]: begin
+        reg_rdata_next[31:0] = soc_doe_intr_msg_data_qs;
       end
 
       default: begin


### PR DESCRIPTION
A mailbox con either be a PCIe mailbox or a FW mailbox. In case of the PCIe setting, the SOC reagisters 0x0 and 0x4 implement the capability header functionality, but this is done outside of the mbx RTL. PCIe mailboxes do not use the SOC_INTR_DATA/ADDR registers. FW-based mailboxes on the other hand only use the SOC_INTR_DATA/ADDR registers but no capability headers. Previously, it was decided to alias both registers as they are used orthogonally. However, this deceission was revised.

This PR moves the SOC_INTR_DATA/ADDR registers to the end of the SOC register interface to not alias with any capability header registers for PCIe mailboxes