### PR TITLE
[sival,sram_ctrl] Fix sram_ctrl_sleep_contents_ret test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3567,24 +3567,12 @@ opentitan_test(
 opentitan_test(
     name = "sram_ctrl_sleep_sram_ret_contents_scramble_test",
     srcs = ["sram_ctrl_sleep_sram_ret_contents_scramble_test.c"],
-    broken = cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_proda_rom_ext": "silicon_owner",
         },
-    ),
-    silicon_owner = silicon_params(
-        tags = ["broken"],
-    ),
-    verilator = verilator_params(
-        timeout = "long",
     ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
+++ b/sw/device/tests/sram_ctrl_sleep_sram_ret_contents_impl.c
@@ -190,7 +190,7 @@ bool execute_sram_ctrl_sleep_ret_sram_contents_test(bool scramble) {
       // retention SRAM when it boots after being scrambled. The ROM_EXT
       // expects a valid version and refuses to boot otherwise.
       //
-      // This is fixed in the prod ROM, but we can must work around it in ES
+      // This is fixed in the prod ROM, but we must work around it in ES
       // tests by restoring the version after the wipe.
       //
       // We write the version pre-scrambling since we want it to be readable


### PR DESCRIPTION
The retention SRAM contains a "version" field which the ROM_EXT expects to be valid in order to boot. The ES version of the ROM does not set this field on every boot. Since the version is invalid after a wipe / scrambling of the retention SRAM, this test was failing due to boot errors.

This is fixed in the production ROM, but we've had to work around it for ES.

The scrambling version of this test:

1. Changes the scrambling key from the default.
2. Writes a pattern to retention SRAM and goes into a normal sleep. After waking up, we check that the pattern reads back the same.
3. Goes into deep sleep and resets using the AON timer.
4. With this kind of reset, the ROM should restore the scrambling key we changed to. We check this by reading back the pattern again.
5. Resets "normally" using the watchdog timer.
6. With that kind of reset, the ROM restores the default scrambling key. We check this happened by trying to read back the pattern and seeing that it has changed.

The workaround:

1. Swaps the order of the deep sleep reset and the "normal" watchdog reset. This is necessary to make the next change work.
2. When scrambling before the normal reset, we manually restore the `version` field into retention SRAM after the wipe but _before_ the scrambling key is changed. This means it's stored using the default scrambling key and the next boot can read it correctly.
3. When scrambling before the deep sleep reset, we manually restore the `version` field _after_ the scrambling key is changed. This means it's stored using our new scrambling key and can be read back correctly at the next boot.