### PR TITLE
[manuf] cleanup cert sizes and fix slight bug

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -227,6 +227,20 @@ extern "C++" {
                 "Unexpected size for " #type)
 
 /**
+ * A macro that expands to an assertion for the size of a struct member.
+ *
+ * Identical to `OT_ASSERT_MEMBER_SIZE`, except the size parameter is provided
+ * as an enum constant.
+ *
+ * @param type A struct type.
+ * @param member A member of the struct.
+ * @param size Expected size of the type as an enum constant.
+ */
+#define OT_ASSERT_MEMBER_SIZE_AS_ENUM(type, member, enum_size) \
+  static_assert(sizeof(((type){0}).member) == enum_size,       \
+                "Unexpected size for " #type)
+
+/**
  * A macro that expands to an assertion for the size of a type.
  *
  * @param type A type.

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -100,17 +100,17 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
  */
 // clang-format off
 #define STRUCT_MANUF_PERSO_CERTS(field, string) \
-    field(uds_tbs_certificate, uint8_t, 880) \
+    field(uds_tbs_certificate, uint8_t, 727) \
     field(uds_tbs_certificate_size, size_t) \
-    field(cdi_0_certificate, uint8_t, 582) \
+    field(cdi_0_certificate, uint8_t, 580) \
     field(cdi_0_certificate_size, size_t) \
-    field(cdi_1_certificate, uint8_t, 631) \
+    field(cdi_1_certificate, uint8_t, 629) \
     field(cdi_1_certificate_size, size_t) \
-    field(tpm_ek_tbs_certificate, uint8_t, 714) \
+    field(tpm_ek_tbs_certificate, uint8_t, 844) \
     field(tpm_ek_tbs_certificate_size, size_t) \
-    field(tpm_cek_tbs_certificate, uint8_t, 714) \
+    field(tpm_cek_tbs_certificate, uint8_t, 456) \
     field(tpm_cek_tbs_certificate_size, size_t) \
-    field(tpm_cik_tbs_certificate, uint8_t, 714) \
+    field(tpm_cik_tbs_certificate, uint8_t, 456) \
     field(tpm_cik_tbs_certificate_size, size_t)
 UJSON_SERDE_STRUCT(ManufCerts, \
                    manuf_certs_t, \
@@ -122,13 +122,13 @@ UJSON_SERDE_STRUCT(ManufCerts, \
  */
 // clang-format off
 #define STRUCT_MANUF_ENDORSED_CERTS(field, string) \
-    field(uds_certificate, uint8_t, 870) \
+    field(uds_certificate, uint8_t, 818) \
     field(uds_certificate_size, size_t) \
-    field(tpm_ek_certificate, uint8_t, 714) \
+    field(tpm_ek_certificate, uint8_t, 935) \
     field(tpm_ek_certificate_size, size_t) \
-    field(tpm_cek_certificate, uint8_t, 714) \
+    field(tpm_cek_certificate, uint8_t, 547) \
     field(tpm_cek_certificate_size, size_t) \
-    field(tpm_cik_certificate, uint8_t, 714) \
+    field(tpm_cik_certificate, uint8_t, 547) \
     field(tpm_cik_certificate_size, size_t)
 UJSON_SERDE_STRUCT(ManufEndorsedCerts, \
                    manuf_endorsed_certs_t, \

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -97,14 +97,18 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
 
 /**
  * DICE certificates exported during personalization.
+ *
+ * See the `OT_ASSERT_MEMBER_SIZE_AS_ENUM` calls in
+ * `sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c`
+ * for how these sizes are chosen.
  */
 // clang-format off
 #define STRUCT_MANUF_PERSO_CERTS(field, string) \
-    field(uds_tbs_certificate, uint8_t, 727) \
+    field(uds_tbs_certificate, uint8_t, 728) \
     field(uds_tbs_certificate_size, size_t) \
     field(cdi_0_certificate, uint8_t, 580) \
     field(cdi_0_certificate_size, size_t) \
-    field(cdi_1_certificate, uint8_t, 629) \
+    field(cdi_1_certificate, uint8_t, 632) \
     field(cdi_1_certificate_size, size_t) \
     field(tpm_ek_tbs_certificate, uint8_t, 844) \
     field(tpm_ek_tbs_certificate_size, size_t) \
@@ -119,16 +123,20 @@ UJSON_SERDE_STRUCT(ManufCerts, \
 
 /**
  * Endorsed certificates imported during personalization.
+ *
+ * See the `OT_ASSERT_MEMBER_SIZE_AS_ENUM` calls in
+ * `sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c`
+ * for how these sizes are chosen.
  */
 // clang-format off
 #define STRUCT_MANUF_ENDORSED_CERTS(field, string) \
-    field(uds_certificate, uint8_t, 818) \
+    field(uds_certificate, uint8_t, 820) \
     field(uds_certificate_size, size_t) \
-    field(tpm_ek_certificate, uint8_t, 935) \
+    field(tpm_ek_certificate, uint8_t, 936) \
     field(tpm_ek_certificate_size, size_t) \
-    field(tpm_cek_certificate, uint8_t, 547) \
+    field(tpm_cek_certificate, uint8_t, 548) \
     field(tpm_cek_certificate_size, size_t) \
-    field(tpm_cik_certificate, uint8_t, 547) \
+    field(tpm_cik_certificate, uint8_t, 548) \
     field(tpm_cik_certificate_size, size_t)
 UJSON_SERDE_STRUCT(ManufEndorsedCerts, \
                    manuf_endorsed_certs_t, \

--- a/sw/device/silicon_creator/lib/cert/tpm_cik.hjson
+++ b/sw/device/silicon_creator/lib/cert/tpm_cik.hjson
@@ -53,7 +53,7 @@
         not_before: "20230101000000Z",
         not_after: "20500101000000Z",
         subject: [
-            { country: "USA" },
+            { country: "US" },
             { state: "CA" },
             { organization: "Google" },
             { organizational_unit: "Engineering" },

--- a/sw/device/silicon_creator/lib/cert/uds.hjson
+++ b/sw/device/silicon_creator/lib/cert/uds.hjson
@@ -49,11 +49,6 @@
             type: "byte-array",
             size: 32,
         },
-        // Hash of the hw_cfg0 OTP partition (SHA256).
-        otp_hw_cfg0_hash: {
-            type: "byte-array",
-            size: 32,
-        },
         // Hash of the hw_cfg1 OTP partition (SHA256).
         otp_hw_cfg1_hash: {
             type: "byte-array",
@@ -120,7 +115,6 @@
                     { hash_algorithm: "sha256", digest: { var: "otp_owner_sw_cfg_hash" } },
                     { hash_algorithm: "sha256", digest: { var: "otp_rot_creator_auth_codesign_hash" } },
                     { hash_algorithm: "sha256", digest: { var: "otp_rot_creator_auth_state_hash" } },
-                    { hash_algorithm: "sha256", digest: { var: "otp_hw_cfg0_hash" } },
                     { hash_algorithm: "sha256", digest: { var: "otp_hw_cfg1_hash" } },
                 ],
                 flags: {

--- a/sw/device/silicon_creator/lib/dice.c
+++ b/sw/device/silicon_creator/lib/dice.c
@@ -54,7 +54,6 @@ static_assert(
     OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE &&
     OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE &&
     OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE &&
-    OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_HW_CFG0_SIZE &&
     OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_HW_CFG1_SIZE,
     "The largest DICE measured OTP partition is no longer the "
     "OwnerSwCfg partition. Update the "
@@ -203,11 +202,13 @@ rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
                                     attestation_public_key_t *uds_pubkey,
                                     uint8_t *tbs_cert, size_t *tbs_cert_size) {
   // Measure OTP partitions.
+  //
+  // Note: we do not measure HwCfg0 as this is the Device ID, which is already
+  // mixed into the keyladder directly via hardware channels.
   hmac_digest_t otp_creator_sw_cfg_measurement = {.digest = {0}};
   hmac_digest_t otp_owner_sw_cfg_measurement = {.digest = {0}};
   hmac_digest_t otp_rot_creator_auth_codesign_measurement = {.digest = {0}};
   hmac_digest_t otp_rot_creator_auth_state_measurement = {.digest = {0}};
-  hmac_digest_t otp_hw_cfg0_measurement = {.digest = {0}};
   hmac_digest_t otp_hw_cfg1_measurement = {.digest = {0}};
   measure_otp_partition(kOtpPartitionCreatorSwCfg,
                         &otp_creator_sw_cfg_measurement);
@@ -216,7 +217,6 @@ rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
                         &otp_rot_creator_auth_codesign_measurement);
   measure_otp_partition(kOtpPartitionRotCreatorAuthState,
                         &otp_rot_creator_auth_state_measurement);
-  measure_otp_partition(kOtpPartitionHwCfg0, &otp_hw_cfg0_measurement);
   measure_otp_partition(kOtpPartitionHwCfg1, &otp_hw_cfg1_measurement);
 
   // Generate the TBS certificate.
@@ -233,8 +233,6 @@ rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
       .otp_rot_creator_auth_state_hash =
           (unsigned char *)otp_rot_creator_auth_state_measurement.digest,
       .otp_rot_creator_auth_state_hash_size = kHmacDigestNumBytes,
-      .otp_hw_cfg0_hash = (unsigned char *)otp_hw_cfg0_measurement.digest,
-      .otp_hw_cfg0_hash_size = kHmacDigestNumBytes,
       .otp_hw_cfg1_hash = (unsigned char *)otp_hw_cfg1_measurement.digest,
       .otp_hw_cfg1_hash_size = kHmacDigestNumBytes,
       .debug_flag = is_debug_exposed(),

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -231,6 +231,7 @@ opentitan_binary(
         "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:status",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/silicon_creator/lib:attestation_key_diversifiers",
         "//sw/device/silicon_creator/lib:dice",

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -4,7 +4,6 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
-#include "sw/device/lib/crypto/impl/sha2/sha256.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
@@ -16,6 +15,7 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/lib/attestation_key_diversifiers.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/dif/dif_flash_ctrl.h"
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
@@ -40,40 +41,29 @@
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
-// Do not update these static asserts without updating the buffer sizes in the
-// following UJSON structs in `sw/device/lib/testing/json/provisioning_data.h`:
-// - manuf_certs_t
-// - manuf_endorsed_certs_t
-static_assert(kUdsMaxTbsSizeBytes == 727,
-              "The `uds_tbs_certificate` buffer size in the `manuf_certs_t` "
-              "struct should match the value of `kUdsMaxTbsSizeBytes`.");
-static_assert(kCdi0MaxCertSizeBytes == 580,
-              "The `cdi_0_certificate` buffer size in the `manuf_certs_t` "
-              "struct should match the value of `kCdi0MaxCertSizeBytes`.");
-static_assert(kCdi1MaxCertSizeBytes == 629,
-              "The `cdi_1_certificate` buffer size in the `manuf_certs_t` "
-              "struct should match the value of `kCdi1MaxCertSizeBytes`.");
-static_assert(kTpmEkMaxTbsSizeBytes == 844,
-              "The `tpm_ek_tbs_certificate` buffer size in the `manuf_certs_t`"
-              "struct should match the value of `kTpmEkMaxTbsSizeBytes`.");
-static_assert(kTpmCekMaxTbsSizeBytes == 456,
-              "The `tpm_cek_tbs_certificate` buffer size in the `manuf_certs_t`"
-              "struct should match the value of `kTpmCekMaxTbsSizeBytes`.");
-static_assert(kTpmCikMaxTbsSizeBytes == 456,
-              "The `tpm_cik_tbs_certificate` buffer size in the `manuf_certs_t`"
-              "struct should match the value of `kTpmCikMaxTbsSizeBytes`.");
-static_assert(kUdsMaxCertSizeBytes == 818,
-              "The `uds_tbs_certificate` buffer size in the `manuf_certs_t` "
-              "struct should match the value of `kUdsMaxTbsSizeBytes`.");
-static_assert(kTpmEkMaxCertSizeBytes == 935,
-              "The `tpm_ek_certificate` buffer size in the `manuf_certs_t` "
-              "struct should match the value of `kTpmEkMaxCertSizeBytes`.");
-static_assert(kTpmCekMaxCertSizeBytes == 547,
-              "The `tpm_cek_certificate` buffer size in the `manuf_certs_t` "
-              "struct should match the value of `kTpmCekMaxCertSizeBytes`.");
-static_assert(kTpmCikMaxCertSizeBytes == 547,
-              "The `tpm_cik_certificate` buffer size in the `manuf_certs_t` "
-              "struct should match the value of `kTpmCikMaxCertSizeBytes`.");
+// Check TBS certificate buffer sizes.
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_certs_t, uds_tbs_certificate,
+                              OT_ALIGN_MEM(kUdsMaxTbsSizeBytes));
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_certs_t, tpm_ek_tbs_certificate,
+                              OT_ALIGN_MEM(kTpmEkMaxTbsSizeBytes));
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_certs_t, tpm_cek_tbs_certificate,
+                              OT_ALIGN_MEM(kTpmCekMaxTbsSizeBytes));
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_certs_t, tpm_cik_tbs_certificate,
+                              OT_ALIGN_MEM(kTpmCikMaxTbsSizeBytes));
+
+// Check endorsed certificate buffer sizes.
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_endorsed_certs_t, uds_certificate,
+                              OT_ALIGN_MEM(kUdsMaxCertSizeBytes));
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_certs_t, cdi_0_certificate,
+                              OT_ALIGN_MEM(kCdi0MaxCertSizeBytes));
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_certs_t, cdi_1_certificate,
+                              OT_ALIGN_MEM(kCdi1MaxCertSizeBytes));
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_endorsed_certs_t, tpm_ek_certificate,
+                              OT_ALIGN_MEM(kTpmEkMaxCertSizeBytes));
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_endorsed_certs_t, tpm_cek_certificate,
+                              OT_ALIGN_MEM(kTpmCekMaxCertSizeBytes));
+OT_ASSERT_MEMBER_SIZE_AS_ENUM(manuf_endorsed_certs_t, tpm_cik_certificate,
+                              OT_ALIGN_MEM(kTpmCikMaxCertSizeBytes));
 
 /**
  * Peripheral handles.

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -19,9 +19,12 @@
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/lib/attestation_key_diversifiers.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
-#include "sw/device/silicon_creator/lib/cert/cdi_0.h"  // Generated.
-#include "sw/device/silicon_creator/lib/cert/cdi_1.h"  // Generated.
-#include "sw/device/silicon_creator/lib/cert/uds.h"    // Generated.
+#include "sw/device/silicon_creator/lib/cert/cdi_0.h"    // Generated.
+#include "sw/device/silicon_creator/lib/cert/cdi_1.h"    // Generated.
+#include "sw/device/silicon_creator/lib/cert/tpm_cek.h"  // Generated.
+#include "sw/device/silicon_creator/lib/cert/tpm_cik.h"  // Generated.
+#include "sw/device/silicon_creator/lib/cert/tpm_ek.h"   // Generated.
+#include "sw/device/silicon_creator/lib/cert/uds.h"      // Generated.
 #include "sw/device/silicon_creator/lib/dice.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
@@ -37,22 +40,40 @@
 
 OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
-static_assert(kUdsMaxTbsSizeBytes == 775,
-              "The `uds_tbs_certificate` buffer size in the "
-              "`manuf_certs_t` struct should match the value of "
-              "`kUdsMaxTbsSizeBytes`.");
-static_assert(kUdsMaxCertSizeBytes == 866,
-              "The `uds_tbs_certificate` buffer size in the "
-              "`manuf_certs_t` struct should match the value of "
-              "`kUdsMaxTbsSizeBytes`.");
+// Do not update these static asserts without updating the buffer sizes in the
+// following UJSON structs in `sw/device/lib/testing/json/provisioning_data.h`:
+// - manuf_certs_t
+// - manuf_endorsed_certs_t
+static_assert(kUdsMaxTbsSizeBytes == 727,
+              "The `uds_tbs_certificate` buffer size in the `manuf_certs_t` "
+              "struct should match the value of `kUdsMaxTbsSizeBytes`.");
 static_assert(kCdi0MaxCertSizeBytes == 580,
-              "The `cdi_0_certificate` buffer size in the "
-              "`manuf_certs_t` struct should match the value of "
-              "`kCdi0MaxCertSizeBytes`.");
+              "The `cdi_0_certificate` buffer size in the `manuf_certs_t` "
+              "struct should match the value of `kCdi0MaxCertSizeBytes`.");
 static_assert(kCdi1MaxCertSizeBytes == 629,
-              "The `cdi_1_certificate` buffer size in the "
-              "`manuf_certs_t` struct should match the value of "
-              "`kCdi1MaxCertSizeBytes`.");
+              "The `cdi_1_certificate` buffer size in the `manuf_certs_t` "
+              "struct should match the value of `kCdi1MaxCertSizeBytes`.");
+static_assert(kTpmEkMaxTbsSizeBytes == 844,
+              "The `tpm_ek_tbs_certificate` buffer size in the `manuf_certs_t`"
+              "struct should match the value of `kTpmEkMaxTbsSizeBytes`.");
+static_assert(kTpmCekMaxTbsSizeBytes == 456,
+              "The `tpm_cek_tbs_certificate` buffer size in the `manuf_certs_t`"
+              "struct should match the value of `kTpmCekMaxTbsSizeBytes`.");
+static_assert(kTpmCikMaxTbsSizeBytes == 456,
+              "The `tpm_cik_tbs_certificate` buffer size in the `manuf_certs_t`"
+              "struct should match the value of `kTpmCikMaxTbsSizeBytes`.");
+static_assert(kUdsMaxCertSizeBytes == 818,
+              "The `uds_tbs_certificate` buffer size in the `manuf_certs_t` "
+              "struct should match the value of `kUdsMaxTbsSizeBytes`.");
+static_assert(kTpmEkMaxCertSizeBytes == 935,
+              "The `tpm_ek_certificate` buffer size in the `manuf_certs_t` "
+              "struct should match the value of `kTpmEkMaxCertSizeBytes`.");
+static_assert(kTpmCekMaxCertSizeBytes == 547,
+              "The `tpm_cek_certificate` buffer size in the `manuf_certs_t` "
+              "struct should match the value of `kTpmCekMaxCertSizeBytes`.");
+static_assert(kTpmCikMaxCertSizeBytes == 547,
+              "The `tpm_cik_certificate` buffer size in the `manuf_certs_t` "
+              "struct should match the value of `kTpmCikMaxCertSizeBytes`.");
 
 /**
  * Peripheral handles.


### PR DESCRIPTION
This cleans up the DICE/TPM certificate sizes and fixes a small bug in the TPM CIK certificate's subject country string. This is in preparation for combining the DICE certs into a single flash info page.