### PR TITLE
Launcher Modification

### DIFF
--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -15,9 +15,6 @@ class LocalLauncher(Launcher):
     Implementation of Launcher to launch jobs in the user's local workstation.
     """
 
-    # Misc common LocalLauncher settings.
-    max_odirs = 5
-
     def __init__(self, deploy):
         '''Initialize common class members.'''
 

--- a/util/dvsim/SgeLauncher.py
+++ b/util/dvsim/SgeLauncher.py
@@ -23,9 +23,6 @@ class SgeLauncher(Launcher):
     Implementation of Launcher to launch jobs in the user's local workstation.
     """
 
-    # Misc common SgeLauncher settings.
-    max_odirs = 5
-
     def __init__(self, deploy):
         '''Initialize common class members.'''
 


### PR DESCRIPTION
Delete the redefinitions in the two subclasses of Launcher.py to ensure the attribute max_odirs given by args of DVSim been correctly passed to clean_odirs() function.

Related to https://github.com/lowRISC/opentitan/issues/23093#issuecomment-2110826639