### PR TITLE
[rom] Change the size of the key pair field in SPHINCS+ addresses.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/address.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/address.h
@@ -38,7 +38,7 @@
  *
  * WOTS+ hash address flexible fields:
  * +---------+------------------+----------+
- * | 16 bits | key pair address | 160..191 |
+ * | 32 bits | key pair address | 160..191 |
  * +---------+------------------+----------+
  * | 8 bits  | chain address    | 192..223 |
  * +---------+------------------+----------+
@@ -47,7 +47,7 @@
  *
  * WOTS+ public key compression flexible fields:
  * +---------+-------------------+----------+
- * | 16 bits | key pair address  | 160..191 |
+ * | 32 bits | key pair address  | 160..191 |
  * +---------+-------------------+----------+
  * | 64 bits | unused (always 0) | 192..255 |
  * +---------+-------------------+----------+
@@ -63,7 +63,7 @@
  *
  * FORS hash address flexible fields:
  * +---------+------------------+----------+
- * | 16 bits | key pair address | 160..191 |
+ * | 32 bits | key pair address | 160..191 |
  * +---------+------------------+----------+
  * | 8 bits  | tree height      | 192..223 |
  * +---------+------------------+----------+
@@ -72,7 +72,7 @@
  *
  * FORS tree root compression flexible fields:
  * +---------+-------------------+----------+
- * | 16 bits | key pair address  | 160..191 |
+ * | 32 bits | key pair address  | 160..191 |
  * +---------+-------------------+----------+
  * | 64 bits | unused (always 0) | 192..255 |
  * +---------+-------------------+----------+

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h
@@ -173,13 +173,9 @@ enum {
    */
   kSpxOffsetType = 19,
   /**
-   * High byte of the key pair.
+   * The start of the 4 byte field used to specify the key pair address.
    */
-  kSpxOffsetKpAddr2 = 22,
-  /**
-   * Low byte of the key pair.
-   */
-  kSpxOffsetKpAddr1 = 23,
+  kSpxOffsetKpAddr = 20,
   /**
    * Byte for the chain address (i.e. which Winternitz chain).
    */


### PR DESCRIPTION
This change does not affect the sphincsplus-shake-128s parameter set we use, since the key pair field is less than two bytes for all of the parameter sets that were submitted to the NIST competition. However, some choices of parameters need a larger field, so for maximum flexibility it makes sense to adjust. This change does not have any significant effect on performance, since these copies/writes are not on the hot path (checked this locally as well).

Corresponds to commit 7ec789a from the SPHINCS+ reference implementation (PR 60):
https://github.com/sphincs/sphincsplus/commit/7ec789ace6874d875f4bb84cb61b81155398167e

One difference between this PR and the commit above is that the check for `SPX_D==1` in `hash_shake.c` doesn't appear here; that's because we actually already had it! I vaguely remember getting a compiler warning about this and adding the check while testing some alternative parameter sets. We check `kSpxTreeBits == 0` instead of checking `d`, which is a slightly more direct way to ensure that `64 - kSpxTreeBits` is not 64. The two checks are equivalent, since `kSpxTreeBits` is the product of a nonzero number and `d-1`. Relevant code snippet is here:
https://github.com/lowRISC/opentitan/blob/2f53e8f8d89cd389b9aa42ecf9d9a009d74c8ff3/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_shake.c#L78-L84