### PR TITLE
[dv] Enable ROM e2e test cases for A1

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -20,13 +20,13 @@
         "+sw_test_timeout_ns=40000000",
         "+use_otp_image=OtpTypeCustom",
       ]
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_shutdown_exception_c
       uvm_test_seq: chip_sw_rom_e2e_shutdown_exception_c_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:rom_e2e_shutdown_exception_c:1:signed:fake_rsa_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:rom_e2e_shutdown_exception_c:1:new_rules",
         "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma:4"
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -34,14 +34,14 @@
         "+sw_test_timeout_ns=40000000",
         "+use_otp_image=OtpTypeCustom",
       ]
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_shutdown_output
       uvm_test_seq: chip_sw_rom_e2e_shutdown_output_vseq
       # Note: this is an unsigned test, as we are verifying a boot failure.
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_unsigned:1:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/shutdown_output:otp_img_shutdown_output_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -49,14 +49,14 @@
         "+sw_test_timeout_ns=20000000",
         "+use_otp_image=OtpTypeCustom",
       ]
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_good_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -71,72 +71,72 @@
       name: rom_e2e_boot_policy_valid_a_good_b_good_dev
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_dev:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_good_prod
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_good_prod_end
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_good_rma
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_rma:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_bad_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -151,72 +151,72 @@
       name: rom_e2e_boot_policy_valid_a_good_b_bad_dev
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_dev:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_bad_prod
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_bad_prod_end
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_good_b_bad_rma
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_rma:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_bad_b_good_test_unlocked0
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -231,72 +231,72 @@
       name: rom_e2e_boot_policy_valid_a_bad_b_good_dev
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_dev:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_bad_b_good_prod
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_bad_b_good_prod_end
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_boot_policy_valid_a_bad_b_good_rma
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b:2:ot_flash_binary:signed:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0:2:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/boot_policy_valid:otp_img_boot_policy_valid_rma:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_bad_test_unlocked0
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0:new_rules",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_test_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_test_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_test_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -311,72 +311,72 @@
       name: rom_e2e_sigverify_always_a_bad_b_bad_dev
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0:new_rules",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_dev_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_dev_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_bad_prod
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_bad_prod_end
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_bad_rma
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:2:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_nothing_test_unlocked0
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_test_key_0:new_rules",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -392,71 +392,71 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_nothing_prod
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_nothing_prod_end
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_bad_b_nothing_rma
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_nothing_b_bad_test_unlocked0
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_test_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_ecdsa_test_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -472,70 +472,70 @@
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_dev_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_ecdsa_dev_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_dev:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_nothing_b_bad_prod
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_nothing_b_bad_prod_end
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_sigverify_always_a_nothing_b_bad_rma
       // We can use the same vseq as the `*_a_bad_b_bad_*` tests above, as we expect the same ROM boot fault value.
       uvm_test_seq: chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_rsa_prod_key_0:new_rules",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_corrupted:1:ot_flash_binary:signed:fake_ecdsa_prod_key_0",
         "//sw/device/silicon_creator/rom/e2e/sigverify_always:otp_img_sigverify_always_rma:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=50_000_000",
+        "+sw_test_timeout_ns=100_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_asm_init_test_unlocked0
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry:otp_img_e2e_bootstrap_entry_test_unlocked0:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -549,7 +549,7 @@
       name: rom_e2e_asm_init_dev
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry:otp_img_e2e_bootstrap_entry_dev:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -557,13 +557,13 @@
         "+use_otp_image=OtpTypeCustom",
         "+sw_test_timeout_ns=20000000",
       ]
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_asm_init_prod
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry:otp_img_e2e_bootstrap_entry_prod:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -571,13 +571,13 @@
         "+use_otp_image=OtpTypeCustom",
         "+sw_test_timeout_ns=20000000",
       ]
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_asm_init_prod_end
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry:otp_img_e2e_bootstrap_entry_prod_end:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -585,13 +585,13 @@
         "+use_otp_image=OtpTypeCustom",
         "+sw_test_timeout_ns=20000000",
       ]
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_asm_init_rma
       uvm_test_seq: chip_sw_rom_e2e_asm_init_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:ot_flash_binary:fake_rsa_prod_key_0",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0:1:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry:otp_img_e2e_bootstrap_entry_rma:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -599,7 +599,7 @@
         "+use_otp_image=OtpTypeCustom",
         "+sw_test_timeout_ns=20000000",
       ]
