### PR TITLE
[sival] Fix Bazel target for UART parity test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -93,7 +93,7 @@
       lc_states: ["PROD"]
       features: ["UART.PARITY"]
       tests: []
-      bazel: ["//sw/device/tests:uart_parity_test"]
+      bazel: ["//sw/device/tests:uart_parity_break_test"]
     }
     {
       name: chip_sw_uart_line_loopback


### PR DESCRIPTION
This test was renamed but its reference in the testplan was not.