### PR TITLE
Launcher modification for DVSim

### DIFF
--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -16,7 +16,7 @@ class LocalLauncher(Launcher):
     """
 
     # Misc common LocalLauncher settings.
-    max_odirs = 5
+    # max_odirs = 5
 
     def __init__(self, deploy):
         '''Initialize common class members.'''

--- a/util/dvsim/SgeLauncher.py
+++ b/util/dvsim/SgeLauncher.py
@@ -24,7 +24,7 @@ class SgeLauncher(Launcher):
     """
 
     # Misc common SgeLauncher settings.
-    max_odirs = 5
+    # max_odirs = 5
 
     def __init__(self, deploy):
         '''Initialize common class members.'''


### PR DESCRIPTION
Delete the redefinitions in the two subclasses of Launcher.py to ensure the attribute max_odirs given by args of DVSim been correctly passed to clean_odirs()  function.

Related to issue: https://github.com/lowRISC/opentitan/issues/23093#issuecomment-2110826639