### PR TITLE
[bazel] Refactor device test execution environment assignments

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -11,6 +11,7 @@ load(
     "opentitan_test",
     "verilator_params",
 )
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -63,9 +64,12 @@ opentitan_test(
 opentitan_test(
     name = "crc32_perftest",
     srcs = ["crc32_perftest.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     fpga = fpga_params(
         tags = [
             "manual",

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -6,12 +6,14 @@ load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_TEST_ENVS",
     "cw310_params",
     "fpga_params",
     "opentitan_test",
     "verilator_params",
 )
 load("//rules:linker.bzl", "ld_library")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -334,10 +336,12 @@ _FLOW_CONTROL_MESSAGE = (
 opentitan_test(
     name = "ottf_flow_control_functest",
     srcs = ["ottf_flow_control_functest.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     fpga = fpga_params(
         flow_control_message = _FLOW_CONTROL_MESSAGE,
         test_cmd = """

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -67,12 +67,16 @@ cc_test(
 opentitan_test(
     name = "boot_data_functest",
     srcs = ["boot_data_functest.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Not intended for ROM_EXT environments.
+            ["//hw/top_earlgrey:fpga_cw310_sival_rom_ext"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+        },
+    ),
     verilator = verilator_params(
         timeout = "eternal",
         tags = ["flaky"],
@@ -491,11 +495,15 @@ cc_library(
 opentitan_test(
     name = "otbn_boot_services_functest",
     srcs = ["otbn_boot_services_functest.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    broken = fpga_params(tags = ["broken"]),
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            # See #21706, expects keymgr state 0 so not working after ROM_EXT.
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+        },
+    ),
     # This target uses OTBN pointers internally, so it cannot work host-side.
     deps = [
         ":otbn_boot_services",

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -112,9 +112,12 @@ opentitan_test(
 opentitan_test(
     name = "mod_exp_ibex_functest_wycheproof",
     srcs = ["mod_exp_ibex_functest.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     fpga = fpga_params(
         timeout = "long",
     ),
@@ -141,10 +144,13 @@ cc_library(
 opentitan_test(
     name = "ecdsa_p256_verify_functest",
     srcs = ["ecdsa_p256_verify_functest.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:fpga_cw340_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw340_test_rom": None,
+        },
+    ),
     deps = [
         ":ecdsa_p256_verify",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -302,10 +308,13 @@ opentitan_test(
 opentitan_test(
     name = "sigverify_dynamic_functest_wycheproof",
     srcs = ["sigverify_dynamic_functest.c"],
-    exec_env = {
-        # Test set is too large as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            # Test set is too large as ROM_EXT
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     fpga = fpga_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
@@ -174,10 +174,16 @@ autogen_cryptotest_header(
 opentitan_test(
     name = "verify_test_kat0",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat0_header",
         "//sw/device/lib/base:memory",
@@ -191,10 +197,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat1",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat1_header",
         "//sw/device/lib/base:memory",
@@ -208,10 +220,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat2",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat2_header",
         "//sw/device/lib/base:memory",
@@ -225,10 +243,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat3",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat3_header",
         "//sw/device/lib/base:memory",
@@ -242,10 +266,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat4",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat4_header",
         "//sw/device/lib/base:memory",
@@ -259,10 +289,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat5",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat5_header",
         "//sw/device/lib/base:memory",
@@ -276,10 +312,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat6",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat6_header",
         "//sw/device/lib/base:memory",
@@ -293,10 +335,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat7",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat7_header",
         "//sw/device/lib/base:memory",
@@ -310,10 +358,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat8",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat8_header",
         "//sw/device/lib/base:memory",
@@ -327,10 +381,16 @@ opentitan_test(
 opentitan_test(
     name = "verify_test_kat9",
     srcs = ["verify_test.c"],
-    exec_env = {
-        # Test set is too large for Verilator or as ROM_EXT
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Test set is too large for Verilator.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     deps = [
         ":sphincsplus_shake_128s_simple_testvectors_kat9_header",
         "//sw/device/lib/base:memory",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -136,7 +136,6 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -184,19 +183,20 @@ opentitan_test(
     srcs = ["alert_handler_lpg_clkoff_test.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        # The test requires the Ibex core to wait long enough
+        # before checking for the ping_timeout error.
+        # The wait-time for the Verilator would be around
+        # 32M*8us = 256s (kClockFreqPeripheralHz = 125K).
+        # Thus it is not recommended to run this test on
+        # Verilator as this wait-time looks impractical. It should still
+        # be run as part of the DV nightly regression.
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:verilator"],
+        ),
         {
-            # The test requires the Ibex core to wait long enough
-            # before checking for the ping_timeout error.
-            # The wait-time for the Verilator would be around
-            # 32M*8us = 256s (kClockFreqPeripheralHz = 125K).
-            # Thus it is not recommended to run this test on
-            # Verilator as this wait-time looks impractical. It should still
-            # be run as part of the DV nightly regression.
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
         },
     ),
     fpga = fpga_params(timeout = "moderate"),
@@ -231,10 +231,14 @@ opentitan_test(
 opentitan_test(
     name = "alert_handler_reverse_ping_in_deep_sleep_test",
     srcs = ["alert_handler_reverse_ping_in_deep_sleep_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    broken = fpga_params(tags = ["broken"]),
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            # See #23038, this test requires a provisioned flash in sival.
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+        },
+    ),
     deps = [
         "//hw/top_earlgrey:alert_handler_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -265,19 +269,20 @@ opentitan_test(
     srcs = ["alert_handler_lpg_reset_toggle.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        # The test requires the Ibex core to wait long enough
+        # before checking for the ping_timeout error.
+        # The wait-time for the Verilator would be around
+        # 32M*8us = 256s (kClockFreqPeripheralHz = 125K).
+        # Thus it is not recommended to run this test on
+        # Verilator as this wait-time looks impractical. It should still
+        # be run as part of the DV nightly regression.
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:verilator"],
+        ),
         {
-            # The test requires the Ibex core to wait long enough
-            # before checking for the ping_timeout error.
-            # The wait-time for the Verilator would be around
-            # 32M*8us = 256s (kClockFreqPeripheralHz = 125K).
-            # Thus it is not recommended to run this test on
-            # Verilator as this wait-time looks impractical. It should still
-            # be run as part of the DV nightly regression.
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
         },
     ),
     fpga = fpga_params(
@@ -314,7 +319,8 @@ opentitan_test(
 opentitan_test(
     name = "alert_handler_lpg_sleep_mode_pings_test",
     srcs = ["alert_handler_lpg_sleep_mode_pings.c"],
-    exec_env = {
+    broken = fpga_params(tags = ["broken"]),
+    exec_env = dicts.add(
         # The test requires the Ibex core to wait long enough
         # before checking for the ping_timeout error.
         # The wait-time for the Verilator would be around
@@ -322,9 +328,15 @@ opentitan_test(
         # Thus it is not recommended to run this test on
         # Verilator as this wait-time looks impractical. It should still
         # be run as part of the DV nightly regression.
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:verilator"],
+        ),
+        {
+            # See #23038, this test requires a provisioned flash in sival.
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+        },
+    ),
     fpga = fpga_params(
         timeout = "moderate",
     ),
@@ -358,13 +370,11 @@ opentitan_test(
     srcs = ["alert_handler_ping_ok_test.c"],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:fpga_cw340_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
         },
     ),
     deps = [
@@ -389,13 +399,8 @@ opentitan_test(
     srcs = ["aon_timer_irq_test.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-            "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
-            "//hw/top_earlgrey:sim_verilator": None,
-        },
+        EARLGREY_TEST_ENVS,
+        {"//hw/top_earlgrey:silicon_creator": None},
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -624,16 +629,16 @@ cc_library(
 opentitan_test(
     name = "clkmgr_external_clk_src_for_sw_fast_test",
     srcs = ["clkmgr_external_clk_src_for_sw_fast_test.c"],
-    exec_env = {
-        # Exclude fpga_cw310_rom_with_fake_keys because they are signed with
+    exec_env = dicts.add(
+        # Exclude fpga_*_rom_with_fake_keys because they are signed with
         # RMA keys, while we need DEV, and the infrastructure doesn't allow
         # changing the key for a single environment.
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys"],
+        ),
+        {"//hw/top_earlgrey:fpga_cw310_sival": None},
+    ),
     fpga = fpga_params(
         otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_dev_manuf_personalized",
     ),
@@ -1167,13 +1172,12 @@ opentitan_test(
     srcs = ["entropy_src_fw_ovr_test.c"],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
         },
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         tags = ["broken"],
     ),
     verilator = verilator_params(tags = ["broken"]),
@@ -1272,12 +1276,10 @@ opentitan_test(
     srcs = ["entropy_src_csrng_test.c"],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
         },
     ),
     verilator = verilator_params(
@@ -1451,13 +1453,10 @@ opentitan_test(
 opentitan_test(
     name = "flash_ctrl_idle_low_power_test",
     srcs = ["flash_ctrl_idle_low_power_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -1632,7 +1631,6 @@ opentitan_test(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
             # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         },
@@ -1684,9 +1682,7 @@ opentitan_test(
     srcs = ["flash_ctrl_write_clear_test.c"],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
-        {
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-        },
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     verilator = verilator_params(timeout = "long"),
     deps = [
@@ -1775,12 +1771,13 @@ opentitan_test(
     srcs = ["gpio_smoketest.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        # Not compatible with the verilated top level.
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:verilator"],
+        ),
         {
-            # Not compatible with the verilated top level.
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
         },
     ),
     silicon = silicon_params(tags = ["broken"]),
@@ -1795,18 +1792,20 @@ opentitan_test(
 opentitan_test(
     name = "gpio_pinmux_test",
     srcs = ["gpio_pinmux_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        },
+    ),
     fpga = fpga_params(
         test_cmd = """
             --bootstrap="{firmware}"
         """,
         test_harness = "//sw/host/tests/chip/gpio",
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
@@ -1825,11 +1824,13 @@ opentitan_test(
 opentitan_test(
     name = "gpio_intr_test",
     srcs = ["gpio_intr_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-    },
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        },
+    ),
     fpga = fpga_params(
         timeout = "moderate",
         test_cmd = """
@@ -1837,7 +1838,7 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/gpio_intr",
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
@@ -1912,7 +1913,6 @@ opentitan_test(
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
     deps = [
@@ -2196,7 +2196,6 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -2385,7 +2384,6 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -2411,7 +2409,6 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -2569,23 +2566,21 @@ opentitan_test(
     srcs = ["pwrmgr_all_reset_reqs_test.c"],
     broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             # FIXME broken in sival ROM_EXT, remove this line when fixed. See #21706.
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-            "//hw/top_earlgrey:fpga_cw310_sival": "test_harness",
-            "//hw/top_earlgrey:fpga_cw310_test_rom": "test_harness",
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
         },
     ),
-    silicon = silicon_params(
+    fpga = fpga_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
-    test_harness = fpga_params(
+    silicon = silicon_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
@@ -2715,21 +2710,20 @@ opentitan_test(
 opentitan_test(
     name = "pwrmgr_deep_sleep_por_reset_test",
     srcs = ["pwrmgr_deep_sleep_por_reset_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+        },
+    ),
     fpga = fpga_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_por",
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
@@ -2754,21 +2748,20 @@ opentitan_test(
 opentitan_test(
     name = "pwrmgr_normal_sleep_por_reset_test",
     srcs = ["pwrmgr_normal_sleep_por_reset_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+        },
+    ),
     fpga = fpga_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_por",
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         test_cmd = """
             --bootstrap={firmware}
         """,
@@ -2793,15 +2786,14 @@ opentitan_test(
 opentitan_test(
     name = "pwrmgr_normal_sleep_all_wake_ups",
     srcs = ["pwrmgr_normal_sleep_all_wake_ups.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
     fpga = fpga_params(
         test_cmd = """
             --bootstrap={firmware}
@@ -2826,15 +2818,14 @@ opentitan_test(
 opentitan_test(
     name = "pwrmgr_deep_sleep_all_wake_ups",
     srcs = ["pwrmgr_deep_sleep_all_wake_ups.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
     fpga = fpga_params(
         test_cmd = """
             --bootstrap={firmware}
@@ -2861,15 +2852,14 @@ opentitan_test(
 opentitan_test(
     name = "pwrmgr_random_sleep_all_wake_ups",
     srcs = ["pwrmgr_random_sleep_all_wake_ups.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
     fpga = fpga_params(
         test_cmd = """
             --bootstrap={firmware}
@@ -2907,14 +2897,14 @@ opentitan_test(
 opentitan_test(
     name = "pwrmgr_sleep_wake_5_bug_test",
     srcs = ["pwrmgr_sleep_wake_5_bug_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
     fpga = fpga_params(
         test_cmd = """
             --bootstrap={firmware}
@@ -2973,7 +2963,6 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
@@ -3059,15 +3048,10 @@ opentitan_test(
     name = "rstmgr_cpu_info_test",
     srcs = ["rstmgr_cpu_info_test.c"],
     exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
-            "//hw/top_earlgrey:sim_verilator": None,
         },
     ),
     verilator = verilator_params(
@@ -3211,11 +3195,10 @@ opentitan_test(
 opentitan_test(
     name = "spi_device_tpm_tx_rx_test",
     srcs = ["spi_device_tpm_tx_rx_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:sim_dv": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     fpga = fpga_params(
         # This test requires the spi full duplex on the hyperdebug board.
         tags = [
@@ -3228,7 +3211,7 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/spi_device:spi_device_tpm_test",
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
             "{firmware:elf}"
@@ -3255,11 +3238,8 @@ opentitan_test(
     name = "spi_device_flash_smoketest",
     srcs = ["spi_device_flash_smoketest.c"],
     exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        },
     ),
     fpga = fpga_params(
         test_cmd = """
@@ -3315,9 +3295,10 @@ cc_library(
 opentitan_test(
     name = "spi_host_smoketest",
     srcs = ["spi_host_smoketest.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     fpga = fpga_params(timeout = "moderate"),
     deps = [
         ":spi_host_flash_test_impl",
@@ -3339,10 +3320,10 @@ opentitan_test(
 opentitan_test(
     name = "spi_host_winbond_flash_test",
     srcs = ["spi_host_winbond_flash_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         ":spi_host_flash_test_impl",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -3363,9 +3344,10 @@ opentitan_test(
 opentitan_test(
     name = "spi_host_irq_test",
     srcs = ["spi_host_irq_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -3553,12 +3535,10 @@ opentitan_test(
     srcs = ["sram_ctrl_sleep_sram_ret_contents_scramble_test.c"],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": None,
         },
     ),
     verilator = verilator_params(
@@ -4062,21 +4042,21 @@ opentitan_test(
 opentitan_test(
     name = "rstmgr_alert_info_test",
     srcs = ["rstmgr_alert_info_test.c"],
-    exec_env = {
-        # TODO(lowrisc/opentitan#20589): Enable _sival* tests when bug is fixed
-        # "//hw/top_earlgrey:fpga_cw310_sival": None,
-        # "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    broken = fpga_params(tags = ["broken"]),
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:silicon_creator": None,
+            # TODO(lowrisc/opentitan#20589): Enable _sival* tests when bug is fixed
+            "//hw/top_earlgrey:fpga_cw310_sival": "broken",
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+        },
+    ),
     fpga = fpga_params(
         timeout = "moderate",
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         tags = ["broken"],
     ),
     verilator = verilator_params(
@@ -4174,15 +4154,13 @@ opentitan_test(
     srcs = ["rv_core_ibex_nmi_irq_test.c"],
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-            "//hw/top_earlgrey:silicon_owner_prodc_rom_ext": "silicon_owner",
         },
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         tags = ["broken"],
     ),
     deps = [
@@ -4348,11 +4326,10 @@ opentitan_test(
     name = "spi_passthru_test",
     srcs = ["spi_passthru_test.c"],
     exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "hyper310",
-            "//hw/top_earlgrey:fpga_hyper310_rom_ext": "hyper310",
         },
     ),
     fpga = fpga_params(
@@ -5472,14 +5449,18 @@ opentitan_test(
 opentitan_test(
     name = "rv_core_ibex_isa_test_test_unlocked0",
     srcs = ["//sw/device/silicon_creator/manuf/tests:idle_functest.c"],
-    exec_env = {
+    exec_env = dicts.add(
         # This test is not compatible with the test_rom because the test_rom
         # does not respect the exec_disabled OTP config word.
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-    },
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:fpga_cw310_test_rom"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
     fpga = fpga_params(
         binaries = {
             ":rv_core_ibex_isa_test_sram": "sram_program",
@@ -5554,13 +5535,17 @@ test_suite(
 opentitan_test(
     name = "rv_core_ibex_epmp_test_functest",
     srcs = ["//sw/device/silicon_creator/manuf/tests:idle_functest.c"],
-    exec_env = {
+    exec_env = dicts.add(
         # This test is not compatible with the test_rom because the test_rom
         # does not respect the exec_disabled OTP config word.
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-    },
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:fpga_cw310_test_rom"],
+        ),
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+        },
+    ),
     fpga = fpga_params(
         binaries = {
             ":rv_core_ibex_epmp_test": "sram_program",
@@ -5614,13 +5599,16 @@ opentitan_binary(
 opentitan_test(
     name = "uart_tx_rx_test",
     srcs = ["uart_tx_rx_test.c"],
+    broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
             "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:sim_dv": None,
+            # See #23468, currently broken on SAM3X execution environments.
+            "//hw/top_earlgrey:fpga_cw310_test_rom": "broken",
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": "broken",
         },
     ),
     fpga = fpga_params(
@@ -5661,14 +5649,18 @@ opentitan_test(
 opentitan_test(
     name = "rv_core_ibex_mem_test_functest",
     srcs = ["//sw/device/silicon_creator/manuf/tests:idle_functest.c"],
-    exec_env = {
+    exec_env = dicts.add(
         # This test is not compatible with the test_rom because the test_rom
         # does not respect the exec_disabled OTP config word.
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
-    },
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:fpga_cw310_test_rom"],
+        ),
+        {
+            "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+        },
+    ),
     fpga = fpga_params(
         binaries = {
             ":rv_core_ibex_mem_test": "sram_program",
@@ -5728,13 +5720,13 @@ opentitan_binary(
 opentitan_test(
     name = "uart_baud_rate_test",
     srcs = ["uart_baud_rate_test.c"],
-    broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
-        # FIXME broken in sival ROM_EXT, change this line when fixed. See #21706.
-        {"//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken"},
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(
+        # FIXME broken in sival ROM_EXT, change this line when fixed. See #21706.
+        tags = ["broken"],
         test_cmd = " ".join([
             "--bootstrap=\"{firmware}\"",
             "--firmware-elf=\"{firmware:elf}\"",
@@ -5765,9 +5757,15 @@ opentitan_test(
 opentitan_test(
     name = "uart_loopback_test",
     srcs = ["uart_loopback_test.c"],
+    broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
-        {"//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None},
+        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            # See #23468: currently broken over the SAM3X interface.
+            "//hw/top_earlgrey:fpga_cw310_test_rom": "broken",
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": "broken",
+        },
     ),
     fpga = fpga_params(
         test_cmd = " ".join([
@@ -5833,11 +5831,17 @@ opentitan_test(
 opentitan_test(
     name = "uart_parity_break_test",
     srcs = ["uart_parity_break_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-    },
+    broken = fpga_params(tags = ["broken"]),
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            # See #23468: currently broken over the SAM3X interface.
+            "//hw/top_earlgrey:fpga_cw310_test_rom": "broken",
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": "broken",
+        },
+    ),
     fpga = fpga_params(
         test_cmd = " ".join([
             "--bootstrap=\"{firmware}\"",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1133,7 +1133,6 @@ opentitan_test(
 opentitan_test(
     name = "edn_kat",
     srcs = ["edn_kat.c"],
-    # Remove this line when fixed.
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,

--- a/sw/device/tests/autogen/BUILD
+++ b/sw/device/tests/autogen/BUILD
@@ -9,12 +9,15 @@
 
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
+    "EARLGREY_TEST_ENVS",
     "cw310_params",
     "fpga_params",
     "opentitan_test",
     "silicon_params",
     "verilator_params",
 )
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,15 +29,15 @@ package(default_visibility = ["//visibility:public"])
             "-DTEST_MIN_IRQ_PERIPHERAL={}".format(min),
             "-DTEST_MAX_IRQ_PERIPHERAL={}".format(min + 10),
         ],
-        exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-            "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-            "//hw/top_earlgrey:sim_dv": None,
-            "//hw/top_earlgrey:sim_verilator": None,
-        },
+        exec_env = dicts.add(
+            EARLGREY_TEST_ENVS,
+            EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+            {
+                "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+                "//hw/top_earlgrey:fpga_cw310_sival": None,
+                "//hw/top_earlgrey:silicon_creator": None,
+            },
+        ),
         verilator = verilator_params(
             timeout = "eternal",
             tags = ["flaky"],
@@ -91,15 +94,16 @@ opentitan_test(
     srcs = ["alert_test.c"],
     # TODO(#22871): Remove "broken" tag once the tests are fixed.
     broken = fpga_params(tags = ["broken"]),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:boot_stage",

--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -5,11 +5,13 @@
 load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
+    "EARLGREY_TEST_ENVS",
     "cw310_params",
     "fpga_params",
     "opentitan_test",
     "silicon_params",
 )
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -311,18 +313,20 @@ opentitan_test(
 opentitan_test(
     name = "i2c_host_fram_test",
     srcs = ["i2c_host_fram_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon_owner",
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+        },
+    ),
     fpga = fpga_params(
         tags = [
             "manual",
             "pmod",
         ],  # Requires the PMOD::BoB.
     ),
-    silicon_owner = silicon_params(
+    silicon = silicon_params(
         tags = [
             "pmod",
         ],  # Requires the PMOD::BoB.

--- a/util/topgen/templates/BUILD.tpl
+++ b/util/topgen/templates/BUILD.tpl
@@ -9,12 +9,15 @@ alert_peripheral_names = sorted({p.name for p in helper.alert_peripherals})
 %>\
 load(
     "//rules/opentitan:defs.bzl",
+    "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
+    "EARLGREY_TEST_ENVS",
     "cw310_params",
     "fpga_params",
     "opentitan_test",
     "silicon_params",
     "verilator_params",
 )
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,15 +29,15 @@ package(default_visibility = ["//visibility:public"])
             "-DTEST_MIN_IRQ_PERIPHERAL={}".format(min),
             "-DTEST_MAX_IRQ_PERIPHERAL={}".format(min + 10),
         ],
-        exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_sival": None,
-            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-            "//hw/top_earlgrey:silicon_creator": None,
-            "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-            "//hw/top_earlgrey:sim_dv": None,
-            "//hw/top_earlgrey:sim_verilator": None,
-        },
+        exec_env = dicts.add(
+            EARLGREY_TEST_ENVS,
+            EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+            {
+                "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+                "//hw/top_earlgrey:fpga_cw310_sival": None,
+                "//hw/top_earlgrey:silicon_creator": None,
+            },
+        ),
         verilator = verilator_params(
             timeout = "eternal",
             tags = ["flaky"],
@@ -72,15 +75,16 @@ opentitan_test(
     srcs = ["alert_test.c"],
     # TODO(#22871): Remove "broken" tag once the tests are fixed.
     broken = fpga_params(tags = ["broken"]),
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_sival": None,
-        "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-        "//hw/top_earlgrey:silicon_creator": None,
-        "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-        "//hw/top_earlgrey:sim_dv": None,
-        "//hw/top_earlgrey:sim_verilator": None,
-    },
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:boot_stage",


### PR DESCRIPTION
This PR updates as many `opentitan_test`s as possible to use `EARLGREY_TEST_ENVS` and `EARLGREY_SILICON_OWNER_ROM_EXT_ENVS`.

* If a test isn't designed for an environment, we remove it with `dicts.omit`.
* If a test is supposed to work but is broken on an environment, we tag `broken`.

I have tried my best not to _remove_ any environments from tests, only add them.

@engdoreis and I discussed some tests in `//sw/device/tests` that do not need to run on `fpga_cw310_test_rom` so removed that environment from those tests.