### PR TITLE
[cherry-pick] #23012: fix provisioning orchistrator

### DIFF
--- a/sw/host/provisioning/cp/BUILD
+++ b/sw/host/provisioning/cp/BUILD
@@ -12,6 +12,9 @@ rust_binary(
     srcs = ["src/main.rs"],
     data = [
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:sram_cp_provision",
+        "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
+        "//third_party/openocd:jtag_olimex_cfg",
+        "//third_party/openocd:openocd_bin",
     ],
     deps = [
         "//sw/host/opentitanlib",

--- a/sw/host/provisioning/ft/BUILD
+++ b/sw/host/provisioning/ft/BUILD
@@ -19,6 +19,9 @@ rust_binary(
     data = [
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize",
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:sram_ft_individualize_all",
+        "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
+        "//third_party/openocd:jtag_olimex_cfg",
+        "//third_party/openocd:openocd_bin",
     ] + FT_PERSONALIZE_KEYS,
     deps = [
         "//sw/host/opentitanlib",

--- a/sw/host/provisioning/orchestrator/ot_device.py
+++ b/sw/host/provisioning/orchestrator/ot_device.py
@@ -90,7 +90,10 @@ class OTDevice:
         else:
             logging.info("CP completed successfully")
 
-    def ft_provision(self, ecc_priv_keyfile, require_confirmation=True):
+    def ft_provision(self,
+                     ecc_priv_keyfile,
+                     ca_priv_keyfile,
+                     require_confirmation=True):
         """Run the FT provisioning Bazel target."""
         logging.info("Running FT Provisioning")
 
@@ -148,9 +151,14 @@ class OTDevice:
 --test-exit-token="{format_hex(self.test_exit_token, width=32)}" \
 --target-mission-mode-lc-state="{self.target_lc_state}" \
 --host-ecc-sk={ecc_priv_keyfile} \
+--cert-endorsement-ecc-sk={ca_priv_keyfile} \
 --rom-ext-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
 --owner-manifest-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
---owner-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"""  # noqa: E501
+--owner-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
+--uds-auth-key-id="0x11223344_55667788_99112233_44556677_88991122"
+--rom-ext-security-version="0"
+--owner-security-version="0"
+"""  # noqa: E501
 
         logging.info(f"Running command: {cmd}")
         if require_confirmation:


### PR DESCRIPTION
This fixes the provisioning orchestrator script and the CP/FT host binary build rules that was triggering errors at run time.

Signed-off-by: Tim Trippel <ttrippel@google.com>
(cherry picked from commit 2db5df6c7cf9a466c19e743d164f6174655e67ec)