### PR TITLE
[top_earlgrey,prim_ram_*_pkg] Connect memory test port

### DIFF
--- a/hw/ip/prim/rtl/prim_ram_1p_pkg.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_pkg.sv
@@ -6,6 +6,7 @@
 package prim_ram_1p_pkg;
 
   typedef struct packed {
+    logic       test;
     logic       cfg_en;
     logic [3:0] cfg;
   } cfg_t;

--- a/hw/ip/prim/rtl/prim_ram_2p_pkg.sv
+++ b/hw/ip/prim/rtl/prim_ram_2p_pkg.sv
@@ -6,6 +6,7 @@
 package prim_ram_2p_pkg;
 
   typedef struct packed {
+    logic       test;
     logic       cfg_en;
     logic [3:0] cfg;
   } cfg_t;

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -788,10 +788,12 @@ module chip_earlgrey_asic #(
   // conversion from ast structure to memory centric structures
   assign ram_1p_cfg = '{
     ram_cfg: '{
+                test:   ast_ram_1p_cfg.test,
                 cfg_en: ast_ram_1p_cfg.marg_en,
                 cfg:    ast_ram_1p_cfg.marg
               },
     rf_cfg:  '{
+                test:   ast_rf_cfg.test,
                 cfg_en: ast_rf_cfg.marg_en,
                 cfg:    ast_rf_cfg.marg
               }
@@ -799,10 +801,12 @@ module chip_earlgrey_asic #(
 
   assign usb_ram_1p_cfg = '{
     ram_cfg: '{
+                test:   ast_ram_1p_cfg.test,
                 cfg_en: ast_ram_1p_cfg.marg_en,
                 cfg:    ast_ram_1p_cfg.marg
               },
     rf_cfg:  '{
+                test:   ast_rf_cfg.test,
                 cfg_en: ast_rf_cfg.marg_en,
                 cfg:    ast_rf_cfg.marg
               }
@@ -812,10 +816,12 @@ module chip_earlgrey_asic #(
   // assign spi_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_lcfg, ram_2p_cfg_i.b_ram_lcfg};
   assign spi_ram_2p_cfg = '{
     a_ram_lcfg: '{
+                   test:   ast_ram_2p_lcfg.test_a,
                    cfg_en: ast_ram_2p_lcfg.marg_en_a,
                    cfg:    ast_ram_2p_lcfg.marg_a
                  },
     b_ram_lcfg: '{
+                   test:   ast_ram_2p_lcfg.test_b,
                    cfg_en: ast_ram_2p_lcfg.marg_en_b,
                    cfg:    ast_ram_2p_lcfg.marg_b
                  },

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -743,10 +743,12 @@ module chip_earlgrey_cw310 #(
   // conversion from ast structure to memory centric structures
   assign ram_1p_cfg = '{
     ram_cfg: '{
+                test:   ast_ram_1p_cfg.test,
                 cfg_en: ast_ram_1p_cfg.marg_en,
                 cfg:    ast_ram_1p_cfg.marg
               },
     rf_cfg:  '{
+                test:   ast_rf_cfg.test,
                 cfg_en: ast_rf_cfg.marg_en,
                 cfg:    ast_rf_cfg.marg
               }
@@ -754,10 +756,12 @@ module chip_earlgrey_cw310 #(
 
   assign usb_ram_1p_cfg = '{
     ram_cfg: '{
+                test:   ast_ram_1p_cfg.test,
                 cfg_en: ast_ram_1p_cfg.marg_en,
                 cfg:    ast_ram_1p_cfg.marg
               },
     rf_cfg:  '{
+                test:   ast_rf_cfg.test,
                 cfg_en: ast_rf_cfg.marg_en,
                 cfg:    ast_rf_cfg.marg
               }
@@ -767,10 +771,12 @@ module chip_earlgrey_cw310 #(
   // assign spi_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_lcfg, ram_2p_cfg_i.b_ram_lcfg};
   assign spi_ram_2p_cfg = '{
     a_ram_lcfg: '{
+                   test:   ast_ram_2p_lcfg.test_a,
                    cfg_en: ast_ram_2p_lcfg.marg_en_a,
                    cfg:    ast_ram_2p_lcfg.marg_a
                  },
     b_ram_lcfg: '{
