### PR TITLE
[pattgen] Add inactive level feature

### DIFF
--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -83,6 +83,9 @@
     { name: "PATTGEN.CONFIG.POLARITY",
       desc: "Each channel's clock can be inverted."
     },
+    { name: "PATTGEN.CONFIG.INACTIVE_LEVEL",
+      desc: "The inactive level of clock and data output of each channel can be configured separately."
+    }
     { name: "PATTGEN.COMPLETE",
       desc: "Once a pattern is finished, an interrupt is raised."
     }
@@ -126,6 +129,38 @@
           resval: "0",
           name: "POLARITY_CH1",
           desc: "Clock (`pcl`) polarity for Channel 1.  If low, `pda` signal changes on falling edge of `pcl` signal, otherwise pda changes on rising edge. Note that writes to a channel's configuration registers have no effect while the channel is enabled."
+        }
+        { bits: "4"
+          resval: "0",
+          name: "INACTIVE_LEVEL_PCL_CH0",
+          desc: '''
+                If 0, `pcl` is low when pattgen is not actively sending data bits (i.e., when pattgen is disabled or all data bits have been sent).
+                If 1, `pcl` is high when pattgen is not actively sending data bits.
+                ''',
+        }
+        { bits: "5"
+          resval: "0",
+          name: "INACTIVE_LEVEL_PDA_CH0",
+          desc: '''
+                If 0, `pda` is low when pattgen is not actively sending data bits (i.e., when pattgen is disabled or all data bits have been sent).
+                If 1, `pda` is high when pattgen is not actively sending data bits.
+                ''',
+        }
+        { bits: "6"
+          resval: "0",
+          name: "INACTIVE_LEVEL_PCL_CH1",
+          desc: '''
+                If 0, `pcl` is low when pattgen is not actively sending data bits (i.e., when pattgen is disabled or all data bits have been sent).
+                If 1, `pcl` is high when pattgen is not actively sending data bits.
+                ''',
+        }
+        { bits: "7"
+          resval: "0",
+          name: "INACTIVE_LEVEL_PDA_CH1",
+          desc: '''
+                If 0, `pda` is low when pattgen is not actively sending data bits (i.e., when pattgen is disabled or all data bits have been sent).
+                If 1, `pda` is high when pattgen is not actively sending data bits.
+                ''',
         }
       ]
     }

