### PR TITLE
[topgen] Support for multiple rv_dm instances

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -529,6 +529,7 @@
           hart: 0x30010000
         }
       }
+      generate_dif: true
     }
     {
       name: gpio
@@ -627,6 +628,7 @@
           hart: 0x30000000
         }
       }
+      generate_dif: true
     }
     {
       name: spi_device
@@ -727,6 +729,7 @@
           hart: 0x30310000
         }
       }
+      generate_dif: true
     }
     {
       name: i2c0
@@ -791,6 +794,7 @@
           hart: 0x30080000
         }
       }
+      generate_dif: true
     }
     {
       name: rv_timer
@@ -841,6 +845,7 @@
           hart: 0x30100000
         }
       }
+      generate_dif: true
     }
     {
       name: otp_ctrl
@@ -1270,6 +1275,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: lc_ctrl
@@ -1839,6 +1845,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: alert_handler
@@ -1974,6 +1981,7 @@
           hart: 0x30150000
         }
       }
+      generate_dif: true
     }
     {
       name: spi_host0
@@ -2050,6 +2058,7 @@
           hart: 0x30300000
         }
       }
+      generate_dif: true
     }
     {
       name: pwrmgr_aon
@@ -2404,6 +2413,7 @@
           hart: 0x30400000
         }
       }
+      generate_dif: true
     }
     {
       name: rstmgr_aon
@@ -2605,6 +2615,7 @@
           hart: 0x30410000
         }
       }
+      generate_dif: true
     }
     {
       name: clkmgr_aon
@@ -2939,6 +2950,7 @@
           hart: 0x30420000
         }
       }
+      generate_dif: true
     }
     {
       name: pinmux_aon
@@ -3358,6 +3370,7 @@
           hart: 0x30460000
         }
       }
+      generate_dif: true
     }
     {
       name: aon_timer_aon
@@ -3477,6 +3490,7 @@
           hart: 0x30470000
         }
       }
+      generate_dif: true
     }
     {
       name: ast
@@ -3585,6 +3599,7 @@
           hart: 0x30480000
         }
       }
+      generate_dif: true
     }
     {
       name: sensor_ctrl
@@ -3697,6 +3712,7 @@
           hart: 0x30020000
         }
       }
+      generate_dif: true
     }
     {
       name: soc_proxy
@@ -4023,6 +4039,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: sram_ctrl_ret_aon
@@ -4227,6 +4244,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: rv_dm
@@ -4263,6 +4281,7 @@
       {
         SecVolatileRawUnlockEn: top_pkg::SecVolatileRawUnlockEn
       }
+      generate_dif: false
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_infra
@@ -4597,6 +4616,7 @@
           hart: 0x28000000
         }
       }
+      generate_dif: true
     }
     {
       name: aes
@@ -4825,6 +4845,7 @@
           hart: 0x21100000
         }
       }
+      generate_dif: true
     }
     {
       name: hmac
@@ -4887,6 +4908,7 @@
           hart: 0x21110000
         }
       }
+      generate_dif: true
     }
     {
       name: kmac
@@ -5115,6 +5137,7 @@
           hart: 0x21120000
         }
       }
+      generate_dif: true
     }
     {
       name: otbn
@@ -5376,6 +5399,7 @@
           hart: 0x21130000
         }
       }
+      generate_dif: true
     }
     {
       name: keymgr_dpe
@@ -5711,6 +5735,7 @@
           hart: 0x21140000
         }
       }
+      generate_dif: true
     }
     {
       name: csrng
@@ -5858,6 +5883,7 @@
           hart: 0x21150000
         }
       }
+      generate_dif: true
     }
     {
       name: edn0
@@ -5943,6 +5969,7 @@
           hart: 0x21170000
         }
       }
+      generate_dif: true
     }
     {
       name: edn1
@@ -6028,6 +6055,7 @@
           hart: 0x21180000
         }
       }
+      generate_dif: true
     }
     {
       name: sram_ctrl_main
@@ -6234,6 +6262,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: sram_ctrl_mbox
@@ -6438,6 +6467,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: rom_ctrl0
@@ -6619,6 +6649,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: rom_ctrl1
@@ -6800,6 +6831,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: dma
@@ -6963,6 +6995,7 @@
           hart: 0x22010000
         }
       }
