### PR TITLE
[otbn,dv] Collect coverage for RMA requests

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -394,6 +394,17 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     }
   endgroup
 
+  // Tracking for the rma_req_i input
+  covergroup rma_req_cg with function sample(lc_ctrl_pkg::lc_tx_t value);
+    // Any value other than On should be ignored. We want to make sure we see genuine On and Off,
+    // but also an invalid value (which will be treated as Off)
+    value_cp: coverpoint {value} {
+      bins off = {lc_ctrl_pkg::Off};
+      bins on  = {lc_ctrl_pkg::On};
+      bins bad = {[0:$]} with (!(item inside {lc_ctrl_pkg::Off, lc_ctrl_pkg::On}));
+    }
+  endgroup
+
   // CMD external CSR
   covergroup ext_csr_cmd_cg
     with function sample(otbn_pkg::cmd_e     value,
@@ -2112,6 +2123,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     super.new(name, parent);
 
     escalate_en_cg = new;
+    rma_req_cg = new;
 
     ext_csr_cmd_cg = new;
     ext_csr_ctrl_cg = new;

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -104,6 +104,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
       process_model_fifo();
       process_trace_fifo();
       watch_escalate_if();
+      watch_rma_if();
     join_none
   endtask
 
@@ -660,6 +661,18 @@ class otbn_scoreboard extends cip_base_scoreboard #(
         cov.escalate_en_cg.sample(cfg.escalate_vif.enable);
       end
       @(cfg.escalate_vif.enable or cfg.clk_rst_vif.rst_n);
+    end
+  endtask
+
+  // This task watches the rma interface and collects coverage whenever it changes
+  //
+  virtual task watch_rma_if();
+    // The 'req' signal is connected to the lc_rma_req_i top-level input
+    forever begin
+      if (cfg.clk_rst_vif.rst_n) begin
+        cov.rma_req_cg.sample(cfg.escalate_vif.req);
+      end
+      @(cfg.escalate_vif.req or cfg.clk_rst_vif.rst_n);
     end
   endtask
 


### PR DESCRIPTION
The point of this is to check that we're handling invalid RMA request values correctly (by ignoring them). Invalid values land in the "bad" bin for the covergroup and completing coverage for the covergroup will ensure that we have genuinely seen this invalid value.

The code in otbn_core_model.sv will ignore that request (using lc_tx_test_true_strict to check it), so the test will fail if the RTL acts on the request.

This should satisfy the second item in #23460.