### PR TITLE
[top_earlgrey,padring] Implement muxing for IOB[0:3]

### DIFF
--- a/hw/top_earlgrey/padring.core
+++ b/hw/top_earlgrey/padring.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:pinmux_component
+      - lowrisc:systems:top_earlgrey_pkg
       - "!fileset_partner ? (lowrisc:systems:physical_pads)"
       - "fileset_partner ? (partner:systems:physical_pads)"
     files:

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -477,6 +477,7 @@ module chip_earlgrey_asic #(
   // This is only used for scan and DFT purposes
     .clk_scan_i   ( ast_base_clks.clk_sys ),
     .scanmode_i   ( scanmode              ),
+    .mux_iob_sel_i ('0), // TODO(#23280)
     .dio_in_raw_o ( dio_in_raw ),
     // Chip IOs
     .dio_pad_io ({

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -355,6 +355,7 @@ module chip_earlgrey_cw310 #(
   // This is only used for scan and DFT purposes
     .clk_scan_i   ( 1'b0                  ),
     .scanmode_i   ( prim_mubi_pkg::MuBi4False ),
+    .mux_iob_sel_i ('0), // TODO(#23280)
     .dio_in_raw_o ( dio_in_raw ),
     // Chip IOs
     .dio_pad_io ({

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -351,6 +351,7 @@ module chip_earlgrey_cw340 #(
   // This is only used for scan and DFT purposes
     .clk_scan_i   ( 1'b0                  ),
     .scanmode_i   ( prim_mubi_pkg::MuBi4False ),
+    .mux_iob_sel_i ('0), // TODO(#23280)
     .dio_in_raw_o ( dio_in_raw ),
     // Chip IOs
     .dio_pad_io ({

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -310,6 +310,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .clk_scan_i   ( 1'b0                  ),
     .scanmode_i   ( prim_mubi_pkg::MuBi4False ),
   % endif
+    .mux_iob_sel_i ('0), // TODO(#23280)
     .dio_in_raw_o ( dio_in_raw ),
     // Chip IOs
     .dio_pad_io ({


### PR DESCRIPTION
In packages with reduced pin count, not all pads can be bonded out.  The
direct-mapped pads have to be bonded out, but Quad SPI may not always be
required.  For use cases where IOB[0:3] are not bonded out but
SPI_HOST_D{2,3} and SPI_DEV_D{2,3} are bonded out but are not used
(because Quad SPI is not used), this commit adds muxes that allow using
those Quad SPI ports via IOB[0:3].

The mux selectors are currently tied off (to the direct connection);
they will be wired up as part of https://github.com/lowRISC/opentitan/issues/23280.