### PR TITLE
Fix `chip_sw_rom_access` / `openocd_debug_test_otp_*` LC states

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -14,7 +14,7 @@
       stage: V2
       si_stage: SV1
       bazel:["//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test"]
-      lc_states: ["PROD"]
+      lc_states: ["TEST_UNLOCKED0", "DEV", "RMA"]
       tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {

--- a/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
@@ -250,11 +250,6 @@ test_suite(
     ],
 )
 
-LC_STATES_DEBUG_DISALLOWED = [
-    CONST.LCV.PROD,
-    CONST.LCV.PROD_END,
-]
-
 [
     opentitan_test(
         name = "openocd_debug_test_otp_" + lc_state,
@@ -268,7 +263,7 @@ LC_STATES_DEBUG_DISALLOWED = [
             logging = "debug",
             needs_jtag = True,
             otp = ":img_{}_exec_disabled".format(lc_state),
-            test_cmd = " --elf={rom:elf}" + (" --expect-fail" if lc_state_val in LC_STATES_DEBUG_DISALLOWED else " "),
+            test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:debug_test",
         ),
         deps = [
@@ -282,8 +277,6 @@ LC_STATES_DEBUG_DISALLOWED = [
         CONST.LCV.TEST_UNLOCKED0,
         CONST.LCV.DEV,
         CONST.LCV.RMA,
-        CONST.LCV.PROD,
-        CONST.LCV.PROD_END,
     )
 ]
 
@@ -296,8 +289,6 @@ test_suite(
             CONST.LCV.TEST_UNLOCKED0,
             CONST.LCV.DEV,
             CONST.LCV.RMA,
-            CONST.LCV.PROD,
-            CONST.LCV.PROD_END,
         )
     ],
 )


### PR DESCRIPTION
We don't have JTAG access in `PROD`. Make the lifecycle states for these tests properly reflect that, instead of "passing when it fails" as was done before for `PROD` and `PROD_END` states.