### PR TITLE
[dv/otp_ctrl] dont compare direct_access_rdata_* on on non-integrity partitions

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_scoreboard.sv.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_scoreboard.sv.tpl
@@ -807,6 +807,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                     predict_no_err(OtpDaiErrIdx);
                     predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
                                   read_out0, read_out1);
+                    // do not check direct_access_rdata_* on ECC errors in
+                    // non-integrity partitions
+                    check_dai_rd_data = 0;
                   end else begin
                     predict_no_err(OtpDaiErrIdx);
                     predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -801,6 +801,9 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                     predict_no_err(OtpDaiErrIdx);
                     predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),
                                   read_out0, read_out1);
+                    // do not check direct_access_rdata_* on ECC errors in
+                    // non-integrity partitions
+                    check_dai_rd_data = 0;
                   end else begin
                     predict_no_err(OtpDaiErrIdx);
                     predict_rdata(is_secret(dai_addr) || is_digest(dai_addr),


### PR DESCRIPTION
For non-integrity partitions (s.a. VENDOR_TEST), the OTP scoreboard backdoor reads the OTP in raw form (doesn't apply ECC corrections) and compares with actual data returned on the DAI interface. However, in case `MacroEccUncorrErr` is injected, the IP might try and correct the errors, and the result on the DAI won't match the actual raw data in that particular address.

This issue causes two failures:

1. [Memory comparison](https://github.com/lowRISC/opentitan/blob/master/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv#L612C1-L616C44). This has been mitigated in CS.

2. [Register comparison for `OTP_CTRL.DIRECT_ACCESS_RDATA_*`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv#L1119-L1130). This is a bit trickier to override in CS, hence this PR is created to address the issue. Just skip the register comparison in case a `MacroEccCorrErr` or `MacroEccUncorrErr` happens when we access one of the non-integrity partitions.
