### PR TITLE
[manuf] remove HW_CFG1 measurement from UDS cert

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -104,7 +104,7 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
  */
 // clang-format off
 #define STRUCT_MANUF_PERSO_CERTS(field, string) \
-    field(uds_tbs_certificate, uint8_t, 728) \
+    field(uds_tbs_certificate, uint8_t, 680) \
     field(uds_tbs_certificate_size, size_t) \
     field(cdi_0_certificate, uint8_t, 580) \
     field(cdi_0_certificate_size, size_t) \
@@ -130,7 +130,7 @@ UJSON_SERDE_STRUCT(ManufCerts, \
  */
 // clang-format off
 #define STRUCT_MANUF_ENDORSED_CERTS(field, string) \
-    field(uds_certificate, uint8_t, 820) \
+    field(uds_certificate, uint8_t, 768) \
     field(uds_certificate_size, size_t) \
     field(tpm_ek_certificate, uint8_t, 936) \
     field(tpm_ek_certificate_size, size_t) \

--- a/sw/device/silicon_creator/lib/cert/uds.hjson
+++ b/sw/device/silicon_creator/lib/cert/uds.hjson
@@ -49,11 +49,6 @@
             type: "byte-array",
             size: 32,
         },
-        // Hash of the hw_cfg1 OTP partition (SHA256).
-        otp_hw_cfg1_hash: {
-            type: "byte-array",
-            size: 32,
-        },
         // Debug (whether LC state exposes JTAG access or not).
         debug_flag: {
             type: "boolean",
@@ -115,7 +110,6 @@
                     { hash_algorithm: "sha256", digest: { var: "otp_owner_sw_cfg_hash" } },
                     { hash_algorithm: "sha256", digest: { var: "otp_rot_creator_auth_codesign_hash" } },
                     { hash_algorithm: "sha256", digest: { var: "otp_rot_creator_auth_state_hash" } },
-                    { hash_algorithm: "sha256", digest: { var: "otp_hw_cfg1_hash" } },
                 ],
                 flags: {
                     not_configured: false,

--- a/sw/device/silicon_creator/lib/dice.c
+++ b/sw/device/silicon_creator/lib/dice.c
@@ -53,8 +53,7 @@ static cdi_1_sig_values_t cdi_1_cert_params = {
 static_assert(
     OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE &&
     OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE &&
-    OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE &&
-    OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_HW_CFG1_SIZE,
+    OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE > OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE,
     "The largest DICE measured OTP partition is no longer the "
     "OwnerSwCfg partition. Update the "
     "kDiceMeasuredOtpPartitionMaxSizeIn32bitWords constant.");
@@ -214,7 +213,6 @@ rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
   hmac_digest_t otp_owner_sw_cfg_measurement = {.digest = {0}};
   hmac_digest_t otp_rot_creator_auth_codesign_measurement = {.digest = {0}};
   hmac_digest_t otp_rot_creator_auth_state_measurement = {.digest = {0}};
-  hmac_digest_t otp_hw_cfg1_measurement = {.digest = {0}};
   measure_otp_partition(kOtpPartitionCreatorSwCfg,
                         &otp_creator_sw_cfg_measurement);
   measure_otp_partition(kOtpPartitionOwnerSwCfg, &otp_owner_sw_cfg_measurement);
@@ -222,7 +220,6 @@ rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
                         &otp_rot_creator_auth_codesign_measurement);
   measure_otp_partition(kOtpPartitionRotCreatorAuthState,
                         &otp_rot_creator_auth_state_measurement);
-  measure_otp_partition(kOtpPartitionHwCfg1, &otp_hw_cfg1_measurement);
 
   // Generate the TBS certificate.
   uds_tbs_values_t uds_cert_tbs_params = {
@@ -238,8 +235,6 @@ rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
       .otp_rot_creator_auth_state_hash =
           (unsigned char *)otp_rot_creator_auth_state_measurement.digest,
       .otp_rot_creator_auth_state_hash_size = kHmacDigestNumBytes,
-      .otp_hw_cfg1_hash = (unsigned char *)otp_hw_cfg1_measurement.digest,
-      .otp_hw_cfg1_hash_size = kHmacDigestNumBytes,
       .debug_flag = is_debug_exposed(),
       .creator_pub_key_id = (unsigned char *)key_ids->cert->digest,
       .creator_pub_key_id_size = kDiceCertKeyIdSizeInBytes,


### PR DESCRIPTION
This measurement is not relevant to the overall identity of the device. This reduces the UDS cert size as well.