### PR TITLE
[spi_host, rtl] Spi host sd_en_o stable through the entire cycle (fsm fix)

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -147,7 +147,7 @@ end
 
 `endif
 
-  
+
   spi_host_reg2hw_t reg2hw;
   spi_host_hw2reg_t hw2reg;
 

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -43,6 +43,111 @@ module spi_host
 
   import spi_host_cmd_pkg::*;
 
+  // Note: this check is carried out via bind. The SVa is copied here in order to reproduce failures
+  //  in this branch, This commit will be dropped
+`ifndef SYNTHESIS
+  import uvm_pkg::*;
+ `include "uvm_macros.svh"
+
+  // Check to ensure cio_sd_o[i] stays stable for a whole clock cycle
+  // Truth table:
+  // ---------------------------------
+  // CPHA | CPOL | posedge | negedge |
+  // ---------------------------------
+  // 0    | 0    | 1       | 0       | -> XNOR(cpha, cpol): drive negedge, sample posedge
+  // 0    | 1    | 0       | 1       | -> XOR(cpha, cpol): drive posedge, sample negedge
+  // 1    | 0    | 0       | 1       | -> XOR(cpha, cpol): drive posedge, sample negedge
+  // 1    | 1    | 1       | 0       | -> XNOR(cpha, cpol): drive negedge, sample posedge
+  // ---------------------------------
+
+
+  //Driven in pos-edge, sampled in neg-edge
+  reg                      sampled_negedge_enable;
+  //Driven in neg-edge, sampled in pos-edge
+  reg                      sampled_posedge_enable;
+  logic                    csbs;
+  // Current design support NumCS=1 only
+  assign csbs = &cio_csb_o;
+
+  //HIGH when driven on pos-edge, sampled on the negedge
+  assign sampled_negedge_enable = !csbs & (configopts.cpha.q ^ configopts.cpol.q);
+  assign sampled_posedge_enable = !csbs & !sampled_negedge_enable;
+
+  for (genvar i = 0; i < 4; i++) begin : g_cio_signal_stable_sva
+    logic neg_value, pos_value;
+    event check_posedge, check_negedge;
+    initial begin
+      forever begin
+        @(negedge csbs);
+        //Initialising the neg/pos_value signals here, so they are ready for the first SPI cycle
+        pos_value <= cio_sd_i[i];
+        neg_value <= cio_sd_i[i];
+        if (sampled_posedge_enable) begin
+          @(negedge cio_sck_o);
+          pos_value <= cio_sd_i[i];
+        end
+        if (sampled_negedge_enable) begin
+          @(posedge cio_sck_o);
+          neg_value <= cio_sd_i[i];
+        end
+      end
+    end
+
+  always @(negedge cio_sck_o or negedge rst_ni) begin
+    if (!rst_ni) begin
+      neg_value <= 0;
+    end else if (!csbs) begin
+      neg_value <= cio_sd_i[i];
+      if (sampled_negedge_enable) begin
+        // TODO: remove IF below when passthrough mode is handled thorougly
+        // SPI-host block level TB drives gibberish to test passthru, which
+        // causes the assertion to fire. Until passthrough is tested via driving
+        // sensible SPI data is best to disable this SVA
+        if (!passthrough_i.passthrough_en)
+          -> check_negedge;
+      end
+    end
+  end
+
+  always @(posedge cio_sck_o or negedge rst_ni) begin
+    if (!rst_ni) begin
+      pos_value <= 0;
+    end else if (!csbs) begin
+      pos_value <= cio_sd_i[i];
+      if (sampled_posedge_enable) begin
+        // TODO: remove IF below when passthrough mode is handled thorougly
+        // SPI-host block level TB drives gibberish to test passthru, which
+        // causes the assertion to fire. Until passthrough is tested via driving
+        // sensible SPI data is best to disable this SVA
+        if (!passthrough_i.passthrough_en)
+          -> check_posedge;
+      end
+    end
+  end // always @ (posedge cio_sck_o or negedge rst_ni)
+
+  NEGEDGE_SAME_VALUE_CHECK_P: assert property (@(check_negedge) pos_value == neg_value) begin
+    `uvm_info("NEGEDGE_SAME_VALUE_CHECK_P", $sformatf("[i=%0d] - ASSERTION PASSED %t",i, $time),
+              UVM_DEBUG);
+  end
+  else begin
+    `uvm_error("NEGEDGE_SAME_VALUE_CHECK_P", {$sformatf("[i=%0d] - ASSERTION FAILED",i), $sformatf(
+                                              " pos_value (0x%0x) != neg_value (0x%0x) - time=%t",
+                                              pos_value, neg_value, $time)})
+  end
+  POSEDGE_SAME_VALUE_CHECK_P: assert property (@(check_posedge) pos_value == neg_value) begin
+    `uvm_info("POSEDGE_SAME_VALUE_CHECK_P", $sformatf("[i=%0d] - ASSERTION PASSED %t",i, $time),
+              UVM_DEBUG);
+  end
+  else begin
+    `uvm_error("POSEDGE_SAME_VALUE_CHECK_P", {$sformatf("[i=%0d] - ASSERTION FAILED",i), $sformatf(
+                                             " pos_value (0x%0x) != neg_value (0x%0x) - time=%t",
+                                             pos_value, neg_value, $time)})
+  end
+end
+
+`endif
+
+  
   spi_host_reg2hw_t reg2hw;
   spi_host_hw2reg_t hw2reg;
 

