### PR TITLE
[i2c,dv] I2C scoreboard rearchitect

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent.core
+++ b/hw/dv/sv/i2c_agent/i2c_agent.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
+      - lowrisc:ip:i2c
     files:
       - i2c_agent_pkg.sv
       - i2c_if.sv

--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -32,6 +32,8 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   int     sent_rd_byte = 0;
   int     rcvd_rd_byte = 0;
 
+  bit     is_read;
+
   // this variables can be configured from host test
   uint i2c_host_min_data_rw = 1;
   uint i2c_host_max_data_rw = 10;
@@ -46,15 +48,29 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   // ack followed by stop test mode
   bit     allow_ack_stop = 0;
   bit     ack_stop_det = 0;
-  bit     allow_bad_addr = 0;
-  // target address is stored when dut is programmed
+
+  ////////////////
+  // Addressing //
+  ////////////////
+
+  // Store the DUT's programmed target addresses
   bit [6:0] target_addr0;
   bit [6:0] target_addr1;
-  // store history of good and bad read target address
-  // '1' good. '0' bad
+
+  // Set this bit when there is the possibility of generating Agent-Controller stimulus
+  // transfers where the address does not match that configured into the DUT.
+  bit       allow_bad_addr = 0;
+
+  bit       valid_addr; // Was the last observed transaction to the DUT addressed correctly?
+  // Store history of good and bad read target address ( '1' = good, '0' = bad )
+  // This is used by the env's scoreboard to adjust its expectations, and also
+  // to adjust the stimulus for reads, so we don't put data into the TXFIFO that will
+  // never be read out.
   bit       read_addr_q[$];
-  bit       valid_addr;
-  bit       is_read;
+
+  ////////////
+  // Resets //
+  ////////////
 
   // reset driver only without resetting dut
   bit       driver_rst = 0;

--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -11,6 +11,8 @@ package i2c_agent_pkg;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
 
+  import i2c_pkg::*;
+
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -184,9 +184,6 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
         // rd_data_cnt is rollled back (no overflow) after reading 256 bytes
         rd_data_cnt++;
       end
-      WrData: begin
-        // nothing to do
-      end
       default: begin
         `uvm_fatal(`gfn, $sformatf("\n  device_driver, received invalid request"))
       end

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -87,7 +87,7 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
   virtual task drive_host_data_bits(ref i2c_item req);
     int num_bits = $bits(req.wdata);
     `uvm_info(`gfn, $sformatf("Driving host item 0x%x", req.wdata), UVM_MEDIUM)
-    `uvm_info(`gfn, $sformatf("wait_cycles 0x%x", req.wait_cycles), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("wait_cycles 0x%x", req.wait_cycles), UVM_HIGH)
     for (int i = num_bits - 1; i >= (num_bits - req.wait_cycles); i--) begin
       cfg.vif.host_data(cfg.timing_cfg, req.wdata[i]);
     end

--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -14,6 +14,7 @@ class i2c_item extends uvm_sequence_item;
   bit                      addr_ack;
   bit                      data_ack_q[$];
   // transaction control part
+  i2c_acq_byte_id_e        signal; // ACQDATA.SIGNAL
   bit                      nack;
   bit                      ack;
   bit                      rstart;
