### PR TITLE
[sram_ctrl/dv] Avoid updating readback CSR on key_req

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -73,6 +73,12 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
             cfg.clk_rst_vif.wait_clks($urandom_range(10, 10_000));
             std::randomize(readback_en) with {
               readback_en inside {MuBi4True, MuBi4False};};
+            // Wait until cfg.in_key_req == 0 as writing to the readback CSR
+            // issues a TL-UL transaction to the register interface of the
+            // module, which triggers the following assertion inside
+            // the sram_ctrl_scoreboard:
+            // `DV_CHECK_EQ(cfg.in_key_req, 0, "No item is accepted during key req")
+            `DV_SPINWAIT(wait (cfg.in_key_req == 0);)
             csr_utils_pkg::wait_no_outstanding_access();
             csr_wr(.ptr(ral.readback), .value(readback_en));
             `uvm_info(`gfn, "Update READBACK Value", UVM_MEDIUM)


### PR DESCRIPTION
When a key request is triggered by the DV environment, we shouldn't update the readback CSR as this triggers the error described in lowRISC/opentitan#23445.

More specifically, writing the readback CSR over the RAL interface issues a TL-UL message to the register interface of the `sram_ctrl` module. However, when `cfg.in_key_req=1`, the `sram_ctrl_scoreboard` checks that no TL-UL transaction is on the bus.

By waiting until `cfg.in_key_req=0` we avoid this error message.

After this change:
![image](https://github.com/lowRISC/opentitan/assets/5767400/a6334870-7c79-40df-b48b-e7e44e44373a)

Closes #23445.