### PR TITLE
Cherry-pick to earlgrey_es_sival: [sival, rv_core_ibex] test rv_core_ibex_isa_test in prod 

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -142,7 +142,7 @@
        stage: V2
        si_stage: SV1
        tests: []
-       bazel: ["//sw/device/tests:rv_core_ibex_isa_test_functest"]
+       bazel: ["//sw/device/tests:rv_core_ibex_isa_test"]
        lc_states: ["PROD"]
        features: [
          "RV_CORE_IBEX.CPU.ISA"

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -142,6 +142,7 @@
        stage: V2
        si_stage: SV1
        tests: []
+       bazel: ["//sw/device/tests:rv_core_ibex_isa_test_functest"]
        lc_states: ["PROD"]
        features: [
          "RV_CORE_IBEX.CPU.ISA"

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5286,15 +5286,14 @@ opentitan_test(
 )
 
 opentitan_test(
-    name = "rv_core_ibex_isa_test_functest",
+    name = "rv_core_ibex_isa_test_test_unlocked0",
     srcs = ["//sw/device/silicon_creator/manuf/tests:idle_functest.c"],
     cw310 = cw310_params(
         binaries = {
-            ":rv_core_ibex_isa_test": "sram_program",
+            ":rv_core_ibex_isa_test_sram": "sram_program",
         },
         needs_jtag = True,
         otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
-        tags = ["manual"],
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
     ),
@@ -5302,20 +5301,10 @@ opentitan_test(
         # This test is not compatible with the test_rom because the test_rom
         # does not respect the exec_disabled OTP config word.
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "hyper310",
-        "//hw/top_earlgrey:fpga_cw310_sival": "hyper310",
+        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
         "//hw/top_earlgrey:silicon_creator": None,
     },
-    hyper310 = cw310_params(
-        binaries = {
-            ":rv_core_ibex_isa_test": "sram_program",
-        },
-        needs_jtag = True,
-        otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
-        tags = ["manual"],
-        test_cmd = "--elf={sram_program}",
-        test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
-    ),
     silicon = silicon_params(
         needs_jtag = True,
         tags = ["manual"],
@@ -5330,8 +5319,10 @@ opentitan_test(
     ],
 )
 
+# This test checks basic Ibex functionality, so we prefer to run as little code as possible before the test.
+# In LC states where JTAG is available, we use SRAM execution to run the test before ROM.
 opentitan_binary(
-    name = "rv_core_ibex_isa_test",
+    name = "rv_core_ibex_isa_test_sram",
     testonly = True,
     srcs = [
         "rv_core_ibex_isa_test.S",
@@ -5345,6 +5336,34 @@ opentitan_binary(
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
+    ],
+)
+
+# For PROD LC state, we run this test as normal.
+opentitan_test(
+    name = "rv_core_ibex_isa_test_prod",
+    srcs = [
+        "rv_core_ibex_isa_test.S",
+        "rv_core_ibex_isa_test.c",
+    ],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    deps = [
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+test_suite(
+    name = "rv_core_ibex_isa_test",
+    tags = ["manual"],
+    tests = [
+        "rv_core_ibex_isa_test_prod",
+        "rv_core_ibex_isa_test_test_unlocked0",
     ],
 )
 

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -11,6 +11,7 @@ test_suite(
         "//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test",
         "//sw/device/tests:rstmgr_cpu_info_test",
         "//sw/device/tests:rv_core_ibex_epmp_test_functest",
+        "//sw/device/tests:rv_core_ibex_isa_test_functest",
         "//sw/device/tests:rv_core_ibex_mem_test_functest",
         "//sw/device/tests:rv_core_ibex_rnd_test",
     ],

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -11,7 +11,7 @@ test_suite(
         "//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test",
         "//sw/device/tests:rstmgr_cpu_info_test",
         "//sw/device/tests:rv_core_ibex_epmp_test_functest",
-        "//sw/device/tests:rv_core_ibex_isa_test_functest",
+        "//sw/device/tests:rv_core_ibex_isa_test",
         "//sw/device/tests:rv_core_ibex_mem_test_functest",
         "//sw/device/tests:rv_core_ibex_rnd_test",
     ],


### PR DESCRIPTION
Cherry-pick of #22876. This also include @HU90m's testplan changes which were not backported.