### PR TITLE
[signing] Remove the legacy `cloud_kms` token

### DIFF
--- a/signing/README.md
+++ b/signing/README.md
@@ -144,7 +144,7 @@ gcloud auth application-default login
 ```
 
 Once authenticated to Google cloud, you can build and sign SiVAL tests
-by requesting the `cloud_kms` token:
+by requesting the `cloud_kms_sival` token:
 
 > You may have to update the permissions on the KMS configuration file as
 follows:
@@ -152,7 +152,7 @@ follows:
 > `chmod 600 signing/tokens/earlgrey_z1_sival.yaml`
 
 ```console
-bazel build --//signing:token=//signing/tokens:cloud_kms //label-of-target
+bazel build --//signing:token=//signing/tokens:cloud_kms_sival //label-of-target
 ```
 
 ## Demo of offline signing

--- a/signing/tokens/BUILD
+++ b/signing/tokens/BUILD
@@ -23,25 +23,6 @@ signing_tool(
     tool = "//sw/host/hsmtool",
 )
 
-# TODO(lowrisc#22428): Remove this target once everyone has started using `cloud_kms_sival`.
-signing_tool(
-    name = "cloud_kms",
-    data = [
-        "earlgrey_z1_sival.yaml",
-        "@cloud_kms_hsm//:libkmsp11",
-    ],
-    deprecation = "Please use the token `//signing/tokens:cloud_kms_sival`.",
-    env = {
-        # The Cloud KMS PKCS11 provider needs to know where the user's home
-        # is in order to load the gclould credentials.
-        "HOME": ENV["HOME"],
-        "HSMTOOL_MODULE": "$(location @cloud_kms_hsm//:libkmsp11)",
-        "KMS_PKCS11_CONFIG": "$(location earlgrey_z1_sival.yaml)",
-    },
-    location = "token",
-    tool = "//sw/host/hsmtool",
-)
-
 signing_tool(
     name = "cloud_kms_sival",
     data = [

--- a/sw/device/tests/doc/sival/README.md
+++ b/sw/device/tests/doc/sival/README.md
@@ -197,11 +197,11 @@ bazel test --define DISABLE_VERILATOR_BUILD=true \
 
 The following command runs the `SV2` test suite using the
 `silicon_owner_sival_rom_ext` execution environment. The binaries are signed
-using the `cloud_kms` signing token configuration.
+using the `cloud_kms_sival` signing token configuration.
 
 ```console
-bazel test --define DISABLE_VERILATOR_BUILD=true    \
-    --//signing:token=//signing/tokens:cloud_kms    \
+bazel test --define DISABLE_VERILATOR_BUILD=true       \
+    --//signing:token=//signing/tokens:cloud_kms_sival \
     --build_tag_filters=silicon_owner_sival_rom_ext,-broken \
     --test_tag_filters=silicon_owner_sival_rom_ext,-broken  \
     --test_output=streamed          \


### PR DESCRIPTION
Remove the `cloud_kms` token label; use `cloud_kms_sival`.

Fixes: #22428