### PR TITLE
[dv] Fix a race condition in tl_device_seq

### DIFF
--- a/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
@@ -183,6 +183,13 @@ class tl_device_seq #(type REQ = tl_seq_item) extends dv_base_seq #(
 
   // Stop running this seq and wait until it has finished gracefully.
   virtual task seq_stop();
+    // We want to tell the sequence to stop by setting the stop flag. The current implementation of
+    // pre_body clears the stop signal. To avoid our stop flag getting cleared before it has any
+    // effect, wait until pre_body is out of the way.
+    if (get_sequence_state() inside {UVM_CREATED, UVM_PRE_START}) begin
+      wait_for_sequence_state(UVM_BODY);
+    end
+
     stop = 1'b1;
     wait_for_sequence_state(UVM_FINISHED);
   endtask


### PR DESCRIPTION
This condition came about because the pre_start task for tl_device_seq clears a flag, which doesn't work if we set the flag just before starting the sequence.

That clearing behaviour came from commit 17d386c879a, which doesn't really explain why it's needed. Maybe we can drop that behaviour entirely, but there's an easy work around just in case it's necessary. This commit does that workaround.