### PR TITLE
[crypto] Change P-384 Pointer Handling

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/ecdh_p384.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p384.c
@@ -14,10 +14,10 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'x')
 
-OTBN_DECLARE_APP_SYMBOLS(p384_ecdh);          // The OTBN ECDSH/P-384 app.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, mode);    // ECDH application mode.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, x);  // The public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, y);  // The public key y-coordinate.
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdh);        // The OTBN ECDSH/P-384 app.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, mode);  // ECDH application mode.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, x);     // The public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, y);     // The public key y-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
                          d0);  // The private key scalar d (share 0).
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,

--- a/sw/device/lib/crypto/impl/ecc/ecdh_p384.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p384.c
@@ -16,18 +16,8 @@
 
 OTBN_DECLARE_APP_SYMBOLS(p384_ecdh);          // The OTBN ECDSH/P-384 app.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, mode);    // ECDH application mode.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, dptr_x);  // The public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, dptr_y);  // The public key y-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
-                         x);  // The pointer to public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
-                         y);  // The pointer to public key y-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(
-    p384_ecdh,
-    dptr_d0);  // The pointer to private key scalar d (share 0).
-OTBN_DECLARE_SYMBOL_ADDR(
-    p384_ecdh,
-    dptr_d1);  // The pointer to private key scalar d (share 1).
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, x);  // The public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, y);  // The public key y-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
                          d0);  // The private key scalar d (share 0).
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
@@ -35,16 +25,8 @@ OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
 
 static const otbn_app_t kOtbnAppEcdh = OTBN_APP_T_INIT(p384_ecdh);
 static const otbn_addr_t kOtbnVarEcdhMode = OTBN_ADDR_T_INIT(p384_ecdh, mode);
-static const otbn_addr_t kOtbnVarEcdhDptrX =
-    OTBN_ADDR_T_INIT(p384_ecdh, dptr_x);
-static const otbn_addr_t kOtbnVarEcdhDptrY =
-    OTBN_ADDR_T_INIT(p384_ecdh, dptr_y);
 static const otbn_addr_t kOtbnVarEcdhX = OTBN_ADDR_T_INIT(p384_ecdh, x);
 static const otbn_addr_t kOtbnVarEcdhY = OTBN_ADDR_T_INIT(p384_ecdh, y);
-static const otbn_addr_t kOtbnVarEcdhDptrD0 =
-    OTBN_ADDR_T_INIT(p384_ecdh, dptr_d0);
-static const otbn_addr_t kOtbnVarEcdhDptrD1 =
-    OTBN_ADDR_T_INIT(p384_ecdh, dptr_d1);
 static const otbn_addr_t kOtbnVarEcdhD0 = OTBN_ADDR_T_INIT(p384_ecdh, d0);
 static const otbn_addr_t kOtbnVarEcdhD1 = OTBN_ADDR_T_INIT(p384_ecdh, d1);
 
@@ -65,38 +47,9 @@ enum {
   // TODO: kOtbnEcdhModeSharedKeyFromSeed = 0x74b;
 };
 
