### PR TITLE
[otbn,dv] Partially fix RMA request handling

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -414,9 +414,6 @@ class OTBNState:
         # Clear any pending request in the RND EDN client
         self.ext_regs.rnd_forget()
 
-        # Clear RMA request flag
-        self.rma_req = False
-
     def get_fsm_state(self) -> FsmState:
         return self._fsm_state
 

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -352,7 +352,7 @@ class OTBNState:
         # externally-visible registers). We want to roll back any of those
         # changes.
         insn_failed = self._err_bits and self._fsm_state == FsmState.EXEC
-        if insn_failed or self.rma_req:
+        if insn_failed:
             self._abort()
 
         # INTR_STATE is the interrupt state register. Bit 0 (which is being

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -144,6 +144,11 @@ class OTBNState:
         # stop_at_end_of_cycle method and this flag.
         self.rma_req = False
 
+        # This flag gets set as soon as we leave the Idle state for the first
+        # time. It reflects the behaviour of wipe_after_urnd_refresh_q in
+        # otbn_start_stop_control.sv, which skips a round of secure wiping
+        self.has_state_to_wipe = False
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override
@@ -312,6 +317,7 @@ class OTBNState:
 
         self._fsm_state = FsmState.PRE_EXEC
         self._next_fsm_state = FsmState.PRE_EXEC
+        self.has_state_to_wipe = True
 
         self.pc = 0
 


### PR DESCRIPTION
This isn't completely working, because of the bug that I tried to fix in (the incorrect) PR #23587. With that incorrect fix working around the problem I was seeing there, I stumbled into some other issues, which this PR fixes properly.

- When we've taken an RMA request, we go down a path where we use the `stop` function to cancel any instructions that happen to be in flight. We want that behaviour, but we don't want the function to also forget about the RMA request. The first commit tidies that up.
- On an RMA request that happens before we run any operations, we don't want OTBN to actually do a secure wipe. In the design, the logic is that there's nothing that needs wiping anyway! The second commit makes the model use the same logic.
- When we take an RMA request, we need the STATUS register to jump to LOCKED. This register is "double flopped" in the model, to represent the exact timing that we expect. But the "I'm locking" logic ends up throwing away the partially committed change to the STATUS register. The third commit stops us from doing that.