### PR TITLE
[manuf] bug fixes for provisioning orchestrator 

### DIFF
--- a/sw/device/silicon_creator/lib/cert/tpm_ek.hjson
+++ b/sw/device/silicon_creator/lib/cert/tpm_ek.hjson
@@ -65,7 +65,7 @@
         not_before: "20230101000000Z",
         not_after: "20500101000000Z",
         subject: [
-            { country: "USA" },
+            { country: "US" },
             { state: "CA" },
             { organization: "Google" },
             { organizational_unit: "Engineering" },

--- a/sw/device/silicon_creator/lib/dice.c
+++ b/sw/device/silicon_creator/lib/dice.c
@@ -182,21 +182,9 @@ static void curr_tbs_signature_le_to_be_convert(attestation_signature_t *sig) {
  */
 static void measure_otp_partition(otp_partition_t partition,
                                   hmac_digest_t *measurement) {
-  // Compute the digest.
   otp_dai_read(partition, /*address=*/0, otp_state,
                kOtpPartitions[partition].size / sizeof(uint32_t));
   hmac_sha256(otp_state, kOtpPartitions[partition].size, measurement);
-
-  // Check the digest matches what is stored in OTP (for partitions that are
-  // locked via software computed digest).
-  if (partition == kOtpPartitionCreatorSwCfg ||
-      partition == kOtpPartitionOwnerSwCfg) {
-    uint64_t expected_digest = otp_partition_digest_read(partition);
-    uint32_t digest_hi = expected_digest >> 32;
-    uint32_t digest_lo = expected_digest & UINT32_MAX;
-    HARDENED_CHECK_EQ(digest_hi, measurement->digest[1]);
-    HARDENED_CHECK_EQ(digest_lo, measurement->digest[0]);
-  }
 }
 
 rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,

--- a/sw/host/provisioning/ft/BUILD
+++ b/sw/host/provisioning/ft/BUILD
@@ -17,6 +17,10 @@ rust_binary(
     testonly = True,
     srcs = ["src/main.rs"],
     data = [
+        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_1",
+        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_2",
+        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_3",
+        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_4",
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:sram_ft_individualize_all",
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/binaries:ft_personalize_1_prod_signed",
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/binaries:ft_personalize_2_prod_signed",

--- a/sw/host/provisioning/orchestrator/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/orchestrator.py
@@ -238,6 +238,7 @@ def main():
                       args.ca_priv_keyfile,
                       args.ca_certfile,
                       args.ca_key_id,
+                      args.target_lc_state,
                       require_confirmation=not args.non_interactive)
     chip.parse_logs()
     chip.record_device(db_conn, commit_hash, timestamp, ecc_keyfile_basename)

--- a/sw/host/provisioning/orchestrator/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/orchestrator.py
@@ -139,6 +139,7 @@ def main():
     parser.add_argument("--ecc_priv_keyfile", required=True)
     parser.add_argument("--ca_priv_keyfile", required=True)
     parser.add_argument("--ca_certfile", required=True)
+    parser.add_argument("--ca_key_id", required=True)
     parser.add_argument("--target_lc_state",
                         help="Target mission mode LC state",
                         choices=["dev", "prod"],
@@ -236,6 +237,7 @@ def main():
     chip.ft_provision(args.ecc_priv_keyfile,
                       args.ca_priv_keyfile,
                       args.ca_certfile,
+                      args.ca_key_id,
                       require_confirmation=not args.non_interactive)
     chip.parse_logs()
     chip.record_device(db_conn, commit_hash, timestamp, ecc_keyfile_basename)

--- a/sw/host/provisioning/orchestrator/ot_device.py
+++ b/sw/host/provisioning/orchestrator/ot_device.py
@@ -95,28 +95,36 @@ class OTDevice:
                      ca_priv_keyfile,
                      ca_certfile,
                      ca_key_id,
+                     mission_mode_state,
                      require_confirmation=True):
         """Run the FT provisioning Bazel target."""
         logging.info("Running FT Provisioning")
 
         sram_ft_indiv_elf_path = "sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/sram_ft_individualize_{}_{}.elf"  # noqa: E501
-        perso_bin_path = "sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/binaries/{}"  # noqa: E501
+        # Default to prod signed binaries unless in DEV state.
+        perso_bin_path = "sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/"  # noqa: E501
+        if mission_mode_state == "dev":
+            perso_bin_path += "{}"
+        else:
+            perso_bin_path += "binaries/{}"
 
         if self.fpga_test:
             elf = sram_ft_indiv_elf_path.format(
                 self.sku, "fpga_cw310_rom_with_fake_keys")
+            signing_key = "{}_key_0".format(mission_mode_state)
+            bazel_suffix = "fpga_cw310_rom_with_fake_keys.{}.signed.bin".format(signing_key)
 
             bootstrap = perso_bin_path.format(
-                "ft_personalize_1_fpga_cw310_rom_with_fake_keys.prod_key_0.signed.bin"
+                "ft_personalize_1_{}".format(bazel_suffix)
             )
             bootstrap2 = perso_bin_path.format(
-                "ft_personalize_2_fpga_cw310_rom_with_fake_keys.prod_key_0.signed.bin"
+                "ft_personalize_2_{}".format(bazel_suffix)
             )
             bootstrap3 = perso_bin_path.format(
-                "ft_personalize_3_fpga_cw310_rom_with_fake_keys.prod_key_0.signed.bin"
+                "ft_personalize_3_{}".format(bazel_suffix)
             )
             bootstrap4 = perso_bin_path.format(
-                "ft_personalize_4_fpga_cw310_rom_with_fake_keys.prod_key_0.signed.bin"
+                "ft_personalize_4_{}".format(bazel_suffix)
             )
 
             platform_bazel_flags = ""
@@ -127,18 +135,20 @@ class OTDevice:
 
         else:
             elf = sram_ft_indiv_elf_path.format(self.sku, "silicon_creator")
+            signing_key = "earlgrey_a0_{}_0".format(mission_mode_state)
+            bazel_suffix = "silicon_creator.{}.signed.bin".format(signing_key)
 
             bootstrap = perso_bin_path.format(
-                "ft_personalize_1_silicon_creator.earlgrey_a0_prod_0.signed.bin"
+                "ft_personalize_1_{}".format(bazel_suffix)
             )
             bootstrap2 = perso_bin_path.format(
-                "ft_personalize_2_silicon_creator.earlgrey_a0_prod_0.signed.bin"
+                "ft_personalize_2_{}".format(bazel_suffix)
             )
             bootstrap3 = perso_bin_path.format(
-                "ft_personalize_3_silicon_creator.earlgrey_a0_prod_0.signed.bin"
+                "ft_personalize_3_{}".format(bazel_suffix)
             )
             bootstrap4 = perso_bin_path.format(
-                "ft_personalize_4_silicon_creator.earlgrey_a0_prod_0.signed.bin"
+                "ft_personalize_4_{}".format(bazel_suffix)
             )
 
             platform_bazel_flags = "--//signing:token=//signing/tokens:nitrokey"

--- a/sw/host/provisioning/orchestrator/ot_device.py
+++ b/sw/host/provisioning/orchestrator/ot_device.py
@@ -207,21 +207,19 @@ class OTDevice:
         logging.debug("Found RESP_OK messages")
 
         # First match is the RMA unlock token payload
-        rma_payload = json.loads(rma_msg_matches[0])
-        wrapped_key = rma_payload["wrapped_rma_unlock_token"]["data"]
-        device_pk = rma_payload["wrapped_rma_unlock_token"]["device_pk"]
+        wrapped_key = ""
+        device_pk = {"x": "", "y": ""}
+        if rma_msg_matches:
+            rma_payload = json.loads(rma_msg_matches[0])
+            wrapped_key = rma_payload["wrapped_rma_unlock_token"]["data"]
+            device_pk = rma_payload["wrapped_rma_unlock_token"]["device_pk"]
         # TODO: parse these keys
         self.enc_rma_unlock = str(wrapped_key)
         self.device_ecc_pub_key_x = str(device_pk["x"])
         self.device_ecc_pub_key_y = str(device_pk["y"])
 
-        # Second match is the certificate payload
-        # cert_payload = json.loads(uds_cert_msg_matches[0])
-        # Note: FT stage currently outputs the public key of the certficate
-        # rather than the cert itself
-        # uds_cert_pub_key = cert_payload["uds_certificate"]
-        # self.uds_cert_pub_key_x = str(uds_cert_pub_key["x"])
-        # self.uds_cert_pub_key_y = str(uds_cert_pub_key["y"])
+        # Second match is the certificate payload.
+        # TODO: parse the certificate payload
         self.uds_cert_pub_key_x = "0"
         self.uds_cert_pub_key_y = "0"
 

--- a/sw/host/provisioning/orchestrator/ot_device.py
+++ b/sw/host/provisioning/orchestrator/ot_device.py
@@ -94,6 +94,7 @@ class OTDevice:
                      ecc_priv_keyfile,
                      ca_priv_keyfile,
                      ca_certfile,
+                     ca_key_id,
                      require_confirmation=True):
         """Run the FT provisioning Bazel target."""
         logging.info("Running FT Provisioning")
@@ -164,9 +165,9 @@ class OTDevice:
 --rom-ext-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
 --owner-manifest-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
 --owner-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
---uds-auth-key-id="0x11223344_55667788_99112233_44556677_88991122"
---rom-ext-security-version="0"
---owner-security-version="0"
+--uds-auth-key-id={ca_key_id} \
+--rom-ext-security-version="0" \
+--owner-security-version="0" \
 """  # noqa: E501
 
         logging.info(f"Running command: {cmd}")


### PR DESCRIPTION
This contains several bug fixes to the Earlgrey ES provisioning flow including:
1. making the flow re-entrant,
2. enabling provisioning with either PROD or DEV signed perso binaries (depending on the target mission mode LC state), and
3. enabling the CA key ID to be a parameter of the script.

This includes a fix from the master branch: #23261

CC: @benjbender