### PR TITLE
[prim_diff_decode] Use `prim_xnor2` to detect integrity issue

### DIFF
--- a/hw/ip/prim/prim_diff_decode.core
+++ b/hw/ip/prim/prim_diff_decode.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:assert
       - lowrisc:prim:flop_2sync
+      - lowrisc:prim:xnor2
     files:
       - rtl/prim_diff_decode.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/rtl/prim_diff_decode.sv
+++ b/hw/ip/prim/rtl/prim_diff_decode.sv
@@ -182,8 +182,16 @@ module prim_diff_decode #(
     // one reg for edge detection
     assign diff_pd = diff_pi;
 
-    // incorrect encoding -> signal integrity issue
-    assign sigint_o = ~(diff_pi ^ diff_ni);
+    // Raise a signal integrity error when the differential signals have equal values.  This is
+    // implemented with a `prim_xnor2` instead of behavioral code to prevent the synthesis tool from
+    // optimizing away combinational logic on the complementary differential signals.
+    prim_xnor2 #(
+      .Width (1)
+    ) u_xnor2_sigint (
+      .in0_i (diff_pi),
+      .in1_i (diff_ni),
+      .out_o (sigint_o)
+    );
 
     assign level_o = (sigint_o) ? level_q : diff_pi;
     assign level_d = level_o;


### PR DESCRIPTION
The differential `diff_pi` and `diff_ni` should not have equal values; otherwise a signal integrity issue exists.  Such issues can be detected with an XNOR.  Prior to this commit, this was implemented with behavioral RTL code, which could allow some synthesis tools to perform undesired optimizations for the complementary differential signals.

This commit changes the implementation to a `prim_xnor2` instance, so that synthesis tools cannot change that logic.

This is a cherry-pick of #22980 to `integrated_dev`.