### PR TITLE
[sival, rv_dm] improve jtag_tap_sel to support multiple lc states

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -227,6 +227,7 @@
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "RMA"]
       tests: ["chip_tap_straps_dev", "chip_tap_straps_prod", "chip_tap_straps_rma",
               "chip_tap_straps_testunlock0"]
+      bazel: ["//sw/device/tests:rv_dm_jtag_tap_sel"],
     }
 
     // PATTGEN (pre-verified IP) integration tests:

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4380,6 +4380,15 @@ test_suite(
     ],
 )
 
+_RV_DM_TAP_SEL_LC_STATES = get_lc_items(
+    CONST.LCV.TEST_UNLOCKED1,
+    CONST.LCV.TEST_LOCKED0,
+    CONST.LCV.DEV,
+    CONST.LCV.PROD,
+    CONST.LCV.PROD_END,
+    CONST.LCV.RMA,
+)
+
 [
     opentitan_test(
         name = "rv_dm_jtag_tap_sel_{}".format(lc_state),
@@ -4387,10 +4396,8 @@ test_suite(
         cw310 = cw310_params(
             needs_jtag = True,
             otp = _SIVAL_OTP_IMAGE[lc_state],
-            # TODO(#22823): Remove "broken" tag once the test is fixed.
             tags = [
                 "lc_{}".format(lc_state),
-                "broken",
             ],
             test_harness = "//sw/host/tests/chip/rv_dm:jtag_tap_sel",
         ),
@@ -4402,19 +4409,15 @@ test_suite(
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
-    for lc_state, _ in _RV_DM_JTAG_LC_STATES
+    for lc_state, _ in _RV_DM_TAP_SEL_LC_STATES
 ]
 
 test_suite(
     name = "rv_dm_jtag_tap_sel",
-    # TODO(#22823): Remove "broken" tag once the test is fixed.
-    tags = [
-        "broken",
-        "manual",
-    ],
+    tags = ["manual"],
     tests = [
         ":rv_dm_jtag_tap_sel_{}".format(lc_state)
-        for lc_state, _ in _RV_DM_JTAG_LC_STATES
+        for lc_state, _ in _RV_DM_TAP_SEL_LC_STATES
     ],
 )
 

--- a/sw/host/tests/chip/rv_dm/src/jtag_tap_sel.rs
+++ b/sw/host/tests/chip/rv_dm/src/jtag_tap_sel.rs
@@ -42,54 +42,103 @@ fn test_jtag_tap_sel(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let lc_state =
         DifLcCtrlState::from_redundant_encoding(jtag.read_lc_ctrl_reg(&LcCtrlReg::LcState)?)?;
 
+    // For test_unlocked* and RMA state, test that we can switch TAP without reset.
+    let (needs_reset, rv_dm_enabled) = match lc_state {
+        DifLcCtrlState::TestUnlocked0
+        | DifLcCtrlState::TestUnlocked1
+        | DifLcCtrlState::TestUnlocked2
+        | DifLcCtrlState::TestUnlocked3
+        | DifLcCtrlState::TestUnlocked4
+        | DifLcCtrlState::TestUnlocked5
+        | DifLcCtrlState::TestUnlocked6
+        | DifLcCtrlState::TestUnlocked7
+        | DifLcCtrlState::Rma => (false, true),
+        DifLcCtrlState::Dev => (true, true),
+        _ => (true, false),
+    };
+
     jtag.disconnect()?;
     transport.pin_strapping("PINMUX_TAP_LC")?.remove()?;
 
     // Test RISC-V TAP
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
-    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+    if needs_reset {
+        transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+    }
 
-    let mut jtag = opts
+    let jtag = opts
         .init
         .jtag_params
         .create(transport)?
-        .connect(JtagTap::RiscvTap)?;
-    let mut lc_state_rv = 0;
-    jtag.read_memory32(
-        top_earlgrey::LC_CTRL_BASE_ADDR as u32 + LcCtrlReg::LcState as u32,
-        core::slice::from_mut(&mut lc_state_rv),
-    )?;
-    let lc_state_rv = DifLcCtrlState::from_redundant_encoding(lc_state_rv)?;
-    assert_eq!(lc_state, lc_state_rv);
+        .connect(JtagTap::RiscvTap);
 
-    jtag.disconnect()?;
+    assert_eq!(rv_dm_enabled, jtag.is_ok());
+
+    if let Ok(mut jtag) = jtag {
+        let mut lc_state_rv = 0;
+        jtag.read_memory32(
+            top_earlgrey::LC_CTRL_BASE_ADDR as u32 + LcCtrlReg::LcState as u32,
+            core::slice::from_mut(&mut lc_state_rv),
+        )?;
+        let lc_state_rv = DifLcCtrlState::from_redundant_encoding(lc_state_rv)?;
+        assert_eq!(lc_state, lc_state_rv);
+        jtag.disconnect()?;
+    }
+
     transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;
 
     // Test DFT TAP
     transport.pin_strapping("PINMUX_TAP_DFT")?.apply()?;
-    transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+    if needs_reset {
+        transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+    }
 
-    // For DFT test we need to do raw OpenOCD command.
+    // If RV-DM is disabled, strapping DFT tap will result in LC TAP being selected.
+    if !rv_dm_enabled {
+        opts.init
+            .jtag_params
+            .create(transport)?
+            .connect(JtagTap::LcTap)?
+            .disconnect()?;
+    } else {
+        // For DFT test we need to do raw OpenOCD command.
+        let mut openocd = opts.init.jtag_params.create(transport)?.into_raw()?;
+        // Perform JTAG initialisation and capture the result.
+        let init_result = openocd.execute("capture \"jtag init\"")?;
+
+        static ID_REGEX: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"tap/device found: 0x([0-9A-Fa-f]+) \(").unwrap());
+        let idcode = if init_result.contains("JTAG scan chain interrogation failed") {
+            None
+        } else {
+            Some(u32::from_str_radix(
+                ID_REGEX
+                    .captures(&init_result)
+                    .context("Failed to parse IDCODE from OpenOCD output")?
+                    .get(1)
+                    .unwrap()
+                    .as_str(),
+                16,
+            )?)
+        };
+
+        // For everything other than test_unlocked* and RMA states, the DFT TAP should not exist.
+        let expected_idcode = if needs_reset { opts.dft_idcode } else { None };
+        assert_eq!(idcode, expected_idcode);
+        openocd.shutdown()?;
+    }
+
+    transport.pin_strapping("PINMUX_TAP_DFT")?.remove()?;
+    if needs_reset {
+        transport.reset_target(opts.init.bootstrap.options.reset_delay, true)?;
+    }
+
+    // Now check that there's no JTAG TAP present.
     let mut openocd = opts.init.jtag_params.create(transport)?.into_raw()?;
     // Perform JTAG initialisation and capture the result.
     let init_result = openocd.execute("capture \"jtag init\"")?;
-
-    static ID_REGEX: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"tap/device found: 0x([0-9A-Fa-f]+) \(").unwrap());
-    let idcode = if init_result.contains("JTAG scan chain interrogation failed") {
-        None
-    } else {
-        Some(u32::from_str_radix(
-            ID_REGEX
-                .captures(&init_result)
-                .context("Failed to parse IDCODE from OpenOCD output")?
-                .get(1)
-                .unwrap()
-                .as_str(),
-            16,
-        )?)
-    };
-    assert_eq!(idcode, opts.dft_idcode);
+    assert!(init_result.contains("JTAG scan chain interrogation failed"));
+    openocd.shutdown()?;
 
     Ok(())
 }


### PR DESCRIPTION
This test now tests PROD states and check in RMA state the tap is continuously sampled. This makes it cover chip_sw_tap_strap_sampling test.