### PR TITLE
[top_earlgrey/dv] Create regression set for nightly Xcelium runs

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -2209,5 +2209,11 @@
               "rom_e2e_smoke",
             ]
     }
+    {
+      name: xcelium_nightly
+      tests: [
+              "chip_padctrl_attributes",
+             ]
+    }
   ]
 }


### PR DESCRIPTION
Some top-level tests depend on Xcelium to run correctly and have all checks active.  As top-level tests for Earlgrey run in VCS by default, all tests in the `nightly` regression set also run in VCS.  This commit creates a new `xcelium_nightly` regression set so that specific tests can be run in Xcelium during nightly regressions.