### PR TITLE
[rom/e2e] Update key_validity tests.

### DIFF
--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -87,6 +87,7 @@ CONST = struct(
             BAD_RSA_KEY = 0x04535603,
             BAD_ECDSA_SIGNATURE = 0x07535603,
             BAD_ECDSA_KEY = 0x09535603,
+            BAD_SPX_KEY = 0x05535603,
         ),
         BOOT_POLICY = struct(
             BAD_IDENTIFIER = 0x0142500d,

--- a/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_e2e_testplan.hjson
@@ -694,7 +694,7 @@
               - Log so that test can be reproduced.
             - Apply bootstrap pin strapping and reset the chip.
             - Load the image.
-            - Verify that boot fails with the expected `BFV`: `kErrorSigverifyBadRsaSignature`.
+            - Verify that boot fails with the expected `BFV`: `kErrorSigverifyBadEcdsaSignature`.
             - Repeat the steps above for TEST, DEV, PROD, PROD_END, and RMA.
 
             See `rom_e2e_boot_policy_valid`.
@@ -737,10 +737,12 @@
       name: rom_e2e_sigverify_key_validity
       desc: '''Verify that ROM only uses authorized keys that are not invalidated.
 
-            - For each key entry in `CREATOR_SW_CFG_SIGVERIFY_RSA_KEY_EN`,
-              - Invalidate the key by setting the entry to a value other than `kHardenedBoolTrue`.
+            - For each key entry in the `ROT_CREATOR_AUTH_STATE` partition,
+              - Invalidate the key by setting the entry to a value other than `PROVISIONED`.
               - Prepare a ROM_EXT image with a valid signature generated using the invalidated key.
-              - Verify that boot fails with `BFV:kErrorSigverifyBadKey`
+              - Verify that boot fails with `BFV:kErrorSigverifyBadEcdsaKey` or
+                `BFV:kErrorSigverifyBadSpxKey` depending on whether the failure is due to a bad
+                ECDSA or SPX key.
 
             | LC State | Allowed key types |
             |:--------:|:-----------------:|

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
@@ -4,6 +4,7 @@
 
 load(
     "//rules/opentitan:defs.bzl",
+    "DEFAULT_TEST_FAILURE_MSG",
     "cw310_params",
     "opentitan_test",
 )
@@ -15,7 +16,7 @@ load(
 )
 load(
     "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
+    "ECDSA_SPX_KEY_STRUCTS",
     "filter_key_structs_for_lc_state",
 )
 load(
@@ -35,74 +36,219 @@ load(
     "MSG_PASS",
     "MSG_TEMPLATE_BFV_LCV",
 )
+load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-otp_json(
-    name = "otp_json_sigverify_key_validity",
-    partitions = [
-        otp_partition(
-            name = "ROT_CREATOR_AUTH_STATE",
-            items = {
-                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY0": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
-                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY1": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
-                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY2": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
-                "ROT_CREATOR_AUTH_STATE_ECDSA_KEY3": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
-                "ROT_CREATOR_AUTH_STATE_SPX_KEY0": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
-                "ROT_CREATOR_AUTH_STATE_SPX_KEY1": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
-                "ROT_CREATOR_AUTH_STATE_SPX_KEY2": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
-                "ROT_CREATOR_AUTH_STATE_SPX_KEY3": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
+# SPHINCS+ is enabled via OTP config in the following lifecycle states.
+SPX_OTP_LC_STATES = get_lc_items(
+    CONST.LCV.DEV,
+    CONST.LCV.PROD,
+    CONST.LCV.PROD_END,
+    CONST.LCV.RMA,
+)
+
+# SPHINCS+ is disabled uncoditionally in these lifecycle states.
+SPX_DISABLED_LC_STATES = get_lc_items(
+    CONST.LCV.TEST_UNLOCKED0,
+    CONST.LCV.TEST_UNLOCKED1,
+    CONST.LCV.TEST_UNLOCKED2,
+    CONST.LCV.TEST_UNLOCKED3,
+    CONST.LCV.TEST_UNLOCKED4,
+    CONST.LCV.TEST_UNLOCKED5,
+    CONST.LCV.TEST_UNLOCKED6,
+    CONST.LCV.TEST_UNLOCKED7,
+)
+
+KEY_VALIDITY_TESTS = [
+    {
+        "name": "ecdsa_revoked",
+        "exit_failure": dicts.add(
+            {
+                lc_state: MSG_PASS
+                for lc_state, _ in get_lc_items()
             },
         ),
-    ],
-)
+        "exit_success": dicts.add(
+            {
+                lc_state: MSG_TEMPLATE_BFV_LCV.format(
+                    hex_digits(CONST.BFV.SIGVERIFY.BAD_ECDSA_KEY),
+                    hex_digits(lc_state_val),
+                )
+                for lc_state, lc_state_val in get_lc_items()
+            },
+        ),
+        "ecdsa_state": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
+        "spx_state": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
+    },
+    {
+        "name": "ecdsa_blank",
+        "exit_failure": dicts.add(
+            {
+                lc_state: MSG_PASS
+                for lc_state, _ in get_lc_items()
+            },
+        ),
+        "exit_success": dicts.add(
+            {
+                lc_state: MSG_TEMPLATE_BFV_LCV.format(
+                    hex_digits(CONST.BFV.SIGVERIFY.BAD_ECDSA_KEY),
+                    hex_digits(lc_state_val),
+                )
+                for lc_state, lc_state_val in get_lc_items()
+            },
+        ),
+        "ecdsa_state": otp_hex(CONST.SIGVERIFY.KEY_STATE.BLANK),
+        "spx_state": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
+    },
+    {
+        "name": "spx_revoked",
+        "exit_failure": dicts.add(
+            {
+                lc_state: MSG_PASS
+                for lc_state, _ in SPX_OTP_LC_STATES
+            },
+            {
+                lc_state: DEFAULT_TEST_FAILURE_MSG
+                for lc_state, _ in SPX_DISABLED_LC_STATES
+            },
+        ),
+        "exit_success": dicts.add(
+            {
+                lc_state: MSG_TEMPLATE_BFV_LCV.format(
+                    hex_digits(CONST.BFV.SIGVERIFY.BAD_SPX_KEY),
+                    hex_digits(lc_state_val),
+                )
+                for lc_state, lc_state_val in SPX_OTP_LC_STATES
+            },
+            {
+                lc_state: MSG_PASS
+                for lc_state, _ in SPX_DISABLED_LC_STATES
+            },
+        ),
+        "ecdsa_state": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
+        "spx_state": otp_hex(CONST.SIGVERIFY.KEY_STATE.REVOKED),
+    },
+    {
+        "name": "spx_blank",
+        "exit_failure": dicts.add(
+            {
+                lc_state: MSG_PASS
+                for lc_state, _ in SPX_OTP_LC_STATES
+            },
+            {
+                lc_state: DEFAULT_TEST_FAILURE_MSG
+                for lc_state, _ in SPX_DISABLED_LC_STATES
+            },
+        ),
+        "exit_success": dicts.add(
+            {
+                lc_state: MSG_TEMPLATE_BFV_LCV.format(
+                    hex_digits(CONST.BFV.SIGVERIFY.BAD_SPX_KEY),
+                    hex_digits(lc_state_val),
+                )
+                for lc_state, lc_state_val in SPX_OTP_LC_STATES
+            },
+            {
+                lc_state: MSG_PASS
+                for lc_state, _ in SPX_DISABLED_LC_STATES
+            },
+        ),
+        "ecdsa_state": otp_hex(CONST.SIGVERIFY.KEY_STATE.PROVISIONED),
+        "spx_state": otp_hex(CONST.SIGVERIFY.KEY_STATE.BLANK),
+    },
+]
+
+[
+    otp_json(
+        name = "otp_json_sigverify_key_validity_{}".format(test["name"]),
+        partitions = [
+            otp_partition(
+                name = "CREATOR_SW_CFG",
+                items = {
+                    "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(CONST.HARDENED_TRUE),
+                },
+            ),
+            otp_partition(
+                name = "ROT_CREATOR_AUTH_STATE",
+                items = {
+                    "ROT_CREATOR_AUTH_STATE_ECDSA_KEY0": test["ecdsa_state"],
+                    "ROT_CREATOR_AUTH_STATE_ECDSA_KEY1": test["ecdsa_state"],
+                    "ROT_CREATOR_AUTH_STATE_ECDSA_KEY2": test["ecdsa_state"],
+                    "ROT_CREATOR_AUTH_STATE_ECDSA_KEY3": test["ecdsa_state"],
+                    "ROT_CREATOR_AUTH_STATE_SPX_KEY0": test["spx_state"],
+                    "ROT_CREATOR_AUTH_STATE_SPX_KEY1": test["spx_state"],
+                    "ROT_CREATOR_AUTH_STATE_SPX_KEY2": test["spx_state"],
+                    "ROT_CREATOR_AUTH_STATE_SPX_KEY3": test["spx_state"],
+                },
+            ),
+        ],
+    )
+    for test in KEY_VALIDITY_TESTS
+]
 
 [
     otp_image(
-        name = "otp_img_sigverify_key_validity_{}".format(lc_state),
+        name = "otp_img_sigverify_key_validity_{}_{}".format(
+            test["name"],
+            lc_state,
+        ),
         src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
-        overlays = STD_OTP_OVERLAYS + [":otp_json_sigverify_key_validity"],
+        overlays = STD_OTP_OVERLAYS + [
+            ":otp_json_sigverify_key_validity_{}".format(test["name"]),
+        ],
     )
+    for test in KEY_VALIDITY_TESTS
     for lc_state, _ in get_lc_items()
 ]
 
 [
     opentitan_test(
-        name = "sigverify_key_validity_{}_{}".format(
+        name = "sigverify_key_validity_{}_{}_{}_{}".format(
+            test["name"],
             lc_state,
             key.ecdsa.name,
+            key.spx.name,
         ),
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test"],
         cw310 = cw310_params(
-            exit_failure = MSG_PASS,
-            exit_success = MSG_TEMPLATE_BFV_LCV.format(
-                hex_digits(CONST.BFV.SIGVERIFY.BAD_ECDSA_KEY),
-                hex_digits(lc_state_val),
+            exit_failure = test["exit_failure"][lc_state],
+            exit_success = test["exit_success"][lc_state],
+            otp = ":otp_img_sigverify_key_validity_{}_{}".format(
+                test["name"],
+                lc_state,
             ),
-            otp = ":otp_img_sigverify_key_validity_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
         ),
         ecdsa_key = {key.ecdsa.label: key.ecdsa.name},
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         },
+        spx_key = {key.spx.label: key.spx.name},
         deps = [
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
+    for test in KEY_VALIDITY_TESTS
     for lc_state, lc_state_val in get_lc_items()
-    for key in filter_key_structs_for_lc_state(ECDSA_ONLY_KEY_STRUCTS, lc_state_val)
+    for key in filter_key_structs_for_lc_state(ECDSA_SPX_KEY_STRUCTS, lc_state_val)
 ]
 
 test_suite(
     name = "rom_e2e_sigverify_key_validity",
     tags = ["manual"],
     tests = [
-        "sigverify_key_validity_{}_{}".format(
+        "sigverify_key_validity_{}_{}_{}_{}".format(
+            test["name"],
             lc_state,
             key.ecdsa.name,
+            key.spx.name,
         )
+        for test in KEY_VALIDITY_TESTS
         for lc_state, lc_state_val in get_lc_items()
-        for key in filter_key_structs_for_lc_state(ECDSA_ONLY_KEY_STRUCTS, lc_state_val)
+        for key in filter_key_structs_for_lc_state(ECDSA_SPX_KEY_STRUCTS, lc_state_val)
     ],
 )

--- a/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
@@ -14,7 +14,6 @@ load(
     "//rules:const.bzl",
     "CONST",
     "get_lc_items",
-    "hex",
 )
 load(
     "//rules:opentitan.bzl",
@@ -23,7 +22,6 @@ load(
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
-    "otp_bytestring",
     "otp_hex",
     "otp_image",
     "otp_json",
@@ -40,10 +38,6 @@ load(
 load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
-)
-load(
-    "@bazel_skylib//lib:shell.bzl",
-    "shell",
 )
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
1. Update tests to cover keys in `REVOKED` and `BLANK` states.
2. Add coverage for SPX+ keys, by enabling `sigverify_spx` in mission states. Expect SPX+ disabled in `TEST_UNLOCKED` states.

This is part of: https://github.com/lowRISC/opentitan/issues/21551