### PR TITLE
[Sival, spi host] Fix PMOD pin mapping for teacup board.

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -467,6 +467,7 @@ cc_library(
     hdrs = ["spi_host_testutils.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        ":pinmux_testutils",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",
         "//sw/device/lib/dif:pinmux",

--- a/sw/device/lib/testing/spi_host_testutils.c
+++ b/sw/device/lib/testing/spi_host_testutils.c
@@ -5,9 +5,112 @@
 #include "sw/device/lib/testing/spi_host_testutils.h"
 
 #include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/**
+ * Define an spi pinmux configuration.
+ */
+typedef struct spi_host1_pinmux_pins {
+  pinmux_testutils_mio_pin_t clk;
+  pinmux_testutils_mio_pin_t sd0;
+  pinmux_testutils_mio_pin_t sd1;
+  pinmux_testutils_mio_pin_t sd2;
+  pinmux_testutils_mio_pin_t sd3;
+} spi_host1_pinmux_pins_t;
+
+/**
+ * This table store spi host 1 pin mappings of different platforms.
+ * This is used to connect spi host 1 to mio pins based on the platform.
+ */
+static const spi_host1_pinmux_pins_t kSpiHost1PinmuxMap[] = {
+    [kSpiPinmuxPlatformIdCw310] =
+        {
+            .clk =
+                {
+                    .insel = kTopEarlgreyPinmuxInselConstantZero,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa3,
+                },
+            .sd0 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa5,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa5,
+                },
+            .sd1 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa4,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa4,
+                },
+            .sd2 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa8,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa8,
+                },
+            .sd3 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa7,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa7,
+                },
+        },
+    [kSpiPinmuxPlatformIdCw340] =
+        {
+            .clk =
+                {
+                    .insel = kTopEarlgreyPinmuxInselConstantZero,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa3,
+                },
+            .sd0 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa5,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa5,
+                },
+            .sd1 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa4,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa4,
+                },
+            .sd2 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa8,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa8,
+                },
+            .sd3 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa7,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa7,
+                },
+        },
+    [kSpiPinmuxPlatformIdTeacup] =
+        {
+            .clk =
+                {
+                    .insel = kTopEarlgreyPinmuxInselConstantZero,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa3,
+                },
+            .sd0 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa4,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa4,
+                },
+            .sd1 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa5,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa5,
+                },
+            .sd2 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa8,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa8,
+                },
+            .sd3 =
+                {
+                    .insel = kTopEarlgreyPinmuxInselIoa7,
+                    .mio_out = kTopEarlgreyPinmuxMioOutIoa7,
+                },
+        },
+};
 
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
@@ -25,33 +128,37 @@ status_t spi_host_testutils_flush(dif_spi_host_t *spi_host) {
 }
 
 status_t spi_host1_pinmux_connect_to_bob(const dif_pinmux_t *pinmux,
-                                         dif_pinmux_index_t csb_outsel) {
+                                         dif_pinmux_index_t csb_outsel,
+                                         spi_pinmux_platform_id_t platform_id) {
+  TRY_CHECK(platform_id < kSpiPinmuxPlatformIdCount);
+  const spi_host1_pinmux_pins_t *platform = &kSpiHost1PinmuxMap[platform_id];
+
   // CSB.
   TRY(dif_pinmux_output_select(pinmux, csb_outsel,
                                kTopEarlgreyPinmuxOutselSpiHost1Csb));
   // SCLK.
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa3,
+  TRY(dif_pinmux_output_select(pinmux, platform->clk.mio_out,
                                kTopEarlgreyPinmuxOutselSpiHost1Sck));
   // SD0.
   TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd0,
-                              kTopEarlgreyPinmuxInselIoa5));
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa5,
+                              platform->sd0.insel));
+  TRY(dif_pinmux_output_select(pinmux, platform->sd0.mio_out,
                                kTopEarlgreyPinmuxOutselSpiHost1Sd0));
 
   // SD1.
   TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd1,
-                              kTopEarlgreyPinmuxInselIoa4));
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa4,
+                              platform->sd1.insel));
+  TRY(dif_pinmux_output_select(pinmux, platform->sd1.mio_out,
                                kTopEarlgreyPinmuxOutselSpiHost1Sd1));
   // SD2.
   TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd2,
-                              kTopEarlgreyPinmuxInselIoa8));
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa8,
+                              platform->sd2.insel));
+  TRY(dif_pinmux_output_select(pinmux, platform->sd2.mio_out,
                                kTopEarlgreyPinmuxOutselSpiHost1Sd2));
   // SD3.
   TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd3,
