### PR TITLE
[dv,usbdev] Monitor improvements and error detection

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -13,6 +13,11 @@ class usb20_agent_cfg extends dv_base_agent_cfg;
 
   `uvm_object_new
 
+  // Exchange the DP/DN signals when driving/monitoring the USB.
+  bit pinflip = 1'b0;
+  // Use the D/SE0 TX outputs from the DUT rather than DP/DN.
+  bit tx_use_d_se0 = 1'b0;
+
   // If this is set then the driver will not perform bitstuffing on the supplied
   // data, so if the caller supplies a sequence of more than six '1' bits,
   // a bitstuffing violation will occur.

--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -12,7 +12,13 @@ package usb20_agent_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // usb20_item enums
+  // USB 2.0 Bus Symbols
+  typedef enum {
+    USB20Sym_SE0,     // EOP, Bus Reset.
+    USB20Sym_J,       // Idle.
+    USB20Sym_K,       // SOP, Resume Signaling.
+    USB20Sym_Invalid  // Not Used.
+  } usb_symbol_e;
 
   // USB-level events; the DP/DN wires are used for transmitting packet data but also held for
   // extended intervals to signal specific bus-level events.

--- a/hw/dv/sv/usb20_agent/usb20_block_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_block_if.sv
@@ -26,7 +26,7 @@ interface usb20_block_if (
   logic usb_tx_use_d_se0_o;
   logic drive_vbus;          // to drive usb_vbus from driver
   logic drive_n;             // to drive usb_n from driver
-  logic drive_p;             // to drive usb_n from driver
+  logic drive_p;             // to drive usb_p from driver
   logic usb_ref_val_o;
   logic usb_ref_pulse_o;
 

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -26,8 +26,8 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
   endfunction
 
   virtual task run_phase(uvm_phase phase);
+    reset_signals();
     forever begin
-      reset_signals();
       get_and_drive();
     end
   endtask
@@ -332,22 +332,9 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     // Bus is unpowered and inactive.
     cfg.bif.drive_vbus = 1'b0;
     cfg.bif.usb_rx_d_i = 1'b0;
-    cfg.bif.drive_p  = 1'b0;
-    cfg.bif.drive_n = 1'b0;
+    cfg.bif.drive_p  = 1'bZ;
+    cfg.bif.drive_n = 1'bZ;
     @(posedge cfg.bif.rst_ni);
-    if (cfg.bif.active) begin
-      // Idle period post DUT reset.
-      repeat (usb_idle_clk_cycles) begin
-        drive_bit_interval(1'b0, 1'b0);
-      end
-      cfg.bif.drive_vbus = 1'b1;
-      repeat (usb_pwr_good_clk_cycles) begin
-        drive_bit_interval(1'b1, 1'b0);
-      end
-      // Waitfor device active state
-      `DV_SPINWAIT(wait(cfg.bif.usb_dp_pullup_o);, "timeout waiting for usb_pullup", 500_000)
-      bus_reset();
-    end
   endtask
 
   // USB Bus Reset

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -15,6 +15,13 @@ class usb20_item extends uvm_sequence_item;
   // Indicates that a timeout occurred when awaiting a response from the device.
   bit timed_out = 1'b0;
 
+  // Validity indicators that apply to all packet types; used by the monitor at metadata for the
+  // scoreboard.
+  bit valid_sync;      // SYNC signal properly formed.
+  bit valid_length;    // Appropriate number of bits.
+  bit valid_stuffing;  // No bit stuffing violations.
+  bit valid_eop;       // End Of Packet correct.
+
   `uvm_object_utils_begin(usb20_item)
   `uvm_object_utils_end
 

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -17,18 +17,26 @@ class usb20_monitor extends dv_base_monitor #(
    data_pkt       m_data_pkt;
    handshake_pkt  m_handshake_pkt;
 
