### PR TITLE
[doc] Add V2S scoping to V2 checklist

### DIFF
--- a/doc/project_governance/checklist/README.md
+++ b/doc/project_governance/checklist/README.md
@@ -516,7 +516,7 @@ In addition, the fully implemented functional coverage plan, the observed covera
 
 ### V3_CHECKLIST_SCOPED
 
-The V3 checklist has been reviewed to understand the scope and estimate effort.
+The V2S and V3 checklists have been reviewed to understand the scope and estimate effort.
 
 ## V2S
 


### PR DESCRIPTION
The existing V2 checklist had an item (V3_CHECKLIST_SCOPED) to understand scope and estimate effort for V3. We added the V2S development stage since that was defined, and we're definitely going to need to estimate effort for that at some point!

Add the task to the V2 checklist accordingly. It will be a reasonably quick job for most blocks.