### PR TITLE
[rom] Relocate exception handlers to their own section

### DIFF
--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -74,12 +74,16 @@ cc_library(
     name = "rom_isrs",
     srcs = [
         "rom_isrs.S",
+        "rom_isrs.c",
     ],
+    hdrs = ["rom_isrs.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/ip_autogen/flash_ctrl/data:flash_ctrl_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:error",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/rom.h
+++ b/sw/device/silicon_creator/rom/rom.h
@@ -12,41 +12,9 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * Denotes functions that have to use the interrupt handler ABI.
- *
- * These must be 4-byte aligned. Note that they don't use the `interrupt`
- * attribute since ROM handlers shut down the chip instead of returning like
- * regular handlers.
- */
-#define ROM_INTERRUPT_HANDLER_ABI __attribute__((aligned(4)))
-
-/**
- * Denotes functions that have to be near the interrupt vector, because they
- * are jumped to from it.
- */
-#define ROM_VECTOR_FUNCTION __attribute__((section(".crt")))
-
-/**
- * The first assembly procedure executed by the ROM (defined in
- * `rom.S`).
- *
- * This procedure does not obey the standard RISC-V calling convention, so it
- * must not be called from other C code.
- */
-ROM_VECTOR_FUNCTION
-noreturn void _rom_start_boot(void);
-
-/**
  * The first C function executed by the ROM (defined in `rom.c`)
  */
 noreturn void rom_main(void);
-
-/**
- * ROM hardware exception handler.
- */
-ROM_VECTOR_FUNCTION
-ROM_INTERRUPT_HANDLER_ABI
-noreturn void rom_interrupt_handler(void);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/rom/rom_isrs.S
+++ b/sw/device/silicon_creator/rom/rom_isrs.S
@@ -107,7 +107,8 @@ rom_exception_handler:
   // `ram_end - 16`.  This allows us to report exceptions after jumping
   // to the next stage if the next stage has trashed its SP register.
   j rom_interrupt_handler
-  unimp
-  unimp
 
+  // Normally, we'd put an `unimp` sled here, however, we know by inspecting
+  // the disassembly of the linked ROM binary that the very next instruction
+  // is the beginning of `rom_interrupt_handler`.
   .size rom_exception_handler, .-rom_exception_handler

--- a/sw/device/silicon_creator/rom/rom_isrs.c
+++ b/sw/device/silicon_creator/rom/rom_isrs.c
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/rom_isrs.h"
+
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+OT_ALWAYS_INLINE
+OT_WARN_UNUSED_RESULT
+static rom_error_t rom_irq_error(void) {
+  uint32_t mcause;
+  CSR_READ(CSR_REG_MCAUSE, &mcause);
+  // Shuffle the mcause bits into the uppermost byte of the word and report
+  // the cause as kErrorInterrupt.
+  // Based on the ibex verilog, it appears that the most significant bit
+  // indicates whether the cause is an exception (0) or external interrupt (1),
+  // and the 5 least significant bits indicate which exception/interrupt.
+  //
+  // Preserve the MSB and shift the 7 LSBs into the upper byte.
+  // (we preserve 7 instead of 5 because the verilog hardcodes the unused bits
+  // as zero and those would be the next bits used should the number of
+  // interrupt causes increase).
+  mcause = (mcause & 0x80000000) | ((mcause & 0x7f) << 24);
+  return kErrorInterrupt + mcause;
+}
+
+void rom_interrupt_handler(void) {
+  register rom_error_t error asm("a0") = rom_irq_error();
+  asm volatile("tail shutdown_finalize;" ::"r"(error));
+  OT_UNREACHABLE();
+}
+
+// We only need a single handler for all ROM interrupts, but we want to
+// keep distinct symbols to make writing tests easier.  In the ROM,
+// alias all interrupt handler symbols to the single handler.
+OT_ALIAS("rom_interrupt_handler")
+noreturn void rom_nmi_handler(void);

--- a/sw/device/silicon_creator/rom/rom_isrs.h
+++ b/sw/device/silicon_creator/rom/rom_isrs.h
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_ROM_ISRS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_ROM_ISRS_H_
+
+#include <stdnoreturn.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Denotes functions that have to use the interrupt handler ABI.
+ *
+ * These must be 4-byte aligned. Note that they don't use the `interrupt`
+ * attribute since ROM handlers shut down the chip instead of returning like
+ * regular handlers.
+ */
+#define ROM_INTERRUPT_HANDLER_ABI __attribute__((aligned(4)))
+
+/**
+ * Denotes functions that have to be near the interrupt vector, because they
+ * are jumped to from it.
+ */
+#define ROM_VECTOR_FUNCTION __attribute__((section(".rom_isrs")))
+
+/**
+ * ROM hardware exception handler.
+ */
+ROM_VECTOR_FUNCTION
+ROM_INTERRUPT_HANDLER_ABI
+noreturn void rom_interrupt_handler(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_ROM_ISRS_H_


### PR DESCRIPTION
1. Move the C-based ISR functions to their own module to better control the link order.