### PR TITLE
[doc] Add SCA guidelines for OTBN from COCO-Alma work.

### DIFF
--- a/doc/contributing/style_guides/otbn_style_guide.md
+++ b/doc/contributing/style_guides/otbn_style_guide.md
@@ -146,6 +146,168 @@ Prefer `.word` over alternatives such as `.quad`.
 
 The following guidelines address cryptography-specific concerns for OTBN assembly.
 
+### Handling secret shares
+
+The following guidelines were determined with the [help of the COCO-Alma tool](https://github.com/lowRISC/opentitan/tree/master/hw/ip/otbn/pre_sca/alma) and help protect against SCA attacks.
+
+**1. Do not overwrite a share with its counterpart share.**
+
+A register or memory location which contains one share must not be overwritten with its counterpart. The following lines would each violate this rule and cause transient leakage:
+```armasm
+/* Leakage (if w0, w1 contain two shares of a secret) */
+bn.and  w1, w0, w0
+bn.addi w1, w0, 0x0
+bn.mov  w1, w0
+bn.sel  w1, w0, w0, FG0.C
+```
+
+**2. Do not use multiple shares in a single instruction without masking.**
+
+Shares may interact with each other in the ALU and cause stable leakage at a gate or a register.
+The following lines would each violate this rule and cause stable leakage:
+```armasm
+/* Leakage (if w0, w1 contain two shares of a secret) */
+bn.add w4, w1, w0
+bn.xor w4, w1, w0
+```
+
+**3. Do not access shares within successive instructions.**
+
+By violating this rule, one can cause a transient leakage.
+Try to reorder the program or interleave the instructions.
+If this is not possible, use a dummy instruction.
+See following example as a dummy instruction usage.
+```armasm
+/* Leakage (if w0, w1 contain two shares of a secret) */
+bn.xor w4, w0, w0
+bn.xor w5, w1, w1
+
+/* No leakage */
+bn.xor w4, w0, w0
+bn.xor w9, w9, w9 /* dummy instruction */
+bn.xor w5, w1, w1
+```
+
+**4. Do not have shares even in different bits of a register.**
+
+Even when the shares are in different indexes, this may still cause a stable leakage due to the ECC bit computation.
+The following lines are an example of a leakage:
+
+```armasm
+/* Leakage (if the LSBs of w0, w1 contain two shares of a secret) */
+bn.xor  w9, w9, w9 /* set w9 to zero */
+bn.rshi w1, w1, w9 >> 254
+bn.xor  w4, w1, w0
+```
+
+**5. Be careful with addition and subtraction instructions.**
+
+The following code will mask the share in `w0` with a random value at first and then add the mask to itself.
+Since the addition and subtraction operation in the LSB bit is simply an xor operation the mask would be removed for the LSB bit and the last instruction will cause a leakage.
+```armasm
+/* No leakage */
+bn.wsrr  w2, URND   /* mask */
+bn.xor   w0, w2, w0
+bn.xor   w9, w9, w9 /* dummy instruction */
+bn.xor   w4, w1, w0
+
+/* Leakage (if w0, w1 contain two shares of a secret) */
+bn.wsrr  w2, URND
+bn.xor   w0, w2, w0
+bn.add   w0, w2, w0
+bn.xor   w9, w9, w9 /* dummy instruction */
+bn.xor   w4, w1, w0
+```
+
+**6. Do not use a source as the destination of the `bn.sel` instruction if the selection flag is secret.**
+
+The following code will cause a power leakage if `FG0.C` is secret because the Hamming Distance between `w5` to `w5` is zero.
+```armasm
+/* Leakage (if FG0.C is secret) */
+bn.sel w5, w5, w4, FG0.C
+
+/* No leakage */
+bn.wsrr w6, URND /* mask */
+bn.sel  w6, w5, w4, FG0.C
+bn.wsrr w5, URND /* overwrite w5 with a random value */
+bn.mov  w5, w6
+```
+
+**7. Do not use two shares of the same secret as the sources of the `bn.sel` instruction.**
+
+Due to [blanking limitations](https://github.com/lowRISC/opentitan/blob/ef42c7498534583141e16a6cd5c8df9e4c041bb2/hw/ip/otbn/rtl/otbn_controller.sv#L1018-L1030) of the bn.sel instruction, do not use shares of the same secret as the sources of `bn.sel`.
+This would cause a transient leakage.
+```
+bn.sel w4, w1, w0, FG0.C
+```
+
+**8. Clear `ACC` and flags between `bn.mulqacc` instructions which use shares of the same secret.**
+
+It is also necessary to use a dummy instruction to eliminate the transient leakage.
+Be aware there are some [flag blanking limitations](https://github.com/lowRISC/opentitan/blob/82bcfcae473e779a77fdabd789476b479cca0077/hw/ip/otbn/rtl/otbn_alu_bignum.sv#L257-L266) on `bn.mulqacc` instructions.
+Note that only the whole-word writeback version of `bn.mulqacc` (`bn.mulqacc.wo`) affects flags.
+```armasm
+/* Leakage (if w0, w1 contain two shares of a secret) */
+bn.mulqacc.wo w6, w4.0, w0.0, 0, FG0
+bn.mulqacc.wo w7, w5.0, w1.0, 0, FG0
+
+/* No leakage; clear ACC and flags before using the same flagset */
+bn.xor        w9, w9, w9             /* create a zero register */
+bn.mulqacc.wo w6, w4.0, w0.0, 0, FG0
+bn.wsrw       ACC, w9                /* clear ACC */
+bn.mulqacc.wo w9, w9.0, w9.0, 0, FG0 /* clear flags, dummy instruction */
+bn.mulqacc.wo w7, w5.0, w1.0, 0, FG0
+
+/* No leakage; clear ACC before using a different flagset */
+bn.xor        w9, w9, w9             /* create a zero register */
+bn.mulqacc.wo w6, w4.0, w0.0, 0, FG0
+bn.wsrw       ACC, w9                /* clear ACC */
+bn.wsrw       ACC, w9                /* dummy instruction */
+bn.mulqacc.wo w7, w5.0, w1.0, 0, FG1
+```
+
+**9. Clear flags after using instructions which set some flags depending on the secret values.**
+
+It is good practice to use the same instruction with non-secret inputs to clear the flags which may include secret shares.
+Since not all of the flags are updated by every instruction type, use the same type of instruction as a dummy instruction to clear flags.
+```armasm
+bn.mulqacc.wo w6, w4.0, w0.0, 0, FG0
+bn.mulqacc.wo w9, w9.0, w9.0, 0, FG0 /* clear flags */
+
+bn.sub w4, w4, w0
+bn.sub w9, w9, w9 /* clear flags */
+```
+
+**10. Apply fresh masking for specific scenarios when needed.**
+
+This is a specific scenario that we have come across when analysing the ECC keygen algorithm with the formal masking verification tool.
+Here you can find a simplified code snippet.
+In summary, there may be some glitches on the bignum flag computation datapath.
+Because of this, masked secret values in different indices come together, mask values may cancel each other out and the separation between the shares may not be preserved.
+To fix that, fresh masking can be applied as you can see in the code snippet below.
+```armasm
+/**
+ * Let's assume that after running a program we have following shares in the LSB two bits:
+ * w4 = {mask, s0[0]}
+ * w5 = {s1[1], s1[0] ^ mask}
+ * If we run the following instruction, there will be a transient leakage
+ * because w4[1] ^ w4[0] ^ w5[0] == s0[0] ^ s1[0].
+ */
+bn.xor   w7, w5, w4
+
+/* To fix that, fresh masking can be applied. */
+bn.wsrr  w8, URND /* fresh mask */
+bn.xor   w8, w31, w3
+/* w5 = w5 ^ fresh_mask = {s1[1] ^ f_m[1], s1[0] ^ mask ^ f_m[0]} */
+bn.xor   w5, w5, w8
+bn.xor   w31, w31, w31 /* dummy instruction */
+/* w7 = w4 ^ w5 = {mask ^ s1[1] ^ f_m[1], s0[0] ^ s1[0] ^ mask ^ f_m[0]} */
+bn.xor   w7, w5, w4
+bn.xor   w31, w31, w31
+/* w7 = w7 ^ fresh_mask = {mask ^ s1[1], s0[0] ^ s1[0] ^ mask} */
+bn.xor   w7, w7, w8
+```
+
 ### Copying register values
 
 Prefer `bn.mov <wrd>, <wrs>` to `bn.addi <wrd>, <wrs>, 0` when copying data between registers.
@@ -159,7 +321,7 @@ In situations where constant- and variable- time code is mixed, it is recommende
 If a piece of code is constant-time with respect to some inputs but not others (e.g. with respect to the `MOD` register but not to the operands), this should be documented.
 
 Example:
-```S
+```armasm
 /**
  * Determine if two 2048-bit operands are equal.
  *


### PR DESCRIPTION
This text is from an OpenTitan-domain [doc](https://docs.google.com/document/d/1kX2fr5lH9xzYcpu2ycsac4JZ2j8L0Vl_0UNmoN3-UlY/edit) that @abdullahvarici wrote a while back, but it seems useful to have on the public documentation website as well.