### PR TITLE
[silicon_creator] add flash_ctrl function to clear faults

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -327,6 +327,46 @@ void flash_ctrl_error_code_get(flash_ctrl_error_code_t *error_code) {
       bitfield_bit32_read(code, FLASH_CTRL_ERR_CODE_OP_ERR_BIT);
 }
 
+void flash_ctrl_fault_status_code_get(
+    flash_ctrl_fault_status_code_t *status_code) {
+  // Read flash fault status code.
+  uint32_t code = abs_mmio_read32(kBase + FLASH_CTRL_FAULT_STATUS_REG_OFFSET);
+
+  // Extract flash controller fault status code bits.
+  status_code->host_gnt_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_HOST_GNT_ERR_BIT);
+  status_code->arb_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_ARB_ERR_BIT);
+  status_code->spurious_ack =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_SPURIOUS_ACK_BIT);
+  status_code->phy_storage_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_PHY_STORAGE_ERR_BIT);
+  status_code->phy_relbl_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_PHY_RELBL_ERR_BIT);
+  status_code->seed_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_SEED_ERR_BIT);
+  status_code->prog_type_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_PROG_TYPE_ERR_BIT);
+  status_code->prog_win_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_PROG_WIN_ERR_BIT);
+  status_code->prog_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_PROG_ERR_BIT);
+  status_code->rd_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_RD_ERR_BIT);
+  status_code->mp_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_MP_ERR_BIT);
+  status_code->op_err =
+      bitfield_bit32_read(code, FLASH_CTRL_FAULT_STATUS_OP_ERR_BIT);
+}
+
+void flash_ctrl_fault_status_clear(void) {
+  uint32_t clear_code = bitfield_bit32_write(
+      0, FLASH_CTRL_FAULT_STATUS_PHY_STORAGE_ERR_BIT, true);
+  clear_code = bitfield_bit32_write(
+      clear_code, FLASH_CTRL_FAULT_STATUS_PHY_RELBL_ERR_BIT, true);
+  abs_mmio_write32(kBase + FLASH_CTRL_FAULT_STATUS_REG_OFFSET, clear_code);
+}
+
 rom_error_t flash_ctrl_data_read(uint32_t addr, uint32_t word_count,
                                  void *data) {
   transaction_start((transaction_params_t){

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -285,6 +285,83 @@ typedef struct flash_ctrl_error_code {
 void flash_ctrl_error_code_get(flash_ctrl_error_code_t *error_code);
 
 /**
+ * (Un)Recoverable fault status bits.
+ */
+typedef struct flash_ctrl_fault_status_code {
+  /**
+   * A host transaction was granted with illegal properties.
+   */
+  bool host_gnt_err;
+  /**
+   * The phy arbiter encountered inconsistent results.
+   */
+  bool arb_err;
+  /**
+   * The flash emitted an unexpected acknowledgement.
+   */
+  bool spurious_ack;
+  /**
+   * The flash macro encountered a storage integrity ECC error.
+   */
+  bool phy_storage_err;
+  /**
+   * The flash macro encountered a storage reliability ECC error.
+   */
+  bool phy_relbl_err;
+  /**
+   * The seed reading process encountered an unexpected error.
+   */
+  bool seed_err;
+  /**
+   * The flash life cycle management interface encountered a program type error.
+   */
+  bool prog_type_err;
+  /**
+   * The flash life cycle management interface encountered a program resolution
+   * error.
+   */
+  bool prog_win_err;
+  /**
+   * The flash life cycle management interface encountered a program error. This
+   * could be a program integirty eror, see STD_FAULT_STATUS for more details.
+   */
+  bool prog_err;
+  /**
+   * The flash life cycle management interface encountered a read error. This
+   * could be a reliability ECC error or an integrity ECC error encountered
+   * during a read, see STD_FAULT_STATUS for more details.
+   */
+  bool rd_err;
+  /**
+   * The flash life cycle management interface encountered a memory permission
+   * error.
+   */
+  bool mp_err;
+  /**
+   * The flash life cycle management interface has supplied an undefined
+   * operation.
+   */
+  bool op_err;
+} flash_ctrl_fault_status_code_t;
+
+/**
+ * Query the fault status code register on the flash controller.
+ *
+ * This function checks the various fault status code bits as described in
+ * `flash_ctrl_fault_status_code_t`.
+ *
+ * @param[out] status_code The current fault status code of the flash
+ *                         controller.
+ */
+void flash_ctrl_fault_status_code_get(
+    flash_ctrl_fault_status_code_t *status_code);
+
+/**
+ * Clears all recoverable faults in the flash controller.
+ */
+void flash_ctrl_fault_status_clear(void);
+
+/**
  * Reads data from the data partition.
  *
  * The flash controller will truncate to the closest, lower word aligned


### PR DESCRIPTION
This adds a flash_ctrl driver function to clear recoverable faults (alerts). This is in preparation to address #21353.