### PR TITLE
[ownership] Add KMAC-based sealing functions

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -375,6 +375,7 @@ opentitan_test(
         ":kmac",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:hexstr",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:error",
     ],

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -203,8 +203,8 @@ static rom_error_t keymgr_wait_until_done(void) {
   return kErrorKeymgrInternal;
 }
 
-rom_error_t sc_keymgr_generate_key_otbn(
-    sc_keymgr_key_type_t key_type,
+rom_error_t sc_keymgr_generate_key(
+    sc_keymgr_dest_t destination, sc_keymgr_key_type_t key_type,
     sc_keymgr_diversification_t diversification) {
   HARDENED_RETURN_IF_ERROR(keymgr_is_idle());
 
@@ -212,7 +212,7 @@ rom_error_t sc_keymgr_generate_key_otbn(
 
   // Select OTBN as the destination.
   ctrl = bitfield_field32_write(0, KEYMGR_CONTROL_SHADOWED_DEST_SEL_FIELD,
-                                KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_OTBN);
+                                destination);
 
   // Select the attestation CDI.
   if (key_type == kScKeymgrKeyTypeAttestation) {
@@ -244,20 +244,19 @@ rom_error_t sc_keymgr_generate_key_otbn(
   return keymgr_wait_until_done();
 }
 
-rom_error_t sc_keymgr_sideload_clear_otbn(void) {
+rom_error_t sc_keymgr_sideload_clear(sc_keymgr_dest_t destination) {
   HARDENED_RETURN_IF_ERROR(keymgr_is_idle());
 
   // Set SIDELOAD_CLEAR to begin continuously clearing the requested slot.
   abs_mmio_write32(
       kBase + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET,
-      bitfield_field32_write(0, KEYMGR_SIDELOAD_CLEAR_VAL_FIELD,
-                             KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_OTBN));
+      bitfield_field32_write(0, KEYMGR_SIDELOAD_CLEAR_VAL_FIELD, destination));
 
   // Read back the value (hardening measure).
   uint32_t sideload_clear =
       abs_mmio_read32(kBase + KEYMGR_SIDELOAD_CLEAR_REG_OFFSET);
   if (bitfield_field32_read(sideload_clear, KEYMGR_SIDELOAD_CLEAR_VAL_FIELD) !=
-      KEYMGR_SIDELOAD_CLEAR_VAL_VALUE_OTBN) {
+      destination) {
     return kErrorKeymgrInternal;
   }
 
@@ -298,3 +297,7 @@ rom_error_t sc_keymgr_owner_advance(keymgr_binding_value_t *sealing_binding,
   HARDENED_RETURN_IF_ERROR(sc_keymgr_state_check(kScKeymgrStateOwnerKey));
   return kErrorOk;
 }
+
+extern rom_error_t sc_keymgr_generate_key_otbn(
+    sc_keymgr_key_type_t key_type, sc_keymgr_diversification_t diversification);
+extern rom_error_t sc_keymgr_sideload_clear_otbn(void);

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -79,6 +79,16 @@ typedef struct sc_keymgr_diversification {
 } sc_keymgr_diversification_t;
 
 /**
+ * Destination for key generation.
+ */
+typedef enum sc_keymgr_dest {
+  kScKeymgrDestNone = 0,
+  kScKeymgrDestAes = 1,
+  kScKeymgrDestKmac = 2,
+  kScKeymgrDestOtbn = 3,
+} sc_keymgr_dest_t;
+
+/**
  * The following constants represent the expected number of sec_mmio register
  * writes performed by functions in provided in this module. See
  * `SEC_MMIO_WRITE_INCREMENT()` for more details.
@@ -192,6 +202,36 @@ typedef enum sc_keymgr_key_type {
 } sc_keymgr_key_type_t;
 
 /**
+ * Generate a key manager key and sideload to the requested block.
+ *
+ * Calls the key manager to sideload a key into the requested hardware block and
+ * waits until the operation is complete before returning. Can sideload an
+ * attestation or sealing key based on user input.
+ *
+ * @param destination: Hardware destination for key material.
+ * @param key_type Key type: attestation or sealing.
+ * @param diversification Diversification input for the key derivation.
+ * @return OK or error.
+ */
+
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_generate_key(sc_keymgr_dest_t destination,
+                                   sc_keymgr_key_type_t key_type,
+                                   sc_keymgr_diversification_t diversification);
+
+/**
+ * Clear the requested sideloaded key slot.
+ *
+ * The entropy complex needs to be initialized before calling this function, so
+ * that keymgr can use it to clear the slot.
+ *
+ * @param destination: Hardware block to clear key material.
+ * @return OK or error.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sc_keymgr_sideload_clear(sc_keymgr_dest_t destination);
+
+/**
  * Generate a key manager key and sideload to the OTBN block.
  *
  * Calls the key manager to sideload a key into the OTBN hardware block and
@@ -203,8 +243,11 @@ typedef enum sc_keymgr_key_type {
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t sc_keymgr_generate_key_otbn(
-    sc_keymgr_key_type_t key_type, sc_keymgr_diversification_t diversification);
+inline rom_error_t sc_keymgr_generate_key_otbn(
+    sc_keymgr_key_type_t key_type,
+    sc_keymgr_diversification_t diversification) {
+  return sc_keymgr_generate_key(kScKeymgrDestOtbn, key_type, diversification);
+}
 
 /**
  * Clear OTBN's sideloaded key slot.
@@ -215,7 +258,9 @@ rom_error_t sc_keymgr_generate_key_otbn(
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t sc_keymgr_sideload_clear_otbn(void);
+inline rom_error_t sc_keymgr_sideload_clear_otbn(void) {
+  return sc_keymgr_sideload_clear(kScKeymgrDestOtbn);
+}
 
 /**
  * Sets the binding registers and advances the keymgr to the

--- a/sw/device/silicon_creator/lib/drivers/kmac.c
+++ b/sw/device/silicon_creator/lib/drivers/kmac.c
@@ -80,6 +80,15 @@ typedef struct kmac_config {
    * Enable KMAC sideload mode.
    */
   bool sideload;
+  /**
+   * Whether or not to use enable KMAC mode.
+   */
+  bool kmac_en;
+
+  /**
+   * The algorithm: SHA3, SHAKE or cSHAKE
+   */
+  uint8_t mode;
 } kmac_config_t;
 
 /**
@@ -169,7 +178,7 @@ static rom_error_t kmac_configure(kmac_config_t config) {
                                    KMAC_CFG_SHADOWED_KSTRENGTH_VALUE_L256);
   // Set `CFG.MODE` field to SHAKE.
   cfg_reg = bitfield_field32_write(cfg_reg, KMAC_CFG_SHADOWED_MODE_FIELD,
-                                   KMAC_CFG_SHADOWED_MODE_VALUE_SHAKE);
+                                   config.mode);
   // Set `CFG.MSG_ENDIANNESS` bit to 0 (little-endian).
   cfg_reg =
       bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_MSG_ENDIANNESS_BIT, 0);
@@ -193,6 +202,8 @@ static rom_error_t kmac_configure(kmac_config_t config) {
 
   cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_MSG_MASK_BIT,
                                  config.msg_mask);
+  cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_KMAC_EN_BIT,
+                                 config.kmac_en);
 
   // Set `CFG.ENTROPY_READY` bit to 1.
   cfg_reg =
@@ -233,6 +244,30 @@ rom_error_t kmac_keymgr_configure(void) {
       .entropy_fast_process = false,
       .msg_mask = true,
       .sideload = true,
+      .kmac_en = false,
+      .mode = KMAC_CFG_SHADOWED_MODE_VALUE_SHAKE,
+  });
+}
+
+rom_error_t kmac_kmac256_sw_configure(void) {
+  kmac_kmac256_set_prefix(NULL, 0);
+  return kmac_configure((kmac_config_t){
+      .entropy_fast_process = false,
+      .msg_mask = false,
+      .sideload = false,
+      .kmac_en = true,
+      .mode = KMAC_CFG_SHADOWED_MODE_VALUE_CSHAKE,
+  });
+}
+
+rom_error_t kmac_kmac256_hw_configure(void) {
+  kmac_kmac256_set_prefix(NULL, 0);
+  return kmac_configure((kmac_config_t){
+      .entropy_fast_process = false,
+      .msg_mask = false,
+      .sideload = true,
+      .kmac_en = true,
+      .mode = KMAC_CFG_SHADOWED_MODE_VALUE_CSHAKE,
   });
 }
 
@@ -241,6 +276,8 @@ rom_error_t kmac_shake256_configure(void) {
       .entropy_fast_process = false,
       .msg_mask = false,
       .sideload = false,
+      .kmac_en = false,
+      .mode = KMAC_CFG_SHADOWED_MODE_VALUE_SHAKE,
   });
 }
 
@@ -352,3 +389,76 @@ rom_error_t kmac_shake256_squeeze_end(uint32_t *out, size_t outlen) {
 
   return kErrorOk;
 }
+
+#define WORD_BITS (sizeof(uint32_t) * 8)
+#define KEY_CASE(x_)                       \
+  case x_ / WORD_BITS:                     \
+    klen = KMAC_KEY_LEN_LEN_VALUE_KEY##x_; \
+    break
+rom_error_t kmac_kmac256_sw_key(const uint32_t *key, size_t len) {
+  uint32_t klen;
+  switch (len) {
+    KEY_CASE(128);
+    KEY_CASE(192);
+    KEY_CASE(256);
+    KEY_CASE(384);
+    KEY_CASE(512);
+    default:
+      return kErrorKmacInvalidKeySize;
+  }
+  abs_mmio_write32(kBase + KMAC_KEY_LEN_REG_OFFSET, klen);
+  for (size_t i = 0; i < KMAC_KEY_SHARE0_MULTIREG_COUNT; ++i) {
+    uint32_t value = i < len ? key[i] : 0;
+    abs_mmio_write32(
+        kBase + KMAC_KEY_SHARE0_0_REG_OFFSET + i * sizeof(uint32_t), value);
+    abs_mmio_write32(
+        kBase + KMAC_KEY_SHARE1_0_REG_OFFSET + i * sizeof(uint32_t), 0);
+  }
+  return kErrorOk;
+}
+
+void kmac_kmac256_set_prefix(const void *prefix, size_t len) {
+  // The length must be less than 32 because this function encodes the prefix
+  // length as a single byte, and 32*8 == 256, which won't fit in a byte.
+  HARDENED_CHECK_LT(len, 32);
+  uint32_t regs[KMAC_PREFIX_MULTIREG_COUNT] = {
+      0x4D4B2001,  //  1  32  'K' 'M'
+      0x00014341,  // 'A' 'C'  1   0
+  };
+  char *r = (char *)&regs[2];
+
+  // The prefix length is the byte immediately before where we'll store the
+  // message (the last `0` byte in the `regs` above).  Set the length and
+  // then copy the prefix into the `regs` buffer.
+  r[-1] = (char)(len * 8);
+  memcpy(r, prefix, len);
+
+  for (size_t i = 0; i < KMAC_PREFIX_MULTIREG_COUNT; ++i) {
+    abs_mmio_write32(kBase + KMAC_PREFIX_0_REG_OFFSET + i * sizeof(uint32_t),
+                     regs[i]);
+  }
+}
+
+rom_error_t kmac_kmac256_final(uint32_t *result, size_t rlen) {
+  // To finalize a kmac operation, we need to right-pad the bit-length of the
+  // result buffer and absorb that padded length value into the sponge.
+  uint8_t buffer[sizeof(size_t) + 1];
+  size_t val = rlen * 32;
+  size_t n = 0;
+  size_t p = sizeof(buffer) - 1;
+  while (val) {
+    buffer[--p] = val & 0xFF;
+    val >>= 8;
+    n++;
+  }
+  buffer[sizeof(buffer) - 1] = (uint8_t)n;
+  kmac_shake256_absorb(buffer + p, n + 1);
+
+  // Now, squeeze out the result.
+  kmac_shake256_squeeze_start();
+  return kmac_shake256_squeeze_end(result, rlen);
+}
+
+// Provide link locations for the inline functions in the header file.
+extern rom_error_t kmac_kmac256_start(void);
+extern void kmac_kmac256_absorb(const void *data, size_t len);

--- a/sw/device/silicon_creator/lib/drivers/kmac.h
+++ b/sw/device/silicon_creator/lib/drivers/kmac.h
@@ -29,6 +29,22 @@ extern "C" {
 rom_error_t kmac_keymgr_configure(void);
 
 /**
+ * Configure the KMAC block for KMAC-256 operation with a key loaded by
+ * software.
+ *
+ * @return Error code indicating if the operation succeeded.
+ */
+rom_error_t kmac_kmac256_sw_configure(void);
+
+/**
+ * Configure the KMAC block for KMAC-256 operation with a key sideloaded from
+ * the keymgr hardware block.
+ *
+ * @return Error code indicating if the operation succeeded.
+ */
+rom_error_t kmac_kmac256_hw_configure(void);
+
+/**
  * Configure the KMAC block at startup.
  *
  * Sets the KMAC block to use software entropy (since we have no secret inputs
@@ -128,6 +144,55 @@ void kmac_shake256_squeeze_start(void);
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t kmac_shake256_squeeze_end(uint32_t *out, size_t outlen);
+
+/**
+ * Load an unmasked software key into KMAC.
+ *
+ * @param key The key material.
+ * @param len The length of the key material in words.
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t kmac_kmac256_sw_key(const uint32_t *key, size_t len);
+
+/**
+ * Set the KMAC prefix value.
+ *
+ * Sets the prefix to the given prefix value.  The prefix
+ * must be 31 bytes or fewer.
+ *
+ * @param prefix The prefix value encoded as words.
+ * @param len The length of the prefix in bytes.
+ */
+void kmac_kmac256_set_prefix(const void *prefix, size_t len);
+
+/**
+ * Start a KMAC-256 operation.
+ *
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+inline rom_error_t kmac_kmac256_start(void) { return kmac_shake256_start(); }
+
+/**
+ * Absorb data into a KMAC-256.
+ *
+ * @param data Data to absorb into the sponge.
+ * @param len Length of the data.
+ */
+inline void kmac_kmac256_absorb(const void *data, size_t len) {
+  kmac_shake256_absorb((const uint8_t *)data, len);
+}
+
+/**
+ * Finalize the KMAC-256 operation.
+ *
+ * @param result Buffer to hold the result of the KMAC operation.
+ * @param rlen Length of the result buffer in words.
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t kmac_kmac256_final(uint32_t *result, size_t rlen);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -118,6 +118,7 @@ enum module_ {
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
   \
   X(kErrorKmacInvalidStatus,          ERROR_(1, kModuleKmac, kInternal)), \
+  X(kErrorKmacInvalidKeySize,         ERROR_(2, kModuleKmac, kInvalidArgument)), \
   \
   X(kErrorOtbnInvalidArgument,        ERROR_(1, kModuleOtbn, kInvalidArgument)), \
   X(kErrorOtbnBadOffsetLen,           ERROR_(2, kModuleOtbn, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -74,6 +74,9 @@ dual_cc_library(
     deps = dual_inputs(
         device = [
             ":ecdsa",
+            "//sw/device/lib/base:hardened_memory",
+            "//sw/device/silicon_creator/lib/drivers:keymgr",
+            "//sw/device/silicon_creator/lib/drivers:kmac",
         ],
         host = [
             "//sw/device/lib/base:global_mock",
@@ -83,6 +86,7 @@ dual_cc_library(
         shared = [
             ":datatypes",
             "//sw/device/lib/base:hardened",
+            "//sw/device/silicon_creator/lib:error",
         ],
     ),
 )

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
@@ -14,5 +14,17 @@ hardened_bool_t ownership_key_validate(size_t page, ownership_key_t key,
                                                len);
 }
 
+rom_error_t ownership_seal_init() {
+  return MockOwnershipKey::Instance().seal_init();
+}
+
+rom_error_t ownership_seal_page(size_t page) {
+  return MockOwnershipKey::Instance().seal_page(page);
+}
+
+rom_error_t ownership_seal_check(size_t page) {
+  return MockOwnershipKey::Instance().seal_check(page);
+}
+
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
@@ -20,6 +20,9 @@ class MockOwnershipKey : public global_mock::GlobalMock<MockOwnershipKey> {
   MOCK_METHOD(hardened_bool_t, validate,
               (size_t, ownership_key_t, const owner_signature_t *, const void *,
                size_t));
+  MOCK_METHOD(rom_error_t, seal_init, ());
+  MOCK_METHOD(rom_error_t, seal_page, (size_t));
+  MOCK_METHOD(rom_error_t, seal_check, (size_t));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -5,6 +5,9 @@
 #include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
 
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+#include "sw/device/silicon_creator/lib/drivers/kmac.h"
 #include "sw/device/silicon_creator/lib/ownership/ecdsa.h"
 
 // RAM copy of the owner INFO pages from flash.
@@ -36,4 +39,42 @@ hardened_bool_t ownership_key_validate(size_t page, ownership_key_t key,
   }
   return ecdsa_verify_message(&owner_page[page].owner_key, signature, message,
                               len);
+}
+
+rom_error_t ownership_seal_init(void) {
+  const sc_keymgr_diversification_t diversifier = {
+      .salt = {4004, 8008, 8080, 1802, 6800, 6502, 6809, 8088},
+      .version = 0,
+  };
+  HARDENED_RETURN_IF_ERROR(sc_keymgr_generate_key(
+      kScKeymgrDestKmac, kScKeymgrKeyTypeSealing, diversifier));
+  HARDENED_RETURN_IF_ERROR(kmac_kmac256_hw_configure());
+  kmac_kmac256_set_prefix("Ownership", 9);
+  return kErrorOk;
+}
+
+static rom_error_t seal_generate(const owner_block_t *page, uint32_t *seal) {
+  size_t sealed_len = offsetof(owner_block_t, seal);
+  HARDENED_RETURN_IF_ERROR(kmac_kmac256_start());
+  kmac_kmac256_absorb(page, sealed_len);
+  return kmac_kmac256_final(seal, ARRAYSIZE(page->seal));
+}
+
+rom_error_t ownership_seal_page(size_t page) {
+  owner_block_t *data = &owner_page[page];
+  return seal_generate(data, data->seal);
+}
+
+rom_error_t ownership_seal_check(size_t page) {
+  owner_block_t *data = &owner_page[page];
+  uint32_t check[ARRAYSIZE(data->seal)];
+  HARDENED_RETURN_IF_ERROR(seal_generate(data, check));
+  hardened_bool_t result =
+      hardened_memeq(data->seal, check, ARRAYSIZE(data->seal));
+  if (result == kHardenedBoolTrue) {
+    // Translate to kErrorOk.  A cast is sufficient because kHardenedBoolTrue
+    // and kErrorOk have the same bit pattern.
+    return (rom_error_t)result;
+  }
+  return kErrorOwnershipInvalidInfoPage;
 }

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNERSHIP_KEY_H_
 
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
 /**
@@ -44,5 +45,31 @@ typedef enum ownership_key {
 hardened_bool_t ownership_key_validate(size_t page, ownership_key_t key,
                                        const owner_signature_t *signature,
                                        const void *message, size_t len);
+
+/**
+ * Initialize sealing.
+ *
+ * Initializes the KMAC block to create a KMAC-256 seal based on a key
+ * created by keymgr.
+ *
+ * @return Success or error code.
+ */
+rom_error_t ownership_seal_init(void);
+
+/**
+ * Generate a seal for an ownership page.
+ *
+ * @param page Owner page for which to generate the sealing value.
+ * @return Success or error code.
+ */
+rom_error_t ownership_seal_page(size_t page);
+
+/**
+ * Check the seal on an ownership page.
+ *
+ * @param page Owner page on which to check the seal.
+ * @return Success or error code.
+ */
+rom_error_t ownership_seal_check(size_t page);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNERSHIP_KEY_H_


### PR DESCRIPTION
In order to bind the owner configuration block to the chip, we seal accepted owner blocks with a keyed KMAC over the contents of the owner block.

1. Add functions to create and check KMAC based seals.
2. Split the attestation keygen function into three functions: one for each of silicon, creator and owner.
3. Call the silicon and creator functions immediately after rom_ext startup.
4. Call the owner function when preparing to boot the owner stage.

Note: This PR depends on #23162; you need only review the last two commits.