### PR TITLE
[flash_ctrl/rtl] Host data XOR address infection

### DIFF
--- a/doc/contributing/hw/comportability/README.md
+++ b/doc/contributing/hw/comportability/README.md
@@ -301,6 +301,7 @@ The following standardised countermeasures are defined:
 | SCRAMBLE       | The asset is scrambled | CONFIG, MEM
 | INTEGRITY      | The asset has integrity protection from a computed value such as a checksum | CONFIG, REG, MEM
 | READBACK       | A readback check is performed to validate that the asset has been correctly modified or fetched | MEM
+| ADDR_INFECTION | The asset is infected using the read address | MEM
 | CONSISTENCY    | This asset is checked for consistency other than by associating integrity bits | CTRL, RST
 | DIGEST         | Similar to integrity but more computationally intensive, implying a full hash function | CONFIG, REG, MEM
 | LC_GATED       | Access to the asset is qualified by life-cycle state | REG, MEM, CONSTANTS, CONFIG

--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl.sv.tpl
@@ -1300,6 +1300,7 @@ module flash_ctrl
   tlul_adapter_sram #(
     .SramAw(BusAddrW),
     .SramDw(BusWidth),
+    .SramBusBankAW(BusBankAddrW),
     .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1),
@@ -1307,7 +1308,8 @@ module flash_ctrl
     .EnableRspIntgGen(1),
     .EnableDataIntgGen(0),
     .EnableDataIntgPt(1),
