### PR TITLE
[dv,usbdev] Fix regressions

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
@@ -208,13 +208,13 @@ class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
     csr_wr(.ptr(ral.ep_in_enable[0]), .value(0));
 
     // Connect the USB device to the USB
-    ral.usbctrl.enable.set(1);
-    csr_update(.csr(ral.usbctrl));
+    usbdev_connect();
 
     // Do not proceed further until the device has exited the Bus Reset signaling of the
     // usb20_driver module; a Bus Reset will cause the data toggles to be reset automatically by
     // the DUT.
     wait_for_link_state({LinkActive, LinkActiveNoSOF}, 10 * 1000 * 48);  // 10ms timeout, at 48MHz
+    usbdev_set_address(dev_addr);
 
     // A Bus Reset should have occurred above, which resets all of the Data Toggle bits to zero.
     exp_out_data_toggles = 0;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -21,9 +21,9 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
   task body();
     uvm_reg_data_t rd_data;
 
-    ral.usbctrl.enable.set(1'b1);  // Set usbdev control register enable bit.
-    ral.usbctrl.device_address.set(0);
-    csr_update(ral.usbctrl);
+    usbdev_connect();
+    wait_for_link_state({LinkActive, LinkActiveNoSOF}, 10 * 1000 * 48);  // 10ms timeout, at 48MHz
+    usbdev_set_address(dev_addr);
 
     configure_out_trans(); // register configurations for OUT Trans.
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -40,7 +40,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
 
     // Read rxfifo reg
     csr_rd(.ptr(ral.rxfifo), .value(read_rxfifo));
-    // Make sure buffer is availabe for next trans
+    // Make sure buffer is available for next trans
     csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id + 1));
 
     // Out token packet followed by a data packet

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -9,8 +9,6 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    super.dut_init("HARD");
-    cfg.clk_rst_vif.wait_clks(200);
     clear_all_interrupts();
     // Configure out transaction
     configure_out_trans();

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -9,8 +9,6 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    super.dut_init("HARD");
-    cfg.clk_rst_vif.wait_clks(200);
     clear_all_interrupts();
     // Configure out transaction
     configure_out_trans();

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_pins_sense_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_pins_sense_vseq.sv
@@ -14,10 +14,8 @@ class usbdev_phy_pins_sense_vseq extends usbdev_base_vseq;
     bit rx_dp;
     bit rx_dn;
 
-    super.dut_init("HARD");
     // Configure phy_pins_drive register
     // Set dp and dn randomly (0 or 1)
-
     csr_wr(.ptr(ral.phy_pins_drive.dp_o), .value(set_dp));
     csr_wr(.ptr(ral.phy_pins_drive.dn_o), .value(set_dn));
     csr_wr(.ptr(ral.phy_pins_drive.oe_o), .value(1'b1));
@@ -31,7 +29,6 @@ class usbdev_phy_pins_sense_vseq extends usbdev_base_vseq;
     // output (sampled by phy_pins_sense reg)
     `DV_CHECK_EQ(set_dp, rx_dp)
     `DV_CHECK_EQ(set_dn, rx_dn)
-
   endtask
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_trans_ignored_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_trans_ignored_vseq.sv
@@ -10,7 +10,6 @@ class usbdev_setup_trans_ignored_vseq extends usbdev_base_vseq;
   bit pkt_received = 1;
 
   task body();
-    super.dut_init("HARD");
     csr_wr(.ptr(ral.rxenable_setup[0].setup[endp]), .value(1'b0)); // Disable rx_enable setup
     csr_wr(.ptr(ral.ep_out_enable[0].enable[endp]), .value(1'b1)); // Enable OUT EP
     cfg.clk_rst_vif.wait_clks(10);


### PR DESCRIPTION
This PR just updates some of the existing block level DV sequences following these changes to the base sequence:
- use a randomized address by default for better testing/coverage
- wait for the USB link to become active so that the Bus Reset performed by the usb20_driver does not interfere with sequence behavior.

A small subset of the existing sequences has been failing in regressions, mostly in a seed-invariant manner, through not being updated following those changes.