### PR TITLE
[sw] Enable unused compiler warning

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,12 +30,6 @@ build --incompatible_enable_cc_toolchain_resolution
 # accessed like we do in util/BUILD
 build --workspace_status_command=util/get_workspace_status.sh
 
-# Enable more compiler warnings.
-build --copt=-Wunused-parameter
-build --copt=-Wunused
-build --copt=-Wno-error=unused-parameter
-build --copt=-Wno-error=unused
-
 # This enables convenient building for opentitan targets with the argument
 # --config=riscv32
 build:riscv32 --platforms=@crt//platforms/riscv32:opentitan

--- a/.bazelrc
+++ b/.bazelrc
@@ -30,6 +30,12 @@ build --incompatible_enable_cc_toolchain_resolution
 # accessed like we do in util/BUILD
 build --workspace_status_command=util/get_workspace_status.sh
 
+# Enable more compiler warnings.
+build --copt=-Wunused-parameter
+build --copt=-Wunused
+build --copt=-Wno-error=unused-parameter
+build --copt=-Wno-error=unused
+
 # This enables convenient building for opentitan targets with the argument
 # --config=riscv32
 build:riscv32 --platforms=@crt//platforms/riscv32:opentitan

--- a/sw/device/lib/base/math_builtins.c
+++ b/sw/device/lib/base/math_builtins.c
@@ -45,21 +45,35 @@ _ot_builtin_div64_intentionally_not_implemented_see_pull_11451(void);
 // is sufficiently pervasive that won't be an issue; at any rate, it means
 // people will land somewhere when they grep for __udivdi3 and friends.
 OT_WEAK int64_t __divdi3(int64_t a, int64_t b) {
+  OT_DISCARD(a);
+  OT_DISCARD(b);
   _ot_builtin_div64_intentionally_not_implemented_see_pull_11451();
 }
 OT_WEAK uint64_t __udivdi3(uint64_t a, uint64_t b) {
+  OT_DISCARD(a);
+  OT_DISCARD(b);
   _ot_builtin_div64_intentionally_not_implemented_see_pull_11451();
 }
 OT_WEAK int64_t __moddi3(int64_t a, int64_t b) {
+  OT_DISCARD(a);
+  OT_DISCARD(b);
   _ot_builtin_div64_intentionally_not_implemented_see_pull_11451();
 }
 OT_WEAK uint64_t __umoddi3(uint64_t a, uint64_t b) {
+  OT_DISCARD(a);
+  OT_DISCARD(b);
   _ot_builtin_div64_intentionally_not_implemented_see_pull_11451();
 }
 OT_WEAK int64_t __divmoddi4(int64_t a, int64_t b, int64_t *rem) {
+  OT_DISCARD(a);
+  OT_DISCARD(b);
+  OT_DISCARD(rem);
   _ot_builtin_div64_intentionally_not_implemented_see_pull_11451();
 }
 OT_WEAK uint64_t __udivmoddi4(uint64_t a, uint64_t b, uint64_t *rem) {
+  OT_DISCARD(a);
+  OT_DISCARD(b);
+  OT_DISCARD(rem);
   _ot_builtin_div64_intentionally_not_implemented_see_pull_11451();
 }
 #endif  // OT_PLATFORM_RV32