-    .SecFifoPtr(1)
+    .SecFifoPtr(1),
+    .DataXorAddr(1)
   ) u_tl_adapter_eflash (
     .clk_i,
     .rst_ni,

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy.sv
@@ -90,7 +90,8 @@ module flash_phy
   logic [ProgTypes-1:0] prog_type_avail;
 
   // common interface
-  logic [BusFullWidth-1:0] rd_data [NumBanks];
+  logic [BusFullWidth-1:0] rd_data_host [NumBanks];
+  logic [BusFullWidth-1:0] rd_data_ctrl [NumBanks];
   logic [NumBanks-1:0] rd_err;
   logic [NumBanks-1:0] spurious_acks;
 
@@ -133,7 +134,7 @@ module flash_phy
   assign flash_ctrl_o.rd_done = rd_done[ctrl_bank_sel];
   assign flash_ctrl_o.prog_done = prog_done[ctrl_bank_sel];
   assign flash_ctrl_o.erase_done = erase_done[ctrl_bank_sel];
-  assign flash_ctrl_o.rd_data = rd_data[ctrl_bank_sel];
+  assign flash_ctrl_o.rd_data = rd_data_ctrl[ctrl_bank_sel];
   assign flash_ctrl_o.rd_err = rd_err[ctrl_bank_sel];
   assign flash_ctrl_o.init_busy = init_busy;
   assign flash_ctrl_o.prog_intg_err = |prog_intg_err;
@@ -239,7 +240,7 @@ module flash_phy
       .clr_i   (1'b0),
       .wvalid_i(host_req_done[bank]),
       .wready_o(host_rsp_avail[bank]),
-      .wdata_i ({rd_err[bank], rd_data[bank]}),
+      .wdata_i ({rd_err[bank], rd_data_host[bank]}),
       .depth_o (),
       .full_o (),
       .rvalid_o(host_rsp_vld[bank]),
@@ -285,7 +286,8 @@ module flash_phy
       .rd_done_o(rd_done[bank]),
       .prog_done_o(prog_done[bank]),
       .erase_done_o(erase_done[bank]),
-      .rd_data_o(rd_data[bank]),
+      .rd_data_host_o(rd_data_host[bank]),
+      .rd_data_ctrl_o(rd_data_ctrl[bank]),
       .rd_err_o(rd_err[bank]),
       .flash_disable_i(flash_disable[bank]),
       .scramble_req_o(scramble_req[bank]),

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_core.sv
@@ -46,7 +46,8 @@ module flash_phy_core
   output logic                       rd_done_o,
   output logic                       prog_done_o,
   output logic                       erase_done_o,
-  output logic [BusFullWidth-1:0]    rd_data_o,
+  output logic [BusFullWidth-1:0]    rd_data_host_o,
+  output logic [BusFullWidth-1:0]    rd_data_ctrl_o,
   output logic                       rd_err_o,
   output logic                       ecc_single_err_o,
   output logic [BusBankAddrW-1:0]    ecc_addr_o,
@@ -433,6 +434,7 @@ module flash_phy_core
     .buf_en_i(rd_buf_en_i),
     //.req_i(reqs[PhyRead] | host_req),
     .req_i(phy_req & (rd_i | host_req)),
+    .host_req_i(host_req),
     .descramble_i(muxed_scramble_en),
     .ecc_i(muxed_ecc_en),
     .prog_i(reqs[PhyProg]),
@@ -445,7 +447,8 @@ module flash_phy_core
     .rdy_o(rd_stage_rdy),
     .data_valid_o(rd_stage_data_valid),
     .data_err_o(phy_rd_err),
-    .data_o(rd_data_o),
+    .data_host_o(rd_data_host_o),
+    .data_ctrl_o(rd_data_ctrl_o),
     .idle_o(rd_stage_idle),
      // a catastrophic arbitration error has been observed, just dump
      // dump returns until all transactions are flushed.

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
@@ -38,6 +38,7 @@ module flash_phy_rd
 
   // interface with arbitration unit
   input req_i,
+  input host_req_i,
   input descramble_i,
   input ecc_i,
   input prog_i,
@@ -51,7 +52,8 @@ module flash_phy_rd
   output logic data_err_o,
   output logic relbl_ecc_err_o,
   output logic intg_ecc_err_o,
-  output logic [BusFullWidth-1:0] data_o,
+  output logic [BusFullWidth-1:0] data_host_o,
+  output logic [BusFullWidth-1:0] data_ctrl_o,
   output logic idle_o, // the entire read pipeline is idle
   input arb_err_i, // a catastrophic arbitration error was observed
 
@@ -465,11 +467,14 @@ module flash_phy_rd
 
   logic fifo_data_ready;
   logic fifo_data_valid;
+  logic fifo_addr_xor_valid;
   logic fifo_forward_pop;
   logic rd_and_mask_fifo_pop;
   logic mask_valid;
   logic [PlainDataWidth-1:0] fifo_data;
   logic [DataWidth-1:0] mask;
+  logic addr_xor_fifo_rdy;
+  logic [BankAddrW-1:0] fifo_addr_xor;
   logic data_fifo_rdy;
   logic mask_fifo_rdy;
   logic descram;
@@ -483,9 +488,9 @@ module flash_phy_rd
   logic hint_descram;
   logic data_err_q;
   logic [NumBuf-1:0] alloc_q2;
-  logic [1:0] unused_rd_depth, unused_mask_depth;
+  logic [1:0] unused_rd_depth, unused_mask_depth, unused_addr_xor_depth;
 
-  assign scramble_stage_rdy = data_fifo_rdy & mask_fifo_rdy;
+  assign scramble_stage_rdy = data_fifo_rdy & mask_fifo_rdy & addr_xor_fifo_rdy;
 
   // descramble is only required if the location is scramble enabled AND it is not erased.
   assign descram = rd_done & rd_attrs.descramble & ~data_erased;
@@ -563,6 +568,27 @@ module flash_phy_rd
     .err_o   ()
   );
 
+  logic host_req;
+  prim_fifo_sync #(
+    .Width   (1+BankAddrW),
+    .Pass    (0),
+    .Depth   (RspOrderDepth),
+    .OutputZeroIfEmpty (1)
+  ) u_addr_xor_storage (
+    .clk_i,
+    .rst_ni,
+    .clr_i   (1'b0),
+    .wvalid_i(rsp_order_fifo_wr),
+    .wready_o(addr_xor_fifo_rdy),
+    .wdata_i ({host_req_i, flash_word_addr}),
+    .depth_o (unused_addr_xor_depth),
+    .full_o  (),
+    .rvalid_o(fifo_addr_xor_valid),
+    .rready_i(data_valid_o),
+    .rdata_o ({host_req, fifo_addr_xor}),
+    .err_o   ()
+  );
+
   // generate the mask calculation request
   // mask calculation is done in parallel to the read stage
   // calc_req_o is done after req_o is accepted so that most of the
@@ -620,6 +646,7 @@ module flash_phy_rd
   logic flash_rsp_match;
   logic [NumBuf-1:0] buf_rsp_match;
   logic [PlainDataWidth-1:0] buf_rsp_data;
+  logic [BankAddrW-1:0] buf_addr_xor;
   logic buf_rsp_err;
 
 
@@ -645,9 +672,11 @@ module flash_phy_rd
   always_comb begin
     buf_rsp_data = muxed_data;
     buf_rsp_err = '0;
+    buf_addr_xor = '0;
     for (int i = 0; i < NumBuf; i++) begin
       if (buf_rsp_match[i]) begin
         buf_rsp_data = read_buf[i].data;
+        buf_addr_xor = read_buf[i].addr;
         buf_rsp_err = buf_rsp_err | read_buf[i].err;
       end
     end
@@ -706,7 +735,33 @@ module flash_phy_rd
     .data_intg_o(inv_data_integ)
   );
 
