### PR TITLE
[edn] Improve FSM coverage

### DIFF
--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -370,7 +370,7 @@ module edn_core import edn_pkg::*;
 
   // CSRNG acknowledgement error status
   assign csrng_ack_err = edn_enable_fo[CsrngAckErr] &&
-                         csrng_cmd_i.csrng_rsp_sts && csrng_cmd_i.csrng_rsp_ack;
+      csrng_cmd_i.csrng_rsp_ack && (csrng_cmd_i.csrng_rsp_sts != csrng_pkg::CMD_STS_SUCCESS);
   assign hw2reg.recov_alert_sts.csrng_ack_err.de = csrng_ack_err;
   assign hw2reg.recov_alert_sts.csrng_ack_err.d  = csrng_ack_err;
 
@@ -608,7 +608,8 @@ module edn_core import edn_pkg::*;
          !edn_enable_fo[HwCmdSts] ? csrng_pkg::CMD_STS_SUCCESS :
          sw_cmd_valid ? csrng_hw_cmd_sts_q :
          (cs_cmd_req_vld_out_q && csrng_cmd_i.csrng_req_ready) ? csrng_pkg::CMD_STS_SUCCESS :
-         csrng_cmd_i.csrng_rsp_ack && csrng_cmd_i.csrng_rsp_sts ? csrng_cmd_i.csrng_rsp_sts :
+         csrng_cmd_i.csrng_rsp_ack && (csrng_cmd_i.csrng_rsp_sts != csrng_pkg::CMD_STS_SUCCESS) ?
+             csrng_cmd_i.csrng_rsp_sts :
          csrng_hw_cmd_sts_q;
   // Set the cmd_ack signal to high whenever a hardware command is acknowledged and set it
   // to low whenever a new hardware command is issued to the CSRNG.
@@ -857,7 +858,8 @@ module edn_core import edn_pkg::*;
 
   assign packer_cs_clr = !edn_enable_fo[CsrngPackerClr];
   assign packer_cs_push = csrng_cmd_i.genbits_valid && !reject_csrng_entropy &&
-                          !(csrng_cmd_i.csrng_rsp_sts && csrng_cmd_i.csrng_rsp_ack);
+                          !((csrng_cmd_i.csrng_rsp_sts != csrng_pkg::CMD_STS_SUCCESS) &&
+                              csrng_cmd_i.csrng_rsp_ack);
   assign packer_cs_wdata = csrng_cmd_i.genbits_bus;
   assign csrng_cmd_o.genbits_ready = packer_cs_wready && !reject_csrng_entropy;
   assign packer_cs_rready = packer_arb_valid;

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -181,7 +181,9 @@ module edn_main_sm import edn_pkg::*; #(
     endcase
 
     if (local_escalate_i || csrng_ack_err_i) begin
-      state_d = local_escalate_i ? Error : RejectCsrngEntropy;
+      // Either move into RejectCsrngEntropy or Error but don't move out of Error as it's terminal.
+      state_d = local_escalate_i ? Error :
+                state_q == Error ? Error : RejectCsrngEntropy;
       // Tie off outputs, except for main_sm_err_o and reject_csrng_entropy_o.
       boot_wr_ins_cmd_o      = 1'b0;
       boot_wr_gen_cmd_o      = 1'b0;

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -6,9 +6,8 @@
 //
 //   does hardware-based csrng app interface command requests
 
-module edn_main_sm import edn_pkg::*; #(
-  localparam int StateWidth = 9
-) (
+module edn_main_sm import edn_pkg::*;
+(
   input logic                   clk_i,
   input logic                   rst_ni,
 


### PR DESCRIPTION
This PR contains two commits that help improving FSM coverage:
1. [[edn/rtl] Make Error main SM state terminal again](https://github.com/lowRISC/opentitan/commit/3d8c6e0e34f2d6fc77f0db4ab6dc616558d45fe9): This is actually a security-relevant bug fix. Previously, the hardware could be made to leave the terminal error state upon receiving an error status signal from CSRNG.
2. [[edn/dv] Fix FSM coverage hole](https://github.com/lowRISC/opentitan/commit/6021c33c18e6061c54381595539358c21b7de62d): There were some systematic coverage holes in the err_test of EDN DV. This commit fixes those.

A third commit has been appended to fix Verilator lint warnings and errors.