### PR TITLE
USBDEV DV changes and additional sequences

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -13,4 +13,15 @@ class usb20_agent_cfg extends dv_base_agent_cfg;
 
   `uvm_object_new
 
+  // If this is set then the driver will not perform bitstuffing on the supplied
+  // data, so if the caller supplies a sequence of more than six '1' bits,
+  // a bitstuffing violation will occur.
+  bit disable_bitstuffing = 1'b0;
+  // This flag serves to evaluate the device's functionality,
+  // particularly regarding the recognition of a single SE0 bit as an end-of-packet,
+  // which necessitates two successive bits otherwise. Once set, it is accompanied by
+  // its respective test sequence, followed by the transmission of a single-bit SE0 as EOP.
+  bit single_bit_SE0 = 1'b0;
+  // Indicates that a timeout occurred when awaiting a response from the device.
+  bit timed_out = 1'b0;
 endclass

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -22,10 +22,6 @@ class token_pkt extends usb20_item;
   rand bit [3:0] endpoint;
   bit [4:0] crc5;
 
-  constraint endpoint_c {
-    endpoint inside {[0:11]};
-  }
-
   `uvm_object_utils_begin(token_pkt)
     `uvm_field_enum(pid_type_e, m_pid_type, UVM_DEFAULT)
     `uvm_field_int(address,                 UVM_DEFAULT)
@@ -38,6 +34,7 @@ class token_pkt extends usb20_item;
   function void post_randomize();
     crc5 = generate_crc5(address, endpoint);
   endfunction
+
   function bit [4:0] generate_crc5(bit [6:0] address, bit [3:0] endpoint);
     bit [4:0] crc;
     bit [4:0] crc_reg;
@@ -92,6 +89,12 @@ class data_pkt extends usb20_item;
              wVL, wVH,
              wIndex[7:0], wIndex[15:8],
              wLength[7:0], wLength[15:8]};