-  assign data_o = data_err_o ? inv_data_integ : data_out_intg;
+  logic [BusFullWidth-1:0] data_out_pre_xor;
+  assign data_out_pre_xor = data_err_o ? inv_data_integ : data_out_intg;
+
+  assign data_ctrl_o = data_out_pre_xor;
+
+  logic [BusBankAddrW-1:0] addr_xor_muxed;
+  logic [BusBankAddrW-1:0] fifo_addr_xor_muxed;
+  logic [BusBankAddrW-1:0] buf_addr_xor_muxed;
+
+  assign fifo_addr_xor_muxed = {fifo_addr_xor, rsp_fifo_rdata.word_sel};
+  assign buf_addr_xor_muxed = {buf_addr_xor, rsp_fifo_rdata.word_sel};
+
+  assign addr_xor_muxed = |buf_rsp_match ? buf_addr_xor_muxed : fifo_addr_xor_muxed;
+
+  logic [BusWidth-1:0] data_out_xor;
+  logic [BusWidth-1:0] data_out_xor_buf;
+  assign data_out_xor = data_out_pre_xor[BusWidth-1:0] ^ addr_xor_muxed;
+
+  // Buffer to ensure that synthesis tool does not optimize the XOR.
+  prim_buf #(
+    .Width(BusWidth)
+  ) u_prim_buf_data_xor_out (
+    .in_i(data_out_xor),
+    .out_o(data_out_xor_buf)
+  );
+
+  assign data_host_o = {data_out_pre_xor[BusFullWidth-1:BusWidth], data_out_xor_buf};
 
   // add plaintext decoding here
   // plaintext error

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl.sv
@@ -1301,6 +1301,7 @@ module flash_ctrl
   tlul_adapter_sram #(
     .SramAw(BusAddrW),
     .SramDw(BusWidth),
+    .SramBusBankAW(BusBankAddrW),
     .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1),
@@ -1308,7 +1309,8 @@ module flash_ctrl
     .EnableRspIntgGen(1),
     .EnableDataIntgGen(0),
     .EnableDataIntgPt(1),
