### PR TITLE
[dv,cov] Improve config for toggle coverage exclusions

### DIFF
--- a/hw/ip_templates/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip_templates/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -49,6 +49,13 @@
   vcs_cov_excl_files: ["{self_dir}/cov/clkmgr_cov_manual_excl.el",
                        "{self_dir}/cov/clkmgr_cov_unr_excl.el"]
 
+  // Handle generated coverage exclusion.
+  overrides: [
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/clkmgr_tgl_excl.cfg"
+    }
+  ]
   // Default UVM test and seq class name.
   uvm_test: clkmgr_base_test
   uvm_test_seq: clkmgr_base_vseq

--- a/hw/ip_templates/clkmgr/dv/cov/clkmgr_tgl_excl.cfg.tpl
+++ b/hw/ip_templates/clkmgr/dv/cov/clkmgr_tgl_excl.cfg.tpl
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//======================================================================
+// This file contains outputs of clkmgr tied to constants.
+//======================================================================
+
+% for k in typed_clocks['ft_clks']:
+-module_node clkmgr cg_en_o.${k.split('clk_')[-1]}
+% endfor

--- a/hw/ip_templates/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg
+++ b/hw/ip_templates/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//======================================================================
+// This file contains outputs of pwrmgr tied to constants.
+//======================================================================
+
+-module_node clkmgr pwr_ast_o.slow_clk_en

--- a/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip_templates/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -30,16 +30,21 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
+  // Exclusion files
+  vcs_cov_excl_files: ["{self_dir}/cov/pwrmgr_cov_manual_excl.el"]
+
   // Overrides
   overrides: [
     {
       name: design_level
       value: "top"
     }
+    // Handle generated coverage exclusion.
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/pwrmgr_tgl_excl.cfg"
+    }
   ]
-
-  // Exclusion files
-  vcs_cov_excl_files: ["{self_dir}/cov/pwrmgr_cov_manual_excl.el"]
 
   // Add additional tops for simulation.
   sim_tops: ["pwrmgr_bind",

--- a/hw/ip_templates/rstmgr/dv/cov/rstmgr_tgl_excl.cfg.tpl
+++ b/hw/ip_templates/rstmgr/dv/cov/rstmgr_tgl_excl.cfg.tpl
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//======================================================================
+// This file contains outputs of rstmgr tied to constants.
+//======================================================================
+
+% for rst in leaf_rsts:
+<%
+  names = [rst['name']]
+  if rst['shadowed']:
+    names.append(f'{names[0]}_shadowed')
+%>\
+  % for name in names:
+    % for domain in power_domains:
+      % if domain not in rst['domains']:
+-module_node rstmgr resets_o.rst_${name}_n[Domain${domain}Sel]
+-module_node rstmgr rst_en_o.${name}[Domain${domain}Sel]
+      % endif
+    % endfor
+  % endfor
+% endfor

--- a/hw/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/ip_templates/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -48,7 +48,7 @@
     }
     {
       name: default_vcs_cov_cfg_file
-      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg"
+      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }
   ]
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -35,6 +35,7 @@
              "xbar_peri_bind"]
 
   top_dv_path: "{proj_root}/hw/top_earlgrey/dv"
+  top_autogen_path: "{proj_root}/hw/top_earlgrey/ip_autogen"
 
   // Import additional common sim cfg files.
   import_cfgs: [// Project wide common sim cfg file
@@ -72,7 +73,7 @@
     // IPs. See `hw/dv/tools/dvsim/common_sim_cfg.hjson` for the default value.
     {
       name: default_vcs_cov_cfg_file
-      value: "-cm_hier {top_dv_path}/cov/chip_cover.cfg+{top_dv_path}/autogen/xbar_tgl_excl.cfg+{top_dv_path}/autogen/rstmgr_tgl_excl.cfg+{top_dv_path}/cov/clkmgr_tgl_excl.cfg+{top_dv_path}/cov/pwrmgr_tgl_excl.cfg -cm_fsmcfg {top_dv_path}/cov/chip_fsm.cfg"
+      value: "-cm_hier {top_dv_path}/cov/chip_cover.cfg+{top_dv_path}/autogen/xbar_tgl_excl.cfg+{top_autogen_path}/rstmgr/dv/cov/rstmgr_tgl_excl.cfg+{top_autogen_path}/clkmgr/dv/cov/clkmgr_tgl_excl.cfg+{top_autogen_path}/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg -cm_fsmcfg {top_dv_path}/cov/chip_fsm.cfg"
     }
     // Used by 'cover_reg_top' only builds - we only cover the *_reg_top of
     // the non-pre-verified modules at the chip level. See

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -49,6 +49,13 @@
   vcs_cov_excl_files: ["{self_dir}/cov/clkmgr_cov_manual_excl.el",
                        "{self_dir}/cov/clkmgr_cov_unr_excl.el"]
 
+  // Handle generated coverage exclusion.
+  overrides: [
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/clkmgr_tgl_excl.cfg"
+    }
+  ]
   // Default UVM test and seq class name.
   uvm_test: clkmgr_base_test
   uvm_test_seq: clkmgr_base_vseq

