### PR TITLE
[rv_dm,dv] Double timeout for rv_dm_jtag_dmi_csr_bit_bash

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -329,7 +329,19 @@ class csr_bit_bash_seq extends csr_base_seq;
   `uvm_object_new
 
   virtual task body();
+    int unsigned total_count = test_csrs.size();
+    int unsigned done_count = 0;
+
+    `uvm_info(`gtn,
+              $sformatf("Running bit bash sequence for %0d registers", total_count),
+              UVM_MEDIUM)
     foreach (test_csrs[i]) begin
+      done_count++;
+      `uvm_info(`gtn,
+                $sformatf("Verifying register bit bash for %0s (register %0d/%0d)",
+                          test_csrs[i].get_full_name(), done_count, total_count),
+                UVM_MEDIUM)
+
       // check if parent block or register is excluded from write
       if (is_excl(test_csrs[i], CsrExclWrite, CsrBitBashTest) ||
           is_excl(test_csrs[i], CsrExclWriteCheck, CsrBitBashTest)) begin
@@ -337,9 +349,6 @@ class csr_bit_bash_seq extends csr_base_seq;
                                   test_csrs[i].get_full_name()), UVM_MEDIUM)
         continue;
       end
-
-      `uvm_info(`gtn, $sformatf("Verifying register bit bash for %0s",
-                test_csrs[i].get_full_name()), UVM_MEDIUM)
 
       begin
         uvm_reg_field   fields[$];

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -140,7 +140,7 @@
       name: rv_dm_jtag_dmi_csr_bit_bash
       uvm_test_seq: rv_dm_jtag_dmi_csr_vseq
       build_mode: "cover_reg_top"
-      run_opts: ["+en_scb=0", "+csr_bit_bash"]
+      run_opts: ["+en_scb=0", "+csr_bit_bash", "+test_timeout_ns=100_000_000"]
       reseed: 5
     }
     {


### PR DESCRIPTION
This PR has two commits. The first just makes some debug prints a bit more helpful. The second (the point of the PR) has the following commit message:

This test is sometimes timing out. The reason is that I tweaked the
DMI driver to deal more gracefully with JTAG frequencies much higher
than the clock frequency. The (usually overly careful) code we ended
up with is a bit slower and we take more than 50ns to run through the
whole list with some seeds.

Double the time available. The simulation that was timing out still
runs in only 3m20s on my laptop so I'm not really concerned about
total time.
