### PR TITLE
[keymgr, dv] Fix a typo in keymgr seq

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
@@ -178,7 +178,7 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     end
 
     // The next operation is disable, and key will be wiped and changed every cycle.
-    $assertoff(0, "tb.dut.top_earlgrey.u_kmac.u_kmac_core.KeyDataStable_M");
+    $assertoff(0, "tb.dut.top_earlgrey.u_kmac.u_kmac_core.KeyDataStableWhenValid_M");
   endtask
 
   virtual task check_kmac_sideload(bit [keymgr_pkg::KeyWidth-1:0] unmasked_key,


### PR DESCRIPTION
keymgr_key_derivation TLT is running 30+ mins. The issue is the typo in the assertion name I think @andreaskurth.

```
/workspaces/repo> ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_keymgr_key_derivation --fixed-seed 1 --waves fsdb
INFO: [dvsim] [proj_root]: /workspaces/repo
INFO: [SimCfg] [scratch_path]: [chip] [/workspaces/repo/scratch/keymgr_reorg_cnsts/chip_earlgrey_asic-sim-vcs]
ERROR: [Regression] Test "chip_plic_all_irqs" added to regression "xcelium_ci_0" not found!
ERROR: [Regression] Test "chip_sw_aes_force_prng_reseed" added to regression "V2" not found!
ERROR: [Regression] Test "chip_plic_all_irqs" added to regression "V2" not found!
ERROR: [Regression] Test "chip_sw_aes_prng_reseed" added to regression "V2" not found!
ERROR: [Regression] Test "rom_e2e_self_hash" added to regression "V3" not found!
ERROR: [Regression] Test "//sw/device/tests:i2c_host_override_test" added to regression "V3" not found!
ERROR: [Scheduler] [00:30:44]: [run]: [status] [chip:0.chip_sw_keymgr_key_derivation.1: F]
INFO: [FlowCfg] [results]: [chip]:
## CHIP Simulation Results
### Tuesday May 07 2024 12:59:35 UTC
### GitHub Revision: [`cee92c6d9b`](https://github.com/lowrisc/opentitan/tree/cee92c6d9b0a32cb67b8258382e0de5edb32ca58)<br>Foundry Revision: `0e5d1ff`
### Branch: keymgr_reorg_cnsts
### [Testplan](https://opentitan.org/book/hw/top_earlgrey/data/chip_testplan.html)
### Simulator: VCS

### Test Results
|  Stage  |             Name              | Tests                         |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:-----------------------------:|:------------------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V2    |  chip_sw_flash_keymgr_seeds   | chip_sw_keymgr_key_derivation |      37.787m      |     9.363ms      |     0     |    1    |   0.00 %    |
|   V2    | chip_sw_keymgr_key_derivation | chip_sw_keymgr_key_derivation |      37.787m      |     9.363ms      |     0     |    1    |   0.00 %    |
|   V2    |    chip_sw_kmac_app_keymgr    | chip_sw_keymgr_key_derivation |      37.787m      |     9.363ms      |     0     |    1    |   0.00 %    |
|   V2    |   chip_sw_lc_ctrl_broadcast   | chip_sw_keymgr_key_derivation |      37.787m      |     9.363ms      |     0     |    1    |   0.00 %    |
|   V2    |     chip_sw_otp_ctrl_keys     | chip_sw_keymgr_key_derivation |      37.787m      |     9.363ms      |     0     |    1    |   0.00 %    |
|   V2    |   chip_sw_otp_ctrl_entropy    | chip_sw_keymgr_key_derivation |      37.787m      |     9.363ms      |     0     |    1    |   0.00 %    |
|   V2    |                               | **TOTAL**                     |                   |                  |     0     |    1    |   0.00 %    |
|         |                               | **TOTAL**                     |                   |                  |     0     |    1    |   0.00 %    |

## Failure Buckets

* `Offending '$stable(key_data_i)'` has 1 failures:
    * Test chip_sw_keymgr_key_derivation has 1 failures.
        * 0.chip_sw_keymgr_key_derivation.1\
          Line 389, in log /workspaces/repo/scratch/keymgr_reorg_cnsts/chip_earlgrey_asic-sim-vcs/0.chip_sw_keymgr_key_derivation/latest/run.log

                	Offending '$stable(key_data_i)'
                UVM_ERROR @ 9362.672200 us: (kmac_core.sv:464) [ASSERT FAILED] KeyDataStableWhenValid_M
                UVM_INFO @ 9362.672200 us: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
```