### PR TITLE
[rom] Switch DAI to use abs_mmio instead of sec_mmio.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -106,7 +106,7 @@ static void dai_read_blocking(otp_partition_t partition,
                               uint32_t relative_address) {
   wait_for_dai_idle();
   HARDENED_CHECK_EQ(relative_address & kOtpPartitions[partition].align_mask, 0);
-  sec_mmio_write32(kBase + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+  abs_mmio_write32(kBase + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                    kOtpPartitions[partition].start_addr + relative_address);
   uint32_t cmd =
       bitfield_bit32_write(0, OTP_CTRL_DIRECT_ACCESS_CMD_RD_BIT, true);
@@ -115,18 +115,16 @@ static void dai_read_blocking(otp_partition_t partition,
 }
 
 uint32_t otp_dai_read32(otp_partition_t partition, uint32_t relative_address) {
-  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioDaiRead32, 1);
   dai_read_blocking(partition, relative_address);
-  return sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET);
+  return abs_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET);
 }
 
 uint64_t otp_dai_read64(otp_partition_t partition, uint32_t relative_address) {
-  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioDaiRead64, 1);
   dai_read_blocking(partition, relative_address);
   uint64_t value =
-      sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET);
+      abs_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET);
   value <<= 32;
-  value |= sec_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET);
+  value |= abs_mmio_read32(kBase + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET);
   return value;
 }
 

--- a/sw/device/silicon_creator/lib/drivers/otp.h
+++ b/sw/device/silicon_creator/lib/drivers/otp.h
@@ -33,8 +33,6 @@ enum {
    * Individual register reads/writes.
    */
   kOtpSecMmioCreatorSwCfgLockDown = 1,
-  kOtpSecMmioDaiRead32 = 1,
-  kOtpSecMmioDaiRead64 = 1,
 };
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -141,11 +141,11 @@ class OtpDaiReadTest : public OtpReadTest,
 
 TEST_F(OtpDaiReadTest, Read32) {
   ExpectDaiIdleCheck(true);
-  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+  EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                      OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET);
   EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
   ExpectDaiIdleCheck(true);
-  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+  EXPECT_ABS_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
                     0x00010203);
   EXPECT_EQ(otp_dai_read32(kOtpPartitionCreatorSwCfg, 0), 0x00010203);
 }
@@ -154,25 +154,25 @@ TEST_F(OtpDaiReadTest, Read32WithIdleWait) {
   ExpectDaiIdleCheck(false);
   ExpectDaiIdleCheck(false);
   ExpectDaiIdleCheck(true);
-  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+  EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                      OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET);
   EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
   ExpectDaiIdleCheck(false);
   ExpectDaiIdleCheck(true);
-  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+  EXPECT_ABS_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
                     0x00010203);
   EXPECT_EQ(otp_dai_read32(kOtpPartitionCreatorSwCfg, 0), 0x00010203);
 }
 
 TEST_F(OtpDaiReadTest, Read64) {
   ExpectDaiIdleCheck(true);
-  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+  EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                      OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET + 4);
   EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
   ExpectDaiIdleCheck(true);
-  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET,
+  EXPECT_ABS_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET,
                     0x00010203);
-  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+  EXPECT_ABS_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
                     0x00040506);
   EXPECT_EQ(otp_dai_read64(kOtpPartitionOwnerSwCfg, 4), 0x0001020300040506);
 }
@@ -180,15 +180,15 @@ TEST_F(OtpDaiReadTest, Read64) {
 TEST_F(OtpDaiReadTest, Read64WithIdleWait) {
   ExpectDaiIdleCheck(false);
   ExpectDaiIdleCheck(true);
-  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
+  EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
                      OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET);
   EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
   ExpectDaiIdleCheck(false);
   ExpectDaiIdleCheck(false);
   ExpectDaiIdleCheck(true);
-  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET,
+  EXPECT_ABS_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_1_REG_OFFSET,
                     0x00010203);
-  EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+  EXPECT_ABS_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
                     0x00040506);
   EXPECT_EQ(otp_dai_read64(kOtpPartitionCreatorSwCfg, 0), 0x0001020300040506);
 }
@@ -197,12 +197,12 @@ TEST_P(OtpDaiReadTest, ReadLenN32bitWords) {
   size_t num_words_to_read = GetParam();
   for (size_t i = 0; i < num_words_to_read; ++i) {
     ExpectDaiIdleCheck(true);
-    EXPECT_SEC_WRITE32(
+    EXPECT_ABS_WRITE32(
         base_ + OTP_CTRL_DIRECT_ACCESS_ADDRESS_REG_OFFSET,
         OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET + i * sizeof(uint32_t));
     EXPECT_ABS_WRITE32(base_ + OTP_CTRL_DIRECT_ACCESS_CMD_REG_OFFSET, 0x1);
     ExpectDaiIdleCheck(true);
-    EXPECT_SEC_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
+    EXPECT_ABS_READ32(base_ + OTP_CTRL_DIRECT_ACCESS_RDATA_0_REG_OFFSET,
                       0x01020300 + i);
   }
 


### PR DESCRIPTION
The DAI interface may change its values depending on the last transaction. It is recommended that consuming software use a different mechanism to ensure values read via DAI are consitent over time.