### PR TITLE
[sival] fix pmp_smoketest_{napot, tor} tests in rom_ext

### DIFF
--- a/sw/device/lib/runtime/pmp.c
+++ b/sw/device/lib/runtime/pmp.c
@@ -546,7 +546,29 @@ pmp_region_configure_result_t pmp_region_configure_tor(
   return kPmpRegionConfigureOk;
 }
 
-pmp_region_configure_result_t pmp_cfg_mode_lock_status_get(
+pmp_region_configure_result_t pmp_region_is_configured(
+    pmp_region_index_t region, bool *configured) {
+  if (region >= PMP_REGIONS_NUM) {
+    return kPmpRegionConfigureBadRegion;
+  }
+
+  if (configured == NULL) {
+    return kPmpRegionConfigureBadArg;
+  }
+
+  uint32_t field_value;
+  pmp_region_configure_result_t result =
+      pmp_csr_cfg_field_read(region, &field_value);
+  if (result != kPmpRegionConfigureOk) {
+    return result;
+  }
+
+  *configured = field_value != 0;
+
+  return kPmpRegionConfigureOk;
+}
+
+pmp_region_configure_result_t pmp_region_lock_status_get(
     pmp_region_index_t region, pmp_region_lock_t *lock) {
   if (region >= PMP_REGIONS_NUM) {
     return kPmpRegionConfigureBadRegion;

--- a/sw/device/lib/runtime/pmp.h
+++ b/sw/device/lib/runtime/pmp.h
@@ -286,6 +286,17 @@ pmp_region_configure_result_t pmp_region_configure_tor(
     uintptr_t address_start, uintptr_t address_end);
 
 /**
+ * Check if the requested region is configured.
+ *
+ * @param region PMP region to query the information for.
+ * @param[out] configured Whether the PMP region is configured.
+ * @return `pmp_region_configure_result_t`.
+ */
+OT_WARN_UNUSED_RESULT
+pmp_region_configure_result_t pmp_region_is_configured(
+    pmp_region_index_t region, bool *configured);
+
+/**
  * Queries the lock status for the requested region.
  *
  * @param region PMP region to query the lock information for.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2456,13 +2456,9 @@ opentitan_test(
 opentitan_test(
     name = "pmp_smoketest_napot",
     srcs = ["pmp_smoketest_napot.c"],
-    broken = cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
-        {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        },
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2477,13 +2473,9 @@ opentitan_test(
 opentitan_test(
     name = "pmp_smoketest_tor",
     srcs = ["pmp_smoketest_tor.c"],
-    broken = cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
-        {
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        },
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/pmp_smoketest_napot.c
+++ b/sw/device/tests/pmp_smoketest_napot.c
@@ -57,12 +57,13 @@ static void pmp_configure_load_napot(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  // Check that `PMP_LOAD_REGION_ID` region is not already used.
-  static_assert(PMP_LOAD_REGION_ID == 7, "PMP_LOAD_REGION_ID does not match");
-  uint32_t pmpcfg1 = 0;
-  CSR_READ(CSR_REG_PMPCFG1, &pmpcfg1);
-  CHECK((pmpcfg1 & 0xff000000) == 0,
-        "expected PMP region %d to be unconfigured", PMP_LOAD_REGION_ID);
+  bool configured;
+  pmp_region_configure_result_t result =
+      pmp_region_is_configured(PMP_LOAD_REGION_ID, &configured);
+  CHECK(result == kPmpRegionConfigureOk,
+        "PMP region %d cfg read failed, error code = %d", PMP_LOAD_REGION_ID,
+        result);
+  CHECK(!configured, "PMP region %d is already configured", PMP_LOAD_REGION_ID);
 
   pmp_load_exception = false;
   char load = pmp_load_store_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];

--- a/sw/device/tests/pmp_smoketest_napot.c
+++ b/sw/device/tests/pmp_smoketest_napot.c
@@ -9,7 +9,10 @@
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-#define PMP_LOAD_REGION_ID 0
+// Usable PMP regions vary depending on different exectuion environments.
+// PMP regions with small or large indices are usually reserved by ROM/ROM_EXT
+// So use PMP region 7 for this test.
+#define PMP_LOAD_REGION_ID 7
 
 #define PMP_LOAD_RANGE_BUFFER_SIZE 1024
 #define PMP_LOAD_RANGE_SIZE 512
@@ -54,6 +57,13 @@ static void pmp_configure_load_napot(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
+  // Check that `PMP_LOAD_REGION_ID` region is not already used.
+  static_assert(PMP_LOAD_REGION_ID == 7, "PMP_LOAD_REGION_ID does not match");
+  uint32_t pmpcfg1 = 0;
+  CSR_READ(CSR_REG_PMPCFG1, &pmpcfg1);
+  CHECK((pmpcfg1 & 0xff000000) == 0,
+        "expected PMP region %d to be unconfigured", PMP_LOAD_REGION_ID);
+
   pmp_load_exception = false;
   char load = pmp_load_store_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];
   CHECK(!pmp_load_exception, "Load access violation before PMP configuration");

--- a/sw/device/tests/pmp_smoketest_tor.c
+++ b/sw/device/tests/pmp_smoketest_tor.c
@@ -25,7 +25,11 @@
  * To protect an address range that starts above 0 address, the first region
  * we can use is 1.
  */
-#define PMP_LOAD_REGION_ID 2
+
+// Usable PMP regions vary depending on different exectuion environments.
+// PMP regions with small or large indices are usually reserved by ROM/ROM_EXT
+// So use PMP region 6 & 7 for this test.
+#define PMP_LOAD_REGION_ID 7
 
 #define PMP_LOAD_RANGE_BUFFER_SIZE 1024
 #define PMP_LOAD_RANGE_SIZE 512
@@ -71,14 +75,14 @@ static void pmp_configure_load_tor(void) {
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
-  // Unlock the entire address space for RWX so that we can run this test with
-  // both rom and test_rom.
-  CSR_SET_BITS(CSR_REG_PMPADDR15, 0x7fffffff);
-  CSR_WRITE(CSR_REG_PMPCFG3, (kEpmpModeNapot | kEpmpPermLockedReadWriteExecute)
-                                 << 24);
-  CSR_WRITE(CSR_REG_PMPCFG2, 0);
-  CSR_WRITE(CSR_REG_PMPCFG1, 0);
-  CSR_WRITE(CSR_REG_PMPCFG0, 0);
+  // Check that `PMP_LOAD_REGION_ID-1` and `PMP_LOAD_REGION_ID` regions are not
+  // already used.
+  static_assert(PMP_LOAD_REGION_ID == 7, "PMP_LOAD_REGION_ID does not match");
+  uint32_t pmpcfg1 = 0;
+  CSR_READ(CSR_REG_PMPCFG1, &pmpcfg1);
+  CHECK((pmpcfg1 & 0xffff0000) == 0,
+        "expected PMP region %d and %d to be unconfigured",
+        PMP_LOAD_REGION_ID - 1, PMP_LOAD_REGION_ID);
 
   pmp_load_exception = false;
   char load = pmp_load_test_data[PMP_LOAD_RANGE_BOTTOM_OFFSET];


### PR DESCRIPTION
Instead of unlocking all address space by unsetting all PMP registers, these tests only need 1 or 2 spare PMP regions. Choose regions 6/7 for this purpose. A test is added to ensure that these regions are not configured.