### PR TITLE
[dv] Tweaks to improve results with sec_cm FI tests

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -66,9 +66,13 @@ virtual task test_sec_cm_fi();
       check_sec_cm_fi_resp(if_proxy);
     end
 
-    sec_cm_fi_ctrl_svas(if_proxy, .enable(1));
     // issue hard reset for fatal alert to recover
     dut_init("HARD");
+
+    // Finally, turn SVAs back on again. Note that this must be done after reset because the fault
+    // injection might have put the device in a state that will fail assertions: we only want to put
+    // the assertions back after the internal state has been reset again.
+    sec_cm_fi_ctrl_svas(if_proxy, .enable(1));
   end
 endtask : test_sec_cm_fi
 

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -170,8 +170,10 @@ class tl_host_driver extends tl_base_driver;
       bit req_found;
       d_ready_delay = $urandom_range(cfg.d_ready_delay_min, cfg.d_ready_delay_max);
       // if a_valid high then d_ready must be high, exit the delay when a_valid is set
-      `DV_SPINWAIT_EXIT(repeat (d_ready_delay) @(cfg.vif.host_cb);,
-         wait(!cfg.host_can_stall_rsp_when_a_valid_high && cfg.vif.h2d_int.a_valid))
+      repeat (d_ready_delay) begin
+        if (!cfg.host_can_stall_rsp_when_a_valid_high && cfg.vif.h2d_int.a_valid) break;
+        @(cfg.vif.host_cb);
+      end
 
       cfg.vif.host_cb.h2d_int.d_ready <= 1'b1;
       @(cfg.vif.host_cb);


### PR DESCRIPTION
There are detailed notes in the respective commits, but the basic idea is that these are tweaks that are needed if the FI test causes the device to start doing silly things on the TL bus.