### PR TITLE
[Sival, Spi device] Sleep test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -109,7 +109,7 @@
         "SPI_DEVICE.MODE.PASSTHROUGH.INTERCEPT_EN",
       ]
       tests: ["chip_sw_spi_device_pass_through_collision"]
-      bazel: []
+      bazel: ["//sw/device/tests:spi_passthru_test"]
     }
     {
       name: chip_sw_spi_device_tpm
@@ -165,7 +165,7 @@
       lc_states: [ "PROD" ]
       features: []
       tests: []
-      bazel: []
+      bazel: ["//sw/device/tests:spi_device_sleep_test"]
     }
   ]
 }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3293,6 +3293,50 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "spi_device_sleep_test",
+    srcs = ["spi_device_sleep_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        EARLGREY_TEST_ENVS,
+    ),
+    fpga = fpga_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/chip/spi_device:spi_device_sleep_test",
+    ),
+    silicon = silicon_params(
+        test_cmd = """
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/chip/spi_device:spi_device_sleep_test",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:pinmux",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:irq",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing:spi_device_testutils",
+        "//sw/device/lib/testing:spi_flash_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:status",
+    ],
+)
+
 cc_library(
     name = "spi_host_flash_test_impl",
     srcs = ["spi_host_flash_test_impl.c"],

--- a/sw/device/tests/spi_device_sleep_test.c
+++ b/sw/device/tests/spi_device_sleep_test.c
@@ -1,0 +1,157 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/spi_flash_emulator.h"
+#include "sw/device/lib/testing/spi_flash_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kWakeupTimeMicros = 500000,
+};
+static dif_spi_device_handle_t spid;
+static dif_pwrmgr_t pwrmgr;
+static dif_aon_timer_t aon_timer;
+static dif_rv_plic_t plic;
+static plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
+                                  .hart_id = kTopEarlgreyPlicTargetIbex0};
+static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
+    .pwrmgr = &pwrmgr,
+    .plic_pwrmgr_start_irq_id = kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+    .expected_irq = kDifPwrmgrIrqWakeup,
+    .is_only_irq = true};
+
+static void enter_low_power(void) {
+  uint64_t wkup_cycles = 0;
+  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_64_from_us(
+      kWakeupTimeMicros, &wkup_cycles));
+  CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(&aon_timer, wkup_cycles));
+
+  dif_pwrmgr_domain_config_t pwrmgr_domain_cfg =
+      kDifPwrmgrDomainOptionMainPowerInLowPower;
+
+  LOG_INFO("SYNC: Entering lowpower mode");
+  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
+      &pwrmgr, kDifPwrmgrWakeupRequestSourceFive, pwrmgr_domain_cfg));
+  wait_for_interrupt();
+  LOG_INFO("SYNC: Wakening up");
+}
+
+static status_t spi_flash_mode(void) {
+  dif_spi_device_flash_id_t id = {
+      .device_id = 0x2298,
+      .manufacturer_id = 0x74,
+      .continuation_code = 0x17,
+      .num_continuation_code = 2,
+  };
+  TRY(dif_spi_device_set_flash_id(&spid, id));
+
+  dif_spi_device_config_t spi_device_config = {
+      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
+      .device_mode = kDifSpiDeviceModeFlashEmulation,
+  };
+  TRY(dif_spi_device_configure(&spid, spi_device_config));
+
+  // Configure the READ_JEDEC_ID command (CMD_INFO_3).
+  dif_spi_device_flash_command_t cmd = {
+      .opcode = kSpiDeviceFlashOpReadJedec,
+      .address_type = kDifSpiDeviceFlashAddrDisabled,
+      .dummy_cycles = 0,
+      .payload_io_type = kDifSpiDevicePayloadIoSingle,
+      .payload_dir_to_host = false,
+      .upload = false,
+  };
+
+  TRY(dif_spi_device_set_flash_command_slot(
+      &spid, kSpiDeviceReadCommandSlotBase + 3, kDifToggleEnabled, cmd));
+
+  LOG_INFO("SYNC: Flash mode");
+
+  busy_spin_micros(1 * 1000 * 1000);
+
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  mmio_region_t addr;
+  addr = mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR);
+  CHECK_DIF_OK(dif_spi_device_init_handle(addr, &spid));
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_pwrmgr_init(addr, &pwrmgr));
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_aon_timer_init(addr, &aon_timer));
+
+  dif_pinmux_t pinmux;
+  addr = mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_pinmux_init(addr, &pinmux));
+
+  addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  CHECK_DIF_OK(dif_rv_plic_init(addr, &plic));
+
+  // Enable all the AON interrupts used in this test.
+  rv_plic_testutils_irq_range_enable(&plic, kTopEarlgreyPlicTargetIbex0,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+
+  // Enable pwrmgr interrupt
+  CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
+
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  LOG_INFO("Setting SPI_DIO1 to high when sleeping");
+  CHECK_DIF_OK(dif_pinmux_pad_sleep_enable(
+      &pinmux, kTopEarlgreyDirectPadsSpiDeviceSd1, kDifPinmuxPadKindDio,
+      kDifPinmuxSleepModeHigh));
+  enter_low_power();
+
+  LOG_INFO("Setting SPI_DIO1 to low when sleeping");
+  CHECK_DIF_OK(dif_pinmux_pad_sleep_enable(
+      &pinmux, kTopEarlgreyDirectPadsSpiDeviceSd1, kDifPinmuxPadKindDio,
+      kDifPinmuxSleepModeLow));
+  enter_low_power();
+
+  CHECK_DIF_OK(dif_pinmux_pad_sleep_clear_state(
+      &pinmux, kTopEarlgreyDirectPadsSpiDeviceSd1, kDifPinmuxPadKindDio));
+  CHECK_DIF_OK(dif_pinmux_pad_sleep_disable(
+      &pinmux, kTopEarlgreyDirectPadsSpiDeviceSd1, kDifPinmuxPadKindDio));
+
+  return status_ok(spi_flash_mode());
+}
+
+/**
+ * External interrupt handler.
+ */
+void ottf_external_isr(uint32_t *exc_info) {
+  dif_pwrmgr_irq_t irq_id;
+  top_earlgrey_plic_peripheral_t peripheral;
+
+  isr_testutils_pwrmgr_isr(plic_ctx, pwrmgr_isr_ctx, &peripheral, &irq_id);
+
+  // Check that both the peripheral and the irq id is correct
+  CHECK(peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon,
+        "IRQ peripheral: %d is incorrect", peripheral);
+  CHECK(irq_id == kDifPwrmgrIrqWakeup, "IRQ ID: %d is incorrect", irq_id);
+}

--- a/sw/host/tests/chip/spi_device/BUILD
+++ b/sw/host/tests/chip/spi_device/BUILD
@@ -54,3 +54,20 @@ rust_binary(
         "@crate_index//:serde_json",
     ],
 )
+
+rust_binary(
+    name = "spi_device_sleep_test",
+    srcs = [
+        "src/spi_device_sleep_test.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:regex",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:object",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/spi_device/src/spi_device_sleep_test.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_device_sleep_test.rs
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use clap::Parser;
+use regex::Regex;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::spi::Transfer;
+use opentitanlib::spiflash::SpiFlash;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+
+    /// Name of the SPI interface to connect to the OTTF console.
+    #[arg(long, default_value = "BOOTSTRAP")]
+    spi: String,
+}
+
+fn spi_sleep_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let spi = transport.spi(&opts.spi)?;
+
+    const DATA_SIZE: usize = 10;
+
+    /* Test the spi dev in sleep with the SD0 in high. */
+    let _ = UartConsole::wait_for(&*uart, r"SYNC: Entering lowpower mode\r\n", opts.timeout)?;
+    let mut buf = [0x55u8; DATA_SIZE];
+    spi.run_transaction(&mut [Transfer::Write(&[0x55; 1]), Transfer::Read(&mut buf)])?;
+    assert_eq!(&buf, &[0xffu8; DATA_SIZE]);
+    let _ = UartConsole::wait_for(&*uart, r"SYNC: Wakening up\r\n", opts.timeout)?;
+
+    /* Test the spi dev in sleep with the SD0 in low. */
+    let _ = UartConsole::wait_for(&*uart, r"SYNC: Entering lowpower mode\r\n", opts.timeout)?;
+    let mut buf = [0x55u8; DATA_SIZE];
+    spi.run_transaction(&mut [Transfer::Write(&[0x55; 1]), Transfer::Read(&mut buf)])?;
+    assert_eq!(&buf, &[0x00u8; DATA_SIZE]);
+    let _ = UartConsole::wait_for(&*uart, r"SYNC: Wakening up\r\n", opts.timeout)?;
+
+    Ok(())
+}
+
+fn spi_flash_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let spi = transport.spi(&opts.spi)?;
+
+    let _ = UartConsole::wait_for(&*uart, r"SYNC: Flash mode\r\n", opts.timeout)?;
+    let jdec_id = SpiFlash::read_jedec_id(&*spi, 5)?;
+
+    assert_eq!(&jdec_id, &[0x17u8, 0x17, 0x74, 0x98, 0x22]);
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(spi_sleep_test, &opts, &transport,);
+    execute_test!(spi_flash_test, &opts, &transport,);
+
+    let uart = transport.uart("console")?;
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_success: Some(Regex::new(r"PASS!\r\n")?),
+        exit_failure: Some(Regex::new(r"FAIL:")?),
+        ..Default::default()
+    };
+
+    // Now watch the console for the exit conditions.
+    let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
+    if result != ExitStatus::ExitSuccess {
+        bail!("FAIL: {:?}", result);
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the test
```
 name: chip_sw_spi_device_output_when_disabled_or_sleeping
      desc: '''Verify spi_device output values when spi_device is disabled or the chip is sleeping.

               SW needs to be able to set the SPI output value when spi_device is disabled or the
               chip is sleeping, to either all-zeros or all-ones, depending on integration
               requirements.  The following scenarios have to be verified:

               After power-on reset:
               - SW to configure pinmux retention logic so that the chip pins connected to
                 spi_device outputs are (a) always zero or (b) always one (SW needs to be able to
                 choose between a and b).
               - DV environment to check that SPI outputs match configuration by SW.

               Going to sleep:
               - SW to disable spi_device, wait until CSb is high, configure pinmux retention logic
                 as it would after POR, and put chip to sleep.
               - DV environment to check that SPI outputs match configuration by SW.

               Wake up from sleep:
               - DV environment to wake chip from sleep.
               - SW to enable spi_device and disable retention logic.
               - DV environment to check that SPI transactions work as usual.

               Notes for silicon targets:
               This test currently does not exercise any features of the spi_device block itself,
               which is why the "features" list is empty. It may be reclassifed in the future.
             '''          
```