### PR TITLE
[tlul] Fix lint warnings and errors

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -503,8 +503,8 @@ module tlul_adapter_sram
           // When DataXorAddr is enabled, on a read, the address is XORed with the data fetched from
           // the memory in the underlying memory controller (e.g., flash controller). At this point,
           // the address is again removed. If the address in the read transaction has been modified,
-          // e.g., due to a fault, rdata now contains faulty data, which is detected by the integrity
-          // mechanism.
+          // e.g., due to a fault, rdata now contains faulty data, which is detected by the
+          // integrity mechanism.
           logic [SramBusBankAW-1:0] addr_xor;
           addr_xor = sramreqaddrfifo_rdata.addr[SramBusBankAW-1:0];
           // data XOR address.
@@ -617,6 +617,11 @@ module tlul_adapter_sram
     );
   end else begin : gen_no_data_xor_addr_fifo
     assign sramreqaddrfifo_wready = 1'b1;
+    assign sramreqaddrfifo_rdata = '0;
+
+    // Tie-off unused signals
+    logic unused_sramreqaddrfifo;
+    assign unused_sramreqaddrfifo = ^{sramreqaddrfifo_wdata, sramreqaddrfifo_rdata};
   end
 
   // Rationale having #Outstanding depth in response FIFO.

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -503,7 +503,8 @@ module tlul_adapter_sram
           // integrity mechanism.
           rdata_tlword = {
               rdata_reshaped[sramreqfifo_rdata.woffset][DataWidth-1:top_pkg::TL_DW],
-              rdata_reshaped[sramreqfifo_rdata.woffset][top_pkg::TL_DW-1:0] ^ sramreqaddrfifo_rdata
+              rdata_reshaped[sramreqfifo_rdata.woffset][top_pkg::TL_DW-1:0] ^
+                  {{(top_pkg::TL_DW-SramBusBankAW){1'b0}}, sramreqaddrfifo_rdata}
           };
         end else begin: gen_no_data_xor_addr
           rdata_tlword = rdata_reshaped[sramreqfifo_rdata.woffset];


### PR DESCRIPTION
This commit fixes a couple lint warnings and errors flagged by multiple tools (AscentLint, Verilator, Verible). It's better to just fix them instead of writing multiple waivers.