### PR TITLE
[test] Fix up spi_passthru test to check WIP

### DIFF
--- a/sw/host/tests/chip/spi_device/src/spi_passthru.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_passthru.rs
@@ -332,6 +332,7 @@ fn test_write_status(opts: &Opts, transport: &TransportWrapper, opcode: u8) -> R
     let spi = transport.spi(&opts.spi)?;
     let info = UploadInfo::execute(&*uart, || {
         spi.run_transaction(&mut [Transfer::Write(&[opcode])])?;
+        SpiFlash::wait_for_busy_clear(&*spi)?;
         Ok(())
     })?;
 


### PR DESCRIPTION
test_write_status was missing the busy bit check, as there is no SpiFlash helper method for WriteStatus1.