### PR TITLE
[keymgr] Abort into Invalid when Creator Root Key is not valid during initialization

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -72,8 +72,8 @@ package keymgr_env_pkg;
       keymgr_pkg::keymgr_working_state_e current_state);
 
     uint next_state = int'(current_state) + 1;
-    if (next_state >= int'(keymgr_pkg::StDisabled)) begin
-      return keymgr_pkg::StDisabled;
+    if (next_state > int'(keymgr_pkg::StDisabled)) begin
+      return current_state;
     end else begin
       `downcast(get_next_state, next_state, , , msg_id);
     end

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -229,6 +229,7 @@ interface keymgr_if(input clk, input rst_n);
                                               );
     keymgr_env_pkg::key_shares_t trun_key_shares = {key_shares[1][keymgr_pkg::KeyWidth-1:0],
                                                     key_shares[0][keymgr_pkg::KeyWidth-1:0]};
+    if (state == keymgr_pkg::StInvalid) return;
     case (dest)
       keymgr_pkg::Kmac: begin
         if (kmac_sideload_status != SideLoadClear) begin

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -1224,8 +1224,22 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
   virtual function keymgr_pkg::keymgr_working_state_e get_next_state(
       keymgr_pkg::keymgr_working_state_e cur = current_state);
-    if (!cfg.keymgr_vif.get_keymgr_en()) return keymgr_pkg::StInvalid;
-    else                                 return keymgr_env_pkg::get_next_state(cur);
+    keymgr_pkg::keymgr_working_state_e next_linear_state = keymgr_env_pkg::get_next_state(cur);
+
+    if (// If keymgr is not enabled in the current LC
+        !cfg.keymgr_vif.get_keymgr_en() ||
+        // or the linearly next state would be initialized but not all of the Creator Root Key
+        // shares are valid
+        (next_linear_state == keymgr_pkg::StInit &&
+         !&{cfg.keymgr_vif.otp_key.creator_root_key_share0_valid,
+            cfg.keymgr_vif.otp_key.creator_root_key_share1_valid})
+    ) begin
+      // then the next state is invalid.
+      return keymgr_pkg::StInvalid;
+    end else begin
+      // Otherwise, the next state is just the linearly next state.
+      return next_linear_state;
+    end
   endfunction
 
   virtual function void update_state(

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -121,6 +121,13 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
         wait(cfg.keymgr_vif.keymgr_en_sync2 == lc_ctrl_pkg::On);
       end
+      forever begin
+        wait(current_state == keymgr_pkg::StInvalid);
+        // Also wipe keys when moving into Invalid state, except if they have already been wiped
+        // because keymgr has been disabled by LC.
+        if (cfg.en_scb && cfg.keymgr_vif.keymgr_en_sync2 == lc_ctrl_pkg::On) wipe_hw_keys();
+        wait(current_state != keymgr_pkg::StInvalid);
+      end
     join_none
   endtask
 

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -586,7 +586,16 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
                 end
                 void'(ral.intr_state.predict(.value(1 << int'(IntrOpDone))));
               end
-              default: begin // other than StReset and StDisabled
+              keymgr_pkg::StInvalid: begin
+                // No operation is allowed in this state.  Expect a recoverable alert, that the
+                // operation status is *failed*, that the `err_code` CSR has `invalid_op` set, and
+                // that the `op_done` IRQ gets raised.
+                set_exp_alert("recov_operation_err");
+                current_op_status = keymgr_pkg::OpDoneFail;
+                void'(ral.err_code.invalid_op.predict(.value(1'b1)));
+                void'(ral.intr_state.predict(.value(1 << int'(IntrOpDone))));
+              end
+              default: begin // other than StReset and StInvalid
                 bit good_key;
                 bit good_data;
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_protect_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_protect_vseq.sv
@@ -50,7 +50,7 @@ class keymgr_sideload_protect_vseq extends keymgr_random_vseq;
       endcase
 
       // Let scb know sw output is random value
-      if (force_hw_key_sel_or_data_en) cfg.scb.is_sw_share_corrupted = 1;
+      if (force_hw_key_sel_or_data_en) cfg.scb.is_sw_share_corrupted = '1;
 
       read_sw_shares(sw_share_output);
       // force on data_sw_en, sw output remains 0

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -633,7 +633,7 @@ module keymgr_ctrl
       end
 
       StCtrlInvalid: begin
-        op_req = op_start_i;
+        invalid_op = op_start_i;
         invalid = 1'b1;
       end
 

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -518,7 +518,7 @@ module keymgr_ctrl
       StCtrlRootKey: begin
         init_o = 1'b1;
         initialized = 1'b1;
-        state_d = en_i ? StCtrlInit : StCtrlWipe;
+        state_d = (en_i && root_key_valid_q) ? StCtrlInit : StCtrlWipe;
       end
 
       // Beginning from the Init state, operations are accepted.

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -133,6 +133,14 @@ status_t keymgr_testutils_try_startup(dif_keymgr_t *keymgr, dif_kmac_t *kmac,
                                       dif_keymgr_state_t *keymgr_state);
 
 /**
+ * Initialize non-volatile memory (flash and OTP) for keymgr and then reset, so
+ * that the relevant OTP partitions become accessible to keymgr.  After calling
+ * this function, keymgr can be initialized.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_testutils_init_nvm_then_reset(void);
+
+/**
  * Programs flash, restarts, and advances keymgr to CreatorRootKey state.
  *
  * This procedure essentially gets the keymgr into the first state where it can

--- a/sw/device/tests/entropy_src_edn_reqs_test.c
+++ b/sw/device/tests/entropy_src_edn_reqs_test.c
@@ -241,6 +241,8 @@ status_t execute_test(void) {
 bool test_main(void) {
   test_initialize();
 
+  CHECK_STATUS_OK(keymgr_testutils_init_nvm_then_reset());
+
   alert_handler_configure(&alert_handler);
   CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
 


### PR DESCRIPTION
Prior to this PR, keymgr could be initialized and would open itself
to operations even if the Creator Root Key shares provided by OTP in the
`root_key_i` input were invalid (although keymgr did write all-zeros and
all-ones instead of the input from OTP into its key shares if that was
the case).  However, the specification dictates that kemygr must signal
an invalid operation, though it did not specify the next state.

This PR fixes the problem by letting keymgr raise an *invalid
operation* error in this case and then transition to the terminal
Invalid state (going through a wipe state to clear any secrets with
entropy).  The rationale for this implementation is that the Creator
Root Key is meant to be static after reset, so SW doesn't have to be
able to retry the initialization.  Letting keymgr abort into a terminal
state thus is an additional HW security countermeasure to deter FI
attacks aimed at loading a manipulated Creator Root Key.

This PR fixes that behavior in its second-last commit, thereby closes https://github.com/lowRISC/opentitan/issues/17776.

This PR contains a second RTL fix in its last commit:
The keymgr specification states that no operation is allowed in the
Invalid state.  Prior to that commit, keymgr did not raise an *invalid
operation* error, raise an alert, nor update the `OP_STATUS` and
`ERR_CODE` CSRs.

The last commit fixes keymgr to do all these things.

Only the last two commits contain RTL changes, which are relatively simple. Those commits also align the DV. All commits before are fixes and extensions to DV and SW that are necessary and sufficient to prepare for the RTL changes. Please see the commit messages for details.

## TODO Items (pre-merge)

- [x] Run related TLTs and check their result.
  --> I ran `util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_keymgr_{key_derivation{,_prod,_jitter_en{,_reduced_freq}},sideload_{kmac,aes,otbn}} -rx 2` and got results that are in-line with those reported in the current nightly regression results: there are some failures but only in `(chip_sw_keymgr_key_derivation_vseq.sv:122) [uvm_test_top.env.virtual_sequencer.chip_sw_keymgr_key_derivation_vseq] wait timeout occurred!` (as in the nightlies).
- [x] Debug and fix failing CW310 ROM test.
- [x] Update documentation.
- [x] Check if other steps in the key ladder need similar fix.
  --> I think they don't. The inputs to the other key ladder steps don't have _valid_ signals associated with them (which could be improved in a future revision) but they get checked by `keymgr_input_checks` if they aren't all-zeros or all-ones. The result of that check then feeds into `keymgr_ctrl`'s `op_err`, which prevents the key ladder from advancing and any keys from being updated, and the error gets reported as _invalid input_ to the `err_code` CSR.
- [x] Split RTL commit because it fixes two orthogonal problems in keymgr.