-    .SecFifoPtr(1)
+    .SecFifoPtr(1),
+    .DataXorAddr(1)
   ) u_tl_adapter_eflash (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy.sv
@@ -90,7 +90,8 @@ module flash_phy
   logic [ProgTypes-1:0] prog_type_avail;
 
   // common interface
-  logic [BusFullWidth-1:0] rd_data [NumBanks];
+  logic [BusFullWidth-1:0] rd_data_host [NumBanks];
+  logic [BusFullWidth-1:0] rd_data_ctrl [NumBanks];
   logic [NumBanks-1:0] rd_err;
   logic [NumBanks-1:0] spurious_acks;
 
@@ -133,7 +134,7 @@ module flash_phy
   assign flash_ctrl_o.rd_done = rd_done[ctrl_bank_sel];
   assign flash_ctrl_o.prog_done = prog_done[ctrl_bank_sel];
   assign flash_ctrl_o.erase_done = erase_done[ctrl_bank_sel];
-  assign flash_ctrl_o.rd_data = rd_data[ctrl_bank_sel];
+  assign flash_ctrl_o.rd_data = rd_data_ctrl[ctrl_bank_sel];
   assign flash_ctrl_o.rd_err = rd_err[ctrl_bank_sel];
   assign flash_ctrl_o.init_busy = init_busy;
   assign flash_ctrl_o.prog_intg_err = |prog_intg_err;
@@ -239,7 +240,7 @@ module flash_phy
       .clr_i   (1'b0),
       .wvalid_i(host_req_done[bank]),
       .wready_o(host_rsp_avail[bank]),
-      .wdata_i ({rd_err[bank], rd_data[bank]}),
+      .wdata_i ({rd_err[bank], rd_data_host[bank]}),
       .depth_o (),
       .full_o (),
       .rvalid_o(host_rsp_vld[bank]),
@@ -285,7 +286,8 @@ module flash_phy
       .rd_done_o(rd_done[bank]),
       .prog_done_o(prog_done[bank]),
       .erase_done_o(erase_done[bank]),
-      .rd_data_o(rd_data[bank]),
+      .rd_data_host_o(rd_data_host[bank]),
+      .rd_data_ctrl_o(rd_data_ctrl[bank]),
       .rd_err_o(rd_err[bank]),
       .flash_disable_i(flash_disable[bank]),
       .scramble_req_o(scramble_req[bank]),

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
@@ -46,7 +46,8 @@ module flash_phy_core
   output logic                       rd_done_o,
   output logic                       prog_done_o,
   output logic                       erase_done_o,
-  output logic [BusFullWidth-1:0]    rd_data_o,
+  output logic [BusFullWidth-1:0]    rd_data_host_o,
+  output logic [BusFullWidth-1:0]    rd_data_ctrl_o,
   output logic                       rd_err_o,
   output logic                       ecc_single_err_o,
   output logic [BusBankAddrW-1:0]    ecc_addr_o,
@@ -433,6 +434,7 @@ module flash_phy_core
     .buf_en_i(rd_buf_en_i),
     //.req_i(reqs[PhyRead] | host_req),
     .req_i(phy_req & (rd_i | host_req)),
+    .host_req_i(host_req),
     .descramble_i(muxed_scramble_en),
     .ecc_i(muxed_ecc_en),
     .prog_i(reqs[PhyProg]),
@@ -445,7 +447,8 @@ module flash_phy_core
     .rdy_o(rd_stage_rdy),
     .data_valid_o(rd_stage_data_valid),
     .data_err_o(phy_rd_err),
-    .data_o(rd_data_o),
+    .data_host_o(rd_data_host_o),
+    .data_ctrl_o(rd_data_ctrl_o),
     .idle_o(rd_stage_idle),
      // a catastrophic arbitration error has been observed, just dump
      // dump returns until all transactions are flushed.

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
@@ -38,6 +38,7 @@ module flash_phy_rd
 
   // interface with arbitration unit
   input req_i,
+  input host_req_i,
   input descramble_i,
   input ecc_i,
   input prog_i,
@@ -51,7 +52,8 @@ module flash_phy_rd
   output logic data_err_o,
   output logic relbl_ecc_err_o,
   output logic intg_ecc_err_o,
-  output logic [BusFullWidth-1:0] data_o,
+  output logic [BusFullWidth-1:0] data_host_o,
+  output logic [BusFullWidth-1:0] data_ctrl_o,
   output logic idle_o, // the entire read pipeline is idle
   input arb_err_i, // a catastrophic arbitration error was observed
 
@@ -465,11 +467,14 @@ module flash_phy_rd
 
   logic fifo_data_ready;
   logic fifo_data_valid;
+  logic fifo_addr_xor_valid;
   logic fifo_forward_pop;
   logic rd_and_mask_fifo_pop;
   logic mask_valid;
   logic [PlainDataWidth-1:0] fifo_data;
   logic [DataWidth-1:0] mask;
+  logic addr_xor_fifo_rdy;
+  logic [BankAddrW-1:0] fifo_addr_xor;
   logic data_fifo_rdy;
   logic mask_fifo_rdy;
   logic descram;
@@ -483,9 +488,9 @@ module flash_phy_rd
   logic hint_descram;
   logic data_err_q;
   logic [NumBuf-1:0] alloc_q2;
-  logic [1:0] unused_rd_depth, unused_mask_depth;
+  logic [1:0] unused_rd_depth, unused_mask_depth, unused_addr_xor_depth;
 
-  assign scramble_stage_rdy = data_fifo_rdy & mask_fifo_rdy;
+  assign scramble_stage_rdy = data_fifo_rdy & mask_fifo_rdy & addr_xor_fifo_rdy;
 
   // descramble is only required if the location is scramble enabled AND it is not erased.
   assign descram = rd_done & rd_attrs.descramble & ~data_erased;
@@ -563,6 +568,27 @@ module flash_phy_rd
     .err_o   ()
   );
 
+  logic host_req;
+  prim_fifo_sync #(
+    .Width   (1+BankAddrW),
+    .Pass    (0),
+    .Depth   (RspOrderDepth),
+    .OutputZeroIfEmpty (1)
+  ) u_addr_xor_storage (
+    .clk_i,
+    .rst_ni,
+    .clr_i   (1'b0),
+    .wvalid_i(rsp_order_fifo_wr),
+    .wready_o(addr_xor_fifo_rdy),
+    .wdata_i ({host_req_i, flash_word_addr}),
+    .depth_o (unused_addr_xor_depth),
+    .full_o  (),
+    .rvalid_o(fifo_addr_xor_valid),
+    .rready_i(data_valid_o),
+    .rdata_o ({host_req, fifo_addr_xor}),
+    .err_o   ()
+  );
+
   // generate the mask calculation request
   // mask calculation is done in parallel to the read stage
   // calc_req_o is done after req_o is accepted so that most of the
@@ -620,6 +646,7 @@ module flash_phy_rd
   logic flash_rsp_match;
   logic [NumBuf-1:0] buf_rsp_match;
   logic [PlainDataWidth-1:0] buf_rsp_data;
+  logic [BankAddrW-1:0] buf_addr_xor;
   logic buf_rsp_err;
 
 
@@ -645,9 +672,11 @@ module flash_phy_rd
   always_comb begin
     buf_rsp_data = muxed_data;
     buf_rsp_err = '0;
+    buf_addr_xor = '0;
     for (int i = 0; i < NumBuf; i++) begin
       if (buf_rsp_match[i]) begin
         buf_rsp_data = read_buf[i].data;
+        buf_addr_xor = read_buf[i].addr;
         buf_rsp_err = buf_rsp_err | read_buf[i].err;
       end
     end
@@ -706,7 +735,33 @@ module flash_phy_rd
     .data_intg_o(inv_data_integ)
   );
 
