### PR TITLE
Rom sensor ctrl

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -234,6 +234,13 @@ otp_json(
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(CONST.HARDENED_FALSE),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
                 "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
+                # By default, the sensor_ctrl should disable all sensors and mark
+                # alerts as recoverable.
+                "OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG": [
+                    otp_hex(0x69696969),
+                    otp_hex(0x69696969),
+                    otp_hex(0x69696969),
+                ],
             },
         ),
     ],

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -186,6 +186,13 @@ otp_json(
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
                 "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
+                # By default, the sensor_ctrl should disable all sensors and mark
+                # alerts as recoverable.
+                "OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG": [
+                    otp_hex(0x69696969),
+                    otp_hex(0x69696969),
+                    otp_hex(0x69696969),
+                ],
             },
         ),
     ],

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -186,6 +186,13 @@ otp_json(
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
                 "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
+                # By default, the sensor_ctrl should disable all sensors and mark
+                # alerts as recoverable.
+                "OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG": [
+                    otp_hex(0x69696969),
+                    otp_hex(0x69696969),
+                    otp_hex(0x69696969),
+                ],
             },
         ),
     ],

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_owner_sw_cfg.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_owner_sw_cfg.hjson
@@ -201,6 +201,16 @@
                 {
                     name: "OWNER_SW_CFG_ROM_ALERT_DIGEST_RMA",
                     value: "0x36ed9cb0",
+                },
+                {
+                    name: "OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG",
+                    // Configure all of the sensors as
+                    // Recov=True(6) Enabled=False(9)
+                    value: [
+                        "0x69696969",
+                        "0x69696969",
+                        "0x69696969",
+                    ],
                 }
             ],
         }

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -755,6 +755,7 @@ cc_library(
     srcs = ["watchdog.c"],
     hdrs = ["watchdog.h"],
     deps = [
+        ":pwrmgr",
         "//hw/ip/aon_timer/data:aon_timer_c_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//hw/top_earlgrey/ip_autogen/pwrmgr:pwrmgr_c_regs",
@@ -860,6 +861,7 @@ cc_library(
     srcs = ["pwrmgr.c"],
     hdrs = ["pwrmgr.h"],
     deps = [
+        ":ibex",
         "//hw/top_earlgrey/ip_autogen/pwrmgr:pwrmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -876,7 +878,6 @@ cc_library(
         ":otp",
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_c_regs",
-        "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -866,3 +866,33 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],
 )
+
+cc_library(
+    name = "sensor_ctrl",
+    srcs = ["sensor_ctrl.c"],
+    hdrs = ["sensor_ctrl.h"],
+    deps = [
+        ":lifecycle",
+        ":otp",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+        "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_c_regs",
+        "//hw/top_earlgrey/ip_autogen/pwrmgr/data:pwrmgr_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_test(
+    name = "sensor_ctrl_unittest",
+    srcs = ["sensor_ctrl_unittest.cc"],
+    deps = [
+        ":sensor_ctrl",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+        "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/sw/device/silicon_creator/lib/drivers/ibex.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex.c
@@ -82,5 +82,7 @@ void ibex_addr_remap_lockdown(uint32_t index) {
 
 // `extern` declarations to give the inline functions in the corresponding
 // header a link location.
+extern void ibex_mcycle_zero(void);
+extern uint32_t ibex_mcycle32(void);
 extern uint64_t ibex_mcycle(void);
 extern uint64_t ibex_time_to_cycles(uint64_t time_us);

--- a/sw/device/silicon_creator/lib/drivers/ibex.h
+++ b/sw/device/silicon_creator/lib/drivers/ibex.h
@@ -25,6 +25,27 @@ OT_WARN_UNUSED_RESULT
 uint32_t ibex_fpga_version(void);
 
 #ifdef OT_PLATFORM_RV32
+/**
+ * Set the MCYCLE counter register to zero.
+ */
+inline void ibex_mcycle_zero(void) {
+  CSR_WRITE(CSR_REG_MCYCLE, 0);
+  CSR_WRITE(CSR_REG_MCYCLEH, 0);
+}
+
+/**
+ * Read the low 32 bits of the MCYCLE counter.
+ */
+OT_WARN_UNUSED_RESULT
+inline uint32_t ibex_mcycle32(void) {
+  uint32_t val;
+  CSR_READ(CSR_REG_MCYCLE, &val);
+  return val;
+}
+
+/**
+ * Read the 64-bit MCYCLE counter.
+ */
 OT_WARN_UNUSED_RESULT
 inline uint64_t ibex_mcycle(void) {
   uint32_t lo, hi, hi2;
@@ -36,10 +57,15 @@ inline uint64_t ibex_mcycle(void) {
   return ((uint64_t)hi << 32) | lo;
 }
 
+/**
+ * Convert from microseconds to CPU cycles.
+ */
 inline uint64_t ibex_time_to_cycles(uint64_t time_us) {
   return to_cpu_cycles(time_us);
 }
 #else
+extern void ibex_mcycle_zero(void);
+extern uint32_t ibex_mcycle32(void);
 extern uint64_t ibex_mcycle(void);
 extern uint64_t ibex_time_to_cycles(uint64_t time_us);
 #endif

--- a/sw/device/silicon_creator/lib/drivers/ibex_host.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex_host.c
@@ -2,19 +2,32 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <pthread.h>
 #include <time.h>
 
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
+
+// These constants are used by the pwrmgr_cdc_sync function to compute its
+// polling delay.  We supply reasonable values for host tests to execute.
+const uint64_t kClockFreqCpuHz = 100000000;
+const uint64_t kClockFreqAonHz = 200000;
 
 // These ibex functions are used to implement milli- or micro-second timeout
 // loops in the firmware.  The host implementations are supplied so that
 // host-based unit tests will compile and link and allow rudimentary testing of
 // the timeout functionality.
+static __thread uint64_t time_zero;
 
-uint64_t ibex_mcycle(void) {
+static uint64_t current_time_us(void) {
   struct timespec tp;
   clock_gettime(CLOCK_MONOTONIC, &tp);
   return tp.tv_sec * 1000000 + tp.tv_nsec / 1000;
 }
+
+void ibex_mcycle_zero(void) { time_zero = current_time_us(); }
+
+uint64_t ibex_mcycle(void) { return current_time_us() - time_zero; }
+
+uint32_t ibex_mcycle32(void) { return (uint32_t)ibex_mcycle(); }
 
 uint64_t ibex_time_to_cycles(uint64_t time_us) { return time_us; }

--- a/sw/device/silicon_creator/lib/drivers/pwrmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/pwrmgr.h
@@ -27,6 +27,16 @@ enum {
 };
 
 /**
+ * Synchronize across clock domain.
+ *
+ * Synchronizes across clock domains by setting the CDC_SYNC register and
+ * waiting for it to clear.
+ *
+ * @param n Number of synchronizations to perform.
+ */
+void pwrmgr_cdc_sync(uint32_t n);
+
+/**
  * Enable all resets.
  */
 void pwrmgr_all_resets_enable(void);

--- a/sw/device/silicon_creator/lib/drivers/sensor_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/sensor_ctrl.c
@@ -1,0 +1,85 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/sensor_ctrl.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+#include "pwrmgr_regs.h"
+#include "sensor_ctrl_regs.h"
+
+enum {
+  kBase = TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR,
+  kPwrMgrBase = TOP_EARLGREY_PWRMGR_AON_BASE_ADDR,
+  kSensorCtrlAlertConfig =
+      OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG_OFFSET,
+  kSensorCtrlAlertSize = SENSOR_CTRL_ALERT_EN_MULTIREG_COUNT,
+};
+
+static_assert(kSensorCtrlAlertSize <=
+                  OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG_SIZE,
+              "sensor_ctrl has more registers than OTP configuraiton bytes");
+
+rom_error_t sensor_ctrl_configure(lifecycle_state_t lc_state) {
+  switch (launder32(lc_state)) {
+    case kLcStateProd:
+    case kLcStateProdEnd:
+    case kLcStateDev:
+      // We don't need hardened checks for mission mode states because we intend
+      // to program the sensor control block.
+      //
+      // We have hardened checks on the test and rma states because those states
+      // skip programming.
+      SEC_MMIO_WRITE_INCREMENT(kSensorCtrlSecMmioConfigure);
+      break;
+    case kLcStateTest:
+      HARDENED_CHECK_EQ(lc_state, kLcStateTest);
+      return kErrorOk;
+    case kLcStateRma:
+      HARDENED_CHECK_EQ(lc_state, kLcStateRma);
+      return kErrorOk;
+    default:
+      HARDENED_TRAP();
+  }
+
+  uint32_t val = 0;
+  uint32_t fatal = 0;
+  for (size_t i = 0; i < kSensorCtrlAlertSize; ++i) {
+    // The OTP configuration words should be thought of as a single byte field
+    // for each of the sensor_ctrl alert enables.  In each byte, the lower
+    // nybble is a Mubi4 specifying whether to enable the alert and the upper
+    // nybble is a Mubi4 specifying whether the alert is recoverable.
+    val = otp_read32(kSensorCtrlAlertConfig + (i & ~3ul));
+    uint32_t shift = 8 * (i % sizeof(uint32_t));
+    sec_mmio_write32(
+        kBase + SENSOR_CTRL_ALERT_EN_0_REG_OFFSET + i * sizeof(uint32_t),
+        bitfield_field32_read(
+            val, ((bitfield_field32_t){.mask = 0xF, .index = shift})));
+
+    shift += 4;
+    // The upper nybble will be Mubi4True (0x6) if the alert is recoverable and
+    // Mubi4False (0x9) if fatal.  We XOR the lower three bits of the nybble
+    // into the fatal-enable bit position for this alert.
+    // When recoverable, the value will be zero (0 ^ 1 ^ 1).
+    // When fatal, the value will be one: (1 ^ 0 ^ 0).
+    fatal ^= (uint32_t)bitfield_bit32_read(val, shift++) << i;
+    fatal ^= (uint32_t)bitfield_bit32_read(val, shift++) << i;
+    fatal ^= (uint32_t)bitfield_bit32_read(val, shift++) << i;
+  }
+  sec_mmio_write32(kBase + SENSOR_CTRL_FATAL_ALERT_EN_REG_OFFSET, fatal);
+  return kErrorOk;
+}
+
+void sensor_ctrl_sync(uint32_t cycles) {
+  for (uint32_t i = 0; i < cycles; ++i) {
+    abs_mmio_write32(kPwrMgrBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    while (abs_mmio_read32(kPwrMgrBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET) != 0)
+      ;
+  }
+}

--- a/sw/device/silicon_creator/lib/drivers/sensor_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/sensor_ctrl.c
@@ -11,12 +11,10 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otp_ctrl_regs.h"
-#include "pwrmgr_regs.h"
 #include "sensor_ctrl_regs.h"
 
 enum {
   kBase = TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR,
-  kPwrMgrBase = TOP_EARLGREY_PWRMGR_AON_BASE_ADDR,
   kSensorCtrlAlertConfig =
       OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG_OFFSET,
   kSensorCtrlAlertSize = SENSOR_CTRL_ALERT_EN_MULTIREG_COUNT,
@@ -74,12 +72,4 @@ rom_error_t sensor_ctrl_configure(lifecycle_state_t lc_state) {
   }
   sec_mmio_write32(kBase + SENSOR_CTRL_FATAL_ALERT_EN_REG_OFFSET, fatal);
   return kErrorOk;
-}
-
-void sensor_ctrl_sync(uint32_t cycles) {
-  for (uint32_t i = 0; i < cycles; ++i) {
-    abs_mmio_write32(kPwrMgrBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
-    while (abs_mmio_read32(kPwrMgrBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET) != 0)
-      ;
-  }
 }

--- a/sw/device/silicon_creator/lib/drivers/sensor_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/sensor_ctrl.h
@@ -24,10 +24,11 @@ enum {
 
 /**
  * Number of cycles to wait for sensor_ctrl to synchronize.
- * See opentitan#23150.
+ * See opentitan#23150.  Since each CDC synchronize event takes
+ * 4 AON clocks, we need 5 cycles.
  */
 enum {
-  kSensorCtrlSyncCycles = 20,
+  kSensorCtrlSyncCycles = 5,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/sensor_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/sensor_ctrl.h
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SENSOR_CTRL_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SENSOR_CTRL_H_
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The following constants represent the expected number of sec_mmio register
+ * writes performed by functions in provided in this module. See
+ * `SEC_MMIO_WRITE_INCREMENT()` for more details.
+ */
+enum {
+  kSensorCtrlSecMmioConfigure = 12,
+};
+
+/**
+ * Number of cycles to wait for sensor_ctrl to synchronize.
+ * See opentitan#23150.
+ */
+enum {
+  kSensorCtrlSyncCycles = 20,
+};
+
+/**
+ * Configure sensors according to their OTP-defined configurations
+ *
+ * @param lc_state Life cycle state of the device.
+ * @return result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t sensor_ctrl_configure(lifecycle_state_t lc_state);
+
+/**
+ * Wait for sensor_ctrl to synchronize.
+ *
+ * @param cycles Number of slow-domain cycles to wait.
+ */
+void sensor_ctrl_sync(uint32_t cycles);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SENSOR_CTRL_H_

--- a/sw/device/silicon_creator/lib/drivers/sensor_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/sensor_ctrl.h
@@ -40,13 +40,6 @@ enum {
 OT_WARN_UNUSED_RESULT
 rom_error_t sensor_ctrl_configure(lifecycle_state_t lc_state);
 
-/**
- * Wait for sensor_ctrl to synchronize.
- *
- * @param cycles Number of slow-domain cycles to wait.
- */
-void sensor_ctrl_sync(uint32_t cycles);
-
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/sensor_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/sensor_ctrl_unittest.cc
@@ -1,0 +1,114 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/sensor_ctrl.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+#include "sensor_ctrl_regs.h"
+
+namespace sensor_ctrl_unittest {
+namespace {
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::NiceMock;
+using ::testing::NotNull;
+using ::testing::Return;
+
+constexpr uint32_t kOtpSensorCtrl =
+    OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG_OFFSET;
+
+class SensorCtrlTest : public rom_test::RomTest,
+                       public testing::WithParamInterface<lifecycle_state_t> {
+ protected:
+  void SetupExpectations() {
+    ON_CALL(otp_, read32(_)).WillByDefault([](uint32_t addr) {
+      // Sensor configuration:
+      //  0: Enabled=True  Recov=True
+      //  1: Enabled=True  Recov=False
+      //  2: Enabled=True  Recov=False
+      //  3: Enabled=True  Recov=True
+      //  4: Enabled=False Recov=False
+      //  5: Enabled=False Recov=False
+      //  6: Enabled=False Recov=False
+      //  7: Enabled=False Recov=False
+      //  The remaining values are zero, which is meaningless for "Enabled", and
+      //  translates to Recov=True because of the bit-ops in the configure
+      //  function.
+      //  8: Enabled=X     Recov=True
+      //  9: Enabled=X     Recov=True
+      // 10: Enabled=X     Recov=True
+      switch (addr) {
+        case kOtpSensorCtrl + 0:
+          return 0x66969666UL;
+        case kOtpSensorCtrl + 4:
+          return 0x99999999UL;
+        case kOtpSensorCtrl + 8:
+          return 0x00000000UL;
+        default:
+          return 0UL;
+      }
+    });
+
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_0_REG_OFFSET, 6));
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_1_REG_OFFSET, 6));
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_2_REG_OFFSET, 6));
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_3_REG_OFFSET, 6));
+
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_4_REG_OFFSET, 9));
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_5_REG_OFFSET, 9));
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_6_REG_OFFSET, 9));
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_7_REG_OFFSET, 9));
+
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_8_REG_OFFSET, 0));
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_9_REG_OFFSET, 0));
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_ALERT_EN_10_REG_OFFSET, 0));
+
+    // Expect to see a 1 bit for every Recov=False configuration.
+    EXPECT_CALL(sec_mmio_,
+                Write32(base_ + SENSOR_CTRL_FATAL_ALERT_EN_REG_OFFSET, 0x0F6));
+  }
+  uint32_t base_ = TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR;
+  rom_test::NiceMockOtp otp_;
+  rom_test::MockSecMmio sec_mmio_;
+};
+
+TEST_P(SensorCtrlTest, Configure) {
+  lifecycle_state_t state = GetParam();
+  switch (state) {
+    case kLcStateTest:
+    case kLcStateRma:
+      // The configure function does nothing for Test and RMA states.
+      break;
+    default:
+      // Normal test conditions.
+      SetupExpectations();
+  }
+  EXPECT_EQ(kErrorOk, sensor_ctrl_configure(state));
+}
+
+INSTANTIATE_TEST_SUITE_P(LcStates, SensorCtrlTest,
+                         testing::Values(kLcStateTest, kLcStateRma, kLcStateDev,
+                                         kLcStateProd, kLcStateProdEnd));
+
+}  // namespace
+}  // namespace sensor_ctrl_unittest

