### PR TITLE
[dv,usbdev] Usbdev DV cleanup

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -22,6 +22,4 @@ class usb20_agent_cfg extends dv_base_agent_cfg;
   // which necessitates two successive bits otherwise. Once set, it is accompanied by
   // its respective test sequence, followed by the transmission of a single-bit SE0 as EOP.
   bit single_bit_SE0 = 1'b0;
-  // Indicates that a timeout occurred when awaiting a response from the device.
-  bit timed_out = 1'b0;
 endclass

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -433,7 +433,7 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
       join
       `uvm_info(`gfn, $sformatf("timed_out = %d", timed_out), UVM_MEDIUM)
       // this bit will indicate if device didn't repond within timeout period.
-      cfg.timed_out = timed_out;
+      rsp_item.timed_out = timed_out;
     end join
   endtask
 

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -15,6 +15,9 @@ class usb20_item extends uvm_sequence_item;
   brequest_e m_bR;
   usb_transfer_e m_usb_transfer;
 
+  // Indicates that a timeout occurred when awaiting a response from the device.
+  bit timed_out = 1'b0;
+
   `uvm_object_utils_begin(usb20_item)
   `uvm_object_utils_end
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -16,9 +16,7 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
     configure_out_trans(ep_default);
     // Out token packet followed by a data packet of 8 bytes
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
-    get_response(rsp_item);
-    $cast(item, rsp_item);
-    item.check_pid_type(PidTypeAck);
+    check_response_matches(PidTypeAck);
 
     // Check that the USB device received a packet with the expected properties.
     check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_av_buffer_vseq.sv
@@ -12,30 +12,16 @@ class usbdev_av_buffer_vseq extends usbdev_base_vseq;
   RSP             rsp_item;
 
   task body();
-    // Configure transaction
-    configure_trans();
+    // Configure support for OUT transaction
+    configure_out_trans(ep_default);
     // Out token packet followed by a data packet of 8 bytes
-    call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
     get_response(rsp_item);
     $cast(item, rsp_item);
     item.check_pid_type(PidTypeAck);
-    cfg.clk_rst_vif.wait_clks(20);
 
     // Check that the USB device received a packet with the expected properties.
-    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
-  endtask
-
-  task configure_trans();
-    // Enable EP0 Out
-    csr_wr(.ptr(ral.ep_out_enable[0].enable[endp]), .value(1'b1));
-    csr_update(ral.ep_out_enable[0]);
-    // Enable rx out
-    ral.rxenable_out[0].out[endp].set(1'b1);
-    csr_update(ral.rxenable_out[0]);
-    // Set buffer
-    csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id));
+    check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);
   endtask
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -226,7 +226,7 @@ endtask
   endtask
 
   // Construct and transmit a token packet to the USB device
-  virtual task call_token_seq(bit [3:0] ep, pid_type_e pid_type, bit inject_crc_error = 0);
+  virtual task send_token_packet(bit [3:0] ep, pid_type_e pid_type, bit inject_crc_error = 0);
     `uvm_create_on(m_token_pkt, p_sequencer.usb20_sequencer_h)
     m_token_pkt.m_ev_type  = EvPacket;
     m_token_pkt.m_pkt_type = PktTypeToken;
@@ -258,7 +258,7 @@ endtask
 
   // Construct and transmit a randomized DATA packet to the USB device, retaining a copy for
   // subsequent checks.
-  virtual task call_data_seq(input pid_type_e pid_type,
+  virtual task send_prnd_data_packet(input pid_type_e pid_type,
                              input bit randomize_length, input bit [6:0] num_of_bytes,
                              input bit isochronous_transfer = 1'b0);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
@@ -278,12 +278,12 @@ endtask
   // Construct and transmit a randomized OUT DATA packet, retaining a copy for subsequent checks.
   virtual task send_prnd_setup_packet(bit [3:0] ep);
     // Send SETUP token packet to the selected endpoint on the specified device.
-    call_token_seq(ep, PidTypeSetupToken);
+    send_token_packet(ep, PidTypeSetupToken);
     // Variable delay between SETUP token packet and the ensuing DATA packet.
     inter_packet_delay();
     // DATA0/DATA packet with randomized content, but we'll honor the rule that SETUP DATA packets
     // are 8 bytes in length. The DUT does not attempt to interpret the packet content.
-    call_data_seq(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
+    send_prnd_data_packet(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
   endtask
 
   // Construct and transmit a randomized OUT DATA packet, retaining a copy for subsequent checks.
@@ -291,18 +291,18 @@ endtask
                                     input bit randomize_length, input bit [6:0] num_of_bytes,
                                     bit isochronous_transfer = 1'b0);
     // Send OUT token packet to the selected endpoint on the specified device.
-    call_token_seq(ep, PidTypeOutToken);
+    send_token_packet(ep, PidTypeOutToken);
     // Variable delay between OUT token packet and the ensuing DATA packet.
     inter_packet_delay();
     // DATA0/DATA packet with randomized content.
-    call_data_seq(pid_type, randomize_length, num_of_bytes, isochronous_transfer);
+    send_prnd_data_packet(pid_type, randomize_length, num_of_bytes, isochronous_transfer);
   endtask
 
   // Construct and transmit an OUT DATA packet containing the supplied data.
   virtual task send_out_packet(bit [3:0] ep, input pid_type_e pid_type, byte unsigned data[],
                                bit isochronous_transfer = 1'b0, bit [6:0] dev_address = dev_addr);
     // Send OUT token packet to the selected endpoint on the specified device.
-    call_token_seq(ep, PidTypeOutToken);
+    send_token_packet(ep, PidTypeOutToken);
     // Variable delay between OUT token packet and the ensuing DATA packet.
     inter_packet_delay();
     // DATA0/DATA1 packet with the given content.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -324,11 +324,15 @@ endtask
     check_tx_packet(in_data, pid_type, data);
   endtask
 
-  virtual task call_handshake_sequence(input pkt_type_e pkt_type, input pid_type_e pid_type);
+  // Send handshake to DUT after an appropriate turn-around delay.
+  virtual task send_handshake(input pid_type_e pid_type);
+    // Must delay for a few bit intervals before responding.
+    response_delay();
+    // Construct and send handshake response.
     `uvm_create_on(m_handshake_pkt, p_sequencer.usb20_sequencer_h)
     start_item(m_handshake_pkt);
     m_handshake_pkt.m_ev_type  = EvPacket;
-    m_handshake_pkt.m_pkt_type = pkt_type;
+    m_handshake_pkt.m_pkt_type = PktTypeHandshake;
     m_handshake_pkt.m_pid_type = pid_type;
     m_usb20_item = m_handshake_pkt;
     finish_item(m_handshake_pkt);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_bitstuff_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_bitstuff_err_vseq.sv
