### PR TITLE
[rom] Rewrite the flash exception handler 

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
@@ -241,12 +241,6 @@ SEC_VERS = [
             otp = ":otp_img_boot_policy_flash_ecc_error",
             slot_a = SLOTS["a"],
             slot_b = SLOTS["b"],
-            # TODO(opentitan#21353): These tests are currently broken.
-            # Re-enable after we fix the exception handling scheme.
-            tags = [
-                "broken",
-                "manual",
-            ],
         ),
     )
     for t in BOOT_POLICY_FLASH_ECC_ERROR_TESTS

--- a/sw/device/silicon_creator/rom/rom_isrs.S
+++ b/sw/device/silicon_creator/rom/rom_isrs.S
@@ -33,67 +33,159 @@ rom_exception_handler:
   // the 4 registers we need to handle the flash exception.
   csrw mscratch, sp
   la   sp, (_stack_end - 16)
-  sw   t0,  0 * OT_WORD_SIZE(sp)
-  sw   t1,  1 * OT_WORD_SIZE(sp)
-  sw   t2,  2 * OT_WORD_SIZE(sp)
-  sw   t3,  3 * OT_WORD_SIZE(sp)
-
-  /**
-   * Compute the MEPC of the instruction after the fault.
-   *
-   * Since we support the RISC-V compressed instructions extension, we need to
-   * check if the two least significant bits of the instruction are
-   * b11 (0x3), which means that the trapped instruction is not compressed,
-   * i.e., the trapped instruction is 32bits = 4bytes. Otherwise, the trapped
-   * instruction is 16bits = 2bytes.
-   */
-  csrr t0, mepc
-  lh t2, 0(t0)
-  addi t0, t0, OT_HALF_WORD_SIZE
-  li t1, 0x3
-  and t3, t2, t1
-  bne t3, t1, .L_rom_16bit_trap_instr
-  // We already added one half word, so for a 32-bit instruction, add another.
-  addi t0, t0, OT_HALF_WORD_SIZE
-.L_rom_16bit_trap_instr:
-  // Hardening: double-check that the retval calculation is 4 bytes or fewer
-  // from the original value of MEPC.
-  addi t1, t1, 1
-  csrr t2, mepc
-  sub t2, t0, t2
-  bgtu t2, t1, .L_not_a_flash_error
+  sw   a0,  0 * OT_WORD_SIZE(sp)
+  sw   a1,  1 * OT_WORD_SIZE(sp)
+  sw   a2,  2 * OT_WORD_SIZE(sp)
+  sw   a3,  3 * OT_WORD_SIZE(sp)
 
   // Get the mcause, mask the reason and check that it is LoadAccessFault.
-  csrr t1, mcause
-  andi t1, t1, 31
-  li t2, LOAD_ACCESS_FAULT
-  bne t1, t2, .L_not_a_flash_error
+  csrr a1, mcause
+  andi a1, a1, 31
+  li   a2, LOAD_ACCESS_FAULT
+  bne  a1, a2, .L_not_a_flash_error
 
   // Check if there is a flash error.
-  li t3, TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
-  lw t1, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(t3)
-  andi t1, t1, PHY_ERRORS
-  beqz t1, .L_not_a_flash_error
+  li   a3, TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
+  lw   a1, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(a3)
+  andi a1, a1, PHY_ERRORS
+  beqz a1, .L_not_a_flash_error
 
   // Clear the flash error.
-  sw x0, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(t3)
+  sw   x0, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(a3)
   // Hardening: check that the error is cleared.
-  lw t1, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(t3)
-  beqz t1, .L_flash_fault_handled
-  j .L_not_a_flash_error
+  lw   a1, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(a3)
+  beqz a1, .L_flash_fault_handled
+  j    .L_not_a_flash_error
   unimp
   unimp
 
 .L_flash_fault_handled:
