### PR TITLE
[i2c,dv] I2C precise perf test

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -17,6 +17,10 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
 
   virtual i2c_if  vif;
 
+  // Performance Monitoring Variables
+  uvm_event start_perf_monitor, stop_perf_monitor;
+  time period_q[$];
+
   bit     host_scl_start;
   bit     host_scl_stop;
   bit     host_scl_force_high;
@@ -101,6 +105,10 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int(i2c_host_max_data_rw,                      UVM_DEFAULT)
   `uvm_object_utils_end
 
-  `uvm_object_new
+  function new(string name = "");
+    super.new(name);
+    start_perf_monitor = new("start_perf_monitor");
+    stop_perf_monitor = new("stop_perf_monitor");
+  endfunction
 
 endclass : i2c_agent_cfg

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -521,7 +521,7 @@
               - Ensure that SCL frequency during data bytes matches expectation
             '''
       stage: V2
-      tests: ["i2c_host_perf"]
+      tests: ["i2c_host_perf", "i2c_host_perf_precise"]
     }
     {
       name: host_mode_clock_stretching

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -521,7 +521,7 @@
               - Ensure that SCL frequency during data bytes matches expectation
             '''
       stage: V2
-      tests: []
+      tests: ["i2c_host_perf"]
     }
     {
       name: host_mode_clock_stretching
@@ -547,7 +547,7 @@
               - Ensure that any documented restrictions are consistent with the behaviour.
             '''
       stage: V2
-      tests: []
+      tests: ["i2c_host_stretch_timeout"]
     }
     {
       name: target_mode_tx_stretch_ctrl

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -36,6 +36,7 @@ filesets:
       - seq_lib/i2c_host_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_fifo_full_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_perf_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_host_perf_precise_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_stretch_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_error_intr_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_host_stress_all_vseq.sv: {is_include_file: true}

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_perf_precise_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_perf_precise_vseq.sv
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test builds on the existing host_perf test, but utilizes an additional monitor mode to
+// measure the bit-period of each data bit throughout a transfer. ACK-bits are excluded by
+// controlling the sampling point inside the monitor.
+// See i2c_monitor::perf_monitor() for implementation details.
+//
+class i2c_host_perf_precise_vseq extends i2c_host_perf_vseq;
+  `uvm_object_utils(i2c_host_perf_precise_vseq)
+  `uvm_object_new
+
+  // Limit the number of runs to shorten the length of the test a bit
+  // (the host_perf_vseq parent class with 5 runs takes 48m in total!)
+  constraint num_trans_c {num_trans == 1;}
+
+  // Override the parent class's implementation to make a more precise measurement
+  // of the bus performance.
+  virtual task perf_monitor();
+    fork
+      begin
+        string str = "";
+        // Watch for the performance monitor process to complete, then check the values it
+        // has captured.
+        cfg.m_i2c_agent_cfg.stop_perf_monitor.wait_trigger();
+
+        `uvm_info(`gfn, $sformatf("clk_period_ps=%0d ps", cfg.clk_rst_vif.clk_period_ps), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("coerced_scl_period=%0d cycles", coerced_scl_period), UVM_HIGH)
+
+        // LOG
+        str = {str, "i2c_host_perf_precise_vseq saw the following SCL periods:"};
+        foreach (cfg.m_i2c_agent_cfg.period_q[i]) begin
+          str = {str, $sformatf("\n[%0d] %t", i, cfg.m_i2c_agent_cfg.period_q[i])};
+        end
+        `uvm_info(`gfn, str, UVM_MEDIUM)
+
+        // CHECK
+        foreach (cfg.m_i2c_agent_cfg.period_q[i]) begin
+          // We captured the period using $realtime. Convert it back to cycles for comparison
+          uint obs_scl_period = uint'(real'(cfg.m_i2c_agent_cfg.period_q[i]) /
+                                      real'(cfg.clk_rst_vif.clk_period_ps * 1ps));
+          `uvm_info(`gfn, $sformatf("obs_scl_period[%0d]=%0d cycles", i, obs_scl_period), UVM_DEBUG)
+
+          if (obs_scl_period != coerced_scl_period) begin
+            `uvm_error(`gfn,
+                       $sformatf({"Observed SCL period[%0d] (%0d cycles) did not match expected!",
+                                  " (%0d cycles)"}, i, obs_scl_period, coerced_scl_period))
+          end
+        end
+      end
+    join_none
+  endtask
+
+  virtual task post_start(); endtask
+
+endclass : i2c_host_perf_precise_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -17,6 +17,7 @@
 `include "i2c_host_rx_oversample_vseq.sv"
 `include "i2c_host_fifo_full_vseq.sv"
 `include "i2c_host_perf_vseq.sv"
+`include "i2c_host_perf_precise_vseq.sv"
 `include "i2c_host_stretch_timeout_vseq.sv"
 `include "i2c_host_error_intr_vseq.sv"
 `include "i2c_host_stress_all_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -116,6 +116,11 @@
     }
 
     {
+      name: i2c_host_perf_precise
+      uvm_test_seq: i2c_host_perf_precise_vseq
+    }
+
+    {
       name: i2c_host_stretch_timeout
       uvm_test_seq: i2c_host_stretch_timeout_vseq
     }


### PR DESCRIPTION
> ~~This PR builds on changes from #23528 and #23192, which should be merged first. Only the final 2 commits are new.~~

This PR adds a new test to more-precisely measure the I2C performance in DUT-Controller mode. This removes the fudge-factor from the existing host_perf_test. This test is mapped to the "host_mode_config_perf" TestPoint, and may be used as a basis for further expanding future coverage crosses against performance / timing configuration.

An additional commit maps a previously-unmapped testpoint to an existing test.

Goes towards #23077 