### PR TITLE
[rom/e2e] Update sigverify_key_test

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
@@ -6,12 +6,10 @@ load(
     "//rules:const.bzl",
     "CONST",
     "get_lc_items",
-    "hex_digits",
 )
 load(
     "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-    "key_allowed_in_lc_state",
+    "ECDSA_SPX_KEY_STRUCTS",
 )
 load(
     "//rules/opentitan:defs.bzl",
@@ -21,25 +19,128 @@ load(
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
+    "otp_hex",
     "otp_image",
+    "otp_json",
+    "otp_partition",
 )
 load(
     "//rules:rom_e2e.bzl",
     "maybe_skip_in_ci",
 )
 load(
-    "//sw/device/silicon_creator/rom/e2e:defs.bzl",
-    "MSG_PASS",
-    "MSG_TEMPLATE_BFV_LCV",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    ":key_type.bzl",
+    "ecdsa_exit_failure",
+    "ecdsa_exit_success",
+    "spx_exit_failure",
+    "spx_exit_success",
 )
 
 package(default_visibility = ["//visibility:public"])
+
+# Expected exit signatures for ECDSA keys against different LC states.
+ECDSA_ALLOWED_IN_LC_STATES = {
+    "exit_failure": dicts.add(
+        {
+            key.ecdsa.name: dicts.add(
+                {
+                    lc_state: ecdsa_exit_failure(lc_state_val, key)
+                    for lc_state, lc_state_val in get_lc_items()
+                },
+            )
+            for key in ECDSA_SPX_KEY_STRUCTS
+        },
+    ),
+    "exit_success": dicts.add(
+        {
+            key.ecdsa.name: dicts.add(
+                {
+                    lc_state: ecdsa_exit_success(lc_state_val, key)
+                    for lc_state, lc_state_val in get_lc_items()
+                },
+            )
+            for key in ECDSA_SPX_KEY_STRUCTS
+        },
+    ),
+}
+
+# Expected exit signatures for SPX keys against different LC states.
+SPX_ALLOWED_IN_LC_STATES = {
+    "exit_failure": dicts.add(
+        {
+            key.spx.name: dicts.add(
+                {
+                    lc_state: spx_exit_failure(lc_state_val, key)
+                    for lc_state, lc_state_val in get_lc_items()
+                },
+            )
+            for key in ECDSA_SPX_KEY_STRUCTS
+        },
+    ),
+    "exit_success": dicts.add(
+        {
+            key.spx.name: dicts.add(
+                {
+                    lc_state: spx_exit_success(lc_state_val, key)
+                    for lc_state, lc_state_val in get_lc_items()
+                },
+            )
+            for key in ECDSA_SPX_KEY_STRUCTS
+        },
+    ),
+}
+
+# ECDSA key type tests. All tests use a PROD SPX key which is valid across all
+# LC states.
+KEY_TYPE_ECDSA_TESTS = [
+    {
+        "name": key.ecdsa.name,
+        "exit_failure": ECDSA_ALLOWED_IN_LC_STATES["exit_failure"][key.ecdsa.name],
+        "exit_success": ECDSA_ALLOWED_IN_LC_STATES["exit_success"][key.ecdsa.name],
+        "ecdsa_key": {key.ecdsa.label: key.ecdsa.name},
+        "spx_key": {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0_spx"},
+    }
+    for key in ECDSA_SPX_KEY_STRUCTS
+]
+
+# SPX key type tests. All tests use a PROD ECDSA key which is valid across all
+# LC states.
+KEY_TYPE_SPX_TESTS = [
+    {
+        "name": key.spx.name,
+        "exit_failure": SPX_ALLOWED_IN_LC_STATES["exit_failure"][key.spx.name],
+        "exit_success": SPX_ALLOWED_IN_LC_STATES["exit_success"][key.spx.name],
+        "ecdsa_key": {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+        "spx_key": {key.spx.label: key.spx.name},
+    }
+    for key in ECDSA_SPX_KEY_STRUCTS
+]
+
+KEY_TYPE_TESTS = KEY_TYPE_ECDSA_TESTS + KEY_TYPE_SPX_TESTS
+
+otp_json(
+    name = "otp_json_enable_spx",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(CONST.HARDENED_TRUE),
+            },
+        ),
+    ],
+)
 
 [
     otp_image(
         name = "otp_img_sigverify_key_type_{}".format(lc_state),
         src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
-        overlays = STD_OTP_OVERLAYS,
+        overlays = STD_OTP_OVERLAYS + [
+            ":otp_json_enable_spx",
+        ],
     )
     for lc_state, _ in get_lc_items()
 ]
@@ -48,41 +149,30 @@ package(default_visibility = ["//visibility:public"])
     opentitan_test(
         name = "sigverify_key_type_{}_{}".format(
             lc_state,
-            key.ecdsa.name,
+            test["name"],
         ),
         srcs = [
             "//sw/device/silicon_creator/rom/e2e:empty_test",
         ],
         cw310 = cw310_params(
-            exit_failure = MSG_PASS if not key_allowed_in_lc_state(
-                key.ecdsa,
-                lc_state_val,
-            ) else MSG_TEMPLATE_BFV_LCV.format(
-                hex_digits(CONST.BFV.SIGVERIFY.BAD_ECDSA_KEY),
-                hex_digits(lc_state_val),
-            ),
-            exit_success = MSG_PASS if key_allowed_in_lc_state(
-                key.ecdsa,
-                lc_state_val,
-            ) else MSG_TEMPLATE_BFV_LCV.format(
-                hex_digits(CONST.BFV.SIGVERIFY.BAD_ECDSA_KEY),
-                hex_digits(lc_state_val),
-            ),
+            exit_failure = test["exit_failure"][lc_state],
+            exit_success = test["exit_success"][lc_state],
             otp = "otp_img_sigverify_key_type_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
         ),
-        ecdsa_key = {key.ecdsa.label: key.ecdsa.name},
+        ecdsa_key = test["ecdsa_key"],
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         },
+        spx_key = test["spx_key"],
         deps = [
             "//sw/device/lib/testing/test_framework:ottf_main",
             "//sw/device/silicon_creator/lib/drivers:otp",
             "//sw/device/silicon_creator/lib/sigverify:spx_verify",
         ],
     )
