### PR TITLE
[rom,e2e] add tests for flash ECC error handling during boot

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
@@ -1,0 +1,63 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules:otp.bzl",
+    "STD_OTP_OVERLAYS",
+    "otp_image",
+    "otp_json",
+    "otp_partition",
+)
+load(
+    "//rules/opentitan:defs.bzl",
+    "cw310_params",
+    "opentitan_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+otp_json(
+    name = "otp_json_flash_data_cfg_default_unprovisioned",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                # Enable flash data page scrambling and ECC.
+                "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
+            },
+        ),
+    ],
+)
+
+otp_image(
+    name = "otp_img_boot_policy_flash_ecc_error",
+    src = "//hw/ip/otp_ctrl/data:otp_json_prod",
+    overlays = STD_OTP_OVERLAYS + [":otp_json_flash_data_cfg_default_unprovisioned"],
+    visibility = ["//visibility:private"],
+)
+
+opentitan_test(
+    name = "boot_policy_flash_ecc_error",
+    srcs = ["flash_ecc_error_test.c"],
+    cw310 = cw310_params(
+        changes_otp = True,
+        otp = ":otp_img_boot_policy_flash_ecc_error",
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_sival": None,
+    },
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+        "//hw/top_earlgrey/ip_autogen/flash_ctrl/data:flash_ctrl_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/base:chip",
+    ],
+)

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
@@ -10,12 +10,40 @@ load(
     "otp_partition",
 )
 load(
+    "//rules:manifest.bzl",
+    "manifest",
+)
+load(
+    "//rules:const.bzl",
+    "CONST",
+    "hex",
+)
+load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
+    "opentitan_binary",
     "opentitan_test",
+)
+load(
+    "//sw/device/silicon_creator/rom/e2e:defs.bzl",
+    "SLOTS",
 )
 
 package(default_visibility = ["//visibility:public"])
