### PR TITLE
[flash/dv] Increase timeout for flash_ctrl_prog_reset

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_prog_reset_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_prog_reset_vseq.sv
@@ -40,7 +40,7 @@ class flash_ctrl_prog_reset_vseq extends flash_ctrl_otf_base_vseq;
   virtual task body();
     flash_op_t ctrl;
     int num, bank, iter;
-    int state_long_timeout_ns = 50_000_000; // 50ms
+    int state_long_timeout_ns = 500_000_000; // 500ms
     int state_timeout_ns = 100000; // 100us
 
     // Don't select a partition defined as read-only

--- a/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -327,7 +327,7 @@
     {
       name: flash_ctrl_prog_reset
       uvm_test_seq: flash_ctrl_prog_reset_vseq
-      run_opts: ["+scb_otf_en=1", "+ecc_mode=1"]
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+test_timeout_ns=500_000_000"]
       reseed: 30
     }
     {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_prog_reset_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_prog_reset_vseq.sv
@@ -40,7 +40,7 @@ class flash_ctrl_prog_reset_vseq extends flash_ctrl_otf_base_vseq;
   virtual task body();
     flash_op_t ctrl;
     int num, bank, iter;
-    int state_long_timeout_ns = 50_000_000; // 50ms
+    int state_long_timeout_ns = 500_000_000; // 500ms
     int state_timeout_ns = 100000; // 100us
 
     // Don't select a partition defined as read-only

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -327,7 +327,7 @@
     {
       name: flash_ctrl_prog_reset
       uvm_test_seq: flash_ctrl_prog_reset_vseq
-      run_opts: ["+scb_otf_en=1", "+ecc_mode=1"]
+      run_opts: ["+scb_otf_en=1", "+ecc_mode=1", "+test_timeout_ns=500_000_000"]
       reseed: 30
     }
     {


### PR DESCRIPTION
flash_ctrl_prog_reset allow in some cases to wait for states that aren't reachable and the timeout used to wait for the test to finish gracefully is in some cases not long enough, so this PR is increase it.