### PR TITLE
[sw/host] Fix UART usage regarding control flow

### DIFF
--- a/sw/host/tests/chip/flash_ctrl/src/main.rs
+++ b/sw/host/tests/chip/flash_ctrl/src/main.rs
@@ -56,6 +56,7 @@ fn test_update_phase(
 
 fn test_end(opts: &Opts, end_test_address: u32, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
     let end_test_value = MemRead32Req::execute(&*uart, end_test_address)?;
     assert!(end_test_value == 0);
     MemWrite32Req::execute(&*uart, end_test_address, /*value=*/ 1)?;

--- a/sw/host/tests/chip/i2c_host_override/src/main.rs
+++ b/sw/host/tests/chip/i2c_host_override/src/main.rs
@@ -46,6 +46,7 @@ fn test_override(
     data: u8,
 ) -> Result<()> {
     let uart = transport.uart("console")?;
+    uart.set_flow_control(true)?;
     let gpio_bitbanging = transport.gpio_bitbanging()?;
 
     const SAMPLES: usize = 5000;

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -12,6 +12,7 @@ use opentitanlib::io::gpio::BitbangEntry;
 use opentitanlib::io::gpio::GpioPin;
 use opentitanlib::io::gpio::PinMode;
 use opentitanlib::io::i2c::Transfer;
+use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils;
 use opentitanlib::test_utils::e2e_command::TestCommand;
 use opentitanlib::test_utils::i2c_target::{I2cTargetAddress, I2cTestConfig, I2cTransferStart};
@@ -42,8 +43,12 @@ const GETTYSBURG: &str = r#"Four score and seven years ago our fathers brought f
 continent, a new nation, conceived in Liberty, and dedicated to the
 proposition that all men are created equal."#;
 
-fn test_set_target_address(_opts: &Opts, transport: &TransportWrapper, instance: u8) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_set_target_address(
+    _opts: &Opts,
+    _transport: &TransportWrapper,
+    uart: &dyn Uart,
+    instance: u8,
+) -> Result<()> {
     let address = I2cTargetAddress {
         instance,
         // Respond to address 0x33.
@@ -53,55 +58,67 @@ fn test_set_target_address(_opts: &Opts, transport: &TransportWrapper, instance:
         id1: 0x70,
         mask1: 0x7c,
     };
-    address.write(&*uart)?;
+    address.write(uart)?;
     Ok(())
 }
 
-fn test_read_transaction(opts: &Opts, transport: &TransportWrapper, address: u8) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_read_transaction(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    address: u8,
+) -> Result<()> {
     let i2c = transport.i2c(&opts.i2c)?;
 
     log::info!("Testing read transaction at I2C address {address:02x}");
     let txn = I2cTransferStart::new(address, b"Hello", true);
     let mut result = vec![0u8; txn.length as usize];
-    txn.execute_read(&*uart, || {
+    txn.execute_read(uart, || {
         i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut result)])
     })?;
     assert_eq!(result.as_slice(), txn.data.as_slice());
     Ok(())
 }
 
-fn test_clock_stretching(opts: &Opts, transport: &TransportWrapper, address: u8) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_clock_stretching(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    address: u8,
+) -> Result<()> {
     let i2c = transport.i2c(&opts.i2c)?;
 
     let stretching_delay = I2cTestConfig {
         clock_stretching_delay_millis: 10,
     };
-    stretching_delay.write(&*uart)?;
+    stretching_delay.write(uart)?;
 
     log::info!("Testing read transaction with clock stretching at I2C address {address:02x}");
     let txn = I2cTransferStart::new(address, b"Stretching the clock", true);
     let mut result = vec![0u8; txn.length as usize];
-    txn.execute_read(&*uart, || {
+    txn.execute_read(uart, || {
         i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut result)])
     })?;
 
     let stretching_delay = I2cTestConfig {
         clock_stretching_delay_millis: 0,
     };
-    stretching_delay.write(&*uart)?;
+    stretching_delay.write(uart)?;
 
     assert_eq!(result.as_slice(), txn.data.as_slice());
     Ok(())
 }
 
-fn test_write_transaction(opts: &Opts, transport: &TransportWrapper, address: u8) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_write_transaction(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    address: u8,
+) -> Result<()> {
     let i2c = transport.i2c(&opts.i2c)?;
     log::info!("Testing write transaction at I2C address {address:02x}");
 
-    let transfer = I2cTransferStart::execute_write(&*uart, || {
+    let transfer = I2cTransferStart::execute_write(uart, || {
         i2c.run_transaction(Some(address), &mut [Transfer::Write(b"Hello World")])
     })?;
     let len = transfer.length as usize;
@@ -114,12 +131,12 @@ fn test_write_transaction(opts: &Opts, transport: &TransportWrapper, address: u8
 fn test_write_transaction_slow(
     opts: &Opts,
     transport: &TransportWrapper,
+    uart: &dyn Uart,
     address: u8,
 ) -> Result<()> {
-    let uart = transport.uart("console")?;
     let i2c = transport.i2c(&opts.i2c)?;
     log::info!("Testing slow write transaction at I2C address {address:02x}");
-    let result = I2cTransferStart::execute_write_slow(&*uart, || {
+    let result = I2cTransferStart::execute_write_slow(uart, || {
         i2c.run_transaction(Some(address), &mut [Transfer::Write(GETTYSBURG.as_bytes())])
     })?;
     let len = result.length as usize;
@@ -129,48 +146,51 @@ fn test_write_transaction_slow(
     Ok(())
 }
 
-fn test_wakeup_normal_sleep(opts: &Opts, transport: &TransportWrapper, address: u8) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_wakeup_normal_sleep(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    address: u8,
+) -> Result<()> {
     let i2c = transport.i2c(&opts.i2c)?;
-    TestCommand::EnterNormalSleep.send(&*uart)?;
+    TestCommand::EnterNormalSleep.send(uart)?;
     std::thread::sleep(Duration::from_secs(2));
     let mut buf = [0u8; 8];
     log::info!("Issuing read transaction to sleeping chip. Expecting transaction error.");
     let result = i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut buf)]);
     log::info!("Transaction error: {}", result.is_err());
-    Status::recv(&*uart, Duration::from_secs(5), false)?;
+    Status::recv(uart, Duration::from_secs(5), false)?;
     log::info!("Chip is awake.  Reissuing read transaction.");
-    test_read_transaction(opts, transport, address)
+    test_read_transaction(opts, transport, uart, address)
 }
 
 fn test_wakeup_deep_sleep(
     opts: &Opts,
     transport: &TransportWrapper,
+    uart: &dyn Uart,
     address: u8,
     instance: u8,
 ) -> Result<()> {
-    let uart = transport.uart("console")?;
     let i2c = transport.i2c(&opts.i2c)?;
-    TestCommand::EnterDeepSleep.send(&*uart)?;
+    TestCommand::EnterDeepSleep.send(uart)?;
     std::thread::sleep(Duration::from_secs(2));
     let mut buf = [0u8; 8];
     log::info!("Issuing read transaction to sleeping chip. Expecting transaction error.");
     let result = i2c.run_transaction(Some(address), &mut [Transfer::Read(&mut buf)]);
     log::info!("Transaction error: {}", result.is_err());
-    Status::recv(&*uart, Duration::from_secs(5), false)?;
+    Status::recv(uart, Duration::from_secs(5), false)?;
     log::info!("Chip is awake.  Reissuing read transaction.");
-    test_set_target_address(opts, transport, instance)?;
-    test_read_transaction(opts, transport, address)
+    test_set_target_address(opts, transport, uart, instance)?;
+    test_read_transaction(opts, transport, uart, address)
 }
 
 fn test_write_repeated_start(
     _opts: &Opts,
     transport: &TransportWrapper,
+    uart: &dyn Uart,
     address: u8,
     gpio_pins: &[Rc<dyn GpioPin>],
 ) -> Result<()> {
-    let uart = transport.uart("console")?;
-
     log::info!("Emulating start with bit-banging");
     let gpio_bitbanging = transport.gpio_bitbanging()?;
     let i2c_bitbang = test_utils::bitbanging::i2c::encoder::Encoder::<0, 1> {};
@@ -200,7 +220,7 @@ fn test_write_repeated_start(
     let mut waveform = [BitbangEntry::Write(transaction)];
 
     log::info!("Testing write transaction at I2C address {address:02x}");
-    let transfer = I2cTransferStart::execute_write(&*uart, || {
+    let transfer = I2cTransferStart::execute_write(uart, || {
         gpio_bitbanging.run(
             &gpio_pins
                 .iter()
@@ -221,11 +241,10 @@ fn test_write_repeated_start(
 fn test_write_read_repeated_start(
     _opts: &Opts,
     transport: &TransportWrapper,
+    uart: &dyn Uart,
     address: u8,
     gpio_pins: &[Rc<dyn GpioPin>],
 ) -> Result<()> {
-    let uart = transport.uart("console")?;
-
     let gpio_bitbanging = transport.gpio_bitbanging()?;
     let i2c_bitbang_encoder = test_utils::bitbanging::i2c::encoder::Encoder::<0, 1> {};
     let mut i2c_bitbang_decoder =
@@ -263,7 +282,7 @@ fn test_write_read_repeated_start(
 
     log::info!("Testing write transaction at I2C address 0x{address:02x}");
     let txn = I2cTransferStart::new(address, READ_REFERENCE_DATA, false);
-    let _ = txn.execute_write_read(&*uart, || {
+    let _ = txn.execute_write_read(uart, || {
         gpio_bitbanging.run(
             &gpio_pins
                 .iter()
@@ -310,18 +329,24 @@ fn main() -> Result<()> {
     uart.clear_rx_buffer()?;
 
     for i2c_instance in 0..3 {
-        execute_test!(test_set_target_address, &opts, &transport, i2c_instance);
-        execute_test!(test_read_transaction, &opts, &transport, 0x33);
-        execute_test!(test_read_transaction, &opts, &transport, 0x70);
-        execute_test!(test_read_transaction, &opts, &transport, 0x71);
-        execute_test!(test_read_transaction, &opts, &transport, 0x72);
-        execute_test!(test_clock_stretching, &opts, &transport, 0x72);
-        execute_test!(test_read_transaction, &opts, &transport, 0x73);
-        execute_test!(test_write_transaction, &opts, &transport, 0x33);
-        execute_test!(test_write_transaction_slow, &opts, &transport, 0x33);
+        execute_test!(
+            test_set_target_address,
+            &opts,
+            &transport,
+            &*uart,
+            i2c_instance
+        );
+        execute_test!(test_read_transaction, &opts, &transport, &*uart, 0x33);
+        execute_test!(test_read_transaction, &opts, &transport, &*uart, 0x70);
+        execute_test!(test_read_transaction, &opts, &transport, &*uart, 0x71);
+        execute_test!(test_read_transaction, &opts, &transport, &*uart, 0x72);
+        execute_test!(test_clock_stretching, &opts, &transport, &*uart, 0x72);
+        execute_test!(test_read_transaction, &opts, &transport, &*uart, 0x73);
+        execute_test!(test_write_transaction, &opts, &transport, &*uart, 0x33);
+        execute_test!(test_write_transaction_slow, &opts, &transport, &*uart, 0x33);
     }
-    execute_test!(test_wakeup_normal_sleep, &opts, &transport, 0x33);
-    execute_test!(test_wakeup_deep_sleep, &opts, &transport, 0x33, 0);
+    execute_test!(test_wakeup_normal_sleep, &opts, &transport, &*uart, 0x33);
+    execute_test!(test_wakeup_deep_sleep, &opts, &transport, &*uart, 0x33, 0);
 
     transport.pin_strapping("RESET")?.apply()?;
     transport.pin_strapping("RESET")?.remove()?;
@@ -337,11 +362,18 @@ fn main() -> Result<()> {
         pin.set_mode(PinMode::OpenDrain)?;
     }
     for i2c_instance in 0..3 {
-        execute_test!(test_set_target_address, &opts, &transport, i2c_instance);
+        execute_test!(
+            test_set_target_address,
+            &opts,
+            &transport,
+            &*uart,
+            i2c_instance
+        );
         execute_test!(
             test_write_repeated_start,
             &opts,
             &transport,
+            &*uart,
             0x33,
             &gpio_pins
         );
@@ -349,6 +381,7 @@ fn main() -> Result<()> {
             test_write_read_repeated_start,
             &opts,
             &transport,
+            &*uart,
             0x33,
             &gpio_pins
         );

--- a/sw/host/tests/chip/mem/src/main.rs
+++ b/sw/host/tests/chip/mem/src/main.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use object::{Object, ObjectSymbol};
-use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::mem::{MemRead32Req, MemReadReq, MemWrite32Req, MemWriteReq};
 use opentitanlib::uart::console::UartConsole;
@@ -30,47 +30,36 @@ struct Opts {
     firmware_elf: PathBuf,
 }
 
-fn test_mem_word_commands(
-    _opts: &Opts,
-    test_word_address: u32,
-    transport: &TransportWrapper,
-) -> Result<()> {
-    let uart = transport.uart("console")?;
-    let read_value = MemRead32Req::execute(&*uart, test_word_address)?;
+fn test_mem_word_commands(_opts: &Opts, test_word_address: u32, uart: &dyn Uart) -> Result<()> {
+    let read_value = MemRead32Req::execute(uart, test_word_address)?;
     assert!(read_value == 0xface1234_u32);
 
     let expected_value = 0x12345678_u32;
-    MemWrite32Req::execute(&*uart, test_word_address, expected_value)?;
-    let read_value = MemRead32Req::execute(&*uart, test_word_address)?;
+    MemWrite32Req::execute(uart, test_word_address, expected_value)?;
+    let read_value = MemRead32Req::execute(uart, test_word_address)?;
     assert!(read_value == expected_value);
     Ok(())
 }
 
-fn test_mem_array_commands(
-    _opts: &Opts,
-    test_bytes_address: u32,
-    transport: &TransportWrapper,
-) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_mem_array_commands(_opts: &Opts, test_bytes_address: u32, uart: &dyn Uart) -> Result<()> {
     let mut data: [u8; 256] = [0; 256];
-    MemReadReq::execute(&*uart, test_bytes_address, data.as_mut_slice())?;
+    MemReadReq::execute(uart, test_bytes_address, data.as_mut_slice())?;
     let mut expected_value = Vec::<u8>::from_iter(0..=255);
     assert!(data.as_slice() == expected_value.as_slice());
 
     data.reverse();
     expected_value.reverse();
-    MemWriteReq::execute(&*uart, test_bytes_address, expected_value.as_slice())?;
-    MemReadReq::execute(&*uart, test_bytes_address, data.as_mut_slice())?;
+    MemWriteReq::execute(uart, test_bytes_address, expected_value.as_slice())?;
+    MemReadReq::execute(uart, test_bytes_address, data.as_mut_slice())?;
     assert!(data.as_slice() == expected_value.as_slice());
     Ok(())
 }
 
-fn test_end(opts: &Opts, end_test_address: u32, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
-    let end_test_value = MemRead32Req::execute(&*uart, end_test_address)?;
+fn test_end(opts: &Opts, end_test_address: u32, uart: &dyn Uart) -> Result<()> {
+    let end_test_value = MemRead32Req::execute(uart, end_test_address)?;
     assert!(end_test_value == 0);
-    MemWrite32Req::execute(&*uart, end_test_address, /*value=*/ 1)?;
-    let _ = UartConsole::wait_for(&*uart, r"PASS![^\r\n]*", opts.timeout)?;
+    MemWrite32Req::execute(uart, end_test_address, /*value=*/ 1)?;
+    let _ = UartConsole::wait_for(uart, r"PASS![^\r\n]*", opts.timeout)?;
     Ok(())
 }
 
@@ -100,18 +89,8 @@ fn main() -> Result<()> {
     let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
     let _ = uart.clear_rx_buffer();
 
-    execute_test!(
-        test_mem_word_commands,
-        &opts,
-        *test_word_address,
-        &transport
-    );
-    execute_test!(
-        test_mem_array_commands,
-        &opts,
-        *test_bytes_address,
-        &transport
-    );
-    execute_test!(test_end, &opts, *end_test_address, &transport);
+    execute_test!(test_mem_word_commands, &opts, *test_word_address, &*uart);
+    execute_test!(test_mem_array_commands, &opts, *test_bytes_address, &*uart);
+    execute_test!(test_end, &opts, *end_test_address, &*uart);
     Ok(())
 }

--- a/sw/host/tests/chip/spi_device/src/spi_passthru.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_passthru.rs
@@ -10,6 +10,7 @@ use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::io::eeprom::AddressMode;
 use opentitanlib::io::spi::{Target, Transfer};
+use opentitanlib::io::uart::Uart;
 use opentitanlib::spiflash::sfdp::SectorErase;
 use opentitanlib::spiflash::{EraseMode, ReadMode, Sfdp, SpiFlash};
 use opentitanlib::test_utils::init::InitializeTest;
@@ -38,15 +39,14 @@ struct Opts {
     spi: String,
 }
 
-fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_jedec_id(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) -> Result<()> {
     let config = ConfigJedecId {
         device_id: 0x1234,
         manufacturer_id: 0x56,
         continuation_code: 0x7f,
         continuation_len: 3,
     };
-    config.execute(&*uart)?;
+    config.execute(uart)?;
 
     let spi = transport.spi(&opts.spi)?;
     let jedec_id = SpiFlash::read_jedec_id(&*spi, 16)?;
@@ -65,30 +65,36 @@ fn test_jedec_id(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     Ok(())
 }
 
-fn test_enter_exit_4b_mode(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_enter_exit_4b_mode(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+) -> Result<()> {
     let spi = transport.spi(&opts.spi)?;
 
     log::info!("Entering 4B address mode");
     spi.run_transaction(&mut [Transfer::Write(&[SpiFlash::ENTER_4B])])?;
-    let sr = StatusRegister::read(&*uart)?;
+    let sr = StatusRegister::read(uart)?;
     assert!(sr.addr_4b, "expected to be in 4b mode");
 
     log::info!("Exiting 4B address mode");
     spi.run_transaction(&mut [Transfer::Write(&[SpiFlash::EXIT_4B])])?;
-    let sr = StatusRegister::read(&*uart)?;
+    let sr = StatusRegister::read(uart)?;
     assert!(!sr.addr_4b, "expected to be in 3b mode");
     Ok(())
 }
 
-fn test_write_enable_disable(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_write_enable_disable(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+) -> Result<()> {
     let spi = transport.spi(&opts.spi)?;
 
     log::info!("Sending WRITE_ENABLE");
     spi.run_transaction(&mut [Transfer::Write(&[SpiFlash::WRITE_ENABLE])])?;
     let status = SpiFlash::read_status(&*spi)?;
-    let sr = StatusRegister::read(&*uart)?;
+    let sr = StatusRegister::read(uart)?;
     assert!(
         status as u32 & FLASH_STATUS_WEL != 0,
         "expected WEL set via read_status"
@@ -101,7 +107,7 @@ fn test_write_enable_disable(opts: &Opts, transport: &TransportWrapper) -> Resul
     log::info!("Sending WRITE_DISABLE");
     spi.run_transaction(&mut [Transfer::Write(&[SpiFlash::WRITE_DISABLE])])?;
     let status = SpiFlash::read_status(&*spi)?;
-    let sr = StatusRegister::read(&*uart)?;
+    let sr = StatusRegister::read(uart)?;
     assert!(
         status as u32 & FLASH_STATUS_WEL == 0,
         "expected WEL clear via read_status"
@@ -113,15 +119,18 @@ fn test_write_enable_disable(opts: &Opts, transport: &TransportWrapper) -> Resul
     Ok(())
 }
 
-fn test_read_status_extended(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_read_status_extended(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+) -> Result<()> {
     let spi = transport.spi(&opts.spi)?;
 
     let sr = StatusRegister {
         status: 0x5A55AA,
         addr_4b: false,
     };
-    sr.write(&*uart)?;
+    sr.write(uart)?;
     // Note: because we're programming the flash_status register in firmware,
     // we require one CS low-to-high transition to latch the values from the
     // CSR into the spi device.  We'd normally expect this type of register
@@ -152,14 +161,13 @@ fn read_sfdp(spi: &dyn Target, offset: u32) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
-fn test_read_sfdp(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_read_sfdp(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) -> Result<()> {
     let spi = transport.spi(&opts.spi)?;
 
     let sfdp = SfdpData {
         data: (0..256).map(|x| x as u8).collect(),
     };
-    sfdp.write(&*uart)?;
+    sfdp.write(uart)?;
 
     // Read and compare the whole SFDP buffer.
     let buf = read_sfdp(&*spi, 0)?;
@@ -176,11 +184,10 @@ fn test_read_sfdp(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     Ok(())
 }
 
-fn test_chip_erase(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_chip_erase(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) -> Result<()> {
     let spi = transport.spi(&opts.spi)?;
     let flash = SpiFlash::default();
-    let info = UploadInfo::execute(&*uart, || {
+    let info = UploadInfo::execute(uart, || {
         flash.chip_erase(&*spi)?;
         Ok(())
     })?;
@@ -198,11 +205,11 @@ fn test_chip_erase(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 fn test_sector_erase(
     opts: &Opts,
     transport: &TransportWrapper,
+    uart: &dyn Uart,
     address: u32,
     size: u32,
     force_4b: bool,
 ) -> Result<()> {
-    let uart = transport.uart("console")?;
     let spi = transport.spi(&opts.spi)?;
     let mut flash = SpiFlash {
         // Double the flash size so we can test 3b and 4b addresses.
@@ -258,7 +265,7 @@ fn test_sector_erase(
         AddressMode::Mode3b
     };
     flash.set_address_mode(&*spi, mode)?;
-    let info = UploadInfo::execute(&*uart, || {
+    let info = UploadInfo::execute(uart, || {
         flash.erase(&*spi, address, size)?;
         Ok(())
     })?;
@@ -275,8 +282,12 @@ fn test_sector_erase(
     Ok(())
 }
 
-fn test_page_program(opts: &Opts, transport: &TransportWrapper, address: u32) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_page_program(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    address: u32,
+) -> Result<()> {
     let spi = transport.spi(&opts.spi)?;
     let data = (0..256).map(|x| x as u8).collect::<Vec<u8>>();
     let mut flash = SpiFlash {
@@ -292,7 +303,7 @@ fn test_page_program(opts: &Opts, transport: &TransportWrapper, address: u32) ->
         AddressMode::Mode4b
     };
     flash.set_address_mode(&*spi, mode)?;
-    let info = UploadInfo::execute(&*uart, || {
+    let info = UploadInfo::execute(uart, || {
         flash.program(&*spi, address, &data)?;
         Ok(())
     })?;
@@ -310,10 +321,14 @@ fn test_page_program(opts: &Opts, transport: &TransportWrapper, address: u32) ->
     Ok(())
 }
 
-fn test_write_status(opts: &Opts, transport: &TransportWrapper, opcode: u8) -> Result<()> {
-    let uart = transport.uart("console")?;
+fn test_write_status(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    opcode: u8,
+) -> Result<()> {
     let spi = transport.spi(&opts.spi)?;
-    let info = UploadInfo::execute(&*uart, || {
+    let info = UploadInfo::execute(uart, || {
         spi.run_transaction(&mut [Transfer::Write(&[opcode])])?;
         Ok(())
     })?;
@@ -325,7 +340,12 @@ fn test_write_status(opts: &Opts, transport: &TransportWrapper, opcode: u8) -> R
     Ok(())
 }
 
-fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) -> Result<()> {
+fn test_read_flash(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    uart: &dyn Uart,
+    mode: ReadMode,
+) -> Result<()> {
     log::info!("using read mode {:?}", mode);
     let capability = match mode {
         ReadMode::Standard => Ok(()),
@@ -341,14 +361,13 @@ fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) ->
         return Ok(());
     }
 
-    let uart = transport.uart("console")?;
     let spi = transport.spi(&opts.spi)?;
 
     let sfdp_read = SpiFlashReadSfdp {
         address: 0u32,
         length: 256u16,
     };
-    let sfdp_data = sfdp_read.execute(&*uart)?;
+    let sfdp_data = sfdp_read.execute(uart)?;
     let sfdp = Sfdp::try_from(sfdp_data.data.as_slice())?;
     let spi_flash = {
         let mut flash = SpiFlash::from_sfdp(sfdp);
@@ -362,7 +381,7 @@ fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) ->
         address: address_inc,
         addr4b: false,
     };
-    erase_op.execute(&*uart)?;
+    erase_op.execute(uart)?;
 
     let write_op_inc = SpiFlashWrite {
         address: address_inc,
@@ -370,7 +389,7 @@ fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) ->
         data: (0..256).map(|x| x as u8).collect(),
         length: 256,
     };
-    write_op_inc.execute(&*uart)?;
+    write_op_inc.execute(uart)?;
 
     // Put decreasing count at 0x11000.
     let address_dec = 0x11000u32;
@@ -378,7 +397,7 @@ fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) ->
         address: address_dec,
         addr4b: false,
     };
-    erase_op.execute(&*uart)?;
+    erase_op.execute(uart)?;
 
     let write_op_dec = SpiFlashWrite {
         address: address_dec,
@@ -386,7 +405,7 @@ fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) ->
         data: (0..256).map(|x| 255u8 - (x as u8)).collect(),
         length: 256,
     };
-    write_op_dec.execute(&*uart)?;
+    write_op_dec.execute(uart)?;
 
     // Put count of evens in mailbox
     let write_op_mbox = SpiMailboxWrite {
@@ -394,7 +413,7 @@ fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) ->
         data: (0..256).map(|x| (x << 1) as u8).collect(),
         length: 256,
     };
-    write_op_mbox.execute(&*uart)?;
+    write_op_mbox.execute(uart)?;
 
     // Read from flash with no special mapping.
     let mut read_data = vec![0; 256];
@@ -410,7 +429,7 @@ fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) ->
         mask: 0x10000u32,
         value: 0x00000u32,
     };
-    address_swap.apply_address_swap(&*uart)?;
+    address_swap.apply_address_swap(uart)?;
 
     let mut read_data = vec![0; 256];
     spi_flash.read(&*spi, address_dec, &mut read_data)?;
@@ -422,20 +441,20 @@ fn test_read_flash(opts: &Opts, transport: &TransportWrapper, mode: ReadMode) ->
         mask: 0u32,
         value: 0u32,
     };
-    address_swap.apply_address_swap(&*uart)?;
+    address_swap.apply_address_swap(uart)?;
 
     // Enable the mailbox at the increasing count's address, and check the read.
     let mbox_map = SpiMailboxMap {
         address: address_inc,
     };
-    mbox_map.apply(&*uart)?;
+    mbox_map.apply(uart)?;
     let mut read_data = vec![0; 256];
     spi_flash.read(&*spi, address_inc, &mut read_data)?;
     assert_eq!(read_data.as_slice(), write_op_mbox.data.as_slice());
     assert_ne!(read_data.as_slice(), write_op_inc.data.as_slice());
 
     // Disable the mailbox.
-    SpiMailboxMap::disable(&*uart)?;
+    SpiMailboxMap::disable(uart)?;
     Ok(())
 }
 
@@ -449,22 +468,29 @@ fn main() -> Result<()> {
     let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
     uart.clear_rx_buffer()?;
 
-    execute_test!(test_read_flash, &opts, &transport, ReadMode::Standard);
-    execute_test!(test_read_flash, &opts, &transport, ReadMode::Fast);
-    execute_test!(test_read_flash, &opts, &transport, ReadMode::Dual);
-    execute_test!(test_read_flash, &opts, &transport, ReadMode::Quad);
-    execute_test!(test_jedec_id, &opts, &transport);
-    execute_test!(test_enter_exit_4b_mode, &opts, &transport);
-    execute_test!(test_write_enable_disable, &opts, &transport);
-    execute_test!(test_read_status_extended, &opts, &transport);
-    execute_test!(test_read_sfdp, &opts, &transport);
-    execute_test!(test_chip_erase, &opts, &transport);
+    execute_test!(
+        test_read_flash,
+        &opts,
+        &transport,
+        &*uart,
+        ReadMode::Standard
+    );
+    execute_test!(test_read_flash, &opts, &transport, &*uart, ReadMode::Fast);
+    execute_test!(test_read_flash, &opts, &transport, &*uart, ReadMode::Dual);
+    execute_test!(test_read_flash, &opts, &transport, &*uart, ReadMode::Quad);
+    execute_test!(test_jedec_id, &opts, &transport, &*uart);
+    execute_test!(test_enter_exit_4b_mode, &opts, &transport, &*uart);
+    execute_test!(test_write_enable_disable, &opts, &transport, &*uart);
+    execute_test!(test_read_status_extended, &opts, &transport, &*uart);
+    execute_test!(test_read_sfdp, &opts, &transport, &*uart);
+    execute_test!(test_chip_erase, &opts, &transport, &*uart);
     // Test each of the erase opcodes based on the erase size.
     // Automatically switch into 4B mode based on the address.
     execute_test!(
         test_sector_erase,
         &opts,
         &transport,
+        &*uart,
         0x0000_4000,
         4096,
         false
@@ -473,6 +499,7 @@ fn main() -> Result<()> {
         test_sector_erase,
         &opts,
         &transport,
+        &*uart,
         0x0100_4000,
         4096,
         false
@@ -481,6 +508,7 @@ fn main() -> Result<()> {
         test_sector_erase,
         &opts,
         &transport,
+        &*uart,
         0x0001_0000,
         65536,
         false
@@ -489,6 +517,7 @@ fn main() -> Result<()> {
         test_sector_erase,
         &opts,
         &transport,
+        &*uart,
         0x0100_8000,
         32768,
         false
@@ -498,6 +527,7 @@ fn main() -> Result<()> {
         test_sector_erase,
         &opts,
         &transport,
+        &*uart,
         0x0000_4000,
         4096,
         true
@@ -506,6 +536,7 @@ fn main() -> Result<()> {
         test_sector_erase,
         &opts,
         &transport,
+        &*uart,
         0x0001_0000,
         65536,
         true
@@ -514,23 +545,32 @@ fn main() -> Result<()> {
         test_sector_erase,
         &opts,
         &transport,
+        &*uart,
         0x0100_8000,
         32768,
         true
     );
-    execute_test!(test_page_program, &opts, &transport, 0x0000_4000);
-    execute_test!(test_page_program, &opts, &transport, 0x0100_4000);
-    execute_test!(test_write_status, &opts, &transport, SpiFlash::WRITE_STATUS);
+    execute_test!(test_page_program, &opts, &transport, &*uart, 0x0000_4000);
+    execute_test!(test_page_program, &opts, &transport, &*uart, 0x0100_4000);
     execute_test!(
         test_write_status,
         &opts,
         &transport,
+        &*uart,
+        SpiFlash::WRITE_STATUS
+    );
+    execute_test!(
+        test_write_status,
+        &opts,
+        &transport,
+        &*uart,
         SpiFlash::WRITE_STATUS2
     );
     execute_test!(
         test_write_status,
         &opts,
         &transport,
+        &*uart,
         SpiFlash::WRITE_STATUS3
     );
     Ok(())

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -15,6 +15,7 @@ use cryptotest_commands::drbg_commands::{CryptotestDrbgInput, CryptotestDrbgOutp
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
 use opentitanlib::uart::console::UartConsole;
@@ -52,7 +53,7 @@ struct DrbgTestCase {
 fn run_drbg_testcase(
     test_case: &DrbgTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    uart: &dyn Uart,
     fail_counter: &mut u32,
 ) -> Result<()> {
     log::info!(
@@ -60,9 +61,8 @@ fn run_drbg_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
 
-    CryptotestCommand::Drbg.send(&*uart)?;
+    CryptotestCommand::Drbg.send(uart)?;
 
     // Convert all inputs to little-endian
     let mut entropy_le = Vec::from(test_case.entropy.as_slice());
@@ -95,10 +95,10 @@ fn run_drbg_testcase(
         additional_input_2_len: addl_2_le.len(),
         output_len: test_case.output.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
     // Get output
-    let drbg_output = CryptotestDrbgOutput::recv(&*uart, opts.timeout, false)?;
+    let drbg_output = CryptotestDrbgOutput::recv(uart, opts.timeout, false)?;
     // The expected output is in a mixed-endian format (32-bit words
     // are in little-endian order, but the bytes within the words are
     // in big-endian order). Convert the actual output to match this
@@ -141,7 +141,7 @@ fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for drbg_test in &drbg_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_drbg_testcase(drbg_test, opts, transport, &mut fail_counter)?;
+            run_drbg_testcase(drbg_test, opts, &*uart, &mut fail_counter)?;
         }
     }
     assert_eq!(

--- a/sw/host/tests/crypto/ecdh_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdh_kat/src/main.rs
@@ -18,6 +18,7 @@ use cryptotest_commands::ecdh_commands::{
 };
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
 use opentitanlib::uart::console::UartConsole;
@@ -65,7 +66,7 @@ struct EcdhTestCase {
 fn run_ecdh_testcase(
     test_case: &EcdhTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    uart: &dyn Uart,
     fail_counter: &mut usize,
     failures: &mut Vec<usize>,
 ) -> Result<()> {
@@ -74,7 +75,6 @@ fn run_ecdh_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
 
     assert_eq!(test_case.algorithm.as_str(), "ecdh");
     // Change byte slice parameters from big endian to little endian
@@ -82,7 +82,7 @@ fn run_ecdh_testcase(
     let qx = BigUint::from_bytes_be(&test_case.qx).to_bytes_le();
     let qy = BigUint::from_bytes_be(&test_case.qy).to_bytes_le();
 
-    CryptotestCommand::Ecdh.send(&*uart)?;
+    CryptotestCommand::Ecdh.send(uart)?;
 
     let (curve, d0, d1) = match test_case.curve.as_str() {
         "p256" => {
@@ -170,7 +170,7 @@ fn run_ecdh_testcase(
         _ => panic!("Invalid ECDH curve name"),
     };
 
-    curve.send(&*uart)?;
+    curve.send(uart)?;
 
     // Sizes were checked already, so we can unwrap() transformations
     // to `ArrayVec`s.  We can inline the `ArrayVec` initialization
@@ -182,21 +182,21 @@ fn run_ecdh_testcase(
         d1: ArrayVec::try_from(d1.as_slice()).unwrap(),
         d1_len: d1.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
     CryptotestEcdhCoordinate {
         coordinate: ArrayVec::try_from(qx.as_slice()).unwrap(),
         coordinate_len: qx.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
     CryptotestEcdhCoordinate {
         coordinate: ArrayVec::try_from(qy.as_slice()).unwrap(),
         coordinate_len: qy.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
-    let ecdh_output = CryptotestEcdhDeriveOutput::recv(&*uart, opts.timeout, false)?;
+    let ecdh_output = CryptotestEcdhDeriveOutput::recv(uart, opts.timeout, false)?;
     let out_len = ecdh_output.shared_secret_len;
     if out_len > ecdh_output.shared_secret.len() {
         panic!("ECDH returned shared secret was too long for device firmware configuration.");
@@ -234,7 +234,7 @@ fn test_ecdh(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for ecdh_test in &ecdh_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_ecdh_testcase(ecdh_test, opts, transport, &mut fail_counter, &mut failures)?;
+            run_ecdh_testcase(ecdh_test, opts, &*uart, &mut fail_counter, &mut failures)?;
         }
     }
     assert_eq!(

--- a/sw/host/tests/crypto/ecdsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdsa_kat/src/main.rs
@@ -30,6 +30,7 @@ use cryptotest_commands::ecdsa_commands::{
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
 use opentitanlib::uart::console::UartConsole;
@@ -176,7 +177,7 @@ fn p384_verify_signature(
 fn run_ecdsa_testcase(
     test_case: &EcdsaTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    uart: &dyn Uart,
     failures: &mut Vec<String>,
 ) -> Result<()> {
     log::info!(
@@ -184,7 +185,6 @@ fn run_ecdsa_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
     assert_eq!(test_case.algorithm.as_str(), "ecdsa");
     let mut qx: Vec<u8> = BigInt::from_str_radix(&test_case.qx, 16)
         .unwrap()
@@ -365,10 +365,10 @@ fn run_ecdsa_testcase(
     };
 
     // Send everything
-    CryptotestCommand::Ecdsa.send(&*uart)?;
-    operation.send(&*uart)?;
-    hash_alg.send(&*uart)?;
-    curve.send(&*uart)?;
+    CryptotestCommand::Ecdsa.send(uart)?;
+    operation.send(uart)?;
+    hash_alg.send(uart)?;
+    curve.send(uart)?;
 
     // Size of `input` is determined at compile-time by type inference
     let mut input = ArrayVec::new();
@@ -384,7 +384,7 @@ fn run_ecdsa_testcase(
         input,
         input_len: msg_len,
     };
-    msg.send(&*uart)?;
+    msg.send(uart)?;
 
     CryptotestEcdsaSignature {
         r: ArrayVec::try_from(r.as_slice()).unwrap(),
@@ -392,19 +392,19 @@ fn run_ecdsa_testcase(
         s: ArrayVec::try_from(s.as_slice()).unwrap(),
         s_len: s.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
     CryptotestEcdsaCoordinate {
         coordinate: ArrayVec::try_from(qx.as_slice()).unwrap(),
         coordinate_len: qx.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
     CryptotestEcdsaCoordinate {
         coordinate: ArrayVec::try_from(qy.as_slice()).unwrap(),
         coordinate_len: qy.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
     CryptotestEcdsaPrivateKey {
         d0: ArrayVec::try_from(d0.as_slice()).unwrap(),
@@ -413,10 +413,10 @@ fn run_ecdsa_testcase(
         d1_len: d1.len(),
         unmasked_len: d0.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
     let success = match operation {
         CryptotestEcdsaOperation::Sign => {
-            let mut output_signature = CryptotestEcdsaSignature::recv(&*uart, opts.timeout, false)?;
+            let mut output_signature = CryptotestEcdsaSignature::recv(uart, opts.timeout, false)?;
             // Truncate signature values to correct size for curve and convert to big-endian
             output_signature.r.truncate(output_signature.r_len);
             output_signature.s.truncate(output_signature.s_len);
@@ -443,7 +443,7 @@ fn run_ecdsa_testcase(
             }
         }
         CryptotestEcdsaOperation::Verify => {
-            let ecdsa_output = CryptotestEcdsaVerifyOutput::recv(&*uart, opts.timeout, false)?;
+            let ecdsa_output = CryptotestEcdsaVerifyOutput::recv(uart, opts.timeout, false)?;
             match ecdsa_output {
                 CryptotestEcdsaVerifyOutput::Success => true,
                 CryptotestEcdsaVerifyOutput::Failure => false,
@@ -490,7 +490,7 @@ fn test_ecdsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for ecdsa_test in &ecdsa_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_ecdsa_testcase(ecdsa_test, opts, transport, &mut failures)?;
+            run_ecdsa_testcase(ecdsa_test, opts, &*uart, &mut failures)?;
         }
     }
     assert_eq!(

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -17,6 +17,7 @@ use cryptotest_commands::hmac_commands::{
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
+use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
 use opentitanlib::uart::console::UartConsole;
@@ -52,7 +53,7 @@ const HMAC_CMD_MAX_KEY_BYTES: usize = 192;
 fn run_hmac_testcase(
     test_case: &HmacTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    uart: &dyn Uart,
     fail_counter: &mut u32,
 ) -> Result<()> {
     log::info!(
@@ -60,10 +61,9 @@ fn run_hmac_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
 
     assert_eq!(test_case.algorithm.as_str(), "hmac");
-    CryptotestCommand::Hmac.send(&*uart)?;
+    CryptotestCommand::Hmac.send(uart)?;
 
     assert!(
         test_case.key.len() <= HMAC_CMD_MAX_KEY_BYTES,
@@ -87,21 +87,21 @@ fn run_hmac_testcase(
         "sha3-512" => CryptotestHmacHashAlg::Sha3_512,
         _ => panic!("Unsupported HMAC hash mode"),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
     CryptotestHmacKey {
         key: ArrayVec::try_from(test_case.key.as_slice()).unwrap(),
         key_len: test_case.key.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
     CryptotestHmacMessage {
         message: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
         message_len: test_case.message.len(),
     }
-    .send(&*uart)?;
+    .send(uart)?;
 
-    let hmac_tag = CryptotestHmacTag::recv(&*uart, opts.timeout, false)?;
+    let hmac_tag = CryptotestHmacTag::recv(uart, opts.timeout, false)?;
     let success = if test_case.tag.len() > hmac_tag.tag_len {
         // If we got a shorter tag back then the test asks for, we can't accept the tag, even if
         // the beginning bytes match.
@@ -140,7 +140,7 @@ fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for hmac_test in &hmac_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_hmac_testcase(hmac_test, opts, transport, &mut fail_counter)?;
+            run_hmac_testcase(hmac_test, opts, &*uart, &mut fail_counter)?;
         }
     }
     assert_eq!(


### PR DESCRIPTION

These rust harnesses enable control flow on a UART object but then
immediately drop it and gets it again in each test function. Since
the UART object is reference counted, it will be destroyed in-between
tests and the control flow setting will be lost. The easiest fix is to
create the object once and pass it around.