### PR TITLE
[dv,flash_ctrl] Fix failures for prog with ecc enabled

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -331,7 +331,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     // So each pop becomes 8 times of fqs.
     int col_sz = exp.fq.size / 8;
     `uvm_info("process_write", $sformatf("process_write: addr:0x%x bank:%0d colsz:%0d ffsz:%0d",
-                       exp.cmd.otf_addr, bank, col_sz, eg_rtl_ctrl_fifo[bank].used()), UVM_MEDIUM)
+              exp.cmd.otf_addr, bank, col_sz, eg_rtl_ctrl_fifo[bank].used()), UVM_MEDIUM)
     eg_rtl_ctrl_fifo[bank].get(item);
 
     `uvm_create_obj(flash_otf_item, obs)

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -72,6 +72,12 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Avoid creating flash program operations that cross program resolution boundaries of 64 byte.
   bit avoid_prog_res_fault;
 
+  // Trigger program resolution error by using large fractions.
+  bit trigger_prog_res_fault;
+
+  // This is used for ecc faults to choose the target addresses.
+  flash_tgt_prefix_e ecc_err_target = TgtRd;
+
   bit op_readonly_on_info_partition;   // Make info  partition read-only.
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
   bit op_readonly_on_info2_partition;  // Make info2 partition read-only.

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_access_after_disable_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_access_after_disable_vseq.sv
@@ -10,17 +10,17 @@ class flash_ctrl_access_after_disable_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_access_after_disable_vseq)
   `uvm_object_new
 
+  constraint op_partition_c {rand_op.partition == FlashPartData;}
+
   virtual task body();
-    int bank;
+    flash_op_t ctrl;
+    int bank, num;
     // Enable ecc for all regions
     flash_otf_region_cfg(.scr_mode(scr_ecc_cfg), .ecc_mode(OTFCfgTrue));
 
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(this,
-                                   rand_op.partition == FlashPartData;)
-    bank = rand_op.addr[OTFBankId];
-
+    `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
     set_otf_exp_alert("recov_err");
-    prog_flash(.flash_op(rand_op), .bank(bank), .num(1), .in_err(1));
+    prog_flash(.flash_op(ctrl), .bank(bank), .num(1), .in_err(1));
     set_local_escalation();
     flash_access_after_disabled();
   endtask // body

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
@@ -13,8 +13,8 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    // After reset, scoreboard need to wait until  wip process is done.
-    // Since common reset test is not awared of it, remove check from sb and
+    // After reset, scoreboard need to wait until wip process is done.
+    // Since common reset test is not aware of it, remove check from sb and
     // have each test check read response.
     if (common_seq_type inside {"stress_all_with_rand_reset", "csr_mem_rw_with_rand_reset"}) begin
       cfg.scb_h.skip_read_check = 1'b1;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
@@ -43,8 +43,10 @@ class flash_ctrl_config_regwen_vseq extends flash_ctrl_otf_base_vseq;
 
     // Launch long operation
     flash_program_data_c.constraint_mode(0);
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(rand_op, rand_op.op == FlashOpProgram;
-                                          rand_op.partition == FlashPartData;)
+    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(
+        rand_op,
+        rand_op.op == FlashOpProgram;
+        rand_op.partition == FlashPartData;)
     rand_op.addr[8:0] = 0;
     rand_op.num_words = 16;
     flash_ctrl_start_op(rand_op);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
@@ -7,6 +7,8 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_derr_detect_vseq)
   `uvm_object_new
 
+  constraint ctrl_info_num_c {ctrl_info_num == ctrl_data_num;}
+
   virtual task body();
     flash_op_t ctrl;
     int num, bank;
@@ -23,19 +25,17 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
       fork
         begin
           repeat(40) begin
-            `DV_CHECK_RANDOMIZE_FATAL(this)
-            ctrl = rand_op;
-            bank = rand_op.addr[OTFBankId];
-            if (ctrl.partition == FlashPartData) begin
-              num = ctrl_num;
-            end else begin
-              num = ctrl_info_num;
-            end
-            // If the partition that selected configured as read-only, skip the program
-            sync_otf_wr_ro_part();
             randcase
-              cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-              1:read_flash(ctrl, bank, num, fractions);
+              cfg.otf_wr_pct:begin
+                `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+                prog_flash(ctrl, bank, num, fractions);
+              end
+              1: begin
+                `DV_CHECK_RANDOMIZE_FATAL(this)
+                ctrl = rand_op;
+                get_bank_and_num(ctrl, bank, num);
+                read_flash(ctrl, bank, num, fractions);
+              end
             endcase
           end
         end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
