### PR TITLE
[tock] Add Tock UART tests.

### DIFF
--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -187,6 +187,7 @@ RUST_TARGETS = [
     "//sw/host/tests/rom/e2e_chip_specific_startup:e2e_chip_specific_startup",
     "//sw/host/tests/rom/sw_strap_value:sw_strap_value",
     "//sw/host/tests/chip/spi_passthru:spi_passthru",
+    "//sw/host/tests/tock/uart:uart",
     "//sw/host/tests/xmodem:lrzsz_test",
     "//sw/host/tests/xmodem:xmodem",
 ]

--- a/sw/device/silicon_owner/tock/tests/uart/BUILD
+++ b/sw/device/silicon_owner/tock/tests/uart/BUILD
@@ -1,0 +1,52 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "cw310_params", "opentitan_test")
+load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "uart",
+    srcs = [
+        "src/main.rs",
+    ],
+    # We specifically restrict our build target to the OpenTitan
+    # CPU because libtock does not support an x86_64 target.
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/silicon_owner/tock/apps:single_app_layout",
+        "@libtock",
+    ],
+)
+
+tock_elf2tab(
+    name = "tab",
+    src = ":uart",
+    arch = "rv32imc",
+)
+
+tock_image(
+    name = "image",
+    app_flash_start = 0x20040000,
+    apps = [":tab"],
+    kernel = "//sw/device/silicon_owner/tock/kernel",
+)
+
+opentitan_test(
+    name = "uart_test",
+    cw310 = cw310_params(
+        binaries = {":image": "firmware"},
+        test_cmd = """
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/tock/uart",
+    ),
+    exec_env = {
+        # TODO: Migrate to a _rom_ext environment once we have Tock successfully
+        # booting in one.
+        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    },
+)

--- a/sw/device/silicon_owner/tock/tests/uart/src/main.rs
+++ b/sw/device/silicon_owner/tock/tests/uart/src/main.rs
@@ -1,0 +1,199 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_main]
+#![no_std]
+
+use core::cell::Cell;
+use core::cmp::min;
+use libtock::console::Console;
+use libtock::platform::{share, AllowRo, DefaultConfig, Subscribe, Syscalls};
+use libtock::runtime::{set_main, stack_size, TockSyscalls};
+
+set_main!(main);
+stack_size!(0x800);
+
+const DRIVER_NUM: u32 = 1;
+const ALLOW_RO_WRITE: u32 = 1;
+const ALLOW_RW_READ: u32 = 1;
+const COMMAND_WRITE: u32 = 1;
+const COMMAND_READ: u32 = 2;
+const SUBSCRIBE_WRITE: u32 = 1;
+const SUBSCRIBE_READ: u32 = 2;
+
+// Reads data from the console input. The data is read in chunks whose length is
+// given by `lens`. The newly-read data is returned. Panics upon encountering an
+// error condition.
+fn read_exact<'b>(buffer: &'b mut [u8], lens: &[usize]) -> &'b [u8] {
+    assert!(buffer.len() >= lens.iter().sum());
+    let upcall: Cell<Option<(u32, u32)>> = Cell::new(None);
+    let mut cursor = 0;
+    share::scope(|handle| {
+        TockSyscalls::subscribe::<_, _, DefaultConfig, DRIVER_NUM, SUBSCRIBE_READ>(handle, &upcall)
+            .unwrap();
+        for &len in lens {
+            let bytes = share::scope(|handle| {
+                TockSyscalls::allow_rw::<DefaultConfig, DRIVER_NUM, ALLOW_RW_READ>(
+                    handle,
+                    &mut buffer[cursor..],
+                )
+                .unwrap();
+                if let Some(error) =
+                    TockSyscalls::command(DRIVER_NUM, COMMAND_READ, len as u32, 0).get_failure()
+                {
+                    panic!("{:?}", error);
+                }
+                loop {
+                    TockSyscalls::yield_wait();
+                    if let Some((_, bytes)) = upcall.take() {
+                        return bytes;
+                    }
+                }
+            });
+            assert_eq!(bytes as usize, len);
+            cursor += len;
+        }
+    });
+    &buffer[..cursor]
+}
+
+// Sends a message to the console while simultaneously reading data from the
+// console. `to_send` is sent repeatedly until a total of `tx_len` bytes have
+// been transmitted. Receives will be limited in size to `max_rx_len`; multiple
+// receives will be issued if this is less than `rx_buffer.len()`. The received
+// message will be returned.
+fn send_and_receive<'b>(
+    to_send: &[u8],
+    tx_len: usize,
+    rx_buffer: &'b mut [u8],
+    max_rx_len: u32,
+) -> &'b [u8] {
+    let rx_upcall: Cell<Option<(u32, u32)>> = Cell::new(None);
+    let tx_upcall: Cell<Option<(u32,)>> = Cell::new(Some((0,)));
+    // rx_cursor and sent_bytes are updated when a read-write is complete, not
+    // when one is issued.
+    let mut rx_cursor = 0;
+    let mut sent_bytes = 0;
+    let rx_len = rx_buffer.len();
+    share::scope::<
+        (
+            Subscribe<_, DRIVER_NUM, SUBSCRIBE_READ>,
+            Subscribe<_, DRIVER_NUM, SUBSCRIBE_WRITE>,
+            AllowRo<_, DRIVER_NUM, ALLOW_RO_WRITE>,
+        ),
+        _,
+        _,
+    >(|handle| {
+        let (rx_upcall_handle, tx_upcall_handle, tx_allow_handle) = handle.split();
+        TockSyscalls::subscribe::<_, _, DefaultConfig, DRIVER_NUM, SUBSCRIBE_READ>(
+            rx_upcall_handle,
+            &rx_upcall,
+        )
+        .unwrap();
+        TockSyscalls::subscribe::<_, _, DefaultConfig, DRIVER_NUM, SUBSCRIBE_WRITE>(
+            tx_upcall_handle,
+            &tx_upcall,
+        )
+        .unwrap();
+        TockSyscalls::allow_ro::<DefaultConfig, DRIVER_NUM, ALLOW_RO_WRITE>(
+            tx_allow_handle,
+            to_send,
+        )
+        .unwrap();
+        while rx_cursor < rx_len || sent_bytes < tx_len {
+            share::scope(|handle| {
+                TockSyscalls::allow_rw::<DefaultConfig, DRIVER_NUM, ALLOW_RW_READ>(
+                    handle,
+                    &mut rx_buffer[rx_cursor..],
+                )
+                .unwrap();
+                if rx_cursor < rx_len {
+                    let read_len = min((rx_len - rx_cursor) as u32, max_rx_len);
+                    if let Some(error) =
+                        TockSyscalls::command(DRIVER_NUM, COMMAND_READ, read_len, 0).get_failure()
+                    {
+                        panic!("{:?}", error);
+                    }
+                }
+                loop {
+                    TockSyscalls::yield_wait();
+                    if let Some((bytes,)) = tx_upcall.take() {
+                        sent_bytes += bytes as usize;
+                        if sent_bytes < tx_len {
+                            let send_len = min(to_send.len(), tx_len - sent_bytes) as u32;
+                            if let Some(error) =
+                                TockSyscalls::command(DRIVER_NUM, COMMAND_WRITE, send_len, 0)
+                                    .get_failure()
+                            {
+                                panic!("{:?}", error);
+                            }
+                        }
+                    }
+                    if let Some((_, bytes)) = rx_upcall.take() {
+                        rx_cursor += bytes as usize;
+                        break;
+                    }
+                    if rx_cursor >= rx_len && sent_bytes >= tx_len {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    &rx_buffer[..rx_cursor]
+}
+
+fn main() {
+    let mut buffer = [0; 256];
+
+    // Test A: Send a message with all printable ASCII characters each
+    // direction. We do host->device first then device->host. The host->device
+    // message is padded to 128 bytes, which matches the hardware receive
+    // buffer.
+    assert_eq!(
+        read_exact(
+            &mut buffer,
+            &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 8]
+        ),
+        concat!(
+            r##"! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"##,
+            r##"`abcdefghijklmnopqrstuvwxyz{|}~Padding to 128 bytes looooooooong"##,
+        )
+        .as_bytes()
+    );
+    Console::write(
+        concat!(
+            r##"! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOP"##,
+            r##"QRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"##,
+            "\n",
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+
+    // Test B: The host sends a message broken into two parts, with a delay
+    // between the parts. The app should be able to receive both of these in one
+    // read operation.
+    assert_eq!(read_exact(&mut buffer, &[15]), b"Broken message.",);
+
+    // Test C: Attempt to send host->device and device->host messages
+    // concurrently. host->device messages are in capital letters and
+    // device->host messages are in lowercase.
+    assert_eq!(
+        send_and_receive(b"abcdefghijklmnopqrstuvwxyz", 26, &mut buffer[..26], 5,),
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    );
+    assert_eq!(
+        send_and_receive(&[b'a'; 25], 100, &mut buffer[..50], 25,),
+        [b'A'; 50],
+    );
+    assert_eq!(
+        send_and_receive(&[b'b'; 6], 37, &mut buffer[..42], 42,),
+        [b'B'; 42],
+    );
+
+    // Tell the host we are done (this makes sure the final receive in Test C
+    // has completed).
+    Console::write(b"DEVICE DONE.\n").unwrap();
+}

--- a/sw/host/tests/tock/uart/BUILD
+++ b/sw/host/tests/tock/uart/BUILD
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "uart",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:once_cell",
+    ],
+)

--- a/sw/host/tests/tock/uart/src/main.rs
+++ b/sw/host/tests/tock/uart/src/main.rs
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+use std::str::from_utf8;
+use std::thread::sleep;
+use std::time::Duration;
+
+use opentitanlib::io::uart::Uart;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+}
+
+fn send_message(uart: &dyn Uart, msg: &str) -> Result<()> {
+    log::info!("Sending (len={}): {}", msg.len(), msg);
+    uart.write(msg.as_bytes())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+    let uart = transport.uart("console")?;
+    UartConsole::wait_for(
+        &*uart,
+        r"OpenTitan( \(downstream\))? initialisation complete\. Entering main loop",
+        opts.timeout,
+    )?;
+
+    // Test A: Send a message with all printable ASCII characters each
+    // direction. We do host->device first then device->host. The host->device
+    // message is padded to 128 bytes, which matches the hardware receive
+    // buffer.
+    send_message(
+        &*uart,
+        concat!(
+            r##"! "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_"##,
+            r##"`abcdefghijklmnopqrstuvwxyz{|}~Padding to 128 bytes looooooooong"##,
+        ),
+    )?;
+    UartConsole::wait_for(
+        &*uart,
+        concat!(
+            r##"! "#\$%&'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNO"##,
+            r##"PQRSTUVWXYZ\[\\\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}~"##,
+        ),
+        opts.timeout,
+    )?;
+
+    // Test B: Send a message broken into two parts, with a delay between the
+    // parts. The app should be able to receive both of these in one read
+    // operation.
+    send_message(&*uart, "Broken ")?;
+    sleep(Duration::from_secs(1));
+    send_message(&*uart, "message.")?;
+
+    // Test C: Attempt to send host->device and device->host messages
+    // concurrently. host->device messages are in capital letters and
+    // device->host messages are in lowercase.
+    send_message(&*uart, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")?;
+    UartConsole::wait_for(&*uart, "abcdefghijklmnopqrstuvwxyz", opts.timeout)?;
+    send_message(&*uart, from_utf8(&[b'A'; 50]).unwrap())?;
+    UartConsole::wait_for(&*uart, from_utf8(&[b'a'; 100]).unwrap(), opts.timeout)?;
+    send_message(&*uart, from_utf8(&[b'B'; 42]).unwrap())?;
+    UartConsole::wait_for(&*uart, from_utf8(&[b'b'; 37]).unwrap(), opts.timeout)?;
+
+    // Verify the device has finished the final receive of test C.
+    UartConsole::wait_for(&*uart, "DEVICE DONE.", opts.timeout)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This test the ability of a Tock app to perform console writes and reads over the UART. It is an integration tests that tests the Console syscall driver, the UART virtualizer, and the UART peripheral driver.