--- a/hw/ip/pattgen/doc/programmers_guide.md
+++ b/hw/ip/pattgen/doc/programmers_guide.md
@@ -25,14 +25,14 @@ Here both channels are configured for simultaneous pattern generation, but the t
   head: {text: 'Effect of the Polarity Registers',tick:0}}
 ```
 
-1. Program the length of seed pattern using the length field, [`SIZE.LEN_CH0`](registers.md#size).
+3. Program the length of seed pattern using the length field, [`SIZE.LEN_CH0`](registers.md#size).
 Note that since the allowed seed length ranges from 1-64, the value of this field should be one less than the pattern length.
 For example, to generate an 16-bit pattern, a value of 15 should be written to the field [`SIZE.LEN_CH0`](registers.md#size).
 1. Program the seed pattern (between 1 and 64 bits in length) using the multi-register [`DATA_CH0_0`](registers.md#data_ch0) and [`DATA_CH0_1`](registers.md#data_ch0).
 The first 32 bits to be transmitted, are programmed in the lower half of the multi-register (i.e. [`DATA_CH0_0`](registers.md#data_ch0)), and the latter 32 bits are programmed in the upper half of the multi-register (i.e. [`DATA_CH0_1`](registers.md#data_ch0)).
 1. Program the clock divider ratio using the register [`PREDIV_CH0.CLK_RATIO`](registers.md#prediv_ch0).
 The resulting clock frequency will be slower than the input I/O clock by a ratio of 2&times;(CLK_RATIO+1):
-$$f_{pclx}=\frac{f_\textrm{I/O clk}}{2(\textrm{CLK_RATIO}+1)}$$
+$$f_{pclx}=\frac{f_\textrm{I/O clk}}{2(\textrm{CLK\_RATIO}+1)}$$
 1. Program the desired number of pattern repetitions using the repetition field [`SIZE.REPS_CH0`](registers.md#size).
 Note that since the allowed number of pattern repetitions ranges from 1-1024, the value of this field should be one less than the desired repetition count.
 For example, to repeat a pattern 30, a value of 29 should written to the field [`SIZE.REPS_CH0`](registers.md#size).

--- a/hw/ip/pattgen/doc/programmers_guide.md
+++ b/hw/ip/pattgen/doc/programmers_guide.md
@@ -39,6 +39,25 @@ For example, to repeat a pattern 30, a value of 29 should written to the field [
 1. Finally to start the pattern, set the [`CTRL.ENABLE_CH0`](registers.md#ctrl).
 To start both channel patterns at the same time, configure both channels then simultaneously assert both the [`CTRL.ENABLE_CH0`](registers.md#ctrl) and [`CTRL.ENABLE_CH1`](registers.md#ctrl) bits in the same register access.
 
+## Using the *inactive level* feature
+
+By default, the `pcl` and `pda` outputs are zero when pattgen is inactive (i.e., when pattgen is disabled or after it has sent all data bits).
+Using the CSR bits [`CTRL.INACTIVE_LEVEL_PCL`](registers.md#ctrl) and [`CTRL.INACTIVE_LEVEL_PDA`](registers.md#ctrl) (one pair of bits for channel 0, the other pair for channel 1), one can set either `pcl` or `pda` or both to one when pattgen is inactive.
+The value of the output changes when these CSR fields are set, as the following example shows:
+```wavejson
+{signal: [
+  {name: 'CTRL.ENABLE',             wave: '0..|1.........|0', node: '....e'},
+  {name: 'CTRL.POLARITY',           wave: '0..|..........|.'},
+  {name: 'CTRL.INACTIVE_LEVEL_PDA', wave: '01.|..........|.', node: '.a'},
+  {name: 'CTRL.INACTIVE_LEVEL_PCL', wave: '01.|..........|.', node: '.c'},
+  {name: 'data',                    wave: 'x..|.3.4.5.6.x|.', node: '.....f', data: "[0]=1'b0 [1]=1'b1 [2]=1'b0 [3]=1'b1"},
+  {name: 'pda',                     wave: '0.1|.0.1.0.1..|.', node: '..b...'},
+  {name: 'pcl',                     wave: '0.1|.01010101.|.', node: '..d..'},
+],
+  edge: ['a~b', 'c~d', 'e~f']
+}
+```
+
 ## Device Interface Functions (DIFs)
 
 - [Device Interface Functions](../../../../sw/device/lib/dif/dif_pattgen.h)

--- a/hw/ip/pattgen/doc/registers.md
+++ b/hw/ip/pattgen/doc/registers.md
@@ -93,21 +93,25 @@ Alert Test Register
 PATTGEN control register
 - Offset: `0x10`
 - Reset default: `0x0`
-- Reset mask: `0xf`
+- Reset mask: `0xff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "ENABLE_CH0", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ENABLE_CH1", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "POLARITY_CH0", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "POLARITY_CH1", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
+{"reg": [{"name": "ENABLE_CH0", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "ENABLE_CH1", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "POLARITY_CH0", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "POLARITY_CH1", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "INACTIVE_LEVEL_PCL_CH0", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "INACTIVE_LEVEL_PDA_CH0", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "INACTIVE_LEVEL_PCL_CH1", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "INACTIVE_LEVEL_PDA_CH1", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 240}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name         | Description                                                                                                                                                                                                                                     |
-|:------:|:------:|:-------:|:-------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:4  |        |         |              | Reserved                                                                                                                                                                                                                                        |
-|   3    |   rw   |   0x0   | POLARITY_CH1 | Clock (`pcl`) polarity for Channel 1.  If low, `pda` signal changes on falling edge of `pcl` signal, otherwise pda changes on rising edge. Note that writes to a channel's configuration registers have no effect while the channel is enabled. |
-|   2    |   rw   |   0x0   | POLARITY_CH0 | Clock (`pcl`) polarity for Channel 0.  If low, `pda` signal changes on falling edge of pcl signal, otherwise pda changes on rising edge. Note that writes to a channel's configuration registers have no effect while the channel is enabled.   |
-|   1    |   rw   |   0x0   | ENABLE_CH1   | Enable pattern generator functionality for Channel 1                                                                                                                                                                                            |
-|   0    |   rw   |   0x0   | ENABLE_CH0   | Enable pattern generator functionality for Channel 0                                                                                                                                                                                            |
+|  Bits  |  Type  |  Reset  | Name                   | Description                                                                                                                                                                                                                                     |
+|:------:|:------:|:-------:|:-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:8  |        |         |                        | Reserved                                                                                                                                                                                                                                        |
+|   7    |   rw   |   0x0   | INACTIVE_LEVEL_PDA_CH1 | If 0, `pda` is low when pattgen is not actively sending data bits (i.e., when pattgen is disabled or all data bits have been sent). If 1, `pda` is high when pattgen is not actively sending data bits.                                         |
+|   6    |   rw   |   0x0   | INACTIVE_LEVEL_PCL_CH1 | If 0, `pcl` is low when pattgen is not actively sending data bits (i.e., when pattgen is disabled or all data bits have been sent). If 1, `pcl` is high when pattgen is not actively sending data bits.                                         |
+|   5    |   rw   |   0x0   | INACTIVE_LEVEL_PDA_CH0 | If 0, `pda` is low when pattgen is not actively sending data bits (i.e., when pattgen is disabled or all data bits have been sent). If 1, `pda` is high when pattgen is not actively sending data bits.                                         |
+|   4    |   rw   |   0x0   | INACTIVE_LEVEL_PCL_CH0 | If 0, `pcl` is low when pattgen is not actively sending data bits (i.e., when pattgen is disabled or all data bits have been sent). If 1, `pcl` is high when pattgen is not actively sending data bits.                                         |
+|   3    |   rw   |   0x0   | POLARITY_CH1           | Clock (`pcl`) polarity for Channel 1.  If low, `pda` signal changes on falling edge of `pcl` signal, otherwise pda changes on rising edge. Note that writes to a channel's configuration registers have no effect while the channel is enabled. |
+|   2    |   rw   |   0x0   | POLARITY_CH0           | Clock (`pcl`) polarity for Channel 0.  If low, `pda` signal changes on falling edge of pcl signal, otherwise pda changes on rising edge. Note that writes to a channel's configuration registers have no effect while the channel is enabled.   |
+|   1    |   rw   |   0x0   | ENABLE_CH1             | Enable pattern generator functionality for Channel 1                                                                                                                                                                                            |
+|   0    |   rw   |   0x0   | ENABLE_CH0             | Enable pattern generator functionality for Channel 0                                                                                                                                                                                            |
 
 ## PREDIV_CH0
 PATTGEN pre-divider register for Channel 0

--- a/hw/ip/pattgen/dv/env/pattgen_channel_cfg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_channel_cfg.sv
@@ -11,10 +11,18 @@ class pattgen_channel_cfg extends uvm_object;
   bit                enable;
 
   rand bit           polarity;
+  rand bit           inactive_level_pcl;
+  rand bit           inactive_level_pda;
   rand bit [31:0]    prediv;
   rand bit [63:0]    data;
   rand bit [5:0]     len;
   rand bit [9:0]     reps;
+
+  // TODO(#23219): Remove this when the scoreboard supports the inactive_level feature.
+  constraint inactive_level_disabled_c {
+    inactive_level_pcl == 1'b0;
+    inactive_level_pda == 1'b0;
+  }
 
   virtual function void reset_channel_config(string kind = "");
     start    = 1'b0;
@@ -32,16 +40,18 @@ class pattgen_channel_cfg extends uvm_object;
   virtual function string convert2string();
       string str;
 
-      str = {str, $sformatf("  start     %b\n",  start)};
-      str = {str, $sformatf("  stop      %b\n",  stop)};
-      str = {str, $sformatf("  enable    %b\n",  enable)};
-      str = {str, $sformatf("  polarity  %b\n",  polarity)};
-      str = {str, $sformatf("  prediv    %0d\n", prediv)};
-      str = {str, $sformatf("  len       %0d\n", len)};
-      str = {str, $sformatf("  reps      %0d\n", reps)};
-      str = {str, $sformatf("  data[0]   %0d\n", data[31:0])};
-      str = {str, $sformatf("  data[1]   %0d\n", data[63:32])};
-      str = {str, $sformatf("  patt_len  %0d",   (len + 1) * (reps + 1))};
+      str = {str, $sformatf("  start              %b\n",  start)};
+      str = {str, $sformatf("  stop               %b\n",  stop)};
+      str = {str, $sformatf("  enable             %b\n",  enable)};
+      str = {str, $sformatf("  polarity           %b\n",  polarity)};
+      str = {str, $sformatf("  inactive_level_pcl %b\n",  inactive_level_pcl)};
+      str = {str, $sformatf("  inactive_level_pda %b\n",  inactive_level_pda)};
+      str = {str, $sformatf("  prediv             %0d\n", prediv)};
+      str = {str, $sformatf("  len                %0d\n", len)};
+      str = {str, $sformatf("  reps               %0d\n", reps)};
+      str = {str, $sformatf("  data[0]            %0d\n", data[31:0])};
+      str = {str, $sformatf("  data[1]            %0d\n", data[63:32])};
+      str = {str, $sformatf("  patt_len           %0d",   (len + 1) * (reps + 1))};
       return str;
   endfunction : convert2string
 

--- a/hw/ip/pattgen/dv/env/pattgen_env.core
+++ b/hw/ip/pattgen/dv/env/pattgen_env.core
@@ -28,6 +28,7 @@ filesets:
       - seq_lib/pattgen_error_vseq.sv: {is_include_file: true}
       - seq_lib/pattgen_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/pattgen_cnt_rollover_vseq.sv: {is_include_file: true}
+      - seq_lib/pattgen_inactive_level_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
@@ -16,6 +16,7 @@ class pattgen_base_vseq extends cip_base_vseq #(
   uint                                num_pattern_gen = 0;
   // channel config
   rand pattgen_channel_cfg            channel_cfg[NUM_PATTGEN_CHANNELS-1:0];
+  bit                                 inactive_level_en = 1'b0;
 
   // indicate channels are setup before enabled
   bit [NUM_PATTGEN_CHANNELS-1:0]      channel_setup = 'h0;
@@ -113,6 +114,8 @@ class pattgen_base_vseq extends cip_base_vseq #(
       csr_wr(.ptr(ral.data_ch0[0]), .value(channel_cfg[0].data[31:0]));
       csr_wr(.ptr(ral.data_ch0[1]), .value(channel_cfg[0].data[63:32]));
       ral.ctrl.polarity_ch0.set(channel_cfg[0].polarity);
+      ral.ctrl.inactive_level_pcl_ch0.set(channel_cfg[0].inactive_level_pcl);
+      ral.ctrl.inactive_level_pda_ch0.set(channel_cfg[0].inactive_level_pda);
       update_pattgen_agent_cfg(.channel(0));
       csr_update(ral.ctrl);
       channel_setup[0] = 1'b1;
@@ -135,6 +138,8 @@ class pattgen_base_vseq extends cip_base_vseq #(
       csr_wr(.ptr(ral.data_ch1[0]), .value(channel_cfg[1].data[31:0]));
       csr_wr(.ptr(ral.data_ch1[1]), .value(channel_cfg[1].data[63:32]));
       ral.ctrl.polarity_ch1.set(channel_cfg[1].polarity);
+      ral.ctrl.inactive_level_pcl_ch1.set(channel_cfg[1].inactive_level_pcl);
+      ral.ctrl.inactive_level_pda_ch1.set(channel_cfg[1].inactive_level_pda);
       update_pattgen_agent_cfg(.channel(1));
       csr_update(ral.ctrl);
       channel_setup[1] = 1'b1;
@@ -339,6 +344,10 @@ class pattgen_base_vseq extends cip_base_vseq #(
   virtual function pattgen_channel_cfg get_random_channel_config(uint channel);
     pattgen_channel_cfg ch_cfg;
     ch_cfg = pattgen_channel_cfg::type_id::create($sformatf("channel_cfg_%0d", channel));
+    if (inactive_level_en) begin
+      // TODO(#23219): Remove this when the scoreboard supports the inactive_level feature.
+      ch_cfg.inactive_level_disabled_c.constraint_mode(0);
+    end
     `DV_CHECK_RANDOMIZE_WITH_FATAL(ch_cfg,
       ch_cfg.polarity dist {
         1'b0 :/ cfg.seq_cfg.pattgen_low_polarity_pct,

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_inactive_level_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_inactive_level_vseq.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Testing inactive_level feature of pattgen
+class pattgen_inactive_level_vseq extends pattgen_base_vseq;
+  `uvm_object_utils(pattgen_inactive_level_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    // Enable inactive_level feature (subject to randomization).
+    inactive_level_en = 1'b1;
+    cfg.en_scb = 1'b0; // TODO(#23219): Remove this when the scoreboard supports the inactive_level
+                       // feature.
+    super.pre_start();
+  endtask
+
+endclass : pattgen_inactive_level_vseq

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_vseq_list.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_vseq_list.sv
@@ -9,3 +9,4 @@
 `include "pattgen_error_vseq.sv"
 `include "pattgen_stress_all_vseq.sv"
 `include "pattgen_cnt_rollover_vseq.sv"
+`include "pattgen_inactive_level_vseq.sv"

--- a/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
+++ b/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson
@@ -71,6 +71,11 @@
       name: cnt_rollover
       uvm_test_seq: pattgen_cnt_rollover_vseq
     }
+
+    {
+      name: pattgen_inactive_level
+      uvm_test_seq: pattgen_inactive_level_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/pattgen/rtl/pattgen_core.sv
+++ b/hw/ip/pattgen/rtl/pattgen_core.sv
@@ -28,21 +28,25 @@ module pattgen_core
   pattgen_chan_ctrl_t ch0_ctrl;
   pattgen_chan_ctrl_t ch1_ctrl;
 
-  assign ch0_ctrl.enable      = reg2hw.ctrl.enable_ch0.q;
-  assign ch0_ctrl.polarity    = reg2hw.ctrl.polarity_ch0.q;
-  assign ch0_ctrl.data[63:32] = reg2hw.data_ch0[1].q;
-  assign ch0_ctrl.data[31:0]  = reg2hw.data_ch0[0].q;
-  assign ch0_ctrl.prediv      = reg2hw.prediv_ch0.q;
-  assign ch0_ctrl.len         = reg2hw.size.len_ch0.q;
-  assign ch0_ctrl.reps        = reg2hw.size.reps_ch0.q;
+  assign ch0_ctrl.enable             = reg2hw.ctrl.enable_ch0.q;
+  assign ch0_ctrl.polarity           = reg2hw.ctrl.polarity_ch0.q;
+  assign ch0_ctrl.inactive_level_pcl = reg2hw.ctrl.inactive_level_pcl_ch0.q;
+  assign ch0_ctrl.inactive_level_pda = reg2hw.ctrl.inactive_level_pda_ch0.q;
+  assign ch0_ctrl.data[63:32]        = reg2hw.data_ch0[1].q;
+  assign ch0_ctrl.data[31:0]         = reg2hw.data_ch0[0].q;
+  assign ch0_ctrl.prediv             = reg2hw.prediv_ch0.q;
+  assign ch0_ctrl.len                = reg2hw.size.len_ch0.q;
+  assign ch0_ctrl.reps               = reg2hw.size.reps_ch0.q;
 
-  assign ch1_ctrl.enable      = reg2hw.ctrl.enable_ch1.q;
-  assign ch1_ctrl.polarity    = reg2hw.ctrl.polarity_ch1.q;
-  assign ch1_ctrl.data[63:32] = reg2hw.data_ch1[1].q;
-  assign ch1_ctrl.data[31:0]  = reg2hw.data_ch1[0].q;
-  assign ch1_ctrl.prediv      = reg2hw.prediv_ch1.q;
-  assign ch1_ctrl.len         = reg2hw.size.len_ch1.q;
-  assign ch1_ctrl.reps        = reg2hw.size.reps_ch1.q;
+  assign ch1_ctrl.enable             = reg2hw.ctrl.enable_ch1.q;
+  assign ch1_ctrl.polarity           = reg2hw.ctrl.polarity_ch1.q;
+  assign ch1_ctrl.inactive_level_pcl = reg2hw.ctrl.inactive_level_pcl_ch1.q;
+  assign ch1_ctrl.inactive_level_pda = reg2hw.ctrl.inactive_level_pda_ch1.q;
+  assign ch1_ctrl.data[63:32]        = reg2hw.data_ch1[1].q;
+  assign ch1_ctrl.data[31:0]         = reg2hw.data_ch1[0].q;
+  assign ch1_ctrl.prediv             = reg2hw.prediv_ch1.q;
+  assign ch1_ctrl.len                = reg2hw.size.len_ch1.q;
+  assign ch1_ctrl.reps               = reg2hw.size.reps_ch1.q;
 
   pattgen_chan chan0 (
     .clk_i,

--- a/hw/ip/pattgen/rtl/pattgen_ctrl_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_ctrl_pkg.sv
@@ -7,6 +7,8 @@ package pattgen_ctrl_pkg;
   typedef struct packed {
     logic        enable;
     logic        polarity;
+    logic        inactive_level_pcl;
+    logic        inactive_level_pda;
     logic [31:0] prediv;
     logic [63:0] data;
     logic [5:0]  len;

--- a/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_pkg.sv
@@ -54,6 +54,18 @@ package pattgen_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } inactive_level_pda_ch1;
+    struct packed {
+      logic        q;
+    } inactive_level_pcl_ch1;
+    struct packed {
+      logic        q;
+    } inactive_level_pda_ch0;
+    struct packed {
+      logic        q;
+    } inactive_level_pcl_ch0;
+    struct packed {
+      logic        q;
     } polarity_ch1;
     struct packed {
       logic        q;
@@ -110,11 +122,11 @@ package pattgen_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    pattgen_reg2hw_intr_state_reg_t intr_state; // [237:236]
-    pattgen_reg2hw_intr_enable_reg_t intr_enable; // [235:234]
-    pattgen_reg2hw_intr_test_reg_t intr_test; // [233:230]
-    pattgen_reg2hw_alert_test_reg_t alert_test; // [229:228]
-    pattgen_reg2hw_ctrl_reg_t ctrl; // [227:224]
+    pattgen_reg2hw_intr_state_reg_t intr_state; // [241:240]
+    pattgen_reg2hw_intr_enable_reg_t intr_enable; // [239:238]
+    pattgen_reg2hw_intr_test_reg_t intr_test; // [237:234]
+    pattgen_reg2hw_alert_test_reg_t alert_test; // [233:232]
+    pattgen_reg2hw_ctrl_reg_t ctrl; // [231:224]
     pattgen_reg2hw_prediv_ch0_reg_t prediv_ch0; // [223:192]
     pattgen_reg2hw_prediv_ch1_reg_t prediv_ch1; // [191:160]
     pattgen_reg2hw_data_ch0_mreg_t [1:0] data_ch0; // [159:96]

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -145,6 +145,14 @@ module pattgen_reg_top (
   logic ctrl_polarity_ch0_wd;
   logic ctrl_polarity_ch1_qs;
   logic ctrl_polarity_ch1_wd;
+  logic ctrl_inactive_level_pcl_ch0_qs;
+  logic ctrl_inactive_level_pcl_ch0_wd;
+  logic ctrl_inactive_level_pda_ch0_qs;
+  logic ctrl_inactive_level_pda_ch0_wd;
+  logic ctrl_inactive_level_pcl_ch1_qs;
+  logic ctrl_inactive_level_pcl_ch1_wd;
+  logic ctrl_inactive_level_pda_ch1_qs;
+  logic ctrl_inactive_level_pda_ch1_wd;
   logic prediv_ch0_we;
   logic [31:0] prediv_ch0_qs;
   logic [31:0] prediv_ch0_wd;
@@ -450,6 +458,114 @@ module pattgen_reg_top (
 
     // to register interface (read)
     .qs     (ctrl_polarity_ch1_qs)
+  );
+
+  //   F[inactive_level_pcl_ch0]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ctrl_inactive_level_pcl_ch0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ctrl_we),
+    .wd     (ctrl_inactive_level_pcl_ch0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ctrl.inactive_level_pcl_ch0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ctrl_inactive_level_pcl_ch0_qs)
+  );
+
+  //   F[inactive_level_pda_ch0]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ctrl_inactive_level_pda_ch0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ctrl_we),
+    .wd     (ctrl_inactive_level_pda_ch0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ctrl.inactive_level_pda_ch0.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ctrl_inactive_level_pda_ch0_qs)
+  );
+
+  //   F[inactive_level_pcl_ch1]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ctrl_inactive_level_pcl_ch1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ctrl_we),
+    .wd     (ctrl_inactive_level_pcl_ch1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ctrl.inactive_level_pcl_ch1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ctrl_inactive_level_pcl_ch1_qs)
+  );
+
+  //   F[inactive_level_pda_ch1]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_ctrl_inactive_level_pda_ch1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ctrl_we),
+    .wd     (ctrl_inactive_level_pda_ch1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ctrl.inactive_level_pda_ch1.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (ctrl_inactive_level_pda_ch1_qs)
   );
 
 
@@ -800,6 +916,14 @@ module pattgen_reg_top (
   assign ctrl_polarity_ch0_wd = reg_wdata[2];
 
   assign ctrl_polarity_ch1_wd = reg_wdata[3];
+
+  assign ctrl_inactive_level_pcl_ch0_wd = reg_wdata[4];
+
+  assign ctrl_inactive_level_pda_ch0_wd = reg_wdata[5];
+
+  assign ctrl_inactive_level_pcl_ch1_wd = reg_wdata[6];
+
+  assign ctrl_inactive_level_pda_ch1_wd = reg_wdata[7];
   assign prediv_ch0_we = addr_hit[5] & reg_we & !reg_error;
 
   assign prediv_ch0_wd = reg_wdata[31:0];
@@ -873,6 +997,10 @@ module pattgen_reg_top (
         reg_rdata_next[1] = ctrl_enable_ch1_qs;
         reg_rdata_next[2] = ctrl_polarity_ch0_qs;
         reg_rdata_next[3] = ctrl_polarity_ch1_qs;
+        reg_rdata_next[4] = ctrl_inactive_level_pcl_ch0_qs;
+        reg_rdata_next[5] = ctrl_inactive_level_pda_ch0_qs;
+        reg_rdata_next[6] = ctrl_inactive_level_pcl_ch1_qs;
+        reg_rdata_next[7] = ctrl_inactive_level_pda_ch1_qs;
       end
 
       addr_hit[5]: begin


### PR DESCRIPTION
This feature allows to define the level that `pcl` and `pda` take when pattgen is not actively sending data  bits (i.e., when pattgen is disabled or all data bits have been sent).

The feature is not yet supported in the scoreboard, so the scoreboard gets disabled for the test that exercises this feature.  This limitation is tracked in a linked issue.  A manual inspection of waves showed that the main use case works as intended, though:
![image](https://github.com/lowRISC/opentitan/assets/3583291/619c6771-491f-4708-96c3-40106fc700cc)
(see https://github.com/lowRISC/opentitan/issues/21924#issuecomment-2120534793 for details)

All existing tests retain their checks, coverage, and pass rate; i.e., when this feature is not used (`inactive_level_p`{`cl`,`da`}` = 0`), pattgen's behavior does not change.

This resolves #21924.

## TODOs (pre-merge)
- [x] Confirm with integration teams that this fulfills their requirements.
- [x] Document use case that led to this feature request in pattgen's Programmer's Guide.
- [x] Create issue to model the new feature in the scoreboard and track its coverage, and link that issue in the `TODO` comment in the code. --> #23219