### PR TITLE
[rv_dm,dv] Add missing waits to rv_dm_jtag_dmi_debug_disabled_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
@@ -57,6 +57,11 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
         cfg.rv_dm_vif.cb.pinmux_hw_debug_en <= pinmux_hw_debug_en;
       end
 
+      // Wait a few cycles to make sure that the changed enable signal has made it through a
+      // prim_lc_sync. If we start the next operation too early, things will get rather confused
+      // because only the latter half of a JTAG operation will get through.
+      cfg.clk_rst_vif.wait_clks(3);
+
       // Write a different value to abstractdata[0] than read it back. The write should be ignored
       // and the register should read as its reset value (because the debug block is disabled).
       write_abstractdata(value1);
@@ -69,8 +74,8 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
       cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
       cfg.rv_dm_vif.cb.pinmux_hw_debug_en <= lc_ctrl_pkg::On;
 
-      // Wait a clock edge to make sure the LC signal has an effect
-      cfg.clk_rst_vif.wait_clks(1);
+      // Wait again to make sure the LC signal makes it through the prim_lc_sync
+      cfg.clk_rst_vif.wait_clks(3);
 
       // Read the contents of abstractdata[0] and check they are what we set at the start.
       read_abstractdata(value0);


### PR DESCRIPTION
This fixes failures for the occasional seed in the rv_dm_jtag_dmi_debug_disabled test. Those failures also cause lots of failures in the rv_dm_stress_all test, which it also fixes.
