### PR TITLE
[rv_dm,dv] Revert "double request" logic in DMI driver and monitor

### DIFF
--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_monitor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_monitor.sv
@@ -43,17 +43,6 @@ class jtag_dmi_monitor #(type ITEM_T = jtag_dmi_item) extends dv_base_monitor#(
     // address.
     bit dmi_selected = 1'b0;
 
-    // Normally, we consider a request to have gone through if the JTAG transaction has a rsp_op
-    // other than DmiOpInProgress. Unfortunately, there's a confusing window immediately after a
-    // request is made: the first JTAG transaction immediately after a request won't necessarily
-    // realise it should respond with DmiOpInProgress.
-    //
-    // To avoid things getting out of sync, we don't have an opinion about whether that transaction
-    // managed to cause a request. If we see a transaction other than DmiOpNone in that position,
-    // the monitor raises an error. The quiet_period flag is set if we can't trust the response of
-    // the next JTAG transaction.
-    bit quiet_period = 1'b0;
-
     forever begin
       bit is_ir_update, is_dr_update;
 
@@ -83,60 +72,46 @@ class jtag_dmi_monitor #(type ITEM_T = jtag_dmi_item) extends dv_base_monitor#(
 
       // At this point, we know we're operating on the DMI register. Handle any DR update.
       if (is_dr_update) begin
-        jtag_dmi_op_req_e req_op = jtag_dmi_op_req_e'(get_field_val(cfg.jtag_dtm_ral.dmi.op,
-                                                                    jtag_item.dr));
 
-        if (quiet_period) begin
-          if (req_op != DmiOpNone) begin
-            `uvm_error(`gfn, $sformatf("JTAG operation %0d != DmiOpNone in quiet period", req_op))
-          end
-          quiet_period = 1'b0;
-        end else begin
-          // The item has both the response for the previous request and a new DMI request. Capture
-          // the response first.
-          bit in_progress = capture_response(jtag_item);
+        // Item has both the response for the previous request and a new DMI request. Capture the
+        // response first.
+        bit busy = capture_response(jtag_item);
 
-          // Since we know we are not in the quiet period, the DUT will have taken the request if it
-          // did not report an operation in progress. Set the quiet_period flag unless the operation
-          // was DmiOpNone.
-          if (req_op != DmiOpNone && !in_progress) begin
-            capture_request(jtag_item);
-            quiet_period = 1'b1;
-          end
-        end
+        // If the TAP was not busy, any previous DMI transaction has completed so the TAP will also
+        // have seen the request.
+        if (!busy) capture_request(jtag_item);
       end
     end
   endtask
 
   // Capture a new DMI request, if the previous DMI transaction is not in progress.
   //
-  // Returns true if there was a previous request which is still in progress. Otherwise returns
-  // false.
+  // Returns true if the response was captured, or if there was no previous request, false if the
+  // response returned was busy.
   virtual function bit capture_response(jtag_item jtag_item);
     jtag_dmi_op_rsp_e rsp_op = jtag_dmi_op_rsp_e'(
         get_field_val(cfg.jtag_dtm_ral.dmi.op, jtag_item.dout));
 
-    if (rsp_op == DmiOpInProgress) begin
-      return 1;
-    end
-
     if (dmi_req_q.size() != 0) begin
-      ITEM_T dmi_item = dmi_req_q.pop_front();
-      dmi_item.rsp_op = rsp_op;
-      if (dmi_item.req_op == DmiOpRead) begin
-        uvm_reg_data_t data = get_field_val(cfg.jtag_dtm_ral.dmi.data,
-                                            jtag_item.dout);
-        dmi_item.rdata = data;
+      if (rsp_op == DmiOpInProgress) begin
+        return 1;
+      end else begin
+        ITEM_T dmi_item = dmi_req_q.pop_front();
+        dmi_item.rsp_op = rsp_op;
+        if (dmi_item.req_op == DmiOpRead) begin
+          uvm_reg_data_t data = get_field_val(cfg.jtag_dtm_ral.dmi.data,
+                                              jtag_item.dout);
+          dmi_item.rdata = data;
+        end
+        `uvm_info(`gfn, $sformatf("Writing DMI item to analysis_port: %0s",
+                                  dmi_item.sprint(uvm_default_line_printer)), UVM_HIGH)
+        analysis_port.write(dmi_item);
       end
-      `uvm_info(`gfn, $sformatf("Writing DMI item to analysis_port: %0s",
-                                dmi_item.sprint(uvm_default_line_printer)), UVM_HIGH)
-      analysis_port.write(dmi_item);
     end else begin
       if (rsp_op != DmiOpOk) begin
         `uvm_error(`gfn, $sformatf("Non-ok response seen with no previous DMI request."))
       end
     end
-
     return 0;
   endfunction
 

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_frontdoor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_frontdoor.sv
@@ -22,8 +22,9 @@ class jtag_dmi_reg_frontdoor extends uvm_reg_frontdoor;
 
   virtual task body();
     csr_field_t         csr_or_fld;
-    uvm_reg_data_t      wdata = 0;
+    uvm_reg_data_t      wdata = 0, rdata;
     jtag_dtm_reg_block  jtag_dtm_ral = jtag_agent_cfg_h.jtag_dtm_ral;
