### PR TITLE
[spi_host] Disable FWFT for the command queue

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_command_queue.sv
+++ b/hw/ip/spi_host/rtl/spi_host_command_queue.sv
@@ -37,7 +37,7 @@ module spi_host_command_queue #(
 
   prim_fifo_sync #(
     .Width(spi_host_cmd_pkg::CmdSize),
-    .Pass(1),
+    .Pass(0),
     .Depth(CmdDepth)
   ) cmd_fifo (
     .clk_i,


### PR DESCRIPTION
Eliminate First Word Fallthrough for the command queue. It was concatenating the bus-write-to-CSR path with the SPI-command-to-I/O-port path, creating an unnecessarily long path for timing.