### PR TITLE
[otbn,dv] Get the otbn_sec_cm test working again without needing do disable FI

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -226,15 +226,22 @@ class otbn_common_vseq extends otbn_base_vseq;
           $asserton(0, "prim_fifo_sync");
         end
 
-        // Disable assertions that we expect to fail if we corrupt a request FIFO. This causes a
-        // reasonable amount of chaos, because we end up with 'X values in our requests, that then
-        // travel all over the dut and are also exposed on external interfaces (TL interfaces).
+        // Disable assertions that we expect to fail if we corrupt a request FIFO. This causes us to
+        // generate spurious TL transactions. Disable the TL checker (which, quite reasonably, will
+        // have assertions that fire).
+        //
+        // Also disable assertions in the tlul_socket_1n in our register block. This gets confused
+        // because of an unexpected response, which causes our num_req_outstanding counter to be
+        // decremented to -1 (which is more than MaxOutstanding when considered as an unsigned
+        // integer).
         if (touching_req_fifo) begin
           if (!enable) begin
             `uvm_info(`gfn, "Doing FI on a request fifo. Disabling related assertions", UVM_HIGH)
             cfg.m_tl_agent_cfg.check_tl_errs = 1'b0;
             $assertoff(0, "tb.dut.tlul_checker");
+            $assertoff(0, "tb.dut.u_reg.u_socket");
           end else begin
+            $asserton(0, "tb.dut.u_reg.u_socket");
             $asserton(0, "tb.dut.tlul_checker");
             cfg.m_tl_agent_cfg.check_tl_errs = 1'b1;
           end

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -164,9 +164,6 @@ class otbn_common_vseq extends otbn_base_vseq;
     end
     if (if_proxy.sec_cm_type == SecCmPrimCount) begin
       cfg.model_agent_cfg.vif.otbn_disable_stack_check();
-      $assertoff(0, "tb.dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack\
-               .next_stack_top_idx_correct");
-      $assertoff(0, "tb.dut.u_otbn_core.u_otbn_rf_base.u_call_stack.next_stack_top_idx_correct");
       if (if_proxy.path == {"tb.dut.u_tlul_adapter_sram_dmem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.",
                             "gen_secure_ptrs.u_wptr"} ||
           if_proxy.path == {"tb.dut.u_tlul_adapter_sram_dmem.u_rspfifo.gen_normal_fifo.u_fifo_cnt.",


### PR DESCRIPTION
This was... more difficult than I expected! The real point of the changes is the last commit of the PR. The other commits are to make everything work.

I'm pleased to say that (with this change) I've just run 24 seeds for the `otbn_sec_cm` sequence. After 50 minutes(!), 19 of them had passed, and the others are still running. So I'm reasonably confident that this works properly.

Update (crikey, that takes a while!): It works!
```
  Stage  |                    Name                    | Tests       |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:------------------------------------------:|:------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V2S   |                tl_intg_err                 | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |               prim_fsm_check               | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |              prim_count_check              | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |      sec_cm_controller_fsm_local_esc       | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |        sec_cm_controller_fsm_sparse        | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |     sec_cm_scramble_ctrl_fsm_local_esc     | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |      sec_cm_scramble_ctrl_fsm_sparse       | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |    sec_cm_start_stop_ctrl_fsm_local_esc    | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |     sec_cm_start_stop_ctrl_fsm_sparse      | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |  sec_cm_rf_base_data_reg_sw_glitch_detect  | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |       sec_cm_stack_wr_ptr_ctr_redun        | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   | sec_cm_rf_bignum_data_reg_sw_glitch_detect | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |        sec_cm_loop_stack_ctr_redun         | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |         sec_cm_tlul_fifo_ctr_redun         | otbn_sec_cm |      55.000m      |     7.672ms      |    24     |   24    |  100.00 %   |
|   V2S   |                                            | **TOTAL**   |                   |                  |    24     |   24    |  100.00 %   |
|         |                                            | **TOTAL**   |                   |                  |    24     |   24    |  100.00 %   |
```