### PR TITLE
[chip-level/sival] Tighten csrng_edn_concurrency test

### DIFF
--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -201,11 +201,15 @@ class CommandTest : public DifCsrngTest {
 };
 
 TEST_F(CommandTest, InstantiateOk) {
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000001 | kMultiBitBool4True << 8);
   EXPECT_DIF_OK(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleDisable,
                                       &seed_material_));
 
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000001 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleEnable,
@@ -213,8 +217,12 @@ TEST_F(CommandTest, InstantiateOk) {
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000011 | kMultiBitBool4False << 8);
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleEnable,
                                       &seed_material_));
@@ -231,14 +239,20 @@ TEST_F(CommandTest, InstantiateBadArgs) {
 }
 
 TEST_F(CommandTest, ReseedOk) {
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000002 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_reseed(&csrng_, &seed_material_));
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000012 | kMultiBitBool4False << 8);
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_csrng_reseed(&csrng_, &seed_material_));
 }
@@ -252,14 +266,20 @@ TEST_F(CommandTest, ReseedBadArgs) {
 }
 
 TEST_F(CommandTest, UpdateOk) {
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000004 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_update(&csrng_, &seed_material_));
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000014 | kMultiBitBool4False << 8);
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_DIF_OK(dif_csrng_update(&csrng_, &seed_material_));
 }
@@ -270,11 +290,15 @@ TEST_F(CommandTest, UpdateBadArgs) {
 
 TEST_F(CommandTest, GenerateOk) {
   // 512bits = 16 x 32bit = 4 x 128bit blocks
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00004003 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_generate_start(&csrng_, /*len=*/16));
 
   // 576bits = 18 x 32bit = 5 x 128bit blocks (rounded up)
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00005003 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_generate_start(&csrng_, /*len=*/18));
@@ -296,6 +320,8 @@ TEST_F(CommandTest, GenerateOutOfRange) {
 }
 
 TEST_F(CommandTest, UninstantiateOk) {
+  EXPECT_READ32(CSRNG_SW_CMD_STS_REG_OFFSET,
+                {{CSRNG_SW_CMD_STS_CMD_RDY_BIT, true}});
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET,
                  0x00000005 | kMultiBitBool4False << 8);
   EXPECT_DIF_OK(dif_csrng_uninstantiate(&csrng_));

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -112,6 +112,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing/test_framework:check",
     ],
 )

--- a/sw/device/lib/testing/csrng_testutils.h
+++ b/sw/device/lib/testing/csrng_testutils.h
@@ -7,6 +7,35 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_csrng_shared.h"
+
+/**
+ * Generates randomized seed material.
+ *
+ * @param disable_rand If set, the generated seed material has length zero.
+ * @param seed_material The seed material to generate.
+ */
+OT_WARN_UNUSED_RESULT
+status_t csrng_testutils_seed_material_build(
+    bool disable_rand, dif_csrng_seed_material_t *seed_material);
+
+/**
+ * Returns a randomized CSRNG application command.
+ *
+ * @param disable_rand If set, a struct containing default values is returned.
+ * @param id CSRNG application command to generate.
+ * @param entropy_src_en If set, Instantiate and Reseed commands use entropy
+ * from the entropy source.
+ * @param glen_val If > 0, the generate length is set to glen_val.
+ * @param seed_material The seed material to generate and use for the generated
+ * application command.
+ * @return The generated CSRNG application command.
+ */
+OT_WARN_UNUSED_RESULT
+csrng_app_cmd_t csrng_testutils_app_cmd_build(
+    bool disable_rand, csrng_app_cmd_id_t id,
+    dif_csrng_entropy_src_toggle_t entropy_src_en, unsigned int glen_val,
+    dif_csrng_seed_material_t *seed_material);
 
 /**
  * Wait for the `csrng` instance command interface to be ready to accept

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -211,9 +211,7 @@ status_t entropy_testutils_drain_observe_fifo(dif_entropy_src_t *entropy_src) {
   return OK_STATUS();
 }
 
-status_t entropy_testutils_stop_all(void) {
-  const dif_entropy_src_t entropy_src = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR)};
+status_t entropy_testutils_stop_csrng_edn(void) {
   const dif_csrng_t csrng = {
       .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR)};
   const dif_edn_t edn0 = {
@@ -224,6 +222,14 @@ status_t entropy_testutils_stop_all(void) {
   TRY(dif_edn_stop(&edn0));
   TRY(dif_edn_stop(&edn1));
   TRY(dif_csrng_stop(&csrng));
+  return OK_STATUS();
+}
+
+status_t entropy_testutils_stop_all(void) {
+  const dif_entropy_src_t entropy_src = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR)};
+
+  CHECK_STATUS_OK(entropy_testutils_stop_csrng_edn());
   TRY(dif_entropy_src_stop(&entropy_src));
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/entropy_testutils.h
+++ b/sw/device/lib/testing/entropy_testutils.h
@@ -70,6 +70,14 @@ status_t entropy_testutils_wait_for_state(const dif_entropy_src_t *entropy_src,
                                           dif_entropy_src_main_fsm_t state);
 
 /**
+ * Stops EDN instances and CSRNG.
+ *
+ * Stops EDN instances before stopping CSRNG.
+ */
+OT_WARN_UNUSED_RESULT
+status_t entropy_testutils_stop_csrng_edn(void);
+
+/**
  * Stops all entropy complex blocks.
  *
  * Stops EDN and CSRNG instances before stopping the entropy source.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -933,6 +933,7 @@ opentitan_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:aes",
         "//sw/device/lib/dif:base",
         "//sw/device/lib/dif:csrng",
         "//sw/device/lib/dif:csrng_shared",


### PR DESCRIPTION
This PR contains a couple of commits to tighten the csrng_edn_concurrency test to stress the entropy complex more heavily (see #22753). Also, the PR carries over a fix from the cryptolib to the dif library to avoid hangs as a result of SW commands being missed / dropped by CSRNG due to handling HW commands.

I recommend reviewing the commit individually.