### PR TITLE
[util] Get rid of "type" field in Modes

### DIFF
--- a/util/dvsim/Regression.py
+++ b/util/dvsim/Regression.py
@@ -20,7 +20,6 @@ class Regression(Mode):
 
     def __init__(self, regdict):
         self.name = ""
-        self.type = ""
 
         # The `tests` member is typically a list, but it defaults to None.
         # There are 3 possible cases after all the HJson files are parsed, when

--- a/util/dvsim/modes.py
+++ b/util/dvsim/modes.py
@@ -22,10 +22,6 @@ class Mode:
             log.error("Key \"name\" missing in mode %s", mdict)
             sys.exit(1)
 
-        if not hasattr(self, "type"):
-            log.fatal("Key \"type\" is missing or invalid")
-            sys.exit(1)
-
         for key in keys:
             if key not in attrs:
                 log.error(f"Key {key} in {mdict} is invalid. Supported "
@@ -33,11 +29,13 @@ class Mode:
                 sys.exit(1)
             setattr(self, key, mdict[key])
 
-    def get_sub_modes(self):
-        return getattr(self, "en_" + self.type + "_modes", [])
+    def get_sub_modes(self) -> List[str]:
+        # Default behaviour is not to have sub-modes
+        return []
 
-    def set_sub_modes(self, sub_modes):
-        setattr(self, "en_" + self.type + "_modes", sub_modes)
+    def set_sub_modes(self, sub_modes: List[str]) -> None:
+        # Default behaviour is not to have sub-modes
+        return None
 
     def merge_mode(self, mode: 'Mode') -> None:
         '''Update this object by merging it with mode.'''
@@ -235,7 +233,6 @@ class BuildMode(Mode):
 
     def __init__(self, bdict):
         self.name = ""
-        self.type = "build"
         self.is_sim_mode = 0
         self.pre_build_cmds = []
         self.post_build_cmds = []
@@ -251,6 +248,12 @@ class BuildMode(Mode):
         super().__init__("build mode", bdict)
         self.en_build_modes = list(set(self.en_build_modes))
 
+    def get_sub_modes(self) -> List[str]:
+        return self.en_build_modes
+
+    def set_sub_modes(self, sub_modes: List[str]) -> None:
+        self.en_build_modes = sub_modes
+
     @staticmethod
     def get_default_mode():
         return BuildMode({"name": "default"})
@@ -264,7 +267,6 @@ class RunMode(Mode):
 
     def __init__(self, rdict):
         self.name = ""
-        self.type = "run"
         self.reseed = None
         self.pre_run_cmds = []
         self.post_run_cmds = []
@@ -281,6 +283,12 @@ class RunMode(Mode):
 
         super().__init__("run mode", rdict)
         self.en_run_modes = list(set(self.en_run_modes))
+
+    def get_sub_modes(self) -> List[str]:
+        return self.en_run_modes
+
+    def set_sub_modes(self, sub_modes: List[str]) -> None:
+        self.en_run_modes = sub_modes
 
     @staticmethod
     def get_default_mode():


### PR DESCRIPTION
The existing python code was using a string to tell the base class how to look up sub-modes for an instance of a given derived class. This was a bit complicated!

There are actually only two places where this does anything anyway, so duplicate them and get rid of the string magic.