### PR TITLE
[dv,jtag] Fix overflow in timeout calculation

### DIFF
--- a/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_rv_debugger.sv
@@ -1116,7 +1116,11 @@ class jtag_rv_debugger extends uvm_object;
           wait(cfg.in_reset);
           begin
             // TODO: Make this timeout controllable.
-            #(cfg.vif.tck_period_ps * 100000 * 1ps);
+
+            longint unsigned timeout_ps = cfg.vif.tck_period_ps;
+            timeout_ps = timeout_ps * 100000;
+
+            #(timeout_ps * 1ps);
             req.timed_out = 1'b1;
             `uvm_info(`gfn, $sformatf("SBA req timed out: %0s",
                                       req.sprint(uvm_default_line_printer)), UVM_LOW)


### PR DESCRIPTION
If the JTAG clock is reasonably slow, multiplying by 100_000 overflows a 32-bit value. In the test I was running, I had tck_period_ps = 258310. After it had overflowed, we were actually just waiting ~250 TCK cycles, which wasn't enough to avoid a timeout.

Cast up to a bigger type to avoid the overflow.