### PR TITLE
[rom] Assert size_t wrap-around with SIZE_MAX

### DIFF
--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -43,7 +43,7 @@ static void upsert_register(uint32_t addr, uint32_t value) {
     }
   }
   if (launder32(i) == last_index && launder32(i) < kSecMmioRegFileSize) {
-    HARDENED_CHECK_EQ((uint32_t)j, UINT32_MAX);
+    HARDENED_CHECK_EQ(j, SIZE_MAX);
     sec_mmio_ctx.addrs[i] = addr;
     sec_mmio_ctx.values[i] = value;
     ++sec_mmio_ctx.last_index;
@@ -64,7 +64,7 @@ void sec_mmio_init(void) {
     sec_mmio_ctx.values[i] = UINT32_MAX;
   }
   HARDENED_CHECK_EQ(i, kEntryCount);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
   uint32_t check = kSecMmioValZero ^ sec_mmio_ctx.last_index;
   check ^= sec_mmio_ctx.write_count;
   check ^= sec_mmio_ctx.check_count;
@@ -81,7 +81,7 @@ void sec_mmio_next_stage_init(void) {
     sec_mmio_ctx.values[i] = UINT32_MAX;
   }
   HARDENED_CHECK_EQ(i, kEntryCount);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
   HARDENED_CHECK_EQ(sec_mmio_ctx.check_count, 0);
 }
 
@@ -135,7 +135,7 @@ void sec_mmio_check_values(uint32_t rnd_offset) {
   }
   // Check for loop completion.
   HARDENED_CHECK_EQ(i, last_index);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
   ++sec_mmio_ctx.check_count;
 }
 
