### PR TITLE
[cryptolib] Eliminate `status_create` symbol use

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -314,7 +314,7 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
     kMaxGenerateSizeIn128BitBlocks = 0x800,
   };
   if (cmd.generate_len > kMaxGenerateSizeIn128BitBlocks) {
-    return OUT_OF_RANGE();
+    return OTCRYPTO_BAD_ARGS;
   }
 
   uint32_t cmd_reg_addr;
@@ -344,7 +344,7 @@ static status_t csrng_send_app_cmd(uint32_t base_address,
       cmd_reg_addr = base_address + EDN_RESEED_CMD_REG_OFFSET;
       break;
     default:
-      return INVALID_ARGUMENT();
+      return OTCRYPTO_BAD_ARGS;
   }
 
   if ((cmd_type == kEntropyCsrngSendAppCmdTypeCsrng) ||


### PR DESCRIPTION
The cryptolib avoid use of the general-purpose `status_t` creating macros like `OK_STATUS()` or `INVALID_ARGUMENT()` which call `status_create()`.  Instead, cryptolib defines its own status types that are compatible with `status_t` but do not invoke `status_create`.

A couple of the general-pupose invocations snuck in.  Eliminate them in favor of `OTCRYPTO_...` definitions.