### PR TITLE
[rom] Configure the SRAM readback feature 

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -232,6 +232,7 @@ otp_json(
                 ),
                 # By default, ROM_EXT's bootstrap feature should be disabled.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(CONST.HARDENED_FALSE),
+                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
             },
         ),
     ],

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -184,6 +184,7 @@ otp_json(
                 "OWNER_SW_CFG_ROM_RSTMGR_INFO_EN": otp_hex(0x0),
                 # Disable ROM_EXT recovery feature.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
+                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
             },
         ),
     ],

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -184,6 +184,7 @@ otp_json(
                 "OWNER_SW_CFG_ROM_RSTMGR_INFO_EN": otp_hex(0x0),
                 # Disable ROM_EXT recovery feature.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
+                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
             },
         ),
     ],

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -871,6 +871,18 @@
       default: "4",
       local: "true"
     },
+    { name: "OwnerSwCfgRomSramReadbackEnOffset",
+      desc: "Offset of OWNER_SW_CFG_ROM_SRAM_READBACK_EN",
+      type: "int",
+      default: "1028",
+      local: "true"
+    },
+    { name: "OwnerSwCfgRomSramReadbackEnSize",
+      desc: "Size of OWNER_SW_CFG_ROM_SRAM_READBACK_EN",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
     { name: "OwnerSwCfgDigestOffset",
       desc: "Offset of OWNER_SW_CFG_DIGEST",
       type: "int",

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -335,6 +335,10 @@
                     name: "OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_DIGEST",
                     size: "4"
                 }
+                {
+                    name: "OWNER_SW_CFG_ROM_SRAM_READBACK_EN",
+                    size: "4"
+                }
             ],
             desc: '''Software configuration partition.
             This contains data that changes software behavior in the ROM, for

--- a/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
+++ b/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
@@ -59,6 +59,7 @@ It has been generated with ./util/design/gen-otp-mmap.py
 |         |                           |            |      32bit       |                      OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN                      |     0x3F0      |     4      |
 |         |                           |            |      32bit       |                   OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_CFG                    |     0x3F4      |     12     |
 |         |                           |            |      32bit       |                  OWNER_SW_CFG_ROM_SENSOR_CTRL_ALERT_DIGEST                  |     0x400      |     4      |
+|         |                           |            |      32bit       |                      OWNER_SW_CFG_ROM_SRAM_READBACK_EN                      |     0x404      |     4      |
 |         |                           |            |      64bit       |              [OWNER_SW_CFG_DIGEST](#Reg_owner_sw_cfg_digest_0)              |     0x470      |     8      |
 |    3    | ROT_CREATOR_AUTH_CODESIGN |    472     |      32bit       |                  ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY_TYPE0                  |     0x478      |     4      |
 |         |                           |            |      32bit       |                    ROT_CREATOR_AUTH_CODESIGN_ECDSA_KEY0                     |     0x47C      |     64     |

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -427,7 +427,8 @@ package otp_ctrl_part_pkg;
     }),
     5312'({
       64'hE29749216775E8A5,
-      864'h0, // unallocated space
+      832'h0, // unallocated space
+      32'h0,
       32'h0,
       96'h0,
       32'h0,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -130,6 +130,8 @@ package otp_ctrl_reg_pkg;
   parameter int OwnerSwCfgRomSensorCtrlAlertCfgSize = 12;
   parameter int OwnerSwCfgRomSensorCtrlAlertDigestOffset = 1024;
   parameter int OwnerSwCfgRomSensorCtrlAlertDigestSize = 4;
+  parameter int OwnerSwCfgRomSramReadbackEnOffset = 1028;
+  parameter int OwnerSwCfgRomSramReadbackEnSize = 4;
   parameter int OwnerSwCfgDigestOffset = 1136;
   parameter int OwnerSwCfgDigestSize = 8;
   parameter int RotCreatorAuthCodesignOffset = 1144;

--- a/sw/device/silicon_creator/rom/e2e/sram/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sram/BUILD
@@ -1,0 +1,82 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "fpga_params",
+    "opentitan_test",
+)
+load(
+    "//rules:const.bzl",
+    "CONST",
+)
+load(
+    "//rules:otp.bzl",
+    "STD_OTP_OVERLAYS",
+    "otp_hex",
+    "otp_image",
+    "otp_json",
+    "otp_partition",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+otp_json(
+    name = "otp_json_readback_enable",
+    partitions = [
+        otp_partition(
+            name = "OWNER_SW_CFG",
+            items = {
+                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_TRUE),
+            },
+        ),
+    ],
+)
+
+# OTP images that enable the watchdog.
+otp_image(
+    name = "otp_img_readback_enable",
+    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":otp_json_readback_enable"],
+)
+
+_TESTS = {
+    "default": {
+        "otp": None,
+    },
+    "enabled": {
+        "otp": ":otp_img_readback_enable",
+    },
+}
+
+[
+    opentitan_test(
+        name = "sram_readback_{}_test".format(name),
+        srcs = ["sram_readback_test.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+        fpga = fpga_params(
+            otp = param["otp"],
+        ),
+        deps = [
+            "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+            "//hw/ip/sram_ctrl/data:sram_ctrl_c_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+        ],
+    )
+    for name, param in _TESTS.items()
+]
+
+test_suite(
+    name = "sram_readback_test",
+    tags = ["manual"],
+    tests = [
+        "sram_readback_{}_test".format(name)
+        for name in _TESTS.keys()
+    ],
+)

--- a/sw/device/silicon_creator/rom/e2e/sram/sram_readback_test.c
+++ b/sw/device/silicon_creator/rom/e2e/sram/sram_readback_test.c
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/manifest_def.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+#include "sram_ctrl_regs.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kSramCtrlBase = TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR,
+};
+
+bool test_main(void) {
+  uint32_t otp =
+      otp_read32(OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SRAM_READBACK_EN_OFFSET);
+  uint32_t cfg = abs_mmio_read32(kSramCtrlBase + SRAM_CTRL_READBACK_REG_OFFSET);
+  LOG_INFO("sram_readback: otp=%x cfg=%x", otp, cfg);
+  return otp == cfg;
+}

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -406,6 +406,7 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   // any other value to enable.
   li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
             OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET)
+  lw   t2, OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SRAM_READBACK_EN_OFFSET(a0)
   lw   t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_SRAM_KEY_RENEW_EN_OFFSET(a0)
   li   t1, HARDENED_BOOL_FALSE
   beq t0, t1, .L_sram_key_renew_skip
@@ -413,6 +414,8 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   li a1, (1 << SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT) | (1 << SRAM_CTRL_CTRL_INIT_BIT)
   sw a1, SRAM_CTRL_CTRL_REG_OFFSET(a0)
 .L_sram_key_renew_skip:
+  // Depending on OTP, enable the SRAM readback feature.
+  sw   t2, SRAM_CTRL_READBACK_REG_OFFSET(a0)
 
   /**
    * Clean Device State Part 1 (Please refer to `boot.md` section "Cleaning Device


### PR DESCRIPTION
1. Configure the SRAM readback feature as specified by OTP.
2. Supply default configurations with readback disabled.
3. Add tests to check the enabled case.

Addresses #23495.