### PR TITLE
[spi_device] Add CSB reset sync for outclk domain

### DIFF
--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -79,6 +79,9 @@ waive -rules TERMINAL_STATE -location {spid_jedec.sv} \
 waive -rules RESET_DRIVER -location {spi_device.sv} \
       -regexp {'rst_(spi|txfifo|rxfifo)_n' is driven} \
       -comment "Async reset generation is required here"
+waive -rules RESET_DRIVER -location {spi_device.sv} \
+      -regexp {'rst_spi_(in|out)_n' is driven} \
+      -comment "Async reset generation is required here"
 waive -rules RESET_MUX    -location {spi_device.sv} \
       -regexp {Asynchronous reset 'rst_(spi|txfifo|rxfifo)_n' is driven} \
       -comment "The MUX is needed to control the reset during scanmode (scanmode_i == 1)"
@@ -89,10 +92,10 @@ waive -rules RESET_MUX -location {spi_device.sv} \
       -regexp {'sram_rst_n.*' is driven by a multiplexer here} \
       -comment "Scan reset mux, but need to have asynchronous reset"
 waive -rules RESET_MUX -location {spi_device.sv} \
-      -regexp {'tpm_rst_n' is driven} \
+      -regexp {'tpm_rst_in_n' is driven} \
       -comment "Async reset generation is required here"
 waive -rules RESET_DRIVER -location {spi_device.sv} \
-      -regexp {'tpm_rst_n' is driven} \
+      -regexp {'tpm_rst_(in|out)_n' is driven} \
       -comment "Async reset generation is required here"
 waive -rules RESET_DRIVER -location {spid_status.sv} \
       -regexp {'status_fifo_rst_n' is driven} \

--- a/hw/ip/spi_device/lint/spi_tpm.waiver
+++ b/hw/ip/spi_device/lint/spi_tpm.waiver
@@ -9,9 +9,6 @@
 waive -rules {RESET_DRIVER RESET_MUX} -location {spi_tpm.sv} \
       -regexp {'rst_n' is driven} \
       -comment "Async reset generated from TPM_CS#"
-waive -rules {RESET_MUX} -location {spi_device.sv} \
-      -regexp {'sys_tpm_rst_n' is driven by a multiplexer} \
-      -comment {The mux is scan mux}
 
 waive -rules TERMINAL_STATE -location {spi_tpm.sv} \
     -regexp {'(StEnd|StInvalid)'} \

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -111,6 +111,7 @@ module spi_readcmd
   input rst_ni,
 
   input clk_out_i, // Output clock (inverted SPI_CLK)
+  input rst_out_ni, // Reset safely timed for output clock
 
   input sys_clk_i,
   input sys_rst_ni, // System reset for buffer tracking pointers
@@ -530,8 +531,8 @@ module spi_readcmd
 
   // outclk latch
   // can't put async fifo. DC constraint should have half clk datapath
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) begin
       p2s_valid_o <= 1'b 0;
       p2s_byte_o  <= '0 ;
     end else begin

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -58,6 +58,7 @@ module spi_tpm
   input clk_in_i,
   input clk_out_i,
   input rst_ni,
+  input rst_out_ni,
 
   input sys_clk_i,
   input sys_rst_ni,
@@ -537,8 +538,8 @@ module spi_tpm
   end
 
   // data_sel (sck -> isck)
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) begin
       isck_data_sel <= SelWait;
     end else begin
       isck_data_sel <= sck_data_sel;
@@ -589,8 +590,8 @@ module spi_tpm
   // address correctly.
   assign sck_fifoaddr_latch = (cmdaddr_bitcnt == 5'h 1F);
 
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) begin
       isck_fifoaddr_latch <= 1'b 0;
     end else begin
       isck_fifoaddr_latch <= sck_fifoaddr_latch;
@@ -615,8 +616,8 @@ module spi_tpm
 
   // fifoaddr latch
   //  clk_out (iSCK)
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) begin
       isck_fifoaddr <= '0;
     end else if (isck_fifoaddr_latch) begin
       // Shall assert when sck_st_q moves away from StAddr
@@ -791,9 +792,9 @@ module spi_tpm
   // Remember that the logic chooses only one HwReg at a transaction.
   // It does not send continuously even the transfer size is greater than the
   // word boundary.
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) isck_hw_reg_idx <= RegAccess;
-    else        isck_hw_reg_idx <= sck_hw_reg_idx;
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) isck_hw_reg_idx <= RegAccess;
+    else             isck_hw_reg_idx <= sck_hw_reg_idx;
   end
 
   // locality store
