### PR TITLE
[rv_dm,dv] Rewrite dtm_idle_hint_vseq to use DMI helpers

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv
@@ -16,22 +16,38 @@ class rv_dm_jtag_dtm_idle_hint_vseq  extends rv_dm_base_vseq;
     scanmode == prim_mubi_pkg::MuBi4False;
   }
 
+  // Read the dtmcs register and check the idle field has the expected value.
+  task check_idle(bit [2:0] expected_idle);
+    uvm_reg_data_t rdata;
+    csr_rd(.ptr(jtag_dtm_ral.dtmcs), .value(rdata));
+    `DV_CHECK_EQ(expected_idle, get_field_val(jtag_dtm_ral.dtmcs.idle, rdata))
+  endtask
+
+  // Read the dtmcs register and check the dmistat field has the expected value.
+  task check_dmistat(bit [1:0] expected_dmistat);
+    uvm_reg_data_t rdata;
+    csr_rd(.ptr(jtag_dtm_ral.dtmcs), .value(rdata));
+    `DV_CHECK_EQ(expected_dmistat, get_field_val(jtag_dtm_ral.dtmcs.dmistat, rdata))
+  endtask
+
   task body();
-     uvm_reg_data_t wdata;
-     uvm_reg_data_t rdata;
-     wdata= $urandom_range(0,31);
-     csr_rd(.ptr(jtag_dtm_ral.dtmcs), .value(rdata));
-     `DV_CHECK_EQ(1,get_field_val(jtag_dtm_ral.dtmcs.idle,rdata))
-     cfg.m_jtag_agent_cfg.min_rti = 1;
-     //back to back indirect dmi accesses {op,address,data}
-     csr_wr(.ptr(jtag_dtm_ral.dmi), .value('h1034563252));
-     csr_rd(.ptr(jtag_dtm_ral.dmi), .value(rdata), .blocking(1));
-     csr_wr(.ptr(jtag_dtm_ral.dmi), .value('h8034003212));
-     csr_rd(.ptr(jtag_dtm_ral.dmi), .value(rdata), .blocking(1));
-     csr_wr(.ptr(jtag_dtm_ral.dmi), .value('h5c34003212));
-     csr_rd(.ptr(jtag_dtm_ral.dmi), .value(rdata), .blocking(1));
-     csr_rd(.ptr(jtag_dtm_ral.dtmcs), .value(rdata));
-     `DV_CHECK_EQ(0,get_field_val(jtag_dtm_ral.dtmcs.dmistat,rdata))
+    uvm_reg_data_t rdata;
+
+    // We expect dtmcs.idle to have value 1, which means that a debugger (user of the debug module)
+    // can avoid a busy dmistat by entering run-test/idle and leaving it immediately.
+    check_idle(3'h1);
+
+    // Tell the JTAG agent to act on this idle value. Setting the min_rti knob bypasses a 1-cycle
+    // minimum delay in run-test/idle that we'd get from the JTAG driver otherwise.
+    cfg.m_jtag_agent_cfg.min_rti = 1;
+
+    // Write some arbitrary data words over DMI
+    csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(32'h0d158c94));
+    csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(32'h0d000c84));
+    csr_wr(.ptr(jtag_dmi_ral.command), .value(32'h0d000c84));
+
+    // Read dtmcs back again and check that dmistat is zero (no error)
+    check_dmistat(2'h0);
   endtask
 
 endclass : rv_dm_jtag_dtm_idle_hint_vseq


### PR DESCRIPTION
This seems less complicated than the code that was there before, which had compiled the various DMI operations into their underlying JTAG writes without comments. Undoing this means I'm getting steadily better with a hex calculator...

There shouldn't be any functional change here, except that we're now using the DMI frontdoor driver, which is probably a bit more robust than what was there before.

Rather confusingly, this is somewhat reverting the change that landed in this file as fde2e0c. That change had an identical commit message to the previous change to the file and there wasn't really a proper discussion on the pull request (#20349). I'm not entirely sure why Basit thought that change was required, but I propose to undo things and revisit it if necessary.

This test should get the rv_dm_jtag_dtm_idle_hint test working in the nightlies again, but the fix will also require the changes in #23002.