### PR TITLE
[jtag,dv] Lots of tidyups in jtag_driver.sv

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -161,8 +161,8 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     // ShiftIR
     `HOST_CB.tms <= 1'b0;
     `HOST_CB.tdi <= 1'b0;
+    @(`HOST_CB);
     for(int i = 0; i < len; i++) begin
-      @(`HOST_CB);
       // ExitIR if end of addr
       `HOST_CB.tms <= (i == len - 1) ? 1'b1 : 1'b0;
       `HOST_CB.tdi <= ir[i];
@@ -175,8 +175,8 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
            UVM_MEDIUM)
         jtag_pause(pause_count, dout);
       end
+      @(`HOST_CB);
     end
-    @(`HOST_CB);
     // go to RTI either via
     // - PauseIR -> exit2IR -> UpdateIR -> RTI or
     // - Exit1IR -> UpdateIR -> RTI
@@ -235,9 +235,8 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     // go to ShiftDR
     `HOST_CB.tms <= 1'b0;
     `HOST_CB.tdi <= 1'b0;
+    @(`HOST_CB);
     for(int i = 0; i < len - 1; i++) begin
-      @(`HOST_CB);
-
       // We're probably currently in ShiftDr and TDO will contain bit i of the output value.
       // However, this is not true if we injected a pause on the last iteration. In that case, we
       // prepended TDO to dout as we left ShiftDR in that iteration and we're currently in Exit2DR
@@ -260,8 +259,8 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
         jtag_pause(pause_count, dout);
         pause_just_injected = 1'b1;
       end
+      @(`HOST_CB);
     end
-    @(`HOST_CB);
     // go to Exit1DR
     `HOST_CB.tms <= 1'b1;
     `HOST_CB.tdi <= dr[len - 1];

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -186,12 +186,9 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
       tms_tdi_step(0, 0);
       // Go to Exit2IR
       tms_tdi_step(1, 0);
-      // Go to UpdateIR
-      tms_tdi_step(1, 0);
-    end else begin
-      // UpdateIR
-      tms_tdi_step(1, 0);
     end
+    // UpdateIR
+    tms_tdi_step(1, 0);
     if (exit_to_rti) begin
       // Go to RTI
       tms_tdi_step(0, 0);
@@ -248,23 +245,21 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     // go to Exit1DR
     dout = {`HOST_CB.tdo, dout[JTAG_DRW-1:1]};
     tms_tdi_step(1, dr[len - 1]);
-    // go to RTI either via
-    // - PauseDR -> exit2DR -> UpdateDR -> RTI or
-    // - Exit1DR -> UpdateDR -> RTI
+
+    // Consume final bit of TDO as we enter the Exit1DR state.
+    dout = {`HOST_CB.tdo, dout[JTAG_DRW-1:1]};
+
+    // Possibly inject two extra steps (PauseDR, Exit2DR) on the way to UpdateDr.
     if (req.exit_via_pause_dr) begin
-      `uvm_info(`gfn, "Exiting via PauseDR", UVM_MEDIUM)
       // Go to PauseDR
-      dout = {`HOST_CB.tdo, dout[JTAG_DRW-1:1]};
       tms_tdi_step(0, 0);
       // Go to Exit2DR
       tms_tdi_step(1, 0);
-      // Go to UpdateDR
-      tms_tdi_step(1, 0);
-    end else begin
-      // go to UpdateDR
-      dout = {`HOST_CB.tdo, dout[JTAG_DRW-1:1]};
-      tms_tdi_step(1, 0);
     end
+
+    // go to UpdateDR
+    tms_tdi_step(1, 0);
+
     if (exit_to_rti) begin
       // go to RTI
       tms_tdi_step(0, 0);

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -81,6 +81,14 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
 
   // Drive TMS, TDI to the given values and wait for a single edge of TCK.
   task tms_tdi_step(bit tms, bit tdi);
+    // We normally expect this task to be called at the negedge of tck (synchronous with HOST_CB).
+    // But that won't quite be true if the clock has been paused for a while because tck=1 when
+    // idle. We can spot that happening because tck will be 1. In that situation, wait for HOST_CB
+    // so we can get back in sync.
+    if (cfg.vif.tck) begin
+      @(`HOST_CB);
+    end
+
     `HOST_CB.tms <= tms;
     `HOST_CB.tdi <= tdi;
     @(`HOST_CB);

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -27,18 +27,15 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
 
   // do reset signals (function)
   virtual function void do_reset_signals();
