### PR TITLE
[deps/crypto] add skeleton code for self-hosted SPHINCS+ library

### DIFF
--- a/sw/host/sphincsplus/BUILD
+++ b/sw/host/sphincsplus/BUILD
@@ -1,0 +1,29 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//bindgen:defs.bzl", "rust_bindgen_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+rust_bindgen_library(
+    name = "sphincsplus_bindgen",
+    bindgen_flags = [
+        "--allowlist-function=crypto_.*",
+        "--allowlist-var=CRYPTO_.*",
+        "--allowlist-var=SPX_.*",
+    ],
+    cc_lib = "@sphincsplus_fips205_ipd//:sphincs_random_shake_128s_simple",
+    clang_flags = ["-DPARAMS=sphincs-shake-128s"],
+    header = "@sphincsplus_fips205_ipd//:api.h",
+)
+
+rust_library(
+    name = "sphincsplus",
+    srcs = ["lib.rs"],
+    deps = [":sphincsplus_bindgen"],
+)
+
+rust_test(
+    name = "sphincsplus_test",
+    crate = ":sphincsplus",
+)

--- a/sw/host/sphincsplus/lib.rs
+++ b/sw/host/sphincsplus/lib.rs
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use sphincsplus_bindgen::SPX_BYTES;
+
+pub fn do_something() -> u32 {
+    SPX_BYTES
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn do_something_test() {
+        assert_eq!(7856, super::do_something());
+    }
+}

--- a/third_party/sphincsplus/BUILD.sphincsplus.bazel
+++ b/third_party/sphincsplus/BUILD.sphincsplus.bazel
@@ -1,0 +1,96 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+exports_files(glob(["**"]))
+
+package(default_visibility = ["//visibility:public"])
+
+HASHES = [
+    [
+        "sha2",
+        "sha2",
+    ],
+    [
+        "shake",
+        "fips202",
+    ],
+    [
+        "haraka",
+        "haraka",
+    ],
+]
+
+LEVELS = [
+    "128",
+    "192",
+    "256",
+]
+
+LETTERS = [
+    "s",
+    "f",
+]
+
+THASHES = [
+    "simple",
+    "robust",
+]
+
+RNG_MODES = [
+    [
+        "random",
+        "randombytes",
+    ],
+    [
+        "deterministic",
+        "rng",
+    ],
+]
+
+[
+    cc_library(
+        name = "sphincs_{}_{}_{}{}_{}".format(rng_mode, hash_alg, level, letter, thash),
+        srcs = [
+            "address.c",
+            "fors.c",
+            "merkle.c",
+            "{}.c".format(rng_mode_c),
+            "sign.c",
+            "utils.c",
+            "utilsx1.c",
+            "wots.c",
+            "wotsx1.c",
+            "{}.c".format(hash_c),
+            "hash_{}.c".format(hash_alg),
+            "thash_{}_{}.c".format(hash_alg, thash),
+        ],
+        hdrs = [
+            "address.h",
+            "api.h",
+            "context.h",
+            "fors.h",
+            "hash.h",
+            "merkle.h",
+            "params.h",
+            "randombytes.h",
+            "rng.h",
+            "thash.h",
+            "utils.h",
+            "utilsx1.h",
+            "wots.h",
+            "wotsx1.h",
+            "{}_offsets.h".format(hash_alg),
+            "{}.h".format(hash_c),
+            "params/params-sphincs-{}-{}{}.h".format(hash_alg, level, letter),
+        ],
+        copts = [
+            "-DPARAMS=sphincs-{}-{}{}".format(hash_alg, level, letter),
+        ],
+    )
+    for rng_mode, rng_mode_c in RNG_MODES
+    for hash_alg, hash_c in HASHES
+    for level in LEVELS
+    for letter in LETTERS
+    for thash in THASHES
+]

--- a/third_party/sphincsplus/repos.bzl
+++ b/third_party/sphincsplus/repos.bzl
@@ -2,9 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:repo.bzl", "http_archive_or_local")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def sphincsplus_repos():
+def sphincsplus_repos(local = None):
     http_archive(
         name = "sphincsplus_kat",
         build_file = Label("//third_party/sphincsplus:BUILD.sphincsplus_common.bazel"),
@@ -18,4 +19,12 @@ def sphincsplus_repos():
             # here because the checksum differs.
             "https://storage.googleapis.com/ot-crypto-test-vectors/sphincsplus/sphincsplus_shake256_128s_round3.zip ",
         ],
+    )
+    http_archive_or_local(
+        name = "sphincsplus_fips205_ipd",
+        local = local,
+        url = "https://github.com/sphincs/sphincsplus/archive/129b72c80e122a22a61f71b5d2b042770890ccee.tar.gz",
+        strip_prefix = "sphincsplus-129b72c80e122a22a61f71b5d2b042770890ccee/ref",
+        build_file = "//third_party/sphincsplus:BUILD.sphincsplus.bazel",
+        sha256 = "b301faa7a42ef538323a732929d49341b1cbd8375f643f7d98ca32cd6efacc32",
     )


### PR DESCRIPTION
Follow-up to #22953 

Background: the existing SPHNICS+ crate that `opentitantool` relies on does not support the `consistent_basew` update to the algorithm in the newest NIST draft standard that is planned for earlgrey prod.

This issue was discussed in the Software WG, and the consensus was that we would develop our own SPHINCS+ crate that imports the correct version of the SPHINCS+ C code.

This PR adds a bazel toolchain to fetch the correct branch of the SPHINCS+ repository (which unfortunately does not have a release, so we fall back to using the `bare_repository` bazel rule). From there, `rules_rust` provides some nice tooling to import the Rust library generated by the `bindgen` tool into our code.