### PR TITLE
[usb,sival] Various improvements and fixes

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3674,6 +3674,13 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_vbus_test",
     srcs = ["usbdev_vbus_test.c"],
+    cw310 = cw310_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --no-wait-for-usb-device
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
+    ),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
@@ -3701,6 +3708,13 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_pullup_test",
     srcs = ["usbdev_pullup_test.c"],
+    cw310 = cw310_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --no-wait-for-usb-device
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
+    ),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
@@ -3798,6 +3812,13 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_aon_pullup_test",
     srcs = ["usbdev_aon_pullup_test.c"],
+    cw310 = cw310_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --no-wait-for-usb-device
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
+    ),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
@@ -3825,6 +3846,13 @@ opentitan_test(
 opentitan_test(
     name = "usbdev_setuprx_test",
     srcs = ["usbdev_setuprx_test.c"],
+    cw310 = cw310_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            --no-wait-for-usb-device
+        """,
+        test_harness = "//sw/host/tests/chip/usb:usb_harness",
+    ),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3683,6 +3683,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --vbus-sense-en=VBUS_SENSE_EN
             --vbus-sense=VBUS_SENSE
+            --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
@@ -3709,6 +3710,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --vbus-sense-en=VBUS_SENSE_EN
             --vbus-sense=VBUS_SENSE
+            --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
@@ -3805,6 +3807,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --vbus-sense-en=VBUS_SENSE_EN
             --vbus-sense=VBUS_SENSE
+            --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
@@ -3831,6 +3834,7 @@ opentitan_test(
             --bootstrap="{firmware}"
             --vbus-sense-en=VBUS_SENSE_EN
             --vbus-sense=VBUS_SENSE
+            --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),

--- a/sw/device/tests/usbdev_iso_test.c
+++ b/sw/device/tests/usbdev_iso_test.c
@@ -39,7 +39,7 @@
 #define NUM_STREAMS 4U
 #endif
 
-#define TRANSFER_BYTES_SILICON (0x10U << 20)
+#define TRANSFER_BYTES_SILICON (4U << 20)
 #define TRANSFER_BYTES_FPGA (8U << 16)
 
 // This is appropriate for a Verilator chip simulation with 15 min timeout

--- a/sw/device/tests/usbdev_mixed_test.c
+++ b/sw/device/tests/usbdev_mixed_test.c
@@ -46,7 +46,7 @@ Thoughts:
 #define NUM_STREAMS USBUTILS_STREAMS_MAX
 #endif
 
-#define TRANSFER_BYTES_SILICON (0x10U << 20)
+#define TRANSFER_BYTES_SILICON (4U << 20)
 #define TRANSFER_BYTES_FPGA (8U << 16)
 
 // This is appropriate for a Verilator chip simulation with 15 min timeout

--- a/sw/device/tests/usbdev_stream_test.c
+++ b/sw/device/tests/usbdev_stream_test.c
@@ -35,7 +35,7 @@
 #define NUM_STREAMS USBUTILS_STREAMS_MAX
 #endif
 
-#define TRANSFER_BYTES_SILICON (0x10U << 20)
+#define TRANSFER_BYTES_SILICON (8U << 20)
 // 16MiB takes about 256s presently with 10MHz CPU in CW310 FPGA and physical
 // USB with randomized packet sizes and the default memcpy implementation;
 // The _MEM_FASTER switch drops the run time to 187s. In CI, we want to keep

--- a/sw/host/tests/chip/usb/usb.rs
+++ b/sw/host/tests/chip/usb/usb.rs
@@ -42,6 +42,16 @@ fn usb_id_parser(id: &str) -> Result<u16> {
     Ok(u16::from_str_radix(id, 16)?)
 }
 
+// Return the device ports path as a string, or an error.
+pub fn port_path_string(dev: &UsbDevice) -> Result<String> {
+    Ok(dev
+        .port_numbers()?
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<_>>()
+        .join("."))
+}
+
 // Represent an already seen device. Rely on the physical location (port numbers)
 // instead of device address.
 #[derive(Hash, PartialEq, Eq)]

--- a/sw/host/tests/chip/usb/usb_harness.rs
+++ b/sw/host/tests/chip/usb/usb_harness.rs
@@ -123,7 +123,12 @@ fn main() -> Result<()> {
 
     // Wait for test to pass.
     log::info!("wait for pass...");
-    UartConsole::wait_for(&*uart, r"PASS!", opts.timeout)?;
+    let res = UartConsole::wait_for(&*uart, r"PASS|FAIL", opts.timeout)?;
+    match res[0].as_str() {
+        "PASS" => (),
+        "FAIL" => bail!("device code reported a failure"),
+        _ => (),
+    };
 
     // Kill executable (if running).
     if let Some(mut child) = child {


### PR DESCRIPTION
The main purpose of this PR is to fix the test harness that I broke by mistake in https://github.com/lowRISC/opentitan/commit/52714dcdce25352e48537c8dc7c9063ee7b261fc
The issue is that in certain test, the harness is needed to enable VBUS sensing but no USB device will actually appear on the bus so the harness must not wait for it. I took this opportunity to do some further cleanup/improvements.
The reason this failure was not caught by CI is that certain tests do not require the harness on the CW310 so it was not used and therefore the CI didn't break. This PR changes that to run the harness (even when almost useless) even on the CW310.