-/**
- * Makes a single dptr in the P384 library point to where its value is stored.
- */
-static void setup_data_pointer(const otbn_addr_t dptr,
-                               const otbn_addr_t value) {
-  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
-}
-
-/**
- * Sets up all data pointers used by the P384 library to point to DMEM.
- *
- * The ECDH P384 OTBN library makes use of "named" data pointers as part of
- * its calling convention, which are exposed as symbol starting with `dptr_`.
- * The DMEM locations these pointers refer to is not mandated by the P384
- * calling convention; the values can be placed anywhere in OTBN DMEM.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static void setup_data_pointers(void) {
-  setup_data_pointer(kOtbnVarEcdhDptrX, kOtbnVarEcdhX);
-  setup_data_pointer(kOtbnVarEcdhDptrY, kOtbnVarEcdhY);
-  setup_data_pointer(kOtbnVarEcdhDptrD0, kOtbnVarEcdhD0);
-  setup_data_pointer(kOtbnVarEcdhDptrD1, kOtbnVarEcdhD1);
-}
-
 status_t ecdh_p384_keypair_start(void) {
   // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
-
-  // Set up the data pointers
-  setup_data_pointers();
 
   // Set mode so start() will jump into keygen.
   uint32_t mode = kOtbnEcdhModeKeypairRandom;
@@ -135,9 +88,6 @@ status_t ecdh_p384_shared_key_start(const p384_masked_scalar_t *private_key,
 
   // Load the ECDH/P-384 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdh));
-
-  // Set up the data pointers
-  setup_data_pointers();
 
   // Set mode so start() will jump into shared-key generation.
   uint32_t mode = kOtbnEcdhModeSharedKey;

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.c
@@ -14,43 +14,17 @@
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'k')
 
 OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_keygen);  // The OTBN ECDSA/P-384 app.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, dptr_k0);  // Pointer to k0.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, dptr_k1);  // Pointer to k1.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, dptr_d0);  // Pointer to d0.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, dptr_d1);  // Pointer to d1.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, k0);  // Random scalar first share.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, k1);  // Random scalar second share.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, d0);  // Private key first share.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, d1);  // Private key second share.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen,
-                         dptr_x);  // pointer to x-coordinate (dptr_x)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen,
-                         dptr_y);  // pointer to y-coordinate (dptr_y)
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, x);  // x-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, y);  // y-coordinate.
 
 static const otbn_app_t kOtbnAppEcdsaKeygen =
     OTBN_APP_T_INIT(p384_ecdsa_keygen);
-static const otbn_addr_t kOtbnVarEcdsaDptrX =
-    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_x);
-static const otbn_addr_t kOtbnVarEcdsaDptrY =
-    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_y);
 static const otbn_addr_t kOtbnVarEcdsaX =
     OTBN_ADDR_T_INIT(p384_ecdsa_keygen, x);
 static const otbn_addr_t kOtbnVarEcdsaY =
     OTBN_ADDR_T_INIT(p384_ecdsa_keygen, y);
-static const otbn_addr_t kOtbnVarEcdsaDptrK0 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_k0);
-static const otbn_addr_t kOtbnVarEcdsaDptrK1 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_k1);
-static const otbn_addr_t kOtbnVarEcdsaDptrD0 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_d0);
-static const otbn_addr_t kOtbnVarEcdsaDptrD1 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, dptr_d1);
-static const otbn_addr_t kOtbnVarEcdsaK0 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, k0);
-static const otbn_addr_t kOtbnVarEcdsaK1 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, k1);
 static const otbn_addr_t kOtbnVarEcdsaD0 =
     OTBN_ADDR_T_INIT(p384_ecdsa_keygen, d0);
 static const otbn_addr_t kOtbnVarEcdsaD1 =
@@ -81,40 +55,9 @@ enum {
   kOtbnEcdsaModeVerify = 0x727,
 };
 
-/**
- * Makes a single dptr in the P384 library point to where its value is stored.
- */
-static void setup_data_pointer(const otbn_addr_t dptr,
-                               const otbn_addr_t value) {
-  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
-}
-
-/**
- * Sets up all data pointers used by the P384 library to point to DMEM.
- *
- * The ECDSA P384 OTBN library makes use of "named" data pointers as part of
- * its calling convention, which are exposed as symbol starting with `dptr_`.
- * The DMEM locations these pointers refer to is not mandated by the P384
- * calling convention; the values can be placed anywhere in OTBN DMEM.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static void setup_data_pointers(void) {
-  setup_data_pointer(kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX);
-  setup_data_pointer(kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY);
-  setup_data_pointer(kOtbnVarEcdsaDptrK0, kOtbnVarEcdsaK0);
-  setup_data_pointer(kOtbnVarEcdsaDptrK1, kOtbnVarEcdsaK1);
-  setup_data_pointer(kOtbnVarEcdsaDptrD0, kOtbnVarEcdsaD0);
-  setup_data_pointer(kOtbnVarEcdsaDptrD1, kOtbnVarEcdsaD1);
-}
-
 status_t ecdsa_p384_keygen_start(void) {
   // Load the ECDSA/P-384 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdsaKeygen));
-
-  // Set up the data pointers
-  setup_data_pointers();
 
   // Start the OTBN routine.
   return otbn_execute();

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.c
@@ -13,11 +13,11 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'k')
 
-OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_keygen);  // The OTBN ECDSA/P-384 app.
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_keygen);      // The OTBN ECDSA/P-384 app.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, d0);  // Private key first share.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, d1);  // Private key second share.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, x);  // x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, y);  // y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, x);   // x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, y);   // y-coordinate.
 
 static const otbn_app_t kOtbnAppEcdsaKeygen =
     OTBN_APP_T_INIT(p384_ecdsa_keygen);

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.c
@@ -14,22 +14,6 @@
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 's')
 
 OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_sign);  // The OTBN ECDSA/P-384 app.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign,
-                         dptr_x);  // pointer to x-coordinate (dptr_x)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign,
-                         dptr_y);  // pointer to y-coordinate (dptr_y)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_k0);  // pointer to k0 (dptr_k0)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_k1);  // pointer to k1 (dptr_k1)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_d0);  // pointer to d0 (dptr_d0)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_d1);  // pointer to d1 (dptr_d1)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign,
-                         dptr_msg);                 // pointer to msg (dptr_msg)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_r);  // pointer to R (dptr_r)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, dptr_s);  // pointer to S (dptr_s)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, x);       // x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, y);       // y-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, k0);      // random scalar first share
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, k1);   // random scalar second share
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, d0);   // private key first share
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, d1);   // private key second share
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, msg);  // hash message to sign/verify
@@ -37,38 +21,16 @@ OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, r);    // r part of signature
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, s);    // s part of signature
 
 static const otbn_app_t kOtbnAppEcdsaSign = OTBN_APP_T_INIT(p384_ecdsa_sign);
-static const otbn_addr_t kOtbnVarEcdsaDptrX =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_x);
-static const otbn_addr_t kOtbnVarEcdsaDptrY =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_y);
-static const otbn_addr_t kOtbnVarEcdsaDptrK0 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_k0);
-static const otbn_addr_t kOtbnVarEcdsaDptrK1 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_k1);
-static const otbn_addr_t kOtbnVarEcdsaDptrD0 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_d0);
-static const otbn_addr_t kOtbnVarEcdsaDptrD1 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_d1);
-static const otbn_addr_t kOtbnVarEcdsaDptrMsg =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_msg);
-static const otbn_addr_t kOtbnVarEcdsaDptrR =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_r);
-static const otbn_addr_t kOtbnVarEcdsaDptrS =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, dptr_s);
-static const otbn_addr_t kOtbnVarEcdsaX = OTBN_ADDR_T_INIT(p384_ecdsa_sign, x);
-static const otbn_addr_t kOtbnVarEcdsaY = OTBN_ADDR_T_INIT(p384_ecdsa_sign, y);
-static const otbn_addr_t kOtbnVarEcdsaK0 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, k0);
-static const otbn_addr_t kOtbnVarEcdsaK1 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, k1);
 static const otbn_addr_t kOtbnVarEcdsaD0 =
     OTBN_ADDR_T_INIT(p384_ecdsa_sign, d0);
 static const otbn_addr_t kOtbnVarEcdsaD1 =
     OTBN_ADDR_T_INIT(p384_ecdsa_sign, d1);
 static const otbn_addr_t kOtbnVarEcdsaMsg =
     OTBN_ADDR_T_INIT(p384_ecdsa_sign, msg);
-otbn_addr_t kOtbnVarEcdsaR = OTBN_ADDR_T_INIT(p384_ecdsa_sign, r);
-otbn_addr_t kOtbnVarEcdsaS = OTBN_ADDR_T_INIT(p384_ecdsa_sign, s);
+static const otbn_addr_t kOtbnVarEcdsaR =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, r);
+static const otbn_addr_t kOtbnVarEcdsaS =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, s);
 
 enum {
   /*
@@ -95,44 +57,10 @@ enum {
   kOtbnEcdsaModeVerify = 0x727,
 };
 
-/**
- * Makes a single dptr in the P384 library point to where its value is stored.
- */
-static void setup_data_pointer(const otbn_addr_t dptr,
-                               const otbn_addr_t value) {
-  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
-}
-
-/**
- * Sets up all data pointers used by the P384 library to point to DMEM.
- *
- * The ECDSA P384 OTBN library makes use of "named" data pointers as part of
- * its calling convention, which are exposed as symbol starting with `dptr_`.
- * The DMEM locations these pointers refer to is not mandated by the P384
- * calling convention; the values can be placed anywhere in OTBN DMEM.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static void setup_data_pointers(void) {
-  setup_data_pointer(kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX);
-  setup_data_pointer(kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY);
-  setup_data_pointer(kOtbnVarEcdsaDptrK0, kOtbnVarEcdsaK0);
-  setup_data_pointer(kOtbnVarEcdsaDptrK1, kOtbnVarEcdsaK1);
-  setup_data_pointer(kOtbnVarEcdsaDptrD0, kOtbnVarEcdsaD0);
-  setup_data_pointer(kOtbnVarEcdsaDptrD1, kOtbnVarEcdsaD1);
-  setup_data_pointer(kOtbnVarEcdsaDptrMsg, kOtbnVarEcdsaMsg);
-  setup_data_pointer(kOtbnVarEcdsaDptrR, kOtbnVarEcdsaR);
-  setup_data_pointer(kOtbnVarEcdsaDptrS, kOtbnVarEcdsaS);
-}
-
 status_t ecdsa_p384_sign_start(const uint32_t digest[kP384ScalarWords],
                                const p384_masked_scalar_t *private_key) {
   // Load the ECDSA/P-384 app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdsaSign));
-
-  // Set up the data pointers
-  setup_data_pointers();
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest, kOtbnVarEcdsaMsg));

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.c
@@ -13,7 +13,7 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 's')
 
-OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_sign);  // The OTBN ECDSA/P-384 app.
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_sign);       // The OTBN ECDSA/P-384 app.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, d0);   // private key first share
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, d1);   // private key second share
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, msg);  // hash message to sign/verify
@@ -27,10 +27,8 @@ static const otbn_addr_t kOtbnVarEcdsaD1 =
     OTBN_ADDR_T_INIT(p384_ecdsa_sign, d1);
 static const otbn_addr_t kOtbnVarEcdsaMsg =
     OTBN_ADDR_T_INIT(p384_ecdsa_sign, msg);
-static const otbn_addr_t kOtbnVarEcdsaR =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, r);
-static const otbn_addr_t kOtbnVarEcdsaS =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sign, s);
+static const otbn_addr_t kOtbnVarEcdsaR = OTBN_ADDR_T_INIT(p384_ecdsa_sign, r);
+static const otbn_addr_t kOtbnVarEcdsaS = OTBN_ADDR_T_INIT(p384_ecdsa_sign, s);
 
 enum {
   /*

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.h
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.h
@@ -16,9 +16,6 @@
 extern "C" {
 #endif  // __cplusplus
 
-extern otbn_addr_t kOtbnVarEcdsaR;
-extern otbn_addr_t kOtbnVarEcdsaS;
-
 /**
  * Start an async ECDSA/P-384 signature generation operation on OTBN.
  *

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.c
@@ -14,11 +14,11 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'v')
 
-OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_verify);  // The OTBN ECDSA/P-384 app.
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_verify);     // The OTBN ECDSA/P-384 app.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, x);  // Public key x-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, y);  // Public key y-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
-                         rnd);  // result of verify (x1 coordinate)
+                         x_r);  // result of verify (x1 coordinate)
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
                          msg);                   // hash message to sign/verify
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, r);  // r part of signature
@@ -37,7 +37,7 @@ static const otbn_addr_t kOtbnVarEcdsaR =
 static const otbn_addr_t kOtbnVarEcdsaS =
     OTBN_ADDR_T_INIT(p384_ecdsa_verify, s);
 static const otbn_addr_t kOtbnVarEcdsaRnd =
-    OTBN_ADDR_T_INIT(p384_ecdsa_verify, rnd);
+    OTBN_ADDR_T_INIT(p384_ecdsa_verify, x_r);
 
 enum {
   /*
@@ -99,10 +99,10 @@ status_t ecdsa_p384_verify_finalize(const ecdsa_p384_signature_t *signature,
   HARDENED_TRY(otbn_busy_wait_for_done());
 
   // Read x_r (recovered R) out of OTBN dmem.
-  uint32_t rnd[kP384ScalarWords];
-  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarEcdsaRnd, rnd));
+  uint32_t x_r[kP384ScalarWords];
+  HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarEcdsaRnd, x_r));
 
-  *result = hardened_memeq(rnd, signature->r, kP384ScalarWords);
+  *result = hardened_memeq(x_r, signature->r, kP384ScalarWords);
 
   // Wipe DMEM.
   HARDENED_TRY(otbn_dmem_sec_wipe());

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_verify.c
@@ -15,16 +15,6 @@
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'v')
 
 OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_verify);  // The OTBN ECDSA/P-384 app.
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
-                         dptr_x);  // pointer to x-coordinate (dptr_x)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
-                         dptr_y);  // pointer to y-coordinate (dptr_y)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
-                         dptr_rnd);  // pointer to rnd (dptr_rnd)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
-                         dptr_msg);  // pointer to msg (dptr_msg)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, dptr_r);  // pointer to R (dptr_r)
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, dptr_s);  // pointer to S (dptr_s)
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, x);  // Public key x-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, y);  // Public key y-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify,
@@ -36,18 +26,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_verify, s);  // s part of signature
 
 static const otbn_app_t kOtbnAppEcdsaVerify =
     OTBN_APP_T_INIT(p384_ecdsa_verify);
-static const otbn_addr_t kOtbnVarEcdsaDptrX =
-    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_x);
-static const otbn_addr_t kOtbnVarEcdsaDptrY =
-    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_y);
-static const otbn_addr_t kOtbnVarEcdsaDptrRnd =
-    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_rnd);
-static const otbn_addr_t kOtbnVarEcdsaDptrMsg =
-    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_msg);
-static const otbn_addr_t kOtbnVarEcdsaDptrR =
-    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_r);
-static const otbn_addr_t kOtbnVarEcdsaDptrS =
-    OTBN_ADDR_T_INIT(p384_ecdsa_verify, dptr_s);
 static const otbn_addr_t kOtbnVarEcdsaX =
     OTBN_ADDR_T_INIT(p384_ecdsa_verify, x);
 static const otbn_addr_t kOtbnVarEcdsaY =
@@ -86,34 +64,6 @@ enum {
   kOtbnEcdsaModeVerify = 0x727,
 };
 
-/**
- * Makes a single dptr in the P384 library point to where its value is stored.
- */
-static void setup_data_pointer(const otbn_addr_t dptr,
-                               const otbn_addr_t value) {
-  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
-}
-
-/**
- * Sets up all data pointers used by the P384 library to point to DMEM.
- *
- * The ECDSA P384 OTBN library makes use of "named" data pointers as part of
- * its calling convention, which are exposed as symbol starting with `dptr_`.
- * The DMEM locations these pointers refer to is not mandated by the P384
- * calling convention; the values can be placed anywhere in OTBN DMEM.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static void setup_data_pointers(void) {
-  setup_data_pointer(kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX);
-  setup_data_pointer(kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY);
-  setup_data_pointer(kOtbnVarEcdsaDptrRnd, kOtbnVarEcdsaRnd);
-  setup_data_pointer(kOtbnVarEcdsaDptrMsg, kOtbnVarEcdsaMsg);
-  setup_data_pointer(kOtbnVarEcdsaDptrR, kOtbnVarEcdsaR);
-  setup_data_pointer(kOtbnVarEcdsaDptrS, kOtbnVarEcdsaS);
-}
-
 status_t ecdsa_p384_verify_start(const ecdsa_p384_signature_t *signature,
                                  const uint32_t digest[kP384ScalarWords],
                                  const p384_point_t *public_key) {
@@ -123,9 +73,6 @@ status_t ecdsa_p384_verify_start(const ecdsa_p384_signature_t *signature,
 
   // Load the ECDSA/P-384 app
   HARDENED_TRY(otbn_load_app(kOtbnAppEcdsaVerify));
-
-  // Set up the data pointers
-  setup_data_pointers();
 
   // Set the message digest.
   HARDENED_TRY(set_message_digest(digest, kOtbnVarEcdsaMsg));

--- a/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.c
+++ b/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.c
@@ -14,57 +14,19 @@
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'c')
 
 OTBN_DECLARE_APP_SYMBOLS(
-    p384_curve_point_valid);  // The OTBN Curve Point Valid Check app.
-OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
-                         dptr_x);  // The public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
-                         dptr_y);  // The public key y-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
-                         x);  // The pointer to public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
-                         y);  // The pointer to public key y-coordinate.
+    p384_curve_point_valid); // The OTBN Curve Point Valid Check app.
+OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid, x); // The public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid, y); // The public key y-coordinate.
 
 static const otbn_app_t kOtbnAppCpv = OTBN_APP_T_INIT(p384_curve_point_valid);
-static const otbn_addr_t kOtbnVarCpvDptrX =
-    OTBN_ADDR_T_INIT(p384_curve_point_valid, dptr_x);
-static const otbn_addr_t kOtbnVarCpvDptrY =
-    OTBN_ADDR_T_INIT(p384_curve_point_valid, dptr_y);
 static const otbn_addr_t kOtbnVarCpvX =
     OTBN_ADDR_T_INIT(p384_curve_point_valid, x);
 static const otbn_addr_t kOtbnVarCpvY =
     OTBN_ADDR_T_INIT(p384_curve_point_valid, y);
 
-/**
- * Makes a single dptr in the P384 library point to where its value is stored.
- */
-static void setup_data_pointer(const otbn_addr_t dptr,
-                               const otbn_addr_t value) {
-  otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr);
-}
-
-/**
- * Sets up all data pointers used by the P384 library to point to DMEM.
- *
- * The Curve Point Valid P384 OTBN library makes use of "named" data pointers
- * as part of its calling convention, which are exposed as symbol starting
- * with `dptr_`. The DMEM locations these pointers refer to is not mandated
- * by the P384 calling convention; the values can be placed anywhere in OTBN
- * DMEM.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static void setup_data_pointers(void) {
-  setup_data_pointer(kOtbnVarCpvDptrX, kOtbnVarCpvX);
-  setup_data_pointer(kOtbnVarCpvDptrY, kOtbnVarCpvY);
-}
-
 status_t p384_curve_point_validate_start(const p384_point_t *public_key) {
   // Load the P-384 Curve Point Valid app. Fails if OTBN is non-idle.
   HARDENED_TRY(otbn_load_app(kOtbnAppCpv));
-
-  // Set up the data pointers
-  setup_data_pointers();
 
   // Set the public key x coordinate.
   HARDENED_TRY(otbn_dmem_write(kP384CoordWords, public_key->x, kOtbnVarCpvX));

--- a/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.c
+++ b/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.c
@@ -14,9 +14,11 @@
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'c')
 
 OTBN_DECLARE_APP_SYMBOLS(
-    p384_curve_point_valid); // The OTBN Curve Point Valid Check app.
-OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid, x); // The public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid, y); // The public key y-coordinate.
+    p384_curve_point_valid);  // The OTBN Curve Point Valid Check app.
+OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
+                         x);  // The public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p384_curve_point_valid,
+                         y);  // The public key y-coordinate.
 
 static const otbn_app_t kOtbnAppCpv = OTBN_APP_T_INIT(p384_curve_point_valid);
 static const otbn_addr_t kOtbnVarCpvX =

--- a/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.h
+++ b/sw/device/lib/crypto/impl/ecc/p384_curve_point_valid.h
@@ -25,6 +25,7 @@ extern "C" {
  * @param public_key Public key (Q).
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t p384_curve_point_validate_start(const p384_point_t *public_key);
 
 /**
@@ -34,6 +35,7 @@ status_t p384_curve_point_validate_start(const p384_point_t *public_key);
  *
  * @return Result of the operation (OK or error).
  */
+OT_WARN_UNUSED_RESULT
 status_t p384_curve_point_validate_finalize(void);
 
 #ifdef __cplusplus

--- a/sw/device/sca/ecc384_serial.c
+++ b/sw/device/sca/ecc384_serial.c
@@ -99,16 +99,6 @@ uint32_t ecc384_msg[kEcc384NumWords] = {
 // p384_ecdsa_sca has randomnization removed.
 OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_sca);
 
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_msg);
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_r);
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_s);
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_x);
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_y);
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_d0);
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_d1);
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_k0);
-OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, dptr_k1);
-
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, mode);
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, msg);
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, r);
@@ -122,25 +112,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sca, k1);
 
 static const otbn_app_t kOtbnAppP384Ecdsa = OTBN_APP_T_INIT(p384_ecdsa_sca);
 
-static const otbn_addr_t kOtbnVarDptrMsg =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_msg);
-static const otbn_addr_t kOtbnVarDptrR =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_r);
-static const otbn_addr_t kOtbnVarDptrS =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_s);
-static const otbn_addr_t kOtbnVarDptrX =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_x);
-static const otbn_addr_t kOtbnVarDptrY =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_y);
-static const otbn_addr_t kOtbnVarDptrD0 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_d0);
-static const otbn_addr_t kOtbnVarDptrD1 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_d1);
-static const otbn_addr_t kOtbnVarDptrK0 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_k0);
-static const otbn_addr_t kOtbnVarDptrK1 =
-    OTBN_ADDR_T_INIT(p384_ecdsa_sca, dptr_k1);
-
 static const otbn_addr_t kOtbnVarMode = OTBN_ADDR_T_INIT(p384_ecdsa_sca, mode);
 static const otbn_addr_t kOtbnVarMsg = OTBN_ADDR_T_INIT(p384_ecdsa_sca, msg);
 static const otbn_addr_t kOtbnVarR = OTBN_ADDR_T_INIT(p384_ecdsa_sca, r);
@@ -151,40 +122,6 @@ static const otbn_addr_t kOtbnVarD0 = OTBN_ADDR_T_INIT(p384_ecdsa_sca, d0);
 static const otbn_addr_t kOtbnVarD1 = OTBN_ADDR_T_INIT(p384_ecdsa_sca, d1);
 static const otbn_addr_t kOtbnVarK0 = OTBN_ADDR_T_INIT(p384_ecdsa_sca, k0);
 static const otbn_addr_t kOtbnVarK1 = OTBN_ADDR_T_INIT(p384_ecdsa_sca, k1);
