### PR TITLE
[i2c,dv] I2C target mode fifo watermark tests

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -499,7 +499,7 @@
                 stay asserted until the causes are addressed.
             '''
       stage: V2
-      tests: ["i2c_host_fifo_watermark"]
+      tests: ["i2c_target_fifo_watermarks_acq"]
     }
     {
       name: host_mode_config_perf

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -499,7 +499,7 @@
                 stay asserted until the causes are addressed.
             '''
       stage: V2
-      tests: ["i2c_target_fifo_watermarks_acq"]
+      tests: ["i2c_target_fifo_watermarks_acq", "i2c_target_fifo_watermarks_tx"]
     }
     {
       name: host_mode_config_perf

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -54,6 +54,7 @@ filesets:
       - seq_lib/i2c_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_may_nack_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_fifo_watermarks_acq_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_fifo_watermarks_tx_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -53,6 +53,7 @@ filesets:
       - seq_lib/i2c_host_mode_toggle_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_may_nack_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_fifo_watermarks_acq_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -429,25 +429,21 @@ class i2c_base_vseq extends cip_base_vseq #(
     ral.timeout_ctrl.en.set(e_timeout);
     ral.timeout_ctrl.val.set(t_timeout);
     csr_update(.csr(ral.timeout_ctrl));
+    ral.host_fifo_config.rx_thresh.set(rx_thresh);
+    ral.host_fifo_config.fmt_thresh.set(fmt_thresh);
+    csr_update(ral.host_fifo_config);
+    ral.target_fifo_config.acq_thresh.set(acq_thresh);
+    ral.target_fifo_config.tx_thresh.set(tx_thresh);
+    csr_update(ral.target_fifo_config);
+
+    `uvm_info(`gfn, $sformatf("Wrote following register values :\n%s",
+      ral.sprint()), UVM_MEDIUM)
+
     // configure i2c_agent_cfg
     cfg.m_i2c_agent_cfg.timing_cfg = timing_cfg;
     `uvm_info(`gfn, $sformatf("\n  cfg.m_i2c_agent_cfg.timing_cfg\n%p",
         cfg.m_i2c_agent_cfg.timing_cfg), UVM_MEDIUM)
 
