### PR TITLE
[opentitantool] Advanced bitbanging

### DIFF
--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -42,7 +42,7 @@ pub enum GpioError {
     MismatchedDataLength(usize, usize),
     #[error("Bitbang data beyond the {0} least significant bits")]
     InvalidBitbangData(usize),
-    #[error("Bitbang delay of zero, or at end of sequence, not permitted")]
+    #[error("Bitbang delay of zero, immediately preceding `await()`, or at end of sequence, not permitted")]
     InvalidBitbangDelay,
     #[error("Generic error: {0}")]
     Generic(String),
@@ -236,6 +236,10 @@ pub enum BitbangEntry<'rd, 'wr> {
     /// `Delay` between two `Write` blocks, which is also equivalent to concatenating the two into
     /// a single `Write` block.
     Delay(u32),
+    /// Similar to `Delay`, but waits until `(pin_values ^ pattern) & mask` equals zero, that is,
+    /// until the set of pins indicated by ones in `mask` all have the the value indicated in
+    /// `pattern`.
+    Await { mask: u8, pattern: u8 },
 }
 
 /// A trait implemented by transports which support synchronous bit-banging on GPIO pins, similar

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -148,6 +148,7 @@ impl<'a> TransportCommandHandler<'a> {
                                     data: vec![0; data.len()],
                                 },
                                 BitbangEntryRequest::Delay { .. } => BitbangEntryResponse::Delay,
+                                BitbangEntryRequest::Await { .. } => BitbangEntryResponse::Await,
                             })
                             .collect();
                         // Now carefully craft a proper parameter to the
@@ -170,6 +171,13 @@ impl<'a> TransportCommandHandler<'a> {
                                     BitbangEntryRequest::Delay { clock_ticks },
                                     BitbangEntryResponse::Delay {},
                                 ) => BitbangEntry::Delay(*clock_ticks),
