### PR TITLE
[sival, rv_core_ibex] test rv_core_ibex_isa_test in prod

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -142,7 +142,7 @@
        stage: V2
        si_stage: SV1
        tests: []
-       bazel: ["//sw/device/tests:rv_core_ibex_isa_test_functest"]
+       bazel: ["//sw/device/tests:rv_core_ibex_isa_test"]
        lc_states: ["PROD"]
        features: [
          "RV_CORE_IBEX.CPU.ISA"

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5244,15 +5244,14 @@ opentitan_test(
 )
 
 opentitan_test(
-    name = "rv_core_ibex_isa_test_functest",
+    name = "rv_core_ibex_isa_test_test_unlocked0",
     srcs = ["//sw/device/silicon_creator/manuf/tests:idle_functest.c"],
     cw310 = cw310_params(
         binaries = {
-            ":rv_core_ibex_isa_test": "sram_program",
+            ":rv_core_ibex_isa_test_sram": "sram_program",
         },
         needs_jtag = True,
         otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
-        tags = ["manual"],
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
     ),
@@ -5278,8 +5277,10 @@ opentitan_test(
     ],
 )
 
+# This test checks basic Ibex functionality, so we prefer to run as little code as possible before the test.
+# In LC states where JTAG is available, we use SRAM execution to run the test before ROM.
 opentitan_binary(
-    name = "rv_core_ibex_isa_test",
+    name = "rv_core_ibex_isa_test_sram",
     testonly = True,
     srcs = [
         "rv_core_ibex_isa_test.S",
@@ -5293,6 +5294,34 @@ opentitan_binary(
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
+    ],
+)
+
+# For PROD LC state, we run this test as normal.
+opentitan_test(
+    name = "rv_core_ibex_isa_test_prod",
+    srcs = [
+        "rv_core_ibex_isa_test.S",
+        "rv_core_ibex_isa_test.c",
+    ],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    deps = [
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+test_suite(
+    name = "rv_core_ibex_isa_test",
+    tags = ["manual"],
+    tests = [
+        "rv_core_ibex_isa_test_prod",
+        "rv_core_ibex_isa_test_test_unlocked0",
     ],
 )
 

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -11,7 +11,7 @@ test_suite(
         "//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test",
         "//sw/device/tests:rstmgr_cpu_info_test",
         "//sw/device/tests:rv_core_ibex_epmp_test_functest",
-        "//sw/device/tests:rv_core_ibex_isa_test_functest",
+        "//sw/device/tests:rv_core_ibex_isa_test",
         "//sw/device/tests:rv_core_ibex_mem_test_functest",
         "//sw/device/tests:rv_core_ibex_rnd_test",
     ],


### PR DESCRIPTION
The current SRAM program can be executed in prod as a normal test.

The same program can be used for both cases with #22834. 