### PR TITLE
[rom_ext] Advance the security version in boot_data

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -112,7 +112,7 @@ def _manifest_impl(ctx):
         mf["extensions"] = [
             "spx_key",
             "spx_signature",
-            None,
+            "secver_write",
             None,
             None,
             None,

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -205,7 +205,6 @@ def _build_binary(ctx, exec_env, name, deps, kind):
             rsa_key = rsa_key,
             spx_key = spx_key,
             manifest = manifest,
-            # FIXME: will need to supply hsmtool when we add NitroKey signing.
         )
     else:
         signed = {}
@@ -315,6 +314,10 @@ common_binary_attrs = {
         doc = "Binary kind: flash, ram or rom",
         default = "flash",
         values = ["flash", "ram", "rom"],
+    ),
+    "secver_write": attr.bool(
+        doc = "Commit the security version to boot_data",
+        default = True,
     ),
     # FIXME(cfrantz): This should come from the ExecEnvInfo provider, but
     # I was unable to make that work.  See the comment in `exec_env.bzl`.

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -399,6 +399,7 @@ enum {
    */
   kManifestExtIdSpxKey = 0x94ac01ec,
   kManifestExtIdSpxSignature = 0xad77f84a,
+  kManifestExtIdSecVerWrite = 0x3f086a41,
   /**
    * ASCII "EXT0.
    */
@@ -407,6 +408,11 @@ enum {
    * ASCII "EXT1.
    */
   kManifestExtNameSpxSignature = 0x31545845,
+  /**
+   * ASCII `SECV`.
+   */
+  kManifestExtNameSecVerWrite = 0x56434553,
+
 };
 
 /**
@@ -438,6 +444,21 @@ typedef struct manifest_ext_spx_signature {
 } manifest_ext_spx_signature_t;
 
 /**
+ * Manifest extension: Write the securty version.
+ */
+typedef struct manifest_ext_secver_write {
+  /**
+   * Required manifest header.
+   */
+  manifest_ext_header_t header;
+  /**
+   * Hardened bool indicating whether or not to write the security version to
+   * boot data.
+   */
+  uint32_t write;
+} manifest_ext_secver_write_t;
+
+/**
  * Table of manifest extensions.
  *
  * Columns: Table index, type name, extenstion name, identifier, signed or not.
@@ -445,7 +466,8 @@ typedef struct manifest_ext_spx_signature {
 // clang-format off
 #define MANIFEST_EXTENSIONS(X) \
   X(0, manifest_ext_spx_key_t,       spx_key,       kManifestExtIdSpxKey,       true ) \
-  X(1, manifest_ext_spx_signature_t, spx_signature, kManifestExtIdSpxSignature, false)
+  X(1, manifest_ext_spx_signature_t, spx_signature, kManifestExtIdSpxSignature, false) \
+  X(2, manifest_ext_secver_write_t,  secver_write,  kManifestExtIdSecVerWrite,  true)
 // clang-format on
 
 #if defined(OT_PLATFORM_RV32) || defined(MANIFEST_UNIT_TEST_)

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -7,9 +7,30 @@ load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
+load("//sw/device/silicon_creator/rom_ext:defs.bzl", "secver_write_selection")
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
+
+string_flag(
+    name = "secver_write",
+    build_setting_default = "true",
+    values = [
+        "true",
+        "false",
+    ],
+)
+
+config_setting(
+    name = "secver_write_true",
+    flag_values = {":secver_write": "true"},
+)
+
+config_setting(
+    name = "secver_write_false",
+    flag_values = {":secver_write": "false"},
+)
 
 cc_library(
     name = "rom_ext_epmp",
@@ -285,6 +306,7 @@ opentitan_binary(
         "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
         "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_test_0"},
     }),
+    secver_write = secver_write_selection(),
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+def secver_write_selection():
+    """Return the secver_write value based on the configuration setting."""
+    return select({
+        "//sw/device/silicon_creator/rom_ext:secver_write_true": True,
+        "//sw/device/silicon_creator/rom_ext:secver_write_false": False,
+    })

--- a/sw/device/silicon_creator/rom_ext/proda/BUILD
+++ b/sw/device/silicon_creator/rom_ext/proda/BUILD
@@ -7,6 +7,7 @@ load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//sw/device/silicon_creator/rom_ext:defs.bzl", "secver_write_selection")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -113,6 +114,7 @@ offline_presigning_artifacts(
     rsa_key = {
         "//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_prod_0",
     },
+    secver_write = secver_write_selection(),
     tags = ["manual"],
 )
 

--- a/sw/device/silicon_creator/rom_ext/prodc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/prodc/BUILD
@@ -7,6 +7,7 @@ load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//sw/device/silicon_creator/rom_ext:defs.bzl", "secver_write_selection")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -113,6 +114,7 @@ offline_presigning_artifacts(
     rsa_key = {
         "//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_prod_2",
     },
+    secver_write = secver_write_selection(),
     tags = ["manual"],
 )
 

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -6,6 +6,7 @@ load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
+load("//sw/device/silicon_creator/rom_ext:defs.bzl", "secver_write_selection")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
@@ -113,6 +114,7 @@ offline_presigning_artifacts(
     rsa_key = {
         "//sw/device/silicon_creator/rom/keys/real/rsa:earlgrey_a0_prod_0": "earlgrey_a0_prod_0",
     },
+    secver_write = secver_write_selection(),
     tags = ["manual"],
 )
 

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -36,8 +36,10 @@ pub const CHIP_MANIFEST_EXT_TABLE_COUNT: usize = 15;
 pub const MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL: u32 = 0xa5a5a5a5;
 pub const MANIFEST_EXT_ID_SPX_KEY: u32 = 0x94ac01ec;
 pub const MANIFEST_EXT_ID_SPX_SIGNATURE: u32 = 0xad77f84a;
+pub const MANIFEST_EXT_ID_SECVER_WRITE: u32 = 0x3f086a41;
 pub const MANIFEST_EXT_NAME_SPX_KEY: u32 = 0x30545845;
 pub const MANIFEST_EXT_NAME_SPX_SIGNATURE: u32 = 0x31545845;
+pub const MANIFEST_EXT_NAME_SECVER_WRITE: u32 = 0x56434553;
 pub const CHIP_ROM_EXT_IDENTIFIER: u32 = 0x4552544f;
 pub const CHIP_BL0_IDENTIFIER: u32 = 0x3042544f;
 pub const CHIP_ROM_EXT_SIZE_MIN: u32 = 8788;
@@ -134,6 +136,14 @@ impl Default for SigverifyBuffer {
     fn default() -> Self {
         Self { data: [0; 96usize] }
     }
+}
+
+/// SecVer Write manifest extension
+#[repr(C)]
+#[derive(AsBytes, FromBytes, FromZeroes, Debug, Default)]
+pub struct ManifestExtSecVerWrite {
+    pub header: ManifestExtHeader,
+    pub write: u32,
 }
 
 /// A type that holds the 256-bit device identifier.

--- a/sw/host/opentitanlib/src/image/testdata/manifest_ext.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest_ext.hjson
@@ -8,6 +8,9 @@
       spx_key: "test_spx.pem",
     },
     {
+      secver_write: true,
+    },
+    {
       name: "0xbeef",
       identifier: "0xabcd",
       value: ["0x01", "0x23", "0x45", "0x67"],


### PR DESCRIPTION
1. When the security version of the just-booted ROM_EXT is greater than the ROM_EXT minimum security version in boot data, move the value forward.
2. Provide a mechanism in the manifest to prevent moving foward even though the version is newer.  This is to release test ROM_EXTs without running afoul of #22941.

This should NOT be cherry-picked to master.  We will fix this on master by adjusting the selection criteria as discussed in #22941.