### PR TITLE
[rv_core_ibex] Move back to V2

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -22,7 +22,7 @@
   version:            "1.0.0",
   life_stage:         "L1",
   design_stage:       "D2S",
-  verification_stage: "V2S",
+  verification_stage: "V2",
   dif_stage:          "S2",
   notes:              "Ibex Verification is tracked in the [Ibex documentation](https://ibex-core.readthedocs.io/en/latest/03_reference/verification_stages.html)."
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true},


### PR DESCRIPTION
Latest sign-off identified some small holes in testing around recently introduced security features (#23542) so moving back to V2 until tests are written to cover these.