### PR TITLE
[hmac,dv] Minor DV assertion fix

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -899,9 +899,9 @@ module hmac
   // are used in Assertion only
   logic in_process;
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)               in_process <= 1'b0;
-    else if (hash_process)     in_process <= 1'b1;
-    else if (reg_hash_done)    in_process <= 1'b0;
+    if (!rst_ni)                              in_process <= 1'b0;
+    else if (hash_process || reg_hash_stop)   in_process <= 1'b1;
+    else if (reg_hash_done)                   in_process <= 1'b0;
   end
 
   logic initiated;
@@ -914,10 +914,10 @@ module hmac
   // the host doesn't write data after hash_process until hash_start_or_continue.
   `ASSERT(ValidWriteAssert, msg_fifo_req |-> !in_process)
 
-  // `hash_process` shall be toggled and paired with `hash_start_or_continue`.
   // Below condition is covered by the design (2020-02-19)
   //`ASSERT(ValidHashStartAssert, hash_start_or_continue |-> !initiated)
-  `ASSERT(ValidHashProcessAssert, hash_process |-> initiated)
+  // `hash_process` or `reg_hash_stop` should be toggled and paired with `hash_start_or_continue`
+  `ASSERT(ValidHashProcessAssert, (hash_process || reg_hash_stop) |-> initiated)
 
   // hmac_en should be modified only when the logic is Idle
   `ASSERT(ValidHmacEnConditionAssert,


### PR DESCRIPTION
This adds checking `reg_hash_stop` in the `ValidHashProcessAssert` assertion for completeness to make sure that `hash_process || reg_hash_stop `are toggled with `hash_start_or_continue`.

Block-level tests at the moment without SAR will not complain of this change. @ballifatih can you plz confirm this works the same at your end with your TLT (though this is a very last priority atm)?