-  assign data_o = data_err_o ? inv_data_integ : data_out_intg;
+  logic [BusFullWidth-1:0] data_out_pre_xor;
+  assign data_out_pre_xor = data_err_o ? inv_data_integ : data_out_intg;
+
+  assign data_ctrl_o = data_out_pre_xor;
+
+  logic [BusBankAddrW-1:0] addr_xor_muxed;
+  logic [BusBankAddrW-1:0] fifo_addr_xor_muxed;
+  logic [BusBankAddrW-1:0] buf_addr_xor_muxed;
+
+  assign fifo_addr_xor_muxed = {fifo_addr_xor, rsp_fifo_rdata.word_sel};
+  assign buf_addr_xor_muxed = {buf_addr_xor, rsp_fifo_rdata.word_sel};
+
+  assign addr_xor_muxed = |buf_rsp_match ? buf_addr_xor_muxed : fifo_addr_xor_muxed;
+
+  logic [BusWidth-1:0] data_out_xor;
+  logic [BusWidth-1:0] data_out_xor_buf;
+  assign data_out_xor = data_out_pre_xor[BusWidth-1:0] ^ addr_xor_muxed;
+
+  // Buffer to ensure that synthesis tool does not optimize the XOR.
+  prim_buf #(
+    .Width(BusWidth)
+  ) u_prim_buf_data_xor_out (
+    .in_i(data_out_xor),
+    .out_o(data_out_xor_buf)
+  );
+
+  assign data_host_o = {data_out_pre_xor[BusFullWidth-1:BusWidth], data_out_xor_buf};
 
   // add plaintext decoding here
   // plaintext error

--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -45,6 +45,7 @@ CM_TYPES = [
     'SCRAMBLE',
     'INTEGRITY',
     'READBACK',
+    'ADDR_INFECTION',
     'CONSISTENCY',
     'DIGEST',
     'LC_GATED',


### PR DESCRIPTION
This commit adds the data XOR address infection mechanism. The goal of this countermeasure is to detect faults on read addresses targeting the flash controller.

On a host flash read, the address used for accessing the data is XORed inside the flash_phy_rd module to the fetched data.

The address then is removed in the u_tl_adapter_eflash where the core has a TL-UL interface to the flash memory. Here, the buffered address from the incoming TL-UL read request is taken.

When a FI attack manipulates an address, data would be fetched from the wrong address in the flash memory. But inside the flash_phy_rd module, this manipulated address is XORed to the data. Now, when removing the address by using the original address, and there is a difference from a FI, the data would be faulty and the subsequent integrity check detects the attack.