+    jtag_dmi_op_rsp_e   op_rsp;
 
     // If the JTAG agent is sitting in reset, print a debug message and exit early
     if (jtag_agent_cfg_h.in_reset) begin
@@ -74,9 +75,26 @@ class jtag_dmi_reg_frontdoor extends uvm_reg_frontdoor;
     // soon, it may end up setting the in progress sticky bit, causing more time wasted.
     jtag_agent_cfg_h.vif.wait_tck(10);
 
-    // Poll for completion.
+    // Poll for completion. Reset DMI if the sticky bit 'InProgress' is set.
     `DV_SPINWAIT_EXIT(
-      read_dmi_over_jtag(jtag_dtm_ral, csr_or_fld);,
+      do begin
+        csr_rd(.ptr(jtag_dtm_ral.dmi), .value(rdata), .blocking(1));
+        op_rsp = jtag_dmi_op_rsp_e'(get_field_val(jtag_dtm_ral.dmi.op, rdata));
+        `uvm_info(`gfn, $sformatf("DMI CSR req status: %0s", op_rsp.name()), UVM_HIGH)
+        if (op_rsp == DmiOpInProgress) begin
+          csr_wr(.ptr(jtag_dtm_ral.dtmcs.dmireset), .value(1), .blocking(1), .predict(1));
+        end else begin
+          rw_info.status = op_rsp == DmiOpOk ? UVM_IS_OK : UVM_NOT_OK;
+          if (rw_info.kind == UVM_READ) begin
+            rdata = get_field_val(jtag_dtm_ral.dmi.data, rdata);
+            if (csr_or_fld.field != null) begin
+              rdata = get_field_val(csr_or_fld.field, rdata);
+            end
+            rw_info.value = new[1];
+            rw_info.value[0] = rdata;
+          end
+        end
+      end while (op_rsp == DmiOpInProgress);,
       begin
         fork
           wait(jtag_agent_cfg_h.in_reset);
@@ -88,58 +106,6 @@ class jtag_dmi_reg_frontdoor extends uvm_reg_frontdoor;
 
     `uvm_info(`gfn, $sformatf("DMI CSR req completed: %0s", rw_info.convert2string()), UVM_HIGH)
     jtag_dtm_ral_sem_h.put();
-  endtask
-
-  // Use JTAG to read the contents of the DMI register
-  //
-  // If the underlying operation in rw_info is UVM_READ, this also updates rw_info.value to contain
-  // the requested register contents.
-  //
-  // For either direction (read or write), it waits until the DMI is running an operation.
-  task read_dmi_over_jtag(jtag_dtm_reg_block jtag_dtm_ral, csr_field_t csr_or_fld);
-    uvm_reg_data_t    dmi_data_rdata;
-    jtag_dmi_op_rsp_e op_rsp;
-    int               num_dones_seen = 0;
-
-    // This loop works around a confusing situation where TCK is running much faster than the main
-    // clock and the first JTAG read responds with DmiOpOk just as it discovers (too late) that
-    // there was actually an operation in progress. The next JTAG read correctly responds with
-    // DmiOpInProgress and the operation is done next time we see DmiOpOk (or DmiOpFailed).
-    //
-    // If we see two results other than DmiOpInProgress, we know that the operation is genuinely
-    // finished.
-    while (num_dones_seen < 2) begin
-      uvm_reg_data_t rdata;
-
-      csr_rd(.ptr(jtag_dtm_ral.dmi), .value(rdata), .blocking(1));
-      op_rsp = jtag_dmi_op_rsp_e'(get_field_val(jtag_dtm_ral.dmi.op, rdata));
-
-      // If DMI responds with DmiOpInProgress, it is telling us that an operation was running. That
-      // flag is sticky, so we need to follow up by writing 1 to "dmireset" over JTAG to clear the
-      // flag.
-      if (op_rsp == DmiOpInProgress) begin
-        csr_wr(.ptr(jtag_dtm_ral.dtmcs.dmireset), .value(1), .blocking(1), .predict(1));
-      end else begin
-        if (num_dones_seen == 0) begin
-          dmi_data_rdata = get_field_val(jtag_dtm_ral.dmi.data, rdata);
-        end
-
-        num_dones_seen++;
-      end
-    end
-
-    // At this point, we've seen two reads where op_rsp is not DmiOpInProgress. Use the results of
-    // the second read to populate rw_info. If we are doing a UVM_READ, this includes extracting the
-    // CSR or field from rdata.
-    rw_info.status = op_rsp == DmiOpOk ? UVM_IS_OK : UVM_NOT_OK;
-    if (rw_info.kind == UVM_READ) begin
-      if (csr_or_fld.field != null) begin
-        dmi_data_rdata = get_field_val(csr_or_fld.field, dmi_data_rdata);
-      end
-
-      rw_info.value = new[1];
-      rw_info.value[0] = dmi_data_rdata;
-    end
   endtask
 
 endclass


### PR DESCRIPTION
I strongly suspect that I misunderstood what was going on when I added this code, and it just makes things more complicated. The failures that I was "working around" were probably due to bugs in the jtag driver, which I believe I have now fixed.