-
-/**
- * Makes a single dptr in the P384 library point to where its value is stored.
- */
-static void setup_data_pointer(const otbn_addr_t dptr,
-                               const otbn_addr_t value) {
-  SS_CHECK_STATUS_OK(
-      otbn_dmem_write(sizeof(value) / sizeof(uint32_t), &value, dptr));
-}
-
-/**
- * Sets up all data pointers used by the P384 library to point to DMEM.
- *
- * The ECDSA P384 OTBN library makes use of "named" data pointers as part of
- * its calling convention, which are exposed as symbol starting with `dptr_`.
- * The DMEM locations these pointers refer to is not mandated by the P384
- * calling convention; the values can be placed anywhere in OTBN DMEM.
- *
- * As convenience, `ecdsa_p384_sca.s` pre-allocates space for the data values.
- *
- * This function makes the data pointers refer to the pre-allocated DMEM
- * regions to store the actual values.
- */
-static void setup_data_pointers(void) {
-  setup_data_pointer(kOtbnVarDptrMsg, kOtbnVarMsg);
-  setup_data_pointer(kOtbnVarDptrR, kOtbnVarR);
-  setup_data_pointer(kOtbnVarDptrS, kOtbnVarS);
-  setup_data_pointer(kOtbnVarDptrX, kOtbnVarX);
-  setup_data_pointer(kOtbnVarDptrY, kOtbnVarY);
-  setup_data_pointer(kOtbnVarDptrD0, kOtbnVarD0);
-  setup_data_pointer(kOtbnVarDptrD1, kOtbnVarD1);
-  setup_data_pointer(kOtbnVarDptrK0, kOtbnVarK0);
-  setup_data_pointer(kOtbnVarDptrK1, kOtbnVarK1);
-}
 
 /**
  * Simple serial 'k' (set ephemeral key) command handler.
@@ -277,9 +214,6 @@ static void p384_dmem_write(const uint32_t src[kEcc384NumWords],
 static void p384_ecdsa_sign(const uint32_t *msg, const uint32_t *private_key_d,
                             uint32_t *signature_r, uint32_t *signature_s,
                             const uint32_t *k) {
-  LOG_INFO("Setup data pointers");
-  setup_data_pointers();
-
   uint32_t mode = 1;  // mode 1 => sign
   // LOG_INFO("Copy data");
   SS_CHECK_STATUS_OK(otbn_dmem_write(/*num_words=*/1, &mode, kOtbnVarMode));

--- a/sw/otbn/crypto/p384_base_mult.s
+++ b/sw/otbn/crypto/p384_base_mult.s
@@ -19,10 +19,8 @@
  * Sets up context and calls the internal scalar multiplication routine.
  * This routine runs in constant time.
  *
- * @param[in]       x17: dptr_d0, pointer to location in dmem containing
- *                                1st private key share d0
- * @param[in]       x19: dptr_d1, pointer to location in dmem containing
- *                                2nd private key share d1
+ * @param[in]  dmem[d0]: 1st private key share d0 in dmem
+ * @param[in]  dmem[d1]: 2nd private key share d1 in dmem
  * @param[out]  dmem[x]: x-coordinate in dmem
  * @param[out]  dmem[y]: y-coordinate in dmem
  *
@@ -32,7 +30,7 @@
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 correspond
  *        to the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x9 to x13, x18 to x21, x26 to x30
+ * clobbered registers: x2, x3, x9 to x13, x17 to x21, x26 to x30
  *                      w0 to w30
  * clobbered flag groups: FG0
  */
@@ -50,6 +48,12 @@ p384_base_mult:
 
   /* set dmem pointer to scratchpad */
   la        x30, scratchpad
+
+  /* set dmem pointer to 1st private key share d0 */
+  la        x17, d0
+
+  /* set dmem pointer to 1st private key share d0 */
+  la        x19, d1
 
   /* load domain parameter n (order of base point)
      [w11, w10] = n = dmem[p384_n] */
@@ -94,6 +98,18 @@ p384_base_mult:
 .section .data
 
 .balign 32
+
+/* 1st private key share d0 */
+.globl d0
+.weak d0
+d0:
+  .zero 64
+
+/* 2nd private key share d1 */
+.globl d1
+.weak d1
+d1:
+  .zero 64
 
 /* buffer for x-coordinate */
 .globl x

--- a/sw/otbn/crypto/p384_base_mult.s
+++ b/sw/otbn/crypto/p384_base_mult.s
@@ -19,12 +19,12 @@
  * Sets up context and calls the internal scalar multiplication routine.
  * This routine runs in constant time.
  *
- * @param[in]  dmem[0]: dptr_d0, pointer to location in dmem containing
- *                      1st private key share d0
- * @param[in]  dmem[4]: dptr_d1, pointer to location in dmem containing
- *                      2nd private key share d1
- * @param[in]  dmem[20]: dptr_x, pointer to result buffer for x-coordinate
- * @param[in]  dmem[24]: dptr_y, pointer to result buffer for y-coordinate
+ * @param[in]       x17: dptr_d0, pointer to location in dmem containing
+ *                                1st private key share d0
+ * @param[in]       x19: dptr_d1, pointer to location in dmem containing
+ *                                2nd private key share d1
+ * @param[out]  dmem[x]: x-coordinate in dmem
+ * @param[out]  dmem[y]: y-coordinate in dmem
  *
  * 384-bit quantities have to be provided in dmem in little-endian format,
  * 512 bit aligned, with the highest 128 bit set to zero.
@@ -44,14 +44,6 @@ p384_base_mult:
 
   /* set dmem pointer to y-coordinate of base point */
   la        x21, p384_gy
-
-  /* set dmem pointer to 1st scalar share d0 */
-  la        x17, dptr_d0
-  lw        x17, 0(x17)
-
-  /* set dmem pointer to 2nd scalar share d1 */
-  la        x19, dptr_d1
-  lw        x19, 0(x19)
 
   /* set dmem pointer to domain parameter b */
   la        x28, p384_b
@@ -84,12 +76,10 @@ p384_base_mult:
   jal       x1, proj_to_affine_p384
 
   /* set dmem pointer to point x-coordinate */
-  la        x20, dptr_x
-  lw        x20, 0(x20)
+  la        x20, x
 
   /* set dmem pointer to point y-coordinate */
-  la        x21, dptr_y
-  lw        x21, 0(x21)
+  la        x21, y
 
   /* store result in dmem */
   li        x2, 25
@@ -100,46 +90,22 @@ p384_base_mult:
 
   ret
 
-/* pointers and scratchpad memory */
+/* variables and scratchpad memory */
 .section .data
 
 .balign 32
 
-  /* pointer to k0 (dptr_k0) */
-.globl dptr_k0
-.weak dptr_k0
-dptr_k0:
-  .zero 4
+/* buffer for x-coordinate */
+.globl x
+.weak x
+x:
+  .zero 64
 
-/* pointer to k1 (dptr_k1) */
-.globl dptr_k1
-.weak dptr_k1
-dptr_k1:
-  .zero 4
-
-/* pointer to d0 (dptr_d0) */
-.globl dptr_d0
-.weak dptr_d0
-dptr_d0:
-  .zero 4
-
-/* pointer to d1 (dptr_d1) */
-.globl dptr_d1
-.weak dptr_d1
-dptr_d1:
-  .zero 4
-
-/* pointer to X (dptr_x) */
-.globl dptr_x
-.weak dptr_x
-dptr_x:
-  .zero 4
-
-/* pointer to Y (dptr_y) */
-.globl dptr_y
-.weak dptr_y
-dptr_y:
-  .zero 4
+/* buffer for y-coordinate */
+.globl y
+.weak y
+y:
+  .zero 64
 
 /* 704 bytes of scratchpad memory */
 .balign 32

--- a/sw/otbn/crypto/p384_curve_point_valid.s
+++ b/sw/otbn/crypto/p384_curve_point_valid.s
@@ -33,18 +33,6 @@ validate_point:
 
 .data
 
-/* pointer to x-coordinate (dptr_x) */
-.globl dptr_x
-.balign 4
-dptr_x:
-  .zero 4
-
-/* pointer to y-coordinate (dptr_y) */
-.globl dptr_y
-.balign 4
-dptr_y:
-  .zero 4
-
 /* Public key x-coordinate. */
 .globl x
 .balign 32

--- a/sw/otbn/crypto/p384_curve_point_valid.s
+++ b/sw/otbn/crypto/p384_curve_point_valid.s
@@ -26,6 +26,10 @@ start:
   unimp
 
 validate_point:
+  /* Fill gpp registers with pointers to coordinates */
+  la        x20, x
+  la        x21, y
+
   /* Call curve point validation function */
   jal       x1, p384_curve_point_valid
 

--- a/sw/otbn/crypto/p384_curve_point_valid.s
+++ b/sw/otbn/crypto/p384_curve_point_valid.s
@@ -26,10 +26,6 @@ start:
   unimp
 
 validate_point:
-  /* Fill gpp registers with pointers to coordinates */
-  la        x20, x
-  la        x21, y
-
   /* Call curve point validation function */
   jal       x1, p384_curve_point_valid
 

--- a/sw/otbn/crypto/p384_ecdh.s
+++ b/sw/otbn/crypto/p384_ecdh.s
@@ -69,18 +69,10 @@ start:
  * clobbered flag groups: FG0
  */
 keypair_random:
-  /* Fill gpp registers with pointers to key shares */
-  la        x20, d0
-  la        x21, d1
-
   /* Generate secret key d in shares.
        dmem[d0] <= d0
        dmem[d1] <= d1 */
   jal       x1, p384_generate_random_key
-
-  /* Fill gpp registers with pointers to key shares */
-  la        x17, d0
-  la        x19, d1
 
   /* Generate public key d*G.
        dmem[x] <= (d*G).x
@@ -113,17 +105,9 @@ keypair_random:
  * clobbered flag groups: FG0
  */
 shared_key:
-  /* Fill gpp registers with pointers to coordinates */
-  la        x20, x
-  la        x21, y
-
-  /* Fill gpp registers with pointers to scalar shares */
-  la        x17, k0
-  la        x19, k1
-
-    /* Generate arithmetically masked shared key d*Q.
-       dmem[x] <= (d*Q).x - m mod p
-       dmem[y] <= m */
+  /* Generate arithmetically masked shared key d*Q.
+     dmem[x] <= (d*Q).x - m mod p
+     dmem[y] <= m */
   jal       x1, p384_scalar_mult
 
   /* Arithmetic-to-boolean conversion*/

--- a/sw/otbn/crypto/p384_ecdsa_keygen.s
+++ b/sw/otbn/crypto/p384_ecdsa_keygen.s
@@ -28,23 +28,25 @@ start:
  * Returns public key Q = d*G in affine coordinates (x, y).
  *
  * @param[in]       w31: all-zero
- * @param[in]   dmem[0]: dptr_d0, pointer to location in dmem containing
- *                       1st private key share d0
- * @param[in]   dmem[4]: dptr_d1, pointer to location in dmem containing
- *                       2nd private key share d1
- * @param[in]  dmem[20]: dptr_x, pointer to result buffer for x-coordinate
- * @param[in]  dmem[24]: dptr_y, pointer to result buffer for y-coordinate
  * @param[out] dmem[d0]: 1st private key share d0
  * @param[out] dmem[d1]: 2nd private key share d1
  * @param[out]  dmem[x]: Public key x-coordinate
- * @param[out]  dmem[y]: Public key y-coordinate]
+ * @param[out]  dmem[y]: Public key y-coordinate
 
  */
 random_keygen:
+  /* Fill gpp registers with pointers to key shares */
+  la        x20, d0
+  la        x21, d1
+
   /* Generate secret key d in shares.
        dmem[d0] <= d0
        dmem[d1] <= d1 */
   jal       x1, p384_generate_random_key
+
+  /* Fill gpp registers with pointers to key shares */
+  la        x17, d0
+  la        x19, d1
 
   /* Generate public key d*G.
        dmem[x] <= (d*G).x
@@ -54,26 +56,6 @@ random_keygen:
   ecall
 
 .bss
-
-/* pointer to k0 (dptr_k0) */
-.globl dptr_k0
-dptr_k0:
-  .zero 4
-
-/* pointer to k1 (dptr_k1) */
-.globl dptr_k1
-dptr_k1:
-  .zero 4
-
-/* pointer to d0 (dptr_d0) */
-.globl dptr_d0
-dptr_d0:
-  .zero 4
-
-/* pointer to d1 (dptr_d1) */
-.globl dptr_d1
-dptr_d1:
-  .zero 4
 
 /* random scalar first share */
 .globl k0
@@ -98,18 +80,6 @@ d0:
 .balign 32
 d1:
   .zero 64
-
-/* pointer to x-coordinate (dptr_x) */
-.globl dptr_x
-.balign 4
-dptr_x:
-  .zero 4
-
-/* pointer to y-coordinate (dptr_y) */
-.globl dptr_y
-.balign 4
-dptr_y:
-  .zero 4
 
 /* x-coordinate. */
 .globl x