--- a/sw/device/lib/base/mock_mmio.cc
+++ b/sw/device/lib/base/mock_mmio.cc
@@ -13,6 +13,7 @@ std::random_device MockDevice::rd;
 extern "C" {
 // dummy
 mmio_region_t mmio_region_from_addr(uintptr_t address) {
+  OT_DISCARD(address);
   return (mmio_region_t){};
 }
 

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -199,9 +199,11 @@ dif_result_t dif_otbn_set_ctrl_software_errs_fatal(const dif_otbn_t *otbn,
 }
 
 size_t dif_otbn_get_dmem_size_bytes(const dif_otbn_t *otbn) {
+  OT_DISCARD(otbn);
   return OTBN_DMEM_SIZE_BYTES;
 }
 
 size_t dif_otbn_get_imem_size_bytes(const dif_otbn_t *otbn) {
+  OT_DISCARD(otbn);
   return OTBN_IMEM_SIZE_BYTES;
 }

--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -52,6 +52,8 @@ static const char kUnknownSpec[15] = "%<unknown spec>";
 static const char kErrorTooWide[12] = "%<bad width>";
 
 static size_t base_dev_null(void *data, const char *buf, size_t len) {
+  OT_DISCARD(data);
+  OT_DISCARD(buf);
   return len;
 }
 static buffer_sink_t base_stdout = {

--- a/sw/device/lib/testing/test_framework/freertos_hooks.c
+++ b/sw/device/lib/testing/test_framework/freertos_hooks.c
@@ -27,6 +27,7 @@ void vApplicationMallocFailedHook(void) {
  * FreeRTOSConfig.h, and a task detects a stack overflow.
  */
 void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName) {
+  OT_DISCARD(xTask);
   LOG_INFO("FreeRTOS stack overflow. Increase stack size of task: %s",
            pcTaskName);
   irq_global_ctrl(false);

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -196,6 +196,7 @@ static status_t manage_flow_control(const dif_uart_t *uart,
 }
 
 bool ottf_console_flow_control_isr(uint32_t *exc_info) {
+  OT_DISCARD(exc_info);
   dif_uart_t *uart = (dif_uart_t *)ottf_console_get();
   flow_control_irqs += 1;
   bool rx;

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -190,7 +190,10 @@ void ottf_timer_isr(uint32_t *exc_info) {
 }
 
 OT_WEAK
-bool ottf_console_flow_control_isr(uint32_t *exc_info) { return false; }
+bool ottf_console_flow_control_isr(uint32_t *exc_info) {
+  OT_DISCARD(exc_info);
+  return false;
+}
 
 OT_WEAK
 void ottf_external_isr(uint32_t *exc_info) {

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -49,6 +49,7 @@ rand_testutils_rng_t rand_testutils_rng_ctx;
 // The OTTF overrides the default machine ecall exception handler to implement
 // FreeRTOS context switching, required for supporting cooperative scheduling.
 void ottf_machine_ecall_handler(uint32_t *exc_info) {
+  OT_DISCARD(exc_info);
   if (pxCurrentTCB != NULL) {
     // If the pointer to the current TCB is not NULL, we are operating in
     // concurrency mode. In this case, our default behavior is to assume a
@@ -139,6 +140,7 @@ static void report_test_status(bool result) {
 // logic to be invoked as a FreeRTOS task. This wrapper can be used by tests
 // that are run on bare-metal.
 static void test_wrapper(void *task_parameters) {
+  OT_DISCARD(task_parameters);
   // Invoke test hooks that can be overridden by closed-source code.
   bool result = manufacturer_pre_test_hook();
   result = result && test_main();

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
@@ -156,6 +156,7 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
                                  const hmac_digest_t *act_digest,
                                  lifecycle_state_t lc_state,
                                  uint32_t *flash_exec) {
+  OT_DISCARD(lc_state);
   sigverify_rsa_buffer_t enc_msg;
   rom_error_t error = sigverify_mod_exp_ibex(key, signature, &enc_msg);
   if (launder32(error) != kErrorOk) {

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.c
@@ -154,9 +154,7 @@ static rom_error_t sigverify_encoded_message_check(
 rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
                                  const sigverify_rsa_key_t *key,
                                  const hmac_digest_t *act_digest,
-                                 lifecycle_state_t lc_state,
                                  uint32_t *flash_exec) {
-  OT_DISCARD(lc_state);
   sigverify_rsa_buffer_t enc_msg;
   rom_error_t error = sigverify_mod_exp_ibex(key, signature, &enc_msg);
   if (launder32(error) != kErrorOk) {

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify.h
@@ -25,13 +25,9 @@ enum {
 /**
  * Verifies an RSASSA-PKCS1-v1_5 signature.
  *
- * The actual implementation that is used (software or OTBN) is determined by
- * the life cycle state of the device and the OTP value.
- *
  * @param signature Signature to be verified.
  * @param key Signer's RSA public key.
  * @param act_digest Actual digest of the message being verified.
- * @param lc_state Life cycle state of the device.
  * @param[out] flash_exec Value to write to the flash_ctrl EXEC register.
  * @return Result of the operation.
  */
@@ -39,7 +35,6 @@ OT_WARN_UNUSED_RESULT
 rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
                                  const sigverify_rsa_key_t *key,
                                  const hmac_digest_t *act_digest,
-                                 lifecycle_state_t lc_state,
                                  uint32_t *flash_exec);
 
 /**

--- a/sw/device/silicon_creator/lib/sigverify/rsa_verify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify/rsa_verify_functest.c
@@ -119,7 +119,7 @@ static const sigverify_rsa_key_t kKeyExp3 = {
 rom_error_t rsa_verify_test_exp_3(void) {
   uint32_t flash_exec = 0;
   // Signature verification should fail when using exponent 3.
-  if (sigverify_rsa_verify(&kSignatureExp3, &kKeyExp3, &act_digest, kLcStateRma,
+  if (sigverify_rsa_verify(&kSignatureExp3, &kKeyExp3, &act_digest,
                            &flash_exec) == kErrorOk) {
     return kErrorUnknown;
   }
@@ -129,9 +129,8 @@ rom_error_t rsa_verify_test_exp_3(void) {
 
 rom_error_t rsa_verify_test_exp_65537(void) {
   uint32_t flash_exec = 0;
-  rom_error_t result =
-      sigverify_rsa_verify(&kSignatureExp65537, &kKeyExp65537, &act_digest,
-                           kLcStateRma, &flash_exec);
+  rom_error_t result = sigverify_rsa_verify(&kSignatureExp65537, &kKeyExp65537,
+                                            &act_digest, &flash_exec);
   CHECK(flash_exec == kSigverifyRsaSuccess);
   return result;
 }
@@ -140,7 +139,7 @@ rom_error_t rsa_verify_test_negative(void) {
   uint32_t flash_exec = 0;
   // Signature verification should fail when using the wrong signature.
   if (sigverify_rsa_verify(&kSignatureExp65537, &kKeyExp3, &act_digest,
-                           kLcStateRma, &flash_exec) == kErrorOk) {
+                           &flash_exec) == kErrorOk) {
     return kErrorUnknown;
   }
   CHECK(flash_exec == UINT32_MAX);

--- a/sw/device/silicon_creator/lib/sigverify/sigverify_dynamic_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_dynamic_functest.c
@@ -28,8 +28,8 @@ rom_error_t sigverify_test(void) {
          kHmacDigestNumWords * sizeof(uint32_t));
 
   uint32_t flash_exec = 0;
-  rom_error_t result = sigverify_rsa_verify(&testvec.sig, &testvec.key, &digest,
-                                            kLcStateRma, &flash_exec);
+  rom_error_t result =
+      sigverify_rsa_verify(&testvec.sig, &testvec.key, &digest, &flash_exec);
 
   rom_error_t test_result;
   if (testvec.valid) {

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_shake.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_shake.c
@@ -49,6 +49,7 @@ static_assert(
     "For the given height, 32 bits is not large enough for a leaf index.");
 
 rom_error_t spx_hash_initialize(spx_ctx_t *ctx) {
+  OT_DISCARD(ctx);
   return kmac_shake256_configure();
 }
 

--- a/sw/device/silicon_creator/rom_ext/keys/fake/sigverify_rsa_keys_fake_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/keys/fake/sigverify_rsa_keys_fake_unittest.cc
@@ -204,7 +204,7 @@ class SigverifyRsaVerify
 TEST_P(SigverifyRsaVerify, Ibex) {
   uint32_t flash_exec = 0;
   EXPECT_EQ(sigverify_rsa_verify(&GetParam().sig, GetParam().key, &kDigest,
-                                 kLcStateProd, &flash_exec),
+                                 &flash_exec),
             kErrorOk);
   EXPECT_EQ(flash_exec, kSigverifyRsaSuccess);
 }

--- a/sw/device/silicon_creator/rom_ext/prodc/keys/sigverify_rsa_keys_prodc_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/prodc/keys/sigverify_rsa_keys_prodc_unittest.cc
@@ -147,7 +147,7 @@ class SigverifyRsaVerify
 TEST_P(SigverifyRsaVerify, Ibex) {
   uint32_t flash_exec = 0;
   EXPECT_EQ(sigverify_rsa_verify(&GetParam().sig, GetParam().key, &kDigest,
-                                 kLcStateProd, &flash_exec),
+                                 &flash_exec),
             kErrorOk);
   EXPECT_EQ(flash_exec, kSigverifyRsaSuccess);
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -264,7 +264,7 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
 
   uint32_t flash_exec = 0;
   return sigverify_rsa_verify(&manifest->rsa_signature, key, &act_digest,
-                              lc_state, &flash_exec);
+                              &flash_exec);
 }
 
 /**

--- a/sw/device/silicon_creator/rom_ext/sival/keys/sigverify_rsa_keys_sival_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/sival/keys/sigverify_rsa_keys_sival_unittest.cc
@@ -144,7 +144,7 @@ class SigverifyRsaVerify
 TEST_P(SigverifyRsaVerify, Ibex) {
   uint32_t flash_exec = 0;
   EXPECT_EQ(sigverify_rsa_verify(&GetParam().sig, GetParam().key, &kDigest,
-                                 kLcStateProd, &flash_exec),
+                                 &flash_exec),
             kErrorOk);
   EXPECT_EQ(flash_exec, kSigverifyRsaSuccess);
 }

--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -82,6 +82,7 @@ static volatile bool has_irq_fired;
  * This overrides the default OTTF load integrity handler.
  */
 void ottf_load_integrity_error_handler(uint32_t *exc_info) {
+  OT_DISCARD(exc_info);
   has_irq_fired = true;
 }
 


### PR DESCRIPTION
Fix #22928.

This commit marks those expected cases explicitly, and enables the warning for detecting potential bugs.