### PR TITLE
[hmac,dv] Minor fixes for HMAC block-level DV

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -28,6 +28,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
   rand bit [5:0]          key_length;
   rand bit                endian_swap;
   rand bit                digest_swap;
+  rand bit                key_swap;
 
   constraint wr_addr_c {
     wr_addr inside {[HMAC_MSG_FIFO_BASE : HMAC_MSG_FIFO_LAST_ADDR]};
@@ -90,6 +91,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
                          bit hmac_en            = 1'b1,
                          bit endian_swap        = 1'b1,
                          bit digest_swap        = 1'b1,
+                         bit key_swap           = 1'b0,
                          bit [3:0] digest_size  = 4'b0001, // SHA-256
                          bit [5:0] key_length   = 6'b00_0010, // 256-bit key
                          bit intr_fifo_empty_en = 1'b1,
@@ -102,6 +104,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     ral.cfg.hmac_en.set(hmac_en);
     ral.cfg.endian_swap.set(endian_swap);
     ral.cfg.digest_swap.set(digest_swap);
+    ral.cfg.key_swap.set(key_swap);
     ral.cfg.digest_size.set(digest_size);
     ral.cfg.key_length.set(key_length);
     csr_update(.csr(ral.cfg));

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -85,8 +85,9 @@ class hmac_smoke_vseq extends hmac_base_vseq;
                 .intr_fifo_empty_en(intr_fifo_empty_en),
                 .intr_hmac_done_en(intr_hmac_done_en), .intr_hmac_err_en(intr_hmac_err_en));
 
-      // can randomly read previous digest
-      if (i != 1 && $urandom_range(0, 1)) rd_digest();
+      // always start off the transaction by reading previous digest to clear
+      // cfg.wipe_secret_triggered flag and update the exp digest val in scb with last digest
+      rd_digest();
 
       if (do_wipe_secret == WipeSecretBeforeKey) begin
         `uvm_info(`gfn, $sformatf("wiping before key"), UVM_HIGH)

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_test_vectors_sha_vseq.sv
@@ -65,7 +65,7 @@ class hmac_test_vectors_sha_vseq extends hmac_base_vseq;
         bit [TL_DW-1:0] intr_state_val;
         `uvm_info(`gfn, $sformatf("vector[%0d]: %0p", j, parsed_vectors[j]), UVM_LOW)
         // wr init: SHA256 only. HMAC, endian swap, digest swap all disabled.
-        hmac_init(.hmac_en(hmac_en), .endian_swap(1'b1), .digest_swap(1'b0),
+        hmac_init(.hmac_en(hmac_en), .endian_swap(1'b1), .digest_swap(1'b0), .key_swap(1'b0),
                   .digest_size(digest_size), .key_length(key_length));
 
         `uvm_info(`gfn, $sformatf("digest size=%4b, key length=%6b",
@@ -74,6 +74,10 @@ class hmac_test_vectors_sha_vseq extends hmac_base_vseq;
         `uvm_info(`gtn, $sformatf("%s, starting seq %0d, msg size = %0d",
                                   vector_list[i], j, parsed_vectors[j].msg_length_byte),
                                   UVM_LOW)
+
+        // always start off the transaction by reading previous digest to clear
+        // cfg.wipe_secret_triggered flag and update the exp digest val in scb with last digest
+        rd_digest();
 
         if ($urandom_range(0, 1) && !hmac_en) begin
           `DV_CHECK_RANDOMIZE_FATAL(this) // only key is randomized


### PR DESCRIPTION
This fixes failing HMAC block-level tests for all digest sizes. With this PR, all block-level tests should pass for HMAC, except the V3 `hmac_stress_all_with_rand_reset`.