### PR TITLE
[otbn,dv] Waive some secure wipe assertions when they won't hold

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1216,7 +1216,8 @@ module otbn
       u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.g_rf_flops[i].rf_reg_q !=
         EccZeroWord,
       clk_i,
-      !rst_ni || u_otbn_core.urnd_reseed_err || u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
+      !rst_ni || u_otbn_core.urnd_reseed_err || u_otbn_core.u_otbn_start_stop_control.mubi_err_d ||
+      u_otbn_core.u_otbn_start_stop_control.state_error_d)
     // After execution, it's expected to see a change resulting with a nonzero register value
     `ASSERT(SecWipeChangedBaseRegs_A,
       $rose(busy_secure_wipe) |-> ((##[0:$]
@@ -1226,7 +1227,8 @@ module otbn
           u_otbn_core.u_otbn_rf_base.gen_rf_base_ff.u_otbn_rf_base_inner.g_rf_flops[i].rf_reg_q))
         within ($rose(busy_secure_wipe) ##[0:$] $fell(busy_secure_wipe))),
       clk_i,
-      !rst_ni || u_otbn_core.urnd_reseed_err || u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
+      !rst_ni || u_otbn_core.urnd_reseed_err || u_otbn_core.u_otbn_start_stop_control.mubi_err_d ||
+      u_otbn_core.u_otbn_start_stop_control.state_error_d)
   end
 
   // We have several assertions that check that secure wipe worked properly. However, we've also got
@@ -1255,7 +1257,8 @@ module otbn
                   EccWideZeroWord,
               clk_i,
               !rst_ni || u_otbn_core.urnd_reseed_err ||
-                u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
+                u_otbn_core.u_otbn_start_stop_control.mubi_err_d ||
+                u_otbn_core.u_otbn_start_stop_control.state_error_d)
 
       // After execution, it's expected to see a change resulting with a nonzero register value
       `ASSERT(SecWipeChangedWideRegs_A,
@@ -1282,32 +1285,41 @@ module otbn
           $fell(busy_secure_wipe) |-> (!u_otbn_core.u_otbn_rf_base.u_call_stack.top_valid_o),
           clk_i,
           !rst_ni || u_otbn_core.urnd_reseed_err ||
-            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d)
   `ASSERT(SecWipeInvalidLoopStack_A,
           $fell(busy_secure_wipe) |->
             (!u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack.top_valid_o),
           clk_i,
           !rst_ni || u_otbn_core.urnd_reseed_err ||
-            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d)
 
   `ASSERT(SecWipeNonZeroMod_A,
           $fell(busy_secure_wipe) |-> u_otbn_core.u_otbn_alu_bignum.mod_intg_q != EccWideZeroWord,
           clk_i,
           !rst_ni || u_otbn_core.urnd_reseed_err ||
-            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d)
 
   `ASSERT(SecWipeNonZeroACC_A,
           $fell(busy_secure_wipe) |->
             u_otbn_core.u_otbn_alu_bignum.ispr_acc_intg_i != EccWideZeroWord,
           clk_i,
           !rst_ni || u_otbn_core.urnd_reseed_err ||
-            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d)
 
   `ASSERT(SecWipeNonZeroFlags_A,
           $fell(busy_secure_wipe) |-> (!u_otbn_core.u_otbn_alu_bignum.flags_flattened),
           clk_i,
           !rst_ni || u_otbn_core.urnd_reseed_err ||
-            u_otbn_core.u_otbn_start_stop_control.mubi_err_d)
+            u_otbn_core.u_otbn_start_stop_control.mubi_err_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d ||
+            u_otbn_core.u_otbn_start_stop_control.state_error_d)
 
   // Secure wipe of IMEM and DMEM first happens with a key change from URND (while valid is zero)
   `ASSERT(ImemSecWipeRequiresUrndKey_A,


### PR DESCRIPTION
These assertions are triggered by `$fell(busy_secure_wipe)`. When they were written, this meant that a secure wipe had finished. With the more recent change in a4d9f164bb7, the busy_secure_wipe signal is actually 1 immediately after reset. This mostly works fine, but it will drop (possibly without doing an actual secure wipe) if the start/stop control state gets corrupted.

This commit disables those assertions if that has happened.