### PR TITLE
[rv_dm,dv] Remove check from scoreboard about unmapped DTM reads

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -70,8 +70,8 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       end
 
       if (selected_dtm_csr == null) begin
-        // Unmapped regions of the JTAG DTM register space should exhibit RAZ/WI behavior.
-        `DV_CHECK_EQ(item.dout, 0)
+        // Behaviour on unmapped regions of the JTAG DTM register space is not defined. In
+        // particular, we don't have an opinion about what dout should contain.
         continue;
       end
 


### PR DESCRIPTION
The dout value here comes from pulp code in dmi_jtag_tap.sv (see the always_comb block that drives tdo_mux) and we'll almost get the BYPASS behaviour, but not quite. Since the correct behaviour of rv_dm doesn't really include an opinion about what happens here, let's ignore it.