### PR TITLE
[manuf] remove HW_CFG measurement from UDS cert

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -100,7 +100,7 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
  */
 // clang-format off
 #define STRUCT_MANUF_DICE_CERTS(field, string) \
-    field(uds_tbs_certificate, uint8_t, 632) \
+    field(uds_tbs_certificate, uint8_t, 580) \
     field(uds_tbs_certificate_size, size_t) \
     field(cdi_0_certificate, uint8_t, 580) \
     field(cdi_0_certificate_size, size_t) \
@@ -116,7 +116,7 @@ UJSON_SERDE_STRUCT(ManufDiceCerts, \
  */
 // clang-format off
 #define STRUCT_MANUF_ENDORSED_DICE_CERTS(field, string) \
-    field(uds_certificate, uint8_t, 724) \
+    field(uds_certificate, uint8_t, 672) \
     field(uds_certificate_size, size_t)
 UJSON_SERDE_STRUCT(ManufEndorsedDiceCerts, \
                    manuf_endorsed_dice_certs_t, \

--- a/sw/device/silicon_creator/lib/cert/uds.hjson
+++ b/sw/device/silicon_creator/lib/cert/uds.hjson
@@ -39,11 +39,6 @@
             type: "byte-array",
             size: 32,
         },
-        // Hash of the hw_cfg OTP partition (SHA256).
-        otp_hw_cfg_hash: {
-            type: "byte-array",
-            size: 32,
-        },
         // Debug (whether LC state exposes JTAG access or not).
         debug_flag: {
             type: "boolean",
@@ -103,7 +98,6 @@
                 fw_ids: [
                     { hash_algorithm: "sha256", digest: { var: "otp_creator_sw_cfg_hash" } },
                     { hash_algorithm: "sha256", digest: { var: "otp_owner_sw_cfg_hash" } },
-                    { hash_algorithm: "sha256", digest: { var: "otp_hw_cfg_hash" } },
                 ],
                 flags: {
                     not_configured: false,

--- a/sw/device/silicon_creator/lib/dice.c
+++ b/sw/device/silicon_creator/lib/dice.c
@@ -51,8 +51,7 @@ static cdi_1_sig_values_t cdi_1_cert_params = {
 
 // clang-format off
 static_assert(
-    OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE >= OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE &&
-    OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE >= OTP_CTRL_PARAM_HW_CFG_SIZE,
+    OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE >= OTP_CTRL_PARAM_CREATOR_SW_CFG_SIZE,
     "The largest DICE measured OTP partition is no longer the "
     "OwnerSwCfg partition. Update the "
     "kDiceMeasuredOtpPartitionMaxSizeIn32bitWords constant.");
@@ -206,11 +205,9 @@ rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
   // Measure OTP partitions.
   hmac_digest_t otp_creator_sw_cfg_measurement = {.digest = {0}};
   hmac_digest_t otp_owner_sw_cfg_measurement = {.digest = {0}};
-  hmac_digest_t otp_hw_cfg_measurement = {.digest = {0}};
   measure_otp_partition(kOtpPartitionCreatorSwCfg,
                         &otp_creator_sw_cfg_measurement);
   measure_otp_partition(kOtpPartitionOwnerSwCfg, &otp_owner_sw_cfg_measurement);
-  measure_otp_partition(kOtpPartitionHwCfg, &otp_hw_cfg_measurement);
 
   // Generate the TBS certificate.
   uds_tbs_values_t uds_cert_tbs_params = {
@@ -220,8 +217,6 @@ rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
       .otp_owner_sw_cfg_hash =
           (unsigned char *)otp_owner_sw_cfg_measurement.digest,
       .otp_owner_sw_cfg_hash_size = kHmacDigestNumBytes,
-      .otp_hw_cfg_hash = (unsigned char *)otp_hw_cfg_measurement.digest,
-      .otp_hw_cfg_hash_size = kHmacDigestNumBytes,
       .debug_flag = is_debug_exposed(),
       .creator_pub_key_id = (unsigned char *)key_ids->cert->digest,
       .creator_pub_key_id_size = kDiceCertKeyIdSizeInBytes,


### PR DESCRIPTION
This measurement is not relevant to the overall identity of the device. Moreover, the device ID (which is part of the HW_CFG partition) is already mixed into the keyladder.

This reduces the UDS cert size as well.