### PR TITLE
[hmac,rtl/dv] Fix digest loading/error wiping and error handling

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -114,7 +114,6 @@ module hmac
 
   sha_word64_t [7:0] digest, digest_sw;
   logic [7:0]        digest_sw_we;
-  sha_word64_t       inter_digest;
 
   digest_mode_e digest_size, digest_size_supplied;
   // this is the digest size captured into HMAC when it gets started
@@ -224,44 +223,49 @@ module hmac
 
   // Retain the previous digest in CSRs until HMAC is actually started with a valid configuration
   always_comb begin : assign_digest_reg
-    for (int i = 0; i < 16; i++) begin
-      // default
-      if (i < 8) begin
-        // digest SW -> HW
-        digest_sw[i]    = '0;
-        digest_sw_we[i] = '0;
-      end
-      // digest HW -> SW
-      hw2reg.digest[i].d = '0;
+    // default
+    // digest SW -> HW
+    digest_sw     = '0;
+    digest_sw_we  = '0;
+    // digest HW -> SW
+    hw2reg.digest = '0;
 
+    for (int i = 0; i < 8; i++) begin
+      // digest SW -> HW (depends on digest size configured even before starting/enabling)
+      // capturing the intermediate digests written by SW when restoring context into the SHA-2
+      // engine before it is started
+      if (digest_size == SHA2_256) begin
+        // digest SW -> HW
+        digest_sw[i][31:0] = conv_endian32(reg2hw.digest[i].q, digest_swap);
+        digest_sw_we[i]    = reg2hw.digest[i].qe;
+      end else if ((digest_size == SHA2_384) || (digest_size == SHA2_512)) begin
+        // digest SW -> HW
+        digest_sw[i][63:32]    = reg2hw.digest[2*i].qe ?
+                                 conv_endian32(reg2hw.digest[2*i].q, digest_swap) :
+                                 digest[i][63:32];
+        digest_sw[i][31:0]     = reg2hw.digest[2*i+1].qe ?
+                                 conv_endian32(reg2hw.digest[2*i+1].q, digest_swap) :
+                                 digest[i][31:0];
+        digest_sw_we[i]        = reg2hw.digest[2*i].qe | reg2hw.digest[2*i+1].qe;
+      end
+
+      // digest HW -> SW (depends on configuration that has been started)
       if (digest_size_started_q == SHA2_256) begin
-        if (i < 8) begin
-          // digest HW -> SW
-          hw2reg.digest[i].d = conv_endian32(digest[i][31:0], digest_swap);
-          // digest SW -> HW
-          digest_sw[i]       = {32'h0, conv_endian32(reg2hw.digest[i].q, digest_swap)};
-          digest_sw_we[i]    = reg2hw.digest[i].qe;
-        end else begin
-          // replicate digest[0..7] into digest[8..15]. Digest[8...15] are irrelevant for SHA2_256,
-          // but this ensures all digest CSRs are wiped out with random value (at wipe_secret)
-          // across different configurations.
-          hw2reg.digest[i].d = conv_endian32(digest[i%8][31:0], digest_swap);
-        end
+        hw2reg.digest[i].d   = conv_endian32(digest[i][31:0], digest_swap);
+        // replicate digest[0..7] into digest[8..15]. Digest[8...15] are irrelevant for SHA2_256,
+        // but this ensures all digest CSRs are wiped out with random value (at wipe_secret)
+        // across different configurations.
+        hw2reg.digest[i+8].d = conv_endian32(digest[i][31:0], digest_swap);
       end else if ((digest_size_started_q == SHA2_384) || (digest_size_started_q == SHA2_512)) begin
-        if (i % 2 == 0 && i < 15) begin // even index
-          // digest HW -> SW
-          inter_digest       = conv_endian64(digest[i/2], digest_swap);
-          hw2reg.digest[i].d = inter_digest[31:0];
-          // digest SW -> HW
-          digest_sw[i/2]    = conv_endian64({reg2hw.digest[i+1].q,reg2hw.digest[i].q}, digest_swap);
-          digest_sw_we[i/2] = reg2hw.digest[i].qe | reg2hw.digest[i+1].qe;
-        end else begin  // odd index
-          inter_digest       = conv_endian64(digest[i/2], digest_swap);
-          hw2reg.digest[i].d = inter_digest[63:32];
-          // digest SW -> HW
-          digest_sw[i/2]    = conv_endian64({reg2hw.digest[i].q,reg2hw.digest[i-1].q}, digest_swap);
-          digest_sw_we[i/2] = reg2hw.digest[i].qe | reg2hw.digest[i-1].qe;
-        end
+        // digest HW -> SW
+        // digest swap only within each 32-bit word of the 64-bit digest word, not digest swap
+        // on the entire 64-bit digest word
+        hw2reg.digest[2*i].d   = conv_endian32(digest[i][63:32], digest_swap);
+        hw2reg.digest[2*i+1].d = conv_endian32(digest[i][31:0], digest_swap);
+      end else begin // for SHA2_None
+        // to ensure secret wiping is always passed to digest CSRs
+        hw2reg.digest[i].d   = conv_endian32(digest[i][31:0], digest_swap);
+        hw2reg.digest[i+8].d = conv_endian32(digest[i][31:0], digest_swap);
       end
     end
   end
@@ -780,8 +784,8 @@ module hmac
                            ((key_length == Key_None) && hmac_en) |
                            ((key_length == Key_1024) && (digest_size == SHA2_256) && hmac_en));
 
-  // invalid_config at reg_hash_start will signal an error to the SW
-  assign invalid_config_atstart = reg_hash_start & invalid_config;
+  // invalid_config at reg_hash_start or reg_hash_continue will signal an error to the SW
+  assign invalid_config_atstart = (reg_hash_start || reg_hash_continue) & invalid_config;
 
   always_comb begin
     update_seckey_inprocess = 1'b0;
@@ -806,13 +810,14 @@ module hmac
 
   always_comb begin
     err_code = NoError;
-    unique case (1'b1)
-      hash_start_sha_disabled: begin
-        err_code = SwHashStartWhenShaDisabled;
+    priority case (1'b1)
+      // SwInvalidConfig has the highest priority: SW configures HMAC incorrectly
+      invalid_config_atstart: begin
+        err_code = SwInvalidConfig;
       end
 
-      update_seckey_inprocess: begin
-        err_code = SwUpdateSecretKeyInProcess;
+      hash_start_sha_disabled: begin
+        err_code = SwHashStartWhenShaDisabled;
       end
 
       hash_start_active: begin
@@ -823,8 +828,8 @@ module hmac
         err_code = SwPushMsgWhenDisallowed;
       end
 
-      invalid_config_atstart: begin
-        err_code = SwInvalidConfig;
+      update_seckey_inprocess: begin
+        err_code = SwUpdateSecretKeyInProcess;
       end
 
       default: begin


### PR DESCRIPTION
This PR depends on PRs https://github.com/lowRISC/opentitan/pull/23108 and https://github.com/lowRISC/opentitan/pull/23220 to get merged. It implements fixes in HMAC RTL and DV scoreboard for digest loading (based on @ballifatih's PR https://github.com/lowRISC/opentitan/pull/23197) besides additional changes to fix issues with secret wiping and error handling (prioritizing `SwInvalidConfig` in case of simultaneous errors) across different digest sizes. 

This also implements a potential fix for https://github.com/lowRISC/opentitan/issues/23181 but needs to be tested - would you test this @ballifatih and let me know if this sorts this out? 