### PR TITLE
[rv_dm,dv] Improvements to rv_dm_tap_fsm_rand_reset

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -104,12 +104,19 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
         1: check_ndmreset();
         1: check_unavailable();
       endcase
+
+      spot_resets(should_stop);
+      if (should_stop) return;
+
       cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
     end
 
     repeat ($urandom_range(1, 5)) begin
       check_dmactive(should_stop);
+      spot_resets(should_stop);
+
       if (should_stop) return;
+
       cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
     end
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -68,9 +68,8 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
   // Verify that writing to dmactive causes dmactive output to be set.
   //
   // If a reset is asserted somewhere in the middle, the DMI write to dmcontrol will have been
-  // ignored. Skip the check.
-  task check_dmactive();
-    bit seen_reset = 1'b0;
+  // ignored. Skip the check and write 1 to seen_reset.
+  task check_dmactive(output bit seen_reset);
     uvm_reg_data_t data = $urandom_range(0, 1);
 
     fork begin : isolation_fork
@@ -96,6 +95,8 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
   endtask
 
   task body();
+    bit should_stop = 1'b0;
+
     repeat ($urandom_range(20, 50)) begin
       randcase
         1: check_idcode();
@@ -107,7 +108,8 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     end
 
     repeat ($urandom_range(1, 5)) begin
-      check_dmactive();
+      check_dmactive(should_stop);
+      if (should_stop) return;
       cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
     end
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -69,7 +69,11 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
   task check_dmactive();
     uvm_reg_data_t data = $urandom_range(0, 1);
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(data));
-    cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
+
+    // Wait for the DMI transaction to make it from the JTAG clock domain to the system clock. This
+    // goes through a dmi_cdc module and takes two JTAG clock cycles.
+    cfg.jtag_vif.wait_tck(2);
+
     `DV_CHECK_EQ(cfg.rv_dm_vif.cb.dmactive, data)
   endtask
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_tap_fsm_vseq.sv
@@ -59,29 +59,53 @@ class rv_dm_tap_fsm_vseq extends rv_dm_base_vseq;
     finish_item(req);
   endtask
 
+  // Use the spot_resets task and return from the current task if spot_resets saw a reset
+`define RUN_SPOT_RESETS         \
+    begin                       \
+      bit should_stop;          \
+      spot_resets(should_stop); \
+      if (should_stop) return;  \
+    end
+
   task body();
     // Read the JTAG IDCODE register and verify that it matches the expected value.
     run_smoke();
     `uvm_info(`gfn, "Starting fsm_tap sequence", UVM_LOW)
 
+    `RUN_SPOT_RESETS
+
     `uvm_info(`gfn, "Test TAP FSM transition from CaptureIr->Exit1Ir", UVM_LOW)
     send_req(.dummy_ir(1'b1));
+
+    `RUN_SPOT_RESETS
 
     `uvm_info(`gfn, "Test TAP FSM transition from UpdateIr->SelectDrScan", UVM_LOW)
     send_req();
 
+    `RUN_SPOT_RESETS
+
     `uvm_info(`gfn, "Test TAP FSM transition from UpdateDr->SelectDrScan", UVM_LOW)
     send_req(.skip_reselected_ir(1));
 
+    `RUN_SPOT_RESETS
+
     run_smoke();
+
+    `RUN_SPOT_RESETS
 
     `uvm_info(`gfn, "Test TAP FSM transition from CaptureDr->Exit1Dr", UVM_LOW)
     send_req(.skip_reselected_ir(1), .dummy_dr(1));
 
+    `RUN_SPOT_RESETS
+
     run_smoke();
+
+    `RUN_SPOT_RESETS
 
     `uvm_info(`gfn, "Test TAP FSM reset", UVM_LOW)
     send_req(.reset_tap_fsm(1));
+
+    `RUN_SPOT_RESETS
 
     run_smoke();
   endtask : body
@@ -91,5 +115,7 @@ class rv_dm_tap_fsm_vseq extends rv_dm_base_vseq;
     `uvm_info(`gfn, "Starting rv_dm_tap_fsm_vseq smoke test", UVM_LOW)
     `uvm_do(seq)
   endtask
+
+`undef RUN_SPOT_RESETS
 
 endclass : rv_dm_tap_fsm_vseq

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -178,7 +178,7 @@
       run_opts: ["+run_stress_all_with_rand_reset",
                  "+stress_seq=rv_dm_tap_fsm_vseq",
                  "+en_scb=0"]
-      reseed: 40
+      reseed: 10
     }
      {
       name: rv_dm_cmderr_busy


### PR DESCRIPTION
There are careful notes in the commit messages, but the overarching theme is to teach `rv_dm_tap_fsm_vseq` and the smoke sequence to allow injection of resets. This gets the pass rate from 2.5% (last night's run) to something more like 80% (where the failures are now all caused by timeouts).