### PR TITLE
[csrng] Make reseed counters always readable, allow locking down internal state access per instance

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -303,6 +303,7 @@
                   Setting this field to kMultiBitBool4True will enable reading from the !!INT_STATE_VAL register.
                   Reading the internal state of the enable instances will be enabled
                   only if the otp_en_csrng_sw_app_read input vector is set to the enable encoding.
+                  Also, the !!INT_STATE_READ_ENABLE bit of the selected instance needs to be set to true for this to work.
                   '''
           resval: false
         },
@@ -497,6 +498,40 @@
         }
       ]
     },
+    {
+      name: "INT_STATE_READ_ENABLE",
+      desc: "Internal state read enable register",
+      swaccess: "rw",
+      hwaccess: "hro",
+      regwen: "INT_STATE_READ_ENABLE_REGWEN",
+      fields: [
+        { bits: "2:0",
+          name: "INT_STATE_READ_ENABLE",
+          desc: '''
+                Per-instance internal state read enable.
+                Defines whether the internal state of the corresponding instance is readable via !!INT_STATE_VAL.
+                Note that for !!INT_STATE_VAL to provide read access to the internal state, also !!CTRL.READ_INT_STATE needs to be set to `kMultiBitBool4True`.
+                In addition, the otp_en_csrng_sw_app_read input needs to be set to `kMultiBitBool8True`.
+                '''
+          resval: 0x7
+        }
+      ]
+    },
+    {
+      name: "INT_STATE_READ_ENABLE_REGWEN",
+      desc: "Internal state read enable REGWEN register",
+      swaccess: "rw0c",
+      hwaccess: "none",
+      fields: [
+        { bits: "0",
+          desc: '''
+                INT_STATE_READ_ENABLE register configuration enable bit.
+                If this is cleared to 0, the INT_STATE_READ_ENABLE register cannot be written anymore.
+                '''
+          resval: 1,
+        }
+      ]
+    },
     { name: "INT_STATE_NUM",
       desc: "Internal state number register",
       swaccess: "rw",
@@ -539,6 +574,7 @@
                 another internal state field can be read.
                 Note that for !!INT_STATE_VAL to provide read access to the internal state, also !!CTRL.READ_INT_STATE needs to be set to `kMultiBitBool4True`.
                 In addition, the otp_en_csrng_sw_app_read input needs to be set to `kMultiBitBool8True`.
+                Also, the !!INT_STATE_READ_ENABLE bit of the selected instance needs to be set to true for this to work.
                 Otherwise, the register reads as 0.
                 '''
         }

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -51,6 +51,14 @@
       local: "false",
       expose: "true"
     },
+    # Note: All parameters below are local, they are not actually configurable.
+    # Selecting values different from the default values below might cause undefined behavior.
+    { name:    "NumApps",
+      type:    "int",
+      default: "3",
+      desc:    "Number of application interfaces",
+      local:   "true"
+    },
   ],
   interrupt_list: [
     { name: "cs_cmd_req_done"
@@ -347,6 +355,27 @@
           resval: 0xffff_ffff
         }
       ]
