### PR TITLE
[Sival, spi] Fix TPM test on teacup boad.

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -238,22 +238,22 @@
       "alias_of": "CN10_10"
     },
     {
-      "name": "SPI1_SCK",
+      "name": "SPI_TPM_SCK",
       "mode": "Input",
       "alias_of": "CN7_15"
     },
     {
-      "name": "SPI1_MOSI",
+      "name": "SPI_TPM_MOSI",
       "mode": "Input",
       "alias_of": "CN7_14"
     },
     {
-      "name": "SPI1_MISO",
+      "name": "SPI_TPM_MISO",
       "mode": "Input",
       "alias_of": "CN7_12"
     },
     {
-      "name": "SPI1_CSB",
+      "name": "SPI_TPM_CSB",
       "mode": "Alternate",
       "pull_mode": "PullUp",
       "alias_of": "IOA7"
@@ -400,19 +400,31 @@
           "level": true
         },
         {
-          "name": "SPI1_SCK",
+          "name": "SPI_DEV_SCK",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_DEV_D0",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_DEV_D1",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_TPM_SCK",
           "mode": "Alternate"
         },
         {
-          "name": "SPI1_MOSI",
+          "name": "SPI_TPM_MOSI",
           "mode": "Alternate"
         },
         {
-          "name": "SPI1_MISO",
+          "name": "SPI_TPM_MISO",
           "mode": "Alternate"
         },
         {
-          "name": "SPI1_CSB",
+          "name": "SPI_TPM_CSB",
           "mode": "PushPull"
         }
       ]


### PR DESCRIPTION
This PR makes the teacup config for SPI TPM exactly the same as the CW310.

Testing:
```
bazel test  --//signing:token=//signing/tokens:cloud_kms_sival \
       //sw/device/tests:spi_device_tpm_tx_rx_test_silicon_owner_sival_rom_ext
```