### PR TITLE
[rom] Rewrite the flash exception handler 

### DIFF
--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -17,10 +17,18 @@ MEMORY {
 }
 
 /**
- * Stack at the top of the main SRAM.
+ * Exception frame at the top of main SRAM
  */
-_stack_size = 16384;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_exception_frame_size = 128;
+_exception_frame_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_exception_frame_start = _exception_frame_end - _exception_frame_size;
+
+
+/**
+ * Stack just below the exception frame.
+ */
+_stack_size = 16384 - _exception_frame_size;
+_stack_end = _exception_frame_start;
 _stack_start = _stack_end - _stack_size;
 
 /**

--- a/sw/device/lib/testing/test_framework/ottf_start.S
+++ b/sw/device/lib/testing/test_framework/ottf_start.S
@@ -126,14 +126,12 @@ _ottf_start:
    * Set up the stack pointer.
    *
    * In RISC-V, the stack grows downwards, so we load the address of the highest
-   * word in the stack into sp. We don't load in `_stack_end`, as that points
-   * beyond the end of RAM, and we always want it to be valid to dereference
-   * `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+   * word in the stack into sp.
    *
    * If an exception fires, the handler is conventionaly only allowed to clobber
    * memory at addresses below `sp`.
    */
-  la   sp, (_stack_end - 16)
+  la   sp, _stack_end
 
   /**
    * Set well-defined interrupt/exception handlers.

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
@@ -241,12 +241,6 @@ SEC_VERS = [
             otp = ":otp_img_boot_policy_flash_ecc_error",
             slot_a = SLOTS["a"],
             slot_b = SLOTS["b"],
-            # TODO(opentitan#21353): These tests are currently broken.
-            # Re-enable after we fix the exception handling scheme.
-            tags = [
-                "broken",
-                "manual",
-            ],
         ),
     )
     for t in BOOT_POLICY_FLASH_ECC_ERROR_TESTS

--- a/sw/device/silicon_creator/rom/rom_isrs.S
+++ b/sw/device/silicon_creator/rom/rom_isrs.S
@@ -30,69 +30,173 @@ rom_exception_handler:
   // stack_end at `ram_end - 128` and the stack grows downwards from there.
   // Save `sp` into `mscratch` and use the 128 bytes reserved at the top of
   // RAM as the exception frame.
+  // Note: we save the exception frame in RISCV register number order so that
+  // we can extract the destination register from the faulting instruction and
+  // use it as an index into the exception frame.
   csrw mscratch, sp
-  la   sp,  _exception_frame_start
-  sw   t0,  0 * OT_WORD_SIZE(sp)
-  sw   t1,  1 * OT_WORD_SIZE(sp)
-  sw   t2,  2 * OT_WORD_SIZE(sp)
-  sw   t3,  3 * OT_WORD_SIZE(sp)
-
-  /**
-   * Compute the MEPC of the instruction after the fault.
-   *
-   * Since we support the RISC-V compressed instructions extension, we need to
-   * check if the two least significant bits of the instruction are
-   * b11 (0x3), which means that the trapped instruction is not compressed,
-   * i.e., the trapped instruction is 32bits = 4bytes. Otherwise, the trapped
-   * instruction is 16bits = 2bytes.
-   */
-  csrr t0, mepc
-  lh t2, 0(t0)
-  addi t0, t0, OT_HALF_WORD_SIZE
-  li t1, 0x3
-  and t3, t2, t1
-  bne t3, t1, .L_rom_16bit_trap_instr
-  // We already added one half word, so for a 32-bit instruction, add another.
-  addi t0, t0, OT_HALF_WORD_SIZE
-.L_rom_16bit_trap_instr:
-  // Hardening: double-check that the retval calculation is 4 bytes or fewer
-  // from the original value of MEPC.
-  addi t1, t1, 1
-  csrr t2, mepc
-  sub t2, t0, t2
-  bgtu t2, t1, .L_not_a_flash_error
+  la   sp, _exception_frame_start
+  sw   x1,  1 * OT_WORD_SIZE(sp)
+  sw   x2,  2 * OT_WORD_SIZE(sp)
+  sw   x3,  3 * OT_WORD_SIZE(sp)
+  sw   x4,  4 * OT_WORD_SIZE(sp)
+  sw   x5,  5 * OT_WORD_SIZE(sp)
+  sw   x6,  6 * OT_WORD_SIZE(sp)
+  sw   x7,  7 * OT_WORD_SIZE(sp)
+  sw   x8,  8 * OT_WORD_SIZE(sp)
+  sw   x9,  9 * OT_WORD_SIZE(sp)
+  sw   x10,  10 * OT_WORD_SIZE(sp)
+  sw   x11,  11 * OT_WORD_SIZE(sp)
+  sw   x12,  12 * OT_WORD_SIZE(sp)
+  sw   x13,  13 * OT_WORD_SIZE(sp)
+  sw   x14,  14 * OT_WORD_SIZE(sp)
+  sw   x15,  15 * OT_WORD_SIZE(sp)
+  sw   x16,  16 * OT_WORD_SIZE(sp)
+  sw   x17,  17 * OT_WORD_SIZE(sp)
+  sw   x18,  18 * OT_WORD_SIZE(sp)
+  sw   x19,  19 * OT_WORD_SIZE(sp)
+  sw   x20,  20 * OT_WORD_SIZE(sp)
+  sw   x21,  21 * OT_WORD_SIZE(sp)
+  sw   x22,  22 * OT_WORD_SIZE(sp)
+  sw   x23,  23 * OT_WORD_SIZE(sp)
+  sw   x24,  24 * OT_WORD_SIZE(sp)
+  sw   x25,  25 * OT_WORD_SIZE(sp)
+  sw   x26,  26 * OT_WORD_SIZE(sp)
+  sw   x27,  27 * OT_WORD_SIZE(sp)
+  sw   x28,  28 * OT_WORD_SIZE(sp)
+  sw   x29,  29 * OT_WORD_SIZE(sp)
+  sw   x30,  30 * OT_WORD_SIZE(sp)
+  sw   x31,  31 * OT_WORD_SIZE(sp)
 
   // Get the mcause, mask the reason and check that it is LoadAccessFault.
