### PR TITLE
[chip-test/sival] Modify config for csrng_edn_concurrency_reduced_freq

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -2086,7 +2086,7 @@
       name: chip_sw_csrng_edn_concurrency_reduced_freq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:csrng_edn_concurrency_test:1:new_rules"]
-      en_run_modes: ["sw_test_mode_test_rom"]
+      en_run_modes: ["sw_test_mode_test_rom", "fast_sim"]
       run_opts: ["+sw_test_timeout_ns=180_000_000", "+rng_srate_value_min=15",
                  "+rng_srate_value_max=20", "+cal_sys_clk_70mhz=1", "+en_jitter=1"]
       run_timeout_mins: 240


### PR DESCRIPTION
We've recently observed some timeouts for this test in the nighlies. This commit thus speeds up the AST power-up time to reduce the test time per seed similar to the non-reduced frequency variant.