@@ -56,7 +56,7 @@ class usbdev_bitstuff_err_vseq extends usbdev_base_vseq;
     // Disable the bit stuffing logic in the driver.
     cfg.m_usb20_agent_cfg.disable_bitstuffing = 1'b1;
 
-    call_token_seq(ep_default, PidTypeOutToken);
+    send_token_packet(ep_default, PidTypeOutToken);
     inter_packet_delay();
     `DV_CHECK_EQ(cfg.intr_vif.pins[IntrRxBitstuffErr], 0)
     send_data_packet(PidTypeData0, data);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_bitstuff_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_bitstuff_err_vseq.sv
@@ -10,7 +10,7 @@ class usbdev_bitstuff_err_vseq extends usbdev_base_vseq;
   task body();
     byte unsigned data[$];
     bit bitstuff_err;
-    configure_out_trans();
+    configure_out_trans(ep_default);
     case ($urandom_range(0,3))
       0: begin
         // We need a known payload to guarantee a bit stuffing violation, and 6 contiguous
@@ -21,7 +21,7 @@ class usbdev_bitstuff_err_vseq extends usbdev_base_vseq;
       1: begin
         // Contiguous run of '1's involving the device address and endpoint
         dev_addr = 7'h78;  // LSB transmitted first...
-        endp = 4'h7;  // ... so this supplies just 7 contiguous '1's.
+        ep_default = 4'h7;  // ... so this supplies just 7 contiguous '1's.
       end
       2: begin
         // Endpoint and CRC5; the final bit of the endpoint, combined with the 5 bits of the
@@ -31,7 +31,7 @@ class usbdev_bitstuff_err_vseq extends usbdev_base_vseq;
         // This OUT data packet will not be stored by the DUT but it does still report the
         // detection of bit stuffing violations in the packet before dropping it.
         dev_addr = 7'h7d;
-        endp = 4'hf;
+        ep_default = 4'hf;
       end
       default: begin
         // Generate a random length packet of random data, and then set 7 bits at a random
@@ -56,7 +56,7 @@ class usbdev_bitstuff_err_vseq extends usbdev_base_vseq;
     // Disable the bit stuffing logic in the driver.
     cfg.m_usb20_agent_cfg.disable_bitstuffing = 1'b1;
 
-    call_token_seq(PidTypeOutToken);
+    call_token_seq(ep_default, PidTypeOutToken);
     inter_packet_delay();
     `DV_CHECK_EQ(cfg.intr_vif.pins[IntrRxBitstuffErr], 0)
     send_data_packet(PidTypeData0, data);
@@ -64,7 +64,7 @@ class usbdev_bitstuff_err_vseq extends usbdev_base_vseq;
     $cast(m_usb20_item, m_response_item);
 
     // All of these packets should be ignored, so we expect no response.
-    `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.timed_out, 1);
+    `DV_CHECK_EQ(m_usb20_item.timed_out, 1);
 
     // Check that the bit stuffing violation was reported.
     csr_rd(.ptr(ral.intr_state.rx_bitstuff_err), .value(bitstuff_err));

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
@@ -31,16 +31,11 @@ class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
   // receives the expected handshake response.
   task send_and_check_packet(bit [3:0] ep, bit data_toggle, bit exp_ack,
                              inout uvm_reg_data_t exp_out_data_toggles);
-    endp = ep;  // TODO: should be a parameter to tasks in base sequence.
-
     // Set up the OUT EP and supply a randomly-chosen buffer.
     `DV_CHECK_STD_RANDOMIZE_FATAL(out_buffer_id);
-    configure_out_trans();
+    configure_out_trans(ep);
 
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(data_toggle ? PidTypeData1 : PidTypeData0, 1, 0);
-    cfg.clk_rst_vif.wait_clks(20);
+    send_prnd_out_packet(ep, data_toggle ? PidTypeData1 : PidTypeData0, 1, 0);
 
     // Check that the transaction received the expected response, which should either be ACK
     // for an accepted packet (matching data toggle) or no response (packet dropped).
@@ -69,13 +64,11 @@ class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
     usb20_item response;
     data_pkt in_data;
 
-    endp = ep; // TODO: should be a parameter to tasks in base sequence.
-
     // Present an IN buffer for collection.
-    configure_in_trans(out_buffer_id, exp_data.size());
+    configure_in_trans(ep, out_buffer_id, exp_data.size());
 
     // Perform the IN transaction.
-    call_token_seq(PidTypeInToken);
+    call_token_seq(ep, PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
@@ -69,17 +69,16 @@ class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
     `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);
     $cast(in_data, response);
     check_tx_packet(in_data, exp_in_data_toggles[ep] ? PidTypeData1 : PidTypeData0, exp_data);
-    cfg.clk_rst_vif.wait_clks(20);
 
     // Respond as chosen to the DATA packet sent by the DUT.
     case (rsp)
       InResponseAck: begin
-        call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+        send_handshake(PidTypeAck);
         // The IN data toggle should now have flipped.
         exp_in_data_toggles[ep] ^= 1;
       end
       InResponseNak: begin
-        call_handshake_sequence(PktTypeHandshake, PidTypeNak);
+        send_handshake(PidTypeNak);
       end
       default: begin
         // No response, nothing to do; the test may proceed to send another a packet within the

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
@@ -40,12 +40,7 @@ class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
     // Check that the transaction received the expected response, which should either be ACK
     // for an accepted packet (matching data toggle) or no response (packet dropped).
     if (exp_ack) begin
