### PR TITLE
Fix pwrmgr sival

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2765,6 +2765,12 @@ opentitan_test(
         "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
+    ),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2798,6 +2804,12 @@ opentitan_test(
         "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
         "//hw/top_earlgrey:sim_dv": None,
     },
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
+    ),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/host/tests/chip/pwrmgr/src/sleep_all_resets.rs
+++ b/sw/host/tests/chip/pwrmgr/src/sleep_all_resets.rs
@@ -24,7 +24,6 @@ struct Opts {
 fn sleep_all_resets_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let ioc0_pin = transport.gpio_pin("Ioc0")?;
     let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
     loop {
         let vec = UartConsole::wait_for(&*uart, r"PASS|FAIL|Sysrst reset in", opts.timeout)?;
         log::info!("read from uart: {}", vec[0]);

--- a/sw/host/tests/chip/pwrmgr/src/sleep_all_wakeups.rs
+++ b/sw/host/tests/chip/pwrmgr/src/sleep_all_wakeups.rs
@@ -24,7 +24,6 @@ struct Opts {
 fn sleep_all_wakeups_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let ioc0_pin = transport.gpio_pin("Ioc0")?;
     let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
     loop {
         let vec = UartConsole::wait_for(
             &*uart,

--- a/sw/host/tests/chip/pwrmgr/src/sleep_por.rs
+++ b/sw/host/tests/chip/pwrmgr/src/sleep_por.rs
@@ -23,7 +23,6 @@ struct Opts {
 
 fn sleep_por_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
     log::info!("Starting host side");
     let vec = UartConsole::wait_for(&*uart, r"PASS|FAIL|Ready for pad POR", opts.timeout)?;
     match vec[0].as_str() {


### PR DESCRIPTION
Even though the test plan says not to run `pwrmgr_normal_sleep_all_wake_ups` (and deep variant) and to prefer the random version, it is current in a weird state where it is enabled but does not specify a test harness which causes it to fail.