+      generate_dif: true
     }
     {
       name: mbx0
@@ -7098,6 +7131,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx1
@@ -7233,6 +7267,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx2
@@ -7368,6 +7403,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx3
@@ -7503,6 +7539,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx4
@@ -7638,6 +7675,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx5
@@ -7773,6 +7811,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx6
@@ -7908,6 +7947,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx_jtag
@@ -8043,6 +8083,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx_pcie0
@@ -8178,6 +8219,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: mbx_pcie1
@@ -8313,6 +8355,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: rv_core_ibex
@@ -8869,6 +8912,7 @@
           hart: 0x211f0000
         }
       }
+      generate_dif: true
     }
   ]
   memory: []

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -582,7 +582,8 @@
         // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR
         // PRODUCTION DEVICES.
         SecVolatileRawUnlockEn: "top_pkg::SecVolatileRawUnlockEn",
-      }
+      },
+      generate_dif: "False"
     },
     { name: "rv_plic",
       type: "rv_plic",

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -586,6 +586,7 @@
           hart: 0x40000000
         }
       }
+      generate_dif: true
     }
     {
       name: uart1
@@ -645,6 +646,7 @@
           hart: 0x40010000
         }
       }
+      generate_dif: true
     }
     {
       name: uart2
@@ -704,6 +706,7 @@
           hart: 0x40020000
         }
       }
+      generate_dif: true
     }
     {
       name: uart3
@@ -763,6 +766,7 @@
           hart: 0x40030000
         }
       }
+      generate_dif: true
     }
     {
       name: gpio
@@ -859,6 +863,7 @@
           hart: 0x40040000
         }
       }
+      generate_dif: true
     }
     {
       name: spi_device
@@ -959,6 +964,7 @@
           hart: 0x40050000
         }
       }
+      generate_dif: true
     }
     {
       name: i2c0
@@ -1018,6 +1024,7 @@
           hart: 0x40080000
         }
       }
+      generate_dif: true
     }
     {
       name: i2c1
@@ -1077,6 +1084,7 @@
           hart: 0x40090000
         }
       }
+      generate_dif: true
     }
     {
       name: i2c2
@@ -1136,6 +1144,7 @@
           hart: 0x400A0000
         }
       }
+      generate_dif: true
     }
     {
       name: pattgen
@@ -1186,6 +1195,7 @@
           hart: 0x400E0000
         }
       }
+      generate_dif: true
     }
     {
       name: rv_timer
@@ -1236,6 +1246,7 @@
           hart: 0x40100000
         }
       }
+      generate_dif: true
     }
     {
       name: otp_ctrl
@@ -1665,6 +1676,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: lc_ctrl
@@ -2248,6 +2260,7 @@
           hart: 0x40140000
         }
       }
+      generate_dif: true
     }
     {
       name: alert_handler
@@ -2383,6 +2396,7 @@
           hart: 0x40150000
         }
       }
+      generate_dif: true
     }
     {
       name: spi_host0
@@ -2454,6 +2468,7 @@
           hart: 0x40300000
         }
       }
+      generate_dif: true
     }
     {
       name: spi_host1
@@ -2523,6 +2538,7 @@
           hart: 0x40310000
         }
       }
+      generate_dif: true
     }
     {
       name: usbdev
@@ -2815,6 +2831,7 @@
           hart: 0x40320000
         }
       }
+      generate_dif: true
     }
     {
       name: pwrmgr_aon
@@ -3166,6 +3183,7 @@
           hart: 0x40400000
         }
       }
+      generate_dif: true
     }
     {
       name: rstmgr_aon
@@ -3367,6 +3385,7 @@
           hart: 0x40410000
         }
       }
+      generate_dif: true
     }
     {
       name: clkmgr_aon
@@ -3701,6 +3720,7 @@
           hart: 0x40420000
         }
       }
+      generate_dif: true
     }
     {
       name: sysrst_ctrl_aon
@@ -3782,6 +3802,7 @@
           hart: 0x40430000
         }
       }
+      generate_dif: true
     }
     {
       name: adc_ctrl_aon
@@ -3865,6 +3886,7 @@
           hart: 0x40440000
         }
       }
+      generate_dif: true
     }
     {
       name: pwm_aon
@@ -3922,6 +3944,7 @@
           hart: 0x40450000
         }
       }
+      generate_dif: true
     }
     {
       name: pinmux_aon
@@ -4380,6 +4403,7 @@
           hart: 0x40460000
         }
       }
+      generate_dif: true
     }
     {
       name: aon_timer_aon
@@ -4499,6 +4523,7 @@
           hart: 0x40470000
         }
       }
+      generate_dif: true
     }
     {
       name: ast
@@ -4607,6 +4632,7 @@
           hart: 0x40480000
         }
       }
