### PR TITLE
[manuf] fix TPM EK cert subject country

### DIFF
--- a/sw/device/silicon_creator/lib/cert/tpm_ek.hjson
+++ b/sw/device/silicon_creator/lib/cert/tpm_ek.hjson
@@ -65,7 +65,7 @@
         not_before: "20230101000000Z",
         not_after: "20500101000000Z",
         subject: [
-            { country: "USA" },
+            { country: "US" },
             { state: "CA" },
             { organization: "Google" },
             { organizational_unit: "Engineering" },


### PR DESCRIPTION
This updates the TPM EK cert's subject country field to match the CIK and CEK certs.