### PR TITLE
[sival] keymgr test updates

### DIFF
--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -37,6 +37,16 @@ enum {
   kFlashInfoPageIdOwnerSecret = 2,
 };
 
+const static char *kKeymgrStageNames[] = {
+    [kDifKeymgrStateReset] = "Reset",
+    [kDifKeymgrStateInitialized] = "Init",
+    [kDifKeymgrStateCreatorRootKey] = "CreatorRootKey",
+    [kDifKeymgrStateOwnerIntermediateKey] = "OwnerIntKey",
+    [kDifKeymgrStateOwnerRootKey] = "OwnerKey",
+    [kDifKeymgrStateDisabled] = "Disabled",
+    [kDifKeymgrStateInvalid] = "Invalid",
+};
+
 static status_t write_info_page(dif_flash_ctrl_state_t *flash, uint32_t page_id,
                                 const keymgr_testutils_secret_t *data,
                                 bool scramble) {
@@ -240,5 +250,51 @@ status_t keymgr_testutils_wait_for_operation_done(const dif_keymgr_t *keymgr) {
   } while (status == 0);
   TRY_CHECK(status == kDifKeymgrStatusCodeIdle, "Unexpected status: %x",
             status);
+  return OK_STATUS();
+}
+
+status_t keymgr_testutils_max_key_version_get(const dif_keymgr_t *keymgr,
+                                              uint32_t *max_key_version) {
+  dif_keymgr_state_t keymgr_state;
+  TRY(dif_keymgr_get_state(keymgr, &keymgr_state));
+
+  if (keymgr_state == kDifKeymgrStateInvalid ||
+      keymgr_state == kDifKeymgrStateDisabled ||
+      keymgr_state == kDifKeymgrStateReset) {
+    LOG_INFO("Unexpected keymgr state: 0x%x", keymgr_state);
+    return INTERNAL();
+  }
+
+  dif_keymgr_max_key_version_t versions;
+  TRY(dif_keymgr_read_max_key_version(keymgr, &versions));
+
+  switch (keymgr_state) {
+    case kDifKeymgrStateCreatorRootKey:
+      *max_key_version = versions.creator_max_key_version;
+      break;
+    case kDifKeymgrStateOwnerIntermediateKey:
+      *max_key_version = versions.owner_int_max_key_version;
+      break;
+    case kDifKeymgrStateOwnerRootKey:
+      *max_key_version = versions.owner_max_key_version;
+      break;
+    default:
+      return INTERNAL();
+  }
+
+  return OK_STATUS();
+}
+
+status_t keymgr_testutils_state_string_get(const dif_keymgr_t *keymgr,
+                                           const char **stage_name) {
+  dif_keymgr_state_t state;
+  CHECK_DIF_OK(dif_keymgr_get_state(keymgr, &state));
+
+  if (state >= ARRAYSIZE(kKeymgrStageNames)) {
+    *stage_name = NULL;
+    return INTERNAL();
+  }
+
+  *stage_name = kKeymgrStageNames[state];
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -214,4 +214,28 @@ status_t keymgr_testutils_disable(const dif_keymgr_t *keymgr);
 OT_WARN_UNUSED_RESULT
 status_t keymgr_testutils_wait_for_operation_done(const dif_keymgr_t *keymgr);
 
+/**
+ * Get the maximum key version supported by the key manager.
+ *
+ * @param keymgr A key manager handle.
+ * @param[out] max_key_version The maximum key version supported by the key
+ *                             manager for its current operating state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_testutils_max_key_version_get(const dif_keymgr_t *keymgr,
+                                              uint32_t *max_key_version);
+
+/**
+ * Get the current state of the key manager.
+ *
+ * @param keymgr A key manager handle.
+ * @param[out] state The current state of the key manager in C string format.
+ *
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_testutils_state_string_get(const dif_keymgr_t *keymgr,
+                                           const char **stage_name);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_TESTUTILS_H_


### PR DESCRIPTION
## `keymgr_testutils`

1. Add `keymgr_testutils_max_key_version_get()` to determine the maximum key version allowable by the current keymgr state.
2. Add `keeymgr_testutils_string_get()` to return a string format version of the current keymgr state.

## `keymgr_sideload_aes_test.c`

1. Implement keymgr initialization via `keymgr_testutils_try_startup()` for silicon targets. The initialization will aim to advance the state `OwnerRootKey` which is the expected initial state for silicon_owner execution environments.
2. Check the max_key_version and adjust the key generation parameters accordingly. In silicon_owner execution environments, the max key version is set by the rom_ext.
3. Update log messages to print the current keymgr state instead of using hard-coded strings.