### PR TITLE
[dv/tlt] Fix ROM JTAG injection tests.

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -647,16 +647,17 @@
       name: rom_e2e_jtag_inject_test_unlocked0
       uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/jtag_inject:img_dev_exec_disabled:4",
+        "//sw/device/silicon_creator/rom/e2e/jtag_inject:img_test_unlocked0_exec_disabled:4",
         "//sw/device/examples/sram_program:sram_program:5",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
+        "+sw_test_timeout_ns=40_000_000",
         "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 200
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_jtag_inject_dev
@@ -667,26 +668,28 @@
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
+        "+sw_test_timeout_ns=40_000_000",
         "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 200
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_jtag_inject_rma
       uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/jtag_inject:img_dev_exec_disabled:4",
+        "//sw/device/silicon_creator/rom/e2e/jtag_inject:img_rma_exec_disabled:4",
         "//sw/device/examples/sram_program:sram_program:5",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [
+        "+sw_test_timeout_ns=40_000_000",
         "+use_jtag_dmi=1",
         "+use_otp_image=OtpTypeCustom",
       ]
       reseed: 1
-      run_timeout_mins: 200
+      run_timeout_mins: 240
     }
     {
       name: rom_e2e_static_critical


### PR DESCRIPTION
The OTP images used in ROM e2e test cases set `EN_SRAM_IFETCH` to `True` inside the `HW_CFG1` partition. The `sram_ctrl` checks the otp value to determine to use the fetch enable signal provided by `lc_ctrl` versus the `sram_ctrl` `exec` register value.

This change enables SRAM execution by setting the `sram_ctrl` exec register. The `chip_sw_sram_ctrl_execution_main` test cases checks all the other OTP versus SRAM register permutations.