### PR TITLE
[csrng/dv] Add DV for the force fips bit functionality

### DIFF
--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -26,9 +26,9 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
   // Knobs & Weights
   uint otp_en_cs_sw_app_read_pct, otp_en_cs_sw_app_read_inval_pct, lc_hw_debug_en_pct, regwen_pct,
-       enable_pct, sw_app_enable_pct, read_int_state_pct, force_state_pct, check_int_state_pct,
-       num_cmds_min, num_cmds_max, aes_halt_pct, min_aes_halt_clks, max_aes_halt_clks,
-       min_num_disable_enable, max_num_disable_enable,
+       enable_pct, sw_app_enable_pct, read_int_state_pct, fips_force_enable_pct, force_state_pct,
+       check_int_state_pct, num_cmds_min, num_cmds_max, aes_halt_pct, min_aes_halt_clks,
+       max_aes_halt_clks, min_num_disable_enable, max_num_disable_enable,
        min_enable_clks, max_enable_clks,
        min_disable_edn_before_csrng_clks, max_disable_edn_before_csrng_clks,
        min_disable_csrng_before_entropy_src_clks, max_disable_csrng_before_entropy_src_clks,
@@ -40,7 +40,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
   rand bit       check_int_state, regwen, hw_app[NUM_HW_APPS],
                  sw_app, aes_halt;
-  rand mubi4_t   enable, sw_app_enable, read_int_state;
+  rand mubi4_t   enable, sw_app_enable, read_int_state, fips_force_enable;
+  rand bit [2:0] fips_force;
   rand bit [3:0] lc_hw_debug_en;
   rand bit [7:0] otp_en_cs_sw_app_read;
 
@@ -109,6 +110,10 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   constraint aes_halt_c { aes_halt dist {
                           1 :/ aes_halt_pct,
                           0 :/ (100 - aes_halt_pct) };}
+
+  constraint fips_force_enable_c { fips_force_enable dist {
+                                   MuBi4True  :/ fips_force_enable_pct,
+                                   MuBi4False :/ (100 - fips_force_enable_pct) };}
 
   // Behind the aes_cipher_sm_err error code, there are which_aes_cm.num() countermeasures each of
   // which can be stimulated by forcing the Sp2VWidth independent logic rails. We bias error
@@ -311,6 +316,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
            regwen)};
     str = {str,  $sformatf("\n\t |***** check_int_state                 : %10d *****| \t",
            check_int_state)};
+    str = {str,  $sformatf("\n\t |***** fips_force_enable               : %10d *****| \t",
+           fips_force_enable)};
     str = {str,  $sformatf("\n\t |---------------- knobs ---------------------------------| \t")};
     str = {str,  $sformatf("\n\t |***** otp_en_cs_sw_app_read_pct       : %10d *****| \t",
            otp_en_cs_sw_app_read_pct) };
@@ -328,6 +335,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
            regwen_pct)};
     str = {str,  $sformatf("\n\t |***** check_int_state_pct             : %10d *****| \t",
            check_int_state_pct)};
+    str = {str,  $sformatf("\n\t |***** fips_force_enable_pct           : %10d *****| \t",
+           fips_force_enable_pct)};
     str = {str,  $sformatf("\n\t |***** num_cmds_min                    : %10d *****| \t",
            num_cmds_min)};
     str = {str,  $sformatf("\n\t |***** num_cmds_max                    : %10d *****| \t",

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -346,6 +346,8 @@ class csrng_scoreboard extends cip_base_scoreboard #(
           );
         end
       end
+      "fips_force": begin
+      end
       "hw_exc_sts": begin
       end
       "recov_alert_sts": begin
@@ -450,7 +452,8 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     cfg.v[app]   = 'h0;
     ctr_drbg_update(app, seed_material);
     cfg.reseed_counter[app] = 1'b0;
-    cfg.compliance[app]     = fips;
+    cfg.compliance[app]     = fips || ((`gmv(ral.ctrl.fips_force_enable) == MuBi4True) &&
+                                        `gmv(ral.fips_force)[app]);
     cfg.status[app]         = 1'b1;
     cov_vif.cg_csrng_state_db_sample(cfg.compliance[app], compliance_previous, app);
   endfunction
@@ -467,7 +470,8 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     seed_material = entropy_input ^ additional_input;
     ctr_drbg_update(app, seed_material);
     cfg.reseed_counter[app] = 1'b0;
-    cfg.compliance[app]     = fips;
+    cfg.compliance[app]     = fips || ((`gmv(ral.ctrl.fips_force_enable) == MuBi4True) &&
+                                        `gmv(ral.fips_force)[app]);
     cov_vif.cg_csrng_state_db_sample(cfg.compliance[app], compliance_previous, app);
   endfunction
 
@@ -476,7 +480,8 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     cfg.key[app] = 'h0;
     cfg.v[app]   = 'h0;
     cfg.reseed_counter[app] = 1'b0;
-    cfg.compliance[app]     = 1'b0;
+    cfg.compliance[app]     =  ((`gmv(ral.ctrl.fips_force_enable) == MuBi4True) &&
+                                 `gmv(ral.fips_force)[app]);
     cfg.status[app]         = 1'b0;
   endfunction
 

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -54,9 +54,11 @@ class csrng_base_vseq extends cip_base_vseq #(
 
     // Enables
     csr_wr(.ptr(ral.regwen), .value(cfg.regwen));
+    csr_wr(.ptr(ral.fips_force), .value(cfg.fips_force));
     ral.ctrl.enable.set(cfg.enable);
     ral.ctrl.sw_app_enable.set(cfg.sw_app_enable);
     ral.ctrl.read_int_state.set(cfg.read_int_state);
+    ral.ctrl.fips_force_enable.set(cfg.fips_force_enable);
     csr_update(.csr(ral.ctrl));
   endtask
 

--- a/hw/ip/csrng/dv/tests/csrng_base_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_base_test.sv
@@ -31,6 +31,7 @@ class csrng_base_test extends cip_base_test #(
     cfg.enable_pct                      = 100;
     cfg.sw_app_enable_pct               = 90;
     cfg.read_int_state_pct              = 90;
+    cfg.fips_force_enable_pct           = 50;
     cfg.check_int_state_pct             = 100;
   endfunction
 


### PR DESCRIPTION
At some point we should probably add some coverage for the new registers. I can do so once I'm back.
Rarely there are still some failures I wasn't able to investigate yet. When I ran a 10% regression I found 1 failure due to the added DV in the csrng_cmds test.

This is the DV for #23324