### PR TITLE
[test] Add `rv_dm` late enable test 

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -228,6 +228,20 @@ otp_json(
 )
 
 otp_json(
+    name = "otp_json_hw_cfg1_enable_rv_dm_late_debug",
+    partitions = [
+        otp_partition(
+            name = "HW_CFG1",
+            items = {
+                # Use legacy behavior and disable late debug enable.
+                "DIS_RV_DM_LATE_DEBUG": False,
+            },
+            lock = True,
+        ),
+    ],
+)
+
+otp_json(
     name = "otp_json_secret1",
     partitions = [
         otp_partition(
@@ -384,6 +398,12 @@ otp_image(
     )
     for lc_state, _ in LC_MISSION_STATES
 ]
+
+otp_image(
+    name = "otp_img_dev_manuf_personalized_enable_rv_dm_late_debug_enable",
+    src = "//hw/ip/otp_ctrl/data:otp_json_dev",
+    overlays = MANUF_PERSONALIZED + [":otp_json_hw_cfg1_enable_rv_dm_late_debug"],
+)
 
 # `MANUF_PERSONALIZED` configuration for RMA. Only available in secure environments.
 otp_image(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4433,51 +4433,88 @@ _RV_DM_JTAG_LC_STATES = get_lc_items(
     CONST.LCV.RMA,
 )
 
+_RV_DM_TEST_CONFIGURATIONS = [
+    {
+        "name": "test_unlocked1",
+        "lc_state": "test_unlocked1",
+        "rv_dm_delayed_en": "",
+        "otp": _SIVAL_OTP_IMAGE["test_unlocked1"],
+    },
+    {
+        "name": "dev_rv_dm_default_enabled",
+        "lc_state": "dev",
+        "rv_dm_delayed_en": "",
+        "otp": _SIVAL_OTP_IMAGE["dev"],
+    },
+    {
+        "name": "dev_rv_dm_delayed_enabled",
+        "lc_state": "dev",
+        "rv_dm_delayed_en": "--rv-dm-delayed-enable",
+        "otp": "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_dev_manuf_personalized_enable_rv_dm_late_debug_enable",
+    },
+    {
+        "name": "rma",
+        "lc_state": "rma",
+        "rv_dm_delayed_en": "",
+        "otp": _SIVAL_OTP_IMAGE["rma"],
+    },
+]
+
 [
     opentitan_test(
-        name = "rv_dm_csr_rw_{}".format(lc_state),
-        srcs = ["example_test_from_flash.c"],
+        name = "rv_dm_csr_rw_{}".format(test_cfg["name"]),
+        srcs = ["rv_dm_delayed_enable.c"],
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
         },
         fpga = fpga_params(
             needs_jtag = True,
-            otp = _SIVAL_OTP_IMAGE[lc_state],
+            otp = test_cfg["otp"],
+            rv_dm_delayed_en = test_cfg["rv_dm_delayed_en"],
             tags = [
-                "lc_{}".format(lc_state),
+                "lc_{}".format(test_cfg["lc_state"]),
             ],
+            test_cmd = """
+                --bootstrap="{firmware}"
+                {rv_dm_delayed_en}
+            """,
             test_harness = "//sw/host/tests/chip/rv_dm:csr_rw",
         ),
         deps = [
+            "//sw/device/lib/base:multibits",
+            "//sw/device/lib/dif:lc_ctrl",
+            "//sw/device/lib/dif:rv_dm",
+            "//sw/device/lib/runtime:hart",
             "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:lc_ctrl_testutils",
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
-    for lc_state, _ in _RV_DM_JTAG_LC_STATES
+    for test_cfg in _RV_DM_TEST_CONFIGURATIONS
 ]
 
 test_suite(
     name = "rv_dm_csr_rw",
     tags = ["manual"],
     tests = [
-        ":rv_dm_csr_rw_{}".format(lc_state)
-        for lc_state, _ in _RV_DM_JTAG_LC_STATES
+        ":rv_dm_csr_rw_{}".format(test_cfg["name"])
+        for test_cfg in _RV_DM_TEST_CONFIGURATIONS
     ],
 )
 
 [
     opentitan_test(
-        name = "rv_dm_mem_access_{}".format(lc_state),
+        name = "rv_dm_mem_access_{}".format(test_cfg["name"]),
         srcs = ["example_test_from_flash.c"],
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
         },
         fpga = fpga_params(
             timeout = "moderate",
             needs_jtag = True,
-            otp = _SIVAL_OTP_IMAGE[lc_state],
+            otp = test_cfg["otp"],
             tags = [
-                "lc_{}".format(lc_state),
+                "lc_{}".format(test_cfg["lc_state"]),
             ],
             test_cmd = " --rom={rom:binary}",
             test_harness = "//sw/host/tests/chip/rv_dm:mem_access",
@@ -4487,15 +4524,15 @@ test_suite(
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )
-    for lc_state, _ in _RV_DM_JTAG_LC_STATES
+    for test_cfg in _RV_DM_TEST_CONFIGURATIONS
 ]
 
 test_suite(
     name = "rv_dm_mem_access",
     tags = ["manual"],
     tests = [
-        ":rv_dm_mem_access_{}".format(lc_state)
-        for lc_state, _ in _RV_DM_JTAG_LC_STATES
+        ":rv_dm_mem_access_{}".format(test_cfg["name"])
+        for test_cfg in _RV_DM_TEST_CONFIGURATIONS
     ],
 )
 
@@ -4504,7 +4541,7 @@ test_suite(
         name = "rv_dm_jtag_{}".format(lc_state),
         srcs = ["example_test_from_flash.c"],
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
         },
         fpga = fpga_params(
             needs_jtag = True,
@@ -4547,7 +4584,7 @@ _RV_DM_TAP_SEL_LC_STATES = get_lc_items(
         exec_env = dicts.add(
             EARLGREY_SILICON_OWNER_ROM_EXT_ENVS if lc_state == "prod" else {},
             {
-                "//hw/top_earlgrey:fpga_cw310_sival": None,
+                "//hw/top_earlgrey:fpga_cw340_sival": None,
             },
         ),
         fpga = fpga_params(
@@ -4613,7 +4650,7 @@ _LC_STATES_DEBUG_DISALLOWED = [
         exec_env = dicts.add(
             EARLGREY_SILICON_OWNER_ROM_EXT_ENVS if lc_state == "prod" else {},
             {
-                "//hw/top_earlgrey:fpga_cw310_sival": None,
+                "//hw/top_earlgrey:fpga_cw340_sival": None,
             },
         ),
         fpga = fpga_params(
@@ -4649,7 +4686,7 @@ test_suite(
         exec_env = dicts.add(
             EARLGREY_SILICON_OWNER_ROM_EXT_ENVS if lc_state == "prod" else {},
             {
-                "//hw/top_earlgrey:fpga_cw310_sival": None,
+                "//hw/top_earlgrey:fpga_cw340_sival": None,
             },
         ),
         fpga = fpga_params(

--- a/sw/device/tests/rv_dm_delayed_enable.c
+++ b/sw/device/tests/rv_dm_delayed_enable.c
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/multibits.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_rv_dm.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/lc_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+
+enum {
+  kRvDmEnableVal = kMultiBitBool32True,
+
+  kDebugEnableDelayMicrosDvSim = 1000,  // 1ms
+
+  // For FPGA and silicon, we need to wait long enough for opentitantoolib to
+  // return an error when trying to perform an operation on the device when
+  // debug mode is not enabled.
+  kDebugEnableDelayMicrosDefault = 1000000,  // 1s
+};
+
+static dif_lc_ctrl_t lc_ctrl;
+static dif_rv_dm_t rv_dm;
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc_ctrl));
+
+  CHECK_DIF_OK(dif_rv_dm_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_DM_REGS_BASE_ADDR), &rv_dm));
+
+  dif_lc_ctrl_state_t state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc_ctrl, &state));
+  CHECK_STATUS_OK(lc_ctrl_testutils_lc_state_log(&state));
+
+  if (state == kDifLcCtrlStateDev) {
+    bool is_locked;
+    CHECK_DIF_OK(dif_rv_dm_late_debug_is_locked(&rv_dm, &is_locked));
+
+    // Until we add support for delayed enable to the ROM_EXT, we expect this
+    // feature to be unlocked.
+    CHECK(!is_locked);
+
+    uint32_t delay_micros = kDebugEnableDelayMicrosDefault;
+    if (kDeviceType == kDeviceSimDV || kDeviceType == kDeviceSimVerilator) {
+      delay_micros = kDebugEnableDelayMicrosDvSim;
+    }
+
+    CHECK_DIF_OK(dif_rv_dm_late_debug_configure(&rv_dm, kDifToggleDisabled));
+    LOG_INFO("DEBUG_MODE_DISABLED");
+    busy_spin_micros(delay_micros);
+
+    // Enable debug mode. Report enablement via UART and busy spin again to
+    // allow the debugger to attach.
+    CHECK_DIF_OK(dif_rv_dm_late_debug_configure(&rv_dm, kDifToggleEnabled));
+
+    // The following string is expected in host side of the test.
+    LOG_INFO("DEBUG_MODE_ENABLED");
+    busy_spin_micros(delay_micros);
+  }
+
+  return true;
+}

--- a/sw/host/tests/chip/rv_dm/BUILD
+++ b/sw/host/tests/chip/rv_dm/BUILD
@@ -17,6 +17,7 @@ rust_binary(
         "//sw/host/opentitanlib/bindgen",
         "@crate_index//:anyhow",
         "@crate_index//:clap",
+        "@crate_index//:humantime",
         "@crate_index//:log",
         "@crate_index//:rand",
         "@crate_index//:rand_chacha",


### PR DESCRIPTION
1. Add OTP image with `RV_DM` late debug feature enabled.
2. Introduce test case on FPGA.
3. Update selected test cases to run in `cw340` FPGA.

This is part of https://github.com/lowRISC/opentitan/issues/21965