### PR TITLE
[dv/tlt] Fix flash_ctrl_lc_rw_en_test.

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
@@ -67,7 +67,7 @@ class chip_sw_flash_ctrl_lc_rw_en_vseq extends chip_sw_base_vseq;
 
     for (int i = 0; i < 5; i++) begin
       `DV_CHECK_EQ_FATAL(get_rw_en_signals(i), lc_ctrl_pkg::Off,
-                         "Mismatch for exepcted rw_en value [%0d] in Scrap LC state", i)
+                         "Mismatch for expected rw_en value [%0d] in Scrap LC state", i)
     end
 
     override_test_status_and_finish(.passed(1'b 1));


### PR DESCRIPTION
The test had issues with handling of the keymgr configuration. The DIF was throwing an error when trying to advance the state of the keymgr when the device is in unprovisioned state.

The test was refactored to make it easier to maintain in the future.