### PR TITLE
[test] Fix keymgr_sideload test cases.

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -231,6 +231,7 @@ cc_library(
     deps = [
         "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:boot_stage",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:keymgr",

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -116,6 +116,23 @@ status_t keymgr_testutils_flash_init(
     const keymgr_testutils_secret_t *owner_secret);
 
 /**
+ * Initializes the key manager and its dependencies for testing.
+ *
+ * This function initializes the key manager and its dependencies for testing.
+ *
+ * This fuction will call `keymgr_testutils_try_startup()` if the boot stage is
+ * `kBootStageOwner`; otherwise, it will call `keymgr_testutils_startup()`.
+ * Additional checks are performed to ensure that the key manager is in a valid
+ * state, and ready to perform key derivations.
+ *
+ * @param keymgr A key manager handle, may be uninitialized.
+ * @param kmac A KMAC handle, may be uninitialized.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t keymgr_testutils_initialize(dif_keymgr_t *keymgr, dif_kmac_t *kmac);
+
+/**
  * Wrapper function to `keymgr_testutils_startup()`.
  *
  * This function checks the state of the key manager before attempting to

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1985,17 +1985,13 @@ opentitan_test(
 opentitan_test(
     name = "keymgr_sideload_kmac_test",
     srcs = ["keymgr_sideload_kmac_test.c"],
-    broken = cw310_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
-            # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         },
     ),
-    silicon = silicon_params(tags = ["broken"]),
     verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/ip/keymgr/data:keymgr_regs",
@@ -2017,16 +2013,12 @@ opentitan_test(
     name = "keymgr_sideload_otbn_test",
     srcs = ["keymgr_sideload_otbn_test.c"],
     exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
-            "//hw/top_earlgrey:sim_verilator": None,
         },
     ),
-    silicon = silicon_params(tags = ["broken"]),
     verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/ip/otbn/data:otbn_regs",

--- a/sw/device/tests/keymgr_sideload_otbn_test.c
+++ b/sw/device/tests/keymgr_sideload_otbn_test.c
@@ -62,6 +62,8 @@ static const dif_otbn_err_bits_t kErrBitsOk = 0x0;
  */
 static void run_x25519_app(dif_otbn_t *otbn, uint32_t *result,
                            dif_otbn_err_bits_t expect_err_bits) {
+  CHECK_DIF_OK(dif_otbn_set_ctrl_software_errs_fatal(otbn, /*enable=*/false));
+
   // Copy the input argument (Montgomery u-coordinate).
   CHECK_STATUS_OK(otbn_testutils_write_data(otbn, sizeof(kEncodedU), &kEncodedU,
                                             kOtbnVarEncU));


### PR DESCRIPTION
This change fixes the following tests:

- keymgr_sideload_kmac_test
- keymgr_sideload_otbn_test
    
It also refactors the following test to reuse common keymgr infrastructure:

- keymgr_sideload_aes_test