### PR TITLE
[dif,alert_handler] Fix dif_alert_handler_get_class_state

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -867,6 +867,12 @@ dif_result_t dif_alert_handler_get_class_state(
     case ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_VALUE_TIMEOUT:
       *state = kDifAlertHandlerClassStateTimeout;
       break;
+    case ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_VALUE_FSMERROR:
+      *state = kDifAlertHandlerClassStateFsmError;
+      break;
+    case ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_VALUE_TERMINAL:
+      *state = kDifAlertHandlerClassStateTerminal;
+      break;
     case ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_VALUE_PHASE0:
       *state = kDifAlertHandlerClassStatePhase0;
       break;
@@ -878,9 +884,6 @@ dif_result_t dif_alert_handler_get_class_state(
       break;
     case ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_VALUE_PHASE3:
       *state = kDifAlertHandlerClassStatePhase3;
-      break;
-    case ALERT_HANDLER_CLASSA_STATE_CLASSA_STATE_VALUE_TERMINAL:
-      *state = kDifAlertHandlerClassStateTerminal;
       break;
     default:
       return kDifError;

--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -133,6 +133,18 @@ typedef enum dif_alert_handler_class_state {
   kDifAlertHandlerClassStateTimeout,
 
   /**
+   * The "fsm_error" state. This is a terminal state indicating the FSM
+   * has been glitched.
+   */
+  kDifAlertHandlerClassStateFsmError,
+  /**
+   * The terminal state. Most configurations will never reach this state, since
+   * one of the previous phases will use an escalation signal to reset the
+   * device.
+   */
+  kDifAlertHandlerClassStateTerminal,
+
+  /**
    * The zeroth escalation phase.
    */
   kDifAlertHandlerClassStatePhase0,
@@ -148,13 +160,6 @@ typedef enum dif_alert_handler_class_state {
    * The third escalation phase.
    */
   kDifAlertHandlerClassStatePhase3,
-
-  /**
-   * The terminal state. Most configurations will never reach this state, since
-   * one of the previous phases will use an escalation signal to reset the
-   * device.
-   */
-  kDifAlertHandlerClassStateTerminal,
 } dif_alert_handler_class_state_t;
 
 /**


### PR DESCRIPTION
A state indicating an fsm error was added about 3 years ago, but apparently the dif code was not updated, and the code would flag an error if it ever hits that state. This state indicates some tampering.