### PR TITLE
[bazel/dv] Fix rom e2e keymgr tests.

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -700,12 +700,12 @@
       name: rom_e2e_keymgr_init_rom_ext_meas
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_ecdsa_test_key_0:ot_flash_binary",
-        "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_rom_ext_meas:4",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_otp_meas:1:new_rules",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_otp_meas:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=20_000_000",
+        "+sw_test_timeout_ns=40_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       run_timeout_mins: 240
@@ -714,12 +714,12 @@
       name: rom_e2e_keymgr_init_rom_ext_no_meas
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_ecdsa_test_key_0:ot_flash_binary",
-        "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_rom_ext_no_meas:4",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_otp_no_meas:1:new_rules",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_otp_no_meas:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=20_000_000",
+        "+sw_test_timeout_ns=40_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       run_timeout_mins: 240
@@ -728,12 +728,12 @@
       name: rom_e2e_keymgr_init_rom_ext_invalid_meas
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_test:1:signed:fake_ecdsa_test_key_0:ot_flash_binary",
-        "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_rom_ext_invalid_meas:4",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:rom_e2e_keymgr_init_otp_invalid_meas:1:new_rules",
+        "//sw/device/silicon_creator/rom/e2e/keymgr:otp_img_keymgr_otp_invalid_meas:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
-        "+sw_test_timeout_ns=20_000_000",
+        "+sw_test_timeout_ns=40_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       run_timeout_mins: 240

--- a/sw/device/silicon_creator/rom/e2e/keymgr/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/keymgr/BUILD
@@ -18,31 +18,11 @@ load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
     "dv_params",
-    "opentitan_binary",
     "opentitan_test",
     "verilator_params",
 )
 
 package(default_visibility = ["//visibility:public"])
-
-opentitan_binary(
-    name = "rom_e2e_keymgr_init_test",
-    testonly = True,
-    srcs = [":rom_e2e_keymgr_init_test.c"],
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
-        "//hw/top_earlgrey:sim_dv",
-        "//hw/top_earlgrey:sim_verilator",
-    ],
-    deps = [
-        "//sw/device/lib/dif:keymgr",
-        "//sw/device/lib/testing:keymgr_testutils",
-        "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/drivers:hmac",
-        "//sw/device/silicon_creator/lib/drivers:otp",
-    ],
-)
 
 rom_e2e_keymgr_init_configs = [
     {
@@ -87,26 +67,34 @@ rom_e2e_keymgr_init_configs = [
 [
     opentitan_test(
         name = "rom_e2e_keymgr_init_{}".format(config["name"]),
+        srcs = [":rom_e2e_keymgr_init_test.c"],
         cw310 = cw310_params(
-            binaries = {":rom_e2e_keymgr_init_test": "firmware"},
             otp = ":otp_img_keymgr_{}".format(config["name"]),
         ),
         dv = dv_params(
-            binaries = {":rom_e2e_keymgr_init_test": "firmware"},
             otp = ":otp_img_keymgr_{}".format(config["name"]),
             rom = "//sw/device/silicon_creator/rom:mask_rom",
         ),
+        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:sim_dv": None,
             "//hw/top_earlgrey:sim_verilator": None,
         },
+        manifest = "//sw/device/silicon_creator/rom_ext:manifest_standard",
         verilator = verilator_params(
             timeout = "eternal",
-            binaries = {":rom_e2e_keymgr_init_test": "firmware"},
             otp = ":otp_img_keymgr_{}".format(config["name"]),
             rom = "//sw/device/silicon_creator/rom:mask_rom",
         ),
+        deps = [
+            "//sw/device/lib/dif:keymgr",
+            "//sw/device/lib/testing:keymgr_testutils",
+            "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+        ],
     )
     for config in rom_e2e_keymgr_init_configs
 ]
@@ -114,7 +102,8 @@ rom_e2e_keymgr_init_configs = [
 test_suite(
     name = "keymgr_init",
     tags = ["manual"],
-    tests = ["rom_e2e_keymgr_init_{}".format(
-        config["name"],
-    ) for config in rom_e2e_keymgr_init_configs],
+    tests = [
+        "rom_e2e_keymgr_init_{}".format(config["name"])
+        for config in rom_e2e_keymgr_init_configs
+    ],
 )


### PR DESCRIPTION
1. Update keymgr init test to generate signed binaries for all execution environments. Remove opentitan_binary targets as these are no longer compatible with dvsim.
2. Update keymgr init targets in chip_rom_tests.hjson to support opentitan_test artifacts.