### PR TITLE
[runtime,log] Make logging usable in DIFs

### DIFF
--- a/sw/device/lib/runtime/BUILD
+++ b/sw/device/lib/runtime/BUILD
@@ -62,7 +62,6 @@ cc_library(
     name = "log",
     srcs = ["log.c"],
     hdrs = ["log.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",

--- a/sw/device/lib/runtime/log.c
+++ b/sw/device/lib/runtime/log.c
@@ -2,13 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/runtime/log.h"
+/* On host, we need access to memrchr */
+#ifndef OT_PLATFORM_RV32
+#define _GNU_SOURCE
+#include <string.h>
+#endif
 
 #include <assert.h>
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
 
 /**
@@ -17,8 +22,10 @@
  * The assertion below helps prevent inadvertant changes to the struct.
  * Please see the description of log_fields_t in log.h for more details.
  */
+#ifdef OT_PLATFORM_RV32
 static_assert(sizeof(log_fields_t) == 20,
               "log_fields_t must always be 20 bytes.");
+#endif
 
 /**
  * Converts a severity to a static string.
@@ -72,6 +79,7 @@ void base_log_internal_core(log_fields_t log, ...) {
   base_printf("\r\n");
 }
 
+#ifdef OT_PLATFORM_RV32
 /**
  * Logs `log` and the values that follow in an efficient, DV-testbench
  * specific way, which bypasses the UART.
@@ -93,3 +101,4 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...) {
   }
   va_end(args);
 }
+#endif /* OT_PLATFORM_RV32 */

--- a/sw/device/lib/runtime/log.h
+++ b/sw/device/lib/runtime/log.h
@@ -6,7 +6,6 @@
 #define OPENTITAN_SW_DEVICE_LIB_RUNTIME_LOG_H_
 
 #include <stdbool.h>
-#include <stdint.h>
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
@@ -93,6 +92,15 @@ typedef struct log_fields {
  * Implementation detail.
  */
 void base_log_internal_core(log_fields_t log, ...);
+
+#define LOG_CORE(severity, format, ...)                    \
+  do {                                                     \
+    log_fields_t log_fields =                              \
+        LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__); \
+    base_log_internal_core(log_fields, ##__VA_ARGS__);     \
+  } while (false)
+
+#ifdef OT_PLATFORM_RV32
 /**
  * Implementation detail.
  */
@@ -125,11 +133,14 @@ extern char _dv_log_offset[];
                            OT_VA_ARGS_COUNT(format, ##__VA_ARGS__), \
                            ##__VA_ARGS__); /* clang-format on */ \
     } else {                                                     \
-      log_fields_t log_fields =                                  \
-          LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);     \
-      base_log_internal_core(log_fields, ##__VA_ARGS__);         \
+      LOG_CORE(severity, format, ##__VA_ARGS__);                 \
     }                                                            \
   } while (false)
+#else /* OT_PLATFORM_RV32 */
+
+#define LOG LOG_CORE
+
+#endif /* OT_PLATFORM_RV32 */
 
 /**
  * Implementation detail of `LOG`.


### PR DESCRIPTION
Presently, it is impossible to use the logging macros in DIFs for somewhat obscure reasons. This is because the DIFs are compiled on host for opentitanlib bindgen, and it fails with a really difficult to debug error about signing select having wrong values. On the other hand, being able to print from the DIFs is really useful when debugging.

This commit change the log library so that it can compile on host, hence enabling usage in DIFs. It requires a bit of ugly conditional compilation because logging in DV relies on magic symbols.