### PR TITLE
Aon timer coverage and minor scb fix

### DIFF
--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cov.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cov.sv
@@ -55,10 +55,59 @@ class aon_timer_env_cov extends cip_base_env_cov #(.CFG_T(aon_timer_env_cfg));
 
   endgroup : timer_cfg_cg
 
+  // Covergroup: wake_up_timer_thold_hit_cg
+  // Samples count, threshold and interrupt for the wake-up timer.
+  // Crosses the threshold with the interrupt
+  covergroup wake_up_timer_thold_hit_cg with function sample(bit        wkup_int,
+                                                             bit [63:0] wkup_thold,
+                                                             bit [63:0] wkup_count);
+
+    wkup_count_cp: coverpoint wkup_count {option.auto_bin_max = 512;}
+    wkup_thold_cp: coverpoint wkup_thold {option.auto_bin_max = 512;}
+    wkup_int_cp  : coverpoint wkup_int   {bins unset          = {0};
+                                          bins set            = {1};
+    }
+    wkup_thold_cpXwkup_int_cp:  cross wkup_thold_cp, wkup_int_cp;
+  endgroup : wake_up_timer_thold_hit_cg
+
+  // Covergroup: watchdog_timer_bite_thold_hit_cg
+  // Samples count, threshold and interrupt for bite interrupt.
+  // Crosses the threshold with the interrupt
+  covergroup watchdog_timer_bite_thold_hit_cg with function sample(bit        wdog_bite_rst,
+                                                                   bit [31:0] wdog_thold,
+                                                                   bit [31:0] wdog_count);
+
+    wdog_count_cp:    coverpoint wdog_count {option.auto_bin_max = 256;}
+    wdog_thold_cp:    coverpoint wdog_thold {option.auto_bin_max = 256;}
+    wdog_bite_rst_cp: coverpoint wdog_bite_rst   { bins unset    = {0};
+                                                   bins set      = {1};
+    }
+    wdog_thold_cpXwdog_bite_rst:  cross wdog_thold_cp, wdog_bite_rst;
+  endgroup : watchdog_timer_bite_thold_hit_cg
+
+  // Covergroup: watchdog_timer_bark_thold_hit_cg
+  // Samples count, threshold and interrupt for bark interrupt.
+  // Crosses the threshold with the interrupt
+  covergroup watchdog_timer_bark_thold_hit_cg with function sample(bit        wdog_bark_int,
+                                                                   bit [31:0] wdog_thold,
+                                                                   bit [31:0] wdog_count);
+
+    wdog_count_cp:    coverpoint wdog_count {option.auto_bin_max = 256;}
+    wdog_thold_cp:    coverpoint wdog_thold {option.auto_bin_max = 256;}
+    wdog_bark_int_cp: coverpoint wdog_bark_int   { bins unset          = {0};
+                                                   bins set            = {1};
+    }
+    wdog_thold_cpXwdog_bark_rst:  cross wdog_thold_cp, wdog_bark_int;
+  endgroup : watchdog_timer_bark_thold_hit_cg
+
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
     // [instantiate covergroups here]
     timer_cfg_cg = new(name);
+    wake_up_timer_thold_hit_cg = new();
+    watchdog_timer_bite_thold_hit_cg = new();
+    watchdog_timer_bark_thold_hit_cg = new();
   endfunction : new
 
 endclass

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_jump_vseq.sv
@@ -6,14 +6,19 @@
 class aon_timer_jump_vseq extends aon_timer_base_vseq;
   `uvm_object_utils(aon_timer_jump_vseq)
 
-  // Randomize Bark/Bite and Wake-up thresholds for the counter
-  rand bit [63:0] wkup_count;
-  rand bit [31:0] wdog_count;
+  // Overrides constraint in parent vseq:
+  constraint thold_count_c {
+    solve wkup_thold before wkup_count;
+    solve aim_bite, wdog_bark_thold, wdog_bite_thold before wdog_count;
+    wkup_thold      <= (2**64-1);
+    wdog_bark_thold <= (2**32-1);
+    wdog_bite_thold <= (2**32-1);
 
-  constraint count_vals_c {
     wkup_count inside {[wkup_thold-10:wkup_thold+10]};
-    wdog_count inside {[wdog_bark_thold-10:wdog_bark_thold+10]};
+    !aim_bite -> wdog_count inside {[wdog_bark_thold-10:wdog_bark_thold+10]};
+    aim_bite  -> wdog_count inside {[wdog_bite_thold-10:wdog_bite_thold+10]};
   }
+
   `uvm_object_new
 
 

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_prescaler_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_prescaler_vseq.sv
@@ -9,10 +9,13 @@ class aon_timer_prescaler_vseq extends aon_timer_base_vseq;
   // Randomize prescaler configuration of the wake up timer.
   randc bit [11:0] prescaler;
 
-  constraint thold_vals_c {
+  //Overrides constraint in parent vseq:
+  constraint thold_count_c {
     wkup_thold      inside {[1:2]};
     wdog_bark_thold inside {[1:2]};
     wdog_bite_thold inside {[1:2]};
+    wkup_count == 0;
+    wdog_count == 0;
   }
 
   `uvm_object_new


### PR DESCRIPTION
This PR adds new covergroups for wkup, bark and bite metrics, including the sampling in the SCB. 
Also rewrites existing VSEQ constraints to allow for a wide range of values for the threshold and count vectors.