### PR TITLE
[hmac,dv/rtl] Fix HMAC DV scoreboard synchronization

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cov.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cov.sv
@@ -58,13 +58,14 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
 
   covergroup err_code_cg with function sample (bit [TL_DW-1:0] err_code);
     hmac_errors: coverpoint err_code {
+      // TODO extend with new error code
       bins no_error                     = {NoError};
       // This error code is not used in this version. PR #13854.
       // bins push_msg_when_sha_disabled   = {SwPushMsgWhenShaDisabled};
       bins hash_start_when_sha_disabled = {SwHashStartWhenShaDisabled};
       bins update_secret_key_in_process = {SwUpdateSecretKeyInProcess};
       bins hash_start_when_active       = {SwHashStartWhenActive};
-      bins push_msg_when_idle           = {SwPushMsgWhenIdle};
+      bins push_msg_when_disallowed     = {SwPushMsgWhenDisallowed};
       bins key_length_higher_blk_size   = {SwInvalidConfig};
       illegal_bins illegalvalue         = default;
     }

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -21,8 +21,11 @@ package hmac_env_pkg;
   `include "dv_macros.svh"
 
   // local parameters and types
-  parameter uint32 HMAC_MSG_FIFO_DEPTH        = 32;
-  parameter uint32 HMAC_MSG_FIFO_DEPTH_BYTES  = HMAC_MSG_FIFO_DEPTH * 4;
+  parameter uint32 HMAC_MSG_FIFO_DEPTH_WR     = 32;
+  parameter uint32 HMAC_MSG_FIFO_DEPTH_RD     = 16;
+  parameter uint32 HMAC_MSG_FIFO_DEPTH_256    = 16;
+  parameter uint32 HMAC_MSG_FIFO_DEPTH_512    = 32;
+  parameter uint32 HMAC_MSG_FIFO_DEPTH_BYTES  = HMAC_MSG_FIFO_DEPTH_WR * 4;
   parameter uint32 HMAC_MSG_FIFO_SIZE         = 2048;
   parameter uint32 HMAC_MSG_FIFO_BASE         = 32'h1000;
   parameter uint32 HMAC_MSG_FIFO_LAST_ADDR    = HMAC_MSG_FIFO_BASE + HMAC_MSG_FIFO_SIZE - 1;
@@ -83,7 +86,7 @@ package hmac_env_pkg;
     SwHashStartWhenShaDisabled = 2,
     SwUpdateSecretKeyInProcess = 3,
     SwHashStartWhenActive      = 4,
-    SwPushMsgWhenIdle          = 5,
+    SwPushMsgWhenDisallowed    = 5,
     SwInvalidConfig            = 6
   } err_code_e;
 

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -42,7 +42,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
   }
 
   constraint burst_wr_c {
-    burst_wr_length inside {[1 : HMAC_MSG_FIFO_DEPTH]};
+    burst_wr_length inside {[1 : HMAC_MSG_FIFO_DEPTH_WR]};
   }
 
   constraint intr_enable_c {
@@ -140,7 +140,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
               end else begin
                 csr_spinwait(.ptr(ral.intr_state.hmac_err), .exp_data(1'b1));
               end
-              `uvm_info(`gfn, $sformatf("HMAC Error,  %b", cfg.intr_vif.pins[HmacErr]), UVM_LOW)
+              check_error_code();
             end
             if (do_burst_wr) burst_wr_msg(msg, burst_wr_length);
             else             wr_msg(msg);
@@ -152,6 +152,8 @@ class hmac_smoke_vseq extends hmac_base_vseq;
               wipe_secrets();
             end
           end
+          csr_rd(.ptr(ral.intr_state), .value(intr_state_val));
+          csr_wr(.ptr(ral.intr_state), .value(intr_state_val));
         join
 
         if (!sha_en) begin
@@ -199,8 +201,7 @@ class hmac_smoke_vseq extends hmac_base_vseq;
             end
             begin
               if (do_wipe_secret == WipeSecretBeforeDone) begin
-                        `uvm_info(`gfn, $sformatf("wiping before done"), UVM_HIGH)
-
+                `uvm_info(`gfn, $sformatf("wiping before done"), UVM_HIGH)
                 cfg.clk_rst_vif.wait_clks($urandom_range(0, 100));
                 wipe_secrets();
               end

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -781,7 +781,7 @@ module hmac
   always_comb begin
     update_seckey_inprocess = 1'b0;
     if (cfg_block) begin
-      for (int i = 0 ; i < 8 ; i++) begin
+      for (int i = 0 ; i < 32 ; i++) begin
         if (reg2hw.key[i].qe) begin
           update_seckey_inprocess = update_seckey_inprocess | 1'b1;
         end


### PR DESCRIPTION
This PR will only have 2 commits to review once this PR https://github.com/lowRISC/opentitan/pull/23108 is merged. This introduces changes in the HMAC DV to enable `do_read_check` that was commented out https://github.com/lowRISC/opentitan/issues/22578 and achieve synchronization with how the FIFO is  verified vs the CSRs being read and compared **but only for SHA-2 256**.  I have disabled `do_read_check` in the meantime to keep the constraints unreleased on the digest sizes and key lengths, until I fix the synchronization issues for 384/512. With this PR, the block test `hmac_error` and `hmac_stress_all` still fail, but have been root-caused and will be fixed in upcoming PRs.