+    for test in KEY_TYPE_TESTS
     for lc_state, lc_state_val in get_lc_items()
-    for key in ECDSA_ONLY_KEY_STRUCTS
 ]
 
 test_suite(
@@ -91,9 +181,9 @@ test_suite(
     tests = [
         "sigverify_key_type_{}_{}".format(
             lc_state,
-            key_name,
+            test["name"],
         )
+        for test in KEY_TYPE_TESTS
         for lc_state, _ in get_lc_items()
-        for key_name in [key.ecdsa.name for key in ECDSA_ONLY_KEY_STRUCTS]
     ],
 )

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_type/key_type.bzl
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_type/key_type.bzl
@@ -1,0 +1,116 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helper functions for generating expected test signatures for sigverify_key_type tests."""
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "DEFAULT_TEST_FAILURE_MSG",
+)
+load(
+    "//rules:const.bzl",
+    "CONST",
+    "hex_digits",
+)
+load(
+    "//sw/device/silicon_creator/rom/e2e:defs.bzl",
+    "MSG_PASS",
+    "MSG_TEMPLATE_BFV_LCV",
+)
+load(
+    "//rules:opentitan.bzl",
+    "key_allowed_in_lc_state",
+)
+
+# SPHINCS+ is disabled uncoditionally in these lifecycle states.
+SPX_DISABLED_LC_STATES = [
+    CONST.LCV.TEST_UNLOCKED0,
+    CONST.LCV.TEST_UNLOCKED1,
+    CONST.LCV.TEST_UNLOCKED2,
+    CONST.LCV.TEST_UNLOCKED3,
+    CONST.LCV.TEST_UNLOCKED4,
+    CONST.LCV.TEST_UNLOCKED5,
+    CONST.LCV.TEST_UNLOCKED6,
+    CONST.LCV.TEST_UNLOCKED7,
+]
+
+def ecdsa_exit_failure(lc_state_val, key):
+    """Generate expected failure test signature.
+
+    Args:
+        lc_state_val: Lifecycle state value.
+        key: Key object. Must have ecdsa key.
+    Returns:
+        Expected failure test signature to be used in opentitan_test.
+    """
+    return MSG_PASS if not key_allowed_in_lc_state(
+        key.ecdsa,
+        lc_state_val,
+    ) else MSG_TEMPLATE_BFV_LCV.format(
+        hex_digits(CONST.BFV.SIGVERIFY.BAD_ECDSA_KEY),
+        hex_digits(lc_state_val),
+    )
+
+def ecdsa_exit_success(lc_state_val, key):
+    """Generate expected success test signature.
+
+    Args:
+        lc_state_val: Lifecycle state value.
+        key: Key object. Must have ecdsa key.
+    Returns:
+        Expected success test signature to be used in opentitan_test.
+    """
+    return MSG_PASS if key_allowed_in_lc_state(
+        key.ecdsa,
+        lc_state_val,
+    ) else MSG_TEMPLATE_BFV_LCV.format(
+        hex_digits(CONST.BFV.SIGVERIFY.BAD_ECDSA_KEY),
+        hex_digits(lc_state_val),
+    )
+
+def spx_exit_failure(lc_state_val, key):
+    """Generate expected failure test signature.
+
+    Returns `MSG_DEFAULT_TEST_FAILURE_MSGPASS` if `lc_state_val` is in
+    `SPX_DISABLED_LC_STATES`. This is because in this case ECDSA signature
+    verification is expected to pass.
+
+    Args:
+        lc_state_val: Lifecycle state value.
+        key: Key object. Must have spx key.
+    Returns:
+        Expected failure test signature to be used in opentitan_test.
+    """
+    if lc_state_val in SPX_DISABLED_LC_STATES:
+        return DEFAULT_TEST_FAILURE_MSG
+    return MSG_PASS if not key_allowed_in_lc_state(
+        key.ecdsa,
+        lc_state_val,
+    ) else MSG_TEMPLATE_BFV_LCV.format(
+        hex_digits(CONST.BFV.SIGVERIFY.BAD_SPX_KEY),
+        hex_digits(lc_state_val),
+    )
+
+def spx_exit_success(lc_state_val, key):
+    """Generate expected success test signature.
+
+    Returns `MSG_PASS` if `lc_state_val` is in `SPX_DISABLED_LC_STATES`. This
+    is because in this case ECDSA signature verification is expected to
+    pass.
+
+    Args:
+        lc_state_val: Lifecycle state value.
+        key: Key object. Must have spx key.
+    Returns:
+        Expected success test signature to be used in opentitat_test.
+    """
+    if lc_state_val in SPX_DISABLED_LC_STATES:
+        return MSG_PASS
+    return MSG_PASS if key_allowed_in_lc_state(
+        key.ecdsa,
+        lc_state_val,
+    ) else MSG_TEMPLATE_BFV_LCV.format(
+        hex_digits(CONST.BFV.SIGVERIFY.BAD_SPX_KEY),
+        hex_digits(lc_state_val),
+    )


### PR DESCRIPTION
Update sigverify_key_test to include coverage of SPX keys.

This change introduces the key_type.bzl module which is used to generate test exit success and failure signatures.

Fixes: https://github.com/lowRISC/opentitan/issues/21551