### PR TITLE
[aes/sw] Load all-zero vector into PRNG buffer stage for masking off

### DIFF
--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -776,8 +776,13 @@ bool test_main(void) {
     LOG_INFO("Initializing entropy complex.");
     CHECK_STATUS_OK(aes_testutils_masking_prng_zero_output_seed());
     CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerPrngReseed));
+    bool idle = false;
+    do {
+      CHECK_DIF_OK(dif_aes_get_status(&aes, kDifAesStatusIdle, &idle));
+    } while (!idle);
   }
 #endif
+  CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerDataOutClear));
 
   LOG_INFO("Starting simple serial packet handling.");
   while (true) {

--- a/sw/device/tests/aes_masking_off_test.c
+++ b/sw/device/tests/aes_masking_off_test.c
@@ -93,6 +93,11 @@ status_t execute_test(void) {
   CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerPrngReseed));
   AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true, kTestTimeout);
 
+  // Trigger the clearing of the output data registers. After this point, also
+  // the PRNG buffer stage will output an all-zero vector.
+  CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerDataOutClear));
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true, kTestTimeout);
+
   // "Convert" plain data byte arrays to `dif_aes_data_t` array.
   enum {
     kAesNumBlocks = 4,

--- a/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/aes_sca.c
@@ -791,7 +791,15 @@ status_t handle_aes_sca_seed_lfsr(ujson_t *uj) {
     if (res.value != 0) {
       return ABORTED();
     }
+    // Load the magic seed into the PRNG. After this, the PRNG outputs
+    // an all-zero vector.
     UJSON_CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerPrngReseed));
+    bool idle = false;
+    do {
+      TRY(dif_aes_get_status(&aes, kDifAesStatusIdle, &idle));
+    } while (!idle);
+    // Load the PRNG output into the buffer stage.
+    UJSON_CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerDataOutClear));
   }
 #endif
 


### PR DESCRIPTION
The input masks are now taken from the PRNG buffer stage. This means after loading the magic seed into the PRNG and having the PRNG output the all-zero vector, the buffer stage needs to be updated as well. This can be achieved by triggering via a clearing operation of the data output registers.

This resolves lowRISC/OpenTitan#22917.