### PR TITLE
[sigverify] Fix dependency error

### DIFF
--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -321,6 +321,7 @@ cc_library(
     ],
     deps = [
         ":sigverify_key_types",
+        ":sigverify_otp_keys",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",


### PR DESCRIPTION
Fix a dependency error that was preventing the `clang-tidy` quality check from running.