### PR TITLE
[prim,fpv] Fix a couple of silly warnings in prim_fifo_sync

### DIFF
--- a/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
@@ -63,9 +63,9 @@ module prim_fifo_sync_assert_fpv #(
               fifo <= wdata_i;
             end else if (wvalid_i && wready_o) begin
               fifo <= wdata_i;
-              ref_depth <= ref_depth + 1;
+              ref_depth <= ref_depth + (DepthW+2)'(1);
             end else if (rvalid_o && rready_i) begin
-              ref_depth <= ref_depth - 1;
+              ref_depth <= ref_depth - (DepthW+2)'(1);
             end
           end
         end

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -135,7 +135,7 @@ module prim_fifo_sync #(
     end
 
     if (OutputZeroIfEmpty == 1'b1) begin : gen_output_zero
-      assign rdata_o = empty ? 'b0 : rdata_int;
+      assign rdata_o = empty ? Width'(0) : rdata_int;
     end else begin : gen_no_output_zero
       assign rdata_o = rdata_int;
     end


### PR DESCRIPTION
These shouldn't cause any change in behaviour, but it's nice to silence some of the cruft from the tool (Jasper) as it reads the code.