### PR TITLE
[chip-test/sival] Optimize csrng_edn_concurrency test and run more seeds in nightlies

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1410,10 +1410,11 @@
       name: chip_sw_csrng_edn_concurrency
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:csrng_edn_concurrency_test:1:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
+      en_run_modes: ["sw_test_mode_test_rom", "fast_sim"]
       run_opts: ["+sw_test_timeout_ns=140_000_000", "+rng_srate_value_min=15",
                  "+rng_srate_value_max=20"]
       run_timeout_mins: 240
+      reseed: 10
     }
     {
       name: chip_sw_csrng_kat_test

--- a/sw/device/tests/csrng_edn_concurrency_test.c
+++ b/sw/device/tests/csrng_edn_concurrency_test.c
@@ -332,12 +332,14 @@ static void csrng_task(void *task_parameters) {
 }
 
 /**
- * Configures the entropy complex, starts both EDNs in auto mode and
- * instantiates the CSRNG SW instance.
+ * Generates a randomized entropy complex configuration and applies it to both
+ * EDNs and the CSRNG SW instance. The configuration of ENTROPY_SRC is left
+ * untouched to optimize test performance.
+ *
+ * Note that to generate the randomized configuration, the entropy complex needs
+ * to be configured in auto mode before calling this function.
  */
 static void entropy_config(void) {
-  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
-
   LOG_INFO("Generating EDN and CSRNG params");
   dif_edn_auto_params_t edn_params0 =
       edn_testutils_auto_params_build(false,
@@ -451,6 +453,7 @@ static void main_task(void *task_parameters) {
 
 bool test_main(void) {
   init_peripherals();
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
 
   // Initialize the test `execution_state` before launching the tasks.
   execution_state_update(kTestStateSetup);


### PR DESCRIPTION
This PR contains three more commits to optimize the `csrng_edn_concurrency` test to focus on the CSRNG and EDN interaction (and reducing wait times for ENTROPY_SRC during the test loop) and it increases the number of seeds we run in the nightlies as proposed #22753 .