### PR TITLE
[hmac/rtl] Fix idle_o when told to stop

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -660,6 +660,7 @@ module hmac
     .key_length_i  (key_length),
 
     .reg_hash_start_i    (hash_start),
+    .reg_hash_stop_i     (reg_hash_stop),
     .reg_hash_continue_i (hash_continue),
     .reg_hash_process_i  (packer_flush_done), // Trigger after all msg written
     .hash_done_o         (reg_hash_done),


### PR DESCRIPTION
Prior to this commit, `hmac_core` and thus the entire `hmac` module would not raise the `idle_o` output when it got told to stop (#23036). This is problematic because then HMAC cannot be clock-gated during context switch (save & restore feature).  Clock gating would only work when a message stream is fully processed (after the *process* command).

This commit fixes the problem by keeping track of idleness inside `hmac_core`.  In addition to the conditions that existed before, this tracker goes to idle when a *stop* command is received and the current message block is completely processed.

This fixes #23036.