--- a/sw/otbn/crypto/p384_ecdsa_keygen.s
+++ b/sw/otbn/crypto/p384_ecdsa_keygen.s
@@ -35,18 +35,10 @@ start:
 
  */
 random_keygen:
-  /* Fill gpp registers with pointers to key shares */
-  la        x20, d0
-  la        x21, d1
-
   /* Generate secret key d in shares.
        dmem[d0] <= d0
        dmem[d1] <= d1 */
   jal       x1, p384_generate_random_key
-
-  /* Fill gpp registers with pointers to key shares */
-  la        x17, d0
-  la        x19, d1
 
   /* Generate public key d*G.
        dmem[x] <= (d*G).x

--- a/sw/otbn/crypto/p384_ecdsa_sca.s
+++ b/sw/otbn/crypto/p384_ecdsa_sca.s
@@ -26,19 +26,6 @@ start:
 
 .text
 p384_ecdsa_sign:
-  /* Fill gpp registers with pointers to variables required for p384_sign */
-  /* scalar shares */
-  la        x17, k0
-  la        x19, k1
-  /* message */
-  la        x6, msg
-  /* signature values */
-  la        x14, r
-  la        x15, s
-  /* secret key shares */
-  la        x4, d0
-  la        x5, d1
-  
   jal      x1, p384_sign
   ecall
 
@@ -65,13 +52,13 @@ k0:
   .zero 64
 
 /* random scalar k1*/
-.global k1
+.globl k1
 .balign 64
 k1:
   .zero 64
 
 /* randomness for blinding */
-.global rnd
+.globl rnd
 .balign 64
 rnd:
   .zero 64

--- a/sw/otbn/crypto/p384_ecdsa_sca.s
+++ b/sw/otbn/crypto/p384_ecdsa_sca.s
@@ -26,54 +26,25 @@ start:
 
 .text
 p384_ecdsa_sign:
-  jal      x1, p384_ecdsa_setup
+  /* Fill gpp registers with pointers to variables required for p384_sign */
+  /* scalar shares */
+  la        x17, k0
+  la        x19, k1
+  /* message */
+  la        x6, msg
+  /* signature values */
+  la        x14, r
+  la        x15, s
+  /* secret key shares */
+  la        x4, d0
+  la        x5, d1
+  
   jal      x1, p384_sign
   ecall
 
 p384_ecdsa_verify:
   /*jal      x1, p384_verify*/
   ecall
-
-/**
- * Populate the variables rnd and k with randomness, and setup data pointers.
- */
-p384_ecdsa_setup:
-  /* Point dptr_k0 to k0. */
-  la        x10, k0
-  la        x11, dptr_k0
-  sw        x10, 0(x11)
-
-  /* Point dptr_k1 to k1. */
-  la        x10, k1
-  la        x11, dptr_k1
-  sw        x10, 0(x11)
-
-  /* Point dptr_d0 to d0. */
-  la        x10, d0
-  la        x11, dptr_d0
-  sw        x10, 0(x11)
-
-  /* Point dptr_d1 to d1. */
-  la        x10, d1
-  la        x11, dptr_d1
-  sw        x10, 0(x11)
-
-  /* Point dptr_msg to msg. */
-  la        x10, msg
-  la        x11, dptr_msg
-  sw        x10, 0(x11)
-
-  /* Point dptr_r to sig_r. */
-  la        x10, r
-  la        x11, dptr_r
-  sw        x10, 0(x11)
-
-  /* Point dptr_s to sig_s. */
-  la        x10, s
-  la        x11, dptr_s
-  sw        x10, 0(x11)
-
-  ret
 
 .data
 
@@ -152,53 +123,3 @@ d1:
 .balign 64
 x_r:
   .zero 64
-
-/* pointer to rnd (dptr_rnd) */
-.globl dptr_rnd
-dptr_rnd:
-  .zero 4
-
-/* pointer to k0 (dptr_k0) */
-.globl dptr_k0
-dptr_k0:
-  .zero 4
-
-/* pointer to k1 (dptr_k1) */
-.globl dptr_k1
-dptr_k1:
-  .zero 4
-
-/* pointer to msg (dptr_msg) */
-.globl dptr_msg
-dptr_msg:
-  .zero 4
-
-/* pointer to R (dptr_r) */
-.globl dptr_r
-dptr_r:
-  .zero 4
-
-/* pointer to S (dptr_s) */
-.globl dptr_s
-dptr_s:
-  .zero 4
-
-/* pointer to X (dptr_x) */
-.globl dptr_x
-dptr_x:
-  .zero 4
-
-/* pointer to Y (dptr_y) */
-.globl dptr_y
-dptr_y:
-  .zero 4
-
-/* pointer to d0 (dptr_d0) */
-.globl dptr_d0
-dptr_d0:
-  .zero 4
-
-/* pointer to d1 (dptr_d1) */
-.globl dptr_d1
-dptr_d1:
-  .zero 4

--- a/sw/otbn/crypto/p384_ecdsa_sign.s
+++ b/sw/otbn/crypto/p384_ecdsa_sign.s
@@ -34,10 +34,6 @@ start:
  * @param[out]   dmem[s]: s component of signature
  */
 ecdsa_sign:
-  /* Fill gpp registers with pointers to scalar shares */
-  la       x20, k0
-  la       x21, k1
-
   /* Generate a fresh random scalar for signing.
        dmem[k0] <= first share of k
        dmem[k1] <= second share of k */
@@ -45,15 +41,15 @@ ecdsa_sign:
 
   /* Fill gpp registers with pointers to variables required for p384_sign */
   /* scalar shares */
-  la        x17, k0
+  /*la        x17, k0
   la        x19, k1
   /* message */
-  la        x6, msg
+  /*la        x6, msg
   /* signature values */
-  la        x14, r
+  /*la        x14, r
   la        x15, s
   /* secret key shares */
-  la        x4, d0
+  /*la        x4, d0
   la        x5, d1
 
   /* Generate the signature. */

--- a/sw/otbn/crypto/p384_ecdsa_sign.s
+++ b/sw/otbn/crypto/p384_ecdsa_sign.s
@@ -25,27 +25,36 @@ start:
  * P-384 ECDSA signature generation.
  * Generate the secret scalar k from a random seed.
  *
- * @param[in]  dmem[0]: dptr_k0, pointer to location in dmem containing
- *                      1st scalar share k0
- * @param[in]  dmem[4]: dptr_k1, pointer to location in dmem containing
- *                      2nd scalar share k1
- * @param[in]  dmem[8]: dptr_msg, pointer to the message to be signed in dmem
- * @param[in]  dmem[12]: dptr_r, pointer to dmem location where s component
- *                               of signature will be placed
- * @param[in]  dmem[16]: dptr_s, pointer to dmem location where r component
- *                               of signature will be placed
- * @param[in]  dmem[28]: dptr_d0, pointer to location in dmem containing
- *                      1st private key share d0
- * @param[in]  dmem[32]: dptr_d1, pointer to location in dmem containing
- *                      2nd private key share d1
- * @param[out] dmem[r]: r component of signature
- * @param[out] dmem[s]: s component of signature
+ * @param[in]   dmem[k0]: 1st scalar share k0
+ * @param[in]   dmem[k1]: 2nd scalar share k1
+ * @param[in]  dmem[msg]: message to be signed in dmem
+ * @param[in]   dmem[d0]: 1st private key share d0
+ * @param[in]   dmem[d1]: 2nd private key share d1
+ * @param[out]   dmem[r]: r component of signature
+ * @param[out]   dmem[s]: s component of signature
  */
 ecdsa_sign:
+  /* Fill gpp registers with pointers to scalar shares */
+  la       x20, k0
+  la       x21, k1
+
   /* Generate a fresh random scalar for signing.
        dmem[k0] <= first share of k
        dmem[k1] <= second share of k */
   jal      x1, p384_generate_k
+
+  /* Fill gpp registers with pointers to variables required for p384_sign */
+  /* scalar shares */
+  la        x17, k0
+  la        x19, k1
+  /* message */
+  la        x6, msg
+  /* signature values */
+  la        x14, r
+  la        x15, s
+  /* secret key shares */
+  la        x4, d0
+  la        x5, d1
 
   /* Generate the signature. */
   jal      x1, p384_sign
@@ -53,53 +62,6 @@ ecdsa_sign:
   ecall
 
 .bss
-
-/* pointer to x-coordinate (dptr_x) */
-.globl dptr_x
-.balign 4
-dptr_x:
-  .zero 4
-
-/* pointer to y-coordinate (dptr_y) */
-.globl dptr_y
-.balign 4
-dptr_y:
-  .zero 4
-
-/* pointer to k0 (dptr_k0) */
-.globl dptr_k0
-dptr_k0:
-  .zero 4
-
-/* pointer to k1 (dptr_k1) */
-.globl dptr_k1
-dptr_k1:
-  .zero 4
-
-/* pointer to d0 (dptr_d0) */
-.globl dptr_d0
-dptr_d0:
-  .zero 4
-
-/* pointer to d1 (dptr_d1) */
-.globl dptr_d1
-dptr_d1:
-  .zero 4
-
-/* pointer to msg (dptr_msg) */
-.globl dptr_msg
-dptr_msg:
-  .zero 4
-
-/* pointer to R (dptr_r) */
-.globl dptr_r
-dptr_r:
-  .zero 4
-
-/* pointer to S (dptr_s) */
-.globl dptr_s
-dptr_s:
-  .zero 4
 
 /* x-coordinate. */
 .globl x

--- a/sw/otbn/crypto/p384_ecdsa_verify.s
+++ b/sw/otbn/crypto/p384_ecdsa_verify.s
@@ -33,13 +33,11 @@ start:
  * host side. The signature is valid if x1 == r.
  * This routine runs in variable time.
  *
- * @param[in]  dmem[4]: dptr_rnd, pointer to dmem location where the reduced
- *                           affine x1-coordinate will be stored
- * @param[in]  dmem[8]: dptr_msg, pointer to the message to be verified in dmem
- * @param[in]  dmem[12]: dptr_r, pointer to r of signature in dmem
- * @param[in]  dmem[16]: dptr_s, pointer to s of signature in dmem
- * @param[in]  dmem[20]: dptr_x, pointer to x-coordinate of public key in dmem
- * @param[in]  dmem[20]: dptr_y, pointer to y-coordinate of public key in dmem
+ * @param[in]  dmem[msg]: message to be verified
+ * @param[in]    dmem[r]: r part of signature
+ * @param[in]    dmem[s]: s part of signature
+ * @param[in]    dmem[x]: x-coordinate of public key
+ * @param[in]    dmem[y]: y-coordinate of public key
  * @param[out] dmem[rnd]: x1 coordinate to be compared to rs
  *
  * !!! Attention !!! - before signature verification p384_curve_point_valid
@@ -47,44 +45,24 @@ start:
  *
  */
 ecdsa_verify:
+  /* Fill gpp registers with pointers to variables required for p384_verify */
+  /* signature values */
+  la        x6, r
+  la        x7, s
+  /* reduced x1-coordinate */
+  la        x8, rnd
+  /* message */
+  la        x9, msg
+  /* public key coordinates*/
+  la        x13, x
+  la        x14, y
+
   /* Verify the signature (compute x1). */
   jal      x1, p384_verify
 
   ecall
 
 .bss
-
-/* pointer to x-coordinate (dptr_x) */
-.globl dptr_x
-.balign 4
-dptr_x:
-  .zero 4
-
-/* pointer to y-coordinate (dptr_y) */
-.globl dptr_y
-.balign 4
-dptr_y:
-  .zero 4
-
-/* pointer to rnd (dptr_rnd) */
-.globl dptr_rnd
-dptr_rnd:
-  .zero 4
-
-/* pointer to msg (dptr_msg) */
-.globl dptr_msg
-dptr_msg:
-  .zero 4
-
-/* pointer to R (dptr_r) */
-.globl dptr_r
-dptr_r:
-  .zero 4
-
-/* pointer to S (dptr_s) */
-.globl dptr_s
-dptr_s:
-  .zero 4
 
 /* result of verify (x1 coordinate) */
 .globl rnd

--- a/sw/otbn/crypto/p384_ecdsa_verify.s
+++ b/sw/otbn/crypto/p384_ecdsa_verify.s
@@ -45,18 +45,6 @@ start:
  *
  */
 ecdsa_verify:
-  /* Fill gpp registers with pointers to variables required for p384_verify */
-  /* signature values */
-  la        x6, r
-  la        x7, s
-  /* reduced x1-coordinate */
-  la        x8, rnd
-  /* message */
-  la        x9, msg
-  /* public key coordinates*/
-  la        x13, x
-  la        x14, y
-
   /* Verify the signature (compute x1). */
   jal      x1, p384_verify
 

--- a/sw/otbn/crypto/p384_ecdsa_verify.s
+++ b/sw/otbn/crypto/p384_ecdsa_verify.s
@@ -38,7 +38,7 @@ start:
  * @param[in]    dmem[s]: s part of signature
  * @param[in]    dmem[x]: x-coordinate of public key
  * @param[in]    dmem[y]: y-coordinate of public key
- * @param[out] dmem[rnd]: x1 coordinate to be compared to rs
+ * @param[out] dmem[x_r]: x1 coordinate to be compared to rs
  *
  * !!! Attention !!! - before signature verification p384_curve_point_valid
  * binary has to be executed to check if the provided public key is valid.
