### PR TITLE
[hmac] Avoid inference of latch

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -535,6 +535,7 @@ module hmac
   logic index;
   always_comb begin : select_fifo_wdata
     // default when !hmac_fifo_wsel
+    index      = 1'b0;
     fifo_wdata = reg_fifo_wentry;
 
     if (hmac_fifo_wsel) begin


### PR DESCRIPTION
The `index` signal did not get assigned a default value in the corresponding always_comb block which may cause the inference of a latch.