### PR TITLE
[rv_dm,jtag,dv] Fix JTAG monitor getting out of sync with the TAP

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
@@ -17,6 +17,9 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
   // Length of IR register. Update this field based on the actual width used in the design.
   uint ir_len = JTAG_IRW;
 
+  // TAP FSM state we go to on a TRST_N reset
+  jtag_fsm_state_e tap_reset_state = JtagResetState;
+
   // JTAG debug transport module (DTM) RAL model based off of RISCV spec 0.13.2 (section 6.1.2).
   jtag_dtm_reg_block jtag_dtm_ral;
 

--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -65,7 +65,10 @@ class jtag_monitor extends dv_base_monitor #(
       wait_tck();
 
       if (!cfg.vif.trst_n) begin
-        jtag_state = JtagResetState;
+        // Jump to the correct "reset state". I suspect this should always be JtagResetState, but
+        // some hardware jumps elsewhere! In particular, the pulp riscv-dbg TAP jumps to
+        // JtagIdleState.
+        jtag_state = cfg.tap_reset_state;
         wait(cfg.vif.trst_n == 1);
         continue;
       end

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -54,8 +54,10 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     m_jtag_agent_cfg.is_active = 1'b1;
     m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
 
-    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
+    // Set the 'correct' IDCODE register value to the JTAG DTM RAL, and correctly model the initial
+    // TAP state on a trst_n.
     m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
+    m_jtag_agent_cfg.tap_reset_state = JtagIdleState;
 
     // Create TL agent config obj for the SBA port.
     m_tl_sba_agent_cfg = tl_agent_cfg::type_id::create("m_tl_sba_agent_cfg");

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -377,7 +377,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     jtag_non_sba_dmi_fifo.flush();
     tl_sba_a_chan_fifo.flush();
     tl_sba_d_chan_fifo.flush();
-    selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.default_map.get_reg_by_offset(0);
+    selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode;
   endfunction
 
   function void check_phase(uvm_phase phase);


### PR DESCRIPTION
There are some detailed notes in the commit messages. Honestly, I'm slightly surprised about the riscv-dbg TAP behaviour here and intend to raise a "huh, really?" issue on the pulp repo to check it's what they intend.