### PR TITLE
[dv, chip]: Change tap_strap_value type

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -763,7 +763,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
       fork
         cfg.clk_rst_vif.wait_clks(max_cycles);
         forever begin
-          uvm_hdl_data_t tap_strap_value;
+          bit[1:0] tap_strap_value;
           string tap_strap_path = {"tb.dut.top_earlgrey.u_pinmux_aon.",
                                    "u_pinmux_strap_sampling.tap_strap"};
           `DV_CHECK(uvm_hdl_read(tap_strap_path, tap_strap_value))


### PR DESCRIPTION
Modifying tap_stap_value type.
 
Currently the tap_strap_value check fails even though the tap_strap have reached the desired value, to fix this the type is changed to bit[1:0].