### PR TITLE
[sival] Refactor testplans for consistency

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_adc_ctrl
+  name: adc_ctrl
   testpoints: [
     // ADC_CTRL (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_aes
+  name: aes
   testpoints: [
     {
       name: chip_sw_aes_enc

--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_alert_handler
+  name: alert_handler
   testpoints: [
     // ALERT_HANDLER (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aon_timer_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_aon_timer
+  name: aon_timer
   testpoints: [
     {
       name: chip_sw_aon_timer_wakeup_irq

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_clkmgr
+  name: clkmgr
   testpoints: [
     // CLKMGR tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_csrng_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_csrng
+  name: csrng
   testpoints: [
     // CSRNG (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_edn_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_edn
+  name: edn
   testpoints: [
     // EDN (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_entropy_src
+  name: entropy_src
   testpoints: [
     // ENTROPY_SRC (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_flash_ctrl
+  name: flash_ctrl
   testpoints: [
     // FLASH integration tests
     {

--- a/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_gpio_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_gpio
+  name: gpio
   testpoints: [
     {
       name: chip_sw_gpio_out

--- a/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_hmac
+  name: hmac
   testpoints: [
     // HMAC integration tests
     {

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_i2c
+  name: i2c
   testpoints: [
     // I2C (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_keymgr
+  name: keymgr
   testpoints: [
     // KEYMGR integration tests
     {

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_kmac
+  name: kmac
   testpoints: [
     // KMAC integration tests
     {

--- a/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_lc_ctrl
+  name: lc_ctrl
   testpoints: [
     // LC_CTRL integration tests
     {

--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_otp_ctrl
+  name: otp_ctrl
   testpoints: [
     // OTP (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_pwrmgr
+  name: pwrmgr
   testpoints: [
     // PWRMGR tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_rom_ctrl
+  name: rom_ctrl
   testpoints: [
     {
       name: chip_sw_rom_access

--- a/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rstmgr_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_rstmgr
+  name: rstmgr
   testpoints: [
     // RSTMGR tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_timer_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_rv_timer
+  name: rv_timer
   testpoints: [
     {
       name: chip_sw_timer

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 {
-  name: chip_spi_device
+  name: spi_device
   testpoints: [
     // SPI_DEVICE (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_spi_host
+  name: spi_host
   testpoints: [
     // SPI_HOST (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_sram_ctrl
+  name: sram_ctrl
   testpoints: [
     // SRAM (pre-verified IP) integration tests:
     {

--- a/hw/top_earlgrey/data/ip/chip_sysrst_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sysrst_ctrl_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_sysrst_ctrl
+  name: sysrst_ctrl
   testpoints: [
     {
       name: chip_sw_sysrst_ctrl_reset

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_uart
+  name: uart
   testpoints: [
     {
       name: chip_sw_uart_tx_rx

--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: chip_usbdev
+  name: usbdev
   testpoints: [
     // USBDEV integration tests
     {


### PR DESCRIPTION
Remove the suffix  `chip_` from ip_block name on testplans for consistency