-      run_timeout_mins: 180
+      run_timeout_mins: 280
     }
     {
       name: rom_e2e_jtag_debug_test_unlocked0
@@ -613,7 +613,7 @@
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_jtag_debug_dev
@@ -627,7 +627,7 @@
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_jtag_debug_rma
@@ -641,7 +641,7 @@
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_jtag_inject_test_unlocked0
@@ -691,16 +691,16 @@
     {
       name: rom_e2e_static_critical
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:signed:fake_rsa_test_key_0"]
+      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:new_rules"]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_keymgr_init_rom_ext_meas
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_rsa_test_key_0:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_ecdsa_test_key_0:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_rom_ext_meas:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -708,13 +708,13 @@
         "+sw_test_timeout_ns=20_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_keymgr_init_rom_ext_no_meas
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_rsa_test_key_0:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_ecdsa_test_key_0:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_rom_ext_no_meas:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -722,13 +722,13 @@
         "+sw_test_timeout_ns=20_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_keymgr_init_rom_ext_invalid_meas
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_rsa_test_key_0:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_ecdsa_test_key_0:ot_flash_binary",
         "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_rom_ext_invalid_meas:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
@@ -736,7 +736,7 @@
         "+sw_test_timeout_ns=20_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
-      run_timeout_mins: 120
+      run_timeout_mins: 240
     }
 
     // Life cycle transitions with production ROM.
@@ -744,7 +744,7 @@
       name: rom_volatile_raw_unlock
       uvm_test_seq: chip_sw_lc_volatile_raw_unlock_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:fake_rsa_test_key_0:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_test_key_0:1:ot_flash_binary",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
@@ -760,7 +760,7 @@
       name: rom_raw_unlock
       uvm_test_seq: chip_sw_lc_raw_unlock_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a:1:signed:fake_rsa_test_key_0:ot_flash_binary",
+        "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_test_key_0:1:ot_flash_binary",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -447,7 +447,13 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
           // suffix to the image name.
           if ("signed" inside {sw_image_flags[i]}) begin
             // Options match DEFAULT_SIGNING_KEYS in `rules/opentitan.bzl`.
-            if ("fake_rsa_dev_key_0" inside {sw_image_flags[i]}) begin
+            if ("fake_ecdsa_dev_key_0" inside {sw_image_flags[i]}) begin
+              sw_images[i] = $sformatf("%0s.fake_ecdsa_dev_key_0.signed", sw_images[i]);
+            end else if ("fake_ecdsa_prod_key_0" inside {sw_image_flags[i]}) begin
+              sw_images[i] = $sformatf("%0s.fake_ecdsa_prod_key_0.signed", sw_images[i]);
+            end else if ("fake_ecdsa_test_key_0" inside {sw_image_flags[i]}) begin
+              sw_images[i] = $sformatf("%0s.fake_ecdsa_test_key_0.signed", sw_images[i]);
+            end else if ("fake_rsa_dev_key_0" inside {sw_image_flags[i]}) begin
               sw_images[i] = $sformatf("%0s.fake_rsa_dev_key_0.signed", sw_images[i]);
             end else if ("fake_rsa_prod_key_0" inside {sw_image_flags[i]}) begin
               sw_images[i] = $sformatf("%0s.fake_rsa_prod_key_0.signed", sw_images[i]);

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -111,9 +111,9 @@ opentitan_test(
 
 [
     opentitan_binary(
-        name = "empty_test_slot_{}".format(slot),
+        name = "empty_test_slot_{}_unsigned".format(slot),
         testonly = True,
-        srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
+        srcs = [":empty_test"],
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310",
             "//hw/top_earlgrey:sim_dv",
@@ -127,6 +127,19 @@ opentitan_test(
             "//sw/device/silicon_creator/lib/drivers:otp",
             "//sw/device/silicon_creator/lib/sigverify:spx_verify",
         ],
+    )
+    for slot in SLOTS
+]
+
+# The following filegroup is required to allow dvsim to build the
+# empty_test_slot_* targets as the `sim_dv` execution environment is expected
+# as a suffix in the target label. For example:
+#  `//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_unsigned_sim_dv`
+[
+    filegroup(
+        name = "empty_test_slot_{}_unsigned_sim_dv".format(slot),
+        testonly = True,
+        srcs = [":empty_test_slot_{}_unsigned".format(slot)],
     )
     for slot in SLOTS
 ]
@@ -159,7 +172,7 @@ opentitan_test(
     opentitan_binary(
         name = "empty_test_slot_{}_{}".format(slot, key),
         testonly = True,
-        srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
+        srcs = [":empty_test"],
         ecdsa_key = ecdsa_key_by_name(ECDSA_ONLY_KEY_STRUCTS, key),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
@@ -167,8 +180,6 @@ opentitan_test(
             "//hw/top_earlgrey:sim_verilator": None,
         },
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
-        # We need to specify the manifest because the simulation environments do not
-        # specify one by default.
         manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
         deps = [
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
@@ -177,6 +188,20 @@ opentitan_test(
             "//sw/device/silicon_creator/lib/drivers:otp",
             "//sw/device/silicon_creator/lib/sigverify:spx_verify",
         ],
+    )
+    for slot in SLOTS
+    for key in SIGVERIFY_LC_KEYS
+]
+
+# The following filegroup is required to allow dvsim to build the
+# empty_test_slot_* targets as the `sim_dv` execution environment is expected
+# as a suffix in the target label. For example:
+#  `//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0_sim_dv`
+[
+    filegroup(
+        name = "empty_test_slot_{}_{}_sim_dv".format(slot, key),
+        testonly = True,
+        srcs = [":empty_test_slot_{}_{}".format(slot, key)],
     )
     for slot in SLOTS
     for key in SIGVERIFY_LC_KEYS
@@ -225,7 +250,7 @@ opentitan_test(
     bin_to_vmem(
         name = "empty_test_slot_{}_{}_corrupted_sim_dv_vmem64_signed".format(slot, key),
         testonly = True,
-        bin = "empty_test_slot_{}_{}_corrupted_sim_dv_signed_bin".format(slot, key),
+        bin = ":empty_test_slot_{}_{}_corrupted_sim_dv_signed_bin".format(slot, key),
         word_size = 64,  # Backdoor-load VMEM image uses 64-bit words
     )
     for slot in SLOTS
@@ -236,7 +261,7 @@ opentitan_test(
     scramble_flash_vmem(
         name = "empty_test_slot_{}_{}_corrupted_sim_dv_scr_vmem64_signed".format(slot, key),
         testonly = True,
-        vmem = "empty_test_slot_{}_{}_corrupted_sim_dv_vmem64_signed".format(slot, key),
+        vmem = ":empty_test_slot_{}_{}_corrupted_sim_dv_vmem64_signed".format(slot, key),
     )
     for slot in SLOTS
     for key in SIGVERIFY_LC_KEYS
@@ -250,7 +275,7 @@ opentitan_test(
         name = "empty_test_slot_{}_corrupted_sim_dv".format(slot),
         testonly = True,
         srcs = [
-            "empty_test_slot_{}_{}_corrupted_sim_dv_{}".format(slot, key, file_type)
+            ":empty_test_slot_{}_{}_corrupted_sim_dv_{}".format(slot, key, file_type)
             for file_type in [
                 "signed_bin",
                 "vmem64_signed",
@@ -287,11 +312,13 @@ opentitan_test(
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom:mask_rom",
     ),
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = {
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:sim_verilator_rom_with_fake_keys": None,
     },
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     verilator = verilator_params(
         timeout = "eternal",
         exit_failure = "NO_FAILURE_MESSAGE",
@@ -335,11 +362,13 @@ opentitan_test(
     dv = dv_params(
         rom = "//sw/device/silicon_creator/rom:mask_rom",
     ),
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = {
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
     },
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
     verilator = verilator_params(
         timeout = "eternal",
         rom = "//sw/device/silicon_creator/rom:mask_rom",


### PR DESCRIPTION
1. Update Bazel rules to provide targets with the `sim_dv` suffix, which is expected by dvsim.
2. Update chip_env_cfg.sv to support handling of ECDSA labels for signed binaries.
3. Update chip_rom_tests.hjson to work with the new `opentitan_test` and `opentitan_binary` rules.

Fixes: https://github.com/lowRISC/opentitan/issues/22919
Fixes: https://github.com/lowRISC/opentitan/issues/22697