### PR TITLE
[cryptolib] Eliminate status_create symbol use

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.c
+++ b/sw/device/lib/crypto/drivers/entropy.c
@@ -352,7 +352,7 @@ static status_t csrng_send_app_cmd(uint32_t reg_address,
     kMaxGenerateSizeIn128BitBlocks = 0x800,
   };
   if (cmd.generate_len > kMaxGenerateSizeIn128BitBlocks) {
-    return OUT_OF_RANGE();
+    return OTCRYPTO_BAD_ARGS;
   }
 
   uint32_t reg;


### PR DESCRIPTION
This is a manual cherry-pick of #23211 to `earlgrey_es_sival`.