### PR TITLE
[rom_ext] Use Ibex for RSA sigverify

### DIFF
--- a/sw/device/silicon_creator/lib/attestation.h
+++ b/sw/device/silicon_creator/lib/attestation.h
@@ -107,8 +107,8 @@ typedef struct attestation_public_key {
  * Holds an attestation signature (ECDSA-P256).
  */
 typedef struct attestation_signature {
-  uint32_t r[kAttestationSignatureWords / 2];
-  uint32_t s[kAttestationSignatureWords / 2];
+  uint32_t r[kAttestationSignatureComponentWords];
+  uint32_t s[kAttestationSignatureComponentWords];
 } attestation_signature_t;
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -92,6 +92,7 @@ enum module_ {
   X(kErrorSigverifyBadRsaKey,         ERROR_(4, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadSpxKey,         ERROR_(5, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyLargeRsaSignature, ERROR_(6, kModuleSigverify, kInvalidArgument)), \
+  X(kErrorSigverifyBadEcdsaSignature,   ERROR_(7, kModuleSigverify, kInvalidArgument)), \
   \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
   \

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -17,31 +17,27 @@
 static_assert(kAttestationSeedWords <= 16,
               "Additional attestation seed needs must be <= 516 bits.");
 
-OTBN_DECLARE_APP_SYMBOLS(boot);           // The OTBN boot-services app.
-OTBN_DECLARE_SYMBOL_ADDR(boot, mode);     // Application mode.
-OTBN_DECLARE_SYMBOL_ADDR(boot, in_mod);   // RSA modulus.
-OTBN_DECLARE_SYMBOL_ADDR(boot, m0inv);    // RSA Montgomery constant.
-OTBN_DECLARE_SYMBOL_ADDR(boot, rsa_in);   // RSA input buffer.
-OTBN_DECLARE_SYMBOL_ADDR(boot, rsa_out);  // RSA output buffer.
-OTBN_DECLARE_SYMBOL_ADDR(boot, msg);      // ECDSA message digest.
-OTBN_DECLARE_SYMBOL_ADDR(boot, x);        // ECDSA public key x-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(boot, y);        // ECDSA public key y-coordinate.
-OTBN_DECLARE_SYMBOL_ADDR(boot, r);        // ECDSA signature component r.
-OTBN_DECLARE_SYMBOL_ADDR(boot, s);        // ECDSA signature component s.
+OTBN_DECLARE_APP_SYMBOLS(boot);        // The OTBN boot-services app.
+OTBN_DECLARE_SYMBOL_ADDR(boot, mode);  // Application mode.
+OTBN_DECLARE_SYMBOL_ADDR(boot, msg);   // ECDSA message digest.
+OTBN_DECLARE_SYMBOL_ADDR(boot, x);     // ECDSA public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(boot, y);     // ECDSA public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(boot, r);     // ECDSA signature component r.
+OTBN_DECLARE_SYMBOL_ADDR(boot, s);     // ECDSA signature component s.
+OTBN_DECLARE_SYMBOL_ADDR(boot, x_r);   // ECDSA verification result.
+OTBN_DECLARE_SYMBOL_ADDR(boot, ok);    // ECDSA verification status.
 OTBN_DECLARE_SYMBOL_ADDR(
     boot, attestation_additional_seed);  // Additional seed for ECDSA keygen.
 
 static const otbn_app_t kOtbnAppBoot = OTBN_APP_T_INIT(boot);
 static const otbn_addr_t kOtbnVarBootMode = OTBN_ADDR_T_INIT(boot, mode);
-static const otbn_addr_t kOtbnVarBootRsaMod = OTBN_ADDR_T_INIT(boot, in_mod);
-static const otbn_addr_t kOtbnVarBootRsaM0inv = OTBN_ADDR_T_INIT(boot, m0inv);
-static const otbn_addr_t kOtbnVarBootRsaIn = OTBN_ADDR_T_INIT(boot, rsa_in);
-static const otbn_addr_t kOtbnVarBootRsaOut = OTBN_ADDR_T_INIT(boot, rsa_out);
 static const otbn_addr_t kOtbnVarBootMsg = OTBN_ADDR_T_INIT(boot, msg);
 static const otbn_addr_t kOtbnVarBootX = OTBN_ADDR_T_INIT(boot, x);
 static const otbn_addr_t kOtbnVarBootY = OTBN_ADDR_T_INIT(boot, y);
 static const otbn_addr_t kOtbnVarBootR = OTBN_ADDR_T_INIT(boot, r);
 static const otbn_addr_t kOtbnVarBootS = OTBN_ADDR_T_INIT(boot, s);
+static const otbn_addr_t kOtbnVarBootXr = OTBN_ADDR_T_INIT(boot, x_r);
+static const otbn_addr_t kOtbnVarBootOk = OTBN_ADDR_T_INIT(boot, ok);
 static const otbn_addr_t kOtbnVarBootAttestationAdditionalSeed =
     OTBN_ADDR_T_INIT(boot, attestation_additional_seed);
 
@@ -51,11 +47,11 @@ enum {
    */
   kOtbnBootModeWords = 1,
   /*
-   * Mode to run RSA modular exponentiation.
+   * Mode to run signature verification.
    *
    * Value taken from `boot.s`.
    */
-  kOtbnBootModeSecBootModexp = 0x7d3,
+  kOtbnBootModeSigverify = 0x7d3,
   /*
    * Mode to generate an attestation keypair.
    *
@@ -247,42 +243,57 @@ rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
   // TODO(#20023): Check the instruction count register (see `mod_exp_otbn`).
 
   // Retrieve the signature (in two parts, r and s).
-  size_t half_num_words = kAttestationSignatureWords / 2;
-  HARDENED_RETURN_IF_ERROR(
-      otbn_dmem_read(half_num_words, kOtbnVarBootR, sig->r));
-  HARDENED_RETURN_IF_ERROR(
-      otbn_dmem_read(half_num_words, kOtbnVarBootS, sig->s));
+  HARDENED_RETURN_IF_ERROR(otbn_dmem_read(kAttestationSignatureComponentWords,
+                                          kOtbnVarBootR, sig->r));
+  HARDENED_RETURN_IF_ERROR(otbn_dmem_read(kAttestationSignatureComponentWords,
+                                          kOtbnVarBootS, sig->s));
 
   return kErrorOk;
 }
 
-rom_error_t otbn_boot_sigverify_mod_exp(const sigverify_rsa_key_t *key,
-                                        const sigverify_rsa_buffer_t *sig,
-                                        sigverify_rsa_buffer_t *result) {
+rom_error_t otbn_boot_sigverify(const attestation_public_key_t *key,
+                                const attestation_signature_t *sig,
+                                const hmac_digest_t *digest,
+                                uint32_t *recovered_r) {
   // Write the mode.
-  uint32_t mode = kOtbnBootModeSecBootModexp;
+  uint32_t mode = kOtbnBootModeSigverify;
   HARDENED_RETURN_IF_ERROR(
       otbn_dmem_write(kOtbnBootModeWords, &mode, kOtbnVarBootMode));
 
-  // Set the modulus (n).
+  // Write the public key.
   HARDENED_RETURN_IF_ERROR(
-      otbn_dmem_write(kSigVerifyRsaNumWords, key->n.data, kOtbnVarBootRsaMod));
-
-  // Set the signature.
+      otbn_dmem_write(kAttestationPublicKeyCoordWords, key->x, kOtbnVarBootX));
   HARDENED_RETURN_IF_ERROR(
-      otbn_dmem_write(kSigVerifyRsaNumWords, sig->data, kOtbnVarBootRsaIn));
+      otbn_dmem_write(kAttestationPublicKeyCoordWords, key->y, kOtbnVarBootY));
 
-  // Set the precomputed constant m0_inv.
-  HARDENED_RETURN_IF_ERROR(otbn_dmem_write(kOtbnWideWordNumWords, key->n0_inv,
-                                           kOtbnVarBootRsaM0inv));
+  // Write the message digest.
+  HARDENED_RETURN_IF_ERROR(
+      otbn_dmem_write(kHmacDigestNumWords, digest->digest, kOtbnVarBootMsg));
+
+  // Write the signature.
+  HARDENED_RETURN_IF_ERROR(otbn_dmem_write(kAttestationSignatureComponentWords,
+                                           sig->r, kOtbnVarBootR));
+  HARDENED_RETURN_IF_ERROR(otbn_dmem_write(kAttestationSignatureComponentWords,
+                                           sig->s, kOtbnVarBootS));
 
   // Start the OTBN routine.
   HARDENED_RETURN_IF_ERROR(otbn_execute());
   SEC_MMIO_WRITE_INCREMENT(kOtbnSecMmioExecute);
 
+  // Check if the signature passed basic checks.
+  uint32_t ok;
+  HARDENED_RETURN_IF_ERROR(otbn_dmem_read(1, kOtbnVarBootOk, &ok));
+  if (launder32(ok) != kHardenedBoolTrue) {
+    return kErrorSigverifyBadEcdsaSignature;
+  }
+
+  // Read the status value again as an extra hardening measure.
+  HARDENED_RETURN_IF_ERROR(otbn_dmem_read(1, kOtbnVarBootOk, &ok));
+  HARDENED_CHECK_EQ(ok, kHardenedBoolTrue);
+
   // TODO(#20023): Check the instruction count register (see `mod_exp_otbn`).
 
-  // Read recovered message out of OTBN dmem.
-  return otbn_dmem_read(kSigVerifyRsaNumWords, kOtbnVarBootRsaOut,
-                        result->data);
+  // Read the recovered `r` value from DMEM.
+  return otbn_dmem_read(kAttestationSignatureComponentWords, kOtbnVarBootXr,
+                        recovered_r);
 }

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -130,27 +130,27 @@ rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
                                           attestation_signature_t *sig);
 
 /**
- * Computes the modular exponentiation of an RSA signature on OTBN.
+ * Computes an ECDSA-P256 signature verification on OTBN.
  *
- * Given an RSA public key and sig, this function computes sig^e mod n using
- * Montgomery multiplication, where
- * - sig is an RSA signature,
- * - e and n are the exponent and the modulus of the key, respectively.
- *
- * The key exponent is always 65537; no other exponents are supported.
+ * May be used for code signatures as well as attestation signatures. Returns
+ * the recovered `r` value in `result`. The signature is valid if this `r`
+ * value matches the `r` component of the signature, but the caller is
+ * responsible for the final comparison.
  *
  * Expects the OTBN boot-services program to already be loaded; see
  * `otbn_boot_app_load`.
  *
- * @param key An RSA public key.
- * @param sig Buffer that holds the signature, little-endian.
- * @param[out] result Buffer to write the result to, little-endian.
+ * @param key An ECDSA-P256 public key.
+ * @param sig An ECDSA-P256 signature.
+ * @param digest Message digest to check against.
+ * @param[out] recovered_r Buffer for the recovered `r` value.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t otbn_boot_sigverify_mod_exp(const sigverify_rsa_key_t *key,
-                                        const sigverify_rsa_buffer_t *sig,
-                                        sigverify_rsa_buffer_t *result);
+rom_error_t otbn_boot_sigverify(const attestation_public_key_t *key,
+                                const attestation_signature_t *sig,
+                                const hmac_digest_t *digest,
+                                uint32_t *recovered_r);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
@@ -20,80 +20,24 @@ OTTF_DEFINE_TEST_CONFIG();
 // Keymgr handle for this test.
 static dif_keymgr_t keymgr;
 
-// sw/device/silicon_creator/rom/keys/fake/test_key_0_rsa_3072_exp_f4.public.der
-static const sigverify_rsa_key_t kRsaKey = {
-    .n = {{
-        0x5801a2bd, 0xeff64a46, 0xc8cf2251, 0xa7cd62cb, 0x634a39c2, 0x55c936d3,
-        0x463d61fc, 0x762ebbaa, 0x01aadfb2, 0x23da15d1, 0x8475fdc6, 0x4ec67b7b,
-        0xe9364570, 0xd23ec7c7, 0x98038d63, 0x5688a56b, 0x68037add, 0xb20ff289,
-        0x9d96c1ce, 0xbac0b8cd, 0xead33d0b, 0x195f89c8, 0xd7dc110e, 0xf5bccc12,
-        0x8dfa33dc, 0xedc404d2, 0x74ef8524, 0x9197c0c8, 0x79cc448e, 0x4c9c505d,
-        0x4a586ad7, 0xe2d0f071, 0x589f28c2, 0x2ca7fc22, 0x0354b0e2, 0xefb63b44,
-        0x33a75b04, 0x9e194454, 0x1b4b2cde, 0x8e3f78e0, 0x5260877c, 0x05685b72,
-        0x4868ad4e, 0x10303ac9, 0x05ac2411, 0x5e797381, 0xd5407668, 0xe3522348,
-        0xa33134f8, 0x38f7a953, 0xd926f672, 0x136f6753, 0xb186b0ab, 0x5ccab586,
-        0x61e5bf2e, 0x9fc0eebb, 0x788ed0bd, 0x47b5fc70, 0xf971262a, 0x3b40d99b,
-        0x5b9fd926, 0xce3c93bf, 0xd406005e, 0x72b9e555, 0xc9b9273e, 0xfcef747f,
-        0xf0a35598, 0x2761e8f6, 0xec1799df, 0x462bc52d, 0x8e47218b, 0x429ccdae,
-        0xe7e7d66c, 0x70c70b03, 0x0356c3d2, 0x3cb3e7d1, 0xd42d035d, 0x83c529a3,
-        0x8df9930e, 0xb082e1f0, 0x07509c30, 0x5c33a350, 0x4f6884b9, 0x7b9d2de0,
-        0x0f1d16b3, 0x38dbcf55, 0x168580ea, 0xc2f2aca4, 0x43f0ae60, 0x227dd2ed,
-        0xd8dc61f4, 0x9404e8bc, 0x0db76fe3, 0x3491d3b0, 0x6ca44e27, 0xcda63719,
-    }},
-    .n0_inv =
-        {
-            0x9c9a176b,
-            0x44d6fa52,
-            0x71a63ec4,
-            0xadc94595,
-            0x3fd9bc73,
-            0xa83cdc95,
-            0xbe1bc819,
-            0x2b421fae,
-        },
+// Message value for signature generation/verification tests.
+const char kTestMessage[] = "Test message.";
+const size_t kTestMessageLen = sizeof(kTestMessage) - 1;
+
+// Valid ECDSA-P256 public key.
+static const attestation_public_key_t kEcdsaKey = {
+    .x = {0x1ceb402b, 0x9dc600d1, 0x182ec21b, 0x5ede3640, 0x3566bdac,
+          0x1debf94b, 0x1a286a75, 0x8904d749},
+    .y = {0x63eab6dc, 0x0c53bf99, 0x086d3ee7, 0x1076efa6, 0x8dd8ece2,
+          0xbfececf0, 0x9b94e34d, 0x59b12f3c},
 };
 
-// Signature for "test message".
-static const sigverify_rsa_buffer_t kRsaSignature = {
-    .data = {
-        0x725bfa2c, 0xdb359e00, 0x4dd50e25, 0x344ce68a, 0x2d49dc6b, 0x4a53a013,
-        0x2abd4a7c, 0x762dd4aa, 0xe1935a41, 0xb807b2c2, 0xdf0222d7, 0x2dc12fdf,
-        0xe432fb54, 0x2a12e15d, 0xf290eb01, 0x2529d6d4, 0x0813ab70, 0x78bd8229,
-        0x63f3064e, 0x1cceba14, 0x4beff42b, 0xb9e98de4, 0x84a7f442, 0xb03649bc,
-        0x7726af3d, 0xeaf2656d, 0xf82f963b, 0x31082a3d, 0x194ff701, 0x86588b75,
-        0x5732f5de, 0x35d14195, 0x262c612d, 0x3f66ce59, 0xa2742c75, 0x276341fb,
-        0x8cb84d0a, 0x1222f7f6, 0xbbd8ec56, 0x36e629b1, 0x891fd231, 0xfb351d0c,
-        0x598dab98, 0x64534c32, 0xbcc39e4c, 0x256e4544, 0x3a3205ab, 0x02c5878c,
-        0x99a7e70a, 0xc65c4d5d, 0xe5bedc24, 0x83de5d15, 0x16429111, 0x05d0b216,
-        0xbf8d4dfe, 0x4be3707f, 0x004d6b75, 0xd64b4c66, 0x6e9e4375, 0xa5e1fc9f,
-        0x4ca3c8f2, 0x544cf3d2, 0x34767ef2, 0xc361639c, 0x6062f836, 0x558ebb62,
-        0xec7ee0af, 0x11033e71, 0x873742d3, 0x0ad49285, 0x6f163385, 0xd880305f,
-        0x76e79003, 0x2bd4c955, 0x4a00fd2a, 0x7a045dd4, 0xdf671f3f, 0xd986e081,
-        0x96cfc193, 0xd211ece5, 0x4486f7cb, 0x47be12f5, 0xe513619c, 0xe1a5f41c,
-        0xbc4fbcb3, 0x78b903b7, 0xc8dcbff8, 0x5c088a19, 0x66301acc, 0x12b05bf9,
-        0xa9c795a9, 0xe229e3ca, 0xe928d10b, 0x96eda9d9, 0x162f4a58, 0x069b950c,
-    }};
-
-// Expected encoded message = (sig ^ 65537) mod N.
-static const sigverify_rsa_buffer_t kRsaExpEncodedMessage = {
-    .data = {
-        0x05468728, 0x3ed0c5ca, 0x025d4fda, 0xcfa3e704, 0x507ce0d8, 0xecb616f6,
-        0xa0a4a460, 0x3f0a377b, 0x05000420, 0x03040201, 0x86480165, 0x0d060960,
-        0x00303130, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
-        0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0x0001ffff,
-    }};
+// Valid ECDSA-P256 signature for `kTestMessage`.
+static const attestation_signature_t kEcdsaSignature = {
+    .r = {0x4811545a, 0x088d927b, 0x5d8624b5, 0x2ef1f329, 0x184ba14a,
+          0xf655eede, 0xaaed0d54, 0xa20e1ac7},
+    .s = {0x729b945d, 0x181dc116, 0x1025dba4, 0xb99828a0, 0xe7225df3,
+          0x0e200e9b, 0x785690b4, 0xf47efe98}};
 
 // Sample key manager diversification data for testing.
 static const keymgr_diversification_t kDiversification = {
@@ -104,54 +48,25 @@ static const keymgr_diversification_t kDiversification = {
 
 // Test values for attestation key seeds.
 static const uint32_t kSeedValues[3][kAttestationSeedWords] = {
-    {
-        0x70717273,
-        0x74757677,
-        0x78797a7b,
-        0x7c7d7e7f,
-        0x80818283,
-        0x84858687,
-        0x88898a8b,
-        0x8c8d8e8f,
-        0x90b1b2b3,
-        0x94959697,
-    },
-    {
-        0xa0a1a2a3,
-        0xa4a5a6a7,
-        0xa8a9aaab,
-        0xacadaeaf,
-        0xb0b1b2b3,
-        0xb4b5b6b7,
-        0xb8b9babb,
-        0xbcbdbebf,
-        0xc0b1b2b3,
-        0xc4c5c6c7,
-    },
-    {
-        0xd0d1d2d3,
-        0xd4d5d6d7,
-        0xd8d9dadb,
-        0xdcdddedf,
-        0xe0e1e2e3,
-        0xe4e5e6e7,
-        0xe8e9eaeb,
-        0xecedeeef,
-        0xf0b1b2b3,
-        0xf4f5f6f7,
-    },
+    {0x70717273, 0x74757677, 0x78797a7b, 0x7c7d7e7f, 0x80818283, 0x84858687,
+     0x88898a8b, 0x8c8d8e8f, 0x90b1b2b3, 0x94959697},
+    {0xa0a1a2a3, 0xa4a5a6a7, 0xa8a9aaab, 0xacadaeaf, 0xb0b1b2b3, 0xb4b5b6b7,
+     0xb8b9babb, 0xbcbdbebf, 0xc0b1b2b3, 0xc4c5c6c7},
+    {0xd0d1d2d3, 0xd4d5d6d7, 0xd8d9dadb, 0xdcdddedf, 0xe0e1e2e3, 0xe4e5e6e7,
+     0xe8e9eaeb, 0xecedeeef, 0xf0b1b2b3, 0xf4f5f6f7},
 };
 
-// Message to sign for endorsement tests.
-const char kEndorseTestMessage[] = "Test message.";
-const size_t kEndorseTestMessageLen = sizeof(kEndorseTestMessage) - 1;
+rom_error_t sigverify_test(void) {
+  // Hash the test message.
+  hmac_digest_t digest;
+  hmac_sha256(kTestMessage, kTestMessageLen, &digest);
 
-rom_error_t modexp_test(void) {
-  sigverify_rsa_buffer_t encoded_message;
+  // The recovered `r` value from sigverify should be equal to the signature
+  // `r` value.
+  uint32_t recovered_r[kAttestationSignatureComponentWords];
   RETURN_IF_ERROR(
-      otbn_boot_sigverify_mod_exp(&kRsaKey, &kRsaSignature, &encoded_message));
-  CHECK_ARRAYS_EQ(encoded_message.data, kRsaExpEncodedMessage.data,
-                  ARRAYSIZE(kRsaExpEncodedMessage.data));
+      otbn_boot_sigverify(&kEcdsaKey, &kEcdsaSignature, &digest, recovered_r));
+  CHECK_ARRAYS_EQ(recovered_r, kEcdsaSignature.r, ARRAYSIZE(kEcdsaSignature.r));
   return kErrorOk;
 }
 
@@ -222,36 +137,22 @@ rom_error_t attestation_advance_and_endorse_test(void) {
 
   // Run endorsement (should overwrite the key with randomness when done).
   hmac_digest_t digest;
-  hmac_sha256(kEndorseTestMessage, kEndorseTestMessageLen, &digest);
+  hmac_sha256(kTestMessage, kTestMessageLen, &digest);
   attestation_signature_t sig;
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
 
-  // TODO: run an ECDSA signature verification here once we have code for that.
-  // For now, just log the key and signature so we can check offline.
-  LOG_INFO("x = 0x%08x%08x%08x%08x%08x%08x%08x%08x", pk.x[7], pk.x[6], pk.x[5],
-           pk.x[4], pk.x[3], pk.x[2], pk.x[1], pk.x[0]);
-  LOG_INFO("y = 0x%08x%08x%08x%08x%08x%08x%08x%08x", pk.y[7], pk.y[6], pk.y[5],
-           pk.y[4], pk.y[3], pk.y[2], pk.y[1], pk.y[0]);
-  LOG_INFO("digest = 0x%08x%08x%08x%08x%08x%08x%08x%08x", digest.digest[7],
-           digest.digest[6], digest.digest[5], digest.digest[4],
-           digest.digest[3], digest.digest[2], digest.digest[1],
-           digest.digest[0]);
-  LOG_INFO("Signature (expected valid):");
-  LOG_INFO("r = 0x%08x%08x%08x%08x%08x%08x%08x%08x", sig.r[7], sig.r[6],
-           sig.r[5], sig.r[4], sig.r[3], sig.r[2], sig.r[1], sig.r[0]);
-  LOG_INFO("s = 0x%08x%08x%08x%08x%08x%08x%08x%08x", sig.s[7], sig.s[6],
-           sig.s[5], sig.s[4], sig.s[3], sig.s[2], sig.s[1], sig.s[0]);
+  // Check that the signature is valid (recovered r == r).
+  uint32_t recovered_r[kAttestationSignatureComponentWords];
+  RETURN_IF_ERROR(otbn_boot_sigverify(&pk, &sig, &digest, recovered_r));
+  CHECK_ARRAYS_EQ(recovered_r, sig.r, ARRAYSIZE(sig.r));
 
   // Run endorsement again (should not return an error, but should produce an
   // invalid signature).
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
 
-  // TODO: run an ECDSA signature verification here once we have code for that.
-  LOG_INFO("Signature (expected invalid):");
-  LOG_INFO("r = 0x%08x%08x%08x%08x%08x%08x%08x%08x", sig.r[7], sig.r[6],
-           sig.r[5], sig.r[4], sig.r[3], sig.r[2], sig.r[1], sig.r[0]);
-  LOG_INFO("s = 0x%08x%08x%08x%08x%08x%08x%08x%08x", sig.s[7], sig.s[6],
-           sig.s[5], sig.s[4], sig.s[3], sig.s[2], sig.s[1], sig.s[0]);
+  // Check that the signature is invalid (recovered r != r).
+  RETURN_IF_ERROR(otbn_boot_sigverify(&pk, &sig, &digest, recovered_r));
+  CHECK_ARRAYS_NE(recovered_r, sig.r, ARRAYSIZE(sig.r));
 
   return kErrorOk;
 }
@@ -269,14 +170,14 @@ rom_error_t attestation_save_clear_key_test(void) {
       kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice,
       kDiversification));
   hmac_digest_t digest;
-  hmac_sha256(kEndorseTestMessage, kEndorseTestMessageLen, &digest);
+  hmac_sha256(kTestMessage, kTestMessageLen, &digest);
   attestation_signature_t sig;
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
 
   // Clear the key and check that endorsing now fails (it should even lock
   // OTBN).
   RETURN_IF_ERROR(otbn_boot_attestation_key_clear());
-  hmac_sha256(kEndorseTestMessage, kEndorseTestMessageLen, &digest);
+  hmac_sha256(kTestMessage, kTestMessageLen, &digest);
   CHECK(otbn_boot_attestation_endorse(&digest, &sig) ==
         kErrorOtbnExecutionFailed);
   return kErrorOk;
@@ -327,7 +228,7 @@ bool test_main(void) {
   // Load the boot services OTBN app.
   CHECK(otbn_boot_app_load() == kErrorOk);
 
-  EXECUTE_TEST(result, modexp_test);
+  EXECUTE_TEST(result, sigverify_test);
   EXECUTE_TEST(result, attestation_keygen_test);
   EXECUTE_TEST(result, attestation_advance_and_endorse_test);
   EXECUTE_TEST(result, attestation_save_clear_key_test);

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -33,13 +33,19 @@ cc_library(
     name = "ecdsa",
     srcs = ["ecdsa.c"],
     hdrs = ["ecdsa.h"],
-    defines = ["USE_CRYPTOC=1"],
+    defines = [
+        "USE_OTBN=1",
+        #"USE_CRYPTOC=1",
+    ],
     deps = [
         ":datatypes",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/drivers:hmac",
-        "//sw/vendor:cryptoc",
+        "//sw/device/silicon_creator/lib:otbn_boot_services",
+        #"//sw/vendor:cryptoc",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/ownership/ecdsa.c
+++ b/sw/device/silicon_creator/lib/ownership/ecdsa.c
@@ -6,9 +6,12 @@
 
 #include <stdbool.h>
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
-#ifdef USE_CRYPTOC
+#if USE_OTBN == 1
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+#elif USE_CRYPTOC == 1
 // TODO(cfrantz): Replace the CryptoC implementation with a native OpenTitan
 // implementation.
 #include "sw/vendor/cryptoc/include/cryptoc/p256.h"
@@ -25,10 +28,29 @@ OT_WEAK void __assert_func(const char *file, int line, const char *func,
 #error "No ECDSA implementation for lib/ownership."
 #endif
 
+rom_error_t ecdsa_init(void) {
+#if USE_OTBN == 1
+  return otbn_boot_app_load();
+#elif USE_CRYPTOC == 1
+  return kErrorOk;
+#endif
+}
+
 hardened_bool_t ecdsa_verify_digest(const owner_key_t *pubkey,
                                     const owner_signature_t *signature,
                                     const hmac_digest_t *digest) {
-#ifdef USE_CRYPTOC
+#if USE_OTBN == 1
+  const attestation_public_key_t *key =
+      (const attestation_public_key_t *)pubkey;
+  const attestation_signature_t *sig =
+      (const attestation_signature_t *)signature;
+  uint32_t rr[8];
+  rom_error_t error = otbn_boot_sigverify(key, sig, digest, rr);
+  if (error != kErrorOk) {
+    return kHardenedBoolFalse;
+  }
+  return hardened_memeq(sig->r, rr, ARRAYSIZE(rr));
+#elif USE_CRYPTOC == 1
   const p256_int *x = (const p256_int *)&pubkey->key[0];
   const p256_int *y = (const p256_int *)&pubkey->key[8];
   const p256_int *r = (const p256_int *)&signature->signature[0];

--- a/sw/device/silicon_creator/lib/ownership/ecdsa.h
+++ b/sw/device/silicon_creator/lib/ownership/ecdsa.h
@@ -9,11 +9,17 @@
 
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Initializes ECDSA crypto.
+ */
+rom_error_t ecdsa_init(void);
 
 /**
  * Verifies an ECDSA P-256 signature.

--- a/sw/device/silicon_creator/lib/ownership/ecdsa_functest.c
+++ b/sw/device/silicon_creator/lib/ownership/ecdsa_functest.c
@@ -60,6 +60,11 @@ void __assert_func(const char *file, int line, const char *func,
   abort();
 }
 
+static status_t initialize(void) {
+  TRY(ecdsa_init());
+  return OK_STATUS();
+}
+
 // Tests that we can verify an ECDSA signature given the digest.
 status_t ecdsa_verify_digest_test(void) {
   hmac_digest_t digest;
@@ -88,7 +93,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
-  status_t result = OK_STATUS();
+  status_t result = initialize();
   EXECUTE_TEST(result, ecdsa_verify_digest_test);
   EXECUTE_TEST(result, ecdsa_verify_message_test);
   return status_ok(result);

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
@@ -180,5 +180,20 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
   return sigverify_encoded_message_check(&enc_msg, act_digest, flash_exec);
 }
 
+rom_error_t sigverify_rsa_verify_ibex(const sigverify_rsa_buffer_t *signature,
+                                      const sigverify_rsa_key_t *key,
+                                      const hmac_digest_t *act_digest,
+                                      lifecycle_state_t lc_state,
+                                      uint32_t *flash_exec) {
+  sigverify_rsa_buffer_t enc_msg;
+  rom_error_t error = sigverify_mod_exp_ibex(key, signature, &enc_msg);
+  if (launder32(error) != kErrorOk) {
+    *flash_exec ^= UINT32_MAX;
+    return error;
+  }
+  HARDENED_CHECK_EQ(error, kErrorOk);
+  return sigverify_encoded_message_check(&enc_msg, act_digest, flash_exec);
+}
+
 // Extern declarations for the inline functions in the header.
 extern uint32_t sigverify_rsa_success_to_ok(uint32_t v);

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.h
@@ -43,6 +43,25 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
                                  uint32_t *flash_exec);
 
 /**
+ * Verifies an RSASSA-PKCS1-v1_5 signature.
+ *
+ * This function uses the Ibex software implementation only.
+ *
+ * @param signature Signature to be verified.
+ * @param key Signer's RSA public key.
+ * @param act_digest Actual digest of the message being verified.
+ * @param lc_state Life cycle state of the device.
+ * @param[out] flash_exec Value to write to the flash_ctrl EXEC register.
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sigverify_rsa_verify_ibex(const sigverify_rsa_buffer_t *signature,
+                                      const sigverify_rsa_key_t *key,
+                                      const hmac_digest_t *act_digest,
+                                      lifecycle_state_t lc_state,
+                                      uint32_t *flash_exec);
+
+/**
  * Transforms `kSigverifyRsaSuccess` into `kErrorOk`.
  *
  * Callers should transform the result to a suitable error value if it is not

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -280,10 +280,6 @@ static rom_error_t rom_ext_attestation_keygen(
     const manifest_t *owner_manifest) {
   hardened_bool_t curr_cert_valid = kHardenedBoolFalse;
 
-  // Load OTBN attestation keygen program.
-  // TODO(#21550): this should already be loaded by the ROM.
-  HARDENED_RETURN_IF_ERROR(otbn_boot_app_load());
-
   // Configure certificate flash info pages.
   flash_ctrl_cert_info_pages_creator_cfg();
 
@@ -765,6 +761,10 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log->rom_ext_nonce = boot_data->nonce;
   boot_log->ownership_state = boot_data->ownership_state;
   boot_log->ownership_transfers = boot_data->ownership_transfers;
+
+  // Load OTBN attestation keygen program.
+  // TODO(#21550): this should already be loaded by the ROM.
+  HARDENED_RETURN_IF_ERROR(otbn_boot_app_load());
 
   // Initialize the chip ownership state.
   HARDENED_RETURN_IF_ERROR(ownership_init());

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -250,8 +250,8 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
   hmac_sha256_final(&act_digest);
 
   uint32_t flash_exec = 0;
-  return sigverify_rsa_verify(&manifest->rsa_signature, key, &act_digest,
-                              lc_state, &flash_exec);
+  return sigverify_rsa_verify_ibex(&manifest->rsa_signature, key, &act_digest,
+                                   lc_state, &flash_exec);
 }
 
 /**

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -13,9 +13,9 @@ otbn_binary(
     ],
     deps = [
         ":p256_base",
+        ":p256_isoncurve",
         ":p256_sign",
-        ":rsa_verify_3072",
-        ":rsa_verify_3072_rr",
+        ":p256_verify",
     ],
 )
 

--- a/sw/otbn/crypto/p256_base.s
+++ b/sw/otbn/crypto/p256_base.s
@@ -813,107 +813,97 @@ proj_to_affine:
   bn.mov    w13, w19
 
   /* w14 <= z^(2^6 - 1) = x6 */
-  loopi     3, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     3, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w13
   jal       x1, mul_modp
   bn.mov    w14, w19
 
   /* w15 <= z^(2^12 - 1) = x12 */
-  loopi     6, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     6, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w14
   jal       x1, mul_modp
   bn.mov    w15, w19
 
   /* w16 <= z^(2^15 - 1) = x15 */
-  loopi     3, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     3, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w13
   jal       x1, mul_modp
   bn.mov    w16, w19
 
   /* w17 <= z^(2^30 - 1) = x30 */
-  loopi     15, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     15, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w16
   jal       x1, mul_modp
   bn.mov    w17, w19
 
   /* w18 <= z^(2^32 - 1) = x32 */
-  loopi     2, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     2, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w12
   jal       x1, mul_modp
   bn.mov    w18, w19
 
   /* w19 <= z^(2^64 - 2^32 + 1) */
-  loopi     32, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     32, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w10
   jal       x1, mul_modp
 
   /* w19 <= z^(2^192 - 2^160 + 2^128 + 2^32 - 1) */
-  loopi     128, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     128, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w18
   jal       x1, mul_modp
 
   /* w19 <= z^(2^224 - 2^192 + 2^160 + 2^64 + 1) */
-  loopi     32, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     32, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w18
   jal       x1, mul_modp
 
   /* w19 <= z^(2^254 - 2^222 + 2^190 + 2^94 - 1) */
-  loopi     30, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     30, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w17
   jal       x1, mul_modp
 
   /* w14 <= z^(2^256 - 2^224 + 2^192 + 2^96 - 2^2 + 1) = z^(p-2) */
-  loopi     2, 4
-    bn.mov    w24, w19
+  bn.mov    w24, w19
+  loopi     2, 3
     bn.mov    w25, w19
     jal       x1, mul_modp
-    nop
-  bn.mov    w24, w19
+    bn.mov    w24, w19
   bn.mov    w25, w10
   jal       x1, mul_modp
   bn.mov    w14, w19

--- a/sw/otbn/crypto/p256_base.s
+++ b/sw/otbn/crypto/p256_base.s
@@ -260,10 +260,8 @@ mod_mul_256x256:
      over from the multiplication routine. */
   bn.sel    w22, w28, w31, M
 
-  /* Reduce product modulo m. */
-  jal       x1, p256_reduce
-
-  ret
+  /* Reduce product modulo m (tail-call). */
+  jal       x0, p256_reduce
 
 /**
  * 320- by 128-bit modular multiplication for P-256 coordinate and scalar fields.
@@ -312,10 +310,8 @@ mod_mul_320x128:
      over from the multiplication routine. */
   bn.sel    w22, w28, w31, M
 
-  /* Reduce product modulo m. */
-  jal       x1, p256_reduce
-
-  ret
+  /* Reduce product modulo m (tail-call). */
+  jal       x0, p256_reduce
 
 /**
  * 256-bit modular multiplication for P-256 coordinate field.
@@ -1091,11 +1087,10 @@ proj_double:
   bn.mov    w12, w9
   bn.mov    w13, w10
 
-  /* R = (x_r, y_r, z_r) = (w11, w12, w13) = P+Q
+  /* Tail-call to addition.
+     R = (x_r, y_r, z_r) = (w11, w12, w13) = P+Q
        = (w8, w9, w10) + (w11, w12, w13) = (x_p, y_p, z_p) + (x_q, y_q, z_q) */
-  jal       x1, proj_add
-
-  ret
+  jal       x0, proj_add
 
 
 /**
@@ -1280,13 +1275,11 @@ scalar_mult_int:
 
   /* Check if the z-coordinate of Q is 0. If so, fail; this represents the
      point at infinity and means the scalar was zero mod n, which likely
-     indicates a fault attack.
+     indicates a fault attack. Tail-call.
 
      FG0.Z <= if (w10 == 0) then 1 else 0 */
   bn.cmp    w10, w31
-  jal       x1, trigger_fault_if_fg0_z
-
-  ret
+  jal       x0, trigger_fault_if_fg0_z
 
 /**
  * P-256 scalar multiplication with base point G


### PR DESCRIPTION
Since we are planning to do away with RSA signatures in favor of ECDSA signatures, we can use Ibex for RSA verification until we fully eliminate the use of RSA.  This important temporary measure allows us to bring the full ECDSA OTBN program into the ROM_EXT and use it for ECDSA verification of ownership transfer operations.

1. Switch RSA sigverify of the owner application firmware over to Ibex-based verification.
2. Cherry-pick jadephilipoom's OTBN P-256 implementation.
3. Use the OTBN implementation for ownership-related verification, thus eliminating CryptoC and saving 12K of flash space.