### PR TITLE
[dv,usbdev] Max traffic, streaming and randomized bus stimuli

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -16,10 +16,13 @@ package usb20_agent_pkg;
 
   // USB-level events; the DP/DN wires are used for transmitting packet data but also held for
   // extended intervals to signal specific bus-level events.
-  //
-  // (DP low, DN low = Bus Reset; DP low, DN high = Resume Signaling; VBUS low when Disconnected,
-  //  and VBUS high when Connected to Host).
-  typedef enum bit [2:0] {EvBusReset, EvResume, EvConnect, EvDisconnect, EvPacket} ev_type_e;
+  typedef enum bit [2:0] {
+      EvBusReset,   // DP low, DN low.
+      EvSuspend,    // Idle for > 3ms.
+      EvResume,     // DP low, DN high.
+      EvDisconnect, // VBUS low when disconnected.
+      EvConnect,    // VBUS high after connection.
+      EvPacket} ev_type_e;
   // Packet Types
   typedef enum bit [2:0] {PktTypeSoF, PktTypeToken, PktTypeData, PktTypeHandshake} pkt_type_e;
   // Packet IDentifiers; the 4 LSBs identify the Packet type, and are reflected in inverted

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -44,7 +44,7 @@ class token_pkt extends usb20_item;
     crc5 = generate_crc5(address, endpoint);
   endfunction
 
-  function bit [4:0] generate_crc5(bit [6:0] address, bit [3:0] endpoint);
+  static function bit [4:0] generate_crc5(bit [6:0] address, bit [3:0] endpoint);
     bit [4:0] crc;
     bit [4:0] crc_reg;
     bit [10:0] data;
@@ -111,7 +111,7 @@ class data_pkt extends usb20_item;
     crc16 = generate_crc16(data);
   endfunction
 
-  function bit [15:0] generate_crc16(input byte unsigned data[]);
+  static function bit [15:0] generate_crc16(input byte unsigned data[]);
     bit [15:0] crc;
     bit [15:0] crc_reg;
     bit        as1;

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -3,7 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class usb20_item extends uvm_sequence_item;
+
+  // Bus-level events
   ev_type_e  m_ev_type;
