### PR TITLE
[flash/dv] Fix flash_ctrl_base_otf_vseq address overflow

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -128,8 +128,10 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     // transaction creates prog_win error.
     // To prevent that, make full size access always start from address[2:0] == 0.
     if (fractions == 16) rand_op.addr[2] == 0;
+    // Make sure that the operation will not cross the selected partition boundries.
     if (rand_op.partition != FlashPartData) {
-      rand_op.addr inside {[0:InfoTypeBytes[rand_op.partition>>1]-1]};
+      rand_op.addr inside
+        {[0:InfoTypeBytes[rand_op.partition>>1]-(FlashBankBytesPerWord*fractions)]};
       rand_op.prog_sel == 1;
     } else {
       rand_op.prog_sel == 0;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -128,8 +128,10 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     // transaction creates prog_win error.
     // To prevent that, make full size access always start from address[2:0] == 0.
     if (fractions == 16) rand_op.addr[2] == 0;
+    // Make sure that the operation will not cross the selected partition boundries.
     if (rand_op.partition != FlashPartData) {
-      rand_op.addr inside {[0:InfoTypeBytes[rand_op.partition>>1]-1]};
+      rand_op.addr inside
+        {[0:InfoTypeBytes[rand_op.partition>>1]-(FlashBankBytesPerWord*fractions)]};
       rand_op.prog_sel == 1;
     } else {
       rand_op.prog_sel == 0;


### PR DESCRIPTION
This fixes some rare failures in test flash_ctrl_fs_sup caused by a possible overflow of the randomized operation by randomizing an address and number of words that exceeding the info partition size.