### PR TITLE
[test] Reduce number of power_virus test iterations.

### DIFF
--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -98,7 +98,7 @@ enum {
   /**
    * Maximum number of test iterations in silicon targets.
    */
-  kMaxIterationsSilicon = 10000,
+  kMaxIterationsSilicon = 1000,
   /**
    * Test timeout parameter.
    */


### PR DESCRIPTION
Reduce the number of power_virus test iterations for silicon targets. This is to make the test run within 5 minutes at a standard core frequency.