+  // in microseconds, 0 = default (minimum specification-compliant delay).
+  int unsigned m_ev_duration_usecs;
+
   pid_type_e m_pid_type;
   pkt_type_e m_pkt_type;
   bmrequesttype_e m_bmRT;

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -704,7 +704,7 @@
               RX FIFO becoming full.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_streaming_out"]
     }
     {
       name: max_clock_error_untracked

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_bus_rand_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_bus_rand_vseq.sv
@@ -1,0 +1,138 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Issue randomized bus-level events (Bus Resets, Suspend-Resume Signaling and/or VBUS
+// disconnections)  during a streaming test. Note that when such a stimulus is produced we do not
+// really expect the current traffic to be unaffected, since the DUT would normally be reconfigured
+// by the USB host upon reconnection.
+//
+// Rather, the aim is to test the DUT does not get stuck in an irrecoverable state preventing
+// communications from being re-established. The host- and device-side code in
+// `usbdev_max_usb_traffic_vseq` is thus notified of Bus Resets event, so that it can adapt its
+// internal state according to the expect DUT changes. (eg. zeroing of device address and resetting
+// of data toggles.)
+
+class usbdev_bus_rand_vseq extends usbdev_max_usb_traffic_vseq;
+  `uvm_object_utils(usbdev_bus_rand_vseq)
+
+  `uvm_object_new
+
+  // Min/max duration of Resume Signaling, in microseconds.
+  //
+  // Note: We cannot shorten the duration of /Suspend/ Signaling (> 3ms) because this is fixed by
+  // the design of the RTL presently. The DUT will not enter a Suspended state until over 3ms of
+  // Idle state has been detected.
+  int unsigned min_resume_duration = 100;
+  int unsigned max_resume_duration = 1000;
+
+  // Min/max duration of Bus Resets, in microseconds.
+  int unsigned min_reset_duration = 10;
+  int unsigned max_reset_duration = 1000;
+
+  // Min/max duration of VBUS Disconnections, in microseconds.
+  int unsigned min_disconnect_duration = 10;
+  int unsigned max_disconnect_duration = 100;
+
+  // Generate a Bus Reset during streaming.
+  //
+  // Note: Bus Resets from a real host would be more than 10ms, but we typically employ a shorter
+  // delay to avoid wasting simulation time.
+  task generate_bus_reset();
+    int unsigned reset_duration_usecs;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(reset_duration_usecs,
+                                       reset_duration_usecs >= min_reset_duration;
+                                       reset_duration_usecs <= max_reset_duration;)
+    `uvm_info(`gfn, "Performing Bus Reset", UVM_MEDIUM)
+    send_bus_reset(reset_duration_usecs);
+  endtask
+
+  // Generate a VBUS Disconnection during streaming.
+  task generate_vbus_disconnect();
+    int unsigned disconn_duration_usecs;
+    int unsigned reset_duration_usecs;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(disconn_duration_usecs,
+                                       disconn_duration_usecs >= min_disconnect_duration;
+                                       disconn_duration_usecs <= max_disconnect_duration;)
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(reset_duration_usecs,
+                                       reset_duration_usecs >= min_reset_duration;
+                                       reset_duration_usecs <= max_reset_duration;)
+    `uvm_info(`gfn, $sformatf("Disconnecting VBUS for %d usecs and resetting for %d usecs",
+                              disconn_duration_usecs, reset_duration_usecs),
+              UVM_MEDIUM)
+    vbus_disconnect(disconn_duration_usecs, reset_duration_usecs);
+  endtask
+
+  // Generate Suspend-Resume Signaling during streaming.
+  //
+  // Note: Resume Signaling from a real host would be more than 20ms, but we employ a shorter
+  // delay to avoid wasting simulation time.
+  task generate_suspend_resume();
+    int unsigned resume_duration_usecs;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(resume_duration_usecs,
+                                       resume_duration_usecs >= min_resume_duration;
+                                       resume_duration_usecs <= max_resume_duration;)
+    suspend_resume(resume_duration_usecs);
+  endtask
+
+  // Parallel process that randomly generates bus events.
+  // - Suspend-Resume Signaling.
+  // - Bus Resets.
+  // - VBUS Disconnections.
+  task generate_bus_events();
+    // The set of events from which we may choose.
+    bit [2:0] event_mask = {do_resume_signaling, do_reset_signaling, do_vbus_disconnects};
+
+    // Report the bus events that we shall generate, and collect the min/max durations if specified
+    // in the test point.
+    if (do_resume_signaling) begin
+      `uvm_info(`gfn, "Performing Suspend-Resume Signaling during sequence", UVM_LOW)
+      void'($value$plusargs("min_resume_duration=%d", min_resume_duration));
+      void'($value$plusargs("max_resume_duration=%d", max_resume_duration));
+    end
+    if (do_reset_signaling) begin
+      `uvm_info(`gfn, "Performing Bus Resets during sequence", UVM_LOW)
+      void'($value$plusargs("min_reset_duration=%d", min_reset_duration));
+      void'($value$plusargs("max_reset_duration=%d", max_reset_duration));
+    end
+    if (do_vbus_disconnects) begin
+      `uvm_info(`gfn, "Performing VBUS Disconnections during sequence", UVM_LOW)
+      void'($value$plusargs("min_disconnect_duration=%d", min_disconnect_duration));
+      void'($value$plusargs("max_disconnect_duration=%d", max_disconnect_duration));
+    end
+
+    // Generate bus events randomly until asked to stop.
+    while (!traffic_stop) begin
+      bit [17:0] event_delay;
+      bit [2:0] event_type;
+      `DV_CHECK_STD_RANDOMIZE_FATAL(event_delay)
+      fork
+        begin : isolation_fork
+          fork
+            cfg.clk_rst_vif.wait_clks(event_delay);
+            wait (traffic_stop);
+          join_any
+          disable fork;
+        end : isolation_fork
+      join
+      // TODO: some kind of arbitration for equal priority would be beneficial here.
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(event_type, (event_type & event_mask) != 0;)
+      casez (event_type)
+        3'b1??:  generate_suspend_resume();
+        3'b01?:  generate_bus_reset();
+        default: generate_vbus_disconnect();
+      endcase
+    end
+  endtask
+
+  virtual task body;
+    // `usbdev_base_vseq` collects the overall bus-level configuration to be used.
+    `uvm_info(`gfn, $sformatf("do_resume_signaling %d", do_resume_signaling), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("do_reset_signaling  %d", do_reset_signaling),  UVM_LOW)
+    `uvm_info(`gfn, $sformatf("do_vbus_disconnects %d", do_vbus_disconnects), UVM_LOW)
+    fork
+      super.body();
+      generate_bus_events();
+    join
+  endtask
+endclass : usbdev_bus_rand_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
@@ -1,0 +1,459 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Configurable USB streaming test that sends OUT packets to a set of endpoints,
+// according to their configuration, and then retrieves those packets from the
+// corresponding IN endpoints, checking against the original data.
+
+// Note: In time this may extend from another sequence that introduces bus framing and models
+// the behavior/timing of real hosts, rather than just fully utilizing the bus.
+//
+// The code structure and naming has been written with this in mind, and the intention is that
+// some of these tasks would be migrated into the parent 'usbdev_usb_host_vseq.'
+class usbdev_max_usb_traffic_vseq extends usbdev_base_vseq;
+ `uvm_object_utils(usbdev_max_usb_traffic_vseq)
+
+  `uvm_object_new
+
+  // This is the total number of packets to be transferred, across all endpoints.
+  constraint num_trans_c { num_trans inside {[64:256]}; }
+
+  // Endpoint configuration.
+  //
+  // Decide upon the Endpoint Type of each endpoint:
+  // - Control Endpoints (accept SETUP packets).
+  // - Isochronous Endpoints (no handshaking).
+  // - Bulk/Interrupt Endpoints; reliable byte stream with
+  //   Data Toggle Synchronization and retrying.
+  rand bit [NEndpoints-1:0] ep_in_enabled;
+  rand bit [NEndpoints-1:0] ep_out_enabled;
+  rand bit [NEndpoints-1:0] ep_setup_enabled;
+  rand bit [NEndpoints-1:0] ep_iso_enabled;
+
+  // Ensure that the test can do something.
+  constraint in_and_out_c {
+    // OUT data is returned as IN data on the same endpoint.
+    (ep_in_enabled & ep_out_enabled) != 0;
+  };
+
+  // Ensure that all streams are bidirectional; no OUT endpoints without corresponding IN endpoints
+  // and vice-versa.
+  constraint bidir_only_c {
+    ep_in_enabled == ep_out_enabled;
+  };
+
+  constraint ep_iso_enabled_c {
+    ep_iso_enabled == 0;
+  };
+
+  // Bitmap of available buffers that are not presently assigned to the DUT.
+  bit [NumBuffers-1:0] buf_avail;
+
+  // We need to track the OUT side Data Toggle(s) otherwise packets will be rejected.
+  bit [NEndpoints-1:0] exp_out_toggle;
+
+  // We track the IN side Data Toggle(s) just to check that the DUT transmissions.
+  bit [NEndpoints-1:0] exp_in_toggle;
+
+  // Number of packets to be transferred per stream.
+  uint packet_count;
+
+  // Number of packets sent to each OUT endpoint.
+  uint packets_sent[NEndpoints];
+  // Number of packets received from each IN endpoint.
+  uint packets_received[NEndpoints];
+
+  // In-flight packets to each of the endpoints.
+  data_pkt packets_in_flight[NEndpoints][$];
+
+  // Number of active streams.
+  uint stream_count;
+
+  // Completion indicator for each stream (= pair of endpoints).
+  bit [NEndpoints-1:0] stream_completed;
+
+  // Stop the traffic test?
+  bit traffic_stop = 0;
+
+  // All traffic transferred successfully?
+  bit traffic_completed = 0;
+
+  event device_ready;
+
+  // ------------------------------------ Host side of test --------------------------------------
+
+  // Set up the host-side state.
+  task host_setup();
+    // Ensure all packet buffer expectations are defined but empty.
+    for (int unsigned ep = 0; ep < NEndpoints; ep++) begin
+      packets_in_flight[ep].delete();
+      packets_received[ep] = 0;
+    end
+    // TODO: we should ideally detect this over the USB itself with changes to the usb20_driver
+    //       to test the state of the pull ups.
+    wait (device_ready.triggered);
+  endtask
+
+  // Attempt to collect an IN packet from the given endpoint.
+  task host_collect_in_packet(bit [3:0] ep);
+    usb20_item response;
+    `uvm_info(`gfn, $sformatf("Requesting IN packet from EP%d", ep), UVM_HIGH)
+    claim_driver();
+    // TODO: base tasks still need parameterising for endpoint number.
+    endp = ep;
+    // Send IN token packet
+    call_token_seq(PidTypeInToken);
+    get_response(m_response_item);
+    $cast(response, m_response_item);
+    case (response.m_pid_type)
+      // DATA packet in response.
+      PidTypeData0, PidTypeData1: begin
+        // Received a packet; check it against expectations.
+        data_pkt exp_data;
+        data_pkt in_data;
+        $cast(in_data, response);
+        `DV_CHECK(packets_in_flight[ep].size() > 0)
+        exp_data = packets_in_flight[ep].pop_front();
+        check_tx_packet(in_data, exp_in_toggle[ep] ? PidTypeData1 : PidTypeData0, exp_data.data);
+        response_delay();
+        if (!ep_iso_enabled[ep]) begin
+          // Since we're acknowledging successful receipt, we flip our toggle.
+          exp_in_toggle[ep] ^= 1'b1;
+          call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+        end
+        // Update the count of received packets.
+        packets_received[ep] = packets_received[ep] + 1;
+        if (packets_received[ep] >= packet_count) stream_completed[ep] = 1'b1;
+      end
+      // Nothing available, try again later.
+      PidTypeNak: begin
+      end
+      default: `uvm_fatal(`gfn, $sformatf("Unexpected response 0x%0x from DUT",
+                          response.m_pid_type))
+    endcase
+    release_driver();
+  endtask
+
+  // Send a pseudo-random packet to the given endpoint number.
+  task host_send_out_packet(bit [3:0] ep, bit is_setup);
+    `uvm_info(`gfn, $sformatf("Sending OUT packet to EP%d", ep), UVM_HIGH)
+    claim_driver();
+    if (is_setup) begin
+      send_prnd_setup_packet(ep);
+      // Sending a SETUP packet clears the data toggle.
+      exp_out_toggle[ep] = 1'b0;
+    end else begin
+      // Choose the packet length and content pseudo-randomly.
+      send_prnd_out_packet(ep, exp_out_toggle[ep] ? PidTypeData1 : PidTypeData0,
+                           1'b1, 0, ep_iso_enabled[ep]);
+      inter_packet_delay();
+    end
+    // Check that the packet was accepted (ACKnowledged) by the USB device.
+    // An Isochronous endpoint returns no handshake and no data toggle bit, so do not wait.
+    if (!ep_iso_enabled[ep]) begin
+      usb20_item response;
+      get_response(m_response_item);
+      $cast(response, m_response_item);
+      `DV_CHECK_EQ(response.m_pkt_type, PktTypeHandshake);
+      `DV_CHECK_EQ(response.m_pid_type, PidTypeAck);
+      // Packet successfully received and ACKnowledged; flip the data toggle.
+      exp_out_toggle[ep] ^= 1'b1;
+    end
+    release_driver();
+    // Remember the packet for subsequent checking.
+    packets_in_flight[ep].push_back(m_data_pkt);
+    // Update the count of transmitted packets.
+    packets_sent[ep] = packets_sent[ep] + 1;
+  endtask
+
+  // Update state to reflect the fact that a Bus Reset has been sent to the DUT.
+  virtual task host_side_handle_bus_reset();
+    // Bus Reset clears all data toggle bits within the DUT.
+    exp_out_toggle = {NEndpoints{1'b0}};
+    exp_in_toggle = {NEndpoints{1'b0}};
+  endtask
+
+  // Host controller.
+  task host_side;
+    // Round-robin servicing of IN and OUT endpoints.
+    uint ep_out = 0;
+    uint ep_in = 0;
+
+    host_setup();
+    do begin
+      // Remember the current endpoints numbers.
+      uint prev_out = ep_out;
+      uint prev_in = ep_in;
+      pid_type_e pid_out;
+
+      // Attempt to collect an IN packet.
+      do begin
+        ep_in++;
+        if (ep_in >= NEndpoints) ep_in = 0;
+      end while (ep_in != prev_in && (!ep_in_enabled[ep_in] || stream_completed[ep_in]));
+      if (ep_in_enabled[ep_in] && !stream_completed[ep_in]) begin
+        host_collect_in_packet(ep_in);
+      end
+
+      // Attempt to transmit an OUT packet.
+      do begin
+        ep_out++;
+        if (ep_out >= NEndpoints) ep_out = 0;
+      end while (ep_out != prev_out && (!ep_out_enabled[ep_out] || stream_completed[ep_out]));
+      if (ep_out_enabled[ep_out] && !stream_completed[ep_out]) begin
+        // Are we permitted to send another OUT packet?
+        // - Isochronous streams continue transmitting until we have received the required
+        //   number of IN packets, since packets may be lost in either direction.
+        if (packets_sent[ep_out] < packet_count || ep_iso_enabled[ep_out]) begin
+          host_send_out_packet(ep_out, pid_out);
+        end
+      end
+
+      traffic_completed = &{stream_completed | ~ep_in_enabled | ~ep_out_enabled};
+    end while (!traffic_completed);
+
+    // Stop all other processes, we've finished.
+    traffic_stop = 1;
+  endtask
+
+  // ----------------------------------- Device side of test -------------------------------------
+
+  // Attempt to supply the specified packet buffer to the DUT for reception.
+  task device_buf_supply(uint buf_num, output bit supplied);
+    uvm_reg_data_t usbstat;
+    `uvm_info(`gfn, $sformatf("Supplying buffer %d for use", buf_num), UVM_HIGH)
+    // Fill the SETUP Buffer FIFO first; this is smaller and more important than the
+    // FIFO for regular OUT buffers.
+    csr_rd(.ptr(ral.usbstat), .value(usbstat));
+    `uvm_info(`gfn, $sformatf(" - usbstat 0x%x", usbstat), UVM_HIGH)
+    if (get_field_val(ral.usbstat.av_setup_full, usbstat)) begin
+      if (get_field_val(ral.usbstat.av_out_full, usbstat)) begin
+        supplied = 1'b0;
+      end else begin
+        csr_wr(.ptr(ral.avoutbuffer), .value(buf_num));
+        supplied = 1'b1;
+      end
+    end else begin
+      csr_wr(.ptr(ral.avsetupbuffer), .value(buf_num));
+      supplied = 1'b1;
+    end
+    // Update the set of buffers that are available for later use, having not been supplied to
+    // the DUT.
+    buf_avail[buf_num] = !supplied;
+    `uvm_info(`gfn, $sformatf("usbstat was 0x%0x and supplied is %d", usbstat, supplied),
+              UVM_HIGH)
+  endtask
+
+  // Keep the 'Available Buffer' FIFOs topped up; we want to keep the traffic streaming,
+  // so there must always be buffers available to the DUT for packet reception.
+  task device_refill_fifos();
+    bit supplied = 1'b1;
+    // Keep going until we run out of space or buffers.
+    while (supplied && buf_avail) begin
+      uint buf_num = 0;
+      while (buf_num < NumBuffers && !buf_avail[buf_num]) buf_num++;
+      `DV_CHECK_FATAL(buf_num < NumBuffers)
+      device_buf_supply(buf_num, supplied);
+    end
+  endtask
+
+  task device_setup;
+    // Populate the 'Available Buffer' FIFOs.
+    uint buf_num = 0;
+    for (uint buf_num = 0; buf_num < NumBuffers; buf_num++) begin
+      bit supplied;
+      device_buf_supply(buf_num, supplied);
+    end
+    // Configure the endpoints; this should strictly be done on the device side really.
+    csr_wr(.ptr(ral.ep_out_enable[0]),  .value(ep_out_enabled));
+    csr_wr(.ptr(ral.ep_in_enable[0]),   .value(ep_in_enabled));
+    csr_wr(.ptr(ral.rxenable_out[0]),   .value(ep_out_enabled));
+    csr_wr(.ptr(ral.rxenable_setup[0]), .value(ep_setup_enabled));
+
+    ->device_ready;
+  endtask
+
+  // Retract the current packet from the given IN endpoint.
+  task device_retract_in_packet(bit [3:0] ep, uvm_reg_data_t configin);
+    bit supplied;
+    // Retraction of IN packet.
+    uint prev_buf = get_field_val(ral.configin[0].buffer, configin);
+    `uvm_info(`gfn, $sformatf("Retracting IN packet from endpoint %d, buffer %d", ep, prev_buf),
+              UVM_MEDIUM)
+    ral.configin[ep].rdy.set(1'b0);
+    csr_update(ral.configin[ep]);
+    // Read back to see whether the packet is being collected right now.
+    csr_rd(.ptr(ral.configin[ep]), .value(configin));
+    `DV_CHECK_EQ(get_field_val(ral.configin[ep].buffer, configin), prev_buf)
+    if (get_field_val(ral.configin[ep].sending, configin)) begin
+      // The IN packet is presently being collected; since the packet size is limited to 64 bytes,
+      // there is an upper bound on how long the transmission can take. With 4x oversampling, and
+      // bit stuffing it's around 'hA30 clock cycles, but difficult to calculate exactly; we just
+      // need to ensure that we wait long enough...
+      uvm_reg_data_t in_sent;
+      for (int unsigned clks = 0; clks < 'hC00; clks++) begin
+        csr_rd(.ptr(ral.configin[ep]), .value(configin));
+        if (!get_field_val(ral.configin[ep].sending, configin)) break;
+      end
+      // The packet will have been either accepted or deferred.
+      csr_rd(.ptr(ral.in_sent[0]), .value(in_sent));
+      `DV_CHECK_FATAL(get_field_val(ral.configin[ep].pend, configin) || in_sent[ep])
+      // Clear the 'pending' indicator and the 'sent' status.
+      ral.configin[ep].pend.set(1'b1);
+      csr_update(ral.configin[ep]);
+      csr_wr(.ptr(ral.in_sent[0]), .value(1 << ep));
+    end
+    device_buf_supply(prev_buf, supplied);
+  endtask
+
+  // Present the IN packet for collection.
+  task device_present_in_packet(bit [3:0] ep, uint buf_num, uint len);
+    uvm_reg_data_t configin;
+    `uvm_info(`gfn, $sformatf("EP %d presenting buf %d, %d byte(s)", ep, buf_num, len), UVM_HIGH)
+    // Clear the existing IN packet, if there is one (packet retraction).
+    csr_rd(.ptr(ral.configin[ep]), .value(configin));
+    if (get_field_val(ral.configin[0].rdy, configin)) begin
+      device_retract_in_packet(ep, configin);
+    end
+    // Validate the buffer properties before supplying them to the DUT.
+    `DV_CHECK_FATAL(len <= MaxPktSizeByte)
+    `DV_CHECK_FATAL(buf_num < NumBuffers)
+    ral.configin[ep].size.set(len);
+    ral.configin[ep].buffer.set(buf_num);
+    ral.configin[ep].rdy.set(1'b0);
+    csr_update(ral.configin[ep]);
+    // Now set the RDY bit
+    ral.configin[ep].rdy.set(1'b1);
+    csr_update(ral.configin[ep]);
+  endtask
+
+  // Device side response to a Bus Reset being issued.
+  virtual task device_side_handle_bus_reset();
+    // We must reinstate the device address following a bus reset.
+    csr_wr(.ptr(ral.usbctrl.device_address), .value(dev_addr));
+    // Endpoint configuration is retained within the DUT but any IN-side packets should have had
+    // their 'RDY' bit cleared.
+    // Since the host-side code does not know whether an OUT packet has been presented for
+    // collection or is still sitting in the RX FIFO, for simplicity we just re-present pending IN
+    // packets.
+    for (int unsigned ep = 0; ep < NEndpoints; ep++) begin
+      uvm_reg_data_t configin;
+      csr_rd(.ptr(ral.configin[ep]), .value(configin));
+      if (get_field_val(ral.configin[ep].pend, configin)) begin
+        // Clear both the 'pend' and 'rdy' bits.
+        ral.configin[ep].pend.set(1'b1);
+        ral.configin[ep].rdy.set(1'b0);
+        csr_update(ral.configin[ep]);
+        // Present the packet again by setting the 'rdy' bit.
+        ral.configin[ep].rdy.set(1'b1);
+        csr_update(ral.configin[ep]);
+      end
+    end
+  endtask
+
+  // Device side, CSR access; this simple task just returns all received
+  // packets unmodified to the host for it to check.
+  task device_side;
+    device_setup();
+
+    while (!traffic_stop) begin
+      uvm_reg_data_t in_sent;
+      uvm_reg_data_t usbstat;
+
+      // Return any buffers that are now available.
+      csr_rd(.ptr(ral.in_sent[0]), .value(in_sent));
+      if (in_sent) begin
+        csr_wr(.ptr(ral.in_sent[0]), .value(in_sent));
+        `uvm_info(`gfn, $sformatf("Read in_sent 0x%x", in_sent), UVM_HIGH)
+        for (uint ep = 0; ep < NEndpoints; ep++) begin
+          if (in_sent[ep]) begin
+            uvm_reg_data_t configin;
+            uint buf_num;
+            bit supplied;
+            csr_rd(.ptr(ral.configin[ep]), .value(configin));
+            `DV_CHECK_EQ(get_field_val(ral.configin[0].rdy, configin), 1'b0, "RDY bit is still set")
+            // Return this buffer.
+            buf_num = get_field_val(ral.configin[0].buffer, configin);
+            device_buf_supply(buf_num, supplied);
+          end
+        end
+      end
+
+      // Keep the 'Available Buffer' FIFOs topped up.
+      device_refill_fifos();
+
+      // Collect and return a received packet if there is one.
+      csr_rd(.ptr(ral.usbstat), .value(usbstat));
+      if (!get_field_val(ral.usbstat.rx_empty, usbstat)) begin
+        uvm_reg_data_t rxfifo;
+        csr_rd(.ptr(ral.rxfifo), .value(rxfifo));
+        `uvm_info(`gfn, $sformatf("Read RXFIFO 0x%x", rxfifo), UVM_HIGH)
+
+        // Note: in time we may want to modify the packets in some way, but for now we just
+        // echo them back and leave the host side to check them.
+
+        // Supply any processed packets for IN collection.
+        device_present_in_packet(get_field_val(ral.rxfifo.ep, rxfifo),
+                                 get_field_val(ral.rxfifo.buffer, rxfifo),
+                                 get_field_val(ral.rxfifo.size, rxfifo));
+      end
+    end
+  endtask
+
+  // Perform Suspend-Resume Signaling.
+  virtual task suspend_resume(int unsigned duration_usecs = 0);
+    claim_driver();
+    // Suspend Signaling.
+    super.send_suspend_signaling(); // Default duration.
+    // Resume Signaling.
+    super.send_resume_signaling(duration_usecs);
+    release_driver();
+  endtask
+
+  // Issue a Bus Reset to the DUT.
+  virtual task send_bus_reset(int unsigned duration_usecs = 0);
+    claim_driver();
+    super.send_bus_reset(duration_usecs);
+    // Both the USB host-side and the device-side code must be informed of bus resets, in order
+    // to update their states appropriately.
+    host_side_handle_bus_reset();
+    device_side_handle_bus_reset();
+    release_driver();
+  endtask
+
+  // Disconnect VBUS for the specified number of microseconds.
+  virtual task vbus_disconnect(int unsigned disconn_duration_usecs,
+                               int unsigned reset_duration_usecs = 0);
+    claim_driver();
+    set_vbus_state(1'b0);
+    // VBUS interruption
+    cfg.clk_rst_vif.wait_clks(disconn_duration_usecs * 48);
+    set_vbus_state(1'b1);
+    // On physical buses with real hosts there would be a much longer delay here to allow power
+    // supplies to stabilize and the device become ready to respond to the Bus Reset.
+    cfg.clk_rst_vif.wait_clks(128);
+    // Following VBUS connection we must perform a Bus Reset on the DUT.
+    super.send_bus_reset(reset_duration_usecs);
+    // Both the USB host-side and the device-side code must be informed of bus resets, in order
+    // to update their states appropriately.
+    host_side_handle_bus_reset();
+    device_side_handle_bus_reset();
+    release_driver();
+  endtask
+
+  virtual task body;
+    // Determine the number of streams and the packets/stream.
+    stream_count = $countones(ep_in_enabled & ep_out_enabled);
+    `DV_CHECK_NE(stream_count, 0)
+    packet_count = num_trans / stream_count;
+    `uvm_info(`gfn, $sformatf("Transferring %d packets for each of %d stream(s)", packet_count,
+                              stream_count), UVM_LOW)
+    // The test runs until all packets have been successfully received and checked by the host.
+    fork
+      host_side();
+      device_side();
+    join
+  endtask
+
+endclass : usbdev_max_usb_traffic_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_streaming_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_streaming_vseq.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_streaming_vseq extends usbdev_max_usb_traffic_vseq;
+  `uvm_object_utils(usbdev_streaming_vseq)
+
+  `uvm_object_new
+
+  // Ensure that a single endpoint pair (IN and OUT) is selected.
+  constraint single_endpoint_c {
+    ep_in_enabled != 0 && (ep_in_enabled & (ep_in_enabled - 1)) == 0;
+  };
+
+endclass : usbdev_streaming_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -20,6 +20,7 @@
 `include "usbdev_in_trans_vseq.sv"
 `include "usbdev_in_iso_vseq.sv"
 `include "usbdev_link_in_err_vseq.sv"
+`include "usbdev_max_usb_traffic_vseq.sv"
 `include "usbdev_nak_trans_vseq.sv"
 `include "usbdev_out_iso_vseq.sv"
 `include "usbdev_out_stall_vseq.sv"
@@ -41,9 +42,12 @@
 // These depend on usbdev_random_length_out_transaction, so need to come after it.
 `include "usbdev_max_length_out_transaction_vseq.sv"
 `include "usbdev_min_length_out_transaction_vseq.sv"
-// This must follow usbdev_in_trans
+// This must follow usbdev_in_trans_vseq.sv
 `include "usbdev_endpoint_access_vseq.sv"
-// This must follow usbdev_pkt_sent
+// This must follow usbdev_pkt_sent_vseq.sv
 `include "usbdev_link_suspend_vseq.sv"
-// This must follow usbdev_link_suspend
+// This must follow usbdev_link_suspend_vseq.sv
 `include "usbdev_aon_wake_vseq.sv"
+// These must follow usbdev_max_usb_traffic_vseq.sv
+`include "usbdev_bus_rand_vseq.sv"
+`include "usbdev_streaming_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/usbdev_vseq_list.sv: {is_include_file: true}
       - seq_lib/usbdev_base_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_bitstuff_err_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_bus_rand_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_common_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_aon_wake_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_data_toggle_restore_vseq.sv: {is_include_file: true}
@@ -47,8 +48,10 @@ filesets:
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_in_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_suspend_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_max_usb_traffic_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_streaming_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_rx_crc_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -120,6 +120,10 @@
       uvm_test_seq: usbdev_disconnected_vseq
     }
     {
+      name: usbdev_max_usb_traffic
+      uvm_test_seq: usbdev_max_usb_traffic_vseq
+    }
+    {
       name: usbdev_nak_trans
       uvm_test_seq: usbdev_nak_trans_vseq
     }
@@ -148,12 +152,45 @@
       uvm_test_seq: usbdev_pkt_sent_vseq
     }
     {
+      name: usbdev_rand_bus_disconnects
+      uvm_test_seq: usbdev_bus_rand_vseq
+      run_opts: ["+do_vbus_disconnects=1"]
+      // Long simulation times
+      reseed: 10
+    }
+    {
+      name: usbdev_rand_bus_resets
+      uvm_test_seq: usbdev_bus_rand_vseq
+      run_opts: ["+do_reset_signaling=1"]
+      // Long simulation times
+      reseed: 10
+    }
+    {
+      name: usbdev_rand_suspends
+      uvm_test_seq: usbdev_bus_rand_vseq
+      run_opts: ["+do_resume_signaling=1"]
+      // Long simulation times
+      reseed: 10
+    }
+    {
       name: usbdev_random_length_out_trans
       uvm_test_seq: usbdev_random_length_out_transaction_vseq
     }
     {
       name: usbdev_stall_trans
       uvm_test_seq: usbdev_stall_trans_vseq
+    }
+    {
+      name: usbdev_streaming_out
+      uvm_test_seq: usbdev_streaming_vseq
+    }
+    {
+      name: usbdev_stress_usb_traffic
+      // In time this shall become a separate sequence with additional fault injection traffic.
+      uvm_test_seq: usbdev_bus_rand_vseq
+      run_opts: ["+do_resume_signaling=1", "+do_reset_signaling=1", "+do_vbus_disconnects=1"],
+      // Very long simulation times
+      reseed: 5
     }
     {
       name: usbdev_rx_crc_err


### PR DESCRIPTION
This PR adds sequences to:
- check back-to-back streaming of packets to single/multiple endpoints (streaming_test)
- check operations under maximum USB utilization (max_usb_traffic)
- generate randomized bus stimuli such as Suspend-Resume Signaling, Bus Resets and VBUS Disconnects during traffic; to check that the DUT is recoverable.
- the PR also addresses some faults and inadequacies of the USB driver
  1. detect and check the SE0/EOP signaling, and additionally the Idle bit interval after the SE0 bits.
  2. prevent collision between reception of DUT traffic and transmission of host packets
  3. calculate and check the CRC16 on IN DATA packets