--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -577,30 +577,61 @@ module spi_host_fsm
 
   assign csb_o = csb_q;
 
+  logic [3:0] sd_en_ff_d, sd_en_ff_q;
+  assign sd_en_ff_d = sd_en_o;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      sd_en_ff_q <= 0;
+    end
+    //TODO: do we need an enable signal?
+    else begin
+      sd_en_ff_q <= sd_en_ff_d;
+    end
+  end
+  logic drive_posedge;
+  // CPOL / CPHASE truth table
+  // ---------------------------------------------
+  // CPHA | CPOL | Drive/sample                  |
+  // ---------------------------------------------
+  // 0    | 0    | drive negedge, sample posedge |
+  // 0    | 1    | drive posedge, sample negedge |
+  // 1    | 0    | drive posedge, sample negedge |
+  // 1    | 1    | drive negedge, sample posedge |
+  // ---------------------------------------------
+  assign drive_posedge = (cpol != cpha);
+
   always_comb begin
     if (&csb_o) begin
       sd_en_o[3:0] = 4'h0;
     end else begin
-      unique case (speed_o)
-        Standard: begin
-          // Observing 'last_bit' ensures we do not deassert the enable too early
-          sd_en_o[0]   = cmd_wr_en_q | cmd_wr_en_last_bit;
-          sd_en_o[1]   = 1'b0;
-          sd_en_o[3:2] = 2'b00;
-        end
-        Dual:     begin
-          sd_en_o[1:0] = {2{cmd_wr_en_q}};
-          sd_en_o[3:2] = 2'b00;
-        end
-        Quad:     begin
-          sd_en_o[3:0] = {4{cmd_wr_en_q}};
-        end
-        default: begin
-          // invalid speed
-          sd_en_o[3:0] = 4'h0;
-        end
-      endcase
-    end
+      // Only update the sd_en_o on the right clock transition. Since sck_o
+      // is generated from the sys clock we ensure we only drive the data on the
+      // right clock edge
+      if( (drive_posedge && sck_o) ||
+          (!drive_posedge && !sck_o) ) begin
+        unique case (speed_o)
+          Standard: begin
+            sd_en_o[0]   = cmd_wr_en_q | cmd_wr_en_last_bit;
+            sd_en_o[1]   = 1'b0;
+            sd_en_o[3:2] = 2'b00;
+          end
+          Dual:     begin
+            sd_en_o[1:0] = {2{cmd_wr_en_q}};
+            sd_en_o[3:2] = 2'b00;
+          end
+          Quad:     begin
+            sd_en_o[3:0] = {4{cmd_wr_en_q}};
+          end
+          default: begin
+            // invalid speed
+            sd_en_o[3:0] = 4'h0;
+          end
+        endcase
+      end
+      else begin
+        sd_en_o  = sd_en_ff_q;
+      end
+    end // else: !if(&csb_o)
   end
 
   //


### PR DESCRIPTION
The RTL has a bug in which if  `cmd_wr_en_q` is set, `sd_en_o` can be switching values mid-spi cyle.
The proposed change suggests only to allow to drive `sd_en_o` directly via `cmd_wr_en_q` when the edge is correct. Otherwise, `sd_en_o` is driven directly by it's latched value.

This PR aims to tackle the RTL side of #22182