### PR TITLE
[sival,sram_ctrl] Fix scrambled_access ECC error counts

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
@@ -149,6 +149,8 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
     int retval;
     bit scr_key_valid;
     int offset = addr - top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR;
+    // `backdoor` comes after `pattern` which is `BACKDOOR_DATA_WORDS` long.
+    offset += BACKDOOR_DATA_WORDS * 4;
     forever begin
       retval = uvm_hdl_read(SRAM_CTRL_RET_SCR_KEY_VALID_PATH, scr_key_valid);
       `DV_CHECK_EQ(retval, 1, $sformatf(
@@ -176,6 +178,8 @@ class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
     int retval;
     bit scr_key_valid;
     int offset = addr - top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR;
+    // `backdoor` comes after `pattern` which is `BACKDOOR_DATA_WORDS` long.
+    offset += BACKDOOR_DATA_WORDS * 4;
     forever begin
       retval = uvm_hdl_read(SRAM_CTRL_MAIN_SCR_KEY_VALID_PATH, scr_key_valid);
       `DV_CHECK_EQ(retval, 1, $sformatf(

--- a/sw/device/tests/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_scrambled_access_test.c
@@ -91,8 +91,8 @@ static_assert(kTestBufferSizeWords == 16,
               "computed again");
 
 typedef struct {
-  uint32_t backdoor[kTestBufferSizeWords];
   uint32_t pattern[kTestBufferSizeWords];
+  uint32_t backdoor[kTestBufferSizeWords];
   uint32_t ecc_error_counter;
 } scramble_test_frame;
 
@@ -139,6 +139,15 @@ static const uint8_t kBackdoorExpectedBytes[kTestBufferSizeBytes];
  * which is kept intact across the system reboot.
  */
 static noreturn void main_sram_scramble(void) {
+  // Copy only the reference pattern in most environments.
+  uint32_t copy_len = sizeof(reference_frame->pattern);
+  // Also copy the backdoor in DV sim. The DV-sim testbench magically corrects
+  // the backdoor data so that its ECC is correct. This won't be true on other
+  // platforms and the number of ECC errors will be doubled.
+  if (kDeviceType == kDeviceSimDV) {
+    copy_len += sizeof(reference_frame->backdoor);
+  }
+
   asm volatile(
       // Save the tests frames addresses before the scrambling.
       "lw a2, 0(%[mainFrame])                                        \n"
@@ -158,7 +167,7 @@ static noreturn void main_sram_scramble(void) {
       "sw a3, 0(%[retFrame])                                         \n"
 
       // Copy the backdoor and pattern buffers from main to the retention SRAM.
-      " addi t1, a3,  %[kCopyLen]                                   \n"
+      " add t1, a3, %[kCopyLen]                                     \n"
       ".L_buffer_copy_loop:                                         \n"
       "  lw t0, 0(a2)                                               \n"
       "  sw t0, 0(a3)                                               \n"
@@ -184,8 +193,7 @@ static noreturn void main_sram_scramble(void) {
         [kSramCtrlKeyScrDone] "I"(0x1 << SRAM_CTRL_STATUS_SCR_KEY_VALID_BIT),
 
         [mainFrame] "r"(&scrambling_frame), [retFrame] "r"(&reference_frame),
-        [kCopyLen] "I"(sizeof(reference_frame->pattern) +
-                       sizeof(reference_frame->backdoor)),
+        [kCopyLen] "r"(copy_len),
 
         [kRstMgrRegsBase] "r"(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR),
         [kRstMgrResetReq] "I"(RSTMGR_RESET_REQ_REG_OFFSET)


### PR DESCRIPTION
Previously the code preserved both the `pattern` and `backdoor` fields when we scramble main SRAM. The `pattern` field is the one that we expect to be scrambled and trigger ECC errors. In DV-sim environments the `backdoor` field is magically corrected so that it's scrambled with the new key and thus doesn't trigger ECC errors.
    
This of course does not (and cannot) happen outside of DV sim, so the number of ECC errors was doubled.
    
Fixed by changing the layout of `scramble_test_frame` so that we can skip copying the `backdoor` field outside of DV-sim.

If this description makes no sense, let me know and I'll try fix up the explanation better.