-                              kTopEarlgreyPinmuxInselIoa7));
-  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoa7,
+                              platform->sd3.insel));
+  TRY(dif_pinmux_output_select(pinmux, platform->sd3.mio_out,
                                kTopEarlgreyPinmuxOutselSpiHost1Sd3));
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/spi_host_testutils.h
+++ b/sw/device/lib/testing/spi_host_testutils.h
@@ -12,6 +12,13 @@
 #include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/dif/dif_spi_host.h"
 
+typedef enum spi_pinmux_platform_id {
+  kSpiPinmuxPlatformIdCw310 = 0,
+  kSpiPinmuxPlatformIdCw340,
+  kSpiPinmuxPlatformIdTeacup,
+  kSpiPinmuxPlatformIdCount,
+} spi_pinmux_platform_id_t;
+
 /**
  * Return True if spi host is active.
  *
@@ -41,10 +48,12 @@ status_t spi_host_testutils_flush(dif_spi_host_t *spi_host);
  * @param pinmux A pinmux handle.
  * @param csb_outsel The chip select pin, this should be one of the eight
  * devices in the BoB connected to the bus. See ::top_earlgrey_pinmux_mio_out_t.
+ * @param platform_id The ID of the platform where the test in running.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 status_t spi_host1_pinmux_connect_to_bob(const dif_pinmux_t *pinmux,
-                                         dif_pinmux_index_t csb_outsel);
+                                         dif_pinmux_index_t csb_outsel,
+                                         spi_pinmux_platform_id_t platform_id);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SPI_HOST_TESTUTILS_H_

--- a/sw/device/tests/pmod/spi_host_gigadevice1Gb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_gigadevice1Gb_flash_test.c
@@ -31,8 +31,25 @@ static void init_test(dif_spi_host_t *spi_host) {
   mmio_region_t base_addr =
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   CHECK_DIF_OK(dif_pinmux_init(base_addr, &pinmux));
+
+  spi_pinmux_platform_id_t platform_id = kSpiPinmuxPlatformIdCount;
+  switch (kDeviceType) {
+    case kDeviceSilicon:
+      platform_id = kSpiPinmuxPlatformIdTeacup;
+      break;
+    case kDeviceFpgaCw310:
+      platform_id = kSpiPinmuxPlatformIdCw310;
+      break;
+    case kDeviceFpgaCw340:
+      platform_id = kSpiPinmuxPlatformIdCw340;
+      break;
+    default:
+      CHECK(false, "Device not supported %u", kDeviceType);
+      break;
+  }
+  dif_pinmux_index_t csb_pin = kTopEarlgreyPinmuxMioOutIoc6;
   CHECK_STATUS_OK(
-      spi_host1_pinmux_connect_to_bob(&pinmux, kTopEarlgreyPinmuxMioOutIoc6));
+      spi_host1_pinmux_connect_to_bob(&pinmux, csb_pin, platform_id));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));

--- a/sw/device/tests/pmod/spi_host_gigadevice1Gb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_gigadevice1Gb_flash_test.c
@@ -37,15 +37,14 @@ static void init_test(dif_spi_host_t *spi_host) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));
 
-  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
-        "kClockFreqPeripheralHz must fit in uint32_t");
+  CHECK(kClockFreqUsbHz <= UINT32_MAX, "kClockFreqUsbHz must fit in uint32_t");
 
-  CHECK_DIF_OK(dif_spi_host_configure(spi_host,
-                                      (dif_spi_host_config_t){
-                                          .spi_clock = 1000000,
-                                          .peripheral_clock_freq_hz =
-                                              (uint32_t)kClockFreqPeripheralHz,
-                                      }),
+  CHECK_DIF_OK(dif_spi_host_configure(
+                   spi_host,
+                   (dif_spi_host_config_t){
+                       .spi_clock = 1000000,
+                       .peripheral_clock_freq_hz = (uint32_t)kClockFreqUsbHz,
+                   }),
                "SPI_HOST config failed!");
 
   CHECK_DIF_OK(dif_spi_host_output_set_enabled(spi_host, true));

--- a/sw/device/tests/pmod/spi_host_gigadevice256Mb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_gigadevice256Mb_flash_test.c
@@ -31,8 +31,25 @@ static void init_test(dif_spi_host_t *spi_host) {
   mmio_region_t base_addr =
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   CHECK_DIF_OK(dif_pinmux_init(base_addr, &pinmux));
+
+  spi_pinmux_platform_id_t platform_id = kSpiPinmuxPlatformIdCount;
+  switch (kDeviceType) {
+    case kDeviceSilicon:
+      platform_id = kSpiPinmuxPlatformIdTeacup;
+      break;
+    case kDeviceFpgaCw310:
+      platform_id = kSpiPinmuxPlatformIdCw310;
+      break;
+    case kDeviceFpgaCw340:
+      platform_id = kSpiPinmuxPlatformIdCw340;
+      break;
+    default:
+      CHECK(false, "Device not supported %u", kDeviceType);
+      break;
+  }
+  dif_pinmux_index_t csb_pin = kTopEarlgreyPinmuxMioOutIoc11;
   CHECK_STATUS_OK(
-      spi_host1_pinmux_connect_to_bob(&pinmux, kTopEarlgreyPinmuxMioOutIoc11));
+      spi_host1_pinmux_connect_to_bob(&pinmux, csb_pin, platform_id));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));

--- a/sw/device/tests/pmod/spi_host_gigadevice256Mb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_gigadevice256Mb_flash_test.c
@@ -37,15 +37,14 @@ static void init_test(dif_spi_host_t *spi_host) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));
 
-  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
-        "kClockFreqPeripheralHz must fit in uint32_t");
+  CHECK(kClockFreqUsbHz <= UINT32_MAX, "kClockFreqUsbHz must fit in uint32_t");
 
-  CHECK_DIF_OK(dif_spi_host_configure(spi_host,
-                                      (dif_spi_host_config_t){
-                                          .spi_clock = 1000000,
-                                          .peripheral_clock_freq_hz =
-                                              (uint32_t)kClockFreqPeripheralHz,
-                                      }),
+  CHECK_DIF_OK(dif_spi_host_configure(
+                   spi_host,
+                   (dif_spi_host_config_t){
+                       .spi_clock = 1000000,
+                       .peripheral_clock_freq_hz = (uint32_t)kClockFreqUsbHz,
+                   }),
                "SPI_HOST config failed!");
 
   CHECK_DIF_OK(dif_spi_host_output_set_enabled(spi_host, true));

--- a/sw/device/tests/pmod/spi_host_macronix_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_macronix_flash_test.c
@@ -30,8 +30,24 @@ static void init_test(dif_spi_host_t *spi_host) {
   mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   CHECK_DIF_OK(dif_pinmux_init(addr, &pinmux));
 
+  spi_pinmux_platform_id_t platform_id = kSpiPinmuxPlatformIdCount;
+  switch (kDeviceType) {
+    case kDeviceSilicon:
+      platform_id = kSpiPinmuxPlatformIdTeacup;
+      break;
+    case kDeviceFpgaCw310:
+      platform_id = kSpiPinmuxPlatformIdCw310;
+      break;
+    case kDeviceFpgaCw340:
+      platform_id = kSpiPinmuxPlatformIdCw340;
+      break;
+    default:
+      CHECK(false, "Device not supported %u", kDeviceType);
+      break;
+  }
   dif_pinmux_index_t csb_pin = kTopEarlgreyPinmuxMioOutIob7;
-  CHECK_STATUS_OK(spi_host1_pinmux_connect_to_bob(&pinmux, csb_pin));
+  CHECK_STATUS_OK(
+      spi_host1_pinmux_connect_to_bob(&pinmux, csb_pin, platform_id));
 
   addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_host_init(addr, spi_host));
@@ -43,6 +59,7 @@ static void init_test(dif_spi_host_t *spi_host) {
                    (dif_spi_host_config_t){
                        .spi_clock = 1000000,
                        .peripheral_clock_freq_hz = (uint32_t)kClockFreqUsbHz,
+                   }),
                "SPI_HOST config failed!");
 
   CHECK_DIF_OK(dif_spi_host_output_set_enabled(spi_host, true));

--- a/sw/device/tests/pmod/spi_host_macronix_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_macronix_flash_test.c
@@ -27,24 +27,22 @@ OTTF_DEFINE_TEST_CONFIG();
 
 static void init_test(dif_spi_host_t *spi_host) {
   dif_pinmux_t pinmux;
-  mmio_region_t base_addr =
-      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
-  CHECK_DIF_OK(dif_pinmux_init(base_addr, &pinmux));
-  CHECK_STATUS_OK(
-      spi_host1_pinmux_connect_to_bob(&pinmux, kTopEarlgreyPinmuxMioOutIob7));
+  mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_pinmux_init(addr, &pinmux));
 
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
-  CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));
+  dif_pinmux_index_t csb_pin = kTopEarlgreyPinmuxMioOutIob7;
+  CHECK_STATUS_OK(spi_host1_pinmux_connect_to_bob(&pinmux, csb_pin));
 
-  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
-        "kClockFreqPeripheralHz must fit in uint32_t");
+  addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
+  CHECK_DIF_OK(dif_spi_host_init(addr, spi_host));
 
-  CHECK_DIF_OK(dif_spi_host_configure(spi_host,
-                                      (dif_spi_host_config_t){
-                                          .spi_clock = 1000000,
-                                          .peripheral_clock_freq_hz =
-                                              (uint32_t)kClockFreqPeripheralHz,
-                                      }),
+  CHECK(kClockFreqUsbHz <= UINT32_MAX, "kClockFreqUsbHz must fit in uint32_t");
+
+  CHECK_DIF_OK(dif_spi_host_configure(
+                   spi_host,
+                   (dif_spi_host_config_t){
+                       .spi_clock = 1000000,
+                       .peripheral_clock_freq_hz = (uint32_t)kClockFreqUsbHz,
                "SPI_HOST config failed!");
 
   CHECK_DIF_OK(dif_spi_host_output_set_enabled(spi_host, true));

--- a/sw/device/tests/pmod/spi_host_micron512Mb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_micron512Mb_flash_test.c
@@ -31,8 +31,25 @@ static void init_test(dif_spi_host_t *spi_host) {
   mmio_region_t base_addr =
       mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
   CHECK_DIF_OK(dif_pinmux_init(base_addr, &pinmux));
+
+  spi_pinmux_platform_id_t platform_id = kSpiPinmuxPlatformIdCount;
+  switch (kDeviceType) {
+    case kDeviceSilicon:
+      platform_id = kSpiPinmuxPlatformIdTeacup;
+      break;
+    case kDeviceFpgaCw310:
+      platform_id = kSpiPinmuxPlatformIdCw310;
+      break;
+    case kDeviceFpgaCw340:
+      platform_id = kSpiPinmuxPlatformIdCw340;
+      break;
+    default:
+      CHECK(false, "Device not supported %u", kDeviceType);
+      break;
+  }
+  dif_pinmux_index_t csb_pin = kTopEarlgreyPinmuxMioOutIoc10;
   CHECK_STATUS_OK(
-      spi_host1_pinmux_connect_to_bob(&pinmux, kTopEarlgreyPinmuxMioOutIoc10));
+      spi_host1_pinmux_connect_to_bob(&pinmux, csb_pin, platform_id));
 
   base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));

--- a/sw/device/tests/pmod/spi_host_micron512Mb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_micron512Mb_flash_test.c
@@ -37,15 +37,14 @@ static void init_test(dif_spi_host_t *spi_host) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
   CHECK_DIF_OK(dif_spi_host_init(base_addr, spi_host));
 
-  CHECK(kClockFreqPeripheralHz <= UINT32_MAX,
-        "kClockFreqPeripheralHz must fit in uint32_t");
+  CHECK(kClockFreqUsbHz <= UINT32_MAX, "kClockFreqUsbHz must fit in uint32_t");
 
-  CHECK_DIF_OK(dif_spi_host_configure(spi_host,
-                                      (dif_spi_host_config_t){
-                                          .spi_clock = 1000000,
-                                          .peripheral_clock_freq_hz =
-                                              (uint32_t)kClockFreqPeripheralHz,
-                                      }),
+  CHECK_DIF_OK(dif_spi_host_configure(
+                   spi_host,
+                   (dif_spi_host_config_t){
+                       .spi_clock = 1000000,
+                       .peripheral_clock_freq_hz = (uint32_t)kClockFreqUsbHz,
+                   }),
                "SPI_HOST config failed!");
 
   CHECK_DIF_OK(dif_spi_host_output_set_enabled(spi_host, true));

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -36,6 +36,7 @@
     },
     {
       "name": "IOA4",
+      "mode": "Input",
       "alias_of": "CN8_10"
     },
     {


### PR DESCRIPTION
This commit fixes the PMOD tests on teacup board.
The teacup board has the SPI_HOST1 sd0 and sd1 pins inverted, so this PR adds a different mapping to work around this problem.