+
+BOOT_POLICY_FLASH_ECC_ERROR_CASES = [
+    {
+        "name": "a_corrupt_b_valid",
+        "a": ":flash_ecc_self_corruption_slot_a",
+        "b": ":empty_test_slot_b",
+    },
+    {
+        "name": "a_valid_b_corrupt",
+        "a": ":empty_test_slot_a",
+        "b": ":flash_ecc_self_corruption_slot_b",
+    },
+    # TODO(#21353): add test case for both images corrupted.
+]
 
 otp_json(
     name = "otp_json_flash_data_cfg_default_unprovisioned",
@@ -37,27 +65,106 @@ otp_image(
     visibility = ["//visibility:private"],
 )
 
-opentitan_test(
+SEC_VERS = [
+    0,
+    1,
+]
+
+[
+    manifest({
+        "name": "manifest_sec_ver_{}".format(sec_ver),
+        "address_translation": hex(CONST.HARDENED_FALSE),
+        "identifier": hex(CONST.ROM_EXT),
+        "security_version": hex(sec_ver),
+    })
+    for sec_ver in SEC_VERS
+]
+
+[
+    opentitan_binary(
+        name = "empty_test_slot_{}".format(slot),
+        testonly = True,
+        srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
+        # Use the prod key because it is valid in every LC state.
+        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+        ],
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
+        local_defines = [
+            "EMPTY_TEST_MSG=\"slot=%p, security_version=%01d, lc_state=0x%08x\", manifest_def_get(), manifest_def_get()->security_version, lifecycle_raw_state_get()",
+        ],
+        # This image always get the lower security version as we want the image that self-corrupts the ECC
+        # of the manifest identifier to always boot first, befause attempting to boot this (known-good) image.
+        manifest = ":manifest_sec_ver_0",
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+            "//sw/device/silicon_creator/lib/sigverify:spx_verify",
+        ],
+    )
+    for slot in SLOTS
+]
+
+[
+    opentitan_binary(
+        name = "flash_ecc_self_corruption_slot_{}".format(slot),
+        testonly = True,
+        srcs = ["flash_ecc_error_test.c"],
+        # Use the prod key because it is valid in every LC state.
+        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
+        ],
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(slot),
+        local_defines = ["CORRUPT_SLOT_{}_ID=\"1\"".format(slot.upper())],
+        # This image always get the higher security version as we want it to always boot first.
+        manifest = ":manifest_sec_ver_1",
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+            "//hw/top_earlgrey/ip_autogen/flash_ctrl/data:flash_ctrl_c_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/dif:flash_ctrl",
+            "//sw/device/lib/dif:otp_ctrl",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:flash_ctrl_testutils",
+            "//sw/device/lib/testing:otp_ctrl_testutils",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/base:chip",
+        ],
+    )
+    for slot in SLOTS
+]
+
+[
+    opentitan_test(
+        name = "boot_policy_flash_ecc_error_{}".format(c["name"]),
+        cw310 = cw310_params(
+            assemble = "{fw_a}@{slot_a} {fw_b}@{slot_b}",
+            binaries = {
+                c["a"]: "fw_a",
+                c["b"]: "fw_b",
+            },
+            otp = ":otp_img_boot_policy_flash_ecc_error",
+            slot_a = SLOTS["a"],
+            slot_b = SLOTS["b"],
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+    )
+    for c in BOOT_POLICY_FLASH_ECC_ERROR_CASES
+]
+
+test_suite(
     name = "boot_policy_flash_ecc_error",
-    srcs = ["flash_ecc_error_test.c"],
-    cw310 = cw310_params(
-        changes_otp = True,
-        otp = ":otp_img_boot_policy_flash_ecc_error",
-    ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-    },
-    deps = [
-        "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
-        "//hw/top_earlgrey/ip_autogen/flash_ctrl/data:flash_ctrl_c_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:abs_mmio",
-        "//sw/device/lib/dif:flash_ctrl",
-        "//sw/device/lib/dif:otp_ctrl",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:flash_ctrl_testutils",
-        "//sw/device/lib/testing:otp_ctrl_testutils",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/base:chip",
+    tags = ["manual"],
+    tests = [
+        "boot_policy_flash_ecc_error_{}".format(c["name"])
+        for c in BOOT_POLICY_FLASH_ECC_ERROR_CASES
     ],
 )

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/flash_ecc_error_test.c
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/flash_ecc_error_test.c
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
+
+#include "flash_ctrl_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"  // Generated.
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_flash_ctrl_state_t flash_ctrl;
+static dif_otp_ctrl_t otp_ctrl;
+
+static dif_flash_ctrl_region_properties_t kFlashFullAccessScrambledEcc = {
+    .ecc_en = kMultiBitBool4True,
+    .high_endurance_en = kMultiBitBool4False,
+    .scramble_en = kMultiBitBool4True,
+    .erase_en = kMultiBitBool4True,
+    .prog_en = kMultiBitBool4True,
+    .rd_en = kMultiBitBool4True};
+
+enum {
+  // Manifest Offsets; See `sw/device/silicon_creator/lib/manifest.h`.
+  kManifestIdOffest = 820,
+
+  // First flash pages in each ROM_EXT slot.
+  kRomExtSlotAFirstPageIndex = 0,
+  kRomExtSlotBFirstPageIndex = FLASH_CTRL_PARAM_REG_PAGES_PER_BANK,
+
+  // Addresses of the first words in each ROM_EXT slot.
+  kRomExtSlotAFirstAddr = TOP_EARLGREY_EFLASH_BASE_ADDR,
+  kRomExtSlotBFirstAddr =
+      TOP_EARLGREY_EFLASH_BASE_ADDR + (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2),
+
+  // Addresses of the manifest identifiers words in each ROM_EXT slot.
+  kRomExtSlotAManifestIdAddr = kRomExtSlotAFirstAddr + kManifestIdOffest,
+  kRomExtSlotBManifestIdAddr = kRomExtSlotBFirstAddr + kManifestIdOffest,
+
+  // Flash banks for each half of flash.
+  kFlashBank0DataRegion = 0,
+  kFlashBank1DataRegion = 1,
+};
+
+void ottf_load_store_fault_handler(uint32_t *exc_info) {
+  LOG_INFO("Load Access Fault ... continuing execution.");
+  return;
+}
+
+static void init_peripherals(void) {
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash_ctrl,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+}
+
+static status_t corrupt_rom_ext_slot_a_identifier(void) {
+  // Setup full access (read, erase, program) to first flash page in slot A.
+  TRY(flash_ctrl_testutils_data_region_setup_properties(
+      &flash_ctrl, kRomExtSlotAFirstPageIndex, kFlashBank0DataRegion,
+      /*region_size=*/1, kFlashFullAccessScrambledEcc, NULL));
+
+  // Read back the manifest identifier via the flash_ctrl and Ibex.
+  uint32_t manifest_identifier = 0;
+  TRY(flash_ctrl_testutils_read(&flash_ctrl, kRomExtSlotAManifestIdAddr,
+                                /*partition_id=*/0, &manifest_identifier,
+                                kDifFlashCtrlPartitionTypeData,
+                                /*word_count=*/1, /*delay_micros=*/0));
+  LOG_INFO("Uncorrupted Manifest ID (Flash Ctrl Read): 0x%08x",
+           manifest_identifier);
+  TRY_CHECK(manifest_identifier == CHIP_ROM_EXT_IDENTIFIER);
+  // Read it back again via Ibex, expecting a load access fault.
+  manifest_identifier = abs_mmio_read32(kRomExtSlotAManifestIdAddr);
+  LOG_INFO("Uncorrupted Manifest ID (Ibex Read):      0x%08x",
+           manifest_identifier);
+  TRY_CHECK(manifest_identifier == CHIP_ROM_EXT_IDENTIFIER);
+
+  // Overwrite the manifest_identifier with inverted value (without first
+  // erasing the page) to corrupt ECC (since flash writes can only transition 1
+  // bits to 0 bit).
+  uint32_t inv_test_data = ~((uint32_t)CHIP_ROM_EXT_IDENTIFIER);
+  TRY(flash_ctrl_testutils_write(&flash_ctrl, kRomExtSlotAManifestIdAddr,
+                                 /*partition_id=*/0, &inv_test_data,
+                                 kDifFlashCtrlPartitionTypeData,
+                                 /*word_count=*/1));
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  init_peripherals();
+
+  CHECK_STATUS_OK(corrupt_rom_ext_slot_a_identifier());
+
+  // Read it back ROM_EXT slot A data via Ibex, expecting a load access fault.
+  // TODO(timothytrippel): replace with chip reset to trigger slot B boot.
+  uint32_t data_read = UINT32_MAX;
+  data_read = abs_mmio_read32(kRomExtSlotAManifestIdAddr);
+  LOG_INFO("Corrupted Data: 0x%08x", data_read);
+
+  return true;
+}


### PR DESCRIPTION
This adds ROM E2E two test cases that corrupt the ROM_EXT manifest identifier in both slots A and B to prepare for the development of a ROM load access fault exception handler to address #21353. Note this just contains the test cases to tease out the flash ECC corruption error cases, but does not yet provide a solution for handling such in the ROM. A solution to handling the ECC error corruption (i.e., continue attempting to boot the next stage) will be developed in a follow up PR.