### PR TITLE
[jtag,dv] Improve driver sync with TCK

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -114,13 +114,9 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
 
   // Drive TMS, TDI to the given values and wait for a single edge of TCK.
   task tms_tdi_step(bit tms, bit tdi);
-    // We normally expect this task to be called at the negedge of tck (synchronous with HOST_CB).
-    // But that won't quite be true if the clock has been paused for a while because tck=1 when
-    // idle. We can spot that happening because tck will be 1. In that situation, wait for HOST_CB
-    // so we can get back in sync.
-    if (cfg.vif.tck) begin
-      @(`HOST_CB);
-    end
+    // When everything is in sync, this task will be called just after the negedge of TCK
+    // (synchronous with HOST_CB). In particular, TCK should be low: check that this is true.
+    `DV_CHECK_FATAL(!cfg.vif.tck);
 
     `HOST_CB.tms <= tms;
     `HOST_CB.tdi <= tdi;

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -95,6 +95,12 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
         $cast(rsp, req.clone());
         rsp.set_id_info(req);
 
+        // Make sure that we're aligned to HOST_CB (on the negedge of TCK). If we have just finished
+        // the previous item, this delay is going to add a cycle of TCK, but we're in RunTest/IDLE,
+        // so it won't cause any harm.
+        cfg.vif.tck_en <= 1'b1;
+        @(`HOST_CB);
+
         `uvm_info(`gfn, req.sprint(uvm_default_line_printer), UVM_HIGH)
         `DV_SPINWAIT_EXIT(drive_jtag_req(req, rsp);,
                           wait (!cfg.vif.trst_n);)


### PR DESCRIPTION
This fixes some silliness that crops up when the jtag driver ends up out of sync with the edges of TCK. We could probably make it more robust, but this should be the simplest tweak that gets everything working more predictably.

Note: this PR looks bigger than it is! The first commit is from PR #23081. Only these three commits are unique to this PR:
- c318b028bc `[jtag,dv] Handle trst_n at start of time in jtag_driver.sv`
- 0c5a40cc13 `[jtag,dv] Sync up with TCK before calling drive_jtag_req`
- a52617fd0b `[jtag,dv] Add a check about synchronisation in jtag driver`

