### PR TITLE
[dv] Fix ROM e2e JTAG tests.

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -122,9 +122,7 @@ ifneq (${sw_images},)
 				--ui_event_filters=-info \
 				--noshow_progress \
 				--output=label_kind | cut -f1 -d' '); \
-			if [[ $${kind} == "opentitan_test" \
-					|| $${bazel_label} == "//sw/device/lib/testing/test_rom:test_rom_sim_dv" \
-					|| $${bazel_label} == "//sw/device/silicon_creator/rom:mask_rom_sim_dv" ]]; then \
+			if [[ $${kind} == "opentitan_test" ]]; then \
 				for artifact in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} \
 					$${bazel_label} \
 					--ui_event_filters=-info \
@@ -132,6 +130,21 @@ ifneq (${sw_images},)
 					--output=starlark \
 					`# An opentitan_test rule has all of its needed files in its runfiles.` \
 					--starlark:expr='"\n".join([f.path for f in target.data_runfiles.files.to_list()])'); do \
+						cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
+						if [[ $$artifact == *.bin && \
+							-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \
+							cp -f "$$(echo $${artifact} | cut -d. -f 1).elf" \
+								$${run_dir}/$$(basename -s .bin $${artifact}).elf; \
+						fi; \
+				done; \
+			elif [[ $${kind} == "alias" || $${kind} == "opentitan_binary" ]]; then \
+				for artifact in $$($${bazel_cmd} cquery $${bazel_airgapped_opts} \
+					$${bazel_label} \
+					--ui_event_filters=-info \
+					--noshow_progress \
+					--output=starlark \
+					`# An opentitan_binary rule has all of its needed files in its runfiles.` \
+					--starlark:expr='"\n".join([f.path for f in target.files.to_list()])'); do \
 						cp -f $${artifact} $${run_dir}/$$(basename $${artifact}); \
 						if [[ $$artifact == *.bin && \
 							-f "$$(echo $${artifact} | cut -d. -f 1).elf" ]]; then \

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -240,6 +240,7 @@ def _opentitan_binary(ctx):
         provides, signed = _build_binary(ctx, exec_env, name, deps, kind)
         providers.append(exec_env.provider(**provides))
         default_info.append(provides["default"])
+        default_info.append(provides["elf"])
 
         # FIXME(cfrantz): logs are a special case and get added into
         # the DefaultInfo provider.

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -4,7 +4,6 @@
 
 load(
     "//rules/opentitan:defs.bzl",
-    "EARLGREY_TEST_ENVS",
     "OPENTITAN_CPU",
     "opentitan_binary",
     "opentitan_test",
@@ -42,6 +41,19 @@ opentitan_binary(
     ],
 )
 
+[
+    # Generate targets with `sim_dv` and `sim_verilator` suffixes as expected
+    # by dvsim.
+    alias(
+        name = "test_rom_{}".format(env),
+        actual = ":test_rom",
+    )
+    for env in [
+        "sim_dv",
+        "sim_verilator",
+    ]
+]
+
 # Create the legacy ROM target names so that existing splicing rules
 # can find the test_rom VMEM files.
 legacy_rom_targets(
@@ -49,8 +61,6 @@ legacy_rom_targets(
         "fpga_cw310",
         "fpga_cw305",
         "fpga_cw340",
-        "sim_dv",
-        "sim_verilator",
     ],
     target = "test_rom",
 )

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -157,11 +157,17 @@ cc_library(
     ],
 )
 
-_ROM_DEVICES = [
-    "sim_dv",
-    "sim_verilator",
-    "fpga_cw310",
-    "fpga_cw340",
+[
+    # Generate targets with `sim_dv` and `sim_verilator` suffixes as expected
+    # by dvsim.
+    alias(
+        name = "mask_rom_{}".format(env),
+        actual = ":mask_rom",
+    )
+    for env in [
+        "sim_dv",
+        "sim_verilator",
+    ]
 ]
 
 opentitan_binary(
@@ -182,7 +188,10 @@ opentitan_binary(
 # Create the legacy ROM target names so that existing splicing rules can find
 # the rom VMEM files.
 legacy_rom_targets(
-    suffixes = _ROM_DEVICES,
+    suffixes = [
+        "fpga_cw310",
+        "fpga_cw340",
+    ],
     target = "mask_rom",
 )
 


### PR DESCRIPTION
1. Add `opentitan_binary` ROM targets with the expected suffix: i.e. `mask_rom_sim_dv`, `mask_rom_sim_verilator`.
2. Update Bazel cc.bzl to export `elf` files in `opentitan_binary` builds.
3. Update sim.mk to query Bazel output files from the `files` group if the target kind is not `opentitan_test`. This works because the ROMs are built using `opentitan_binary` targets.