### PR TITLE
[topgen] Support for parametrized inter-module signals

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -123,6 +123,23 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "NumAppIntf"
+      type:    "int"
+      default: "3"
+      desc:    "Number of application interfaces"
+      local:   "false"
+      expose:  "true"
+    }
+    { name:                "AppCfg"
+      desc:                '''Application interface configuration.
+                           Top-level connection to the application interface must follow this definition.
+                           '''
+      type:                "kmac_pkg::app_config_t"
+      unpacked_dimensions: "[KmacNumAppIntf]"
+      default:             "'{kmac_pkg::AppCfgKeyMgr, kmac_pkg::AppCfgLcCtrl, kmac_pkg::AppCfgRomCtrl}"
+      local:               "false"
+      expose:              "true"
+    }
     { name:    "NumWordsKey"
       type:    "int"
       default: "16"
@@ -196,7 +213,7 @@
       name:    "app"
       act:     "rsp"
       package: "kmac_pkg"
-      width:   "3"
+      width:   "NumAppIntf"
     }
     { struct:  "edn"
       type:    "req_rsp"

--- a/hw/ip/kmac/doc/interfaces.md
+++ b/hw/ip/kmac/doc/interfaces.md
@@ -10,15 +10,15 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name      | Package::Struct        | Type    | Act   |   Width | Description   |
-|:---------------|:-----------------------|:--------|:------|--------:|:--------------|
-| keymgr_key     | keymgr_pkg::hw_key_req | uni     | rcv   |       1 |               |
-| app            | kmac_pkg::app          | req_rsp | rsp   |       3 |               |
-| entropy        | edn_pkg::edn           | req_rsp | req   |       1 |               |
-| idle           | prim_mubi_pkg::mubi4   | uni     | req   |       1 |               |
-| en_masking     | logic                  | uni     | req   |       1 |               |
-| lc_escalate_en | lc_ctrl_pkg::lc_tx     | uni     | rcv   |       1 |               |
-| tl             | tlul_pkg::tl           | req_rsp | rsp   |       1 |               |
+| Port Name      | Package::Struct        | Type    | Act   | Width      | Description   |
+|:---------------|:-----------------------|:--------|:------|:-----------|:--------------|
+| keymgr_key     | keymgr_pkg::hw_key_req | uni     | rcv   | 1          |               |
+| app            | kmac_pkg::app          | req_rsp | rsp   | NumAppIntf |               |
+| entropy        | edn_pkg::edn           | req_rsp | req   | 1          |               |
+| idle           | prim_mubi_pkg::mubi4   | uni     | req   | 1          |               |
+| en_masking     | logic                  | uni     | req   | 1          |               |
+| lc_escalate_en | lc_ctrl_pkg::lc_tx     | uni     | rcv   | 1          |               |
+| tl             | tlul_pkg::tl           | req_rsp | rsp   | 1          |               |
 
 ## Interrupts
 

--- a/hw/ip/kmac/dv/README.md
+++ b/hw/ip/kmac/dv/README.md
@@ -123,8 +123,8 @@ The `kmac_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
 * tl_a_chan_fifo: TL address channel
 * tl_d_chan_fifo: TL data channel
-* kmac_app_req_fifo[kmac_pkg::NumAppIntf]: An array of analysis FIFOs to hold request transactions coming from the various application interfaces
-* kmac_app_rsp_fifo[kmac_pkg::NumAppIntf]: An array of analysis FIFOs to hold response transactions coming from the various application interfaces
+* kmac_app_req_fifo[NUM_APP_INTF]: An array of analysis FIFOs to hold request transactions coming from the various application interfaces
+* kmac_app_rsp_fifo[NUM_APP_INTF]: An array of analysis FIFOs to hold response transactions coming from the various application interfaces
 * edn_fifo: FIFO used to hold transactions coming from the EDN interface
 
 The KMAC scoreboard implements a cycle-accurate model of the DUT that is used to thoroughly check the operation of the KMAC IP.

--- a/hw/ip/kmac/dv/env/kmac_env.sv
+++ b/hw/ip/kmac/dv/env/kmac_env.sv
@@ -12,13 +12,13 @@ class kmac_env extends cip_base_env #(
 
   `uvm_component_new
 
-  kmac_app_agent m_kmac_app_agent[kmac_pkg::NumAppIntf];
+  kmac_app_agent m_kmac_app_agent[kmac_env_pkg::NUM_APP_INTF];
   key_sideload_agent keymgr_sideload_agent;
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
-    for (int i = 0; i < kmac_pkg::NumAppIntf; i++) begin
+    for (int i = 0; i < kmac_env_pkg::NUM_APP_INTF; i++) begin
       string name = $sformatf("m_kmac_app_agent[%0d]", i);
       m_kmac_app_agent[i] = kmac_app_agent::type_id::create(name, this);
       uvm_config_db#(kmac_app_agent_cfg)::set(this, name, "cfg", cfg.m_kmac_app_agent_cfg[i]);
@@ -39,7 +39,7 @@ class kmac_env extends cip_base_env #(
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
 
-    for (int i = 0; i < kmac_pkg::NumAppIntf; i++) begin
+    for (int i = 0; i < kmac_env_pkg::NUM_APP_INTF; i++) begin
       m_kmac_app_agent[i].monitor.analysis_port.connect(scoreboard.kmac_app_rsp_fifo[i].analysis_export);
       m_kmac_app_agent[i].m_data_push_agent.monitor.analysis_port.connect(
         scoreboard.kmac_app_req_fifo[i].analysis_export);

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -7,7 +7,7 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
   // ext interfaces
   kmac_vif kmac_vif;
 
-  rand kmac_app_agent_cfg m_kmac_app_agent_cfg[kmac_pkg::NumAppIntf];
+  rand kmac_app_agent_cfg m_kmac_app_agent_cfg[kmac_env_pkg::NUM_APP_INTF];
   rand key_sideload_agent_cfg keymgr_sideload_agent_cfg;
 
   // Masked KMAC is the default configuration
@@ -50,7 +50,7 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
     shadow_storage_err_status_fields[ral.cfg_regwen.en] = 0;
     shadow_storage_err_status_fields[ral.status.sha3_idle] = 0;
 
-    for (int i = 0; i < kmac_pkg::NumAppIntf; i++) begin
+    for (int i = 0; i < kmac_env_pkg::NUM_APP_INTF; i++) begin
       string name = $sformatf("m_kmac_app_agent_cfg[%0d]", i);
       m_kmac_app_agent_cfg[i] = kmac_app_agent_cfg::type_id::create(name);
       m_kmac_app_agent_cfg[i].if_mode = dv_utils_pkg::Host;

--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -205,7 +205,7 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
   config_masked_cg config_masked_cg;
   config_unmasked_cg config_unmasked_cg;
 
-  app_cg_wrap app_cg_wrappers[kmac_pkg::NumAppIntf];
+  app_cg_wrap app_cg_wrappers[kmac_env_pkg::NUM_APP_INTF];
 
   covergroup msg_len_cg with function sample(int len);
     msg_len: coverpoint len {

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -71,6 +71,11 @@ package kmac_env_pkg;
 
   parameter uint NUM_EDN = 1;
 
+  // Earlgrey has 3 application interfaces
+  parameter uint NUM_APP_INTF = 3;
+  parameter app_config_t APP_CFG[NUM_APP_INTF] =
+    '{kmac_pkg::AppCfgKeyMgr, kmac_pkg::AppCfgLcCtrl, kmac_pkg::AppCfgRomCtrl};
+
   /////////////////////////////
   // Timing Model Parameters //
   /////////////////////////////

--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -9,8 +9,8 @@ interface kmac_if(input clk_i, input rst_ni);
   logic                                          en_masking_o;
   lc_ctrl_pkg::lc_tx_t                           lc_escalate_en_i;
   prim_mubi_pkg::mubi4_t                         idle_o;
-  kmac_pkg::app_req_t [kmac_pkg::NumAppIntf-1:0] app_req;
-  kmac_pkg::app_rsp_t [kmac_pkg::NumAppIntf-1:0] app_rsp;
+  kmac_pkg::app_req_t [kmac_env_pkg::NUM_APP_INTF-1:0] app_req;
+  kmac_pkg::app_rsp_t [kmac_env_pkg::NUM_APP_INTF-1:0] app_rsp;
 
   function automatic void drive_lc_escalate(lc_ctrl_pkg::lc_tx_t val);
     lc_escalate_en_i = val;

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -153,16 +153,16 @@ class kmac_scoreboard extends cip_base_scoreboard #(
                                 ({KMAC_FIFO_DEPTH{1'b1}} << KmacStatusFifoDepthLSB);
 
   // TLM fifos
-  uvm_tlm_analysis_fifo #(kmac_app_item) kmac_app_rsp_fifo[kmac_pkg::NumAppIntf];
+  uvm_tlm_analysis_fifo #(kmac_app_item) kmac_app_rsp_fifo[NUM_APP_INTF];
   uvm_tlm_analysis_fifo #(push_pull_agent_pkg::push_pull_item #(
     .HostDataWidth(kmac_app_agent_pkg::KMAC_REQ_DATA_WIDTH)))
-    kmac_app_req_fifo[kmac_pkg::NumAppIntf];
+    kmac_app_req_fifo[NUM_APP_INTF];
 
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    for (int i = 0; i < kmac_pkg::NumAppIntf; i++) begin
+    for (int i = 0; i < NUM_APP_INTF; i++) begin
       kmac_app_req_fifo[i] = new($sformatf("kmac_app_req_fifo[%0d]", i), this);
       kmac_app_rsp_fifo[i] = new($sformatf("kmac_app_rsp_fifo[%0d]", i), this);
     end
@@ -1729,8 +1729,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     byte fname_arr[];
     byte custom_str_arr[];
 
-    if (en_kmac_app && kmac_pkg::AppCfg[app_mode].PrefixMode) begin
-      prefix_bytes = {<< byte {kmac_pkg::AppCfg[app_mode].Prefix}};
+    if (en_kmac_app && APP_CFG[app_mode].PrefixMode) begin
+      prefix_bytes = {<< byte {APP_CFG[app_mode].Prefix}};
     end else begin
       prefix_bytes = {<< 32 {prefix}};
       prefix_bytes = {<< byte {prefix_bytes}};

--- a/hw/ip/kmac/dv/env/kmac_virtual_sequencer.sv
+++ b/hw/ip/kmac/dv/env/kmac_virtual_sequencer.sv
@@ -10,7 +10,7 @@ class kmac_virtual_sequencer extends cip_base_virtual_sequencer #(
 
   `uvm_component_new
 
-  kmac_app_sequencer kmac_app_sequencer_h[kmac_pkg::NumAppIntf];
+  kmac_app_sequencer kmac_app_sequencer_h[kmac_env_pkg::NUM_APP_INTF];
   key_sideload_sequencer key_sideload_sequencer_h;
 
 endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_app_with_partial_data_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_app_with_partial_data_vseq.sv
@@ -11,7 +11,7 @@ class kmac_app_with_partial_data_vseq extends kmac_app_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    for (int i = 0; i < kmac_pkg::NumAppIntf; i++) begin
+    for (int i = 0; i < kmac_env_pkg::NUM_APP_INTF; i++) begin
       cfg.m_kmac_app_agent_cfg[i].inject_zero_in_host_strb = 1;
     end
     cfg.do_cycle_accurate_check = 0;

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -19,8 +19,8 @@ module tb;
   // keymgr/kmac sideload wires
   keymgr_pkg::hw_key_req_t kmac_sideload_key;
   // kmac_app interfaces
-  kmac_pkg::app_req_t [kmac_pkg::NumAppIntf-1:0] app_req;
-  kmac_pkg::app_rsp_t [kmac_pkg::NumAppIntf-1:0] app_rsp;
+  kmac_pkg::app_req_t [NUM_APP_INTF-1:0] app_req;
+  kmac_pkg::app_rsp_t [NUM_APP_INTF-1:0] app_rsp;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -37,7 +37,7 @@ module tb;
     .sideload_key (kmac_sideload_key)
   );
 
-  kmac_app_intf kmac_app_if[kmac_pkg::NumAppIntf](.clk(clk), .rst_n(rst_n));
+  kmac_app_intf kmac_app_if[NUM_APP_INTF](.clk(clk), .rst_n(rst_n));
 
   // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
   `DV_EDN_IF_CONNECT
@@ -48,7 +48,8 @@ module tb;
 
   kmac #(
     .EnMasking(`EN_MASKING),
-    .SwKeyMasked(`SW_KEY_MASKED)
+    .SwKeyMasked(`SW_KEY_MASKED),
+    .NumAppIntf(NUM_APP_INTF)
   ) dut (
     .clk_i              (clk            ),
     .rst_ni             (rst_n          ),
@@ -89,7 +90,7 @@ module tb;
     .entropy_i          ({edn_if[0].ack, edn_if[0].d_data} )
   );
 
-  for (genvar i = 0; i < kmac_pkg::NumAppIntf; i++) begin : gen_kmac_app_intf
+  for (genvar i = 0; i < NUM_APP_INTF; i++) begin : gen_kmac_app_intf
     assign app_req[i]                   = kmac_app_if[i].kmac_data_req;
     assign kmac_app_if[i].kmac_data_rsp = app_rsp[i];
     assign kmac_if.app_req[i] = app_req[i];

--- a/hw/ip/kmac/lint/kmac.waiver
+++ b/hw/ip/kmac/lint/kmac.waiver
@@ -9,7 +9,7 @@ waive -rules {HIER_NET_NOT_READ NOT_READ INPUT_NOT_READ} -location {kmac.sv} -re
 
 waive -rules {HIER_NET_NOT_READ NOT_READ INPUT_NOT_READ} -location {kmac.sv} \
     -regexp {'tlram_addr' is not read} \
-    -comment "MSG_FIFO ignores the exact memory address but use strobe for alignement"
+    -comment "MSG_FIFO ignores the exact memory address but use strobe for alignment"
 
 waive -rules {HIER_NET_NOT_READ NOT_READ INPUT_NOT_READ} \
     -location {kmac_msgfifo.sv} -regexp {'packer_wmask.* is not read} \
@@ -29,3 +29,16 @@ waive -rules {INTEGER} -location {kmac_entropy.sv} \
 
 waive -rules {CASE_SEL_EXPR} -location {kmac_app.sv} \
     -comment "not a problem, just a suggested alternate implementation"
+
+waive -rules TWO_STATE_TYPE -location {kmac_pkg.sv} \
+      -regexp {'PrefixMode' is of two state type} \
+      -comment "Enum bit is used as a generate selection. OK to be two state"
+waive -rules TWO_STATE_TYPE -location {kmac_pkg.sv} \
+      -regexp {'app_mode_e' is of two state type} \
+      -comment "Enum bit is used in ifs only. OK to be two state"
+waive -rules TWO_STATE_TYPE -location {kmac_pkg.sv} \
+      -regexp {'Mode' is of two state type} \
+      -comment "Enum bit is used in ifs only. OK to be two state"
+waive -rules TWO_STATE_TYPE -location {kmac_pkg.sv} \
+      -regexp {'app_config_t' is of type struct which contains two state type field} \
+      -comment "Struct fields waived separately. OK to be two state"

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -28,7 +28,9 @@ module kmac
   parameter int SecCmdDelay = 0,
 
   // Accept SW message when idle and before receiving a START command. Useful for SCA only.
-  parameter bit SecIdleAcceptSwMsg = 1'b0,
+  parameter bit SecIdleAcceptSwMsg          = 1'b0,
+  parameter int unsigned NumAppIntf         = 3,
+  parameter app_config_t AppCfg[NumAppIntf] = '{AppCfgKeyMgr, AppCfgLcCtrl, AppCfgRomCtrl},
 
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
@@ -1042,7 +1044,9 @@ module kmac
   // Application interface Mux/Demux
   kmac_app #(
     .EnMasking(EnMasking),
-    .SecIdleAcceptSwMsg(SecIdleAcceptSwMsg)
+    .SecIdleAcceptSwMsg(SecIdleAcceptSwMsg),
+    .NumAppIntf(NumAppIntf),
+    .AppCfg(AppCfg)
   ) u_app_intf (
     .clk_i,
     .rst_ni,

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -10,9 +10,11 @@ module kmac_app
   import kmac_pkg::*;
 #(
   // App specific configs are defined in kmac_pkg
-  parameter  bit EnMasking = 1'b0,
-  localparam int Share = (EnMasking) ? 2 : 1, // derived parameter
-  parameter  bit SecIdleAcceptSwMsg = 1'b0
+  parameter  bit          EnMasking          = 1'b0,
+  localparam int          Share              = (EnMasking) ? 2 : 1, // derived parameter
+  parameter  bit          SecIdleAcceptSwMsg = 1'b0,
+  parameter  int unsigned NumAppIntf         = 3,
+  parameter  app_config_t AppCfg[NumAppIntf] = '{AppCfgKeyMgr, AppCfgLcCtrl, AppCfgRomCtrl}
 ) (
   input clk_i,
   input rst_ni,
@@ -872,7 +874,7 @@ module kmac_app
       kmac_en_o         <= AppCfg[arb_idx].Mode == AppKMAC ? 1'b 1 : 1'b 0;
       sha3_mode_o       <= AppCfg[arb_idx].Mode == AppSHA3
                            ? sha3_pkg::Sha3 : sha3_pkg::CShake;
-      keccak_strength_o <= AppCfg[arb_idx].Strength ;
+      keccak_strength_o <= AppCfg[arb_idx].KeccakStrength ;
     end else if (st == StIdle) begin
       kmac_en_o         <= reg_kmac_en_i;
       sha3_mode_o       <= reg_sha3_mode_i;

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -190,15 +190,6 @@ package kmac_pkg;
   // Application interface //
   ///////////////////////////
 
-  // Number of the application interface
-  // Currently KMAC has three interface.
-  // 0: KeyMgr
-  // 1: LC_CTRL
-  // 2: ROM_CTRL
-  // Make sure to change `width` of app inter-module signal definition
-  // if this value is changed.
-  parameter int unsigned NumAppIntf = 3;
-
   // Application Algorithm
   // Each interface can choose algorithms among SHA3, cSHAKE, KMAC
   typedef enum bit [1:0] {
@@ -228,7 +219,7 @@ package kmac_pkg;
   typedef struct packed {
     app_mode_e Mode;
 
-    sha3_pkg::keccak_strength_e Strength;
+    sha3_pkg::keccak_strength_e KeccakStrength;
 
     // PrefixMode determines the origin value of Prefix that is used in KMAC
     // and cSHAKE operations.
@@ -241,33 +232,28 @@ package kmac_pkg;
     logic [NSPrefixW-1:0] Prefix;
   } app_config_t;
 
-  parameter app_config_t AppCfg [NumAppIntf] = '{
-    // KeyMgr
-    '{
-      Mode:       AppKMAC, // KeyMgr uses KMAC operation
-      Strength:   sha3_pkg::L256,
-      PrefixMode: 1'b 1,   // Use prefix parameter
-      // {fname: encoded_string("KMAC"), custom_str: encoded_string("")}
-      Prefix:     NSPrefixW'({EncodedStringEmpty, EncodedStringKMAC})
-    },
+  parameter app_config_t AppCfgKeyMgr = '{
+    Mode: AppKMAC, // KeyMgr uses KMAC operation
+    KeccakStrength: sha3_pkg::L256,
+    PrefixMode: 1'b1,   // Use prefix parameter
+    // {fname: encoded_string("KMAC"), custom_str: encoded_string("")}
+    Prefix: NSPrefixW'({EncodedStringEmpty, EncodedStringKMAC})
+  };
 
-    // LC_CTRL
-    '{
-      Mode:       AppCShake,
-      Strength:   sha3_pkg::L128,
-      PrefixMode: 1'b 1,     // Use prefix parameter
-      // {fname: encode_string(""), custom_str: encode_string("LC_CTRL")}
-      Prefix: NSPrefixW'({EncodedStringLcCtrl, EncodedStringEmpty})
-    },
+  parameter app_config_t AppCfgLcCtrl= '{
+    Mode: AppCShake,
+    KeccakStrength: sha3_pkg::L128,
+    PrefixMode: 1'b1,     // Use prefix parameter
+    // {fname: encode_string(""), custom_str: encode_string("LC_CTRL")}
+    Prefix: NSPrefixW'({EncodedStringLcCtrl, EncodedStringEmpty})
+  };
 
-    // ROM_CTRL
-    '{
-      Mode:       AppCShake,
-      Strength:   sha3_pkg::L256,
-      PrefixMode: 1'b 1,     // Use prefix parameter
-      // {fname: encode_string(""), custom_str: encode_string("ROM_CTRL")}
-      Prefix: NSPrefixW'({EncodedStringRomCtrl, EncodedStringEmpty})
-    }
+  parameter app_config_t AppCfgRomCtrl = '{
+    Mode: AppCShake,
+    KeccakStrength: sha3_pkg::L256,
+    PrefixMode: 1'b1,     // Use prefix parameter
+    // {fname: encode_string(""), custom_str: encode_string("ROM_CTRL")}
+    Prefix: NSPrefixW'({EncodedStringRomCtrl, EncodedStringEmpty})
   };
 
   // Exporting the app internal mux selection enum into the package. So that DV

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -5,6 +5,7 @@ ${gencmd}
 <%
 import re
 import topgen.lib as lib
+from reggen.params import Parameter
 from topgen.clocks import Clocks
 from topgen.resets import Resets
 
@@ -22,7 +23,13 @@ num_dio_total = top['pinmux']['io_counts']['dedicated']['inouts'] + \
                 top['pinmux']['io_counts']['dedicated']['inputs'] + \
                 top['pinmux']['io_counts']['dedicated']['outputs']
 
-num_im = sum([x["width"] if "width" in x else 1 for x in top["inter_signal"]["external"]])
+num_im = 0
+for x in top["inter_signal"]["external"]:
+    width = 1
+    if "width" in x:
+      width = (x["width"].default
+               if isinstance(x["width"], Parameter) else x["width"])
+    num_im += width
 
 max_sigwidth = max([x["width"] if "width" in x else 1 for x in top["pinmux"]["ios"]])
 max_sigwidth = len("{}".format(max_sigwidth))
@@ -54,7 +61,7 @@ module top_${top["name"]} #(
 <% continue %>
   % endif
   // parameters for ${m['name']}
-  % for p_exp in [p for p in m["param_list"] if p.get("expose") == "true" ]:
+  % for p_exp in [p for p in m["param_list"] if p.get("local") == "false" and p.get("expose") == "true" ]:
 <%
     p_type = p_exp.get('type')
     p_type_word = p_type + ' ' if p_type else ''
@@ -69,7 +76,7 @@ module top_${top["name"]} #(
     params_follow = not loop.last or loop.parent.index < last_modidx_with_params
     comma_char = ',' if params_follow else ''
 %>\
-    % if 12 + len(p_lhs) + 3 + len(p_rhs) + 1 < 100:
+    % if 12 + len(p_lhs) + 3 + len(str(p_rhs)) + 1 < 100:
   parameter ${p_lhs} = ${p_rhs}${comma_char}
     % else:
   parameter ${p_lhs} =
@@ -101,7 +108,11 @@ module top_${top["name"]} #(
 
   // Inter-module Signal External type
   % for sig in top["inter_signal"]["external"]:
+    % if isinstance(sig["width"], Parameter):
+  ${lib.get_direction(sig)} ${lib.im_defname(sig)} [${sig["width"].name_top}-1:0] ${sig["signame"]},
+    % else:
   ${lib.get_direction(sig)} ${lib.im_defname(sig)} ${lib.bitarray(sig["width"],1)} ${sig["signame"]},
+    % endif
   % endfor
 
 % endif
@@ -126,6 +137,34 @@ module top_${top["name"]} #(
   import top_${top["name"]}_pkg::*;
   // Compile-time random constants
   import top_${top["name"]}_rnd_cnst_pkg::*;
+
+  // Local Parameters
+% for m in top["module"]:
+  % if not lib.is_inst(m):
+<% continue %>
+  % endif
+<%
+    localparams = [p for p in m["param_list"] if p.get("local") == "true" and p.get("expose") == "true"]
+    if not len(localparams):
+        continue
+%>\
+  // local parameters for ${m['name']}
+  % for p_exp in localparams:
+<%
+    p_type = p_exp.get('type')
+    p_type_word = p_type + ' ' if p_type else ''
+
+    p_lhs = f'{p_type_word}{p_exp["name_top"]}'
+    p_rhs = p_exp['default']
+%>\
+    % if 13 + len(p_lhs) + 3 + len(str(p_rhs)) + 1 < 100:
+  localparam ${p_lhs} = ${p_rhs};
+    % else:
+  localparam ${p_lhs} =
+      ${p_rhs};
+    % endif
+  % endfor
+% endfor
 
   // Signals
   logic [${num_mio_inputs - 1}:0] mio_p2d;
@@ -193,7 +232,11 @@ module top_${top["name"]} #(
   // define inter-module signals
 % endif
 % for sig in top["inter_signal"]["definitions"]:
+  % if isinstance(sig["width"], Parameter):
+  ${lib.im_defname(sig)} [${sig["width"].name_top}-1:0] ${sig["signame"]};
+  % else:
   ${lib.im_defname(sig)} ${lib.bitarray(sig["width"],1)} ${sig["signame"]};
+  % endif
 % endfor
 
 ## Mixed connection to port
@@ -219,19 +262,28 @@ module top_${top["name"]} #(
 ## Partial inter-module definition tie-off
   // define partial inter-module tie-off
 % for sig in unused_im_defs:
-  % for idx in range(sig['end_idx'], sig['width']):
+<%
+  width = sig['width'].default if isinstance(sig['width'], Parameter) else sig['width']
+%>\
+  % for idx in range(sig['end_idx'], width):
   ${lib.im_defname(sig)} unused_${sig["signame"]}${idx};
   % endfor
 % endfor
 
   // assign partial inter-module tie-off
 % for sig in unused_im_defs:
-  % for idx in range(sig['end_idx'], sig['width']):
+<%
+  width = sig['width'].default if isinstance(sig['width'], Parameter) else sig['width']
+%>\
+  % for idx in range(sig['end_idx'], width):
   assign unused_${sig["signame"]}${idx} = ${sig["signame"]}[${idx}];
   % endfor
 % endfor
 % for sig in undriven_im_defs:
-  % for idx in range(sig['end_idx'], sig['width']):
+<%
+  width = sig['width'].default if isinstance(sig['width'], Parameter) else sig['width']
+%>\
+  % for idx in range(sig['end_idx'], width):
   assign ${sig["signame"]}[${idx}] = ${sig["default"]};
   % endfor
 % endfor

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -882,6 +882,7 @@
           desc: Instantiates 2-flop synchronizers on all GPIO inputs if set to 1.
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: GpioGpioAsyncOn
         }
@@ -890,6 +891,7 @@
           desc: Enable HW straps sampling logic for GPIO inputs at initial cold boot
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: GpioGpioAsHwStrapsEn
         }
@@ -977,6 +979,7 @@
           desc: Sram Entries. Word size is 32bit width.
           type: spi_device_pkg::sram_type_e
           default: spi_device_pkg::DefaultSramType
+          local: "false"
           expose: "true"
           name_top: SpiDeviceSramType
         }
@@ -1091,6 +1094,7 @@
             '''
           type: int
           default: "0"
+          local: "false"
           expose: "true"
           name_top: I2c0InputDelayCycles
         }
@@ -1183,6 +1187,7 @@
             '''
           type: int
           default: "0"
+          local: "false"
           expose: "true"
           name_top: I2c1InputDelayCycles
         }
@@ -1275,6 +1280,7 @@
             '''
           type: int
           default: "0"
+          local: "false"
           expose: "true"
           name_top: I2c2InputDelayCycles
         }
@@ -1483,6 +1489,7 @@
           desc: VMEM file to initialize the OTP macro.
           type: ""
           default: '''""'''
+          local: "false"
           expose: "true"
           name_top: OtpCtrlMemInitFile
         }
@@ -1930,6 +1937,7 @@
             '''
           type: bit
           default: top_pkg::SecVolatileRawUnlockEn
+          local: "false"
           expose: "true"
           name_top: SecLcCtrlVolatileRawUnlockEn
         }
@@ -1938,6 +1946,7 @@
           desc: When 1, a TLUL-based DMI interface is used. When 0, a JTAG TAP is used.
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: LcCtrlUseDmiInterface
         }
@@ -2006,6 +2015,7 @@
           desc: Chip generation number.
           type: logic [15:0]
           default: 16'h 4001
+          local: "false"
           expose: "true"
           name_top: LcCtrlSiliconCreatorId
         }
@@ -2014,6 +2024,7 @@
           desc: Chip revision number.
           type: logic [15:0]
           default: 16'h 0002
+          local: "false"
           expose: "true"
           name_top: LcCtrlProductId
         }
@@ -2022,6 +2033,7 @@
           desc: Chip revision number.
           type: logic [7:0]
           default: 8'h 01
+          local: "false"
           expose: "true"
           name_top: LcCtrlRevisionId
         }
@@ -2030,6 +2042,7 @@
           desc: JTAG ID code.
           type: logic [31:0]
           default: jtag_id_pkg::LC_CTRL_JTAG_IDCODE
+          local: "false"
           expose: "true"
           name_top: LcCtrlIdcodeValue
         }
@@ -2821,6 +2834,7 @@
           desc: Stub out the core of entropy_src logic
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: UsbdevStub
         }
@@ -2829,6 +2843,7 @@
           desc: Maximum number of microseconds for the differential receiver to become operational
           type: int
           default: "100"
+          local: "false"
           expose: "true"
           name_top: UsbdevRcvrWakeTimeUs
         }
@@ -3484,6 +3499,7 @@
             '''
           type: bit
           default: 1'b1
+          local: "false"
           expose: "true"
           name_top: SecRstmgrAonCheck
         }
@@ -3492,6 +3508,7 @@
           desc: The maximum synchronization delay for parent / child reset checks.
           type: int
           default: "2"
+          local: "false"
           expose: "true"
           name_top: SecRstmgrAonMaxSyncDelay
         }
@@ -4240,6 +4257,7 @@
             '''
           type: bit
           default: top_pkg::SecVolatileRawUnlockEn
+          local: "false"
           expose: "true"
           name_top: SecPinmuxAonVolatileRawUnlockEn
         }
@@ -4248,6 +4266,7 @@
           desc: Target specific pinmux configuration.
           type: pinmux_pkg::target_cfg_t
           default: pinmux_pkg::DefaultTargetCfg
+          local: "false"
           expose: "true"
           name_top: PinmuxAonTargetCfg
         }
@@ -5119,6 +5138,7 @@
           desc: Support execution from SRAM
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: SramCtrlRetAonInstrExec
         }
@@ -5127,6 +5147,7 @@
           desc: Number of PRINCE half rounds for the SRAM scrambling feature
           type: int
           default: "3"
+          local: "false"
           expose: "true"
           name_top: SramCtrlRetAonNumPrinceRoundsHalf
         }
@@ -5350,6 +5371,7 @@
           desc: Compile-time option to enable flash scrambling
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: SecFlashCtrlScrambleEn
         }
@@ -5358,6 +5380,7 @@
           desc: Depth of program fifo
           type: int
           default: "4"
+          local: "false"
           expose: "true"
           name_top: FlashCtrlProgFifoDepth
         }
@@ -5366,6 +5389,7 @@
           desc: Depth of read fifo
           type: int
           default: "16"
+          local: "false"
           expose: "true"
           name_top: FlashCtrlRdFifoDepth
         }
@@ -5730,6 +5754,7 @@
           desc: RISC-V debug module JTAG ID code.
           type: logic [31:0]
           default: jtag_id_pkg::RV_DM_JTAG_IDCODE
+          local: "false"
           expose: "true"
           name_top: RvDmIdcodeValue
         }
@@ -5738,6 +5763,7 @@
           desc: When 1, a TLUL-based DMI interface is used. When 0, a JTAG TAP is used.
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: RvDmUseDmiInterface
         }
@@ -5753,6 +5779,7 @@
             '''
           type: bit
           default: 1'b0
+          local: "false"
           expose: "true"
           name_top: SecRvDmVolatileRawUnlockEn
         }
@@ -6158,6 +6185,7 @@
           desc: Disable (0) or enable (1) support for 192-bit key lengths (AES-192).
           type: bit
           default: 1'b1
+          local: "false"
           expose: "false"
           name_top: AesAES192Enable
         }
@@ -6170,6 +6198,7 @@
             '''
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: SecAesMasking
         }
@@ -6178,6 +6207,7 @@
           desc: Selection of the S-Box implementation. See aes_pkg.sv.
           type: aes_pkg::sbox_impl_e
           default: aes_pkg::SBoxImplDom
+          local: "false"
           expose: "true"
           name_top: SecAesSBoxImpl
         }
@@ -6190,6 +6220,7 @@
             '''
           type: int unsigned
           default: "0"
+          local: "false"
           expose: "true"
           name_top: SecAesStartTriggerDelay
         }
@@ -6203,6 +6234,7 @@
             '''
           type: bit
           default: 1'b0
+          local: "false"
           expose: "true"
           name_top: SecAesAllowForcingMasks
         }
@@ -6216,6 +6248,7 @@
             '''
           type: bit
           default: 1'b0
+          local: "false"
           expose: "true"
           name_top: SecAesSkipPRNGReseeding
         }
@@ -6449,6 +6482,7 @@
           desc: Disable(0) or enable(1) first-order masking of Keccak round.
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: KmacEnMasking
         }
@@ -6463,6 +6497,7 @@
             '''
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: KmacSwKeyMasked
         }
@@ -6477,6 +6512,7 @@
             '''
           type: int
           default: "0"
+          local: "false"
           expose: "true"
           name_top: SecKmacCmdDelay
         }
@@ -6490,6 +6526,7 @@
             '''
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: SecKmacIdleAcceptSwMsg
         }
@@ -6694,6 +6731,7 @@
           desc: Stub out the core of Otbn logic
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: OtbnStub
         }
@@ -6702,6 +6740,7 @@
           desc: Selection of the register file implementation. See otbn_pkg.sv.
           type: otbn_pkg::regfile_e
           default: otbn_pkg::RegFileFF
+          local: "false"
           expose: "true"
           name_top: OtbnRegFile
         }
@@ -6725,6 +6764,7 @@
             '''
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: SecOtbnMuteUrnd
         }
@@ -6738,6 +6778,7 @@
             '''
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: SecOtbnSkipUrndReseedAtStart
         }
@@ -6941,6 +6982,7 @@
             '''
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: KeymgrUseOtpSeedsInsteadOfFlash
         }
@@ -6949,6 +6991,7 @@
           desc: Flag indicating with kmac masking is enabled
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: KeymgrKmacEnMasking
         }
@@ -7321,6 +7364,7 @@
           desc: Selection of the S-Box implementation. See aes_pkg.sv.
           type: aes_pkg::sbox_impl_e
           default: aes_pkg::SBoxImplCanright
+          local: "false"
           expose: "true"
           name_top: CsrngSBoxImpl
         }
@@ -7452,6 +7496,7 @@
           desc: Number of 384-bit entries in the esfinal FIFO
           type: int
           default: "3"
+          local: "false"
           expose: "true"
           name_top: EntropySrcEsFifoDepth
         }
@@ -7460,6 +7505,7 @@
           desc: Number of 32-bit entries in the distr FIFO
           type: int unsigned
           default: "2"
+          local: "false"
           expose: "true"
           name_top: EntropySrcDistrFifoDepth
         }
@@ -7468,6 +7514,7 @@
           desc: Stub out the core of entropy_src logic
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: EntropySrcStub
         }
@@ -7873,6 +7920,7 @@
           desc: Support execution from SRAM
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: SramCtrlMainInstrExec
         }
@@ -7881,6 +7929,7 @@
           desc: Number of PRINCE half rounds for the SRAM scrambling feature
           type: int
           default: "2"
+          local: "false"
           expose: "true"
           name_top: SramCtrlMainNumPrinceRoundsHalf
         }
@@ -8034,6 +8083,7 @@
           desc: Contents of ROM
           type: ""
           default: '''""'''
+          local: "false"
           expose: "true"
           name_top: RomCtrlBootRomInitFile
         }
@@ -8068,6 +8118,7 @@
             '''
           type: bit
           default: 1'b0
+          local: "false"
           expose: "true"
           name_top: SecRomCtrlDisableScrambling
         }
@@ -8290,6 +8341,7 @@
           desc: Enable PMP
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexPMPEnable
         }
@@ -8298,6 +8350,7 @@
           desc: PMP Granularity
           type: int unsigned
           default: "0"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexPMPGranularity
         }
@@ -8306,6 +8359,7 @@
           desc: PMP number of regions
           type: int unsigned
           default: "16"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexPMPNumRegions
         }
@@ -8314,6 +8368,7 @@
           desc: "Number of the MHPM counter "
           type: int unsigned
           default: "2"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexMHPMCounterNum
         }
@@ -8322,6 +8377,7 @@
           desc: "Width of the MHPM Counter "
           type: int unsigned
           default: "32"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexMHPMCounterWidth
         }
@@ -8331,6 +8387,7 @@
           type: ibex_pkg::pmp_cfg_t
           unpacked_dimensions: "[16]"
           default: ibex_pmp_reset_pkg::PmpCfgRst
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexPMPRstCfg
         }
@@ -8340,6 +8397,7 @@
           type: logic [33:0]
           unpacked_dimensions: "[16]"
           default: ibex_pmp_reset_pkg::PmpAddrRst
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexPMPRstAddr
         }
@@ -8348,6 +8406,7 @@
           desc: Reset value of MSECCFG CSR
           type: ibex_pkg::pmp_mseccfg_t
           default: ibex_pmp_reset_pkg::PmpMseccfgRst
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexPMPRstMsecCfg
         }
@@ -8356,6 +8415,7 @@
           desc: RV32E
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexRV32E
         }
@@ -8364,6 +8424,7 @@
           desc: RV32M
           type: ibex_pkg::rv32m_e
           default: ibex_pkg::RV32MSingleCycle
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexRV32M
         }
@@ -8372,6 +8433,7 @@
           desc: RV32B
           type: ibex_pkg::rv32b_e
           default: ibex_pkg::RV32BOTEarlGrey
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexRV32B
         }
@@ -8380,6 +8442,7 @@
           desc: Reg file
           type: ibex_pkg::regfile_e
           default: ibex_pkg::RegFileFF
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexRegFile
         }
@@ -8388,6 +8451,7 @@
           desc: Branch target ALU
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexBranchTargetALU
         }
@@ -8396,6 +8460,7 @@
           desc: Write back stage
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexWritebackStage
         }
@@ -8404,6 +8469,7 @@
           desc: Instruction cache
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexICache
         }
@@ -8412,6 +8478,7 @@
           desc: Instruction cache ECC
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexICacheECC
         }
@@ -8420,6 +8487,7 @@
           desc: Scramble instruction cach
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexICacheScramble
         }
@@ -8428,6 +8496,7 @@
           desc: Branch predictor
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexBranchPredictor
         }
@@ -8436,6 +8505,7 @@
           desc: Enable degug trigger
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexDbgTriggerEn
         }
@@ -8444,6 +8514,7 @@
           desc: Number of debug hardware break
           type: int
           default: "4"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexDbgHwBreakNum
         }
@@ -8452,6 +8523,7 @@
           desc: "Width of the MHPM Counter "
           type: bit
           default: "1"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexSecureIbex
         }
@@ -8460,6 +8532,7 @@
           desc: Halt address
           type: int unsigned
           default: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexDmHaltAddr
         }
@@ -8468,6 +8541,7 @@
           desc: Exception address
           type: int unsigned
           default: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexDmExceptionAddr
         }
@@ -8476,6 +8550,7 @@
           desc: Pipe line
           type: bit
           default: "0"
+          local: "false"
           expose: "true"
           name_top: RvCoreIbexPipeLine
         }

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6531,6 +6531,29 @@
           name_top: SecKmacIdleAcceptSwMsg
         }
         {
+          name: NumAppIntf
+          desc: Number of application interfaces
+          type: int
+          default: 3
+          local: "false"
+          expose: "true"
+          name_top: KmacNumAppIntf
+        }
+        {
+          name: AppCfg
+          desc:
+            '''
+            Application interface configuration.
+            Top-level connection to the application interface must follow this definition.
+            '''
+          type: kmac_pkg::app_config_t
+          unpacked_dimensions: "[KmacNumAppIntf]"
+          default: "'{kmac_pkg::AppCfgKeyMgr, kmac_pkg::AppCfgLcCtrl, kmac_pkg::AppCfgRomCtrl}"
+          local: "false"
+          expose: "true"
+          name_top: KmacAppCfg
+        }
+        {
           name: RndCnstLfsrSeed
           desc: Compile-time random data for PRNG default seed
           type: kmac_pkg::lfsr_seed_t
@@ -6591,7 +6614,17 @@
           package: kmac_pkg
           type: req_rsp
           act: rsp
-          width: 3
+          width:
+          {
+            name: NumAppIntf
+            desc: Number of application interfaces
+            param_type: int
+            unpacked_dimensions: null
+            default: 3
+            local: false
+            expose: true
+            name_top: KmacNumAppIntf
+          }
           inst_name: kmac
           default: ""
           end_idx: -1
@@ -20343,7 +20376,17 @@
         package: kmac_pkg
         type: req_rsp
         act: rsp
-        width: 3
+        width:
+        {
+          name: NumAppIntf
+          desc: Number of application interfaces
+          param_type: int
+          unpacked_dimensions: null
+          default: 3
+          local: false
+          expose: true
+          name_top: KmacNumAppIntf
+        }
         inst_name: kmac
         default: ""
         end_idx: -1
@@ -23449,7 +23492,17 @@
         package: kmac_pkg
         struct: app_req
         signame: kmac_app_req
-        width: 3
+        width:
+        {
+          name: NumAppIntf
+          desc: Number of application interfaces
+          param_type: int
+          unpacked_dimensions: null
+          default: 3
+          local: false
+          expose: true
+          name_top: KmacNumAppIntf
+        }
         type: req_rsp
         end_idx: -1
         act: rsp
@@ -23460,7 +23513,17 @@
         package: kmac_pkg
         struct: app_rsp
         signame: kmac_app_rsp
-        width: 3
+        width:
+        {
+          name: NumAppIntf
+          desc: Number of application interfaces
+          param_type: int
+          unpacked_dimensions: null
+          default: 3
+          local: false
+          expose: true
+          name_top: KmacNumAppIntf
+        }
         type: req_rsp
         end_idx: -1
         act: rsp

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -227,6 +227,8 @@ module top_earlgrey #(
   // Compile-time random constants
   import top_earlgrey_rnd_cnst_pkg::*;
 
+  // Local Parameters
+
   // Signals
   logic [56:0] mio_p2d;
   logic [74:0] mio_d2p;
@@ -784,6 +786,7 @@ module top_earlgrey #(
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp7;
 
   // assign partial inter-module tie-off
+
   assign unused_otp_ctrl_sram_otp_key_rsp3 = otp_ctrl_sram_otp_key_rsp[3];
   assign unused_edn1_edn_rsp1 = edn1_edn_rsp[1];
   assign unused_edn1_edn_rsp2 = edn1_edn_rsp[2];

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -83,6 +83,9 @@ module top_earlgrey #(
   parameter bit KmacSwKeyMasked = 0,
   parameter int SecKmacCmdDelay = 0,
   parameter bit SecKmacIdleAcceptSwMsg = 0,
+  parameter int KmacNumAppIntf = 3,
+  parameter kmac_pkg::app_config_t KmacAppCfg[KmacNumAppIntf] =
+      '{kmac_pkg::AppCfgKeyMgr, kmac_pkg::AppCfgLcCtrl, kmac_pkg::AppCfgRomCtrl},
   // parameters for otbn
   parameter bit OtbnStub = 0,
   parameter otbn_pkg::regfile_e OtbnRegFile = otbn_pkg::RegFileFF,
@@ -601,8 +604,8 @@ module top_earlgrey #(
   keymgr_pkg::hw_key_req_t       keymgr_aes_key;
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
   keymgr_pkg::otbn_key_req_t       keymgr_otbn_key;
-  kmac_pkg::app_req_t [2:0] kmac_app_req;
-  kmac_pkg::app_rsp_t [2:0] kmac_app_rsp;
+  kmac_pkg::app_req_t [KmacNumAppIntf-1:0] kmac_app_req;
+  kmac_pkg::app_rsp_t [KmacNumAppIntf-1:0] kmac_app_rsp;
   logic       kmac_en_masking;
   prim_mubi_pkg::mubi4_t [3:0] clkmgr_aon_idle;
   jtag_pkg::jtag_req_t       pinmux_aon_lc_jtag_req;
@@ -2318,6 +2321,8 @@ module top_earlgrey #(
     .SwKeyMasked(KmacSwKeyMasked),
     .SecCmdDelay(SecKmacCmdDelay),
     .SecIdleAcceptSwMsg(SecKmacIdleAcceptSwMsg),
+    .NumAppIntf(KmacNumAppIntf),
+    .AppCfg(KmacAppCfg),
     .RndCnstLfsrSeed(RndCnstKmacLfsrSeed),
     .RndCnstLfsrPerm(RndCnstKmacLfsrPerm),
     .RndCnstBufferLfsrSeed(RndCnstKmacBufferLfsrSeed),

--- a/util/reggen/gen_cfg_md.py
+++ b/util/reggen/gen_cfg_md.py
@@ -9,6 +9,7 @@ from reggen.ip_block import IpBlock
 from reggen.md_helpers import (
     title, url, italic, coderef, regref_to_link, name_width, table, list_item,
 )
+from reggen.params import Parameter
 
 
 def gen_cfg_md(cfgs: IpBlock, output: TextIO, register_file: Optional[str] = None) -> None:
@@ -78,7 +79,10 @@ def gen_cfg_md(cfgs: IpBlock, output: TextIO, register_file: Optional[str] = Non
             pkg_struct = ims.package + "::" + ims.struct if ims.package is not None else ims.struct
             sig_type = ims.signal_type
             act = ims.act
-            width = str(ims.width) if ims.width is not None else "1"
+            if isinstance(ims.width, Parameter):
+                width = ims.width.name
+            else:
+                width = str(ims.width) if ims.width is not None else "1"
             desc = ims.desc if ims.desc is not None else ""
             rows.append([name, pkg_struct, sig_type, act, width, desc])
 

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -340,6 +340,7 @@ class IpBlock:
                                      'inter_signal_list field')
         inter_signals = [
             InterSignal.from_raw(
+                params,
                 'entry {} of the inter_signal_list field'.format(idx + 1),
                 entry) for idx, entry in enumerate(r_inter_signals)
         ]

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -26,6 +26,7 @@ from reggen import access, gen_rtl, gen_sec_cm_testplan, window
 from reggen.countermeasure import CounterMeasure
 from reggen.inter_signal import InterSignal
 from reggen.ip_block import IpBlock
+from reggen.params import ReggenParams
 from reggen.lib import check_list
 from topgen import get_hjsonobj_xbars
 from topgen import intermodule as im
@@ -151,6 +152,7 @@ def generate_xbars(top: Dict[str, object], out_path: Path) -> None:
                 "inter_signal_list field")
             obj["inter_signal_list"] = [
                 InterSignal.from_raw(
+                    ReggenParams(),
                     "entry {} of the inter_signal_list field".format(idx + 1),
                     entry) for idx, entry in enumerate(r_inter_signal_list)
             ]
@@ -1134,7 +1136,7 @@ def main():
 """.format(top_name=top_name, seed=completecfg["rnd_cnst_seed"])
 
     genhjson_path.write_text(genhdr + gencmd +
-                             hjson.dumps(completecfg, for_json=True) + '\n')
+                             hjson.dumps(completecfg, for_json=True, default=vars) + '\n')
 
     # Generate Rust toplevel definitions
     if not args.no_rust:

--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Tuple
 
 from reggen.ip_block import IpBlock
 from reggen.inter_signal import InterSignal
+from reggen.params import Parameter
 from reggen.validate import check_int
 from topgen import lib
 
@@ -641,20 +642,20 @@ def check_intermodule_field(sig: OrderedDict,
                                 name=sig['name']))
             error += 1
     # Check 'width' field
-    width = 1
-    if "width" not in sig:
-        sig["width"] = 1
-    elif not isinstance(sig["width"], int):
-        width, err = check_int(sig["width"], sig["name"])
-        if err:
-            log.error("{prefix} Inter-module {inst}.{sig} 'width' "
-                      "should be int type.".format(prefix=prefix,
-                                                   inst=sig["inst_name"],
-                                                   sig=sig["name"]))
-            error += 1
-        else:
-            # convert to int value
-            sig["width"] = width
+    raw_width = sig.get("width", 1)
+    raw_width_value = raw_width
+    if isinstance(raw_width, Parameter):
+        raw_width_value = raw_width.default
+
+    width, err = check_int(raw_width_value, sig["name"])
+    if err:
+        log.error(f"{prefix} Inter-module {sig['inst_name']}.{sig['name']} 'width' "
+                  "should be int type.")
+        error += 1
+
+    # We leave parameters as they are. If it's an int, use the converted value
+    if not isinstance(raw_width, Parameter):
+        sig["width"] = width
 
     # Add empty string if no explicit default for dangling pins is given.
     # In that case, dangling pins of type struct will be tied to the default
@@ -821,20 +822,26 @@ def check_intermodule(topcfg: Dict, prefix: str) -> int:
 
         # Determine if broadcast or one-to-N
         log.debug("Handling inter-sig {} {}".format(req_struct['name'], total_width))
+
+        if isinstance(req_struct["width"], Parameter):
+            width = int(req_struct["width"].default)
+        else:
+            width = req_struct["width"]
+
         req_struct["end_idx"] = -1
-        if req_struct["width"] > 1 or len(rsps) != 1:
+        if width > 1 or len(rsps) != 1:
             # If req width is same to the every width of rsps ==> broadcast
-            if len(rsps) * [req_struct["width"]] == widths:
+            if len(rsps) * [width] == widths:
                 log.debug("broadcast type")
                 req_struct["top_type"] = "broadcast"
 
             # If req width is same as total width of rsps ==> one-to-N
-            elif req_struct["width"] == total_width:
+            elif width == total_width:
                 log.debug("one-to-N type")
                 req_struct["top_type"] = "one-to-N"
 
             # one-to-N connection is not fully populated
-            elif req_struct["width"] > total_width:
+            elif width > total_width:
                 log.debug("partial one-to-N type")
                 req_struct["top_type"] = "partial-one-to-N"
                 req_struct["end_idx"] = len(rsps)
@@ -950,8 +957,13 @@ def im_netname(sig: OrderedDict,
             # custom default has been specified
             if obj["default"]:
                 return obj["default"]
-            return "{package}::{struct}_DEFAULT".format(
-                package=obj["package"], struct=obj["struct"].upper())
+            if isinstance(sig["width"], Parameter):
+                return "{{{param}{{{package}::{struct}_DEFAULT}}}}".format(
+                    param=sig["width"].name_top, package=obj["package"],
+                    struct=obj["struct"].upper())
+            else:
+                return "{package}::{struct}_DEFAULT".format(
+                    package=obj["package"], struct=obj["struct"].upper())
 
         return ""
 

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -166,6 +166,14 @@ def elaborate_instance(instance, block: IpBlock):
     # to convert and copy them here.
     instance["inter_signal_list"] = [s.as_dict() for s in block.inter_signals]
 
+    # If we have width-parametrized intersignal, we need to update the intersignal param name
+    # the the instance mangled param name
+    for s in instance["inter_signal_list"]:
+        if isinstance(s['width'], Parameter):
+            for p in instance["param_list"]:
+                if p['name'] == s['width'].name:
+                    s['width'].name_top = p['name_top']
+
     # An instance must either have a 'base_addr' address or a 'base_addrs'
     # address, but can't have both.
     base_addrs = instance.get('base_addrs')


### PR DESCRIPTION
This PR adds support for parametrized inter-module signals. Previously, when an inter-module signal depended on a parameter, you needed to specify the `width` value twice. Once for the parameter and once when the value is used for the width of the inter-module signal. 

This PR fixes that and adds support for parameters being used for the width of an inter-module signal. When you want to do that, you need to expose the parameter. If `local` is set, the parameter will be created as localparam in the top-level file, and the interconnection uses that parameter. If `local` is `false`, a top-level parameter is created, but also a local parameter within the `reg_pkg` of the IP.

The PR is separated into 2 parts:
1. The infrastructure implemetnation
2. Using that feature for the KMAC `NumAppIntf` parameter

