### PR TITLE
[dv/tlt] Fix rom_e2e_static_critical

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -691,9 +691,15 @@
     {
       name: rom_e2e_static_critical
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:new_rules"]
+      sw_images: [
+        "//sw/device/silicon_creator/rom/e2e:rom_e2e_static_critical:1:new_rules"
+        "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma:4"
+      ]
       en_run_modes: ["sw_test_mode_mask_rom"]
-      run_opts: ["+sw_test_timeout_ns=20000000"]
+      run_opts: [
+        "+sw_test_timeout_ns=40000000",
+        "+use_otp_image=OtpTypeCustom",
+      ]
       run_timeout_mins: 240
     }
     {


### PR DESCRIPTION
Increase the timeout. ECDSA sigverify takes longer compared to the previous RSA implementation.