### PR TITLE
[rom] Document `alert_ping_enable`

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/alert.h
+++ b/sw/device/silicon_creator/lib/drivers/alert.h
@@ -145,6 +145,9 @@ rom_error_t alert_class_configure(alert_class_t cls,
 
 /**
  * Enable the ping timer mechanism.
+ *
+ * TODO(#23393): Do not call this function in the ROM unless there is an OTP
+ * configuation to control whether or not to enable the ping mechanism.
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t alert_ping_enable(void);


### PR DESCRIPTION
Make sure `alert_ping_enable` is either:
- Not called from ROM
- Controllable with an OTP configuration

Addresses #23393.