+      generate_dif: true
     }
     {
       name: sensor_ctrl
@@ -4745,6 +4771,7 @@
           hart: 0x40490000
         }
       }
+      generate_dif: true
     }
     {
       name: sram_ctrl_ret_aon
@@ -4949,6 +4976,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: flash_ctrl
@@ -5401,6 +5429,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: rv_dm
@@ -5433,6 +5462,7 @@
           hart: 0x41200000
         }
       }
+      generate_dif: false
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_infra
@@ -5690,6 +5720,7 @@
           hart: 0x48000000
         }
       }
+      generate_dif: true
     }
     {
       name: aes
@@ -5918,6 +5949,7 @@
           hart: 0x41100000
         }
       }
+      generate_dif: true
     }
     {
       name: hmac
@@ -5980,6 +6012,7 @@
           hart: 0x41110000
         }
       }
+      generate_dif: true
     }
     {
       name: kmac
@@ -6208,6 +6241,7 @@
           hart: 0x41120000
         }
       }
+      generate_dif: true
     }
     {
       name: otbn
@@ -6469,6 +6503,7 @@
           hart: 0x41130000
         }
       }
+      generate_dif: true
     }
     {
       name: keymgr
@@ -6846,6 +6881,7 @@
           hart: 0x41140000
         }
       }
+      generate_dif: true
     }
     {
       name: csrng
@@ -6995,6 +7031,7 @@
           hart: 0x41150000
         }
       }
+      generate_dif: true
     }
     {
       name: entropy_src
@@ -7159,6 +7196,7 @@
           hart: 0x41160000
         }
       }
+      generate_dif: true
     }
     {
       name: edn0
@@ -7244,6 +7282,7 @@
           hart: 0x41170000
         }
       }
+      generate_dif: true
     }
     {
       name: edn1
@@ -7329,6 +7368,7 @@
           hart: 0x41180000
         }
       }
+      generate_dif: true
     }
     {
       name: sram_ctrl_main
@@ -7535,6 +7575,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: rom_ctrl0
@@ -7716,6 +7757,7 @@
           index: -1
         }
       ]
+      generate_dif: true
     }
     {
       name: rv_core_ibex
@@ -8272,6 +8314,7 @@
           hart: 0x411F0000
         }
       }
+      generate_dif: true
     }
   ]
   memory: []

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -704,7 +704,8 @@
       base_addrs: {
         mem:  {hart: "0x00010000"},
         regs: {hart: "0x41200000"}
-      }
+      },
+      generate_dif: "False"
     },
     { name: "rv_plic",
       type: "rv_plic",

--- a/util/topgen/c_test.py
+++ b/util/topgen/c_test.py
@@ -125,8 +125,7 @@ class TopGenCTest(TopGenC):
             if inst_name not in self.top["alert_module"]:
                 continue
 
-            # RV_DM module does not have DIF.
-            if inst_name == "rv_dm":
+            if not entry['generate_dif']:
                 continue
 
             for item in self.top['module']:

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -14,6 +14,7 @@ from .clocks import Clocks
 from .resets import Resets
 from reggen.ip_block import IpBlock
 from reggen.params import LocalParam, Parameter, RandParameter, MemSizeParameter
+from reggen.validate import check_bool
 
 
 def _get_random_data_hex_literal(width):
@@ -214,6 +215,12 @@ def elaborate_instance(instance, block: IpBlock):
 
     if 'base_addr' in instance:
         del instance['base_addr']
+
+    # Default value if no value provided and otherwise convert string to bool
+    if 'generate_dif' not in instance:
+        instance['generate_dif'] = True
+    else:
+        instance['generate_dif'], _ = check_bool(instance['generate_dif'], False)
 
 
 # TODO: Replace this part to be configurable from Hjson or template

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -201,7 +201,8 @@ module_optional = {
     'base_addrs': ['g', 'hex start addresses of the peripheral '
                         ' (if the IP has multiple TL-UL interfaces)'],
     'memory': ['g', 'optional dict with memory region attributes'],
-    'param_decl': ['g', 'optional dict that allows to override instantiation parameters']
+    'param_decl': ['g', 'optional dict that allows to override instantiation parameters'],
+    'generate_dif': ['pb', 'optional bool to indicate if a DIF should be generated for that module']
 }
 
 module_added = {


### PR DESCRIPTION
There might be multiple rv_dm instances in the system. Therefore, use the module property to determine there is no DIF for rv_dm modules rather than the name