### PR TITLE
[entropy_src/doc] Fix some documentation issues

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1305,6 +1305,7 @@
                 Setting this field to `kMultiBitBool4True` will put the entropy flow in firmware override mode.
                 In this mode, firmware can monitor the post-health test entropy by reading
                 the observe FIFO (see !!FW_OV_RD_DATA).
+                This includes the entropy bits used for the startup health testing.
                 For this to work, the otp_en_entropy_src_fw_over input needs to be set to `kMultiBitBool8True`.
 
                 Note that the post-health test entropy bits collected in the observe FIFO continue to flow through the hardware pipeline and may eventually reach the block hardware interface.
@@ -1328,6 +1329,8 @@
                 Any entropy bits arriving after the observe FIFO is full are being discarded.
                 Firmware has to read out the entire observe FIFO to restart entropy collection.
                 Only entropy bits inserted by firmware by writing !!FW_OV_WR_DATA may eventually reach the block hardware interface.
+
+                Also, the hardware startup health testing is skipped and firmware becomes responsible for performing any startup health testing.
                 '''
           mubi: true,
           resval: false

--- a/hw/ip/entropy_src/doc/programmers_guide.md
+++ b/hw/ip/entropy_src/doc/programmers_guide.md
@@ -34,7 +34,7 @@ For more details on the individual modes, refer to [Theory of Operations](theory
 
 ### Firmware Override - Observe
 
-Using the firmware override function, firmware can observe post-health test entropy bits by reading from the [`FW_OV_RD_DATA`](registers.md#fw_ov_rd_data) register (observe FIFO), e.g., for validation testing.
+Using the firmware override function, firmware can observe post-health test entropy bits (including entropy bits used for startup health testing) by reading from the [`FW_OV_RD_DATA`](registers.md#fw_ov_rd_data) register (observe FIFO), e.g., for validation testing.
 To this end, the `otp_en_entropy_src_fw_over` input needs to be set to `kMultiBitBool8True`.
 In addition, firmware has to set the `FW_OV_MODE` field in the [`FW_OV_CONTROL`](registers.md#fw_ov_control) register to `kMultiBitBool4True`.
 
@@ -60,6 +60,8 @@ The observe FIFO will collect 1 kBit of contiguous entropy bits.
 Any entropy bits arriving after the observe FIFO is full are being discarded.
 Firmware has to read out the entire observe FIFO to restart entropy collection.
 Only entropy bits inserted by firmware by writing the [`FW_OV_WR_DATA`](registers.md#fw_ov_wr_data) register may eventually reach the block hardware interface.
+
+Also, the hardware startup health testing is skipped and firmware becomes responsible for performing any startup health testing.
 
 If firmware does not want to use hardware conditioning for the inserted entropy bits, it has to do one of the two following points:
 1. Set the `FIPS_ENABLE` field in the [`CONF`](registers.md#conf) register to `kMultiBitBool4False`.

--- a/hw/ip/entropy_src/doc/registers.md
+++ b/hw/ip/entropy_src/doc/registers.md
@@ -1144,10 +1144,13 @@ Any entropy bits arriving after the observe FIFO is full are being discarded.
 Firmware has to read out the entire observe FIFO to restart entropy collection.
 Only entropy bits inserted by firmware by writing [`FW_OV_WR_DATA`](#fw_ov_wr_data) may eventually reach the block hardware interface.
 
+Also, the hardware startup health testing is skipped and firmware becomes responsible for performing any startup health testing.
+
 ### FW_OV_CONTROL . FW_OV_MODE
 Setting this field to `kMultiBitBool4True` will put the entropy flow in firmware override mode.
 In this mode, firmware can monitor the post-health test entropy by reading
 the observe FIFO (see [`FW_OV_RD_DATA`](#fw_ov_rd_data)).
+This includes the entropy bits used for the startup health testing.
 For this to work, the otp_en_entropy_src_fw_over input needs to be set to `kMultiBitBool8True`.
 
 Note that the post-health test entropy bits collected in the observe FIFO continue to flow through the hardware pipeline and may eventually reach the block hardware interface.

--- a/hw/ip/entropy_src/doc/theory_of_operation.md
+++ b/hw/ip/entropy_src/doc/theory_of_operation.md
@@ -56,13 +56,13 @@ In the case of health tests, firmware can turn off one or all of the health test
 A data path is provided in the hardware such that the inbound entropy can be trapped in the observe FIFO.
 Once a pre-determined threshold of entropy has been reached in this FIFO, and interrupt is raised to let firmware read the entropy bits out of the FIFO.
 The exact mechanism for this functionality starts with setting the [`FW_OV_MODE`](registers.md#fw_ov_control--fw_ov_mode) field in the [`FW_OV_CONTROL`](registers.md#fw_ov_control) register.
-This will enable firmware to monitor post-health test entropy bits by reading from the [`FW_OV_RD_DATA`](registers.md#fw_ov_rd_data) register.
+This will enable firmware to monitor post-health test entropy bits (including entropy bits used for startup health testing) by reading from the [`FW_OV_RD_DATA`](registers.md#fw_ov_rd_data) register.
 Firmware can use the [`OBSERVE_FIFO_THRESH`](registers.md#observe_fifo_thresh) and [`OBSERVE_FIFO_DEPTH`](registers.md#observe_fifo_depth) to determine the state of the OBSERVE FIFO.
 At this point, firmware can do additional health checks on the entropy.
 Optionally, firmware can do the conditioning function, assuming the hardware is configured to bypass the conditioner block.
 Once firmware has processed the entropy, it can then write the results back into the [`FW_OV_WR_DATA`](registers.md#fw_ov_wr_data) register (pre-conditioner FIFO).
 The [`FW_OV_ENTROPY_INSERT`](registers.md#fw_ov_control--fw_ov_entropy_insert) in the [`FW_OV_CONTROL`](registers.md#fw_ov_control) register will enable inserting entropy bits back into the entropy flow.
-The firmware override control fields will be set such that the new entropy will resume normal flow operation.
+If enabled, any startup health testing has to be performed by the firmware.
 
 An additional feature of the firmware override function is to insert entropy bits into the flow and still use the conditioning function in the hardware.
 Setting the [`FW_OV_INSERT_START`](registers.md#fw_ov_sha3_start--fw_ov_insert_start) field in the [`FW_OV_SHA3_START`](registers.md#fw_ov_sha3_start) register will prepare the hardware for this flow.


### PR DESCRIPTION
While prepping the V2S sign-off issue and going through open issues, I noted that I still had prepared some commits earlier to fix an open doc issue.