### PR TITLE
[otbn,dv] Disable an FI test which causes (spurious) DV failures

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -45,6 +45,10 @@ virtual task test_sec_cm_fi();
   while (if_proxy_q.size) begin
     sec_cm_base_if_proxy if_proxy = if_proxy_q.pop_front();
 
+    // If fault injection is disabled at this instance of the interface, skip it (and don't inject
+    // anything)
+    if (if_proxy.fi_disabled) continue;
+
     sec_cm_fi_ctrl_svas(if_proxy, .enable(0));
     sec_cm_inject_fault(if_proxy);
 

--- a/hw/dv/sv/sec_cm/sec_cm_base_if_proxy.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_base_if_proxy.sv
@@ -7,6 +7,15 @@ virtual class sec_cm_base_if_proxy extends uvm_object;
   sec_cm_type_e sec_cm_type;
   string path;
 
+  // If this bit is set then fault injection sequences will skip this proxy. Code that sets the
+  // fi_disabled flag should have a detailed comment explaining why it is needed.
+  bit fi_disabled = 1'b0;
+
+  function void disable_fi();
+    `uvm_info(`gfn, $sformatf("Disabling fault injection at %0s", path), UVM_MEDIUM)
+    fi_disabled = 1'b1;
+  endfunction
+
   `uvm_object_new
 
   pure virtual task automatic inject_fault();


### PR DESCRIPTION
See the second commit message for a careful description of what this is doing. Fixes #23578.

After writing this, it occurred to me that another approach might have been to write zeros to the backing memory for the FIFOs in question (rather than 'X). This would have fixed the FSM lock-up behaviour that we were seeing. If this "disable the buggy check" approach feels unsafe, we could always follow up with that more principled approach, but it's probably worth merging this version to fix the failing nightly in the meantime.

Note: There's currently a "TODO(???)" comment, which is supposed to track a specific PR discussing the thing we're working around. Don't merge this without linking it up properly.

For proof that this genuinely fixes the linked issue:
```
rupert@halibut /s/l/opentitan (otbn-sec-cm-debugging) [1]> util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_sec_cm --fixed-seed=123 -vh
INFO: [dvsim] [proj_root]: /src/lr/opentitan
INFO: [SimCfg] [scratch_path]: [otbn] [/src/lr/opentitan/scratch/otbn-sec-cm-debugging/otbn-sim-xcelium]
INFO: [FlowCfg] [results]: [otbn]:
## OTBN Simulation Results
### Tuesday June 11 2024 15:18:11 UTC
### GitHub Revision: [`a4c2d125cd`](https://github.com/lowrisc/opentitan/tree/a4c2d125cd925f2afb8a93f175b4b4d8c60204f9)
### Branch: otbn-sec-cm-debugging
### [Testplan](https://opentitan.org/book/hw/ip/otbn/dv/data/otbn_testplan.html)
### Simulator: XCELIUM

### Test Results
|  Stage  |                    Name                    | Tests       |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:------------------------------------------:|:------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V2S   |                tl_intg_err                 | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |               prim_fsm_check               | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |              prim_count_check              | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |      sec_cm_controller_fsm_local_esc       | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |        sec_cm_controller_fsm_sparse        | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |     sec_cm_scramble_ctrl_fsm_local_esc     | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |      sec_cm_scramble_ctrl_fsm_sparse       | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |    sec_cm_start_stop_ctrl_fsm_local_esc    | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |     sec_cm_start_stop_ctrl_fsm_sparse      | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |  sec_cm_rf_base_data_reg_sw_glitch_detect  | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |       sec_cm_stack_wr_ptr_ctr_redun        | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   | sec_cm_rf_bignum_data_reg_sw_glitch_detect | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |        sec_cm_loop_stack_ctr_redun         | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |         sec_cm_tlul_fifo_ctr_redun         | otbn_sec_cm |      12.283m      |     1.778ms      |     1     |    1    |  100.00 %   |
|   V2S   |                                            | **TOTAL**   |                   |                  |     1     |    1    |  100.00 %   |
|         |                                            | **TOTAL**   |                   |                  |     1     |    1    |  100.00 %   |
```
(yes, I ran it on quite a slow computer)