### PR TITLE
[sival] add field to testplan to indicate required boot stages

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -509,7 +509,6 @@
               "chip_sw_hmac_smoketest",
               "chip_sw_kmac_smoketest",
               "chip_sw_otbn_smoketest",
-              "chip_sw_otp_ctrl_smoketest",
               "chip_sw_pwrmgr_smoketest",
               "chip_sw_pwrmgr_usbdev_smoketest",
               "chip_sw_rv_plic_smoketest",
@@ -529,7 +528,6 @@
         "//sw/device/tests:hmac_smoketest",
         "//sw/device/tests:kmac_smoketest",
         "//sw/device/tests:otbn_smoketest",
-        "//sw/device/tests:otp_ctrl_smoketest",
         "//sw/device/tests:pmp_smoketest_napot",
         "//sw/device/tests:pmp_smoketest_tor",
         "//sw/device/tests:pwrmgr_smoketest",
@@ -541,6 +539,20 @@
         "//sw/device/tests:sram_ctrl_smoketest",
         "//sw/device/tests:uart_smoketest",
       ]
+    }
+    {
+      name: chip_sw_otp_smoketest
+      desc: '''Run smoke tests developed for OTP.
+
+            This smoketest is separated from the chip_sw_smoketest since it
+            cannot be executed in silicon owner stage.
+            '''
+      stage: V2
+      si_stage: SV2
+      lc_states: ["PROD"],
+      boot_stages: ["rom_ext"],
+      tests: ["chip_sw_otp_ctrl_smoketest"],
+      bazel: ["//sw/device/tests:otp_ctrl_smoketest"],
     }
     {
       name: chip_sw_rom_functests

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -66,6 +66,7 @@
       si_stage: SV3
       tests: ["chip_sw_rv_core_ibex_address_translation"]
       lc_states: ["PROD"]
+      boot_stages: ["rom_ext"],
       features: [
         "RV_CORE_IBEX.ADDRESS_TRANSLATION"
       ]
@@ -169,6 +170,7 @@
        tests: []
        bazel: ["//sw/device/tests:rv_core_ibex_epmp_test_functest"]
        lc_states: ["TEST_UNLOCKED", "DEV", "RMA", "PROD", "PROD_END"]
+       boot_stages: ["rom_ext"],
        features: [
          "RV_CORE_IBEX.CPU.EPMP"
        ]


### PR DESCRIPTION
Due to rom_ext locking down a bunch of stuff, some tests cannot be run in silicon owner stage. This is orthogonal to the lifecycle states, so adding a new field to testplan to indicate this.

The idea is that the new `boot_stages` field is used to indicate which boot stages the test can run in. For example,
```
boot_stages: ["rom_ext"]
```
limits the test to rom_ext stage, where
```
boot_stages: ["silicon_owner"]
```
limits the test to silicon owner stage. I suppose for tests that use SRAM injection they can have `"rom"` as boot stage since they run before ROM is executed.

When nothing is specified the test should be treated as having
```
boot_stages: ["rom_ext", "silicon_owner"]
```