### PR TITLE
[csrng/rtl] csrng move cmd checks into the cmd stage

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -547,7 +547,7 @@
                 '''
         }
         { bits: "13",
-          name: "CS_MAIN_SM_ALERT",
+          name: "CMD_STAGE_INVALID_ACMD_ALERT",
           desc: '''
                 This bit is set when an unsupported/illegal CSRNG command is received by the
                 main state machine.
@@ -556,7 +556,7 @@
                 '''
         }
         { bits: "14",
-          name: "CS_MAIN_SM_INVALID_CMD_SEQ",
+          name: "CMD_STAGE_INVALID_CMD_SEQ_ALERT",
           desc: '''
                 This bit is set when an out of order command is received by the main state machine.
                 This happens when an instantiate command is sent for a state that was already

--- a/hw/ip/csrng/doc/registers.md
+++ b/hw/ip/csrng/doc/registers.md
@@ -366,21 +366,21 @@ Recoverable alert status register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "SW_APP_ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "READ_INT_STATE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "ACMD_FLAG0_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 8}, {"name": "CS_BUS_CMP_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CS_MAIN_SM_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CS_MAIN_SM_INVALID_CMD_SEQ", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_RESEED_CNT_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 280}}
+{"reg": [{"name": "ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "SW_APP_ENABLE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "READ_INT_STATE_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "ACMD_FLAG0_FIELD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 8}, {"name": "CS_BUS_CMP_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_INVALID_ACMD_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_INVALID_CMD_SEQ_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"name": "CMD_STAGE_RESEED_CNT_ALERT", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 330}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                                                                       |
-|:------:|:------:|:-------:|:---------------------------------------------------------------------------|
-| 31:16  |        |         | Reserved                                                                   |
-|   15   |  rw0c  |   0x0   | [CMD_STAGE_RESEED_CNT_ALERT](#recov_alert_sts--cmd_stage_reseed_cnt_alert) |
-|   14   |  rw0c  |   0x0   | [CS_MAIN_SM_INVALID_CMD_SEQ](#recov_alert_sts--cs_main_sm_invalid_cmd_seq) |
-|   13   |  rw0c  |   0x0   | [CS_MAIN_SM_ALERT](#recov_alert_sts--cs_main_sm_alert)                     |
-|   12   |  rw0c  |   0x0   | [CS_BUS_CMP_ALERT](#recov_alert_sts--cs_bus_cmp_alert)                     |
-|  11:4  |        |         | Reserved                                                                   |
-|   3    |  rw0c  |   0x0   | [ACMD_FLAG0_FIELD_ALERT](#recov_alert_sts--acmd_flag0_field_alert)         |
-|   2    |  rw0c  |   0x0   | [READ_INT_STATE_FIELD_ALERT](#recov_alert_sts--read_int_state_field_alert) |
-|   1    |  rw0c  |   0x0   | [SW_APP_ENABLE_FIELD_ALERT](#recov_alert_sts--sw_app_enable_field_alert)   |
-|   0    |  rw0c  |   0x0   | [ENABLE_FIELD_ALERT](#recov_alert_sts--enable_field_alert)                 |
+|  Bits  |  Type  |  Reset  | Name                                                                                 |
+|:------:|:------:|:-------:|:-------------------------------------------------------------------------------------|
+| 31:16  |        |         | Reserved                                                                             |
+|   15   |  rw0c  |   0x0   | [CMD_STAGE_RESEED_CNT_ALERT](#recov_alert_sts--cmd_stage_reseed_cnt_alert)           |
+|   14   |  rw0c  |   0x0   | [CMD_STAGE_INVALID_CMD_SEQ_ALERT](#recov_alert_sts--cmd_stage_invalid_cmd_seq_alert) |
+|   13   |  rw0c  |   0x0   | [CMD_STAGE_INVALID_ACMD_ALERT](#recov_alert_sts--cmd_stage_invalid_acmd_alert)       |
+|   12   |  rw0c  |   0x0   | [CS_BUS_CMP_ALERT](#recov_alert_sts--cs_bus_cmp_alert)                               |
+|  11:4  |        |         | Reserved                                                                             |
+|   3    |  rw0c  |   0x0   | [ACMD_FLAG0_FIELD_ALERT](#recov_alert_sts--acmd_flag0_field_alert)                   |
+|   2    |  rw0c  |   0x0   | [READ_INT_STATE_FIELD_ALERT](#recov_alert_sts--read_int_state_field_alert)           |
+|   1    |  rw0c  |   0x0   | [SW_APP_ENABLE_FIELD_ALERT](#recov_alert_sts--sw_app_enable_field_alert)             |
+|   0    |  rw0c  |   0x0   | [ENABLE_FIELD_ALERT](#recov_alert_sts--enable_field_alert)                           |
 
 ### RECOV_ALERT_STS . CMD_STAGE_RESEED_CNT_ALERT
 This bit is set when the maximum number of generate requests between reseeds is
@@ -388,7 +388,7 @@ exceeded.
 The invalid generate command is ignored and CSRNG continues to operate.
 Writing a zero resets this status bit.
 
-### RECOV_ALERT_STS . CS_MAIN_SM_INVALID_CMD_SEQ
+### RECOV_ALERT_STS . CMD_STAGE_INVALID_CMD_SEQ_ALERT
 This bit is set when an out of order command is received by the main state machine.
 This happens when an instantiate command is sent for a state that was already
 instantiated or when any command other than instantiate is sent for a state that
@@ -396,7 +396,7 @@ wasn't instantiated yet.
 The invalid command is ignored and CSRNG continues to operate.
 Writing a zero resets this status bit.
 
-### RECOV_ALERT_STS . CS_MAIN_SM_ALERT
+### RECOV_ALERT_STS . CMD_STAGE_INVALID_ACMD_ALERT
 This bit is set when an unsupported/illegal CSRNG command is received by the
 main state machine.
 The invalid command is ignored and CSRNG continues to operate.

--- a/hw/ip/csrng/doc/theory_of_operation.md
+++ b/hw/ip/csrng/doc/theory_of_operation.md
@@ -47,7 +47,7 @@ This process repeats until the `glen` field value has been matched.
 Because each request is pipelined, requests from other `cmd_stage` blocks can be processed before the original generate command is completely done.
 This provides some interleaving of commands since a generate command can be programmed to take a very long time.
 
-When sending an unsupported or illegal command, `CS_MAIN_SM_ALERT` will be triggered, but there will be no status response or indication of which app the error occurred in.
+When sending an unsupported or illegal command, `CMD_STAGE_INVALID_ACMD_ALERT` will be triggered, but there will be no status response or indication of which app the error occurred in.
 
 #### Working State Values
 The CSRNG working state data base (`state_db`) contains the current working state for a given DRBG instance.

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -168,12 +168,14 @@ package csrng_env_pkg;
   } err_code_bit_e;
 
   typedef enum int {
-    ENABLE_FIELD_ALERT         = 0,
-    SW_APP_ENABLE_FIELD_ALERT  = 1,
-    READ_INT_STATE_FIELD_ALERT = 2,
-    ACMD_FLAG0_FIELD_ALERT     = 3,
-    CS_BUS_CMP_ALERT           = 12,
-    CS_MAIN_SM_ALERT           = 13
+    ENABLE_FIELD_ALERT              = 0,
+    SW_APP_ENABLE_FIELD_ALERT       = 1,
+    READ_INT_STATE_FIELD_ALERT      = 2,
+    ACMD_FLAG0_FIELD_ALERT          = 3,
+    CS_BUS_CMP_ALERT                = 12,
+    CMD_STAGE_INVALID_ACMD_ALERT    = 13,
+    CMD_STAGE_INVALID_CMD_SEQ_ALERT = 14,
+    CMD_STAGE_RESEED_CNT_ALERT      = 15
   } recov_alert_bit_e;
 
   typedef enum int {

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_alert_vseq.sv
@@ -23,7 +23,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
     uvm_reg       csr;
     uvm_reg_field fld;
 
-    // Values for the cs_main_sm_alert test.
+    // Values for the CMD_STAGE_INVALID_ACMD_ALERT test.
     `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(illegal_command, illegal_command inside {INV, GENB,
                                                                                    GENU};)
     // For clen we just care about 0, 1 and the max value (coverage).
@@ -205,10 +205,11 @@ class csrng_alert_vseq extends csrng_base_vseq;
     // Check recov_alert_sts register has cleared.
     csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
 
-    `uvm_info(`gfn, $sformatf("Testing cs_main_sm_alert for app %d", cfg.which_app_err_alert), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("Testing CMD_STAGE_INVALID_ACMD_ALERT for app %d",
+        cfg.which_app_err_alert), UVM_MEDIUM)
 
-    // Here we send an illegal command to CSRNG to check that cs_main_sm_alert is triggered.
-    // Sending an illegal command does not get a response from CSRNG.
+    // Here we send an illegal command to CSRNG to check that CMD_STAGE_INVALID_ACMD_ALERT is
+    // triggered. Sending an illegal command does not get a response from CSRNG.
     cs_item.acmd  = illegal_command;
     cs_item.clen  = clen;
     cs_item.flags = get_rand_mubi4_val(.t_weight(4), .f_weight(4), .other_weight(0));
@@ -220,7 +221,7 @@ class csrng_alert_vseq extends csrng_base_vseq;
 
     `uvm_info(`gfn, $sformatf("Checking RECOV_ALERT_STS register"), UVM_MEDIUM)
     exp_recov_alert_sts = 32'b0;
-    exp_recov_alert_sts[ral.recov_alert_sts.cs_main_sm_alert.get_lsb_pos()] = 1;
+    exp_recov_alert_sts[ral.recov_alert_sts.cmd_stage_invalid_acmd_alert.get_lsb_pos()] = 1;
     csr_spinwait(.ptr(ral.recov_alert_sts), .exp_data(exp_recov_alert_sts));
     // Since we already did a backdoor check, sampling with this value is sufficient.
     cov_vif.cg_recov_alert_sample(.recov_alert(exp_recov_alert_sts));

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -6,17 +6,13 @@
 //
 //  - handles all app cmd requests from all requesting interfaces
 
-module csrng_main_sm import csrng_pkg::*; #(
-  parameter int unsigned NApps = 3,
-  localparam int unsigned NAppsLog = $clog2(NApps)
-) (
+module csrng_main_sm import csrng_pkg::*; (
   input logic                         clk_i,
   input logic                         rst_ni,
 
   input logic                         enable_i,
   input logic                         acmd_avail_i,
   output logic                        acmd_accept_o,
-  input logic [NAppsLog-1:0]          shid_i,
   input logic [2:0]                   acmd_i,
   input logic                         acmd_eop_i,
   input logic                         ctr_drbg_cmd_req_rdy_i,
@@ -31,39 +27,17 @@ module csrng_main_sm import csrng_pkg::*; #(
   output logic                        clr_adata_packer_o,
   input logic                         cmd_complete_i,
   input logic                         local_escalate_i,
-  output logic                        invalid_cmd_seq_o,
   output logic [MainSmStateWidth-1:0] main_sm_state_o,
-  output logic                        main_sm_alert_o,
   output logic                        main_sm_err_o
 );
 
   main_sm_state_e state_d, state_q;
-  // For each instance we need 1 bit to track whether the instance was instantiated or not.
-  logic [NApps-1:0] instantiated_d, instantiated_q;
-  logic [NApps-1:0] shid_one_hot;
   `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, main_sm_state_e, MainSmIdle)
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      instantiated_q <= '0;
-    end else begin
-      instantiated_q <= instantiated_d;
-    end
-  end
 
   assign main_sm_state_o = {state_q};
 
-  prim_onehot_enc #(
-    .OneHotWidth (NApps)
-  ) u_shid_one_hot_enc (
-    .in_i   (shid_i),
-    .en_i   (1'b1),
-    .out_o  (shid_one_hot)
-  );
-
   always_comb begin
     state_d            = state_q;
-    instantiated_d     = instantiated_q;
     acmd_accept_o      = 1'b0;
     cmd_entropy_req_o  = 1'b0;
     instant_req_o      = 1'b0;
@@ -72,9 +46,7 @@ module csrng_main_sm import csrng_pkg::*; #(
     update_req_o       = 1'b0;
     uninstant_req_o    = 1'b0;
     clr_adata_packer_o = 1'b0;
-    main_sm_alert_o    = 1'b0;
     main_sm_err_o      = 1'b0;
-    invalid_cmd_seq_o  = 1'b0;
 
     if (state_q == MainSmError) begin
       // In case we are in the Error state we must ignore the local escalate and enable signals.
@@ -90,7 +62,6 @@ module csrng_main_sm import csrng_pkg::*; #(
                                               MainSmClrAData, MainSmCmdCompWait}) begin
       // In case the module is disabled and we are in a legal state we must go into idle state.
       state_d = MainSmIdle;
-      instantiated_d = '0;
     end else begin
       // Otherwise do the state machine as normal.
       unique case (state_q)
@@ -105,59 +76,20 @@ module csrng_main_sm import csrng_pkg::*; #(
           end
         end
         MainSmParseCmd: begin
-          if (ctr_drbg_cmd_req_rdy_i) begin
+          if (ctr_drbg_cmd_req_rdy_i && acmd_eop_i) begin
             if (acmd_i == INS) begin
-              if (acmd_eop_i) begin
-                if ((instantiated_q & shid_one_hot) == 'b0) begin
-                  state_d = MainSmInstantPrep;
-                  // Toggle the instantiated state from off to on for the current shid.
-                  instantiated_d = instantiated_q ^ shid_one_hot;
-                end
-                if ((instantiated_q & shid_one_hot) != 'b0) begin
-                  state_d = MainSmIdle;
-                  invalid_cmd_seq_o = 1'b1;
-                end
-              end
+              state_d = MainSmInstantPrep;
             end else if (acmd_i == RES) begin
-              if (acmd_eop_i) begin
-                if ((instantiated_q & shid_one_hot) != 'b0) begin
-                  state_d = MainSmReseedPrep;
-                end
-                if ((instantiated_q & shid_one_hot) == 'b0) begin
-                  state_d = MainSmIdle;
-                  invalid_cmd_seq_o = 1'b1;
-                end
-              end
+              state_d = MainSmReseedPrep;
             end else if (acmd_i == GEN) begin
-              if (acmd_eop_i) begin
-                if ((instantiated_q & shid_one_hot) != 'b0) begin
-                  state_d = MainSmGeneratePrep;
-                end
-                if ((instantiated_q & shid_one_hot) == 'b0) begin
-                  state_d = MainSmIdle;
-                  invalid_cmd_seq_o = 1'b1;
-                end
-              end
+              state_d = MainSmGeneratePrep;
             end else if (acmd_i == UPD) begin
-              if (acmd_eop_i) begin
-                if ((instantiated_q & shid_one_hot) != 'b0) begin
-                  state_d = MainSmUpdatePrep;
-                end
-                if ((instantiated_q & shid_one_hot) == 'b0) begin
-                  state_d = MainSmIdle;
-                  invalid_cmd_seq_o = 1'b1;
-                end
-              end
+              state_d = MainSmUpdatePrep;
             end else if (acmd_i == UNI) begin
-              if (acmd_eop_i) begin
-                // Set the instantiation to zero for the relevant shid.
-                instantiated_d = instantiated_q & ~shid_one_hot;
-                state_d = MainSmUninstantPrep;
-              end
+              state_d = MainSmUninstantPrep;
             end else begin
               // Command was not supported.
               state_d = MainSmIdle;
-              main_sm_alert_o = 1'b1;
             end
           end
         end

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -198,11 +198,11 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } cs_main_sm_alert;
+    } cmd_stage_invalid_acmd_alert;
     struct packed {
       logic        d;
       logic        de;
-    } cs_main_sm_invalid_cmd_seq;
+    } cmd_stage_invalid_cmd_seq_alert;
     struct packed {
       logic        d;
       logic        de;

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -189,10 +189,10 @@ module csrng_reg_top (
   logic recov_alert_sts_acmd_flag0_field_alert_wd;
   logic recov_alert_sts_cs_bus_cmp_alert_qs;
   logic recov_alert_sts_cs_bus_cmp_alert_wd;
-  logic recov_alert_sts_cs_main_sm_alert_qs;
-  logic recov_alert_sts_cs_main_sm_alert_wd;
-  logic recov_alert_sts_cs_main_sm_invalid_cmd_seq_qs;
-  logic recov_alert_sts_cs_main_sm_invalid_cmd_seq_wd;
+  logic recov_alert_sts_cmd_stage_invalid_acmd_alert_qs;
+  logic recov_alert_sts_cmd_stage_invalid_acmd_alert_wd;
+  logic recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_qs;
+  logic recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_wd;
   logic recov_alert_sts_cmd_stage_reseed_cnt_alert_qs;
   logic recov_alert_sts_cmd_stage_reseed_cnt_alert_wd;
   logic err_code_sfifo_cmd_err_qs;
@@ -1098,23 +1098,23 @@ module csrng_reg_top (
     .qs     (recov_alert_sts_cs_bus_cmp_alert_qs)
   );
 
-  //   F[cs_main_sm_alert]: 13:13
+  //   F[cmd_stage_invalid_acmd_alert]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
-  ) u_recov_alert_sts_cs_main_sm_alert (
+  ) u_recov_alert_sts_cmd_stage_invalid_acmd_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (recov_alert_sts_we),
-    .wd     (recov_alert_sts_cs_main_sm_alert_wd),
+    .wd     (recov_alert_sts_cmd_stage_invalid_acmd_alert_wd),
 
     // from internal hardware
-    .de     (hw2reg.recov_alert_sts.cs_main_sm_alert.de),
-    .d      (hw2reg.recov_alert_sts.cs_main_sm_alert.d),
+    .de     (hw2reg.recov_alert_sts.cmd_stage_invalid_acmd_alert.de),
+    .d      (hw2reg.recov_alert_sts.cmd_stage_invalid_acmd_alert.d),
 
     // to internal hardware
     .qe     (),
@@ -1122,26 +1122,26 @@ module csrng_reg_top (
     .ds     (),
 
     // to register interface (read)
-    .qs     (recov_alert_sts_cs_main_sm_alert_qs)
+    .qs     (recov_alert_sts_cmd_stage_invalid_acmd_alert_qs)
   );
 
-  //   F[cs_main_sm_invalid_cmd_seq]: 14:14
+  //   F[cmd_stage_invalid_cmd_seq_alert]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
-  ) u_recov_alert_sts_cs_main_sm_invalid_cmd_seq (
+  ) u_recov_alert_sts_cmd_stage_invalid_cmd_seq_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (recov_alert_sts_we),
-    .wd     (recov_alert_sts_cs_main_sm_invalid_cmd_seq_wd),
+    .wd     (recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_wd),
 
     // from internal hardware
-    .de     (hw2reg.recov_alert_sts.cs_main_sm_invalid_cmd_seq.de),
-    .d      (hw2reg.recov_alert_sts.cs_main_sm_invalid_cmd_seq.d),
+    .de     (hw2reg.recov_alert_sts.cmd_stage_invalid_cmd_seq_alert.de),
+    .d      (hw2reg.recov_alert_sts.cmd_stage_invalid_cmd_seq_alert.d),
 
     // to internal hardware
     .qe     (),
@@ -1149,7 +1149,7 @@ module csrng_reg_top (
     .ds     (),
 
     // to register interface (read)
-    .qs     (recov_alert_sts_cs_main_sm_invalid_cmd_seq_qs)
+    .qs     (recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_qs)
   );
 
   //   F[cmd_stage_reseed_cnt_alert]: 15:15
@@ -2074,9 +2074,9 @@ module csrng_reg_top (
 
   assign recov_alert_sts_cs_bus_cmp_alert_wd = reg_wdata[12];
 
-  assign recov_alert_sts_cs_main_sm_alert_wd = reg_wdata[13];
+  assign recov_alert_sts_cmd_stage_invalid_acmd_alert_wd = reg_wdata[13];
 
-  assign recov_alert_sts_cs_main_sm_invalid_cmd_seq_wd = reg_wdata[14];
+  assign recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_wd = reg_wdata[14];
 
   assign recov_alert_sts_cmd_stage_reseed_cnt_alert_wd = reg_wdata[15];
   assign err_code_test_we = addr_hit[16] & reg_we & !reg_error;
@@ -2187,8 +2187,8 @@ module csrng_reg_top (
         reg_rdata_next[2] = recov_alert_sts_read_int_state_field_alert_qs;
         reg_rdata_next[3] = recov_alert_sts_acmd_flag0_field_alert_qs;
         reg_rdata_next[12] = recov_alert_sts_cs_bus_cmp_alert_qs;
-        reg_rdata_next[13] = recov_alert_sts_cs_main_sm_alert_qs;
-        reg_rdata_next[14] = recov_alert_sts_cs_main_sm_invalid_cmd_seq_qs;
+        reg_rdata_next[13] = recov_alert_sts_cmd_stage_invalid_acmd_alert_qs;
+        reg_rdata_next[14] = recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_qs;
         reg_rdata_next[15] = recov_alert_sts_cmd_stage_reseed_cnt_alert_qs;
       end
 

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -342,12 +342,12 @@ typedef enum dif_csrng_recoverable_alert {
    * Indicates an unsupported CSRNG command was issued.
    */
   kDifCsrngRecoverableAlertBadCsrngCmd =
-      1U << CSRNG_RECOV_ALERT_STS_CS_MAIN_SM_ALERT_BIT,
+      1U << CSRNG_RECOV_ALERT_STS_CMD_STAGE_INVALID_ACMD_ALERT_BIT,
   /**
    * Indicates a supported CSRNG command was issued out of sequence.
    */
   kDifCsrngRecoverableAlertBadCsrngCmdSeq =
-      1U << CSRNG_RECOV_ALERT_STS_CS_MAIN_SM_INVALID_CMD_SEQ_BIT,
+      1U << CSRNG_RECOV_ALERT_STS_CMD_STAGE_INVALID_CMD_SEQ_ALERT_BIT,
   /**
    * Indicates that too many generate commands were issued in a row.
    */


### PR DESCRIPTION
Please see the commit message for a description.

I ran a regression with 0.1 multiplier and a few more tests than usual are failing (~5 more than expected).

I didn't have time to debug all of them but I think this PR is ready to at least be looked at.

depends on #22883