### PR TITLE
[sival, rv_core_ibex] make rv_core_ibex_mem_test work on silicon

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -207,7 +207,7 @@
          "RV_CORE_IBEX.CPU.ICACHE",
          "RV_CORE_IBEX.CPU.MEMORY"
        ]
-       bazel: ["//sw/device/tests:rv_core_ibex_mem_test_functest"]
+       bazel: ["//sw/device/tests:rv_core_ibex_mem_test"]
     }
     {
      name: chip_sw_rv_core_ibex_lockstep_glitch

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5545,18 +5545,14 @@ opentitan_test(
 )
 
 opentitan_test(
-    name = "rv_core_ibex_mem_test_functest",
+    name = "rv_core_ibex_mem_test_test_unlocked0",
     srcs = ["//sw/device/silicon_creator/manuf/tests:idle_functest.c"],
     cw310 = cw310_params(
         binaries = {
-            ":rv_core_ibex_mem_test": "sram_program",
+            ":rv_core_ibex_mem_test_sram": "sram_program",
         },
         needs_jtag = True,
         otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
-        tags = [
-            "broken",
-            "manual",
-        ],
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
     ),
@@ -5580,7 +5576,7 @@ opentitan_test(
     ),
     silicon = silicon_params(
         binaries = {
-            ":rv_core_ibex_mem_test": "sram_program",
+            ":rv_core_ibex_mem_test_sram": "sram_program",
         },
         needs_jtag = True,
         tags = ["manual"],
@@ -5595,7 +5591,7 @@ opentitan_test(
 )
 
 opentitan_binary(
-    name = "rv_core_ibex_mem_test",
+    name = "rv_core_ibex_mem_test_sram",
     testonly = True,
     srcs = ["rv_core_ibex_mem_test.c"],
     exec_env = {
@@ -5605,7 +5601,7 @@ opentitan_binary(
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
     deps = [
         "//hw/ip/pwm/data:pwm_regs",
-        "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
+        "//hw/ip/rv_timer/data:rv_timer_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
@@ -5617,7 +5613,43 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
+    ],
+)
+
+opentitan_test(
+    name = "rv_core_ibex_mem_test_prod",
+    srcs = ["rv_core_ibex_mem_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    deps = [
+        "//hw/ip/pwm/data:pwm_regs",
+        "//hw/ip/rv_timer/data:rv_timer_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:pmp",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+        "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib/base:chip",
+    ],
+)
+
+test_suite(
+    name = "rv_core_ibex_mem_test",
+    tags = ["manual"],
+    tests = [
+        "rv_core_ibex_mem_test_prod",
+        "rv_core_ibex_mem_test_test_unlocked0",
     ],
 )
 

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -12,7 +12,7 @@ test_suite(
         "//sw/device/tests:rstmgr_cpu_info_test",
         "//sw/device/tests:rv_core_ibex_epmp_test_functest",
         "//sw/device/tests:rv_core_ibex_isa_test",
-        "//sw/device/tests:rv_core_ibex_mem_test_functest",
+        "//sw/device/tests:rv_core_ibex_mem_test",
         "//sw/device/tests:rv_core_ibex_rnd_test",
     ],
 )


### PR DESCRIPTION
Changes made:
* ROM check is skipped because it's locked by ROM_EXT.
* Since ROM_EXT locks address translation, the MMIO test location is
  switched to a rv_timer register instead.
* ROM_EXT locks down its own flash pages, so the page being tested is moved
  from page 0 to an accessible page. The default property config is also
  changed to a specific data region.