### PR TITLE
[spi_host] Add ability to suppress clock edges

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -410,6 +410,16 @@
       hwext: "true",
       hwqe: "true",
       fields: [
+        { bits: "14",
+          name: "CLKIDLE",
+          desc: '''Suppress output clock edges for this command.
+
+                   This keeps SCK at the idle value throughout this command.
+                   As a result, different patterns can be created on the pins without clocking data.
+                   This could be used for software control of the chip select, for example.
+                '''
+          resval: "0x0"
+        }
         { bits: "13:12",
           name: "DIRECTION",
           desc: '''The direction for the following command: "0" = Dummy cycles

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -236,6 +236,7 @@ module spi_host
 
   assign command.segment.len         = reg2hw.command.len.q;
   assign command.segment.csaat       = reg2hw.command.csaat.q;
+  assign command.segment.idle_clk    = reg2hw.command.clkidle.q;
   assign command.segment.speed       = reg2hw.command.speed.q;
 
 
@@ -245,7 +246,8 @@ module spi_host
       reg2hw.command.len.qe,
       reg2hw.command.speed.qe,
       reg2hw.command.direction.qe,
-      reg2hw.command.csaat.qe
+      reg2hw.command.csaat.qe,
+      reg2hw.command.clkidle.qe
   };
 
   // Any qe pin from COMMAND will suffice.

--- a/hw/ip/spi_host/rtl/spi_host_cmd_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_cmd_pkg.sv
@@ -42,6 +42,7 @@ package spi_host_cmd_pkg;
     logic       cmd_rd_en;
     logic [8:0] len;
     logic       csaat;
+    logic       idle_clk;
   } segment_t;
 
   typedef struct packed {

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -103,6 +103,10 @@ package spi_host_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+      logic        qe;
+    } clkidle;
+    struct packed {
       logic [1:0]  q;
       logic        qe;
     } direction;
@@ -279,14 +283,14 @@ package spi_host_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_host_reg2hw_intr_state_reg_t intr_state; // [126:125]
-    spi_host_reg2hw_intr_enable_reg_t intr_enable; // [124:123]
-    spi_host_reg2hw_intr_test_reg_t intr_test; // [122:119]
-    spi_host_reg2hw_alert_test_reg_t alert_test; // [118:117]
-    spi_host_reg2hw_control_reg_t control; // [116:98]
-    spi_host_reg2hw_configopts_mreg_t [0:0] configopts; // [97:67]
-    spi_host_reg2hw_csid_reg_t csid; // [66:35]
-    spi_host_reg2hw_command_reg_t command; // [34:17]
+    spi_host_reg2hw_intr_state_reg_t intr_state; // [128:127]
+    spi_host_reg2hw_intr_enable_reg_t intr_enable; // [126:125]
+    spi_host_reg2hw_intr_test_reg_t intr_test; // [124:121]
+    spi_host_reg2hw_alert_test_reg_t alert_test; // [120:119]
+    spi_host_reg2hw_control_reg_t control; // [118:100]
+    spi_host_reg2hw_configopts_mreg_t [0:0] configopts; // [99:69]
+    spi_host_reg2hw_csid_reg_t csid; // [68:37]
+    spi_host_reg2hw_command_reg_t command; // [36:17]
     spi_host_reg2hw_error_enable_reg_t error_enable; // [16:12]
     spi_host_reg2hw_error_status_reg_t error_status; // [11:6]
     spi_host_reg2hw_event_enable_reg_t event_enable; // [5:0]
@@ -319,11 +323,12 @@ package spi_host_reg_pkg;
   parameter logic [0:0] SPI_HOST_INTR_TEST_SPI_EVENT_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_HOST_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_HOST_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
-  parameter logic [13:0] SPI_HOST_COMMAND_RESVAL = 14'h 0;
+  parameter logic [14:0] SPI_HOST_COMMAND_RESVAL = 15'h 0;
   parameter logic [8:0] SPI_HOST_COMMAND_LEN_RESVAL = 9'h 0;
   parameter logic [0:0] SPI_HOST_COMMAND_CSAAT_RESVAL = 1'h 0;
   parameter logic [1:0] SPI_HOST_COMMAND_SPEED_RESVAL = 2'h 0;
   parameter logic [1:0] SPI_HOST_COMMAND_DIRECTION_RESVAL = 2'h 0;
+  parameter logic [0:0] SPI_HOST_COMMAND_CLKIDLE_RESVAL = 1'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] SPI_HOST_RXDATA_OFFSET = 6'h 24;

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -235,6 +235,7 @@ module spi_host_reg_top (
   logic command_csaat_wd;
   logic [1:0] command_speed_wd;
   logic [1:0] command_direction_wd;
+  logic command_clkidle_wd;
   logic error_enable_we;
   logic error_enable_cmdbusy_qs;
   logic error_enable_cmdbusy_wd;
@@ -1182,7 +1183,7 @@ module spi_host_reg_top (
 
   // R[command]: V(True)
   logic command_qe;
-  logic [3:0] command_flds_we;
+  logic [4:0] command_flds_we;
   assign command_qe = &command_flds_we;
   //   F[len]: 8:0
   prim_subreg_ext #(
@@ -1247,6 +1248,22 @@ module spi_host_reg_top (
     .qs     ()
   );
   assign reg2hw.command.direction.qe = command_qe;
+
+  //   F[clkidle]: 14:14
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_command_clkidle (
+    .re     (1'b0),
+    .we     (command_we),
+    .wd     (command_clkidle_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (command_flds_we[4]),
+    .q      (reg2hw.command.clkidle.q),
+    .ds     (),
+    .qs     ()
+  );
+  assign reg2hw.command.clkidle.qe = command_qe;
 
 
   // R[error_enable]: V(False)
@@ -1806,6 +1823,8 @@ module spi_host_reg_top (
   assign command_speed_wd = reg_wdata[11:10];
 
   assign command_direction_wd = reg_wdata[13:12];
+
+  assign command_clkidle_wd = reg_wdata[14];
   assign error_enable_we = addr_hit[9] & reg_we & !reg_error;
 
   assign error_enable_cmdbusy_wd = reg_wdata[0];
@@ -1928,6 +1947,7 @@ module spi_host_reg_top (
         reg_rdata_next[9] = '0;
         reg_rdata_next[11:10] = '0;
         reg_rdata_next[13:12] = '0;
+        reg_rdata_next[14] = '0;
       end
 
       addr_hit[9]: begin


### PR DESCRIPTION
Add a command segment bit that tells SPI host to hold SCK at the idle value. This enables software control of CSB, and it allows creating various signal patterns, such as the JESD252 serial flash reset request.