### PR TITLE
[hmac,rtl/dv] DV synchronization and error handling fixes

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -28,6 +28,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
   rand bit [5:0]          key_length;
   rand bit                endian_swap;
   rand bit                digest_swap;
+  // TODO (issue #23245): verify key_swap
   rand bit                key_swap;
 
   constraint wr_addr_c {

--- a/hw/ip/prim/rtl/prim_sha2.sv
+++ b/hw/ip/prim/rtl/prim_sha2.sv
@@ -40,6 +40,7 @@ module prim_sha2 import prim_sha2_pkg::*;
   input  logic [7:0]        digest_we_i,
   output sha_word64_t [7:0] digest_o, // tie off unused port slice when MultimodeEn = 0
   output logic digest_on_blk_o, // digest being computed for a complete block
+  output fifoctl_state_e fifo_st_o,
   output logic hash_running_o, // `1` iff hash computation is active (as opposed to `idle_o`, which
                                // is also `0` and thus 'busy' when waiting for a FIFO input)
   output logic idle_o
@@ -306,13 +307,9 @@ module prim_sha2 import prim_sha2_pkg::*;
     else         hash_done_o <= hash_done_next;
   end
 
-  typedef enum logic [1:0] {
-    FifoIdle,
-    FifoLoadFromFifo,
-    FifoWait
-  } fifoctl_state_e;
-
   fifoctl_state_e fifo_st_q, fifo_st_d;
+
+  assign fifo_st_o = fifo_st_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) fifo_st_q <= FifoIdle;

--- a/hw/ip/prim/rtl/prim_sha2_pkg.sv
+++ b/hw/ip/prim/rtl/prim_sha2_pkg.sv
@@ -26,6 +26,12 @@ package prim_sha2_pkg;
                                  // set to all-1 for word-aligned input
   } sha_fifo64_t;
 
+  typedef enum logic [1:0] {
+    FifoIdle,
+    FifoLoadFromFifo,
+    FifoWait
+  } fifoctl_state_e;
+
   // one-hot encoded
   typedef enum logic [3:0] {
     SHA2_256  = 4'b0001,


### PR DESCRIPTION
This synchronizes the scoreboard checks for digest sizes 384 and 512, and once merged would close https://github.com/lowRISC/opentitan/issues/22578. This also implements a minor RTL fix with the loading from the message FIFO for SHA-2 384/512; this has no impact on functionality and digests computation, but aligns reading the words from the FIFO (and thus depth and status throughout) with what would be expected. This also implements additional DV fixes for the error handling checks when simultaneous errors are triggered.