### PR TITLE
[silicon_creator, hmac] Permit big- and little-endian results

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -239,6 +239,7 @@ opentitan_test(
     deps = [
         ":hmac",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/testing:hexstr",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:error",
     ],

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -35,10 +35,22 @@ typedef struct hmac_digest {
  * Initializes the HMAC in SHA256 mode.
  *
  * This function resets the HMAC module to clear the digest register.
+ * It then configures the HMAC block in SHA256 mode with digest output
+ * in the requested endianness.
+ *
+ * @param big_endian Whether or not to initialize the peripheral for big-endian
+ *                   results.
+ */
+void hmac_sha256_init_endian(bool big_endian_digest);
+
+/**
+ * Initializes the HMAC in SHA256 mode with little-endian output.
+ *
+ * This function resets the HMAC module to clear the digest register.
  * It then configures the HMAC block in SHA256 mode with little endian
  * data input and digest output.
  */
-void hmac_sha256_init(void);
+inline void hmac_sha256_init(void) { hmac_sha256_init_endian(false); }
 
 /**
  * Sends `len` bytes from `data` to the SHA2-256 function.

--- a/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
@@ -62,6 +62,10 @@ class HmacTest : public rom_test::RomTest {
                        {
                            {HMAC_INTR_STATE_HMAC_DONE_BIT, true},
                        });
+    // The `final` function checks the DIGEST_SWAP bit to know
+    // the endianness of the result.  We're testing little-endian
+    // in the unit test.
+    EXPECT_ABS_READ32(base_ + HMAC_CFG_REG_OFFSET, 0u);
 
     // Set expectations explicitly to ensure that the registers
     // are contiguous.


### PR DESCRIPTION
To ease implementation of SLH-DSA (#23144), it is convenient to collect SHA256 digests in big-endian order.