@@ -53,9 +53,9 @@ ecdsa_verify:
 .bss
 
 /* result of verify (x1 coordinate) */
-.globl rnd
+.globl x_r
 .balign 32
-rnd:
+x_r:
   .zero 64
 
 .data

--- a/sw/otbn/crypto/p384_internal_mult.s
+++ b/sw/otbn/crypto/p384_internal_mult.s
@@ -68,8 +68,8 @@ store_proj_randomize:
 
   /* fetch x-coordinate from dmem
      [w16, w17] = x <= [dmem[dptr_x], dmem[dptr_x+32]] */
-  li x12, 16
-  li x13, 17
+  li        x12, 16
+  li        x13, 17
   bn.lid    x12,  0(x20)
   bn.lid    x13, 32(x20)
 

--- a/sw/otbn/crypto/p384_isoncurve.s
+++ b/sw/otbn/crypto/p384_isoncurve.s
@@ -131,10 +131,8 @@ p384_isoncurve:
  * This routine raises a software error and halts operation if the curve point
  * is invalid.
  *
- * @param[in]  x20: dptr_x, pointer to dmem location containing affine
- *                          x-coordinate of input point
- * @param[in]  x21: dptr_y, pointer to dmem location containing affine
- *                          y-coordinate of input point
+ * @param[in]  dmem[x]: affine x-coordinate of input point in dmem
+ * @param[in]  dmem[y]: affine y-coordinate of input point in dmem
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
@@ -145,6 +143,12 @@ p384_isoncurve:
 p384_curve_point_valid:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
+
+  /* set dmem pointer to point x-coordinate */
+  la        x20, x
+
+  /* set dmem pointer to point y-coordinate */
+  la        x21, y
 
   /* load domain parameter p (modulus)
      [w13, w12] = p = dmem[p384_p] */
@@ -244,6 +248,20 @@ p384_curve_point_valid:
   ret
 
 .data
+
+/* x-coordinate */
+.globl x
+.weak x
+.balign 32
+x:
+  .zero 64
+
+/* y-coordinate */
+.globl y
+.weak y
+.balign 32
+y:
+  .zero 64
 
 /* Right side of Weierstrass equation */
 .globl rhs

--- a/sw/otbn/crypto/p384_keygen.s
+++ b/sw/otbn/crypto/p384_keygen.s
@@ -151,16 +151,22 @@ p384_random_scalar:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * @param[in]  x20: dptr_d0, pointer to bufffer of 1st private key share d0
- * @param[in]  x21: dptr_d1, pointer to bufffer of 2nd private key share d1
+ * @param[out]  dmem[d0]: 1st private key share d0
+ * @param[out]  dmem[d1]: 2nd private key share d1
  *
- * clobbered registers: x2, x3, x20, w4 to w11, w14, w16 to w28
+ * clobbered registers: x2, x3, x20, x21, w4 to w11, w14, w16 to w28
  * clobbered flag groups: FG0
  */
 .globl p384_generate_random_key
 p384_generate_random_key:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
+
+  /* set dmem pointer to 1st private key share d0 */
+  la        x20, d0
+
+  /* set dmem pointer to 1st private key share d1 */
+  la        x21, d1
 
   /* Generate a random scalar in two 448-bit shares.
      [w7,w6] <= d0
@@ -185,16 +191,22 @@ p384_generate_random_key:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * @param[in]  x20: dptr_k0, pointer to bufffer of 1st scalar share k0
- * @param[in]  x21: dptr_k1, pointer to bufffer of 2nd scalar share k1
+ * @param[out]  dmem[k0]: 1st scalar share k0
+ * @param[out]  dmem[k1]: 2nd scalar share k1
  *
- * clobbered registers: x2, x3, x20, w4 to w11, w14, w16 to w28
+ * clobbered registers: x2, x3, x20, x21, w4 to w11, w14, w16 to w28
  * clobbered flag groups: FG0
  */
 .globl p384_generate_k
 p384_generate_k:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
+
+  /* set dmem pointer to 1st scalar share k0 */
+  la        x20, k0
+
+  /* set dmem pointer to 1st scalar share k1 */
+  la        x21, k1
 
   /* Generate a random scalar in two 448-bit shares.
      [w7,w6] <= k0
@@ -213,3 +225,31 @@ p384_generate_k:
   bn.sid    x2++, 32(x21)
 
   ret
+
+.section .data
+
+.balign 32
+
+/* 1st scalar share d0 */
+.globl k0
+.weak k0
+k0:
+  .zero 64
+
+/* 2nd scalar share d1 */
+.globl k1
+.weak k1
+k1:
+  .zero 64
+
+/* 1st private key share d0 */
+.globl d0
+.weak d0
+d0:
+  .zero 64
+
+/* 2nd private key share d1 */
+.globl d1
+.weak d1
+d1:
+  .zero 64

--- a/sw/otbn/crypto/p384_keygen.s
+++ b/sw/otbn/crypto/p384_keygen.s
@@ -151,10 +151,8 @@ p384_random_scalar:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * @param[in]  dmem[0]: dptr_d0, pointer to location in dmem containing
- *                      1st private key share d0
- * @param[in]  dmem[4]: dptr_d1, pointer to location in dmem containing
- *                      2nd private key share d1
+ * @param[in]  x20: dptr_d0, pointer to bufffer of 1st private key share d0
+ * @param[in]  x21: dptr_d1, pointer to bufffer of 2nd private key share d1
  *
  * clobbered registers: x2, x3, x20, w4 to w11, w14, w16 to w28
  * clobbered flag groups: FG0
@@ -171,18 +169,14 @@ p384_generate_random_key:
 
   /* Write first share to DMEM.
      dmem[d0] <= [w7,w6] = d0 */
-  la        x20, dptr_d0
-  lw        x20, 0(x20)
   li        x2, 6
   bn.sid    x2++, 0(x20)
   bn.sid    x2++, 32(x20)
 
   /* Write second share to DMEM.
      dmem[d1] <= [w9,w8] = d1 */
-  la        x20, dptr_d1
-  lw        x20, 0(x20)
-  bn.sid    x2++, 0(x20)
-  bn.sid    x2++, 32(x20)
+  bn.sid    x2++, 0(x21)
+  bn.sid    x2++, 32(x21)
 
   ret
 
@@ -191,10 +185,8 @@ p384_generate_random_key:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * @param[in]  dmem[0]: dptr_k0, pointer to location in dmem containing
- *                      1st scalar share k0
- * @param[in]  dmem[4]: dptr_k1, pointer to location in dmem containing
- *                      2nd scalar share k1
+ * @param[in]  x20: dptr_k0, pointer to bufffer of 1st scalar share k0
+ * @param[in]  x21: dptr_k1, pointer to bufffer of 2nd scalar share k1
  *
  * clobbered registers: x2, x3, x20, w4 to w11, w14, w16 to w28
  * clobbered flag groups: FG0
@@ -211,46 +203,13 @@ p384_generate_k:
 
   /* Write first share to DMEM.
      dmem[k0] <= [w7,w6] = k0 */
-  la        x20, dptr_k0
-  lw        x20, 0(x20)
   li        x2, 6
   bn.sid    x2++, 0(x20)
   bn.sid    x2++, 32(x20)
 
   /* Write second share to DMEM.
      dmem[k1] <= [w9,w8] = k1 */
-  la        x20, dptr_k1
-  lw        x20, 0(x20)
-  bn.sid    x2++, 0(x20)
-  bn.sid    x2++, 32(x20)
+  bn.sid    x2++, 0(x21)
+  bn.sid    x2++, 32(x21)
 
   ret
-
-/* pointers */
-.section .data
-
-.balign 32
-
-/* pointer to k0 (dptr_k0) */
-.globl dptr_k0
-.weak dptr_k0
-dptr_k0:
-  .zero 4
-
-/* pointer to k1 (dptr_k1) */
-.globl dptr_k1
-.weak dptr_k1
-dptr_k1:
-  .zero 4
-
-/* pointer to d0 (dptr_d0) */
-.globl dptr_d0
-.weak dptr_d0
-dptr_d0:
-  .zero 4
-
-/* pointer to d1 (dptr_d1) */
-.globl dptr_d1
-.weak dptr_d1
-dptr_d1:
-  .zero 4

--- a/sw/otbn/crypto/p384_scalar_mult.s
+++ b/sw/otbn/crypto/p384_scalar_mult.s
@@ -19,12 +19,12 @@
  * Sets up context and calls the internal scalar multiplication routine.
  * This routine runs in constant time.
  *
- * @param[in]   dmem[0]: dptr_k0, pointer to location in dmem containing
- *                       1st scalar share k0
- * @param[in]   dmem[4]: dptr_k1, pointer to location in dmem containing
- *                       2nd scalar share k1
- * @param[in]  dmem[20]: dptr_x, pointer to affine x-coordinate in dmem
- * @param[in]  dmem[22]: dptr_y, pointer to affine y-coordinate in dmem
+ * @param[in]   x20:     dptr_x, pointer to affine x-coordinate in dmem
+ * @param[in]   x21:     dptr_y, pointer to affine y-coordinate in dmem
+ * @param[in]   x17:     dptr_k0, pointer to location in dmem containing
+ *                                1st scalar share k0
+ * @param[in]   x19:     dptr_k1, pointer to location in dmem containing
+ *                                2nd scalar share k1
  * @param[out]  dmem[x]: masked x coordinate of R
  * @param[out]  dmem[y]: corresponding mask
  *
@@ -43,22 +43,6 @@ p384_scalar_mult:
 
   /* Init all-zero register. */
   bn.xor  w31, w31, w31
-
-  /* set dmem pointer to point x-coordinate */
-  la        x20, dptr_x
-  lw        x20, 0(x20)
-
-  /* set dmem pointer to point y-coordinate */
-  la        x21, dptr_y
-  lw        x21, 0(x21)
-
-  /* set dmem pointer to 1st scalar share k0 */
-  la        x17, dptr_k0
-  lw        x17, 0(x17)
-
-  /* set dmem pointer to 2nd scalar share k1 */
-  la        x19, dptr_k1
-  lw        x19, 0(x19)
 
   /* set dmem pointer to domain parameter b */
   la        x28, p384_b
@@ -178,46 +162,8 @@ p384_scalar_mult:
 
   ret
 
-/* pointers and scratchpad memory */
+/* scratchpad memory */
 .section .data
-
-.balign 32
-
-  /* pointer to k0 (dptr_k0) */
-.globl dptr_k0
-.weak dptr_k0
-dptr_k0:
-  .zero 4
-
-/* pointer to k1 (dptr_k1) */
-.globl dptr_k1
-.weak dptr_k1
-dptr_k1:
-  .zero 4
-
-/* pointer to d0 (dptr_d0) */
-.globl dptr_d0
-.weak dptr_d0
-dptr_d0:
-  .zero 4
-
-/* pointer to d1 (dptr_d1) */
-.globl dptr_d1
-.weak dptr_d1
-dptr_d1:
-  .zero 4
-
-/* pointer to X (dptr_x) */
-.globl dptr_x
-.weak dptr_x
-dptr_x:
-  .zero 4
-
-/* pointer to Y (dptr_y) */
-.globl dptr_y
-.weak dptr_y
-dptr_y:
-  .zero 4
 
 /* 704 bytes of scratchpad memory */
 .balign 32

--- a/sw/otbn/crypto/p384_scalar_mult.s
+++ b/sw/otbn/crypto/p384_scalar_mult.s
@@ -19,12 +19,10 @@
  * Sets up context and calls the internal scalar multiplication routine.
  * This routine runs in constant time.
  *
- * @param[in]   x20:     dptr_x, pointer to affine x-coordinate in dmem
- * @param[in]   x21:     dptr_y, pointer to affine y-coordinate in dmem
- * @param[in]   x17:     dptr_k0, pointer to location in dmem containing
- *                                1st scalar share k0
- * @param[in]   x19:     dptr_k1, pointer to location in dmem containing
- *                                2nd scalar share k1
+ * @param[in]   dmem[x]: affine x-coordinate in dmem
+ * @param[in]   dmem[y]: affine y-coordinate in dmem
+ * @param[in]  dmem[k0]: 1st scalar share k0 in dmem
+ * @param[in]  dmem[k1]: 2nd scalar share k1 in dmem
  * @param[out]  dmem[x]: masked x coordinate of R
  * @param[out]  dmem[y]: corresponding mask
  *
@@ -34,7 +32,7 @@
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x9 to x13, x18 to x21, x26 to x30
+ * clobbered registers: x2, x3, x9 to x13, x17 to x21, x26 to x30
  *                      w0 to w30
  * clobbered flag groups: FG0
  */
@@ -49,6 +47,18 @@ p384_scalar_mult:
 
   /* set dmem pointer to scratchpad */
   la        x30, scratchpad
+
+  /* set dmem pointer to point to x-coordinate */
+  la       x20, x
+
+  /* set dmem pointer to point to y-coordinate */
+  la       x21, y
+
+  /* set dmem pointer to point to 1st scalar share k0 */
+  la       x17, k0
+
+  /* set dmem pointer to point to 2nd scalar share k1 */
+  la       x19, k1
 
   /* load domain parameter p (modulus)
      [w13, w12] = p = dmem[p384_p] */
