### PR TITLE
[host] Switch SPHINCS+ lib to use our own bindgen library.

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -283,6 +283,7 @@ rust_library(
     deps = [
         "//hw/top_earlgrey/sw/autogen/chip:top_earlgrey",
         "//sw/host/opentitanlib/bindgen",
+        "//sw/host/sphincsplus",
         "@crate_index//:anyhow",
         "@crate_index//:arrayvec",
         "@crate_index//:bitflags",
@@ -312,8 +313,6 @@ rust_library(
         "@crate_index//:once_cell",
         "@crate_index//:p256",
         "@crate_index//:pem-rfc7468",
-        "@crate_index//:pqcrypto-sphincsplus",
-        "@crate_index//:pqcrypto-traits",
         "@crate_index//:rand",
         "@crate_index//:regex",
         "@crate_index//:rsa",

--- a/sw/host/opentitanlib/src/image/manifest_ext.rs
+++ b/sw/host/opentitanlib/src/image/manifest_ext.rs
@@ -134,7 +134,7 @@ impl ManifestExtEntry {
                     name: MANIFEST_EXT_NAME_SPX_SIGNATURE,
                 },
                 signature: SigverifySpxSignature {
-                    data: le_bytes_to_word_arr(&signature.0.to_le_bytes())?,
+                    data: le_bytes_to_word_arr(signature.sig_as_bytes())?,
                 },
             },
         )))

--- a/sw/host/opentitantool/src/command/spx.rs
+++ b/sw/host/opentitantool/src/command/spx.rs
@@ -82,9 +82,11 @@ pub enum SpxKeySubcommands {
     Generate(SpxKeyGenerateCommand),
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, Annotate)]
 pub struct SpxSignResult {
-    pub signature: String,
+    #[serde(with = "serde_bytes")]
+    #[annotate(format = hexstr)]
+    pub signature: Vec<u8>,
 }
 
 #[derive(Debug, Args)]
@@ -92,7 +94,7 @@ pub struct SpxSignCommand {
     /// The filename for the message to sign.
     message: PathBuf,
 
-    /// The file contianing SPHICS+ keypair.
+    /// The file containing the SPHINCS+ keypair.
     #[arg(value_name = "KEY_FILE")]
     keypair: PathBuf,
     /// The filename to write the signature to.
@@ -113,9 +115,9 @@ impl CommandDispatch for SpxSignCommand {
             signature.write_to_file(output)?;
             return Ok(None);
         }
-        Ok(Some(Box::new(SpxSignResult {
-            signature: signature.to_string(),
-        })))
+        let mut sig = Vec::new();
+        signature.to_writer(&mut sig)?;
+        Ok(Some(Box::new(SpxSignResult { signature: sig })))
     }
 }
 

--- a/sw/host/sphincsplus/lib.rs
+++ b/sw/host/sphincsplus/lib.rs
@@ -41,6 +41,62 @@ pub enum SpxError {
     BadSignature,
 }
 
+impl SpxPublicKey {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl TryFrom<[u8; SPX_PUBLIC_KEY_BYTES]> for SpxPublicKey {
+    type Error = SpxError;
+    #[inline]
+    fn try_from(buf: [u8; SPX_PUBLIC_KEY_BYTES]) -> Result<Self, SpxError> {
+        Ok(SpxPublicKey(buf))
+    }
+}
+
+impl SpxSecretKey {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl TryFrom<[u8; SPX_SECRET_KEY_BYTES]> for SpxSecretKey {
+    type Error = SpxError;
+    #[inline]
+    fn try_from(buf: [u8; SPX_SECRET_KEY_BYTES]) -> Result<Self, SpxError> {
+        Ok(SpxSecretKey(buf))
+    }
+}
+
+impl SpxSignature {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl TryFrom<[u8; SPX_SIGNATURE_BYTES]> for SpxSignature {
+    type Error = SpxError;
+    #[inline]
+    fn try_from(buf: [u8; SPX_SIGNATURE_BYTES]) -> Result<Self, SpxError> {
+        Ok(SpxSignature(buf))
+    }
+}
+
+impl SpxSeed {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl TryFrom<[u8; SPX_SEED_BYTES]> for SpxSeed {
+    type Error = SpxError;
+    #[inline]
+    fn try_from(buf: [u8; SPX_SEED_BYTES]) -> Result<Self, SpxError> {
+        Ok(SpxSeed(buf))
+    }
+}
+
 // Generate a new keypair from a seed.
 pub fn spx_keypair_from_seed(seed: &SpxSeed) -> Result<(SpxPublicKey, SpxSecretKey), SpxError> {
     let mut pk = [0u8; SPX_PUBLIC_KEY_BYTES];
@@ -68,7 +124,7 @@ pub fn spx_keypair_generate() -> Result<(SpxPublicKey, SpxSecretKey), SpxError> 
 }
 
 // Generate a detached signature for the message using the secret key.
-pub fn spx_sign(sk: &SpxSecretKey, msg: &Vec<u8>) -> Result<SpxSignature, SpxError> {
+pub fn spx_sign(sk: &SpxSecretKey, msg: &[u8]) -> Result<SpxSignature, SpxError> {
     let mut sig = [0u8; SPX_SIGNATURE_BYTES];
     let mut sig_bytes_written = 0;
     let err_code =
@@ -96,7 +152,7 @@ pub fn spx_sign(sk: &SpxSecretKey, msg: &Vec<u8>) -> Result<SpxSignature, SpxErr
 }
 
 // Verify a detached signature and return true if the signature is valid.
-pub fn spx_verify(pk: &SpxPublicKey, sig: &SpxSignature, msg: &Vec<u8>) -> Result<(), SpxError> {
+pub fn spx_verify(pk: &SpxPublicKey, sig: &SpxSignature, msg: &[u8]) -> Result<(), SpxError> {
     let err_code =
         // SAFETY: the signature and public key buffers here are fixed-length arrays of the size
         // expected by the C code, and the message buffer is passed along with its length.
@@ -153,7 +209,7 @@ mod test {
     fn sign_verify_test() {
         // Check that a generated signature passes verification.
         let (pk, sk) = spx_keypair_generate().unwrap();
-        let msg: Vec<u8> = vec![255u8; 100];
+        let msg = [255u8; 100];
         let mut sig = spx_sign(&sk, &msg).unwrap();
         assert!(spx_verify(&pk, &sig, &msg).is_ok());
 


### PR DESCRIPTION
Instead of using the pqcrypto crate to indirectly access the reference implementation, we now directly invoke our own bindings for the reference implementation. After this commit, the `pqcrypto` crate dependency can be safely removed.

We may need to combine this with https://github.com/lowRISC/opentitan/pull/22953 to get the host and device-side code to match up, since I believe the bindgen library we're switching to here already includes the endianness change. But I thought it would be easier to review as a separate PR; I'll cherry-pick the commit into #22953 if needed.