+                   test:   ast_ram_2p_lcfg.test_b,
                    cfg_en: ast_ram_2p_lcfg.marg_en_b,
                    cfg:    ast_ram_2p_lcfg.marg_b
                  },

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -734,10 +734,12 @@ module chip_earlgrey_cw340 #(
   // conversion from ast structure to memory centric structures
   assign ram_1p_cfg = '{
     ram_cfg: '{
+                test:   ast_ram_1p_cfg.test,
                 cfg_en: ast_ram_1p_cfg.marg_en,
                 cfg:    ast_ram_1p_cfg.marg
               },
     rf_cfg:  '{
+                test:   ast_rf_cfg.test,
                 cfg_en: ast_rf_cfg.marg_en,
                 cfg:    ast_rf_cfg.marg
               }
@@ -745,10 +747,12 @@ module chip_earlgrey_cw340 #(
 
   assign usb_ram_1p_cfg = '{
     ram_cfg: '{
+                test:   ast_ram_1p_cfg.test,
                 cfg_en: ast_ram_1p_cfg.marg_en,
                 cfg:    ast_ram_1p_cfg.marg
               },
     rf_cfg:  '{
+                test:   ast_rf_cfg.test,
                 cfg_en: ast_rf_cfg.marg_en,
                 cfg:    ast_rf_cfg.marg
               }
@@ -758,10 +762,12 @@ module chip_earlgrey_cw340 #(
   // assign spi_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_lcfg, ram_2p_cfg_i.b_ram_lcfg};
   assign spi_ram_2p_cfg = '{
     a_ram_lcfg: '{
+                   test:   ast_ram_2p_lcfg.test_a,
                    cfg_en: ast_ram_2p_lcfg.marg_en_a,
                    cfg:    ast_ram_2p_lcfg.marg_a
                  },
     b_ram_lcfg: '{
+                   test:   ast_ram_2p_lcfg.test_b,
                    cfg_en: ast_ram_2p_lcfg.marg_en_b,
                    cfg:    ast_ram_2p_lcfg.marg_b
                  },

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -579,10 +579,12 @@ module chip_${top["name"]}_${target["name"]} #(
   // conversion from ast structure to memory centric structures
   assign ram_1p_cfg = '{
     ram_cfg: '{
+                test:   ast_ram_1p_cfg.test,
                 cfg_en: ast_ram_1p_cfg.marg_en,
                 cfg:    ast_ram_1p_cfg.marg
               },
     rf_cfg:  '{
+                test:   ast_rf_cfg.test,
                 cfg_en: ast_rf_cfg.marg_en,
                 cfg:    ast_rf_cfg.marg
               }
@@ -590,10 +592,12 @@ module chip_${top["name"]}_${target["name"]} #(
 
   assign usb_ram_1p_cfg = '{
     ram_cfg: '{
+                test:   ast_ram_1p_cfg.test,
                 cfg_en: ast_ram_1p_cfg.marg_en,
                 cfg:    ast_ram_1p_cfg.marg
               },
     rf_cfg:  '{
+                test:   ast_rf_cfg.test,
                 cfg_en: ast_rf_cfg.marg_en,
                 cfg:    ast_rf_cfg.marg
               }
@@ -603,10 +607,12 @@ module chip_${top["name"]}_${target["name"]} #(
   // assign spi_ram_2p_cfg = {10'h000, ram_2p_cfg_i.a_ram_lcfg, ram_2p_cfg_i.b_ram_lcfg};
   assign spi_ram_2p_cfg = '{
     a_ram_lcfg: '{
+                   test:   ast_ram_2p_lcfg.test_a,
                    cfg_en: ast_ram_2p_lcfg.marg_en_a,
                    cfg:    ast_ram_2p_lcfg.marg_a
                  },
     b_ram_lcfg: '{
+                   test:   ast_ram_2p_lcfg.test_b,
                    cfg_en: ast_ram_2p_lcfg.marg_en_b,
                    cfg:    ast_ram_2p_lcfg.marg_b
                  },


### PR DESCRIPTION
This adds a memory test port and connects it to the AST interface added in PR #23531.