### PR TITLE
[sival, otbn] Map randoness test in testplan

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson
@@ -64,6 +64,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_otbn_randomness"]
+      bazel: ["//sw/device/tests:otbn_randomness_test"]
       lc_states: ["PROD"]
       features: [
         "OTBN.RANDOM"
@@ -78,6 +79,7 @@
       stage: V2
       si_stage: SV3
       tests:  ["chip_sw_otbn_randomness"]
+      bazel: ["//sw/device/tests:otbn_randomness_test"]
       lc_states: ["PROD"]
       features: [
         "OTBN.RANDOM"
@@ -101,6 +103,7 @@
       stage: V2
       si_stage: SV3
       tests: ["chip_sw_otbn_randomness"]
+      bazel: ["//sw/device/tests:otbn_randomness_test"]
       lc_states: ["PROD"]
       features: []
     }


### PR DESCRIPTION
This is a manual backport of https://github.com/lowRISC/opentitan/pull/21047.
Somehow git couldn't find the commit hash with `git cherry-pick`. So I made a new commit.