@@ -10,18 +10,20 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_integrity_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
+  constraint ctrl_num_c {
+    ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2};
+  }
   constraint fractions_c {
-       solve ctrl_num before fractions;
-       if (ctrl_num == 1)
-          fractions dist { [1:4] := 4, [5:16] := 1};
-       else
-          fractions == 16;
+    solve ctrl_num before fractions;
+    if (ctrl_num == 1)
+       fractions dist { [1:4] := 4, [5:16] := 1};
+    else
+       fractions == 16;
   }
 
   constraint odd_addr_c {
-       solve fractions before is_addr_odd;
-       (fractions == 16) -> is_addr_odd == 0;
+    solve fractions before is_addr_odd;
+    (fractions == 16) -> is_addr_odd == 0;
   }
 
   virtual task body();
@@ -34,13 +36,19 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(100) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          bank = $urandom_range(0, 1);
-          ctrl.partition  = FlashPartData;
-          ctrl.otf_addr = is_addr_odd * 4;
+          if (cfg.stop_transaction_generators()) break;
           randcase
-            1:prog_flash(ctrl, bank, ctrl_num, fractions);
-            1:read_flash(ctrl, bank, ctrl_num, fractions);
+            1: begin
+              `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+              prog_flash(ctrl, bank, num, fractions);
+            end
+            1: begin
+              set_ecc_err_target(TgtRd);
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              ctrl = rand_op;
+              get_bank_and_num(ctrl, bank, num);
+              read_flash(ctrl, bank, num, fractions);
+            end
           endcase
         end
       end
@@ -54,5 +62,5 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
         csr_utils_pkg::wait_no_outstanding_access();
       end
     join
-  endtask // body
-endclass // flash_ctrl_integrity_vseq
+  endtask : body
+endclass : flash_ctrl_integrity_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_wr_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_wr_vseq.sv
@@ -7,6 +7,8 @@ class flash_ctrl_intr_wr_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_intr_wr_vseq)
   `uvm_object_new
 
+  constraint ctrl_data_num_c {ctrl_data_num inside {[1 : 32]};}
+
   task pre_start();
     cfg.intr_mode = 1;
     super.pre_start();
@@ -18,18 +20,10 @@ class flash_ctrl_intr_wr_vseq extends flash_ctrl_otf_base_vseq;
 
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
-
     flash_program_data_c.constraint_mode(0);
     repeat(100) begin
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-      ctrl = rand_op;
-      if (ctrl.partition == FlashPartData) begin
-        num = $urandom_range(1, 32);
-      end else begin
-        num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-      end
-      bank = rand_op.addr[OTFBankId];
-      prog_flash(ctrl, bank, num);
+      `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+      prog_flash(ctrl, bank, num, fractions);
     end
   endtask
-endclass // flash_ctrl_intr_wr_vseq
+endclass : flash_ctrl_intr_wr_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
@@ -35,12 +35,7 @@ class flash_ctrl_rd_ooo_vseq extends flash_ctrl_legacy_base_vseq;
           `DV_CHECK_RANDOMIZE_FATAL(this)
           ctrl = rand_op;
           bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = ctrl_num;
-          end else begin
-            num = ctrl_info_num;
-          end
-          read_flash(ctrl, bank, num, fractions);
+          read_flash(ctrl, bank, ctrl_num, fractions);
         end
       end
     join

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
@@ -7,20 +7,19 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_rnd_wd_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
+  constraint ctrl_data_num_c {ctrl_num inside {[1:32]};}
   constraint fractions_c {
-       solve ctrl_num before fractions;
-       if (ctrl_num == 1)
-          fractions dist { [1:4] := 4, [5:16] := 1};
-       else
-          fractions == 16;
+    solve ctrl_num before fractions;
+    if (ctrl_num == 1)
+      fractions dist { [1:4] := 4, [5:16] := 1};
+    else
+      fractions == 16;
   }
 
   constraint odd_addr_c {
-                         solve fractions before is_addr_odd;
-                         (fractions == 16) -> is_addr_odd == 0;
-                         }
-
+    solve fractions before is_addr_odd;
+    (fractions == 16) -> is_addr_odd == 0;
+  }
 
   virtual task body();
     flash_op_t ctrl;
@@ -31,24 +30,19 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(500) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          ctrl = rand_op;
-          bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = $urandom_range(1, 32);
-          end else begin
-            num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-            // Max transfer size of info is 512Byte.
-            if (num * fractions > 128) begin
-              num = 128 / fractions;
-            end
-          end
-          // If the partition that selected configured as read-only, skip the program
-          sync_otf_wr_ro_part();
+          bit is_prog = 0;
           randcase