-   bit bit_destuffed[$];
-   bit [2:0] eop_cnt = 3'b000;
-   bit [7:0] packet_type;
-
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+    m_usb20_item = usb20_item::type_id::create("m_usb20_item", this);
     m_sof_pkt = sof_pkt::type_id::create("m_sof_pkt", this);
     m_token_pkt = token_pkt::type_id::create("m_token_pkt", this);
     m_data_pkt = data_pkt::type_id::create("m_data_pkt", this);
     m_handshake_pkt = handshake_pkt::type_id::create("m_handshake_pkt", this);
+    // Complete the event type for the packet objects because these never change.
+    m_sof_pkt.m_ev_type = EvPacket;
+    m_token_pkt.m_ev_type = EvPacket;
+    m_data_pkt.m_ev_type = EvPacket;
+    m_handshake_pkt.m_ev_type = EvPacket;
+    // TODO: presently we do not expect any invalid SYNC signals, but at some point we should be
+    // testing that the DUT correctly ignores such packets/interference.
+    m_sof_pkt.valid_sync = 1;
+    m_token_pkt.valid_sync = 1;
+    m_data_pkt.valid_sync = 1;
+    m_handshake_pkt.valid_sync = 1;
     if (!uvm_config_db#(virtual usb20_block_if)::get(this, "*.env.m_usb20_agent*", "bif",
                                                      cfg.bif)) begin
       `uvm_fatal(`gfn, "failed to get usb20_block_if handle from uvm_config_db")
@@ -41,145 +49,319 @@ class usb20_monitor extends dv_base_monitor #(
 
   task run_phase(uvm_phase phase);
     detect_reset();
+
+    // Wait for VBUS assertion; this will be the first attempt of the driver to connect to the DUT;
+    // also - importantly - some of the sequences exercise the ability of the DUT to drive the
+    // USB lines directly, when the USB is not active. In these tests VBUS has never been asserted,
+    // so we shan't attempt to decode - and thus reject - invalid bus states.
+    wait (cfg.bif.usb_vbus);
+
+    // Wait for device connection; either DP or DN shall be pulled high by the DUT.
+    wait_transition();
+
     forever begin
-      collect_trans();
+      usb_symbol_e sym = USB20Sym_J;
+      // Number of bit intervals for which the USB has been in Idle state.
+      int unsigned idle_time = 0;
+      bit suspended = 0;
+      bit got_sym = 0;
+
+      // To cope with the frequency delta between the host and the device, both of which are
+      // driving the USB, it's important not to sample the bus with a fixed phase, but rather we
+      // detect the transition on the bus and then commence symbol capture.
+      //
+      // We use a parallel process to detect the long duration of Suspend Signaling and thus
+      // differentiate the K state of Resume Signaling from the K state of the Start Of Packet.
+      fork begin : isolation_fork
+        fork
+          begin
+            while (sym == USB20Sym_J) begin
+              // An Idle state for more than 3ms constitutes Suspend Signaling,
+              // measured according to the host-side clock; 12Mbps.
+              if (idle_time > 3_000 * 12) suspended = 1;
+              else idle_time++;
+              collect_symbol(sym);
+            end
+            got_sym = 1;
+          end
+          // Wait until the USB changes state, away from J state.
+          wait_transition();
+        join_any
+        disable fork;
+      end : isolation_fork
+      join
+
+      // Do we still need to collect the first non-J sample?
+      if (!got_sym) collect_symbol(sym);
+      case (sym)
+        // K state indicate SOP, or beginning of Resume Signaling.
+        USB20Sym_K:
+          if (suspended) begin
+            collect_resume_signaling();
+            suspended = 0;
+          end else begin
+            collect_packet();
+          end
+        // Detection of Bus Resets.
+        USB20Sym_SE0: collect_bus_reset();
+        USB20Sym_J: `uvm_fatal(`gfn, "J state should be impossible here")
+        default: `uvm_fatal(`gfn, "Invalid bus state")
+      endcase
     end
   endtask
 
