### PR TITLE
[dv,usdbev] usbdev_aon_wake sequences

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -13,6 +13,14 @@ package usb20_agent_pkg;
   `include "dv_macros.svh"
 
   // usb20_item enums
+
+  // USB-level events; the DP/DN wires are used for transmitting packet data but also held for
+  // extended intervals to signal specific bus-level events.
+  //
+  // (DP low, DN low = Bus Reset; DP low, DN high = Resume Signaling; VBUS low when Disconnected,
+  //  and VBUS high when Connected to Host).
+  typedef enum bit [2:0] {EvBusReset, EvResume, EvConnect, EvDisconnect, EvPacket} ev_type_e;
+  // Packet Types
   typedef enum bit [2:0] {PktTypeSoF, PktTypeToken, PktTypeData, PktTypeHandshake} pkt_type_e;
   // Packet IDentifiers; the 4 LSBs identify the Packet type, and are reflected in inverted
   //   form as the 4 MSBs to provide some internal error checking.

--- a/hw/dv/sv/usb20_agent/usb20_block_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_block_if.sv
@@ -30,6 +30,9 @@ interface usb20_block_if (
   logic usb_ref_val_o;
   logic usb_ref_pulse_o;
 
+  // Wake request from AON/Wake module.
+  logic wake_req_aon;
+
   // Are our drivers connected?
   bit connected = 0;
 

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -3,18 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class usb20_item extends uvm_sequence_item;
+  ev_type_e  m_ev_type;
   pid_type_e m_pid_type;
   pkt_type_e m_pkt_type;
   bmrequesttype_e m_bmRT;
   brequest_e m_bR;
   usb_transfer_e m_usb_transfer;
 
+  `uvm_object_utils_begin(usb20_item)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
   // Check the PID type of this item is the expected value. If not, raise a fatal error.
   function void check_pid_type(pid_type_e expected);
     `DV_CHECK_EQ_FATAL(m_pid_type, expected)
   endfunction
-
-  `uvm_object_new
 endclass
 
 class token_pkt extends usb20_item;

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -878,7 +878,7 @@
               ie. the DP pullup is enabled and DP is high.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_aon_wake_resume"]
     }
     {
       name: aon_wake_reset
@@ -900,7 +900,7 @@
               ie. the DP pullup is enabled and DP is high.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_aon_wake_reset"]
     }
     {
       name: aon_wake_disconnect
@@ -922,7 +922,7 @@
             - Disable the AON/Wake module and verify that the USB device remains disconnected.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_aon_wake_disconnect"]
     }
     {
       name: invalid_sync

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_aon_wake_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_aon_wake_vseq.sv
@@ -1,0 +1,164 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Basic test of AON/Wake module functionality.
+class usbdev_aon_wake_vseq extends usbdev_link_suspend_vseq;
+  `uvm_object_utils(usbdev_aon_wake_vseq)
+
+  `uvm_object_new
+
+  // Delay before producing stimulus to AON/Wake module.
+  rand int stim_delay_clks;
+  constraint stim_delay_clks_c {
+    // Weighted to make 'no delay' a more frequent occurrence,
+    // by treating all negative values as per zero.
+    stim_delay_clks >= -50 && stim_delay_clks <= 2000;
+  };
+
+  // Delay before optional reconnection of VBUS after disconnection.
+  rand int disconn_interval_clks;
+  constraint disconn_interval_clks_c {
+    // In practice the DUT will have capacitance on the VBUS line to stabilize it and to ignore
+    // transients. Additionally, the AON/Wake module operates on a much lower clock frequency than
+    // the DUT, so glitches will (deliberately) be filtered out.
+    //
+    // We therefore need to make the VBUS removal long enough to be detected.
+    disconn_interval_clks >= 2000 && disconn_interval_clks <= 50000;
+  }
+
+  // Attempt to modify the pull-up enables whilst AON/Wake is activated?
+  rand bit perturb_enables;
+
+  // Attempt to disrupt the USB pull-up enables
+  // (any changes that we make should not be visible on the USB when the AON/Wake module has
+  //  control).
+  task attempted_change();
+    bit pullup_maintained = $urandom & 1;
+    bit flip_pins = $urandom & 1;
+    ral.usbctrl.enable.set(pullup_maintained);
+    csr_update(.csr(ral.usbctrl));
+    ral.phy_config.pinflip.set(flip_pins);
+    csr_update(.csr(ral.phy_config));
+    `uvm_info(`gfn, $sformatf("Attempted to set enable %d flip pins %d",
+                              pullup_maintained, flip_pins), UVM_HIGH)
+  endtask
+
+  task body();
+    bit exp_dp_pullup, exp_dn_pullup;
+    uvm_reg_data_t wake_events;
+    int delay_clks;
+
+    // Set up the DUT, do some minimal traffic and then check that the USBDEV has detected
+    // and reported that it has been Suspended; `usbdev_link_suspend_vseq` supplies the
+    // Suspend signaling.
+    super.body();
+
+    // Report configuration.
+    `uvm_info(`gfn, $sformatf("do_resume_signaling %d do_reset_signaling %d do_vbus_disconnects %d",
+                              do_resume_signaling, do_reset_signaling, do_vbus_disconnects),
+              UVM_MEDIUM)
+    // `usbdev_base_vseq` shall collect bus stimuli to be provided; just check here that we've been
+    // asked for only one.
+    `DV_CHECK_EQ(32'(do_resume_signaling) + 32'(do_reset_signaling) + 32'(do_vbus_disconnects), 1)
+
+    // Hand over control of the USB to the `usbdev_aon_wake` module
+    // TODO: we ought to try to overlap the stimulus and the AON/Wake activation.
+    aon_wake_activate();
+
+    // Expected state of pull-up enables after deactivating the AON/Wake module later.
+    exp_dp_pullup = !phy_pinflip;
+    exp_dn_pullup =  phy_pinflip;
+
+    // AON/Wake module should now have control of the USB pull ups; try to break things
+    // (but not in every case because doing so introduces a delay and we must test
+    //  immediate stimuli too)...
+    if (perturb_enables) attempted_change();
+
+    // Just introduce a small variable delay before we send the test stimulus.
+    if (stim_delay_clks > 0) begin
+      cfg.clk_rst_vif.wait_clks(stim_delay_clks);
+    end
+
+    // Produce the appropriate stimulus; only one shall have been requested (see above).
+    casez ({do_resume_signaling, do_reset_signaling, do_vbus_disconnects})
+      3'b1??:  send_resume_signaling();
+      3'b01?:  send_bus_reset();
+      default: begin
+        set_vbus_state(0);
+        // Decide whether to reconnect the VBUS; a fairly brief interruption should also be
+        // detected and reported, but glitches are intended to be ignored.
+        cfg.clk_rst_vif.wait_clks(disconn_interval_clks);
+        if ($urandom & 1) begin
+          set_vbus_state(1);
+          // Another short delay to check that reinstating VBUS does not clear the wake request
+          // and/or reported event.
+          cfg.clk_rst_vif.wait_clks($urandom_range(1, 2000));
+
+          // TODO: Draft PR #19270 contends that perhaps this is undesirable behavior, but the
+          // pull-up presently will be re-enabled if VBUS is reinstated. Firmware may detect and
+          // prevent this if required.
+        end else begin
+          // If VBUS remains deasserted, the pull-up enable shall remain deasserted by the DUT too.
+          if (phy_pinflip) exp_dn_pullup = 1'b0;
+          else exp_dp_pullup = 1'b0;
+        end
+      end
+    endcase
+
+    // AON/Wake module filters the input stimuli to provide some protection against transients;
+    // - the CDC signals may be 3 cycles, filtering another 4 and then a couple of register delays
+    //   until the new state information is presented in the DUT via the CSRs.
+    // - there is also CDC crossing back to the 48MHz clock, so allow 12 cycles total.
+    cfg.aon_clk_rst_vif.wait_clks(12);
+
+    // Check that the AON/Wake module has signaled the 'Wake up' request (this would normally go
+    // to the power management within the SoC).
+    `DV_CHECK_CASE_EQ(cfg.m_usb20_agent_cfg.bif.wake_req_aon, 1'b1, "Wake up request not detected")
+
+    // Check the event report from the AON/Wake module; we should see only the stimulus that we
+    // supplied.
+    csr_rd(.ptr(ral.wake_events), .value(wake_events));
+    `uvm_info(`gfn, $sformatf("Wake events returned as 0x%x", wake_events), UVM_MEDIUM)
+
+    `DV_CHECK_EQ(get_field_val(ral.wake_events.module_active, wake_events), 1'b1)
+    `DV_CHECK_EQ(get_field_val(ral.wake_events.disconnected, wake_events), do_vbus_disconnects)
+    `DV_CHECK_EQ(get_field_val(ral.wake_events.bus_reset, wake_events), do_reset_signaling)
+    // Note that a Bus Reset also constitutes 'Bus not idle' because it's not 'J/Idle' state.
+    `DV_CHECK_EQ(get_field_val(ral.wake_events.bus_not_idle, wake_events),
+                 do_resume_signaling | do_reset_signaling)
+
+    // The DUT (USBDEV) should not have control of the pull up enables at this point; our efforts
+    // at breaking things above should have been unsuccessful.
+    `DV_CHECK_CASE_EQ(cfg.m_usb20_agent_cfg.bif.usb_dp_pullup_o, !phy_pinflip,
+                      "DP pull up not as expected with AON/Wake module active")
+    `DV_CHECK_CASE_EQ(cfg.m_usb20_agent_cfg.bif.usb_dn_pullup_o,  phy_pinflip,
+                      "DN pull up not as expected with AON/Wake module active")
+
+    // Reinstate our pull up enable.
+    ral.usbctrl.enable.set(1'b1);
+    csr_update(.csr(ral.usbctrl));
+    ral.phy_config.pinflip.set(1'b0);
+    csr_update(.csr(ral.phy_config));
+
+    // Instruct the AON/Wake module to hand back control of the USB.
+    aon_wake_deactivate();
+
+    // Check that the 'wake up' request has been removed.
+    `DV_CHECK_CASE_EQ(cfg.m_usb20_agent_cfg.bif.wake_req_aon, 1'b0, "Wake up request not removed")
+
+    // USBDEV should once again have control of the pull-up enables.
+    `DV_CHECK_CASE_EQ(cfg.m_usb20_agent_cfg.bif.usb_dp_pullup_o, exp_dp_pullup,
+                      "DP pull up was not returned")
+    `DV_CHECK_CASE_EQ(cfg.m_usb20_agent_cfg.bif.usb_dn_pullup_o, exp_dn_pullup,
+                      "DN pull up was not returned")
+
+    usbdev_disconnect();
+
+    // Check that the USBDEV has disconnected successfully.
+    `DV_CHECK_CASE_EQ(cfg.m_usb20_agent_cfg.bif.usb_dp_pullup_o, 1'b0,
+                      "DP pull up was not released")
+    `DV_CHECK_CASE_EQ(cfg.m_usb20_agent_cfg.bif.usb_dn_pullup_o, 1'b0,
+                      "DN pull up was not released")
+  endtask
+endclass : usbdev_aon_wake_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -31,6 +31,12 @@ constraint endpoint_c {
   endp inside {[0:11]};
 }
 
+// Bus events/stimuli to be presented during the sequence
+//   (these are used in the `aon_wake_` and `rand_bus...` tests points).
+bit do_reset_signaling  = 1'b0;
+bit do_resume_signaling = 1'b0;
+bit do_vbus_disconnects = 1'b0;
+
 // Connect the usb20_agent via the block level interface?
 bit do_agent_connect = 1'b1;
 
@@ -47,6 +53,16 @@ bit apply_post_reset_delays_for_sync = 1'b1;
 bit phy_eop_single_bit = 1'b0;  // Note: the default reset value is 1
 bit phy_usb_ref_disable = 1'b0;
 bit phy_tx_osc_test_mode = 1'b0;
+// TODO: support pin-flipping through the DV including the usb20_driver and usb20_monitor.
+bit phy_pinflip = 1'b0;
+
+// Approx. over-estimate of the USBDEV:AON/Wake clock ratio; we expect the USB device to be
+// operating at no more than 48.24kHz, and the AON/Wake module to be operating at >= 200KHz.
+// In fact we have permitted a ratio of up to 300:1 in the constraints.
+uint usbdev_aon_wake_clk_ratio = 300;
+// but we also have the two-cycle CDC synchronizer to consider.
+uint aon_wake_control_wr_clks = (1 + 2) * usbdev_aon_wake_clk_ratio;
+uint aon_wake_events_rd_clks = usbdev_aon_wake_clk_ratio;
 
 `uvm_object_new
 
@@ -134,6 +150,12 @@ endtask
   // Give derived sequences the opportunity to override the connection of the usb20_agent via the
   // the interface.
   virtual task pre_start();
+    // These options are common to a few tests, but will not be specified for most so they default
+    // to zero (above).
+    void'($value$plusargs("do_reset_signaling=%0b",  do_reset_signaling));
+    void'($value$plusargs("do_resume_signaling=%0b", do_resume_signaling));
+    void'($value$plusargs("do_vbus_disconnects=%0b", do_vbus_disconnects));
+
     if (do_agent_connect) begin
       // Connect the USB20 agent and ensure that the USBDPI model is not connected.
       cfg.m_usb20_agent_cfg.bif.enable_driver(1'b1);
@@ -188,6 +210,7 @@ endtask
   // Construct and transmit a token packet to the USB device
   virtual task call_token_seq(input pid_type_e pid_type, bit inject_crc_error = 0);
     `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
+    m_token_pkt.m_ev_type  = EvPacket;
     m_token_pkt.m_pkt_type = PktTypeToken;
     m_token_pkt.m_pid_type = pid_type;
     assert(m_token_pkt.randomize() with {m_token_pkt.address == dev_addr;
@@ -203,6 +226,7 @@ endtask
   virtual task send_data_packet(input pid_type_e pid_type, input byte unsigned data[],
                                 input bit isochronous_transfer = 1'b0);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
+    m_data_pkt.m_ev_type  = EvPacket;
     m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;
     if (isochronous_transfer) begin
@@ -220,6 +244,7 @@ endtask
                              input bit randomize_length, input bit [6:0] num_of_bytes,
                              input bit isochronous_transfer = 1'b0);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
+    m_data_pkt.m_ev_type  = EvPacket;
     m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;
     if (isochronous_transfer) begin
@@ -279,6 +304,7 @@ endtask
 
   virtual task call_handshake_sequence(input pkt_type_e pkt_type, input pid_type_e pid_type);
     `uvm_create_on(m_handshake_pkt, p_sequencer.usb20_sequencer_h)
+    m_handshake_pkt.m_ev_type  = EvPacket;
     m_handshake_pkt.m_pkt_type = pkt_type;
     m_handshake_pkt.m_pid_type = pid_type;
     m_usb20_item = m_handshake_pkt;
@@ -454,6 +480,8 @@ endtask
   virtual task usbdev_init(bit [TL_DW-1:0] device_address = 0,
                            // PHY Configuration for this test; all permutations should be tested.
                            bit use_diff_rcvr = 0, bit tx_use_d_se0 = 0, bit pinflip = 0);
+    // Remember the pinflip setting.
+    phy_pinflip = pinflip;
     // Configure PHY
     // - the different modes of operation may be set using parameters,
     ral.phy_config.use_diff_rcvr.set(use_diff_rcvr);
@@ -556,12 +584,72 @@ endtask
 
   virtual task call_sof_seq(input pid_type_e pid_type);
     `uvm_create_on(m_sof_pkt, p_sequencer.usb20_sequencer_h)
+    m_sof_pkt.m_ev_type  = EvPacket;
     m_sof_pkt.m_pkt_type = PktTypeSoF;
     m_sof_pkt.m_pid_type = pid_type;
     assert(m_sof_pkt.randomize());
     m_usb20_item = m_sof_pkt;
     start_item(m_sof_pkt);
     finish_item(m_sof_pkt);
+  endtask
+
+  // Perform Resume Signaling on the USB; this instructs the DUT to exit a Suspended state.
+  virtual task send_resume_signaling();
+    usb20_item item;
+    `uvm_create_on(item, p_sequencer.usb20_sequencer_h)
+    start_item(item);
+    item.m_ev_type = EvResume;
+    finish_item(item);
+  endtask
+
+  // Issue a Bus Reset to the DUT.
+  virtual task send_bus_reset();
+    usb20_item item;
+    `uvm_create_on(item, p_sequencer.usb20_sequencer_h)
+    start_item(item);
+    item.m_ev_type = EvBusReset;
+    finish_item(item);
+  endtask
+
+  // Set the state of the VBUS signal from the usb20_driver, indicating the presence/absence
+  // of a host connection.
+  virtual task set_vbus_state(bit enabled);
+    usb20_item item;
+    `uvm_create_on(item, p_sequencer.usb20_sequencer_h)
+    start_item(item);
+    item.m_ev_type = enabled ? EvConnect : EvDisconnect;
+    finish_item(item);
+  endtask
+
+  // Hand over control of the USB to the AON/Wake module.
+  virtual task aon_wake_activate();
+    bit active = 1'b0;
+    ral.wake_control.suspend_req.set(1'b1);
+    csr_update(.csr(ral.wake_control));
+    aon_wake_wait_status(1'b1, active);
+    `DV_CHECK_EQ(active, 1'b1, "AON/Wake module did not become active when expected")
+  endtask
+
+  // Recover control of the USB from the AON/Wake module.
+  virtual task aon_wake_deactivate();
+    bit active = 1'b1;
+    ral.wake_control.wake_ack.set(1'b1);
+    csr_update(.csr(ral.wake_control));
+    aon_wake_wait_status(1'b0, active);
+    `DV_CHECK_EQ(active, 1'b0, "AON/Wake module did not deactivate as expected")
+  endtask
+
+  // Wait until the 'module_active' status indicator has the desired value or it has not
+  // changed within the expected interval.
+  virtual task aon_wake_wait_status(bit exp_active, output bit active);
+    // The 'control' write into the AON/Wake domain takes some time because of its much slower
+    // clock frequency, and then we must read back the status indication too.
+    uint delay_max = aon_wake_control_wr_clks + aon_wake_events_rd_clks;
+    for (int unsigned i = 0; i < delay_max; i++) begin
+      // Wait until the AON/Wake module indicates that it is inactive.
+      csr_rd(.ptr(ral.wake_events.module_active), .value(active));
+      if (active == exp_active) break;
+    end
   endtask
 
   virtual task inter_packet_delay(int delay = 0);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_stage_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_stage_vseq.sv
@@ -28,6 +28,7 @@ class usbdev_setup_stage_vseq extends usbdev_base_vseq;
   // Construct and transmit a DATA packet containing a SETUP descriptor to the USB device
   task call_desc_sequence(input pid_type_e pid_type);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
+    m_data_pkt.m_ev_type  = EvPacket;
     m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;
     m_data_pkt.m_bmRT = bmrequesttype_e'(bmRequestType3);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -88,6 +88,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     usb20_item response;
     RSP rsp_item;
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
+    m_data_pkt.m_ev_type  = EvPacket;
     m_data_pkt.m_pkt_type = pkt_type;
     m_data_pkt.m_pid_type = pid_type;
     // Construct a GET DESCRIPTOR request that retrieves the Device descriptor

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -45,3 +45,5 @@
 `include "usbdev_endpoint_access_vseq.sv"
 // This must follow usbdev_pkt_sent
 `include "usbdev_link_suspend_vseq.sv"
+// This must follow usbdev_link_suspend
+`include "usbdev_aon_wake_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -28,6 +28,7 @@ filesets:
       - seq_lib/usbdev_base_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_bitstuff_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_common_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_aon_wake_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_data_toggle_restore_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_dpi_config_host_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_smoke_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -22,13 +22,15 @@ class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
 
   // Constrain the AON clock to be slower than the USB clock. For the usbdev_aon_wake logic
   // to operate correctly and not generate spurious reports of bus resets when detecting Low Speed
-  // signaling, it requires a clock frequency lower than 2MHz cf the usbdev clock at 48MHz, so the
-  // ratio should exceed 24.
+  // signaling, it requires a clock frequency lower than 1MHz cf the usbdev clock at 48MHz, so the
+  // ratio should exceed 48. This is because 2 bit intervals @ 1.5Mbps may be seen - in the limit -
+  // as being high for 3 clock edges at frequencies above 1MHz.
+  //
   // In a real device we expect it to be as low as 200kHz.
   rand uint aon_clk_freq_khz;
   constraint aon_clk_freq_khz_c {
     aon_clk_freq_khz >  usb_clk_freq_khz / 300 &&
-    aon_clk_freq_khz <= usb_clk_freq_khz / 24;
+    aon_clk_freq_khz <= usb_clk_freq_khz / 48;
   }
 
   // Constrain the host clock to be close to that of the DUT at present; in time we shall want

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -77,6 +77,9 @@ module tb;
   wire usb_aon_sense_lost;
   wire usb_aon_wake_detect_active;
 
+  // Wake request from AON/Wake to usb20_agent
+  wire wake_req_aon;
+
   // interfaces
   clk_rst_if aon_clk_rst_if(.clk(aon_clk), .rst_n(aon_rst_n));
   clk_rst_if usbdev_clk_rst_if(.clk(usb_clk), .rst_n(usb_rst_n));
@@ -181,6 +184,7 @@ module tb;
   assign usb20_block_if.usb_dn_en_o     = cio_usb_dn_en;
   assign usb20_block_if.usb_dp_o        = cio_usb_dp;
   assign usb20_block_if.usb_dn_o        = cio_usb_dn;
+  assign usb20_block_if.wake_req_aon    = wake_req_aon;
 
   // Drivers from the USB device
   assign (strong0, strong1) usb_p = cio_usb_dp_en ? cio_usb_dp : 1'bZ;
@@ -249,8 +253,8 @@ module tb;
     .usb_dppullup_en_o        (usb_dp_pullup_en),
     .usb_dnpullup_en_o        (usb_dn_pullup_en),
 
-    // TODO: this signal should be made available for testing somehow.
-    .wake_req_aon_o           (),
+    // Wake request from AON/Wake to usb20_agent
+    .wake_req_aon_o           (wake_req_aon),
 
     .bus_not_idle_aon_o       (usb_aon_bus_not_idle),
     .bus_reset_aon_o          (usb_aon_bus_reset),

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -51,6 +51,21 @@
       uvm_test_seq: usbdev_smoke_vseq
     }
     {
+      name: usbdev_aon_wake_disconnect
+      uvm_test_seq: usbdev_aon_wake_vseq
+      run_opts: ["+do_vbus_disconnects=1"]
+    }
+    {
+      name: usbdev_aon_wake_reset
+      uvm_test_seq: usbdev_aon_wake_vseq
+      run_opts: ["+do_reset_signaling=1"]
+    }
+    {
+      name: usbdev_aon_wake_resume
+      uvm_test_seq: usbdev_aon_wake_vseq
+      run_opts: ["+do_resume_signaling=1"]
+    }
+    {
       name: usbdev_av_buffer
       uvm_test_seq: usbdev_av_buffer_vseq
     }


### PR DESCRIPTION
This PR introduces a single sequence that addresses the following test points:

- usbdev_aon_wake_resume
- usbdev_aon_wake_reset
- usbdev_aon_wake_disconnect

These are checking that the `usbdev_aon_wake` module responds to the appropriate newly-introduced USB bus events from the usb20_driver, and that it issues a 'wake request' in response. The request would ordinarily be received by power management hardware and cause the SoC to resume from Normal/Deep Sleep.

The PR also makes some minimal modifications to `usb20_monitor` to correct its decoding and handling of valid packet data on the USB, since that was found to be leading to failures in the new tests (as well as a number of the existing sequences). It does not attempt to fix up the monitor behavior for invalid traffic such as that presently being generated by the 'usbdev_bitstuff_err' sequence; that will be addressed in a later PR.
