### PR TITLE
[silicon_creator] make rnd32 work at owner stage

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -578,6 +578,7 @@ dual_cc_library(
     deps = dual_inputs(
         device = [
             ":otp",
+            "//sw/device/lib/arch:boot_stage",
             "//sw/device/lib/base:csr",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:hardened",
@@ -609,6 +610,7 @@ cc_test(
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//hw/ip/rv_core_ibex/data:rv_core_ibex_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:boot_stage_rom_ext",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:csr",
         "//sw/device/silicon_creator/lib/base:sec_mmio",

--- a/sw/device/silicon_creator/lib/drivers/rnd.c
+++ b/sw/device/silicon_creator/lib/drivers/rnd.c
@@ -1,8 +1,10 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 
+#include "sw/device/lib/arch/boot_stage.h"
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/crc32.h"
 #include "sw/device/lib/base/csr.h"
@@ -105,8 +107,9 @@ rom_error_t rnd_health_config_check(lifecycle_state_t lc_state) {
 }
 
 uint32_t rnd_uint32(void) {
-  if (otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_EN_OFFSET) ==
-      kHardenedBoolTrue) {
+  if (kBootStage == kBootStageOwner ||
+      otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_EN_OFFSET) ==
+          kHardenedBoolTrue) {
     // When bit-0 is clear an EDN request for new data for RND_DATA is
     // pending.
     while (!abs_mmio_read32(kBaseIbex + RV_CORE_IBEX_RND_STATUS_REG_OFFSET)) {


### PR DESCRIPTION
The ROM_EXT locks out OTP access, and the rnd32 function attempts to read a field in OTP, which was causing a load access fault when executed at the owner stage. This updates the rnd32 function to only read from OTP if it is executed at the ROM or ROM_EXT boot stages.