### PR TITLE
[dv] fix chip_sw_flash_ctrl_write_clear bazel target

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1959,7 +1959,7 @@
     {
       name: chip_sw_flash_ctrl_write_clear
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/tests/sim_dv:flash_ctrl_write_clear_test:1:new_rules"]
+      sw_images: ["//sw/device/tests:flash_ctrl_write_clear_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+test_timeout_ns=8_000_000"]
     }


### PR DESCRIPTION
The test was moved from sw/device/tests/sim_dv to sw/device/tests and the hjson hasn't been updated.