### PR TITLE
entropy_src: add test to retrieve entropy via UART and run NIST tools

### DIFF
--- a/entropy.py
+++ b/entropy.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import binascii
+import sys
+import traceback
+
+def extract_hex_between_delimiters(filename):
+    """Reads a file, extracts hexadecimal digits between "+++" delimiters."""
+
+    hex_dumps = []
+    hex_data = ""
+    capture = False
+    counter = int(0)
+    with open(filename, "r", errors="ignore") as file:
+        for line in file:
+            if line.strip() == "~~~":
+                if capture:  # Second delimiter found, stop capturing
+                    print(f'Dump {counter} starts with {hex_data[:16]}')
+                    hex_dumps.append(bytes.fromhex(hex_data))
+                    hex_data = ""
+                    capture = False
+                    counter += 1
+                else:  # First delimiter found, start capturing
+                    capture = True
+                    print(f'Loading dump {counter}...')
+            elif capture:  # Capture hex digits if in between delimiters
+                hex_data += "".join(c for c in line if c in "0123456789ABCDEF")
+
+    return hex_dumps
+
+def extract_bits(value:int, mask:int) -> int:
+    """Extracts bits from an integer using a mask.
+    Args:
+        value: The integer from which to extract bits.
+        mask: The mask specifying which bits to extract.
+    Returns:
+        An integer representing the extracted bits, right-aligned.
+    """
+    extracted_bits = 0
+    shift_count = 0
+
+    # Iterate while the mask has remaining 1-bits
+    while mask:
+        if mask & 1:
+            extracted_bits |= (value & 1) << shift_count
+            shift_count += 1
+        value >>= 1
+        mask >>= 1
+
+    return extracted_bits
+
+def split_samples(dump:bytes, n_input: int, out_mask:int) -> bytes:
+    """Converts a hexadecimal string to a bit string (little-endian 32-bit words)."""
+
+    if len(dump) % 4 != 0:
+        print("Invalid dump length", len(dump))
+
+    groups = 8 // n_input
+    samples = bytearray(len(dump)*groups)
+    sample_count = int(0)
+    mask = int((1 << n_input) - 1)
+    if out_mask == 0:
+          out_mask = mask
+    out_bits = out_mask.bit_count()
+    if out_mask > mask:
+        print(f"Invalid out mask ({out_mask}) has {out_bits} bits; input ({n_input})")
+    for i in dump:
+        for _ in range(0, groups):
+            v = i & mask
+            i >>= n_input
+            samples[sample_count] = extract_bits(v, out_mask)
+            sample_count+=1
+
+    return bytes(samples)
+
+# ./bazelisk.sh test   --//signing:token=//signing/tokens:cloud_kms_prodc    --test_output=streamed   --cache_test_results=no //sw/device/tests:entropy_src_fw_observe_retrieve_test_silicon_owner_prodc_rom_ext
+# bazel-testlogs/sw/device/tests/entropy_src_fw_observe_retrieve_test_silicon_owner_prodc_rom_ext/test.log
+def main():
+    if len(sys.argv) != 2:  # Check if exactly one argument (filename) was provided
+        print("Usage: python script_name.py <filename>")
+        sys.exit(1)
+
+    filename = sys.argv[1]
+    try:
+      extracted_hex = extract_hex_between_delimiters(filename)
+      print(f'Loaded {len(extracted_hex)} dumps')
+      # print(binascii.hexlify(extracted_hex[0][0:8]))
+      # print(binascii.hexlify(split_samples(extracted_hex[0][0:8], 4, 5)))
+      # print(binascii.hexlify(split_samples(extracted_hex[0][0:8], 2, 3)))
+      # print(binascii.hexlify(split_samples(extracted_hex[0][0:8], 1, 0)))
+
+      # for i in extracted_hex[0][0:8]:
+      #     print(hex(i))
+      # exit(0)
+
+      restart_dump = False
+      prev_len = 0
+      counter = 0
+      for dump in extracted_hex:
+          if prev_len != len(dump) and restart_dump:
+              restart_dump = False
+              counter += 1
+          bits = 4 if len(dump) == 500000 else 1 if len(dump) == 125000 else None
+          print(f"Dump {counter} size {len(dump)}, bits {bits},"
+                f"restart {restart_dump}, starts {binascii.hexlify(dump[0:8])}")
+          # Restart dump follows continuous one, if length is the same
+          suffix="_restart" if restart_dump else ""
+          filename=f'test_{counter}{suffix}'
+          print(f'Writing to {filename}')
+          with open(filename, "wb") as file:
+              file.write(split_samples(dump, bits, 0))
+          if bits == 4:
+              for mask in range(1, 15):
+                filename=f'test_{counter}_m{mask}{suffix}'
+                print(f'Writing to {filename}')
+                with open(filename, "wb") as file:
+                    file.write(split_samples(dump, bits, mask))
+
+          restart_dump = not restart_dump
+          if not restart_dump:
+              counter +=1
+          prev_len = len(dump)
+
+    except Exception as e:
+            _, _, exc_traceback = sys.exc_info()
+            exc_file, exc_line = traceback.extract_tb(exc_traceback)[-1][:2]
+            print('\nError in %s:%s: ' % (exc_file, exc_line), {e})
+if __name__ == "__main__":
+    main()

