### PR TITLE
[dv,top_level] Fix chip_sw_power_idle_load

### DIFF
--- a/sw/device/tests/chip_power_idle_load.c
+++ b/sw/device/tests/chip_power_idle_load.c
@@ -195,15 +195,17 @@ bool test_main(void) {
       .ping_timeout = UINT16_MAX,
   };
 
-  // 5. Configure Alerts
-  CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,
-                                                        kDifToggleEnabled));
+  // 5. Configure Alerts as unlocked so pings are disabled.
+  // TODO(lowrisc/opentitan#23644) enable locked when fixed to enable pings.
+  CHECK_STATUS_OK(
+      alert_handler_testutils_configure_all(&alert_handler, config,
+                                            /*locked=*/kDifToggleDisabled));
 
   // Checks whether alert handler's ping timer is locked
   bool is_locked;
   CHECK_DIF_OK(
       dif_alert_handler_is_ping_timer_locked(&alert_handler, &is_locked));
-  CHECK(is_locked, "Expected alerts to be locked");
+  CHECK(!is_locked, "Expected ping timer to be unlocked");
 
   LOG_INFO("Alert ping is active");
 


### PR DESCRIPTION
Disables alert_handler outgoing alert pings, since they cause the ping response to be confused for an outgoing alert. This workaround can be removed when #23644 is fixed.

Fixes #23570