### PR TITLE
[cherry-pick] #23401 and #23403 to `earlgrey_es_sival` branch

### DIFF
--- a/sw/device/silicon_creator/lib/attestation.h
+++ b/sw/device/silicon_creator/lib/attestation.h
@@ -90,6 +90,13 @@ typedef enum {
 } attestation_key_seed_t;
 
 /**
+ * Attestation key generation scheme version.
+ */
+enum {
+  kAttestationKeyGenVersion0 = 0,
+};
+
+/**
  * Holds an attestation public key (ECDSA-P256).
  */
 typedef struct attestation_public_key {

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -704,7 +704,6 @@ static const flash_ctrl_info_page_t *kInfoPagesNoOwnerAccess[] = {
     &kFlashCtrlInfoPageCreatorSecret,
     &kFlashCtrlInfoPageOwnerSecret,
     &kFlashCtrlInfoPageWaferAuthSecret,
-    &kFlashCtrlInfoPageAttestationKeySeeds,
     // Bank 1
     &kFlashCtrlInfoPageBootData0,
     &kFlashCtrlInfoPageBootData1,
@@ -731,6 +730,7 @@ void flash_ctrl_creator_info_pages_lockdown(void) {
 
 const flash_ctrl_info_page_t
     *kCertificateInfoPages[kFlashCtrlNumCertInfoPages] = {
+        &kFlashCtrlInfoPageAttestationKeySeeds,
         &kFlashCtrlInfoPageUdsCertificate,
         &kFlashCtrlInfoPageCdi0Certificate,
         &kFlashCtrlInfoPageCdi1Certificate,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -165,9 +165,9 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  * ```
  */
 enum {
-  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 18,
-  kFlashCtrlSecMmioCertInfoPagesCreatorCfg = 8,
-  kFlashCtrlSecMmioCertInfoPagesOwnerRestrict = 4,
+  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 16,
+  kFlashCtrlSecMmioCertInfoPagesCreatorCfg = 10,
+  kFlashCtrlSecMmioCertInfoPagesOwnerRestrict = 5,
   kFlashCtrlSecMmioDataDefaultCfgSet = 1,
   kFlashCtrlSecMmioDataDefaultPermsSet = 1,
   kFlashCtrlSecMmioExecSet = 1,
@@ -588,10 +588,13 @@ void flash_ctrl_exec_set(uint32_t exec_val);
 void flash_ctrl_creator_info_pages_lockdown(void);
 
 /**
- * Number of flash info pages reserved for storing certificates.
+ * Number of flash info pages reserved for storing:
+ *
+ * 1. any DRBG seed material needed to reproduce private keys, and
+ * 2. the certificates themselves.
  */
 enum {
-  kFlashCtrlNumCertInfoPages = 4,
+  kFlashCtrlNumCertInfoPages = 5,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -682,16 +682,11 @@ INSTANTIATE_TEST_SUITE_P(AllCases, FlashCtrlCfgSetTest,
                              }));
 
 TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
-  std::array<const flash_ctrl_info_page_t *, 9> no_owner_access = {
-      &kFlashCtrlInfoPageFactoryId,
-      &kFlashCtrlInfoPageCreatorSecret,
-      &kFlashCtrlInfoPageOwnerSecret,
-      &kFlashCtrlInfoPageWaferAuthSecret,
-      &kFlashCtrlInfoPageAttestationKeySeeds,
-      &kFlashCtrlInfoPageBootData0,
-      &kFlashCtrlInfoPageBootData1,
-      &kFlashCtrlInfoPageOwnerSlot0,
-      &kFlashCtrlInfoPageOwnerSlot1,
+  std::array<const flash_ctrl_info_page_t *, 8> no_owner_access = {
+      &kFlashCtrlInfoPageFactoryId,   &kFlashCtrlInfoPageCreatorSecret,
+      &kFlashCtrlInfoPageOwnerSecret, &kFlashCtrlInfoPageWaferAuthSecret,
+      &kFlashCtrlInfoPageBootData0,   &kFlashCtrlInfoPageBootData1,
+      &kFlashCtrlInfoPageOwnerSlot0,  &kFlashCtrlInfoPageOwnerSlot1,
   };
   for (auto page : no_owner_access) {
     auto info_page = InfoPages().at(page);
@@ -717,7 +712,8 @@ TEST_F(FlashCtrlTest, BankErasePermsSet) {
 }
 
 TEST_F(FlashCtrlTest, CertInfoCreatorCfg) {
-  std::array<const flash_ctrl_info_page_t *, 4> cert_pages = {
+  std::array<const flash_ctrl_info_page_t *, 5> cert_pages = {
+      &kFlashCtrlInfoPageAttestationKeySeeds,
       &kFlashCtrlInfoPageUdsCertificate,
       &kFlashCtrlInfoPageCdi0Certificate,
       &kFlashCtrlInfoPageCdi1Certificate,
@@ -736,7 +732,8 @@ TEST_F(FlashCtrlTest, CertInfoCreatorCfg) {
 }
 
 TEST_F(FlashCtrlTest, CertInfoOwnerRestrict) {
-  std::array<const flash_ctrl_info_page_t *, 4> cert_pages = {
+  std::array<const flash_ctrl_info_page_t *, 5> cert_pages = {
+      &kFlashCtrlInfoPageAttestationKeySeeds,
       &kFlashCtrlInfoPageUdsCertificate,
       &kFlashCtrlInfoPageCdi0Certificate,
       &kFlashCtrlInfoPageCdi1Certificate,

--- a/sw/device/silicon_creator/lib/otbn_boot_services.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.c
@@ -81,20 +81,6 @@ enum {
 OT_WARN_UNUSED_RESULT
 static rom_error_t load_attestation_keygen_seed(
     attestation_key_seed_t additional_seed, uint32_t *seed) {
-  // Set flash page configuration and permissions.
-  flash_ctrl_info_perms_set(&kFlashCtrlInfoPageAttestationKeySeeds,
-                            (flash_ctrl_perms_t){
-                                .read = kMultiBitBool4True,
-                                .write = kMultiBitBool4False,
-                                .erase = kMultiBitBool4True,
-                            });
-  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageAttestationKeySeeds,
-                          (flash_ctrl_cfg_t){
-                              .scrambling = kMultiBitBool4True,
-                              .ecc = kMultiBitBool4True,
-                              .he = kMultiBitBool4False,
-                          });
-
   // Read seed from flash info page.
   uint32_t seed_flash_offset = 0 + (additional_seed * kAttestationSeedBytes);
   rom_error_t err =

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -104,6 +104,13 @@ const flash_info_field_t kFlashInfoFieldTpmCikAttestationKeySeed = {
     .byte_offset = (5 * kAttestationSeedBytes),
 };
 
+const flash_info_field_t kFlashInfoFieldAttestationKeyGenVersion = {
+    .partition = 0,
+    .bank = 0,
+    .page = 4,
+    .byte_offset = FLASH_CTRL_PARAM_BYTES_PER_PAGE - sizeof(uint32_t),
+};
+
 status_t manuf_flash_info_field_read(dif_flash_ctrl_state_t *flash_state,
                                      flash_info_field_t field,
                                      uint32_t *data_out, size_t num_words) {

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -47,6 +47,7 @@ extern const flash_info_field_t kFlashInfoFieldCdi1AttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldTpmEkAttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldTpmCekAttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldTpmCikAttestationKeySeed;
+extern const flash_info_field_t kFlashInfoFieldAttestationKeyGenVersion;
 
 /**
  * Reads info flash page field.

--- a/sw/device/silicon_creator/manuf/lib/personalize.c
+++ b/sw/device/silicon_creator/manuf/lib/personalize.c
@@ -390,6 +390,14 @@ status_t manuf_personalize_device_secrets(
                                        kFlashInfoFieldTpmCikAttestationKeySeed,
                                        kAttestationSeedWords));
 
+  // Provision the attestation key generation version field (at the end of the
+  // attestation seed info page).
+  uint32_t kKeyGenVersion = kAttestationKeyGenVersion0;
+  TRY(manuf_flash_info_field_write(flash_state,
+                                   kFlashInfoFieldAttestationKeyGenVersion,
+                                   /*data_in=*/&kKeyGenVersion, /*num_words=*/1,
+                                   /*erase_page_before_write=*/false));
+
   // Provision the OTP SECRET2 partition.
   TRY(otp_partition_secret2_configure(otp_ctrl, wrapped_rma_token));
 

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,8 +14,8 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "2",
-    SECURITY = "1",
+    MINOR = "3",
+    SECURITY = "3",
 )
 
 SLOTS = [


### PR DESCRIPTION
This cherry picks two fixes to the earlgrey_es_sival branch:
1. a ROM_EXT fix to enable reading the attestation seed flash info page at the owner stage (to enable TPM/CDI_1 keygen there as was originally intended), and
2. the addition of a keygen version field to the attestation key seed INFO page