### PR TITLE
[pwrmgr] Don't lock CONTROL until observing core_sleep

### DIFF
--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Decription:
 // Create low power transition and wakeup a few times.
-// When PWRMGR.CONTROL.LOW_POWER_HINT is set,
+// When PWRMGR.CONTROL.LOW_POWER_HINT is set and core_sleep is high,
 // issue random write to PWRMGR.CONTROL and check
-// PWRMGR.CONTROL value is not changed.
+// PWRMGR.CONTROL value is not changed, except for LOW_POWER_HINT.
 class pwrmgr_sec_cm_ctrl_config_regwen_vseq extends pwrmgr_wakeup_vseq;
   `uvm_object_utils(pwrmgr_sec_cm_ctrl_config_regwen_vseq)
 
@@ -17,7 +17,12 @@ class pwrmgr_sec_cm_ctrl_config_regwen_vseq extends pwrmgr_wakeup_vseq;
   endtask : pre_start
 
   task proc_illegal_ctrl_access();
-    uvm_reg_data_t wdata, expdata;
+    uvm_reg_data_t wdata, expdata, compare_mask;
+    // CONTROL.LOW_POWER_HINT is hardware-writeable, so mask it from checking.
+    // It gets cleared very quickly.
+    compare_mask = '1;
+    compare_mask = compare_mask - ral.control.low_power_hint.get_field_mask();
+
     cfg.clk_rst_vif.wait_clks(1);
     wait(cfg.pwrmgr_vif.lowpwr_cfg_wen == 0);
 
@@ -26,13 +31,18 @@ class pwrmgr_sec_cm_ctrl_config_regwen_vseq extends pwrmgr_wakeup_vseq;
       expdata = ral.control.get();
       `uvm_info(`gfn, $sformatf("csr start %x", ral.control.get()), UVM_HIGH)
       csr_wr(.ptr(ral.control), .value(wdata));
-      csr_rd_check(.ptr(ral.control), .compare_value(expdata));
+      csr_rd_check(.ptr(ral.control), .compare_value(expdata), .compare_mask(compare_mask));
       `uvm_info(`gfn, "csr done", UVM_HIGH)
     end
   endtask : proc_illegal_ctrl_access
 
-  virtual task wait_for_csr_to_propagate_to_slow_domain();
-    proc_illegal_ctrl_access();
-    super.wait_for_csr_to_propagate_to_slow_domain();
+  virtual task initiate_low_power_transition();
+    super.initiate_low_power_transition();
+    // The access checks can only happen if the bus is powered and the clock
+    // is active.
+    if ((ral.control.main_pd_n.get_mirrored_value() == 1'b1) &&
+        (ral.control.io_clk_en.get_mirrored_value() == 1'b1)) begin
+      proc_illegal_ctrl_access();
+    end
   endtask
 endclass : pwrmgr_sec_cm_ctrl_config_regwen_vseq

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
@@ -69,8 +69,7 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       update_control_csr();
 
       // Initiate low power transition.
-      cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
-      set_nvms_idle();
+      initiate_low_power_transition();
 
       if (ral.control.main_pd_n.get_mirrored_value() == 1'b0) begin
         wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
@@ -124,4 +123,8 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
     clear_wake_info();
   endtask
 
+  virtual task initiate_low_power_transition();
+    cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
+    set_nvms_idle();
+  endtask
 endclass : pwrmgr_wakeup_vseq

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv
@@ -274,6 +274,7 @@ module pwrmgr
   prim_mubi_pkg::mubi4_t rom_ctrl_good;
 
   logic core_sleeping;
+  logic low_power_entry;
 
   ////////////////////////////
   ///  clk_slow_i domain declarations
@@ -339,7 +340,7 @@ module pwrmgr
       lowpwr_cfg_wen <= 1'b1;
     end else if (!lowpwr_cfg_wen && (clr_cfg_lock || wkup)) begin
       lowpwr_cfg_wen <= 1'b1;
-    end else if (low_power_hint) begin
+    end else if (low_power_entry) begin
       lowpwr_cfg_wen <= 1'b0;
     end
   end
@@ -577,6 +578,7 @@ module pwrmgr
   ////////////////////////////
 
   assign low_power_hint = reg2hw.control.low_power_hint.q == LowPower;
+  assign low_power_entry = core_sleeping & low_power_hint;
 
   pwrmgr_fsm u_fsm (
     .clk_i,
@@ -590,7 +592,7 @@ module pwrmgr
     .ack_pwrup_o         (ack_pwrup),
     .req_pwrdn_o         (req_pwrdn),
     .ack_pwrdn_i         (ack_pwrdn),
-    .low_power_entry_i   (core_sleeping & low_power_hint),
+    .low_power_entry_i   (low_power_entry),
     .reset_reqs_i        (peri_reqs_masked.rstreqs),
     .fsm_invalid_i       (fsm_invalid),
     .clr_slow_req_o      (clr_slow_req),

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1855,6 +1855,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_pwrmgr_lowpower_cancel
+      uvm_test_seq: "chip_sw_base_vseq"
+      sw_images: ["//sw/device/tests:pwrmgr_lowpower_cancel_test:1:new_rules"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_pwrmgr_deep_sleep_all_wake_ups
       uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
       sw_images: ["//sw/device/tests:pwrmgr_deep_sleep_all_wake_ups:1:new_rules"]

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_sec_cm_ctrl_config_regwen_vseq.sv
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Decription:
 // Create low power transition and wakeup a few times.
-// When PWRMGR.CONTROL.LOW_POWER_HINT is set,
+// When PWRMGR.CONTROL.LOW_POWER_HINT is set and core_sleep is high,
 // issue random write to PWRMGR.CONTROL and check
-// PWRMGR.CONTROL value is not changed.
+// PWRMGR.CONTROL value is not changed, except for LOW_POWER_HINT.
 class pwrmgr_sec_cm_ctrl_config_regwen_vseq extends pwrmgr_wakeup_vseq;
   `uvm_object_utils(pwrmgr_sec_cm_ctrl_config_regwen_vseq)
 
@@ -17,7 +17,12 @@ class pwrmgr_sec_cm_ctrl_config_regwen_vseq extends pwrmgr_wakeup_vseq;
   endtask : pre_start
 
   task proc_illegal_ctrl_access();
-    uvm_reg_data_t wdata, expdata;
+    uvm_reg_data_t wdata, expdata, compare_mask;
+    // CONTROL.LOW_POWER_HINT is hardware-writeable, so mask it from checking.
+    // It gets cleared very quickly.
+    compare_mask = '1;
+    compare_mask = compare_mask - ral.control.low_power_hint.get_field_mask();
+
     cfg.clk_rst_vif.wait_clks(1);
     wait(cfg.pwrmgr_vif.lowpwr_cfg_wen == 0);
 
@@ -26,13 +31,18 @@ class pwrmgr_sec_cm_ctrl_config_regwen_vseq extends pwrmgr_wakeup_vseq;
       expdata = ral.control.get();
       `uvm_info(`gfn, $sformatf("csr start %x", ral.control.get()), UVM_HIGH)
       csr_wr(.ptr(ral.control), .value(wdata));
-      csr_rd_check(.ptr(ral.control), .compare_value(expdata));
+      csr_rd_check(.ptr(ral.control), .compare_value(expdata), .compare_mask(compare_mask));
       `uvm_info(`gfn, "csr done", UVM_HIGH)
     end
   endtask : proc_illegal_ctrl_access
 
