### PR TITLE
[ci] change filter on nightly

### DIFF
--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -101,7 +101,7 @@ jobs:
       ci/bazelisk.sh test \
         --define DISABLE_VERILATOR_BUILD=true \
         --define bitstream=gcp_splice \
-        --test_tag_filters=-verilator,-dv,-broken \
+        --test_tag_filters=cw310,-broken \
         --build_tests_only \
         --test_output=errors \
         //sw/device/silicon_creator/rom/e2e/...


### PR DESCRIPTION
Currently the nightly pipeline tries to run silicon and cw340 ROM E2E tests. Add a cw310 filter to prevent them from running.