### PR TITLE
[rtl] MuBi encoding of iCache memory ctrl signals

### DIFF
--- a/hw/ip/i2c/rtl/i2c_fifos.sv
+++ b/hw/ip/i2c/rtl/i2c_fifos.sv
@@ -298,7 +298,8 @@ import i2c_reg_pkg::AcqFifoDepth;
     .rdata_o (ram_rdata),
     .rvalid_o(ram_rvalid),
     .rerror_o(/* unused */),
-    .cfg_i   (ram_cfg_i)
+    .cfg_i   (ram_cfg_i),
+    .alert_o (/* unused */)
   );
   assign {ram_write, ram_addr, ram_wdata} = ram_arb_oup_data;
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -278,7 +278,9 @@ module otbn_top_sim (
     .cfg_i            ( '0                ),
 
     .wr_collision_o   (                   ),
-    .write_pending_o  (                   )
+    .write_pending_o  (                   ),
+
+    .alert_o          (                   )
   );
 
   // No integrity errors in Verilator testbench
@@ -321,7 +323,9 @@ module otbn_top_sim (
     .cfg_i            ( '0                      ),
 
     .wr_collision_o   (                         ),
-    .write_pending_o  (                         )
+    .write_pending_o  (                         ),
+
+    .alert_o          (                         )
   );
 
   // When OTBN is done let a few more cycles run then finish simulation

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -358,7 +358,9 @@ module otbn
     .cfg_i   (ram_cfg_i),
 
     .wr_collision_o   (imem_wr_collision),
-    .write_pending_o  (imem_wpending)
+    .write_pending_o  (imem_wpending),
+
+    .alert_o ()
   );
 
   // We should never see a request that doesn't get granted. A fatal error is raised if this occurs.
@@ -570,7 +572,9 @@ module otbn
     .cfg_i   (ram_cfg_i),
 
     .wr_collision_o   (dmem_wr_collision),
-    .write_pending_o  (dmem_wpending)
+    .write_pending_o  (dmem_wpending),
+
+    .alert_o ()
   );
 
   // We should never see a request that doesn't get granted. A fatal error is raised if this occurs.

--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -382,7 +382,8 @@ module prim_generic_otp
     .rdata_o  ( rdata_ecc              ),
     .rvalid_o ( rvalid                 ),
     .rerror_o (                        ),
