### PR TITLE
[test] Enable SLH-DSA on fpga_cw310_sival.

### DIFF
--- a/hw/bitstream/README.md
+++ b/hw/bitstream/README.md
@@ -35,7 +35,7 @@ opentitan_test(
     name = "individualize_sw_cfg_functest",
     srcs = ["individualize_sw_cfg_functest.c"],
     fpga = fpga_params(
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_test_unlocked0_manuf_initialized",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_test_unlocked0_manuf_initialized",
         tags = ["manuf"],
     ),
     exec_env = {

--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival/BUILD
@@ -18,7 +18,6 @@ load(
     "//rules:otp.bzl",
     "otp_alert_classification",
     "otp_alert_digest",
-    "otp_bytestring",
     "otp_hex",
     "otp_image",
     "otp_image_consts",
@@ -48,18 +47,19 @@ otp_json(
                 # and not listed directly in this configuration.
                 "CREATOR_SW_CFG_AST_INIT_EN": otp_hex(CONST.MUBI4_TRUE),
                 "CREATOR_SW_CFG_ROM_EXT_SKU": otp_hex(0x0),
-                # Disable SPX+ signature verification. See the definitions of
-                # `kSigverifySpxDisabledOtp` and `kSigverifySpxEnabledOtp` in
-                # sw/device/silicon_creator/lib/sigverify/spx_verify.h.
-                "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(0x8d6c8c17),
+                # Enable SPX+ signature verification. See the definitions of
+                # `kSigverifySpxDisabledOtp` in
+                # sw/device/silicon_creator/lib/sigverify/spx_verify.h for
+                # details on how to disable this feature.
+                "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(0x0),
                 # Enable flash data page scrambling and ECC.
                 "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
                 "CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG": otp_hex(0x0),
                 "CREATOR_SW_CFG_FLASH_HW_INFO_CFG_OVERRIDE": otp_hex(0x0),
                 # Disable use of entropy for countermeasures. See the definition
                 # of `hardened_bool_t` in sw/device/lib/base/hardened.h.
-                "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_TRUE),
-                "CREATOR_SW_CFG_JITTER_EN": otp_hex(CONST.MUBI4_TRUE),
+                "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_FALSE),
+                "CREATOR_SW_CFG_JITTER_EN": otp_hex(CONST.MUBI4_FALSE),
                 "CREATOR_SW_CFG_RET_RAM_RESET_MASK": otp_hex(0x0),
                 "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
                 # ROM execution is enabled if this item is set to a non-zero
@@ -326,7 +326,6 @@ cc_library(
 otp_image(
     name = "otp_img_test_unlocked0_manuf_empty",
     src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked0",
-    visibility = ["//visibility:private"],
 )
 
 # `MANUF_INITIALIZED` configuration. This configuration will be generally used

--- a/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup/BUILD
@@ -18,7 +18,6 @@ load(
     "//rules:otp.bzl",
     "otp_alert_classification",
     "otp_alert_digest",
-    "otp_bytestring",
     "otp_hex",
     "otp_image",
     "otp_image_consts",
@@ -48,10 +47,11 @@ otp_json(
                 # and not listed directly in this configuration.
                 "CREATOR_SW_CFG_AST_INIT_EN": otp_hex(CONST.MUBI4_TRUE),
                 "CREATOR_SW_CFG_ROM_EXT_SKU": otp_hex(0x0),
-                # Disable SPX+ signature verification. See the definitions of
-                # `kSigverifySpxDisabledOtp` and `kSigverifySpxEnabledOtp` in
-                # sw/device/silicon_creator/lib/sigverify/spx_verify.h.
-                "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(0x8d6c8c17),
+                # Enable SPX+ signature verification. See the definitions of
+                # `kSigverifySpxDisabledOtp` in
+                # sw/device/silicon_creator/lib/sigverify/spx_verify.h for
+                # details on how to disable this feature.
+                "CREATOR_SW_CFG_SIGVERIFY_SPX_EN": otp_hex(0x0),
                 # Enable flash data page scrambling and ECC.
                 "CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG": "0000090606",
                 "CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG": otp_hex(0x0),

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -212,7 +212,7 @@ fpga_cw310(
     # binary.
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = "fpga_cw310_sival",
-    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
     spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     tags = ["cw310_sival"],
 )
@@ -231,7 +231,7 @@ fpga_cw310(
         "//sw/device/lib/arch:boot_stage_owner",
         "//sw/device/lib/arch:fpga_cw310",
     ],
-    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
     rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
     tags = ["cw310_sival_rom_ext"],
@@ -368,7 +368,7 @@ fpga_cw340(
     # binary.
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = "fpga_cw340_sival",
-    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
     tags = ["cw340_sival"],
 )
 
@@ -386,7 +386,7 @@ fpga_cw340(
         "//sw/device/lib/arch:boot_stage_owner",
         "//sw/device/lib/arch:fpga_cw340",
     ],
-    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
     rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
     rsa_key = {"//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_prod_private_key_0": "prod_key_0"},
     tags = ["cw340_sival_rom_ext"],

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -213,6 +213,7 @@ fpga_cw310(
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = "fpga_cw310_sival",
     otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     tags = ["cw310_sival"],
 )
 

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -271,7 +271,7 @@ opentitan_test(
         changes_otp = True,
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
         needs_jtag = True,
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_dev_manuf_individualized",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_manuf_individualized",
         # TODO(#22823): Remove "broken" tag once the test is fixed.
         tags = [
             "broken",

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -123,7 +123,7 @@ opentitan_test(
         binaries = {":sram_cp_provision": "sram_cp_provision"},
         changes_otp = True,
         needs_jtag = True,
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_test_unlocked0_manuf_empty",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_test_unlocked0_manuf_empty",
         # TODO(#22823): Remove "broken" tag once the test is fixed.
         tags = [
             "broken",
@@ -291,7 +291,7 @@ opentitan_test(
         changes_otp = True,
         data = FT_PERSONALIZE_KEYS,
         needs_jtag = True,
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_test_locked0_manuf_initialized",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_test_locked0_manuf_initialized",
         # TODO(#22823): Remove "broken" tag once the test is fixed.
         tags = [
             "broken",

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -6,7 +6,7 @@ load("//rules:const.bzl", "CONST", "get_lc_items")
 load("//rules:lc.bzl", "lc_raw_unlock_token")
 load(
     "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
+    "ECDSA_SPX_KEY_STRUCTS",
 )
 load(
     "//rules:otp.bzl",
@@ -15,12 +15,12 @@ load(
 )
 load(
     "//rules/opentitan:defs.bzl",
-    "cw310_params",
     "ecdsa_key_for_lc_state",
     "fpga_params",
     "opentitan_binary",
     "opentitan_test",
     "silicon_params",
+    "spx_key_for_lc_state",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -74,7 +74,7 @@ _MANUF_TEST_LOCKED_KEY = None
     opentitan_test(
         name = "manuf_scrap_functest_{}".format(lc_state.lower()),
         srcs = ["empty_functest.c"],
-        ecdsa_key = _MANUF_TEST_LOCKED_KEY if (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS else ecdsa_key_for_lc_state(ECDSA_ONLY_KEY_STRUCTS, lc_val),
+        ecdsa_key = _MANUF_TEST_LOCKED_KEY if (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS else ecdsa_key_for_lc_state(ECDSA_SPX_KEY_STRUCTS, lc_val),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         },
@@ -309,7 +309,7 @@ opentitan_binary(
         srcs = ["flash_device_info_flash_wr_functest.c"],
         # We select the PROD key since the SRAM test program does an LC transition to DEV.
         ecdsa_key = ecdsa_key_for_lc_state(
-            ECDSA_ONLY_KEY_STRUCTS,
+            ECDSA_SPX_KEY_STRUCTS,
             CONST.LCV.PROD,
         ),
         exec_env = {
@@ -330,6 +330,10 @@ opentitan_binary(
                 --elf={sram_program}
             """,
             test_harness = "//sw/host/tests/manuf/manuf_cp_device_info_flash_wr",
+        ),
+        spx_key = spx_key_for_lc_state(
+            ECDSA_SPX_KEY_STRUCTS,
+            CONST.LCV.PROD,
         ),
         deps = [
             ":test_wafer_auth_secret",

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -284,6 +284,7 @@ opentitan_binary(
     ],
     linker_script = ":ld_slot_a",
     manifest = ":manifest",
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",
@@ -306,6 +307,7 @@ opentitan_binary(
     ],
     linker_script = ":ld_slot_b",
     manifest = ":manifest",
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         ":rom_ext",
         "//sw/device/lib/crt",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -605,7 +605,7 @@ opentitan_test(
         "//hw/top_earlgrey:sim_verilator": None,
     },
     fpga = fpga_params(
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_dev_manuf_personalized",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_manuf_personalized",
     ),
     verilator = verilator_params(tags = ["broken"]),
     deps = [
@@ -622,7 +622,7 @@ opentitan_test(
         "//hw/top_earlgrey:sim_verilator": None,
     },
     fpga = fpga_params(
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_dev_manuf_personalized",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_manuf_personalized",
         # TODO(lowrisc/opentitan#19620): fpga doesn't support lowering main clk frequency
         tags = ["broken"],
     ),
@@ -1551,13 +1551,13 @@ test_suite(
         name = "flash_ctrl_info_access_lc_{}_personalized".format(lc_state),
         srcs = ["flash_ctrl_info_access_lc.c"],
         dv = dv_params(
-            otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_{}_manuf_personalized".format(lc_state),
+            otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_{}_manuf_personalized".format(lc_state),
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
         },
         fpga = fpga_params(
-            otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_{}_manuf_personalized".format(lc_state),
+            otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_{}_manuf_personalized".format(lc_state),
         ),
         deps = [
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -1707,7 +1707,7 @@ opentitan_test(
     fpga = fpga_params(
         changes_otp = True,
         needs_jtag = True,
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_dev_manuf_personalized",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_dev_manuf_personalized",
         tags = [
             "broken",
             "lc_dev",
@@ -4218,7 +4218,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
         test_cmd = """
             --bootstrap="{firmware}"
         """,
@@ -5812,7 +5812,7 @@ opentitan_test(
     fpga = fpga_params(
         timeout = "moderate",
         needs_jtag = True,
-        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_rma_manuf_personalized",
+        otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_rma_manuf_personalized",
         test_cmd = " ".join([
             "--bootstrap=\"{firmware}\"",
             "--firmware-elf=\"{firmware:elf}\"",

--- a/sw/device/tests/doc/sival/devguide.md
+++ b/sw/device/tests/doc/sival/devguide.md
@@ -187,7 +187,7 @@ Configuration:
 ```python
 {
     rom = "//sw/device/silicon_creator/rom:mask_rom",
-    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival_bringup:otp_img_prod_manuf_personalized",
+    otp = "//hw/ip/otp_ctrl/data/earlgrey_a0_skus/sival:otp_img_prod_manuf_personalized",
 }
 ```
 


### PR DESCRIPTION
Enable SLH-DSA (SPX+) for test targets using the following execution environments:

- `//hw/top_earlgrey:fpga_cw310_sival`
- `//hw/top_earlgrey:fpga_cw310_sival_rom_ext`