### PR TITLE
[pwm/dv] Remove unfit covergroups

### DIFF
--- a/hw/ip/pwm/data/pwm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_testplan.hjson
@@ -142,12 +142,6 @@
 
  covergroups: [
     {
-     name: regwen_cg
-      desc: '''
-            Covers that an attempt to write wen REG enable was made and was unsuccessful
-            '''
-    }
-    {
      name: cfg_cg
       desc: '''
             Covers that valid settings for the PWM.CFG register has been tested.

--- a/hw/ip/pwm/data/pwm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_testplan.hjson
@@ -205,11 +205,5 @@
             Cover that a range of frequencies have been tested for the PWM clock including a clock that matches the TL clk.
             '''
     }
-    {
-     name: overwrite_conf_cg
-      desc: '''
-            Cover that a the PWM configuration cannot be altered while a channel is active
-            '''
-    }
   ]
 }

--- a/hw/ip/pwm/dv/env/pwm_env_cov.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_cov.sv
@@ -205,7 +205,6 @@ class pwm_env_cov extends cip_base_env_cov #(.CFG_T(pwm_env_cfg));
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    //regwen_cg = new(); // TODO stage V2S
     cfg_cg = new();
     pwm_chan_en_inv_cg = new();
     pwm_per_channel_cg = new();


### PR DESCRIPTION
`regwen_cg` and `overwrite_conf_cg` don't make sense (anymore), so this PR removes them from the testplan. Please see commit messages for details.

This resolves #17369.