### PR TITLE
[sival,sram_ctrl] Fix SRAM execution test in ROM_EXT environments

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3501,13 +3501,10 @@ opentitan_test(
 opentitan_test(
     name = "sram_ctrl_execution_test",
     srcs = ["sram_ctrl_execution_test.c"],
-    broken = cw310_params(tags = ["broken"]),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:csr",

--- a/sw/device/tests/sram_ctrl_execution_test.c
+++ b/sw/device/tests/sram_ctrl_execution_test.c
@@ -75,11 +75,14 @@ bool test_main(void) {
 
   // Unlock the entire address space for RWX so that we can run this test with
   // both rom and test_rom.
-  CSR_SET_BITS(CSR_REG_PMPADDR15, 0x7fffffff);
-  CSR_SET_BITS(CSR_REG_PMPCFG3, kEpmpPermLockedReadWriteExecute << 24);
-  CSR_WRITE(CSR_REG_PMPCFG2, 0);
-  CSR_WRITE(CSR_REG_PMPCFG1, 0);
-  CSR_WRITE(CSR_REG_PMPCFG0, 0);
+  CSR_WRITE(CSR_REG_PMPADDR7, 0x7fffffff);
+
+  uint32_t pmpcfg1 = 0;
+  CSR_READ(CSR_REG_PMPCFG1, &pmpcfg1);
+  CHECK(pmpcfg1 == 0, "expected PMPCFG1 to be unconfigured before changing it");
+
+  CSR_WRITE(CSR_REG_PMPCFG1, (kEpmpModeNapot | kEpmpPermLockedReadWriteExecute)
+                                 << 24);
 
   // Note: We can test the negative case only using the retention SRAM since
   // execution is unconditionally enabled for the main SRAM in the RMA life


### PR DESCRIPTION
This test was failing in `ROM_EXT` environments because the ROM_EXT sets the `MMWP` bit in ePMP.

This changes the behaviour for unconfigured ePMP regions from them being ignored (everything allowed) to blocked (everything disallowed).

The test was removing configurations including seemingly for the region that the test was running out of flash from. This caused Ibex to just stop in the middle of the test.

This PR changes this part of the test to change to configuration of the actual region we care about and leave the others alone.