### PR TITLE
[rv_dm,dv] Increase the wait time for injecting resets

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_common_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_common_vseq.sv
@@ -22,6 +22,14 @@ class rv_dm_common_vseq extends rv_dm_base_vseq;
     unavailable == 0;
   }
 
+  // This function controls how long we will wait for a quiet period when we want to issue a reset
+  // in the wait_to_issue_reset task. Some of our existing vseqs do lots of back-to-back CSR
+  // operations. Bumping this up from the default 10k cycles guarantees that we will find a good
+  // time to inject the reset.
+  virtual function int wait_cycles_with_no_outstanding_accesses();
+    return 50_000;
+  endfunction
+
   // This is a thin wrapper around the base class version of run_csr_vseq, but setting the timeout
   // for the CSR operations to be larger. This is needed because the timeout counts from (roughly)
   // the start of the CSR sequence and isn't enough to allow for slow values of the JTAG clock.


### PR DESCRIPTION
The impact of this change can be seen in e.g. rv_dm_tap_fsm_vseq. With the original 10,000 cycle wait, the back-to-back DMI operations took too long and we never managed to inject the reset.

(I should say: this doesn't actually get the test passing! But I think that's a separate issue, which I will try to address in a separate PR)