### PR TITLE
[csrng/dv] Correct prediction of FIPS/CC compliance flag for UNI cmd

### DIFF
--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -493,8 +493,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
     cfg.key[app] = 'h0;
     cfg.v[app]   = 'h0;
     cfg.reseed_counter[app] = 1'b0;
-    cfg.compliance[app]     =  ((`gmv(ral.ctrl.fips_force_enable) == MuBi4True) &&
-                                 `gmv(ral.fips_force)[app]);
+    cfg.compliance[app]     = 1'b0;
     cfg.status[app]         = 1'b0;
   endfunction
 


### PR DESCRIPTION
This got accidentally modified with commit 3b47465d33e980e728ce96168cab07093efcf6ee. See also lowRISC/OpenTitan#23349.