### PR TITLE
Clarify flash ctrl info access

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -156,6 +156,7 @@
       stage: V2
       si_stage: SV3
       lc_states: ["TEST_LOCKED", "DEV", "PROD", "SCRAP"]
+      boot_stages: ["rom_ext"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
       bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states",
               "//sw/device/tests:flash_ctrl_info_access_lc_states_personalized"]
@@ -189,6 +190,7 @@
       si_stage: SV3
       lc_states: ["TEST_LOCKED", "DEV", "PROD", "SCRAP"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      boot_stages: ["rom_ext"]
       bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states"]
     }
     {
@@ -208,6 +210,7 @@
       si_stage: SV3
       lc_states: ["DEV", "PROD", "SCRAP"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      boot_stages: ["rom_ext"]
       bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states"]
     }
     {
@@ -227,6 +230,7 @@
       si_stage: SV3
       lc_states: ["TEST_LOCKED", "DEV", "PROD", "SCRAP"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      boot_stages: ["rom_ext"]
       bazel: ["//sw/device/tests:flash_ctrl_info_access_lc_states"]
     }
     {
@@ -243,6 +247,7 @@
       stage: V2
       si_stage: SV3
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
+      boot_stages: ["rom_ext"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1549,6 +1549,7 @@ test_suite(
     tests = ["flash_ctrl_info_access_lc_{}".format(lc_state.lower()) for lc_state, _ in _FLASH_CTRL_INFO_ACCESS_LC_STATES],
 )
 
+# These tests cannot run at the owner stage because the ROM_EXT locks the info pages.
 [
     opentitan_test(
         name = "flash_ctrl_info_access_lc_{}_personalized".format(lc_state),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1517,7 +1517,7 @@ _FLASH_CTRL_INFO_ACCESS_LC_STATES = get_lc_items(
         name = "flash_ctrl_info_access_lc_{}".format(lc_state.lower()),
         srcs = ["flash_ctrl_info_access_lc.c"],
         cw310 = cw310_params(
-            bitstream = "//hw/bitstream:rom_with_fake_keys_otp_{}".format(lc_state.lower()),
+            otp = "//hw/ip/otp_ctrl/data:img_{}".format(lc_state),
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,


### PR DESCRIPTION
- small fix to `flash_ctrl_info_access_lc_*` bazel
- mark `flash_ctrl_info_access_lc_*` as not runnable at the owner stage (see commit)

This PR uses the testplan `boot_stage` attribute introduced in #22898. #22898 should be merged before this PR?