### PR TITLE
[rom_e2e] Disable broken flash ECC tests

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
@@ -241,6 +241,12 @@ SEC_VERS = [
             otp = ":otp_img_boot_policy_flash_ecc_error",
             slot_a = SLOTS["a"],
             slot_b = SLOTS["b"],
+            # TODO(opentitan#21353): These tests are currently broken.
+            # Re-enable after we fix the exception handling scheme.
+            tags = [
+                "broken",
+                "manual",
+            ],
         ),
     )
     for t in BOOT_POLICY_FLASH_ECC_ERROR_TESTS


### PR DESCRIPTION
The flash ECC tests are broken due to an oversight in the way the exception is handled.

Addresses #21353.