### PR TITLE
[signing] Update offline signing demo.

### DIFF
--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -494,6 +494,9 @@ def _offline_fake_rsa_sign(ctx):
     rsa_key = key_from_dict(ctx.attr.rsa_key, "rsa_key")
     tool, _, _ = _signing_tool_info(ctx, ctx.attr.rsa_key, tc.tools.opentitantool)
     for file in ctx.files.srcs:
+        # Skip the presigning script.
+        if file.basename.endswith(".json"):
+            continue
         _, sig, _ = _local_sign(ctx, tool, file, None, rsa_key)
         outputs.append(sig)
     return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
@@ -518,6 +521,9 @@ def _offline_fake_ecdsa_sign(ctx):
     ecdsa_key = key_from_dict(ctx.attr.ecdsa_key, "ecdsa_key")
     tool, _, _ = _signing_tool_info(ctx, ctx.attr.ecdsa_key, tc.tools.opentitantool)
     for file in ctx.files.srcs:
+        # Skip the presigning script.
+        if file.basename.endswith(".json"):
+            continue
         sig, _, _ = _local_sign(ctx, tool, file, ecdsa_key, None)
         outputs.append(sig)
     return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]

--- a/signing/README.md
+++ b/signing/README.md
@@ -2,6 +2,8 @@
 
 ## Configuration of NitroKeys
 
+> The following configuration only works in the `earlgrey_es_sival` branch.
+
 NitroKeys are a personal security token used to hold the signing keys for
 TEST and DEV devices.  NitroKeys can be used to sign tests and binaries for
 devices in the TEST or DEV lifecycle states.
@@ -28,6 +30,8 @@ mode to 600.
 ```
 
 ## Signing with a token
+
+> The following configuration only works in the `earlgrey_es_sival` branch.
 
 Once a profile configuration is in place, you can build binaries signed by
 the keyset by telling bazel that you want to use a token.
@@ -184,7 +188,7 @@ instead of the real keys:
 
 ```console
 opentitantool \
-   rsa sign \
+   ecdsa sign \
    --input=<sha256 digest> \
    --output=<signed digest> \
    <private key file>
@@ -196,7 +200,7 @@ Normally, in this step, the signatures created in the signing ceremony
 would be copied into the target directory.
 
 ```console
-cp -f bazel-bin/signing/examples/*.sig signing/examples/signatures/
+cp -f bazel-bin/signing/examples/*sig signing/examples/signatures/
 ```
 
 ### Attach signatures producing final signed binaries

--- a/signing/examples/BUILD
+++ b/signing/examples/BUILD
@@ -4,7 +4,7 @@
 
 load(
     "//rules:signing.bzl",
-    "offline_fake_rsa_sign",
+    "offline_fake_ecdsa_sign",
     "offline_presigning_artifacts",
     "offline_signature_attach",
 )
@@ -14,31 +14,6 @@ package(default_visibility = ["//visibility:public"])
 
 offline_presigning_artifacts(
     name = "presigning",
-    testonly = True,
-    srcs = [
-        "//sw/device/examples/hello_world",
-    ],
-    manifest = "//sw/device/silicon_creator/rom_ext:manifest",
-    # To sign with real keys, replace the rsa_key with the label of a real
-    # key (e.g. //sw/device/silicon_creator/rom/keys/real/rsa:earlgrey_a0_test_0).
-    # This is left as a fake key so that the presigning artifacts will be
-    # appropriate for the `fake_sign` rule below.
-    rsa_key = {
-        "//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "fake_test_key_0",
-    },
-    tags = ["manual"],
-)
-
-pkg_tar(
-    name = "digests",
-    testonly = True,
-    srcs = [":presigning"],
-    mode = "0644",
-    tags = ["manual"],
-)
-
-offline_presigning_artifacts(
-    name = "presigning_ecdsa",
     testonly = True,
     srcs = [
         "//sw/device/examples/hello_world",
@@ -55,9 +30,9 @@ offline_presigning_artifacts(
 )
 
 pkg_tar(
-    name = "digests_ecdsa",
+    name = "digests",
     testonly = True,
-    srcs = [":presigning_ecdsa"],
+    srcs = [":presigning"],
     mode = "0644",
     tags = ["manual"],
 )
@@ -66,12 +41,12 @@ pkg_tar(
 # that would normally be created by the offline signing operation.
 # These signatures can be copied into the `signatures` directory and attached
 # to the binaries to test the offline signing flow without an HSM operation.
-offline_fake_rsa_sign(
+offline_fake_ecdsa_sign(
     name = "fake",
     testonly = True,
     srcs = [":presigning"],
-    rsa_key = {
-        "//sw/device/silicon_creator/rom/keys/fake/rsa:test_private_key_0": "fake_test_key_0",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256": "fake_test_key_0",
     },
     tags = ["manual"],
 )
@@ -82,8 +57,8 @@ offline_signature_attach(
     srcs = [
         ":presigning",
     ],
-    rsa_signatures = [
-        "//signing/examples/signatures:rsa_signatures",
+    ecdsa_signatures = [
+        "//signing/examples/signatures:ecdsa_signatures",
     ],
     tags = ["manual"],
 )

--- a/signing/examples/signatures/BUILD
+++ b/signing/examples/signatures/BUILD
@@ -5,8 +5,8 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "rsa_signatures",
-    srcs = glob(["*.rsa_sig"]),
+    name = "ecdsa_signatures",
+    srcs = glob(["*.ecdsa_sig"]),
 )
 
 filegroup(


### PR DESCRIPTION
Update the offline signing demo to work with ECDSA keys. Update the documentation to note that RSA signing examples only work with in the `earlgrey_es_sival` branch.