### PR TITLE
[rom] Make the flash exception handler OTP controlled 

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -233,6 +233,7 @@ otp_json(
                 # By default, ROM_EXT's bootstrap feature should be disabled.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(CONST.HARDENED_FALSE),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
             },
         ),
     ],

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -185,6 +185,7 @@ otp_json(
                 # Disable ROM_EXT recovery feature.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
             },
         ),
     ],

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -185,6 +185,7 @@ otp_json(
                 # Disable ROM_EXT recovery feature.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
                 "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
             },
         ),
     ],

--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -82,6 +82,7 @@ CONST = struct(
         INTERRUPT = struct(
             INSTRUCTION_ACCESS = 0x01495202,
             ILLEGAL_INSTRUCTION = 0x02495202,
+            LOAD_ACCESS = 0x05495202,
             STORE_ACCESS = 0x07495202,
         ),
         SIGVERIFY = struct(

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_flash_ecc_error/BUILD
@@ -6,6 +6,7 @@ load(
     "//rules:const.bzl",
     "CONST",
     "hex",
+    "hex_digits",
 )
 load(
     "//rules:manifest.bzl",
@@ -130,10 +131,32 @@ otp_json(
     ],
 )
 
+otp_json(
+    name = "otp_json_flash_exc_handler_disabled",
+    partitions = [
+        otp_partition(
+            name = "OWNER_SW_CFG",
+            items = {
+                "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_FALSE),
+            },
+        ),
+    ],
+)
+
 otp_image(
     name = "otp_img_boot_policy_flash_ecc_error",
     src = "//hw/ip/otp_ctrl/data:otp_json_prod",
     overlays = STD_OTP_OVERLAYS + [":otp_json_flash_data_cfg_default_scr_and_ecc_enabled"],
+    visibility = ["//visibility:private"],
+)
+
+otp_image(
+    name = "otp_img_flash_exc_handler_disabled",
+    src = "//hw/ip/otp_ctrl/data:otp_json_prod",
+    overlays = STD_OTP_OVERLAYS + [
+        ":otp_json_flash_data_cfg_default_scr_and_ecc_enabled",
+        ":otp_json_flash_exc_handler_disabled",
+    ],
     visibility = ["//visibility:private"],
 )
 
@@ -246,6 +269,27 @@ SEC_VERS = [
     for t in BOOT_POLICY_FLASH_ECC_ERROR_TESTS
     for c in FLASH_ECC_ERROR_CAUSES
 ]
+
+opentitan_test(
+    name = "flash_exc_handler_disabled_test",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
+    fpga = fpga_params(
+        assemble = "{fw_a}@{slot_a} {fw_b}@{slot_b}",
+        binaries = {
+            ":flash_ecc_self_corruption_slot_a_manifest_identifier": "fw_a",
+            ":uncorrupted_test_slot_b": "fw_b",
+        },
+        # Since the flash ecc exception handler is disabled in this test,
+        # we expect to see a load access fault when the ROM accesses the
+        # corrupted flash word.
+        exit_success = "BFV:{}".format(hex_digits(CONST.BFV.INTERRUPT.LOAD_ACCESS)),
+        otp = ":otp_img_flash_exc_handler_disabled",
+        slot_a = SLOTS["a"],
+        slot_b = SLOTS["b"],
+    ),
+)
 
 test_suite(
     name = "boot_policy_flash_ecc_error",

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -93,6 +93,8 @@ boot_data_t boot_data = {0};
 static hardened_bool_t waking_from_low_power = 0;
 // First stage (ROM-->ROM_EXT) secure boot keys loaded from OTP.
 static sigverify_otp_key_ctx_t sigverify_ctx;
+// A ram copy of the OTP word controlling how to handle flash ECC errors.
+uint32_t flash_ecc_exc_handler_en;
 
 /**
  * Prints a status message indicating that the ROM is entering bootstrap mode.
@@ -175,6 +177,8 @@ static rom_error_t rom_init(void) {
 
   flash_ctrl_init();
   SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInit);
+  flash_ecc_exc_handler_en = otp_read32(
+      OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN_OFFSET);
 
   // Initialize in-memory copy of the ePMP register configuration.
   rom_epmp_state_init(lc_state);

--- a/sw/device/silicon_creator/rom/rom_isrs.S
+++ b/sw/device/silicon_creator/rom/rom_isrs.S
@@ -4,6 +4,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/hardened_asm.h"
 #include "flash_ctrl_regs.h"
 
 .equ LOAD_ACCESS_FAULT, 5
@@ -25,15 +26,25 @@
   .balign 4
   .global rom_exception_handler
   .type rom_exception_handler, @function
+  .extern flash_ecc_exc_handler_en
 rom_exception_handler:
   // Save all registers to the exception frame.  The ROM locates its initial
   // stack_end at `ram_end - 128` and the stack grows downwards from there.
   // Save `sp` into `mscratch` and use the 128 bytes reserved at the top of
   // RAM as the exception frame.
+  csrw mscratch, sp
+
+  // Before saving the stack frame, check if handling of flash exceptions is
+  // enabled.  Determine this with just the stack pointer so that if not enabled,
+  // we don't have to do any other register save/restore.
+  la   sp, flash_ecc_exc_handler_en
+  lw   sp, 0(sp)
+  xori sp, sp, HARDENED_BOOL_TRUE
+  bnez sp, .L_no_flash_exceptions
+
   // Note: we save the exception frame in RISCV register number order so that
   // we can extract the destination register from the faulting instruction and
   // use it as an index into the exception frame.
-  csrw mscratch, sp
   la   sp, _exception_frame_start
   sw   x1,  1 * OT_WORD_SIZE(sp)
   sw   x2,  2 * OT_WORD_SIZE(sp)
@@ -200,6 +211,8 @@ rom_exception_handler:
   csrr sp, mscratch
   mret
 
+.L_no_flash_exceptions:
+  csrr sp, mscratch
 .L_not_a_flash_error:
   // Since we aren't dealing with a flash error, we'll jump to the normal
   // handler for all other exceptiosn and interrupts.  That handler emits


### PR DESCRIPTION
Since the flash ECC exception handler is a complex bit of low-level
code, mitigate risk by enabling or disabling the handler via OTP.

1. Enable the handler in the default OTP configurations.
2. Test at exception entry whether or not we want to handle ECC errors.
3. Add a test that confirms that when flash ECC exception handling is
   disabled, an ECC error results in a classic Load Access Fault.
