### PR TITLE
[hjson,englishbreakfast] Do not declare aon_timer as templated

### DIFF
--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -318,7 +318,6 @@
       reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon"},
       domain: ["Aon"],
       base_addr: "0x40470000",
-      attr: "templated",
     },
     { name: "ast",
       type: "ast",


### PR DESCRIPTION
The aon_timer module is a regular IP block, so it should not be marked as `attr: "templated"`, since that causes a failure in the countermeasures check.

Fixes #23649