### PR TITLE
[csrng] Add SVAs to check for unexpected pushes to the genbits FIFO

### DIFF
--- a/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_err_vseq.sv
@@ -47,15 +47,24 @@ class csrng_err_vseq extends csrng_base_vseq;
     // Turn off fatal alert check
     expect_fatal_alerts = 1'b1;
 
+    `define CMD_STAGE_0 tb.dut.u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage
+    `define CMD_STAGE_1 tb.dut.u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage
+    `define CMD_STAGE_2 tb.dut.u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage
+
+    `define HIER_PATH(prefix, suffix) `"prefix.suffix`"
+
     // Turn off assertions
     $assertoff(0, "tb.entropy_src_if.ReqHighUntilAck_A");
     $assertoff(0, "tb.entropy_src_if.AckAssertedOnlyWhenReqAsserted_A");
     $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.LockArbDecision_A");
     $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_benblk_arb.ReqStaysHighUntilGranted0_M");
     $assertoff(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.ReqStaysHighUntilGranted0_M");
-    $assertoff(0, "tb.dut.u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.u_state_regs_A");
-    $assertoff(0, "tb.dut.u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.u_state_regs_A");
-    $assertoff(0, "tb.dut.u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.u_state_regs_A");
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_0, u_state_regs_A));
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_1, u_state_regs_A));
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_2, u_state_regs_A));
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_0, CsrngCmdStageGenbitsFifoPushExpected_A));
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_1, CsrngCmdStageGenbitsFifoPushExpected_A));
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_2, CsrngCmdStageGenbitsFifoPushExpected_A));
     cfg.csrng_assert_vif.assert_off();
     `DV_ASSERT_CTRL_REQ("CmdStageFifoAsserts", 0)
 
@@ -294,9 +303,19 @@ class csrng_err_vseq extends csrng_base_vseq;
     $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.LockArbDecision_A");
     $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_benblk_arb.ReqStaysHighUntilGranted0_M");
     $asserton(0, "tb.dut.u_csrng_core.u_prim_arbiter_ppc_updblk_arb.ReqStaysHighUntilGranted0_M");
-    $asserton(0, "tb.dut.u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage.u_state_regs_A");
-    $asserton(0, "tb.dut.u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage.u_state_regs_A");
-    $asserton(0, "tb.dut.u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage.u_state_regs_A");
+    $asserton(0, `HIER_PATH(`CMD_STAGE_0, u_state_regs_A));
+    $asserton(0, `HIER_PATH(`CMD_STAGE_1, u_state_regs_A));
+    $asserton(0, `HIER_PATH(`CMD_STAGE_2, u_state_regs_A));
+    $asserton(0, `HIER_PATH(`CMD_STAGE_0, CsrngCmdStageGenbitsFifoPushExpected_A));
+    $asserton(0, `HIER_PATH(`CMD_STAGE_1, CsrngCmdStageGenbitsFifoPushExpected_A));
+    $asserton(0, `HIER_PATH(`CMD_STAGE_2, CsrngCmdStageGenbitsFifoPushExpected_A));
+
+    `undef CMD_STAGE_0
+    `undef CMD_STAGE_1
+    `undef CMD_STAGE_2
+
+    `undef HIER_PATH
+
     cfg.csrng_assert_vif.assert_on();
 
   endtask : body


### PR DESCRIPTION
The ready signal of the genbits FIFO is not considered when pushing the FIFO which may raise concerns. However, by inspecting the command stage FSM, one can see that the FSM only ever triggers the generation of more bits if the genbits FIFO is empty.

This commit documents these findings in the RTL and adds some SVAs to check that 1) the FSM indeed only ever enters the stage where it requests more bits after finding an empty FIFO and 2) that the genbits FIFO is only ever pushed in the in the FSM states where this can be expected.

This resolves lowRISC/OpenTitan#16563.