### PR TITLE
[rom] Reclaim 662 bytes of unused space

### DIFF
--- a/sw/device/silicon_creator/rom/rom.ld
+++ b/sw/device/silicon_creator/rom/rom.ld
@@ -90,7 +90,6 @@ SECTIONS {
     ASSERT(
         SIZEOF(.vectors) + SIZEOF(.crt) <= _epmp_reset_rx_size,
         "Error: .crt overflows reset ePMP region");
-    . = MAX(., _epmp_reset_rx_size - SIZEOF(.vectors));
   } > rom
 
   /**


### PR DESCRIPTION
We have been padding the `.crt` section out to consume the whole of `epmp_reset_rx_size` (the size of the initial EPMP executable region coming out of reset).

Reclaim this unused space for ROM code.