### PR TITLE
[jtag,dv] Handle trst_n at start of time in jtag_driver.sv

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -74,18 +74,35 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     `DV_CHECK_FATAL(cfg.if_mode == Host, "Only Host mode is supported", "jtag_driver")
 
     forever begin
+      // Wait until we either go into reset or we get an item to drive.
+      fork : isolation_fork
+        begin
+          fork
+            wait (! cfg.vif.trst_n);
+            seq_item_port.wait_for_sequences();
+          join_any
+          disable fork;
+        end
+      join
+
       if (!cfg.vif.trst_n) begin
         `DV_WAIT(cfg.vif.trst_n)
         cfg.vif.wait_tck(1);
         drive_jtag_test_logic_reset();
+      end else begin
+        // Since trst_n is not 0, the wait_for_sequences() task must have completed and there must
+        // be an item that we can handle. Retrieve it.
+        seq_item_port.peek(req);
+        `DV_CHECK_FATAL(req != null)
+
+        $cast(rsp, req.clone());
+        rsp.set_id_info(req);
+
+        `uvm_info(`gfn, req.sprint(uvm_default_line_printer), UVM_HIGH)
+        `DV_SPINWAIT_EXIT(drive_jtag_req(req, rsp);,
+                          wait (!cfg.vif.trst_n);)
+        seq_item_port.item_done(rsp);
       end
-      seq_item_port.get_next_item(req);
-      $cast(rsp, req.clone());
-      rsp.set_id_info(req);
-      `uvm_info(`gfn, req.sprint(uvm_default_line_printer), UVM_HIGH)
-      `DV_SPINWAIT_EXIT(drive_jtag_req(req, rsp);,
-                        wait (!cfg.vif.trst_n);)
-      seq_item_port.item_done(rsp);
     end
   endtask
 


### PR DESCRIPTION
The existing code worked as long as the get_and_drive() task started after we had driven trst_n to zero AND we didn't ever want to drive it to zero afterwards.

It turns out that this wasn't the situation I was seeing in my simulations and the result was that the driver thought the JTAG FSM was in the RTI state, but it was actually in Test-Logic-Reset and everything got rather confused.

With this change, we will always notice if we see a trst_n reset, and the driver and bus shouldn't get out of sync in the same way.

(This PR contains just the first commit from #23097, a PR that's failing in CI. I'm hopeful that the failures there are caused by one of the later commits, and *this one* fixes a bunch of tests that failed on Tuesday night).