### PR TITLE
[dv,usbdev] External diff rcvr at block level, and fix setup_trans_ignored

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
@@ -29,8 +29,8 @@ class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
 
   // Send an OUT packet with the specified DATAx token to the DUT and check that it
   // receives the expected handshake response.
-  task send_out_packet(bit [3:0] ep, bit data_toggle, bit exp_ack,
-                       inout uvm_reg_data_t exp_out_data_toggles);
+  task send_and_check_packet(bit [3:0] ep, bit data_toggle, bit exp_ack,
+                             inout uvm_reg_data_t exp_out_data_toggles);
     endp = ep;  // TODO: should be a parameter to tasks in base sequence.
 
     // Set up the OUT EP and supply a randomly-chosen buffer.
@@ -243,8 +243,8 @@ class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
       `DV_CHECK_STD_RANDOMIZE_FATAL(in_rsp);
 
       // Send a randomized packet to the chosen OUT endpoint.
-      send_out_packet(ep_out, exp_out_data_toggles[ep_out] ^ out_provoke_mismatch,
-                      !out_provoke_mismatch, exp_out_data_toggles);
+      send_and_check_packet(ep_out, exp_out_data_toggles[ep_out] ^ out_provoke_mismatch,
+                           !out_provoke_mismatch, exp_out_data_toggles);
       // Disable all OUT endpoints. See Note 1.
       csr_wr(.ptr(ral.ep_out_enable[0]), .value(0));
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -9,7 +9,9 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   virtual task body();
-    uvm_reg_data_t rxfifo;
+    int unsigned max_tries = 4;
+    usb20_item response;
+    bit pkt_sent;
     bit in_sent;
 
     ral.intr_enable.pkt_sent.set(1'b1); // Enable pkt_sent interrupt
@@ -17,40 +19,41 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // For IN transaction need to do first OUT transaction
     // to store data in buffer memory for read through IN.
     configure_out_trans(); // register configurations for OUT Trans.
-    // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+
+    send_prnd_out_packet(endp, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeAck);
-    cfg.clk_rst_vif.wait_clks(20);
-    // Read rxfifo reg
-    csr_rd(.ptr(ral.rxfifo), .value(rxfifo));
+    $cast(response, m_response_item);
+    `DV_CHECK_EQ(response.m_pkt_type, PktTypeHandshake);
+    `DV_CHECK_EQ(response.m_pid_type, PidTypeAck);
+
+    check_rx_packet(endp, 1'b0, out_buffer_id, m_data_pkt.data);
+
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(out_buffer_id, m_data_pkt.data.size());
-    // Token pkt followed by handshake pkt
+
+    // Attempt to collect IN DATA packet in response.
     call_token_seq(PidTypeInToken);
     get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    get_data_pid_from_device(m_usb20_item, PidTypeData0);
-    cfg.clk_rst_vif.wait_clks(20);
+    $cast(response, m_response_item);
+    get_data_pid_from_device(response, PidTypeData0);
+    // ACKnowledge successful reception of the IN DATA packet.
+    response_delay();
     call_handshake_sequence(PktTypeHandshake, PidTypeAck);
-    cfg.clk_rst_vif.wait_clks(20);
-    // Verify Transaction reads register status and verifis that IN transtion is successfull.
-    check_trans_accuracy();
-    // Write 1 to clear particular EPs in_sent
+
+    // We need to wait a few clock cycles for the interrupt state to change.
+    for (int unsigned try = 0; try < 4; try++) begin
+      csr_rd(.ptr(ral.intr_state.pkt_sent), .value(pkt_sent));
+      if (pkt_sent) break;
+    end
+    // `pkt_sent` interrupt should now be asserted...
+    `DV_CHECK_EQ(pkt_sent, 1);
+    // ... as should the bit for this endpoint within the 'in_sent' register.
+    csr_rd(.ptr(ral.in_sent[0].sent[endp]), .value(in_sent));
+    `DV_CHECK_EQ(in_sent, 1);
+
+    // Write 1 to clear particular EP's bit in `in_sent`
     csr_wr(.ptr(ral.in_sent[0].sent[endp]), .value(1'b1));
     csr_rd(.ptr(ral.in_sent[0].sent[endp]), .value(in_sent));
-    `DV_CHECK_EQ(0, in_sent); // verify that after writting one in_sent bit is cleared.
-  endtask
-
-  task check_trans_accuracy();
-    bit pkt_sent;
-    bit sent;
-    csr_rd(.ptr(ral.intr_state.pkt_sent), .value(pkt_sent));
-    csr_rd(.ptr(ral.in_sent[0].sent[endp]), .value(sent));
-    `DV_CHECK_EQ(1, pkt_sent);
-    `DV_CHECK_EQ(1, sent);
+    `DV_CHECK_EQ(0, in_sent); // verify that after writing, the in_sent bit is cleared.
   endtask
 endclass

--- a/hw/ip/usbdev/dv/usbdev_sim.core
+++ b/hw/ip/usbdev/dv/usbdev_sim.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:dv:usb20_usbdpi
       - lowrisc:dv_dpi_c:usbdpi
       - lowrisc:dv_dpi_sv:usbdpi
+      - lowrisc:prim_generic:usb_diff_rx
     files:
       - tb/tb.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This is based on PR #23061 with all but the first two commits being identical at this time, because it requires the usb20_driver changes that supports 'no response' from the DUT, reported as a 'time out.'

The two commits unique to this PR:
1. Instantiate and use the external differential receiver, a la OpenTitan ASIC implementation.
2. Fix the test sequence 'usbdev_setup_trans_ignored' which was previously doing nothing useful, as well as tidying the 'usbdev_in_trans' sequence and introducing some further tasks in the base functions, to be used throughout the remaining sequences in future changes.

The PHY configuration is presently not varied, but the configuration is presented in the same USBDEV register, and the bits being available paves the way for satisfying further test points.