-  virtual task wait_for_csr_to_propagate_to_slow_domain();
-    proc_illegal_ctrl_access();
-    super.wait_for_csr_to_propagate_to_slow_domain();
+  virtual task initiate_low_power_transition();
+    super.initiate_low_power_transition();
+    // The access checks can only happen if the bus is powered and the clock
+    // is active.
+    if ((ral.control.main_pd_n.get_mirrored_value() == 1'b1) &&
+        (ral.control.io_clk_en.get_mirrored_value() == 1'b1)) begin
+      proc_illegal_ctrl_access();
+    end
   endtask
 endclass : pwrmgr_sec_cm_ctrl_config_regwen_vseq

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
@@ -69,8 +69,7 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       update_control_csr();
 
       // Initiate low power transition.
-      cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
-      set_nvms_idle();
+      initiate_low_power_transition();
 
       if (ral.control.main_pd_n.get_mirrored_value() == 1'b0) begin
         wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
@@ -124,4 +123,8 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
     clear_wake_info();
   endtask
 
+  virtual task initiate_low_power_transition();
+    cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
+    set_nvms_idle();
+  endtask
 endclass : pwrmgr_wakeup_vseq

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -274,6 +274,7 @@ module pwrmgr
   prim_mubi_pkg::mubi4_t rom_ctrl_good;
 
   logic core_sleeping;
+  logic low_power_entry;
 
   ////////////////////////////
   ///  clk_slow_i domain declarations
@@ -339,7 +340,7 @@ module pwrmgr
       lowpwr_cfg_wen <= 1'b1;
     end else if (!lowpwr_cfg_wen && (clr_cfg_lock || wkup)) begin
       lowpwr_cfg_wen <= 1'b1;
-    end else if (low_power_hint) begin
+    end else if (low_power_entry) begin
       lowpwr_cfg_wen <= 1'b0;
     end
   end
@@ -577,6 +578,7 @@ module pwrmgr
   ////////////////////////////
 
   assign low_power_hint = reg2hw.control.low_power_hint.q == LowPower;
+  assign low_power_entry = core_sleeping & low_power_hint;
 
   pwrmgr_fsm u_fsm (
     .clk_i,
@@ -590,7 +592,7 @@ module pwrmgr
     .ack_pwrup_o         (ack_pwrup),
     .req_pwrdn_o         (req_pwrdn),
     .ack_pwrdn_i         (ack_pwrdn),
-    .low_power_entry_i   (core_sleeping & low_power_hint),
+    .low_power_entry_i   (low_power_entry),
     .reset_reqs_i        (peri_reqs_masked.rstreqs),
     .fsm_invalid_i       (fsm_invalid),
     .clr_slow_req_o      (clr_slow_req),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5909,6 +5909,31 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "pwrmgr_lowpower_cancel_test",
+    srcs = ["pwrmgr_lowpower_cancel_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+    ),
+    deps = [
+        "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
     name = "sram_ctrl_lc_escalation_test",
     srcs = ["sram_ctrl_lc_escalation_test.c"],
     exec_env = {

--- a/sw/device/tests/pwrmgr_lowpower_cancel_test.c
+++ b/sw/device/tests/pwrmgr_lowpower_cancel_test.c
@@ -1,0 +1,167 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "pwrmgr_regs.h"
+
+dif_pwrmgr_t pwrmgr;
+dif_rv_plic_t rv_plic;
+
+static dif_pwrmgr_request_sources_t wakeup_src =
+    kDifPwrmgrWakeupRequestSourceFive;
+static uint32_t wakeup_source = PWRMGR_PARAM_AON_TIMER_AON_WKUP_REQ_IDX;
+
+static dif_aon_timer_t timer;
+
+void ottf_external_isr(uint32_t *exc_info) {
+  dif_rv_plic_irq_id_t irq_id;
+  CHECK_DIF_OK(
+      dif_rv_plic_irq_claim(&rv_plic, kTopEarlgreyPlicTargetIbex0, &irq_id));
+
+  top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
+      top_earlgrey_plic_interrupt_for_peripheral[irq_id];
+
+  if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
+    LOG_INFO("AON Timer ISR");
+    dif_aon_timer_irq_t irq =
+        (dif_aon_timer_irq_t)(irq_id -
+                              (dif_rv_plic_irq_id_t)
+                                  kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+
+    if (irq_id == kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired) {
+      CHECK_DIF_OK(dif_aon_timer_wakeup_stop(&timer));
+    } else if (irq_id == kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark) {
+      CHECK_DIF_OK(dif_aon_timer_watchdog_stop(&timer));
+    }
+    CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(&timer, irq));
+    bool is_pending = true;
+    CHECK_DIF_OK(dif_aon_timer_irq_is_pending(
+        &timer, kDifAonTimerIrqWkupTimerExpired, &is_pending));
+    CHECK(!is_pending);
+  } else if (peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon) {
+    LOG_INFO("Pwrmgr ISR");
+    dif_pwrmgr_irq_t irq =
+        (dif_pwrmgr_irq_t)(irq_id - (dif_rv_plic_irq_id_t)
+                                        kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+    CHECK(irq == kDifPwrmgrIrqWakeup, "Pwrmgr IRQ ID: %d is incorrect", irq);
+    CHECK_DIF_OK(dif_pwrmgr_irq_acknowledge(&pwrmgr, irq));
+  } else {
+    CHECK(false, "IRQ peripheral: %d is incorrect", peripheral);
+  }
+
+  // Complete the IRQ by writing the IRQ source to the Ibex specific CC.
+  // register
+  CHECK_DIF_OK(
+      dif_rv_plic_irq_complete(&rv_plic, kTopEarlgreyPlicTargetIbex0, irq_id));
+}
+
+static bool get_wakeup_status(void) {
+  dif_pwrmgr_request_sources_t wake_req = ~0u;
+  CHECK_DIF_OK(dif_pwrmgr_get_current_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, &wake_req));
+  return (wake_req > 0);
+}
+
+static void clear_wakeup(void) {
+  CHECK_DIF_OK(dif_aon_timer_clear_wakeup_cause(&timer));
+  // Ensure the de-asserted events have cleared from the wakeup pipeline
+  // within 100us.
+  IBEX_SPIN_FOR(!get_wakeup_status(), 100);
+  CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_clear(&pwrmgr));
+}
+
+static void test_init(void) {
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_rv_plic_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR), &rv_plic));
+
+  // Enable AON interrupts.
+  rv_plic_testutils_irq_range_enable(&rv_plic, kTopEarlgreyPlicTargetIbex0,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+  rv_plic_testutils_irq_range_enable(
+      &rv_plic, kTopEarlgreyPlicTargetIbex0,
+      kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
+      kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark);
+
+  // Enable pwrmgr interrupt
+  CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
+
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &timer));
+  CHECK_DIF_OK(dif_aon_timer_wakeup_stop(&timer));
+}
+
+static void set_timer(uint64_t time) {
+  uint32_t cycles = 0;
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_32_from_us(time, &cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(&timer, cycles));
+}
+
+static bool lowpower_hint_is_cleared(void) {
+  dif_toggle_t low_power_enabled = kDifToggleEnabled;
+  CHECK_DIF_OK(dif_pwrmgr_low_power_get_enabled(&pwrmgr, &low_power_enabled));
+  return low_power_enabled == kDifToggleDisabled;
+}
+
+static void test_sleep(bool wfi_fallthrough) {
+  LOG_INFO("Low power WFI (fallthrough=%d)", wfi_fallthrough);
+
+  dif_pwrmgr_domain_config_t domain_config =
+      kDifPwrmgrDomainOptionMainPowerInLowPower;
+  CHECK_STATUS_OK(
+      pwrmgr_testutils_enable_low_power(&pwrmgr, wakeup_src, domain_config));
+  irq_global_ctrl(false);
+  if (wfi_fallthrough) {
+    LOG_INFO("Fallthough WFI due to timer pending");
+    set_timer(100);
+    busy_spin_micros(200);
+  } else {
+    set_timer(100);
+  }
+  wait_for_interrupt();
+  LOG_INFO("Woke up by source %d", wakeup_source);
+  CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(&pwrmgr, kDifToggleDisabled,
+                                                kDifToggleDisabled));
+  IBEX_SPIN_FOR(lowpower_hint_is_cleared(), 100);
+  irq_global_ctrl(true);
+  clear_wakeup();
+
+  LOG_INFO("Normal WFI");
+  // Now do WFI without the LOW_POWER_HINT.
+  irq_global_ctrl(false);
+  set_timer(100);
+  wait_for_interrupt();
+  irq_global_ctrl(true);
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  test_init();
+  if (UNWRAP(pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0)) != true) {
+    return false;
+  }
+  test_sleep(false);
+  test_sleep(true);
+  return true;
+}


### PR DESCRIPTION
To avoid race conditions with WFI and locking the CONTROL CSR prematurely, wait until the transition out of FastPwrStateActive that begins low power entry before locking the CONTROL CSR.
    
This allows software to clear CONTROL.LOW_POWER_HINT if an early interrupt caused the "core_sleep" pulse to be too short for pwrmgr to capture. Then, subsequent WFI instructions may still choose between full power and a low power mode.
    
When software wakes up, it must attempt to clear CONTROL.LOW_POWER_HINT, then busy-poll until it reads its value as 0. If pwrmgr triggered low power entry, the CPU will poll until pwrmgr completes the low power sequence. If pwrmgr did not trigger low power entry, the CPU's write will succeed, and the read will immediately return 0.

Also add a test that causes Ibex to decode WFI with an IRQ pending and not issue core_sleep (modified from a submission from @ecgh0). Check for correct recovery of the CONTROL CSR and that software can clear LOW_POWER_HINT.