### PR TITLE
[rv_core_ibex] Re-vendor Ibex and reduce number of PRINCE rounds for ICache scrambling

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -366,39 +366,40 @@ module rv_core_ibex
 
   ibex_pkg::crash_dump_t crash_dump;
   ibex_top #(
-    .PMPEnable                ( PMPEnable                ),
-    .PMPGranularity           ( PMPGranularity           ),
-    .PMPNumRegions            ( PMPNumRegions            ),
-    .MHPMCounterNum           ( MHPMCounterNum           ),
-    .MHPMCounterWidth         ( MHPMCounterWidth         ),
-    .RV32E                    ( RV32E                    ),
-    .RV32M                    ( RV32M                    ),
-    .RV32B                    ( RV32B                    ),
-    .RegFile                  ( RegFile                  ),
-    .BranchTargetALU          ( BranchTargetALU          ),
-    .WritebackStage           ( WritebackStage           ),
-    .ICache                   ( ICache                   ),
+    .PMPEnable                   ( PMPEnable                ),
+    .PMPGranularity              ( PMPGranularity           ),
+    .PMPNumRegions               ( PMPNumRegions            ),
+    .MHPMCounterNum              ( MHPMCounterNum           ),
+    .MHPMCounterWidth            ( MHPMCounterWidth         ),
+    .RV32E                       ( RV32E                    ),
+    .RV32M                       ( RV32M                    ),
+    .RV32B                       ( RV32B                    ),
+    .RegFile                     ( RegFile                  ),
+    .BranchTargetALU             ( BranchTargetALU          ),
+    .WritebackStage              ( WritebackStage           ),
+    .ICache                      ( ICache                   ),
     // Our automatic SEC_CM label check doesn't look at vendored code so the SEC_CM labels need
     // to be mentioned here. The real locations can be found by grepping the vendored code.
     // TODO(#10071): this should be fixed.
     // SEC_CM: ICACHE.MEM.INTEGRITY
-    .ICacheECC                ( ICacheECC                ),
+    .ICacheECC                   ( ICacheECC                ),
     // SEC_CM: ICACHE.MEM.SCRAMBLE, SCRAMBLE.KEY.SIDELOAD
-    .ICacheScramble           ( ICacheScramble           ),
-    .BranchPredictor          ( BranchPredictor          ),
-    .DbgTriggerEn             ( DbgTriggerEn             ),
-    .DbgHwBreakNum            ( DbgHwBreakNum            ),
+    .ICacheScramble              ( ICacheScramble           ),
+    .ICacheScrNumPrinceRoundsHalf( 3                        ),
+    .BranchPredictor             ( BranchPredictor          ),
+    .DbgTriggerEn                ( DbgTriggerEn             ),
+    .DbgHwBreakNum               ( DbgHwBreakNum            ),
     // SEC_CM: LOGIC.SHADOW
     // SEC_CM: PC.CTRL_FLOW.CONSISTENCY, CTRL_FLOW.UNPREDICTABLE, CORE.DATA_REG_SW.SCA
     // SEC_CM: EXCEPTION.CTRL_FLOW.GLOBAL_ESC, EXCEPTION.CTRL_FLOW.LOCAL_ESC
     // SEC_CM: DATA_REG_SW.INTEGRITY, DATA_REG_SW.GLITCH_DETECT
