### PR TITLE
[rescue] Support faster UART speeds 

### DIFF
--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -123,15 +123,31 @@ extern const uint64_t kUartBaudrate;
  * the NCO width, use NCO = 0xffff for this case since the error is tolerable.
  * Refer to #4263
  */
-#define CALCULATE_UART_NCO(baudrate, peripheral_clock)  \
+#define CALCULATE_UART_NCO_(baudrate, peripheral_clock) \
   (baudrate == 1500000 && peripheral_clock == 24000000) \
       ? 0xffff                                          \
-      : (((baudrate) << (16 + 4)) / (peripheral_clock))
+      : (uint32_t)(((uint64_t)(baudrate) << (16 + 4)) / (peripheral_clock))
+
+#define CALCULATE_UART_NCO(baudrate, peripheral_clock)      \
+  CALCULATE_UART_NCO_(baudrate, peripheral_clock) < 0x10000 \
+      ? CALCULATE_UART_NCO_(baudrate, peripheral_clock)     \
+      : 0;
 
 /**
  * The pre-calculated UART NCO value based on the Baudrate and Peripheral clock.
  */
 extern const uint32_t kUartNCOValue;
+
+/**
+ * Additional pre-calculated UART NCO values.  If the pre-calculated value is
+ * zero, then the corresponding baudrate is not supported.
+ */
+extern const uint32_t kUartBaud115K;
+extern const uint32_t kUartBaud230K;
+extern const uint32_t kUartBaud460K;
+extern const uint32_t kUartBaud921K;
+extern const uint32_t kUartBaud1M33;
+extern const uint32_t kUartBaud1M50;
 
 /**
  * Helper macro to calculate the time it takes to transmit the entire UART TX

--- a/sw/device/lib/arch/device_fpga_cw305.c
+++ b/sw/device/lib/arch/device_fpga_cw305.c
@@ -33,6 +33,19 @@ const uint64_t kUartBaudrate = 115200;
 const uint32_t kUartNCOValue =
     CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
 
+const uint32_t kUartBaud115K =
+    CALCULATE_UART_NCO(115200, kClockFreqPeripheralHz);
+const uint32_t kUartBaud230K =
+    CALCULATE_UART_NCO(115200 * 2, kClockFreqPeripheralHz);
+const uint32_t kUartBaud460K =
+    CALCULATE_UART_NCO(115200 * 4, kClockFreqPeripheralHz);
+const uint32_t kUartBaud921K =
+    CALCULATE_UART_NCO(115200 * 8, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M33 =
+    CALCULATE_UART_NCO(1333333, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M50 =
+    CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
+
 const uint32_t kUartTxFifoCpuCycles =
     CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
 

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -35,6 +35,19 @@ const uint64_t kUartBaudrate = 115200;
 const uint32_t kUartNCOValue =
     CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
 
+const uint32_t kUartBaud115K =
+    CALCULATE_UART_NCO(115200, kClockFreqPeripheralHz);
+const uint32_t kUartBaud230K =
+    CALCULATE_UART_NCO(115200 * 2, kClockFreqPeripheralHz);
+const uint32_t kUartBaud460K =
+    CALCULATE_UART_NCO(115200 * 4, kClockFreqPeripheralHz);
+const uint32_t kUartBaud921K =
+    CALCULATE_UART_NCO(115200 * 8, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M33 =
+    CALCULATE_UART_NCO(1333333, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M50 =
+    CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
+
 const uint32_t kUartTxFifoCpuCycles =
     CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
 

--- a/sw/device/lib/arch/device_fpga_cw340.c
+++ b/sw/device/lib/arch/device_fpga_cw340.c
@@ -35,6 +35,19 @@ const uint64_t kUartBaudrate = 115200;
 const uint32_t kUartNCOValue =
     CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
 
+const uint32_t kUartBaud115K =
+    CALCULATE_UART_NCO(115200, kClockFreqPeripheralHz);
+const uint32_t kUartBaud230K =
+    CALCULATE_UART_NCO(115200 * 2, kClockFreqPeripheralHz);
+const uint32_t kUartBaud460K =
+    CALCULATE_UART_NCO(115200 * 4, kClockFreqPeripheralHz);
+const uint32_t kUartBaud921K =
+    CALCULATE_UART_NCO(115200 * 8, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M33 =
+    CALCULATE_UART_NCO(1333333, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M50 =
+    CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
+
 const uint32_t kUartTxFifoCpuCycles =
     CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
 

--- a/sw/device/lib/arch/device_silicon.c
+++ b/sw/device/lib/arch/device_silicon.c
@@ -34,6 +34,19 @@ const uint64_t kUartBaudrate = 115200;
 const uint32_t kUartNCOValue =
     CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
 
+const uint32_t kUartBaud115K =
+    CALCULATE_UART_NCO(115200, kClockFreqPeripheralHz);
+const uint32_t kUartBaud230K =
+    CALCULATE_UART_NCO(115200 * 2, kClockFreqPeripheralHz);
+const uint32_t kUartBaud460K =
+    CALCULATE_UART_NCO(115200 * 4, kClockFreqPeripheralHz);
+const uint32_t kUartBaud921K =
+    CALCULATE_UART_NCO(115200 * 8, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M33 =
+    CALCULATE_UART_NCO(1333333, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M50 =
+    CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
+
 const uint32_t kUartTxFifoCpuCycles =
     CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
 

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -37,6 +37,19 @@ const uint64_t kUartBaudrate = 1 * 1000 * 1000;  // 1Mbps
 const uint32_t kUartNCOValue =
     CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
 
+const uint32_t kUartBaud115K =
+    CALCULATE_UART_NCO(115200, kClockFreqPeripheralHz);
+const uint32_t kUartBaud230K =
+    CALCULATE_UART_NCO(115200 * 2, kClockFreqPeripheralHz);
+const uint32_t kUartBaud460K =
+    CALCULATE_UART_NCO(115200 * 4, kClockFreqPeripheralHz);
+const uint32_t kUartBaud921K =
+    CALCULATE_UART_NCO(115200 * 8, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M33 =
+    CALCULATE_UART_NCO(1333333, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M50 =
+    CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
+
 const uint32_t kUartTxFifoCpuCycles =
     CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
 

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -44,6 +44,19 @@ const uint64_t kUartBaudrate = 7200;
 const uint32_t kUartNCOValue =
     CALCULATE_UART_NCO(kUartBaudrate, kClockFreqPeripheralHz);
 
+const uint32_t kUartBaud115K =
+    CALCULATE_UART_NCO(115200, kClockFreqPeripheralHz);
+const uint32_t kUartBaud230K =
+    CALCULATE_UART_NCO(115200 * 2, kClockFreqPeripheralHz);
+const uint32_t kUartBaud460K =
+    CALCULATE_UART_NCO(115200 * 4, kClockFreqPeripheralHz);
+const uint32_t kUartBaud921K =
+    CALCULATE_UART_NCO(115200 * 8, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M33 =
+    CALCULATE_UART_NCO(1333333, kClockFreqPeripheralHz);
+const uint32_t kUartBaud1M50 =
+    CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
+
 const uint32_t kUartTxFifoCpuCycles =
     CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
 

--- a/sw/device/silicon_creator/rom_ext/doc/rescue.md
+++ b/sw/device/silicon_creator/rom_ext/doc/rescue.md
@@ -43,7 +43,7 @@ Alternate modes are requested by sending the mode's 4-byte code followed by a ne
 
 The following sections detail each of the supported alternate modes.
 
-#### Firmware Rescue (`RESQ`)
+#### Firmware Rescue (`RESQ`, `RESB`)
 
 The firmware rescue mode may be requested with the 4-byte code `RESQ`.
 The ROM_EXT will acknowledge entry of this mode with the following message:
@@ -54,6 +54,9 @@ ok: send firmware via xmodem-crc
 ```
 
 The ROM_EXT will then prompt for the transfer to start by sending the Xmodem-CRC start character (which is the ASCII character `C`).
+Normally, the rescue payload is stored into slot A of the flash.
+The alternative code `RESB` causes the ROM_EXT to store the payload in slot B of the flash.
+After receiving the payload, the ROM_EXT will reboot the chip (unless commanded to `WAIT`).
 
 #### Request Boot Log Data (`BLOG`)
 
@@ -79,7 +82,7 @@ ok: send boot_svc request via xmodem-crc
 ```
 
 The ROM_EXT will then will prompt for the transfer to start by sending the Xmodem-CRC start character (which is the ASCII character `C`).
-After completing this action, the ROM_EXT will switch back to firmware rescue mode.
+After receiving the payload, the ROM_EXT will reboot the chip (unless commanded to `WAIT`).
 
 
 #### Request the last Boot Services Response (`BRSP`)
@@ -107,7 +110,7 @@ ok: send owner_block via xmodem-crc
 ```
 
 The ROM_EXT will then will prompt for the transfer to start by sending the Xmodem-CRC start character (which is the ASCII character `C`).
-After completing this action, the ROM_EXT will switch back to firmware rescue mode.
+After receiving the payload, the ROM_EXT will reboot the chip (unless commanded to `WAIT`).
 
 Note: the ROM_EXT will only accept the Owner Block if the chip is in an ownership transfer state and the receive owner block meets all validity criteria.
 
@@ -123,6 +126,18 @@ ok: reboot
 ```
 
 The ROM_EXT will then exit rescue mode and reboot the chip.
+
+#### Disable automatic reboot (`WAIT`)
+
+The user may request that the ROM_EXT disable the automatic reboot after upload actions with the 4-byte code `WAIT`.
+The ROM_EXT will acknowledge this request with the following message:
+
+```
+mode: WAIT
+ok: wait after upload
+```
+
+Once commanded to `WAIT`, the ROM_EXT will need an explicit reboot after an upload action.
 
 ### Error Conditions
 

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -18,9 +18,11 @@ package(default_visibility = ["//visibility:public"])
 _POSITIONS = {
     "slot_a": {
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
+        "slot": "SlotA",
     },
     "slot_b": {
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
+        "slot": "SlotB",
     },
 }
 
@@ -45,30 +47,34 @@ _POSITIONS = {
     for name, position in _POSITIONS.items()
 ]
 
-opentitan_test(
-    name = "firmware",
-    cw310 = cw310_params(
-        assemble = "",
-        binaries = {
-            ":boot_test_slot_a": "slot_a",
+[
+    opentitan_test(
+        name = "rescue_firmware_{}".format(name),
+        cw310 = cw310_params(
+            assemble = "",
+            binaries = {
+                ":boot_test_{}".format(name): "payload",
+            },
+            slot = position["slot"],
+            test_cmd = """
+                --exec="transport init"
+                --exec="fpga load-bitstream {bitstream}"
+                --exec="bootstrap --clear-uart=true {rom_ext}"
+                # First make sure the ROM_EXT is faulting because there is no firmware
+                --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
+                # Load firmware via rescue
+                --exec="rescue firmware --slot={slot} {payload:signed_bin}"
+                # Check for firmware execution
+                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
+                no-op
+            """,
+        ),
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
         },
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {rom_ext}"
-            # First make sure the ROM_EXT is faulting because there is no firmware
-            --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
-            # Load firmware via rescue
-            --exec="rescue firmware {slot_a:signed_bin}"
-            # Check for firmware execution
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
-    ),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
-    },
-)
+    )
+    for name, position in _POSITIONS.items()
+]
 
 opentitan_test(
     name = "next_slot",

--- a/sw/device/silicon_creator/rom_ext/rescue.c
+++ b/sw/device/silicon_creator/rom_ext/rescue.c
@@ -18,6 +18,9 @@
 // any function in real firmware.
 #define iohandle NULL
 
+const uint32_t kFlashPageSize = FLASH_CTRL_PARAM_BYTES_PER_PAGE;
+const uint32_t kFlashBankSize =
+    kFlashPageSize * FLASH_CTRL_PARAM_REG_PAGES_PER_BANK;
 static rescue_state_t rescue_state;
 
 rom_error_t flash_firmware_block(rescue_state_t *state) {
@@ -27,14 +30,14 @@ rom_error_t flash_firmware_block(rescue_state_t *state) {
         .write = kMultiBitBool4True,
         .erase = kMultiBitBool4True,
     });
-    for (uint32_t addr = state->flash_start; addr < state->flash_limit;
-         addr += FLASH_CTRL_PARAM_BYTES_PER_PAGE) {
+    for (uint32_t addr = state->flash_start; addr <= state->flash_limit;
+         addr += kFlashPageSize) {
       HARDENED_RETURN_IF_ERROR(
           flash_ctrl_data_erase(addr, kFlashCtrlEraseTypePage));
     }
     state->flash_offset = state->flash_start;
   }
-  if (state->flash_offset < state->flash_limit) {
+  if (state->flash_offset <= state->flash_limit) {
     HARDENED_RETURN_IF_ERROR(flash_ctrl_data_write(
         state->flash_offset, sizeof(state->data) / sizeof(uint32_t),
         state->data));
@@ -73,13 +76,22 @@ static void validate_mode(uint32_t mode, rescue_state_t *state) {
       break;
     case kRescueModeFirmware:
       dbg_printf("ok: send firmware via xmodem-crc\r\n");
+      // Ensure the start/limit are in SlotA.
+      state->flash_start &= ~kFlashBankSize;
+      state->flash_limit &= ~kFlashBankSize;
+      break;
+    case kRescueModeFirmwareSlotB:
+      dbg_printf("ok: send slot-b firmware via xmodem-crc\r\n");
+      // Ensure the start/limit are in SlotB.
+      state->flash_start |= kFlashBankSize;
+      state->flash_limit |= kFlashBankSize;
       break;
     case kRescueModeReboot:
       dbg_printf("ok: reboot\r\n");
       break;
-    case kRescueModeDWIM:
-      // Easter egg :)
-      dbg_printf("error: i don't know what you mean\r\n");
+    case kRescueModeWait:
+      state->reboot = false;
+      dbg_printf("ok: wait after upload\r\n");
       return;
     default:
       // User input error.  Do not change modes.
@@ -106,6 +118,7 @@ static rom_error_t handle_send_modes(rescue_state_t *state) {
     case kRescueModeBootSvcReq:
     case kRescueModeOwnerBlock:
     case kRescueModeFirmware:
+    case kRescueModeFirmwareSlotB:
       // Nothing to do for receive modes.
       return kErrorOk;
     case kRescueModeReboot:
@@ -141,6 +154,7 @@ static rom_error_t handle_recv_modes(rescue_state_t *state) {
       }
       break;
     case kRescueModeFirmware:
+    case kRescueModeFirmwareSlotB:
       if (state->offset == sizeof(state->data)) {
         HARDENED_RETURN_IF_ERROR(flash_firmware_block(state));
         state->offset = 0;
@@ -160,13 +174,14 @@ static rom_error_t protocol(rescue_state_t *state) {
   uint8_t command;
   uint32_t next_mode = 0;
 
+  state->reboot = true;
   validate_mode(kRescueModeFirmware, &rescue_state);
 
   // The rescue region starts immediately after the ROM_EXT and ends
   // at the end of the flash bank.
   // TODO(cfrantz): This needs to be owner-configurable.
   state->flash_start = 0x10000;
-  state->flash_limit = 0x80000;
+  state->flash_limit = 0x7FFFF;
 
   xmodem_recv_start(iohandle);
   while (true) {
@@ -194,6 +209,12 @@ static rom_error_t protocol(rescue_state_t *state) {
           HARDENED_RETURN_IF_ERROR(handle_recv_modes(&rescue_state));
         }
         xmodem_ack(iohandle, true);
+        if (!state->reboot) {
+          state->frame = 1;
+          state->offset = 0;
+          state->flash_offset = 0;
+          continue;
+        }
         return kErrorRescueReboot;
       case kErrorXModemCrc:
         xmodem_ack(iohandle, false);

--- a/sw/device/silicon_creator/rom_ext/rescue.h
+++ b/sw/device/silicon_creator/rom_ext/rescue.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_RESCUE_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_RESCUE_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "sw/device/silicon_creator/lib/error.h"
@@ -27,19 +28,28 @@ typedef enum {
   kRescueModeOwnerBlock = 0x4f574e52,
   /** `RESQ` */
   kRescueModeFirmware = 0x52455351,
