### PR TITLE
Cherry-pick to earlgrey_es_sival: [rom_ext] Add KMAC256 operations using software and hardware keys

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -376,6 +376,7 @@ opentitan_test(
         ":kmac",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:hexstr",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:error",
     ],

--- a/sw/device/silicon_creator/lib/drivers/kmac.h
+++ b/sw/device/silicon_creator/lib/drivers/kmac.h
@@ -29,6 +29,22 @@ extern "C" {
 rom_error_t kmac_keymgr_configure(void);
 
 /**
+ * Configure the KMAC block for KMAC-256 operation with a key loaded by
+ * software.
+ *
+ * @return Error code indicating if the operation succeeded.
+ */
+rom_error_t kmac_kmac256_sw_configure(void);
+
+/**
+ * Configure the KMAC block for KMAC-256 operation with a key sideloaded from
+ * the keymgr hardware block.
+ *
+ * @return Error code indicating if the operation succeeded.
+ */
+rom_error_t kmac_kmac256_hw_configure(void);
+
+/**
  * Configure the KMAC block at startup.
  *
  * Sets the KMAC block to use software entropy (since we have no secret inputs
@@ -128,6 +144,55 @@ void kmac_shake256_squeeze_start(void);
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t kmac_shake256_squeeze_end(uint32_t *out, size_t outlen);
+
+/**
+ * Load an unmasked software key into KMAC.
+ *
+ * @param key The key material.
+ * @param len The length of the key material in words.
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t kmac_kmac256_sw_key(const uint32_t *key, size_t len);
+
+/**
+ * Set the KMAC prefix value.
+ *
+ * Sets the prefix to the given prefix value.  The prefix
+ * must be 31 bytes or fewer.
+ *
+ * @param prefix The prefix value encoded as words.
+ * @param len The length of the prefix in bytes.
+ */
+void kmac_kmac256_set_prefix(const void *prefix, size_t len);
+
+/**
+ * Start a KMAC-256 operation.
+ *
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+inline rom_error_t kmac_kmac256_start(void) { return kmac_shake256_start(); }
+
+/**
+ * Absorb data into a KMAC-256.
+ *
+ * @param data Data to absorb into the sponge.
+ * @param len Length of the data.
+ */
+inline void kmac_kmac256_absorb(const void *data, size_t len) {
+  kmac_shake256_absorb((const uint8_t *)data, len);
+}
+
+/**
+ * Finalize the KMAC-256 operation.
+ *
+ * @param result Buffer to hold the result of the KMAC operation.
+ * @param rlen Length of the result buffer in words.
+ * @return Error code indicating if the operation succeeded.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t kmac_kmac256_final(uint32_t *result, size_t rlen);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -116,6 +116,7 @@ enum module_ {
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
   \
   X(kErrorKmacInvalidStatus,          ERROR_(1, kModuleKmac, kInternal)), \
+  X(kErrorKmacInvalidKeySize,         ERROR_(2, kModuleKmac, kInvalidArgument)), \
   \
   X(kErrorOtbnInvalidArgument,        ERROR_(1, kModuleOtbn, kInvalidArgument)), \
   X(kErrorOtbnBadOffsetLen,           ERROR_(2, kModuleOtbn, kInvalidArgument)), \

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -81,6 +81,9 @@ dual_cc_library(
     deps = dual_inputs(
         device = [
             ":ecdsa",
+            "//sw/device/lib/base:hardened_memory",
+            "//sw/device/silicon_creator/lib/drivers:keymgr",
+            "//sw/device/silicon_creator/lib/drivers:kmac",
         ],
         host = [
             "//sw/device/lib/base:global_mock",
@@ -90,6 +93,7 @@ dual_cc_library(
         shared = [
             ":datatypes",
             "//sw/device/lib/base:hardened",
+            "//sw/device/silicon_creator/lib:error",
         ],
     ),
 )

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
@@ -14,5 +14,17 @@ hardened_bool_t ownership_key_validate(size_t page, ownership_key_t key,
                                                len);
 }
 
+rom_error_t ownership_seal_init() {
+  return MockOwnershipKey::Instance().seal_init();
+}
+
+rom_error_t ownership_seal_page(size_t page) {
+  return MockOwnershipKey::Instance().seal_page(page);
+}
+
+rom_error_t ownership_seal_check(size_t page) {
+  return MockOwnershipKey::Instance().seal_check(page);
+}
+
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
@@ -20,6 +20,9 @@ class MockOwnershipKey : public global_mock::GlobalMock<MockOwnershipKey> {
   MOCK_METHOD(hardened_bool_t, validate,
               (size_t, ownership_key_t, const owner_signature_t *, const void *,
                size_t));
+  MOCK_METHOD(rom_error_t, seal_init, ());
+  MOCK_METHOD(rom_error_t, seal_page, (size_t));
+  MOCK_METHOD(rom_error_t, seal_check, (size_t));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNERSHIP_KEY_H_
 
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
 /**
@@ -44,5 +45,31 @@ typedef enum ownership_key {
 hardened_bool_t ownership_key_validate(size_t page, ownership_key_t key,
                                        const owner_signature_t *signature,
                                        const void *message, size_t len);
+
+/**
+ * Initialize sealing.
+ *
+ * Initializes the KMAC block to create a KMAC-256 seal based on a key
+ * created by keymgr.
+ *
+ * @return Success or error code.
+ */
+rom_error_t ownership_seal_init(void);
+
+/**
+ * Generate a seal for an ownership page.
+ *
+ * @param page Owner page for which to generate the sealing value.
+ * @return Success or error code.
+ */
+rom_error_t ownership_seal_page(size_t page);
+
+/**
+ * Check the seal on an ownership page.
+ *
+ * @param page Owner page on which to check the seal.
+ * @return Success or error code.
+ */
+rom_error_t ownership_seal_check(size_t page);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNERSHIP_KEY_H_


### PR DESCRIPTION
This is a manual cherry-pick of  #23162 and #23183 to `earlgrey_es_sival`.