@@ -51,27 +52,28 @@ class i2c_item extends uvm_sequence_item;
   }
 
   `uvm_object_utils_begin(i2c_item)
-    `uvm_field_int(tran_id,                 UVM_DEFAULT)
-    `uvm_field_enum(bus_op_e, bus_op,       UVM_DEFAULT)
-    `uvm_field_int(addr,                    UVM_DEFAULT)
-    `uvm_field_int(num_data,                UVM_DEFAULT)
-    `uvm_field_int(start,                   UVM_DEFAULT)
-    `uvm_field_int(stop,                    UVM_DEFAULT)
-    `uvm_field_int(wdata,                   UVM_DEFAULT | UVM_NOCOMPARE)
-    `uvm_field_queue_int(data_q,            UVM_DEFAULT | UVM_NOPRINT)
-    `uvm_field_queue_int(fmt_ovf_data_q,    UVM_DEFAULT | UVM_NOCOMPARE)
-    `uvm_field_int(rdata,                   UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
-    `uvm_field_int(rstart,                  UVM_DEFAULT | UVM_NOCOMPARE)
-    `uvm_field_int(fbyte,                   UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
-    `uvm_field_int(ack,                     UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
-    `uvm_field_int(nack,                    UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
-    `uvm_field_int(read,                    UVM_DEFAULT | UVM_NOCOMPARE)
-    `uvm_field_int(rcont,                   UVM_DEFAULT | UVM_NOCOMPARE)
-    `uvm_field_int(nakok,                   UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
-    `uvm_field_enum(drv_type_e,  drv_type,  UVM_DEFAULT | UVM_NOCOMPARE)
-    `uvm_field_int(wait_cycles,             UVM_DEFAULT | UVM_NOCOMPARE)
-    `uvm_field_int(addr_ack,                UVM_DEFAULT | UVM_NOCOMPARE | UVM_NOPRINT)
-    `uvm_field_queue_int(data_ack_q,        UVM_DEFAULT | UVM_NOCOMPARE | UVM_NOPRINT)
+    `uvm_field_int(tran_id,                    UVM_DEFAULT)
+    `uvm_field_enum(bus_op_e, bus_op,          UVM_DEFAULT)
+    `uvm_field_int(addr,                       UVM_DEFAULT)
+    `uvm_field_int(num_data,                   UVM_DEFAULT)
+    `uvm_field_int(start,                      UVM_DEFAULT)
+    `uvm_field_int(stop,                       UVM_DEFAULT)
+    `uvm_field_int(wdata,                      UVM_DEFAULT | UVM_NOCOMPARE)
+    `uvm_field_queue_int(data_q,               UVM_DEFAULT)
+    `uvm_field_queue_int(fmt_ovf_data_q,       UVM_DEFAULT | UVM_NOCOMPARE)
+    `uvm_field_int(rdata,                      UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
+    `uvm_field_enum(i2c_acq_byte_id_e, signal, UVM_DEFAULT | UVM_NOCOMPARE)
+    `uvm_field_int(rstart,                     UVM_DEFAULT | UVM_NOCOMPARE)
+    `uvm_field_int(fbyte,                      UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
+    `uvm_field_int(ack,                        UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
+    `uvm_field_int(nack,                       UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
+    `uvm_field_int(read,                       UVM_DEFAULT | UVM_NOCOMPARE)
+    `uvm_field_int(rcont,                      UVM_DEFAULT | UVM_NOCOMPARE)
+    `uvm_field_int(nakok,                      UVM_DEFAULT | UVM_NOPRINT | UVM_NOCOMPARE)
+    `uvm_field_enum(drv_type_e,  drv_type,     UVM_DEFAULT | UVM_NOCOMPARE)
+    `uvm_field_int(wait_cycles,                UVM_DEFAULT | UVM_NOCOMPARE)
+    `uvm_field_int(addr_ack,                   UVM_DEFAULT | UVM_NOCOMPARE | UVM_NOPRINT)
+    `uvm_field_queue_int(data_ack_q,           UVM_DEFAULT | UVM_NOCOMPARE | UVM_NOPRINT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -197,11 +197,6 @@ class i2c_monitor extends dv_base_monitor #(
           fork
             begin
               bit ack_nack;
-               `uvm_info(`gfn, "Req analysis port: write thread data", UVM_HIGH)
-              // ask driver's response a write request
-              mon_dut_item.drv_type = WrData;
-              `downcast(clone_item, mon_dut_item.clone());
-              req_analysis_port.write(clone_item);
               for (int i = 7; i >= 0; i--) begin
                 cfg.vif.get_bit_data("host", cfg.timing_cfg, mon_data[i]);
               end
@@ -437,8 +432,6 @@ class i2c_monitor extends dv_base_monitor #(
     fork begin
       fork
         while (!mon_dut_item.stop && !mon_dut_item.rstart) begin
-
-          mon_dut_item.drv_type = WrData;
 
           begin
             bit [6:0] data;

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -464,16 +464,17 @@
     {
       name: target_mode_glitch
       desc: '''
-            Test handling of RStart ot Stop glitches in Target mode
+            Test handling of RSTART or STOP glitches in Target mode
 
             Stimulus:
               - Configure DUT/Agent to Target/Host mode respectively
-              - Issue a new request(RStart) to DUT during an active transfer
-              - Stop current request(Stop) to DUT during an active transfer
+              - Insert a "glitched" transaction (early Sr/P)
+                - Issue a new transfer(RSTART) to DUT during an active transfer
+                - Stop current transfer(STOP) to DUT during an active transfer
               - Continue issuing requests to check if DUT FSM handles the transaction correctly
 
             Checking:
-            Ensure all transactions including glitches are observed in i2c.ACQDATA FIFO
+              - Ensure all transactions including glitches are observed in i2c.ACQDATA FIFO
             '''
       stage: V2
       tests: ["i2c_target_hrst"]

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -19,6 +19,7 @@ filesets:
       - i2c_env_cov.sv: {is_include_file: true}
       - i2c_env.sv: {is_include_file: true}
       - i2c_virtual_sequencer.sv: {is_include_file: true}
+      - i2c_reference_model.sv: {is_include_file: true}
       - i2c_scoreboard.sv: {is_include_file: true}
       - seq_lib/i2c_vseq_list.sv: {is_include_file: true}
       - seq_lib/i2c_base_vseq.sv: {is_include_file: true}

--- a/hw/ip/i2c/dv/env/i2c_env.sv
+++ b/hw/ip/i2c/dv/env/i2c_env.sv
@@ -8,10 +8,10 @@ class i2c_env extends cip_base_env #(
     .VIRTUAL_SEQUENCER_T  (i2c_virtual_sequencer),
     .SCOREBOARD_T         (i2c_scoreboard));
 
-  `uvm_component_utils(i2c_env)
-
   i2c_agent m_i2c_agent;
+  i2c_reference_model model;
 
+  `uvm_component_utils(i2c_env)
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -24,24 +24,51 @@ class i2c_env extends cip_base_env #(
     uvm_config_db#(i2c_agent_cfg)::set(this, "m_i2c_agent*", "cfg", cfg.m_i2c_agent_cfg);
     cfg.m_i2c_agent_cfg.en_cov = cfg.en_cov;
     cfg.m_i2c_agent_cfg.en_monitor = 1'b1;
+
+    model = i2c_reference_model::type_id::create("model", this);
+    model.cfg = cfg;
+    scoreboard.model = model;
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
-    if (cfg.en_scb) begin
-      m_i2c_agent.monitor.rd_item_port.connect(scoreboard.rd_item_fifo.analysis_export);
-      m_i2c_agent.monitor.wr_item_port.connect(scoreboard.wr_item_fifo.analysis_export);
-    end
 
     virtual_sequencer.i2c_sequencer_h = m_i2c_agent.sequencer;
-    // Configuration for I2C DUT in TARGET/DEVICE mode (agent in HOST mode)
+
+    if (cfg.en_scb) begin
+      // MONITOR -> SCOREBOARD
+
+      m_i2c_agent.monitor.rd_item_port.connect(
+        scoreboard.controller_mode_rd_obs_fifo.analysis_export);
+      m_i2c_agent.monitor.wr_item_port.connect(
+        scoreboard.controller_mode_wr_obs_fifo.analysis_export);
+      m_i2c_agent.monitor.analysis_port.connect(
+        scoreboard.target_mode_rd_obs_fifo.analysis_export);
+
+      // MODEL -> SCOREBOARD
+
+      model.controller_mode_wr_port.connect(scoreboard.controller_mode_wr_exp_fifo.analysis_export);
+      model.controller_mode_rd_port.connect(scoreboard.controller_mode_rd_exp_fifo.analysis_export);
+      model.target_mode_wr_port.connect(scoreboard.target_mode_wr_exp_fifo.analysis_export);
+      model.target_mode_rd_port.connect(scoreboard.target_mode_rd_exp_fifo.analysis_export);
+      model.target_mode_wr_obs_port.connect(scoreboard.target_mode_wr_obs_fifo.analysis_export);
+    end
+
+    // The following connections are used for the (DUT:Agent == TARGET:CONTROLLER) configuration
+    //
+    // When generating stimulus in this configuration, instead of purely forming our expectations
+    // based on monitor-observed items, we actually use the sequence items created by the stimulus
+    // vseqs to form our expectation. These items are written to the vseqr '*_exp_port's, which
+    // are connected through to the model, and then onto the scoreboard.
+    // Also connect the monitor to the reference model, which helps us cheat a bit for some
+    // directed testcases where we don't fully model everything.
     if (cfg.m_i2c_agent_cfg.if_mode == Host) begin
       virtual_sequencer.target_mode_wr_exp_port.connect(
-              scoreboard.target_mode_wr_exp_fifo.analysis_export);
-      m_i2c_agent.monitor.analysis_port.connect(
-              scoreboard.target_mode_rd_obs_fifo.analysis_export);
+        model.target_mode_wr_stim_fifo.analysis_export);
       virtual_sequencer.target_mode_rd_exp_port.connect(
-              scoreboard.target_mode_rd_exp_fifo.analysis_export);
+        model.target_mode_rd_stim_fifo.analysis_export);
+      m_i2c_agent.monitor.analysis_port.connect(
+        model.target_mode_rd_obs_fifo.analysis_export);
     end
   endfunction
 

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -5,32 +5,37 @@ typedef class i2c_scoreboard;
 
 class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
 
-  // i2c address mode (only support 7-bit address for targets)
-  i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
+  i2c_scoreboard scoreboard;
+  virtual i2c_dv_if i2c_dv_vif;
 
-  // i2c_agent cfg
+  ////////////////////////////////
+  // Test Configuration Options //
+  ////////////////////////////////
+
   rand i2c_agent_cfg m_i2c_agent_cfg;
-
-  // seq cfg
   i2c_seq_cfg seq_cfg;
-  bit [7:0]  lastbyte;
+
+  i2c_target_addr_mode_e target_addr_mode = Addr7BitMode; // (dv supports 7-bit addresses only)
 
   int        spinwait_timeout_ns = 10_000_000; // 10ms
   int        long_spinwait_timeout_ns = 400_000_000;
-  int        sent_acq_cnt;
-  int        rcvd_acq_cnt;
 
-  // Ratio between write and read
+  // Constrain the direction of each randomly-generated Agent-Controller transfer.
+  // - These values become weights in a randcase statement, so setting to 0 will disable a
+  //   particular direction of transfer.
   int        wr_pct = 1;
   int        rd_pct = 1;
+  // If enabled, 'bad_addr_pct' gives each generated Agent-Controller transaction the possibilty
+  // of selecting an address that does not match the DUT's configuration.
   int        bad_addr_pct = 0;
 
-  // re-start injection rate between 1~10
-  int        rs_pct = 1;
-
-  // dut target mode parameters
+  // Constrain the min/max number of bytes that should make up a stimulated
+  // DUT-target transaction. Note this constrains each whole transaction, and RSTARTs
+  // may be injected to break it up into many smaller contiguous transfers.
   int        min_data = 1;
   int        max_data = 60;
+  // RSTART injection rate (between 1~10)
+  int        rs_pct = 1;
 
   // This sets the minimum length of a transfer (START/RSTART -> RSTART/STOP) within
   // any larger transaction. A transfer with no data, where the address byte is NACK'd,
@@ -38,18 +43,18 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // circumstances.
   int        min_xfer_len = 0;
 
-  // Use i2c interrupt handler
+  // The vseq stimulus has routines to generate interrupt and polling-driven stimulus.
+  // This bit (settable via a plusarg) allows individual tests to specify which generic
+  // handling routines should be used. (0==polling/1==interrupts)
   bit        use_intr_handler = 1'b0;
-  bit        stop_intr_handler = 1'b0;
-  bit        read_all_acq_entries = 1'b0;
 
-  // Use ACK Control Mode
+  // If set, 50% chance to enable ACK Control Mode
   bit        ack_ctrl_en = 1'b0;
 
-  // Slow acq process
+  // Enabling these bits add extra delays to the testbench processes that read back the ACQFIFO and
+  // write into the TXFIFO for DUT-Target operation. This allows stimulating full/empty stalls and
+  // stretches.
   bit        slow_acq = 1'b0;
-
-  // Slow tx process
   bit        slow_txq = 1'b0;
 
   // In Target-mode, read data is created by i2c_base_seq::fetch_txn().
@@ -59,15 +64,23 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // also flushed.
   bit        read_rnd_data = 0;
 
+  ////////////////////////////////
+  // Helper Variables (not cfg) //
+  ////////////////////////////////
+
+  int        sent_acq_cnt;
+  int        rcvd_acq_cnt;
+  bit [7:0]  lastbyte;
+
   // Flags for the 'ack_stop' test
   int        sent_ack_stop = 0;
   int        rcvd_ack_stop = 0;
 
-  // Timing parameter related settings
-  uint                   scl_frequency = 100; //in KHz
+  // Flags that test sequences can use to cleanup
+  bit        stop_intr_handler = 1'b0;
+  bit        read_all_acq_entries = 1'b0;
 
-  i2c_scoreboard scb_h;
-  virtual    i2c_dv_if i2c_dv_vif;
+  uint scl_frequency = 100; //in KHz
 
   `uvm_object_utils_begin(i2c_env_cfg)
     `uvm_field_object(m_i2c_agent_cfg, UVM_DEFAULT)
@@ -79,20 +92,15 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
     list_of_alerts = i2c_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
 
-    // create i2c_agent_cfg
     m_i2c_agent_cfg = i2c_agent_cfg::type_id::create("m_i2c_agent_cfg");
-    // set agent to Device mode
     m_i2c_agent_cfg.if_mode = Device;
-    // set time to stop test
     m_i2c_agent_cfg.ok_to_end_delay_ns = 5000;
-    // config target address mode of agent to the same
     m_i2c_agent_cfg.target_addr_mode = Addr7BitMode;
-
     m_tl_agent_cfg.max_outstanding_req = 1;
-    // create the seq_cfg
+
     seq_cfg = i2c_seq_cfg::type_id::create("seq_cfg");
 
-    // set num_interrupts & num_alerts
+    // set num_interrupts
     begin
       uvm_reg rg = ral.get_reg_by_name("intr_state");
       if (rg != null) begin

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -128,4 +128,10 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
     rcvd_ack_stop = 0;
   endfunction : reset_seq_cfg
 
+  task wait_fifo_not_empty(i2c_analysis_fifo fifo);
+    while (!fifo.is_empty()) begin
+      clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
 endclass : i2c_env_cfg

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -52,7 +52,14 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // Slow tx process
   bit        slow_txq = 1'b0;
 
-  //  ack stop test
+  // In Target-mode, read data is created by i2c_base_seq::fetch_txn().
+  // Random TXFIFO flush events make it difficult to check read path integrity.
+  // By setting 'read_rnd_data = 1', the expected read data is instead collected
+  // right at the input of TXFIFO. On TXFIFO reset, any expected read data is
+  // also flushed.
+  bit        read_rnd_data = 0;
+
+  // Flags for the 'ack_stop' test
   int        sent_ack_stop = 0;
   int        rcvd_ack_stop = 0;
 

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -70,6 +70,8 @@ package i2c_env_pkg;
     FastPlus
   } speed_mode_e;
 
+  typedef uvm_tlm_analysis_fifo #(i2c_item) i2c_analysis_fifo;
+
   parameter uint I2C_FMT_FIFO_DEPTH = i2c_reg_pkg::FifoDepth;
   parameter uint I2C_RX_FIFO_DEPTH  = i2c_reg_pkg::FifoDepth;
   parameter uint I2C_TX_FIFO_DEPTH  = i2c_reg_pkg::FifoDepth;
@@ -140,6 +142,7 @@ package i2c_env_pkg;
   `include "i2c_env_cfg.sv"
   `include "i2c_env_cov.sv"
   `include "i2c_virtual_sequencer.sv"
+  `include "i2c_reference_model.sv"
   `include "i2c_scoreboard.sv"
   `include "i2c_env.sv"
   `include "i2c_vseq_list.sv"

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -15,6 +15,7 @@ package i2c_env_pkg;
   import cip_base_pkg::*;
   import i2c_reg_pkg::*;
   import i2c_ral_pkg::*;
+  import i2c_pkg::*;
 
   // macro includes
   `include "dv_macros.svh"
@@ -78,22 +79,41 @@ package i2c_env_pkg;
   parameter uint NUM_ALERTS = i2c_reg_pkg::NumAlerts;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
 
-  function automatic i2c_item acq2item(bit[9:0] data);
+  function automatic i2c_item acq2item(bit [bus_params_pkg::BUS_DW-1:0] data);
     i2c_item item;
     `uvm_create_obj(i2c_item, item);
 
+    // abyte+signal use the lower 11 bits of the ACQDATA register
+    // Check unused upper bits are zero
+    `DV_CHECK_EQ(data >> 11, '0, , , $sformatf("%m"))
+
+    // Decode ACQFIFO item
     item.wdata = data[7:0];
-    if (data[9:8] == 2'b11) begin
-      item.rstart = 1;
-    end else begin
-      item.start = data[8];
-      item.stop = data[9];
-    end
-    if (item.start || item.rcont) begin
-      item.read = data[0];
+    item.signal = i2c_acq_byte_id_e'(data[10:8]);
+
+    // Set additional helper fields
+    case (item.signal)
+      3'd0: ;
+      3'd1: item.start = 1;
+      3'd2: item.stop = 1;
+      3'd3: item.rstart = 1;
+      3'd4: item.nack = 1;
+      3'd5: begin
+        item.nack = 1;
+        item.start = 1;
+      end
+      3'd6: begin
+        item.nack = 1;
+        item.stop = 1;
+      end
+      default:;
+    endcase
+    if (item.start || item.rstart) begin
+      item.addr = item.wdata[7:1];
+      item.read = item.wdata[0];
     end
     return item;
-  endfunction // acq2item
+  endfunction: acq2item
 
   // Print write data with 16 byte aligned.
   function automatic void print_host_wr_data(bit [7:0] data[$]);

--- a/hw/ip/i2c/dv/env/i2c_reference_model.sv
+++ b/hw/ip/i2c/dv/env/i2c_reference_model.sv
@@ -1,0 +1,572 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// RAL /////////////////////////////////////////////////////////////////////////
+//
+// The tb's RAL model, similar to most other OpenTitan testbenches, does not use
+// a conventional UVM prediction scheme.
+// We do not use 'implicit prediction' (auto_predict is left at 0 by default),
+// but we do not use a canonical form of 'explicit prediction' either.
+// A reg_adapter is configured to make frontdoor accesses, but we do not
+// instantiate a uvm_reg_predictor component, and instead predictions are made by
+// calling the predict() routine explicitly in the scoreboard/model.
+// The scb base-class subscribes to the relevant bus activity and provides
+// a method "process_tl_access()" which hooks all bus accesses.
+//
+// The testbench architect is then responsible for calling predict() when they
+// know the DUT's registers have changed value, or should have changed.
+// Based on the bus accesses, if the accessed CSRs don't have unusual access
+// behaviours, we can simply predict based on the data seen in the bus item.
+// This takes the possible access-controls into account, such as RC/RS/WO/W1C/W0C etc.
+// (Registers may be read or write sensitive)
+//
+// However, we still needs to model the internal effect of those accesses to try and
+// form new predictions/expectations of the DUT's behaviour.
+// This is where the reference_model comes in.
+//
+// REFMODEL /////////////////////////////////////////////////////////////////////
+//
+// This (I2C) reference model uses two class variables (exp_wr_item/exp_rd_item) to accumulate
+// multiple fifo writes (FMTFIFO,TXFIFO) and reads (ACQFIFO,RXFIFO) into completed i2c_items
+// that represent the entire expected transfer/transactions.
+//
+// As a DUT-Controller, for both writes and reads, we start forming expectations based on the
+// first write to the FMTFIFO. This first write sets the transfer direction and address. The
+// sequence item is created at this point, but it is not yet complete. We store these
+// intermediate-items across multiple CSR accesses, as follows:
+//
+// - The 'wr' items are formed solely from FMTFIFO writes, starting from a START/RSTART to the
+//   next RSTART/STOP. Additional data-only writes (after the start/address) to the FMTFIFO push
+//   bytes into the sequence item. Each item therefore represents a single I2C write transfer.
+//
+// - The 'rd' items are slightly more complex.
+//   FMTFIFO writes with readb=1 are used to specify how much data should be read from the bus
+//   (into the RXFIFO), so we update the item on these writes. For each of these writes that
+//   update the existing item, we clone the item and push it into the 'rd_pending_q[$]'. The
+//   item is only discarded/cleared when a 'stop' is seen. For reads which use RCONT to chain
+//   longer accesses, this means that multiple items are pushed into the pending queue for a
+//   single read transfer.
+//
+//   These items pushed to 'rd_pending_q[$]' tell us how many data bytes we should expect to
+//   read from the RXFIFO. The RXFIFO read handler pops an item from the rd_pending_q, and
+//   pushes data into it until it has pushed the number of bytes specified in the item (set from
+//   the value written into the fmtfifo.)
+//   After the item has been populated with the amount of data it expects, and the 'stop' bit
+//   was seen from the fmtfifo, it is pushed into the 'exp_rd_q[$]' for checking against the
+//   item captured by the monitor. If RCONT was used to create multiple pending read items in
+//   the queue, each time the byte count is reached we pop the next queued item, and add its
+//   count to the previous item.
+//
+//////////////////////////////////////////
+//
+// DUT-Controller Mode
+// - EXP : Output from RefModel, based on CSR accesses to FMTFIFO/RXFIFO
+// - OBS : Output from Monitor
+//
+// DUT-Target Mode
+// - EXP : Output from stimulus generation routines in vseq's (same as input to Agent)
+//   - cfg.read_rnd_data -> EXP : Output from RefModel, based on writes to TXFIFO
+// - OBS : Output from Monitor
+//
+//////////////////////////////////////////
+//
+class i2c_reference_model extends uvm_component;
+  `uvm_component_utils(i2c_reference_model)
+
+  i2c_env_cfg cfg;
+  i2c_reg_block ral;
+
+  /////////////////////////////////
+  //
+  // Ports
+  // Inputs <- StimulusVseq/Monitor/DUT
+  // Outputs -> Scoreboard
+
+  // Inputs
+
+  uvm_tlm_analysis_fifo #(i2c_item) target_mode_wr_stim_fifo; // Input -> Stimulus vseqs (seqr)
+  uvm_tlm_analysis_fifo #(i2c_item) target_mode_rd_stim_fifo; // Input -> Stimulus vseqs (seqr)
+  uvm_tlm_analysis_fifo #(i2c_item) target_mode_rd_obs_fifo;  // Input -> Monitor 'analysis_port'
+
+  // Outputs
+
+  uvm_analysis_port #(i2c_item) controller_mode_wr_port;
+  uvm_analysis_port #(i2c_item) controller_mode_rd_port;
+  uvm_analysis_port #(i2c_item) target_mode_wr_port;
+  uvm_analysis_port #(i2c_item) target_mode_rd_port;
+  uvm_analysis_port #(i2c_item) target_mode_wr_obs_port; // Captures reads from 'ACQDATA'
+
+  /////////////////////////////////
+  //
+  // Modelling Variables
+  //
+
+  // DUT-Controller
+  //
+  // The following local seq_items are used to construct larger transactions.
+  // We update the local items as different events occur, then push the item
+  // into a queue for checking after the end of the transaction has been detected.
+  // See the header comment for more details.
+  //
+  local i2c_item exp_wr_item;
+  local i2c_item exp_rd_item, rd_pending_item;
+  local i2c_item rd_pending_q[$]; // Helper-queue : holds partial read transactions
+  local uint rdata_cnt = 0; // Count data-bytes read in a single transfer (DUT-Controller)
+
+  // DUT-Target
+  //
+  // In Target-mode, read data is created in the stimulus vseqs by i2c_base_seq::fetch_txn(),
+  // and by default we form our expectations based on these items.
+  // However, sometimes we want to determine what our expected read data is just by looking
+  // at the inputs to the DUT (in particular, writes to TXDATA). Store all writes to txdata
+  // into this queue.
+  bit [7:0] txdata_wr[$];
+
+  `uvm_component_new
+
+  ///////////////////
+  // CLASS METHODS //
+  ///////////////////
+  //
+  // {build,connect,run,report,check}_phase()
+  //
+  // process_tl_access()
+  // update_on_read()
+  //   rdata_read()
+  // update_on_write
+  //   fmtfifo_write()
+  //
+  //////////////////////////////////////
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    ral = cfg.ral;
+
+    // seq_items used to model in-progress transactions
+    exp_rd_item = new("exp_rd_item");
+    exp_wr_item = new("exp_wr_item");
+    rd_pending_item = new("rd_pending_item");
+
+    // Input fifos
+    target_mode_wr_stim_fifo = new("target_mode_wr_stim_fifo", this);
+    target_mode_rd_stim_fifo = new("target_mode_rd_stim_fifo", this);
+    target_mode_rd_obs_fifo = new("target_mode_rd_obs_fifo", this);
+    // Output ports
+    controller_mode_wr_port = new("controller_mode_wr_port", this);
+    controller_mode_rd_port = new("controller_mode_rd_port", this);
+    target_mode_wr_obs_port = new("target_mode_wr_obs_port", this);
+    target_mode_wr_port = new("target_mode_wr_port", this);
+    target_mode_rd_port = new("target_mode_rd_port", this);
+  endfunction: build_phase
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    fork
+      forever create_wr_exp_from_stim();
+      forever create_rd_exp_from_stim();
+    join_none
+  endtask: run_phase
+
+  // Update our reference model, and hence our predictions/expectations, based on observed TileLink
+  // accesses.
+  //
+  virtual task process_tl_access(tl_seq_item item,
+                                 tl_channels_e channel,
+                                 string ral_name,
+                                 uvm_reg csr);
+
+    // The 'do_read_check' bit enables a check analagous to using 'reg.mirror(.check(UVM_CHECK))',
+    // or if reg.set_check_on_read(1) was set for the RAL model. These settings would cause the
+    // UVM RAL routines to hook do_check() upon reading from the DUT, and setting this bit will
+    // cause an equivalent check to be performed at the end of the read access handler below.
+    //
+    // For any registers where hw can modify the register's value, and our refmodel / scoreboard
+    // are unable to predict this new value before the read takes place, the code below should
+    // ensure this bit is cleared so that no check takes place.
+    bit do_read_check = 1'b1;
+
+    bit write = item.is_write();
+    bit tl_get           = (!write && channel == AddrChannel);
+    bit tl_putdata       =  (write && channel == AddrChannel); // write
+    bit tl_accessackdata = (!write && channel == DataChannel); // read
+    bit tl_accessack     =  (write && channel == DataChannel);
+
+    if (tl_putdata) begin
+      // Incoming access is a write to a valid csr, so update the RAL right away
+      void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
+
+      // Update the refmodel's state based on the observed write.
+      update_on_write(item.a_data, csr);
+    end
+
+    if (tl_accessackdata) begin
+      // Update the refmodel's state based on the observed read.
+      update_on_read(item.d_data, csr);
+
+      // Mark registers which we are currently unable to predict / unmodelled, so we don't
+      // check the read data against the RAL's mirrored value.
+      if (csr.get_name() inside
+          {"rdata",
+           "intr_state",
+           "status",
+           "host_fifo_status",
+           "target_fifo_status",
+           "acqdata",
+           "ovrd",
+           "host_fifo_config",
+           "target_fifo_config",
+           "target_nack_count",
+           "controller_events",
+           "target_events"}
+          ) begin
+        do_read_check = 1'b0;
+      end
+
+      if (do_read_check) begin
+        `DV_CHECK_EQ(`gmv(csr), item.d_data,
+          $sformatf("Read-Check of %0s failed: mirror = 0x%0x, DUT = 0x%0x",
+          csr.get_full_name(), `gmv(csr), item.d_data))
+      end else begin
+        // If we disabled the read-check, now update the RAL to take our
+        // observed value from the DUT. We're not modelling these registers,
+        // so this is the only way they are updated.
+        void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
+      end
+    end
+
+  endtask : process_tl_access
+
+
+  // Update our model and predictions based on the write event.
+  //
+  task update_on_write(bit [bus_params_pkg::BUS_DW-1:0] data, uvm_reg csr);
+    case (csr.get_name())
+
+      "target_id": begin
+        // If we write new addresses into the DUT, also update the agent's configuration
+        // with the same value(s).
+        cfg.m_i2c_agent_cfg.target_addr0 = get_field_val(ral.target_id.address0, data);
+        cfg.m_i2c_agent_cfg.target_addr1 = get_field_val(ral.target_id.address1, data);
+      end
+
+      "fdata": begin // aka. FMTFIFO
+        // Only capture items if not in reset, and HOST/CONTROLLER mode is active.
+        if (!cfg.under_reset && `gmv(ral.ctrl.enablehost)) begin
+          // Capture exp/obs data for checking.
+          fmtfifo_write(data);
+        end
+      end
+
+      "fifo_ctrl": begin
+        bit rxrst_val = get_field_val(ral.fifo_ctrl.rxrst, data);
+        if (rxrst_val) begin
+          rd_pending_q = {};
+          rd_pending_item.clear_all();
+          exp_rd_item.clear_all();
+        end
+      end
+
+      "txdata": begin
+        // If 'cfg.read_rnd_data' is set (because we are unable to accurately predict the exp
+        // due to un-modelled control flow) capture expected read-op data at the point it is
+        // written into the TXFIFO (instead of getting it directly from the stimulus generator)
+        if (cfg.read_rnd_data) txdata_wr.push_back(data[7:0]);
+      end
+
+      default:;
+    endcase
+  endtask: update_on_write
+
+  // Update our model and predictions based on the read event.
+  //
+  task update_on_read(bit [bus_params_pkg::BUS_DW-1:0] data, uvm_reg csr);
+    case (csr.get_name())
+      "rdata": begin
+        // Capture exp/obs data for checking.
+        rdata_read(data);
+      end
+
+      "acqdata": begin
+        i2c_item obs;
+        `uvm_create_obj(i2c_item, obs);
+
+        obs = acq2item(data);
+        cfg.rcvd_acq_cnt++;
+
+        `uvm_info(`gfn, $sformatf("Pushing obs[%0d] to target_mode_wr_obs_port now!",
+                                  obs.tran_id), UVM_MEDIUM)
+
+        target_mode_wr_obs_port.write(obs);
+      end
+
+      default:;
+    endcase
+  endtask: update_on_read
+
+  // Task to accumulate expected items based on writes to the FMTFIFO
+  //
+  task fmtfifo_write(bit [bus_params_pkg::BUS_DW-1:0] data);
+
+    bit [7:0] fbyte = get_field_val(ral.fdata.fbyte, data);
+    bit start = get_field_val(ral.fdata.start, data);
+    bit stop  = get_field_val(ral.fdata.stop,  data);
+    bit readb = get_field_val(ral.fdata.readb, data);
+    bit rcont = get_field_val(ral.fdata.rcont, data);
+    bit nakok = get_field_val(ral.fdata.nakok, data);
+
+    // If the start bit is set, we're writing the first indicator of a
+    // transfer (maybe a START or RSTART), where the FBYTE contains address + rw-bit.
+    if (start) begin
+
+      if (exp_wr_item.start) begin
+        // If there is an in-progress write transfer, and this fmtfifo write has start = 1,
+        // the current transfer ends (with an RSTART beginning a new transfer.)
+        exp_wr_item.rstart = 1'b1;
+        exp_wr_item.stop = 1'b1;
+        push_complete_write_txn(exp_wr_item);
+        exp_wr_item = new("exp_wr_item");
+      end
+
+      // Create a new seq_item for the transfer we are starting.
+      // This item is currently populated with address + direction from the first byte
+      // of the transfer. Upon further writes to the FMTFIFO, we will fill in the remaining
+      // fields.
+      case (fbyte[0])
+        1'b1: begin // read transfer
+          exp_rd_item = new("exp_rd_item");
+          exp_rd_item.bus_op = BusOpRead;
+          exp_rd_item.addr   = fbyte[7:1];
+          exp_rd_item.start  = 1;
+          exp_rd_item.stop   = stop;
+        end
+        1'b0: begin // write transfer
+          exp_wr_item = new("exp_wr_item");
+          exp_wr_item.bus_op = BusOpWrite;
+          exp_wr_item.addr   = fbyte[7:1];
+          exp_wr_item.start  = 1;
+          exp_wr_item.stop   = stop;
+        end
+        default:;
+      endcase
+
+    // If the start-bit was not set as part of the fmtfifo write, we may be writing part of a
+    // larger transfer. Check if there is an in-progress transfer, and amend it with any new
+    // expectations.
+    end else begin // fdata.start == 0
+
+      if (exp_wr_item.start) begin
+        // There is already an in-progress write transfer.
+
+        // Capture the data byte
+        exp_wr_item.data_q.push_back(fbyte);
+        exp_wr_item.num_data++;
+
+        // If stop was set, that concludes the in-progress write
+        // transfer. Push it to a queue for checking.
+        exp_wr_item.stop = stop;
+        if (stop) begin
+          push_complete_write_txn(exp_wr_item);
+          exp_wr_item = new("exp_wr_item");
+        end
+      end
+
+      if (exp_rd_item.start) begin
+        // There is an in-progress read transfer.
+
+        // If the 'readb' bit was set, we know more about the upcoming read transfer.
+        // Capture this information and push it to the pending queue, which can be
+        // completed when reading 'rdata' tells us what data we actually got from the bus.
+        if (readb) begin
+          i2c_item tmp_rd_item;
+
+          // First, get the number of bytes to read
+          // If RCONT is set, we add this to the previous item's count, which
+          // represents our expectation for chained-reads
+          uint num_rd_bytes = (fbyte == 8'd0) ? 256 : fbyte;
+          if (exp_rd_item.rcont && (rcont || stop)) begin
+            exp_rd_item.num_data += num_rd_bytes;
+          end else begin
+            exp_rd_item.num_data  = num_rd_bytes;
+          end
+          exp_rd_item.stop   = stop;
+          exp_rd_item.rcont  = rcont;
+          exp_rd_item.read   = readb;
+          exp_rd_item.nakok  = nakok;
+          exp_rd_item.nack   = ~exp_rd_item.rcont;
+          exp_rd_item.rstart = (exp_rd_item.stop) ? 1'b0 : 1'b1;
+          // Note. 'start' is ignored when used with 'readb'.
+
+          // The rx_overflow vseq overflows the RXFIFO by 1 word of data, so
+          // decrement here in anticipation of that.
+          if (cfg.seq_cfg.en_rx_overflow) exp_rd_item.num_data--;
+
+          // Push the expected transaction into the queue, to be handled again during
+          // reads from 'rdata'.
+          `downcast(tmp_rd_item, exp_rd_item.clone());
+          rd_pending_q.push_back(tmp_rd_item);
+
+          // If this read also set the 'stop' bit to end the transaction, clear the
+          // temporary variable we use to accumulate chained reads.
+          if (exp_rd_item.stop) exp_rd_item = new("exp_rd_item");
+
+        end
+
+      end
+    end
+
+  endtask: fmtfifo_write
+
+  // Push DUT-Controller write items to the scoreboard once all data for the transfer
+  // has been received at the fmtfifo.
+  //
+  task push_complete_write_txn(i2c_item wr_item);
+    // If we wrote to the FMTFIFO while in-reset or host/controller-mode was
+    // inactive, break here so we don't push the expectation for checking.
+    if (cfg.under_reset || !(`gmv(ral.ctrl.enablehost))) return;
+
+    begin
+      i2c_item temp_item;
+      `downcast(temp_item, wr_item.clone());
+      controller_mode_wr_port.write(temp_item);
+    end
+  endtask: push_complete_write_txn
+
+  // Complete forming our expectations of DUT-Controller read items by capturing data read from the
+  // RXFIFO and adding it into the items created when we started a read xfer in the fmtfifo.
+  //
+  task rdata_read(bit [bus_params_pkg::BUS_DW-1:0] data);
+    if (`gmv(ral.ctrl.enablehost)) begin
+
+      // First, check if we need to wait for new data from a FMTFIFO write.
+      //
+      // 1) If read data count is 0, it means the transaction has not yet started.
+      //
+      // 2) If read data count is non-zero and equals the expected number of bytes while the stop
+      //    bit is not set, it means a chained read has been issued and we need to update the
+      //    expected transaction with the amount of data in the next item.
+      //
+      // 3) After the stop bit was set in the FMTFIFO, we won't pop any seq_items from the
+      //    pending queue until we have finished reading enough data bytes to complete the
+      //    length of the read transfer. Once we complete the read and push the item for checking,
+      //    'rdata_cnt' is reset to zero, and then we enter this block and pick up the start item
+      //    of the next read.
+      if (rdata_cnt == 0 ||                        // 1)
+          rdata_cnt == rd_pending_item.num_data && // 2)
+          !rd_pending_item.stop) begin             // 3)
+
+        // Block until a FMTFIFO-write creates a new item, then update our expectations.
+        wait(rd_pending_q.size() > 0 ||
+             cfg.under_reset); // for on-the-fly reset, immediately finish task to avoid blocking
+        if (cfg.under_reset) return;
+
+        begin
+          i2c_item temp_item = rd_pending_q.pop_front();
+          if (rdata_cnt == 0) begin
+            // If our bytecount is 0, this is the first item created by the FMTFIFO write, so take
+            // the item and acculuate read data into it directly. This item contains the address
+            // etc., and further items will only contain the expected byte count for chained reads,
+            // or a stop-indicator to end the transfer.
+            rd_pending_item = temp_item;
+          end else begin
+            // If 'rdata_cnt' is non_zero, then we have already recevied at least one item from
+            // the FMTFIFO, therefore we are in a chain read (RCONT).
+            // Update the expected number of bytes (so we keep capturing new bytes into the existing
+            // item), and the stop bit if the end of the read has been marked.
+            rd_pending_item.num_data = temp_item.num_data;
+            rd_pending_item.stop = temp_item.stop;
+          end
+        end
+
+      end
+
+      rd_pending_item.data_q.push_back(data);
+      rdata_cnt++;
+
+      // If we have completed a read transaction, push it to the 'controller_mode_rd_port'
+      if (rd_pending_item.num_data == rdata_cnt &&
+          rd_pending_item.stop) begin
+        rdata_cnt = 0;
+
+        if (!cfg.under_reset) begin
+          i2c_item tmp_rd_item;
+          `downcast(tmp_rd_item, rd_pending_item.clone());
+          controller_mode_rd_port.write(tmp_rd_item);
+          // Zero-out the pending item, though we will soon drop it for a new
+          // item the next time we go around and pick up the new FMTFIFO write.
+          rd_pending_item.clear_all();
+        end
+      end
+
+    end
+
+  endtask: rdata_read
+
+  // Convert stimulus items into expectations for checking.
+  //
+  virtual task create_wr_exp_from_stim();
+    i2c_item exp_wr;
+    i2c_item wr_stim_item;
+
+    // Get the stimulus item from the vseq when it is created.
+    // Push the stimulus item directly to the scoreboard as our wr_exp item.
+    target_mode_wr_stim_fifo.get(wr_stim_item);
+    `downcast(exp_wr, wr_stim_item.clone());
+
+    target_mode_wr_port.write(exp_wr);
+  endtask: create_wr_exp_from_stim
+
+  // Convert stimulus items into expectations for checking.
+  //
+  virtual task create_rd_exp_from_stim();
+    i2c_item exp_rd;
+    i2c_item rd_stim_item;
+
+    // Get the stimulus item from the vseq when it is created.
+    target_mode_rd_stim_fifo.get(rd_stim_item);
+
+    case (cfg.read_rnd_data)
+      1'b0: begin
+        // If disabled, we use the stimulus item directly as our expectation.
+        `downcast(exp_rd, rd_stim_item.clone());
+      end
+      1'b1: begin
+        i2c_item obs_rd;
+        // If enabled, we completely ignore the stimulus item that came from the vseq.
+        // Instead, we capture data that was written to the CSRs, and create an entirely new
+        // item from that. 'txdata_wr[$]' is used to capture all write data to the TXFIFO,
+        // so we pop data from this queue to create our new expected item.
+
+        // First, block until we get the obs_item from the monitor, so we know:
+        // 1) When the transaction has finished.
+        // 2) How much data should be in the expected item.
+        begin
+          i2c_item temp;
+          target_mode_rd_obs_fifo.get(temp);
+          `downcast(obs_rd, temp.clone())
+        end
+
+        // Create NEW item.
+        `uvm_create_obj(i2c_item, exp_rd);
+        exp_rd.num_data = obs_rd.num_data;
+        repeat (obs_rd.num_data) exp_rd.data_q.push_back(txdata_wr.pop_front);
+      end
+      default:;
+    endcase
+
+    // Push the item to the scoreboard as our rd_exp item.
+    target_mode_rd_port.write(exp_rd);
+  endtask: create_rd_exp_from_stim
+
+
+  // Reset local fifos, queues and variables
+  virtual function void reset();
+    rd_pending_q = {};
+    rd_pending_item.clear_all();
+    exp_rd_item.clear_all();
+    exp_wr_item.clear_all();
+    rdata_cnt = 0;
+    txdata_wr = '{};
+  endfunction : reset
+
+endclass : i2c_reference_model

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -63,11 +63,6 @@ class i2c_scoreboard extends cip_base_scoreboard #(
   int                        obs_wr_id = 0;
   bit                        skip_acq_comp = 0; // used only for fifo_reset test
 
-  // In Target-mode, read data is created by i2c_base_seq::fetch_txn().
-  // With a random tx fifo flush event, this makes it difficult to check read path integrity.
-  // By setting 'read_rnd_data = 1', expected read data is collected right at the input of tx fifo
-  // and at the tx fifo reset event, expected read data also get flushed.
-  bit                        read_rnd_data = 0;
   bit [7:0]                  mirrored_txdata[$];
 
   // skip segment comparison
@@ -152,7 +147,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
             end
             obs_rd_item.pname = "obs_rd";
             obs_rd_item.tran_id = num_obs_rd++;
-            if (read_rnd_data) begin
+            if (cfg.read_rnd_data) begin
               // With read_rnd_data mode, only read data can be compared.
               // Other variables cannot be predictable.
               `uvm_create_obj(i2c_item, exp_rd_item);
@@ -427,7 +422,7 @@ class i2c_scoreboard extends cip_base_scoreboard #(
         end
 
         "txdata": begin
-          if (read_rnd_data) begin
+          if (cfg.read_rnd_data) begin
             mirrored_txdata.push_back(item.a_data[7:0]);
           end
         end

--- a/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_seq_cfg.sv
@@ -40,8 +40,11 @@ class i2c_seq_cfg extends uvm_object;
   uint i2c_prob_sda_interference = 30;
   uint i2c_prob_scl_interference = 70;
 
-  // bits to control fifos access
-  // set en_rx_overflow to ensure ensure rx_overflow irq is triggered
+  // The follow control bits are related to fifo accesses
+
+  // This bit makes the tb adjust its expectation based upon 1 data
+  // byte being dropped due to overflowing the RXFIFO. If set, the stimulus
+  // should ensure this exact overflow condition will occur.
   bit en_rx_overflow             = 1'b0;
   // set en_rx_threshold to ensure rx_threshold irq is triggered
   bit en_rx_threshold            = 1'b0;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_mode_toggle_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_mode_toggle_vseq.sv
@@ -77,8 +77,8 @@ class i2c_host_mode_toggle_vseq extends i2c_base_vseq;
     // Clear all interrupts
     process_interrupts();
     // Clear scoreboard FIFO
-    cfg.scb_h.target_mode_wr_exp_fifo.flush();
-    cfg.scb_h.target_mode_wr_obs_fifo.flush();
+    cfg.scoreboard.target_mode_wr_exp_fifo.flush();
+    cfg.scoreboard.target_mode_wr_obs_fifo.flush();
     // Enable scorebaord
     cfg.en_scb = 1;
     `uvm_info(`gfn, "Enable Host mode", UVM_LOW)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_acq_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_acq_vseq.sv