--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -244,6 +244,41 @@
       bazel: ["//sw/device/tests:entropy_src_fw_observe_many_contiguous_test"]
     },
     {
+      name: chip_sw_entropy_src_fw_observe_retrieve
+      desc: '''Retrieve large number of contiguous samples and dump them for analysis.
+
+            Procedure:
+            - Disable the entropy complex.
+            - Disable health checks.
+            - Enable ENTROPY_SRC in FIPS mode
+            - Enable Firmware Override - Observe.
+            - Drain the observe FIFO.
+            - Collect 31250 (1,000,000 bits) contiguous 32-bit samples from the observe FIFO:
+              - Verify after reading each sample that the observe FIFO overflow status has not been set.
+              - Drain the observe FIFO.
+              - When internal buffer is full, dump its content as hex dump on UART console and check
+	        that FIFO overflow took place.
+
+            Tests:
+            - The procedure must be run once with ENTROPY_SRC.RNG_BIT_ENABLE disabled (4-bit / sample) and
+              four times with the ENTROPY_SRC.RNG_BIT_ENABLE feature being enabled (once for every channel).
+
+            Notes for silicon targets:
+            - This test requires access to the ENTROPY_SRC.FW_OV.OBSERVE feature, which is gated by OTP.
+              This test might thus need to be done in a secure facility.
+            '''
+      features: [
+        "ENTROPY_SRC.MODE.FIPS",
+        "ENTROPY_SRC.FW_OV.OBSERVE"
+        "ENTROPY_SRC.RNG_BIT_ENABLE",
+      ]
+      stage: V2
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: []
+      bazel: ["//sw/device/tests:entropy_src_fw_observe_many_contiguous_test"]
+    },
+    {
       name: chip_sw_entropy_src_fw_extract_and_insert
       desc: '''Verify that the software can observe samples fast enough to extract many contiguous samples.
 

--- a/nist_test.sh
+++ b/nist_test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2019 The ChromiumOS Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# NIST toolset needs sudo emerge dev-libs/libdivsufsort and bz2
+# apt-get install libbz2-dev libdivsufsort-dev libjsoncpp-dev libssl-dev libmpfr-dev
+set -e
+TMP_PATH="nist_entropy"
+NIST_URL="https://github.com/usnistgov/SP800-90B_EntropyAssessment.git"
+TRNG_OUT="$1"
+TRNG_OUT_RESTART="$1""_restart"
+EA_LOG="ea_non_iid.log"
+echo Using ${TRNG_OUT} and ${TRNG_OUT_RESTART}
+#rm -rf "${TMP_PATH}"
+if [ ! -f "${TMP_PATH}/cpp/ea_non_iid" ];then
+git clone --depth 1 "${NIST_URL}" "${TMP_PATH}" || true
+# build entropy assessment tool using mode for non independent and identically
+# distributed data, as for  H1 TRNG we can't justify the oppposite
+make -j -C "${TMP_PATH}/cpp/" non_iid restart
+fi
+rm -f "${EA_LOG}"
+"${TMP_PATH}/cpp/ea_non_iid" -v -a "${TRNG_OUT}" | tee "${EA_LOG}"
+entropy="$(awk '/min/ {print $5}' "${EA_LOG}")"
+if [[ -z "${entropy}" ]]; then
+    entropy="$(awk '/H_original/ {print $2}' "${EA_LOG}")"
+fi
+echo "Minimal entropy ${entropy}"
+"${TMP_PATH}/cpp/ea_restart" -v "${TRNG_OUT_RESTART}" \
+    "${entropy}" | tee -a "${EA_LOG}"

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1321,6 +1321,36 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "entropy_src_fw_observe_retrieve_test",
+    srcs = ["entropy_src_fw_observe_retrieve.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    silicon = silicon_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//hw/ip/entropy_src/data:entropy_src_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:edn_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:rv_core_ibex_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "entropy_src_edn_reqs_test",
     srcs = ["entropy_src_edn_reqs_test.c"],
     # The SiVal ROM_EXT locks down the OTP and prevents reads by using the ePMP

--- a/sw/device/tests/entropy_src_fw_observe_retrieve.c
+++ b/sw/device/tests/entropy_src_fw_observe_retrieve.c
@@ -1,0 +1,316 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <climits>
+#include <stdint.h>
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/edn_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
+#include "entropy_src_regs.h"                         // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kEntropySrcHealthTestWindowSize = 0x200,
+  /**
+   * Observe FIFO threshold: half of the FIFO size.
+   */
+  kEntropySrcFifoThreshold = 32,
+  /**
+   * The number of contiguous samples we want to capture.
+   * Ideally we need 31250 words = 1000000 bits, but don't have enough SRAM
+   */
+  kContiguousSamplesCount = 20480,
+  /**
+   * Number of bits per sample.
+   */
+  kBitsPerSample = 4,
+};
+
+static uint32_t sample_buffer[kContiguousSamplesCount];
+static dif_entropy_src_t entropy_src;
+static dif_csrng_t csrng;
+static dif_edn_t edn0;
+static dif_edn_t edn1;
+static dif_uart_t *uart;
+
+/**
+ * Determine whether the observe FIFO has overflowed.
+ *
+ * TODO(#21279) Normally, one would rely on the FW_OV_RD_FIFO_OVERFLOW
+ * register but due to an RTL bug, the overflow bit is pulsed
+ * instead of latched so we cannot rely on it. Instead, rely
+ * on OBSERVE_FIFO_DEPTH and assume that if the FIFO is full
+ * then it has overflowed.
+ */
+bool entropy_src_fifo_has_overflowed(void) {
+  uint32_t fifo_depth;
+  CHECK_DIF_OK(dif_entropy_src_get_fifo_depth(&entropy_src, &fifo_depth));
+  return fifo_depth == ENTROPY_SRC_PARAM_OBSERVE_FIFO_DEPTH;
+}
+
+// Configure the entropy complex.
+static status_t entropy_config(
+    dif_entropy_src_single_bit_mode_t single_bit_mode) {
+
+  // Disable the entropy complex.
+  TRY(entropy_testutils_stop_all());
+  // Disable all health tests.
+  TRY(entropy_testutils_disable_health_tests(&entropy_src));
+
+  // Enable FW override.
+  TRY(dif_entropy_src_fw_override_configure(
+      &entropy_src,
+      (dif_entropy_src_fw_override_config_t){
+          .entropy_insert_enable = false,
+          .buffer_threshold = kEntropySrcFifoThreshold,
+      },
+      kDifToggleEnabled));
+  // Enable entropy_src.
+  TRY(dif_entropy_src_configure(
+      &entropy_src,
+      (dif_entropy_src_config_t){
+          .fips_enable = true,
+          .route_to_firmware = false,
+          .bypass_conditioner = false,
+          .single_bit_mode = single_bit_mode,
+          .health_test_threshold_scope = false,
+          .health_test_window_size = kEntropySrcHealthTestWindowSize,
+          .alert_threshold = UINT16_MAX},
+      kDifToggleEnabled));
+
+  return OK_STATUS();
+}
+
+static void print_uart(const char *buf, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    while (dif_uart_byte_send_polled(uart, (uint8_t)buf[i]) != kDifOk)
+      ;
+  }
+  return;
+}
+
+static size_t print_hex_uart(const uint8_t *buf, size_t len, size_t counter) {
+  char out[4];
+  out[2] = '\r';
+  out[3] = '\n';
+
+  for (size_t i = 0; i < len; ++i) {
+    uint8_t l = buf[i] & 0xf;
+    uint8_t h = buf[i] >> 4;
+    l += (l < 10) ? '0' : 'A' - 10;
+    h += (h < 10) ? '0' : 'A' - 10;
+    out[0] = h;
+    out[1] = l;
+    counter += 2;
+    if ((counter & 63) == 0)
+      print_uart(out, 4);
+    else
+      print_uart(out, 2);
+  }
+  return counter;
+}
+// End of UART stack
+
+/**
+ * Test the firmware override observe path.
+ *
+ * @param entropy An Entropy handle.
+ */
+status_t firmware_override_observe(
+    int32_t nr_samples, dif_entropy_src_single_bit_mode_t single_bit_mode) {
+  const int32_t nr_bits =
+      nr_samples *
+      ((single_bit_mode == kDifEntropySrcSingleBitModeDisabled) ? 4 : 1);
+  // Slow computation: do it once.
+  const int32_t bits_per_word = CHAR_BIT * sizeof(sample_buffer[0]);
+  // We always read 32-bits. TODO: multiply by 4 in 4-bit mode?
+  const int32_t nr_sample_words = (nr_bits + bits_per_word - 1) / bits_per_word;
+  int32_t words_left = nr_sample_words;
+  // Configure the entropy complex.
+  entropy_config(single_bit_mode);
+
+  LOG_INFO("==================");
+  LOG_INFO("Running test in mode %u, retrieve %u words", single_bit_mode,
+           nr_sample_words);
+
+  // Set timeout to worst case.
+  ibex_timeout_t tmo = ibex_timeout_init(6000000);
+  // Drain FIFO to make sure we get contiguous samples.
+  LOG_INFO("drain observe FIFO overflow...");
+  print_uart("~~~\r\n", 5);
+  TRY(entropy_testutils_drain_observe_fifo(&entropy_src));
+  uint32_t entropy_full_event = 0;
+  uint32_t expected_entropy_full = 0;
+  uint32_t uart_counter=0;
+  uint64_t elapsed = 0;
+  bool timeout = false;
+  while (words_left) {
+    // Collect samples from the the observe FIFO.
+    int32_t words_to_read = (words_left < kContiguousSamplesCount)
+                                ? words_left
+                                : kContiguousSamplesCount;
+    int32_t words_read_in_round = words_to_read;
+    uint32_t *sample_buffer_ptr = sample_buffer;
+
+    // Collect.
+    while (words_to_read > 0 && !(timeout = ibex_timeout_check(&tmo))) {
+      size_t len = (size_t)words_to_read;
+      // Check FIFO did not overflow during collection.
+      entropy_full_event += entropy_src_fifo_has_overflowed();
+      TRY(dif_entropy_src_observe_fifo_nonblocking_read(
+          &entropy_src, sample_buffer_ptr, &len));
+      sample_buffer_ptr += len;
+      words_to_read -= len;
+    }
+    elapsed += ibex_timeout_elapsed(&tmo);
+    // Handle partial & timed-out reads
+    words_left -= words_read_in_round - words_to_read;
+    if (timeout)
+      break;
+    // Printing will cause fifo overflow
+    if (words_left)
+      expected_entropy_full++;
+    // Print output
+    uart_counter = print_hex_uart(
+        (uint8_t *)sample_buffer,
+        (size_t)words_read_in_round * sizeof(uint32_t), uart_counter);
+    // Reset timer for next iteration
+    tmo = ibex_timeout_init(6000000);
+  }
+  print_uart("\r\n~~~\r\n", 7);
+  TRY_CHECK(!timeout, "Timeout during capture");
+  TRY_CHECK(entropy_full_event <= expected_entropy_full,
+            "Unexpected stalls at collection %u vs %u", entropy_full_event,
+            expected_entropy_full);
+  // Make sure the FIFO did not overflow.
+
+  uint64_t freq =
+      udiv64_slow((uint64_t)(nr_sample_words - words_left) * (uint64_t)1000000,
+                  elapsed, NULL);
+  LOG_INFO("done in %ums (~ %usamples/s)",
+           (uint32_t)udiv64_slow(elapsed, 1000, NULL), (uint32_t)freq);
+
+  return OK_STATUS();
+}
+
+// Dump in batches of 1000 samples and then restart
+status_t firmware_override_observe_restart(
+    int32_t nr_samples, dif_entropy_src_single_bit_mode_t single_bit_mode) {
+
+  const int32_t total_rounds = (nr_samples + 999) / 1000;
+  int32_t rounds_to_run = total_rounds;
+  const int32_t bits_in_round = 1000 * ((single_bit_mode == kDifEntropySrcSingleBitModeDisabled) ? 4 : 1);
+  // Slow computation: do it once.
+  const int32_t bits_per_word = CHAR_BIT * sizeof(sample_buffer[0]);
+  // We always read 32-bits. TODO: multiply by 4 in 4-bit mode?
+  const int32_t words_in_round = (bits_in_round + bits_per_word - 1) / bits_per_word;
+  const int32_t bytes_in_round = (bits_in_round + CHAR_BIT - 1) / CHAR_BIT;
+
+  LOG_INFO("==================");
+  LOG_INFO("Running restart test in mode %u, retrieve %u words, bytes %u, rounds %u",
+           single_bit_mode, words_in_round, bytes_in_round, total_rounds);
+  if (words_in_round > kContiguousSamplesCount)
+	return INVALID_ARGUMENT();
+
+  // Set timeout to worst case.
+  ibex_timeout_t tmo = ibex_timeout_init(6000000);
+  // Drain FIFO to make sure we get contiguous samples.
+  print_uart("~~~\n", 4);
+  uint32_t entropy_full_event = 0;
+  uint64_t elapsed = 0;
+  bool timeout = false;
+  uint32_t uart_counter = 0;
+  while (rounds_to_run) {
+    // Collect samples from the the observe FIFO.
+    int32_t words_to_read = words_in_round;
+    uint32_t *sample_buffer_ptr = sample_buffer;
+
+    // Restart the entropy complex.
+    entropy_config(single_bit_mode);
+
+    // Drain stale entropy if any
+    // TRY(entropy_testutils_drain_observe_fifo(&entropy_src));
+
+    // Collect.
+    while (words_to_read > 0 && !(timeout = ibex_timeout_check(&tmo))) {
+      size_t len = (size_t)words_to_read;
+      uint32_t err_code;
+      TRY(dif_entropy_src_get_errors(&entropy_src, &err_code));
+      if (err_code)
+        LOG_ERROR("entropy_src status. err: 0x%x", err_code);
+
+      // Check FIFO did not overflow during collection.
+      entropy_full_event += entropy_src_fifo_has_overflowed();
+      TRY(dif_entropy_src_observe_fifo_nonblocking_read(
+          &entropy_src, sample_buffer_ptr, &len));
+      sample_buffer_ptr += len;
+      words_to_read -= len;
+    }
+    elapsed += ibex_timeout_elapsed(&tmo);
+    // Handle partial & timed-out reads
+    rounds_to_run--;
+    if (timeout)
+      break;
+    // Print output
+    uart_counter = print_hex_uart((uint8_t *)sample_buffer,
+                                  (size_t)bytes_in_round, uart_counter);
+    // Reset timer for next iteration
+    tmo = ibex_timeout_init(6000000);
+  }
+  print_uart("\n~~~\n", 5);
+  TRY_CHECK(!timeout, "Timeout during capture");
+  TRY_CHECK(entropy_full_event == 0, "Unexpected stalls at collection %u",
+            entropy_full_event);
+  // Make sure the FIFO did not overflow.
+
+  uint64_t freq = udiv64_slow(
+      ((uint64_t)(total_rounds - rounds_to_run) * (uint64_t)words_in_round) *
+          (uint64_t)1000000,
+      elapsed, NULL);
+  LOG_INFO("done in %ums (~ %usamples/s)",
+           (uint32_t)udiv64_slow(elapsed, 1000, NULL), (uint32_t)freq);
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  CHECK_DIF_OK(dif_csrng_init(
+      mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+  CHECK_DIF_OK(
+      dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
+  CHECK_DIF_OK(
+      dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR), &edn1));
+
+  // Test all modes.
+  static dif_entropy_src_single_bit_mode_t kModes[] = {
+      kDifEntropySrcSingleBitModeDisabled,
+      kDifEntropySrcSingleBitMode0,
+      kDifEntropySrcSingleBitMode1,
+      kDifEntropySrcSingleBitMode2,
+      kDifEntropySrcSingleBitMode3,
+  };
+  // This is a hack to quickly get UART access and avoid slow base_printf()
+  uart = (dif_uart_t *)ottf_console_get();
+  CHECK_DIF_OK(dif_uart_watermark_tx_set(uart, kDifUartWatermarkByte64));
+  status_t test_result = OK_STATUS();
+  for (size_t i = 0; i < ARRAYSIZE(kModes); i++) {
+    EXECUTE_TEST(test_result, firmware_override_observe, 1000000, kModes[i]);
+    EXECUTE_TEST(test_result, firmware_override_observe_restart, 1000000,
+                 kModes[i]);
+  }
+
+  return status_ok(test_result);
+}


### PR DESCRIPTION
Added a test to retrieve entropy from entropy_src and dump in on UART as hex, scripts to parse log and extract it and prepare for NIST Entropy Assessment tools.

Entropy is captured in 2 modes:
- Continuous, in chunks of 80KB (limited to memory buffer), which is 655360 1-bit samples or 163840 4-bit samples.
- Restart mode in chunks of 1000 1-bit or 4-bit samples alternated with module disable/enable for restart test (check that entropy doesn't degrade if entropy source is power cycled).

./bazelisk.sh run //sw/host/opentitantool -- transport init

./bazelisk.sh test --test_output=streamed --cache_test_results=no \
 //sw/device/tests:entropy_src_fw_observe_retrieve_test_silicon_owner_prodc_rom_ext

./entropy.py bazel-testlogs/sw/device/tests/entropy_src_fw_observe_retrieve_test_silicon_owner_prodc_rom_ext/test.log

./nist_test.sh test_0

Issue https://github.com/lowRISC/opentitan/issues/2111