### PR TITLE
[otbn] Detect unexpected partial "secure" wipes

### DIFF
--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -100,7 +100,9 @@ module otbn_alu_bignum
 
   output logic                        reg_intg_violation_err_o,
 
-  input logic                         sec_wipe_mod_urnd_i,
+  input  logic                        sec_wipe_mod_urnd_i,
+  input  logic                        sec_wipe_running_i,
+  output logic                        sec_wipe_err_o,
 
   input  flags_t                      mac_operation_flags_i,
   input  flags_t                      mac_operation_flags_en_i,
@@ -962,6 +964,9 @@ module otbn_alu_bignum
   // invalid.
   assign reg_intg_violation_err_o = mod_used & |(mod_intg_err);
   `ASSERT_KNOWN(RegIntgErrKnown_A, reg_intg_violation_err_o)
+
+  // Detect and signal unexpected secure wipe signals.
+  assign sec_wipe_err_o = sec_wipe_mod_urnd_i & ~sec_wipe_running_i;
 
   // Blanking Assertions
   // All blanking assertions are reset with predec_error or overall error in the whole system

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -22,8 +22,10 @@ module otbn_mac_bignum
   input  mac_predec_bignum_t mac_predec_bignum_i,
   output logic               predec_error_o,
 
-  input logic [WLEN-1:0] urnd_data_i,
-  input logic            sec_wipe_acc_urnd_i,
+  input  logic [WLEN-1:0] urnd_data_i,
+  input  logic            sec_wipe_acc_urnd_i,
+  input  logic            sec_wipe_running_i,
+  output logic            sec_wipe_err_o,
 
   output logic [ExtWLEN-1:0] ispr_acc_intg_o,
   input  logic [ExtWLEN-1:0] ispr_acc_wr_data_intg_i,
@@ -235,6 +237,8 @@ module otbn_mac_bignum
   // SEC_CM: CTRL.REDUN
   assign predec_error_o = |{expected_op_en     != mac_predec_bignum_i.op_en,
                             expected_acc_rd_en != mac_predec_bignum_i.acc_rd_en};
+
+  assign sec_wipe_err_o = sec_wipe_acc_urnd_i & ~sec_wipe_running_i;
 
   `ASSERT(NoISPRAccWrAndMacEn, ~(ispr_acc_wr_en_i & mac_en_i))
 endmodule

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -38,6 +38,7 @@ module otbn_rf_base
 
   input  logic                     state_reset_i,
   input  logic                     sec_wipe_stack_reset_i,
+  input  logic                     sec_wipe_running_i,
 
   input  logic [4:0]               wr_addr_i,
   input  logic                     wr_en_i,
@@ -59,7 +60,8 @@ module otbn_rf_base
   output logic                     call_stack_sw_err_o,
   output logic                     call_stack_hw_err_o,
   output logic                     intg_err_o,
-  output logic                     spurious_we_err_o
+  output logic                     spurious_we_err_o,
+  output logic                     sec_wipe_err_o
 );
   localparam int unsigned CallStackRegIndex = 1;
   localparam int unsigned CallStackDepth = 8;
@@ -233,4 +235,6 @@ module otbn_rf_base
   // secure wipe.
   `ASSERT(OtbnRfBaseRdAKnown, rd_en_a_i && !pop_stack_a |-> !$isunknown(rd_data_a_raw_intg))
   `ASSERT(OtbnRfBaseRdBKnown, rd_en_b_i && !pop_stack_b |-> !$isunknown(rd_data_b_raw_intg))
+
+  assign sec_wipe_err_o = sec_wipe_stack_reset_i & ~sec_wipe_running_i;
 endmodule

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -79,6 +79,7 @@ module otbn_start_stop_control
   logic mubi_err_q, mubi_err_d;
   logic urnd_reseed_err_q, urnd_reseed_err_d;
   logic secure_wipe_error_q, secure_wipe_error_d;
+  logic secure_wipe_running_q, secure_wipe_running_d;
   logic skip_reseed_q;
 
   logic addr_cnt_inc;
@@ -165,7 +166,7 @@ module otbn_start_stop_control
     sec_wipe_zero_o           = 1'b0;
     addr_cnt_inc              = 1'b0;
     secure_wipe_ack_o         = 1'b0;
-    secure_wipe_running_o     = 1'b0;
+    secure_wipe_running_d     = 1'b0;
     state_error_d             = state_error_q;
     allow_secure_wipe         = 1'b0;
     expect_secure_wipe        = 1'b0;
@@ -176,7 +177,7 @@ module otbn_start_stop_control
 
     unique case (state_q)
       OtbnStartStopStateInitial: begin
-        secure_wipe_running_o = 1'b1;
+        secure_wipe_running_d = 1'b1;
         urnd_reseed_req_o     = 1'b1;
         if (rma_request) begin
           // If we get an RMA request before the URND got reseeded, proceed with the initial secure
@@ -203,7 +204,8 @@ module otbn_start_stop_control
           if (rma_request) begin
             // Do not reseed URND before secure wipe for RMA, as the entropy complex may not be able
             // to provide entropy at this point.
-            state_d = OtbnStartStopSecureWipeWdrUrnd;
+            secure_wipe_running_d = 1'b1;
+            state_d               = OtbnStartStopSecureWipeWdrUrnd;
             // As we don't reseed URND, there's no point in doing two rounds of wiping, so we
             // pretend that the first round is already the second round.
             wipe_after_urnd_refresh_d = MuBi4True;
