### PR TITLE
[rom_ext] Communicate minimum security version in the boot_log

### DIFF
--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -45,8 +45,12 @@ typedef struct boot_log {
   uint32_t ownership_state;
   /** Number of ownership transfers this chip has had. */
   uint32_t ownership_transfers;
+  /** Minimum security version permitted for ROM_EXT payloads */
+  uint32_t rom_ext_min_sec_ver;
+  /** Minimum security version permitted for application payloads */
+  uint32_t bl0_min_sec_ver;
   /** Pad to 128 bytes. */
-  uint32_t reserved[12];
+  uint32_t reserved[10];
 } boot_log_t;
 
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, digest, 0);
@@ -60,7 +64,9 @@ OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_nonce, 60);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_slot, 68);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, ownership_state, 72);
 OT_ASSERT_MEMBER_OFFSET(boot_log_t, ownership_transfers, 76);
-OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 80);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, rom_ext_min_sec_ver, 80);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, bl0_min_sec_ver, 84);
+OT_ASSERT_MEMBER_OFFSET(boot_log_t, reserved, 88);
 
 enum {
   /**

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -765,6 +765,8 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log->rom_ext_nonce = boot_data->nonce;
   boot_log->ownership_state = boot_data->ownership_state;
   boot_log->ownership_transfers = boot_data->ownership_transfers;
+  boot_log->rom_ext_min_sec_ver = boot_data->min_security_version_rom_ext;
+  boot_log->bl0_min_sec_ver = boot_data->min_security_version_bl0;
 
   // Initialize the chip ownership state.
   HARDENED_RETURN_IF_ERROR(ownership_init());


### PR DESCRIPTION
1. Add `min_sec_ver` fields to the `boot_log` structure.
2. Initialize the minimum security versions to the values contained in the `boot_data` structure.