### PR TITLE
[usbdev,sival] Enable streaming test

### DIFF
--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -175,6 +175,7 @@ def opentitan_test(
         dv = _dv_params(),
         silicon = _silicon_params(),
         verilator = _verilator_params(),
+        data = [],
         **kwargs):
     """Instantiate a test per execution environment.
 
@@ -252,7 +253,7 @@ def opentitan_test(
             post_test_harness = getattr(tparam, "post_test_harness", None),
             test_cmd = tparam.test_cmd,
             param = tparam.param,
-            data = tparam.data,
+            data = data + tparam.data,
             ecdsa_key = ecdsa_key,
             rsa_key = rsa_key,
             spx_key = spx_key,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3609,6 +3609,15 @@ opentitan_test(
     ],
 )
 
+# Work around https://github.com/bazelbuild/bazel/pull/16381
+# When adding an executable as a data dependency, it expands
+# to multiple locations. This alias forces bazel to only "see"
+# the default output and therefore expand to a single file.
+alias(
+    name = "usbdev_stream_host_harness",
+    actual = "//sw/host/tests/usbdev/usbdev_stream:stream_test",
+)
+
 opentitan_test(
     name = "usbdev_pincfg_test",
     srcs = ["usbdev_pincfg_test.c"],
@@ -3808,12 +3817,27 @@ opentitan_test(
     name = "usbdev_mixed_test",
     srcs = ["usbdev_mixed_test.c"],
     cw310 = cw310_params(
-        timeout = "eternal",
-        tags = ["manual"],
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --exec=$(rootpath :usbdev_stream_host_harness)
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
+    data = [
+        ":usbdev_stream_host_harness",
+    ],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --vbus-sense-en=VBUS_SENSE_EN
+            --vbus-sense=VBUS_SENSE
+            --exec=$(rootpath :usbdev_stream_host_harness)
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
@@ -3832,12 +3856,27 @@ opentitan_test(
     name = "usbdev_iso_test",
     srcs = ["usbdev_iso_test.c"],
     cw310 = cw310_params(
-        timeout = "eternal",
-        tags = ["manual"],
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --exec=$(rootpath :usbdev_stream_host_harness)
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
+    data = [
+        ":usbdev_stream_host_harness",
+    ],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --vbus-sense-en=VBUS_SENSE_EN
+            --vbus-sense=VBUS_SENSE
+            --exec=$(rootpath :usbdev_stream_host_harness)
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
@@ -3856,12 +3895,27 @@ opentitan_test(
     name = "usbdev_stream_test",
     srcs = ["usbdev_stream_test.c"],
     cw310 = cw310_params(
-        timeout = "eternal",
-        tags = ["manual"],
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --exec=$(rootpath :usbdev_stream_host_harness)
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
+    data = [
+        ":usbdev_stream_host_harness",
+    ],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --vbus-sense-en=VBUS_SENSE_EN
+            --vbus-sense=VBUS_SENSE
+            --exec=$(rootpath :usbdev_stream_host_harness)
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [

--- a/sw/device/tests/usbdev_iso_test.c
+++ b/sw/device/tests/usbdev_iso_test.c
@@ -39,10 +39,8 @@
 #define NUM_STREAMS 4U
 #endif
 
-// This takes about 256s presently with 10MHz CPU in CW310 FPGA and physical
-// USB with randomized packet sizes and the default memcpy implementation;
-// The _MEM_FASTER switch drops the run time to 187s
-#define TRANSFER_BYTES_FPGA (0x10U << 20)
+#define TRANSFER_BYTES_SILICON (0x10U << 20)
+#define TRANSFER_BYTES_FPGA (8U << 16)
 
 // This is appropriate for a Verilator chip simulation with 15 min timeout
 #define TRANSFER_BYTES_VERILATOR 0x2400U
@@ -174,6 +172,7 @@ bool test_main(void) {
       transfer_bytes = TRANSFER_BYTES_DVSIM;
       break;
     case kDeviceSilicon:
+      transfer_bytes = TRANSFER_BYTES_SILICON;
       break;
     case kDeviceFpgaCw340:
       break;

--- a/sw/device/tests/usbdev_mixed_test.c
+++ b/sw/device/tests/usbdev_mixed_test.c
@@ -46,10 +46,8 @@ Thoughts:
 #define NUM_STREAMS USBUTILS_STREAMS_MAX
 #endif
 
-// This takes about 256s presently with 10MHz CPU in CW310 FPGA and physical
-// USB with randomized packet sizes and the default memcpy implementation;
-// The _MEM_FASTER switch drops the run time to 187s
-#define TRANSFER_BYTES_FPGA (0x10U << 20)
+#define TRANSFER_BYTES_SILICON (0x10U << 20)
+#define TRANSFER_BYTES_FPGA (8U << 16)
 
 // This is appropriate for a Verilator chip simulation with 15 min timeout
 #define TRANSFER_BYTES_VERILATOR 0x2400U
@@ -186,6 +184,7 @@ bool test_main(void) {
       transfer_bytes = TRANSFER_BYTES_DVSIM;
       break;
     case kDeviceSilicon:
+      transfer_bytes = TRANSFER_BYTES_SILICON;
       break;
     case kDeviceFpgaCw340:
       break;

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -35,10 +35,12 @@
 #define NUM_STREAMS USBUTILS_STREAMS_MAX
 #endif
 
-// This takes about 256s presently with 10MHz CPU in CW310 FPGA and physical
+#define TRANSFER_BYTES_SILICON (0x10U << 20)
+// 16MiB takes about 256s presently with 10MHz CPU in CW310 FPGA and physical
 // USB with randomized packet sizes and the default memcpy implementation;
-// The _MEM_FASTER switch drops the run time to 187s
-#define TRANSFER_BYTES_FPGA (0x10U << 20)
+// The _MEM_FASTER switch drops the run time to 187s. In CI, we want to keep
+// tests short so we reduce the amount transfered.
+#define TRANSFER_BYTES_FPGA (0x10U << 16)
 
 // This is appropriate for a Verilator chip simulation with 15 min timeout
 #define TRANSFER_BYTES_VERILATOR 0x2400U
@@ -194,6 +196,7 @@ bool test_main(void) {
       transfer_bytes = TRANSFER_BYTES_DVSIM;
       break;
     case kDeviceSilicon:
+      transfer_bytes = TRANSFER_BYTES_SILICON;
       break;
     case kDeviceFpgaCw340:
       break;

--- a/sw/host/tests/chip/usb/BUILD
+++ b/sw/host/tests/chip/usb/BUILD
@@ -36,3 +36,18 @@ rust_binary(
         "@crate_index//:rusb",
     ],
 )
+
+rust_binary(
+    name = "usb_harness",
+    srcs = [
+        "usb_harness.rs",
+    ],
+    deps = [
+        ":usb",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+    ],
+)

--- a/sw/host/tests/chip/usb/usb_harness.rs
+++ b/sw/host/tests/chip/usb/usb_harness.rs
@@ -1,0 +1,125 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, ensure, Context, Result};
+use clap::Parser;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+use usb::UsbOpts;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console/USB timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "60s")]
+    timeout: Duration,
+
+    /// USB options.
+    #[command(flatten)]
+    usb: UsbOpts,
+
+    /// Executable to run after USB device connection.
+    /// This harness will spawn a process to execute and continue monitoring the UART
+    /// until the test passes (or fails). After that, the process will be killed.
+    #[arg(long)]
+    exec: Option<PathBuf>,
+
+    /// Arguments to pass to the executable.
+    #[arg(long)]
+    exec_arg: Vec<std::ffi::OsString>,
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    // Wait until test is running.
+    let uart = transport.uart("console")?;
+    UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+
+    // Enable VBUS sense on the board if necessary.
+    if opts.usb.vbus_control_available() {
+        opts.usb.enable_vbus(&transport, true)?;
+    }
+    // Sense VBUS if available.
+    if opts.usb.vbus_sense_available() {
+        ensure!(
+            opts.usb.vbus_present(&transport)?,
+            "OT USB does not appear to be connected to a host (VBUS not detected)"
+        );
+    }
+    // Wait for USB device to appear.
+    log::info!("waiting for device...");
+    let devices = opts.usb.wait_for_device(opts.timeout)?;
+    if devices.is_empty() {
+        bail!("no USB device found");
+    }
+    if devices.len() > 1 {
+        log::error!("several USB devices found:");
+        for dev in devices {
+            log::error!(
+                "- bus={} address={}",
+                dev.device().bus_number(),
+                dev.device().address()
+            );
+        }
+        bail!("several USB devices found");
+    }
+    let device = &devices[0];
+    log::info!(
+        "device found at bus={} address={}",
+        device.device().bus_number(),
+        device.device().address()
+    );
+
+    // Run executable if requested.
+    let child = match opts.exec {
+        Some(exec) => {
+            let mut cmd = Command::new(exec);
+            cmd.arg("--device").arg(format!(
+                "{}:{}",
+                device.device().bus_number(),
+                device.device().address()
+            ));
+            cmd.args(opts.exec_arg);
+            log::info!(
+                "calling {:?} on {:?}",
+                cmd.get_program(),
+                cmd.get_args().collect::<Vec<_>>()
+            );
+            Some(cmd.spawn().context("could not start executable")?)
+        }
+        None => None,
+    };
+
+    // Wait for test to pass.
+    log::info!("wait for pass...");
+    UartConsole::wait_for(&*uart, r"PASS!", opts.timeout)?;
+
+    // Kill executable (if running).
+    if let Some(mut child) = child {
+        match child.try_wait() {
+            Ok(Some(status)) => log::info!("executable exited with: {status}"),
+            Ok(None) => {
+                log::info!("executable did not finish and will be killed");
+                let _ = child.kill();
+            }
+            Err(e) => {
+                println!("error attempting to get executable status: {e}");
+                log::info!("killing executable");
+                let _ = child.kill();
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/sw/host/tests/chip/usb/usbdev_aon_wake.rs
+++ b/sw/host/tests/chip/usb/usbdev_aon_wake.rs
@@ -39,7 +39,7 @@ enum WakeMethod {
 }
 
 // Wait for a device to appear and then return the parent device and port number.
-fn wait_for_device_and_get_parent(opts: &Opts) -> Result<(rusb::Device<rusb::GlobalContext>, u8)> {
+fn wait_for_device_and_get_parent(opts: &Opts) -> Result<(rusb::Device<rusb::Context>, u8)> {
     // Wait for USB device to appear.
     log::info!("waiting for device...");
     let devices = opts.usb.wait_for_device(opts.timeout)?;

--- a/sw/host/tests/usbdev/usbdev_stream/stream_test.cc
+++ b/sw/host/tests/usbdev/usbdev_stream/stream_test.cc
@@ -332,7 +332,7 @@ static int RunTest(USBDevice *dev, const char *in_port, const char *out_port) {
     }
   }
 
-  std::cout << "Streaming...\r" << std::flush;
+  std::cout << "Streaming..." << std::endl;
 
   // Times are in microseconds.
   constexpr uint32_t kRunInterval = 5 * 1000000;  // Running before suspending.
@@ -459,8 +459,8 @@ static int RunTest(USBDevice *dev, const char *in_port, const char *out_port) {
       uint32_t bytes_left =
           (total_sent < total_bytes) ? (total_bytes - total_sent) : 0U;
       std::cout << "Bytes received: 0x" << std::hex << total_recv
-                << " -- Left to send: 0x" << bytes_left << "         \r"
-                << std::dec << std::flush;
+                << " -- Left to send: 0x" << bytes_left << "         "
+                << std::dec << std::endl;
       prev_bytes = total_sent;
     }
   } while (!done);


### PR DESCRIPTION
This PR builds on #22409, it cherry picks the USB harness from the sival branch and extends it so it can run the C++ host streaming code and monitor for success.

At the moment, I had to reduce the number of bytes sent in those tests because they are way too long (5min for each test). @alees24 is that fine or should we find a way to make this configurable? I think for CI it should be sufficient to aim for maybe a 30s test?

Still TODO:

- [x] set the number of transferred bytes depending on the target (FPGA vs silicon)