### PR TITLE
[opentitantool] Improvements for C2D2 debugger support

### DIFF
--- a/sw/host/opentitanlib/src/app/config/h1dx_devboard_c2d2.json
+++ b/sw/host/opentitanlib/src/app/config/h1dx_devboard_c2d2.json
@@ -19,11 +19,17 @@
 	  "level": false
 	}
       ]
+    },
+    {
+      "name": "ROM_BOOTSTRAP"
     }
   ],
   "uarts": [
     {
       "name": "console",
+      "baudrate": 115200,
+      "parity": "None",
+      "stopbits": "Stop1",
       "alias_of": "CR50"
     }
   ]


### PR DESCRIPTION
Add the ROM_BOOTSTRAP strapping which allows the `bootstrap -p legacy-rescue` operation to work.

Add more information to UART which allows the C2D2 to perform a UART break condition
