### PR TITLE
[otbn,dv] Increase run timeout by a factor of 10 to 10ms

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -480,8 +480,8 @@ class otbn_base_vseq extends cip_base_vseq #(
     fork begin : isolation_fork
       fork
         begin
-          `DV_WAIT_TIMEOUT(1_000_000, ,
-                           "Timed out waiting for OTBN run to complete by polling status")
+          `DV_WAIT_TIMEOUT(10_000_000, ,
+                           "Timed out waiting for OTBN run to complete")
         end
         begin
           if (_pick_use_interrupt()) begin


### PR DESCRIPTION
The previous timeout was 1ms, which I chose pretty arbitrarily. It turns out that this isn't long enough for some runs in the otbn_multi vseq.

Increase to 10ms, which is still short enough that a failure should only take a couple of minutes.

This commit also tweaks the timeout error message. When I originally wrote it, it only applied to status polling timeouts. Before pushing the PR, I generalised things to cope with interrupts too, but forgot to fix the error message. Now done!

Fixes #23418.