### PR TITLE
[opentitantool] Factor JSON configuration files

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -1,3 +1,20 @@
+/*
+ * This file declares the signal routing of the Teacup board.  This file is
+ * meant to be used with multiple iterations of the silicon chip (possibly
+ * requiring separate chip-specific JSON configuration files to declare where,
+ * e.g. the DFT strap pins are placed on a particular chip).  This file is also
+ * meant to be used by tests that require different incompatible default pin
+ * setups, e.g. some tests may want all pins to be GPIO on HyperDebug to be able
+ * to test pinmux, others may want to make use of HyperDebug UART features on
+ * some pins.  Such preferences should be declared in a test-suite-specific JSON
+ * configuration file.  Third-party users of OpenTitan are expected to have
+ * their own test-suite JSON files outside of the OpenTitan repository, and
+ * combine those with this file, as long as they use the physical Teacup board.
+ *
+ * Initially, chip and default test preferences have been moved to
+ * hyperdebug_teacup_default.json, and it what users get with `--interface
+ * teacup`.
+ */
 {
   "includes": ["/__builtin__/opentitan.json"],
   "interface": "teacup",
@@ -36,7 +53,6 @@
     },
     {
       "name": "IOA4",
-      "mode": "Input",
       "alias_of": "CN8_10"
     },
     {
@@ -222,6 +238,70 @@
     {
       "name": "CC2",
       "alias_of": "CN7_10"
+    },
+    {
+      "name": "PMOD1_1",
+      "alias_of": "IOA2"
+    },
+    {
+      "name": "PMOD1_2",
+      "alias_of": "IOA4"
+    },
+    {
+      "name": "PMOD1_3",
+      "alias_of": "IOA5"
+    },
+    {
+      "name": "PMOD1_4",
+      "alias_of": "IOA3"
+    },
+    {
+      "name": "PMOD1_5",
+      "alias_of": "IOA6"
+    },
+    {
+      "name": "PMOD1_6",
+      "alias_of": "IOC12"
+    },
+    {
+      "name": "PMOD1_7",
+      "alias_of": "IOA8"
+    },
+    {
+      "name": "PMOD1_8",
+      "alias_of": "IOA7"
+    },
+    {
+      "name": "PMOD2_1",
+      "alias_of": "IOC9"
+    },
+    {
+      "name": "PMOD2_2",
+      "alias_of": "IOC6"
+    },
+    {
+      "name": "PMOD2_3",
+      "alias_of": "IOC10"
+    },
+    {
+      "name": "PMOD2_4",
+      "alias_of": "IOC11"
+    },
+    {
+      "name": "PMOD2_5",
+      "alias_of": "IOB7"
+    },
+    {
+      "name": "PMOD2_6",
+      "alias_of": "IOB8"
+    },
+    {
+      "name": "PMOD2_7",
+      "alias_of": "IOB11"
+    },
+    {
+      "name": "PMOD2_8",
+      "alias_of": "IOB12"
     },
     {
       "name": "SPI_DEV_SCK",

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup_default.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup_default.json
@@ -1,0 +1,40 @@
+/*
+ * This file declares the default way that test in OpenTitan repository prefers
+ * the signals to an Earlgrey chip on a Teacup shield to be.
+ */
+{
+  "includes": ["/__builtin__/hyperdebug_teacup.json"],
+  "interface": "teacup",
+  "pins": [
+    {
+      "name": "DFT_STRAP0",
+      "mode": "Alternate",
+    },
+    {
+      "name": "DFT_STRAP1",
+      "mode": "Alternate",
+    },
+    {
+      /* HyperDebug would disturb PMOD signal by default */
+      "name": "PMOD1_2",
+      "mode": "Input",
+    }
+  ],
+  "strappings": [
+    {
+      "name": "PRERESET_DFT_DISABLE",
+      "pins": [
+        {
+          "name": "DFT_STRAP0",
+          "mode": "PushPull",
+          "level": false
+        },
+        {
+          "name": "DFT_STRAP1",
+          "mode": "PushPull",
+          "level": false
+        }
+      ]
+    }
+  ]
+}

--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -106,7 +106,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
         ),
         "teacup" => (
             hyperdebug::create::<StandardFlavor>(args)?,
-            Some(Path::new("/__builtin__/hyperdebug_teacup.json")),
+            Some(Path::new("/__builtin__/hyperdebug_teacup_default.json")),
         ),
         "hyper340" => (
             hyperdebug::create::<ChipWhispererFlavor<Cw340>>(args)?,


### PR DESCRIPTION
Third-party developers, such as Chrome OS, who use Teacup boards for development and testing, will want to use how pins of HyperDebug are routed to pins of the OpenTitan chip as declared in hyperdebug_teacup.json.  However, depending on their test suites, they may want HyperDebug to drive e.g. IOA4 as a UART, as GPIO with some default level, or not drive in the "default" state prior to test execution.  Even within OpenTitan repository, one could imagine separate test suites wanting different default state.

In order to accomodate such differences, while still allowing re-use of the lengthy list of how e.g. IOA4 is connected to CN8_10 on the board (which will necessarily apply to all users of the Teacup board), this PR factors `hyperdebug_teacup.json` into two files.  All users will continue to use `hyperdebug_teacup.json`, which declares the signal routing.  Tests in OpenTitan repo will additionally use the new `hyperdebug_teacup_default.json` which sets up defaults on particular pins.  Other users will combine the former with their own configuration files.