-    if (cfg.if_mode == Host) begin
-      cfg.vif.tck_en <= 1'b0;
-      cfg.vif.tms <= 1'b0;
-      cfg.vif.tdi <= 1'b0;
-      selected_ir = '{default:0};
-      selected_ir_len = 0;
-      exit_to_rti_ir_past = 1;
-      exit_to_rti_dr_past = 1;
-    end
-    else begin
-      cfg.vif.tdo <= 1'b0;
-    end
+    `DV_CHECK_FATAL(cfg.if_mode == Host, "Only Host mode is supported", "jtag_driver")
+
+    cfg.vif.tck_en <= 1'b0;
+    cfg.vif.tms <= 1'b0;
+    cfg.vif.tdi <= 1'b0;
+    selected_ir = '{default:0};
+    selected_ir_len = 0;
+    exit_to_rti_ir_past = 1;
+    exit_to_rti_dr_past = 1;
   endfunction
 
   // reset signals task
@@ -53,16 +50,8 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
 
   // drive trans received from sequencer
   virtual task get_and_drive();
-    if (cfg.if_mode == Host) begin
-      get_and_drive_host_mode();
-    end
-    else begin
-      `uvm_fatal(`gfn, "Device mode driver is not supported yet.")
-    end
-  endtask
+    `DV_CHECK_FATAL(cfg.if_mode == Host, "Only Host mode is supported", "jtag_driver")
 
-  // drive trans received from sequencer
-  virtual task get_and_drive_host_mode();
     forever begin
       if (!cfg.vif.trst_n) begin
         `DV_WAIT(cfg.vif.trst_n)

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -18,8 +18,6 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
   logic [JTAG_IRW-1:0]  selected_ir;
   uint                  selected_ir_len;
 
-  // Variable to save the previous value of exit_to_rti_ir
-  bit                   exit_to_rti_ir_past = 1;
   // Variable to save the previous value of exit_to_rti_dr
   // Before fetching a new request, `drive_jtag_req` task waits for a clock cycle.
   // Since, in the `drive_ir` task, there is a possibility to introduce TAP reset by consecutively
@@ -41,7 +39,6 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     cfg.vif.tck_en <= 1'b0;
     cfg.vif.tms <= 1'b0;
     cfg.vif.tdi <= 1'b0;
-    exit_to_rti_ir_past = 1;
     exit_to_rti_dr_past = 1;
   endfunction
 
@@ -150,7 +147,6 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
                      uint pause_cycle = 0,
                      bit exit_to_rti = 1'b1);
     logic [JTAG_DRW-1:0] dout;
-    exit_to_rti_ir_past = exit_to_rti;
     `uvm_info(`gfn, $sformatf("ir: 0x%0h, len: %0d", ir, len), UVM_MEDIUM)
     // Assume starting in RTI state
     // SelectDR

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -123,8 +123,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
         drive_jtag_ir(req.ir_len,
                       req.ir,
                       req.ir_pause_count,
-                      req.ir_pause_cycle,
-                      req.exit_to_rti_ir);
+                      req.ir_pause_cycle);
       end
     end
     if (req.dr_len) begin
@@ -144,8 +143,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
   task drive_jtag_ir(int len,
                      bit [JTAG_DRW-1:0] ir,
                      uint pause_count = 0,
-                     uint pause_cycle = 0,
-                     bit exit_to_rti = 1'b1);
+                     uint pause_cycle = 0);
     logic [JTAG_DRW-1:0] dout;
     `uvm_info(`gfn, $sformatf("ir: 0x%0h, len: %0d", ir, len), UVM_MEDIUM)
     // Assume starting in RTI state
@@ -185,12 +183,10 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     end
     // UpdateIR
     tms_tdi_step(1, 0);
-    if (exit_to_rti) begin
-      // Go to RTI
-      tms_tdi_step(0, 0);
-    end else begin
-      `uvm_info(`gfn, "drive_ir: skip going to RTI", UVM_MEDIUM)
-    end
+
+    // Go to RTI
+    tms_tdi_step(0, 0);
+
     selected_ir = ir;
     selected_ir_len = len;
   endtask

--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -20,7 +20,7 @@ interface jtag_if #(parameter int unsigned JtagDefaultTckPeriodPs = 20_000) ();
   int unsigned tck_period_ps = JtagDefaultTckPeriodPs;
 
   // Use negedge to drive jtag inputs because design also use posedge clock edge to sample.
-  clocking host_cb @(posedge tck);
+  clocking host_cb @(negedge tck);
     default output #1ns;
     output  tms;
     output  tdi;

--- a/hw/dv/sv/jtag_agent/jtag_item.sv
+++ b/hw/dv/sv/jtag_agent/jtag_item.sv
@@ -47,8 +47,6 @@ class jtag_item extends uvm_sequence_item;
   rand bit exit_via_pause_ir;
   // This field is used to indicate if DR transaction exit happens via PauseDR state
   rand bit exit_via_pause_dr;
-  // This field is used to indicate if at the end of IR transaction FSM moves to RunTestIdle state
-  rand bit exit_to_rti_ir;
   // This field is used to indicate if at the end of DR transaction FSM moves to RunTestIdle state
   rand bit exit_to_rti_dr;
   // This field is used to reset TAP FSM to TestLogicReset state
@@ -60,10 +58,6 @@ class jtag_item extends uvm_sequence_item;
 
   constraint dr_len_c {
     dr_len <= JTAG_DRW;
-  }
-
-  constraint exit_to_rti_ir_c {
-    soft exit_to_rti_ir == 1;
   }
 
   constraint exit_to_rti_dr_c {

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
@@ -45,8 +45,7 @@ class rv_dm_tap_fsm_vseq extends rv_dm_base_vseq;
       dr_pause_count == 0;
       exit_via_pause_dr == 0;
       exit_via_pause_ir == 0;
-      exit_to_rti_dr == 0;
-      exit_to_rti_ir == 0;)
+      exit_to_rti_dr == 0;)
 
     // The randomisation constraints in jtag_item don't have any "cross-field" items on fields that
     // we touch, so it's reasonable to randomise and then update the occasional field afterwards.


### PR DESCRIPTION
The main impetus for this came from trying to sort out an rv_dm test which was failing because of incorrect use of a clocking block (see "Remove use of HOST_CB clocking block"), but I spent a while looking at the rather complicated code and trying to tidy it up a bit.

The commit described above should be the only one that changes behaviour (and it changes it for the better!). The others should all be tidyups that make the code clearer without changing behaviour.