@@ -25,19 +25,21 @@ class i2c_target_fifo_reset_acq_vseq extends i2c_target_runtime_base_vseq;
   endtask: body
 
   virtual task end_of_stim_hook();
-    // flush acq
+    // Flush acqfifo
     ral.fifo_ctrl.acqrst.set(1'b1);
     csr_update(ral.fifo_ctrl);
 
-    // clean up sb
-    cfg.scb_h.target_mode_wr_exp_fifo.flush();
-    cfg.scb_h.target_mode_wr_obs_fifo.flush();
-    cfg.scb_h.skip_acq_comp = 1;
-
     #10us;
+
+    `uvm_info(`gfn, $sformatf("Resetting scoreboard now."), UVM_MEDIUM)
+    // Clear base-vseq id for exp_items
     tran_id = 0;
-    cfg.scb_h.obs_wr_id = 0;
-    cfg.scb_h.skip_acq_comp = 0;
+    // Flush any leftover data from the fifos
+    ral.fifo_ctrl.acqrst.set(1'b1);
+    ral.fifo_ctrl.txrst.set(1'b1);
+    csr_update(ral.fifo_ctrl);
+    // Clean up sb
+    cfg.scoreboard.reset();
 
     // random delay before the next round
     #($urandom_range(1, 5) * 10us);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_acq_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_acq_vseq.sv
@@ -12,7 +12,7 @@ class i2c_target_fifo_reset_acq_vseq extends i2c_target_runtime_base_vseq;
   virtual task pre_start();
     super.pre_start();
 
-    cfg.scb_h.read_rnd_data = 1;
+    cfg.read_rnd_data = 1;
     seq_runtime_us = 10000;
   endtask
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_tx_vseq.sv
@@ -12,7 +12,7 @@ class i2c_target_fifo_reset_tx_vseq extends i2c_target_runtime_base_vseq;
   virtual task pre_start();
     super.pre_start();
 
-    cfg.scb_h.read_rnd_data = 1;
+    cfg.read_rnd_data = 1;
     cfg.rd_pct = 3;
     seq_runtime_us = 10000;
   endtask

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_tx_vseq.sv
@@ -26,13 +26,20 @@ class i2c_target_fifo_reset_tx_vseq extends i2c_target_runtime_base_vseq;
   endtask: body
 
   virtual task end_of_stim_hook();
-    // flush acq
+    `uvm_info(`gfn, $sformatf("Flushing txfifo now."), UVM_MEDIUM)
+    // flush txfifo
     ral.fifo_ctrl.txrst.set(1'b1);
     csr_update(ral.fifo_ctrl);
 
+    #10us;
+
+    // Flush any leftover data from the fifos
+    ral.fifo_ctrl.acqrst.set(1'b1);
+    ral.fifo_ctrl.txrst.set(1'b1);
+    csr_update(ral.fifo_ctrl);
+    `uvm_info(`gfn, $sformatf("Resetting scoreboard now."), UVM_MEDIUM)
     // clean up sb
-    cfg.scb_h.target_mode_rd_obs_fifo.flush();
-    cfg.scb_h.mirrored_txdata = '{};
+    cfg.scoreboard.reset();
 
     // random delay before the next round
     #($urandom_range(1, 5) * 10us);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
@@ -2,25 +2,47 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test to check the behaviour of DUT in case of RSTART or STOP githces in Target mode
-// Sequence:
+// Test to check the DUT-Target behaviour with early assertion of RSTART or STOP
+// (We refer to this behaviour as 'glitches' in within this vseq)
+//
+// The main function of this vseq is to increase coverage of FSM state transitions
+// back to the idle/acquire states upon the early Sr/P conditions short-circuiting the
+// normal transfer/transaction process.
+//
+// Test Procedure:
 // > Initialize DUT in Target mode
 // > Randomly introduce glitches specified by enum `glitch_e`
-//   > For each gltich type, byte transmission will be interrupted causing the internal FSM to
+//   > For each glitch type, byte transmission will be interrupted causing the internal FSM to
 //     go to Idle/AcquireStart state
-// > Issue transactions after glitch to check if DUT is processing transactions as expected
+// > Issue new transactions after glitch to check if DUT is processing transactions as expected
 
 class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
-  `uvm_object_utils(i2c_target_hrst_vseq)
-  `uvm_object_new
+
+  // Control-flags used to sequence tasks
+
+  // Used to track which call to fetch_txn should avoid appending Start
+  bit skip_start = 0;
+
+  rand uint glitch_txn_num; // This indicates the index of the transaction we will glitch
 
   // Protocol glitch type
   rand glitch_e glitch;
   // 0 - Indicates Start/Stop glitch in Write transaction
   // 1 - Indicates Start/Stop glitch in Read transaction
   rand tran_type_e rw_bit;
-  // Used to track which call to fetch_txn should avoid appending Start
-  bit skip_start;
+
+  `uvm_object_utils(i2c_target_hrst_vseq)
+  `uvm_object_new
+
+  /////////////////
+  // CONSTRAINTS //
+  /////////////////
+
+  constraint num_trans_c {num_trans == 5;}
+  // Constrain the glitched transaction to allow a number of post-glitch normal
+  // transactions to test recovery.
+  constraint glitch_txn_num_c {glitch_txn_num < num_trans - 2;}
+
   constraint rw_bit_c {
     // Read state glitches covered in i2c_glitch_vseq
     rw_bit dist {ReadOnly := 0, WriteOnly := 1};
@@ -45,195 +67,242 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
      solve rw_bit before glitch;
   }
 
+  ///////////////////
+  // CLASS METHODS //
+  ///////////////////
+
   virtual task pre_start();
     super.pre_start();
     expected_intr[UnexpStop] = 1;
   endtask
 
+
   virtual task body();
-    i2c_target_base_seq m_i2c_host_seq;
-    i2c_item txn_q[$];
-    int reset_txn_num = 1;
-    bit reset_drv_st = 0;
-    bit resume_sb = 0;
-
-    // Add some config noise to stretch coverage
-    ral.ctrl.enablehost.set(1'b0);
-    ral.ctrl.enabletarget.set(1'b1);
-    csr_update(ral.ctrl);
-    ral.ctrl.enablehost.set(1'b1);
-    ral.ctrl.enabletarget.set(1'b0);
-    csr_update(ral.ctrl);
-    skip_start = 0;
-
-    // Intialize dut in device mode and agent in host mode
+    // Intialize DUT in target mode and agent in controller mode
     initialization();
+
     `uvm_info("cfg_summary",
               $sformatf("target_addr0:0x%x target_addr1:0x%x illegal_addr:0x%x num_trans:%0d",
                         target_addr0, target_addr1, illegal_addr, num_trans), UVM_MEDIUM)
+
     fork
-      begin
-        `uvm_info(`gfn, $sformatf("num_trans:%0d", num_trans), UVM_MEDIUM)
-        num_trans = 5;
-        reset_txn_num = $urandom_range(1, 3);
-
-        for (int i = 0; i < num_trans; i++) begin
-          `uvm_info("seq", $sformatf("round %0d reset_txn_num:%0d", i, reset_txn_num), UVM_MEDIUM)
-          if (i > 0) begin
-            // Wait for previous stop before proceeding with next sequence.
-            `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop,, cfg.spinwait_timeout_ns, "target_hrst_vseq")
-            cfg.m_i2c_agent_cfg.got_stop = 0;
-            // Reset i2c.TXDATA fifo after completion of glitch transaction
-            if (i == reset_txn_num + 1 && rw_bit == ReadOnly) begin
-              ral.fifo_ctrl.txrst.set(1'b1);
-              csr_update(ral.fifo_ctrl);
-            end
-          end
-          // exclude timing param update during and right after runt transaction
-          if (!(i inside {reset_txn_num, (reset_txn_num + 1)})) begin
-            get_timing_values();
-            program_registers();
-          end
-          `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
-
-          // Make sure error txn has long enough to have various transaction segment
-          if (i == reset_txn_num) begin
-            cfg.min_data = 20;
-          end
-          create_txn(txn_q);
-          // Populate transaction queue
-          if (i == reset_txn_num) begin
-            `uvm_info("seq", $sformatf("test skip comparison is set %0d", i), UVM_HIGH)
-            reset_drv_st = 1;
-            fetch_no_tb_txn(m_i2c_host_seq.req_q);
-          end else begin
-            fetch_txn(txn_q, m_i2c_host_seq.req_q, .skip_start(skip_start));
-          end
-          // Start sequence
-          fork
-            begin : main_thread
-              m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
-            end : main_thread
-            begin : monitor_reset
-              if (i == reset_txn_num) begin
-                // Wait until just before glitch is introduced and then issue monitor reset
-                // Wait_cycles variable indicates at which point monitor on TB has to be reset.
-                // During data transmission, glitch is introduced on a random bit using
-                //   <i2c_item>.wait_cycles
-                // So, monitor should be reset before the earliest glitch cycle.
-                // - For AddressByteStart the minimum is 1 cycle
-                // - For AddressByteStop, the minimum is 9 cycles (Start+Address+ACK).
-                // To prevent TB side races, +1 is added to these limits.
-                int wait_cycles = glitch inside {AddressByteStart, AddressByteStop} ? 2 : 10;
-                repeat(wait_cycles) @(posedge cfg.m_i2c_agent_cfg.vif.scl_i);
-                `uvm_info(`gfn, "Issue monitor_rst", UVM_MEDIUM)
-                // Reset monitor
-                cfg.m_i2c_agent_cfg.monitor_rst = 1;
-                cfg.clk_rst_vif.wait_clks(2);
-                cfg.m_i2c_agent_cfg.monitor_rst = 0;
-                `uvm_info(`gfn, "Clear monitor_rst", UVM_MEDIUM)
-              end
-            end : monitor_reset
-          join
-          // reset skip_start after reset_txn_num+1 iteration
-          if (i > reset_txn_num) begin
-            skip_start = 0;
-          end
-          if (i == reset_txn_num) begin
-            resume_sb = 1;
-            `uvm_info("seq", $sformatf("resume test comparison %0d", i), UVM_HIGH)
-          end
-          sent_txn_cnt++;
-        end
-      end
+      // Send all transaction stimulus
+      for (uint i = 0; i < num_trans; i++) send_trans(i);
+      // Handle normal interrupts, and gracefully stop interrupt handlers at end of test
       while (!cfg.stop_intr_handler) process_target_interrupts();
       stop_target_interrupt_handler();
-      // Wait for completion of all transactions issued in the sequence
-      begin
-        `DV_WAIT(reset_drv_st,, cfg.spinwait_timeout_ns, "tb_comp_off")
-        `DV_SPINWAIT(while (!cfg.scb_h.target_mode_wr_exp_fifo.is_empty()) begin
-                       cfg.clk_rst_vif.wait_clks(1);
-                     end,
-                     $sformatf("timed out waiting for target_mode_wr_exp_fifo size:%0d",
-                       cfg.scb_h.target_mode_wr_exp_fifo.used()),
-                     cfg.spinwait_timeout_ns)
-        cfg.scb_h.skip_target_txn_comp = 1;
-        `DV_SPINWAIT(while (!cfg.scb_h.target_mode_rd_exp_fifo.is_empty()) begin
-                       cfg.clk_rst_vif.wait_clks(1);
-                     end,
-                     $sformatf("timed out waiting for target_mode_rd_exp_fifo size:%0d",
-                       cfg.scb_h.target_mode_rd_exp_fifo.used()),
-                     cfg.spinwait_timeout_ns)
-        cfg.scb_h.skip_target_rd_comp = 1;
-        `DV_WAIT(resume_sb,, cfg.spinwait_timeout_ns, "resume_sb")
-      end
     join
   endtask : body
 
-  // Update expected transaction from ACQDATA register
-  function void push_exp_txn(ref i2c_item exp_txn);
-    // Push transaction for expected ACQ data
-    p_sequencer.target_mode_wr_exp_port.write(exp_txn);
-    exp_txn.tran_id = this.tran_id;
-    cfg.sent_acq_cnt++;
-    this.tran_id++;
-  endfunction
+
+  task send_trans(uint i);
+    // Agent-Controller sequence to generate stimulus
+    i2c_target_base_seq m_i2c_host_seq;
+
+    `uvm_info(`gfn, $sformatf("start of round %0d/%0d (glitch_txn:%0d)",
+                              i + 1, num_trans, glitch_txn_num + 1), UVM_MEDIUM)
+
+    // Wait for previous stop-condition before proceeding with next transaction.
+    if (i > 0) begin
+      `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop,, cfg.spinwait_timeout_ns, "target_hrst_vseq")
+      cfg.m_i2c_agent_cfg.got_stop = 0;
+    end
+
+    // If the glitched transaction was a Read, reset the DUT's TXFIFO after completion.
+    // This ensures there is no stale data left in the fifo for the next read transaction.
+    if (i == (glitch_txn_num + 1) && rw_bit == ReadOnly) begin
+      ral.fifo_ctrl.txrst.set(1'b1);
+      csr_update(ral.fifo_ctrl);
+    end
+
+    // Apply a new set of timing parameters for the next transaction.
+    // However, don't update new timing params during and right after the glitched runt transaction
+    if (!(i inside {glitch_txn_num, (glitch_txn_num + 1)})) begin
+      get_timing_values();
+      program_registers();
+    end
+
+    // Populate item queue that defines the upcoming transaction
+    `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
+    if (i == glitch_txn_num) begin
+      `uvm_info(`gfn, $sformatf("Creating glitched transaction stimulus as trans %0d/%0d",
+        i+1, num_trans), UVM_MEDIUM)
+      // This special routine creates the glitched transaction
+      fetch_no_tb_txn(m_i2c_host_seq.req_q);
+    end else begin
+      // Create a normal transaction
+      i2c_item txn_q[$];
+      create_txn(txn_q);
+      fetch_txn(txn_q, m_i2c_host_seq.req_q, .skip_start(skip_start));
+    end
+
+    fork
+      // Start stimulus sequence
+      m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
+      if (i == glitch_txn_num) fork
+        // Reset the monitor state just before the glitch is introduced.
+        reset_monitor();
+        // Wait for completion of the glitch transaction, and cleanup the scoreboard for further
+        // transactions to test recovery.
+        cleanup_scoreboard();
+      join
+    join_any
+
+    `uvm_info("seq", $sformatf("End of round %0d/%0d", i + 1, num_trans), UVM_MEDIUM)
+
+    // Reset 'skip_start' the iteration after the glitched transaction
+    if (i == (glitch_txn_num + 1)) skip_start = 0;
+
+    sent_txn_cnt++;
+  endtask: send_trans
+
+
+  // We need to reset some of the monitor state just before introducing the 'glitch' condition,
+  // as the environment is currently incapable of modelling this behaviour precisely.
+  // During data transmission, the glitch is introduced on a random bit using the
+  // <i2c_item>.wait_cycles field. The monitor state should be reset before the earliest
+  // possible cycle a glitch may be introduced.
+  //
+  task reset_monitor();
+    // The 'wait_cycles' variable indicates at which point the monitor should be reset.
+    // - For AddressByteStart the minimum is 1 cycle
+    // - For AddressByteStop, the minimum is 9 cycles (Start+Address+ACK).
+    // To prevent TB side races, +1 is added to these limits.
+
+    int wait_cycles = glitch inside {AddressByteStart, AddressByteStop} ? 2 : 10;
+    repeat(wait_cycles) @(posedge cfg.m_i2c_agent_cfg.vif.scl_i);
+
+    `uvm_info(`gfn, "Issuing monitor_rst now.", UVM_MEDIUM)
+    cfg.m_i2c_agent_cfg.monitor_rst = 1;
+
+    cfg.clk_rst_vif.wait_clks(2);
+
+    `uvm_info(`gfn, "Clearing monitor_rst now.", UVM_MEDIUM)
+    cfg.m_i2c_agent_cfg.monitor_rst = 0;
+  endtask: reset_monitor
+
+
+  task cleanup_scoreboard();
+    // We're now driving the glitched transaction. After the expected item is sent
+    // to the scoreboard, wait until the queue becomes empty, indicating the scoreboard has
+    // popped the item for comparison.
+
+    fork
+      if (!cfg.scoreboard.target_mode_wr_exp_fifo.is_empty()) begin
+        `uvm_info(`gfn, "Waiting for target_mode_wr_exp_fifo to become empty.", UVM_MEDIUM)
+        `DV_SPINWAIT(// WAIT_
+                     cfg.wait_fifo_not_empty(cfg.scoreboard.target_mode_wr_exp_fifo);,
+                     // MSG_
+                     "Timed-out waiting for target_mode_wr_exp_fifo to become empty.",
+                     // TIMEOUT_NS_
+                     cfg.spinwait_timeout_ns)
+
+        // Reset the scoreboard checking routine
+        `uvm_info(`gfn, "target_mode_wr_exp_fifo is empty. Resetting the scb checking routine now.",
+                  UVM_MEDIUM)
+        cfg.scoreboard.reset_dut_target_wr_compare.trigger();
+      end
+      if (!cfg.scoreboard.target_mode_rd_exp_fifo.is_empty()) begin
+        `uvm_info(`gfn, "Waiting for target_mode_rd_exp_fifo to become empty.", UVM_MEDIUM)
+        `DV_SPINWAIT(// WAIT_
+                     cfg.wait_fifo_not_empty(cfg.scoreboard.target_mode_rd_exp_fifo);,
+                     // MSG_
+                     "Timed-out waiting for target_mode_rd_exp_fifo to become empty.",
+                     // TIMEOUT_NS_
+                     cfg.spinwait_timeout_ns)
+
+        // Reset the scoreboard checking routine
+        `uvm_info(`gfn, "target_mode_rd_exp_fifo is empty. Resetting the scb checking routine now.",
+                  UVM_MEDIUM)
+        cfg.scoreboard.reset_dut_target_rd_compare.trigger();
+      end
+    join
+
+  endtask: cleanup_scoreboard
+
+
+  // Populate transaction queue with glitches based on glitch variable
+  task fetch_no_tb_txn(ref i2c_item dst_q[$]);
+
+    // Make sure error txn is long enough to have various different transaction segments
+    cfg.min_data = 20;
+    // Disable address randomization for the glitch txn
+    cfg.bad_addr_pct = 0;
+
+    // Add 'START' to the front
+    begin
+      i2c_item txn;
+      `uvm_create_obj(i2c_item, txn)
+      txn.drv_type = HostStart;
+      dst_q.push_back(txn);
+    end
+
+    `uvm_info(`gfn, $sformatf("Glitching a %0s transaction", rw_bit ? "Read" : "Write"), UVM_MEDIUM)
+    case (rw_bit)
+      ReadOnly: create_read_glitch(dst_q);
+      WriteOnly: create_write_glitch(dst_q);
+      default:;
+    endcase
+
+    // If we glitched with an unexpected start condition, we don't need to create
+    // a start condition for the next stimulus transaction that tests recovery. So skip it.
+    if (glitch == AddressByteStart) skip_start = 1;
+
+  endtask
+
 
   // Populate transaction queue to introduce Start/Stop conditions in Write Data/Address byte
   function void create_write_glitch(ref i2c_item driver_q[$]);
     i2c_item txn;
     i2c_item exp_txn;
-    bit valid_addr;
-    bit got_valid;
     `uvm_info(`gfn, $sformatf("Introducing %s glitch", glitch.name()), UVM_LOW)
+
     // Address byte
     `uvm_create_obj(i2c_item, txn)
-    `uvm_create_obj(i2c_item, exp_txn)
-    txn.wdata[7:1] = get_target_addr(); //target_addr0;
-    txn.wdata[0] = rw_bit == ReadOnly;
+    txn.wdata[7:1] = get_target_addr(); // target_addr0;
+    txn.wdata[0] = (rw_bit == ReadOnly); // dir
     txn.drv_type = HostData;
-    valid_addr = is_target_addr(txn.wdata[7:1]);
-    exp_txn.wdata = txn.wdata;
-    // Push transaction to driver queue
     driver_q.push_back(txn);
-    // Update glitch data
+
+    `uvm_create_obj(i2c_item, exp_txn)
+    exp_txn.wdata = txn.wdata;
+
+
+    // Add entry for Address glitch
     if (glitch inside {AddressByteStart, AddressByteStop}) begin
-      i2c_item  glitch_txn;
-      txn.wait_cycles = $urandom_range(2,6);
-      // Add entry for Address glitch
+
+      i2c_item glitch_txn;
       `uvm_create_obj(i2c_item, glitch_txn)
-      if (glitch == AddressByteStart) begin
-        txn.wdata = 8'hFF;
-        // Add Start glitch
-        glitch_txn.drv_type = HostRStart;
-        skip_start = 1;
-      end else begin
-        txn.wdata = 8'h00;
-        // Add Stop glitch
-        glitch_txn.drv_type = HostStop;
-      end
-      // Push transaction for driver
+      case (glitch)
+        AddressByteStart: glitch_txn.drv_type = HostRStart; // Add Start glitch
+        AddressByteStop: glitch_txn.drv_type = HostStop; // Add Stop glitch
+        default:;
+      endcase
       driver_q.push_back(glitch_txn);
+
       // There should be no entry in the ACQ FIFO for an AddressByte*
       // glitch, since this is a new transaction that never completes
       // addressing the target.
       return; // return, since glitch entry is done
+
     end else begin
-      // for valid address transaction indicate start bit
-      txn.start = 1;
+      // for valid address transaction, indicate start bit
       exp_txn.start = 1;
       push_exp_txn(exp_txn);
     end
+
     // Data byte
     `uvm_create_obj(i2c_item, txn)
-    `uvm_create_obj(i2c_item, exp_txn)
     txn.wdata = $urandom_range(1, 127);
+
+    `uvm_create_obj(i2c_item, exp_txn)
     exp_txn.wdata = 8'hDD;
+
     // Glitch in Data byte
     if (glitch inside {WriteDataByteStart, WriteDataByteStop}) begin
       txn.drv_type = HostDataNoWaitForACK;
       txn.wait_cycles = $urandom_range(2, 6);
-      if(glitch == WriteDataByteStart) begin
+      if (glitch == WriteDataByteStart) begin
         txn.wdata = 8'hFF;
       end else if (glitch == WriteDataByteStop) begin
         txn.wdata = 8'h00;
@@ -242,7 +311,7 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
       driver_q.push_back(txn);
       // Add glitch transaction
       `uvm_create_obj(i2c_item, txn)
-      if(glitch == WriteDataByteStart) begin
+      if (glitch == WriteDataByteStart) begin
         txn.drv_type = HostRStart;
         txn.rstart = 1;
         skip_start = 1;
@@ -262,6 +331,7 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
       push_exp_txn(exp_txn);
     end
   endfunction
+
 
   task create_read_glitch(ref i2c_item driver_q[$]);
     i2c_item txn;
@@ -355,23 +425,16 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
     end
   endtask
 
-  // Populate transaction queue with glitches based on glitch variable
-  task fetch_no_tb_txn(ref i2c_item dst_q[$]);
-    i2c_item txn;
-    cfg.bad_addr_pct = 0; // Disable address randomization
-    `uvm_info("seq", $sformatf("rw_bit:%0b ", bit'(rw_bit)), UVM_MEDIUM)
 
-    // Add 'START' to the front
-    `uvm_create_obj(i2c_item, txn)
-    txn.drv_type = HostStart;
-    dst_q.push_back(txn);
+  // Update expected transaction from ACQDATA register
+  function void push_exp_txn(ref i2c_item exp_txn);
+    // Push transaction for expected ACQ data
+    p_sequencer.target_mode_wr_exp_port.write(exp_txn);
+    exp_txn.tran_id = this.tran_id;
+    cfg.sent_acq_cnt++;
+    this.tran_id++;
+  endfunction
 
-    if (rw_bit == ReadOnly) begin
-      create_read_glitch(dst_q);
-    end else begin
-      create_write_glitch(dst_q);
-    end
-  endtask
 
   task stop_target_interrupt_handler();
     string id = "stop_interrupt_handler";

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_all_vseq.sv
@@ -57,7 +57,7 @@ class i2c_target_stress_all_vseq extends i2c_target_smoke_vseq;
         `uvm_info(`gfn, "\n  reset may be driven by upper_seq thus not be issued", UVM_DEBUG)
       end
       // Need to reset scoreboard whenever sequence start over regardless of dut reset
-      cfg.scb_h.reset("SOFT");
+      cfg.scoreboard.reset("SOFT");
 
       i2c_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(i2c_vseq)


### PR DESCRIPTION
This PR cleans up the architecture of the I2C scoreboard to create a clean break between comparison (scoreboard) and modelling (reference model / predictor). This change is a precursor to further DV, which builds upon the new infrastructure to model more behaviour in the refModel and less in the vseqs. The I2C DV environment in it's current form is difficult to work on, and this change should go a long way towards improving it.

This is a big PR, and is therefore difficult to judge based on the diff only. I have regressed it locally, and only seen a difference to the "i2c_target_hrst_vseq" test, which is currently passing approx 30% of the time. This vseq is quite unpleasant in the way it interacts with the agent/scoreboard, and is very brittle to change, while mainly targeting an increase in FSM transition coverage via short-circuiting normal I2C transactions with early RSTART/STOP conditions. I have made some changes to the test to begin to clean it up, but it remains partially broken, and I propose to leave it this way and to come back and cleanup later.

Definitely best review commit-by-commit, with the final commit containing the most substantial changes, and the earlier 3 being more cleanup that functional change.

Commit message from final scoreboard refactor commit:
> The current state of the I2C DV environment is not great. Very little of the
> hardware is modelled, sequence items are used to represent vastly different
> things in different contexts, and checking in the scoreboard is deliberately
> limited to a subset of fields we believe to have modelled correctly. The vseq's
> frequently intertwine stimulus and checking, and often reach into other parts of
> the DV environment (e.g. agent's monitor, scoreboard) to reset state when our
> modelling is insufficient. This is not great.
> 
> This change begins to setup a new, principled foundation for DV by tackling the
> scoreboard. Currently, as often is done in OpenTitan DV, the scoreboard performs
> two functions, both the intended checking component, but also acts as a
> reference model to try and predict future DUT behaviour. This leads to a very
> dense and overloaded module, and makes it difficult to modify while maintaining
> a clean seperation.
> This commit splits the modelling components of the existing scoreboard into a
> seperate component "i2c_reference_model" (aka predictor), leaving the scoreboard
> as a more bare-bones comparator. The scoreboard maintains a handle to the
> reference model, and is responsible for calling "process_tl_access()" based on
> observed TL-UL bus activity. Ideally the reference model would communicate with
> the scoreboard only via TLM ports/fifo, but this is not yet implemented.
> 
> This change also routes stimulus seq_items, generated by the vseq's to drive the
> agent (particularly for DUT-Target tests), first into the reference model and
> then onto the scoreboard. In some cases the items are passed-on unchanged to the
> scoreboard, but sometimes we make modifications. This architecture is maybe not
> ideal, but does clean up what we have currently, and could be iterated on.m


### Old regression results (hash) : https://reports.opentitan.org/hw/ip/i2c/dv/2024.06.03_06.49.14/report.html
![image](https://github.com/lowRISC/opentitan/assets/102029880/fbcf522b-a68f-43be-8de1-cdafa09df80d)

![image](https://github.com/lowRISC/opentitan/assets/102029880/ee7fe9e0-1dba-446c-94b7-8f9882b79348)


---

### New regression results (hash)

I2C Simulation Results
Thursday June 06 2024 09:45:36 UTC
GitHub Revision: [25ebe35d7a](https://github.com/lowrisc/opentitan/tree/25ebe35d7aceb7a065fb61fad89023cd052b4c48)
Branch: HEAD
[Testplan](https://opentitan.org/book/hw/ip/i2c/data/i2c_testplan.html)
Simulator: XCELIUM
![image](https://github.com/lowRISC/opentitan/assets/102029880/72f3232c-85df-41dd-ad76-3065c7de6601)

---
