### PR TITLE
Cherry-pick to master: [sival, rv_core_ibex] make rv_core_ibex_mem_test work on silicon

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -209,7 +209,7 @@
          "RV_CORE_IBEX.CPU.ICACHE",
          "RV_CORE_IBEX.CPU.MEMORY"
        ]
-       bazel: ["//sw/device/tests:rv_core_ibex_mem_test_functest"]
+       bazel: ["//sw/device/tests:rv_core_ibex_mem_test"]
     }
     {
      name: chip_sw_rv_core_ibex_lockstep_glitch

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5714,7 +5714,7 @@ opentitan_test(
 )
 
 opentitan_test(
-    name = "rv_core_ibex_mem_test_functest",
+    name = "rv_core_ibex_mem_test_test_unlocked0",
     srcs = ["//sw/device/silicon_creator/manuf/tests:idle_functest.c"],
     exec_env = dicts.add(
         # This test is not compatible with the test_rom because the test_rom
@@ -5730,20 +5730,16 @@ opentitan_test(
     ),
     fpga = fpga_params(
         binaries = {
-            ":rv_core_ibex_mem_test": "sram_program",
+            ":rv_core_ibex_mem_test_sram": "sram_program",
         },
         needs_jtag = True,
         otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
-        tags = [
-            "broken",
-            "manual",
-        ],
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
     ),
     silicon = silicon_params(
         binaries = {
-            ":rv_core_ibex_mem_test": "sram_program",
+            ":rv_core_ibex_mem_test_sram": "sram_program",
         },
         needs_jtag = True,
         tags = ["manual"],
@@ -5758,7 +5754,7 @@ opentitan_test(
 )
 
 opentitan_binary(
-    name = "rv_core_ibex_mem_test",
+    name = "rv_core_ibex_mem_test_sram",
     testonly = True,
     srcs = ["rv_core_ibex_mem_test.c"],
     exec_env = {
@@ -5768,7 +5764,7 @@ opentitan_binary(
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
     deps = [
         "//hw/ip/pwm/data:pwm_c_regs",
-        "//hw/ip/rv_core_ibex/data:rv_core_ibex_c_regs",
+        "//hw/ip/rv_timer/data:rv_timer_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
@@ -5780,7 +5776,43 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
+    ],
+)
+
+opentitan_test(
+    name = "rv_core_ibex_mem_test_prod",
+    srcs = ["rv_core_ibex_mem_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    deps = [
+        "//hw/ip/pwm/data:pwm_c_regs",
+        "//hw/ip/rv_timer/data:rv_timer_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:pmp",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+        "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib/base:chip",
+    ],
+)
+
+test_suite(
+    name = "rv_core_ibex_mem_test",
+    tags = ["manual"],
+    tests = [
+        "rv_core_ibex_mem_test_prod",
+        "rv_core_ibex_mem_test_test_unlocked0",
     ],
 )
 

--- a/sw/device/tests/rv_core_ibex_mem_test.c
+++ b/sw/device/tests/rv_core_ibex_mem_test.c
@@ -136,6 +136,13 @@ static void setup_flash(void) {
       8, config, TOP_EARLGREY_EFLASH_BASE_ADDR, TOP_EARLGREY_EFLASH_SIZE_BYTES);
   CHECK(result == kPmpRegionConfigureNapotOk,
         "Load configuration failed, error code = %d", result);
+  // When running as ROM_EXT, ROM configures the flash memory to be readonly.
+  // We need to execute so we need to unconfigure it.
+  // This region is unconfigured by ROM_EXT so is no-op for silicon owner stage.
+  pmp_region_configure_result_t configure_result =
+      pmp_region_configure_off(5, 0);
+  CHECK(configure_result == kPmpRegionConfigureOk,
+        "Load configuration failed, error code = %d", configure_result);
 
   // Initialise the flash controller.
   dif_flash_ctrl_state_t flash_ctrl;

--- a/sw/device/tests/sival/BUILD
+++ b/sw/device/tests/sival/BUILD
@@ -12,7 +12,7 @@ test_suite(
         "//sw/device/tests:rstmgr_cpu_info_test",
         "//sw/device/tests:rv_core_ibex_epmp_test_functest",
         "//sw/device/tests:rv_core_ibex_isa_test",
-        "//sw/device/tests:rv_core_ibex_mem_test_functest",
+        "//sw/device/tests:rv_core_ibex_mem_test",
         "//sw/device/tests:rv_core_ibex_rnd_test",
     ],
 )


### PR DESCRIPTION
This is cherry-pick of #23254 to master, needed because in master `<IP>_regs` is renamed to `<IP>_c_regs`.