### PR TITLE
[rom] Print a banner at startup 

### DIFF
--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -40,6 +40,7 @@ cc_library(
     srcs = ["device_fpga_cw305.c"],
     deps = [
         ":device",
+        "//hw/ip/uart/data:uart_c_regs",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/drivers:ibex",
         "//sw/device/silicon_creator/lib/drivers:uart",
@@ -51,6 +52,7 @@ cc_library(
     srcs = ["device_fpga_cw310.c"],
     deps = [
         ":device",
+        "//hw/ip/uart/data:uart_c_regs",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/drivers:ibex",
         "//sw/device/silicon_creator/lib/drivers:uart",
@@ -62,6 +64,7 @@ cc_library(
     srcs = ["device_fpga_cw340.c"],
     deps = [
         ":device",
+        "//hw/ip/uart/data:uart_c_regs",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib/drivers:ibex",
         "//sw/device/silicon_creator/lib/drivers:uart",
@@ -74,6 +77,7 @@ cc_library(
     deps = [
         ":device",
         "//hw/ip/rv_core_ibex/data:rv_core_ibex_c_regs",
+        "//hw/ip/uart/data:uart_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
     ],
 )
@@ -84,6 +88,7 @@ cc_library(
     deps = [
         ":device",
         "//hw/ip/rv_core_ibex/data:rv_core_ibex_c_regs",
+        "//hw/ip/uart/data:uart_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
     ],
 )
@@ -94,6 +99,7 @@ cc_library(
     deps = [
         ":device",
         "//hw/ip/rv_core_ibex/data:rv_core_ibex_c_regs",
+        "//hw/ip/uart/data:uart_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
     ],
 )

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -41,8 +41,8 @@ cc_library(
     deps = [
         ":device",
         "//sw/device/lib/base:macros",
-        "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib/drivers:ibex",
+        "//sw/device/silicon_creator/lib/drivers:uart",
     ],
 )
 
@@ -52,8 +52,8 @@ cc_library(
     deps = [
         ":device",
         "//sw/device/lib/base:macros",
-        "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib/drivers:ibex",
+        "//sw/device/silicon_creator/lib/drivers:uart",
     ],
 )
 
@@ -63,8 +63,8 @@ cc_library(
     deps = [
         ":device",
         "//sw/device/lib/base:macros",
-        "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib/drivers:ibex",
+        "//sw/device/silicon_creator/lib/drivers:uart",
     ],
 )
 

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -156,8 +156,8 @@ extern const uint32_t kUartBaud1M50;
  * This macro assumes 10 bits per byte (no parity bits) and a 128 byte deep TX
  * FIFO.
  */
-#define CALCULATE_UART_TX_FIFO_CPU_CYCLES(baud_rate_, cpu_freq_) \
-  ((cpu_freq_)*10 * 128 / (baud_rate_))
+#define CALCULATE_UART_TX_FIFO_CPU_CYCLES(baud_rate_, cpu_freq_, fifo_depth_) \
+  ((cpu_freq_)*10 * (fifo_depth_) / (baud_rate_))
 
 /**
  * The time it takes to transmit the entire UART TX fifo in CPU cycles.

--- a/sw/device/lib/arch/device_fpga_cw305.c
+++ b/sw/device/lib/arch/device_fpga_cw305.c
@@ -6,8 +6,8 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
-#include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
 
 /**
  * @file
@@ -59,7 +59,11 @@ const uintptr_t kDeviceLogBypassUartAddress = 0;
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.
   uint32_t fpga = ibex_fpga_version();
+  //                       : M O R
+  const uint32_t kRom = 0x3a4d4f52;
+  uart_write_imm(kRom);
   // The cast to unsigned int stops GCC from complaining about uint32_t
   // being a `long unsigned int` while the %x specifier takes `unsigned int`.
-  dbg_printf("ROM:%x\r\n", (unsigned int)fpga);
+  const uint32_t kNewline = 0x0a0d;
+  uart_write_hex(fpga, sizeof(fpga), kNewline);
 }

--- a/sw/device/lib/arch/device_fpga_cw305.c
+++ b/sw/device/lib/arch/device_fpga_cw305.c
@@ -9,6 +9,8 @@
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 
+#include "uart_regs.h"
+
 /**
  * @file
  * @brief Device-specific symbol definitions for the ChipWhisperer CW305 device.
@@ -46,8 +48,8 @@ const uint32_t kUartBaud1M33 =
 const uint32_t kUartBaud1M50 =
     CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
 
-const uint32_t kUartTxFifoCpuCycles =
-    CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
+const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
+    kUartBaudrate, kClockFreqCpuHz, UART_PARAM_TX_FIFO_DEPTH);
 
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -6,8 +6,8 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
-#include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
 
 /**
  * @file
@@ -61,7 +61,11 @@ const uintptr_t kDeviceLogBypassUartAddress = 0;
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.
   uint32_t fpga = ibex_fpga_version();
+  //                       : M O R
+  const uint32_t kRom = 0x3a4d4f52;
+  uart_write_imm(kRom);
   // The cast to unsigned int stops GCC from complaining about uint32_t
   // being a `long unsigned int` while the %x specifier takes `unsigned int`.
-  dbg_printf("ROM:%x\r\n", (unsigned int)fpga);
+  const uint32_t kNewline = 0x0a0d;
+  uart_write_hex(fpga, sizeof(fpga), kNewline);
 }

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -9,6 +9,8 @@
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 
+#include "uart_regs.h"
+
 /**
  * @file
  * @brief Device-specific symbol definitions for the ChipWhisperer CW310 device.
@@ -48,8 +50,8 @@ const uint32_t kUartBaud1M33 =
 const uint32_t kUartBaud1M50 =
     CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
 
-const uint32_t kUartTxFifoCpuCycles =
-    CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
+const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
+    kUartBaudrate, kClockFreqCpuHz, UART_PARAM_TX_FIFO_DEPTH);
 
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);

--- a/sw/device/lib/arch/device_fpga_cw340.c
+++ b/sw/device/lib/arch/device_fpga_cw340.c
@@ -6,8 +6,8 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
-#include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
 
 /**
  * @file
@@ -63,7 +63,11 @@ const bool kJitterEnabled = false;
 void device_fpga_version_print(void) {
   // This value is guaranteed to be zero on all non-FPGA implementations.
   uint32_t fpga = ibex_fpga_version();
+  //                       : M O R
+  const uint32_t kRom = 0x3a4d4f52;
+  uart_write_imm(kRom);
   // The cast to unsigned int stops GCC from complaining about uint32_t
   // being a `long unsigned int` while the %x specifier takes `unsigned int`.
-  dbg_printf("ROM:%x\r\n", (unsigned int)fpga);
+  const uint32_t kNewline = 0x0a0d;
+  uart_write_hex(fpga, sizeof(fpga), kNewline);
 }

--- a/sw/device/lib/arch/device_fpga_cw340.c
+++ b/sw/device/lib/arch/device_fpga_cw340.c
@@ -9,6 +9,8 @@
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 
+#include "uart_regs.h"
+
 /**
  * @file
  * @brief Device-specific symbol definitions for the ChipWhisperer CW310 device.
@@ -48,8 +50,8 @@ const uint32_t kUartBaud1M33 =
 const uint32_t kUartBaud1M50 =
     CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
 
-const uint32_t kUartTxFifoCpuCycles =
-    CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
+const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
+    kUartBaudrate, kClockFreqCpuHz, UART_PARAM_TX_FIFO_DEPTH);
 
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);

--- a/sw/device/lib/arch/device_silicon.c
+++ b/sw/device/lib/arch/device_silicon.c
@@ -8,6 +8,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
+#include "uart_regs.h"
 
 /**
  * Device-specific symbol definitions for the Silicon device.
@@ -47,8 +48,8 @@ const uint32_t kUartBaud1M33 =
 const uint32_t kUartBaud1M50 =
     CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
 
-const uint32_t kUartTxFifoCpuCycles =
-    CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
+const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
+    kUartBaudrate, kClockFreqCpuHz, UART_PARAM_TX_FIFO_DEPTH);
 
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -8,6 +8,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
+#include "uart_regs.h"
 
 /**
  * Device-specific symbol definitions for the DV simulation device.
@@ -50,8 +51,8 @@ const uint32_t kUartBaud1M33 =
 const uint32_t kUartBaud1M50 =
     CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
 
-const uint32_t kUartTxFifoCpuCycles =
-    CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
+const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
+    kUartBaudrate, kClockFreqCpuHz, UART_PARAM_TX_FIFO_DEPTH);
 
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -9,6 +9,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
+#include "uart_regs.h"
 
 /**
  * @file
@@ -57,8 +58,8 @@ const uint32_t kUartBaud1M33 =
 const uint32_t kUartBaud1M50 =
     CALCULATE_UART_NCO(1500000, kClockFreqPeripheralHz);
 
-const uint32_t kUartTxFifoCpuCycles =
-    CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
+const uint32_t kUartTxFifoCpuCycles = CALCULATE_UART_TX_FIFO_CPU_CYCLES(
+    kUartBaudrate, kClockFreqCpuHz, UART_PARAM_TX_FIFO_DEPTH);
 
 const uint32_t kAstCheckPollCpuCycles =
     CALCULATE_AST_CHECK_POLL_CPU_CYCLES(kClockFreqCpuHz);

--- a/sw/device/silicon_creator/lib/drivers/uart.h
+++ b/sw/device/silicon_creator/lib/drivers/uart.h
@@ -50,9 +50,35 @@ int uart_getchar(uint32_t timeout_ms);
  *
  * @param data Pointer to buffer to write.
  * @param len Length of the buffer to write.
- * @return Number of bytes written.
  */
-size_t uart_write(const uint8_t *data, size_t len);
+void uart_write(const void *data, size_t len);
+
+/**
+ * Write an unsigned integer as hex to the UART.
+ *
+ * @param val The value to write to the UART.
+ * @param len The length of the value in bytes (1, 2, or 4 bytes).
+ * @param after Packed ASCII values to write after the hex value.
+ */
+void uart_write_hex(uint32_t val, size_t len, uint32_t after);
+
+/**
+ * Write an immediate value to the UART a byte at a time.
+ *
+ * This function is used to print a few imporant user-facing strings
+ * from the ROM, but without having to dereference pointers.  The
+ * string to be written is encoded as ASCII in an integer in little-endian
+ * order (ie: the string is reversed).  A maximum of eight bytes can be printed
+ * in this way.  A zero byte in the value terminates the output.
+ *
+ * @param val The bytes to print.
+ */
+void uart_write_imm(uint64_t val);
+
+inline void uart_write_newline(void) {
+  //               \n\r
+  uart_write_imm(0x0a0d);
+}
 
 /**
  * Read from the UART into a buffer.

--- a/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
@@ -99,8 +99,7 @@ class BytesSendTest : public UartTest {
 TEST_F(BytesSendTest, SendBuffer) {
   ExpectSendBytes();
   // Calling uart_write implicitly tests uart_putchar.
-  EXPECT_EQ(uart_write(kBytesArray.data(), kBytesArray.size()),
-            kBytesArray.size());
+  uart_write(kBytesArray.data(), kBytesArray.size());
 }
 
 TEST_F(BytesSendTest, SendByteBusy) {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5636,6 +5636,7 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
     ],
 )

--- a/sw/host/tests/rom/e2e_openocd_debug_test/src/debug_test.rs
+++ b/sw/host/tests/rom/e2e_openocd_debug_test/src/debug_test.rs
@@ -331,7 +331,8 @@ fn debug_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 
     // Execute code
     for c in "GDB-OK\r\n".bytes() {
-        dbg.call("uart_putchar", &[c as u32], opts.breakpoint_timeout)?;
+        // `uart_write_imm` takes a uint64_t as an argument.
+        dbg.call("uart_write_imm", &[c as u32, 0u32], opts.breakpoint_timeout)?;
     }
 
     dbg.resume()?;


### PR DESCRIPTION
1. Print `OpenTitan:<lifecycle_hw_rev>` and `GIT:<git revision>` at startup.
2. The UART FIFO size was reduced from 128 to 32 for the TX FIFO, but the shutdown function assumed a 128 byte FIFO.
3. Because of the smaller FIFO, we cannot emit all of the fault info into the FIFO in one shot.  Move the UART wait function into shutdown_print.