### PR TITLE
[rom_ext] Relax EDN0 configuration.

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -246,7 +246,7 @@ static const entropy_complex_config_t
                 .edn0 =
                     {
                         .base_address = kBaseEdn0,
-                        .reseed_interval = 32,
+                        .reseed_interval = 128,
                         .instantiate =
                             {
                                 .id = kEntropyDrbgOpInstantiate,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -277,6 +277,12 @@ static rom_error_t rom_ext_attestation_keygen(
   HARDENED_RETURN_IF_ERROR((rom_error_t)entropy_complex_init().value);
   HARDENED_RETURN_IF_ERROR(kmac_keymgr_configure());
 
+  // Set keymgr reseed interval. Start with the maximum value to avoid
+  // entropy complex contention during the boot process.
+  const uint16_t kScKeymgrEntropyReseedInterval = UINT16_MAX;
+  sc_keymgr_entropy_reseed_interval_set(kScKeymgrEntropyReseedInterval);
+  SEC_MMIO_WRITE_INCREMENT(kScKeymgrSecMmioEntropyReseedIntervalSet);
+
   // ROM sets the SW binding values for the first key stage (CreatorRootKey) but
   // does not initialize the key manager. Advance key manager state twice to
   // transition to the CreatorRootKey state.


### PR DESCRIPTION
This change aims to mitigate some of the side effects caused by lowRISC/opentitan#22877.

1. Increase the reseed interval in EDN0 to reduce the number of requests going to entropy_src.
2. Increase the reseed interval in keymgr to reduce the number of requests going to edn0.

Both configuration values will be updated later on based on recommendations derived from penetration testing and pre-silicon evaluation.