### PR TITLE
[otbn,dv] Add missing include to otbn_trace_entry.h

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -4,6 +4,7 @@
 #ifndef OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_ENTRY_H_
 #define OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_ENTRY_H_
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This header uses uint32_t and builds with recent versions of GCC and Verilator don't get that included transitively, causing a build failure. Fix the silly bug.