### PR TITLE
[test] Make e2e_bootstrap_rma test more resilient

### DIFF
--- a/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
+++ b/sw/host/tests/rom/e2e_bootstrap_rma/src/main.rs
@@ -209,9 +209,12 @@ fn test_rma_command(opts: &Opts, transport: &TransportWrapper) -> anyhow::Result
 
     assert_eq!(jtag.read_lc_ctrl_reg(&LcCtrlReg::TransitionRegwen)?, 0);
 
-    let status = jtag.read_lc_ctrl_reg(&LcCtrlReg::Status)?;
-    let status = LcCtrlStatus::from_bits(status).context("invalid status bits")?;
-    assert_eq!(status, LcCtrlStatus::INITIALIZED);
+    lc_transition::wait_for_status(
+        &mut *jtag,
+        Duration::from_secs(3),
+        LcCtrlStatus::INITIALIZED,
+    )
+    .context("failed to wait for LC to report INITIALIZED status")?;
 
     // Poll until status register reports a successful transition.
     lc_transition::wait_for_status(


### PR DESCRIPTION
There was an assert checking that the LC controller's status was `INITIALIZED`. This failed if the status was `INITIALIZED | READY`.

Changed to use the `wait_for_status` function which allows unions and also has retries built in.