### PR TITLE
[pwrmgr,sival] Disable wakeup source 5 in normal tests

### DIFF
--- a/sw/device/tests/pwrmgr_deep_sleep_all_wake_ups.c
+++ b/sw/device/tests/pwrmgr_deep_sleep_all_wake_ups.c
@@ -76,6 +76,13 @@ bool test_main(void) {
     CHECK_STATUS_OK(ret_sram_testutils_counter_increment(kCounterCases));
     CHECK_STATUS_OK(
         ret_sram_testutils_counter_get(kCounterCases, &wakeup_unit));
+    // There is a bug in the last wakeup (5), so this test skips that
+    // and there is a separate test that triggers it.
+    // TODO(lowrisc/opentitan#20798) Enable all wakeups once this is addressed.
+    if (wakeup_unit == PWRMGR_PARAM_SENSOR_CTRL_AON_WKUP_REQ_IDX) {
+      CHECK_STATUS_OK(ret_sram_testutils_counter_increment(kCounterCases));
+      wakeup_unit++;
+    }
     if (wakeup_unit >= PWRMGR_PARAM_NUM_WKUPS) {
       return true;
     } else if (kDeviceType != kDeviceSimDV &&

--- a/sw/device/tests/pwrmgr_normal_sleep_all_wake_ups.c
+++ b/sw/device/tests/pwrmgr_normal_sleep_all_wake_ups.c
@@ -58,6 +58,13 @@ bool test_main(void) {
           wakeup_unit == PWRMGR_PARAM_ADC_CTRL_AON_WKUP_REQ_IDX) {
         continue;
       }
+      // There is a bug in the last wakeup (5), so this test skips that
+      // and there is a separate test that triggers it.
+      // TODO(lowrisc/opentitan#20798) Enable all wakeups once this is
+      // addressed.
+      if (wakeup_unit == PWRMGR_PARAM_SENSOR_CTRL_AON_WKUP_REQ_IDX) {
+        continue;
+      }
       LOG_INFO("Test %d begin", wakeup_unit);
       execute_test(wakeup_unit, /*deep_sleep=*/false);
       check_wakeup_reason(wakeup_unit);


### PR DESCRIPTION
Wakeup source 5 is already disabled in the randomized version.

*DO NOT CHERRY-PICK TO mater*