### PR TITLE
[dv] Reduce number of seeds for stress_all_with_rand_reset tests

### DIFF
--- a/hw/ip/csrng/dv/csrng_sim_cfg.hjson
+++ b/hw/ip/csrng/dv/csrng_sim_cfg.hjson
@@ -100,6 +100,11 @@
       uvm_test: csrng_regwen_test
       uvm_test_seq: csrng_regwen_vseq
     }
+
+    {
+      name: csrng_stress_all_with_rand_reset
+      reseed: 10
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -114,7 +114,7 @@
       // Append the common stress_tests.hjson entry for more run_opts.
       name: hmac_stress_all_with_rand_reset
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
-      reseed: 200
+      reseed: 10
     }
   ]
 

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -226,6 +226,7 @@
       run_opts: ["+run_stress_all_with_rand_reset",
                  "+stress_seq=i2c_host_stress_all_vseq"]
       run_timeout_mins: 20
+      reseed: 10
     }
     {
       name: "i2c_target_stress_all_with_rand_reset"
@@ -234,6 +235,7 @@
                  "+run_stress_all_with_rand_reset",
                  "+stress_seq=i2c_target_stress_all_vseq"]
       run_timeout_mins: 20
+      reseed: 10
     }
     {
       name: "i2c_host_mode_toggle"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -214,6 +214,7 @@
     {
       name: kmac_stress_all_with_rand_reset
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
+      reseed: 10
     }
   ]
 

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -281,6 +281,10 @@
       name: rv_dm_stress_all
       uvm_test_seq: rv_dm_stress_all_vseq
     }
+    {
+      name: rv_dm_stress_all_with_rand_reset
+      reseed: 10
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -246,6 +246,11 @@
       uvm_test_seq: usbdev_in_rand_trans_vseq
       run_opts: ["+num_of_bytes=64"]
     }
+
+    {
+      name: usbdev_stress_all_with_rand_reset
+      reseed: 10
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This is a V3 test and quite a few IP blocks for which we are primarily targeting V2S (AES, CSRNG, HMAC, I2C, KMAC, RV_DM, USBDEV) have a very low pass rate for this test right now.

To save DV resources, this commit reduces the number of seeds for this test for blocks not targeting V3 right now.