### PR TITLE
Certificate signing with Google Cloud KMS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -142,3 +142,6 @@ build --output_groups=+modid_checks
 
 # Import site-specific configuration.
 try-import .bazelrc-site
+
+# Shortcut for enabling Cloud KMS certificate endorsement during test
+build --flag_alias=ckms_cert_endorsement=//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:endorse_certs_with_ckms

--- a/sw/device/silicon_creator/manuf/keys/fake/BUILD
+++ b/sw/device/silicon_creator/manuf/keys/fake/BUILD
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "cert_endorsement_key.sk.der",
+    "ckms_ca.pem",
     "fake_ca.pem",
     "rma_unlock_token_export_key.sk_hsm.der",
 ])

--- a/sw/device/silicon_creator/manuf/keys/fake/gen_fake_ca.sh
+++ b/sw/device/silicon_creator/manuf/keys/fake/gen_fake_ca.sh
@@ -9,13 +9,13 @@
 # a key stored in Google Cloud KMS.
 #
 # Signing with Cloud KMS requires the following:
-# - a Google KMS intergration  library
-#   (https://github.com/GoogleCloudPlatform/kms-integrations) moudle
-# - a configuraton file describing the Cloud KMS project contaning the key.
+# - a Google KMS integration  library
+#   (https://github.com/GoogleCloudPlatform/kms-integrations) module
+# - a configuration file describing the Cloud KMS project containing the key.
 #
 # PKCS11_MODULE_PATH and KMS_PKCS11_CONFIG environment variables are set to
 # point at these objects. If both variables are present the script attempts to
-# geenrate a Cloud KMS signed ceritficate.
+# generate a Cloud KMS signed certificate.
 #
 # The generated certificates are named fake_ca and ckms_ca and are saved in both
 # DER and PEM forms, certificate file names are printed by this script upon

--- a/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
@@ -22,6 +22,7 @@ CP_PROVISIONING_INPUTS = _DEVICE_ID_AND_TEST_TOKENS + """
 FT_PERSONALIZE_KEYS = [
     "//sw/device/silicon_creator/manuf/keys/fake:cert_endorsement_key.sk.der",
     "//sw/device/silicon_creator/manuf/keys/fake:fake_ca.pem",
+    "//sw/device/silicon_creator/manuf/keys/fake:ckms_ca.pem",
     "//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der",
 ]
 
@@ -29,14 +30,23 @@ FT_PERSONALIZE_KEYS = [
 FT_PROVISIONING_INPUTS = _DEVICE_ID_AND_TEST_TOKENS + """
   --target-mission-mode-lc-state="prod"
   --host-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der)"
-  --cert-endorsement-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:cert_endorsement_key.sk.der)"
   --rom-ext-measurement="0x11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111"
   --owner-manifest-measurement="0x22222222_22222222_22222222_22222222_22222222_22222222_22222222_22222222"
   --owner-measurement="0x33333333_33333333_33333333_33333333_33333333_33333333_33333333_33333333"
-  --uds-auth-key-id="0xfe584ae7_53790cfd_8601a312_fb32d3c1_b822d112"
   --rom-ext-security-version="0"
   --owner-security-version="0"
+"""
+
+LOCAL_CERT_ENDORSEMENT_PARAMS = """
+  --cert-endorsement-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:cert_endorsement_key.sk.der)"
+  --uds-auth-key-id="0xfe584ae7_53790cfd_8601a312_fb32d3c1_b822d112"
   --ca-certificate="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:fake_ca.pem)"
+"""
+
+CLOUD_KMS_CERT_ENDORSEMENT_PARAMS = """
+  --uds-auth-key-id="0x40aac5fb_2b1205f9_003f40ab_7f3df784_1d5b59f5"
+  --ca-certificate="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:ckms_ca.pem)"
+  --ckms-ecc-key-id="gcs-kms-earlgrey-ze-ca-p256-sha256-key"
 """
 
 # TODO(#22780): Integrate real keys for A1 flows.

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -11,12 +11,15 @@ load(
 )
 load(
     "//sw/device/silicon_creator/manuf:provisioning_inputs.bzl",
+    "CLOUD_KMS_CERT_ENDORSEMENT_PARAMS",
     "CP_PROVISIONING_INPUTS",
     "EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS",
     "FT_PERSONALIZE_KEYS",
     "FT_PERSONALIZE_SIGNING_KEYS",
     "FT_PROVISIONING_INPUTS",
+    "LOCAL_CERT_ENDORSEMENT_PARAMS",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -256,10 +259,23 @@ _FT_PROVISIONING_BINARIES = {
     ":ft_personalize": "ft_personalize",
 }
 
+config_setting(
+    name = "ckms_cert_endorsement_params",
+    flag_values = {":endorse_certs_with_ckms": "True"},
+)
+
+bool_flag(
+    name = "endorse_certs_with_ckms",
+    build_setting_default = False,
+)
+
 _FT_PROVISIONING_CMD_ARGS = """
   --elf={sram_ft_individualize}
   --bootstrap={ft_personalize}
-""" + FT_PROVISIONING_INPUTS
+""" + FT_PROVISIONING_INPUTS + select({
+    ":ckms_cert_endorsement_params": CLOUD_KMS_CERT_ENDORSEMENT_PARAMS,
+    "//conditions:default": LOCAL_CERT_ENDORSEMENT_PARAMS,
+})
 
 _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
 

--- a/sw/host/provisioning/ft_lib/BUILD
+++ b/sw/host/provisioning/ft_lib/BUILD
@@ -9,7 +9,11 @@ package(default_visibility = ["//visibility:public"])
 rust_library(
     name = "ft_lib",
     srcs = ["src/lib.rs"],
-    data = ["//sw/device/silicon_creator/manuf/keys/fake:fake_ca.pem"],
+    data = [
+        "//sw/device/silicon_creator/manuf/keys/fake:cert_endorsement_key.sk.der",
+        "//sw/device/silicon_creator/manuf/keys/fake:ckms_ca.pem",
+        "//sw/device/silicon_creator/manuf/keys/fake:fake_ca.pem",
+    ],
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/ot_certs",
@@ -22,6 +26,7 @@ rust_library(
         "@crate_index//:hex",
         "@crate_index//:log",
         "@crate_index//:num-bigint-dig",
+        "@crate_index//:openssl",
         "@crate_index//:p256",
         "@crate_index//:serde",
         "@crate_index//:serde_json",


### PR DESCRIPTION
the first patch of the two patchsets of this PR was submitted as a separate PR (https://github.com/lowRISC/opentitan/pull/23066)  and will be updated here if the review of 23066 calls for modifications.

The second patch implements support of two modes of certificate signing, either using a local private key (test mode), or a key stored in Google Cloud KMS (ckms). Signing mode is picked based on which key parameter is passed to the signing utility.

Testing of both modes is supported, by default local key mode is used, adding `--define  cert_signer=cloud_kms` to test invocation will trigger testing the Cloud KMS based signign.