@@ -165,7 +165,7 @@ void sec_mmio_check_values_except_otp(uint32_t rnd_offset, uint32_t otp_base) {
   }
   // Check for loop completion.
   HARDENED_CHECK_EQ(i, last_index);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
   ++sec_mmio_ctx.check_count;
 }
 

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -92,7 +92,7 @@ static hardened_bool_t boot_data_is_empty(const void *boot_data) {
     boot_data = (char *)boot_data + sizeof(uint32_t);
   }
   HARDENED_CHECK_EQ(i, kBootDataNumWords);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
   if (launder32(res) == kFlashCtrlErasedWord) {
     HARDENED_CHECK_EQ(res, kFlashCtrlErasedWord);
     return is_empty;

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.c
@@ -5,16 +5,14 @@
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
 
 void boot_svc_empty_init(boot_svc_empty_t *msg) {
-  // We use `uint32_t` instead of `size_t` so that end-of-loop check passes both
-  // on- and off-target tests.
-  uint32_t i = 0, j = kBootSvcEmptyPayloadWordCount - 1;
+  size_t i = 0, j = kBootSvcEmptyPayloadWordCount - 1;
   for (; launder32(i) < kBootSvcEmptyPayloadWordCount &&
          launder32(j) < kBootSvcEmptyPayloadWordCount;
        ++i, --j) {
     msg->payload[i] = 0;
   }
   HARDENED_CHECK_EQ(i, kBootSvcEmptyPayloadWordCount);
-  HARDENED_CHECK_EQ(j, UINT32_MAX);
+  HARDENED_CHECK_EQ(j, SIZE_MAX);
   boot_svc_header_finalize(kBootSvcEmptyType, sizeof(boot_svc_empty_t),
                            &msg->header);
 }

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -132,7 +132,7 @@ static void fifo_read(size_t word_count, void *data) {
     data = (char *)data + sizeof(uint32_t);
   }
   HARDENED_CHECK_EQ(i, word_count);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
 }
 
 /**
@@ -150,7 +150,7 @@ static void fifo_write(size_t word_count, const void *data) {
     data = (const char *)data + sizeof(uint32_t);
   }
   HARDENED_CHECK_EQ(i, word_count);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
 }
 
 /**
@@ -421,7 +421,7 @@ rom_error_t flash_ctrl_data_erase_verify(uint32_t addr,
     error &= word;
   }
   HARDENED_CHECK_EQ(i, byte_count);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
 
   if (launder32(mask) == kFlashCtrlErasedWord) {
     HARDENED_CHECK_EQ(mask, kFlashCtrlErasedWord);
@@ -726,7 +726,7 @@ void flash_ctrl_creator_info_pages_lockdown(void) {
     page_lockdown(kInfoPagesNoOwnerAccess[i]);
   }
   HARDENED_CHECK_EQ(i, kInfoPagesNoOwnerAccessCount);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
 }
 
 const flash_ctrl_info_page_t
@@ -764,7 +764,7 @@ void flash_ctrl_cert_info_pages_creator_cfg(void) {
                               kCertificateInfoPagesCreatorAccess);
   }
   HARDENED_CHECK_EQ(i, kFlashCtrlNumCertInfoPages);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
 }
 
 void flash_ctrl_cert_info_pages_owner_restrict(void) {
@@ -778,5 +778,5 @@ void flash_ctrl_cert_info_pages_owner_restrict(void) {
                               kCertificateInfoPagesOwnerAccess);
   }
   HARDENED_CHECK_EQ(i, kFlashCtrlNumCertInfoPages);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
 }

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -85,7 +85,7 @@ void lifecycle_device_id_get(lifecycle_device_id_t *device_id) {
         kBase + LC_CTRL_DEVICE_ID_0_REG_OFFSET + i * sizeof(uint32_t));
   }
   HARDENED_CHECK_EQ(i, kLifecycleDeviceIdNumWords);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
 }
 
 void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -91,7 +91,7 @@ static void sc_otbn_write(uint32_t dest_addr, const uint32_t *src,
     HARDENED_CHECK_LT(i, num_words);
   }
   HARDENED_CHECK_EQ(iter_cnt, num_words);
-  HARDENED_CHECK_EQ((uint32_t)r_iter_cnt, UINT32_MAX);
+  HARDENED_CHECK_EQ(r_iter_cnt, SIZE_MAX);
 }
 
 OT_WARN_UNUSED_RESULT
@@ -121,7 +121,7 @@ rom_error_t sc_otbn_dmem_read(size_t num_words, sc_otbn_addr_t src,
                               i * sizeof(uint32_t));
   }
   HARDENED_CHECK_EQ(i, num_words);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -82,7 +82,7 @@ void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
     data[i] = sec_mmio_read32(kBase + reg_offset + i * sizeof(uint32_t));
   }
   HARDENED_CHECK_EQ(i, num_words);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
 }
 
 uint64_t otp_partition_digest_read(otp_partition_t partition) {
@@ -140,7 +140,7 @@ rom_error_t otp_dai_read(otp_partition_t partition, uint32_t relative_address,
     addr += sizeof(uint32_t);
   }
   HARDENED_CHECK_EQ(i, num_words);
-  HARDENED_CHECK_EQ((uint32_t)r, UINT32_MAX);
+  HARDENED_CHECK_EQ(r, SIZE_MAX);
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/lib/sigverify/spx_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/spx_verify.c
@@ -95,7 +95,7 @@ rom_error_t sigverify_spx_verify(
       // Set `flash_exec_spx` to `UINT32_MAX` if `actual_root` is incorrect.
       flash_exec_spx |= diff;
     }
-    HARDENED_CHECK_EQ(i, UINT32_MAX);
+    HARDENED_CHECK_EQ(i, SIZE_MAX);
     error = sigverify_spx_success_to_ok(flash_exec_spx);
     *flash_exec ^= flash_exec_spx;
   } else {

--- a/sw/device/silicon_creator/rom/sigverify_otp_keys.c
+++ b/sw/device/silicon_creator/rom/sigverify_otp_keys.c
@@ -271,7 +271,7 @@ rom_error_t sigverify_otp_keys_get(sigverify_otp_keys_get_params_t params,
   }
   // Ensure that the loop was executed exactly `params.key_cnt` times.
   HARDENED_CHECK_EQ(iter_cnt, params.key_cnt);
-  HARDENED_CHECK_EQ((uint32_t)r_iter_cnt, UINT32_MAX);
+  HARDENED_CHECK_EQ(r_iter_cnt, SIZE_MAX);
 
   // Verify the key a second time and only return it if it passes all checks.
   // The hardened check macros create barriers in the code, causing the binary


### PR DESCRIPTION
Fix #22925 to refactor the hardened size_t wrap-around tests.

The hardened checks test against the `SIZE_MAX` instead of `UINT32_MAX`, which works both on-device and off-device while preserving the size semantics.

Change all applicable lines that match both “CHECK” and “UINT32_MAX”.