### PR TITLE
[hmac,dv/rtl] Implement DV checks for new digest sizes/key lengths

### DIFF
--- a/hw/ip/hmac/README.md
+++ b/hw/ip/hmac/README.md
@@ -36,7 +36,7 @@ The 1024-bit secret key is written in [`KEY_0`](doc/registers.md#key) to [`KEY_3
 For example, to use a 256-bit secret key, [`CFG.key_length`] should be configured to 0x02 and then only secret key registers [`KEY_0`](doc/registers.md#key) to [`KEY_7`] are read and relevant for the HMAC operation.
 The digest size required is configured in [`CFG.digest_size`].
 The message to authenticate is written to [`MSG_FIFO`](doc/registers.md#msg_fifo) and the HMAC generates a 256/384/512-bit digest value (depending on the digest size configuration provided) which can be read from [`DIGEST_0`](doc/registers.md#digest) to [`DIGEST_7`](doc/registers.md#digest) for SHA-2 256, or from [`DIGEST_0`] to [`DIGEST_12`] for SHA-2 384, or from [`DIGEST_0`] to [`DIGEST_15`] for SHA-2 512.
-The `hash_done` interrupt is raised to report to software that the final digest is available.
+The `hmac_done` interrupt is raised to report to software that the final digest is available.
 
 This module allows software to save and restore the hashing context so that different message streams can be interleaved; please check the [Programmer's Guide](doc/programmers_guide.md#saving-and-restoring-the-context) for more information.
 

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -195,7 +195,7 @@
           desc: '''SHA-2 enable.
 
                  If 0, the SHA engine will not initiate compression, this is used to stop operation of the SHA-2 engine until configuration has been done.
-                 When the SHA-2 engine is disabled the digest is cleared.'''
+                 When the SHA-2 engine is disabled the digest is cleared, and the digest can be written to from SW which enables restoring context (to support context switching).'''
           tags: [// don't enable hmac and sha data paths - we will do that in functional tests
                  "excl:CsrNonInitTests:CsrExclWrite"]
         }
@@ -440,11 +440,11 @@
 
               If HMAC is disabled, the register shows result of SHA-2 256/384/512.
               Order of the 512-bit digest[511:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST15}.
-              For SHA-2 256 order of the 256-bit digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, DIGEST3, DIGEST4, DIGEST5, DIGEST6, DIGEST7} and {DIGEST8 - DIGEST15} are all-zero.
-              For SHA-2 384, {DIGEST12-DIGEST15} are truncated and are all-zero.
+              For SHA-2 256 order of the 256-bit digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, DIGEST3, DIGEST4, DIGEST5, DIGEST6, DIGEST7} and {DIGEST8 - DIGEST15} are irrelevant and should not be read out.
+              For SHA-2 384, {DIGEST12-DIGEST15} are truncated; they are irrelevant and should not be read out.
 
               The digest gets cleared when `CFG.sha_en` transitions from 1 to 0.
-              When `CFG.sha_en` is 0, these registers can be written by software.
+              When `CFG.sha_en` is 0, these registers can be written to by software.
               ''',
         count: "NumDigestWords",
         cname: "HMAC",

--- a/hw/ip/hmac/doc/programmers_guide.md
+++ b/hw/ip/hmac/doc/programmers_guide.md
@@ -38,6 +38,9 @@ void hmac_init(unsigned int endianess, unsigned int digest_endian) {
 The following code shows how to send a message to the HMAC, the procedure is the same whether a full HMAC or just a SHA-2 computation is required (choose between them using [`CFG.hmac_en`](registers.md#cfg)).
 In both cases the SHA-2 engine must be enabled using [`CFG.sha_en`](registers.md#cfg) (once all other configuration has been properly set).
 If the message is larger than 512-bit, the software must wait until the FIFO is not full before writing further bits.
+For SHA-2 256, only `DIGEST_0`..`7` should be read out; the redundant digests are irrelevant and would hold irrelevant values.
+For SHA-2 384, only `DIGEST_0`..`11` should be read out, the rest should be truncated out by not being read via SW.
+For SHA-2 512, all `DIGEST_0`..`15` should be read out.
 
 ```c
 void run_hmac(uint32_t *msg, uint32_t msg_len, uint32_t *hash) {

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -232,7 +232,7 @@ From a hardware perspective byte swaps are performed on a TL-UL word granularity
 SHA-2 enable.
 
  If 0, the SHA engine will not initiate compression, this is used to stop operation of the SHA-2 engine until configuration has been done.
- When the SHA-2 engine is disabled the digest is cleared.
+ When the SHA-2 engine is disabled the digest is cleared, and the digest can be written to from SW which enables restoring context (to support context switching).
 
 ### CFG . hmac_en
 HMAC datapath enable.
@@ -396,11 +396,11 @@ Digest output.
 
 If HMAC is disabled, the register shows result of SHA-2 256/384/512.
 Order of the 512-bit digest[511:0] = {DIGEST0, DIGEST1, DIGEST2, ... , DIGEST15}.
-For SHA-2 256 order of the 256-bit digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, DIGEST3, DIGEST4, DIGEST5, DIGEST6, DIGEST7} and {DIGEST8 - DIGEST15} are all-zero.
-For SHA-2 384, {DIGEST12-DIGEST15} are truncated and are all-zero.
+For SHA-2 256 order of the 256-bit digest[255:0] = {DIGEST0, DIGEST1, DIGEST2, DIGEST3, DIGEST4, DIGEST5, DIGEST6, DIGEST7} and {DIGEST8 - DIGEST15} are irrelevant and should not be read out.
+For SHA-2 384, {DIGEST12-DIGEST15} are truncated; they are irrelevant and should not be read out.
 
 The digest gets cleared when `CFG.sha_en` transitions from 1 to 0.
-When `CFG.sha_en` is 0, these registers can be written by software.
+When `CFG.sha_en` is 0, these registers can be written to by software.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -107,7 +107,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
       if (i != 1 && $urandom_range(0, 1)) rd_digest();
 
       if (do_wipe_secret == WipeSecretBeforeKey) begin
-        `uvm_info(`gfn, $sformatf("wiping before key"), UVM_LOW)
+        `uvm_info(`gfn, $sformatf("wiping before key"), UVM_HIGH)
         wipe_secrets();
         // Check if digest data are corrupted by wiping secrets.
         rd_digest();
@@ -120,7 +120,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
       if (i != 1 && $urandom_range(0, 1)) rd_digest();
 
       if (do_wipe_secret == WipeSecretBeforeStart) begin
-        `uvm_info(`gfn, $sformatf("wiping before start"), UVM_LOW)
+        `uvm_info(`gfn, $sformatf("wiping before start"), UVM_HIGH)
         wipe_secrets();
         // Here the wipe secret will only corrupt secret keys and current digests.
         // If HMAC is not enabled, check if digest is corrupted.
@@ -136,7 +136,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
             if (invalid_cfg & do_hash_start) begin // error would only be signalled when started
               // wait for interrupt to assert, check status and clear it
               if (intr_hmac_err_en) begin
-                `DV_WAIT(cfg.intr_vif.pins[HmacErr] === 1'b1);
+                `DV_WAIT(cfg.intr_vif.pins[HmacErr] === 1'b1)
               end else begin
                 csr_spinwait(.ptr(ral.intr_state.hmac_err), .exp_data(1'b1));
               end
@@ -147,7 +147,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
           end
           begin
             if (do_wipe_secret == WipeSecretBeforeProcess) begin
-              `uvm_info(`gfn, $sformatf("wiping before process"), UVM_LOW)
+              `uvm_info(`gfn, $sformatf("wiping before process"), UVM_HIGH)
               cfg.clk_rst_vif.wait_clks($urandom_range(0, msg.size() * 10));
               wipe_secrets();
             end
@@ -166,7 +166,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
 
         if (do_hash_start_when_active && do_hash_start) begin
           trigger_hash_when_active();
-          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(msg);
+          `DV_CHECK_MEMBER_RANDOMIZE_FATAL(msg)
           wr_msg(msg);
         end
 
@@ -191,7 +191,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
               if (!invalid_cfg) begin
                 // wait for interrupt to assert, check status and clear it
                 if (intr_hmac_done_en) begin
-                  `DV_WAIT(cfg.intr_vif.pins[HmacDone] === 1'b1);
+                  `DV_WAIT(cfg.intr_vif.pins[HmacDone] === 1'b1)
                 end else begin
                   csr_spinwait(.ptr(ral.intr_state.hmac_done), .exp_data(1'b1));
                 end
@@ -199,7 +199,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
             end
             begin
               if (do_wipe_secret == WipeSecretBeforeDone) begin
-                        `uvm_info(`gfn, $sformatf("wiping before done"), UVM_LOW)
+                        `uvm_info(`gfn, $sformatf("wiping before done"), UVM_HIGH)
 
                 cfg.clk_rst_vif.wait_clks($urandom_range(0, 100));
                 wipe_secrets();
@@ -216,7 +216,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
       if ($urandom_range(0, 1)) rd_msg_length();
 
       // read digest from DUT
-      `uvm_info(`gfn, $sformatf("reading digest now"), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("reading digest"), UVM_LOW)
       rd_digest();
     end
   endtask : body

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -240,7 +240,10 @@ module hmac
           digest_sw[i]       = {32'h0, conv_endian32(reg2hw.digest[i].q, digest_swap)};
           digest_sw_we[i]    = reg2hw.digest[i].qe;
         end else begin
-          hw2reg.digest[i].d = '0;
+          // replicate digest[0..7] into digest[8..15]. Digest[8...15] are irrelevant for SHA2_256,
+          // but this ensures all digest CSRs are wiped out with random value (at wipe_secret)
+          // across different configurations.
+          hw2reg.digest[i].d = conv_endian32(digest[i%8][31:0], digest_swap);
         end
       end else if ((digest_size_started_q == SHA2_384) || (digest_size_started_q == SHA2_512)) begin
         if (i % 2 == 0 && i < 15) begin // even index

--- a/hw/ip/prim/rtl/prim_sha2.sv
+++ b/hw/ip/prim/rtl/prim_sha2.sv
@@ -161,17 +161,6 @@ module prim_sha2 import prim_sha2_pkg::*;
       end else if (update_digest) begin
         for (int i = 0 ; i < 8 ; i++) begin
           digest_d[i] = digest_q[i] + hash_q[i];
-          if (digest_mode_flag_q == SHA2_256) digest_d[i][63:32] = 32'b0;
-        end
-        if (hash_done_o == 1'b1 && digest_mode_flag_q == SHA2_384) begin
-          // final digest truncation for SHA-2 384
-          digest_d[6] = '0;
-          digest_d[7] = '0;
-        end else if (hash_done_o == 1'b1 && digest_mode_flag_q == SHA2_256) begin
-          // make sure to clear out most significant 32-bits of each digest word (zero-padding)
-          for (int i = 0 ; i < 8 ; i++) begin
-            digest_d[i][63:32] = 32'b0;
-          end
         end
       end
     end : compute_digest_multimode


### PR DESCRIPTION
This PR implements scoreboard checks for the new HMAC digest sizes and key lengths for normal operation and whenever secure wiping is triggered.  For ease of DV checks and consistency across configuration changes where previous digests remain held in CSRs until HMAC starts a new operation, this PR also removes the clearing of redundant digest values for the smaller digest sizes in the RTL. It also updates the documentation to clarify that SW should only read the relevant digest CSRs for the digest size configured - @ballifatih (only read digests 0..7 for SHA-2 256 and digests 0..11 for SHA-2 384, i.e., do not assume the redundant digest values in these sizes will be all-zero.)

This should also fix the failing hmac_wipe_secret test (https://github.com/lowRISC/opentitan/issues/23053) and close other pending DV TODOS.