### PR TITLE
[rom] Cleanup ecdsa sigverify dependencies and add otbn mock

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -466,25 +466,37 @@ cc_library(
     deps = ["//sw/device/silicon_creator/lib/drivers:keymgr"],
 )
 
-cc_library(
+dual_cc_library(
     name = "otbn_boot_services",
-    srcs = ["otbn_boot_services.c"],
-    hdrs = ["otbn_boot_services.h"],
-    # This target uses OTBN pointers internally, so it cannot work host-side.
-    target_compatible_with = [OPENTITAN_CPU],
-    deps = [
-        ":attestation",
-        "//sw/device/lib/base:macros",
-        "//sw/device/silicon_creator/lib:dbg_print",
-        "//sw/device/silicon_creator/lib:error",
-        "//sw/device/silicon_creator/lib/base:sec_mmio",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/lib/drivers:hmac",
-        "//sw/device/silicon_creator/lib/drivers:keymgr",
-        "//sw/device/silicon_creator/lib/drivers:otbn",
-        "//sw/device/silicon_creator/lib/sigverify:rsa_key",
-        "//sw/otbn/crypto:boot",
-    ],
+    srcs = dual_inputs(
+        device = ["otbn_boot_services.c"],
+        host = ["mock_otbn_boot_services.cc"],
+    ),
+    hdrs = dual_inputs(
+        host = ["mock_otbn_boot_services.h"],
+        shared = ["otbn_boot_services.h"],
+    ),
+    deps = dual_inputs(
+        device = [
+            "//sw/device/lib/base:macros",
+            "//sw/device/silicon_creator/lib:dbg_print",
+            "//sw/device/silicon_creator/lib:error",
+            "//sw/device/silicon_creator/lib/base:sec_mmio",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/lib/drivers:otbn",
+            "//sw/otbn/crypto:boot",
+        ],
+        host = [
+            "//sw/device/lib/base:global_mock",
+            "//sw/device/silicon_creator/testing:rom_test",
+            "@googletest//:gtest",
+        ],
+        shared = [
+            ":attestation",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
+            "//sw/device/silicon_creator/lib/drivers:keymgr",
+        ],
+    ),
 )
 
 opentitan_test(

--- a/sw/device/silicon_creator/lib/mock_otbn_boot_services.cc
+++ b/sw/device/silicon_creator/lib/mock_otbn_boot_services.cc
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/mock_otbn_boot_services.h"
+
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+
+namespace rom_test {
+extern "C" {
+
+rom_error_t otbn_boot_app_load() {
+  return MockOtbnBootServices::Instance().otbn_boot_app_load();
+}
+
+rom_error_t otbn_boot_attestation_keygen(
+    attestation_key_seed_t additional_seed,
+    otbn_boot_attestation_key_type_t key_type,
+    sc_keymgr_diversification_t diversification,
+    attestation_public_key_t *public_key) {
+  return MockOtbnBootServices::Instance().otbn_boot_attestation_keygen(
+      additional_seed, key_type, diversification, public_key);
+}
+
+rom_error_t otbn_boot_attestation_key_save(
+    attestation_key_seed_t additional_seed,
+    otbn_boot_attestation_key_type_t key_type,
+    sc_keymgr_diversification_t diversification) {
+  return MockOtbnBootServices::Instance().otbn_boot_attestation_key_save(
+      additional_seed, key_type, diversification);
+}
+
+rom_error_t otbn_boot_attestation_key_clear() {
+  return MockOtbnBootServices::Instance().otbn_boot_attestation_key_clear();
+}
+
+rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
+                                          attestation_signature_t *sig) {
+  return MockOtbnBootServices::Instance().otbn_boot_attestation_endorse(digest,
+                                                                        sig);
+}
+
+rom_error_t otbn_boot_sigverify(const attestation_public_key_t *key,
+                                const attestation_signature_t *sig,
+                                const hmac_digest_t *digest,
+                                uint32_t *recovered_r) {
+  return MockOtbnBootServices::Instance().otbn_boot_sigverify(key, sig, digest,
+                                                              recovered_r);
+}
+
+}  // extern "C"
+}  // namespace rom_test

--- a/sw/device/silicon_creator/lib/mock_otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/mock_otbn_boot_services.h
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_OTBN_BOOT_SERVICES_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_OTBN_BOOT_SERVICES_H_
+
+#include "sw/device/lib/base/global_mock.h"
+#include "sw/device/silicon_creator/lib/otbn_boot_services.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace rom_test {
+namespace internal {
+
+/**
+ * Mock class for otbn_boot_services.h.
+ */
+class MockOtbnBootServices
+    : public global_mock::GlobalMock<MockOtbnBootServices> {
+ public:
+  MOCK_METHOD(rom_error_t, otbn_boot_app_load, ());
+  MOCK_METHOD(rom_error_t, otbn_boot_attestation_keygen,
+              (attestation_key_seed_t, otbn_boot_attestation_key_type_t,
+               sc_keymgr_diversification_t, attestation_public_key_t *));
+  MOCK_METHOD(rom_error_t, otbn_boot_attestation_key_save,
+              (attestation_key_seed_t, otbn_boot_attestation_key_type_t,
+               sc_keymgr_diversification_t));
+  MOCK_METHOD(rom_error_t, otbn_boot_attestation_key_clear, ());
+  MOCK_METHOD(rom_error_t, otbn_boot_attestation_endorse,
+              (const hmac_digest_t *, attestation_signature_t *));
+  MOCK_METHOD(rom_error_t, otbn_boot_sigverify,
+              (const attestation_public_key_t *,
+               const attestation_signature_t *, const hmac_digest_t *,
+               uint32_t *));
+};
+
+}  // namespace internal
+
+using MockOtbnBootServices =
+    testing::StrictMock<internal::MockOtbnBootServices>;
+using NiceMockOtbnBootServices =
+    testing::NiceMock<internal::MockOtbnBootServices>;
+
+}  // namespace rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_OTBN_BOOT_SERVICES_H_

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -11,7 +11,6 @@
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
-#include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -131,7 +131,10 @@ cc_library(
     hdrs = ["ecdsa_p256_verify.h"],
     deps = [
         ":ecdsa_p256_key",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:attestation",
+        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:otbn_boot_services",
         "//sw/device/silicon_creator/lib/drivers:hmac",
     ],

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.c
@@ -4,7 +4,11 @@
 
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h"
 
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
+#include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h
@@ -5,8 +5,9 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_ECDSA_P256_VERIFY_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_ECDSA_P256_VERIFY_H_
 
+#include <stdint.h>
+
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
-#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 

--- a/sw/device/silicon_creator/lib/sigverify/sigverify.h
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h"
+#include "sw/device/silicon_creator/lib/sigverify/rsa_verify.h"
 #include "sw/device/silicon_creator/lib/sigverify/spx_verify.h"
 #include "sw/device/silicon_creator/lib/sigverify/usage_constraints.h"
 


### PR DESCRIPTION
The dependencies between `ecdsa_p256_verify` and the underlying `otbn_boot_services` are tangled together. This commit ensures the included headers are all listed in the deps field.

Also adds an OTBN mock for off-device testing.