-            cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-            1:read_flash(ctrl, bank, num, fractions);
+            cfg.otf_wr_pct: begin
+              `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+              is_prog = 1;
+            end
+            1: begin
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              get_bank_and_num(ctrl, bank, num);
+            end
           endcase
+          if (is_prog) prog_flash(ctrl, bank, num, fractions);
+          else read_flash(ctrl, bank, num, fractions);
         end
       end
       begin
@@ -62,4 +56,4 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
       end
     join
   endtask
-endclass // flash_ctrl_rw_rnd_wd_vseq
+endclass : flash_ctrl_rw_rnd_wd_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
@@ -17,19 +17,9 @@ class flash_ctrl_wo_vseq extends flash_ctrl_otf_base_vseq;
     flash_program_data_c.constraint_mode(0);
 
     repeat(100) begin
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-      ctrl = rand_op;
-      if (ctrl.partition == FlashPartData) begin
-        num = $urandom_range(1, 32);
-      end else begin
-        num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-        // Max transfer size of info is 512Byte.
-        if (num * fractions > 128) begin
-          num = 128 / fractions;
-        end
-      end
-      bank = rand_op.addr[OTFBankId];
+      if (cfg.stop_transaction_generators()) break;
+      `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
       prog_flash(ctrl, bank, num);
     end
   endtask
-endclass // flash_ctrl_wo_vseq
+endclass : flash_ctrl_wo_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -43,7 +43,7 @@ class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
           repeat(cfg.otf_num_rw) begin
             randcase
               cfg.otf_wr_pct: begin
-                `DV_CHECK(try_create_prog_op(), "Could not create a prog flash op")
+                `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
                 cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
                 cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
                 cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
@@ -8,6 +8,8 @@ class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_write_word_sweep_vseq)
   `uvm_object_new
 
+  constraint ctrl_num_c {ctrl_num == 1;}
+  constraint fractions_c {fractions == 1;}
   virtual task body();
     flash_op_t ctrl;
     int num, bank;
@@ -15,15 +17,12 @@ class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
 
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
-
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-    ctrl = rand_op;
-    bank = rand_op.addr[OTFBankId];
-    num = 1;
-    mywd = 1;
+    `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+    mywd = fractions;
+    `DV_CHECK_EQ(mywd, 1)
     repeat(20) begin
       prog_flash(ctrl, bank, num, mywd);
       mywd = (mywd % 16) + 1;
     end
   endtask
-endclass // flash_ctrl_wo_vseq
+endclass : flash_ctrl_write_word_sweep_vseq

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -331,7 +331,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     // So each pop becomes 8 times of fqs.
     int col_sz = exp.fq.size / 8;
     `uvm_info("process_write", $sformatf("process_write: addr:0x%x bank:%0d colsz:%0d ffsz:%0d",
-                       exp.cmd.otf_addr, bank, col_sz, eg_rtl_ctrl_fifo[bank].used()), UVM_MEDIUM)
+              exp.cmd.otf_addr, bank, col_sz, eg_rtl_ctrl_fifo[bank].used()), UVM_MEDIUM)
     eg_rtl_ctrl_fifo[bank].get(item);
 
     `uvm_create_obj(flash_otf_item, obs)

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -72,6 +72,12 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Avoid creating flash program operations that cross program resolution boundaries of 64 byte.
   bit avoid_prog_res_fault;
 
+  // Trigger program resolution error by using large fractions.
+  bit trigger_prog_res_fault;
+
+  // This is used for ecc faults to choose the target addresses.
+  flash_tgt_prefix_e ecc_err_target = TgtRd;
+
   bit op_readonly_on_info_partition;   // Make info  partition read-only.
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
   bit op_readonly_on_info2_partition;  // Make info2 partition read-only.

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_access_after_disable_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_access_after_disable_vseq.sv
@@ -10,17 +10,17 @@ class flash_ctrl_access_after_disable_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_access_after_disable_vseq)
   `uvm_object_new
 
+  constraint op_partition_c {rand_op.partition == FlashPartData;}
+
   virtual task body();
