### PR TITLE
[exec_env] Fix commandline arguments

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -431,7 +431,7 @@ silicon(
     name = "silicon_owner_sival_rom_ext",
     testonly = True,
     args = [
-        "--rcfile=__builtin__/hyperdebug_teacup.json",
+        "--rcfile=",
         "--logging=info",
         "--interface={interface}",
     ],


### PR DESCRIPTION
The `--rcfile=` argument in the `silicon_owner_sival_rom_ext` is incorrect.  That argument is used to control or override the loading of `$XDG_CONFIG_HOME/opentitantool/config`, which is a list of command-line arguments the user wants applied to each invocation of `opentitantool`.

It cannot parse a json config file (that can be done with `--conf=...`. In this case, using `--conf` should not be necessary because any of the built-in configurations are resolved and parsed by the `--interface` selection.