### PR TITLE
[sram_ctrl/rtl] Use flop instead of prim_sparse_flop

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -606,10 +606,6 @@ module sram_ctrl
       u_tlul_adapter_sram.u_reqfifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
       alert_tx_o[0])
 
-  // Alert assertions for sparse FSM.
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(TlSramByteFsm_A,
-      u_tlul_adapter_sram.u_sram_byte.gen_integ_handling.u_state_regs, alert_tx_o[0])
-
   // `tlul_gnt` doesn't factor in `sram_gnt` for timing reasons. This assertions checks that
   // `tlul_gnt` is the same as `sram_gnt` when there's an active `tlul_req` that isn't being ignored
   // because the SRAM is initializing.

--- a/hw/ip/tlul/rtl/tlul_sram_byte.sv
+++ b/hw/ip/tlul/rtl/tlul_sram_byte.sv
@@ -101,7 +101,13 @@ module tlul_sram_byte import tlul_pkg::*; #(
     logic rdback_wait;
     state_e state_d, state_q;
 
-    `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StPassThru)
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        state_q <= StPassThru;
+      end else begin
+        state_q <= state_d;
+      end
+    end
 
     // transaction qualifying signals
     logic a_ack;  // upstream a channel acknowledgement


### PR DESCRIPTION
This commit changes back the PRIM_FLOP_SPARSE_FSM to an ordinary flop.