-    int bank;
+    flash_op_t ctrl;
+    int bank, num;
     // Enable ecc for all regions
     flash_otf_region_cfg(.scr_mode(scr_ecc_cfg), .ecc_mode(OTFCfgTrue));
 
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(this,
-                                   rand_op.partition == FlashPartData;)
-    bank = rand_op.addr[OTFBankId];
-
+    `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
     set_otf_exp_alert("recov_err");
-    prog_flash(.flash_op(rand_op), .bank(bank), .num(1), .in_err(1));
+    prog_flash(.flash_op(ctrl), .bank(bank), .num(1), .in_err(1));
     set_local_escalation();
     flash_access_after_disabled();
   endtask // body

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
@@ -13,8 +13,8 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    // After reset, scoreboard need to wait until  wip process is done.
-    // Since common reset test is not awared of it, remove check from sb and
+    // After reset, scoreboard need to wait until wip process is done.
+    // Since common reset test is not aware of it, remove check from sb and
     // have each test check read response.
     if (common_seq_type inside {"stress_all_with_rand_reset", "csr_mem_rw_with_rand_reset"}) begin
       cfg.scb_h.skip_read_check = 1'b1;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
@@ -43,8 +43,10 @@ class flash_ctrl_config_regwen_vseq extends flash_ctrl_otf_base_vseq;
 
     // Launch long operation
     flash_program_data_c.constraint_mode(0);
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(rand_op, rand_op.op == FlashOpProgram;
-                                          rand_op.partition == FlashPartData;)
+    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(
+        rand_op,
+        rand_op.op == FlashOpProgram;
+        rand_op.partition == FlashPartData;)
     rand_op.addr[8:0] = 0;
     rand_op.num_words = 16;
     flash_ctrl_start_op(rand_op);

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
@@ -7,6 +7,8 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_derr_detect_vseq)
   `uvm_object_new
 
+  constraint ctrl_info_num_c {ctrl_info_num == ctrl_data_num;}
+
   virtual task body();
     flash_op_t ctrl;
     int num, bank;
@@ -23,19 +25,17 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
       fork
         begin
           repeat(40) begin
-            `DV_CHECK_RANDOMIZE_FATAL(this)
-            ctrl = rand_op;
-            bank = rand_op.addr[OTFBankId];
-            if (ctrl.partition == FlashPartData) begin
-              num = ctrl_num;
-            end else begin
-              num = ctrl_info_num;
-            end
-            // If the partition that selected configured as read-only, skip the program
-            sync_otf_wr_ro_part();
             randcase
-              cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-              1:read_flash(ctrl, bank, num, fractions);
+              cfg.otf_wr_pct:begin
+                `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+                prog_flash(ctrl, bank, num, fractions);
+              end
+              1: begin
+                `DV_CHECK_RANDOMIZE_FATAL(this)
+                ctrl = rand_op;
+                get_bank_and_num(ctrl, bank, num);
+                read_flash(ctrl, bank, num, fractions);
+              end
             endcase
           end
         end

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
@@ -10,18 +10,20 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_integrity_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
+  constraint ctrl_num_c {
+    ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2};
+  }
   constraint fractions_c {
-       solve ctrl_num before fractions;
-       if (ctrl_num == 1)
-          fractions dist { [1:4] := 4, [5:16] := 1};
-       else
-          fractions == 16;
+    solve ctrl_num before fractions;
+    if (ctrl_num == 1)
+       fractions dist { [1:4] := 4, [5:16] := 1};
+    else
+       fractions == 16;
   }
 
   constraint odd_addr_c {
-       solve fractions before is_addr_odd;
-       (fractions == 16) -> is_addr_odd == 0;
+    solve fractions before is_addr_odd;
+    (fractions == 16) -> is_addr_odd == 0;
   }
 
   virtual task body();
@@ -34,13 +36,19 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(100) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          bank = $urandom_range(0, 1);
-          ctrl.partition  = FlashPartData;
-          ctrl.otf_addr = is_addr_odd * 4;
+          if (cfg.stop_transaction_generators()) break;
           randcase
-            1:prog_flash(ctrl, bank, ctrl_num, fractions);
-            1:read_flash(ctrl, bank, ctrl_num, fractions);
+            1: begin
+              `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+              prog_flash(ctrl, bank, num, fractions);
+            end
+            1: begin
+              set_ecc_err_target(TgtRd);
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              ctrl = rand_op;
+              get_bank_and_num(ctrl, bank, num);
+              read_flash(ctrl, bank, num, fractions);
+            end
           endcase
         end
       end
@@ -54,5 +62,5 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
         csr_utils_pkg::wait_no_outstanding_access();
       end
     join
-  endtask // body
-endclass // flash_ctrl_integrity_vseq
+  endtask : body
+endclass : flash_ctrl_integrity_vseq

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_wr_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_wr_vseq.sv
@@ -7,6 +7,8 @@ class flash_ctrl_intr_wr_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_intr_wr_vseq)
   `uvm_object_new
 
+  constraint ctrl_data_num_c {ctrl_data_num inside {[1 : 32]};}
+
   task pre_start();
     cfg.intr_mode = 1;
     super.pre_start();
@@ -18,18 +20,10 @@ class flash_ctrl_intr_wr_vseq extends flash_ctrl_otf_base_vseq;
 
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
-
     flash_program_data_c.constraint_mode(0);
     repeat(100) begin
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-      ctrl = rand_op;
-      if (ctrl.partition == FlashPartData) begin
-        num = $urandom_range(1, 32);
-      end else begin
-        num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-      end
-      bank = rand_op.addr[OTFBankId];
-      prog_flash(ctrl, bank, num);
+      `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+      prog_flash(ctrl, bank, num, fractions);
     end
   endtask
