### PR TITLE
[lint] Waive lint warnings and errors in prim_[generic_]_flop_2sync

### DIFF
--- a/hw/ip/prim/lint/prim_flop_2sync.waiver
+++ b/hw/ip/prim/lint/prim_flop_2sync.waiver
@@ -12,3 +12,6 @@ waive -rules {PARAM_NOT_USED} -location {prim_flop_2sync.sv} -regexp {Parameter 
 
 waive -rules {SAME_NAME_TYPE} -location {prim_flop_2sync.sv} -regexp {'ResetValue' is used as a parameter here, and as an enumeration value at prim.*} \
       -comment "Parameter name reuse."
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_flop_2sync.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim_generic/lint/prim_generic_flop_2sync.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_flop_2sync.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_generic_flop_2sync
+
+waive -rules {IFDEF_CODE} -location {prim_generic_flop_2sync.sv} -regexp {.*contained within \`else block.*} \
+      -comment "Ifdefs are required for prim_generic_flop_2sync since it is turned on only for simulation."

--- a/hw/ip/prim_generic/prim_generic_flop_2sync.core
+++ b/hw/ip/prim_generic/prim_generic_flop_2sync.core
@@ -25,6 +25,9 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
+    files:
+      - lint/prim_generic_flop_2sync.waiver
+    file_type: waiver
 
   files_veriblelint_waiver:
     depend:


### PR DESCRIPTION
The prim_flop_2sync primitive is now generated via primgen, meaning some additional lint waiver rules are needed.