### PR TITLE
[dv] Minor cleanups in `run_seq_with_rand_reset_vseq`

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -691,7 +691,9 @@ class cip_base_vseq #(
     int had_stress_seq_plusarg = $value$plusargs("stress_seq=%0s", stress_seq_name);
     `DV_CHECK_FATAL(had_stress_seq_plusarg)
 
-    run_seq_with_rand_reset_vseq(create_seq_by_name(stress_seq_name), num_times);
+    run_seq_with_rand_reset_vseq(.seq(create_seq_by_name(stress_seq_name)),
+                                 .num_times(num_times),
+                                 .reset_delay_bound(10_000_000));
   endtask
 
   // Some blocks needs input ports and status / intr csr clean up
@@ -704,8 +706,8 @@ class cip_base_vseq #(
   // reset_delay_bound cycles. When we come out of reset, check all CSR values to ensure they are
   // the documented reset values.
   virtual task run_seq_with_rand_reset_vseq(uvm_sequence seq,
-                                            int          num_times = 1,
-                                            uint         reset_delay_bound = 10_000_000);
+                                            int          num_times,
+                                            uint         reset_delay_bound);
     `DV_CHECK_FATAL(seq != null)
     `uvm_info(`gfn, $sformatf("running run_seq_with_rand_reset_vseq for sequence %s",
                                seq.get_full_name()), UVM_MEDIUM)

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -787,7 +787,7 @@ class cip_base_vseq #(
   // accesses can also be set by derived classes for special cases. If the wait doesn't clear
   // something is probably wrong: perhaps some loop sending CSR transactions is missing a
   // break if stop_transaction_generators() is set.
-  virtual task wait_to_issue_reset(uint reset_delay_bound = 10_000_000);
+  virtual task wait_to_issue_reset(uint reset_delay_bound);
     int cycles_with_no_accesses = 0;
     int cycles_waited;
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -700,12 +700,11 @@ class cip_base_vseq #(
   virtual task rand_reset_eor_clean_up();
   endtask
 
-  // Run the given sequence and possibly a TL errors vseq (if do_tl_err is set). Suddenly inject a
-  // reset after at most reset_delay_bound cycles. When we come out of reset, check all CSR values
-  // to ensure they are the documented reset values.
+  // Run the given sequence together with a TL errors vseq. Suddenly inject a reset after at most
+  // reset_delay_bound cycles. When we come out of reset, check all CSR values to ensure they are
+  // the documented reset values.
   virtual task run_seq_with_rand_reset_vseq(uvm_sequence seq,
                                             int          num_times = 1,
-                                            bit          do_tl_err = 1,
                                             uint         reset_delay_bound = 10_000_000);
     `DV_CHECK_FATAL(seq != null)
     `uvm_info(`gfn, $sformatf("running run_seq_with_rand_reset_vseq for sequence %s",
@@ -718,16 +717,14 @@ class cip_base_vseq #(
                                 i, num_times), UVM_LOW)
       // Arbitration: requests at highest priority granted in FIFO order, so that we can predict
       // results for many non-blocking accesses
-      if (do_tl_err) p_sequencer.tl_sequencer_h.set_arbitration(UVM_SEQ_ARB_STRICT_FIFO);
+      p_sequencer.tl_sequencer_h.set_arbitration(UVM_SEQ_ARB_STRICT_FIFO);
       fork
         begin: isolation_fork
           fork : run_test_seqs
             begin : seq_wo_reset
               fork
                 begin : tl_err_seq
-                  if (do_tl_err) begin
-                    run_tl_errors_vseq(.num_times($urandom_range(10, 1000)), .do_wait_clk(1'b1));
-                  end
+                  run_tl_errors_vseq(.num_times($urandom_range(10, 1000)), .do_wait_clk(1'b1));
                 end
                 begin : run_stress_seq
                   dv_base_vseq #(RAL_T, CFG_T, COV_T, VIRTUAL_SEQUENCER_T) dv_vseq;
@@ -1037,8 +1034,7 @@ class cip_base_vseq #(
     // injecting a reset. Since the IP block is otherwise quiescent, we only really care about what
     // point in a TL transaction the reset occurs. Each TL transaction takes roughly 10 cycles, so
     // there's no need to wait longer than 1000 cycles (which would be ~100 TL transactions).
-    run_seq_with_rand_reset_vseq(.seq(cip_seq), .num_times(num_times), .do_tl_err(1),
-                                 .reset_delay_bound(1000));
+    run_seq_with_rand_reset_vseq(.seq(cip_seq), .num_times(num_times), .reset_delay_bound(1000));
   endtask
 
   // TLUL mask must be contiguous, e.g. 'b1001, 'b1010 aren't allowed

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_common_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_common_vseq.sv
@@ -28,7 +28,7 @@ class hmac_common_vseq extends hmac_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
-  virtual task wait_to_issue_reset(uint reset_delay_bound = 10_000_000);
+  virtual task wait_to_issue_reset(uint reset_delay_bound);
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(trig_rst_during_hash)
 
     if (trig_rst_during_hash) begin


### PR DESCRIPTION
There are some notes in the individual commits, but the motivation was that I had to squint a bit to work out what the code was doing, and realised that it could be somewhat simpler.