### PR TITLE
[rv_dm] Fix RDC and DFT issue with resets

### DIFF
--- a/hw/vendor/patches/pulp_riscv_dbg/0003-Use-lowrisc-instead-of-PULP-primitives.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0003-Use-lowrisc-instead-of-PULP-primitives.patch
@@ -143,8 +143,8 @@ index f9d66fd..ef9e57c 100644
 +    .ResetValue(0)
 +  ) u_combined_rstn_sync (
 +    .clk_i,
-+    .rst_ni(rst_ni & jtag_combined_rstn),
-+    .d_i(1'b1),
++    .rst_ni(rst_ni),
++    .d_i(jtag_combined_rstn),
 +    .q_o(combined_rstn_premux)
    );
  

--- a/hw/vendor/pulp_riscv_dbg/src/dmi_cdc.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dmi_cdc.sv
@@ -67,8 +67,8 @@ module dmi_cdc (
     .ResetValue(0)
   ) u_combined_rstn_sync (
     .clk_i,
-    .rst_ni(rst_ni & jtag_combined_rstn),
-    .d_i(1'b1),
+    .rst_ni(rst_ni),
+    .d_i(jtag_combined_rstn),
     .q_o(combined_rstn_premux)
   );
 


### PR DESCRIPTION
Convert the JTAG combined resets to have a synchronous assertion timing in the core clock domain, placing them on the D input of the first flop of the prim_flop_2sync, instead of the reset inputs of both flops. This removes the asynchronous reset assertion that may cause RDC issues, and it restores scan reset as the only reset for those 2 flops when in scan mode.

Note that prim_fifo_async_simple guarantees that a prior transaction in flight will at least maintain its data values, since the holding register is *not* reset. This mechanism does not guarantee that the request will be squashed, but it *does* guarantee that the request will not be malformed by the reset. In addition, if the JTAG reset is held for long enough (i.e. >= the round-trip delay), the response for any previously in-flight request will be dropped.