### PR TITLE
[rom] Stack usage report

### DIFF
--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -85,6 +85,7 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:multibits",
         "//sw/device/lib/dif:rstmgr_intf",
+        "//sw/device/silicon_creator/lib:stack_utilization",
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -361,6 +361,7 @@ dual_cc_library(
             ":chip_info",
             ":error",
             ":epmp_defs",
+            ":stack_utilization",
             "//sw/device/lib/base:hardened",
             "//sw/device/lib/base:macros",
             "//sw/device/silicon_creator/lib/drivers:lifecycle",
@@ -403,6 +404,7 @@ cc_library(
     srcs = ["bootstrap.c"],
     hdrs = ["bootstrap.h"],
     deps = [
+        ":stack_utilization",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/lib:error",
@@ -565,5 +567,17 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
+    ],
+)
+
+cc_library(
+    name = "stack_utilization",
+    srcs = ["stack_utilization.c"],
+    hdrs = [
+        "stack_utilization.h",
+        "stack_utilization_asm.h",
+    ],
+    deps = [
+        "//sw/device/silicon_creator/lib/drivers:uart",
     ],
 )

--- a/sw/device/silicon_creator/lib/bootstrap.c
+++ b/sw/device/silicon_creator/lib/bootstrap.c
@@ -14,6 +14,7 @@
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/spi_device.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/stack_utilization.h"
 
 #include "flash_ctrl_regs.h"
 
@@ -294,6 +295,8 @@ static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
                                      cmd.payload);
       break;
     case kSpiDeviceOpcodeReset:
+      // In a normal build, this function inlines to nothing.
+      stack_utilization_print();
       rstmgr_reset();
 #ifdef OT_PLATFORM_RV32
       HARDENED_TRAP();

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -21,6 +21,7 @@
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/epmp_defs.h"
+#include "sw/device/silicon_creator/lib/stack_utilization.h"
 
 #include "alert_handler_regs.h"
 #include "flash_ctrl_regs.h"
