### PR TITLE
[rom] Fix sec_mmio audit script and update ROM manual test plan

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,22 +225,6 @@ jobs:
       echo -//sw/otbn/crypto/... >> "${TARGET_PATTERN_FILE}"
       echo -//third_party/riscv-compliance/... >> "${TARGET_PATTERN_FILE}"
       echo -//hw:all >> "${TARGET_PATTERN_FILE}"
-      echo -//hw/ip_templates/clkmgr/data:clkmgr_c_regs \
-        >> "${TARGET_PATTERN_FILE}"
-      echo -//hw/ip_templates/clkmgr/data:clkmgr_rust_regs \
-        >> "${TARGET_PATTERN_FILE}"
-      echo -//hw/ip_templates/flash_ctrl/data:flash_ctrl_c_regs \
-        >> "${TARGET_PATTERN_FILE}"
-      echo -//hw/ip_templates/flash_ctrl/data:flash_ctrl_rust_regs \
-        >> "${TARGET_PATTERN_FILE}"
-      echo -//hw/ip_templates/pwrmgr/data:pwrmgr_c_regs \
-        >> "${TARGET_PATTERN_FILE}"
-      echo -//hw/ip_templates/pwrmgr/data:pwrmgr_rust_regs \
-        >> "${TARGET_PATTERN_FILE}"
-      echo -//hw/ip_templates/rstmgr/data:rstmgr_c_regs \
-        >> "${TARGET_PATTERN_FILE}"
-      echo -//hw/ip_templates/rstmgr/data:rstmgr_rust_regs \
-        >> "${TARGET_PATTERN_FILE}"
       ci/bazelisk.sh cquery \
         --noinclude_aspects \
         --output=starlark \

--- a/hw/ip_templates/clkmgr/data/BUILD
+++ b/hw/ip_templates/clkmgr/data/BUILD
@@ -4,26 +4,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "//rules:autogen.bzl",
-    "autogen_hjson_c_header",
-    "autogen_hjson_rust_header",
-)
-
-autogen_hjson_c_header(
-    name = "clkmgr_c_regs",
-    srcs = [
-        "clkmgr.hjson",
-    ],
-)
-
-autogen_hjson_rust_header(
-    name = "clkmgr_rust_regs",
-    srcs = [
-        "clkmgr.hjson",
-    ],
-)
-
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),

--- a/hw/ip_templates/flash_ctrl/data/BUILD
+++ b/hw/ip_templates/flash_ctrl/data/BUILD
@@ -4,28 +4,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "//rules:autogen.bzl",
-    "autogen_hjson_c_header",
-    "autogen_hjson_rust_header",
-)
-
-autogen_hjson_c_header(
-    name = "flash_ctrl_c_regs",
-    srcs = [
-        "flash_ctrl.hjson",
-    ],
-    node = "core",
-)
-
-autogen_hjson_rust_header(
-    name = "flash_ctrl_rust_regs",
-    srcs = [
-        "flash_ctrl.hjson",
-    ],
-    node = "core",
-)
-
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),

--- a/hw/ip_templates/pwrmgr/data/BUILD
+++ b/hw/ip_templates/pwrmgr/data/BUILD
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "//rules:autogen.bzl",
     "autogen_hjson_c_header",
     "autogen_hjson_rust_header",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 autogen_hjson_c_header(
     name = "pwrmgr_c_regs",

--- a/hw/ip_templates/rstmgr/data/BUILD
+++ b/hw/ip_templates/rstmgr/data/BUILD
@@ -4,26 +4,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "//rules:autogen.bzl",
-    "autogen_hjson_c_header",
-    "autogen_hjson_rust_header",
-)
-
-autogen_hjson_c_header(
-    name = "rstmgr_c_regs",
-    srcs = [
-        "rstmgr.hjson",
-    ],
-)
-
-autogen_hjson_rust_header(
-    name = "rstmgr_rust_regs",
-    srcs = [
-        "rstmgr.hjson",
-    ],
-)
-
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),