+                                (
+                                    BitbangEntryRequest::Await { mask, pattern },
+                                    BitbangEntryResponse::Await {},
+                                ) => BitbangEntry::Await {
+                                    mask: *mask,
+                                    pattern: *pattern,
+                                },
                                 _ => {
                                     // This can only happen if the logic in this method is
                                     // flawed.  (Never due to network input.)

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -127,16 +127,20 @@ pub enum BitbangEntryResponse {
 
 #[derive(Serialize, Deserialize)]
 pub enum GpioBitRequest {
-    Run {
+    Start {
         pins: Vec<String>,
         clock_ns: u64,
         entries: Vec<BitbangEntryRequest>,
     },
+    Query,
 }
 
 #[derive(Serialize, Deserialize)]
 pub enum GpioBitResponse {
-    Run { entries: Vec<BitbangEntryResponse> },
+    Start,
+    // GpioBitRequest::Query will be answered by either QueryNotDone or QueryDone.
+    QueryNotDone,
+    QueryDone { entries: Vec<BitbangEntryResponse> },
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -114,6 +114,7 @@ pub enum BitbangEntryRequest {
     Write { data: Vec<u8> },
     Both { data: Vec<u8> },
     Delay { clock_ticks: u32 },
+    Await { mask: u8, pattern: u8 },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -121,6 +122,7 @@ pub enum BitbangEntryResponse {
     Write,
     Both { data: Vec<u8> },
     Delay,
+    Await,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -684,6 +684,11 @@ fn encode_waveform(waveform: &[BitbangEntry], num_pins: usize) -> Result<Vec<u8>
             BitbangEntry::Delay(n @ 1..) => {
                 delay += *n;
             }
+            BitbangEntry::Await { mask, pattern } => {
+                ensure!(delay == 0, GpioError::InvalidBitbangDelay);
+                encoded_waveform.extend_from_slice(&[0x80, 0x80, *mask, *pattern]);
+                delay = 0;
+            }
         }
     }
 
@@ -724,6 +729,9 @@ fn decode_waveform(
                 while encoded_response[index] & 0x80 != 0 {
                     index += 1;
                 }
+            }
+            BitbangEntry::Await { .. } => {
+                index += 4;
             }
         }
     }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -13,8 +13,9 @@ use std::time::Duration;
 use zerocopy::{FromBytes, FromZeroes};
 
 use crate::io::gpio::{
-    BitbangEntry, ClockNature, Edge, GpioBitbanging, GpioError, GpioMonitoring, GpioPin,
-    MonitoringEvent, MonitoringReadResponse, MonitoringStartResponse, PinMode, PullMode,
+    BitbangEntry, ClockNature, Edge, GpioBitbangOperation, GpioBitbanging, GpioError,
+    GpioMonitoring, GpioPin, MonitoringEvent, MonitoringReadResponse, MonitoringStartResponse,
+    PinMode, PullMode,
 };
 use crate::transport::hyperdebug::{BulkInterface, Inner};
 use crate::transport::TransportError;
@@ -483,18 +484,6 @@ pub struct HyperdebugGpioBitbanging {
 }
 
 impl HyperdebugGpioBitbanging {
-    /// CMSIS extension for HyperDebug GPIO.
-    const CMSIS_DAP_CUSTOM_COMMAND_GPIO: u8 = 0x83;
-
-    /// Sub-command for HyperDebug GPIO bitbanging.
-    const GPIO_BITBANG: u8 = 0x10;
-    const GPIO_BITBANG_STREAMING: u8 = 0x11;
-
-    /// Device status (whether there is an ongoing bitbang operation)
-    const STATUS_BITBANG_IDLE: u8 = 0x00;
-    const STATUS_BITBANG_ONGOING: u8 = 0x01;
-    const STATUS_BITBANG_ERROR_WAVEFORM: u8 = 0x80;
-
     pub fn open(inner: &Rc<Inner>, cmsis_interface: BulkInterface) -> Result<Self> {
         // Exclusively claim CMSIS-DAP interface, preparing for bulk transfers.
         inner
@@ -509,44 +498,64 @@ impl HyperdebugGpioBitbanging {
 }
 
 impl GpioBitbanging for HyperdebugGpioBitbanging {
-    fn run(
+    fn start<'a>(
         &self,
         pins: &[&dyn GpioPin],
         clock_tick: Duration,
-        waveform: &mut [BitbangEntry],
-    ) -> Result<()> {
-        // Verify that `waveform` is valid, by converting into the binary representation to send
-        // to HyperDebug.
-        let mut encoded_waveform = encode_waveform(waveform, pins.len())?;
+        waveform: Box<[BitbangEntry<'a, 'a>]>,
+    ) -> Result<Box<dyn GpioBitbangOperation<'a, 'a> + 'a>> {
+        Ok(Box::new(HyperdebugGpioBitbangOperation::new(
+            Rc::clone(&self.inner),
+            self.cmsis_interface,
+            pins,
+            clock_tick,
+            waveform,
+        )?))
+    }
+}
 
-        // Tell HyperDebug about the set of pins to manipulate, and the clock speed, using the
-        // textual console protocol.
-        let mut pin_names = Vec::new();
-        for pin in pins {
-            pin_names.push(
-                pin.get_internal_pin_name()
-                    .ok_or(TransportError::InvalidOperation)?,
-            );
-        }
-        self.inner.cmd_no_output(&format!(
-            "gpio bit-bang {} {}",
-            clock_tick.as_nanos(),
-            pin_names.join(" ")
-        ))?;
+/// Represents a two-way streaming binary data transfer operation, as is used for bit-banging, or
+/// for outputting arbitrary waveforms via a DAC.
+pub struct HyperdebugDataOperation {
+    inner: Rc<Inner>,
+    cmsis_interface: BulkInterface,
+    encoded_waveform: Vec<u8>,
+    free_bytes: usize,
+    out_ptr: usize,
+    in_ptr: usize,
+}
 
+impl HyperdebugDataOperation {
+    /// CMSIS extension for HyperDebug GPIO.
+    const CMSIS_DAP_CUSTOM_COMMAND_GPIO: u8 = 0x83;
+
+    /// Sub-command for HyperDebug GPIO bitbanging.
+    const GPIO_BITBANG: u8 = 0x10;
+    const GPIO_BITBANG_STREAMING: u8 = 0x11;
+
+    /// Device status (whether there is an ongoing bitbang operation)
+    const STATUS_BITBANG_IDLE: u8 = 0x00;
+    const STATUS_BITBANG_ONGOING: u8 = 0x01;
+    const STATUS_BITBANG_ERROR_WAVEFORM: u8 = 0x80;
+
+    fn new(
+        inner: Rc<Inner>,
+        cmsis_interface: BulkInterface,
+        encoded_waveform: Vec<u8>,
+    ) -> Result<HyperdebugDataOperation> {
         // Send an initial request, to ask how much buffer space HyperDebug has, so that we can
         // fill the buffer, while avoiding overflows.
-        let usb = self.inner.usb_device.borrow();
-        let mut free_bytes: usize = {
+        let free_bytes: usize = {
+            let usb = inner.usb_device.borrow();
             let mut pkt = Vec::<u8>::new();
             pkt.write_u8(Self::CMSIS_DAP_CUSTOM_COMMAND_GPIO)?;
             pkt.write_u8(Self::GPIO_BITBANG)?;
             pkt.write_u16::<LittleEndian>(0)?;
-            usb.write_bulk(self.cmsis_interface.out_endpoint, &pkt)?;
+            usb.write_bulk(cmsis_interface.out_endpoint, &pkt)?;
 
             let mut databytes = [0u8; 64];
 
-            let c = usb.read_bulk(self.cmsis_interface.in_endpoint, &mut databytes)?;
+            let c = usb.read_bulk(cmsis_interface.in_endpoint, &mut databytes)?;
             let mut rdr = Cursor::new(&databytes[..c]);
             ensure!(
                 rdr.read_u8()? == Self::CMSIS_DAP_CUSTOM_COMMAND_GPIO,
@@ -563,6 +572,123 @@ impl GpioBitbanging for HyperdebugGpioBitbanging {
             let free_bytes = rdr.read_u16::<LittleEndian>()?;
             free_bytes as usize
         };
+        Ok(Self {
+            inner,
+            cmsis_interface,
+            encoded_waveform,
+            free_bytes,
+            out_ptr: 0,
+            in_ptr: 0,
+        })
+    }
+
+    fn query(&mut self) -> Result<bool> {
+        if self.in_ptr >= self.encoded_waveform.len() {
+            return Ok(true);
+        }
+
+        let usb = self.inner.usb_device.borrow();
+        let chunk_size = std::cmp::min(self.encoded_waveform.len() - self.out_ptr, self.free_bytes);
+
+        let mut pkt = Vec::<u8>::new();
+        pkt.write_u8(Self::CMSIS_DAP_CUSTOM_COMMAND_GPIO)?;
+        if self.out_ptr + chunk_size < self.encoded_waveform.len() {
+            // We prefer partial response, in order to be able to fill up buffer before
+            // HyperDebug runs out of data to clock out.
+            pkt.write_u8(Self::GPIO_BITBANG_STREAMING)?;
+        } else {
+            // We want response only after every byte is transmitted
+            pkt.write_u8(Self::GPIO_BITBANG)?;
+        }
+        pkt.write_u16::<LittleEndian>(chunk_size as u16)?;
+        pkt.extend_from_slice(&self.encoded_waveform[self.out_ptr..self.out_ptr + chunk_size]);
+        usb.write_bulk(self.cmsis_interface.out_endpoint, &pkt)?;
+
+        let mut databytes = [0u8; 64];
+
+        let c = usb.read_bulk(self.cmsis_interface.in_endpoint, &mut databytes)?;
+        let mut rdr = Cursor::new(&databytes[..c]);
+        ensure!(
+            rdr.read_u8()? == Self::CMSIS_DAP_CUSTOM_COMMAND_GPIO,
+            TransportError::CommunicationError(
+                "Incorrect CMSIS-DAP header in response to GPIO request".to_string()
+            )
+        );
+        match rdr.read_u8()? {
+            Self::STATUS_BITBANG_ONGOING => (),
+            Self::STATUS_BITBANG_IDLE => bail!(TransportError::CommunicationError(
+                "GPIO request aborted".to_string()
+            )),
+            Self::STATUS_BITBANG_ERROR_WAVEFORM => bail!(TransportError::CommunicationError(
+                "HyperDebug reports encoding error".to_string()
+            )),
+            status => bail!(TransportError::CommunicationError(std::format!(
+                "Unrecognized status code: {}",
+                status
+            ))),
+        }
+
+        self.free_bytes = rdr.read_u16::<LittleEndian>()? as usize;
+        let response_size = rdr.read_u16::<LittleEndian>()? as usize;
+
+        let final_in_ptr = self.in_ptr + response_size;
+
+        // Copy any data in initial packet
+        let data_in_header = c - rdr.position() as usize;
+        self.encoded_waveform[self.in_ptr..self.in_ptr + data_in_header]
+            .copy_from_slice(&databytes[rdr.position() as usize..][..data_in_header]);
+        self.in_ptr += data_in_header;
+
+        while self.in_ptr < final_in_ptr {
+            self.in_ptr += usb.read_bulk(
+                self.cmsis_interface.in_endpoint,
+                &mut self.encoded_waveform[self.in_ptr..final_in_ptr],
+            )?;
+        }
+
+        self.out_ptr += chunk_size;
+
+        if self.in_ptr >= self.encoded_waveform.len() {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+/// Represents an ongoing operation of bit-banging a number of GPIO pins.
+pub struct HyperdebugGpioBitbangOperation<'a> {
+    num_pins: usize,
+    waveform: Box<[BitbangEntry<'a, 'a>]>,
+    operation: HyperdebugDataOperation,
+}
+
+impl<'a> HyperdebugGpioBitbangOperation<'a> {
+    fn new(
+        inner: Rc<Inner>,
+        cmsis_interface: BulkInterface,
+        pins: &[&dyn GpioPin],
+        clock_tick: Duration,
+        waveform: Box<[BitbangEntry<'a, 'a>]>,
+    ) -> Result<Self> {
+        // Verify that `waveform` is valid, by converting into the binary representation to send
+        // to HyperDebug.
+        let encoded_waveform = encode_waveform(&waveform, pins.len())?;
+
+        // Tell HyperDebug about the set of pins to manipulate, and the clock speed, using the
+        // textual console protocol.
+        let mut pin_names = Vec::new();
+        for pin in pins {
+            pin_names.push(
+                pin.get_internal_pin_name()
+                    .ok_or(TransportError::InvalidOperation)?,
+            );
+        }
+        inner.cmd_no_output(&format!(
+            "gpio bit-bang {} {}",
+            clock_tick.as_nanos(),
+            pin_names.join(" ")
+        ))?;
 
         // Here is the main two-way transfer logic.  At each iteration we send a number of bytes,
         // capped at what HyperDebug has most recently indicated was available.  In response we
@@ -572,76 +698,33 @@ impl GpioBitbanging for HyperdebugGpioBitbanging {
         // (relevant for slow clock speeds).  With this scheme, the bit-banging of waveforms
         // longer than what fits in HyperDebug memory can be produced, without HyperDebug ever
         // needing to "stop the clock" waiting for more data.
-        let mut out_ptr = 0usize;
-        let mut in_ptr = 0usize;
-        while in_ptr < encoded_waveform.len() {
-            let chunk_size = std::cmp::min(encoded_waveform.len() - out_ptr, free_bytes);
+        Ok(Self {
+            num_pins: pins.len(),
+            waveform,
+            operation: HyperdebugDataOperation::new(inner, cmsis_interface, encoded_waveform)?,
+        })
+    }
+}
 
-            let mut pkt = Vec::<u8>::new();
-            pkt.write_u8(Self::CMSIS_DAP_CUSTOM_COMMAND_GPIO)?;
-            if out_ptr + chunk_size < encoded_waveform.len() {
-                // We prefer partial response, in order to be able to fill up buffer before
-                // HyperDebug runs out of data to clock out.
-                pkt.write_u8(Self::GPIO_BITBANG_STREAMING)?;
-            } else {
-                // We want response only after every byte is transmitted
-                pkt.write_u8(Self::GPIO_BITBANG)?;
-            }
-            pkt.write_u16::<LittleEndian>(chunk_size as u16)?;
-            pkt.extend_from_slice(&encoded_waveform[out_ptr..out_ptr + chunk_size]);
-            usb.write_bulk(self.cmsis_interface.out_endpoint, &pkt)?;
-
-            let mut databytes = [0u8; 64];
-
-            let c = usb.read_bulk(self.cmsis_interface.in_endpoint, &mut databytes)?;
-            let mut rdr = Cursor::new(&databytes[..c]);
-            ensure!(
-                rdr.read_u8()? == Self::CMSIS_DAP_CUSTOM_COMMAND_GPIO,
-                TransportError::CommunicationError(
-                    "Incorrect CMSIS-DAP header in response to GPIO request".to_string()
-                )
-            );
-            match rdr.read_u8()? {
-                Self::STATUS_BITBANG_ONGOING => (),
-                Self::STATUS_BITBANG_IDLE => bail!(TransportError::CommunicationError(
-                    "GPIO request aborted".to_string()
-                )),
-                Self::STATUS_BITBANG_ERROR_WAVEFORM => bail!(TransportError::CommunicationError(
-                    "HyperDebug reports encoding error".to_string()
-                )),
-                status => bail!(TransportError::CommunicationError(std::format!(
-                    "Unrecognized status code: {}",
-                    status
-                ))),
-            }
-
-            free_bytes = rdr.read_u16::<LittleEndian>()? as usize;
-            let response_size = rdr.read_u16::<LittleEndian>()? as usize;
-
-            let final_in_ptr = in_ptr + response_size;
-
-            // Copy any data in initial packet
-            let data_in_header = c - rdr.position() as usize;
-            encoded_waveform[in_ptr..in_ptr + data_in_header]
-                .copy_from_slice(&databytes[rdr.position() as usize..][..data_in_header]);
-            in_ptr += data_in_header;
-
-            while in_ptr < final_in_ptr {
-                in_ptr += usb.read_bulk(
-                    self.cmsis_interface.in_endpoint,
-                    &mut encoded_waveform[in_ptr..final_in_ptr],
-                )?;
-            }
-
-            out_ptr += chunk_size;
+impl<'a> GpioBitbangOperation<'a, 'a> for HyperdebugGpioBitbangOperation<'a> {
+    fn query(&mut self) -> Result<bool> {
+        if self.operation.query()? {
+            // Decode the binary representation from HyperDebug into any `BitbangEntry::Both()`
+            // entries in `waveform`, allowing the caller to inspect data sampled at bitbanging
+            // clock ticks (useful with open drain or pure input pins).
+            decode_waveform(
+                &mut self.waveform,
+                &self.operation.encoded_waveform,
+                self.num_pins,
+            )?;
+            Ok(true)
+        } else {
+            Ok(false)
         }
+    }
 
-        // Decode the binary representation from HyperDebug into any `BitbangEntry::Both()`
-        // entries in `waveform`, allowing the caller to inspect data sampled at bitbanging clock
-        // ticks (useful with open drain or pure input pins).
-        decode_waveform(waveform, encoded_waveform, pins.len())?;
-
-        Ok(())
+    fn get_result(self: Box<Self>) -> Result<Box<[BitbangEntry<'a, 'a>]>> {
+        Ok(self.waveform)
     }
 }
 
@@ -680,6 +763,29 @@ fn encode_waveform(waveform: &[BitbangEntry], num_pins: usize) -> Result<Vec<u8>
                 encoded_waveform.extend_from_slice(wbuf);
                 delay = 0;
             }
+            BitbangEntry::WriteOwned(wbuf) | BitbangEntry::BothOwned(wbuf) => {
+                if delay > 1 {
+                    // Delays are encoded using one or more bytes with the MSB set to one.  Each
+                    // containing 7 bits of the delay value, with the least significant bits in
+                    // the first byte.
+                    let encoded_delay = delay - 1;
+                    let mut shift = 0;
+                    while (encoded_delay >> shift) != 0 {
+                        encoded_waveform.push(0x80 | ((encoded_delay >> shift) & 0x7F) as u8);
+                        shift += 7;
+                    }
+                }
+                // A sequence of samples using up to 7 of the lowest bits, with the MSB set to
+                // zero.
+                for byte in wbuf.iter() {
+                    ensure!(
+                        (byte >> num_pins) == 0,
+                        GpioError::InvalidBitbangData(num_pins)
+                    );
+                }
+                encoded_waveform.extend_from_slice(wbuf);
+                delay = 0;
+            }
             BitbangEntry::Delay(0) => bail!(GpioError::InvalidBitbangDelay),
             BitbangEntry::Delay(n @ 1..) => {
                 delay += *n;
@@ -703,7 +809,7 @@ fn encode_waveform(waveform: &[BitbangEntry], num_pins: usize) -> Result<Vec<u8>
 /// open drain or pure input pins).
 fn decode_waveform(
     waveform: &mut [BitbangEntry],
-    encoded_response: Vec<u8>,
+    encoded_response: &Vec<u8>,
     num_pins: usize,
 ) -> Result<()> {
     ensure!(
@@ -717,6 +823,9 @@ fn decode_waveform(
             BitbangEntry::Write(wbuf) => {
                 index += wbuf.len();
             }
+            BitbangEntry::WriteOwned(wbuf) => {
+                index += wbuf.len();
+            }
             BitbangEntry::Both(wbuf, rbuf) => {
                 ensure!(
                     rbuf.len() == wbuf.len(),
@@ -724,6 +833,10 @@ fn decode_waveform(
                 );
                 rbuf.copy_from_slice(&encoded_response[index..][..rbuf.len()]);
                 index += wbuf.len();
+            }
+            BitbangEntry::BothOwned(rbuf) => {
+                rbuf.copy_from_slice(&encoded_response[index..][..rbuf.len()]);
+                index += rbuf.len();
             }
             BitbangEntry::Delay(_) => {
                 while encoded_response[index] & 0x80 != 0 {

--- a/sw/host/opentitanlib/src/transport/proxy/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/gpio.rs
@@ -211,6 +211,10 @@ impl GpioBitbanging for GpioBitbangingImpl {
                 BitbangEntry::Delay(ticks) => req.push(BitbangEntryRequest::Delay {
                     clock_ticks: *ticks,
                 }),
+                BitbangEntry::Await { mask, pattern } => req.push(BitbangEntryRequest::Await {
+                    mask: *mask,
+                    pattern: *pattern,
+                }),
             }
         }
         match self.execute_command(GpioBitRequest::Run {

--- a/sw/host/opentitanlib/src/transport/proxy/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/gpio.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 
 use super::ProxyError;
 use crate::io::gpio::{
-    BitbangEntry, ClockNature, GpioBitbanging, GpioError, GpioMonitoring, GpioPin,
-    MonitoringReadResponse, MonitoringStartResponse, PinMode, PullMode,
+    BitbangEntry, ClockNature, GpioBitbangOperation, GpioBitbanging, GpioError, GpioMonitoring,
+    GpioPin, MonitoringReadResponse, MonitoringStartResponse, PinMode, PullMode,
 };
 use crate::proxy::protocol::{
     BitbangEntryRequest, BitbangEntryResponse, GpioBitRequest, GpioBitResponse, GpioMonRequest,
@@ -182,12 +182,12 @@ impl GpioBitbangingImpl {
 }
 
 impl GpioBitbanging for GpioBitbangingImpl {
-    fn run(
+    fn start<'a>(
         &self,
         pins: &[&dyn GpioPin],
         clock_tick: Duration,
-        waveform: &mut [BitbangEntry],
-    ) -> Result<()> {
+        waveform: Box<[BitbangEntry<'a, 'a>]>,
+    ) -> Result<Box<dyn GpioBitbangOperation<'a, 'a> + 'a>> {
         let pins = pins
             .iter()
             .map(|p| p.get_internal_pin_name().unwrap().to_string())
@@ -208,6 +208,12 @@ impl GpioBitbanging for GpioBitbangingImpl {
                         data: wbuf.to_vec(),
                     })
                 }
+                BitbangEntry::WriteOwned(buf) => {
+                    req.push(BitbangEntryRequest::Write { data: buf.to_vec() })
+                }
+                BitbangEntry::BothOwned(buf) => {
+                    req.push(BitbangEntryRequest::Both { data: buf.to_vec() })
+                }
                 BitbangEntry::Delay(ticks) => req.push(BitbangEntryRequest::Delay {
                     clock_ticks: *ticks,
                 }),
@@ -217,30 +223,65 @@ impl GpioBitbanging for GpioBitbangingImpl {
                 }),
             }
         }
-        match self.execute_command(GpioBitRequest::Run {
+        match self.execute_command(GpioBitRequest::Start {
             pins,
             clock_ns: clock_tick.as_nanos() as u64,
             entries: req,
         })? {
-            GpioBitResponse::Run { entries: resp } => {
+            GpioBitResponse::Start => Ok(Box::new(GpioBitbangOperationImpl {
+                inner: Rc::clone(&self.inner),
+                waveform,
+            })),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+}
+
+pub struct GpioBitbangOperationImpl<'a> {
+    inner: Rc<Inner>,
+    waveform: Box<[BitbangEntry<'a, 'a>]>,
+}
+
+impl<'a> GpioBitbangOperationImpl<'a> {
+    // Convenience method for issuing GPIO bitbanging commands via proxy protocol.
+    fn execute_command(&self, command: GpioBitRequest) -> Result<GpioBitResponse> {
+        match self
+            .inner
+            .execute_command(Request::GpioBitbanging { command })?
+        {
+            Response::GpioBitbanging(resp) => Ok(resp),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+}
+
+impl<'a> GpioBitbangOperation<'a, 'a> for GpioBitbangOperationImpl<'a> {
+    fn query(&mut self) -> Result<bool> {
+        match self.execute_command(GpioBitRequest::Query)? {
+            GpioBitResponse::QueryNotDone => Ok(false),
+            GpioBitResponse::QueryDone { entries: resp } => {
                 ensure!(
-                    resp.len() == waveform.len(),
+                    resp.len() == self.waveform.len(),
                     ProxyError::UnexpectedReply()
                 );
-                for pair in resp.iter().zip(waveform.iter_mut()) {
+                for pair in resp.iter().zip(self.waveform.iter_mut()) {
                     match pair {
                         (BitbangEntryResponse::Both { data }, BitbangEntry::Both(_, rbuf)) => {
                             rbuf.clone_from_slice(data);
                         }
                         (BitbangEntryResponse::Write, BitbangEntry::Write(_)) => (),
                         (BitbangEntryResponse::Delay, BitbangEntry::Delay(_)) => (),
+                        (BitbangEntryResponse::Await, BitbangEntry::Await { .. }) => (),
                         _ => bail!(ProxyError::UnexpectedReply()),
                     }
                 }
-                Ok(())
+                Ok(true)
             }
-            // Insert the below line, when a second kind of bitbanging request is added:
-            // _ => bail!(ProxyError::UnexpectedReply()),
+            _ => bail!(ProxyError::UnexpectedReply()),
         }
+    }
+
+    fn get_result(self: Box<Self>) -> Result<Box<[BitbangEntry<'a, 'a>]>> {
+        Ok(self.waveform)
     }
 }

--- a/sw/host/opentitanlib/src/util/bitbang.rs
+++ b/sw/host/opentitanlib/src/util/bitbang.rs
@@ -136,13 +136,14 @@ pub fn parse_clock_frequency(input: &str) -> Result<Duration> {
 /// list of `BitbangEntry` corresponding to the parsed instructions.  The slices in the entries
 /// will refer to one of the two "accumulator vectors" provided by the caller, which this function
 /// will clear out and resize according to need.
+#[allow(clippy::type_complexity)]
 pub fn parse_sequence<'a, 'wr, 'rd>(
     input: &'a str,
     num_pins: usize,
     clock: Duration,
     accumulator_rd: &'rd mut Vec<u8>,
     accumulator_wr: &'wr mut Vec<u8>,
-) -> Result<(Vec<BitbangEntry<'rd, 'wr>>, HashMap<&'a str, usize>)> {
+) -> Result<(Box<[BitbangEntry<'rd, 'wr>]>, HashMap<&'a str, usize>)> {
     ensure!(
         num_pins > 0,
         "Must specify at least one GPIO pin for bitbanging"
@@ -315,7 +316,7 @@ pub fn parse_sequence<'a, 'wr, 'rd>(
         }
     }
 
-    Ok((result, token_map))
+    Ok((result.into(), token_map))
 }
 
 #[cfg(test)]

--- a/sw/host/opentitanlib/src/util/bitbang.rs
+++ b/sw/host/opentitanlib/src/util/bitbang.rs
@@ -15,6 +15,11 @@ enum Token<'a> {
     Numeric(&'a str),
     Alphabetic(&'a str),
     Quoted(&'a str),
+
+    Await,
+
+    LParen,
+    RParen,
 }
 
 fn get_token<'a>(
@@ -53,7 +58,10 @@ fn get_token<'a>(
                 None => break input.len(),
             }
         };
-        Ok(Some(Token::Alphabetic(&input[token_start..token_end])))
+        match &input[token_start..token_end] {
+            "await" => Ok(Some(Token::Await)),
+            other => Ok(Some(Token::Alphabetic(other))),
+        }
     } else if first_char == '\'' {
         let token_end = loop {
             match iter.next() {
@@ -84,6 +92,10 @@ fn get_token<'a>(
             }
         };
         Ok(Some(Token::Quoted(&input[token_start..token_end])))
+    } else if first_char == '(' {
+        Ok(Some(Token::LParen))
+    } else if first_char == ')' {
+        Ok(Some(Token::RParen))
     } else {
         bail!("Unexpected character `{}`", first_char);
     }
@@ -131,6 +143,10 @@ pub fn parse_sequence<'a, 'wr, 'rd>(
     accumulator_rd: &'rd mut Vec<u8>,
     accumulator_wr: &'wr mut Vec<u8>,
 ) -> Result<(Vec<BitbangEntry<'rd, 'wr>>, HashMap<&'a str, usize>)> {
+    ensure!(
+        num_pins > 0,
+        "Must specify at least one GPIO pin for bitbanging"
+    );
     let all_tokens = get_all_tokens(input)?;
 
     let mut token_map: HashMap<&'a str, usize> = HashMap::new();
@@ -141,6 +157,31 @@ pub fn parse_sequence<'a, 'wr, 'rd>(
     let mut tokens: &[Token] = &all_tokens;
     loop {
         match tokens {
+            [Token::Await, Token::LParen, rest @ ..] => {
+                ensure!(
+                    !last_token_was_capture,
+                    "Capturing GPIO samples only supported immediately preceeding output, not `await`.  (Consider repeating the previous output values before the `await`.)",
+                );
+                tokens = rest;
+                loop {
+                    match tokens {
+                        [Token::Numeric(_), rest @ ..] => {
+                            tokens = rest;
+                        }
+                        [Token::Alphabetic(_), rest @ ..] => {
+                            tokens = rest;
+                        }
+                        [Token::RParen, rest @ ..] => {
+                            tokens = rest;
+                            break;
+                        }
+                        _ => {
+                            bail!("Mismatched parenthesis");
+                        }
+                    }
+                }
+                last_token_was_capture = false;
+            }
             [Token::Numeric(_), Token::Alphabetic(_), rest @ ..] => {
                 ensure!(
                     !last_token_was_capture,
@@ -181,6 +222,47 @@ pub fn parse_sequence<'a, 'wr, 'rd>(
     let mut tokens: &[Token] = &all_tokens;
     loop {
         match tokens {
+            [Token::Await, Token::LParen, rest @ ..] => {
+                tokens = rest;
+                let mut pattern = String::new();
+                loop {
+                    match tokens {
+                        [Token::Numeric(p), rest @ ..] => {
+                            pattern = pattern + p;
+                            tokens = rest;
+                        }
+                        [Token::Alphabetic(p), rest @ ..] => {
+                            pattern = pattern + p;
+                            tokens = rest;
+                        }
+                        [Token::RParen, rest @ ..] => {
+                            tokens = rest;
+                            break;
+                        }
+                        _ => {
+                            bail!("Mismatched parenthesis");
+                        }
+                    }
+                }
+                let pattern_str = pattern.as_bytes();
+                let mut mask = 0u8;
+                let mut pattern = 0u8;
+                for (i, ch) in pattern_str.iter().enumerate() {
+                    match pattern_str[i] {
+                        b'0' => {
+                            mask |= 1 << i;
+                        }
+                        b'1' => {
+                            pattern |= 1 << i;
+                            mask |= 1 << i;
+                        }
+                        b'x' | b'X' => (),
+                        _ => bail!("Unexpected character in await pattern: `{}`", ch),
+                    }
+                }
+                ensure!(mask != 0, "Pattern consisting of only x'es not allowed");
+                result.push(BitbangEntry::Await { mask, pattern });
+            }
             [Token::Numeric(num), Token::Alphabetic(time_unit), rest @ ..] => {
                 let ticks = if *time_unit == "ticks" {
                     num.parse::<u32>().unwrap()
@@ -278,6 +360,23 @@ mod tests {
                 Token::Alphabetic("ms"),
                 Token::Numeric("10"),
                 Token::Quoted("'s7'"),
+            ],
+        );
+        assert_eq!(
+            // Combined example, using "await(...)".
+            get_all_tokens("01 25ms await(x1) 100us 11").unwrap(),
+            [
+                Token::Numeric("01"),
+                Token::Numeric("25"),
+                Token::Alphabetic("ms"),
+                Token::Await,
+                Token::LParen,
+                Token::Alphabetic("x"),
+                Token::Numeric("1"),
+                Token::RParen,
+                Token::Numeric("100"),
+                Token::Alphabetic("us"),
+                Token::Numeric("11"),
             ],
         );
     }

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -601,7 +601,7 @@ impl CommandDispatch for GpioBitbang {
         let gpio_pins = transport.gpio_pins(&self.pins)?;
         let mut outbound_data_accumulator: Vec<u8> = Vec::new();
         let mut inbound_data_accumulator: Vec<u8> = Vec::new();
-        let (mut sequence, output_map) = opentitanlib::util::bitbang::parse_sequence(
+        let (sequence, output_map) = opentitanlib::util::bitbang::parse_sequence(
             &self.sequence,
             gpio_pins.len(),
             self.clock,
@@ -614,7 +614,7 @@ impl CommandDispatch for GpioBitbang {
                 .map(Rc::borrow)
                 .collect::<Vec<&dyn GpioPin>>(),
             self.clock,
-            &mut sequence,
+            sequence,
         )?;
         let mut samples = HashMap::new();
         for (label, byte_index) in output_map {

--- a/sw/host/tests/chip/i2c_host_override/src/main.rs
+++ b/sw/host/tests/chip/i2c_host_override/src/main.rs
@@ -51,7 +51,7 @@ fn test_override(
     const SAMPLES: usize = 5000;
     let mut samples = vec![0x00; SAMPLES];
     let output = &[0x03; SAMPLES];
-    let mut waveform = [BitbangEntry::Both(output, &mut samples)];
+    let waveform = Box::new([BitbangEntry::Both(output, &mut samples)]);
 
     UartConsole::wait_for(
         &*uart,
@@ -66,7 +66,7 @@ fn test_override(
             .map(Rc::borrow)
             .collect::<Vec<&dyn GpioPin>>(),
         Duration::from_micros(10),
-        &mut waveform,
+        waveform,
     )?;
 
     let mut i2c_bitbang_decoder =

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -197,7 +197,7 @@ fn test_write_repeated_start(
         test_utils::bitbanging::i2c::encoder::Transfer::Write(REFERENCE_DATA),
         test_utils::bitbanging::i2c::encoder::Transfer::Stop,
     ]);
-    let mut waveform = [BitbangEntry::Write(transaction)];
+    let waveform = Box::new([BitbangEntry::Write(transaction)]);
 
     log::info!("Testing write transaction at I2C address {address:02x}");
     let transfer = I2cTransferStart::execute_write(&*uart, || {
@@ -207,7 +207,7 @@ fn test_write_repeated_start(
                 .map(Rc::borrow)
                 .collect::<Vec<&dyn GpioPin>>(),
             Duration::from_micros(10),
-            &mut waveform,
+            waveform,
         )?;
         Ok(())
     })?;
@@ -259,7 +259,7 @@ fn test_write_read_repeated_start(
     // Extend the number of samples to make sure that the stop bit will be captured in the read buffer.
     transfer.extend([0x03; 5]);
     let mut buffer = vec![0u8; transfer.len()];
-    let mut waveform = [BitbangEntry::Both(&transfer, &mut buffer)];
+    let waveform = Box::new([BitbangEntry::Both(&transfer, &mut buffer)]);
 
     log::info!("Testing write transaction at I2C address 0x{address:02x}");
     let txn = I2cTransferStart::new(address, READ_REFERENCE_DATA, false);
@@ -270,7 +270,7 @@ fn test_write_read_repeated_start(
                 .map(Rc::borrow)
                 .collect::<Vec<&dyn GpioPin>>(),
             Duration::from_micros(10),
-            &mut waveform,
+            waveform,
         )?;
         Ok(())
     })?;

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240501_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "add2552c940603af0f810f94e4d397ec60f8184722a08e386dcbb91b8e01fe37",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240510_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "72ce00ab54ea03583085b146ec26c9592bef177737c7635260fe2ab462589d47",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
This PR enhances the existing FTDI-inspired bitbanging supported by HyperDebug.  In particular, it adds means of specifying that generation of the waveform should be put on "pause" at a certain point, until a certain logic level is seen on particular pins.

This feature allows generating I2C waveforms, while allowing the I2C device to stretch the clock.  Or generating an edge on a GPIO pin at a very precise time after OT has toggled some other pin, in order for a test case to attempt to trigger a race condition.

The command below will flash the blue LED on HyperDebug half a second after the user presses the blue button.  The new `await(1x)` directive means to pause until a high level on the first pin (and any level on the second pin) is seen.  (The initial zero on the waveform output samples `00` and `01` has no effect, since that pin is in input mode.)  The command will block until the waveform has completed, but HyperDebug is able to respond to other commands in the meantime.
```
opentitantool gpio bitbang --clock "100kHz" -s "00 await(1x) .5s 01 .1s 00" NUCLEO_USER_BTN NUCLEO_LED2
```

