### PR TITLE
[dv/tlt] Fix Coremark test.

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1655,9 +1655,9 @@
       sw_images: ["//third_party/coremark/top_earlgrey:coremark_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+en_uart_logger=1",
-                 "+sw_test_timeout_ns=100_000_000"]
+                 "+sw_test_timeout_ns=200_000_000"]
       reseed: 1
-      run_timeout_mins: 180
+      run_timeout_mins: 240
     }
     {
       name: chip_sw_pwrmgr_b2b_sleep_reset_req


### PR DESCRIPTION
Increase timeout to solve test failure.

Fixes: https://github.com/lowRISC/opentitan/issues/23325