### PR TITLE
[opentitantool] Arbitrary waveform generation via HyperDebug

### DIFF
--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -40,6 +40,7 @@ pub enum Request {
     Gpio { id: String, command: GpioRequest },
     GpioMonitoring { command: GpioMonRequest },
     GpioBitbanging { command: GpioBitRequest },
+    GpioDacBanging { command: GpioDacRequest },
     Uart { id: String, command: UartRequest },
     Spi { id: String, command: SpiRequest },
     I2c { id: String, command: I2cRequest },
@@ -54,6 +55,7 @@ pub enum Response {
     Gpio(GpioResponse),
     GpioMonitoring(GpioMonResponse),
     GpioBitbanging(GpioBitResponse),
+    GpioDacBanging(GpioDacResponse),
     Uart(UartResponse),
     Spi(SpiResponse),
     I2c(I2cResponse),
@@ -141,6 +143,31 @@ pub enum GpioBitResponse {
     // GpioBitRequest::Query will be answered by either QueryNotDone or QueryDone.
     QueryNotDone,
     QueryDone { entries: Vec<BitbangEntryResponse> },
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum DacBangEntryRequest {
+    Write { data: Vec<f32> },
+    Delay { clock_ticks: u32 },
+    Linear { clock_ticks: u32 },
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum GpioDacRequest {
+    Start {
+        pins: Vec<String>,
+        clock_ns: u64,
+        entries: Vec<DacBangEntryRequest>,
+    },
+    Query,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum GpioDacResponse {
+    Start,
+    // GpioDacRequest::Query will be answered by either QueryNotDone or QueryDone.
+    QueryNotDone,
+    QueryDone,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/util/bitbang.rs
+++ b/sw/host/opentitanlib/src/util/bitbang.rs
@@ -8,7 +8,7 @@ use std::iter::Peekable;
 use std::ops::Mul;
 use std::time::Duration;
 
-use crate::io::gpio::BitbangEntry;
+use crate::io::gpio::{BitbangEntry, DacBangEntry};
 
 #[derive(Debug, Eq, PartialEq)]
 enum Token<'a> {
@@ -17,6 +17,7 @@ enum Token<'a> {
     Quoted(&'a str),
 
     Await,
+    Linear,
 
     LParen,
     RParen,
@@ -60,6 +61,7 @@ fn get_token<'a>(
         };
         match &input[token_start..token_end] {
             "await" => Ok(Some(Token::Await)),
+            "linear" => Ok(Some(Token::Linear)),
             other => Ok(Some(Token::Alphabetic(other))),
         }
     } else if first_char == '\'' {
@@ -169,7 +171,7 @@ pub fn parse_delay(num: &str, time_unit: &str, clock: Duration) -> Result<u32> {
     let actual_duration = clock.mul(closest_ticks);
     let ratio = actual_duration.as_secs_f64() / duration;
     ensure!(
-        0.99 <= ratio && ratio <= 1.01,
+        (0.99..=1.00).contains(&ratio),
         "Requested delay cannot be approximated to within 1%, try increasing clock frequency",
     );
     Ok(closest_ticks)
@@ -342,6 +344,108 @@ pub fn parse_sequence<'a, 'wr, 'rd>(
     Ok((result.into(), token_map))
 }
 
+/// This function parses the main string argument to `opentitantool gpio dac-bang`, producing a
+/// list of `DacBangEntry` corresponding to the parsed instructions.  The slices in the entries
+/// will refer to the "accumulator vector" provided by the caller, which this function will clear
+/// out and resize according to need.
+pub fn parse_dac_sequence<'a, 'wr>(
+    input: &'a str,
+    num_pins: usize,
+    clock: Duration,
+    accumulator: &'wr mut Vec<f32>,
+) -> Result<Box<[DacBangEntry<'wr>]>> {
+    ensure!(
+        num_pins > 0,
+        "Must specify at least one analog pin for dac-banging"
+    );
+    let all_tokens = get_all_tokens(input)?;
+
+    // First pass, check how many data bytes are needed.
+    let mut needed_entries = 0usize;
+    let mut run_start = 0usize;
+    let mut run_lengths: Vec<usize> = Vec::new();
+    let mut tokens: &[Token] = &all_tokens;
+    loop {
+        match tokens {
+            [Token::Numeric(_), Token::Alphabetic(_), rest @ ..]
+            | [Token::Linear, Token::LParen, Token::Numeric(_), Token::Alphabetic(_), Token::RParen, rest @ ..] =>
+            {
+                if needed_entries > run_start {
+                    let run_length = needed_entries - run_start;
+                    ensure!(
+                        run_length % num_pins == 0,
+                        "Unexpected number of samples {}, should be multiple of the number of pins {}",
+                        run_length,
+                        num_pins,
+                    );
+                    run_lengths.push(run_length);
+                }
+                run_start = needed_entries;
+                tokens = rest;
+            }
+            [Token::Numeric(_), rest @ ..] => {
+                needed_entries += 1;
+                tokens = rest;
+            }
+            [] => break,
+            _ => bail!("Parse error"),
+        }
+    }
+    if needed_entries > run_start {
+        let run_length = needed_entries - run_start;
+        ensure!(
+            run_length % num_pins == 0,
+            "Unexpected number of samples {}, should be multiple of the number of pins {}",
+            run_length,
+            num_pins,
+        );
+        run_lengths.push(run_length);
+    }
+    accumulator.clear();
+    accumulator.resize(needed_entries, 0.0);
+    let mut slice_wr: &'wr mut [f32] = accumulator;
+    let mut run_lengths: &[usize] = &run_lengths;
+
+    // Second pass, create `DacBangEntry` instances referring to data in the accumulator.
+    let mut result = Vec::new();
+    let mut tokens: &[Token] = &all_tokens;
+    loop {
+        match tokens {
+            [Token::Numeric(num), Token::Alphabetic(time_unit), rest @ ..] => {
+                result.push(DacBangEntry::Delay(parse_delay(num, time_unit, clock)?));
+                tokens = rest;
+            }
+            [Token::Linear, Token::LParen, Token::Numeric(num), Token::Alphabetic(time_unit), Token::RParen, rest @ ..] =>
+            {
+                result.push(DacBangEntry::Linear(parse_delay(num, time_unit, clock)?));
+                tokens = rest;
+            }
+            [Token::Numeric(_), ..] => {
+                let samples = run_lengths[0];
+                let (left_wr, right_wr) = slice_wr.split_at_mut(samples);
+
+                for i in 0..samples {
+                    match tokens[i] {
+                        Token::Numeric(voltage) => {
+                            left_wr[i] = voltage.parse::<f32>()?;
+                        }
+                        _ => bail!("Parse error"),
+                    }
+                }
+
+                result.push(DacBangEntry::Write(left_wr));
+                slice_wr = right_wr;
+                tokens = &tokens[samples..];
+                run_lengths = &run_lengths[1..];
+            }
+            [] => break,
+            _ => bail!("Parse error"),
+        }
+    }
+
+    Ok(result.into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -401,6 +505,19 @@ mod tests {
                 Token::Numeric("100"),
                 Token::Alphabetic("us"),
                 Token::Numeric("11"),
+            ],
+        );
+        assert_eq!(
+            // Analog voltage output example, using "linear(...)" for interpolation.
+            get_all_tokens("1.0 linear(1ms) 0.0").unwrap(),
+            [
+                Token::Numeric("1.0"),
+                Token::Linear,
+                Token::LParen,
+                Token::Numeric("1"),
+                Token::Alphabetic("ms"),
+                Token::RParen,
+                Token::Numeric("0.0"),
             ],
         );
     }

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -136,7 +136,7 @@ pub struct GpioSet {
     #[arg(long, ignore_case = true)]
     pub pull: Option<PullMode>,
     /// The analog value to write to the pin in volts, has effect only in AnalogOutput mode.
-    #[arg(long, value_parser = bool::from_str)]
+    #[arg(long)]
     pub voltage: Option<Voltage>,
 }
 
@@ -194,8 +194,7 @@ pub struct GpioAnalogWrite {
     /// The GPIO pin to write.
     pub pin: String,
     /// The analog value to write to the pin in volts, has effect only in AnalogOutput mode.
-    #[arg(value_parser = bool::from_str)]
-    pub volts: f32,
+    pub voltage: Voltage,
 }
 
 impl CommandDispatch for GpioAnalogWrite {
@@ -207,7 +206,7 @@ impl CommandDispatch for GpioAnalogWrite {
         transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
 
-        gpio_pin.analog_write(self.volts)?;
+        gpio_pin.analog_write(self.voltage.as_volts() as f32)?;
         Ok(None)
     }
 }
@@ -552,7 +551,7 @@ impl CommandDispatch for GpioMonitoring {
 #[derive(Debug, Args)]
 /// Manipulates a given set of GPIO pins, clocking out successive samples at a given frequency.
 pub struct GpioBitbang {
-    /// The list of GPIO pins to monitor (space separated).
+    /// The list of GPIO pins to manipulate (space separated).
     pub pins: Vec<String>,
 
     #[arg(long, value_parser = opentitanlib::util::bitbang::parse_clock_frequency)]

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240529_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "1ed9231800d6bf42ad28b5e44708bbcb63bb9611191be8886861970b0c58909d",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240621_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "649a8cd6d183bc3fb286ea5895c752cfec3aa29b9990f44bb9e7621c0414c7de",
         build_file = "@//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
HyperDebug has fast DACs, meaning that we can have them generate arbitrary waveforms on the analog output pins.

This is useful for verifying that the OpenTitan ADC filters have been configured as intended, by simulating e.g. USB-PD negotiation going on "on top of" the steady state CC voltage levels.

This feature builds on the existing support for streaming binary data for bit-banging, and handling it on HyperDebug via a timer interrupt.

Current HyperDebug firmware supports short bursts of up to 2000 samples at up to 1Msps, or streamed generation of arbitrary lengths at up to around 80ksps.  (If necessary, HyperDebug firmware could be modified to allocate larger buffers, such that more than 2000 samples could be emitted at the maximum speed.)

Example commands below.

Fast USB-PD-like communication "on top of" steady level of 0.25 volt (argument needs to be a lot longer for realistic packet, can be generated programmatically if using opentitanlib):
```
opentitantool --exec="gpio set CN7_9 --mode AnalogOutput --voltage 0.25" \
    gpio dac-bang --clock="600kHz" CN7_9 -s "0.5 0.0 0.5 0.5 0.0 0.5 0.0 0.0 0.5 0.0 0.5 0.25"
```

Gradual voltage drop from 0.25V down to zero in the course of 300 microseconds. (Will be implemented as steps at the given frequency, 180 steps in this example. If the waveform exceeds 2000 samples, HyperDebug may not be able to keep up):
```
opentitantool --exec="gpio set CN7_9 --mode AnalogOutput --voltage 0.25" \
    gpio dac-bang --clock="600kHz" CN7_9 -s "0.25 linear(300us) 0.0"
```

Pauses between bursts (this uses efficient encoding of pauses, so that they do not count towards the 2000 samples):
```
opentitantool --exec="gpio set CN7_9 --mode AnalogOutput --voltage 0.25" \
    gpio dac-bang --clock="600kHz" CN7_9 -s "0.5 0.0 0.5 0.25  100ms   0.5 0.0 0.5 0.25"
```