-endclass // flash_ctrl_intr_wr_vseq
+endclass : flash_ctrl_intr_wr_vseq

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
@@ -35,12 +35,7 @@ class flash_ctrl_rd_ooo_vseq extends flash_ctrl_legacy_base_vseq;
           `DV_CHECK_RANDOMIZE_FATAL(this)
           ctrl = rand_op;
           bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = ctrl_num;
-          end else begin
-            num = ctrl_info_num;
-          end
-          read_flash(ctrl, bank, num, fractions);
+          read_flash(ctrl, bank, ctrl_num, fractions);
         end
       end
     join

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
@@ -7,20 +7,19 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_rnd_wd_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
+  constraint ctrl_data_num_c {ctrl_num inside {[1:32]};}
   constraint fractions_c {
-       solve ctrl_num before fractions;
-       if (ctrl_num == 1)
-          fractions dist { [1:4] := 4, [5:16] := 1};
-       else
-          fractions == 16;
+    solve ctrl_num before fractions;
+    if (ctrl_num == 1)
+      fractions dist { [1:4] := 4, [5:16] := 1};
+    else
+      fractions == 16;
   }
 
   constraint odd_addr_c {
-                         solve fractions before is_addr_odd;
-                         (fractions == 16) -> is_addr_odd == 0;
-                         }
-
+    solve fractions before is_addr_odd;
+    (fractions == 16) -> is_addr_odd == 0;
+  }
 
   virtual task body();
     flash_op_t ctrl;
@@ -31,24 +30,19 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(500) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          ctrl = rand_op;
-          bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = $urandom_range(1, 32);
-          end else begin
-            num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-            // Max transfer size of info is 512Byte.
-            if (num * fractions > 128) begin
-              num = 128 / fractions;
-            end
-          end
-          // If the partition that selected configured as read-only, skip the program
-          sync_otf_wr_ro_part();
+          bit is_prog = 0;
           randcase
-            cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-            1:read_flash(ctrl, bank, num, fractions);
+            cfg.otf_wr_pct: begin
+              `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+              is_prog = 1;
+            end
+            1: begin
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              get_bank_and_num(ctrl, bank, num);
+            end
           endcase
+          if (is_prog) prog_flash(ctrl, bank, num, fractions);
+          else read_flash(ctrl, bank, num, fractions);
         end
       end
       begin
@@ -62,4 +56,4 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
       end
     join
   endtask
-endclass // flash_ctrl_rw_rnd_wd_vseq
+endclass : flash_ctrl_rw_rnd_wd_vseq

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
@@ -17,19 +17,9 @@ class flash_ctrl_wo_vseq extends flash_ctrl_otf_base_vseq;
     flash_program_data_c.constraint_mode(0);
 
     repeat(100) begin
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-      ctrl = rand_op;
-      if (ctrl.partition == FlashPartData) begin
-        num = $urandom_range(1, 32);
-      end else begin
-        num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-        // Max transfer size of info is 512Byte.
-        if (num * fractions > 128) begin
-          num = 128 / fractions;
-        end
-      end
-      bank = rand_op.addr[OTFBankId];
+      if (cfg.stop_transaction_generators()) break;
+      `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
       prog_flash(ctrl, bank, num);
     end
   endtask
-endclass // flash_ctrl_wo_vseq
+endclass : flash_ctrl_wo_vseq

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -43,7 +43,7 @@ class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
           repeat(cfg.otf_num_rw) begin
             randcase
               cfg.otf_wr_pct: begin
-                `DV_CHECK(try_create_prog_op(), "Could not create a prog flash op")
+                `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
                 cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
                 cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
                 cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
@@ -8,6 +8,8 @@ class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_write_word_sweep_vseq)
   `uvm_object_new
 
+  constraint ctrl_num_c {ctrl_num == 1;}
+  constraint fractions_c {fractions == 1;}
   virtual task body();
     flash_op_t ctrl;
     int num, bank;
@@ -15,15 +17,12 @@ class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
 
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
-
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-    ctrl = rand_op;
-    bank = rand_op.addr[OTFBankId];
-    num = 1;
-    mywd = 1;
+    `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+    mywd = fractions;
+    `DV_CHECK_EQ(mywd, 1)
     repeat(20) begin
       prog_flash(ctrl, bank, num, mywd);
       mywd = (mywd % 16) + 1;
     end
   endtask