-    .SecureIbex               ( SecureIbex               ),
-    .RndCnstLfsrSeed          ( RndCnstLfsrSeed          ),
-    .RndCnstLfsrPerm          ( RndCnstLfsrPerm          ),
-    .RndCnstIbexKey           ( RndCnstIbexKeyDefault    ),
-    .RndCnstIbexNonce         ( RndCnstIbexNonceDefault  ),
-    .DmHaltAddr               ( DmHaltAddr               ),
-    .DmExceptionAddr          ( DmExceptionAddr          )
+    .SecureIbex                  ( SecureIbex               ),
+    .RndCnstLfsrSeed             ( RndCnstLfsrSeed          ),
+    .RndCnstLfsrPerm             ( RndCnstLfsrPerm          ),
+    .RndCnstIbexKey              ( RndCnstIbexKeyDefault    ),
+    .RndCnstIbexNonce            ( RndCnstIbexNonceDefault  ),
+    .DmHaltAddr                  ( DmHaltAddr               ),
+    .DmExceptionAddr             ( DmExceptionAddr          )
   ) u_core (
     .clk_i              (ibex_top_clk_i),
     .rst_ni,

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -385,7 +385,10 @@ module rv_core_ibex
     .ICacheECC                   ( ICacheECC                ),
     // SEC_CM: ICACHE.MEM.SCRAMBLE, SCRAMBLE.KEY.SIDELOAD
     .ICacheScramble              ( ICacheScramble           ),
-    .ICacheScrNumPrinceRoundsHalf( 3                        ),
+    // Reduce the number of PRINCE half rounds to 2 (5 effective rounds) to ease timing. This is
+    // acceptable for the instruction cache, whereas 3 half rounds (7 effective rounds) are used
+    // elsewhere in the design.
+    .ICacheScrNumPrinceRoundsHalf( 2                        ),
     .BranchPredictor             ( BranchPredictor          ),
     .DbgTriggerEn                ( DbgTriggerEn             ),
     .DbgHwBreakNum               ( DbgHwBreakNum            ),

--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 27dd6b2e06f3110904dda9db1abc4e1d466db30a
+    rev: eea2bf0c1c62bbd676edf69cc60a56041d53b669
   }
 }

