### PR TITLE
[ci] Apply "Manually CherryPick" label when backporting fails

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -30,9 +30,17 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Create backport PRs
+        id: backport
         uses: korthout/backport-action@e8161d6a0dbfa2651b7daa76cbb75bc7c925bbf3 # v2.4.1
         with:
           label_pattern: "^CherryPick:([^ ]+)$"
           pull_title: "Cherry-pick to ${target_branch}: ${pull_title}"
           pull_description: |
             This is an automatic cherry-pick of #${pull_number} to branch `${target_branch}`.
+
+      - name: Apply label for manually cherry picking
+        if: ${{ steps.backport.outputs.was_successful == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label 'Manually CherryPick'


### PR DESCRIPTION
Fixes #23447

This change causes the `Manually CherryPick` label to be added to a PR if its automated cherry picking fails. This makes it easier to find and fix failed backports.