-endclass // flash_ctrl_wo_vseq
+endclass : flash_ctrl_write_word_sweep_vseq

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_otf_scoreboard.sv
@@ -331,7 +331,7 @@ class flash_ctrl_otf_scoreboard extends uvm_scoreboard;
     // So each pop becomes 8 times of fqs.
     int col_sz = exp.fq.size / 8;
     `uvm_info("process_write", $sformatf("process_write: addr:0x%x bank:%0d colsz:%0d ffsz:%0d",
-                       exp.cmd.otf_addr, bank, col_sz, eg_rtl_ctrl_fifo[bank].used()), UVM_MEDIUM)
+              exp.cmd.otf_addr, bank, col_sz, eg_rtl_ctrl_fifo[bank].used()), UVM_MEDIUM)
     eg_rtl_ctrl_fifo[bank].get(item);
 
     `uvm_create_obj(flash_otf_item, obs)

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -72,6 +72,12 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Avoid creating flash program operations that cross program resolution boundaries of 64 byte.
   bit avoid_prog_res_fault;
 
+  // Trigger program resolution error by using large fractions.
+  bit trigger_prog_res_fault;
+
+  // This is used for ecc faults to choose the target addresses.
+  flash_tgt_prefix_e ecc_err_target = TgtRd;
+
   bit op_readonly_on_info_partition;   // Make info  partition read-only.
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
   bit op_readonly_on_info2_partition;  // Make info2 partition read-only.

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_access_after_disable_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_access_after_disable_vseq.sv
@@ -10,17 +10,17 @@ class flash_ctrl_access_after_disable_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_access_after_disable_vseq)
   `uvm_object_new
 
+  constraint op_partition_c {rand_op.partition == FlashPartData;}
+
   virtual task body();
-    int bank;
+    flash_op_t ctrl;
+    int bank, num;
     // Enable ecc for all regions
     flash_otf_region_cfg(.scr_mode(scr_ecc_cfg), .ecc_mode(OTFCfgTrue));
 
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(this,
-                                   rand_op.partition == FlashPartData;)
-    bank = rand_op.addr[OTFBankId];
-
+    `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
     set_otf_exp_alert("recov_err");
-    prog_flash(.flash_op(rand_op), .bank(bank), .num(1), .in_err(1));
+    prog_flash(.flash_op(ctrl), .bank(bank), .num(1), .in_err(1));
     set_local_escalation();
     flash_access_after_disabled();
   endtask // body

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_common_vseq.sv
@@ -13,8 +13,8 @@ class flash_ctrl_common_vseq extends flash_ctrl_otf_base_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    // After reset, scoreboard need to wait until  wip process is done.
-    // Since common reset test is not awared of it, remove check from sb and
+    // After reset, scoreboard need to wait until wip process is done.
+    // Since common reset test is not aware of it, remove check from sb and
     // have each test check read response.
     if (common_seq_type inside {"stress_all_with_rand_reset", "csr_mem_rw_with_rand_reset"}) begin
       cfg.scb_h.skip_read_check = 1'b1;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_config_regwen_vseq.sv
@@ -43,8 +43,10 @@ class flash_ctrl_config_regwen_vseq extends flash_ctrl_otf_base_vseq;
 
     // Launch long operation
     flash_program_data_c.constraint_mode(0);
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(rand_op, rand_op.op == FlashOpProgram;
-                                          rand_op.partition == FlashPartData;)
+    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(
+        rand_op,
+        rand_op.op == FlashOpProgram;
+        rand_op.partition == FlashPartData;)
     rand_op.addr[8:0] = 0;
     rand_op.num_words = 16;
     flash_ctrl_start_op(rand_op);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_derr_detect_vseq.sv
@@ -7,6 +7,8 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_derr_detect_vseq)
   `uvm_object_new
 
+  constraint ctrl_info_num_c {ctrl_info_num == ctrl_data_num;}
+
   virtual task body();
     flash_op_t ctrl;
     int num, bank;
@@ -23,19 +25,17 @@ class flash_ctrl_derr_detect_vseq extends flash_ctrl_otf_base_vseq;
       fork
         begin
           repeat(40) begin
-            `DV_CHECK_RANDOMIZE_FATAL(this)
-            ctrl = rand_op;
-            bank = rand_op.addr[OTFBankId];
-            if (ctrl.partition == FlashPartData) begin
-              num = ctrl_num;
-            end else begin
-              num = ctrl_info_num;
-            end
-            // If the partition that selected configured as read-only, skip the program
-            sync_otf_wr_ro_part();
             randcase