@@ -225,7 +227,7 @@ module otbn_start_stop_control
             // wait for the ACK and then do a secure wipe.
             allow_secure_wipe     = 1'b1;
             expect_secure_wipe    = 1'b1;
-            secure_wipe_running_o = 1'b1;
+            secure_wipe_running_d = 1'b1;
             if (urnd_reseed_ack_i) begin
               state_d = OtbnStartStopSecureWipeWdrUrnd;
             end
@@ -242,7 +244,7 @@ module otbn_start_stop_control
             // wait for the ACK and then do a secure wipe.
             allow_secure_wipe     = 1'b1;
             expect_secure_wipe    = 1'b1;
-            secure_wipe_running_o = 1'b1;
+            secure_wipe_running_d = 1'b1;
             if (urnd_reseed_ack_i) begin
               state_d = OtbnStartStopSecureWipeWdrUrnd;
             end
@@ -254,7 +256,8 @@ module otbn_start_stop_control
         allow_secure_wipe = 1'b1;
 
         if (stop) begin
-          state_d = OtbnStartStopSecureWipeWdrUrnd;
+          secure_wipe_running_d = 1'b1;
+          state_d               = OtbnStartStopSecureWipeWdrUrnd;
         end
       end
       // SEC_CM: DATA_REG_SW.SEC_WIPE
@@ -266,7 +269,7 @@ module otbn_start_stop_control
         sec_wipe_wdr_urnd_o   = 1'b1;
         allow_secure_wipe     = 1'b1;
         expect_secure_wipe    = 1'b1;
-        secure_wipe_running_o = 1'b1;
+        secure_wipe_running_d = 1'b1;
 
         // Count one extra cycle when wiping the WDR, because the wipe signals to the WDR
         // (`sec_wipe_wdr_o` and `sec_wipe_wdr_urnd_o`) are flopped once but the wipe signals to the
@@ -291,7 +294,7 @@ module otbn_start_stop_control
         addr_cnt_inc          = 1'b1;
         allow_secure_wipe     = 1'b1;
         expect_secure_wipe    = 1'b1;
-        secure_wipe_running_o = 1'b1;
+        secure_wipe_running_d = 1'b1;
         // The first two clock cycles are used to write random data to accumulator and modulus.
         sec_wipe_acc_urnd_o   = (addr_cnt_q == 6'b000000);
         sec_wipe_mod_urnd_o   = (addr_cnt_q == 6'b000001);
@@ -305,10 +308,9 @@ module otbn_start_stop_control
       // Writing zeros to the CSRs and reset the stack. The other registers are intentionally not
       // overwritten with zero.
        OtbnStartStopSecureWipeAllZero: begin
-        sec_wipe_zero_o       = 1'b1;
-        allow_secure_wipe     = 1'b1;
-        expect_secure_wipe    = 1'b1;
-        secure_wipe_running_o = 1'b1;
+        sec_wipe_zero_o    = 1'b1;
+        allow_secure_wipe  = 1'b1;
+        expect_secure_wipe = 1'b1;
 
         // Leave this state after a single cycle, which is sufficient to reset the CSRs and the
         // stack.
@@ -316,12 +318,14 @@ module otbn_start_stop_control
           // This is the first round of wiping with random numbers, refresh URND and do a second
           // round.
           state_d = OtbnStartStopStateUrndRefresh;
+          secure_wipe_running_d     = 1'b1;
           wipe_after_urnd_refresh_d = MuBi4True;
         end else begin
           // This is the second round of wiping with random numbers, so the secure wipe is
           // complete.
           state_d = OtbnStartStopSecureWipeComplete;
-          secure_wipe_ack_o = 1'b1;
+          secure_wipe_running_d = 1'b0;
+          secure_wipe_ack_o     = 1'b1;
         end
       end
       OtbnStartStopSecureWipeComplete: begin
@@ -396,11 +400,13 @@ module otbn_start_stop_control
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      addr_cnt_q           <= 6'd0;
-      init_sec_wipe_done_q <= 1'b0;
+      addr_cnt_q            <= 6'd0;
+      init_sec_wipe_done_q  <= 1'b0;
+      secure_wipe_running_q <= 1'b1;
     end else begin
-      addr_cnt_q           <= addr_cnt_d;
-      init_sec_wipe_done_q <= init_sec_wipe_done_d;
+      addr_cnt_q            <= addr_cnt_d;
+      init_sec_wipe_done_q  <= init_sec_wipe_done_d;
+      secure_wipe_running_q <= secure_wipe_running_d;
     end
   end
 
@@ -453,6 +459,8 @@ module otbn_start_stop_control
   assign fatal_error_o = urnd_reseed_err_o | state_error_d | secure_wipe_error_q | mubi_err_q;
 
   assign rma_ack_o = rma_ack_q;
+
+  assign secure_wipe_running_o = secure_wipe_running_q;
 
   `ASSERT(StartStopStateValid_A,
       state_q inside {OtbnStartStopStateInitial,


### PR DESCRIPTION
This commit adds a little bit of security hardening around signals used for zeroing parts of the OTBN state during secure wipe. To this end, the secure_wipe_running_o signal is registered inside the start stop controller (to get distinct driving cells) and the critical signals are compared against the secure_wipe_running signal at the point of consumption.

This resolves lowRISC/OpenTitan#12061.