-//-----------------------------------------Collect Trans------------------------------------------//
-  virtual protected task collect_trans();
+  // Await a transition on the USB.
+  task wait_transition();
+    if (cfg.tx_use_d_se0) begin
+      // D/SE0 signaling is being used by the DUT.
+      @(posedge cfg.bif.usb_tx_d_o   or negedge cfg.bif.usb_tx_d_o or
+        posedge cfg.bif.usb_tx_se0_o or negedge cfg.bif.usb_tx_se0_o);
+    end else begin
+      // DP/DN signals are being used directly.
+      @(posedge cfg.bif.usb_n or negedge cfg.bif.usb_n or
+        posedge cfg.bif.usb_p or negedge cfg.bif.usb_p);
+    end
+  endtask
+
+  // Sample USB DP/DN signals.
+  task collect_symbol(output usb_symbol_e sym);
+    // Advance to centre of bit interval.
+    @(posedge cfg.bif.clk_i);
+    @(posedge cfg.bif.clk_i);
+    // Return the symbol currently on the bus, according to the pin configuration.
+    if (cfg.tx_use_d_se0) begin
+      casez ({cfg.bif.usb_tx_d_o, cfg.bif.usb_tx_se0_o})
+        2'b00:   sym = USB20Sym_K;
+        2'b01:   sym = USB20Sym_SE0;
+        2'b10:   sym = USB20Sym_J;
+        default: sym = USB20Sym_Invalid;
+      endcase
+    end else begin
+      casez ({cfg.bif.usb_n, cfg.bif.usb_p})
+        2'b00:   sym = USB20Sym_SE0;
+        2'b01:   sym = (cfg.pinflip ? USB20Sym_K : USB20Sym_J);
+        2'b10:   sym = (cfg.pinflip ? USB20Sym_J : USB20Sym_K);
+        default: sym = USB20Sym_Invalid;
+      endcase
+    end
+    // Advance to next bit interval change.
+    @(posedge cfg.bif.clk_i);
+    @(posedge cfg.bif.clk_i);
+  endtask
+
+  // Bus Reset detected on the USB.
+  virtual task collect_bus_reset();
+    int unsigned bit_cnt = 0;
+    usb_symbol_e sym;
+    collect_symbol(sym);
+    while (sym == USB20Sym_SE0) begin
+      bit_cnt++;
+      collect_symbol(sym);
+    end
+    // TODO: presently we are still relying upon the DUT driver enable to ascertain who is talking;
+    // the DUT shall NEVER be generating Bus Reset Signaling.
+    `DV_CHECK_EQ(cfg.bif.usb_dp_en_o, 0, "Bus Reset Signaling generated by DUT")
+    `uvm_info(`gfn, $sformatf("Bus Reset of %d bit intervals detected", bit_cnt), UVM_MEDIUM)
+    m_usb20_item.m_ev_type = EvBusReset;
+    m_usb20_item.m_ev_duration_usecs = (bit_cnt + 11) / 12;
+    req_analysis_port.write(m_usb20_item);
+  endtask
+
+  // Resume Signaling detected on the USB.
+  virtual task collect_resume_signaling();
+    int unsigned bit_cnt = 0;
+    usb_symbol_e sym;
+    bit valid;
+    collect_symbol(sym);
+    while (sym == USB20Sym_K) begin
+      bit_cnt++;
+      collect_symbol(sym);
+    end
+    valid = (sym == USB20Sym_SE0);
+    // The Resume Signaling ends with a Low Speed EOP (2 SE0 bits and 1 Idle) and is 8 times
+    // slower than Full Speed signaling, but we have already collected the first symbol.
+    for (int i = 0; i < 23; i++) begin
+      collect_symbol(sym);
+      valid = valid & (sym == ((i >= 15) ? USB20Sym_J : USB20Sym_SE0));
+    end
+    // TODO: presently we are still relying upon the DUT driver enable to ascertain who is talking;
+    // the DUT shall NEVER be generating Resume Signaling.
+    `DV_CHECK_EQ(cfg.bif.usb_dp_en_o, 0, "Bus Resume Signaling generated by DUT")
+    // Check that the Resume Signaling from the driver is as expected.
+    `DV_CHECK_EQ(valid, 1, "Invalid Resume Signaling")
+    `uvm_info(`gfn, $sformatf("Resume Signaling of %d bit intervals detected", bit_cnt), UVM_MEDIUM)
+    m_usb20_item.m_ev_type = EvResume;
+    m_usb20_item.m_ev_duration_usecs = (bit_cnt + 11) / 12;
+    req_analysis_port.write(m_usb20_item);
+  endtask
+
+//----------------------------------------Collect Packet------------------------------------------//
+  virtual task collect_packet();
+    // The first byte of every packet is the SYNC signal to permit DPLLs to lock.
+    byte unsigned sync = 8'h2a;
+    int unsigned eop_bits = 0;
     bit monitored_decoded_packet[];
-    bit use_negedge;
+    bit destuffed_packet[$];
+    bit valid_stuffing;
+    usb_symbol_e sym;
+    bit valid_eop;
     bit packet[$];
 
-    // Wait until bus becomes Idle
-    while(!(cfg.bif.usb_p & ~cfg.bif.usb_n)) @(posedge cfg.bif.clk_i);
-    @(posedge cfg.bif.clk_i);
-    // Entry to K state detected here; SOP signaling.
-    wait(~cfg.bif.usb_p & cfg.bif.usb_n);
-    @(posedge cfg.bif.clk_i);
-    @(posedge cfg.bif.clk_i);
-
-    // Collecting usb_p from interface
-    while (cfg.bif.usb_p || cfg.bif.usb_n) begin
-      packet.push_back(cfg.bif.usb_p);
-      @(posedge cfg.bif.clk_i);
-      @(posedge cfg.bif.clk_i);
-      @(posedge cfg.bif.clk_i);
-      @(posedge cfg.bif.clk_i);
+    // We have already detected the first K state of the SYNC signaling.
+    packet.push_back(1'b0);
+    // Keep collecting symbols until we detect something that is neither J nor K.
+    collect_symbol(sym);
+    while (sym == USB20Sym_J || sym == USB20Sym_K) begin
+      packet.push_back(sym == USB20Sym_J);
+      collect_symbol(sym);
     end
-    // TODO: this does not even check the EOP!
-    // TODO: we should almost certainly be consuming the EOP interval here.
+    // TODO: Consider 'dribble' tolerance here.
+    // Detect and validate the EOP signaling.
+    while (sym == USB20Sym_SE0) begin
+      eop_bits++;
+      collect_symbol(sym);
+    end
+    valid_eop = (eop_bits == 2);
 
-    `uvm_info(`gfn, $sformatf("Complete monitored packet = %p ", packet), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("Complete monitored packet = %p ", packet), UVM_MEDIUM)
+
+    // We never expect to receive invalid SYNC signals at present; at some point we may generate
+    // them from the driver, but the DUT should never generate them.
+    `DV_CHECK_GT(packet.size(), 8, "Incomplete SYNC signal detected")
+    for (int unsigned b = 0; b < 8; b++) begin
+      `DV_CHECK_EQ(packet[b], sync[b], $sformatf("Invalid SYNC signal detected %p", packet))
+    end
+
     nrzi_decoder(packet, monitored_decoded_packet);
-    bit_destuffing(monitored_decoded_packet, bit_destuffed);
-    classifies_packet();
-    packet.delete();
+    bit_destuffing(monitored_decoded_packet, valid_stuffing, destuffed_packet);
+    classifies_packet(valid_eop, valid_stuffing, destuffed_packet);
   endtask
 
 //----------------------------------------Classifies Trans----------------------------------------//
-  virtual task classifies_packet();
+  function classifies_packet(bit valid_eop, bit valid_stuffing, ref bit destuffed_packet[$]);
+    // Read the Packet IDentifier and check its validity.
+    pid_type_e pid_e;
+    bit [7:0] pid;
     for (int i = 0; i < 8; i++) begin
-    packet_type[i] = bit_destuffed[i + 8];
+      pid[i] = destuffed_packet[i + 8];
     end
-    `uvm_info(`gfn, $sformatf(".......Packet PID = %b ", packet_type), UVM_HIGH)
-    case (packet_type)
-      PidTypeOutToken: token_packet();
-      PidTypeInToken: token_packet();
-      PidTypeSetupToken: token_packet();
-      PidTypeSofToken: sof_packet();
-      PidTypeData0: data_packet();
-      PidTypeData1: data_packet();
-      PidTypeAck: handshake_packet();
-      PidTypeNak: handshake_packet();
-      PidTypeStall: handshake_packet();
-      default: invalid_packet_pid();
+    `uvm_info(`gfn, $sformatf(".......Packet PID = %b", pid), UVM_HIGH)
+    pid_e = pid_type_e'(pid);
+    case (pid)
+      // Token PID Types.
+      PidTypeOutToken,
+      PidTypeInToken,
+      PidTypeSetupToken: token_packet(pid_e, valid_eop, valid_stuffing, destuffed_packet);
+      PidTypeSofToken: sof_packet(pid_e, valid_eop, valid_stuffing, destuffed_packet);
+      // Data PID Types.
+      PidTypeData0,
+      PidTypeData1,
+      PidTypeData2,
+      PidTypeMData: data_packet(pid_e, valid_eop, valid_stuffing, destuffed_packet);
+      // Handshake PID Types.
+      PidTypeAck,
+      PidTypeNak,
+      PidTypeStall,
+      PidTypeNyet: handshake_packet(pid_e, valid_eop, valid_stuffing, destuffed_packet);
+      // TODO: Special PID Types not yet relevant.
+      default: invalid_packet_pid(pid_e, valid_eop, valid_stuffing, destuffed_packet);
     endcase
-  endtask
+  endfunction
 
 //-------------------------------------------SOF Packet-------------------------------------------//
-  virtual task sof_packet();
-    typedef bit [31:0] sof_p;
-    sof_p sof_result;
-
+  function sof_packet(pid_type_e pid, bit valid_eop, bit valid_stuffing,
+                      ref bit destuffed_packet[$]);
     // bits to binary conversion
-    sof_result = sof_p'(bit_destuffed);
-    m_sof_pkt.m_pid_type = pid_type_e'(packet_type);
-    m_sof_pkt.framenum = {<<{sof_result[18:8]}};
-    m_sof_pkt.crc5 = {<<{sof_result[7:3]}};
+    m_sof_pkt.m_pid_type = pid;
+    m_sof_pkt.valid_eop = valid_eop;
+    m_sof_pkt.valid_stuffing = valid_stuffing;
+    if (destuffed_packet.size() == 32) begin
+      m_sof_pkt.framenum = {<<{destuffed_packet[18:8]}};
+      m_sof_pkt.crc5 = {<<{destuffed_packet[7:3]}};
+      m_sof_pkt.valid_length = 1;
+    end else m_sof_pkt.valid_length = 0;
+
     req_analysis_port.write(m_sof_pkt);
-  endtask
+  endfunction
 
 //------------------------------------------Token Packet------------------------------------------//
-  virtual task token_packet();
-    typedef bit [31:0] token_p;
-    token_p token_result;
-
+  function token_packet(pid_type_e pid, bit valid_eop, bit valid_stuffing,
+                        ref bit destuffed_packet[$]);
     // bits to binary conversion
-    token_result = token_p'(bit_destuffed);
-    m_token_pkt.m_pid_type =  pid_type_e'(packet_type);
-    m_token_pkt.address = {<<{token_result[18:12]}};
-    m_token_pkt.endpoint = {<<{token_result[11:8]}};
-    m_token_pkt.crc5 = {<<{token_result[7:3]}};
+    m_token_pkt.m_pid_type = pid;
+    m_token_pkt.valid_eop = valid_eop;
+    m_token_pkt.valid_stuffing = valid_stuffing;
+    if (destuffed_packet.size() == 32) begin
+      m_token_pkt.address = {<<{destuffed_packet[18:12]}};
+      m_token_pkt.endpoint = {<<{destuffed_packet[11:8]}};
+      m_token_pkt.crc5 = {<<{destuffed_packet[7:3]}};
+      m_token_pkt.valid_length = 1;
+    end else m_token_pkt.valid_length = 0;
+
     req_analysis_port.write(m_token_pkt);
-  endtask
+  endfunction
 
 //------------------------------------------Data Packet-------------------------------------------//
-  virtual task data_packet();
-    bit [7:0] data_pid;
-    bit [7:0] data_temp[];
+  function data_packet(pid_type_e pid, bit valid_eop, bit valid_stuffing,
+                       ref bit destuffed_packet[$]);
     bit data[];
-    bit [6:0] size;
-    bit [63:0] data_result;
     bit [15:0] data_crc16;
     byte unsigned byte_data[];
 
     // Converting complete packet into transaction level (field wise)
     // Data_PID
-    m_data_pkt.m_pid_type = pid_type_e'(packet_type);
-    // Data_in_bits
-    for (int i = 0 ; i < bit_destuffed.size() - 32; i++) begin
-      data = new[data.size() + 1](data);
-      data[i] = bit_destuffed[i + 16];
-    end
-    data = {<<8{data}};
-    data = {<<{data}};
-    // Bits_to_byte conversion of data
-    byte_data = {>>byte{data}};
-    m_data_pkt.data = byte_data;
-    // Crc16
-    for (int i= 0; i < 16; i = i+1) begin
-      data_crc16[i] = bit_destuffed[i + 16 + data.size()];
-    end
-    m_data_pkt.crc16 = data_crc16;
-     if (cfg.bif.usb_dp_en_o) rsp_analysis_port.write(m_data_pkt);
+    m_data_pkt.m_pid_type = pid;
+    m_data_pkt.valid_eop = valid_eop;
+    m_data_pkt.valid_stuffing = valid_stuffing;
+    if (destuffed_packet.size() >= 32 && !(destuffed_packet.size() & 7)) begin
+      // Data_in_bits
+      for (int i = 0 ; i < destuffed_packet.size() - 32; i++) begin
+        data = new[data.size() + 1](data);
+        data[i] = destuffed_packet[i + 16];
+      end
+      data = {<<8{data}};
+      data = {<<{data}};
+      // Bits_to_byte conversion of data
+      byte_data = {>>byte{data}};
+      m_data_pkt.data = byte_data;
+      // Crc16
+      for (int i= 0; i < 16; i = i+1) begin
+        data_crc16[i] = destuffed_packet[i + 16 + data.size()];
+      end
+      m_data_pkt.crc16 = data_crc16;
+      m_data_pkt.valid_length = 1;
+    end else m_data_pkt.valid_length = 0;
+
+    if (cfg.bif.usb_dp_en_o) rsp_analysis_port.write(m_data_pkt);
     else req_analysis_port.write(m_data_pkt);
-  endtask
+  endfunction
 
 //----------------------------------------Handshake Packet----------------------------------------//
-  virtual task handshake_packet();
-    typedef bit [15:0] handshake_p;
-    handshake_p handshake_result;
-
+  function handshake_packet(pid_type_e pid, bit valid_eop, bit valid_stuffing,
+                            ref bit destuffed_packet[$]);
     // bits to binary conversion
-    handshake_result = handshake_p'(bit_destuffed);
-    m_handshake_pkt.m_pid_type = pid_type_e'(packet_type);
+    m_handshake_pkt.m_pid_type = pid;
+    m_handshake_pkt.valid_eop = valid_eop;
+    m_handshake_pkt.valid_stuffing = valid_stuffing;
+    if (destuffed_packet.size() == 16) begin
+      m_handshake_pkt.valid_length = 1;
+    end else m_handshake_pkt.valid_length = 0;
+
     if (cfg.bif.usb_dp_en_o) rsp_analysis_port.write(m_handshake_pkt);
     else req_analysis_port.write(m_handshake_pkt);
-  endtask
+  endfunction
 
   //----------------------------------------Invalid Packet----------------------------------------//
-  virtual task invalid_packet_pid();
-    typedef bit [7:0] invalid_pid_p;
-    invalid_pid_p invalid_pid_result;
-    int unsigned size;
-    size = $size(bit_destuffed);
+  function invalid_packet_pid(pid_type_e pid, bit valid_eop, bit valid_stuffing,
+                                  ref bit destuffed_packet[$]);
+    int unsigned size = destuffed_packet.size();
     `uvm_info(`gfn, $sformatf("packet size = %d", size), UVM_HIGH)
-    if (size == 32) token_packet();
-    else if (size == 16) handshake_packet();
-    else data_packet();
-  endtask
+    case (size)
+      16:      handshake_packet(pid, valid_eop, valid_stuffing, destuffed_packet);
+      32:      token_packet(pid, valid_eop, valid_stuffing, destuffed_packet);
+      default: data_packet(pid, valid_eop, valid_stuffing, destuffed_packet);
+    endcase
+  endfunction
 
   // NRZI decoder
   task nrzi_decoder(input bit nrzi_in[], output bit monitored_decoded_packet[]);
@@ -200,15 +382,21 @@ class usb20_monitor extends dv_base_monitor #(
   endtask
 
   // Bit Destuffing
-  task bit_destuffing(input bit packet[], output bit packet_destuffed[$]);
+  task bit_destuffing(input bit packet[], output bit valid_stuffing,
+                      output bit packet_destuffed[$]);
     int unsigned consecutive_ones_count = 0;
     int i;
+
+    // Clear the validity flag if we encounter any violations whilst destuffing.
+    valid_stuffing = 1;
+
     for (i = 0; i < packet.size(); i++) begin
       if (consecutive_ones_count >= 6) begin
         if (packet[i] != 1'b0) begin
           // TODO: record and forward the bit stuffing violation for error-injection sequences.
           `uvm_info(`gfn, $sformatf("Bit stuffing violation detected in %p at bit %d",
                                     packet, i), UVM_LOW)
+          valid_stuffing = 0;
         end
         consecutive_ones_count = 0;
       end else begin
@@ -221,6 +409,7 @@ class usb20_monitor extends dv_base_monitor #(
       // TODO: record and forward the bit stuffing violation for error-injection sequences.
       `uvm_info(`gfn, $sformatf("Bit stuffing violation detected in %p at bit %d", packet, i),
                 UVM_LOW)
+      valid_stuffing = 0;
     end
     `uvm_info(`gfn, $sformatf("Monitored Destuffed Packet = %p", packet_destuffed), UVM_HIGH)
   endtask
@@ -236,25 +425,4 @@ class usb20_monitor extends dv_base_monitor #(
     // the negedge of the clk.
     cfg.clk_rst_if_i.wait_for_reset(0, 1);
   endtask
-
-  // TODO: is this used; what was it meant to do?!
-  virtual task monitor_ready_to_end();
-    detect_reset();
-    wait(cfg.bif.usb_p & ~cfg.bif.usb_n);
-    while(!(cfg.bif.usb_p & ~cfg.bif.usb_n)) @(posedge cfg.bif.clk_i);
-    forever begin
-      @(posedge cfg.bif.clk_i);
-      if (~cfg.bif.usb_p & ~cfg.bif.usb_n) begin
-        eop_cnt++;
-        if (eop_cnt == 3'b110) begin
-          ok_to_end = 1;
-          eop_cnt = 0;
-          break;
-        end else begin
-          ok_to_end = 0;
-        end
-      end
-    end
-    `uvm_info(`gfn, $sformatf("ok_to_end = %b", ok_to_end), UVM_HIGH)
-  endtask : monitor_ready_to_end
 endclass

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_pins_sense_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_pins_sense_vseq.sv
@@ -10,6 +10,17 @@ class usbdev_phy_pins_sense_vseq extends usbdev_base_vseq;
   rand bit set_dp;
   rand bit set_dn;
 
+  task pre_start();
+    // Prevent normal device initialization.
+    //
+    // This sequence is designed to drive the USB lines without valid USB traffic, so the
+    // last thing we need is the driver and monitor connecting. The monitor would reject the bus
+    // state or apparent traffic.
+    do_usbdev_init = 1'b0;
+
+    super.pre_start();
+  endtask
+
   task body();
     bit rx_dp;
     bit rx_dn;
@@ -20,7 +31,7 @@ class usbdev_phy_pins_sense_vseq extends usbdev_base_vseq;
     csr_wr(.ptr(ral.phy_pins_drive.dn_o), .value(set_dn));
     csr_wr(.ptr(ral.phy_pins_drive.oe_o), .value(1'b1));
     csr_wr(.ptr(ral.phy_pins_drive.en), .value(1'b1));
-    cfg.clk_rst_vif.wait_clks(5);
+    loopback_delay();
 
     // Read phy_pins_sense reg
     csr_rd(.ptr(ral.phy_pins_sense.rx_dp_i), .value(rx_dp));

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -190,8 +190,8 @@ module tb;
   assign (strong0, strong1) usb_p = cio_usb_dp_en ? cio_usb_dp : 1'bZ;
   assign (strong0, strong1) usb_n = cio_usb_dn_en ? cio_usb_dn : 1'bZ;
   // Implement pull ups for the physical USB connection to USBDPI model.
-  assign (weak0, pull1) usb_p = (usb20_if.connected & usb_dp_pullup_en) ? 1'b1 : 1'bz;
-  assign (weak0, pull1) usb_n = (usb20_if.connected & usb_dn_pullup_en) ? 1'b1 : 1'bz;
+  assign (weak0, pull1) usb_p = usb_dp_pullup_en ? 1'b1 : 1'bz;
+  assign (weak0, pull1) usb_n = usb_dn_pullup_en ? 1'b1 : 1'bz;
 
   // Instantiate & connect the USB DPI model for additional block-level testing and coverage.
   usb20_usbdpi u_usb20_usbdpi (


### PR DESCRIPTION
This PR mostly extends the usb20_monitor to support other bus configurations and non-packet signaling on the USB, and to detect and indicate the presence of errors in the received packets. The driver is also simplified slightly to leave only the 'mechanism' within the driver and leave the sequence to determine what activity shall be generated ('policy').

- Correct the collection of packet traffic to validate the End Of Packet.
- Generalize the collection of symbols from the USB so that the other bus configuration may readily be tested later.
- Implement the detection of invalid SYNC signals, invalid EOP and bit stuffing errors; flag these in the item that we will forward to the scoreboard.
- This also means that the agent is now using true tri-stated USB signaling.
- Support the detection and reporting of non-packet USB events (Bus Reset, Suspend-Resume Signaling) in the usb20_monitor.
- Modify the start up sequence of the usb20_driver to be passive, so that the sequence may determine whether to generate valid USB traffic. This then permits the usb20_monitor to start up appropriately or to remain inactive and not report invalid bus states.

Following the above changes in the agent, the sequences are simplified with regard to connection and device initialization, and the generation of invalid bus traffic shall now be detected and tolerated in the monitor.This should raise the overall DV test pass rate into the high 90s for the first time and all extant tests should now pass with all seeds.