### PR TITLE
[kmac,prim_sha2/rtl] Fix lint error in endian conversion functions

### DIFF
--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -417,7 +417,8 @@ package kmac_pkg;
 
   // Endian conversion functions (32-bit, 64-bit)
   function automatic logic [31:0] conv_endian32( input logic [31:0] v, input logic swap);
-    logic [31:0] conv_data = {<<8{v}};
+    logic [31:0] conv_data;
+    conv_data = {<<8{v}};
     conv_endian32 = (swap) ? conv_data : v ;
   endfunction : conv_endian32
 

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -421,9 +421,4 @@ package kmac_pkg;
     conv_endian32 = (swap) ? conv_data : v ;
   endfunction : conv_endian32
 
-  function automatic logic [63:0] conv_endian64( input logic [63:0] v, input logic swap);
-    logic [63:0] conv_data = {<<8{v}};
-    conv_endian64 = (swap) ? conv_data : v ;
-  endfunction : conv_endian64
-
 endpackage : kmac_pkg

--- a/hw/ip/prim/rtl/prim_sha2_pkg.sv
+++ b/hw/ip/prim/rtl/prim_sha2_pkg.sv
@@ -113,7 +113,8 @@ package prim_sha2_pkg;
   };
 
   function automatic sha_word32_t conv_endian32(input sha_word32_t v, input logic swap);
-    sha_word32_t conv_data = {<<8{v}};
+    sha_word32_t conv_data;
+    conv_data = {<<8{v}};
     conv_endian32 = (swap) ? conv_data : v;
   endfunction : conv_endian32
 

--- a/hw/ip/prim/rtl/prim_sha2_pkg.sv
+++ b/hw/ip/prim/rtl/prim_sha2_pkg.sv
@@ -117,11 +117,6 @@ package prim_sha2_pkg;
     conv_endian32 = (swap) ? conv_data : v;
   endfunction : conv_endian32
 
-  function automatic sha_word64_t conv_endian64(input sha_word64_t v, input logic swap);
-    sha_word64_t conv_data = {<<8{v}};
-    conv_endian64 = (swap) ? conv_data : v;
-  endfunction : conv_endian64
-
   function automatic sha_word32_t rotr32(input sha_word32_t v, input integer amt);
     rotr32 = (v >> amt) | (v << (32-amt));
   endfunction : rotr32


### PR DESCRIPTION
The linter flags an error when `conv_data` gets declared and initialized in one statement.  Splitting this into two statements removes the lint error.  This shouldn't make any functional difference inside a function, but it gets the file lint-clean without the need for a waiver.