### PR TITLE
[keymgr, rtl] Reorganize keymgr advance payloads 

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -429,17 +429,15 @@ module keymgr
   //   end
   // end
   // assign adv_matrix[Creator] = AdvDataWidth'({sw_binding,
-  //                                             revision_seed,
   //                                             otp_device_id_i,
   //                                             lc_keymgr_div_i,
   //                                             rom_digests,
-  //                                             creator_seed});
+  //                                             revision_seed});
   assign adv_matrix[Creator] = AdvDataWidth'({sw_binding,
-                                              revision_seed,
                                               otp_device_id_i,
                                               lc_keymgr_div_i,
                                               rom_digest_i.data,
-                                              creator_seed});
+                                              revision_seed});
 
   assign adv_dvalid[Creator] = creator_seed_vld &
                                devid_vld &
@@ -458,11 +456,11 @@ module keymgr
                                  otp_key_i.owner_seed_valid};
     assign owner_seed = flash_i.seeds[flash_ctrl_pkg::OwnerSeedIdx];
   end
-  assign adv_matrix[OwnerInt] = AdvDataWidth'({sw_binding,owner_seed});
+  assign adv_matrix[OwnerInt] = AdvDataWidth'({sw_binding, creator_seed});
   assign adv_dvalid[OwnerInt] = owner_seed_vld;
 
   // Advance to owner_key
-  assign adv_matrix[Owner] = AdvDataWidth'(sw_binding);
+  assign adv_matrix[Owner] = AdvDataWidth'({sw_binding, owner_seed});
   assign adv_dvalid[Owner] = 1'b1;
 
   // Generate Identity operation input construction

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -74,7 +74,7 @@ package keymgr_pkg;
 
   // Width calculations
   // These are the largest calculations in use across all stages
-  parameter int AdvDataWidth = SwBindingWidth + 3*KeyWidth + DevIdWidth + HealthStateWidth;
+  parameter int AdvDataWidth = SwBindingWidth + 2*KeyWidth + DevIdWidth + HealthStateWidth;
   parameter int IdDataWidth = KeyWidth;
   // key version + salt + key ID + constant
   parameter int GenDataWidth = 32 + SaltWidth + KeyWidth*2;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
@@ -30,18 +30,17 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
 
   typedef struct packed {
     bit [keymgr_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0] SoftwareBinding;
-    bit [keymgr_pkg::KeyWidth-1:0]         HardwareRevisionSecret;
-    bit [keymgr_pkg::DevIdWidth-1:0]       DeviceIdentifier;
-    bit [keymgr_pkg::HealthStateWidth-1:0] HealthMeasurement;
-    bit [keymgr_pkg::KeyWidth-1:0]         RomDigest;
-    bit [keymgr_pkg::KeyWidth-1:0]         DiversificationKey;
+    bit [keymgr_pkg::DevIdWidth-1:0]                     DeviceIdentifier;
+    bit [keymgr_pkg::HealthStateWidth-1:0]               HealthMeasurement;
+    bit [keymgr_pkg::KeyWidth-1:0]                       RomDigest;
+    bit [keymgr_pkg::KeyWidth-1:0]                       HardwareRevisionSecret;
   } adv_creator_data_t;
 
   typedef struct packed {
     // some portions are unused, which are 0s
     bit [keymgr_pkg::AdvDataWidth-keymgr_pkg::KeyWidth-keymgr_pkg::SwBindingWidth-1:0] unused;
     bit [keymgr_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0] SoftwareBinding;
-    bit [keymgr_pkg::KeyWidth-1:0] OwnerRootSecret;
+    bit [keymgr_pkg::KeyWidth-1:0]                       CreatorSeed;
   } adv_owner_int_data_t;
 
   typedef struct packed {
@@ -217,11 +216,9 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
   // HardwareRevisionSecret: backdoor read CSRs at ral.lc_ctrl.device_id
   // HealthMeasurement: HW random constant - RndCnstLcCtrlLcKeymgrDivTestDevRma
   // RomDigest:  backdoor read CSRs at ral.rom_ctrl_regs.digest
-  // DiversificationKey: program fixed value to flash in the C test
   virtual task get_creator_data(output bit [keymgr_pkg::AdvDataWidth-1:0] creator_data_out);
     adv_creator_data_t creator_data;
     creator_data.SoftwareBinding = CreatorSwBinding;
-    creator_data.HardwareRevisionSecret = top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrRevisionSeed;
 
     for (int i = 0; i < keymgr_pkg::DevIdWidth / TL_DW; i++) begin
       bit [TL_DW-1:0] rdata = csr_peek(ral.lc_ctrl.device_id[i]);
@@ -246,14 +243,16 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     `uvm_info(`gfn, $sformatf("RomDigest 0x%0h", creator_data.RomDigest),
               UVM_LOW)
 
-    creator_data.DiversificationKey = CreatorFlashSeeds;
+    creator_data.HardwareRevisionSecret = top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrRevisionSeed;
     creator_data_out = keymgr_pkg::AdvDataWidth'(creator_data);
   endtask
 
+  // Here is how the OwnerIntermediateKey data are found
+  // CreatorSeed: program fixed value to flash in the C test
   virtual function bit [keymgr_pkg::AdvDataWidth-1:0] get_owner_int_data();
     adv_owner_int_data_t owner_int_data;
     owner_int_data.SoftwareBinding = OwnerIntSwBinding;
-    owner_int_data.OwnerRootSecret = OwnerFlashSeeds;
+    owner_int_data.CreatorSeed     = CreatorFlashSeeds;
 
     return keymgr_pkg::AdvDataWidth'(owner_int_data);
   endfunction


### PR DESCRIPTION
I am having some issues with my environment and I need to runt this through CI.

It basically tries to address to #22565 by:

* Not introducing extra seeds that incur extra area.
* Cleaner diversifications for Keymgr calls, so that we can claim no message collisions for different use cases.