-              cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-              1:read_flash(ctrl, bank, num, fractions);
+              cfg.otf_wr_pct:begin
+                `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+                prog_flash(ctrl, bank, num, fractions);
+              end
+              1: begin
+                `DV_CHECK_RANDOMIZE_FATAL(this)
+                ctrl = rand_op;
+                get_bank_and_num(ctrl, bank, num);
+                read_flash(ctrl, bank, num, fractions);
+              end
             endcase
           end
         end

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_integrity_vseq.sv
@@ -10,18 +10,20 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_integrity_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
+  constraint ctrl_num_c {
+    ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2};
+  }
   constraint fractions_c {
-       solve ctrl_num before fractions;
-       if (ctrl_num == 1)
-          fractions dist { [1:4] := 4, [5:16] := 1};
-       else
-          fractions == 16;
+    solve ctrl_num before fractions;
+    if (ctrl_num == 1)
+       fractions dist { [1:4] := 4, [5:16] := 1};
+    else
+       fractions == 16;
   }
 
   constraint odd_addr_c {
-       solve fractions before is_addr_odd;
-       (fractions == 16) -> is_addr_odd == 0;
+    solve fractions before is_addr_odd;
+    (fractions == 16) -> is_addr_odd == 0;
   }
 
   virtual task body();
@@ -34,13 +36,19 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(100) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          bank = $urandom_range(0, 1);
-          ctrl.partition  = FlashPartData;
-          ctrl.otf_addr = is_addr_odd * 4;
+          if (cfg.stop_transaction_generators()) break;
           randcase
-            1:prog_flash(ctrl, bank, ctrl_num, fractions);
-            1:read_flash(ctrl, bank, ctrl_num, fractions);
+            1: begin
+              `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+              prog_flash(ctrl, bank, num, fractions);
+            end
+            1: begin
+              set_ecc_err_target(TgtRd);
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              ctrl = rand_op;
+              get_bank_and_num(ctrl, bank, num);
+              read_flash(ctrl, bank, num, fractions);
+            end
           endcase
         end
       end
@@ -54,5 +62,5 @@ class flash_ctrl_integrity_vseq extends flash_ctrl_otf_base_vseq;
         csr_utils_pkg::wait_no_outstanding_access();
       end
     join
-  endtask // body
-endclass // flash_ctrl_integrity_vseq
+  endtask : body
+endclass : flash_ctrl_integrity_vseq

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_wr_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_intr_wr_vseq.sv
@@ -7,6 +7,8 @@ class flash_ctrl_intr_wr_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_intr_wr_vseq)
   `uvm_object_new
 
+  constraint ctrl_data_num_c {ctrl_data_num inside {[1 : 32]};}
+
   task pre_start();
     cfg.intr_mode = 1;
     super.pre_start();
@@ -18,18 +20,10 @@ class flash_ctrl_intr_wr_vseq extends flash_ctrl_otf_base_vseq;
 
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
-
     flash_program_data_c.constraint_mode(0);
     repeat(100) begin
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-      ctrl = rand_op;
-      if (ctrl.partition == FlashPartData) begin
-        num = $urandom_range(1, 32);
-      end else begin
-        num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-      end
-      bank = rand_op.addr[OTFBankId];
-      prog_flash(ctrl, bank, num);
+      `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+      prog_flash(ctrl, bank, num, fractions);
     end
   endtask
-endclass // flash_ctrl_intr_wr_vseq
+endclass : flash_ctrl_intr_wr_vseq

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_ooo_vseq.sv
@@ -35,12 +35,7 @@ class flash_ctrl_rd_ooo_vseq extends flash_ctrl_legacy_base_vseq;
           `DV_CHECK_RANDOMIZE_FATAL(this)
           ctrl = rand_op;
           bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = ctrl_num;
-          end else begin
-            num = ctrl_info_num;
-          end
-          read_flash(ctrl, bank, num, fractions);
+          read_flash(ctrl, bank, ctrl_num, fractions);
         end
       end
     join

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_rw_rnd_wd_vseq.sv
@@ -7,20 +7,19 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_rw_rnd_wd_vseq)
   `uvm_object_new
 
-  constraint ctrl_num_c { ctrl_num dist { CtrlTransMin := 7, [2:31] :/ 1, CtrlTransMax := 2}; }
+  constraint ctrl_data_num_c {ctrl_num inside {[1:32]};}
   constraint fractions_c {
-       solve ctrl_num before fractions;
-       if (ctrl_num == 1)
-          fractions dist { [1:4] := 4, [5:16] := 1};
-       else
-          fractions == 16;
+    solve ctrl_num before fractions;
+    if (ctrl_num == 1)
+      fractions dist { [1:4] := 4, [5:16] := 1};
+    else
+      fractions == 16;
   }
 
   constraint odd_addr_c {
-                         solve fractions before is_addr_odd;
-                         (fractions == 16) -> is_addr_odd == 0;
-                         }
-
+    solve fractions before is_addr_odd;
+    (fractions == 16) -> is_addr_odd == 0;
+  }
 
   virtual task body();
     flash_op_t ctrl;
@@ -31,24 +30,19 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
     fork
       begin
         repeat(500) begin
-          `DV_CHECK_RANDOMIZE_FATAL(this)
-          ctrl = rand_op;
-          bank = rand_op.addr[OTFBankId];
-          if (ctrl.partition == FlashPartData) begin
-            num = $urandom_range(1, 32);
-          end else begin
-            num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-            // Max transfer size of info is 512Byte.
-            if (num * fractions > 128) begin
-              num = 128 / fractions;
-            end
-          end
-          // If the partition that selected configured as read-only, skip the program
-          sync_otf_wr_ro_part();
+          bit is_prog = 0;
           randcase
