### PR TITLE
Cherry-pick to master: [rom_ext] Set the ROM_EXT version number

### DIFF
--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -579,8 +579,8 @@ def _offline_signature_attach(ctx):
             ctx,
             tc.tools.opentitantool,
             inputs[f]["bin"],
-            getattr(inputs[f], "ecdsa_sig", None),
-            getattr(inputs[f], "rsa_sig", None),
+            inputs[f].get("ecdsa_sig"),
+            inputs[f].get("rsa_sig"),
             inputs[f].get("spx_sig"),
         )
         outputs.append(out)

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -268,7 +268,7 @@ manifest(d = {
     "identifier": hex(CONST.ROM_EXT),
     "visibility": ["//visibility:public"],
     "version_major": ROM_EXT_VERSION.MAJOR,
-    "version_minor": ROM_EXT_VERSION.MAJOR,
+    "version_minor": ROM_EXT_VERSION.MINOR,
     "security_version": ROM_EXT_VERSION.SECURITY,
 })
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -7,6 +7,10 @@ load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VERSION",
+)
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -263,6 +267,9 @@ manifest(d = {
     "address_translation": hex(CONST.HARDENED_FALSE),
     "identifier": hex(CONST.ROM_EXT),
     "visibility": ["//visibility:public"],
+    "version_major": ROM_EXT_VERSION.MAJOR,
+    "version_minor": ROM_EXT_VERSION.MAJOR,
+    "security_version": ROM_EXT_VERSION.SECURITY,
 })
 
 manifest(d = {

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# The ROM_EXT version number to encode into the manifest.
+# NOTE: the version numbers are integers, but have to be encoded as strings
+# because of how the bazel rule accepts attributes.
+ROM_EXT_VERSION = struct(
+    MAJOR = "0",
+    MINOR = "1",
+    SECURITY = "0",
+)

--- a/sw/device/silicon_creator/rom_ext/prodc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/prodc/BUILD
@@ -7,6 +7,10 @@ load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VERSION",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -22,6 +26,9 @@ manifest(d = {
     "address_translation": hex(CONST.HARDENED_FALSE),
     "identifier": hex(CONST.ROM_EXT),
     "manuf_state_creator": hex(CONST.MANUF_STATE.PRODC),
+    "version_major": ROM_EXT_VERSION.MAJOR,
+    "version_minor": ROM_EXT_VERSION.MAJOR,
+    "security_version": ROM_EXT_VERSION.SECURITY,
     "visibility": ["//visibility:public"],
 })
 

--- a/sw/device/silicon_creator/rom_ext/prodc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/prodc/BUILD
@@ -27,7 +27,7 @@ manifest(d = {
     "identifier": hex(CONST.ROM_EXT),
     "manuf_state_creator": hex(CONST.MANUF_STATE.PRODC),
     "version_major": ROM_EXT_VERSION.MAJOR,
-    "version_minor": ROM_EXT_VERSION.MAJOR,
+    "version_minor": ROM_EXT_VERSION.MINOR,
     "security_version": ROM_EXT_VERSION.SECURITY,
     "visibility": ["//visibility:public"],
 })

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -27,7 +27,7 @@ manifest(d = {
     "identifier": hex(CONST.ROM_EXT),
     "manuf_state_creator": hex(CONST.MANUF_STATE.SIVAL),
     "version_major": ROM_EXT_VERSION.MAJOR,
-    "version_minor": ROM_EXT_VERSION.MAJOR,
+    "version_minor": ROM_EXT_VERSION.MINOR,
     "security_version": ROM_EXT_VERSION.SECURITY,
     "visibility": ["//visibility:private"],
 })

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -6,6 +6,10 @@ load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VERSION",
+)
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
@@ -22,6 +26,9 @@ manifest(d = {
     "address_translation": hex(CONST.HARDENED_FALSE),
     "identifier": hex(CONST.ROM_EXT),
     "manuf_state_creator": hex(CONST.MANUF_STATE.SIVAL),
+    "version_major": ROM_EXT_VERSION.MAJOR,
+    "version_minor": ROM_EXT_VERSION.MAJOR,
+    "security_version": ROM_EXT_VERSION.SECURITY,
     "visibility": ["//visibility:private"],
 })
 


### PR DESCRIPTION
This is a manual cherry-pick of #22949 and #23009 to master.

1. Corrects a bug in `dict` handling when signing.
2. Applies a version number to the per-product ROM_EXT manifests.