+    },
+    { multireg: {
+      name: "RESEED_COUNTER",
+      desc: '''
+        Reseed counter.
+
+        The per-instance reseed counter indicates the number of Generate requests that have been completed since new entropy input has been obtained with an Instantiate or a Reseed command.
+      '''
+      count: "NumApps",
+      cname: "RESEED_COUNTER",
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext:    "true",
+      fields: [
+        { bits: "31:0",
+          name: "RESEED_COUNTER",
+          desc: "Reseed Counter indicating the number of completed Generate requests since the last Instantiate or Reseed command."
+          resval: "0",
+        }
+      ],
+      },
     },
     {
       name: "SW_CMD_STS",

--- a/hw/ip/csrng/doc/registers.md
+++ b/hw/ip/csrng/doc/registers.md
@@ -3,30 +3,32 @@
 <!-- BEGIN CMDGEN util/regtool.py -d ./hw/ip/csrng/data/csrng.hjson -->
 ## Summary
 
-| Name                                        | Offset   |   Length | Description                                                                |
-|:--------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------|
-| csrng.[`INTR_STATE`](#intr_state)           | 0x0      |        4 | Interrupt State Register                                                   |
-| csrng.[`INTR_ENABLE`](#intr_enable)         | 0x4      |        4 | Interrupt Enable Register                                                  |
-| csrng.[`INTR_TEST`](#intr_test)             | 0x8      |        4 | Interrupt Test Register                                                    |
-| csrng.[`ALERT_TEST`](#alert_test)           | 0xc      |        4 | Alert Test Register                                                        |
-| csrng.[`REGWEN`](#regwen)                   | 0x10     |        4 | Register write enable for all control registers                            |
-| csrng.[`CTRL`](#ctrl)                       | 0x14     |        4 | Control register                                                           |
-| csrng.[`CMD_REQ`](#cmd_req)                 | 0x18     |        4 | Command request register                                                   |
-| csrng.[`RESEED_INTERVAL`](#reseed_interval) | 0x1c     |        4 | CSRNG maximum number of generate requests allowed between reseeds register |
-| csrng.[`RESEED_COUNTER_0`](#reseed_counter) | 0x20     |        4 | Reseed counter.                                                            |
-| csrng.[`RESEED_COUNTER_1`](#reseed_counter) | 0x24     |        4 | Reseed counter.                                                            |
-| csrng.[`RESEED_COUNTER_2`](#reseed_counter) | 0x28     |        4 | Reseed counter.                                                            |
-| csrng.[`SW_CMD_STS`](#sw_cmd_sts)           | 0x2c     |        4 | Application interface command status register                              |
-| csrng.[`GENBITS_VLD`](#genbits_vld)         | 0x30     |        4 | Generate bits returned valid register                                      |
-| csrng.[`GENBITS`](#genbits)                 | 0x34     |        4 | Generate bits returned register                                            |
-| csrng.[`INT_STATE_NUM`](#int_state_num)     | 0x38     |        4 | Internal state number register                                             |
-| csrng.[`INT_STATE_VAL`](#int_state_val)     | 0x3c     |        4 | Internal state read access register                                        |
-| csrng.[`FIPS_FORCE`](#fips_force)           | 0x40     |        4 | FIPS/CC compliance flag forcing register                                   |
-| csrng.[`HW_EXC_STS`](#hw_exc_sts)           | 0x44     |        4 | Hardware instance exception status register                                |
-| csrng.[`RECOV_ALERT_STS`](#recov_alert_sts) | 0x48     |        4 | Recoverable alert status register                                          |
-| csrng.[`ERR_CODE`](#err_code)               | 0x4c     |        4 | Hardware detection of error conditions status register                     |
-| csrng.[`ERR_CODE_TEST`](#err_code_test)     | 0x50     |        4 | Test error conditions register                                             |
-| csrng.[`MAIN_SM_STATE`](#main_sm_state)     | 0x54     |        4 | Main state machine state debug register                                    |
+| Name                                                                  | Offset   |   Length | Description                                                                |
+|:----------------------------------------------------------------------|:---------|---------:|:---------------------------------------------------------------------------|
+| csrng.[`INTR_STATE`](#intr_state)                                     | 0x0      |        4 | Interrupt State Register                                                   |
+| csrng.[`INTR_ENABLE`](#intr_enable)                                   | 0x4      |        4 | Interrupt Enable Register                                                  |
+| csrng.[`INTR_TEST`](#intr_test)                                       | 0x8      |        4 | Interrupt Test Register                                                    |
+| csrng.[`ALERT_TEST`](#alert_test)                                     | 0xc      |        4 | Alert Test Register                                                        |
+| csrng.[`REGWEN`](#regwen)                                             | 0x10     |        4 | Register write enable for all control registers                            |
+| csrng.[`CTRL`](#ctrl)                                                 | 0x14     |        4 | Control register                                                           |
+| csrng.[`CMD_REQ`](#cmd_req)                                           | 0x18     |        4 | Command request register                                                   |
+| csrng.[`RESEED_INTERVAL`](#reseed_interval)                           | 0x1c     |        4 | CSRNG maximum number of generate requests allowed between reseeds register |
+| csrng.[`RESEED_COUNTER_0`](#reseed_counter)                           | 0x20     |        4 | Reseed counter.                                                            |
+| csrng.[`RESEED_COUNTER_1`](#reseed_counter)                           | 0x24     |        4 | Reseed counter.                                                            |
+| csrng.[`RESEED_COUNTER_2`](#reseed_counter)                           | 0x28     |        4 | Reseed counter.                                                            |
+| csrng.[`SW_CMD_STS`](#sw_cmd_sts)                                     | 0x2c     |        4 | Application interface command status register                              |
+| csrng.[`GENBITS_VLD`](#genbits_vld)                                   | 0x30     |        4 | Generate bits returned valid register                                      |
+| csrng.[`GENBITS`](#genbits)                                           | 0x34     |        4 | Generate bits returned register                                            |
+| csrng.[`INT_STATE_READ_ENABLE`](#int_state_read_enable)               | 0x38     |        4 | Internal state read enable register                                        |
+| csrng.[`INT_STATE_READ_ENABLE_REGWEN`](#int_state_read_enable_regwen) | 0x3c     |        4 | Internal state read enable REGWEN register                                 |
+| csrng.[`INT_STATE_NUM`](#int_state_num)                               | 0x40     |        4 | Internal state number register                                             |
+| csrng.[`INT_STATE_VAL`](#int_state_val)                               | 0x44     |        4 | Internal state read access register                                        |
+| csrng.[`FIPS_FORCE`](#fips_force)                                     | 0x48     |        4 | FIPS/CC compliance flag forcing register                                   |
+| csrng.[`HW_EXC_STS`](#hw_exc_sts)                                     | 0x4c     |        4 | Hardware instance exception status register                                |
+| csrng.[`RECOV_ALERT_STS`](#recov_alert_sts)                           | 0x50     |        4 | Recoverable alert status register                                          |
+| csrng.[`ERR_CODE`](#err_code)                                         | 0x54     |        4 | Hardware detection of error conditions status register                     |
+| csrng.[`ERR_CODE_TEST`](#err_code_test)                               | 0x58     |        4 | Test error conditions register                                             |
+| csrng.[`MAIN_SM_STATE`](#main_sm_state)                               | 0x5c     |        4 | Main state machine state debug register                                    |
 
 ## INTR_STATE
 Interrupt State Register
@@ -136,13 +138,32 @@ Control register
 {"reg": [{"name": "ENABLE", "bits": 4, "attr": ["rw"], "rotate": 0}, {"name": "SW_APP_ENABLE", "bits": 4, "attr": ["rw"], "rotate": -90}, {"name": "READ_INT_STATE", "bits": 4, "attr": ["rw"], "rotate": -90}, {"name": "FIPS_FORCE_ENABLE", "bits": 4, "attr": ["rw"], "rotate": -90}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name              | Description                                                                                                                                                                                                                                                           |
-|:------:|:------:|:-------:|:------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 31:16  |        |         |                   | Reserved                                                                                                                                                                                                                                                              |
-| 15:12  |   rw   |   0x9   | FIPS_FORCE_ENABLE | Setting this field to kMultiBitBool4True enables forcing the FIPS/CC compliance flag to true via the [`FIPS_FORCE`](#fips_force) register.                                                                                                                            |
-|  11:8  |   rw   |   0x9   | READ_INT_STATE    | Setting this field to kMultiBitBool4True will enable reading from the [`INT_STATE_VAL`](#int_state_val) register. Reading the internal state of the enable instances will be enabled only if the otp_en_csrng_sw_app_read input vector is set to the enable encoding. |
-|  7:4   |   rw   |   0x9   | SW_APP_ENABLE     | Setting this field to kMultiBitBool4True will enable reading from the [`GENBITS`](#genbits) register. This application interface for software (register based) will be enabled only if the otp_en_csrng_sw_app_read input vector is set to the enable encoding.       |
-|  3:0   |   rw   |   0x9   | ENABLE            | Setting this field to kMultiBitBool4True will enable the CSRNG module. The modules of the entropy complex may only be enabled and disabled in a specific order, see Programmers Guide for details.                                                                    |
+|  Bits  |  Type  |  Reset  | Name                                          |
+|:------:|:------:|:-------:|:----------------------------------------------|
+| 31:16  |        |         | Reserved                                      |
+| 15:12  |   rw   |   0x9   | [FIPS_FORCE_ENABLE](#ctrl--fips_force_enable) |
+|  11:8  |   rw   |   0x9   | [READ_INT_STATE](#ctrl--read_int_state)       |
+|  7:4   |   rw   |   0x9   | [SW_APP_ENABLE](#ctrl--sw_app_enable)         |
+|  3:0   |   rw   |   0x9   | [ENABLE](#ctrl--enable)                       |
+
+### CTRL . FIPS_FORCE_ENABLE
+Setting this field to kMultiBitBool4True enables forcing the FIPS/CC compliance flag to true via the [`FIPS_FORCE`](#fips_force) register.
+
+### CTRL . READ_INT_STATE
+Setting this field to kMultiBitBool4True will enable reading from the [`INT_STATE_VAL`](#int_state_val) register.
+Reading the internal state of the enable instances will be enabled
+only if the otp_en_csrng_sw_app_read input vector is set to the enable encoding.
+Also, the [`INT_STATE_READ_ENABLE`](#int_state_read_enable) bit of the selected instance needs to be set to true for this to work.
+
+### CTRL . SW_APP_ENABLE
+Setting this field to kMultiBitBool4True will enable reading from the [`GENBITS`](#genbits) register.
+This application interface for software (register based) will be enabled
+only if the otp_en_csrng_sw_app_read input vector is set to the enable encoding.
+
+### CTRL . ENABLE
+Setting this field to kMultiBitBool4True will enable the CSRNG module. The modules
+of the entropy complex may only be enabled and disabled in a specific order, see
+Programmers Guide for details.
 
 ## CMD_REQ
 Command request register
@@ -306,9 +327,50 @@ Note that for [`GENBITS`](#genbits) to be able to deliver random numbers, also [
 In addition, the otp_en_csrng_sw_app_read input needs to be set to `kMultiBitBool8True`.
 Otherwise, the register reads as 0.
 
+## INT_STATE_READ_ENABLE
+Internal state read enable register
+- Offset: `0x38`
+- Reset default: `0x7`
+- Reset mask: `0x7`
+- Register enable: [`INT_STATE_READ_ENABLE_REGWEN`](#int_state_read_enable_regwen)
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "INT_STATE_READ_ENABLE", "bits": 3, "attr": ["rw"], "rotate": -90}, {"bits": 29}], "config": {"lanes": 1, "fontsize": 10, "vspace": 230}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                                                                   |
+|:------:|:------:|:-------:|:-----------------------------------------------------------------------|
+|  31:3  |        |         | Reserved                                                               |
+|  2:0   |   rw   |   0x7   | [INT_STATE_READ_ENABLE](#int_state_read_enable--int_state_read_enable) |
+
+### INT_STATE_READ_ENABLE . INT_STATE_READ_ENABLE
+Per-instance internal state read enable.
+Defines whether the internal state of the corresponding instance is readable via [`INT_STATE_VAL.`](#int_state_val)
+Note that for [`INT_STATE_VAL`](#int_state_val) to provide read access to the internal state, also [`CTRL.READ_INT_STATE`](#ctrl) needs to be set to `kMultiBitBool4True`.
+In addition, the otp_en_csrng_sw_app_read input needs to be set to `kMultiBitBool8True`.
+
+## INT_STATE_READ_ENABLE_REGWEN
+Internal state read enable REGWEN register
+- Offset: `0x3c`
+- Reset default: `0x1`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "INT_STATE_READ_ENABLE_REGWEN", "bits": 1, "attr": ["rw0c"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 300}}
+```
+
+|  Bits  |  Type  |  Reset  | Name                         | Description                                                                                                                                     |
+|:------:|:------:|:-------:|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:1  |        |         |                              | Reserved                                                                                                                                        |
+|   0    |  rw0c  |   0x1   | INT_STATE_READ_ENABLE_REGWEN | INT_STATE_READ_ENABLE register configuration enable bit. If this is cleared to 0, the INT_STATE_READ_ENABLE register cannot be written anymore. |
+
 ## INT_STATE_NUM
 Internal state number register
-- Offset: `0x38`
+- Offset: `0x40`
 - Reset default: `0x0`
 - Reset mask: `0xf`
 
@@ -336,7 +398,7 @@ that the [`INT_STATE_VAL`](#int_state_val) read back is accurate.
 
 ## INT_STATE_VAL
 Internal state read access register
-- Offset: `0x3c`
+- Offset: `0x44`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -359,11 +421,12 @@ can be re-written at this time (internal read pointer is also reset), and then
 another internal state field can be read.
 Note that for [`INT_STATE_VAL`](#int_state_val) to provide read access to the internal state, also [`CTRL.READ_INT_STATE`](#ctrl) needs to be set to `kMultiBitBool4True`.
 In addition, the otp_en_csrng_sw_app_read input needs to be set to `kMultiBitBool8True`.
+Also, the [`INT_STATE_READ_ENABLE`](#int_state_read_enable) bit of the selected instance needs to be set to true for this to work.
 Otherwise, the register reads as 0.
 
 ## FIPS_FORCE
 FIPS/CC compliance flag forcing register
-- Offset: `0x40`
+- Offset: `0x48`
 - Reset default: `0x0`
 - Reset mask: `0x7`
 - Register enable: [`REGWEN`](#regwen)
@@ -389,7 +452,7 @@ Note that for this to work, [`CTRL.FIPS_FORCE_ENABLE`](#ctrl) needs to be set to
 
 ## HW_EXC_STS
 Hardware instance exception status register
-- Offset: `0x44`
+- Offset: `0x4c`
 - Reset default: `0x0`
 - Reset mask: `0xffff`
 
@@ -414,7 +477,7 @@ resets the status bits.
 
 ## RECOV_ALERT_STS
 Recoverable alert status register
-- Offset: `0x48`
+- Offset: `0x50`
 - Reset default: `0x0`
 - Reset mask: `0xf01f`
 
@@ -489,7 +552,7 @@ Writing a zero resets this status bit.
 
 ## ERR_CODE
 Hardware detection of error conditions status register
-- Offset: `0x4c`
+- Offset: `0x54`
 - Reset default: `0x0`
 - Reset mask: `0x77f0ffff`
 
@@ -690,7 +753,7 @@ This bit will stay set until the next reset.
 
 ## ERR_CODE_TEST
 Test error conditions register
-- Offset: `0x50`
+- Offset: `0x58`
 - Reset default: `0x0`
 - Reset mask: `0x1f`
 - Register enable: [`REGWEN`](#regwen)
@@ -716,7 +779,7 @@ an interrupt or an alert.
 
 ## MAIN_SM_STATE
 Main state machine state debug register
-- Offset: `0x54`
+- Offset: `0x5c`
 - Reset default: `0x4e`
 - Reset mask: `0xff`
 

--- a/hw/ip/csrng/doc/registers.md
+++ b/hw/ip/csrng/doc/registers.md
@@ -13,17 +13,20 @@
 | csrng.[`CTRL`](#ctrl)                       | 0x14     |        4 | Control register                                                           |
 | csrng.[`CMD_REQ`](#cmd_req)                 | 0x18     |        4 | Command request register                                                   |
 | csrng.[`RESEED_INTERVAL`](#reseed_interval) | 0x1c     |        4 | CSRNG maximum number of generate requests allowed between reseeds register |
-| csrng.[`SW_CMD_STS`](#sw_cmd_sts)           | 0x20     |        4 | Application interface command status register                              |
-| csrng.[`GENBITS_VLD`](#genbits_vld)         | 0x24     |        4 | Generate bits returned valid register                                      |
-| csrng.[`GENBITS`](#genbits)                 | 0x28     |        4 | Generate bits returned register                                            |
-| csrng.[`INT_STATE_NUM`](#int_state_num)     | 0x2c     |        4 | Internal state number register                                             |
-| csrng.[`INT_STATE_VAL`](#int_state_val)     | 0x30     |        4 | Internal state read access register                                        |
-| csrng.[`FIPS_FORCE`](#fips_force)           | 0x34     |        4 | FIPS/CC compliance flag forcing register                                   |
-| csrng.[`HW_EXC_STS`](#hw_exc_sts)           | 0x38     |        4 | Hardware instance exception status register                                |
-| csrng.[`RECOV_ALERT_STS`](#recov_alert_sts) | 0x3c     |        4 | Recoverable alert status register                                          |
-| csrng.[`ERR_CODE`](#err_code)               | 0x40     |        4 | Hardware detection of error conditions status register                     |
-| csrng.[`ERR_CODE_TEST`](#err_code_test)     | 0x44     |        4 | Test error conditions register                                             |
-| csrng.[`MAIN_SM_STATE`](#main_sm_state)     | 0x48     |        4 | Main state machine state debug register                                    |
+| csrng.[`RESEED_COUNTER_0`](#reseed_counter) | 0x20     |        4 | Reseed counter.                                                            |
+| csrng.[`RESEED_COUNTER_1`](#reseed_counter) | 0x24     |        4 | Reseed counter.                                                            |
+| csrng.[`RESEED_COUNTER_2`](#reseed_counter) | 0x28     |        4 | Reseed counter.                                                            |
+| csrng.[`SW_CMD_STS`](#sw_cmd_sts)           | 0x2c     |        4 | Application interface command status register                              |
+| csrng.[`GENBITS_VLD`](#genbits_vld)         | 0x30     |        4 | Generate bits returned valid register                                      |
+| csrng.[`GENBITS`](#genbits)                 | 0x34     |        4 | Generate bits returned register                                            |
+| csrng.[`INT_STATE_NUM`](#int_state_num)     | 0x38     |        4 | Internal state number register                                             |
+| csrng.[`INT_STATE_VAL`](#int_state_val)     | 0x3c     |        4 | Internal state read access register                                        |
+| csrng.[`FIPS_FORCE`](#fips_force)           | 0x40     |        4 | FIPS/CC compliance flag forcing register                                   |
+| csrng.[`HW_EXC_STS`](#hw_exc_sts)           | 0x44     |        4 | Hardware instance exception status register                                |
+| csrng.[`RECOV_ALERT_STS`](#recov_alert_sts) | 0x48     |        4 | Recoverable alert status register                                          |
+| csrng.[`ERR_CODE`](#err_code)               | 0x4c     |        4 | Hardware detection of error conditions status register                     |
+| csrng.[`ERR_CODE_TEST`](#err_code_test)     | 0x50     |        4 | Test error conditions register                                             |
+| csrng.[`MAIN_SM_STATE`](#main_sm_state)     | 0x54     |        4 | Main state machine state debug register                                    |
 
 ## INTR_STATE
 Interrupt State Register
@@ -184,9 +187,35 @@ will be acknowledged with a status error.
 If the violating command was issued by a HW instance, an interrupt will
 be triggered.
 
+## RESEED_COUNTER
+Reseed counter.
+
+The per-instance reseed counter indicates the number of Generate requests that have been completed since new entropy input has been obtained with an Instantiate or a Reseed command.
+- Reset default: `0x0`
+- Reset mask: `0xffffffff`
+
+### Instances
+
+| Name             | Offset   |
+|:-----------------|:---------|
+| RESEED_COUNTER_0 | 0x20     |
+| RESEED_COUNTER_1 | 0x24     |
+| RESEED_COUNTER_2 | 0x28     |
+
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "RESEED_COUNTER", "bits": 32, "attr": ["ro"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name           | Description                                                                                                       |
+|:------:|:------:|:-------:|:---------------|:------------------------------------------------------------------------------------------------------------------|
+|  31:0  |   ro   |   0x0   | RESEED_COUNTER | Reseed Counter indicating the number of completed Generate requests since the last Instantiate or Reseed command. |
+
 ## SW_CMD_STS
 Application interface command status register
-- Offset: `0x20`
+- Offset: `0x2c`
 - Reset default: `0x0`
 - Reset mask: `0x3e`
 
@@ -235,7 +264,7 @@ Before starting to write a new command to [`SW_CMD_REQ`](#sw_cmd_req), this fiel
 
 ## GENBITS_VLD
 Generate bits returned valid register
-- Offset: `0x24`
+- Offset: `0x30`
 - Reset default: `0x0`
 - Reset mask: `0x3`
 
@@ -253,7 +282,7 @@ Generate bits returned valid register
 
 ## GENBITS
 Generate bits returned register
-- Offset: `0x28`
+- Offset: `0x34`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -279,7 +308,7 @@ Otherwise, the register reads as 0.
 
 ## INT_STATE_NUM
 Internal state number register
-- Offset: `0x2c`
+- Offset: `0x38`
 - Reset default: `0x0`
 - Reset mask: `0xf`
 
@@ -307,7 +336,7 @@ that the [`INT_STATE_VAL`](#int_state_val) read back is accurate.
 
 ## INT_STATE_VAL
 Internal state read access register
-- Offset: `0x30`
+- Offset: `0x3c`
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -334,7 +363,7 @@ Otherwise, the register reads as 0.
 
 ## FIPS_FORCE
 FIPS/CC compliance flag forcing register
-- Offset: `0x34`
+- Offset: `0x40`
 - Reset default: `0x0`
 - Reset mask: `0x7`
 - Register enable: [`REGWEN`](#regwen)
@@ -360,7 +389,7 @@ Note that for this to work, [`CTRL.FIPS_FORCE_ENABLE`](#ctrl) needs to be set to
 
 ## HW_EXC_STS
 Hardware instance exception status register
-- Offset: `0x38`
+- Offset: `0x44`
 - Reset default: `0x0`
 - Reset mask: `0xffff`
 
@@ -385,7 +414,7 @@ resets the status bits.
 
 ## RECOV_ALERT_STS
 Recoverable alert status register
-- Offset: `0x3c`
+- Offset: `0x48`
 - Reset default: `0x0`
 - Reset mask: `0xf01f`
 
@@ -460,7 +489,7 @@ Writing a zero resets this status bit.
 
 ## ERR_CODE
 Hardware detection of error conditions status register
-- Offset: `0x40`
+- Offset: `0x4c`
 - Reset default: `0x0`
 - Reset mask: `0x77f0ffff`
 
@@ -661,7 +690,7 @@ This bit will stay set until the next reset.
 
 ## ERR_CODE_TEST
 Test error conditions register
-- Offset: `0x44`
+- Offset: `0x50`
 - Reset default: `0x0`
 - Reset mask: `0x1f`
 - Register enable: [`REGWEN`](#regwen)
@@ -687,7 +716,7 @@ an interrupt or an alert.
 
 ## MAIN_SM_STATE
 Main state machine state debug register
-- Offset: `0x48`
+- Offset: `0x54`
 - Reset default: `0x4e`
 - Reset mask: `0xff`
 

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -268,6 +268,15 @@ class csrng_scoreboard extends cip_base_scoreboard #(
       end
       "reseed_interval": begin
       end
+      "reseed_counter_0": begin
+        do_read_check = 1'b0;
+      end
+      "reseed_counter_1": begin
+        do_read_check = 1'b0;
+      end
+      "reseed_counter_2": begin
+        do_read_check = 1'b0;
+      end
       "sw_cmd_sts": begin
         do_read_check = 1'b0;
       end

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -341,6 +341,10 @@ class csrng_scoreboard extends cip_base_scoreboard #(
           end
         end
       end
+      "int_state_read_enable": begin
+      end
+      "int_state_read_enable_regwen": begin
+      end
       "int_state_num": begin
       end
       "int_state_val": begin

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_intr_vseq.sv
@@ -196,6 +196,15 @@ class csrng_intr_vseq extends csrng_base_vseq;
     fifo_err_value[0] = '{"write": 1'b1, "read": 1'b1, "state": 1'b1};
     fifo_err_value[1] = '{"write": 1'b1, "read": 1'b0, "state": 1'b0};
 
+    // Turn off some SVAs which are likely triggering when injecting fatal errors.
+    `define CMD_STAGE_0 tb.dut.u_csrng_core.gen_cmd_stage[0].u_csrng_cmd_stage
+    `define CMD_STAGE_1 tb.dut.u_csrng_core.gen_cmd_stage[1].u_csrng_cmd_stage
+    `define CMD_STAGE_2 tb.dut.u_csrng_core.gen_cmd_stage[2].u_csrng_cmd_stage
+    `define HIER_PATH(prefix, suffix) `"prefix.suffix`"
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_0, CsrngCmdStageGenbitsFifoPushExpected_A));
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_1, CsrngCmdStageGenbitsFifoPushExpected_A));
+    $assertoff(0, `HIER_PATH(`CMD_STAGE_2, CsrngCmdStageGenbitsFifoPushExpected_A));
+
     // Enable CSRNG
     ral.ctrl.enable.set(prim_mubi_pkg::MuBi4True);
     csr_update(.csr(ral.ctrl));
@@ -315,6 +324,16 @@ class csrng_intr_vseq extends csrng_base_vseq;
     endcase // case (cfg.which_fatal_err)
     csr_rd(.ptr(ral.err_code), .value(backdoor_err_code_val));
     cov_vif.cg_err_code_sample(.err_code(backdoor_err_code_val));
+
+    // Turn SVAs back on.
+    $asserton(0, `HIER_PATH(`CMD_STAGE_0, CsrngCmdStageGenbitsFifoPushExpected_A));
+    $asserton(0, `HIER_PATH(`CMD_STAGE_1, CsrngCmdStageGenbitsFifoPushExpected_A));
+    $asserton(0, `HIER_PATH(`CMD_STAGE_2, CsrngCmdStageGenbitsFifoPushExpected_A));
+    `undef CMD_STAGE_0
+    `undef CMD_STAGE_1
+    `undef CMD_STAGE_2
+    `undef HIER_PATH
+
   endtask // test_cs_fatal_err
 
   task body();

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -340,6 +340,7 @@ module csrng_core import csrng_pkg::*; #(
   logic                        state_db_reg_rd_id_pulse;
   logic [StateId-1:0]          state_db_reg_rd_id;
   logic [31:0]                 state_db_reg_rd_val;
+  logic [NApps-1:0]            int_state_read_enable;
 
   logic [30:0]                 err_code_test_bit;
   logic                        ctr_drbg_upd_es_ack;
@@ -1226,7 +1227,7 @@ module csrng_core import csrng_pkg::*; #(
   assign state_db_reg_rd_id_pulse = reg2hw.int_state_num.qe;
   assign hw2reg.int_state_val.d = state_db_reg_rd_val;
   assign state_db_is_dump_en = cs_enable_fo[40] && read_int_state && efuse_sw_app_enable[1];
-
+  assign int_state_read_enable = reg2hw.int_state_read_enable.q;
 
   csrng_state_db #(
     .NApps(NApps),
@@ -1264,6 +1265,7 @@ module csrng_core import csrng_pkg::*; #(
     .state_db_sts_ack_o(state_db_sts_ack),
     .state_db_sts_sts_o(state_db_sts_sts),
     .state_db_sts_id_o(state_db_sts_id),
+    .int_state_read_enable_i(int_state_read_enable),
 
     .reseed_counter_o(reseed_counter)
   );

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -108,6 +108,10 @@ package csrng_reg_pkg;
   } csrng_reg2hw_genbits_reg_t;
 
   typedef struct packed {
+    logic [2:0]  q;
+  } csrng_reg2hw_int_state_read_enable_reg_t;
+
+  typedef struct packed {
     logic [3:0]  q;
     logic        qe;
   } csrng_reg2hw_int_state_num_reg_t;
@@ -339,14 +343,15 @@ package csrng_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    csrng_reg2hw_intr_state_reg_t intr_state; // [181:178]
-    csrng_reg2hw_intr_enable_reg_t intr_enable; // [177:174]
-    csrng_reg2hw_intr_test_reg_t intr_test; // [173:166]
-    csrng_reg2hw_alert_test_reg_t alert_test; // [165:162]
-    csrng_reg2hw_ctrl_reg_t ctrl; // [161:146]
-    csrng_reg2hw_cmd_req_reg_t cmd_req; // [145:113]
-    csrng_reg2hw_reseed_interval_reg_t reseed_interval; // [112:80]
-    csrng_reg2hw_genbits_reg_t genbits; // [79:47]
+    csrng_reg2hw_intr_state_reg_t intr_state; // [184:181]
+    csrng_reg2hw_intr_enable_reg_t intr_enable; // [180:177]
+    csrng_reg2hw_intr_test_reg_t intr_test; // [176:169]
+    csrng_reg2hw_alert_test_reg_t alert_test; // [168:165]
+    csrng_reg2hw_ctrl_reg_t ctrl; // [164:149]
+    csrng_reg2hw_cmd_req_reg_t cmd_req; // [148:116]
+    csrng_reg2hw_reseed_interval_reg_t reseed_interval; // [115:83]
+    csrng_reg2hw_genbits_reg_t genbits; // [82:50]
+    csrng_reg2hw_int_state_read_enable_reg_t int_state_read_enable; // [49:47]
     csrng_reg2hw_int_state_num_reg_t int_state_num; // [46:42]
     csrng_reg2hw_int_state_val_reg_t int_state_val; // [41:9]
     csrng_reg2hw_fips_force_reg_t fips_force; // [8:6]
@@ -382,14 +387,16 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 2c;
   parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 30;
   parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] CSRNG_FIPS_FORCE_OFFSET = 7'h 40;
-  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 44;
-  parameter logic [BlockAw-1:0] CSRNG_RECOV_ALERT_STS_OFFSET = 7'h 48;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 4c;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 50;
-  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STATE_OFFSET = 7'h 54;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_READ_ENABLE_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_READ_ENABLE_REGWEN_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 44;
+  parameter logic [BlockAw-1:0] CSRNG_FIPS_FORCE_OFFSET = 7'h 48;
+  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 4c;
+  parameter logic [BlockAw-1:0] CSRNG_RECOV_ALERT_STS_OFFSET = 7'h 50;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 54;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 58;
+  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STATE_OFFSET = 7'h 5c;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] CSRNG_INTR_TEST_RESVAL = 4'h 0;
@@ -426,6 +433,8 @@ package csrng_reg_pkg;
     CSRNG_SW_CMD_STS,
     CSRNG_GENBITS_VLD,
     CSRNG_GENBITS,
+    CSRNG_INT_STATE_READ_ENABLE,
+    CSRNG_INT_STATE_READ_ENABLE_REGWEN,
     CSRNG_INT_STATE_NUM,
     CSRNG_INT_STATE_VAL,
     CSRNG_FIPS_FORCE,
@@ -437,7 +446,7 @@ package csrng_reg_pkg;
   } csrng_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CSRNG_PERMIT [22] = '{
+  parameter logic [3:0] CSRNG_PERMIT [24] = '{
     4'b 0001, // index[ 0] CSRNG_INTR_STATE
     4'b 0001, // index[ 1] CSRNG_INTR_ENABLE
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
@@ -452,14 +461,16 @@ package csrng_reg_pkg;
     4'b 0001, // index[11] CSRNG_SW_CMD_STS
     4'b 0001, // index[12] CSRNG_GENBITS_VLD
     4'b 1111, // index[13] CSRNG_GENBITS
-    4'b 0001, // index[14] CSRNG_INT_STATE_NUM
-    4'b 1111, // index[15] CSRNG_INT_STATE_VAL
-    4'b 0001, // index[16] CSRNG_FIPS_FORCE
-    4'b 0011, // index[17] CSRNG_HW_EXC_STS
-    4'b 0011, // index[18] CSRNG_RECOV_ALERT_STS
-    4'b 1111, // index[19] CSRNG_ERR_CODE
-    4'b 0001, // index[20] CSRNG_ERR_CODE_TEST
-    4'b 0001  // index[21] CSRNG_MAIN_SM_STATE
+    4'b 0001, // index[14] CSRNG_INT_STATE_READ_ENABLE
+    4'b 0001, // index[15] CSRNG_INT_STATE_READ_ENABLE_REGWEN
+    4'b 0001, // index[16] CSRNG_INT_STATE_NUM
+    4'b 1111, // index[17] CSRNG_INT_STATE_VAL
+    4'b 0001, // index[18] CSRNG_FIPS_FORCE
+    4'b 0011, // index[19] CSRNG_HW_EXC_STS
+    4'b 0011, // index[20] CSRNG_RECOV_ALERT_STS
+    4'b 1111, // index[21] CSRNG_ERR_CODE
+    4'b 0001, // index[22] CSRNG_ERR_CODE_TEST
+    4'b 0001  // index[23] CSRNG_MAIN_SM_STATE
   };
 
 endpackage

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -7,6 +7,7 @@
 package csrng_reg_pkg;
 
   // Param list
+  parameter int NumApps = 3;
   parameter int NumAlerts = 2;
 
   // Address widths within the block
@@ -143,6 +144,10 @@ package csrng_reg_pkg;
       logic        de;
     } cs_fatal_err;
   } csrng_hw2reg_intr_state_reg_t;
+
+  typedef struct packed {
+    logic [31:0] d;
+  } csrng_hw2reg_reseed_counter_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -350,7 +355,8 @@ package csrng_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [177:170]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [273:266]
+    csrng_hw2reg_reseed_counter_mreg_t [2:0] reseed_counter; // [265:170]
     csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [169:162]
     csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [161:160]
     csrng_hw2reg_genbits_reg_t genbits; // [159:128]
@@ -370,17 +376,20 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_CTRL_OFFSET = 7'h 14;
   parameter logic [BlockAw-1:0] CSRNG_CMD_REQ_OFFSET = 7'h 18;
   parameter logic [BlockAw-1:0] CSRNG_RESEED_INTERVAL_OFFSET = 7'h 1c;
-  parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 20;
-  parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 24;
-  parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 28;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 2c;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 30;
-  parameter logic [BlockAw-1:0] CSRNG_FIPS_FORCE_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] CSRNG_RECOV_ALERT_STS_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 40;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 44;
-  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STATE_OFFSET = 7'h 48;
+  parameter logic [BlockAw-1:0] CSRNG_RESEED_COUNTER_0_OFFSET = 7'h 20;
+  parameter logic [BlockAw-1:0] CSRNG_RESEED_COUNTER_1_OFFSET = 7'h 24;
+  parameter logic [BlockAw-1:0] CSRNG_RESEED_COUNTER_2_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] CSRNG_FIPS_FORCE_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 44;
+  parameter logic [BlockAw-1:0] CSRNG_RECOV_ALERT_STS_OFFSET = 7'h 48;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 4c;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 50;
+  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STATE_OFFSET = 7'h 54;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] CSRNG_INTR_TEST_RESVAL = 4'h 0;
@@ -391,6 +400,12 @@ package csrng_reg_pkg;
   parameter logic [1:0] CSRNG_ALERT_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] CSRNG_ALERT_TEST_RECOV_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] CSRNG_ALERT_TEST_FATAL_ALERT_RESVAL = 1'h 0;
+  parameter logic [31:0] CSRNG_RESEED_COUNTER_0_RESVAL = 32'h 0;
+  parameter logic [31:0] CSRNG_RESEED_COUNTER_0_RESEED_COUNTER_0_RESVAL = 32'h 0;
+  parameter logic [31:0] CSRNG_RESEED_COUNTER_1_RESVAL = 32'h 0;
+  parameter logic [31:0] CSRNG_RESEED_COUNTER_1_RESEED_COUNTER_1_RESVAL = 32'h 0;
+  parameter logic [31:0] CSRNG_RESEED_COUNTER_2_RESVAL = 32'h 0;
+  parameter logic [31:0] CSRNG_RESEED_COUNTER_2_RESEED_COUNTER_2_RESVAL = 32'h 0;
   parameter logic [1:0] CSRNG_GENBITS_VLD_RESVAL = 2'h 0;
   parameter logic [31:0] CSRNG_GENBITS_RESVAL = 32'h 0;
   parameter logic [31:0] CSRNG_INT_STATE_VAL_RESVAL = 32'h 0;
@@ -405,6 +420,9 @@ package csrng_reg_pkg;
     CSRNG_CTRL,
     CSRNG_CMD_REQ,
     CSRNG_RESEED_INTERVAL,
+    CSRNG_RESEED_COUNTER_0,
+    CSRNG_RESEED_COUNTER_1,
+    CSRNG_RESEED_COUNTER_2,
     CSRNG_SW_CMD_STS,
     CSRNG_GENBITS_VLD,
     CSRNG_GENBITS,
@@ -419,7 +437,7 @@ package csrng_reg_pkg;
   } csrng_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CSRNG_PERMIT [19] = '{
+  parameter logic [3:0] CSRNG_PERMIT [22] = '{
     4'b 0001, // index[ 0] CSRNG_INTR_STATE
     4'b 0001, // index[ 1] CSRNG_INTR_ENABLE
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
@@ -428,17 +446,20 @@ package csrng_reg_pkg;
     4'b 0011, // index[ 5] CSRNG_CTRL
     4'b 1111, // index[ 6] CSRNG_CMD_REQ
     4'b 1111, // index[ 7] CSRNG_RESEED_INTERVAL
-    4'b 0001, // index[ 8] CSRNG_SW_CMD_STS
-    4'b 0001, // index[ 9] CSRNG_GENBITS_VLD
-    4'b 1111, // index[10] CSRNG_GENBITS
-    4'b 0001, // index[11] CSRNG_INT_STATE_NUM
-    4'b 1111, // index[12] CSRNG_INT_STATE_VAL
-    4'b 0001, // index[13] CSRNG_FIPS_FORCE
-    4'b 0011, // index[14] CSRNG_HW_EXC_STS
-    4'b 0011, // index[15] CSRNG_RECOV_ALERT_STS
-    4'b 1111, // index[16] CSRNG_ERR_CODE
-    4'b 0001, // index[17] CSRNG_ERR_CODE_TEST
-    4'b 0001  // index[18] CSRNG_MAIN_SM_STATE
+    4'b 1111, // index[ 8] CSRNG_RESEED_COUNTER_0
+    4'b 1111, // index[ 9] CSRNG_RESEED_COUNTER_1
+    4'b 1111, // index[10] CSRNG_RESEED_COUNTER_2
+    4'b 0001, // index[11] CSRNG_SW_CMD_STS
+    4'b 0001, // index[12] CSRNG_GENBITS_VLD
+    4'b 1111, // index[13] CSRNG_GENBITS
+    4'b 0001, // index[14] CSRNG_INT_STATE_NUM
+    4'b 1111, // index[15] CSRNG_INT_STATE_VAL
+    4'b 0001, // index[16] CSRNG_FIPS_FORCE
+    4'b 0011, // index[17] CSRNG_HW_EXC_STS
+    4'b 0011, // index[18] CSRNG_RECOV_ALERT_STS
+    4'b 1111, // index[19] CSRNG_ERR_CODE
+    4'b 0001, // index[20] CSRNG_ERR_CODE_TEST
+    4'b 0001  // index[21] CSRNG_MAIN_SM_STATE
   };
 
 endpackage

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -52,9 +52,9 @@ module csrng_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [18:0] reg_we_check;
+  logic [21:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(19)
+    .OneHotWidth(22)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -164,6 +164,12 @@ module csrng_reg_top (
   logic reseed_interval_we;
   logic [31:0] reseed_interval_qs;
   logic [31:0] reseed_interval_wd;
+  logic reseed_counter_0_re;
+  logic [31:0] reseed_counter_0_qs;
+  logic reseed_counter_1_re;
+  logic [31:0] reseed_counter_1_qs;
+  logic reseed_counter_2_re;
+  logic [31:0] reseed_counter_2_qs;
   logic sw_cmd_sts_cmd_rdy_qs;
   logic sw_cmd_sts_cmd_ack_qs;
   logic [2:0] sw_cmd_sts_cmd_sts_qs;
@@ -779,6 +785,57 @@ module csrng_reg_top (
     .qs     (reseed_interval_qs)
   );
   assign reg2hw.reseed_interval.qe = reseed_interval_qe;
+
+
+  // Subregister 0 of Multireg reseed_counter
+  // R[reseed_counter_0]: V(True)
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_reseed_counter_0 (
+    .re     (reseed_counter_0_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.reseed_counter[0].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .ds     (),
+    .qs     (reseed_counter_0_qs)
+  );
+
+
+  // Subregister 1 of Multireg reseed_counter
+  // R[reseed_counter_1]: V(True)
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_reseed_counter_1 (
+    .re     (reseed_counter_1_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.reseed_counter[1].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .ds     (),
+    .qs     (reseed_counter_1_qs)
+  );
+
+
+  // Subregister 2 of Multireg reseed_counter
+  // R[reseed_counter_2]: V(True)
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_reseed_counter_2 (
+    .re     (reseed_counter_2_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.reseed_counter[2].d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .ds     (),
+    .qs     (reseed_counter_2_qs)
+  );
 
 
   // R[sw_cmd_sts]: V(False)
@@ -2048,7 +2105,7 @@ module csrng_reg_top (
 
 
 
-  logic [18:0] addr_hit;
+  logic [21:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CSRNG_INTR_STATE_OFFSET);
@@ -2059,17 +2116,20 @@ module csrng_reg_top (
     addr_hit[ 5] = (reg_addr == CSRNG_CTRL_OFFSET);
     addr_hit[ 6] = (reg_addr == CSRNG_CMD_REQ_OFFSET);
     addr_hit[ 7] = (reg_addr == CSRNG_RESEED_INTERVAL_OFFSET);
-    addr_hit[ 8] = (reg_addr == CSRNG_SW_CMD_STS_OFFSET);
-    addr_hit[ 9] = (reg_addr == CSRNG_GENBITS_VLD_OFFSET);
-    addr_hit[10] = (reg_addr == CSRNG_GENBITS_OFFSET);
-    addr_hit[11] = (reg_addr == CSRNG_INT_STATE_NUM_OFFSET);
-    addr_hit[12] = (reg_addr == CSRNG_INT_STATE_VAL_OFFSET);
-    addr_hit[13] = (reg_addr == CSRNG_FIPS_FORCE_OFFSET);
-    addr_hit[14] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
-    addr_hit[15] = (reg_addr == CSRNG_RECOV_ALERT_STS_OFFSET);
-    addr_hit[16] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
-    addr_hit[17] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
-    addr_hit[18] = (reg_addr == CSRNG_MAIN_SM_STATE_OFFSET);
+    addr_hit[ 8] = (reg_addr == CSRNG_RESEED_COUNTER_0_OFFSET);
+    addr_hit[ 9] = (reg_addr == CSRNG_RESEED_COUNTER_1_OFFSET);
+    addr_hit[10] = (reg_addr == CSRNG_RESEED_COUNTER_2_OFFSET);
+    addr_hit[11] = (reg_addr == CSRNG_SW_CMD_STS_OFFSET);
+    addr_hit[12] = (reg_addr == CSRNG_GENBITS_VLD_OFFSET);
+    addr_hit[13] = (reg_addr == CSRNG_GENBITS_OFFSET);
+    addr_hit[14] = (reg_addr == CSRNG_INT_STATE_NUM_OFFSET);
+    addr_hit[15] = (reg_addr == CSRNG_INT_STATE_VAL_OFFSET);
+    addr_hit[16] = (reg_addr == CSRNG_FIPS_FORCE_OFFSET);
+    addr_hit[17] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
+    addr_hit[18] = (reg_addr == CSRNG_RECOV_ALERT_STS_OFFSET);
+    addr_hit[19] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
+    addr_hit[20] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
+    addr_hit[21] = (reg_addr == CSRNG_MAIN_SM_STATE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -2095,7 +2155,10 @@ module csrng_reg_top (
                (addr_hit[15] & (|(CSRNG_PERMIT[15] & ~reg_be))) |
                (addr_hit[16] & (|(CSRNG_PERMIT[16] & ~reg_be))) |
                (addr_hit[17] & (|(CSRNG_PERMIT[17] & ~reg_be))) |
-               (addr_hit[18] & (|(CSRNG_PERMIT[18] & ~reg_be)))));
+               (addr_hit[18] & (|(CSRNG_PERMIT[18] & ~reg_be))) |
+               (addr_hit[19] & (|(CSRNG_PERMIT[19] & ~reg_be))) |
+               (addr_hit[20] & (|(CSRNG_PERMIT[20] & ~reg_be))) |
+               (addr_hit[21] & (|(CSRNG_PERMIT[21] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -2149,19 +2212,22 @@ module csrng_reg_top (
   assign reseed_interval_we = addr_hit[7] & reg_we & !reg_error;
 
   assign reseed_interval_wd = reg_wdata[31:0];
-  assign genbits_vld_re = addr_hit[9] & reg_re & !reg_error;
-  assign genbits_re = addr_hit[10] & reg_re & !reg_error;
-  assign int_state_num_we = addr_hit[11] & reg_we & !reg_error;
+  assign reseed_counter_0_re = addr_hit[8] & reg_re & !reg_error;
+  assign reseed_counter_1_re = addr_hit[9] & reg_re & !reg_error;
+  assign reseed_counter_2_re = addr_hit[10] & reg_re & !reg_error;
+  assign genbits_vld_re = addr_hit[12] & reg_re & !reg_error;
+  assign genbits_re = addr_hit[13] & reg_re & !reg_error;
+  assign int_state_num_we = addr_hit[14] & reg_we & !reg_error;
 
   assign int_state_num_wd = reg_wdata[3:0];
-  assign int_state_val_re = addr_hit[12] & reg_re & !reg_error;
-  assign fips_force_we = addr_hit[13] & reg_we & !reg_error;
+  assign int_state_val_re = addr_hit[15] & reg_re & !reg_error;
+  assign fips_force_we = addr_hit[16] & reg_we & !reg_error;
 
   assign fips_force_wd = reg_wdata[2:0];
-  assign hw_exc_sts_we = addr_hit[14] & reg_we & !reg_error;
+  assign hw_exc_sts_we = addr_hit[17] & reg_we & !reg_error;
 
   assign hw_exc_sts_wd = reg_wdata[15:0];
-  assign recov_alert_sts_we = addr_hit[15] & reg_we & !reg_error;
+  assign recov_alert_sts_we = addr_hit[18] & reg_we & !reg_error;
 
   assign recov_alert_sts_enable_field_alert_wd = reg_wdata[0];
 
@@ -2180,7 +2246,7 @@ module csrng_reg_top (
   assign recov_alert_sts_cmd_stage_invalid_cmd_seq_alert_wd = reg_wdata[14];
 
   assign recov_alert_sts_cmd_stage_reseed_cnt_alert_wd = reg_wdata[15];
-  assign err_code_test_we = addr_hit[17] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[20] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
 
@@ -2198,14 +2264,17 @@ module csrng_reg_top (
     reg_we_check[8] = 1'b0;
     reg_we_check[9] = 1'b0;
     reg_we_check[10] = 1'b0;
-    reg_we_check[11] = int_state_num_we;
+    reg_we_check[11] = 1'b0;
     reg_we_check[12] = 1'b0;
-    reg_we_check[13] = fips_force_gated_we;
-    reg_we_check[14] = hw_exc_sts_we;
-    reg_we_check[15] = recov_alert_sts_we;
-    reg_we_check[16] = 1'b0;
-    reg_we_check[17] = err_code_test_gated_we;
-    reg_we_check[18] = 1'b0;
+    reg_we_check[13] = 1'b0;
+    reg_we_check[14] = int_state_num_we;
+    reg_we_check[15] = 1'b0;
+    reg_we_check[16] = fips_force_gated_we;
+    reg_we_check[17] = hw_exc_sts_we;
+    reg_we_check[18] = recov_alert_sts_we;
+    reg_we_check[19] = 1'b0;
+    reg_we_check[20] = err_code_test_gated_we;
+    reg_we_check[21] = 1'b0;
   end
 
   // Read data return
@@ -2258,37 +2327,49 @@ module csrng_reg_top (
       end
 
       addr_hit[8]: begin
+        reg_rdata_next[31:0] = reseed_counter_0_qs;
+      end
+
+      addr_hit[9]: begin
+        reg_rdata_next[31:0] = reseed_counter_1_qs;
+      end
+
+      addr_hit[10]: begin
+        reg_rdata_next[31:0] = reseed_counter_2_qs;
+      end
+
+      addr_hit[11]: begin
         reg_rdata_next[1] = sw_cmd_sts_cmd_rdy_qs;
         reg_rdata_next[2] = sw_cmd_sts_cmd_ack_qs;
         reg_rdata_next[5:3] = sw_cmd_sts_cmd_sts_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = genbits_vld_genbits_vld_qs;
         reg_rdata_next[1] = genbits_vld_genbits_fips_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[13]: begin
         reg_rdata_next[31:0] = genbits_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[14]: begin
         reg_rdata_next[3:0] = int_state_num_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[15]: begin
         reg_rdata_next[31:0] = int_state_val_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[16]: begin
         reg_rdata_next[2:0] = fips_force_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[17]: begin
         reg_rdata_next[15:0] = hw_exc_sts_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[18]: begin
         reg_rdata_next[0] = recov_alert_sts_enable_field_alert_qs;
         reg_rdata_next[1] = recov_alert_sts_sw_app_enable_field_alert_qs;
         reg_rdata_next[2] = recov_alert_sts_read_int_state_field_alert_qs;
@@ -2300,7 +2381,7 @@ module csrng_reg_top (
         reg_rdata_next[15] = recov_alert_sts_cmd_stage_reseed_cnt_alert_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = err_code_sfifo_cmd_err_qs;
         reg_rdata_next[1] = err_code_sfifo_genbits_err_qs;
         reg_rdata_next[2] = err_code_sfifo_cmdreq_err_qs;
@@ -2329,11 +2410,11 @@ module csrng_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[20]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[21]: begin
         reg_rdata_next[7:0] = main_sm_state_qs;
       end
 

--- a/hw/ip/csrng/rtl/csrng_state_db.sv
+++ b/hw/ip/csrng/rtl/csrng_state_db.sv
@@ -47,6 +47,7 @@ module csrng_state_db import csrng_pkg::*; #(
   output logic               state_db_sts_ack_o,
   output csrng_cmd_sts_e     state_db_sts_sts_o,
   output logic [StateId-1:0] state_db_sts_id_o,
+  input logic [NApps-1:0]    int_state_read_enable_i,
 
   // The reseed counters are always readable via register interface.
   output logic [NApps-1:0][31:0] reseed_counter_o
@@ -114,7 +115,8 @@ module csrng_state_db import csrng_pkg::*; #(
     assign int_st_out_sel[rd] = (state_db_rd_inst_id_i == rd);
     assign int_st_dump_sel[rd] = (int_st_dump_id_q == rd);
     assign internal_states_out[rd] = int_st_out_sel[rd] ? internal_states_q[rd] : '0;
-    assign internal_states_dump[rd] = int_st_dump_sel[rd] ? internal_states_q[rd] : '0;
+    assign internal_states_dump[rd] =
+        int_st_dump_sel[rd] && int_state_read_enable_i[rd] ? internal_states_q[rd] : '0;
   end
 
   // since only one of the internal states is active at a time, a

--- a/hw/ip/csrng/rtl/csrng_state_db.sv
+++ b/hw/ip/csrng/rtl/csrng_state_db.sv
@@ -46,7 +46,10 @@ module csrng_state_db import csrng_pkg::*; #(
   output logic [31:0]        state_db_reg_rd_val_o,
   output logic               state_db_sts_ack_o,
   output csrng_cmd_sts_e     state_db_sts_sts_o,
-  output logic [StateId-1:0] state_db_sts_id_o
+  output logic [StateId-1:0] state_db_sts_id_o,
+
+  // The reseed counters are always readable via register interface.
+  output logic [NApps-1:0][31:0] reseed_counter_o
 );
 
   localparam int InternalStateWidth = 2+KeyLen+BlkLen+CtrLen;
@@ -168,6 +171,11 @@ module csrng_state_db import csrng_pkg::*; #(
          state_db_reg_rd_id_pulse_i ? state_db_reg_rd_id_i :
          int_st_dump_id_q;
 
+  // The reseed counters are always readable via register interface.
+  for (genvar i = 0; i < NApps; i++) begin : gen_reseed_counter
+    assign reseed_counter_o[i] = internal_states_q[i][31:0];
+  end
+
   //--------------------------------------------
   // write state logic
   //--------------------------------------------
@@ -212,7 +220,6 @@ module csrng_state_db import csrng_pkg::*; #(
   assign state_db_sts_sts_o = state_db_sts_sts_q;
   assign state_db_sts_id_o = state_db_sts_id_q;
   assign state_db_wr_req_rdy_o = 1'b1;
-
 
   // Assertions
   `ASSERT_KNOWN(IntStOutSelOneHot_A, $onehot(int_st_out_sel))


### PR DESCRIPTION
As discussed here: https://github.com/lowRISC/opentitan/issues/21141#issuecomment-2082289550