### PR TITLE
[opentitantool] Fix config files bug

### DIFF
--- a/sw/host/opentitanlib/src/app/config/mod.rs
+++ b/sw/host/opentitanlib/src/app/config/mod.rs
@@ -72,6 +72,7 @@ static BUILTINS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         "/__builtin__/hyperdebug_cw310.json" => include_str!("hyperdebug_cw310.json"),
         "/__builtin__/hyperdebug_cw340.json" => include_str!("hyperdebug_cw340.json"),
         "/__builtin__/hyperdebug_teacup.json" => include_str!("hyperdebug_teacup.json"),
+        "/__builtin__/hyperdebug_teacup_default.json" => include_str!("hyperdebug_teacup_default.json"),
         "/__builtin__/opentitan_ultradebug.json" => include_str!("opentitan_ultradebug.json"),
         "/__builtin__/opentitan_verilator.json" => include_str!("opentitan_verilator.json"),
     }


### PR DESCRIPTION
It appears that `hyperdebug_teacup_default.json` got left out of the list of built-in config files.