### PR TITLE
[sw] Enable `clippy::undocumented_unsafe_blocks` lint

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -134,7 +134,7 @@ build --@rules_rust//rust/toolchain/channel=nightly
 # Configure the rust 'clippy' linter.
 build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build --output_groups=+clippy_checks
-build --@rules_rust//:clippy_flags="-Aclippy::bool_assert_comparison,-Aclippy::uninlined_format_args,-Dwarnings"
+build --@rules_rust//:clippy_flags="-Aclippy::bool_assert_comparison,-Aclippy::uninlined_format_args,-Wclippy::undocumented_unsafe_blocks,-Dwarnings"
 
 # Configure the module ID check.
 build --aspects=rules/quality.bzl%modid_check_aspect

--- a/sw/host/opentitanlib/bindgen/BUILD
+++ b/sw/host/opentitanlib/bindgen/BUILD
@@ -217,6 +217,8 @@ rust_bindgen_library(
         "--allowlist-function=status_err",
         "--allowlist-function=status_ok",
         "--generate-inline-functions",
+        "--with-derive-custom=ot_status_create_record=zerocopy::FromZeroes",
+        "--with-derive-custom=ot_status_create_record=zerocopy::FromBytes",
     ],
     cc_lib = "//sw/device/lib/base:status",
     header = "//sw/device/lib/base:status.h",
@@ -224,6 +226,9 @@ rust_bindgen_library(
         "--allow=non_snake_case",
         "--allow=non_upper_case_globals",
         "--allow=non_camel_case_types",
+    ],
+    deps = [
+        "@crate_index//:zerocopy",
     ],
 )
 


### PR DESCRIPTION
This lint requires a `// SAFETY: ...` comment above `unsafe { ... }` blocks which explain why the unsafe code is safe.

See https://rust-lang.github.io/rust-clippy/master/index.html#/undocumented_unsafe_blocks for more details.

Most of our code is already clean for this lint, but I've added two commits which fix or add these annotations.

The `status.rs` file just needed the comments to match the format `clippy` expects.

The `xmodem.rs` test file needed `SAFETY` comments writing which hopefully I've gotten right.