-    .cfg_i    ( '0                     )
+    .cfg_i    ( '0                     ),
+    .alert_o  (                        )
   );
 
   // Currently it is assumed that no wrap arounds can occur.

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -314,6 +314,15 @@
                   ''',
             resval: 0,
           }
+          { bits: "7"
+            name: "SRAM_ALERT"
+            desc: '''
+                  This bit is set to 1 if a multi bit encoding error has been detected inside the RAM modules.
+                  This error triggers a fatal_error alert.
+                  This condition is terminal.
+                  ''',
+            resval: 0,
+          }
         ]
       }
       { name: "EXEC_REGWEN",

--- a/hw/ip/sram_ctrl/doc/registers.md
+++ b/hw/ip/sram_ctrl/doc/registers.md
@@ -1,6 +1,3 @@
-# Registers
-
-<!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/sram_ctrl/data/sram_ctrl.hjson -->
 ## Summary of the **`regs`** interface's registers
 
 | Name                                            | Offset   |   Length | Description                                  |
@@ -36,17 +33,18 @@ Alert Test Register
 SRAM status register.
 - Offset: `0x4`
 - Reset default: `0x0`
-- Reset mask: `0x7f`
+- Reset mask: `0xff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "BUS_INTEG_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "INIT_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ESCALATED", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SCR_KEY_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SCR_KEY_SEED_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "INIT_DONE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "READBACK_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 25}], "config": {"lanes": 1, "fontsize": 10, "vspace": 200}}
+{"reg": [{"name": "BUS_INTEG_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "INIT_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ESCALATED", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SCR_KEY_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SCR_KEY_SEED_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "INIT_DONE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "READBACK_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "SRAM_ALERT", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 200}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                              |
 |:------:|:------:|:-------:|:--------------------------------------------------|
-|  31:7  |        |         | Reserved                                          |
+|  31:8  |        |         | Reserved                                          |
+|   7    |   ro   |   0x0   | [SRAM_ALERT](#status--sram_alert)                 |
 |   6    |   ro   |   0x0   | [READBACK_ERROR](#status--readback_error)         |
 |   5    |   ro   |   0x0   | [INIT_DONE](#status--init_done)                   |
 |   4    |   ro   |   0x0   | [SCR_KEY_SEED_VALID](#status--scr_key_seed_valid) |
@@ -54,6 +52,11 @@ SRAM status register.
 |   2    |   ro   |   0x0   | [ESCALATED](#status--escalated)                   |
 |   1    |   ro   |   0x0   | [INIT_ERROR](#status--init_error)                 |
 |   0    |   ro   |   0x0   | [BUS_INTEG_ERROR](#status--bus_integ_error)       |
+
+### STATUS . SRAM_ALERT
+This bit is set to 1 if a multi bit encoding error has been detected inside the RAM modules.
+This error triggers a fatal_error alert.
+This condition is terminal.
 
 ### STATUS . READBACK_ERROR
 This bit is set to 1 if a SRAM readback check failed.
@@ -250,4 +253,3 @@ A readback of each memory write or read request will be performed and a comparis
 Any other value than kMultiBitBool4False written to this field is interpreted as kMultiBitBool4True.
 
 This interface does not expose any registers.
-<!-- END CMDGEN -->

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_pkg.sv
@@ -25,6 +25,9 @@ package sram_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } sram_alert;
+    struct packed {
+      logic        q;
     } readback_error;
     struct packed {
       logic        q;
@@ -91,6 +94,10 @@ package sram_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } readback_error;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sram_alert;
   } sram_ctrl_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -100,8 +107,8 @@ package sram_ctrl_reg_pkg;
 
   // Register -> HW type for regs interface
   typedef struct packed {
-    sram_ctrl_reg2hw_alert_test_reg_t alert_test; // [19:18]
-    sram_ctrl_reg2hw_status_reg_t status; // [17:12]
+    sram_ctrl_reg2hw_alert_test_reg_t alert_test; // [20:19]
+    sram_ctrl_reg2hw_status_reg_t status; // [18:12]
     sram_ctrl_reg2hw_exec_reg_t exec; // [11:8]
     sram_ctrl_reg2hw_ctrl_reg_t ctrl; // [7:4]
     sram_ctrl_reg2hw_readback_reg_t readback; // [3:0]
@@ -109,7 +116,7 @@ package sram_ctrl_reg_pkg;
 
   // HW -> register type for regs interface
   typedef struct packed {
-    sram_ctrl_hw2reg_status_reg_t status; // [18:5]
+    sram_ctrl_hw2reg_status_reg_t status; // [20:5]
     sram_ctrl_hw2reg_scr_key_rotated_reg_t scr_key_rotated; // [4:0]
   } sram_ctrl_regs_hw2reg_t;
 

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -130,6 +130,7 @@ module sram_ctrl_regs_reg_top (
   logic status_scr_key_seed_valid_qs;
   logic status_init_done_qs;
   logic status_readback_error_qs;
+  logic status_sram_alert_qs;
   logic exec_regwen_we;
   logic exec_regwen_qs;
   logic exec_regwen_wd;
@@ -361,6 +362,33 @@ module sram_ctrl_regs_reg_top (
 
     // to register interface (read)
     .qs     (status_readback_error_qs)
+  );
+
+  //   F[sram_alert]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_status_sram_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.status.sram_alert.de),
+    .d      (hw2reg.status.sram_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.status.sram_alert.q),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (status_sram_alert_qs)
   );
 
 
@@ -699,6 +727,7 @@ module sram_ctrl_regs_reg_top (
         reg_rdata_next[4] = status_scr_key_seed_valid_qs;
         reg_rdata_next[5] = status_init_done_qs;
         reg_rdata_next[6] = status_readback_error_qs;
+        reg_rdata_next[7] = status_sram_alert_qs;
       end
 
       addr_hit[2]: begin

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -860,7 +860,8 @@ module usbdev
       .rdata_o    (mem_rdata),
       .rvalid_o   (mem_rvalid),
       .rerror_o   (mem_rerror),
-      .cfg_i      (ram_cfg_i)
+      .cfg_i      (ram_cfg_i),
+      .alert_o    ()
     );
   end : gen_no_stubbed_memory
 

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/ibex_dv.f
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/ibex_dv.f
@@ -33,6 +33,7 @@ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_hamming_39_32_dec.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_hamming_39_32_enc.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_hamming_72_64_dec.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_hamming_72_64_enc.sv
+${LOWRISC_IP_DIR}/ip/prim/rtl/prim_mubi_pkg.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_ram_1p_pkg.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_ram_1p_adv.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -69,7 +70,6 @@ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_72_64_dec.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_onehot_check.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_onehot_enc.sv
 ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_onehot_mux.sv
-${LOWRISC_IP_DIR}/ip/prim/rtl/prim_mubi_pkg.sv
 
 // ibex CORE RTL files
 +incdir+${PRJ_DIR}/rtl

--- a/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/tb/tb.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/tb/tb.sv
@@ -158,7 +158,8 @@ module tb #(
       .rvalid_o    (ram_if.ic_tag_rvalid[way]),
       .raddr_o     (),
       .rerror_o    (),
-      .cfg_i       ('0)
+      .cfg_i       ('0),
+      .alert_o     ()
     );
 
     // Data RAM instantiation
@@ -190,7 +191,8 @@ module tb #(
       .rvalid_o    (ram_if.ic_data_rvalid[way]),
       .raddr_o     (),
       .rerror_o    (),
-      .cfg_i       ('0)
+      .cfg_i       ('0),
+      .alert_o     ()
     );
   end
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -552,6 +552,9 @@ module ibex_top import ibex_pkg::*; #(
   // Rams Instantiation //
   ////////////////////////
 
+  logic [IC_NUM_WAYS-1:0] icache_tag_alert;
+  logic [IC_NUM_WAYS-1:0] icache_data_alert;
+
   if (ICache) begin : gen_rams
 
     for (genvar way = 0; way < IC_NUM_WAYS; way++) begin : gen_rams_inner
@@ -590,7 +593,9 @@ module ibex_top import ibex_pkg::*; #(
           .rerror_o         (),
           .cfg_i            (ram_cfg_i),
           .wr_collision_o   (),
-          .write_pending_o  ()
+          .write_pending_o  (),
+
+          .alert_o          (icache_tag_alert[way])
         );
 
         // Data RAM instantiation
@@ -625,7 +630,9 @@ module ibex_top import ibex_pkg::*; #(
           .rerror_o         (),
           .cfg_i            (ram_cfg_i),
           .wr_collision_o   (),
-          .write_pending_o  ()
+          .write_pending_o  (),
+
+          .alert_o          (icache_data_alert[way])
         );
 
         `ifdef INC_ASSERT
@@ -698,6 +705,8 @@ module ibex_top import ibex_pkg::*; #(
           .cfg_i       (ram_cfg_i)
         );
 
+        assign icache_tag_alert  = '{default:'b0};
+        assign icache_data_alert = '{default:'b0};
       end
     end
 
@@ -716,6 +725,8 @@ module ibex_top import ibex_pkg::*; #(
     assign ic_tag_rdata      = '{default:'b0};
     assign ic_data_rdata     = '{default:'b0};
 
+    assign icache_tag_alert  = '{default:'b0};
+    assign icache_data_alert = '{default:'b0};
   end
 
   assign data_wdata_o = data_wdata_core[31:0];
@@ -1086,9 +1097,15 @@ module ibex_top import ibex_pkg::*; #(
     assign unused_scan = scan_rst_ni;
   end
 
+  // Enable or disable iCache multi bit encoding checking error generation.
+  // If enabled and a MuBi encoding error is detected, raise a major alert.
+  logic icache_alert_major_internal;
+  assign icache_alert_major_internal = (|icache_tag_alert) | (|icache_data_alert);
+
   assign alert_major_internal_o = core_alert_major_internal |
                                   lockstep_alert_major_internal |
-                                  rf_alert_major_internal;
+                                  rf_alert_major_internal |
+                                  icache_alert_major_internal;
   assign alert_major_bus_o      = core_alert_major_bus | lockstep_alert_major_bus;
   assign alert_minor_o          = core_alert_minor | lockstep_alert_minor;
 

--- a/hw/vendor/patches/lowrisc_ibex/dv/0002-dv-Add-error-ports-to-ram.patch
+++ b/hw/vendor/patches/lowrisc_ibex/dv/0002-dv-Add-error-ports-to-ram.patch
@@ -1,0 +1,52 @@
+commit 5629ed59bba2e2cfe2dcc87d58e86d3d272fe39f
+Author: Pascal Nasahl <nasahlpa@lowrisc.org>
+Date:   Sun May 26 16:38:52 2024 +0000
+
+    [PATCH] [dv] Add alerts to RAMs
+    
+    Signed-off-by: Pascal Nasahl <nasahlpa@lowrisc.org>
+
+diff --git a/uvm/core_ibex/ibex_dv.f b/uvm/core_ibex/ibex_dv.f
+index 5bd9930375..07cd9f5571 100644
+--- a/uvm/core_ibex/ibex_dv.f
++++ b/uvm/core_ibex/ibex_dv.f
+@@ -33,6 +33,7 @@ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_hamming_39_32_dec.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_hamming_39_32_enc.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_hamming_72_64_dec.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_hamming_72_64_enc.sv
++${LOWRISC_IP_DIR}/ip/prim/rtl/prim_mubi_pkg.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_ram_1p_pkg.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_ram_1p_adv.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_ram_1p_scr.sv
+@@ -69,7 +70,6 @@ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_secded_72_64_dec.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_onehot_check.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_onehot_enc.sv
+ ${LOWRISC_IP_DIR}/ip/prim/rtl/prim_onehot_mux.sv
+-${LOWRISC_IP_DIR}/ip/prim/rtl/prim_mubi_pkg.sv
+ 
+ // ibex CORE RTL files
+ +incdir+${PRJ_DIR}/rtl
+diff --git a/uvm/icache/dv/tb/tb.sv b/uvm/icache/dv/tb/tb.sv
+index 9848cc8ec0..918b2003d7 100644
+--- a/uvm/icache/dv/tb/tb.sv
++++ b/uvm/icache/dv/tb/tb.sv
+@@ -158,7 +158,8 @@ module tb #(
+       .rvalid_o    (ram_if.ic_tag_rvalid[way]),
+       .raddr_o     (),
+       .rerror_o    (),
+-      .cfg_i       ('0)
++      .cfg_i       ('0),
++      .alert_o     ()
+     );
+ 
+     // Data RAM instantiation
+@@ -190,7 +191,8 @@ module tb #(
+       .rvalid_o    (ram_if.ic_data_rvalid[way]),
+       .raddr_o     (),
+       .rerror_o    (),
+-      .cfg_i       ('0)
++      .cfg_i       ('0),
++      .alert_o     ()
+     );
+   end
+ 

--- a/hw/vendor/patches/lowrisc_ibex/rtl/0002-rtl-Add-error-ports-to-ram.patch
+++ b/hw/vendor/patches/lowrisc_ibex/rtl/0002-rtl-Add-error-ports-to-ram.patch
@@ -1,0 +1,79 @@
+commit b44855f44fe5863898cc403d74f980123accd9c0
+Author: Pascal Nasahl <nasahlpa@lowrisc.org>
+Date:   Sun May 26 16:33:55 2024 +0000
+
+    [PATCH] [rtl] Add alerts to RAMs
+    
+    Signed-off-by: Pascal Nasahl <nasahlpa@lowrisc.org>
+
+diff --git a/ibex_top.sv b/ibex_top.sv
+index df1e607ac4..81e49633cb 100644
+--- a/ibex_top.sv
++++ b/ibex_top.sv
+@@ -552,6 +552,9 @@ module ibex_top import ibex_pkg::*; #(
+   // Rams Instantiation //
+   ////////////////////////
+ 
++  logic [IC_NUM_WAYS-1:0] icache_tag_alert;
++  logic [IC_NUM_WAYS-1:0] icache_data_alert;
++
+   if (ICache) begin : gen_rams
+ 
+     for (genvar way = 0; way < IC_NUM_WAYS; way++) begin : gen_rams_inner
+@@ -590,7 +593,9 @@ module ibex_top import ibex_pkg::*; #(
+           .rerror_o         (),
+           .cfg_i            (ram_cfg_i),
+           .wr_collision_o   (),
+-          .write_pending_o  ()
++          .write_pending_o  (),
++
++          .alert_o          (icache_tag_alert[way])
+         );
+ 
+         // Data RAM instantiation
+@@ -625,7 +630,9 @@ module ibex_top import ibex_pkg::*; #(
+           .rerror_o         (),
+           .cfg_i            (ram_cfg_i),
+           .wr_collision_o   (),
+-          .write_pending_o  ()
++          .write_pending_o  (),
++
++          .alert_o          (icache_data_alert[way])
+         );
+ 
+         `ifdef INC_ASSERT
+@@ -698,6 +705,8 @@ module ibex_top import ibex_pkg::*; #(
+           .cfg_i       (ram_cfg_i)
+         );
+ 
++        assign icache_tag_alert  = '{default:'b0};
++        assign icache_data_alert = '{default:'b0};
+       end
+     end
+ 
+@@ -716,6 +725,8 @@ module ibex_top import ibex_pkg::*; #(
+     assign ic_tag_rdata      = '{default:'b0};
+     assign ic_data_rdata     = '{default:'b0};
+ 
++    assign icache_tag_alert  = '{default:'b0};
++    assign icache_data_alert = '{default:'b0};
+   end
+ 
+   assign data_wdata_o = data_wdata_core[31:0];
+@@ -1086,9 +1097,15 @@ module ibex_top import ibex_pkg::*; #(
+     assign unused_scan = scan_rst_ni;
+   end
+ 
++  // Enable or disable iCache multi bit encoding checking error generation.
++  // If enabled and a MuBi encoding error is detected, raise a major alert.
++  logic icache_alert_major_internal;
++  assign icache_alert_major_internal = (|icache_tag_alert) | (|icache_data_alert);
++
+   assign alert_major_internal_o = core_alert_major_internal |
+                                   lockstep_alert_major_internal |
+-                                  rf_alert_major_internal;
++                                  rf_alert_major_internal |
++                                  icache_alert_major_internal;
+   assign alert_major_bus_o      = core_alert_major_bus | lockstep_alert_major_bus;
+   assign alert_minor_o          = core_alert_minor | lockstep_alert_minor;
+ 


### PR DESCRIPTION
This commit encodes all flopped 1-bit control signals into multi bit signals in the `prim_ram_1p_scr` and `prim_ram_1p_adv` module. When an encoding error is detected, a major alert is triggered within Ibex.