### PR TITLE
[csrng/rtl] Check for GENU instead of GEN for CMD_STS_INVALID_GEN_CMD

### DIFF
--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -593,7 +593,7 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
 
   // Return a status error when the genbits FIFO is popped while ctr_drbg_gen_ccmd_o is not
   // equal to GEN.
-  assign ctr_drbg_gen_sts_err = sfifo_genbits_pop && (ctr_drbg_gen_ccmd_o != GEN);
+  assign ctr_drbg_gen_sts_err = sfifo_genbits_pop && (ctr_drbg_gen_ccmd_o != GENU);
 
   assign ctr_drbg_gen_sts_o = ctr_drbg_gen_sts_err ? CMD_STS_INVALID_GEN_CMD : CMD_STS_SUCCESS;
 


### PR DESCRIPTION
This commit changes the check for the CMD_STS_INVALID_GEN_CMD error status response. Since GEN commands are renamed to GENB and finally to GENU we should check whether the acked command is GENU instead of GEN in csrng_ctr_drbg_gen.sv.

Resolves [#23131](https://github.com/lowRISC/opentitan/issues/23131)