+  // Compute the MEPC of the instruction after the fault.
+  //
+  // Since we support the RISC-V compressed instructions extension, we need to
+  // check if the two least significant bits of the instruction are
+  // b11 (0x3), which means that the trapped instruction is not compressed,
+  // i.e., the trapped instruction is 32bits = 4bytes. Otherwise, the trapped
+  // instruction is 16bits = 2bytes.
+  //
+  // Instruction formats for loads:
+  //
+  //  LB, LH, LW, LBU, LHU:
+  //  31                  20 19      15 14  12 11       7 6            0
+  // +----------------------+----------+------+----------+--------------+
+  // |      imm[11:0]       |    rs1   |funct3|    rd    |   0000011    |
+  // +----------------------+----------+------+----------+--------------+
+  //
+  // C.LW
+  //  15  13 12  10 9    7 6  5 4    2 1  0
+  // +------+------+------+----+------+----+
+  // |funct3| imm  | rs1' | imm|  rd' | 00 |
+  // +------+------+------+----+------+----+
+  // Where rd' and rs1' are (register_num - 8, ie: rd' of 0 means reg x8).
+  //
+
+  csrr a0, mepc
+  lh   a2, 0(a0)
+  addi a0, a0, OT_HALF_WORD_SIZE
+  // Check if its a 16-bit compressed instruction.
+  li   a1, 3
+  and  a3, a2, a1
+  bne  a3, a1, .L_compressed_trap_instr
+  // Check if its an uncompressed load instruction by checking that the next
+  // five bits are zero.
+  srli a3, a2, 2
+  andi a3, a3, 0x1f
+  bnez a3, .L_not_a_flash_error
+  // Get the register number into a3 by masking off the rd field.
+  srli a3, a2, 7
+  andi a3, a3, 0x1f
+  // We already added one half word, so for a 32-bit instruction, add another.
+  addi a0, a0, OT_HALF_WORD_SIZE
+  j    .L_hardened_mepc_check
+
+.L_compressed_trap_instr:
+  // Check if its a compressed load instruction.
+  bnez a3, .L_not_a_flash_error
+  // Get the register number into a3 by masking off the rd' field and adding 8.
+  srli a3, a2, 2
+  andi a3, a3, 7
+  addi a3, a3, 8
+
+.L_hardened_mepc_check:
+  // Hardening: double-check that the retval calculation is 4 bytes or fewer
+  // from the original value of MEPC.
+  addi a1, a1, 1
+  csrr a2, mepc
+  sub  a2, a0, a2
+  bgtu a2, a1, .L_not_a_flash_error
+
+
+// The following two macros help build an if/else tree to load the
+// correct register with zero.
+#define LOAD_ZERO_INTO_REG(reg_) \
+  addi a3, a3, -1; \
+  bnez a3, 1f; \
+  mv   reg_, a2; \
+  j    .L_flash_fault_done; \
+  1:
+
+#define LOAD_ZERO_STACK_REG(reg_) \
+  addi a3, a3, -1; \
+  bnez a3, 1f; \
+  sw   a2, reg_ * OT_WORD_SIZE(sp); \
+  j    .L_flash_fault_done; \
+  1:
+
+  // Now, using `rd` from the faulting instruction (in a3), load a zero into
+  // that register.
+  // RISCV register x0, aka zero.  This register is always const 0, so there
+  // is nothing to do.
+  beqz a3, .L_flash_fault_done
+
+  // All other register load the value 0xFFFFFFFF as the faulting value.
+  li   a2, -1
+  LOAD_ZERO_INTO_REG(x1)   // Register x1 aka ra
+  LOAD_ZERO_INTO_REG(x2)   // Register x2 aka sp
+  LOAD_ZERO_INTO_REG(x3)   // Register x3 aka gp
+  LOAD_ZERO_INTO_REG(x4)   // Register x4 aka tp
+  LOAD_ZERO_INTO_REG(x5)   // Register x5 aka t0
+  LOAD_ZERO_INTO_REG(x6)   // Register x6 aka t1
+  LOAD_ZERO_INTO_REG(x7)   // Register x7 aka t2
+  LOAD_ZERO_INTO_REG(x8)   // Register x8 aka s0
+  LOAD_ZERO_INTO_REG(x9)   // Register x9 aka s1
+  LOAD_ZERO_STACK_REG(0)   // Register x10 aka a0
+  LOAD_ZERO_STACK_REG(1)   // Register x11 aka a1
+  LOAD_ZERO_STACK_REG(2)   // Register x12 aka a2
+  LOAD_ZERO_STACK_REG(3)   // Register x13 aka a3
+  LOAD_ZERO_INTO_REG(x14)  // Register x14 aka a4
+  LOAD_ZERO_INTO_REG(x15)  // Register x15 aka a5
+  LOAD_ZERO_INTO_REG(x16)  // Register x16 aka a6
+  LOAD_ZERO_INTO_REG(x17)  // Register x17 aka a7
+  LOAD_ZERO_INTO_REG(x18)  // Register x18 aka s2
+  LOAD_ZERO_INTO_REG(x19)  // Register x19 aka s3
+  LOAD_ZERO_INTO_REG(x20)  // Register x20 aka s4
+  LOAD_ZERO_INTO_REG(x21)  // Register x21 aka s5
+  LOAD_ZERO_INTO_REG(x22)  // Register x22 aka s6
+  LOAD_ZERO_INTO_REG(x23)  // Register x23 aka s7
+  LOAD_ZERO_INTO_REG(x24)  // Register x24 aka s8
+  LOAD_ZERO_INTO_REG(x25)  // Register x25 aka s9
+  LOAD_ZERO_INTO_REG(x26)  // Register x26 aka s10
+  LOAD_ZERO_INTO_REG(x27)  // Register x27 aka s11
+  LOAD_ZERO_INTO_REG(x28)  // Register x28 aka t3
+  LOAD_ZERO_INTO_REG(x29)  // Register x29 aka t4
+  LOAD_ZERO_INTO_REG(x30)  // Register x30 aka t5
+  LOAD_ZERO_INTO_REG(x31)  // Register x31 aka t6
+
+.L_flash_fault_done:
   // Exception handler exit and return to C:
   // Load the correct MEPC for the next instruction in the current task.
-  csrw mepc, t0
+  csrw mepc, a0
 
   // Restore all registers from the stack and restore SP to its former value.
-  lw   t0,  0 * OT_WORD_SIZE(sp)
-  lw   t1,  1 * OT_WORD_SIZE(sp)
-  lw   t2,  2 * OT_WORD_SIZE(sp)
-  lw   t3,  3 * OT_WORD_SIZE(sp)
+  lw   a0,  0 * OT_WORD_SIZE(sp)
+  lw   a1,  1 * OT_WORD_SIZE(sp)
+  lw   a2,  2 * OT_WORD_SIZE(sp)
+  lw   a3,  3 * OT_WORD_SIZE(sp)
   csrr sp, mscratch
   mret
 


### PR DESCRIPTION
1. Use registers `a0-a3` instead of `t0-t3` to permit compressed
   instruction encodings in the exception handler itself.
2. Re-arrange the exception logic to check mstatus and the flash
   controller fault status first.
3. Decode the faulting instruction.  If the instruction is a load,
   extract the destination register.  Load all-ones into the
   destination register before returning from the exception.