### PR TITLE
[rv_dm,dv] Avoid a fast JTAG clock

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -19,9 +19,9 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   rand int unsigned tck_period_ps;
   constraint tck_period_ps_c {
     tck_period_ps dist {
-      [10_000:20_000] :/ 1,  // 50-100MHz
-      [20_001:42_000] :/ 1,  // 24-50MHz
-      [42_001:100_000] :/ 1  // 10-24MHz
+      [100_000:200_000] :/ 1,  // 5-10MHz
+      [200_001:420_000] :/ 1,  // 2.4-5MHz
+      [420_001:1000_000] :/ 1  // 1-2.4MHz
     };
   }
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_common_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_common_vseq.sv
@@ -22,6 +22,21 @@ class rv_dm_common_vseq extends rv_dm_base_vseq;
     unavailable == 0;
   }
 
+  // This is a thin wrapper around the base class version of run_csr_vseq, but setting the timeout
+  // for the CSR operations to be larger. This is needed because the timeout counts from (roughly)
+  // the start of the CSR sequence and isn't enough to allow for slow values of the JTAG clock.
+  virtual task run_csr_vseq(string csr_test_type,
+                            int    num_test_csrs = 0,
+                            bit    do_rand_wr_and_reset = 1,
+                            dv_base_reg_block models[$] = {},
+                            string ral_name = "");
+    uint old_dtn = csr_utils_pkg::default_timeout_ns;
+
+    csr_utils_pkg::default_timeout_ns = 10 * old_dtn;
+    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset, models, ral_name);
+    csr_utils_pkg::default_timeout_ns = old_dtn;
+  endtask
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body


### PR DESCRIPTION
If the JTAG clock runs much faster than the system clock then things can get a bit out of sync for DMI accesses. This is tracked in an issue in the pulp-dbg module that we vendor.

Tightening the constraint slightly like this should avoid the issue that led to the problem in the first place (where the system clock was at 25MHz and the JTAG tck ran at about 100MHz).

The pulp-dbg issue is https://github.com/pulp-platform/riscv-dbg/issues/163.