### PR TITLE
[otbn,dv] Collect coverage from lc_escalate_en_i signal

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -383,6 +383,17 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
 
   // Non-core covergroups //////////////////////////////////////////////////////
 
+  // Tracking for the escalate_en_i input
+  covergroup escalate_en_cg with function sample(lc_ctrl_pkg::lc_tx_t value);
+    // Any value other than Off should be treated as an escalation request. We want to make sure we
+    // see genuine On and Off, but also an invalid value (which will be treated as On)
+    value_cp: coverpoint {value} {
+      bins off = {lc_ctrl_pkg::Off};
+      bins on  = {lc_ctrl_pkg::On};
+      bins bad = {[0:$]} with (!(item inside {lc_ctrl_pkg::Off, lc_ctrl_pkg::On}));
+    }
+  endgroup
+
   // CMD external CSR
   covergroup ext_csr_cmd_cg
     with function sample(otbn_pkg::cmd_e     value,
@@ -2099,6 +2110,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
+
+    escalate_en_cg = new;
 
     ext_csr_cmd_cg = new;
     ext_csr_ctrl_cg = new;

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -103,6 +103,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     fork
       process_model_fifo();
       process_trace_fifo();
+      watch_escalate_if();
     join_none
   endtask
 
@@ -647,6 +648,18 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     super.process_mem_read(item, ral_name);
     if (model_status == 'b1 && item.d_data != 0) begin
       `uvm_error(`gfn, "read data is non zero when memory is accessed while otbn is busy")
+    end
+  endtask
+
+  // This task watches the escalate interface and collects coverage whenever it changes
+  //
+  virtual task watch_escalate_if();
+    // The 'enable' signal is connected to the lc_escalate_en_i top-level input
+    forever begin
+      if (cfg.clk_rst_vif.rst_n) begin
+        cov.escalate_en_cg.sample(cfg.escalate_vif.enable);
+      end
+      @(cfg.escalate_vif.enable or cfg.clk_rst_vif.rst_n);
     end
   endtask
 


### PR DESCRIPTION
This signal is not really synchronous with anything else: an escalation request can come at any time. Collect very basic coverage of whether it is Off, On or undefined (treated as On).

The "bad" bin for this covergroup is true whenever an unknown value is sent on the lc_escalate_en_i. We expect this to be treated as an escalation request (because of the lc_tx_test_true_loose call in otbn_core_model.sv), so completing coverage for this covergroup will check that we do indeed treat unknown values on lc_escalate_en_i as good escalation requests.

This should satisfy the first item in #23460.