-            cfg.otf_wr_pct:prog_flash(ctrl, bank, num, fractions);
-            1:read_flash(ctrl, bank, num, fractions);
+            cfg.otf_wr_pct: begin
+              `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+              is_prog = 1;
+            end
+            1: begin
+              `DV_CHECK_RANDOMIZE_FATAL(this)
+              get_bank_and_num(ctrl, bank, num);
+            end
           endcase
+          if (is_prog) prog_flash(ctrl, bank, num, fractions);
+          else read_flash(ctrl, bank, num, fractions);
         end
       end
       begin
@@ -62,4 +56,4 @@ class flash_ctrl_rw_rnd_wd_vseq extends flash_ctrl_otf_base_vseq;
       end
     join
   endtask
-endclass // flash_ctrl_rw_rnd_wd_vseq
+endclass : flash_ctrl_rw_rnd_wd_vseq

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_wo_vseq.sv
@@ -17,19 +17,9 @@ class flash_ctrl_wo_vseq extends flash_ctrl_otf_base_vseq;
     flash_program_data_c.constraint_mode(0);
 
     repeat(100) begin
-      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-      ctrl = rand_op;
-      if (ctrl.partition == FlashPartData) begin
-        num = $urandom_range(1, 32);
-      end else begin
-        num = $urandom_range(1, InfoTypeSize[rand_op.partition >> 1]);
-        // Max transfer size of info is 512Byte.
-        if (num * fractions > 128) begin
-          num = 128 / fractions;
-        end
-      end
-      bank = rand_op.addr[OTFBankId];
+      if (cfg.stop_transaction_generators()) break;
+      `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
       prog_flash(ctrl, bank, num);
     end
   endtask
-endclass // flash_ctrl_wo_vseq
+endclass : flash_ctrl_wo_vseq

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_wr_path_intg_vseq.sv
@@ -43,7 +43,7 @@ class flash_ctrl_wr_path_intg_vseq extends flash_ctrl_rw_vseq;
           repeat(cfg.otf_num_rw) begin
             randcase
               cfg.otf_wr_pct: begin
-                `DV_CHECK(try_create_prog_op(), "Could not create a prog flash op")
+                `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
                 cfg.scb_h.expected_alert["fatal_std_err"].expected = 1;
                 cfg.scb_h.expected_alert["fatal_std_err"].max_delay = 2000;
                 cfg.scb_h.exp_alert_contd["fatal_std_err"] = 10000;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
@@ -8,6 +8,8 @@ class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_write_word_sweep_vseq)
   `uvm_object_new
 
+  constraint ctrl_num_c {ctrl_num == 1;}
+  constraint fractions_c {fractions == 1;}
   virtual task body();
     flash_op_t ctrl;
     int num, bank;
@@ -15,15 +17,12 @@ class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
 
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
-
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rand_op)
-    ctrl = rand_op;
-    bank = rand_op.addr[OTFBankId];
-    num = 1;
-    mywd = 1;
+    `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+    mywd = fractions;
+    `DV_CHECK_EQ(mywd, 1)
     repeat(20) begin
       prog_flash(ctrl, bank, num, mywd);
       mywd = (mywd % 16) + 1;
     end
   endtask
-endclass // flash_ctrl_wo_vseq
+endclass : flash_ctrl_write_word_sweep_vseq


### PR DESCRIPTION
This fixes failures introduced in #22804. That PR didn't run a full flash_ctrl block regression, and it caused lots of breakages in tests that launched program flash ops but were not instrumented as the flash_ctrl_rw_vseq was.

This also fixes other issues found while developing this:
- The detection of program resolution violations needs to consider all address bits past the resolution size.
- The workaround to avoid program resolution window faults needs to be extended to handle multiple splits.
- The data to be sent with a program request needs to be initialized for each flash control start.

Fixes #22973