### PR TITLE
[edn] Hold csrng_req_valid until valid/ready handshake completes

### DIFF
--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -95,6 +95,7 @@
       name: edn_alert
       uvm_test: edn_alert_test
       uvm_test_seq: edn_alert_vseq
+      reseed: 200
     }
 
     {


### PR DESCRIPTION
Previously, EDN could immediately de-assert the valid upon getting an ACK error thereby violating the valid/ready handshake protocol between EDN and CSRNG.