-  csrr t1, mcause
-  andi t1, t1, 31
-  li t2, LOAD_ACCESS_FAULT
-  bne t1, t2, .L_not_a_flash_error
+  csrr a1, mcause
+  andi a1, a1, 31
+  li   a2, LOAD_ACCESS_FAULT
+  bne  a1, a2, .L_not_a_flash_error
 
   // Check if there is a flash error.
-  li t3, TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
-  lw t1, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(t3)
-  andi t1, t1, PHY_ERRORS
-  beqz t1, .L_not_a_flash_error
+  li   a3, TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
+  lw   a1, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(a3)
+  andi a1, a1, PHY_ERRORS
+  beqz a1, .L_not_a_flash_error
 
   // Clear the flash error.
-  sw x0, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(t3)
+  sw   x0, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(a3)
   // Hardening: check that the error is cleared.
-  lw t1, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(t3)
-  beqz t1, .L_flash_fault_handled
-  j .L_not_a_flash_error
+  lw   a1, FLASH_CTRL_FAULT_STATUS_REG_OFFSET(a3)
+  beqz a1, .L_flash_fault_handled
+  j    .L_not_a_flash_error
   unimp
   unimp
 
 .L_flash_fault_handled:
+  // Compute the MEPC of the instruction after the fault.
+  //
+  // Since we support the RISC-V compressed instructions extension, we need to
+  // check if the two least significant bits of the instruction are
+  // b11 (0x3), which means that the trapped instruction is not compressed,
+  // i.e., the trapped instruction is 32bits = 4bytes. Otherwise, the trapped
+  // instruction is 16bits = 2bytes.
+  //
+  // Instruction formats for loads:
+  //
+  //  LB, LH, LW, LBU, LHU:
+  //  31                  20 19      15 14  12 11       7 6            0
+  // +----------------------+----------+------+----------+--------------+
+  // |      imm[11:0]       |    rs1   |funct3|    rd    |   0000011    |
+  // +----------------------+----------+------+----------+--------------+
+  //
+  // C.LW
+  //  15  13 12  10 9    7 6  5 4    2 1  0
+  // +------+------+------+----+------+----+
+  // |funct3| imm  | rs1' | imm|  rd' | 00 |
+  // +------+------+------+----+------+----+
+  // Where rd' and rs1' are (register_num - 8, ie: rd' of 0 means reg x8).
+  //
+
+  csrr a0, mepc
+  lh   a2, 0(a0)
+  addi a0, a0, OT_HALF_WORD_SIZE
+  // Check if its a 16-bit compressed instruction.
+  li   a1, 3
+  and  a3, a2, a1
+  bne  a3, a1, .L_compressed_trap_instr
+  // Check if its an uncompressed load instruction by checking that the next
+  // five bits are zero.
+  srli a3, a2, 2
+  andi a3, a3, 0x1f
+  bnez a3, .L_not_a_flash_error
+  // Get the register number into a3 by masking off the rd field.
+  srli a3, a2, 7
+  andi a3, a3, 0x1f
+  // We already added one half word, so for a 32-bit instruction, add another.
+  addi a0, a0, OT_HALF_WORD_SIZE
+  j    .L_hardened_mepc_check
+
+.L_compressed_trap_instr:
+  // Check if its a compressed load instruction.
+  bnez a3, .L_not_a_flash_error
+  // Get the register number into a3 by masking off the rd' field and adding 8.
+  srli a3, a2, 2
+  andi a3, a3, 7
+  addi a3, a3, 8
+
+.L_hardened_mepc_check:
+  // Hardening: double-check that the retval calculation is 4 bytes or fewer
+  // from the original value of MEPC.
+  addi a1, a1, 1
+  csrr a2, mepc
+  sub  a2, a0, a2
+  bgtu a2, a1, .L_not_a_flash_error
+
+  // Now, using `rd` from the faulting instruction (in a3), load all ones into
+  // that register.
+  // RISCV register x0, aka zero.  This register is always const 0, so there
+  // is nothing to do.
+  beqz a3, .L_flash_fault_done
+
+  // All other registers load the value 0xFFFFFFFF as the faulting value.
+  li   a2, -1
+  slli a3, a3, 2
+  add  a3, a3, sp
+  sw   a2, 0(a3)
+
+.L_flash_fault_done:
   // Exception handler exit and return to C:
   // Load the correct MEPC for the next instruction in the current task.
