### PR TITLE
[prim,fpv] Avoid warning message from Jasper with ASSERT_AT_RESET

### DIFF
--- a/hw/ip/prim/rtl/prim_assert_standard_macros.svh
+++ b/hw/ip/prim/rtl/prim_assert_standard_macros.svh
@@ -50,16 +50,24 @@
   end                                                                        \
 `endif
 
-`define ASSERT_AT_RESET(__name, __prop, __rst = `ASSERT_DEFAULT_RST)         \
-  // `__rst` is active-high for these macros, so trigger on its posedge.     \
-  // The values inside the property are sampled just before the trigger,     \
-  // which is necessary to make the evaluation of `__prop` on a reset edge   \
-  // meaningful.  On any reset posedge at the start of time, `__rst` itself  \
-  // is unknown, and at that time `__prop` is likely not initialized either, \
-  // so this assertion does not evaluate `__prop` when `__rst` is unknown.   \
-  __name: assert property (@(posedge __rst) $isunknown(__rst) || (__prop))   \
-    else begin                                                               \
-      `ASSERT_ERROR(__name)                                                  \
+`define ASSERT_AT_RESET(__name, __prop, __rst = `ASSERT_DEFAULT_RST)          \
+  // `__rst` is active-high for these macros, so trigger on its posedge.      \
+  // The values inside the property are sampled just before the trigger,      \
+  // which is necessary to make the evaluation of `__prop` on a reset edge    \
+  // meaningful.  On any reset posedge at the start of time, `__rst` itself   \
+  // is unknown, and at that time `__prop` is likely not initialized either,  \
+  // so this assertion does not evaluate `__prop` when `__rst` is unknown.    \
+  //                                                                          \
+  // This extra behaviour is not used for FPV, because Jasper doesn't support \
+  // it and instead prints the WNL038 warning. Avoid the check and warning    \
+  // message in this case.                                                    \
+`ifndef FPV_ON                                                                \
+  __name: assert property (@(posedge __rst) $isunknown(__rst) || (__prop))    \
+`else                                                                         \
+  __name: assert property (@(posedge __rst) (__prop))                         \
+`endif                                                                        \
+    else begin                                                                \
+      `ASSERT_ERROR(__name)                                                   \
     end
 
 `define ASSERT_AT_RESET_AND_FINAL(__name, __prop, __rst = `ASSERT_DEFAULT_RST) \


### PR DESCRIPTION
No functional change: the warning message from Jasper was saying that the $isunknown(__rst) was being treated as "0", which is the behaviour we're making explicit.

But now we don't get a warning message, which makes genuine problems a little more obvious.