### PR TITLE
[prim,fpv] Tweak how a parameter gets used in some assertions

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_bind_fpv.sv
@@ -6,18 +6,19 @@
 module prim_esc_rxtx_bind_fpv;
 
   bind prim_esc_rxtx_fpv
-        prim_esc_rxtx_assert_fpv prim_esc_rxtx_assert_fpv (
-    .clk_i       ,
-    .rst_ni      ,
-    .resp_err_pi ,
-    .resp_err_ni ,
-    .esc_err_pi  ,
-    .esc_err_ni  ,
-    .esc_req_i   ,
-    .ping_req_i  ,
-    .ping_ok_o   ,
-    .integ_fail_o,
-    .esc_req_o
-  );
+    prim_esc_rxtx_assert_fpv #(TimeoutCntDw(TimeoutCntDw))
+    prim_esc_rxtx_assert_fpv (
+      .clk_i       ,
+      .rst_ni      ,
+      .resp_err_pi ,
+      .resp_err_ni ,
+      .esc_err_pi  ,
+      .esc_err_ni  ,
+      .esc_req_i   ,
+      .ping_req_i  ,
+      .ping_ok_o   ,
+      .integ_fail_o,
+      .esc_req_o
+    );
 
 endmodule : prim_esc_rxtx_bind_fpv

--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_tb.sv
@@ -23,6 +23,10 @@ module prim_esc_rxtx_tb
   output logic esc_req_o
 );
 
+  // This gets passed to the prim_esc_receiver that we instantiate below. Doing so reduces the state
+  // space for the counter from 2**24 to 2**6, speeding up convergence.
+  localparam int TimeoutCntDw = 6;
+
   esc_rx_t esc_rx_in, esc_rx_out;
   esc_tx_t esc_tx_in, esc_tx_out;
 
@@ -43,9 +47,7 @@ module prim_esc_rxtx_tb
   );
 
   prim_esc_receiver #(
-    // This reduces the state space for this counter
-    // from 2**24 to 2**6 to speed up convergence.
-    .TimeoutCntDw(6)
+    .TimeoutCntDw(TimeoutCntDw)
   ) u_prim_esc_receiver (
     .clk_i    ,
     .rst_ni   ,


### PR DESCRIPTION
The existing code wasn't strictly legal SystemVerilog because it contained a hierarchical reference in something that is being used as a constant (in the "[*0::xyz]" term).

This is not too difficult to fix, because we can just pass the parameter in explicitly constrain the width and then wire it up properly in the bind statement.

To make sure that the assertions don't change meaning, we add an extra assertion (which uses a hierarchical reference in an allowable context).