### PR TITLE
[dv,otp_ctrl] Check ECC errors in VENDOR_TEST partition

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_base_vseq.sv.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_base_vseq.sv.tpl
@@ -352,9 +352,11 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     end
   endtask
 
-  // This function backdoor inject error according to ecc_err.
-  // For example, if err_mask is set to 'b01, bit 1 in OTP macro will be flipped.
-  // This function will output original backdoor read data for the given address.
+  // This function backdoor inject error according to ecc_err:
+  // - for OtpEccUncorrErr it injects a 2 bit eror
+  // - for OtpEccCorrErr it injects a 1 bit eror
+  // This function will output original backdoor read data for the given address
+  // so the error can be cleared.
   virtual function bit [TL_DW-1:0] backdoor_inject_ecc_err(bit [TL_DW-1:0] addr,
                                                            otp_ecc_err_e   ecc_err);
     bit [TL_DW-1:0] val;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -412,9 +412,11 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     end
   endtask
 
-  // This function backdoor inject error according to ecc_err.
-  // For example, if err_mask is set to 'b01, bit 1 in OTP macro will be flipped.
-  // This function will output original backdoor read data for the given address.
+  // This function backdoor inject error according to ecc_err:
+  // - for OtpEccUncorrErr it injects a 2 bit eror
+  // - for OtpEccCorrErr it injects a 1 bit eror
+  // This function will output original backdoor read data for the given address
+  // so the error can be cleared.
   virtual function bit [TL_DW-1:0] backdoor_inject_ecc_err(bit [TL_DW-1:0] addr,
                                                            otp_ecc_err_e   ecc_err);
     bit [TL_DW-1:0] val;

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -851,6 +851,12 @@
       reseed: 1
     }
     {
+      name: chip_sw_otp_ctrl_ecc_error_vendor_test
+      uvm_test_seq: chip_sw_otp_ctrl_vendor_test_ecc_error_vseq
+      sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_vendor_test_ecc_error_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
       name: chip_sw_lc_ctrl_transition
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -100,6 +100,7 @@ filesets:
       - seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_otp_ctrl_escalation_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_otp_ctrl_vendor_test_ecc_error_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_host_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_passthrough_collision_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_passthrough_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_ecc_error_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_otp_ctrl_vendor_test_ecc_error_vseq.sv
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This virtual sequence checks that ECC errors in the vendor test partition
+// don't trigger a fault. The sequence injects single and double bit errors.
+// It communicates the address to the C side via backdoor, since this test is
+// only feasible in simulation. The C code checks for expected status.
+
+class chip_sw_otp_ctrl_vendor_test_ecc_error_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_otp_ctrl_vendor_test_ecc_error_vseq)
+
+  `uvm_object_new
+
+  virtual task body();
+    bit [TL_AW-1:0] address = otp_ctrl_reg_pkg::VendorTestOffset +
+        otp_ctrl_reg_pkg::VendorTestSize / 2;
+    bit [TL_DW-1:0] otp_value;
+    bit [7:0] address_as_bytes[4] = {<<byte{address}};
+
+    super.body();
+
+    // Let SW know the expected partition and address.
+    sw_symbol_backdoor_overwrite("kTestAddress", address_as_bytes);
+
+    // Wait for C-side to be ready.
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Ready for single fault injection",
+             "Timeout waiting for fault injection request.")
+    otp_value = cfg.mem_bkdr_util_h[Otp].read32(address);
+    // Inject 1 bit error to trigger an ECC correctable error.
+    `uvm_info(`gfn, $sformatf("Injecting single bit ECC error at OTP address 0x%x", address),
+              UVM_MEDIUM)
+    cfg.mem_bkdr_util_h[Otp].inject_errors(address, 1);
+    // And wait for C-side for double fault.
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Ready for double fault injection",
+             "Timeout waiting for fault injection request.")
+    // Inject 2 bit error to trigger an ECC uncorrectable error.
+    `uvm_info(`gfn, $sformatf("Injecting double bit ECC error at OTP address 0x%x", address),
+              UVM_MEDIUM)
+    cfg.mem_bkdr_util_h[Otp].inject_errors(address, 2);
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "Address done",
+             "Timeout waiting for OTP_CTRL being done with this address.")
+    // Backdoor write back the original value so the chip can reboot successfully.
+    cfg.mem_bkdr_util_h[Otp].write32(address, otp_value);
+  endtask
+
+endclass : chip_sw_otp_ctrl_vendor_test_ecc_error_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -47,6 +47,7 @@
 `include "chip_sw_lc_walkthrough_testunlocks_vseq.sv"
 `include "chip_sw_otp_ctrl_vendor_test_csr_access_vseq.sv"
 `include "chip_sw_otp_ctrl_escalation_vseq.sv"
+`include "chip_sw_otp_ctrl_vendor_test_ecc_error_vseq.sv"
 `include "chip_sw_spi_host_tx_rx_vseq.sv"
 `include "chip_sw_spi_passthrough_vseq.sv"
 `include "chip_sw_spi_passthrough_collision_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -197,6 +197,23 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "otp_ctrl_vendor_test_ecc_error_test",
+    srcs = ["otp_ctrl_vendor_test_ecc_error_test.c"],
+    exec_env = {"//hw/top_earlgrey:sim_dv": None},
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 cc_library(
     name = "lc_ctrl_transition_impl",
     srcs = ["lc_ctrl_transition_impl.c"],

--- a/sw/device/tests/sim_dv/otp_ctrl_vendor_test_ecc_error_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_vendor_test_ecc_error_test.c
@@ -1,0 +1,79 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// This is the address that has an ecc error injected.
+static volatile const uint32_t kTestAddress = 0;
+
+static dif_otp_ctrl_t otp;
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static void init_peripherals(void) {
+  dif_otp_ctrl_config_t config = {
+      .check_timeout = 100000,
+      .integrity_period_mask = 0x3ffff,
+      .consistency_period_mask = 0x3ffffff,
+  };
+  // OTP
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(dif_otp_ctrl_configure(&otp, config));
+}
+
+static void check_status(uint32_t expected_code,
+                         dif_otp_ctrl_error_t expected_cause) {
+  dif_otp_ctrl_status_t status;
+  CHECK_DIF_OK(dif_otp_ctrl_get_status(&otp, &status));
+  // Clear the non-error status.codes.
+  status.codes &= ~((1u << kDifOtpCtrlStatusCodeDaiIdle) |
+                    (1u << kDifOtpCtrlStatusCodeCheckPending));
+  if (expected_code == 0) {
+    CHECK(status.codes == 0,
+          "Unexpected OTP status codes, got 0x%x, expected 0", status.codes);
+  } else {
+    CHECK(status.codes == (1 << expected_code),
+          "Unexpected OTP status, got 0x%x, expected 0x%x", status.codes,
+          (1 << expected_cause));
+    CHECK(status.causes[expected_code] == expected_cause,
+          "Unexpected error cause, got 0x%x, expected 0x%x",
+          status.causes[expected_code], expected_cause);
+  }
+}
+
+/**
+ * A simple SW test to read from vendor test partition at a location that had
+ * an ecc error injected. The expectation is that no error or fault will be
+ * triggered. The ecc eror is injected in the associated SV sequence.
+ */
+bool test_main(void) {
+  static const uint32_t kTestPartition = 0;
+
+  init_peripherals();
+
+  uint32_t value;
+  LOG_INFO("Testing at OTP address 0x%x", kTestAddress);
+  LOG_INFO("Ready for single fault injection");
+  busy_spin_micros(1);
+  CHECK_STATUS_OK(otp_ctrl_testutils_dai_read32(&otp, kTestPartition,
+                                                kTestAddress, &value));
+  check_status(0, kDifOtpCtrlErrorOk);
+  LOG_INFO("Ready for double fault injection");
+  busy_spin_micros(1);
+  CHECK_STATUS_OK(otp_ctrl_testutils_dai_read32(&otp, kTestPartition,
+                                                kTestAddress, &value));
+  check_status(0, kDifOtpCtrlErrorOk);
+  LOG_INFO("Address done");
+  return true;
+}


### PR DESCRIPTION
Add a top level test that injects singe and double bit errors in the VENDOR_TEST partition, expecting no error to occur reading the otp_ctrl `STATUS` csr.

Fixes #21265