### PR TITLE
[dv/tlt] Increase timeouts for `chip_sw_csrng_edn_concurrency_reduced_freq` and `chip_sw_uart_tx_rx_bootstrap` tests.

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -556,8 +556,8 @@
       sw_images: ["//sw/device/tests:uart_tx_rx_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_spi_load_bootstrap=1", "+calibrate_usb_clk=1",
-                 "+test_timeout_ns=80_000_000"]
-      run_timeout_mins: 240
+                 "+test_timeout_ns=160_000_000"]
+      run_timeout_mins: 480
     }
     {
       name: chip_sw_usbdev_vbus

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -2087,9 +2087,9 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["//sw/device/tests:csrng_edn_concurrency_test:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom", "fast_sim"]
-      run_opts: ["+sw_test_timeout_ns=180_000_000", "+rng_srate_value_min=15",
+      run_opts: ["+sw_test_timeout_ns=360_000_000", "+rng_srate_value_min=15",
                  "+rng_srate_value_max=20", "+cal_sys_clk_70mhz=1", "+en_jitter=1"]
-      run_timeout_mins: 240
+      run_timeout_mins: 480
     }
     {
       name: chip_sw_power_idle_load


### PR DESCRIPTION
1. Increase chip_sw_csrng_edn_concurrency_reduced_freq timeout: This is to account for the more aggressive entropy complex configuration introduced in earlier changes.
2. Increase chip_sw_uart_tx_rx_bootstrap timeout to take twice as long. A follow PR will reduce this time once we get an idea of how much time is needed to run this test.