@@ -514,6 +515,8 @@ __attribute__((section(".shutdown")))
 #endif
 void shutdown_finalize(rom_error_t reason) {
   shutdown_report_error(reason);
+  // In a normal build, this function inlines to nothing.
+  stack_utilization_print();
   shutdown_software_escalate();
   shutdown_keymgr_kill();
   // Reset before killing the flash to be able to use this also in flash.

--- a/sw/device/silicon_creator/lib/stack_utilization.c
+++ b/sw/device/silicon_creator/lib/stack_utilization.c
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/stack_utilization.h"
+
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+
+#ifdef STACK_UTILIZATION_CHECK
+void stack_utilization_print(void) {
+  extern uint32_t _stack_start[], _stack_end[];
+  // We configure a No-Access ePMP NA4 region at stack_start as a
+  // stack guard.  We cannot access that word, so start the scan
+  // after the stack guard.
+  const uint32_t *sp = _stack_start + 1;
+  uint32_t free = 0;
+  uint32_t total = (uintptr_t)_stack_end - (uintptr_t)_stack_start;
+  while (sp < _stack_end && *sp == STACK_UTILIZATION_FREE_PATTERN) {
+    free += sizeof(uint32_t);
+    sp++;
+  }
+  uint32_t used = total - free;
+  //                          : K T S
+  const uint32_t kPrefix = 0x3a4b5453;
+  //                          \n\r
+  const uint32_t kNewline = 0x0a0d;
+  uart_write_imm(kPrefix);
+  uart_write_hex(used, sizeof(used), '/');
+  uart_write_hex(total, sizeof(total), kNewline);
+}
+#endif

--- a/sw/device/silicon_creator/lib/stack_utilization.h
+++ b/sw/device/silicon_creator/lib/stack_utilization.h
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_STACK_UTILIZATION_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_STACK_UTILIZATION_H_
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/stack_utilization_asm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Examine stack utilization.
+ */
+#ifdef STACK_UTILIZATION_CHECK
+void stack_utilization_print(void);
+#else
+#define stack_utilization_print() \
+  do {                            \
+  } while (0)
+#endif
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_STACK_UTILIZATION_H_

--- a/sw/device/silicon_creator/lib/stack_utilization_asm.h
+++ b/sw/device/silicon_creator/lib/stack_utilization_asm.h
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_STACK_UTILIZATION_ASM_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_STACK_UTILIZATION_ASM_H_
+
+#define STACK_UTILIZATION_FREE_PATTERN 0xCAFECAFE
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_STACK_UTILIZATION_ASM_H_

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -8,7 +8,7 @@ load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
 load("//rules:files.bzl", "output_groups")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:opentitan_test.bzl", "manual_test")
-load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_test")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "fpga_params", "opentitan_binary", "opentitan_test")
 load("//rules/opentitan:legacy.bzl", "legacy_rom_targets")
 
 package(default_visibility = ["//visibility:public"])
@@ -150,6 +150,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:manifest",
         "//sw/device/silicon_creator/lib:otbn_boot_services",
         "//sw/device/silicon_creator/lib:shutdown",
+        "//sw/device/silicon_creator/lib:stack_utilization",
         "//sw/device/silicon_creator/lib/base:chip",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/base:static_critical",
@@ -499,4 +500,80 @@ genrule(
         fi
     done
     """,
+)
+
+genrule(
+    name = "empty_flash",
+    testonly = True,
+    outs = ["empty_flash.bin"],
+    cmd = """
+        head --bytes=65536 /dev/zero | tr '\\0' '\\377' > $@
+    """,
+)
+
+opentitan_test(
+    name = "stack_utilization_test",
+    cw310 = fpga_params(
+        binaries = {
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0_fpga_cw310_rom_with_fake_keys_signed_bin": "good_a",
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_b_fake_ecdsa_prod_key_0_fpga_cw310_rom_with_fake_keys_signed_bin": "good_b",
+            "//sw/device/silicon_creator/rom/e2e:empty_test_slot_a_fake_ecdsa_prod_key_0_corrupted_fpga_cw310_rom_with_fake_keys_signed_bin": "bad_a",
+            ":empty_flash": "empty",
+        },
+        stack_usage = "STK:[0-9A-Fa-f/]+\r\n",
+        tags = ["manual"],
+        test_cmd = """
+            --exec="no-op --info '
+            ###########################################################################
+            # This is a manual test.  Run it with:
+            #     --test_output=streamed --copt=-DSTACK_UTILIZATION_CHECK
+            ###########################################################################'"
+            --exec="transport init"
+            --exec="fpga load-bitstream {bitstream}"
+
+            --exec="no-op --info '### Measuring stack utilization for bootstrap slot A'"
+            --exec="bootstrap --clear-uart=true --leave-in-bootstrap {good_a}"
+            --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='{exit_failure}'"
+
+            --exec="gpio remove ROM_BOOTSTRAP"
+            --exec="gpio apply RESET"
+            --exec="gpio remove RESET"
+            --exec="no-op --info '### Measuring stack utilization for booting slot A'"
+            --exec="console --non-interactive --exit-success='PASS.*\r\n' --exit-failure='{exit_failure}'"
+
+            --exec="no-op --info '### Measuring stack utilization for bootstrap slot B'"
+            --exec="bootstrap --mirror=false --clear-uart=true --leave-in-bootstrap {good_b}@0x80000"
+            --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='{exit_failure}'"
+
+            --exec="gpio remove ROM_BOOTSTRAP"
+            --exec="gpio apply RESET"
+            --exec="gpio remove RESET"
+            --exec="no-op --info '### Measuring stack utilization for booting slot A'"
+            --exec="console --non-interactive --exit-success='PASS.*\r\n' --exit-failure='{exit_failure}'"
+
+            --exec="no-op --info '### Measuring stack utilization for bootstrap slot A (corrupted image)'"
+            --exec="bootstrap --clear-uart=true --leave-in-bootstrap {bad_a}"
+            --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='{exit_failure}'"
+
+            --exec="gpio remove ROM_BOOTSTRAP"
+            --exec="gpio apply RESET"
+            --exec="gpio remove RESET"
+            --exec="no-op --info '### Measuring stack utilization for failed boot of slot A'"
+            --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='PASS|FAIL'"
+
+            --exec="no-op --info '### Measuring stack utilization for bootstrap slot A (empty image)'"
+            --exec="bootstrap --clear-uart=true --leave-in-bootstrap {empty}"
+            --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='{exit_failure}'"
+
+            --exec="gpio remove ROM_BOOTSTRAP"
+            --exec="gpio apply RESET"
+            --exec="gpio remove RESET"
+            --exec="no-op --info '### Measuring stack utilization for empty flash'"
+            --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='PASS|FAIL'"
+            no-op
+        """,
+    ),
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+    },
 )

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -42,6 +42,7 @@
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
+#include "sw/device/silicon_creator/lib/stack_utilization.h"
 #include "sw/device/silicon_creator/rom/boot_policy.h"
 #include "sw/device/silicon_creator/rom/boot_policy_ptrs.h"
 #include "sw/device/silicon_creator/rom/bootstrap.h"
@@ -618,8 +619,11 @@ static rom_error_t rom_boot(const manifest_t *manifest, uint32_t flash_exec) {
     HARDENED_CHECK_EQ(manifest_entry_point_get(manifest_check), entry_point);
   }
   CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomBoot, 5);
-  ((rom_ext_entry_point *)entry_point)();
 
+  // In a normal build, this function inlines to nothing.
+  stack_utilization_print();
+
+  ((rom_ext_entry_point *)entry_point)();
   return kErrorRomBootFailed;
 }
 

--- a/sw/device/silicon_creator/rom/rom_start.S
+++ b/sw/device/silicon_creator/rom/rom_start.S
@@ -6,6 +6,7 @@
 #include "sw/device/lib/base/hardened_asm.h"
 #include "sw/device/lib/base/multibits_asm.h"
 #include "sw/device/silicon_creator/lib/base/chip.h"
+#include "sw/device/silicon_creator/lib/stack_utilization_asm.h"
 #include "aon_timer_regs.h"
 #include "ast_regs.h"
 #include "clkmgr_regs.h"
@@ -474,6 +475,20 @@ LABEL_FOR_TEST(kRomStartWatchdogEnabled)
   // If an exception fires, the handler is conventionally only allowed to clobber
   // memory at addresses below `sp`.
   la sp, _stack_end
+
+#ifdef STACK_UTILIZATION_CHECK
+  // Fill the stack with a known pattern
+  // We configure a No-Access ePMP NA4 region at stack_start as a
+  // stack guard.  We cannot access that word, so start filling
+  // after the stack guard.
+.L_stack_clear:
+  la   a0, _stack_start + 4
+  li   a1, STACK_UTILIZATION_FREE_PATTERN
+.L_stack_clear_loop:
+  sw   a1, 0(a0)
+  addi a0, a0, 4
+  bltu a0, sp, .L_stack_clear_loop
+#endif
 
   // Set up shadow stack pointer.
   //

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -45,6 +45,12 @@ pub struct NoOp {
     /// Delay execution.
     #[arg(short = 'd', long, value_parser = humantime::parse_duration)]
     delay: Option<Duration>,
+    /// Log a string at the `info` level.
+    #[arg(long)]
+    info: Option<String>,
+    /// Log a string at the `error` level.
+    #[arg(long)]
+    error: Option<String>,
 }
 
 impl CommandDispatch for NoOp {
@@ -55,6 +61,12 @@ impl CommandDispatch for NoOp {
     ) -> Result<Option<Box<dyn Annotate>>> {
         if let Some(d) = self.delay {
             std::thread::sleep(d);
+        }
+        if let Some(info) = &self.info {
+            log::info!("{info}");
+        }
+        if let Some(error) = &self.error {
+            log::error!("{error}");
         }
         Ok(None)
     }


### PR DESCRIPTION
1. Add infrastructure to measure stack utilization.  The code is gated behind the preprocessor symbol `STACK_UTILIZATION_CHECK`.
2. Enhance bootstrap to skip the post-bootstrap reset step, allowing the stack utilization to be printed.
3. Add a manual test to measure stack utilization in various circumstances:
   - Bootstrap
   - A good image in slot A
   - A good image in slot B
   - A bad image in slot A
   - Empty flash

Addresses #14707.