### PR TITLE
[prim/rtl] Allow for tech-specific impls of `prim_flop_2sync`

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -271,7 +271,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
        0: path = {path, ".i_sync_n"};
        1: path = {path, ".i_sync_p"};
      endcase
-     disabled_prim_cdc_rand_delays[i] = {path, ".u_prim_cdc_rand_delay"};
+     disabled_prim_cdc_rand_delays[i] = {path, ".gen_generic.u_impl_generic.u_prim_cdc_rand_delay"};
     end
   endfunction
 

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_volatile_unlock_disabled_unr_exclude.el
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_volatile_unlock_disabled_unr_exclude.el
@@ -9,7 +9,7 @@
 // ExclMode: default
 //==================================================
 CHECKSUM: "1599929061 1913160869"
-INSTANCE: tb.dut.u_dmi_jtag.i_dmi_cdc.u_combined_rstn_sync.u_prim_cdc_rand_delay
+INSTANCE: tb.dut.u_dmi_jtag.i_dmi_cdc.u_combined_rstn_sync.gen_generic.u_impl_generic.u_prim_cdc_rand_delay
 ANNOTATION: "VC_COV_UNR"
 Toggle 0to1 dst_data_o [0] "logic dst_data_o[0:0]"
 ANNOTATION: "VC_COV_UNR"

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_volatile_unlock_enabled_unr_exclude.el
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_volatile_unlock_enabled_unr_exclude.el
@@ -9,7 +9,7 @@
 // ExclMode: default
 //==================================================
 CHECKSUM: "1599929061 1913160869"
-INSTANCE: tb.dut.u_dmi_jtag.i_dmi_cdc.u_combined_rstn_sync.u_prim_cdc_rand_delay
+INSTANCE: tb.dut.u_dmi_jtag.i_dmi_cdc.u_combined_rstn_sync.gen_generic.u_impl_generic.u_prim_cdc_rand_delay
 ANNOTATION: "VC_COV_UNR"
 Toggle 0to1 dst_data_o [0] "logic dst_data_o[0:0]"
 ANNOTATION: "VC_COV_UNR"

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -57,7 +57,6 @@ filesets:
       - lowrisc:ip:otbn_pkg
       - lowrisc:ip:otp_ctrl_pkg
     files:
-      - rtl/otbn_reg_pkg.sv
       - rtl/otbn_reg_top.sv
       - rtl/otbn_scramble_ctrl.sv
       - rtl/otbn.sv

--- a/hw/ip/otbn/otbn_pkg.core
+++ b/hw/ip/otbn/otbn_pkg.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:ip:otp_ctrl_pkg
     files:
+      - rtl/otbn_reg_pkg.sv
       - rtl/otbn_pkg.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/prim/pre_dv/prim_flop_2sync/tb.sv
+++ b/hw/ip/prim/pre_dv/prim_flop_2sync/tb.sv
@@ -27,7 +27,7 @@ module tb;
     clk_rst_if.apply_reset(.reset_width_clks(10));
 
     $display("Using prim_cdc_rand_delay_mode slow");
-    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(1);
+    dut.gen_generic.u_impl_generic.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(1);
     repeat (100) begin
       src_d <= $urandom();
       clk_rst_if.wait_clks($urandom_range(1, 20));
@@ -35,7 +35,7 @@ module tb;
     clk_rst_if.wait_clks(200);
 
     $display("Using prim_cdc_rand_delay_mode once");
-    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(2);
+    dut.gen_generic.u_impl_generic.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(2);
     repeat (100) begin
       src_d <= $urandom();
       clk_rst_if.wait_clks($urandom_range(1, 20));
@@ -43,8 +43,8 @@ module tb;
     clk_rst_if.wait_clks(200);
 
     $display("Using prim_cdc_rand_delay_mode interval = 10");
-    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(3);
-    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(10);
+    dut.gen_generic.u_impl_generic._prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(3);
+    dut.gen_generic.u_impl_generic.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(10);
     repeat (100) begin
       src_d <= $urandom();
       clk_rst_if.wait_clks($urandom_range(1, 20));
@@ -52,7 +52,7 @@ module tb;
     clk_rst_if.wait_clks(200);
 
     $display("Using prim_cdc_rand_delay_mode interval = 1");
-    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(1);
+    dut.gen_generic.u_impl_generic.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(1);
     repeat (100) begin
       src_d <= $urandom();
       clk_rst_if.wait_clks($urandom_range(1, 20));
@@ -60,7 +60,7 @@ module tb;
     clk_rst_if.wait_clks(200);
 
     $display("Using prim_cdc_rand_delay_mode interval = 0");
-    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(0);
+    dut.gen_generic.u_impl_generic.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(0);
     repeat (100) begin
       src_d <= $urandom();
       clk_rst_if.wait_clks($urandom_range(1, 20));

