### PR TITLE
[manuf] enable orchestrator script use a cloud KMS CA endorsement key

### DIFF
--- a/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
@@ -39,15 +39,15 @@ FT_PROVISIONING_INPUTS = _DEVICE_ID_AND_TEST_TOKENS + """
 """
 
 LOCAL_CERT_ENDORSEMENT_PARAMS = """
-  --cert-endorsement-ecc-sk="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:cert_endorsement_key.sk.der)"
-  --uds-auth-key-id="0xfe584ae7_53790cfd_8601a312_fb32d3c1_b822d112"
+  --ca-key-der-file="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:cert_endorsement_key.sk.der)"
+  --ca-key-id="0xfe584ae7_53790cfd_8601a312_fb32d3c1_b822d112"
   --ca-certificate="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:fake_ca.pem)"
 """
 
 CLOUD_KMS_CERT_ENDORSEMENT_PARAMS = """
-  --uds-auth-key-id="0x40aac5fb_2b1205f9_003f40ab_7f3df784_1d5b59f5"
+  --ca-key-ckms-id="gcs-kms-earlgrey-ze-ca-p256-sha256-key"
+  --ca-key-id="0x40aac5fb_2b1205f9_003f40ab_7f3df784_1d5b59f5"
   --ca-certificate="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:ckms_ca.pem)"
-  --ckms-ecc-key-id="gcs-kms-earlgrey-ze-ca-p256-sha256-key"
 """
 
 FT_PERSONALIZE_SIGNING_KEYS = select({

--- a/sw/host/provisioning/ft/BUILD
+++ b/sw/host/provisioning/ft/BUILD
@@ -17,10 +17,6 @@ rust_binary(
     testonly = True,
     srcs = ["src/main.rs"],
     data = [
-        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_1",
-        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_2",
-        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_3",
-        "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:ft_personalize_4",
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:sram_ft_individualize_all",
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/binaries:ft_personalize_1_prod_signed",
         "//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/binaries:ft_personalize_2_prod_signed",

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -42,14 +42,6 @@ pub struct ManufFtProvisioningDataInput {
     #[arg(long)]
     host_ecc_sk: PathBuf,
 
-    /// Certificate endorsement ECC (P256) private key DER file.
-    #[arg(long, default_value = None,  required = true, conflicts_with = "ckms_ecc_key_id")]
-    cert_endorsement_ecc_sk: Option<PathBuf>,
-
-    /// UDS authority (endorsement) key ID hexstring.
-    #[arg(long)]
-    pub uds_auth_key_id: String,
-
     /// Measurement of the ROM_EXT image to be loaded onto the device.
     #[arg(long)]
     pub rom_ext_measurement: String,
@@ -70,13 +62,21 @@ pub struct ManufFtProvisioningDataInput {
     #[arg(long, default_value = "0")]
     pub owner_security_version: u32,
 
-    /// CA certificate to be used for verifying.
+    /// CA (ECC P256) endorsement key as a DER file path.
+    #[arg(long, default_value = None,  required = true, conflicts_with = "ca_key_ckms_id")]
+    ca_key_der_file: Option<PathBuf>,
+
+    /// CA endorsement key as a Google Cloud KMS key ID string.
+    #[arg(long, default_value = None, required = true, conflicts_with = "ca_key_der_file")]
+    pub ca_key_ckms_id: Option<String>,
+
+    /// CA key ID hexstring.
+    #[arg(long)]
+    pub ca_key_id: String,
+
+    /// CA certificate to be used for verifying a cert chain.
     #[arg(long)]
     pub ca_certificate: PathBuf,
-
-    /// Cloud KMS Key ID of the key used for certificate endorsement.
-    #[arg(long, default_value = None, required = true, conflicts_with = "cert_endorsement_ecc_sk")]
-    pub ckms_ecc_key_id: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -138,15 +138,14 @@ fn main() -> Result<()> {
     let owner_measurement =
         hex_string_to_u32_arrayvec::<8>(opts.provisioning_data.owner_measurement.as_str())?;
     let owner_security_version = opts.provisioning_data.owner_security_version;
-    let uds_auth_key_id =
-        hex_string_to_u8_arrayvec::<20>(opts.provisioning_data.uds_auth_key_id.as_str())?;
+    let ca_key_id = hex_string_to_u8_arrayvec::<20>(opts.provisioning_data.ca_key_id.as_str())?;
     let _perso_certgen_inputs = ManufCertgenInputs {
         rom_ext_measurement: rom_ext_measurement.clone(),
         rom_ext_security_version,
         owner_manifest_measurement: owner_manifest_measurement.clone(),
         owner_measurement: owner_measurement.clone(),
         owner_security_version,
-        auth_key_key_id: uds_auth_key_id.clone(),
+        auth_key_key_id: ca_key_id.clone(),
     };
 
     // Only run test unlock operation if we are in a locked LC state.
@@ -217,8 +216,8 @@ fn main() -> Result<()> {
     transport.ignore_dft_straps_on_reset()?;
 
     let cert_endorsement_key_wrapper = match (
-        opts.provisioning_data.ckms_ecc_key_id,
-        opts.provisioning_data.cert_endorsement_ecc_sk,
+        opts.provisioning_data.ca_key_ckms_id,
+        opts.provisioning_data.ca_key_der_file,
     ) {
         (Some(ckms), None) => KeyWrapper::CkmsKey(ckms),
         (None, Some(local)) => KeyWrapper::LocalKey(local),

--- a/sw/host/provisioning/orchestrator/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/orchestrator.py
@@ -238,7 +238,6 @@ def main():
                       args.ca_priv_keyfile,
                       args.ca_certfile,
                       args.ca_key_id,
-                      args.target_lc_state,
                       require_confirmation=not args.non_interactive)
     chip.parse_logs()
     chip.record_device(db_conn, commit_hash, timestamp, ecc_keyfile_basename)

--- a/sw/host/provisioning/orchestrator/ot_device.py
+++ b/sw/host/provisioning/orchestrator/ot_device.py
@@ -170,14 +170,14 @@ class OTDevice:
 --test-exit-token="{format_hex(self.test_exit_token, width=32)}" \
 --target-mission-mode-lc-state="{self.target_lc_state}" \
 --host-ecc-sk={ecc_priv_keyfile} \
---cert-endorsement-ecc-sk={ca_priv_keyfile} \
---ca-certificate={ca_certfile} \
 --rom-ext-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
 --owner-manifest-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
 --owner-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
---uds-auth-key-id={ca_key_id} \
 --rom-ext-security-version="0" \
 --owner-security-version="0" \
+--ca-key-der-file={ca_priv_keyfile} \
+--ca-key-id={ca_key_id} \
+--ca-certificate={ca_certfile} \
 """  # noqa: E501
 
         logging.info(f"Running command: {cmd}")

--- a/sw/host/provisioning/orchestrator/ot_device.py
+++ b/sw/host/provisioning/orchestrator/ot_device.py
@@ -95,37 +95,29 @@ class OTDevice:
                      ca_priv_keyfile,
                      ca_certfile,
                      ca_key_id,
-                     mission_mode_state,
                      require_confirmation=True):
         """Run the FT provisioning Bazel target."""
         logging.info("Running FT Provisioning")
 
         sram_ft_indiv_elf_path = "sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/sram_ft_individualize_{}_{}.elf"  # noqa: E501
         # Default to prod signed binaries unless in DEV state.
-        perso_bin_path = "sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/"  # noqa: E501
-        if mission_mode_state == "dev":
-            perso_bin_path += "{}"
-        else:
-            perso_bin_path += "binaries/{}"
+        perso_bin_path = "sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/binaries/{}"  # noqa: E501
 
         if self.fpga_test:
             elf = sram_ft_indiv_elf_path.format(
                 self.sku, "fpga_cw310_rom_with_fake_keys")
-            signing_key = "{}_key_0".format(mission_mode_state)
-            bazel_suffix = "fpga_cw310_rom_with_fake_keys.{}.signed.bin".format(signing_key)
+            signing_key = "prod_key_0"
+            bazel_suffix = "fpga_cw310_rom_with_fake_keys.{}.signed.bin".format(
+                signing_key)
 
             bootstrap = perso_bin_path.format(
-                "ft_personalize_1_{}".format(bazel_suffix)
-            )
+                "ft_personalize_1_{}".format(bazel_suffix))
             bootstrap2 = perso_bin_path.format(
-                "ft_personalize_2_{}".format(bazel_suffix)
-            )
+                "ft_personalize_2_{}".format(bazel_suffix))
             bootstrap3 = perso_bin_path.format(
-                "ft_personalize_3_{}".format(bazel_suffix)
-            )
+                "ft_personalize_3_{}".format(bazel_suffix))
             bootstrap4 = perso_bin_path.format(
-                "ft_personalize_4_{}".format(bazel_suffix)
-            )
+                "ft_personalize_4_{}".format(bazel_suffix))
 
             platform_bazel_flags = ""
             platform_harness_flags = """--interface=cw310 --clear-bitstream \
@@ -135,21 +127,17 @@ class OTDevice:
 
         else:
             elf = sram_ft_indiv_elf_path.format(self.sku, "silicon_creator")
-            signing_key = "earlgrey_a0_{}_0".format(mission_mode_state)
+            signing_key = "earlgrey_a0_prod_0"
             bazel_suffix = "silicon_creator.{}.signed.bin".format(signing_key)
 
             bootstrap = perso_bin_path.format(
-                "ft_personalize_1_{}".format(bazel_suffix)
-            )
+                "ft_personalize_1_{}".format(bazel_suffix))
             bootstrap2 = perso_bin_path.format(
-                "ft_personalize_2_{}".format(bazel_suffix)
-            )
+                "ft_personalize_2_{}".format(bazel_suffix))
             bootstrap3 = perso_bin_path.format(
-                "ft_personalize_3_{}".format(bazel_suffix)
-            )
+                "ft_personalize_3_{}".format(bazel_suffix))
             bootstrap4 = perso_bin_path.format(
-                "ft_personalize_4_{}".format(bazel_suffix)
-            )
+                "ft_personalize_4_{}".format(bazel_suffix))
 
             platform_bazel_flags = "--//signing:token=//signing/tokens:nitrokey"
             platform_harness_flags = """--interface=teacup \

--- a/sw/host/provisioning/orchestrator/ot_device.py
+++ b/sw/host/provisioning/orchestrator/ot_device.py
@@ -92,8 +92,9 @@ class OTDevice:
 
     def ft_provision(self,
                      ecc_priv_keyfile,
-                     ca_priv_keyfile,
-                     ca_certfile,
+                     ca_key_der_file,
+                     ca_key_ckms_id,
+                     ca_certificate,
                      ca_key_id,
                      require_confirmation=True):
         """Run the FT provisioning Bazel target."""
@@ -163,9 +164,9 @@ class OTDevice:
 --owner-measurement=0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000  \
 --rom-ext-security-version="0" \
 --owner-security-version="0" \
---ca-key-der-file={ca_priv_keyfile} \
+--ca-key-der-file={ca_key_der_file} \
 --ca-key-id={ca_key_id} \
---ca-certificate={ca_certfile} \
+--ca-certificate={ca_certificate} \
 """  # noqa: E501
 
         logging.info(f"Running command: {cmd}")


### PR DESCRIPTION
This updates the provisioning orchestrator script to use a cloud KMS CA endorsement key or a local key file (as is the currently supported behavior).