### PR TITLE
[rom] Change the endianness of the digest for the HMAC driver.

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -493,6 +493,7 @@ opentitan_test(
     srcs = ["otbn_boot_services_functest.c"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_sival": None,
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:sim_dv": None,
         "//hw/top_earlgrey:sim_verilator": None,
     },

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -23,12 +23,12 @@ void hmac_sha256_init(void) {
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
                    UINT32_MAX);
 
+  // Configure the HMAC block to run SHA2-256 with a 256-bit key.
   uint32_t reg = 0;
-  reg = bitfield_bit32_write(reg, HMAC_CFG_DIGEST_SWAP_BIT, false);
+  reg = bitfield_bit32_write(reg, HMAC_CFG_DIGEST_SWAP_BIT, true);
   reg = bitfield_bit32_write(reg, HMAC_CFG_ENDIAN_SWAP_BIT, false);
   reg = bitfield_bit32_write(reg, HMAC_CFG_SHA_EN_BIT, true);
   reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, false);
-  // configure to run SHA-2 256 with 256-bit key
   reg = bitfield_field32_write(reg, HMAC_CFG_DIGEST_SIZE_FIELD,
                                HMAC_CFG_DIGEST_SIZE_VALUE_SHA2_256);
   reg = bitfield_field32_write(reg, HMAC_CFG_KEY_LENGTH_FIELD,
@@ -75,11 +75,9 @@ void hmac_sha256_final(hmac_digest_t *digest) {
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
                    reg);
 
-  // Read the digest in reverse to preserve the numerical value.
-  // The least significant word is at HMAC_DIGEST_7_REG_OFFSET.
   for (size_t i = 0; i < ARRAYSIZE(digest->digest); ++i) {
     digest->digest[i] =
-        abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_DIGEST_7_REG_OFFSET -
+        abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_DIGEST_0_REG_OFFSET +
                         (i * sizeof(uint32_t)));
   }
 }

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -29,11 +29,12 @@ static const char kGettysburgPrelude[] =
 // $ echo -n "Four score and seven years ago our fathers brought forth on this
 // continent, a new nation, conceived in Liberty, and dedicated to the
 // proposition that all men are created equal." |
-//     sha256sum - | cut -f1 -d' ' | sed -e "s/......../0x&,\n/g" | tac
+//     sha256sum - | cut -f1 -d' '  | fold -w2 | tac | tr -d "\n" |
+//     sed -e "s/......../0x&,\n/g" | tac
 //
 static const uint32_t kGettysburgDigest[] = {
-    0x8b8cc7ba, 0xe29f6ac0, 0xeb3dd433, 0x420ec587,
-    0x96c324ed, 0x775708a3, 0x0f9034cd, 0x1e6fd403,
+    0x03d46f1e, 0xcd34900f, 0xa3085777, 0xed24c396,
+    0x87c50e42, 0x33d43deb, 0xc06a9fe2, 0xbac78c8b,
 };
 
 rom_error_t hmac_test(void) {

--- a/util/design/gen-otp-rot-auth-json.py
+++ b/util/design/gen-otp-rot-auth-json.py
@@ -152,7 +152,8 @@ class RotCreatorAuthCodesign:
         partition_buffer += self.build_key_type_buffer(_STRUCT_ITEM_NAMES_SPX,
                                                        _SPX_KEY_COUNT)
         digest = SHA256.new(partition_buffer).digest()
-        return partition_buffer, bytes(digest)
+        digest = bytes(reversed(digest))
+        return partition_buffer, digest
 
     def update_json_with_partition_digest(self, digest):
         """Update the JSON with the partition digest.


### PR DESCRIPTION
Part of https://github.com/lowRISC/opentitan/issues/23144

Previously, the HMAC driver emitted the digest in "little-endian" mode (bytes reversed within words); this change flips it to "big-endian" mode. Normally, we represent everything in ROM in little-endian, and in general I'm a fan of that. However, in the case of HMAC/SHA2, the output is more like a byte sequence than an integer.

Before, we were essentially flipping bytes twice to cancel out big-endianness. Standards love big-endian, so both ECDSA and RSA interpret the byte sequence as a big-endian integer. When we only needed those, little-endian mode for SHA2 kind of made sense; we produce the output with flipped bytes and then just flip them again when we interpret the integer in the way OTBN and most other processors prefer (little-endian) as opposed to the awkward way FIPS wants them to interpret it (big-endian).

However, the second you want to use a digest to be anything other than an integer (for example, in SPHINCS+, when you want it to be part of the input to another hash function), the flipped bytes cause issues; there's no integer interpretation to cancel it out. Conceptually, it makes more sense to me to not flip the bytes in the first place and simply represent the bytes in the same order on the processor as the SHA2 specification dictates. This means for ECDSA, we have to flip the bytes when we write them to OTBN, but that seems preferable to me both logically and performance-wise than flipping them in SPHINCS+. The cryptolib already does this for ECDSA; I copied the `set_message_digest` routine from there.

I also had to change the `gen-otp-rot-auth-json.py` script to flip the bytes for the OTP auth digest. I expected to remove a reversal here, not add one, since `Crypto.Hash.SHA256` should produce output in the same order as the HMAC block does with this change. But it looks like the script flips bytes for every _other_ field (e.g. when computing the hash) but previously didn't for the digest; now it needs to do that for the digest too.

Also added back a `"//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys"` env for `otbn_boot_data_functest`; I think this was (mistakenly?) removed in b217f41a378e30cdef6685c1d26fb3e990db0b4e but I don't see why it shouldn't be running and would like to have the coverage. It passes in seconds.