-    //*** program Host mode FIFO thresholds
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(rx_thresh)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(fmt_thresh)
-    ral.host_fifo_config.rx_thresh.set(rx_thresh);
-    ral.host_fifo_config.fmt_thresh.set(fmt_thresh);
-    csr_update(ral.host_fifo_config);
-    //*** program Target mode FIFO thresholds
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(acq_thresh)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(tx_thresh)
-    ral.target_fifo_config.acq_thresh.set(acq_thresh);
-    ral.target_fifo_config.tx_thresh.set(tx_thresh);
-    csr_update(ral.target_fifo_config);
-    //*** set FIFO_CTRL register
-    csr_update(ral.fifo_ctrl);
   endtask : program_registers
 
   virtual task program_format_flag(i2c_item item, string msg = "", bit do_print = 1'b0);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_acq_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_acq_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This sequecne assert 'fifo_ctrl.acqrst' at the end of transaction.
+// This sequence asserts 'fifo_ctrl.acqrst' at the end of transaction.
 // Upon asserting 'fifo_ctrl.acqrst', dut has to be 'target idle' state.
 // Before it resume a new transaction, all tb pipeline are flushed.
 class i2c_target_fifo_reset_acq_vseq extends i2c_target_runtime_base_vseq;
@@ -13,51 +13,39 @@ class i2c_target_fifo_reset_acq_vseq extends i2c_target_runtime_base_vseq;
     super.pre_start();
 
     cfg.scb_h.read_rnd_data = 1;
-    seq_runtime = 10000;
+    seq_runtime_us = 10000;
   endtask
 
-  task test_event();
+  virtual task body();
     #50us;
-    repeat (5) begin
-      wait(cfg.m_i2c_agent_cfg.got_stop);
-      // stop reading acq fifo and sequence
-      pause_seq = 1;
+    fork
+      super.body();
+      process_acq();
+    join
+  endtask: body
 
-      // flush acq
-      ral.fifo_ctrl.acqrst.set(1'b1);
-      csr_update(ral.fifo_ctrl);
+  virtual task end_of_stim_hook();
+    // flush acq
+    ral.fifo_ctrl.acqrst.set(1'b1);
+    csr_update(ral.fifo_ctrl);
 
-      // clean up sb
-      cfg.scb_h.target_mode_wr_exp_fifo.flush();
-      cfg.scb_h.target_mode_wr_obs_fifo.flush();
-      cfg.scb_h.skip_acq_comp = 1;
+    // clean up sb
+    cfg.scb_h.target_mode_wr_exp_fifo.flush();
+    cfg.scb_h.target_mode_wr_obs_fifo.flush();
+    cfg.scb_h.skip_acq_comp = 1;
 
-      #10us;
-      tran_id = 0;
-      cfg.scb_h.obs_wr_id = 0;
-      cfg.scb_h.skip_acq_comp = 0;
-      pause_seq = 0;
+    #10us;
+    tran_id = 0;
+    cfg.scb_h.obs_wr_id = 0;
+    cfg.scb_h.skip_acq_comp = 0;
 
-      // random delay before the next round
-      #($urandom_range(1, 5) * 10us);
-    end
-  endtask // test_event
+    // random delay before the next round
+    #($urandom_range(1, 5) * 10us);
+  endtask
 
   task proc_intr_cmdcomplete();
     // read acq fifo in 'body' task
     clear_interrupt(CmdComplete, 0);
-  endtask // proc_itnr_cmd_complete
+  endtask: proc_intr_cmdcomplete
 
-  task process_acq();
-    bit fifo_empty, pop_all;
-    int delay;
-
-    while (!cfg.stop_intr_handler) begin
-      delay = $urandom_range(0, 10);
-      cfg.clk_rst_vif.wait_clks(delay * acq_rd_cyc);
-      // pop one all entries by 25% of chance.
-      pop_all = ($urandom_range(0,3) > 0);
-      if (!pause_seq) read_acq_fifo(~pop_all, fifo_empty);
-    end
-  endtask // process_acq
-endclass // i2c_target_fifo_reset_acq_vseq
+endclass: i2c_target_fifo_reset_acq_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_watermarks_acq_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_watermarks_acq_vseq.sv
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test provides a basic check of the ACQFIFO watermarks and watermark
+// interrupts.
+//
+// This test stimulates write transfers from the Agent, which fill the acqfifo
+// above the configured watermark. After each write transaction, we check that
+// the 'AcqThreshold' interrupt has asserted, and remained asserted as a
+// status-type irq. After clearing the acqfifo, we then check the interrupt has
+// de-asserted.
+//
+// (DUT:Agent == Target:Controller)
+// This test is interrupt driven, so needs the plusarg '+use_intr_handler=1' set.
+//
+class i2c_target_fifo_watermarks_acq_vseq extends i2c_target_runtime_base_vseq;
+  `uvm_object_utils(i2c_target_fifo_watermarks_acq_vseq)
+  `uvm_object_new
+
+  uint acq_threshold_intr_poscnt;
+  uint acq_threshold_intr_negcnt;
+
+  virtual task pre_start();
+    super.pre_start();
+
+    seq_runtime_us = 1_000;
+
+    // Only write transactions.
+    cfg.rd_pct = 0;
+
+    // Constrain each transaction to be larger than the configured 'acq_thresh'.
+    cfg.min_data = acq_thresh;
+    cfg.max_data = I2C_ACQ_FIFO_DEPTH;
+
+    // Disable ACK-Control mode ('acqstretch' can only be due to acqfull)
+    cfg.ack_ctrl_en = 0;
+  endtask: pre_start
+
+  virtual task body();
+    fork
+      super.body();
+      count_edge_intr(AcqThreshold, acq_threshold_intr_poscnt, acq_threshold_intr_negcnt);
+    join_any
+  endtask: body
+
+  // This hook is called at the start of each new stimulus iteration.
+  //
+  virtual task setup_hook();
+    // Cleanup for next iteration.
+    acq_threshold_intr_poscnt = 0;
+    acq_threshold_intr_negcnt = 0;
+  endtask
+
+  virtual task end_of_stim_hook();
+    bit acq_fifo_empty;
+
+    // The ACQFIFO begins empty. We stimulated a transaction which should
+    // have generated at-least as much data as the configured threshold.
+
+    check_one_intr(AcqThreshold, 1);
+    `DV_CHECK_EQ(acq_threshold_intr_poscnt, 1, "acq_threshold interrupt did not trigger correctly!")
+    `DV_CHECK_EQ(acq_threshold_intr_negcnt, 0, "acq_threshold de-asserted when not expected!")
+
+    // If we filled the acqfifo, wait for it to become not full. That way we
+    // don't fight the acq_stretch handler. Currently the scoreboard does not
+    // tolerate extra reads from the acqfifo.
+    csr_spinwait(.ptr(ral.status.acqfull), .exp_data(1'b0));
+    // Empty out the ACQFIFO now.
+    read_acq_fifo(.read_one(0), .acq_fifo_empty(acq_fifo_empty));
+
+    `DV_CHECK_EQ(acq_threshold_intr_negcnt, 1, "acq_threshold should drop once on fifo drain!")
+    check_one_intr(AcqThreshold, 0);
+  endtask
+
+  // Interrupt handler for the "cmd_complete" interrupt
+  // (This overrides the parent class impl.)
+  virtual task proc_intr_cmdcomplete();
+    `uvm_info(`gfn, "proc_intr_cmdcomplete()", UVM_MEDIUM)
+    // Simply acknowledge and clear this 'event'-type interrupt.
+    clear_interrupt(CmdComplete, 0);
+  endtask: proc_intr_cmdcomplete
+
+  // Interrupt handler for the "acq_stretch" interrupt
+  //
+  // Desc:
+  //   Read the ACQFIFO a single time, which in this test is due to
+  //   it becoming full from write txn stimulus.
+  //   This is required to allow the stimulus transaction to complete,
+  //   if it should be larger than the ACQFIFO, as otherwise we would
+  //   stretch indefinitely.
+  //
+  virtual task proc_intr_acqstretch();
+    bit acq_fifo_empty;
+    `uvm_info(`gfn, "proc_intr_acqstretch()", UVM_MEDIUM)
+    read_acq_fifo(.read_one(1), .acq_fifo_empty(acq_fifo_empty));
+  endtask: proc_intr_acqstretch
+
+endclass: i2c_target_fifo_watermarks_acq_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_watermarks_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_watermarks_tx_vseq.sv
@@ -1,0 +1,133 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test provides a basic check of the TXFIFO watermarks and watermark
+// interrupts.
+//
+// Desc:
+//   Stimulate read transactions, filling the TXFIFO with data before starting
+//   driving the bus. By choosing a read-size which is larger than the
+//   configured tx_threshold watermark, we can see the "tx_threshold" interrupt
+//   begin asserted when populating with data, de-assert once the TXFIFO is filled
+//   beyond the threshold, then assert again as the bus stimulus empties the fifo.
+//
+// (DUT:Agent == Target:Controller)
+// This test is interrupt driven, so needs the plusarg '+use_intr_handler=1' set.
+//
+class i2c_target_fifo_watermarks_tx_vseq extends i2c_target_runtime_base_vseq;
+  `uvm_object_utils(i2c_target_fifo_watermarks_tx_vseq)
+  `uvm_object_new
+
+  // EXP
+  uint tx_threshold_exp_state;
+  uint tx_threshold_exp_intr_poscnt = 0;
+  uint tx_threshold_exp_intr_negcnt = 0;
+
+  // OBS
+  uint tx_threshold_obs_intr_poscnt = 0;
+  uint tx_threshold_obs_intr_negcnt = 0;
+
+  virtual task pre_start();
+    super.pre_start();
+
+    seq_runtime_us = 1_000;
+
+    // Only read transactions.
+    cfg.wr_pct = 0;
+
+    // Constrain each transaction to be larger than the configured 'tx_thresh'.
+    cfg.min_data = tx_thresh + 1;
+    cfg.max_data = I2C_TX_FIFO_DEPTH;
+
+    // Disable ACK-Control mode ('acqstretch' can only be due to acqfull)
+    cfg.ack_ctrl_en = 0;
+  endtask: pre_start
+
+  virtual task body();
+    fork
+      super.body();
+      count_edge_intr(TxThreshold, tx_threshold_obs_intr_poscnt, tx_threshold_obs_intr_negcnt);
+    join_any
+  endtask: body
+
+  // This hook is called at the start of each new stimulus iteration.
+  //
+  virtual task setup_hook();
+    // Cleanup for next iteration.
+    tx_threshold_obs_intr_poscnt = 0;
+    tx_threshold_obs_intr_negcnt = 0;
+    tx_threshold_exp_intr_poscnt = 0;
+    tx_threshold_exp_intr_negcnt = 0;
+  endtask
+
+  virtual task start_of_stim_hook();
+    // At the start of stimulus, the txfifo should be empty.
+    csr_rd_check(.ptr(ral.target_fifo_status.txlvl), .compare_value(0));
+    // Unless the threshold is also configured to zero, this means the
+    // interrupt should be asserted.
+    tx_threshold_exp_state = bit'(tx_thresh > 0);
+    check_one_intr(TxThreshold, tx_threshold_exp_state);
+
+    // Write all rdata for the next read transaction to the TXFIFO
+    while (read_rcvd.size() > 0) write_tx_fifo();
+
+    // This should be enough data to now exceed the watermark, and hence the
+    // interrupt will deassert (if the interrupt was active to begin with).
+    // This check is done before any agent-stimulus is generated, so data
+    // cannot yet leave the txfifo.
+    if (tx_threshold_exp_state) tx_threshold_exp_intr_negcnt++;
+    tx_threshold_exp_state = 1'b0;
+
+    `DV_CHECK_EQ(tx_threshold_obs_intr_poscnt, tx_threshold_exp_intr_poscnt,
+                 "tx_threshold interrupt did not trigger correctly!")
+    `DV_CHECK_EQ(tx_threshold_obs_intr_negcnt, tx_threshold_exp_intr_negcnt,
+                 "tx_threshold de-asserted when not expected!")
+  endtask
+
+  virtual task end_of_stim_hook();
+    bit acq_fifo_empty;
+
+    // After the transaction completes, the txfifo should now be empty, and
+    // (unless threshold == 0) the watermark interrupt should be asserted again.
+    tx_threshold_exp_state = bit'(tx_thresh > 0);
+    if (tx_threshold_exp_state) tx_threshold_exp_intr_poscnt++;
+
+    check_one_intr(TxThreshold, tx_threshold_exp_state);
+    `DV_CHECK_EQ(tx_threshold_obs_intr_poscnt, tx_threshold_exp_intr_poscnt,
+                 "acq_threshold interrupt did not trigger correctly!")
+    `DV_CHECK_EQ(tx_threshold_obs_intr_negcnt, tx_threshold_exp_intr_negcnt,
+                 "acq_threshold de-asserted when not expected!")
+
+    // Empty out the ACQFIFO now.
+    `uvm_info(`gfn, "Emptying ACQFIFO now.", UVM_MEDIUM)
+    read_acq_fifo(.read_one(0), .acq_fifo_empty(acq_fifo_empty));
+    `uvm_info(`gfn, "ACQFIFO is now empty.", UVM_MEDIUM)
+
+    #1ns; // Otherwise our cleanup races with the scoreboard checking the acqfifo read above.
+  endtask
+
+  // Interrupt handler for the "cmd_complete" interrupt
+  // (This overrides the parent class impl.)
+  virtual task proc_intr_cmdcomplete();
+    `uvm_info(`gfn, "proc_intr_cmdcomplete()", UVM_MEDIUM)
+    // Simply acknowledge and clear this 'event'-type interrupt.
+    clear_interrupt(CmdComplete, 0);
+  endtask: proc_intr_cmdcomplete
+
+  // Interrupt handler for a '"tx_stretch" interrupt.
+  //
+  // Desc:
+  //   In this test, we add all the rddata into the TXFIFO before the
+  //   agent begins the read transaction. However, the DUT will still
+  //   stretch (tx_stretch) once more than one item is in the ACQFIFO.
+  //   This handler simply reads the ACQFIFO once when called.
+  virtual task proc_intr_txstretch();
+    bit acq_fifo_empty;
+    `uvm_info(`gfn, "proc_intr_acqstretch()", UVM_MEDIUM)
+    `uvm_info(`gfn, "Reading ACQFIFO once now.", UVM_MEDIUM)
+    read_acq_fifo(.read_one(1), .acq_fifo_empty(acq_fifo_empty));
+    `uvm_info(`gfn, "ACQFIFO read once.", UVM_MEDIUM)
+  endtask: proc_intr_txstretch
+
+endclass: i2c_target_fifo_watermarks_tx_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
@@ -146,7 +146,7 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
           sent_txn_cnt++;
         end
       end
-      process_target_interrupts();
+      while (!cfg.stop_intr_handler) process_target_interrupts();
       stop_target_interrupt_handler();
       // Wait for completion of all transactions issued in the sequence
       begin

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_runtime_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_runtime_base_vseq.sv
@@ -2,91 +2,211 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This is base sequence for any data path drop test for target_mode i2c.
-// Random data path drop event make difficult to predict sent/rcvd counter.
-// This base sequence run the sequence for 'seq_runtime' and
-// test execution does not rely on sent / rcvd counter.
+// Base sequence for i2c target-mode tests that creates a framework to be
+// used for directed-tests which involve dropping data.
+//
+// Without precise modelling, random datapath drop events make it difficult to
+// predict the values of sent/rcvd item counts in the scoreboard, and to tie
+// up obs items against the correct exp.
+// This base sequence is a framework that generates stimulus for 'seq_runtime_us'
+// microseconds, intended for any test execution that can't rely on the
+// the scoreboard's sent / rcvd counters. (This framework overrides the framework
+// defined in 'i2c_target_smoke_vseq::body()'). Hook-methods are defined which
+// allow vseq's to set-up and tear-down directed test cases, returning the checking
+// machinery to a good known state for the next iteration.
+//
 class i2c_target_runtime_base_vseq extends i2c_target_smoke_vseq;
   `uvm_object_utils(i2c_target_runtime_base_vseq)
   `uvm_object_new
 
-  // sequence running time in us
-  // update this value using 'pre_start' in child sequence.
-  int seq_runtime = 0;
-  // set this bit to 1 to hold next sequence start.
-  bit pause_seq = 0;
-  // 1 bit cycle : thigh + tlow
-  // one acq entry can be popped every 9 bit cycles (8bit + ack)
-  int acq_rd_cyc;
-  i2c_target_base_seq m_i2c_host_seq;
+  ///////////////////
+  // CONTROL KNOBS //
+  ///////////////////
+
+  // Sequence run time in us.
+  // Derived sequences should set this to an appropriate value in 'pre_start'.
+  int seq_runtime_us = 0;
+
+  /////////////////////
+  // CLASS VARIABLES //
+  /////////////////////
+
+  // This bit is set when a timer that runs for 'seq_runtime_us' expires.
+  // When this occurs, the test is about to end.
+  protected bit timer_expired = 0;
+
+  typedef enum int {
+    StIdle,
+    StStimGen,
+    StPreHook,
+    StStim,
+    StPostHook,
+    StComplete
+  } runtime_state_t;
+  // This state variable controls the test execution between the agent
+  // stimulus-generation loop inside body(), and the test_event() loop which
+  // derived tests can hook-into to drive stimulus and check state at certain
+  // controlled times throughout the test.
+  protected runtime_state_t runtime_state = StIdle;
+
+  // The stimulus sequence that will be run on the agent.
+  // Derived testcases can observe the generated stimulus before it is driven by the agent
+  // by examining the items in 'm_i2c_host_seq.req_q' during the start_of_stim_hook().
+  protected i2c_target_base_seq m_i2c_host_seq;
+
+  ///////////////////
+  // CLASS METHODS //
+  ///////////////////
+
+  // Common routine to advance the runtime state machine.
+  // This is used to synchronize the test runtime between generate_stimulus() and
+  // test_event().
+  //
+  // Small delays around the state change are added, to prevent races between waiting on
+  // state changes and advancing to a new state.
+  virtual task advance_runtime_state(runtime_state_t to);
+    #1ns;
+    `uvm_info(`gfn, $sformatf("Advancing runtime state to %0s", to.name()), UVM_MEDIUM)
+    runtime_state = to;
+    #1ns;
+  endtask: advance_runtime_state
+
+  virtual task wait_for_runtime_state(runtime_state_t await);
+    `uvm_info(`gfn, $sformatf("Waiting for runtime state %0s", await.name()), UVM_MEDIUM)
+    wait(runtime_state == await);
+  endtask: wait_for_runtime_state
 
   virtual task body();
-    i2c_item txn_q[$];
-    bit timer_expired = 0;
+    `DV_CHECK(seq_runtime_us > 0)
 
     initialization();
-    `uvm_info("cfg_summary", $sformatf("target_addr0:0x%x target_addr1:0x%x num_trans:%0d",
-                             target_addr0, target_addr1, num_trans), UVM_MEDIUM)
-    acq_rd_cyc = 9 * (thigh + tlow);
+
     fork
-      begin
+      while (!timer_expired) begin
         fork
-          while (timer_expired == 0) begin
-            `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
-            create_txn(txn_q);
-            fetch_txn(txn_q, m_i2c_host_seq.req_q);
-            m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
-            `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop, "got_stop wait timeout occurred!",
-                     cfg.spinwait_timeout_ns, "target_runtime_base_vseq")
-            cfg.m_i2c_agent_cfg.got_stop = 0;
-            // To avoid race between 'pause_seq set' and
-            // 'cfg.m_i2c_agent_cfg.got_stop = 1'
-            cfg.clk_rst_vif.wait_clks(1);
-            `DV_WAIT(pause_seq == 0, "pause_seq == 0 wait timeout occurred!",
-                     cfg.spinwait_timeout_ns, "target_runtime_base_vseq")
-          end
-          process_target_interrupts();
+          generate_stimulus();
+          test_event();
         join
+        if (timer_expired) advance_runtime_state(.to(StComplete));
       end
+      while (!cfg.stop_intr_handler) process_target_interrupts();
       begin
-        #(seq_runtime * 1us);
-        `uvm_info("seq", "timer expired", UVM_MEDIUM)
+        // Count out the time delay specified by 'seq_runtime_us', then bring the stimulus to
+        // a close.
+        #(seq_runtime_us * 1us);
         timer_expired = 1;
-        `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop, "got_stop wait timeout occurred!",
-                 cfg.spinwait_timeout_ns, "target_runtime_base_vseq")
-        cfg.stop_intr_handler = 1;
-      end
-      begin
-        test_event();
-      end
-      begin
-        process_acq();
+        `uvm_info(`gfn, "Runtime_base_vseq timer expired", UVM_MEDIUM)
+        // Only stop the interrupt handler once the stimulus generation and checking routines
+        // have completed. The 'StComplete' state is used to synchronize on this event.
+        wait_for_runtime_state(.await(StComplete));
+        `uvm_info(`gfn, "Stopping interrupt handlers.", UVM_MEDIUM)
+        cfg.stop_intr_handler = 1; // Stop the process_target_interrupts() irq-handler routine.
       end
     join
   endtask
-  virtual task test_event; endtask
-  virtual task process_acq; endtask
 
-  // If txfifo is not full,
-  // fill random size of tx data upon receiving txstretch interrupt.
-  // expected data will be stored at the scoreboard
-  task proc_intr_txstretch();
-    bit [7:0] wdata;
-    int       lvl;
-    int       delay;
-    uvm_reg_data_t data;
-    delay = $urandom_range(0, 10);
-    cfg.clk_rst_vif.wait_clks(delay * acq_rd_cyc);
-    csr_rd(.ptr(ral.target_fifo_status.txlvl), .value(data));
-    data = 64 - data;
+  virtual task generate_stimulus();
+    wait_for_runtime_state(.await(StStimGen));
 
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(lvl, lvl dist {[1:16] := 7, [17:63] := 1, 64 := 2};)
-    if (lvl > data) lvl = data;
-
-    repeat (lvl) begin
-      wdata = $urandom();
-      csr_wr(.ptr(ral.txdata), .value(wdata));
+    // Construct the I2C Controller sequence that defines the agent stimulus
+    // for this test.
+    begin
+      i2c_item txn_q[$];
+      `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
+      create_txn(txn_q);
+      fetch_txn(txn_q, m_i2c_host_seq.req_q);
     end
-    clear_interrupt(TxStretch, 0);
-  endtask // proc_intr_txstretch
+
+    advance_runtime_state(.to(StPreHook));
+    wait_for_runtime_state(.await(StStim));
+
+    // Run the stimulus sequence on the agent
+    m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
+  endtask
+
+  // Child vseq's should implement these routines to perform checks before and
+  // after the transaction generated by the agent.
+  virtual task setup_hook; endtask
+  virtual task start_of_stim_hook; endtask
+  virtual task end_of_stim_hook; endtask
+
+  virtual task test_event();
+    setup_hook();
+
+    advance_runtime_state(.to(StStimGen));
+    wait_for_runtime_state(.await(StPreHook));
+
+    start_of_stim_hook();
+
+    advance_runtime_state(.to(StStim));
+    // Wait until the end of the stimulus transaction.
+    wait(cfg.m_i2c_agent_cfg.got_stop);
+
+    advance_runtime_state(.to(StPostHook));
+
+    // Reset 'got_stop' for the next iteration, which is used by
+    // the timer process to end gracefully.
+    cfg.m_i2c_agent_cfg.got_stop = 0;
+
+    end_of_stim_hook();
+  endtask
+
+
+  // The TB's interrupt handler should call this routine whenever the "tx_stretch"
+  // interrupt is pending.
+  // (This definition overrides the base_vseq implementation)
+  //
+  // Desc:
+  //   If txfifo is not full, write more data into it.
+  //   (The scoreboard captures these writes to form its expectations)
+  virtual task proc_intr_txstretch();
+    uvm_reg_data_t curr_txlvl;
+    int num_writes, max_writes;
+
+    // One acqfifo entry can be popped every 9 bit cycles (8bit + ack),
+    // where a cycle takes (thigh + tlow) cycles of the underlying clock.
+    int acq_rd_cyc = 9 * (thigh + tlow);
+    int delay = $urandom_range(0, 10);
+    `uvm_info(`gfn, "proc_intr_txstretch()", UVM_MEDIUM)
+    cfg.clk_rst_vif.wait_clks(delay * acq_rd_cyc);
+
+    // Determine how many writes we are going to make to the txfifo.
+    // This algorithm is fairly crude.
+    csr_rd(.ptr(ral.target_fifo_status.txlvl), .value(curr_txlvl));
+    max_writes = I2C_TX_FIFO_DEPTH - curr_txlvl;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_writes,
+      num_writes dist {[ 1:               16] := 7,
+                       [17:I2C_TX_FIFO_DEPTH] := 1,
+                            I2C_TX_FIFO_DEPTH := 2};
+    )
+    if (num_writes > max_writes) num_writes = max_writes;
+
+    repeat (num_writes) begin
+      bit [7:0] wdata = $urandom();
+      csr_wr(.ptr(ral.txdata), .value(wdata));
+      `uvm_info(`gfn, $sformatf("proc_intr_txstretch(): wrote 0x%2x to TXFIFO.", wdata), UVM_MEDIUM)
+    end
+  endtask: proc_intr_txstretch
+
+  // ACQFIFO handler routine
+  // - Random delay before reading, of between 0 and 10*(9*t_bit) cycles
+  // - 25% chance to pop all entries each time, otherwise just pop one.
+  //
+  task process_acq();
+
+    // One acqfifo entry can be popped every 9 bit cycles (8bit + ack),
+    // where a cycle takes (thigh + tlow) cycles of the underlying clock.
+    int acq_rd_cyc = 9 * (thigh + tlow);
+
+    while (!cfg.stop_intr_handler) begin
+      bit fifo_empty;
+      bit pop_all = ($urandom_range(0,3) > 0);
+      int delay = $urandom_range(0, 10);
+      cfg.clk_rst_vif.wait_clks(delay * acq_rd_cyc);
+      if (runtime_state == StStim) read_acq_fifo(~pop_all, fifo_empty);
+    end
+
+    `uvm_info(`gfn, "End of process_acq().", UVM_MEDIUM)
+  endtask: process_acq
+
 endclass

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -114,7 +114,7 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
         if (cfg.use_intr_handler == 1'b0 && cfg.rd_pct != 0) process_txq();
       end
       begin
-        if (cfg.use_intr_handler) process_target_interrupts();
+        if (cfg.use_intr_handler) while (!cfg.stop_intr_handler) process_target_interrupts();
       end
       begin
         if (cfg.use_intr_handler) stop_target_interrupt_handler();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -36,3 +36,4 @@
 `include "i2c_glitch_vseq.sv"
 `include "i2c_host_may_nack_vseq.sv"
 `include "i2c_target_fifo_watermarks_acq_vseq.sv"
+`include "i2c_target_fifo_watermarks_tx_vseq.sv"

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -35,3 +35,4 @@
 `include "i2c_host_mode_toggle_vseq.sv"
 `include "i2c_glitch_vseq.sv"
 `include "i2c_host_may_nack_vseq.sv"
+`include "i2c_target_fifo_watermarks_acq_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -246,6 +246,13 @@
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
     }
+    {
+      name: i2c_target_fifo_watermarks_tx
+      uvm_test_seq: i2c_target_fifo_watermarks_tx_vseq
+      run_opts: ["+i2c_agent_mode=Host",
+                 "+test_timeout_ns=20_000_000",
+                 "+use_intr_handler=1"]
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -239,6 +239,13 @@
       name: "i2c_host_may_nack"
       uvm_test_seq: "i2c_host_may_nack_vseq"
     }
+    {
+      name: i2c_target_fifo_watermarks_acq
+      uvm_test_seq: i2c_target_fifo_watermarks_acq_vseq
+      run_opts: ["+i2c_agent_mode=Host",
+                 "+test_timeout_ns=20_000_000",
+                 "+use_intr_handler=1"]
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR adds two new directed testcases for the I2C target-mode watermark interrupts added in #21621.
See the commit message + vseq header comment for more details about each test.

Some test machinery changes and cleanups have been done to support these new testcases, which comprises the first 4 commits. The final two commits add each testcase.

Best reviewed commit-by-commit.

Goes towards #23077