### PR TITLE
[dv,usbdev] Tidy up test plan and usb20_item handling

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -20,6 +20,18 @@ package usb20_agent_pkg;
     USB20Sym_Invalid  // Not Used.
   } usb_symbol_e;
 
+  // TODO: rename this enumeration type; not all usb20_item instances are packets any longer.
+  //
+  // Item Types
+  typedef enum bit [2:0] {
+      // Packet objects.
+      PktTypeSoF,
+      PktTypeToken,
+      PktTypeData,
+      PktTypeHandshake,
+      // Non-packet items.
+      PktTypeEvent} pkt_type_e;
+
   // USB-level events; the DP/DN wires are used for transmitting packet data but also held for
   // extended intervals to signal specific bus-level events.
   typedef enum bit [2:0] {
@@ -29,8 +41,7 @@ package usb20_agent_pkg;
       EvDisconnect, // VBUS low when disconnected.
       EvConnect,    // VBUS high after connection.
       EvPacket} ev_type_e;
-  // Packet Types
-  typedef enum bit [2:0] {PktTypeSoF, PktTypeToken, PktTypeData, PktTypeHandshake} pkt_type_e;
+
   // Packet IDentifiers; the 4 LSBs identify the Packet type, and are reflected in inverted
   //   form as the 4 MSBs to provide some internal error checking.
   typedef enum bit [7:0] {

--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -490,8 +490,6 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
 
     case (rsp_item.m_pid_type)
       PidTypeData0, PidTypeData1: begin
-        // TODO: Ignoring the 16-bits of CRC, and we have possibly captured some additional bit(s)
-        // from the EOP (SE0) signaling.
         bit [15:0] calc_crc16;
         bit [15:0] rx_crc16;
         int unsigned len = (decoded_received_pkt.size() - 32) & ~7;  // integral byte count

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -393,7 +393,6 @@ class usb20_monitor extends dv_base_monitor #(
     for (i = 0; i < packet.size(); i++) begin
       if (consecutive_ones_count >= 6) begin
         if (packet[i] != 1'b0) begin
-          // TODO: record and forward the bit stuffing violation for error-injection sequences.
           `uvm_info(`gfn, $sformatf("Bit stuffing violation detected in %p at bit %d",
                                     packet, i), UVM_LOW)
           valid_stuffing = 0;
@@ -406,7 +405,6 @@ class usb20_monitor extends dv_base_monitor #(
       end
     end
     if (consecutive_ones_count >= 6) begin
-      // TODO: record and forward the bit stuffing violation for error-injection sequences.
       `uvm_info(`gfn, $sformatf("Bit stuffing violation detected in %p at bit %d", packet, i),
                 UVM_LOW)
       valid_stuffing = 0;

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -117,7 +117,7 @@
               device in the data packet of the OUT transaction.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_pkt_buffer"]
     }
     {
       name: phy_config_tx_osc_test_mode
@@ -206,7 +206,7 @@
               bit stuffing errors and with a correct CRC16.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_max_length_in_transaction"]
     }
     {
       name: min_length_out_transaction
@@ -236,10 +236,10 @@
               bit stuffing errors and with a correct CRC16.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_min_length_in_transaction"]
     }
     {
-      name: random_length_out_trans
+      name: random_length_out_transaction
       desc: '''
             Verify the reception of random length OUT data packets.
 
@@ -250,10 +250,10 @@
             - Verify that the DUT acknowledges receipt with an ACK handshake packet.
             '''
       stage: V2
-      tests: ["usbdev_random_length_out_trans"]
+      tests: ["usbdev_random_length_out_transaction"]
     }
     {
-      name: random_length_in_trans
+      name: random_length_in_transaction
       desc: '''
             Verify the transmission of random length IN data packets.
 
@@ -264,7 +264,7 @@
               corresponding bit of the 'in_sent' register.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_random_length_in_transaction"]
     }
     {
       name: out_stall
@@ -300,7 +300,7 @@
             - Verify that the device does not send any handshake packet in response.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_out_iso"]
     }
     {
       name: in_iso
@@ -519,12 +519,12 @@
     {
       name: resume_link_active
       desc: '''
-            Verify that when Write a 1 to this bit to instruct usbdev to jump to the LinkResuming state
-            then write will only have an effect when the device is in the LinkPowered state.
+            Verify that the DUT moves from the LinkPowered state to the LinkResuming state in response to
+            the 'resume_link_active' bit being set.
 
             - Perform no operation in J state for more than 3 ms.
-            - Read the link state from usbstate register to see if it is in powered state and then send the
-              resume signal (K state) for 20 ms and set the usbctrl.resume_link_active.
+            - Read the link state from `usbstat` register to see if it is in powered state and then send
+              the resume signal (K state) for 20 ms and set the usbctrl.resume_link_active.
             - Verify that the resume_link_active interrupt goes high and device will be resumed.
             '''
       stage: V2
@@ -998,7 +998,7 @@
               stuck or hold persistent inappropriate state.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_rand_bus_resets"]
     }
     {
       name: rand_disconnects
@@ -1016,7 +1016,7 @@
               configuration completes successfully this time when no disconnection occurs.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_rand_bus_disconnects"]
     }
     {
       name: max_usb_traffic
@@ -1027,7 +1027,7 @@
             interrupts.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_max_usb_traffic"]
     }
     {
       name: stress_usb_traffic
@@ -1037,7 +1037,7 @@
             not interfere with the transmission and reception of valid traffic.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_stress_usb_traffic"]
     }
     {
       name: in_packet_retraction

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -173,7 +173,7 @@
       reseed: 10
     }
     {
-      name: usbdev_random_length_out_trans
+      name: usbdev_random_length_out_transaction
       uvm_test_seq: usbdev_random_length_out_transaction_vseq
     }
     {
@@ -233,16 +233,16 @@
       uvm_test_seq: usbdev_in_iso_vseq
     }
     {
-      name: random_length_in_trans
+      name: usbdev_random_length_in_transaction
       uvm_test_seq: usbdev_in_rand_trans_vseq
     }
     {
-      name: min_length_in_transaction
+      name: usbdev_min_length_in_transaction
       uvm_test_seq: usbdev_in_rand_trans_vseq
       run_opts: ["+num_of_bytes=0"]
     }
     {
-      name: max_length_in_transaction
+      name: usbdev_max_length_in_transaction
       uvm_test_seq: usbdev_in_rand_trans_vseq
       run_opts: ["+num_of_bytes=64"]
     }


### PR DESCRIPTION
This PR just collects a few uncontentious tidy ups and introduces constructors for use in subsequent code and to simplify/tidy the existing code in time. Presently objects are created and subsequently populated, which results in a lot of error-prone replication of code.