### PR TITLE
[rom] Build for the silicon_creator target

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -419,6 +419,7 @@ silicon(
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
+    rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
     test_cmd = """
         --exec="transport init"
         --exec="bootstrap --clear-uart=true {firmware}"

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -188,6 +188,7 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
+        "//hw/top_earlgrey:silicon_creator",
     ],
     kind = "rom",
     linker_script = ":linker_script",
@@ -420,6 +421,10 @@ output_groups(
         "sim_verilator_elf",
         "sim_verilator_rom",
         "sim_verilator_mapfile",
+        "silicon_creator_binary",
+        "silicon_creator_elf",
+        "silicon_creator_rom",
+        "silicon_creator_mapfile",
     ],
 )
 
@@ -447,6 +452,7 @@ output_groups(
         "fpga_cw340_binary",
         "sim_dv_binary",
         "sim_verilator_binary",
+        "silicon_creator_binary",
     ],
 )
 
@@ -458,6 +464,7 @@ output_groups(
         "fpga_cw340_disassembly",
         "sim_dv_disassembly",
         "sim_verilator_disassembly",
+        "silicon_creator_disassembly",
     ],
 )
 


### PR DESCRIPTION
1. Give the silicon target the capability to emit a ROM target.
2. Add `silicon_creator` as a exec_env for the ROM.

Fixes: #23641