### PR TITLE
[rom] Report the correct boot log `rom_ext_slot`

### DIFF
--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -111,6 +111,7 @@ cc_library(
     ],
     deps = [
         ":boot_policy",
+        ":boot_policy_ptrs",
         ":bootstrap",
         ":rom_epmp",
         ":sigverify_keys_ecdsa_p256",


### PR DESCRIPTION
The rom was incorrectly determining the value to place into the `rom_ext_slot` of the boot log.