@@ -164,6 +174,32 @@ p384_scalar_mult:
 
 /* scratchpad memory */
 .section .data
+
+.balign 32
+
+/* 1st scalar share d0 */
+.globl k0
+.weak k0
+k0:
+  .zero 64
+
+/* 2nd scalar share d1 */
+.globl k1
+.weak k1
+k1:
+  .zero 64
+
+/* x-coordinate */
+.globl x
+.weak x
+x:
+  .zero 64
+
+/* y-coordinate */
+.globl y
+.weak y
+y:
+  .zero 64
 
 /* 704 bytes of scratchpad memory */
 .balign 32

--- a/sw/otbn/crypto/p384_sign.s
+++ b/sw/otbn/crypto/p384_sign.s
@@ -22,19 +22,19 @@
  *
  * This routine runs in constant time.
  *
- * @param[in]  dmem[0]: dptr_k0, pointer to location in dmem containing
- *                      1st scalar share k0
- * @param[in]  dmem[4]: dptr_k1, pointer to location in dmem containing
- *                      2nd scalar share k1
- * @param[in]  dmem[8]: dptr_msg, pointer to the message to be signed in dmem
- * @param[in]  dmem[12]: dptr_r, pointer to dmem location where s component
- *                               of signature will be placed
- * @param[in]  dmem[16]: dptr_s, pointer to dmem location where r component
- *                               of signature will be placed
- * @param[in]  dmem[28]: dptr_d0, pointer to location in dmem containing
- *                      1st private key share d0
- * @param[in]  dmem[32]: dptr_d1, pointer to location in dmem containing
- *                      2nd private key share d1
+ * @param[in]  x17:  dptr_k0, pointer to location in dmem containing
+ *                            1st scalar share k0
+ * @param[in]  x19:  dptr_k1, pointer to location in dmem containing
+ *                            2nd scalar share k1
+ * @param[in]   x6:  dptr_msg, pointer to the message to be signed in dmem
+ * @param[in]  x14:  dptr_r, pointer to dmem location where s component
+ *                           of signature will be placed
+ * @param[in]  x15:  dptr_s, pointer to dmem location where r component
+ *                           of signature will be placed
+ * @param[in]   x4:  dptr_d0, pointer to location in dmem containing
+ *                            1st private key share d0
+ * @param[in]   x5:  dptr_d1, pointer to location in dmem containing
+ *                            2nd private key share d1
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
@@ -55,34 +55,6 @@ p384_sign:
 
   /* get dmem pointer of base point y-coordinate */
   la        x21, p384_gy
-
-  /* get dmem pointer of 1st scalar share k0 */
-  la        x17, dptr_k0
-  lw        x17, 0(x17)
-
-  /* get dmem pointer of 2nd scalar share k1 */
-  la        x19, dptr_k1
-  lw        x19, 0(x19)
-
-  /* get dmem pointer of 1st private key share d0 */
-  la        x4, dptr_d0
-  lw        x4, 0(x4)
-
-  /* get dmem pointer of 2nd private key share d1 */
-  la        x5, dptr_d1
-  lw        x5, 0(x5)
-
-  /* get dmem pointer of message msg */
-  la        x6, dptr_msg
-  lw        x6, 0(x6)
-
-  /* get dmem pointer of signature r */
-  la        x14, dptr_r
-  lw        x14, 0(x14)
-
-  /* get dmem pointer of signature s */
-  la        x15, dptr_s
-  lw        x15, 0(x15)
 
   /* get dmem pointer of scratchpad */
   la        x30, scratchpad
@@ -266,64 +238,8 @@ p384_sign:
   ret
 
 
-/* pointers and scratchpad memory */
+/* scratchpad memory */
 .section .data
-
-.balign 32
-
-/* pointer to k0 (dptr_k0) */
-.globl dptr_k0
-.weak dptr_k0
-dptr_k0:
-  .zero 4
-
-/* pointer to k1 (dptr_k1) */
-.globl dptr_k1
-.weak dptr_k1
-dptr_k1:
-  .zero 4
-
-/* pointer to msg (dptr_msg) */
-.globl dptr_msg
-.weak dptr_msg
-dptr_msg:
-  .zero 4
-
-/* pointer to R (dptr_r) */
-.globl dptr_r
-.weak dptr_r
-dptr_r:
-  .zero 4
-
-/* pointer to S (dptr_s) */
-.globl dptr_s
-.weak dptr_s
-dptr_s:
-  .zero 4
-
-/* pointer to X (dptr_x) */
-.globl dptr_x
-.weak dptr_x
-dptr_x:
-  .zero 4
-
-/* pointer to Y (dptr_y) */
-.globl dptr_y
-.weak dptr_y
-dptr_y:
-  .zero 4
-
-/* pointer to d0 (dptr_d0) */
-.globl dptr_d0
-.weak dptr_d0
-dptr_d0:
-  .zero 4
-
-/* pointer to d1 (dptr_d1) */
-.globl dptr_d1
-.weak dptr_d1
-dptr_d1:
-  .zero 4
 
 /* 704 bytes of scratchpad memory */
 .balign 32

--- a/sw/otbn/crypto/p384_sign.s
+++ b/sw/otbn/crypto/p384_sign.s
@@ -22,19 +22,13 @@
  *
  * This routine runs in constant time.
  *
- * @param[in]  x17:  dptr_k0, pointer to location in dmem containing
- *                            1st scalar share k0
- * @param[in]  x19:  dptr_k1, pointer to location in dmem containing
- *                            2nd scalar share k1
- * @param[in]   x6:  dptr_msg, pointer to the message to be signed in dmem
- * @param[in]  x14:  dptr_r, pointer to dmem location where s component
- *                           of signature will be placed
- * @param[in]  x15:  dptr_s, pointer to dmem location where r component
- *                           of signature will be placed
- * @param[in]   x4:  dptr_d0, pointer to location in dmem containing
- *                            1st private key share d0
- * @param[in]   x5:  dptr_d1, pointer to location in dmem containing
- *                            2nd private key share d1
+ * @param[in]  dmem[k0]: 1st scalar share k0 in dmem
+ * @param[in]  dmem[k1]: 2nd scalar share k1 in dmem
+ * @param[in] dmem[msg]: message to be signed in dmem
+ * @param[in]  dmem[d0]: 1st private key share d0 in dmem
+ * @param[in]  dmem[d1]: 2nd private key share d1 in dmem
+ * @param[out]  dmem[r]: r component of signature
+ * @param[out]  dmem[s]: s component of signature
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
@@ -58,6 +52,27 @@ p384_sign:
 
   /* get dmem pointer of scratchpad */
   la        x30, scratchpad
+
+  /* get dmem pointer of 1st scalar share k0 */
+  la        x17, k0
+
+  /* get dmem pointer of 1st scalar share k1 */
+  la        x19, k1
+
+  /* get dmem pointer of message */
+  la        x6, msg
+
+  /* get dmem pointer of r component */
+  la        x14, r
+
+  /* get dmem pointer of s component */
+  la        x15, s
+
+  /* get dmem pointer of 1st private key share d0 */
+  la        x4, d0
+
+  /* get dmem pointer of 1st private key share d0 */
+  la        x5, d1
 
   /* load domain parameter p (modulus)
      [w13, w12] <= p = dmem[dptr_p] */
@@ -240,6 +255,50 @@ p384_sign:
 
 /* scratchpad memory */
 .section .data
+
+.balign 32
+
+/* message to be signed */
+.globl msg
+.weak msg
+msg:
+  .zero 64
+
+/* r component of signature */
+.globl r
+.weak r
+r:
+  .zero 64
+
+/* s component of signature */
+.globl s
+.weak s
+s:
+  .zero 64
+
+/* 1st scalar share d0 */
+.globl k0
+.weak k0
+k0:
+  .zero 64
+
+/* 2nd scalar share d1 */
+.globl k1
+.weak k1
+k1:
+  .zero 64
+
+/* 1st private key share d0 */
+.globl d0
+.weak d0
+d0:
+  .zero 64
+
+/* 2nd private key share d1 */
+.globl d1
+.weak d1
+d1:
+  .zero 64
 
 /* 704 bytes of scratchpad memory */
 .balign 32

--- a/sw/otbn/crypto/p384_verify.s
+++ b/sw/otbn/crypto/p384_verify.s
@@ -95,13 +95,12 @@ store_proj:
  * host side. The signature is valid if x1 == r.
  * This routine runs in variable time.
  *
- * @param[in]  x6:  dptr_r, pointer to r of signature in dmem
- * @param[in]  x7:  dptr_s, pointer to s of signature in dmem
- * @param[in]  x8:  dptr_rnd, pointer to dmem location where the reduced
- *                            affine x1-coordinate will be stored
- * @param[in]  x9:  dptr_msg, pointer to the message to be verified in dmem
- * @param[in]  x13: dptr_x, pointer to x-coordinate of public key in dmem
- * @param[in]  x14: dptr_y, pointer to y-coordinate of public key in dmem
+ * @param[in]    dmem[r]: r component of signature in dmem
+ * @param[in]    dmem[s]: s component of signature in dmem
+ * @param[in]  dmem[msg]: message to be verified in dmem
+ * @param[in]    dmem[x]: x-coordinate of public key in dmem
+ * @param[in]    dmem[y]: y-coordinate of public key in dmem
+ * @param[out] dmem[rnd]: verification result: reduced affine x1-coordinate
  *
  * Scratchpad memory layout:
  * The routine expects at least 896 bytes of scratchpad memory at dmem
@@ -124,6 +123,24 @@ p384_verify:
 
   /* init all-zero reg */
   bn.xor    w31, w31, w31
+
+  /* get dmem pointer of r component */
+  la        x6, r
+
+  /* get dmem pointer of s component */
+  la        x7, s
+
+  /* get dmem pointer of verification result (x1-coordinate) */
+  la        x8, rnd
+
+  /* get dmem pointer of message */
+  la        x9, msg
+
+  /* get dmem pointer of public key x-coordinate */
+  la        x13, x
+
+  /* get dmem pointer of public key y-coordinate */
+  la        x14, y
 
   /* load domain parameter n (order of base point)
      [w13, w12] <= n = dmem[p384_n] */
@@ -406,6 +423,44 @@ fail:
 
 /* scratchpad memory */
 .section .data
+
+.balign 32
+
+/* message to be signed */
+.globl msg
+.weak msg
+msg:
+  .zero 64
+
+/* r component of signature */
+.globl r
+.weak r
+r:
+  .zero 64
+
+/* s component of signature */
+.globl s
+.weak s
+s:
+  .zero 64
+
+/* public key x-coordinate */
+.globl x
+.weak x
+x:
+  .zero 64
+
+/* public key y-coordinate */
+.globl y
+.weak y
+y:
+  .zero 64
+
+/* verification result (x1-coordinate) */
+.globl rnd
+.weak rnd
+rnd:
+  .zero 64
 
 /* Scratchpad memory */
 .balign 32

--- a/sw/otbn/crypto/p384_verify.s
+++ b/sw/otbn/crypto/p384_verify.s
@@ -100,7 +100,7 @@ store_proj:
  * @param[in]  dmem[msg]: message to be verified in dmem
  * @param[in]    dmem[x]: x-coordinate of public key in dmem
  * @param[in]    dmem[y]: y-coordinate of public key in dmem
- * @param[out] dmem[rnd]: verification result: reduced affine x1-coordinate
+ * @param[out] dmem[x_r]: verification result: reduced affine x1-coordinate
  *
  * Scratchpad memory layout:
  * The routine expects at least 896 bytes of scratchpad memory at dmem
@@ -131,7 +131,7 @@ p384_verify:
   la        x7, s
 
   /* get dmem pointer of verification result (x1-coordinate) */
-  la        x8, rnd
+  la        x8, x_r
 
   /* get dmem pointer of message */
   la        x9, msg
@@ -405,7 +405,7 @@ p384_verify:
   bn.sel    w4, w16, w4, C
   bn.sel    w5, w17, w5, C
 
-  /* store affine x-coordinate in dmem: dmem[dptr_rnd] <= x1 = [w5,w4] */
+  /* store affine x-coordinate in dmem: dmem[x_r] <= x1 = [w5,w4] */
   li        x2, 4
   bn.sid    x2++, 0(x8)
   bn.sid    x2++, 32(x8)
@@ -457,9 +457,9 @@ y:
   .zero 64
 
 /* verification result (x1-coordinate) */
-.globl rnd
-.weak rnd
-rnd:
+.globl x_r
+.weak x_r
+x_r:
   .zero 64
 
 /* Scratchpad memory */

--- a/sw/otbn/crypto/tests/p384_base_mult_test.s
+++ b/sw/otbn/crypto/tests/p384_base_mult_test.s
@@ -15,10 +15,6 @@
 .section .text.start
 
 p384_base_mult_test:
-  /* Fill gpp registers with pointers to variables */
-  la        x17, d0
-  la        x19, d1
-
   /* call base point multiplication routine in P-384 lib */
   jal       x1, p384_base_mult
 