-  csrw mepc, t0
+  csrw mepc, a0
 
   // Restore all registers from the stack and restore SP to its former value.
-  lw   t0,  0 * OT_WORD_SIZE(sp)
-  lw   t1,  1 * OT_WORD_SIZE(sp)
-  lw   t2,  2 * OT_WORD_SIZE(sp)
-  lw   t3,  3 * OT_WORD_SIZE(sp)
+  lw   x1,  1 * OT_WORD_SIZE(sp)
+  lw   x2,  2 * OT_WORD_SIZE(sp)
+  lw   x3,  3 * OT_WORD_SIZE(sp)
+  lw   x4,  4 * OT_WORD_SIZE(sp)
+  lw   x5,  5 * OT_WORD_SIZE(sp)
+  lw   x6,  6 * OT_WORD_SIZE(sp)
+  lw   x7,  7 * OT_WORD_SIZE(sp)
+  lw   x8,  8 * OT_WORD_SIZE(sp)
+  lw   x9,  9 * OT_WORD_SIZE(sp)
+  lw   x10,  10 * OT_WORD_SIZE(sp)
+  lw   x11,  11 * OT_WORD_SIZE(sp)
+  lw   x12,  12 * OT_WORD_SIZE(sp)
+  lw   x13,  13 * OT_WORD_SIZE(sp)
+  lw   x14,  14 * OT_WORD_SIZE(sp)
+  lw   x15,  15 * OT_WORD_SIZE(sp)
+  lw   x16,  16 * OT_WORD_SIZE(sp)
+  lw   x17,  17 * OT_WORD_SIZE(sp)
+  lw   x18,  18 * OT_WORD_SIZE(sp)
+  lw   x19,  19 * OT_WORD_SIZE(sp)
+  lw   x20,  20 * OT_WORD_SIZE(sp)
+  lw   x21,  21 * OT_WORD_SIZE(sp)
+  lw   x22,  22 * OT_WORD_SIZE(sp)
+  lw   x23,  23 * OT_WORD_SIZE(sp)
+  lw   x24,  24 * OT_WORD_SIZE(sp)
+  lw   x25,  25 * OT_WORD_SIZE(sp)
+  lw   x26,  26 * OT_WORD_SIZE(sp)
+  lw   x27,  27 * OT_WORD_SIZE(sp)
+  lw   x28,  28 * OT_WORD_SIZE(sp)
+  lw   x29,  29 * OT_WORD_SIZE(sp)
+  lw   x30,  30 * OT_WORD_SIZE(sp)
+  lw   x31,  31 * OT_WORD_SIZE(sp)
   csrr sp, mscratch
   mret
 

--- a/sw/device/silicon_creator/rom/rom_isrs.S
+++ b/sw/device/silicon_creator/rom/rom_isrs.S
@@ -26,13 +26,12 @@
   .global rom_exception_handler
   .type rom_exception_handler, @function
 rom_exception_handler:
-  // Save all registers to an exception stack.  The ROM locates its initial
-  // stack at `ram_end - 16` and the stack grows downwards from there, leaving
-  // 16 bytes at the top of RAM.  We need exactly 16 bytes to handle the flash
-  // exception, so we save `sp` into `mscratch` and use those 16 bytes to save
-  // the 4 registers we need to handle the flash exception.
+  // Save all registers to the exception frame.  The ROM locates its initial
+  // stack_end at `ram_end - 128` and the stack grows downwards from there.
+  // Save `sp` into `mscratch` and use the 128 bytes reserved at the top of
+  // RAM as the exception frame.
   csrw mscratch, sp
-  la   sp, (_stack_end - 16)
+  la   sp,  _exception_frame_start
   sw   t0,  0 * OT_WORD_SIZE(sp)
   sw   t1,  1 * OT_WORD_SIZE(sp)
   sw   t2,  2 * OT_WORD_SIZE(sp)
@@ -104,7 +103,7 @@ rom_exception_handler:
   // preservation is necessary because we're not coming back.
   //
   // Note: we _also_ do not restore SP - we'll restart the stack at
-  // `ram_end - 16`.  This allows us to report exceptions after jumping
+  // `ram_end - 128`.  This allows us to report exceptions after jumping
   // to the next stage if the next stage has trashed its SP register.
   j rom_interrupt_handler
   unimp

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -466,13 +466,11 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   // Set up stack pointer.
   //
   // In RISC-V, the stack grows downwards, so we load the address of the highest
-  // word in the stack into sp. We don't load in `_stack_end`, as that points
-  // beyond the end of RAM, and we always want it to be valid to dereference
-  // `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+  // word in the stack into sp.
   //
   // If an exception fires, the handler is conventionally only allowed to clobber
   // memory at addresses below `sp`.
-  la sp, (_stack_end - 16)
+  la sp, _stack_end
 
   // Set up shadow stack pointer.
   //

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_start.S
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/fault_start.S
@@ -54,14 +54,12 @@ _start_boot:
    * Set up the stack pointer.
    *
    * In RISC-V, the stack grows downwards, so we load the address of the highest
-   * word in the stack into sp. We don't load in `_stack_end`, as that points
-   * beyond the end of RAM, and we always want it to be valid to dereference
-   * `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+   * word in the stack into sp.
    *
    * If an exception fires, the handler is conventionaly only allowed to clobber
    * memory at addresses below `sp`.
    */
-  la   sp, (_stack_end - 16)
+  la   sp, _stack_end
 
   /**
    * Do NOT set interrupt/exception handlers.  We want to leave the ROM_EXT

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -110,14 +110,12 @@ _rom_ext_start_boot:
    * Set up the stack pointer.
    *
    * In RISC-V, the stack grows downwards, so we load the address of the highest
-   * word in the stack into sp. We don't load in `_stack_end`, as that points
-   * beyond the end of RAM, and we always want it to be valid to dereference
-   * `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+   * word in the stack into sp.
    *
    * If an exception fires, the handler is conventionaly only allowed to clobber
    * memory at addresses below `sp`.
    */
-  la   sp, (_stack_end - 16)
+  la   sp, _stack_end
 
   /**
    * Setup C Runtime

--- a/sw/device/silicon_owner/bare_metal/bare_metal_start.S
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_start.S
@@ -140,14 +140,12 @@ _start_boot:
    * Set up the stack pointer.
    *
    * In RISC-V, the stack grows downwards, so we load the address of the highest
-   * word in the stack into sp. We don't load in `_stack_end`, as that points
-   * beyond the end of RAM, and we always want it to be valid to dereference
-   * `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+   * word in the stack into sp.
    *
    * If an exception fires, the handler is conventionaly only allowed to clobber
    * memory at addresses below `sp`.
    */
-  la   sp, (_stack_end - 16)
+  la   sp, _stack_end
 
   /**
    * Set well-defined interrupt/exception handlers

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -64,10 +64,18 @@ MEMORY {
 }
 
 /**
- * Stack at the top of the main SRAM.
+ * Exception frame at the top of main SRAM
  */
-_stack_size = 16384;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_exception_frame_size = 128;
+_exception_frame_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_exception_frame_start = _exception_frame_end - _exception_frame_size;
+
+
+/**
+ * Stack just below the exception frame.
+ */
+_stack_size = 16384 - _exception_frame_size;
+_stack_end = _exception_frame_start;
 _stack_start = _stack_end - _stack_size;
 
 /**


### PR DESCRIPTION
1. Store all registers in the exception frame to permit the
   fault handler to update the value of the faulting load.
2. Re-arrange the exception logic to check mstatus and the flash
   controller fault status first.
3. Decode the faulting instruction.  If the instruction is a load,
   extract the destination register.  Load all-ones into the
   destination register before returning from the exception.

Note: this is an alternative approach to #23634
Addresses #21353 