### PR TITLE
[sival] Fix keymgr_sideload_aes_test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1955,23 +1955,18 @@ opentitan_test(
 opentitan_test(
     name = "keymgr_sideload_aes_test",
     srcs = ["keymgr_sideload_aes_test.c"],
-    broken = cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         },
     ),
-    silicon = silicon_params(tags = ["broken"]),
-    verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/ip/aes/data:aes_regs",
         "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/ip/kmac/data:kmac_regs",
-        "//sw/device/lib/arch:device",
+        "//sw/device/lib/arch:boot_stage",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/dif:aes",
         "//sw/device/lib/dif:keymgr",

--- a/sw/device/tests/keymgr_sideload_aes_test.c
+++ b/sw/device/tests/keymgr_sideload_aes_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_aes.h"
@@ -84,7 +85,7 @@ static void keymgr_initialize_sival(void) {
 }
 
 static void keymgr_initialize(void) {
-  if (kDeviceType == kDeviceSilicon) {
+  if (kBootStage == kBootStageOwner) {
     keymgr_initialize_sival();
   } else {
     // All other configurations use the sim_dv initialization.


### PR DESCRIPTION
Update the test case to call `keymgr_initialize_sival()` only if `kBootStage == kBootStageOwner`. Tested change on silicon and cw310 sival execution environments.