### PR TITLE
[keymgr] Don't update and reseed PRNG in Disabled/Invalid state forever

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -185,6 +185,7 @@ module keymgr
   logic [LfsrWidth-1:0] seed;
   logic reseed_req;
   logic reseed_ack;
+  logic reseed_done;
   logic reseed_cnt_err;
 
   keymgr_reseed_ctrl u_reseed_ctrl (
@@ -194,6 +195,7 @@ module keymgr
     .rst_edn_ni,
     .reseed_req_i(reseed_req),
     .reseed_ack_o(reseed_ack),
+    .reseed_done_o(reseed_done),
     .reseed_interval_i(reg2hw.reseed_interval_shadowed.q),
     .edn_o,
     .edn_i,
@@ -285,6 +287,7 @@ module keymgr
     .sideload_fsm_err_i(sideload_fsm_err),
     .prng_reseed_req_o(reseed_req),
     .prng_reseed_ack_i(reseed_ack),
+    .prng_reseed_done_i(reseed_done),
     .prng_en_o(ctrl_lfsr_en),
     .entropy_i(ctrl_rand),
     .op_i(keymgr_ops_e'(reg2hw.control_shadowed.operation.q)),

--- a/hw/ip/keymgr/rtl/keymgr_reseed_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reseed_ctrl.sv
@@ -16,6 +16,7 @@ module keymgr_reseed_ctrl import keymgr_pkg::*; (
   // interface to keymgr_ctrl
   input reseed_req_i,
   output logic reseed_ack_o,
+  output logic reseed_done_o,
 
   // interface to software
   input [15:0] reseed_interval_i,
@@ -57,6 +58,7 @@ module keymgr_reseed_ctrl import keymgr_pkg::*; (
 
   assign seed_en_o = edn_ack;
   assign reseed_ack_o = reseed_req_i & edn_ack;
+  assign reseed_done_o = edn_done;
 
   prim_edn_req #(
     .OutWidth(LfsrWidth)


### PR DESCRIPTION
Previously, keymgr would keep updating and reseeding the PRNG forever once entering the StCtrlDisabled or StCtrlInvalid state. This is not ideal from an entropy and power consumption viewpoint.

This commit changes the design to - once one of the two states is entered - to keep updating the PRNG (which also triggers the reseed operation) until two more PRNG reseed operation have happened.

This resolves lowRISC/OpenTitan#22997.

FYI, once in the Invalid or Disabled state and after having stopped PRNG update requests inside the main controller, it's still possible that the PRNG is advanced and that reseed operations are started. E.g. if there are still some handshakes on the KMAC app interface or on the sideload ports (see figure below). However, once in the Disabled state, those are not going to be constantly active as before this commit. I think this should be okay.

![Screenshot from 2024-05-13 10-01-56](https://github.com/lowRISC/opentitan/assets/20307557/84238439-d0aa-4273-99a8-14379c244e66)
