### PR TITLE
[rom] Maybe don't clear the reset reason

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -233,6 +233,7 @@ otp_json(
                 # By default, ROM_EXT's bootstrap feature should be disabled.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(CONST.HARDENED_FALSE),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_FALSE),
                 "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
             },
         ),

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -185,6 +185,9 @@ otp_json(
                 # Disable ROM_EXT recovery feature.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                # TODO(#23411): The customer wants this to be HARDENED_TRUE
+                # for production chips.
+                "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_FALSE),
                 "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
             },
         ),

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -185,6 +185,7 @@ otp_json(
                 # Disable ROM_EXT recovery feature.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_FALSE),
                 "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
             },
         ),

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -217,6 +217,7 @@ cc_library(
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crt",
+        "//sw/device/lib/dif:rstmgr",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:ibex",

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -14,6 +14,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
@@ -147,6 +148,14 @@ static void test_wrapper(void *task_parameters) {
 
 void _ottf_main(void) {
   test_status_set(kTestStatusInTest);
+
+  // Clear reset reason register.
+  dif_rstmgr_t rstmgr;
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+  if (kOttfTestConfig.clear_reset_reason) {
+    CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+  }
 
   // Initialize the console to enable logging for non-DV simulation platforms.
   if (kDeviceType != kDeviceSimDV) {

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -74,6 +74,13 @@ typedef struct ottf_test_config {
   bool enable_uart_flow_control;
 
   /**
+   * Indicates that this test needs an explicit clear of the RSTMGR reset_reason
+   * register.  This may be necessary for tests that execute with the OTP
+   * configuration OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN set to true.
+   */
+  bool clear_reset_reason;
+
+  /**
    * Name of the file in which `kOttfTestConfig` is defined. Most of the time,
    * this will be the file that defines `test_main()`.
    */

--- a/sw/device/silicon_creator/rom/e2e/reset_reason/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/reset_reason/BUILD
@@ -1,0 +1,57 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "fpga_params",
+    "opentitan_test",
+)
+load(
+    "//rules:const.bzl",
+    "CONST",
+)
+load(
+    "//rules:otp.bzl",
+    "STD_OTP_OVERLAYS",
+    "otp_hex",
+    "otp_image",
+    "otp_json",
+    "otp_partition",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+otp_json(
+    name = "otp_json_reset_reason",
+    partitions = [
+        otp_partition(
+            name = "OWNER_SW_CFG",
+            items = {
+                "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_TRUE),
+            },
+        ),
+    ],
+)
+
+# OTP images that enable the watchdog.
+otp_image(
+    name = "otp_img_reset_reason",
+    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":otp_json_reset_reason"],
+)
+
+opentitan_test(
+    name = "reset_reasons_test",
+    srcs = ["reset_reasons_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    fpga = fpga_params(
+        otp = ":otp_img_reset_reason",
+    ),
+    deps = [
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)

--- a/sw/device/silicon_creator/rom/e2e/reset_reason/reset_reasons_test.c
+++ b/sw/device/silicon_creator/rom/e2e/reset_reason/reset_reasons_test.c
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kPor = 1 << kRstmgrReasonPowerOn,
+  kSwReset = 1 << kRstmgrReasonSoftwareRequest,
+};
+
+bool test_main(void) {
+  uint32_t reasons = rstmgr_reason_get();
+  LOG_INFO("reset_reasons = %08x", reasons);
+  if (reasons == kPor) {
+    // If the reasons are only POR, then reset to accumulate reasons and
+    // re-enter the test program.
+    rstmgr_reset();
+  } else if (reasons == (kPor | kSwReset)) {
+    // If the reasons are exactly POR|SW, then we're in the second iteration of
+    // this test and the ROM did not clear the reset reason (as instructed by
+    // OTP).
+    return true;
+  }
+  return false;
+}

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -210,7 +210,11 @@ static rom_error_t rom_init(void) {
 
   // Store the reset reason in retention RAM and clear the register.
   retention_sram_get()->creator.reset_reasons = reset_reasons;
-  rstmgr_reason_clear(reset_reasons);
+  if (otp_read32(
+          OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN_OFFSET) !=
+      kHardenedBoolTrue) {
+    rstmgr_reason_clear(reset_reasons);
+  }
 
   // This function is a NOP unless ROM is built for an fpga.
   device_fpga_version_print();


### PR DESCRIPTION
1. Add an OTP to control preserving the reset reason in rstmgr (default configuration: clear it).
2. Do not clear the reset reason if instructed to preserve it by OTP.
3. Add a test for the reset-reason-preserving OTP configuration.

Addresses #21355.