--- a/sw/device/silicon_creator/rom/data/rom_manual_testplan.hjson
+++ b/sw/device/silicon_creator/rom/data/rom_manual_testplan.hjson
@@ -48,6 +48,34 @@
       tests: ["rom_e2e_c_init"]
     }
     {
+      name: rom_manual_sec_mmio_audit
+      desc: '''Verify that the registers accessed by `sec_mmio` functions are not modifiable by
+            hardware.
+
+            See https://github.com/lowRISC/opentitan/issues/18634 for additional context.
+
+            The following utility may be helpful in auditing the code:
+
+            bazel run //util/py/scripts:audit_sec_mmio_calls -- --log-level info
+            '''
+    }
+    {
+      name: rom_manual_stack_utilization
+      desc: '''Verify stack utilization.
+
+            Ensure that the worst case utilization paths are below the space allocated for the
+            stack.
+            '''
+    }
+    {
+      name: rom_manual_alert_handler_ping_disabled
+      desc: '''Ensure the alert handler ping mechanism is not enabled in the ROM.
+
+            The alert handler ping mechanism has not been qualified to work with the ROM. The
+            earliest stage in which it can be used is the ROM_EXT.
+            '''
+    }
+    {
       name: rom_manual_open_issues_tasks
       desc: '''Verify that there are no blocking issues on GitHub or tasks in the tracker.'''
       tags: ["manual"]

--- a/util/py/packages/lib/register_usage_report.py
+++ b/util/py/packages/lib/register_usage_report.py
@@ -176,7 +176,7 @@ class RegisterTokenPattern:
     def find_first_match(
             patterns: list['RegisterTokenPattern'], tokens: list[str],
             function_name: str,
-            call_site: clang.cindex.Cursor) -> RegisterUsageReport:
+            call_site: clang.cindex.Cursor) -> Optional[RegisterUsageReport]:
         for pattern in patterns:
             report = RegisterUsageReport(
                 function_name=function_name,
@@ -199,8 +199,9 @@ class RegisterTokenPattern:
                 report.unparsed_callsites.add(extent)
             return report
 
-        raise Exception("No pattern matched tokens at call-site for " +
-                        f"{call_site.displayname}: {tokens}")
+        print("No pattern matched tokens at call-site for " +
+              f"{call_site.displayname}: {tokens}")
+        return None
 
 
 @functools.cache
@@ -292,6 +293,7 @@ class CallSiteAnalyzer:
 
             report = RegisterTokenPattern.find_first_match(
                 self._patterns, tokens, cursor.displayname, cursor)
-            reports.append(report)
+            if report is not None:
+                reports.append(report)
 
         return RegisterUsageReport.merge_reports(reports)

--- a/util/py/scripts/audit_sec_mmio_calls.py
+++ b/util/py/scripts/audit_sec_mmio_calls.py
@@ -63,12 +63,12 @@ class BazelTool:
         bazel.try_escape_sandbox()
 
     def query_hjson_sources(self) -> list[Path]:
-        """Find hjson files associated with autogen_hjson_header targets."""
-        log.info("Querying Bazel for autogen_hjson_header srcs")
+        """Find hjson files associated with autogen_hjson_c_header targets."""
+        log.info("Querying Bazel for autogen_hjson_c_header srcs")
         query_lines = run.run(
             "./bazelisk.sh",
             "cquery",
-            "labels(srcs, kind(autogen_hjson_header, //...))",
+            "labels(srcs, kind(autogen_hjson_c_header, //...))",
             "--output=starlark",
             "--starlark:expr='\\n'.join([f.path for f in target.files.to_list()])",
         )


### PR DESCRIPTION
## Changes

1. Remove invalid autogen header targets from `ip_template` folders. These targets were not working due to invalid dependencies. Removing these invalid targets help simplify build target queries, which are used in the `sec_mmio` auditing script. 
2. Fix the `audit_sec_mmio_calls.py` script. The script was failing due missing updates to required bazel target queries.
3. Update the ROM manual test plan to include the following targets:
  a. `rom_manual_sec_mmio_audit`
  b. `rom_manual_stack_utilization`
  c. `rom_manual_alert_handler_ping_disabled`

Fixes: https://github.com/lowRISC/opentitan/issues/19288
Part of: https://github.com/lowRISC/opentitan/issues/23393
Part of: https://github.com/lowRISC/opentitan/issues/14707