### PR TITLE
[edn/dv] Add transition to reject entropy state to alert test

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
+++ b/hw/dv/sv/csrng_agent/csrng_agent_cfg.sv
@@ -21,6 +21,7 @@ class csrng_agent_cfg extends dv_base_agent_cfg;
                     min_cmd_rdy_dly, max_cmd_rdy_dly,
                     reseed_cnt, generate_cnt, generate_between_reseeds_cnt;
   bit               cmd_zero_delays;
+  bit               cmd_force_ack;
   bit               under_reset;
   csrng_cmd_sts_e   rsp_sts_err;
 

--- a/hw/ip/edn/dv/env/edn_if.sv
+++ b/hw/ip/edn/dv/env/edn_if.sv
@@ -24,6 +24,7 @@ interface edn_if(input clk, input rst_n);
         return {core_path, ep_blk_path, ".u_edn_ack_sm_ep.state_q"};
       end
       "edn_main_sm": return {core_path, ".u_edn_main_sm.state_q"};
+      "edn_main_sm_next": return {core_path, ".u_edn_main_sm.state_d"};
       default: `uvm_fatal("edn_if", "Invalid sm name!")
     endcase // case (which_sm)
   endfunction // sm_err_path

--- a/hw/ip/edn/dv/tests/edn_base_test.sv
+++ b/hw/ip/edn/dv/tests/edn_base_test.sv
@@ -27,6 +27,7 @@ class edn_base_test extends cip_base_test #(
     cfg.enable_pct = 100;
 
     cfg.m_csrng_agent_cfg.cmd_zero_delays = 0; // For cmd_ack and cmd_ready
+    cfg.m_csrng_agent_cfg.cmd_force_ack   = 0;
     cfg.m_csrng_agent_cfg.min_cmd_ack_dly = 4;
     cfg.m_csrng_agent_cfg.max_cmd_ack_dly = 32;
     cfg.m_csrng_agent_cfg.min_genbits_dly = 0;


### PR DESCRIPTION
This PR is related to [#22352](https://github.com/lowRISC/opentitan/issues/22352)

I wasn't able to confirm with the coverage yet if this fills the FSM coverage hole since I was working on debugging.
Through this PR I was able to find some potential minor issues.
Some might not even be issues but are still worthy of discussion.

These include:
- HW_CMD_STS only shows boot/auto mode after the INS command (For auto mode this probably makes sense since INS is SW controlled).
- After reenabling EDN the HW_CMD_STS still shows the last command before EDN was disabled.
- Two assertoffs I added need to be checked if they can be added or if there is a bug.

Furthermore, the alert test does not have a check for SW_MODE since the probability of having both auto mode and boot mode disabled in the CTRL reg is 0 for this test. This hole needs to be filled.