### PR TITLE
Cherry-pick to master: [rom_ext] Use Ibex for RSA sigverify

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -33,13 +33,19 @@ cc_library(
     name = "ecdsa",
     srcs = ["ecdsa.c"],
     hdrs = ["ecdsa.h"],
-    defines = ["USE_CRYPTOC=1"],
+    defines = [
+        "USE_OTBN=1",
+        #"USE_CRYPTOC=1",
+    ],
     deps = [
         ":datatypes",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/drivers:hmac",
-        "//sw/vendor:cryptoc",
+        "//sw/device/silicon_creator/lib:otbn_boot_services",
+        #"//sw/vendor:cryptoc",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/ownership/ecdsa.c
+++ b/sw/device/silicon_creator/lib/ownership/ecdsa.c
@@ -6,9 +6,12 @@
 
 #include <stdbool.h>
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
-#ifdef USE_CRYPTOC
+#if USE_OTBN == 1
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+#elif USE_CRYPTOC == 1
 // TODO(cfrantz): Replace the CryptoC implementation with a native OpenTitan
 // implementation.
 #include "sw/vendor/cryptoc/include/cryptoc/p256.h"
@@ -25,10 +28,29 @@ OT_WEAK void __assert_func(const char *file, int line, const char *func,
 #error "No ECDSA implementation for lib/ownership."
 #endif
 
+rom_error_t ecdsa_init(void) {
+#if USE_OTBN == 1
+  return otbn_boot_app_load();
+#elif USE_CRYPTOC == 1
+  return kErrorOk;
+#endif
+}
+
 hardened_bool_t ecdsa_verify_digest(const owner_key_t *pubkey,
                                     const owner_signature_t *signature,
                                     const hmac_digest_t *digest) {
-#ifdef USE_CRYPTOC
+#if USE_OTBN == 1
+  const attestation_public_key_t *key =
+      (const attestation_public_key_t *)pubkey;
+  const attestation_signature_t *sig =
+      (const attestation_signature_t *)signature;
+  uint32_t rr[8];
+  rom_error_t error = otbn_boot_sigverify(key, sig, digest, rr);
+  if (error != kErrorOk) {
+    return kHardenedBoolFalse;
+  }
+  return hardened_memeq(sig->r, rr, ARRAYSIZE(rr));
+#elif USE_CRYPTOC == 1
   const p256_int *x = (const p256_int *)&pubkey->key[0];
   const p256_int *y = (const p256_int *)&pubkey->key[8];
   const p256_int *r = (const p256_int *)&signature->signature[0];

--- a/sw/device/silicon_creator/lib/ownership/ecdsa.h
+++ b/sw/device/silicon_creator/lib/ownership/ecdsa.h
@@ -9,11 +9,17 @@
 
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * Initializes ECDSA crypto.
+ */
+rom_error_t ecdsa_init(void);
 
 /**
  * Verifies an ECDSA P-256 signature.

--- a/sw/device/silicon_creator/lib/ownership/ecdsa_functest.c
+++ b/sw/device/silicon_creator/lib/ownership/ecdsa_functest.c
@@ -60,6 +60,11 @@ void __assert_func(const char *file, int line, const char *func,
   abort();
 }
 
+static status_t initialize(void) {
+  TRY(ecdsa_init());
+  return OK_STATUS();
+}
+
 // Tests that we can verify an ECDSA signature given the digest.
 status_t ecdsa_verify_digest_test(void) {
   hmac_digest_t digest;
@@ -88,7 +93,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
-  status_t result = OK_STATUS();
+  status_t result = initialize();
   EXECUTE_TEST(result, ecdsa_verify_digest_test);
   EXECUTE_TEST(result, ecdsa_verify_message_test);
   return status_ok(result);

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
@@ -166,5 +166,20 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
   return sigverify_encoded_message_check(&enc_msg, act_digest, flash_exec);
 }
 
+rom_error_t sigverify_rsa_verify_ibex(const sigverify_rsa_buffer_t *signature,
+                                      const sigverify_rsa_key_t *key,
+                                      const hmac_digest_t *act_digest,
+                                      lifecycle_state_t lc_state,
+                                      uint32_t *flash_exec) {
+  sigverify_rsa_buffer_t enc_msg;
+  rom_error_t error = sigverify_mod_exp_ibex(key, signature, &enc_msg);
+  if (launder32(error) != kErrorOk) {
+    *flash_exec ^= UINT32_MAX;
+    return error;
+  }
+  HARDENED_CHECK_EQ(error, kErrorOk);
+  return sigverify_encoded_message_check(&enc_msg, act_digest, flash_exec);
+}
+
 // Extern declarations for the inline functions in the header.
 extern uint32_t sigverify_rsa_success_to_ok(uint32_t v);

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.h
@@ -43,6 +43,25 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
                                  uint32_t *flash_exec);
 
 /**
+ * Verifies an RSASSA-PKCS1-v1_5 signature.
+ *
+ * This function uses the Ibex software implementation only.
+ *
+ * @param signature Signature to be verified.
+ * @param key Signer's RSA public key.
+ * @param act_digest Actual digest of the message being verified.
+ * @param lc_state Life cycle state of the device.
+ * @param[out] flash_exec Value to write to the flash_ctrl EXEC register.
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sigverify_rsa_verify_ibex(const sigverify_rsa_buffer_t *signature,
+                                      const sigverify_rsa_key_t *key,
+                                      const hmac_digest_t *act_digest,
+                                      lifecycle_state_t lc_state,
+                                      uint32_t *flash_exec);
+
+/**
  * Transforms `kSigverifyRsaSuccess` into `kErrorOk`.
  *
  * Callers should transform the result to a suitable error value if it is not

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -259,8 +259,8 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
   memcpy(&boot_measurements.bl0, &act_digest, sizeof(boot_measurements.bl0));
 
   uint32_t flash_exec = 0;
-  return sigverify_rsa_verify(&manifest->rsa_signature, key, &act_digest,
-                              lc_state, &flash_exec);
+  return sigverify_rsa_verify_ibex(&manifest->rsa_signature, key, &act_digest,
+                                   lc_state, &flash_exec);
 }
 
 /**

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -289,10 +289,6 @@ static rom_error_t rom_ext_attestation_keygen(
     const manifest_t *owner_manifest) {
   hardened_bool_t curr_cert_valid = kHardenedBoolFalse;
 
-  // Load OTBN attestation keygen program.
-  // TODO(#21550): this should already be loaded by the ROM.
-  HARDENED_RETURN_IF_ERROR(otbn_boot_app_load());
-
   // Configure certificate flash info pages.
   flash_ctrl_cert_info_pages_creator_cfg();
 
@@ -755,6 +751,10 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log->rom_ext_nonce = boot_data->nonce;
   boot_log->ownership_state = boot_data->ownership_state;
   boot_log->ownership_transfers = boot_data->ownership_transfers;
+
+  // Load OTBN attestation keygen program.
+  // TODO(#21550): this should already be loaded by the ROM.
+  HARDENED_RETURN_IF_ERROR(otbn_boot_app_load());
 
   // Initialize the chip ownership state.
   HARDENED_RETURN_IF_ERROR(ownership_init());


### PR DESCRIPTION
This is a manual cherry-pick of #23064 to master.

Since we are planning to do away with RSA signatures in favor of ECDSA signatures, we can use Ibex for RSA verification until we fully eliminate the use of RSA. This important temporary measure allows us to bring the full ECDSA OTBN program into the ROM_EXT and use it for ECDSA verification of ownership transfer operations.

Switch RSA sigverify of the owner application firmware over to Ibex-based verification.
Cherry-pick jadephilipoom's OTBN P-256 implementation.
Use the OTBN implementation for ownership-related verification, thus eliminating CryptoC and saving 12K of flash space.