### PR TITLE
[rom, rom_ext] Fix address translation

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/ibex.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex.c
@@ -22,9 +22,14 @@ uint32_t ibex_fpga_version(void) {
 
 void ibex_addr_remap_0_set(uint32_t matching_addr, uint32_t remap_addr,
                            size_t size) {
-  uint32_t mask = matching_addr | ((size - 1) >> 1);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET, mask);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET, mask);
+  // Work-around for opentitan#22884: Mask off bits below the alignment size
+  // prior to programming the REMAP_ADDR register.
+  size = size - 1;
+  uint32_t match = (matching_addr & ~size) | size >> 1;
+  remap_addr &= ~size;
+
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET, match);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET, match);
 
   sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET,
                    remap_addr);
@@ -38,9 +43,14 @@ void ibex_addr_remap_0_set(uint32_t matching_addr, uint32_t remap_addr,
 
 void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
                            size_t size) {
-  uint32_t mask = matching_addr | ((size - 1) >> 1);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_REG_OFFSET, mask);
-  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_REG_OFFSET, mask);
+  // Work-around for opentitan#22884: Mask off bits below the alignment size
+  // prior to programming the REMAP_ADDR register.
+  size = size - 1;
+  uint32_t match = (matching_addr & ~size) | size >> 1;
+  remap_addr &= ~size;
+
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_REG_OFFSET, match);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_REG_OFFSET, match);
 
   sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_1_REG_OFFSET,
                    remap_addr);

--- a/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
@@ -44,13 +44,15 @@ TEST_F(AddressTranslationTest, Slot0Sucess) {
 }
 
 TEST_F(AddressTranslationTest, Slot1Sucess) {
+  // Note: 0xB040_0000 is not power-of-two aligned with respect to the size.
+  // The remap function will force-align the matching_addr to the size.
   uint32_t matching_addr = 0xB040000;
   uint32_t remap_addr = 0x6000000;
   uint32_t size = 0x80000;
   EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_REG_OFFSET,
-                     0xb07ffff);
+                     0xb03ffff);
   EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_REG_OFFSET,
-                     0xb07ffff);
+                     0xb03ffff);
 
   EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_REMAP_ADDR_1_REG_OFFSET,
                      remap_addr);


### PR DESCRIPTION
1. The address translation windows do not properly mask off low bits in hardware.  Mask them off in software before programming.
2. The address translation windows must be power-of-two aligned with respect to the window size.  Forcibly align the remap address.

This partially addresses #22884.