### PR TITLE
[dv/tlt] Fix power virus test.

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -2117,9 +2117,11 @@
         "//sw/device/tests:power_virus_systemtest:1:new_rules",
         "//sw/device/tests:power_virus_systemtest_otp_img_rma:4",
       ]
-      en_run_modes: ["sw_test_mode_test_rom"]
+      en_run_modes: ["sw_test_mode_test_rom", "fast_sim"]
       run_opts: [
-        "+sw_test_timeout_ns=200_000_000",
+        "+rng_srate_value_min=15",
+        "+rng_srate_value_max=20",
+        "+sw_test_timeout_ns=400_000_000",
         "+use_otp_image=OtpTypeCustom",
       ]
       run_timeout_mins: 300


### PR DESCRIPTION
1. Add fast sim and rng_srate +plusargs to speed up simulation time. This may be removed by the backend integrator as needed.
2. Increase SW timeout.
3. Update entropy complex configuration to force more operations.