### PR TITLE
[jtag,dv] Do not collect JTAG items with zero DR and IR length

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -81,8 +81,8 @@ class jtag_monitor extends dv_base_monitor #(
         JtagUpdateDrState: begin
           jtag_state = `MON_CB.tms ? JtagSelectDrState : JtagIdleState;
 
-          // Send DR packet to analysis port
-          if (cfg.vif.trst_n) begin
+          // Send DR packet to analysis port, so long as the DR length is positive
+          if (cfg.vif.trst_n && counter > 0) begin
             item        = jtag_item::type_id::create("item");
             item.ir_len = 0;
             item.dr_len = counter;
@@ -121,8 +121,8 @@ class jtag_monitor extends dv_base_monitor #(
         JtagUpdateIrState: begin
           jtag_state = `MON_CB.tms ? JtagSelectDrState : JtagIdleState;
 
-          // Send IR packet to analysis port
-          if (cfg.vif.trst_n) begin
+          // Send IR packet to analysis port, so long as the IR length is positive.
+          if (cfg.vif.trst_n && counter > 0) begin
             item        = jtag_item::type_id::create("item");
             item.ir_len = counter;
             item.dr_len = 0;


### PR DESCRIPTION
The driver can sometimes decide to send special "dummy" DR or IR transactions. This is reasonable, but the end result is that we fall out of the Update-DR or Update-IR state in the FSM without any actual data.

This is hard to represent in our data model because jtag_item distinguishes between the two cases (when something has come from the monitor) by expecting exactly one of ir_len and dr_len to be positive.

To avoid a dummy packet where both lengths are zero (which isn't even recognisable as IR or DR), tweak the monitor so that it no longer creates the transaction item.

This change fixes a rare case where (at least) the `rv_dm` smoke test fails for the occasional seed. It turns out that this happens exactly when the request happens to have the `dummy_ir` flag set (which occasionally at random).