--- a/sw/otbn/crypto/tests/p384_base_mult_test.s
+++ b/sw/otbn/crypto/tests/p384_base_mult_test.s
@@ -15,36 +15,19 @@
 .section .text.start
 
 p384_base_mult_test:
-
-  /* set dmem pointer to point to 1st scalar share d0 (private key) */
-  la       x2, d0
-  la       x3, dptr_d0
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to 2nd scalar share d1 (private key) */
-  la       x2, d1
-  la       x3, dptr_d1
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to x-coordinate */
-  la       x2, p1_x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to y-coordinate */
-  la       x2, p1_y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
+  /* Fill gpp registers pointers to variables */
+  la        x17, d0
+  la        x19, d1
 
   /* call base point multiplication routine in P-384 lib */
-  jal      x1, p384_base_mult
+  jal       x1, p384_base_mult
 
   /* load result to WDRs for comparison with reference */
   li        x2, 0
-  la        x3, p1_x
+  la        x3, x
   bn.lid    x2++, 0(x3)
   bn.lid    x2++, 32(x3)
-  la        x3, p1_y
+  la        x3, y
   bn.lid    x2++, 0(x3)
   bn.lid    x2, 32(x3)
 
@@ -54,6 +37,8 @@ p384_base_mult_test:
 .section .data
 
 /* 1st scalar share d0 (448-bit) */
+.globl d0
+.balign 32
 d0:
   .word 0x5c832a51
   .word 0x3eb17c27
@@ -72,6 +57,8 @@ d0:
   .zero 8
 
 /* 2nd scalar share d1 (448-bit) */
+.globl d1
+.balign 32
 d1:
   .word 0x33eae098
   .word 0xd31b18d5
@@ -106,9 +93,13 @@ scalar:
   .zero 16
 
 /* result buffer x-coordinate */
-p1_x:
+.globl x
+.balign 32
+x:
   .zero 64
 
 /* result buffer y-coordinate */
-p1_y:
+.globl y
+.balign 32
+y:
   .zero 64

--- a/sw/otbn/crypto/tests/p384_base_mult_test.s
+++ b/sw/otbn/crypto/tests/p384_base_mult_test.s
@@ -15,7 +15,7 @@
 .section .text.start
 
 p384_base_mult_test:
-  /* Fill gpp registers pointers to variables */
+  /* Fill gpp registers with pointers to variables */
   la        x17, d0
   la        x19, d1
 

--- a/sw/otbn/crypto/tests/p384_curve_point_valid_test.s
+++ b/sw/otbn/crypto/tests/p384_curve_point_valid_test.s
@@ -15,10 +15,6 @@ p384_curve_point_valid_test:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
 
-  /* Fill gpp registers with pointers to variables */
-  la        x20, x
-  la        x21, y
-
   jal       x1, p384_curve_point_valid
 
   ecall

--- a/sw/otbn/crypto/tests/p384_curve_point_valid_test.s
+++ b/sw/otbn/crypto/tests/p384_curve_point_valid_test.s
@@ -3,53 +3,27 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
- * Standalone elliptic curve P-384 ECDH shared key generation test
+ * Standalone test for P-384 curve point test
  *
- * Uses OTBN ECC P-384 lib to perform a scalar multiplication with a valid
- * example curve point and an example scalar. Both scalar and coordinates of
- * the curve point are contained in the .data section below.
- * The x coordinate of the resulting curve point is masked arithmetically
- * with a random value. As the x coorodinate represents the actual
- * shared key, the x coordinate and its mask are then converted from an
- * arithmetic to a boolean masking scheme.
- *
- * The result of boolean unmasking is then compared with the expected shared
- * key value.
+ * Runs the P-384 curve point test to check whether a point (given in affine
+ * space) is a valid P-384 curve point.
  */
 
 .section .text.start
 
 p384_curve_point_valid_test:
-  /* Set  pointer to x coordinate */
-  la        x3, dptr_x
-  la        x4, x
-  sw        x4, 0(x3)
-
-  /* Set  pointer to y coordinate */
-  la        x3, dptr_y
-  la        x4, x
-  sw        x4, 0(x3)
-
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
+
+  /* Fill gpp registers with pointers to variables */
+  la        x20, x
+  la        x21, y
 
   jal       x1, p384_curve_point_valid
 
   ecall
 
 .data
-
-/* pointer to x-coordinate (dptr_x) */
-.globl dptr_x
-.balign 4
-dptr_x:
-  .zero 4
-
-/* pointer to y-coordinate (dptr_y) */
-.globl dptr_y
-.balign 4
-dptr_y:
-  .zero 4
 
 /* Curve point x-coordinate. */
 .globl x

--- a/sw/otbn/crypto/tests/p384_ecdh_shared_key_test.s
+++ b/sw/otbn/crypto/tests/p384_ecdh_shared_key_test.s
@@ -23,38 +23,24 @@ p384_ecdh_shared_key_test:
   /* init all-zero register */
   bn.xor    w31, w31, w31
 
-  /* set dmem pointer to point to x-coordinate */
-  la       x2, p1_x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to y-coordinate */
-  la       x2, p1_y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to 1st scalar share k0 */
-  la       x2, k0
-  la       x3, dptr_k0
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to 2nd scalar share k1 */
-  la       x2, k1
-  la       x3, dptr_k1
-  sw       x2, 0(x3)
+  /* fill gpp registers with pointers to relevant variables */
+  la        x17, k0
+  la        x19, k1
+  la        x20, x
+  la        x21, y
 
   /* call scalar point multiplication routine in P-384 lib */
-  jal      x1, p384_scalar_mult
+  jal       x1, p384_scalar_mult
 
   /* load result to WDRs for unmasking and comparison with reference
      [w12,w11] <= dmem[p1_x] = x_m
      [w19,w18] <= dmem[p1_y] = m */
   li        x2, 11
-  la        x3, p1_x
+  la        x3, x
   bn.lid    x2++, 0(x3)
   bn.lid    x2++, 32(x3)
   li        x2, 18
-  la        x3, p1_y
+  la        x3, y
   bn.lid    x2++, 0(x3)
   bn.lid    x2, 32(x3)
 
@@ -80,8 +66,9 @@ p384_ecdh_shared_key_test:
 
 .balign 32
 
-/* point 1 x-cooridante p1_x */
-p1_x:
+/* point 1 x-cooridante x */
+.globl x
+x:
   .word 0x1a11808b
   .word 0x02e3d5a9
   .word 0x440d8db6
@@ -96,8 +83,9 @@ p1_x:
   .word 0x3af8f1c5
   .zero 16
 
-/* point 1 y-cooridante p1_y*/
-p1_y:
+/* point 1 y-cooridante y*/
+.globl y
+y:
   .word 0xa9f8b96e
   .word 0x82f268be
   .word 0x8e51c662
@@ -113,6 +101,7 @@ p1_y:
   .zero 16
 
 /* 1st scalar share k0 (448-bit) */
+.globl k0
 k0:
   .word 0x5c832a51
   .word 0x3eb17c27
@@ -131,6 +120,7 @@ k0:
   .zero 8
 
 /* 2nd scalar share k1 (448-bit) */
+.globl k1
 k1:
   .word 0x33eae098
   .word 0xd31b18d5

--- a/sw/otbn/crypto/tests/p384_ecdh_shared_key_test.s
+++ b/sw/otbn/crypto/tests/p384_ecdh_shared_key_test.s
@@ -24,7 +24,7 @@ p384_ecdh_shared_key_test:
   bn.xor    w31, w31, w31
 
   /* fill gpp registers with pointers to relevant variables */
-  la        x17, k0
+  /*la        x17, k0
   la        x19, k1
   la        x20, x
   la        x21, y

--- a/sw/otbn/crypto/tests/p384_ecdsa_sign_test.s
+++ b/sw/otbn/crypto/tests/p384_ecdsa_sign_test.s
@@ -14,50 +14,25 @@
 .section .text.start
 
 p384_ecdsa_sign_test:
-
-  /* set dmem pointer to point to 1st scalar share k0 */
-  la       x2, k0
-  la       x3, dptr_k0
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to 2nd scalar share k1 */
-  la       x2, k1
-  la       x3, dptr_k1
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to 1st scalar share d0 (private key) */
-  la       x2, d0
-  la       x3, dptr_d0
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to 2nd scalar share d1 (private key) */
-  la       x2, d1
-  la       x3, dptr_d1
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to message */
-  la       x2, msg
-  la       x3, dptr_msg
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to signature */
-  la       x2, sig_r
-  la       x3, dptr_r
-  sw       x2, 0(x3)
-  la       x2, sig_s
-  la       x3, dptr_s
-  sw       x2, 0(x3)
+  /* Fill gpp registers with pointers to variables */
+  la        x17, k0
+  la        x19, k1
+  la        x6, msg
+  la        x14, r
+  la        x15, s
+  la        x4, d0
+  la        x5, d1
 
   /* call ECDSA signing subroutine in P-384 lib */
-  jal      x1, p384_sign
+  jal       x1, p384_sign
 
   /* load signature to wregs for comparison with reference */
   li        x2, 0
-  la        x3, sig_r
+  la        x3, r
   bn.lid    x2++, 0(x3)
   bn.lid    x2, 32(x3)
   li        x2, 2
-  la        x3, sig_s
+  la        x3, s
   bn.lid    x2++, 0(x3)
   bn.lid    x2, 32(x3)
 
@@ -187,9 +162,9 @@ msg:
   .zero 16
 
 /* signature R */
-sig_r:
+r:
   .zero 64
 
 /* signature S */
-sig_s:
+s:
   .zero 64

--- a/sw/otbn/crypto/tests/p384_ecdsa_sign_test.s
+++ b/sw/otbn/crypto/tests/p384_ecdsa_sign_test.s
@@ -14,15 +14,6 @@
 .section .text.start
 
 p384_ecdsa_sign_test:
-  /* Fill gpp registers with pointers to variables */
-  la        x17, k0
-  la        x19, k1
-  la        x6, msg
-  la        x14, r
-  la        x15, s
-  la        x4, d0
-  la        x5, d1
-
   /* call ECDSA signing subroutine in P-384 lib */
   jal       x1, p384_sign
 
@@ -42,6 +33,7 @@ p384_ecdsa_sign_test:
 .data
 
 /* 1st scalar share k0 (448-bit) */
+.globl k0
 k0:
   .word 0x5c832a51
   .word 0x3eb17c27
@@ -60,6 +52,7 @@ k0:
   .zero 8
 
 /* 2nd scalar share k1 (448-bit) */
+.globl k1
 k1:
   .word 0xe50b5e8e
   .word 0x776ad076
@@ -94,6 +87,7 @@ nonce_k:
   .zero 16
 
 /* 1st private key share d0 (448-bit) */
+.globl d0
 d0:
   .word 0x5c832a51
   .word 0x3eb17c27
@@ -112,6 +106,7 @@ d0:
   .zero 8
 
 /* 2nd private key share d1 (448-bit) */
+.globl d1
 d1:
   .word 0x33eae098
   .word 0xd31b18d5
@@ -146,6 +141,7 @@ priv_key_d:
   .zero 16
 
 /* message */
+.globl msg
 msg:
   .word 0x55555555
   .word 0x55555555
@@ -162,9 +158,11 @@ msg:
   .zero 16
 
 /* signature R */
+.globl r
 r:
   .zero 64
 
 /* signature S */
+.globl s
 s:
   .zero 64

--- a/sw/otbn/crypto/tests/p384_ecdsa_verify_test.s
+++ b/sw/otbn/crypto/tests/p384_ecdsa_verify_test.s
@@ -14,14 +14,6 @@
 .section .text.start
 
 p384_ecdsa_verify_test:
-  /* Fill gpp registers with pointers to variables */
-  la        x6, r
-  la        x7, s
-  la        x8, rnd
-  la        x9, msg
-  la        x13, x
-  la        x14, y
-
   /* call ECDSA signature verification subroutine in P-384 lib */
   jal      x1, p384_verify
 
@@ -37,6 +29,7 @@ p384_ecdsa_verify_test:
 .data
 
 /* message */
+.globl msg
 msg:
   .word 0x55555555
   .word 0x55555555
@@ -53,6 +46,7 @@ msg:
   .zero 16
 
 /* signature R */
+.globl r
 r:
   .word 0xb68c28d8
   .word 0x2b23ce3a
@@ -69,6 +63,7 @@ r:
   .zero 16
 
 /* signature S */
+.globl s
 s:
   .word 0x24bc1bf9
   .word 0x752042f5
@@ -85,6 +80,7 @@ s:
   .zero 16
 
 /* public key x-coordinate */
+.globl x
 x:
   .word 0x4877f3d1
   .word 0x7b829460
@@ -101,6 +97,7 @@ x:
   .zero 16
 
 /* public key y-coordinate */
+.globl y
 y:
   .word 0xc181f90f
   .word 0xc31ef079
@@ -117,5 +114,6 @@ y:
   .zero 16
 
 /* signature verification result x_res (rnd) */
+.globl rnd
 rnd:
   .zero 64

--- a/sw/otbn/crypto/tests/p384_ecdsa_verify_test.s
+++ b/sw/otbn/crypto/tests/p384_ecdsa_verify_test.s
@@ -19,7 +19,7 @@ p384_ecdsa_verify_test:
 
   /* load signature to wregs for comparison with reference */
   li        x2, 0