+  /** `RESB` */
+  kRescueModeFirmwareSlotB = 0x52455342,
   /** `REBO` */
   kRescueModeReboot = 0x5245424f,
-  /** `DWIM` */
-  kRescueModeDWIM = 0x4457494d,
+  /** `WAIT` */
+  kRescueModeWait = 0x57414954,
 } rescue_mode_t;
 
 typedef struct RescueState {
   rescue_mode_t mode;
+  // Whether to reboot automatically after an xmodem upload.
+  bool reboot;
+  // Current xmodem frame.
   uint32_t frame;
+  // Current data offset.
   uint32_t offset;
+  // Current flash write offset.
   uint32_t flash_offset;
+  // Range to erase and write for firmware rescue (inclusive).
   uint32_t flash_start;
   uint32_t flash_limit;
+  // Data buffer to hold xmodem upload data.
   uint8_t data[2048];
 } rescue_state_t;
 

--- a/sw/device/silicon_creator/rom_ext/rescue.h
+++ b/sw/device/silicon_creator/rom_ext/rescue.h
@@ -18,6 +18,8 @@ enum {
 };
 
 typedef enum {
+  /** `BAUD` */
+  kRescueModeBaud = 0x42415544,
   /** `BLOG` */
   kRescueModeBootLog = 0x424c4f47,
   /** `BRSP` */
@@ -35,6 +37,21 @@ typedef enum {
   /** `WAIT` */
   kRescueModeWait = 0x57414954,
 } rescue_mode_t;
+
+typedef enum {
+  /** `115K` */
+  kRescueBaud115K = 0x4b353131,
+  /** `230K` */
+  kRescueBaud230K = 0x4b303332,
+  /** `460K` */
+  kRescueBaud460K = 0x4b303634,
+  /** `921K` */
+  kRescueBaud921K = 0x4b313239,
+  /** `1M33` */
+  kRescueBaud1M33 = 0x33334d31,
+  /** `1M50` */
+  kRescueBaud1M50 = 0x30354d31,
+} rescue_baud_t;
 
 typedef struct RescueState {
   rescue_mode_t mode;

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -31,6 +31,8 @@ pub struct RawBytes(
 pub struct Firmware {
     #[command(flatten)]
     params: UartParams,
+    #[arg(long, help = "After connecting to rescue, negotiate faster baudrate")]
+    rate: Option<u32>,
     #[arg(long, default_value = "SlotA", help = "Which flash slot to rescue")]
     slot: BootSlot,
     #[arg(long, value_parser = usize::from_str, help = "Offset of application image")]
@@ -74,6 +76,9 @@ impl CommandDispatch for Firmware {
         let uart = self.params.create(transport)?;
         let rescue = RescueSerial::new(uart);
         rescue.enter(transport)?;
+        if let Some(rate) = self.rate {
+            rescue.set_baud(rate)?;
+        }
         if self.wait {
             rescue.wait()?;
         }


### PR DESCRIPTION
Allow the rescue protocol to negotiate a speed faster than the standard 115200 bps.  The faster rates are the "extended standard" rates of 230400, 460800 and 921600 bps.

This addresses #22943.

This PR depends on #23205; you need only review the last 2 commits.