### PR TITLE
[rom_ext] Print fault info in the exception handler

### DIFF
--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -105,6 +105,13 @@ OT_WARN_UNUSED_RESULT
 static rom_error_t rom_ext_irq_error(void) {
   uint32_t mcause;
   CSR_READ(CSR_REG_MCAUSE, &mcause);
+
+  // TODO(opentitan#22947): Remove this debug print prior to a formal release.
+  uint32_t mepc, mtval;
+  CSR_READ(CSR_REG_MEPC, &mepc);
+  CSR_READ(CSR_REG_MTVAL, &mtval);
+  dbg_printf("MCAUSE=%x MEPC=%x MTVAL=%x\r\n", mcause, mepc, mtval);
+
   // Shuffle the mcause bits into the uppermost byte of the word and report
   // the cause as kErrorRomExtInterrupt.
   // Based on the ibex verilog, it appears that the most significant bit


### PR DESCRIPTION
During bring-up and debug, having the ROM_EXT print fault information is very helpful.