### PR TITLE
[rom_ext] enable read access to attestation seed pages

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -704,7 +704,6 @@ static const flash_ctrl_info_page_t *kInfoPagesNoOwnerAccess[] = {
     &kFlashCtrlInfoPageCreatorSecret,
     &kFlashCtrlInfoPageOwnerSecret,
     &kFlashCtrlInfoPageWaferAuthSecret,
-    &kFlashCtrlInfoPageAttestationKeySeeds,
     // Bank 1
     &kFlashCtrlInfoPageBootData0,
     &kFlashCtrlInfoPageBootData1,
@@ -731,6 +730,7 @@ void flash_ctrl_creator_info_pages_lockdown(void) {
 
 const flash_ctrl_info_page_t
     *kCertificateInfoPages[kFlashCtrlNumCertInfoPages] = {
+        &kFlashCtrlInfoPageAttestationKeySeeds,
         &kFlashCtrlInfoPageUdsCertificate,
         &kFlashCtrlInfoPageCdi0Certificate,
         &kFlashCtrlInfoPageCdi1Certificate,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -165,9 +165,9 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  * ```
  */
 enum {
-  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 18,
-  kFlashCtrlSecMmioCertInfoPagesCreatorCfg = 8,
-  kFlashCtrlSecMmioCertInfoPagesOwnerRestrict = 4,
+  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 16,
+  kFlashCtrlSecMmioCertInfoPagesCreatorCfg = 10,
+  kFlashCtrlSecMmioCertInfoPagesOwnerRestrict = 5,
   kFlashCtrlSecMmioDataDefaultCfgSet = 1,
   kFlashCtrlSecMmioDataDefaultPermsSet = 1,
   kFlashCtrlSecMmioExecSet = 1,
@@ -588,10 +588,13 @@ void flash_ctrl_exec_set(uint32_t exec_val);
 void flash_ctrl_creator_info_pages_lockdown(void);
 
 /**
- * Number of flash info pages reserved for storing certificates.
+ * Number of flash info pages reserved for storing:
+ *
+ * 1. any DRBG seed material needed to reproduce private keys, and
+ * 2. the certificates themselves.
  */
 enum {
-  kFlashCtrlNumCertInfoPages = 4,
+  kFlashCtrlNumCertInfoPages = 5,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -682,16 +682,11 @@ INSTANTIATE_TEST_SUITE_P(AllCases, FlashCtrlCfgSetTest,
                              }));
 
 TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
-  std::array<const flash_ctrl_info_page_t *, 9> no_owner_access = {
-      &kFlashCtrlInfoPageFactoryId,
-      &kFlashCtrlInfoPageCreatorSecret,
-      &kFlashCtrlInfoPageOwnerSecret,
-      &kFlashCtrlInfoPageWaferAuthSecret,
-      &kFlashCtrlInfoPageAttestationKeySeeds,
-      &kFlashCtrlInfoPageBootData0,
-      &kFlashCtrlInfoPageBootData1,
-      &kFlashCtrlInfoPageOwnerSlot0,
-      &kFlashCtrlInfoPageOwnerSlot1,
+  std::array<const flash_ctrl_info_page_t *, 8> no_owner_access = {
+      &kFlashCtrlInfoPageFactoryId,   &kFlashCtrlInfoPageCreatorSecret,
+      &kFlashCtrlInfoPageOwnerSecret, &kFlashCtrlInfoPageWaferAuthSecret,
+      &kFlashCtrlInfoPageBootData0,   &kFlashCtrlInfoPageBootData1,
+      &kFlashCtrlInfoPageOwnerSlot0,  &kFlashCtrlInfoPageOwnerSlot1,
   };
   for (auto page : no_owner_access) {
     auto info_page = InfoPages().at(page);
@@ -717,7 +712,8 @@ TEST_F(FlashCtrlTest, BankErasePermsSet) {
 }
 
 TEST_F(FlashCtrlTest, CertInfoCreatorCfg) {
-  std::array<const flash_ctrl_info_page_t *, 4> cert_pages = {
+  std::array<const flash_ctrl_info_page_t *, 5> cert_pages = {
+      &kFlashCtrlInfoPageAttestationKeySeeds,
       &kFlashCtrlInfoPageUdsCertificate,
       &kFlashCtrlInfoPageCdi0Certificate,
       &kFlashCtrlInfoPageCdi1Certificate,
@@ -736,7 +732,8 @@ TEST_F(FlashCtrlTest, CertInfoCreatorCfg) {
 }
 
 TEST_F(FlashCtrlTest, CertInfoOwnerRestrict) {
-  std::array<const flash_ctrl_info_page_t *, 4> cert_pages = {
+  std::array<const flash_ctrl_info_page_t *, 5> cert_pages = {
+      &kFlashCtrlInfoPageAttestationKeySeeds,
       &kFlashCtrlInfoPageUdsCertificate,
       &kFlashCtrlInfoPageCdi0Certificate,
       &kFlashCtrlInfoPageCdi1Certificate,

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -81,20 +81,6 @@ enum {
 OT_WARN_UNUSED_RESULT
 static rom_error_t load_attestation_keygen_seed(
     attestation_key_seed_t additional_seed, uint32_t *seed) {
-  // Set flash page configuration and permissions.
-  flash_ctrl_info_perms_set(&kFlashCtrlInfoPageAttestationKeySeeds,
-                            (flash_ctrl_perms_t){
-                                .read = kMultiBitBool4True,
-                                .write = kMultiBitBool4False,
-                                .erase = kMultiBitBool4True,
-                            });
-  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageAttestationKeySeeds,
-                          (flash_ctrl_cfg_t){
-                              .scrambling = kMultiBitBool4True,
-                              .ecc = kMultiBitBool4True,
-                              .he = kMultiBitBool4False,
-                          });
-
   // Read seed from flash info page.
   uint32_t seed_flash_offset = 0 + (additional_seed * kAttestationSeedBytes);
   rom_error_t err =


### PR DESCRIPTION
This fixes a bug in the ROM_EXT to enable read access (while removing write and erase access) to the attestation seed INFO page so that CDI_1 and TPM attestation keys can be generated at the Owner stage, as was originally intended.