### PR TITLE
[flash_ctrl,dv] Correct macro names in flash_ctrl_phy_arb_redun_vseq

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -126,15 +126,15 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
       1: begin
       end
       2: begin
-        $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_0, `SVA_STAY_HIGH_SUFFIX));
+        $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_0, `FIXED_SVA_STAY_HIGH_SUFFIX));
         $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_0, `RR_SVA_LOCK_ARB_DEC_SUFFIX));
-        $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_1, `SVA_STAY_HIGH_SUFFIX));
+        $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_1, `FIXED_SVA_STAY_HIGH_SUFFIX));
         $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_1, `RR_SVA_LOCK_ARB_DEC_SUFFIX));
       end
       3: begin
-        $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_0, `SVA_STAY_HIGH_SUFFIX));
+        $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_0, `FIXED_SVA_STAY_HIGH_SUFFIX));
         $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_0, `RR_SVA_LOCK_ARB_DEC_SUFFIX));
-        $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_1, `SVA_STAY_HIGH_SUFFIX));
+        $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_1, `FIXED_SVA_STAY_HIGH_SUFFIX));
         $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_1, `RR_SVA_LOCK_ARB_DEC_SUFFIX));
       end
       default:

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -126,15 +126,15 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
       1: begin
       end
       2: begin
-        $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_0, `SVA_STAY_HIGH_SUFFIX));
+        $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_0, `FIXED_SVA_STAY_HIGH_SUFFIX));
         $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_0, `RR_SVA_LOCK_ARB_DEC_SUFFIX));
-        $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_1, `SVA_STAY_HIGH_SUFFIX));
+        $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_1, `FIXED_SVA_STAY_HIGH_SUFFIX));
         $asserton(0, `HIER_PATH(`CALC_ARB_PREFIX, `COPY_1, `RR_SVA_LOCK_ARB_DEC_SUFFIX));
       end
       3: begin
-        $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_0, `SVA_STAY_HIGH_SUFFIX));
+        $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_0, `FIXED_SVA_STAY_HIGH_SUFFIX));
         $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_0, `RR_SVA_LOCK_ARB_DEC_SUFFIX));
-        $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_1, `SVA_STAY_HIGH_SUFFIX));
+        $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_1, `FIXED_SVA_STAY_HIGH_SUFFIX));
         $asserton(0, `HIER_PATH(`OP_ARB_PREFIX, `COPY_1, `RR_SVA_LOCK_ARB_DEC_SUFFIX));
       end
       default:


### PR DESCRIPTION
These macros are used to construct paths for asserton/assertoff macros that were added in f541c61. I believe that a prefix was missing from the name (and Xcelium rejects the code at compile time).