### PR TITLE
[rv_dm,dv] Improve the rv_dm_jtag_dmi_dm_inactive vseq

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -188,11 +188,15 @@
     {
       name: jtag_dmi_dm_inactive
       desc: '''
-            Verify that writes to DMI registers other than dmcontrol[dmactive] and ignored and they
-            all retain the reset values on reads.
 
-            - Perform random writes to DMI registers while dmcontrol[dmactive] is 0 (exclude it).
-            - Read all DMI registers back and verify they reflect POR values.
+            Verify that DMI writes to data other than dmcontrol.dmactive are ignored when dmactive
+            is false. All of these registers should return their reset values on reads.
+
+            - Write 0 to DMCONTROL.DMACTIVE to put the debug module into its reset state.
+            - Perform random DMI writes, constrained only by requiring that they don't write 1 to
+              DMCONTROL.DMACTIVE.
+            - Write 1 to DMCONTROL.DMACTIVE to leave the reset state.
+            - Read DMI registers back and check they have their POR values.
             '''
       stage: V2
       tests: ["rv_dm_jtag_dmi_dm_inactive"]

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -204,11 +204,12 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     end
   endtask
 
-  // Task to halt the hart.
+  // Tell rv_dm to request a halt, then "acknowledge" its forwarded request as the CPU after a few
+  // cycles (hartsel=0 give a hart ID of 0 as we only have one hart).
   task request_halt();
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(1));
     `DV_CHECK_EQ(cfg.rv_dm_vif.cb.debug_req, 1)
-    cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+    cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
     csr_wr(.ptr(tl_mem_ral.halted), .value(0));
   endtask
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv
@@ -15,29 +15,46 @@ class rv_dm_jtag_dmi_dm_inactive_vseq extends rv_dm_common_vseq;
     scanmode == prim_mubi_pkg::MuBi4False;
   }
 
-  task body();
-    uvm_reg_data_t wdata;
+  // Write random data to the given register
+  task randomise_register(input uvm_object ptr);
+    uvm_reg_data_t wdata = $urandom_range(0, 1000);
+    csr_wr(.ptr(ptr), .value(wdata));
+  endtask
+
+  // Check that the given register has its reset value
+  task check_rst_value(input uvm_object ptr);
+    uvm_reg as_reg;
     uvm_reg_data_t rdata;
-    wdata=$urandom_range(0,31);
-    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(0), .blocking(1), .predict(1));
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-    csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(wdata));
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-    csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(wdata));
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-    csr_wr(.ptr(jtag_dmi_ral.abstractdata[1]), .value(wdata));
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-    csr_wr(.ptr(jtag_dmi_ral.progbuf[1]), .value(wdata));
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
-    `DV_CHECK_EQ(rdata, jtag_dmi_ral.abstractdata[0].get_reset());
-    csr_rd(.ptr(jtag_dmi_ral.progbuf[0]), .value(rdata));
-    `DV_CHECK_EQ(rdata, jtag_dmi_ral.progbuf[0].get_reset());
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-    csr_rd(.ptr(jtag_dmi_ral.abstractdata[1]), .value(rdata));
-    `DV_CHECK_EQ(rdata, jtag_dmi_ral.abstractdata[1].get_reset());
-    csr_rd(.ptr(jtag_dmi_ral.progbuf[1]), .value(rdata));
-    `DV_CHECK_EQ(rdata, jtag_dmi_ral.progbuf[1].get_reset());
+
+    `DV_CHECK_FATAL($cast(as_reg, ptr));
+
+    csr_rd(.ptr(ptr), .value(rdata));
+    `DV_CHECK_EQ(rdata, as_reg.get_reset());
+  endtask
+
+  task body();
+    uvm_object ptrs[] = {jtag_dmi_ral.abstractdata[0],
+                         jtag_dmi_ral.abstractdata[1],
+                         jtag_dmi_ral.progbuf[0],
+                         jtag_dmi_ral.progbuf[1]};
+    bit is_active = 1'b0;
+
+    // Start by setting dmactive=0, which should put the debug module into a reset state.
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(is_active), .blocking(1), .predict(1));
+
+    repeat (20) begin
+      uvm_object ptr = ptrs[$urandom_range(ptrs.size() - 1)];
+
+      randcase
+        10 * !is_active: randomise_register(.ptr(ptr));
+        10:              check_rst_value(.ptr(ptr));
+        1: begin
+          is_active = !is_active;
+          csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive),
+                 .value(is_active), .blocking(1), .predict(1));
+        end
+      endcase
+    end
   endtask
 
 endclass : rv_dm_jtag_dmi_dm_inactive_vseq


### PR DESCRIPTION
This isn't really meant to make big changes, but the vseq becomes a bit less magical (fewer magic hex constants), and it's a bit more obvious what it's doing. Descriptions in the commit messages (the last one is the main commit).