-  la        x3, rnd
+  la        x3, x_r
   bn.lid    x2++, 0(x3)
   bn.lid    x2, 32(x3)
 
@@ -113,7 +113,7 @@ y:
   .word 0xaaafcad2
   .zero 16
 
-/* signature verification result x_res (rnd) */
-.globl rnd
-rnd:
+/* signature verification result x_res (x_r) */
+.globl x_r
+x_r:
   .zero 64

--- a/sw/otbn/crypto/tests/p384_ecdsa_verify_test.s
+++ b/sw/otbn/crypto/tests/p384_ecdsa_verify_test.s
@@ -14,39 +14,20 @@
 .section .text.start
 
 p384_ecdsa_verify_test:
-
-  /* set dmem pointer to point to message */
-  la       x2, msg
-  la       x3, dptr_msg
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to signature */
-  la       x2, sig_r
-  la       x3, dptr_r
-  sw       x2, 0(x3)
-  la       x2, sig_s
-  la       x3, dptr_s
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to public key */
-  la       x2, pub_x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
-  la       x2, pub_y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to signature verifcation result */
-  la       x2, sig_xres
-  la       x3, dptr_rnd
-  sw       x2, 0(x3)
+  /* Fill gpp registers with pointers to variables */
+  la        x6, r
+  la        x7, s
+  la        x8, rnd
+  la        x9, msg
+  la        x13, x
+  la        x14, y
 
   /* call ECDSA signature verification subroutine in P-384 lib */
   jal      x1, p384_verify
 
   /* load signature to wregs for comparison with reference */
   li        x2, 0
-  la        x3, sig_xres
+  la        x3, rnd
   bn.lid    x2++, 0(x3)
   bn.lid    x2, 32(x3)
 
@@ -72,7 +53,7 @@ msg:
   .zero 16
 
 /* signature R */
-sig_r:
+r:
   .word 0xb68c28d8
   .word 0x2b23ce3a
   .word 0x9a1a30fc
@@ -88,7 +69,7 @@ sig_r:
   .zero 16
 
 /* signature S */
-sig_s:
+s:
   .word 0x24bc1bf9
   .word 0x752042f5
   .word 0x98144c27
@@ -104,7 +85,7 @@ sig_s:
   .zero 16
 
 /* public key x-coordinate */
-pub_x:
+x:
   .word 0x4877f3d1
   .word 0x7b829460
   .word 0xb1cac609
@@ -120,7 +101,7 @@ pub_x:
   .zero 16
 
 /* public key y-coordinate */
-pub_y:
+y:
   .word 0xc181f90f
   .word 0xc31ef079
   .word 0xbf3aff6e
@@ -135,6 +116,6 @@ pub_y:
   .word 0xaaafcad2
   .zero 16
 
-/* signature verification result x_res */
-sig_xres:
+/* signature verification result x_res (rnd) */
+rnd:
   .zero 64

--- a/sw/otbn/crypto/tests/p384_isoncurve_test.s
+++ b/sw/otbn/crypto/tests/p384_isoncurve_test.s
@@ -13,34 +13,28 @@
 .section .text.start
 
 p384_oncurve_test:
+  /* load domain parameter p (modulus)
+     [w13, w12] = p = dmem[p384_p] */
+  li        x2, 12
+  la        x3, p384_p
+  bn.lid    x2++, 0(x3)
+  bn.lid    x2++, 32(x3)
 
-  /* set dmem to result */
-  la       x2, rhs
-  la       x3, dptr_rhs
-  sw       x2, 0(x3)
-  la       x2, lhs
-  la       x3, dptr_lhs
-  sw       x2, 0(x3)
-
-  /* set dmem pointer to point to cuve point */
-  la       x2, x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
-  la       x2, y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
+  /* Fill gpp registers with pointers to variables */
+  la        x20, x
+  la        x21, y
+  la        x22, rhs
+  la        x23, lhs
 
   /* call curve point test routine in P-384 lib */
-  jal      x1, p384_isoncurve
+  jal       x1, p384_isoncurve
 
   /* load result to WDRs for comparison with reference */
   li        x2, 0
-  la        x3, rhs
-  bn.lid    x2++, 0(x3)
-  bn.lid    x2++, 32(x3)
-  la        x3, lhs
-  bn.lid    x2++, 0(x3)
-  bn.lid    x2++, 32(x3)
+  bn.lid    x2++, 0(x22)
+  bn.lid    x2++, 32(x22)
+  bn.lid    x2++, 0(x23)
+  bn.lid    x2++, 32(x23)
 
   ecall
 
@@ -48,14 +42,17 @@ p384_oncurve_test:
 .data
 
 /* buffer for right side result of Weierstrass equation */
+.globl rhs
 rhs:
   .zero 64
 
 /* buffer for left side result of Weierstrass equation */
+.globl lhs
 lhs:
   .zero 64
 
 /* point affine x-coordinate */
+.globl x
 x:
   .word 0x4877f3d1
   .word 0x7b829460
@@ -72,6 +69,7 @@ x:
   .zero 16
 
 /* point affine y-coordinate */
+.globl y
 y:
   .word 0xc181f90f
   .word 0xc31ef079

--- a/sw/otbn/crypto/tests/p384_isoncurve_test.s
+++ b/sw/otbn/crypto/tests/p384_isoncurve_test.s
@@ -20,7 +20,7 @@ p384_oncurve_test:
   bn.lid    x2++, 0(x3)
   bn.lid    x2++, 32(x3)
 
-  /* Fill gpp registers with pointers to variables */
+  /* Fill gpr registers with pointers to variables */
   la        x20, x
   la        x21, y
   la        x22, rhs

--- a/sw/otbn/crypto/tests/p384_keygen_test.s
+++ b/sw/otbn/crypto/tests/p384_keygen_test.s
@@ -25,13 +25,9 @@ p384_keygen_test:
   bn.xor    w31, w31, w31
 
   /* generate 4 random 448-bit values and write them to d0, d1 */
-  la        x20, d0
-  la        x21, d1
   jal       x1, p384_generate_random_key
 
   /* generate 4 random 448-bit values and write them to k0, k1 */
-  la        x20, k0
-  la        x21, k1
   jal       x1, p384_generate_k
 
   /* load generated values into WDRs for range/distinctiveness check */

--- a/sw/otbn/crypto/tests/p384_keygen_test.s
+++ b/sw/otbn/crypto/tests/p384_keygen_test.s
@@ -24,54 +24,36 @@ p384_keygen_test:
   /* Init all-zero register. */
   bn.xor    w31, w31, w31
 
-  /* set dmem pointer to point to 1st scalar share k0 */
-  la        x2, k0
-  la        x3, dptr_k0
-  sw        x2, 0(x3)
-
-  /* set dmem pointer to point to 2nd scalar share k1 */
-  la        x2, k1
-  la        x3, dptr_k1
-  sw        x2, 0(x3)
-
-  /* set dmem pointer to point to 1st scalar share d0 (private key) */
-  la        x2, d0
-  la        x3, dptr_d0
-  sw        x2, 0(x3)
-
-  /* set dmem pointer to point to 2nd scalar share d1 (private key) */
-  la        x2, d1
-  la        x3, dptr_d1
-  sw        x2, 0(x3)
-
-  /* generate 4 random 448-bit values and write them to d0, d1, k0, k1 */
+  /* generate 4 random 448-bit values and write them to d0, d1 */
+  la        x20, d0
+  la        x21, d1
   jal       x1, p384_generate_random_key
+
+  /* generate 4 random 448-bit values and write them to k0, k1 */
+  la        x20, k0
+  la        x21, k1
   jal       x1, p384_generate_k
 
   /* load generated values into WDRs for range/distinctiveness check */
   li        x2, 4
 
   /* [w5,w4] <= d0 */
-  la        x3, dptr_d0
-  lw        x4, 0(x3)
+  la        x4, d0
   bn.lid    x2++, 0(x4)
   bn.lid    x2++, 32(x4)
 
   /* [w7,w6] <= d1 */
-  la        x3, dptr_d1
-  lw        x4, 0(x3)
+  la        x4, d1
   bn.lid    x2++, 0(x4)
   bn.lid    x2++, 32(x4)
 
   /* [w9,w8] <= k0 */
-  la        x3, dptr_k0
-  lw        x4, 0(x3)
+  la        x4, k0
   bn.lid    x2++, 0(x4)
   bn.lid    x2++, 32(x4)
 
   /* [w11,w10] <= k1 */
-  la        x3, dptr_k1
-  lw        x4, 0(x3)
+  la        x4, k1
   bn.lid    x2++, 0(x4)
   bn.lid    x2++, 32(x4)
 
@@ -346,17 +328,21 @@ p384_keygen_test:
 .balign 32
 
 /* 1st private key share d0 (448-bit) */
+.globl d0
 d0:
   .zero 64
 
 /* 2nd private key share d1 (448-bit) */
+.globl d1
 d1:
   .zero 64
 
 /* 1st scalar share k0 (448-bit) */
+.globl k0
 k0:
   .zero 64
 
 /* 2nd scalar share k1 (448-bit) */
+.globl k1
 k1:
   .zero 64

--- a/sw/otbn/crypto/tests/p384_scalar_mult_test.s
+++ b/sw/otbn/crypto/tests/p384_scalar_mult_test.s
@@ -21,34 +21,26 @@ p384_scalar_mult_test:
   bn.xor  w31, w31, w31
 
   /* set dmem pointer to point to x-coordinate */
-  la       x2, p1_x
-  la       x3, dptr_x
-  sw       x2, 0(x3)
+  la       x20, x
 
   /* set dmem pointer to point to y-coordinate */
-  la       x2, p1_y
-  la       x3, dptr_y
-  sw       x2, 0(x3)
+  la       x21, y
 
   /* set dmem pointer to point to 1st scalar share k0 */
-  la       x2, k0
-  la       x3, dptr_k0
-  sw       x2, 0(x3)
+  la       x17, k0
 
   /* set dmem pointer to point to 2nd scalar share k1 */
-  la       x2, k1
-  la       x3, dptr_k1
-  sw       x2, 0(x3)
+  la       x19, k1
 
   /* call scalar point multiplication routine in P-384 lib */
   jal      x1, p384_scalar_mult
 
   /* load result to WDRs for comparison with reference */
   li        x2, 0
-  la        x3, p1_x
+  la        x3, x
   bn.lid    x2++, 0(x3)
   bn.lid    x2++, 32(x3)
-  la        x3, p1_y
+  la        x3, y
   bn.lid    x2++, 0(x3)
   bn.lid    x2, 32(x3)
 
@@ -78,7 +70,7 @@ p384_scalar_mult_test:
 .balign 32
 
 /* point 1 x-cooridante p1_x */
-p1_x:
+x:
   .word 0x1a11808b
   .word 0x02e3d5a9
   .word 0x440d8db6
@@ -94,7 +86,7 @@ p1_x:
   .zero 16
 
 /* point 1 y-cooridante p1_y*/
-p1_y:
+y:
   .word 0xa9f8b96e
   .word 0x82f268be
   .word 0x8e51c662

--- a/sw/otbn/crypto/tests/p384_scalar_mult_test.s
+++ b/sw/otbn/crypto/tests/p384_scalar_mult_test.s
@@ -20,18 +20,6 @@ p384_scalar_mult_test:
   /* Init all-zero register. */
   bn.xor  w31, w31, w31
 
-  /* set dmem pointer to point to x-coordinate */
-  la       x20, x
-
-  /* set dmem pointer to point to y-coordinate */
-  la       x21, y
-
-  /* set dmem pointer to point to 1st scalar share k0 */
-  la       x17, k0
-
-  /* set dmem pointer to point to 2nd scalar share k1 */
-  la       x19, k1
-
   /* call scalar point multiplication routine in P-384 lib */
   jal      x1, p384_scalar_mult
 
@@ -70,6 +58,7 @@ p384_scalar_mult_test:
 .balign 32
 
 /* point 1 x-cooridante p1_x */
+.globl x
 x:
   .word 0x1a11808b
   .word 0x02e3d5a9
@@ -86,6 +75,7 @@ x:
   .zero 16
 
 /* point 1 y-cooridante p1_y*/
+.globl y
 y:
   .word 0xa9f8b96e
   .word 0x82f268be
@@ -102,6 +92,7 @@ y:
   .zero 16
 
 /* 1st scalar share k0 (448-bit) */
+.globl k0
 k0:
   .word 0x5c832a51
   .word 0x3eb17c27
@@ -120,6 +111,7 @@ k0:
   .zero 8
 
 /* 2nd scalar share k1 (448-bit) */
+.globl k1
 k1:
   .word 0x33eae098
   .word 0xd31b18d5


### PR DESCRIPTION
This PR removes `dptr_<x>` variables and adapts the code to function without it.

Previously, to reference a value in the data memory, the memory address of the value was stored in addition to the actual value. 
However, this is not absolutely necessary to reference values in the data memory. It is also possible to do this without extra pointer variables. 
This means that instead of storing the pointer (i.e. the memory address of the value) in the data memory, the pointer is only used in registers without writing it to the data memory. 
This reduces the number of instructions required in the code and therefore saves instruction and data memory.