### PR TITLE
[rom] Support both big- and little-endian digests in the HMAC driver.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -32,13 +32,20 @@ typedef struct hmac_digest {
 } hmac_digest_t;
 
 /**
- * Initializes the HMAC in SHA256 mode.
+ * HMAC block configuration.
+ */
+typedef struct hmac_config {
+  bool big_endian_digest;
+} hmac_config_t;
+
+/**
+ * Initializes the HMAC block in SHA256 mode.
  *
  * This function resets the HMAC module to clear the digest register.
  * It then configures the HMAC block in SHA256 mode with little endian
  * data input and digest output.
  */
-void hmac_sha256_init(void);
+void hmac_sha256_init(hmac_config_t config);
 
 /**
  * Sends `len` bytes from `data` to the SHA2-256 function.

--- a/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
@@ -82,9 +82,10 @@ class HmacTest : public rom_test::RomTest {
 class Sha256InitTest : public HmacTest {};
 
 TEST_F(Sha256InitTest, Initialize) {
-  ExpectInit();
+  hmac_config_t config = {.big_endian_digest = false};
+  ExpectInit(config);
 
-  hmac_sha256_init();
+  hmac_sha256_init(config);
 }
 
 class Sha256UpdateTest : public HmacTest {};

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.cc
@@ -6,7 +6,9 @@
 
 namespace rom_test {
 extern "C" {
-void hmac_sha256_init(void) { MockHmac::Instance().sha256_init(); }
+void hmac_sha256_init(hmac_config_t config) {
+  MockHmac::Instance().sha256_init(config);
+}
 
 void hmac_sha256_update(const void *data, size_t len) {
   MockHmac::Instance().sha256_update(data, len);

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -239,7 +239,7 @@ static void compute_keymgr_owner_int_binding(manuf_certgen_inputs_t *inputs) {
  */
 static void compute_keymgr_owner_binding(manuf_certgen_inputs_t *inputs) {
   hmac_digest_t combined_measurements;
-  hmac_sha256_init();
+  hmac_sha256_init((hmac_config_t){.big_endian_digest = false});
   hmac_sha256_update((unsigned char *)inputs->owner_measurement,
                      kDiceMeasurementSizeInBytes);
   hmac_sha256_update((unsigned char *)inputs->owner_manifest_measurement,
@@ -326,7 +326,7 @@ static status_t log_hash_of_all_certs(ujson_t *uj) {
   uint32_t cert_size;
   uint32_t page_offset = 0;
   serdes_sha256_hash_t hash;
-  hmac_sha256_init();
+  hmac_sha256_init((hmac_config_t){.big_endian_digest = false});
 
   // Push DICE certificates into the hash (each resides on a separate page).
   TRY(hash_certificate(&kFlashCtrlInfoPageUdsCertificate, 0, NULL));

--- a/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
@@ -51,7 +51,7 @@ extern const char _chip_info_start[];
 
 // We hash the ROM using the SHA256 algorithm and print the hash to the console.
 status_t hash_rom(void) {
-  hmac_sha256_init();
+  hmac_sha256_init((hmac_config_t){.big_endian_digest = false});
   hmac_sha256_update((void *)TOP_EARLGREY_ROM_BASE_ADDR, kGoldenRomSizeBytes);
   hmac_digest_t rom_hash;
   hmac_sha256_final(&rom_hash);

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -303,7 +303,7 @@ static rom_error_t rom_verify(const manifest_t *manifest,
   memset(boot_measurements.rom_ext.data, (int)rnd_uint32(),
          sizeof(boot_measurements.rom_ext.data));
   // Add anti-rollback poisoning word to measurement.
-  hmac_sha256_init();
+  hmac_sha256_init((hmac_config_t){.big_endian_digest = false});
   hmac_sha256_update(anti_rollback, anti_rollback_len);
   HARDENED_CHECK_GE(manifest->security_version,
                     boot_data.min_security_version_rom_ext);
@@ -440,7 +440,7 @@ static rom_error_t rom_measure_otp_partitions(
   // These is no need to harden these data copies as any poisoning of the OTP
   // measurements will result in the derivation of a different UDS identity
   // which will not be endorsed. Hence we save the cycles of using sec_mmio.
-  hmac_sha256_init();
+  hmac_sha256_init((hmac_config_t){.big_endian_digest = false});
   static_assert(
       (OTP_CTRL_CREATOR_SW_CFG_DIGEST_CREATOR_SW_CFG_DIGEST_FIELD_WIDTH *
        OTP_CTRL_CREATOR_SW_CFG_DIGEST_MULTIREG_COUNT / 8) == sizeof(uint64_t),

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -237,7 +237,7 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
   memset(boot_measurements.bl0.data, (int)rnd_uint32(),
          sizeof(boot_measurements.bl0.data));
 
-  hmac_sha256_init();
+  hmac_sha256_init((hmac_config_t){.big_endian_digest = false});
   // Hash usage constraints.
   manifest_usage_constraints_t usage_constraints_from_hw;
   sigverify_usage_constraints_get(manifest->usage_constraints.selector_bits,


### PR DESCRIPTION
Replacement for https://github.com/lowRISC/opentitan/pull/23527
Part of https://github.com/lowRISC/opentitan/issues/23144

To allow SPHINCS+ to use HMAC in big-endian order without disrupting existing infrastructure, this adds a configuration option to the HMAC driver that lets the caller set the digest-endianness configuration bit. Because that bit only changes the order of bytes within words (not words themselves), we then have to check the bit in `final` to read the words in the right order. Thanks @cfrantz for your help on this one!

Overall the code size of `hmac.c` actually goes down as a result of this change (302B -> 284B) because `hmac_256` takes up less space. Compilers are mysterious beasts.