### PR TITLE
[spi_device] Mux in missing scan_rst_ni connectivity

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -555,6 +555,7 @@ package spi_device_pkg;
     CsbRstMuxSel,
     ClkMuxSel,
     TpmRstSel,
+    StatusFifoRstSel,
     ScanModeUseLast
   } scan_mode_e;
 


### PR DESCRIPTION
The newer out_clk-synchronized resets were missing direct connectivity for scan reset, as was the CSR-connected reset to the prim_fifo_async used for flash status register updates moving from SW to the SPI clock domain. Add the requisite muxes to patch that up.