--- a/hw/vendor/lowrisc_ibex/dv/cosim/spike_cosim.cc
+++ b/hw/vendor/lowrisc_ibex/dv/cosim/spike_cosim.cc
@@ -48,10 +48,17 @@ SpikeCosim::SpikeCosim(const std::string &isa_string, uint32_t start_pc,
       std::make_unique<processor_t>(isa_string.c_str(), "MU", DEFAULT_VARCH,
                                     this, 0, false, log_file, std::cerr);
 #else
-  isa_parser = std::make_unique<isa_parser_t>(isa_string.c_str(), "MU");
 
+#ifdef COSIM_SIGSEGV_WORKAROUND
+  isa_parser = new isa_parser_t(isa_string.c_str(), "MU");
+  processor = std::make_unique<processor_t>(isa_parser, DEFAULT_VARCH, this, 0,
+                                            false, log_file, std::cerr);
+#else
+  isa_parser = std::make_unique<isa_parser_t>(isa_string.c_str(), "MU");
   processor = std::make_unique<processor_t>(
       isa_parser.get(), DEFAULT_VARCH, this, 0, false, log_file, std::cerr);
+#endif
+
 #endif
 
   processor->set_pmp_num(pmp_num_regions);

--- a/hw/vendor/lowrisc_ibex/dv/cosim/spike_cosim.h
+++ b/hw/vendor/lowrisc_ibex/dv/cosim/spike_cosim.h
@@ -22,7 +22,17 @@
 
 class SpikeCosim : public simif_t, public Cosim {
  private:
+  // A sigsegv has been observed when deleting isa_parser_t instances under
+  // Xcelium on CentOS 7. The root cause is unknown so for a workaround simply
+  // use a raw pointer for isa_parser that never gets deleted. This produces a
+  // minor memory leak but it is of little consequence as when SpikeCosim is
+  // being deleted it is the end of simulation and the process will be
+  // terminated shortly anyway.
+#ifdef COSIM_SIGSEGV_WORKAROUND
+  isa_parser_t *isa_parser;
+#else
   std::unique_ptr<isa_parser_t> isa_parser;
+#endif
   std::unique_ptr<processor_t> processor;
   std::unique_ptr<log_file_t> log;
   bus_t bus;

--- a/hw/vendor/lowrisc_ibex/dv/riscv_compliance/ibex_riscv_compliance.core
+++ b/hw/vendor/lowrisc_ibex/dv/riscv_compliance/ibex_riscv_compliance.core
@@ -161,6 +161,6 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g"'
+          - '-CFLAGS "-std=c++14 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_riscv_compliance -g"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/Makefile
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/Makefile
@@ -52,6 +52,12 @@ IBEX_CONFIG         := opentitan
 # Path to DUT used for coverage reports
 DUT_COV_RTL_PATH    := "ibex_top"
 
+export EXTRA_COSIM_CFLAGS ?=
+
+ifeq ($(COSIM_SIGSEGV_WORKAROUND), 1)
+	EXTRA_COSIM_CFLAGS += -DCOSIM_SIGSEGV_WORKAROUND
+endif
+
 ###############################################################################
 
 # Setup the necessary paths for all python scripts to find all other relevant modules.

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/fcov/core_ibex_fcov_if.sv
@@ -656,7 +656,8 @@ interface core_ibex_fcov_if import ibex_pkg::*; (
       illegal_bins illegal =
         // Only Div, Mul, Branch and Jump instructions can see an instruction stall
         (!binsof(cp_id_instr_category) intersect {InstrCategoryDiv, InstrCategoryMul,
-                                                 InstrCategoryBranch, InstrCategoryJump} &&
+                                                 InstrCategoryBranch, InstrCategoryJump,
+                                                 InstrCategoryFenceI} &&
          binsof(cp_stall_type_id) intersect {IdStallTypeInstr})
     ||
         // Only ALU, Mul, Div, Branch, Jump, Load, Store and CSR Access can see a load hazard stall
@@ -701,7 +702,8 @@ interface core_ibex_fcov_if import ibex_pkg::*; (
       illegal_bins illegal =
         // Only Div, Mul, Branch and Jump instructions can see an instruction stall
         (!binsof(cp_id_instr_category) intersect {InstrCategoryDiv, InstrCategoryMul,
-                                                 InstrCategoryBranch, InstrCategoryJump} &&
+                                                 InstrCategoryBranch, InstrCategoryJump,
+                                                 InstrCategoryFenceI} &&
          binsof(cp_stall_type_id) intersect {IdStallTypeInstr})
     ||
         // Only ALU, Mul, Div, Branch, Jump, Load, Store and CSR Access can see a load hazard stall

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/ibex_asm_program_gen.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/ibex_asm_program_gen.sv
@@ -153,6 +153,13 @@ class ibex_asm_program_gen extends riscv_asm_program_gen;
 
     super.gen_init_section(hart);
 
+    // RISCV-DV assumes main is immediately after init when riscv_instr_pkg::support_pmp isn't set.
+    // This override of gen_init_section breaks that assumption so add a jump to main here so the
+    // test starts correctly for configurations that don't support PMP.
+    if (!riscv_instr_pkg::support_pmp) begin
+      instr_stream.push_back({indent, "j main"});
+    end
+
     gen_test_end(.result(TEST_PASS), .instr(instr));
     instr_stream = {instr_stream,
                     {format_string("test_done:", LABEL_STR_LEN)},

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/ibex_directed_instr_lib.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/ibex_directed_instr_lib.sv
@@ -114,15 +114,15 @@ class ibex_rand_cpuctrlsts_stream extends riscv_directed_instr_stream;
     end
 
     // DIT is Data Independent Timing
-    if (!$value$plusargs("toggle_dit", toggle_dit)) begin
+    if (!$value$plusargs("toggle_dit=%d", toggle_dit)) begin
       toggle_dit = 1'b0;
     end
 
-    if (!$value$plusargs("toggle_dummy_instr", toggle_dummy_instr)) begin
+    if (!$value$plusargs("toggle_dummy_instr=%d", toggle_dummy_instr)) begin
       toggle_dummy_instr = 1'b0;
     end
 
-    if (!$value$plusargs("toggle_icache", toggle_icache)) begin
+    if (!$value$plusargs("toggle_icache=%d", toggle_icache)) begin
       toggle_icache = 1'b0;
     end
 

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -677,6 +677,8 @@
   iterations: 15
   gen_test: riscv_rand_instr_test
   rtl_test: core_ibex_pc_intg_test
+  rtl_params:
+    SecureIbex: 1
 
 - test: riscv_rf_intg_test
   description: >
@@ -684,6 +686,8 @@
   iterations: 15
   gen_test: riscv_rand_instr_test
   rtl_test: core_ibex_rf_intg_test
+  rtl_params:
+    SecureIbex: 1
 
 - test: riscv_icache_intg_test
   description: >
@@ -691,6 +695,8 @@
   iterations: 15
   gen_test: riscv_rand_instr_test
   rtl_test: core_ibex_icache_intg_test
+  rtl_params:
+    SecureIbex: 1
 
 - test: riscv_rv32im_instr_test
   description: >

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/scripts/collect_results.py
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/scripts/collect_results.py
@@ -18,7 +18,16 @@ from report_lib.text import output_results_text, gen_summary_line
 from report_lib.html import output_results_html
 from report_lib.junit_xml import output_run_results_junit_xml
 from report_lib.dvsim_json import output_results_dvsim_json
-from report_lib.svg import output_results_svg
+
+try:
+    # SVG requires python 3.7 and above, for environments that don't have python
+    # 3.7 (e.g. CentOS 7) detect failure to import and just skip any svg
+    # generation.
+    import svg
+    from report_lib.svg import output_results_svg
+    SVG_MODULE_PRESENT = True
+except ImportError:
+    SVG_MODULE_PRESENT = False
 
 def main() -> int:
     """Collect all test results into summary files.
@@ -93,10 +102,13 @@ def main() -> int:
             output_results_dvsim_json(md, test_summary_dict, cov_summary_dict,
                                       json_report_file)
 
-        svg_summary_filename = md.dir_run/'summary.svg'
-        with open(svg_summary_filename, 'w') as svg_summary_file:
-            output_results_svg(test_summary_dict, cov_summary_dict,
-                    svg_summary_file)
+        if SVG_MODULE_PRESENT:
+            svg_summary_filename = md.dir_run/'summary.svg'
+            with open(svg_summary_filename, 'w') as svg_summary_file:
+                output_results_svg(test_summary_dict, cov_summary_dict,
+                        svg_summary_file)
+        else:
+            print('WARNING: svg module not available, skipping SVG results output')
 
         # Print a summary line to the terminal
         print(gen_summary_line(passing_tests, failing_tests))

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/scripts/report_lib/util.py
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/scripts/report_lib/util.py
@@ -38,10 +38,12 @@ def gen_test_run_result_text(trr: TestRunResult) -> str:
     test_underline = '-' * len(test_name_idx)
     info_lines: List[str] = [test_name_idx, test_underline]
 
-    #  Filter out relevant fields, and print as relative to the dir_test for readability
-    lesskeys = {k: str(v.relative_to(trr.dir_test))  # Improve readability
-                for k, v in dataclasses.asdict(trr).items()
-                if k in ['binary', 'rtl_log', 'rtl_trace', 'iss_cosim_trace']}
+    # Filter out relevant fields, and print as relative to the dir_test for
+    # readability.
+    lesskeys = \
+            {k: str(v.relative_to(trr.dir_test) if v is not None else 'MISSING')
+             for k, v in dataclasses.asdict(trr).items()
+             if k in ['binary', 'rtl_log', 'rtl_trace', 'iss_cosim_trace']}
     strdict = ibex_lib.format_dict_to_printable_dict(lesskeys)
 
     trr_yaml = io.StringIO()

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/scripts/run_rtl.py
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/scripts/run_rtl.py
@@ -67,6 +67,7 @@ def _main() -> int:
         'rtl_sim_log': trr.rtl_log,
         'rtl_trace': trr.rtl_trace.parent/'trace_core',
         'iss_cosim_trace': trr.iss_cosim_trace,
+        'core_ibex': md.ibex_dv_root,
         'sim_opts': (f"+signature_addr={md.signature_addr}\n" +
                      f"+test_timeout_s={trr.timeout_s}\n" +
                      f"{get_sim_opts(md.ibex_config, md.simulator)}\n" +

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/yaml/rtl_simulation.yaml
@@ -18,7 +18,7 @@
 # As a result, passing -fno-extended-identifiers tells G++ to pretend that
 # everything is ASCII, preventing strange compilation errors.
 - tool: vcs
-  env_var: IBEX_ROOT
+  env_var: IBEX_ROOT, EXTRA_COSIM_CFLAGS
   compile:
     cmd:
       - >-
@@ -39,6 +39,7 @@
           -xlrm uniq_prior_final
           -CFLAGS '--std=c99 -fno-extended-identifiers'
           -lca -kdb
+          -debug_access+f
           <cmp_opts> <wave_opts> <cov_opts> <cosim_opts>
     cov_opts: >-
       -cm line+tgl+assert+fsm+branch
@@ -51,11 +52,10 @@
     wave_opts: >-
       -debug_access+all
       -ucli
-      -do vcs.tcl
     cosim_opts: >-
       -f <core_ibex>/ibex_dv_cosim_dpi.f
       -LDFLAGS '<ISS_LDFLAGS>'
-      -CFLAGS '<ISS_CFLAGS>'
+      -CFLAGS '<ISS_CFLAGS> <EXTRA_COSIM_CFLAGS>'
       -CFLAGS '-I<IBEX_ROOT>/dv/cosim'
       <ISS_LIBS>
       -lstdc++
@@ -71,6 +71,7 @@
             +bin=<binary>
             +ibex_tracer_file_base=<rtl_trace>
             +cosim_log_file=<iss_cosim_trace>
+            -l <rtl_sim_log>
             <sim_opts> <wave_opts> <cov_opts>
     cov_opts: >
       -cm line+tgl+assert+fsm+branch
@@ -81,7 +82,7 @@
       +enable_ibex_fcov=1
     wave_opts: >
       -ucli
-      -do <cwd>/vcs.tcl
+      -do <core_ibex>/vcs.tcl
 
 
 ############################################################
@@ -224,7 +225,7 @@
 
 ############################################################
 - tool: xlm
-  env_var: dv_root, DUT_TOP, IBEX_ROOT
+  env_var: dv_root, DUT_TOP, IBEX_ROOT, EXTRA_COSIM_CFLAGS
   compile:
     cmd:
       - >-
@@ -254,6 +255,7 @@
       -I<IBEX_ROOT>/dv/cosim
       <ISS_LIBS>
       <ISS_CFLAGS>
+      <EXTRA_COSIM_CFLAGS>
       -Wld,<ISS_LDFLAGS>
       -lstdc++
   sim:

--- a/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/fcov/ibex_icache_fcov_if.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/fcov/ibex_icache_fcov_if.sv
@@ -1,3 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 interface ibex_icache_fcov_if import ibex_pkg::*; #(
   parameter int NUM_FB = 4
 ) (

--- a/hw/vendor/lowrisc_ibex/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
+++ b/hw/vendor/lowrisc_ibex/dv/verilator/simple_system_cosim/ibex_simple_system_cosim.core
@@ -179,7 +179,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`"'
+          - '-CFLAGS "-std=c++14 -Wall -DVL_USER_STOP -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_simple_system -g `pkg-config --cflags riscv-riscv riscv-disasm riscv-fdt`"'
           - '-LDFLAGS "-pthread -lutil -lelf `pkg-config --libs riscv-riscv riscv-disasm riscv-fdt`"'
           - "-Wall"
           - "-Wwarn-IMPERFECTSCH"

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.f
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_core.f
@@ -1,3 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 ibex_pkg.sv
 ibex_alu.sv
 ibex_compressed_decoder.sv

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_counter.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_counter.sv
@@ -1,3 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 module ibex_counter #(
   parameter int CounterWidth = 32,
   // When set `counter_val_upd_o` provides an incremented version of the counter value, otherwise

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -13,28 +13,29 @@
  * Top level module of the ibex RISC-V core
  */
 module ibex_top import ibex_pkg::*; #(
-  parameter bit          PMPEnable        = 1'b0,
-  parameter int unsigned PMPGranularity   = 0,
-  parameter int unsigned PMPNumRegions    = 4,
-  parameter int unsigned MHPMCounterNum   = 0,
-  parameter int unsigned MHPMCounterWidth = 40,
-  parameter bit          RV32E            = 1'b0,
-  parameter rv32m_e      RV32M            = RV32MFast,
-  parameter rv32b_e      RV32B            = RV32BNone,
-  parameter regfile_e    RegFile          = RegFileFF,
-  parameter bit          BranchTargetALU  = 1'b0,
-  parameter bit          WritebackStage   = 1'b0,
-  parameter bit          ICache           = 1'b0,
-  parameter bit          ICacheECC        = 1'b0,
-  parameter bit          BranchPredictor  = 1'b0,
-  parameter bit          DbgTriggerEn     = 1'b0,
-  parameter int unsigned DbgHwBreakNum    = 1,
-  parameter bit          SecureIbex       = 1'b0,
-  parameter bit          ICacheScramble   = 1'b0,
-  parameter lfsr_seed_t  RndCnstLfsrSeed  = RndCnstLfsrSeedDefault,
-  parameter lfsr_perm_t  RndCnstLfsrPerm  = RndCnstLfsrPermDefault,
-  parameter int unsigned DmHaltAddr       = 32'h1A110800,
-  parameter int unsigned DmExceptionAddr  = 32'h1A110808,
+  parameter bit          PMPEnable                    = 1'b0,
+  parameter int unsigned PMPGranularity               = 0,
+  parameter int unsigned PMPNumRegions                = 4,
+  parameter int unsigned MHPMCounterNum               = 0,
+  parameter int unsigned MHPMCounterWidth             = 40,
+  parameter bit          RV32E                        = 1'b0,
+  parameter rv32m_e      RV32M                        = RV32MFast,
+  parameter rv32b_e      RV32B                        = RV32BNone,
+  parameter regfile_e    RegFile                      = RegFileFF,
+  parameter bit          BranchTargetALU              = 1'b0,
+  parameter bit          WritebackStage               = 1'b0,
+  parameter bit          ICache                       = 1'b0,
+  parameter bit          ICacheECC                    = 1'b0,
+  parameter bit          BranchPredictor              = 1'b0,
+  parameter bit          DbgTriggerEn                 = 1'b0,
+  parameter int unsigned DbgHwBreakNum                = 1,
+  parameter bit          SecureIbex                   = 1'b0,
+  parameter bit          ICacheScramble               = 1'b0,
+  parameter int unsigned ICacheScrNumPrinceRoundsHalf = 2,
+  parameter lfsr_seed_t  RndCnstLfsrSeed              = RndCnstLfsrSeedDefault,
+  parameter lfsr_perm_t  RndCnstLfsrPerm              = RndCnstLfsrPermDefault,
+  parameter int unsigned DmHaltAddr                   = 32'h1A110800,
+  parameter int unsigned DmExceptionAddr              = 32'h1A110808,
   // Default seed and nonce for scrambling
   parameter logic [SCRAMBLE_KEY_W-1:0]   RndCnstIbexKey   = RndCnstIbexKeyDefault,
   parameter logic [SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonce = RndCnstIbexNonceDefault
@@ -560,11 +561,12 @@ module ibex_top import ibex_pkg::*; #(
         // SEC_CM: ICACHE.MEM.SCRAMBLE
         // Tag RAM instantiation
         prim_ram_1p_scr #(
-          .Width            (TagSizeECC),
-          .Depth            (IC_NUM_LINES),
-          .DataBitsPerMask  (TagSizeECC),
-          .EnableParity     (0),
-          .NumAddrScrRounds (NumAddrScrRounds)
+          .Width              (TagSizeECC),
+          .Depth              (IC_NUM_LINES),
+          .DataBitsPerMask    (TagSizeECC),
+          .EnableParity       (0),
+          .NumPrinceRoundsHalf(ICacheScrNumPrinceRoundsHalf),
+          .NumAddrScrRounds   (NumAddrScrRounds)
         ) tag_bank (
           .clk_i,
           .rst_ni,
@@ -596,6 +598,7 @@ module ibex_top import ibex_pkg::*; #(
           .DataBitsPerMask    (LineSizeECC),
           .ReplicateKeyStream (1),
           .EnableParity       (0),
+          .NumPrinceRoundsHalf(ICacheScrNumPrinceRoundsHalf),
           .NumAddrScrRounds   (NumAddrScrRounds)
         ) data_bank (
           .clk_i,

--- a/hw/vendor/lowrisc_ibex/util/Makefile
+++ b/hw/vendor/lowrisc_ibex/util/Makefile
@@ -1,3 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 .PHONY: lint
 lint:
 	mypy --strict sv2v_in_place.py


### PR DESCRIPTION
This PR mainly reduced the number of PRINCE rounds for ICache scrambling to improve the timing. From a security perspective, this is acceptable. The scrambling of the other memory primitives (OTBN IMEM, DMEM, ROM etc.) is not touched.

To enable this change, Ibex needs to be re-vendored.

This is related to #22462. 