### PR TITLE
[sival] Verify all strap combinations

### DIFF
--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -165,6 +165,8 @@ uint32_t pinmux_testutils_read_strap_pin(dif_pinmux_t *pinmux, dif_gpio_t *gpio,
   dif_pinmux_pad_attr_t attr_out;
   CHECK_DIF_OK(dif_pinmux_pad_write_attrs(pinmux, pad, kDifPinmuxPadKindMio,
                                           attr, &attr_out));
+  // Let the change propagate.
+  busy_spin_micros(100);
   bool state;
   // The value read is unmodified by the internal pull resistors and represents
   // the upper bit of the 4 possible states [Strong0, Weak0, Weak1,
@@ -179,6 +181,8 @@ uint32_t pinmux_testutils_read_strap_pin(dif_pinmux_t *pinmux, dif_gpio_t *gpio,
                (state ? 0 : kDifPinmuxPadAttrPullResistorUp);
   CHECK_DIF_OK(dif_pinmux_pad_write_attrs(pinmux, pad, kDifPinmuxPadKindMio,
                                           attr, &attr_out));
+  // Let the change propagate.
+  busy_spin_micros(100);
   // Combine the result of the contest between the external signal in internal
   // pull resistors.  This represents the lower bit of the 4 possible states.
   CHECK_DIF_OK(dif_gpio_read(gpio, io, &state));

--- a/sw/device/silicon_creator/rom/e2e/weak_straps/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/weak_straps/BUILD
@@ -5,6 +5,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "CLEAR_TEST_CMD",
     "opentitan_test",
+    "silicon_params",
     "verilator_params",
 )
 load(":gpio.bzl", "strap_combinations_test")
@@ -22,7 +23,16 @@ strap_combinations_test(
 opentitan_test(
     name = "sw_strap_value",
     srcs = ["sw_straps_test.c"],
-    exec_env = {"//hw/top_earlgrey:sim_verilator": None},
+    exec_env = {
+        "//hw/top_earlgrey:sim_verilator": None,
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
+    },
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/rom/sw_strap_value",
+    ),
     verilator = verilator_params(
         timeout = "long",
         test_cmd = CLEAR_TEST_CMD,

--- a/sw/device/silicon_creator/rom/e2e/weak_straps/sw_straps_test.c
+++ b/sw/device/silicon_creator/rom/e2e/weak_straps/sw_straps_test.c
@@ -22,7 +22,14 @@ static dif_pinmux_t pinmux;
 OTTF_DEFINE_TEST_CONFIG();
 
 status_t test_sw_strap_read(ujson_t *uj) {
+  const char bits[] = {'s', 'w', 'W', 'S'};
+  char pattern[4] = {0};
   uint32_t strap = pinmux_testutils_read_straps(&pinmux, &gpio);
+  for (size_t i = 0; i < 3; ++i) {
+    uint32_t v = (strap >> (2 * i)) & 3;
+    pattern[2 - i] = bits[v];
+  }
+  LOG_INFO("strap = %02x, pattern = %s", strap, pattern);
   return RESP_OK_STATUS(uj, (int32_t)strap);
 }
 


### PR DESCRIPTION
1. Add some propagation delays to `pinmux_testutils`.
2. Add some debug output to the `sw_straps` test program and test harness.
3. Add support for the teacup board's `SW_STRAPn_WEAK` pins to allow testing of weak values through high-value (1 Mohm) resistors.

Partially addresses #21630.