### PR TITLE
[sival] Enable //third_party/coremark/top_earlgrey:coremark_test.

### DIFF
--- a/third_party/coremark/top_earlgrey/BUILD
+++ b/third_party/coremark/top_earlgrey/BUILD
@@ -2,8 +2,15 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Build configuration for CoreMark test."""
+
+load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "EARLGREY_TEST_ENVS",
     "opentitan_test",
     "verilator_params",
@@ -30,12 +37,15 @@ opentitan_test(
         "-Wno-implicit-int-conversion",
         "-Wno-sign-conversion",
         "-Wno-shorten-64-to-32",
-        "-DITERATIONS=8",
+        "-DITERATIONS=12",
         "-DPERFORMANCE_RUN=1",
         "-DTOTAL_DATA_SIZE=2000",
         "-DMAIN_HAS_NOARGC=1",
     ],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     verilator = verilator_params(
         timeout = "eternal",
     ),


### PR DESCRIPTION
Add silicon_owner execution environments to the coremark_test target.