### PR TITLE
[rv_dm,dv] Tidy up how we disable scan mode

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_abstractcmd_status_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_abstractcmd_status_vseq.sv
@@ -10,9 +10,6 @@ class rv_dm_abstractcmd_status_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   // The expected contents of the debug ROM that we will read through the abstract command
   // interface.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -25,6 +25,16 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     };
   }
 
+  // A constraint that disables scanmode. This is generally needed because scan mode breaks JTAG
+  // access for the usual jtag_driver: the driver sees a different clock from the TAP and everything
+  // quickly gets out of sync.
+  //
+  // A vseq that actually wants to exercise scanmode should override this constraint and turn it
+  // back on.
+  constraint no_scanmode_c {
+    scanmode != prim_mubi_pkg::MuBi4True;
+  }
+
   // SBA TL device sequence. Class member for more controllability.
   protected cip_tl_device_seq m_tl_sba_device_seq;
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_busy_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_busy_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_cmderr_busy_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
   task body();
     write_chk(.ptr(jtag_dmi_ral.progbuf[0]),.cmderr(1),.command(32'h00231000));
     write_chk(.ptr(jtag_dmi_ral.abstractdata[0]),.cmderr(1),.command(32'h00231000));

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_exception_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_exception_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_cmderr_exception_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task body();
     // Verify that the cmderr should be AbstractCmdErrException,

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_halt_resume_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_halt_resume_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_cmderr_halt_resume_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task body();
     uvm_reg_data_t data;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_not_supported_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_not_supported_vseq.sv
@@ -10,9 +10,6 @@ class rv_dm_cmderr_not_supported_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
   task body();
     write_chk(.ptr(jtag_dmi_ral.progbuf[0]),.cmderr(2),.command(32'h10231000));
     write_chk(.ptr(jtag_dmi_ral.command),.cmderr(2),.command(32'h10231000));

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_common_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_common_vseq.sv
@@ -15,9 +15,6 @@ class rv_dm_common_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
   constraint unavailable_c {
     unavailable == 0;
   }

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_dataaddr_rw_access_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_dataaddr_rw_access_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_dataaddr_rw_access_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
   task write_and_verify(input uvm_object ptr,int idx);
     uvm_reg_data_t data;
     uvm_reg_data_t rdata;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_halt_resume_whereto_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_halt_resume_whereto_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_halt_resume_whereto_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   // Pretend to be the hart entering debug mode and write the ID (hartsel) to the HALTED register to
   // indicate that we are halted.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_hart_unavail_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_hart_unavail_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_hart_unavail_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task body();
     uvm_reg_data_t data;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
@@ -11,10 +11,6 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
 
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
-
   task automatic write_abstractdata(uvm_reg_data_t value);
     csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(value));
   endtask

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_jtag_dmi_dm_inactive_vseq extends rv_dm_common_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task body();
     uvm_reg_data_t wdata;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv
@@ -10,9 +10,6 @@ class rv_dm_jtag_dtm_hard_reset_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task body();
     uvm_reg_data_t wdata;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv
@@ -12,10 +12,6 @@ class rv_dm_jtag_dtm_idle_hint_vseq  extends rv_dm_base_vseq;
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
 
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
-
   // Read the dtmcs register and check the idle field has the expected value.
   task check_idle(bit [2:0] expected_idle);
     uvm_reg_data_t rdata;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_mem_tl_access_halted_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task body();
     uvm_reg_data_t r_data;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_resuming_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_resuming_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_mem_tl_access_resuming_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task body();
     uvm_reg_data_t wdata;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_ndmreset_req_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_ndmreset_req_vseq.sv
@@ -18,9 +18,6 @@ class rv_dm_ndmreset_req_vseq extends rv_dm_base_vseq;
   constraint pinmux_hw_debug_en_c {
     pinmux_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task body();
     uvm_reg_data_t wdata;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_busy_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_busy_vseq.sv
@@ -11,9 +11,7 @@ class rv_dm_progbuf_busy_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
+
   task body();
     uvm_reg_data_t data;
     uvm_reg_data_t r_data;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_read_write_execute_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_read_write_execute_vseq.sv
@@ -10,9 +10,6 @@ class rv_dm_progbuf_read_write_execute_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task progbuf_rw(int idx);
     uvm_reg_data_t data = $urandom;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_rom_read_access_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_rom_read_access_vseq.sv
@@ -11,9 +11,7 @@ class rv_dm_rom_read_access_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
+
   task body();
     string         path;
     bit [31:0]     lower_mem_val;

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_sba_tl_access_vseq_lib.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_sba_tl_access_vseq_lib.sv
@@ -69,9 +69,6 @@ class rv_dm_sba_tl_access_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
   constraint unavailable_c {
     unavailable == 0;
   }

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -11,9 +11,6 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   // Read the JTAG IDCODE register and verify that it matches the expected value.
   task check_idcode();

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
@@ -21,9 +21,6 @@ class rv_dm_tap_fsm_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
 
   task send_req(bit dummy_ir = 1'b0,
                 bit dummy_dr = 1'b0,


### PR DESCRIPTION
Rather than explicitly setting it to MuBi4False in each vseq, let's move the constraint to the base class. This fixes things for the stress sequence which didn't have the individual copied constraint, and hopefully makes the code a bit clearer.