### PR TITLE
[rom_ext] Skip extra OTBN initialization 

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
@@ -166,20 +166,5 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
   return sigverify_encoded_message_check(&enc_msg, act_digest, flash_exec);
 }
 
-rom_error_t sigverify_rsa_verify_ibex(const sigverify_rsa_buffer_t *signature,
-                                      const sigverify_rsa_key_t *key,
-                                      const hmac_digest_t *act_digest,
-                                      lifecycle_state_t lc_state,
-                                      uint32_t *flash_exec) {
-  sigverify_rsa_buffer_t enc_msg;
-  rom_error_t error = sigverify_mod_exp_ibex(key, signature, &enc_msg);
-  if (launder32(error) != kErrorOk) {
-    *flash_exec ^= UINT32_MAX;
-    return error;
-  }
-  HARDENED_CHECK_EQ(error, kErrorOk);
-  return sigverify_encoded_message_check(&enc_msg, act_digest, flash_exec);
-}
-
 // Extern declarations for the inline functions in the header.
 extern uint32_t sigverify_rsa_success_to_ok(uint32_t v);

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.h
@@ -43,25 +43,6 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
                                  uint32_t *flash_exec);
 
 /**
- * Verifies an RSASSA-PKCS1-v1_5 signature.
- *
- * This function uses the Ibex software implementation only.
- *
- * @param signature Signature to be verified.
- * @param key Signer's RSA public key.
- * @param act_digest Actual digest of the message being verified.
- * @param lc_state Life cycle state of the device.
- * @param[out] flash_exec Value to write to the flash_ctrl EXEC register.
- * @return Result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-rom_error_t sigverify_rsa_verify_ibex(const sigverify_rsa_buffer_t *signature,
-                                      const sigverify_rsa_key_t *key,
-                                      const hmac_digest_t *act_digest,
-                                      lifecycle_state_t lc_state,
-                                      uint32_t *flash_exec);
-
-/**
  * Transforms `kSigverifyRsaSuccess` into `kErrorOk`.
  *
  * Callers should transform the result to a suitable error value if it is not

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -259,8 +259,8 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
   memcpy(&boot_measurements.bl0, &act_digest, sizeof(boot_measurements.bl0));
 
   uint32_t flash_exec = 0;
-  return sigverify_rsa_verify_ibex(&manifest->rsa_signature, key, &act_digest,
-                                   lc_state, &flash_exec);
+  return sigverify_rsa_verify(&manifest->rsa_signature, key, &act_digest,
+                              lc_state, &flash_exec);
 }
 
 /**

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -767,10 +767,6 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log->bl0_min_sec_ver = boot_data->min_security_version_bl0;
   boot_log->primary_bl0_slot = boot_data->primary_bl0_slot;
 
-  // Load OTBN attestation keygen program.
-  // TODO(#21550): this should already be loaded by the ROM.
-  HARDENED_RETURN_IF_ERROR(otbn_boot_app_load());
-
   // Initialize the chip ownership state.
   HARDENED_RETURN_IF_ERROR(ownership_init());
 


### PR DESCRIPTION
On the `master` branch, the ROM loads the OTBN application; the ROM_EXT does not need to.

Fixes #23222.