### PR TITLE
[fpv] Tweak report headers to match Jasper version

### DIFF
--- a/hw/formal/tools/jaspergold/parse-formal-report.py
+++ b/hw/formal/tools/jaspergold/parse-formal-report.py
@@ -147,9 +147,9 @@ def get_cov_results(logpath, dut_name):
             cov_pattern = r"\s*\|\d*.\d\d%\s\(\d*\/\d*\)"  # cov pattern: 100.00% (5/5)
             pattern_match = r"\s*\|(\d*.\d\d)%\s\(\d*\/\d*\)"  # extract percentage in cov_pattern
             coverage_patterns = \
-                [("stimuli", r"^\|" + dut_name + pattern_match + cov_pattern + cov_pattern),
-                 ("coi", r"^\|" + dut_name + cov_pattern + pattern_match + cov_pattern),
-                 ("proof", r"^\|" + dut_name + cov_pattern + cov_pattern + pattern_match)]
+                [("formal", r"^\|" + dut_name + pattern_match + cov_pattern + cov_pattern),
+                 ("stimuli", r"^\|" + dut_name + cov_pattern + pattern_match + cov_pattern),
+                 ("checker", r"^\|" + dut_name + cov_pattern + cov_pattern + pattern_match)]
             cov_results = extract_messages(full_file, coverage_patterns)
             for key, item in cov_results.items():
                 if len(item) == 1:
@@ -191,9 +191,9 @@ def main():
         },
         If coverage is enabled, this script will also parse the coverage result:
         "coverage": {
+          formal:  "90 %",
           stimuli: "90 %",
-          coi    : "90 %",
-          proof  : "80 %"
+          checker: "80 %"
         }
         The script returns nonzero status if any errors or property failures including
         "cex, undetermined, unreachable" are presented.

--- a/util/dvsim/FormalCfg.py
+++ b/util/dvsim/FormalCfg.py
@@ -35,7 +35,7 @@ class FormalCfg(OneShotCfg):
             self.publish_report = False
         self.sub_flow = hjson_data['sub_flow']
         self.summary_header = [
-            "name", "pass_rate", "stimuli_cov", "coi_cov", "prove_cov"
+            "name", "pass_rate", "formal_cov", "stimuli_cov", "checker_cov"
         ]
         self.results_title = self.name.upper(
         ) + " Formal " + self.sub_flow.upper() + " Results"
@@ -112,16 +112,16 @@ class FormalCfg(OneShotCfg):
             results_str = "No coverage information found\n"
             summary = ["N/A", "N/A", "N/A"]
         else:
-            cov_header = ["stimuli", "coi", "proof"]
+            cov_header = ["formal", "stimuli", "checker"]
             cov_colalign = ("center", ) * len(cov_header)
             cov_table = [cov_header]
             cov_table.append([
-                formal_coverage["stimuli"], formal_coverage["coi"],
-                formal_coverage["proof"]
+                formal_coverage["formal"], formal_coverage["stimuli"],
+                formal_coverage["checker"]
             ])
+            summary.append(formal_coverage["formal"])
             summary.append(formal_coverage["stimuli"])
-            summary.append(formal_coverage["coi"])
-            summary.append(formal_coverage["proof"])
+            summary.append(formal_coverage["checker"])
 
             if len(cov_table) > 1:
                 results_str = tabulate(cov_table,
@@ -196,9 +196,9 @@ class FormalCfg(OneShotCfg):
         # If coverage was enabled then results.hjson will also have an item that
         # shows formal coverage. It will have the following format:
         #   "coverage": {
+        #      formal:  "90 %",
         #      stimuli: "90 %",
-        #      coi    : "90 %",
-        #      proof  : "80 %"
+        #      checker: "80 %"
         #   }
         results_str = "## " + self.results_title + "\n\n"
         results_str += "### " + self.timestamp_long + "\n"


### PR DESCRIPTION
Looking at documentation for the current version of Jasper, and also for Jasper version 2021.12, the reported numbers are not called stimuli/coi/proof any more. Tweak to match the names used in recent versions.

The most recent nightly run gave the following result:
![image](https://github.com/lowRISC/opentitan/assets/104845/fd6f34d7-0970-46fc-a44d-73195ee0cbb5)

This makes rather more sense if the "green column" is stimuli coverage (which essentially checks whether all the inputs of all the modules in the design can be 0/1).