### PR TITLE
[dv] Enable rom_e2e_smoke test

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -12,7 +12,7 @@
       name: rom_e2e_smoke
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:rom_e2e_smoke:1:new_rules",
         "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma:4"
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -20,6 +20,7 @@
         "+sw_test_timeout_ns=40000000",
         "+use_otp_image=OtpTypeCustom",
       ]
+      run_timeout_mins: 120
     }
     {
       name: rom_e2e_shutdown_exception_c

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -2206,9 +2206,7 @@
               "chip_sw_pwrmgr_sleep_disabled",
               "chip_sw_csrng_kat_test",
               "chip_sw_sysrst_ctrl_inputs",
-              // TODO(#21204): Disable ROM e2e smoke test until we are done
-              // migrating ROM to use ECDSA keys.
-              // "rom_e2e_smoke",
+              "rom_e2e_smoke",
             ]
     }
   ]

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -310,17 +310,15 @@ opentitan_test(
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom:mask_rom",
     ),
-    exec_env = dicts.add(
-        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw340_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
-            "//hw/top_earlgrey:sim_verilator": None,
-        },
-    ),
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw340_sival": None,
+        "//hw/top_earlgrey:silicon_creator": None,
+        "//hw/top_earlgrey:sim_dv": None,
+        "//hw/top_earlgrey:sim_verilator": None,
+    },
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     verilator = verilator_params(
         timeout = "eternal",
         rom = "//sw/device/silicon_creator/rom:mask_rom",


### PR DESCRIPTION
1. Configure the sim_dv rom_e2e_somke test to use the opentitan_test target used in FPGA execution enviornments.
2. Update the //sw/device/silicon_creator/rom/e2e:rom_e2e_smoke target to always perform signing, independent of the execution environment. This is so that we can use the regular `sim_dv` target at build time to avoid having to refactor the dvsim makefile.
3. Increase the runtime of the rom_e2e_smoke test as it now takes longer due to the new signing configuration.

This is part of https://github.com/lowRISC/opentitan/issues/22697.