--- a/sw/device/silicon_creator/lib/drivers/watchdog.c
+++ b/sw/device/silicon_creator/lib/drivers/watchdog.c
@@ -8,6 +8,7 @@
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/drivers/pwrmgr.h"
 
 #include "aon_timer_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -77,7 +78,7 @@ void watchdog_configure(watchdog_config_t config) {
       bitfield_bit32_write(
           0, kTopEarlgreyPowerManagerResetRequestsAonTimerAonAonTimerRstReq,
           true));
-  abs_mmio_write32(kPwrMgrBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+  pwrmgr_cdc_sync(1);
 
   // Set the watchdog bite and bark thresholds.
   sec_mmio_write32(kBase + AON_TIMER_WDOG_CTRL_REG_OFFSET, kCtrlDisable);
@@ -105,7 +106,7 @@ void watchdog_configure(watchdog_config_t config) {
 
   // Redundantly re-request the pwrmgr configuration sync since it isn't
   // possible to use sec_mmio for it.
-  abs_mmio_write32(kPwrMgrBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+  pwrmgr_cdc_sync(1);
 }
 
 void watchdog_disable(void) {

--- a/sw/device/silicon_creator/lib/drivers/watchdog_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/watchdog_unittest.cc
@@ -24,6 +24,13 @@ using ::testing::Return;
 
 class WatchdogTest : public rom_test::RomTest {
  protected:
+  void ExpectCdcSync() {
+    // The pwrmgr_cdc_sync function reads to check that the sync bit is clear,
+    // writes to the sync bit and then reads back waiting for it to clear.
+    EXPECT_ABS_READ32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 0);
+    EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    EXPECT_ABS_READ32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 0);
+  }
   /**
    * Sets up expectations for `watchdog_init()`.
    *
@@ -41,7 +48,7 @@ class WatchdogTest : public rom_test::RomTest {
                        {
                            {PWRMGR_RESET_EN_EN_1_BIT, true},
                        });
-    EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    ExpectCdcSync();
     EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
                        0 << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
     EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
@@ -51,7 +58,7 @@ class WatchdogTest : public rom_test::RomTest {
                        kBiteThreshold);
     EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
                        enabled << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
-    EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    ExpectCdcSync();
   }
 
   uint32_t pwrmgr_ = TOP_EARLGREY_PWRMGR_AON_BASE_ADDR;

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -166,6 +166,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:sensor_ctrl",
         "//sw/device/silicon_creator/lib/drivers:uart",
         "//sw/device/silicon_creator/lib/drivers:watchdog",
         "//sw/device/silicon_creator/lib/sigverify",

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -35,6 +35,7 @@
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/sensor_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/drivers/watchdog.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -170,6 +171,10 @@ static rom_error_t rom_init(void) {
     // previous configuration).
     watchdog_init(lc_state);
     SEC_MMIO_WRITE_INCREMENT(kWatchdogSecMmioInit);
+
+    // Re-initialize sensor_ctrl.
+    HARDENED_RETURN_IF_ERROR(sensor_ctrl_configure(lc_state));
+    sensor_ctrl_sync(kSensorCtrlSyncCycles);
   }
 
   // Initialize the shutdown policy.

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -174,7 +174,7 @@ static rom_error_t rom_init(void) {
 
     // Re-initialize sensor_ctrl.
     HARDENED_RETURN_IF_ERROR(sensor_ctrl_configure(lc_state));
-    sensor_ctrl_sync(kSensorCtrlSyncCycles);
+    pwrmgr_cdc_sync(kSensorCtrlSyncCycles);
   }
 
   // Initialize the shutdown policy.


### PR DESCRIPTION
Add a sensor_ctrl driver to configure the peripheral from OTP.
Configure sensor_ctrl during ROM bootup.

Addresses: #23150, #21871.
