### PR TITLE
[sival,alert] Enable `alert_handler_reverse_ping_in_deep_sleep` in sival

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -230,10 +230,10 @@ opentitan_test(
 opentitan_test(
     name = "alert_handler_reverse_ping_in_deep_sleep_test",
     srcs = ["alert_handler_reverse_ping_in_deep_sleep_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey:alert_handler_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
This PR enables the `alert_handler_reverse_pin_in_deep_sleep` test in sival environments.

A change was needed for FPGA environments to work around either the ROM or ROM_EXT always triggering a `FlashCtrlFatalErr` when the chip boots. This alert is ignored.

There are a few tests affected by this alert and we're not 100% sure we want to add the workaround to all of them, so we can hold off on merging this for now.