-      usb20_item response;
-
-      get_response(m_response_item);
-      $cast(response, m_response_item);
-      `DV_CHECK_EQ(response.m_pkt_type, PktTypeHandshake);
-      `DV_CHECK_EQ(response.m_pid_type, PidTypeAck);
+      check_response_matches(PidTypeAck);
 
       // Check the contents of the packet buffer memory against the OUT packet that was sent.
       check_rx_packet(ep, 1'b0, out_buffer_id, m_data_pkt.data);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_data_toggle_restore_vseq.sv
@@ -68,7 +68,7 @@ class usbdev_data_toggle_restore_vseq extends usbdev_base_vseq;
     configure_in_trans(ep, out_buffer_id, exp_data.size());
 
     // Perform the IN transaction.
-    call_token_seq(ep, PidTypeInToken);
+    send_token_packet(ep, PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_disconnected_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_disconnected_vseq.sv
@@ -15,8 +15,8 @@ class usbdev_disconnected_vseq extends usbdev_base_vseq;
     // Clear disconnected interrupt to make sure it's in reset state.
     csr_wr(.ptr(ral.intr_state.disconnected), .value(1'b1));
     // send pkt to device
-    configure_out_trans();
-    call_sof_seq(PidTypeSofToken);
+    configure_out_trans(ep_default);
+    send_sof_packet(PidTypeSofToken);
     for (int i = 0; i < 4; i++) begin
       @(posedge cfg.m_usb20_agent_cfg.bif.clk_i);
       if (cfg.m_usb20_agent_cfg.bif.usb_ref_val_o) break;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -25,21 +25,19 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     wait_for_link_state({LinkActive, LinkActiveNoSOF}, 10 * 1000 * 48);  // 10ms timeout, at 48MHz
     usbdev_set_address(dev_addr);
 
-    configure_out_trans(); // register configurations for OUT Trans.
+    configure_out_trans(ep_default); // register configurations for OUT Trans.
 
     // Enable pkt_received interrupt
     ral.intr_enable.pkt_received.set(1'b1);
     csr_update(ral.intr_enable);
 
-    call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(10);
-    call_data_seq(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeAck);
 
     // Check that the USB device received a packet with the expected properties.
-    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
+    check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);
   endtask
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_enable_vseq.sv
@@ -32,9 +32,7 @@ class usbdev_enable_vseq extends usbdev_base_vseq;
     csr_update(ral.intr_enable);
 
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b0), .num_of_bytes(8));
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeAck);
+    check_response_matches(PidTypeAck);
 
     // Check that the USB device received a packet with the expected properties.
     check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_endpoint_access_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_endpoint_access_vseq.sv
@@ -9,9 +9,11 @@ class usbdev_endpoint_access_vseq extends usbdev_in_trans_vseq;
   `uvm_object_new
 
   task body();
-    // Perform OUT and IN transactions to all endpoints 0-11
-    // Extend from usbdev_in_trans b/c its doing OUT and IN to a specific endpoint number.
-    for (endp = 0; endp <= 11; endp++) begin
+    // Perform OUT and IN transactions to all supported endpoints.
+    //
+    // Extend from usbdev_in_trans because it's doing OUT and IN traffic to a specific endpoint
+    // number, so this covers all endpoints.
+    for (ep_default = 0; ep_default < NEndpoints; ep_default++) begin
       super.body();
     end
   endtask

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_iso_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_iso_vseq.sv
@@ -8,21 +8,19 @@ class usbdev_in_iso_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    configure_out_trans();
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    configure_out_trans(ep_default);
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     // check OUT response
     m_usb20_item.check_pid_type(PidTypeAck);
     inter_packet_delay();
     // register configurations for IN Trans.
-    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
+    configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     // ISO EP1 OUT
-    csr_wr(.ptr(ral.in_iso[0].iso[endp]), .value(1'b1));
+    csr_wr(.ptr(ral.in_iso[0].iso[ep_default]), .value(1'b1));
     // Token pkt followed by handshake pkt
-    call_token_seq(PidTypeInToken);
+    call_token_seq(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeData0);
@@ -30,6 +28,6 @@ class usbdev_in_iso_vseq extends usbdev_base_vseq;
     // after succesful IN. ACK from Host is not required because the endpoint
     // hase been configured for isochronous traffic.
     // Verify Transaction reads register status and verifis that IN trans is successfull.
-    check_in_sent(); // verify that IN transaction is successfull.
+    check_in_sent(ep_default); // verify that IN transaction is successfull.
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_iso_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_iso_vseq.sv
@@ -10,20 +10,15 @@ class usbdev_in_iso_vseq extends usbdev_base_vseq;
   task body();
     configure_out_trans(ep_default);
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
     // check OUT response
-    m_usb20_item.check_pid_type(PidTypeAck);
-    inter_packet_delay();
+    check_response_matches(PidTypeAck);
     // register configurations for IN Trans.
     configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     // ISO EP1 OUT
     csr_wr(.ptr(ral.in_iso[0].iso[ep_default]), .value(1'b1));
     // Token pkt followed by handshake pkt
     send_token_packet(ep_default, PidTypeInToken);
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    get_data_pid_from_device(m_usb20_item, PidTypeData0);
+    check_response_matches(PidTypeData0);
     // For completion of IN transaction and assertion of in_sent interrupt
     // after succesful IN. ACK from Host is not required because the endpoint
     // hase been configured for isochronous traffic.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_iso_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_iso_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_in_iso_vseq extends usbdev_base_vseq;
     // ISO EP1 OUT
     csr_wr(.ptr(ral.in_iso[0].iso[ep_default]), .value(1'b1));
     // Token pkt followed by handshake pkt
-    call_token_seq(ep_default, PidTypeInToken);
+    send_token_packet(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeData0);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
@@ -24,17 +24,12 @@ class usbdev_in_rand_trans_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b0),
                          .num_of_bytes(num_of_bytes));
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeAck);
-    inter_packet_delay();
+    check_response_matches(PidTypeAck);
     // IN Trans configurations
     configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     // Token pkt followed by handshake pkt
     send_token_packet(ep_default, PidTypeInToken);
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    get_data_pid_from_device(m_usb20_item, PidTypeData0);
+    check_response_matches(PidTypeData0);
     response_delay();
     call_handshake_sequence(PktTypeHandshake, PidTypeAck);
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
@@ -20,24 +20,24 @@ class usbdev_in_rand_trans_vseq extends usbdev_base_vseq;
 
     // For IN transaction need to do first OUT transaction
     // to store data in buffer memory for read through IN.
-    configure_out_trans(); // register configurations for OUT Trans.
+    configure_out_trans(ep_default); // register configurations for OUT Trans.
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, 1'b0, num_of_bytes);
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b0),
+                         .num_of_bytes(num_of_bytes));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeAck);
     inter_packet_delay();
     // IN Trans configurations
-    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
+    configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     // Token pkt followed by handshake pkt
-    call_token_seq(PidTypeInToken);
+    call_token_seq(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeData0);
-    inter_packet_delay();
+    response_delay();
     call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+
     for (int i = 0; i < 10; i++) begin
       csr_rd(ral.intr_state.pkt_sent, .value(pkt_sent));
       if (pkt_sent) break;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
@@ -31,7 +31,7 @@ class usbdev_in_rand_trans_vseq extends usbdev_base_vseq;
     // IN Trans configurations
     configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     // Token pkt followed by handshake pkt
-    call_token_seq(ep_default, PidTypeInToken);
+    send_token_packet(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeData0);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_rand_trans_vseq.sv
@@ -30,8 +30,7 @@ class usbdev_in_rand_trans_vseq extends usbdev_base_vseq;
     // Token pkt followed by handshake pkt
     send_token_packet(ep_default, PidTypeInToken);
     check_response_matches(PidTypeData0);
-    response_delay();
-    call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+    send_handshake(PidTypeAck);
 
     for (int i = 0; i < 10; i++) begin
       csr_rd(ral.intr_state.pkt_sent, .value(pkt_sent));

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
@@ -10,10 +10,10 @@ class usbdev_in_stall_vseq extends usbdev_base_vseq;
   task body();
     // Configure IN endpoint with a zero-length packet for collection; packet length
     // does not matter since we're expecting to receive a STALL anyway.
-    configure_in_trans(out_buffer_id, 0);
-    csr_wr(.ptr(ral.in_stall[0].endpoint[endp]),  .value(1'b1)); // Stall EP IN
+    configure_in_trans(ep_default, out_buffer_id, 0);
+    csr_wr(.ptr(ral.in_stall[0].endpoint[ep_default]),  .value(1'b1)); // Stall EP IN
     // Token pkt followed by handshake pkt
-    call_token_seq(PidTypeInToken);
+    call_token_seq(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeStall);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
@@ -13,7 +13,7 @@ class usbdev_in_stall_vseq extends usbdev_base_vseq;
     configure_in_trans(ep_default, out_buffer_id, 0);
     csr_wr(.ptr(ral.in_stall[0].endpoint[ep_default]),  .value(1'b1)); // Stall EP IN
     // Token pkt followed by handshake pkt
-    call_token_seq(ep_default, PidTypeInToken);
+    send_token_packet(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeStall);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_stall_vseq.sv
@@ -14,8 +14,6 @@ class usbdev_in_stall_vseq extends usbdev_base_vseq;
     csr_wr(.ptr(ral.in_stall[0].endpoint[ep_default]),  .value(1'b1)); // Stall EP IN
     // Token pkt followed by handshake pkt
     send_token_packet(ep_default, PidTypeInToken);
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeStall);
+    check_response_matches(PidTypeStall);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -32,7 +32,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
 
     // Attempt to collect IN DATA packet in response.
-    call_token_seq(ep_default, PidTypeInToken);
+    send_token_packet(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     get_data_pid_from_device(response, PidTypeData0);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -18,21 +18,21 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     csr_update(ral.intr_enable);
     // For IN transaction need to do first OUT transaction
     // to store data in buffer memory for read through IN.
-    configure_out_trans(); // register configurations for OUT Trans.
+    configure_out_trans(ep_default); // register configurations for OUT Trans.
 
-    send_prnd_out_packet(endp, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(response, m_response_item);
     `DV_CHECK_EQ(response.m_pkt_type, PktTypeHandshake);
     `DV_CHECK_EQ(response.m_pid_type, PidTypeAck);
 
-    check_rx_packet(endp, 1'b0, out_buffer_id, m_data_pkt.data);
+    check_rx_packet(ep_default, 1'b0, out_buffer_id, m_data_pkt.data);
 
     // Note: data should have been written into the current OUT buffer by the above transaction
-    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
+    configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
 
     // Attempt to collect IN DATA packet in response.
-    call_token_seq(PidTypeInToken);
+    call_token_seq(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     get_data_pid_from_device(response, PidTypeData0);
@@ -48,12 +48,12 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     // `pkt_sent` interrupt should now be asserted...
     `DV_CHECK_EQ(pkt_sent, 1);
     // ... as should the bit for this endpoint within the 'in_sent' register.
-    csr_rd(.ptr(ral.in_sent[0].sent[endp]), .value(in_sent));
+    csr_rd(.ptr(ral.in_sent[0].sent[ep_default]), .value(in_sent));
     `DV_CHECK_EQ(in_sent, 1);
 
     // Write 1 to clear particular EP's bit in `in_sent`
-    csr_wr(.ptr(ral.in_sent[0].sent[endp]), .value(1'b1));
-    csr_rd(.ptr(ral.in_sent[0].sent[endp]), .value(in_sent));
+    csr_wr(.ptr(ral.in_sent[0].sent[ep_default]), .value(1'b1));
+    csr_rd(.ptr(ral.in_sent[0].sent[ep_default]), .value(in_sent));
     `DV_CHECK_EQ(0, in_sent); // verify that after writing, the in_sent bit is cleared.
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -31,8 +31,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     send_token_packet(ep_default, PidTypeInToken);
     check_response_matches(PidTypeData0);
     // ACKnowledge successful reception of the IN DATA packet.
-    response_delay();
-    call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+    send_handshake(PidTypeAck);
 
     // We need to wait a few clock cycles for the interrupt state to change.
     for (int unsigned try = 0; try < 4; try++) begin

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_in_trans_vseq.sv
@@ -10,7 +10,6 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
 
   virtual task body();
     int unsigned max_tries = 4;
-    usb20_item response;
     bit pkt_sent;
     bit in_sent;
 
@@ -21,10 +20,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
     configure_out_trans(ep_default); // register configurations for OUT Trans.
 
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    get_response(m_response_item);
-    $cast(response, m_response_item);
-    `DV_CHECK_EQ(response.m_pkt_type, PktTypeHandshake);
-    `DV_CHECK_EQ(response.m_pid_type, PidTypeAck);
+    check_response_matches(PidTypeAck);
 
     check_rx_packet(ep_default, 1'b0, out_buffer_id, m_data_pkt.data);
 
@@ -33,9 +29,7 @@ class usbdev_in_trans_vseq extends usbdev_base_vseq;
 
     // Attempt to collect IN DATA packet in response.
     send_token_packet(ep_default, PidTypeInToken);
-    get_response(m_response_item);
-    $cast(response, m_response_item);
-    get_data_pid_from_device(response, PidTypeData0);
+    check_response_matches(PidTypeData0);
     // ACKnowledge successful reception of the IN DATA packet.
     response_delay();
     call_handshake_sequence(PktTypeHandshake, PidTypeAck);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
@@ -19,10 +19,9 @@ class usbdev_link_in_err_vseq extends usbdev_base_vseq;
     configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     send_token_packet(ep_default, PidTypeInToken);
     check_response_matches(PidTypeData0);
-    response_delay();
     // Send unexpected PID to USB device and device will assert link_in_err interrupt.
     // Expected pkt is ACK but send NYET packet.
-    call_handshake_sequence(PktTypeHandshake, PidTypeNyet);
+    send_handshake(PidTypeNyet);
     // The 'link_in_err' interrupt will take a few cycles to be asserted.
     for (uint i = 0; i < 16; i++) begin
       csr_rd(.ptr(ral.intr_state.link_in_err), .value(link_error));

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
@@ -10,10 +10,8 @@ class usbdev_link_in_err_vseq extends usbdev_base_vseq;
   virtual task body();
     bit link_error;
 
-    configure_out_trans();
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    configure_out_trans(ep_default);
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeAck);
@@ -21,8 +19,8 @@ class usbdev_link_in_err_vseq extends usbdev_base_vseq;
     // Check that link_in_err interrupt is zero.
     csr_rd(.ptr(ral.intr_state.link_in_err), .value(link_error));
     `DV_CHECK_EQ(0, link_error);
-    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
-    call_token_seq(PidTypeInToken);
+    configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
+    call_token_seq(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeData0);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
@@ -20,7 +20,7 @@ class usbdev_link_in_err_vseq extends usbdev_base_vseq;
     csr_rd(.ptr(ral.intr_state.link_in_err), .value(link_error));
     `DV_CHECK_EQ(0, link_error);
     configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
-    call_token_seq(ep_default, PidTypeInToken);
+    send_token_packet(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     get_data_pid_from_device(m_usb20_item, PidTypeData0);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_in_err_vseq.sv
@@ -12,18 +12,13 @@ class usbdev_link_in_err_vseq extends usbdev_base_vseq;
 
     configure_out_trans(ep_default);
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    get_data_pid_from_device(m_usb20_item, PidTypeAck);
-    inter_packet_delay();
+    check_response_matches(PidTypeAck);
     // Check that link_in_err interrupt is zero.
     csr_rd(.ptr(ral.intr_state.link_in_err), .value(link_error));
     `DV_CHECK_EQ(0, link_error);
     configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     send_token_packet(ep_default, PidTypeInToken);
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    get_data_pid_from_device(m_usb20_item, PidTypeData0);
+    check_response_matches(PidTypeData0);
     response_delay();
     // Send unexpected PID to USB device and device will assert link_in_err interrupt.
     // Expected pkt is ACK but send NYET packet.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
@@ -150,11 +150,7 @@ class usbdev_max_usb_traffic_vseq extends usbdev_base_vseq;
     // Check that the packet was accepted (ACKnowledged) by the USB device.
     // An Isochronous endpoint returns no handshake and no data toggle bit, so do not wait.
     if (!ep_iso_enabled[ep]) begin
-      usb20_item response;
-      get_response(m_response_item);
-      $cast(response, m_response_item);
-      `DV_CHECK_EQ(response.m_pkt_type, PktTypeHandshake);
-      `DV_CHECK_EQ(response.m_pid_type, PidTypeAck);
+      check_response_matches(PidTypeAck);
       // Packet successfully received and ACKnowledged; flip the data toggle.
       exp_out_toggle[ep] ^= 1'b1;
     end

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
@@ -114,11 +114,10 @@ class usbdev_max_usb_traffic_vseq extends usbdev_base_vseq;
         `DV_CHECK(packets_in_flight[ep].size() > 0)
         exp_data = packets_in_flight[ep].pop_front();
         check_tx_packet(in_data, exp_in_toggle[ep] ? PidTypeData1 : PidTypeData0, exp_data.data);
-        response_delay();
         if (!ep_iso_enabled[ep]) begin
           // Since we're acknowledging successful receipt, we flip our toggle.
           exp_in_toggle[ep] ^= 1'b1;
-          call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+          send_handshake(PidTypeAck);
         end
         // Update the count of received packets.
         packets_received[ep] = packets_received[ep] + 1;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
@@ -101,7 +101,7 @@ class usbdev_max_usb_traffic_vseq extends usbdev_base_vseq;
     `uvm_info(`gfn, $sformatf("Requesting IN packet from EP%d", ep), UVM_HIGH)
     claim_driver();
     // Send IN token packet
-    call_token_seq(ep, PidTypeInToken);
+    send_token_packet(ep, PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     case (response.m_pid_type)

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
@@ -100,10 +100,8 @@ class usbdev_max_usb_traffic_vseq extends usbdev_base_vseq;
     usb20_item response;
     `uvm_info(`gfn, $sformatf("Requesting IN packet from EP%d", ep), UVM_HIGH)
     claim_driver();
-    // TODO: base tasks still need parameterising for endpoint number.
-    endp = ep;
     // Send IN token packet
-    call_token_seq(PidTypeInToken);
+    call_token_seq(ep, PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     case (response.m_pid_type)

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -23,9 +23,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
 
     // Check first transaction accuracy
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeAck);
+    check_response_matches(PidTypeAck);
 
     // Read rxenable_out
     csr_rd(.ptr(ral.rxenable_out[0]), .value(rx_enable));
@@ -43,9 +41,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     send_prnd_out_packet(ep_default, PidTypeData1, .randomize_length(1'b1), .num_of_bytes(0));
 
     // Check second transaction accuracy
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeNak);
+    check_response_matches(PidTypeNak);
   endtask
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_nak_trans_vseq.sv
@@ -14,22 +14,18 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     bit            rx_enable_out;
 
     // Configure transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Set nak_out
-    ral.set_nak_out[0].enable[endp].set(1'b1);
+    ral.set_nak_out[0].enable[ep_default].set(1'b1);
     csr_update(ral.set_nak_out[0]);
 
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    cfg.clk_rst_vif.wait_clks(20);
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
 
     // Check first transaction accuracy
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeAck);
-    cfg.clk_rst_vif.wait_clks(20);
 
     // Read rxenable_out
     csr_rd(.ptr(ral.rxenable_out[0]), .value(rx_enable));
@@ -44,10 +40,7 @@ class usbdev_nak_trans_vseq extends usbdev_base_vseq;
     csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id + 1));
 
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData1, .randomize_length(1'b1), .num_of_bytes(0));
-    cfg.clk_rst_vif.wait_clks(20);
+    send_prnd_out_packet(ep_default, PidTypeData1, .randomize_length(1'b1), .num_of_bytes(0));
 
     // Check second transaction accuracy
     get_response(m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_iso_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_iso_vseq.sv
@@ -13,20 +13,19 @@ class usbdev_out_iso_vseq extends usbdev_base_vseq;
     // Expected data content of packet
     byte unsigned exp_data[];
     bit pkt_received;
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // ISO EP OUT
-    csr_wr(.ptr(ral.out_iso[0].iso[endp]), .value(1'b1));
+    csr_wr(.ptr(ral.out_iso[0].iso[ep_default]), .value(1'b1));
     // write to clear pkt_received interrupt; we want to verify this becomes asserted in
     // response to the transaction.
     csr_wr(.ptr(ral.intr_state.pkt_received), .value(1'b1));
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, .randomize_length(1'b0), .num_of_bytes(64),
-                  .isochronous_transfer(1'b1));
-    // Wait until usbdev generates an interrupt to show the packet has been received.
-    // The device should not seen an ACK in this case because the traffic is isochronous.
-    // TODO: when the usb20_driver is capable of indicating 'no response' check this here.
-    //       For now this sequence just checks the line state directly.
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    // The device should not see an ACK in this case because the traffic is isochronous.
+    get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
+    `DV_CHECK_EQ(m_usb20_item.timed_out, 1)
+    // Wait until usbdev generates an interrupt to show the packet has been received, and then
+    // validate the received packet.
     for (int i = 0; i < 10; i++) begin
       csr_rd(.ptr(ral.intr_state.pkt_received), .value(pkt_received));
       if (pkt_received) break;
@@ -34,6 +33,6 @@ class usbdev_out_iso_vseq extends usbdev_base_vseq;
     if (!pkt_received) begin
       `uvm_error(`gfn, "usbdev didn't generate expected pkt_received interrupt")
     end
-    check_rx_packet(endp, 1'b0, out_buffer_id, m_data_pkt.data);
+    check_rx_packet(ep_default, 1'b0, out_buffer_id, m_data_pkt.data);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -16,8 +16,6 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
     csr_update(ral.out_stall[0]);
     // Out token packet followed by a data packet
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeStall);
+    check_response_matches(PidTypeStall);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_stall_vseq.sv
@@ -9,17 +9,13 @@ class usbdev_out_stall_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    clear_all_interrupts();
     // Configure out transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Set out_stall endpoint
-    ral.out_stall[0].endpoint[endp].set(1'b1);
+    ral.out_stall[0].endpoint[ep_default].set(1'b1);
     csr_update(ral.out_stall[0]);
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    cfg.clk_rst_vif.wait_clks(20);
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeStall);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -16,8 +16,6 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
     csr_update(ral.rxenable_out[0]);
     // Out token packet followed by a data packet
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeNak);
+    check_response_matches(PidTypeNak);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_out_trans_nak_vseq.sv
@@ -9,17 +9,13 @@ class usbdev_out_trans_nak_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    clear_all_interrupts();
     // Configure out transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Clear RX Out
-    ral.rxenable_out[0].out[endp].set(1'b0);
+    ral.rxenable_out[0].out[ep_default].set(1'b0);
     csr_update(ral.rxenable_out[0]);
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    cfg.clk_rst_vif.wait_clks(20);
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeNak);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pending_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pending_in_trans_vseq.sv
@@ -20,9 +20,7 @@ class usbdev_pending_in_trans_vseq extends usbdev_base_vseq;
     // to cancel any pending IN transactions. The device will prioritize
     // the setup transaction by clearing the 'rdy' bit in the configin register.
     send_prnd_setup_packet(ep_default);
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeAck);
+    check_response_matches(PidTypeAck);
     // Verify that after the setup transaction, the waiting IN transction is canceled
     // by checking 'rdy' and 'pend' bit of configin register.
     csr_rd(ral.configin[ep_default], config_in);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pending_in_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pending_in_trans_vseq.sv
@@ -10,25 +10,23 @@ class usbdev_pending_in_trans_vseq extends usbdev_base_vseq;
   task body();
     uvm_reg_data_t config_in;
     // register configurations for Setup Trans.
-    configure_setup_trans();
+    configure_setup_trans(ep_default);
     // register configurations for IN Trans.
-    configure_in_trans(in_buffer_id, 0);
-    csr_rd(ral.configin[endp], config_in);
-    `DV_CHECK_EQ(get_field_val(ral.configin[endp].rdy, config_in), 1);
-    `DV_CHECK_EQ(get_field_val(ral.configin[endp].pend, config_in), 0);
+    configure_in_trans(ep_default, in_buffer_id, 0);
+    csr_rd(ral.configin[ep_default], config_in);
+    `DV_CHECK_EQ(get_field_val(ral.configin[ep_default].rdy, config_in), 1);
+    `DV_CHECK_EQ(get_field_val(ral.configin[ep_default].pend, config_in), 0);
     // Following the IN configuration, send a packet with a setup token
     // to cancel any pending IN transactions. The device will prioritize
     // the setup transaction by clearing the 'rdy' bit in the configin register.
-    call_token_seq(PidTypeSetupToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    send_prnd_setup_packet(ep_default);
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeAck);
     // Verify that after the setup transaction, the waiting IN transction is canceled
     // by checking 'rdy' and 'pend' bit of configin register.
-    csr_rd(ral.configin[endp], config_in);
-    `DV_CHECK_EQ(get_field_val(ral.configin[endp].rdy, config_in), 0);
-    `DV_CHECK_EQ(get_field_val(ral.configin[endp].pend, config_in), 1);
+    csr_rd(ral.configin[ep_default], config_in);
+    `DV_CHECK_EQ(get_field_val(ral.configin[ep_default].rdy, config_in), 0);
+    `DV_CHECK_EQ(get_field_val(ral.configin[ep_default].pend, config_in), 1);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_eop_single_bit_handling_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_eop_single_bit_handling_vseq.sv
@@ -15,9 +15,7 @@ class usbdev_phy_config_eop_single_bit_handling_vseq extends usbdev_base_vseq;
     csr_wr (.ptr(ral.phy_config.eop_single_bit), .value(1'b1));
 
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeAck);
+    check_response_matches(PidTypeAck);
     check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_eop_single_bit_handling_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_eop_single_bit_handling_vseq.sv
@@ -10,15 +10,14 @@ class usbdev_phy_config_eop_single_bit_handling_vseq extends usbdev_base_vseq;
   task body();
     // Set single_bit_SE0 flag then usb20_agent will drive single SE0 as EoP.
     cfg.m_usb20_agent_cfg.single_bit_SE0 = 1'b1;
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Set eop_single_bit field of phy_config register.
     csr_wr (.ptr(ral.phy_config.eop_single_bit), .value(1'b1));
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeAck);
-    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
+    check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);
   endtask
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_usb_ref_disable_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_usb_ref_disable_vseq.sv
@@ -8,10 +8,10 @@ class usbdev_phy_config_usb_ref_disable_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Tx Start of Frame (SoF) packet to the device.
     // The device will receive the SoF and in response, it will assert the usb_ref_val_o signal.
-    call_sof_seq(PidTypeSofToken);
+    send_sof_packet(PidTypeSofToken);
     inter_packet_delay();
     // Verify that the device has asserted the usb_ref_val_o signal after receiving the SoF packet.
     `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.bif.usb_ref_val_o, 1)
@@ -19,7 +19,7 @@ class usbdev_phy_config_usb_ref_disable_vseq extends usbdev_base_vseq;
     csr_wr(.ptr(ral.phy_config.usb_ref_disable), .value(1'b1));
     // Check that usb_ref_val_o is zero.
     `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.bif.usb_ref_val_o, 0)
-    call_sof_seq(PidTypeSofToken);
+    send_sof_packet(PidTypeSofToken);
     // Confirm that after setting usb_ref_disable to 1,
     // the device will not assert the synchronous usb_ref_val_o signal.
     `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.bif.usb_ref_val_o, 0)

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_buffer_vseq.sv
@@ -109,8 +109,7 @@ class usbdev_pkt_buffer_vseq extends usbdev_base_vseq;
     `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);
     $cast(in_data, response);
     check_tx_packet(in_data, exp_in_toggle[ep] ? PidTypeData1 : PidTypeData0, pkt_data);
-    cfg.clk_rst_vif.wait_clks(20);
-    call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+    send_handshake(PidTypeAck);
 
     // Flip the IN side Data Toggle in anticipation of the next packet transfer.
     exp_in_toggle[ep] ^= 1;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_buffer_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_buffer_vseq.sv
@@ -103,7 +103,7 @@ class usbdev_pkt_buffer_vseq extends usbdev_base_vseq;
     csr_update(ral.configin[ep]);
 
     // Token pkt followed by handshake pkt
-    call_token_seq(ep, PidTypeInToken);
+    send_token_packet(ep, PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_received_vseq.sv
@@ -10,21 +10,19 @@ class usbdev_pkt_received_vseq extends usbdev_base_vseq;
 
   task body();
     // Configure transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Enable pkt_received interrupt
     ral.intr_enable.pkt_received.set(1'b1);
     csr_update(ral.intr_enable);
 
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(10);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeAck);
 
     // Check that the USB device received a packet with the expected properties.
-    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
+    check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);
   endtask
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -36,8 +36,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     send_token_packet(ep_default, PidTypeInToken);
     // Get response from DUT
     check_response_matches(PidTypeData0);
-    response_delay();
-    call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+    send_handshake(PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Check transaction accuracy

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -36,7 +36,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Note: data should have been written into the current OUT buffer by the above transaction
     configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     // Token pkt followed by handshake pkt
-    call_token_seq(ep_default, PidTypeInToken);
+    send_token_packet(ep_default, PidTypeInToken);
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -14,15 +14,13 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // OUT TRANS
     // -------------------------------
     // Configure out transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Enable pkt_sent interrupt
     ral.intr_enable.pkt_sent.set(1'b1);
     csr_update(ral.intr_enable);
 
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
@@ -36,9 +34,9 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // --------------------------------
     // Configure in transaction
     // Note: data should have been written into the current OUT buffer by the above transaction
-    configure_in_trans(out_buffer_id, m_data_pkt.data.size());
+    configure_in_trans(ep_default, out_buffer_id, m_data_pkt.data.size());
     // Token pkt followed by handshake pkt
-    call_token_seq(PidTypeInToken);
+    call_token_seq(ep_default, PidTypeInToken);
     // Get response from DUT
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_pkt_sent_vseq.sv
@@ -21,10 +21,7 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
 
     // Out token packet followed by a data packet
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
-    // Get response from DUT
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeAck);
+    check_response_matches(PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
 
     // Read rxfifo reg
@@ -38,10 +35,8 @@ class usbdev_pkt_sent_vseq extends usbdev_base_vseq;
     // Token pkt followed by handshake pkt
     send_token_packet(ep_default, PidTypeInToken);
     // Get response from DUT
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    get_data_pid_from_device(m_usb20_item, PidTypeData0);
-    cfg.clk_rst_vif.wait_clks(20);
+    check_response_matches(PidTypeData0);
+    response_delay();
     call_handshake_sequence(PktTypeHandshake, PidTypeAck);
     cfg.clk_rst_vif.wait_clks(20);
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -21,10 +21,7 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
     // Out token packet followed by a data packet of random bytes
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(randomize_length),
                          .num_of_bytes(num_of_bytes));
-
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    m_usb20_item.check_pid_type(PidTypeAck);
+    check_response_matches(PidTypeAck);
 
     // Check that the USB device received a packet with the expected properties.
     check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_random_length_out_transaction_vseq.sv
@@ -16,18 +16,18 @@ class usbdev_random_length_out_transaction_vseq extends usbdev_base_vseq;
 
   task body();
     // Configure out transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
+
     // Out token packet followed by a data packet of random bytes
-    call_token_seq(PidTypeOutToken);
-    cfg.clk_rst_vif.wait_clks(20);
-    call_data_seq(PidTypeData0, .randomize_length(randomize_length), .num_of_bytes(num_of_bytes));
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(randomize_length),
+                         .num_of_bytes(num_of_bytes));
+
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     m_usb20_item.check_pid_type(PidTypeAck);
-    cfg.clk_rst_vif.wait_clks(20);
 
     // Check that the USB device received a packet with the expected properties.
-    check_pkt_received(endp, 0, out_buffer_id, m_data_pkt.data);
+    check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);
   endtask
 
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
@@ -15,7 +15,7 @@ class usbdev_rx_crc_err_vseq extends usbdev_base_vseq;
     csr_wr(.ptr(ral.intr_enable.rx_crc_err), .value(1'b1));
 
     // Out Token packet with corrupted CRC5
-    call_token_seq(ep_default, PidTypeOutToken, .inject_crc_error(1));
+    send_token_packet(ep_default, PidTypeOutToken, .inject_crc_error(1));
 
     // Wait a little while for the interrupt signal to become asserted.
     for (int i = 0; i < 16; i++) begin

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
@@ -9,13 +9,13 @@ class usbdev_rx_crc_err_vseq extends usbdev_base_vseq;
 
   task body();
     // Configure transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
 
     // Enable rx_crc_err interrupt
     csr_wr(.ptr(ral.intr_enable.rx_crc_err), .value(1'b1));
 
     // Out Token packet with corrupted CRC5
-    call_token_seq(PidTypeOutToken, .inject_crc_error(1));
+    call_token_seq(ep_default, PidTypeOutToken, .inject_crc_error(1));
 
     // Wait a little while for the interrupt signal to become asserted.
     for (int i = 0; i < 16; i++) begin

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_stage_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_stage_vseq.sv
@@ -19,15 +19,13 @@ class usbdev_setup_stage_vseq extends usbdev_base_vseq;
     call_desc_sequence(PidTypeData0);
 
     // Check that the packet was accepted (ACKnowledged) by the USB device.
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    `DV_CHECK_EQ(m_usb20_item.m_pkt_type, PktTypeHandshake);
-    `DV_CHECK_EQ(m_usb20_item.m_pid_type, PidTypeAck);
+    check_response_matches(PidTypeAck);
   endtask
 
   // Construct and transmit a DATA packet containing a SETUP descriptor to the USB device
   task call_desc_sequence(input pid_type_e pid_type);
     `uvm_create_on(m_data_pkt, p_sequencer.usb20_sequencer_h)
+    start_item(m_data_pkt);
     m_data_pkt.m_ev_type  = EvPacket;
     m_data_pkt.m_pkt_type = PktTypeData;
     m_data_pkt.m_pid_type = pid_type;
@@ -36,7 +34,6 @@ class usbdev_setup_stage_vseq extends usbdev_base_vseq;
     // Send control data for GET_DESCRIPTOR request
     m_data_pkt.make_device_request(m_data_pkt.m_bmRT, m_data_pkt.m_bR,
                                    8'h00, 8'h01, 16'h0, 16'd18);
-    start_item(m_data_pkt);
     finish_item(m_data_pkt);
   endtask
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_stage_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_stage_vseq.sv
@@ -9,12 +9,12 @@ class usbdev_setup_stage_vseq extends usbdev_base_vseq;
 
   task body();
     // Configure setup transaction
-    configure_setup_trans();
+    configure_setup_trans(ep_default);
 
     // -------------------------------------------------------------------------------------
     // SETUP token packet followed by a control DATA packet of 8 bytes
     // -------------------------------------------------------------------------------------
-    call_token_seq(PidTypeSetupToken);
+    call_token_seq(ep_default, PidTypeSetupToken);
     inter_packet_delay();
     call_desc_sequence(PidTypeData0);
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_stage_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_stage_vseq.sv
@@ -14,7 +14,7 @@ class usbdev_setup_stage_vseq extends usbdev_base_vseq;
     // -------------------------------------------------------------------------------------
     // SETUP token packet followed by a control DATA packet of 8 bytes
     // -------------------------------------------------------------------------------------
-    call_token_seq(ep_default, PidTypeSetupToken);
+    send_token_packet(ep_default, PidTypeSetupToken);
     inter_packet_delay();
     call_desc_sequence(PidTypeData0);
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_trans_ignored_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_trans_ignored_vseq.sv
@@ -11,19 +11,20 @@ class usbdev_setup_trans_ignored_vseq extends usbdev_base_vseq;
     uvm_reg_data_t rx_depth;
     bit pkt_received = 1;
 
-    csr_wr(.ptr(ral.rxenable_setup[0].setup[endp]), .value(1'b0)); // Disable rx_enable setup
-    csr_wr(.ptr(ral.ep_out_enable[0].enable[endp]), .value(1'b1)); // Enable OUT EP
+    csr_wr(.ptr(ral.rxenable_setup[0].setup[ep_default]), .value(1'b0)); // Disable rx_enable setup
+    csr_wr(.ptr(ral.ep_out_enable[0].enable[ep_default]), .value(1'b1)); // Enable OUT EP
 
     // Enable pkt_received interrupt
     ral.intr_enable.pkt_received.set(1'b1);
     csr_update(ral.intr_enable);
 
     // Send a randomized SETUP packet to the selected endpoint.
-    send_prnd_setup_packet(endp);
+    send_prnd_setup_packet(ep_default);
     get_response(m_response_item);
+    $cast(m_usb20_item, m_response_item);
 
     // An ignored SETUP packet shall receive no response.
-    `DV_CHECK_EQ(cfg.m_usb20_agent_cfg.timed_out, 1);
+    `DV_CHECK_EQ(m_usb20_item.timed_out, 1);
 
     csr_rd(.ptr(ral.intr_state.pkt_received), .value(pkt_received));
     // Verify the packet received bit is zero.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -62,9 +62,8 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     // Send IN request and collect DATA packet in response.
     send_token_packet(ep_default, PidTypeInToken);
     check_in_packet(PidTypeData1, tx_data);
-    response_delay();
     // ACKnowledge receipt of the data packet.
-    call_handshake_sequence(PktTypeHandshake, PidTypeAck);
+    send_handshake(PidTypeAck);
     // in_sent register/interrupt assertion occurs a few cycles after the ACK has been received.
     cfg.clk_rst_vif.wait_clks(20);
     // Verify Transaction reads register status and verifies that IN transaction is successful.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_smoke_vseq.sv
@@ -25,7 +25,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     // ---------------------------------------------------------------------------------------------
     // SETUP token packet followed by a DATA packet of 8 bytes
     // ---------------------------------------------------------------------------------------------
-    call_token_seq(ep_default, PidTypeSetupToken);
+    send_token_packet(ep_default, PidTypeSetupToken);
     inter_packet_delay();
     call_desc_sequence(PktTypeData, PidTypeData0);
     cfg.clk_rst_vif.wait_clks(20);
@@ -65,7 +65,7 @@ class usbdev_smoke_vseq extends usbdev_base_vseq;
     csr_update(ral.configin[ep_default]);
 
     // Send IN request and collect DATA packet in response.
-    call_token_seq(ep_default, PidTypeInToken);
+    send_token_packet(ep_default, PidTypeInToken);
     get_response(m_response_item);
     $cast(response, m_response_item);
     `DV_CHECK_EQ(response.m_pkt_type, PktTypeData);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_priority_over_nak_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_priority_over_nak_vseq.sv
@@ -10,15 +10,13 @@ class usbdev_stall_priority_over_nak_vseq extends usbdev_base_vseq;
 
   task body();
     // Configure out transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Set nak_out endpoint
-    csr_wr(ral.set_nak_out[0].enable[endp], 1'b1);
+    csr_wr(ral.set_nak_out[0].enable[ep_default], 1'b1);
     // Set out_stall endpoint
-    csr_wr(ral.out_stall[0].endpoint[endp], 1'b1);
+    csr_wr(ral.out_stall[0].endpoint[ep_default], 1'b1);
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
     get_response(m_response_item);
     $cast(m_usb20_item, m_response_item);
     // Verify that the device responds with a Stall PID instead of a nak,

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_trans_vseq.sv
@@ -9,14 +9,12 @@ class usbdev_stall_trans_vseq extends usbdev_base_vseq;
 
   task body();
     // Configure out transaction
-    configure_out_trans();
+    configure_out_trans(ep_default);
     // Set stall on endp
-    csr_wr(.ptr(ral.out_stall[0].endpoint[endp]), .value(1'b1));
+    csr_wr(.ptr(ral.out_stall[0].endpoint[ep_default]), .value(1'b1));
 
     // Out token packet followed by a data packet
-    call_token_seq(PidTypeOutToken);
-    inter_packet_delay();
-    call_data_seq(PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
+    send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
 
     // Check that the DUT reponds with the PidTypeStall
     get_response(m_response_item);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_trans_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_stall_trans_vseq.sv
@@ -17,10 +17,7 @@ class usbdev_stall_trans_vseq extends usbdev_base_vseq;
     send_prnd_out_packet(ep_default, PidTypeData0, .randomize_length(1'b1), .num_of_bytes(0));
 
     // Check that the DUT reponds with the PidTypeStall
-    get_response(m_response_item);
-    $cast(m_usb20_item, m_response_item);
-    `DV_CHECK_EQ(m_usb20_item.m_pkt_type, PktTypeHandshake);
-    `DV_CHECK_EQ(m_usb20_item.m_pid_type, PidTypeStall);
+    check_response_matches(PidTypeStall);
   endtask
 
 endclass


### PR DESCRIPTION
This PR reduces the amount of replicated code and simplifies the code base, as well as using clearer naming for some base tasks.

_This PR is built on and includes #23313 which requires review and merge first._
The last 4 commits:

- Avoid the use of impicits endpoints ('endp' member in base class) by specifying the endpoint being addressed.
- Provide a randomized default endpoint to those sequences that address only one endpoint.
- Return 'timed out' indication in response item, rather than via agent configuration.
- Rename base tasks to be clearer.
- Modify start/finish_item creation of sequence items according to convention (no functional change).
- Introduce simplified base tasks for checking responses and IN packets, and for sending handshakes back to the DUT.

Pass rates unaffected, no functional changes. This is ongoing tidying and simplification.

_This PR is built on and includes #23313 which requires review and merge first._