### PR TITLE
Revert "[bazel] Remove invalid autogen_targets."

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,6 +225,22 @@ jobs:
       echo -//sw/otbn/crypto/... >> "${TARGET_PATTERN_FILE}"
       echo -//third_party/riscv-compliance/... >> "${TARGET_PATTERN_FILE}"
       echo -//hw:all >> "${TARGET_PATTERN_FILE}"
+      echo -//hw/ip_templates/clkmgr/data:clkmgr_c_regs \
+        >> "${TARGET_PATTERN_FILE}"
+      echo -//hw/ip_templates/clkmgr/data:clkmgr_rust_regs \
+        >> "${TARGET_PATTERN_FILE}"
+      echo -//hw/ip_templates/flash_ctrl/data:flash_ctrl_c_regs \
+        >> "${TARGET_PATTERN_FILE}"
+      echo -//hw/ip_templates/flash_ctrl/data:flash_ctrl_rust_regs \
+        >> "${TARGET_PATTERN_FILE}"
+      echo -//hw/ip_templates/pwrmgr/data:pwrmgr_c_regs \
+        >> "${TARGET_PATTERN_FILE}"
+      echo -//hw/ip_templates/pwrmgr/data:pwrmgr_rust_regs \
+        >> "${TARGET_PATTERN_FILE}"
+      echo -//hw/ip_templates/rstmgr/data:rstmgr_c_regs \
+        >> "${TARGET_PATTERN_FILE}"
+      echo -//hw/ip_templates/rstmgr/data:rstmgr_rust_regs \
+        >> "${TARGET_PATTERN_FILE}"
       ci/bazelisk.sh cquery \
         --noinclude_aspects \
         --output=starlark \

--- a/hw/ip_templates/clkmgr/data/BUILD
+++ b/hw/ip_templates/clkmgr/data/BUILD
@@ -4,6 +4,26 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//rules:autogen.bzl",
+    "autogen_hjson_c_header",
+    "autogen_hjson_rust_header",
+)
+
+autogen_hjson_c_header(
+    name = "clkmgr_c_regs",
+    srcs = [
+        "clkmgr.hjson",
+    ],
+)
+
+autogen_hjson_rust_header(
+    name = "clkmgr_rust_regs",
+    srcs = [
+        "clkmgr.hjson",
+    ],
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),

--- a/hw/ip_templates/flash_ctrl/data/BUILD
+++ b/hw/ip_templates/flash_ctrl/data/BUILD
@@ -4,6 +4,28 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//rules:autogen.bzl",
+    "autogen_hjson_c_header",
+    "autogen_hjson_rust_header",
+)
+
+autogen_hjson_c_header(
+    name = "flash_ctrl_c_regs",
+    srcs = [
+        "flash_ctrl.hjson",
+    ],
+    node = "core",
+)
+
+autogen_hjson_rust_header(
+    name = "flash_ctrl_rust_regs",
+    srcs = [
+        "flash_ctrl.hjson",
+    ],
+    node = "core",
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),

--- a/hw/ip_templates/pwrmgr/data/BUILD
+++ b/hw/ip_templates/pwrmgr/data/BUILD
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+package(default_visibility = ["//visibility:public"])
+
 load(
     "//rules:autogen.bzl",
     "autogen_hjson_c_header",
     "autogen_hjson_rust_header",
 )
-
-package(default_visibility = ["//visibility:public"])
 
 autogen_hjson_c_header(
     name = "pwrmgr_c_regs",

--- a/hw/ip_templates/rstmgr/data/BUILD
+++ b/hw/ip_templates/rstmgr/data/BUILD
@@ -4,6 +4,26 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load(
+    "//rules:autogen.bzl",
+    "autogen_hjson_c_header",
+    "autogen_hjson_rust_header",
+)
+
+autogen_hjson_c_header(
+    name = "rstmgr_c_regs",
+    srcs = [
+        "rstmgr.hjson",
+    ],
+)
+
+autogen_hjson_rust_header(
+    name = "rstmgr_rust_regs",
+    srcs = [
+        "rstmgr.hjson",
+    ],
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),


### PR DESCRIPTION
This commit was causing issues with the ipgen flow.

This reverts commit 52a36297706242e26435e2ca7440aa6ec3096c3a.