+    crc16 = generate_crc16(data);
+  endfunction
+
+  // Set the content of the data packet and ensure that the CRC is set accordingly.
+  function void set_data(byte unsigned content[]);
+    data = content;
     crc16 = generate_crc16(data);
   endfunction
 

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -468,7 +468,7 @@
             - Verify that the rx_crc_err should go high following the reception of erroneous packet.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_rx_crc_err"]
     }
     {
       name: rx_pid_err

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -406,7 +406,7 @@
       name: av_empty
       desc: '''
             Verify the functionality of 'av_out_empty' and 'av_setup_empty' interrupts when the
-	    Av OUT/SETUP Buffer FIFO is empty.
+      	    Av OUT/SETUP Buffer FIFO is empty.
 
             - Choose at random whether to test the AV OUT Buffer FIFO or the AV SETUP Buffer FIFO.
             - Enable the interrupt for AV OUT/SETUP empty by setting INTR_ENABLE[7/17] and then send back to back
@@ -569,30 +569,6 @@
             '''
       stage: V2
       tests: ["usbdev_setup_stage"]
-    }
-    {
-      name: in_data_stage
-      desc: '''
-            Verify the IN Transfer with Device Descriptor Data.
-
-            - Issue an IN token to request control data from the device.
-            - Verify that the device should respond with a DATA packet containing the information
-              required by host or a NAK packet if there is no data available.
-            '''
-      stage: V2
-      tests: []
-    }
-    {
-      name: out_data_stage
-      desc: '''
-            Verify the OUT Transfer with DEVICE Settings.
-
-            - Send an OUT token followed by a data packet containing control data to the device.
-            - Verify that the device should acknowledge the successful receipt of data by sending
-              an ACK packet or return a NAK if it is still processing previous data.
-            '''
-      stage: V2
-      tests: []
     }
     {
       name: endpoint_access

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -605,7 +605,7 @@
               accesses and data_packet for IN Accesses.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_endpoint_access"]
     }
     {
       name: disable_endpoint

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -388,7 +388,7 @@
             - Verify that the interrupt pin goes high once the link suspended.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_link_suspend"]
     }
     {
       name: link_resume

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -143,7 +143,7 @@
 	      does not ignore the packet or raise any link_err interrupts.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_phy_config_eop_single_bit_handling"]
     }
     {
       name: phy_config_pinflip

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -490,7 +490,7 @@
             - Verify that the interrupt pin goes high indicating bitstuff error.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_bitstuff_err"]
     }
     {
       name: link_out_err

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -457,7 +457,7 @@
             - Verify that the link_in_err interrupt goes high following the handshake packet sent by the host.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_link_in_err"]
     }
     {
       name: rx_crc_err

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -347,7 +347,7 @@
             - Verify that the corresponding Interrupt pin goes high after the link disconnected.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_disconnected"]
     }
     {
       name: host_lost

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -183,10 +183,14 @@ endtask
 
   // Construct and transmit a DATA packet to the USB device
   virtual task call_data_seq(input pid_type_e pid_type,
-                             input bit randomize_length, input bit [6:0] num_of_bytes);
+                             input bit randomize_length, input bit [6:0] num_of_bytes,
+                             input bit isochronous_transfer = 1'b0);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
     m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;
+    if (isochronous_transfer) begin
+      m_data_pkt.m_usb_transfer = usb_transfer_e'(IsoTrans);
+    end
     `DV_CHECK_RANDOMIZE_WITH_FATAL(m_data_pkt,
                                    !randomize_length -> m_data_pkt.data.size() == num_of_bytes;)
     m_usb20_item = m_data_pkt;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -170,12 +170,14 @@ endtask
   endtask
 
   // Construct and transmit a token packet to the USB device
-  virtual task call_token_seq(input pid_type_e pid_type);
+  virtual task call_token_seq(input pid_type_e pid_type, bit inject_crc_error = 0);
     `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
     m_token_pkt.m_pkt_type = PktTypeToken;
     m_token_pkt.m_pid_type = pid_type;
     assert(m_token_pkt.randomize() with {m_token_pkt.address inside {7'b0};
                                          m_token_pkt.endpoint == endp;});
+    // Any fault injections requested?
+    if (inject_crc_error) m_token_pkt.crc5 = ~m_token_pkt.crc5;
     m_usb20_item = m_token_pkt;
     start_item(m_token_pkt);
     finish_item(m_token_pkt);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_bitstuff_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_bitstuff_err_vseq.sv
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_bitstuff_err_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_bitstuff_err_vseq)
+
+  `uvm_object_new
+
+  task body();
+    byte unsigned data[$];
+    bit bitstuff_err;
+    configure_out_trans();
+    case ($urandom_range(0,3))
+      0: begin
+        // We need a known payload to guarantee a bit stuffing violation, and 6 contiguous
+        // '1's shall be followed by a '0'...ie. 7 or more is a violation.
+        data.push_back(8'hf0);  // LSB transmitted first...
+        data.push_back(8'h07);  // ... so this supplies just 7 contiguous 1 bits.
+      end
+      1: begin
+        // Contiguous run of '1's involving the device address and endpoint
+        dev_addr = 7'h78;  // LSB transmitted first...
+        endp = 4'h7;  // ... so this supplies just 7 contiguous '1's.
+      end
+      2: begin
+        // Endpoint and CRC5; the final bit of the endpoint, combined with the 5 bits of the
+        // CRC5 constitute a series of 6 but we can't emit 7 '1's and thus violate bit stuffing
+        // without choosing an unimplemented endpoint.
+        //
+        // This OUT data packet will not be stored by the DUT but it does still report the
+        // detection of bit stuffing violations in the packet before dropping it.
+        dev_addr = 7'h7d;
+        endp = 4'hf;
+      end
+      default: begin
+        // Generate a random length packet of random data, and then set 7 bits at a random
+        // position. We thus require a packet length of at least 1 byte in this case.
+        //
+        // The aim here is to exercise all alignments w.r.t. byte boundaries.
+        uint len = $urandom_range(1, MaxPktSizeByte) * 8;
+        uint start = $urandom_range(0, len - 7);
+        bit bit_data[$];
+        for (uint b = 0; b < len; b++) begin
+          bit_data.push_back((b >= start && b - start < 8) | ($urandom() & 1));
+        end
+        `uvm_info(`gfn, $sformatf("start %d len %d", start, len), UVM_DEBUG)
+        `uvm_info(`gfn, $sformatf("bit_data %p", bit_data), UVM_DEBUG)
+        // We need to ensure that the contiguous run of '1's is in the MSBs of the first byte
+        // transmitted and the ensuing LSBs of the subsequent byte if it spans a byte boundary.
+        data = {<<8{bit_data}};
+        `uvm_info(`gfn, $sformatf("data %p", data), UVM_DEBUG)
+      end
+    endcase
+
+    // Disable the bit stuffing logic in the driver.
+    cfg.m_usb20_agent_cfg.disable_bitstuffing = 1'b1;
+
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrRxBitstuffErr], 0)
+    send_data_packet(PidTypeData0, data);
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+
+    // All of these packets should be ignored, so we expect no response.
+    `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.timed_out, 1);
+
+    // Check that the bit stuffing violation was reported.
+    csr_rd(.ptr(ral.intr_state.rx_bitstuff_err), .value(bitstuff_err));
+    `DV_CHECK_EQ(1, bitstuff_err);
+  endtask
+endclass : usbdev_bitstuff_err_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_disconnected_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_disconnected_vseq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_disconnected_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_disconnected_vseq)
+
+  `uvm_object_new
+
+  task body();
+    uvm_reg_data_t rd_data;
+    bit disconnected;
+    // Enable disconnected interrupt
+    csr_wr(.ptr(ral.intr_enable.disconnected), .value(1'b1));
+    // Clear disconnected interrupt to make sure it's in reset state.
+    csr_wr(.ptr(ral.intr_state.disconnected), .value(1'b1));
+    // send pkt to device
+    configure_out_trans();
+    call_sof_seq(PidTypeSofToken);
+    for (int i = 0; i < 4; i++) begin
+      @(posedge cfg.m_usb20_agent_cfg.bif.clk_i);
+      if (cfg.m_usb20_agent_cfg.bif.usb_ref_val_o) break;
+    end
+    // Verify that the device has asserted the usb_ref_val_o signal after receiving the SoF packet.
+    `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.bif.usb_ref_val_o, 1)
+    // Check the disconnected interrupt isn't yet asserted
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrDisconnected], 0)
+    // Drive 0 on usb_vbus signal to tell device that it has been disconnected.
+    cfg.m_usb20_agent_cfg.bif.drive_vbus = 1'b0;
+    // Expect the disconnected interrupt within a short time
+    for (int i = 0; i < 40; i++) begin
+      @(posedge cfg.m_usb20_agent_cfg.bif.clk_i);
+      if (cfg.intr_vif.pins[IntrDisconnected]) break;
+    end
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrDisconnected], 1)
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_endpoint_access_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_endpoint_access_vseq.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// usbdev_endp_acc test vseq
+class usbdev_endpoint_access_vseq extends usbdev_in_trans_vseq;
+  `uvm_object_utils(usbdev_endpoint_access_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Perform OUT and IN transactions to all endpoints 0-11
+    // Extend from usbdev_in_trans b/c its doing OUT and IN to a specific endpoint number.
+    for (endp = 0; endp <= 11; endp++) begin
+      super.body();
+    end
+  endtask
+endclass : usbdev_endpoint_access_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_link_in_err_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_link_in_err_vseq)
+
+  `uvm_object_new
+
+  virtual task body();
+    bit link_error;
+    configure_out_trans();
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    get_data_pid_from_device(m_usb20_item, PidTypeAck);
+    inter_packet_delay();
+    // Check that link_in_err interrupt is zero.
+    csr_rd(.ptr(ral.intr_state.link_in_err), .value(link_error));
+    `DV_CHECK_EQ(0, link_error);
+    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
+    call_token_seq(PidTypeInToken);
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    get_data_pid_from_device(m_usb20_item, PidTypeData0);
+    inter_packet_delay();
+    // Send unexpected PID to USB device and device will assert link_in_err interrupt.
+    // Expected pkt is ACK but send NYET packet.
+    call_handshake_sequence(PktTypeHandshake, PidTypeNyet);
+    csr_rd(.ptr(ral.intr_state.link_in_err), .value(link_error));
+    // Check link_in_err is asserted.
+    `DV_CHECK_EQ(1, link_error);
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_suspend_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_suspend_vseq.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// usbdev_link_suspend test vseq
+class usbdev_link_suspend_vseq extends usbdev_pkt_sent_vseq;
+  `uvm_object_utils(usbdev_link_suspend_vseq)
+
+  `uvm_object_new
+
+  // Section 7.1.7.6 of the USB 2.0 Protocol Specification
+  // - more than 3.0ms of constant Idle signaling shall put the device in
+  //   Suspend state.
+  uint link_rst_suspend_ns = 3_100 * 48; // 3.1ms in 48MHz clock cycles.
+
+  task body();
+    uvm_reg_data_t link_suspend;
+    uvm_reg_data_t link_state;
+
+    // Send transaction to make link active
+    super.body();
+
+    // Read USB status to check link is active
+    // Link state should be active no SOF
+    csr_rd(.ptr(ral.usbstat.link_state), .value(link_state));
+    `DV_CHECK_EQ(usbdev_link_state_e'(link_state), LinkActiveNoSOF)
+
+    // Wait for longer than 3ms, generating no activity; bus remains Idle.
+    cfg.clk_rst_vif.wait_clks(link_rst_suspend_ns);
+
+    // Read USB status register to check link state field
+    // Link state should be suspended
+    csr_rd(.ptr(ral.usbstat.link_state), .value(link_state));
+    `DV_CHECK_EQ(usbdev_link_state_e'(link_state), LinkSuspended)
+
+    // Read USB interrupt register to check link suspend interrupt is set
+    // Link Supended Interrupt
+    csr_rd(.ptr(ral.intr_state.link_suspend), .value(link_suspend));
+    `DV_CHECK_EQ(link_suspend, 1'b1);
+  endtask
+endclass : usbdev_link_suspend_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_iso_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_iso_vseq.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Isochronous OUT transaction.
+
+class usbdev_out_iso_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_out_iso_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Expected data content of packet
+    byte unsigned exp_data[];
+    bit pkt_received;
+    configure_out_trans();
+    // ISO EP OUT
+    csr_wr(.ptr(ral.out_iso[0].iso[endp]), .value(1'b1));
+    // write to clear pkt_received interrupt; we want to verify this becomes asserted in
+    // response to the transaction.
+    csr_wr(.ptr(ral.intr_state.pkt_received), .value(1'b1));
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_data_seq(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(64),
+                  .isochronous_transfer(1'b1));
+    // Wait until usbdev generates an interrupt to show the packet has been received.
+    // The device should not seen an ACK in this case because the traffic is isochronous.
+    // TODO: when the usb20_driver is capable of indicating 'no response' check this here.
+    //       For now this sequence just checks the line state directly.
+    for (int i = 0; i < 10; i++) begin
+      csr_rd(.ptr(ral.intr_state.pkt_received), .value(pkt_received));
+      if (pkt_received) break;
+    end
+    if (!pkt_received) begin
+      `uvm_error(`gfn, "usbdev didn't generate expected pkt_received interrupt")
+    end
+    check_rx_packet(endp, 1'b0, out_buffer_id, m_data_pkt.data);
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_eop_single_bit_handling_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_eop_single_bit_handling_vseq.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_phy_config_eop_single_bit_handling_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_phy_config_eop_single_bit_handling_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Set single_bit_SE0 flag then usb20_agent will drive single SE0 as EoP.
+    cfg.m_usb20_agent_cfg.single_bit_SE0 = 1'b1;
+    configure_out_trans();
+    // Set eop_single_bit field of phy_config register.
+    csr_wr (.ptr(ral.phy_config.eop_single_bit), .value(1'b1));
+    call_token_seq(PidTypeOutToken);
+    inter_packet_delay();
+    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    m_usb20_item.check_pid_type(PidTypeAck);
+    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
+  endtask
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_rx_crc_err_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_rx_crc_err_vseq)
+
+  `uvm_object_new
+
+  task body();
+    // Configure transaction
+    configure_out_trans();
+
+    // Enable rx_crc_err interrupt
+    csr_wr(.ptr(ral.intr_enable.rx_crc_err), .value(1'b1));
+
+    // Out Token packet with corrupted CRC5
+    call_token_seq(PidTypeOutToken, .inject_crc_error(1));
+
+    // Wait a little while for the interrupt signal to become asserted.
+    for (int i = 0; i < 16; i++) begin
+      if (1'b1 === cfg.intr_vif.sample_pin(IntrRxCrcErr)) break;
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+
+    // Check that the interrupt has become asserted to inform firmware that a CRC error was
+    // detected on an OUT packet; the correct DUT behavior on the USB is simply to ignore the
+    // packet; the host will retry the transmission.
+    `DV_CHECK_EQ(cfg.intr_vif.sample_pin(IntrRxCrcErr), 1'b1)
+  endtask
+
+endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -18,6 +18,7 @@
 `include "usbdev_in_trans_vseq.sv"
 `include "usbdev_in_iso_vseq.sv"
 `include "usbdev_nak_trans_vseq.sv"
+`include "usbdev_out_iso_vseq.sv"
 `include "usbdev_out_stall_vseq.sv"
 `include "usbdev_out_trans_nak_vseq.sv"
 `include "usbdev_pending_in_trans_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -8,6 +8,7 @@
 `include "usbdev_smoke_vseq.sv"
 
 `include "usbdev_av_buffer_vseq.sv"
+`include "usbdev_bitstuff_err_vseq.sv"
 `include "usbdev_csr_test_vseq.sv"
 `include "usbdev_data_toggle_restore_vseq.sv"
 `include "usbdev_disconnected_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -18,6 +18,7 @@
 `include "usbdev_in_stall_vseq.sv"
 `include "usbdev_in_trans_vseq.sv"
 `include "usbdev_in_iso_vseq.sv"
+`include "usbdev_link_in_err_vseq.sv"
 `include "usbdev_nak_trans_vseq.sv"
 `include "usbdev_out_iso_vseq.sv"
 `include "usbdev_out_stall_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -29,6 +29,7 @@
 `include "usbdev_pkt_sent_vseq.sv"
 `include "usbdev_random_length_out_transaction_vseq.sv"
 `include "usbdev_stall_trans_vseq.sv"
+`include "usbdev_rx_crc_err_vseq.sv"
 `include "usbdev_setup_trans_ignored_vseq.sv"
 `include "usbdev_stall_priority_over_nak_vseq.sv"
 `include "usbdev_setup_stage_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -27,6 +27,7 @@
 `include "usbdev_pending_in_trans_vseq.sv"
 `include "usbdev_phy_config_usb_ref_disable_vseq.sv"
 `include "usbdev_phy_pins_sense_vseq.sv"
+`include "usbdev_phy_config_eop_single_bit_handling_vseq.sv"
 `include "usbdev_pkt_buffer_vseq.sv"
 `include "usbdev_pkt_received_vseq.sv"
 `include "usbdev_pkt_sent_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -10,6 +10,7 @@
 `include "usbdev_av_buffer_vseq.sv"
 `include "usbdev_csr_test_vseq.sv"
 `include "usbdev_data_toggle_restore_vseq.sv"
+`include "usbdev_disconnected_vseq.sv"
 `include "usbdev_dpi_config_host_vseq.sv"
 `include "usbdev_enable_vseq.sv"
 `include "usbdev_fifo_rst_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -39,3 +39,5 @@
 // These depend on usbdev_random_length_out_transaction, so need to come after it.
 `include "usbdev_max_length_out_transaction_vseq.sv"
 `include "usbdev_min_length_out_transaction_vseq.sv"
+// This must follow usbdev_in_trans
+`include "usbdev_endpoint_access_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -41,3 +41,5 @@
 `include "usbdev_min_length_out_transaction_vseq.sv"
 // This must follow usbdev_in_trans
 `include "usbdev_endpoint_access_vseq.sv"
+// This must follow usbdev_pkt_sent
+`include "usbdev_link_suspend_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -40,6 +40,7 @@ filesets:
       - seq_lib/usbdev_pkt_sent_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_nak_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_endpoint_access_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_rand_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_in_err_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -26,6 +26,7 @@ filesets:
       - usbdev_env.sv: {is_include_file: true}
       - seq_lib/usbdev_vseq_list.sv: {is_include_file: true}
       - seq_lib/usbdev_base_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_bitstuff_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_common_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_data_toggle_restore_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_dpi_config_host_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_rand_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_link_in_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_rx_crc_err_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -44,6 +44,7 @@ filesets:
       - seq_lib/usbdev_in_rand_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_in_err_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_link_suspend_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_rx_crc_err_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -32,6 +32,7 @@ filesets:
       - seq_lib/usbdev_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_csr_test_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_pkt_received_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_disconnected_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_av_buffer_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_setup_trans_ignored_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_pkt_buffer_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -45,6 +45,7 @@ filesets:
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_out_iso_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_stall_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_trans_nak_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_fifo_rst_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -58,6 +58,7 @@ filesets:
       - seq_lib/usbdev_pending_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_config_usb_ref_disable_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_pins_sense_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_phy_config_eop_single_bit_handling_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_stall_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_priority_over_nak_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_iso_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -43,6 +43,7 @@ filesets:
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_rx_crc_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_iso_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -89,6 +89,10 @@
       uvm_test_seq: usbdev_nak_trans_vseq
     }
     {
+      name: usbdev_out_iso
+      uvm_test_seq: usbdev_out_iso_vseq
+    }
+    {
       name: usbdev_out_stall
       uvm_test_seq: usbdev_out_stall_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -85,6 +85,10 @@
       uvm_test_seq: usbdev_link_in_err_vseq
     }
     {
+      name: usbdev_link_suspend
+      uvm_test_seq: usbdev_link_suspend_vseq
+    }
+    {
       name: usbdev_max_length_out_transaction
       uvm_test_seq: usbdev_max_length_out_transaction_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -85,6 +85,10 @@
       uvm_test_seq: usbdev_min_length_out_transaction_vseq
     }
     {
+      name: usbdev_disconnected
+      uvm_test_seq: usbdev_disconnected_vseq
+    }
+    {
       name: usbdev_nak_trans
       uvm_test_seq: usbdev_nak_trans_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -121,6 +121,10 @@
       uvm_test_seq: usbdev_stall_trans_vseq
     }
     {
+      name: usbdev_rx_crc_err
+      uvm_test_seq: usbdev_rx_crc_err_vseq
+    }
+    {
       name: usbdev_setup_trans_ignored
       uvm_test_seq: usbdev_setup_trans_ignored_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -55,6 +55,10 @@
       uvm_test_seq: usbdev_av_buffer_vseq
     }
     {
+      name: usbdev_bitstuff_err
+      uvm_test_seq: usbdev_bitstuff_err_vseq
+    }
+    {
       name: usbdev_dpi_config_host
       uvm_test_seq: usbdev_dpi_config_host_vseq
       // Limited use of randomization presently

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -65,6 +65,10 @@
       uvm_test_seq: usbdev_data_toggle_restore_vseq
     }
     {
+      name: usbdev_endpoint_access
+      uvm_test_seq: usbdev_endpoint_access_vseq
+    }
+    {
       name: usbdev_enable
       uvm_test_seq: usbdev_enable_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -77,6 +77,10 @@
       uvm_test_seq: usbdev_in_trans_vseq
     }
     {
+      name: usbdev_link_in_err
+      uvm_test_seq: usbdev_link_in_err_vseq
+    }
+    {
       name: usbdev_max_length_out_transaction
       uvm_test_seq: usbdev_max_length_out_transaction_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -157,6 +157,10 @@
       uvm_test_seq: usbdev_phy_config_usb_ref_disable_vseq
     }
     {
+      name: usbdev_phy_config_eop_single_bit_handling
+      uvm_test_seq: usbdev_phy_config_eop_single_bit_handling_vseq
+    }
+    {
       name: usbdev_setup_stage
       uvm_test_seq: usbdev_setup_stage_vseq
     }


### PR DESCRIPTION
This PR collects all of the changes in the following PRs from the original authors (@MubashirSaleem775, @Saad22386) and modifies them where necessary for inclusion in the current DV environment in the push towards the V2 milestone.

- #21928 - Out iso - Modify comment - modified comments and dropped broken bus state check
- #22376 - rx_crc_err - integrated with modifications to reduce code replication
- #22379 - usbdev_disconnected - small modifications and integrated
- #22422 - integrated with minor updates
- #22442 - usbdev_endpoint_access - simple sequence, integrated with minor fixups
- #22461 - usbdev_link_suspend - integrated with changes for readability
- #22725 - usbdev_bitstuff_err - integrated with a couple of functional fixes and extended significantly to guarantee that a bit suffing violation occurs, as well as exercising awkward cases such as violations in token packets, at the end of token/data packets etc.
- #22726 - usbdev_phy_config_eop_single_bit - integrated unchanged

Note: CI was faulting a number of the sign-off messages for lacking two parts to the 'real name' so I have taken the liberty whilst rebasing this PR of modifying them to 'Mubashir Saleem' as per the github account. I hope this is acceptable.

Thanks for all contributions.
