### PR TITLE
[spi_device, dv] disallow certain commands if busy

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -42,6 +42,9 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   // Controls address size for flash_cmd_info of type SpiFlashAddrCfg.
   bit              flash_addr_4b_en;
 
+  // If set to null then CSB is high - variable only valid for flash
+  spi_item ongoing_flash_cmd;
+
   // set this mode before starting an item
   spi_func_mode_e  spi_func_mode;
 

--- a/hw/ip/spi_device/dv/base_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/base_sim_cfg.hjson
@@ -143,6 +143,11 @@
     }
 
     {
+      name: spi_device_flash_mode_ignore_cmds
+      uvm_test_seq: spi_device_flash_mode_ignore_cmds_vseq
+    }
+
+    {
       name: spi_device_read_buffer_direct
       uvm_test_seq: spi_device_read_buffer_direct_vseq
       // it's a direct test, and checking is done in seq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -86,6 +86,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
     `DV_SPINWAIT(
       while (1) begin
         cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+        `uvm_info(`gfn, "Sending READ_STATUS#1", UVM_DEBUG)
         `DV_CHECK_RANDOMIZE_WITH_FATAL(m_spi_host_seq,
                                       opcode == READ_STATUS_1;
                                       address_q.size() == 0;

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_ignore_cmds_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_flash_mode_ignore_cmds_vseq.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: fix description
+// Enable all passthrough/flash related features during init, and then randomly send valid commands
+class spi_device_flash_mode_ignore_cmds_vseq extends spi_device_flash_all_vseq;
+  `uvm_object_utils(spi_device_flash_mode_ignore_cmds_vseq)
+  `uvm_object_new
+
+  bit         busy;
+  bit [7:0]   valid_ignored_while_busy_opcode_q[$];
+
+  virtual task body();
+    super.body();
+  endtask : body
+
+  virtual task knobs_before_randomize_op_addr_size();
+    super.knobs_before_randomize_op_addr_size();
+    get_flash_status_busy(busy);
+    wait_on_busy = 0;
+  endtask
+
+  function void randomize_op_addr_size();
+    super.randomize_op_addr_size();
+
+    if(busy) begin
+      // 1 - populate a queue of commands which may get ignored
+      valid_ignored_while_busy_opcode_q.push_back(WREN);
+      valid_ignored_while_busy_opcode_q.push_back(WRDI);
+      valid_ignored_while_busy_opcode_q.push_back(EN4B);
+      valid_ignored_while_busy_opcode_q.push_back(EX4B);
+      // The above plus upload commands that are valid
+      foreach (cfg.spi_host_agent_cfg.cmd_infos[idx])  begin
+        if(ral.cmd_info[idx].upload && ral.cmd_info[idx].valid && ral.cmd_info[idx].busy) begin
+          valid_ignored_while_busy_opcode_q.push_back(cfg.spi_host_agent_cfg.cmd_infos[idx].opcode);
+        end
+        if(!std::randomize(opcode) with {opcode inside {valid_ignored_while_busy_opcode_q}; })
+          `uvm_fatal(`gfn, "Randomization Failure")
+      end
+    end // if (busy)
+
+  endfunction // randomize_op_addr_size
+
+endclass : spi_device_flash_mode_ignore_cmds_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -22,6 +22,7 @@
 `include "spi_device_flash_mode_vseq.sv"
 `include "spi_device_read_buffer_direct_vseq.sv"
 `include "spi_device_flash_all_vseq.sv"
+`include "spi_device_flash_mode_ignore_cmds_vseq.sv"
 `include "spi_device_flash_and_tpm_vseq.sv"
 `include "spi_device_flash_and_tpm_min_idle_vseq.sv"
 `include "spi_device_stress_all_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -39,6 +39,7 @@ filesets:
       - seq_lib/spi_device_flash_mode_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_read_buffer_direct_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_flash_all_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_flash_mode_ignore_cmds_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_flash_and_tpm_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_flash_and_tpm_min_idle_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_stress_all_vseq.sv: {is_include_file: true}

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -41,6 +41,10 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
   // work correctly
   bit                 last_flash_cmd_set_busy = 0;
 
+  // vseq_txn_finished is used to avoid blocking on flash_status.busy being set
+  // If the busy set
+  bit                 vseq_txn_finished;
+
   `uvm_object_utils_begin(spi_device_env_cfg)
     `uvm_field_object(spi_host_agent_cfg, UVM_DEFAULT)
     `uvm_field_object(spi_device_agent_cfg, UVM_DEFAULT)

--- a/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cov.sv
@@ -22,6 +22,14 @@ class tpm_read_hw_reg_cg_wrap;
   endfunction : sample
 endclass
 
+covergroup busy_blocks_command_cg with function sample (bit command_blocked);
+  option.per_instance = 1;
+  cp_blocked_or_allowed: coverpoint command_blocked {
+    bins allowed = {0};
+    bins blocked = {1};
+  }
+endgroup
+
 class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
   `uvm_component_utils(spi_device_env_cov)
   tpm_read_hw_reg_cg_wrap tpm_read_hw_reg_cg_wraps[string];
@@ -276,6 +284,12 @@ class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
     }
   endgroup
 
+  busy_blocks_command_cg en4b_block_cmd_cg;
+  busy_blocks_command_cg ex4b_block_cmd_cg;
+  busy_blocks_command_cg wren_block_cmd_cg;
+  busy_blocks_command_cg wrdi_block_cmd_cg;
+  busy_blocks_command_cg upload_block_cmd_cg;
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
     // add more covergroup here
@@ -306,6 +320,13 @@ class spi_device_env_cov extends cip_base_env_cov #(.CFG_T(spi_device_env_cfg));
     tpm_interleave_with_flash_item_cg = new();
     en4b_flash_cmd_clash_with_addr_mode_write_cg = new();
     ex4b_flash_cmd_clash_with_addr_mode_write_cg = new();
+
+
+    en4b_block_cmd_cg = new();
+    ex4b_block_cmd_cg = new();
+    wren_block_cmd_cg = new();
+    wrdi_block_cmd_cg = new();
+    upload_block_cmd_cg = new();
 
   endfunction : new
 


### PR DESCRIPTION
en/ex4b wren/wrdis and upload commands are ignored if busy bit is set 
FCOV has been added to know when a command is ignored due to flash status busy bit being set