### PR TITLE
[prim] Fix typo'd loop increment

### DIFF
--- a/hw/ip/prim/rtl/prim_clock_gp_mux2.sv
+++ b/hw/ip/prim/rtl/prim_clock_gp_mux2.sv
@@ -28,7 +28,7 @@ assign stage_d = {sel_i & !stage_q[0], !sel_i & !stage_q[1]};
 
 generate
   genvar i;
-  for (i = 0; i < 2; i = i++) begin: gen_two_flops
+  for (i = 0; i < 2; i++) begin: gen_two_flops
     always_ff @(posedge clk_gp[i] or negedge rst_ni) begin: stage1
       if (!rst_ni) begin
         intq[i] <= 1'b0;


### PR DESCRIPTION
Happened to see this bit of code that looks like a typo.

Not sure about SystemVerilog, but in C this loop would never terminate. Better safe than sorry.