### PR TITLE
[sival,pwrmgr] Add test harness for pwrmgr_deep_sleep_all_reset_reqs

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2609,21 +2609,20 @@ opentitan_test(
     name = "pwrmgr_deep_sleep_all_reset_reqs_test",
     srcs = ["pwrmgr_deep_sleep_all_reset_reqs_test.c"],
     cw310 = cw310_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
+        test_cmd = "--bootstrap={firmware}",
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        EARLGREY_TEST_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:silicon_creator": None,
             "//hw/top_earlgrey:sim_dv": None,
         },
     ),
     silicon = silicon_params(
-        tags = ["broken"],
+        test_cmd = "--bootstrap={firmware}",
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
This test was missing its test harness in the silicon env.

Also added the rest of the `EARLGREY_TEST_ENVS` since it seems to work in `fpga_cw310_sival_rom_ext` now and unmarking as broken.

Semi-related: https://github.com/lowRISC/opentitan/issues/23051 - the test seems to be broken in DV. Maybe the UVM harness is out of date.