@@ -887,7 +888,7 @@ module spi_tpm
   );
 
   // Output data mux
-  `ASSERT_KNOWN(DataSelKnown_A, isck_data_sel, clk_out_i, !rst_ni)
+  `ASSERT_KNOWN(DataSelKnown_A, isck_data_sel, clk_out_i, !rst_out_ni)
   always_comb begin
     isck_p2s_data = 8'h 00;
 
@@ -929,7 +930,7 @@ module spi_tpm
     .data_o (isck_hw_reg_byte)
   );
 
-  `ASSERT_KNOWN(HwRegIdxKnown_A, isck_hw_reg_idx, clk_out_i, !rst_ni)
+  `ASSERT_KNOWN(HwRegIdxKnown_A, isck_hw_reg_idx, clk_out_i, !rst_out_ni)
   always_comb begin : hw_reg_mux
     isck_hw_reg_word = 32'h FFFF_FFFF;
 
@@ -1007,8 +1008,8 @@ module spi_tpm
   //  signal (`rready`) at the 8th beat.
   logic [2:0] isck_p2s_bitcnt; // loop from 7 to 0
 
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) begin
       isck_p2s_bitcnt <= 3'h 7;
     end else begin
       isck_p2s_bitcnt <= isck_p2s_bitcnt - 1'b 1;
@@ -1019,9 +1020,9 @@ module spi_tpm
   //                                        ~|isck_p2s_bitcnt
   assign isck_p2s_sent = isck_p2s_valid && (isck_p2s_bitcnt == '0);
 
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) isck_p2s_valid <= 1'b 0;
-    else        isck_p2s_valid <= sck_p2s_valid;
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) isck_p2s_valid <= 1'b 0;
+    else             isck_p2s_valid <= sck_p2s_valid;
   end
 
   // Decided to implement 8-to-1 mux rather than conventional shift out for
@@ -1047,8 +1048,8 @@ module spi_tpm
   // Read FIFO data selection and FIFO ready
   assign isck_rd_byte_sent = isck_p2s_sent && (isck_data_sel == SelRdFifo);
   // Select RdFIFO RDATA
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) begin
       isck_sel_rdata <= '0;
     end else begin
       isck_sel_rdata <= sck_rdfifo_rdata[NumBits*sck_rdfifo_idx+:NumBits];

--- a/hw/ip/spi_device/rtl/spid_jedec.sv
+++ b/hw/ip/spi_device/rtl/spid_jedec.sv
@@ -13,6 +13,7 @@ module spid_jedec
   input rst_ni,
 
   input clk_out_i, // Output clock (inverted SCK)
+  input rst_out_ni, // Reset safely timed for output clock
 
   input cmd_sync_pulse_i,
 
@@ -86,8 +87,8 @@ module spid_jedec
   end
 
   // Output to Parallel-to-Serial
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) begin
       outclk_p2s_valid_o <= 1'b 0;
       outclk_p2s_byte_o  <= 8'h 0;
     end else begin

--- a/hw/ip/spi_device/rtl/spid_status.sv
+++ b/hw/ip/spi_device/rtl/spid_status.sv
@@ -25,6 +25,7 @@ module spid_status
   input rst_ni,
 
   input clk_out_i, // Output clock (inverted SCK)
+  input rst_out_ni, // Reset safely timed for output clock
 
   input clk_csb_i, // CSb clock source
 
@@ -301,8 +302,8 @@ module spid_status
   /////////////////
 
   // Latch in clk_out
-  always_ff @(posedge clk_out_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_out_i or negedge rst_out_ni) begin
+    if (!rst_out_ni) begin
       outclk_p2s_valid_o <= 1'b 0;
       outclk_p2s_byte_o  <= '0;
     end else begin


### PR DESCRIPTION
For flops that latch on the falling edge of SCK, an unsafe reset timing can occur if SCK is permitted to toggle while CSB toggles. SPI NOR flash datasheets typically only specify setup and hold requirements around the rising edge of SCK, so these flops are not protected (at least without OT-specific requirements on the datasheet).

Add a synchronizing flop that releases the CSB reset on the rising edge of SCK, and create a separate reset network for the outclk domain to fix the RDC issue.