### PR TITLE
[tool,fpvgen] Fix variable in fusesoc.core.tpl

### DIFF
--- a/util/fpvgen/fusesoc.core.tpl
+++ b/util/fpvgen/fusesoc.core.tpl
@@ -25,8 +25,8 @@ generate:
   csr_assert_gen:
     generator: csr_assert_gen
     parameters:
-      spec: ../data/${dut_name}.hjson
-      depend: lowrisc:ip:${dut_name}
+      spec: ../data/${dut.name}.hjson
+      depend: lowrisc:ip:${dut.name}
 % endif
 
 targets:


### PR DESCRIPTION
Weirdly, I don't think the previous code ever worked! Grepping for dut_name in 9292494f0c5 (where the code was added) doesn't find any other hits.

Fixes #23232.