### PR TITLE
[ast] adding memory test port controllability

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -54,13 +54,16 @@ parameter int unsigned AstLastRegOffset = (AstRegsNum-1)*4;
 
 // Memories Read-Write Margin Interface
 typedef struct packed {
+  logic          test_a;
   logic          marg_en_a;
   logic [4-1:0]  marg_a;
+  logic          test_b;
   logic          marg_en_b;
   logic [4-1:0]  marg_b;
 } dpm_rm_t;
 
 typedef struct packed {
+  logic          test;
   logic          marg_en;
   logic [4-1:0]  marg;
 } spm_rm_t;


### PR DESCRIPTION
Please propagate it to the prim_ram_*p_pkg::ram_*p_cfg_t on chip top level.