### PR TITLE
[spi_device] Block flash write commands when busy

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -284,6 +284,7 @@ module spi_device
   // Important status bits for tracking in the upload module
   logic cmd_sync_status_busy;
   logic cmd_sync_status_wel;
+  logic sck_status_busy;
 
   // Read Status input and broadcast
   logic sck_status_busy_set;       // set by HW (upload)
@@ -1114,6 +1115,8 @@ module spi_device
 
     .cmd_info_i   (cmd_info),
 
+    .sck_status_busy_i(sck_status_busy),
+
     .io_mode_o    (sub_iomode[IoModeCmdParse]),
 
     .sel_dp_o          (cmd_dp_sel),
@@ -1250,6 +1253,7 @@ module spi_device
     .inclk_status_commit_i  (s2p_data_valid),
     .cmd_sync_status_busy_o (cmd_sync_status_busy),
     .cmd_sync_status_wel_o  (cmd_sync_status_wel),
+    .sck_status_busy_o      (sck_status_busy),
     .csb_busy_broadcast_o   (csb_status_busy_broadcast) // SCK domain
   );
 

--- a/hw/ip/spi_device/rtl/spid_status.sv
+++ b/hw/ip/spi_device/rtl/spid_status.sv
@@ -76,6 +76,9 @@ module spid_status
   output logic cmd_sync_status_busy_o,
   output logic cmd_sync_status_wel_o,
 
+  // Represents current busy bit, for cmdparse to block commands.
+  output logic sck_status_busy_o,
+
   // indicator of busy for blocking passthrough
   output logic csb_busy_broadcast_o // CSB domain
 );
@@ -216,6 +219,7 @@ module spid_status
 
   assign cmd_sync_status_busy_o = sck_status_to_commit[BitBusy];
   assign cmd_sync_status_wel_o = sck_status_to_commit[BitWe];
+  assign sck_status_busy_o = sck_status_committed[BitBusy];
 
   // Staged to Committed at CSb de-assertion
   // SW and the passthrough gate only receive the final values of


### PR DESCRIPTION
Block uploads, WREN, WRDI, EN4B, and EX4B when the busy bit is set. The state of the device should not change until the busy bit is cleared.

This may be especially important to avoid the payload buffer changing its contents while software is processing a command.

Fixes #21700 