### PR TITLE
[otbn,rtl] Avoid locking on corrupt RMA signal

### DIFF
--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -374,8 +374,6 @@ module otbn_start_stop_control
     end
     if (mubi4_test_invalid(rma_ack_q)) begin
       rma_ack_d = MuBi4False;
-      mubi_err_d = 1'b1;
-      state_d = OtbnStartStopStateLocked;
     end
   end
 


### PR DESCRIPTION
The RMA signal comes into the block with an rma_req_i port and is encoded as lc_ctrl_pkg::lc_tx_t. If this happens to appear through a CDC then the 4-bit signal might be corrupted for a cycle on the way and the design is supposed to ignore it (until the value is strictly equal to lc_ctrl_pkg::On.

For the ES chip, there was a bug here, where we would lock OTBN if this happened. This bug was mostly fixed by commit 5228dfc, but that isn't quite a complete fix. The problem is that rma_req_i gets sampled and stored into rma_ack_d when the start/stop control block is in FSM state OtbnStartStopSecureWipeComplete.

This is then clocked into rma_ack_q. The existing code correctly squashed rma_ack_d back to MuBi4False if rma_ack_q was invalid. But it also locked OTBN, which is different from the intended behaviour (ignore invalid signals).

This commit is rather trivial and drops the code that was handling the invalid signals.

Fixes #23585. @vogelpi: would you mind taking a look? I *think* it's a reasonably trivial tidy-up, but I'd love a proper review from someone who knows how this is supposed to work.