### PR TITLE
[rv_dm,dv] Increase rv_dm_jtag_dmi_csr_bit_bash timeout

### DIFF
--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -140,7 +140,7 @@
       name: rv_dm_jtag_dmi_csr_bit_bash
       uvm_test_seq: rv_dm_jtag_dmi_csr_vseq
       build_mode: "cover_reg_top"
-      run_opts: ["+en_scb=0", "+csr_bit_bash", "+test_timeout_ns=100_000_000"]
+      run_opts: ["+en_scb=0", "+csr_bit_bash", "+test_timeout_ns=150_000_000"]
       reseed: 5
     }
     {


### PR DESCRIPTION
We increase to to 150ms in the rv_dm base vseq, but this gets overridden by the command line argument from the hjson file. The whole point of that argument was to give a *higher* timeout, which isn't quite what is happening! Bump up to 150ms as an initial step to match.