### PR TITLE
[dv] Fix e2e sigverify_always tests.

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_common_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_common_pkg.sv
@@ -25,9 +25,9 @@ package chip_common_pkg;
   parameter uint ROM_CONSOLE_UART = 0;
 
   // ROM Boot Fault Values, matches definitions in `rules/const.bzl`.
-  parameter string ROM_BFV_BAD_IDENTIFIER     = "0142500d";
-  parameter string ROM_BFV_BAD_RSA_SIGNATURE    = "01535603";
-  parameter string ROM_BFV_INSTRUCTION_ACCESS = "01495202";
+  parameter string ROM_BFV_BAD_IDENTIFIER       = "0142500d";
+  parameter string ROM_BFV_BAD_ECDSA_SIGNATURE  = "07535603";
+  parameter string ROM_BFV_INSTRUCTION_ACCESS   = "01495202";
 
   // ROM Lifecycle Values, matches definitions in `rules/const.bzl`.
   parameter string ROM_LCV_TEST_UNLOCKED0 = "02108421";

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv
@@ -14,7 +14,7 @@ class chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq extends
     connect_rom_uart_agent();
     lc_state = cfg.mem_bkdr_util_h[Otp].otp_read_lc_partition_state();
     check_uart_output_msg(
-      $sformatf("BFV:%0s\x0d\nLCV:%0s\x0d\n", ROM_BFV_BAD_RSA_SIGNATURE,
+      $sformatf("BFV:%0s\x0d\nLCV:%0s\x0d\n", ROM_BFV_BAD_ECDSA_SIGNATURE,
       lc_state_2_rom_lcv[lc_state]));
     disconnect_rom_uart_agent();
     rom_e2e_test_boot_fault_success();


### PR DESCRIPTION
Update the expected ROM error to `ROM_BFV_BAD_ECDSA_SIGNATURE`.

Fixes: https://github.com/lowRISC/opentitan/issues/22919