--- a/hw/ip/prim_generic/prim_generic_flop_2sync.core
+++ b/hw/ip/prim_generic/prim_generic_flop_2sync.core
@@ -3,38 +3,33 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:flop_2sync"
-description: "Flop-based synchronizer"
+name: "lowrisc:prim_generic:flop_2sync"
+description: "Generic implementation of a flop-based synchronizer"
 filesets:
-  primgen_dep:
+  files_rtl:
     depend:
-      - lowrisc:prim:prim_pkg
-      - lowrisc:prim:primgen
+      # Needed because the generic impl instantiates prim_flop.
+      - lowrisc:prim:flop
+      # Needed for DV.
+      - lowrisc:prim:cdc_rand_delay
+    files:
+      - rtl/prim_generic_flop_2sync.sv
+    file_type: systemVerilogSource
 
   files_verilator_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    file_type: vlt
 
   files_ascentlint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-    files:
-      - lint/prim_flop_2sync.waiver
-    file_type: waiver
 
   files_veriblelint_waiver:
     depend:
       # common waivers
       - lowrisc:lint:common
-
-generate:
-  impl:
-    generator: primgen
-    parameters:
-      prim_name: flop_2sync
 
 targets:
   default:
@@ -42,6 +37,4 @@ targets:
       - tool_verilator   ? (files_verilator_waiver)
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
-      - primgen_dep
-    generate:
-    - impl
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_flop_2sync.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flop_2sync.sv
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Generic double-synchronizer flop
-// This may need to be moved to prim_generic if libraries have a specific cell
-// for synchronization
+// Double-flop-based synchronizer
 
-module prim_flop_2sync #(
+module prim_generic_flop_2sync #(
   parameter int               Width      = 16,
   parameter logic [Width-1:0] ResetValue = '0,
   parameter bit               EnablePrimCdcRand = 1
@@ -58,4 +56,4 @@ module prim_flop_2sync #(
     .q_o
   );
 
-endmodule : prim_flop_2sync
+endmodule : prim_generic_flop_2sync

--- a/hw/ip/uart/dv/env/seq_lib/uart_noise_filter_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_noise_filter_vseq.sv
@@ -8,7 +8,8 @@ class uart_noise_filter_vseq extends uart_tx_rx_vseq;
 
   `uvm_object_new
 
-  string cdc_sel_path = "tb.dut.uart_core.sync_rx.u_prim_cdc_rand_delay.gen_enable.data_sel";
+  string cdc_sel_path = "tb.dut.uart_core.sync_rx.gen_generic.u_impl_generic" +
+                        ".u_prim_cdc_rand_delay.gen_enable.data_sel";
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);

--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -324,7 +324,7 @@ set_multicycle_path -hold -end -from [get_clocks clk_spi_tpm] \
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.
-set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]
+set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/gen_generic.u_impl_generic/u_sync_1/gen_*/q_o_reg[0]/D]
 
 ## USB input delay to accommodate T_FST (full-speed transition time) and the
 ## PHY's sampling logic. The PHY expects to only see up to one transient / fake

--- a/hw/top_earlgrey/data/clocks_cw341.xdc
+++ b/hw/top_earlgrey/data/clocks_cw341.xdc
@@ -350,4 +350,4 @@ set_multicycle_path -hold -end -from [get_clocks clk_spi_tpm] \
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.
-set_false_path -from [get_clocks clk_usb_48] -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]
+set_false_path -from [get_clocks clk_usb_48] -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/gen_generic.u_impl_generic/u_sync_1/gen_*/q_o_reg[0]/D]

--- a/hw/top_englishbreakfast/data/clocks.xdc
+++ b/hw/top_englishbreakfast/data/clocks.xdc
@@ -87,4 +87,4 @@ set_clock_groups -group ${clks_10_unbuf} -group ${clks_48_unbuf} -group ${clks_a
 
 ## The usb calibration handling inside ast is assumed to be async to the outside world
 ## even though its interface is also a usb clock.
-set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/u_sync_1/gen_*/q_o_reg[0]/D]
+set_false_path -from ${clks_48_unbuf} -to [get_pins u_ast/u_usb_clk/u_ref_pulse_sync/u_sync*/gen_generic.u_impl_generic/u_sync_1/gen_*/q_o_reg[0]/D]


### PR DESCRIPTION
This allows for technology/library-specific implementations of `prim_flop_2sync`.  The generic implementation is based on two back-to-back `prim_flop`s, which is identical to how `prim_flop_2sync` was implemented before.

This PR doesn't add FPGA-specific implementations; this will be tracked in an issue and might get implemented later.

### TODOs
- [ ] Create issue to track FPGA impl and link this PR.