### PR TITLE
[hmac/lint] Remove unused localparam

### DIFF
--- a/hw/ip/hmac/rtl/hmac_core.sv
+++ b/hw/ip/hmac/rtl/hmac_core.sv
@@ -56,11 +56,6 @@ module hmac_core import prim_sha2_pkg::*; (
   localparam bit [63:0] BlockSizeSHA256in64  = 64'(BlockSizeSHA256);
   localparam bit [63:0] BlockSizeSHA512in64  = 64'(BlockSizeSHA512);
 
-  localparam bit [BlockSizeBitsSHA256:0] BlockSizeBSBSHA256 =
-                                                            BlockSizeSHA256[BlockSizeBitsSHA256:0];
-  localparam bit [BlockSizeBitsSHA512:0] BlockSizeBSBSHA512 =
-                                                            BlockSizeSHA512[BlockSizeBitsSHA512:0];
-
   logic hash_start;    // generated from internal state machine
   logic hash_continue; // generated from internal state machine
   logic hash_process;  // generated from internal state machine to trigger hash


### PR DESCRIPTION
Should clear following linting errors:
```
E   PARAM_NOT_USED:   hmac_core.sv:59           Localparam 'BlockSizeBSBSHA256' not used in module 'hmac_core'                           New
E   PARAM_NOT_USED:   hmac_core.sv:61           Localparam 'BlockSizeBSBSHA512' not used in module 'hmac_core'                           New
```