### PR TITLE
[rom] Reject unaligned manifest extensions

### DIFF
--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -488,6 +488,13 @@ inline rom_error_t manifest_check(const manifest_t *manifest) {
     return kErrorManifestBadEntryPoint;
   }
 
+  // Manifest extension offset must be word aligned.
+  for (size_t i = 0; i < CHIP_MANIFEST_EXT_TABLE_ENTRY_COUNT; ++i) {
+    if ((manifest->extensions.entries[i].offset & 0x3) != 0) {
+      return kErrorManifestBadExtension;
+    }
+  }
+
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/lib/manifest_unittest.cc
+++ b/sw/device/silicon_creator/lib/manifest_unittest.cc
@@ -79,6 +79,11 @@ TEST_F(ManifestTest, CodeRegionUnalignedEnd) {
   EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadCodeRegion);
 }
 
+TEST_F(ManifestTest, ExtensionOffsetUnaligned) {
+  manifest_.extensions.entries[1].offset = 1;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadExtension);
+}
+
 TEST_F(ManifestTest, EntryPointBeforeCodeStart) {
   manifest_.entry_point = manifest_.code_start - 1;
   EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadEntryPoint);


### PR DESCRIPTION
Fix #22923 to reject unaligned manifest extensions.

The `manifest_check` function will now return `kErrorManifestBadExtension` if the given manifest has an unaligned extension offset.