### PR TITLE
[hmac,regs/rtl] Add key_swap field and expose Idle status to SW

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -225,7 +225,20 @@
             "excl:CsrAllTests:CsrExclWrite"
           ]
         }
-        { bits: "7:4",
+        { bits: "4",
+          name: "key_swap",
+          desc: '''Key register byte swap.
+
+                If 1 the endianness of each KEY_* register is swapped. Default value (value 0) is big endian representation of the KEY_* CSRs.
+                ''',
+          resval: "0",
+          tags: [
+            // Don't enable/disable key swap in automated CSR tests because it will have side effects on the KEY_* CSRs that the automated tests don't know of.
+            // This field will be covered in functional tests instead.
+            "excl:CsrAllTests:CsrExclWrite"
+          ]
+        }
+        { bits: "8:5",
           name: "digest_size",
           resval: "0x08",
           desc: '''Digest size configuration.
@@ -263,7 +276,7 @@
           tags: [// Exclude fields with non-zero reset value from write-read checks.
                "excl:CsrNonInitTests:CsrExclWriteCheck"]
         }
-        { bits: "13:8",
+        { bits: "14:9",
           name: "key_length",
           resval: "0x20",
           desc: '''Key length configuration.
@@ -362,11 +375,16 @@
       hwext: "true",
       fields: [
         { bits: "0",
+          name: "hmac_idle",
+          desc: "HMAC idle status."
+          resval: "1"
+        }
+        { bits: "1",
           name: "fifo_empty",
           desc: "FIFO empty",
           resval: "1"
         }
-        { bits: "1",
+        { bits: "2",
           name: "fifo_full",
           desc: "FIFO full. Data written to the FIFO whilst it is full will cause back-pressure on the interconnect"
         }

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -160,20 +160,21 @@ HMAC Configuration register.
 The register is updated when the engine is in Idle.
 If the software updates the register while the engine computes the hash, the updated value is discarded.
 - Offset: `0x10`
-- Reset default: `0x2080`
-- Reset mask: `0x3fff`
+- Reset default: `0x4100`
+- Reset mask: `0x7fff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "hmac_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "sha_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "endian_swap", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "digest_swap", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "digest_size", "bits": 4, "attr": ["rw"], "rotate": -90}, {"name": "key_length", "bits": 6, "attr": ["rw"], "rotate": 0}, {"bits": 18}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
+{"reg": [{"name": "hmac_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "sha_en", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "endian_swap", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "digest_swap", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "key_swap", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "digest_size", "bits": 4, "attr": ["rw"], "rotate": -90}, {"name": "key_length", "bits": 6, "attr": ["rw"], "rotate": 0}, {"bits": 17}], "config": {"lanes": 1, "fontsize": 10, "vspace": 130}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                             |
 |:------:|:------:|:-------:|:---------------------------------|
-| 31:14  |        |         | Reserved                         |
-|  13:8  |   rw   |  0x20   | [key_length](#cfg--key_length)   |
-|  7:4   |   rw   |   0x8   | [digest_size](#cfg--digest_size) |
+| 31:15  |        |         | Reserved                         |
+|  14:9  |   rw   |  0x20   | [key_length](#cfg--key_length)   |
+|  8:5   |   rw   |   0x8   | [digest_size](#cfg--digest_size) |
+|   4    |   rw   |   0x0   | [key_swap](#cfg--key_swap)       |
 |   3    |   rw   |   0x0   | [digest_swap](#cfg--digest_swap) |
 |   2    |   rw   |   0x0   | [endian_swap](#cfg--endian_swap) |
 |   1    |   rw   |    x    | [sha_en](#cfg--sha_en)           |
@@ -212,6 +213,11 @@ Invalid/unsupported values, i.e., values that don't correspond to SHA2_256, SHA2
 | 0x8     | SHA2_None | 4'b1000: Unsupported/invalid values and all-zero values are mapped to SHA2_None. With this value, when HMAC/SHA-2 is triggered to start operation (via `hash_start` or `hash_continue`), it will be blocked from starting and an error is signalled to the SW. |
 
 Other values are reserved.
+
+### CFG . key_swap
+Key register byte swap.
+
+If 1 the endianness of each KEY_* register is swapped. Default value (value 0) is big endian representation of the KEY_* CSRs.
 
 ### CFG . digest_swap
 Digest register byte swap.
@@ -277,22 +283,23 @@ CPU must configure relative information first, such as the digest size, secret k
 ## STATUS
 HMAC Status register
 - Offset: `0x18`
-- Reset default: `0x1`
-- Reset mask: `0x3f3`
+- Reset default: `0x3`
+- Reset mask: `0x3f7`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "fifo_empty", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "fifo_full", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 2}, {"name": "fifo_depth", "bits": 6, "attr": ["ro"], "rotate": 0}, {"bits": 22}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
+{"reg": [{"name": "hmac_idle", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "fifo_empty", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "fifo_full", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 1}, {"name": "fifo_depth", "bits": 6, "attr": ["ro"], "rotate": 0}, {"bits": 22}], "config": {"lanes": 1, "fontsize": 10, "vspace": 120}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name       | Description                                                                                        |
 |:------:|:------:|:-------:|:-----------|:---------------------------------------------------------------------------------------------------|
 | 31:10  |        |         |            | Reserved                                                                                           |
 |  9:4   |   ro   |    x    | fifo_depth | FIFO entry count.                                                                                  |
-|  3:2   |        |         |            | Reserved                                                                                           |
-|   1    |   ro   |    x    | fifo_full  | FIFO full. Data written to the FIFO whilst it is full will cause back-pressure on the interconnect |
-|   0    |   ro   |   0x1   | fifo_empty | FIFO empty                                                                                         |
+|   3    |        |         |            | Reserved                                                                                           |
+|   2    |   ro   |    x    | fifo_full  | FIFO full. Data written to the FIFO whilst it is full will cause back-pressure on the interconnect |
+|   1    |   ro   |   0x1   | fifo_empty | FIFO empty                                                                                         |
+|   0    |   ro   |   0x1   | hmac_idle  | HMAC idle status.                                                                                  |
 
 ## ERR_CODE
 HMAC Error Code

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -54,8 +54,10 @@ package hmac_env_pkg;
 
   // HMAC status register indices
   typedef enum int {
-    HmacStaMsgFifoEmpty     = 0,
-    HmacStaMsgFifoFull      = 1,
+    // TODO verify HmacIdle
+    HmacIdle                = 0,
+    HmacStaMsgFifoEmpty     = 1,
+    HmacStaMsgFifoFull      = 2,
     HmacStaMsgFifoDepthLsb  = 4,
     HmacStaMsgFifoDepthMsb  = 9
   } hmac_sta_e;
@@ -66,10 +68,12 @@ package hmac_env_pkg;
     ShaEn         = 1,
     EndianSwap    = 2,
     DigestSwap    = 3,
-    DigestSizeLsb = 4,
-    DigestSizeMsb = 7,
-    KeyLengthLsb  = 8,
-    KeyLengthMsb  = 13
+    // TODO (issue #23245)
+    KeySwap    = 4,
+    DigestSizeLsb = 5,
+    DigestSizeMsb = 8,
+    KeyLengthLsb  = 9,
+    KeyLengthMsb  = 14
   } hmac_cfg_e;
 
   // HMAC cmd register indices

--- a/hw/ip/hmac/rtl/hmac_reg_pkg.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_pkg.sv
@@ -74,6 +74,10 @@ package hmac_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
+    } key_swap;
+    struct packed {
+      logic        q;
+      logic        qe;
     } digest_swap;
     struct packed {
       logic        q;
@@ -162,6 +166,9 @@ package hmac_reg_pkg;
       logic        d;
     } digest_swap;
     struct packed {
+      logic        d;
+    } key_swap;
+    struct packed {
       logic [3:0]  d;
     } digest_size;
     struct packed {
@@ -170,6 +177,9 @@ package hmac_reg_pkg;
   } hmac_hw2reg_cfg_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic        d;
+    } hmac_idle;
     struct packed {
       logic        d;
     } fifo_empty;
@@ -204,11 +214,11 @@ package hmac_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    hmac_reg2hw_intr_state_reg_t intr_state; // [1724:1722]
-    hmac_reg2hw_intr_enable_reg_t intr_enable; // [1721:1719]
-    hmac_reg2hw_intr_test_reg_t intr_test; // [1718:1713]
-    hmac_reg2hw_alert_test_reg_t alert_test; // [1712:1711]
-    hmac_reg2hw_cfg_reg_t cfg; // [1710:1691]
+    hmac_reg2hw_intr_state_reg_t intr_state; // [1726:1724]
+    hmac_reg2hw_intr_enable_reg_t intr_enable; // [1723:1721]
+    hmac_reg2hw_intr_test_reg_t intr_test; // [1720:1715]
+    hmac_reg2hw_alert_test_reg_t alert_test; // [1714:1713]
+    hmac_reg2hw_cfg_reg_t cfg; // [1712:1691]
     hmac_reg2hw_cmd_reg_t cmd; // [1690:1683]
     hmac_reg2hw_wipe_secret_reg_t wipe_secret; // [1682:1650]
     hmac_reg2hw_key_mreg_t [31:0] key; // [1649:594]
@@ -219,9 +229,9 @@ package hmac_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    hmac_hw2reg_intr_state_reg_t intr_state; // [1660:1655]
-    hmac_hw2reg_cfg_reg_t cfg; // [1654:1641]
-    hmac_hw2reg_status_reg_t status; // [1640:1633]
+    hmac_hw2reg_intr_state_reg_t intr_state; // [1662:1657]
+    hmac_hw2reg_cfg_reg_t cfg; // [1656:1642]
+    hmac_hw2reg_status_reg_t status; // [1641:1633]
     hmac_hw2reg_err_code_reg_t err_code; // [1632:1600]
     hmac_hw2reg_key_mreg_t [31:0] key; // [1599:576]
     hmac_hw2reg_digest_mreg_t [15:0] digest; // [575:64]
@@ -297,13 +307,15 @@ package hmac_reg_pkg;
   parameter logic [0:0] HMAC_INTR_TEST_HMAC_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] HMAC_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] HMAC_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
-  parameter logic [13:0] HMAC_CFG_RESVAL = 14'h 2080;
+  parameter logic [14:0] HMAC_CFG_RESVAL = 15'h 4100;
   parameter logic [0:0] HMAC_CFG_ENDIAN_SWAP_RESVAL = 1'h 0;
   parameter logic [0:0] HMAC_CFG_DIGEST_SWAP_RESVAL = 1'h 0;
+  parameter logic [0:0] HMAC_CFG_KEY_SWAP_RESVAL = 1'h 0;
   parameter logic [3:0] HMAC_CFG_DIGEST_SIZE_RESVAL = 4'h 8;
   parameter logic [5:0] HMAC_CFG_KEY_LENGTH_RESVAL = 6'h 20;
   parameter logic [3:0] HMAC_CMD_RESVAL = 4'h 0;
-  parameter logic [9:0] HMAC_STATUS_RESVAL = 10'h 1;
+  parameter logic [9:0] HMAC_STATUS_RESVAL = 10'h 3;
+  parameter logic [0:0] HMAC_STATUS_HMAC_IDLE_RESVAL = 1'h 1;
   parameter logic [0:0] HMAC_STATUS_FIFO_EMPTY_RESVAL = 1'h 1;
   parameter logic [31:0] HMAC_WIPE_SECRET_RESVAL = 32'h 0;
   parameter logic [31:0] HMAC_KEY_0_RESVAL = 32'h 0;


### PR DESCRIPTION
This PR adds the `key_swap` field to the HMAC `CFG` CSR per this issue https://github.com/lowRISC/opentitan/issues/23158 and exposes the HMAC idle status via the `STATUS` CSR per this issue https://github.com/lowRISC/opentitan/issues/22916. Both changes would need to be covered by DV in M5 @martin-velay.

This PR depends on previous PRs; once they are merged, it will only be the last commit c5e80715a4e1c7b0dcdcb48bb44d56dfea1584f2.