### PR TITLE
[sival,alert] Enable `alert_handler_lpg_sleep_mode_pings` test in sival environments

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -316,7 +316,7 @@ opentitan_test(
     cw310 = cw310_params(
         timeout = "moderate",
     ),
-    exec_env = {
+    exec_env = dicts.add(
         # The test requires the Ibex core to wait long enough
         # before checking for the ping_timeout error.
         # The wait-time for the Verilator would be around
@@ -324,9 +324,9 @@ opentitan_test(
         # Thus it is not recommended to run this test on
         # Verilator as this wait-time looks impractical. It should still
         # be run as part of the DV nightly regression.
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+        dicts.omit(EARLGREY_TEST_ENVS, ["//hw/top_earlgrey:sim_verilator"]),
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey:alert_handler_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -80,23 +80,31 @@ static void init_peripherals(void) {
  */
 void wait_enough_for_alert_ping(void) {
   // wait enough
-  if (kDeviceType == kDeviceFpgaCw310) {
-    // 2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
-    // 2*4*(2**16)*(400ns) = 0.2s
-    busy_spin_micros(1000 * 200);
-  } else if (kDeviceType == kDeviceSimDV) {
-    // NUM_ALERTS*2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
-    // 2*4*(2**3)*(40ns) = 3us
-    busy_spin_micros(3);
-  } else {
-    // Verilator
-    // 2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
-    // 2*4*(2**16)*(8us) = 4s
-    // This seems to be impractical for the current clock frequency config
-    // of the Verilator tests (kClockFreqPeripheralHz = 125K).
-    LOG_FATAL("SUPPORTED PLATFORMS: DV and FPGA");
-    LOG_FATAL("TO SUPPORT THE PLATFORM %d, COMPUTE THE RIGHT WAIT-TIME",
-              kDeviceType);
+  switch (kDeviceType) {
+    case kDeviceFpgaCw310:
+    case kDeviceFpgaCw340:
+      // 2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
+      // 2*4*(2**16)*(400ns) = 0.2s
+      busy_spin_micros(1000 * 200);
+      break;
+    case kDeviceSimDV:
+      // NUM_ALERTS*2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
+      // 2*4*(2**3)*(40ns) = 3us
+      busy_spin_micros(3);
+      break;
+    case kDeviceSimVerilator:
+      // Verilator
+      // 2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
+      // 2*4*(2**16)*(8us) = 4s
+      // This seems to be impractical for the current clock frequency config
+      // of the Verilator tests (kClockFreqPeripheralHz = 125K).
+      OT_FALLTHROUGH_INTENDED;
+    default:
+      LOG_FATAL("SUPPORTED PLATFORMS: DV and FPGA");
+      LOG_FATAL("TO SUPPORT THE PLATFORM %d, COMPUTE THE RIGHT WAIT-TIME",
+                kDeviceType);
+      test_status_set(kTestStatusFailed);
+      abort();
   }
 }
 

--- a/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
+++ b/sw/device/tests/alert_handler_lpg_sleep_mode_pings.c
@@ -87,10 +87,15 @@ void wait_enough_for_alert_ping(void) {
       // 2*4*(2**16)*(400ns) = 0.2s
       busy_spin_micros(1000 * 200);
       break;
+    case kDeviceSilicon:
+      // 2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
+      // 2*4*(2**16)*(42ns) = 22ms
+      busy_spin_micros(1000 * 22);
+      break;
     case kDeviceSimDV:
       // NUM_ALERTS*2*margin_of_safety*(2**DW)*(1/kClockFreqPeripheralHz)
-      // 2*4*(2**3)*(40ns) = 3us
-      busy_spin_micros(3);
+      // 2*4*(2**16)*(42ns) = 22ms
+      busy_spin_micros(1000 * 22);
       break;
     case kDeviceSimVerilator:
       // Verilator


### PR DESCRIPTION
* Added the sival test environments, but kept Verilator disabled.
* Changed the platform-dependent handling to a switch/case to make the verilator case clearer.
* Added a case for silicon.