### PR TITLE
[cryptolib] Fix CSRNG driver

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -297,28 +297,6 @@ static const entropy_complex_config_t
             },
 };
 
-// TODO(#19568): CSRNG commands may hang if the main FSM is not idle.
-// This function is used as a workaround to poll for the internal FSM state,
-// blocking until it reaches the `kCsrngMainSmIdle` state. The function
-// attempts `kCsrngIdleNumTries` before returning `OTCRYPTO_RECOV_ERR` if
-// unable to detect idle state.
-OT_WARN_UNUSED_RESULT
-static status_t csrng_fsm_idle_wait(void) {
-  enum {
-    kCsrngIdleNumTries = 100000,
-
-    // This value needs to match `MainSmIdle` in csrng_pkg.sv.
-    kCsrngMainSmIdle = 0x4e,
-  };
-  for (size_t i = 0; i < kCsrngIdleNumTries; ++i) {
-    uint32_t reg = abs_mmio_read32(kBaseCsrng + CSRNG_MAIN_SM_STATE_REG_OFFSET);
-    if (reg == kCsrngMainSmIdle) {
-      return OTCRYPTO_OK;
-    }
-  }
-  return OTCRYPTO_RECOV_ERR;
-}
-
 // Write a CSRNG command to a register. That register can be the SW interface
 // of CSRNG, in which case the `check_completion` argument should be `true`.
 // That register can alternatively be one of EDN's that holds commands that EDN


### PR DESCRIPTION
This PR contains two commits, the really relevant one changes the entropy driver of cryptolib to also poll the CSRNG command ready bit for additional data. Previously, the command register ready bit was only polled for the additional data when writing commands to the SW register of EDN.

When writing commands to CSRNG instead, not polling the command ready bit could cause CSRNG to drop additional data provided by software while handling a hardware command. Once the hardware command was handled, the software instance would win arbitration and CSRNG would wait for software to provide the dropped additional data, thereby stalling the entire entropy complex. This would happen for example if a HW instance request would collide with a software request. Since the software command FIFO is only 2 entries deep, it can only be guaranteed to absorb 2 words if the software interface doesn't win arbitration immediately.

This is related to https://github.com/lowRISC/opentitan/issues/22209 and https://github.com/lowRISC/opentitan/issues/22210.