--- a/hw/top_earlgrey/ip_autogen/clkmgr/dv/cov/clkmgr_tgl_excl.cfg
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/dv/cov/clkmgr_tgl_excl.cfg
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//======================================================================
+// This file contains outputs of clkmgr tied to constants.
+//======================================================================
+
+-module_node clkmgr cg_en_o.io_div4_powerup
+-module_node clkmgr cg_en_o.aon_powerup
+-module_node clkmgr cg_en_o.main_powerup
+-module_node clkmgr cg_en_o.io_powerup
+-module_node clkmgr cg_en_o.usb_powerup
+-module_node clkmgr cg_en_o.io_div2_powerup
+-module_node clkmgr cg_en_o.aon_secure
+-module_node clkmgr cg_en_o.aon_peri
+-module_node clkmgr cg_en_o.aon_timers

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//======================================================================
+// This file contains outputs of pwrmgr tied to constants.
+//======================================================================
+
+-module_node clkmgr pwr_ast_o.slow_clk_en

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -30,16 +30,21 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
+  // Exclusion files
+  vcs_cov_excl_files: ["{self_dir}/cov/pwrmgr_cov_manual_excl.el"]
+
   // Overrides
   overrides: [
     {
       name: design_level
       value: "top"
     }
+    // Handle generated coverage exclusion.
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/pwrmgr_tgl_excl.cfg"
+    }
   ]
-
-  // Exclusion files
-  vcs_cov_excl_files: ["{self_dir}/cov/pwrmgr_cov_manual_excl.el"]
 
   // Add additional tops for simulation.
   sim_tops: ["pwrmgr_bind",

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/cov/rstmgr_tgl_excl.cfg
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/cov/rstmgr_tgl_excl.cfg
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//======================================================================
+// This file contains outputs of rstmgr tied to constants.
+//======================================================================
+
+-module_node rstmgr resets_o.rst_por_n[Domain0Sel]
+-module_node rstmgr rst_en_o.por[Domain0Sel]
+-module_node rstmgr resets_o.rst_por_io_n[Domain0Sel]
+-module_node rstmgr rst_en_o.por_io[Domain0Sel]
+-module_node rstmgr resets_o.rst_por_io_div2_n[Domain0Sel]
+-module_node rstmgr rst_en_o.por_io_div2[Domain0Sel]
+-module_node rstmgr resets_o.rst_por_io_div4_n[Domain0Sel]
+-module_node rstmgr rst_en_o.por_io_div4[Domain0Sel]
+-module_node rstmgr resets_o.rst_por_usb_n[Domain0Sel]
+-module_node rstmgr rst_en_o.por_usb[Domain0Sel]
+-module_node rstmgr resets_o.rst_lc_aon_n[Domain0Sel]
+-module_node rstmgr rst_en_o.lc_aon[Domain0Sel]
+-module_node rstmgr resets_o.rst_sys_n[DomainAonSel]
+-module_node rstmgr rst_en_o.sys[DomainAonSel]
+-module_node rstmgr resets_o.rst_sys_io_div4_n[Domain0Sel]
+-module_node rstmgr rst_en_o.sys_io_div4[Domain0Sel]
+-module_node rstmgr resets_o.rst_spi_device_n[DomainAonSel]
+-module_node rstmgr rst_en_o.spi_device[DomainAonSel]
+-module_node rstmgr resets_o.rst_spi_host0_n[DomainAonSel]
+-module_node rstmgr rst_en_o.spi_host0[DomainAonSel]
+-module_node rstmgr resets_o.rst_spi_host1_n[DomainAonSel]
+-module_node rstmgr rst_en_o.spi_host1[DomainAonSel]
+-module_node rstmgr resets_o.rst_usb_n[DomainAonSel]
+-module_node rstmgr rst_en_o.usb[DomainAonSel]
+-module_node rstmgr resets_o.rst_usb_aon_n[DomainAonSel]
+-module_node rstmgr rst_en_o.usb_aon[DomainAonSel]
+-module_node rstmgr resets_o.rst_i2c0_n[DomainAonSel]
+-module_node rstmgr rst_en_o.i2c0[DomainAonSel]
+-module_node rstmgr resets_o.rst_i2c1_n[DomainAonSel]
+-module_node rstmgr rst_en_o.i2c1[DomainAonSel]
+-module_node rstmgr resets_o.rst_i2c2_n[DomainAonSel]
+-module_node rstmgr rst_en_o.i2c2[DomainAonSel]

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -48,7 +48,7 @@
     }
     {
       name: default_vcs_cov_cfg_file
-      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg"
+      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{self_dir}/cov/rstmgr_cover.cfg+{self_dir}/cov/rstmgr_tgl_excl.cfg"
     }
   ]
 


### PR DESCRIPTION
- Generate the exclusions for clkmgr and rstmgr from templates. This is easier to maintain since the information comes from the hjson files.
- Create exclusion for pwrmgr with a single item.
- Use `module_name` directive for exclusion since it makes it possible to use the same config at block and full chip level.
- Add these exclusions to each block environment as well.
- Add these exclusions to full chip.

Fixes #16640 