### PR TITLE
[flash_ctrl] Fix lint errors and warnings

### DIFF
--- a/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -33,8 +33,10 @@ module flash_ctrl_erase import flash_ctrl_pkg::*; (
   // PageAddrMask would be 0xF_FFFF_0000
   // BankAddrMask would be 0xF_0000_0000
   //
-  localparam logic[BusAddrW-1:0] PageAddrMask = ~(('h1 << WordsBitWidth) - 1'b1);
-  localparam logic[BusAddrW-1:0] BankAddrMask = ~(('h1 << (PagesBitWidth + WordsBitWidth)) - 1'b1);
+  localparam int unsigned PageAddrMaskInt = ~(('h1 << WordsBitWidth) - 1'b1);
+  localparam int unsigned BankAddrMaskInt = ~(('h1 << (PagesBitWidth + WordsBitWidth)) - 1'b1);
+  localparam logic [BusAddrW-1:0] PageAddrMask = PageAddrMaskInt[BusAddrW-1:0];
+  localparam logic [BusAddrW-1:0] BankAddrMask = BankAddrMaskInt[BusAddrW-1:0];
 
   // out of bounds condition, the initial starting address is beyond the flash
   logic oob_err;

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_core.sv
@@ -434,7 +434,6 @@ module flash_phy_core
     .buf_en_i(rd_buf_en_i),
     //.req_i(reqs[PhyRead] | host_req),
     .req_i(phy_req & (rd_i | host_req)),
-    .host_req_i(host_req),
     .descramble_i(muxed_scramble_en),
     .ecc_i(muxed_ecc_en),
     .prog_i(reqs[PhyProg]),

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
@@ -748,7 +748,8 @@ module flash_phy_rd
 
   logic [BusWidth-1:0] data_out_xor;
   logic [BusWidth-1:0] data_out_xor_buf;
-  assign data_out_xor = data_out_pre_xor[BusWidth-1:0] ^ addr_xor_muxed;
+  assign data_out_xor =
+      data_out_pre_xor[BusWidth-1:0] ^ {{(BusWidth-BusBankAddrW){1'b0}}, addr_xor_muxed};
 
   // Buffer to ensure that synthesis tool does not optimize the XOR.
   prim_buf #(

--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
@@ -38,7 +38,6 @@ module flash_phy_rd
 
   // interface with arbitration unit
   input req_i,
-  input host_req_i,
   input descramble_i,
   input ecc_i,
   input prog_i,
@@ -467,7 +466,6 @@ module flash_phy_rd
 
   logic fifo_data_ready;
   logic fifo_data_valid;
-  logic fifo_addr_xor_valid;
   logic fifo_forward_pop;
   logic rd_and_mask_fifo_pop;
   logic mask_valid;
@@ -568,9 +566,8 @@ module flash_phy_rd
     .err_o   ()
   );
 
-  logic host_req;
   prim_fifo_sync #(
-    .Width   (1+BankAddrW),
+    .Width   (BankAddrW),
     .Pass    (0),
     .Depth   (RspOrderDepth),
     .OutputZeroIfEmpty (1)
@@ -580,12 +577,12 @@ module flash_phy_rd
     .clr_i   (1'b0),
     .wvalid_i(rsp_order_fifo_wr),
     .wready_o(addr_xor_fifo_rdy),
-    .wdata_i ({host_req_i, flash_word_addr}),
+    .wdata_i (flash_word_addr),
     .depth_o (unused_addr_xor_depth),
     .full_o  (),
-    .rvalid_o(fifo_addr_xor_valid),
+    .rvalid_o(),
     .rready_i(data_valid_o),
-    .rdata_o ({host_req, fifo_addr_xor}),
+    .rdata_o (fifo_addr_xor),
     .err_o   ()
   );
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -33,8 +33,10 @@ module flash_ctrl_erase import flash_ctrl_pkg::*; (
   // PageAddrMask would be 0xF_FFFF_0000
   // BankAddrMask would be 0xF_0000_0000
   //
-  localparam logic[BusAddrW-1:0] PageAddrMask = ~(('h1 << WordsBitWidth) - 1'b1);
-  localparam logic[BusAddrW-1:0] BankAddrMask = ~(('h1 << (PagesBitWidth + WordsBitWidth)) - 1'b1);
+  localparam int unsigned PageAddrMaskInt = ~(('h1 << WordsBitWidth) - 1'b1);
+  localparam int unsigned BankAddrMaskInt = ~(('h1 << (PagesBitWidth + WordsBitWidth)) - 1'b1);
+  localparam logic [BusAddrW-1:0] PageAddrMask = PageAddrMaskInt[BusAddrW-1:0];
+  localparam logic [BusAddrW-1:0] BankAddrMask = BankAddrMaskInt[BusAddrW-1:0];
 
   // out of bounds condition, the initial starting address is beyond the flash
   logic oob_err;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_core.sv
@@ -434,7 +434,6 @@ module flash_phy_core
     .buf_en_i(rd_buf_en_i),
     //.req_i(reqs[PhyRead] | host_req),
     .req_i(phy_req & (rd_i | host_req)),
-    .host_req_i(host_req),
     .descramble_i(muxed_scramble_en),
     .ecc_i(muxed_ecc_en),
     .prog_i(reqs[PhyProg]),

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
@@ -748,7 +748,8 @@ module flash_phy_rd
 
   logic [BusWidth-1:0] data_out_xor;
   logic [BusWidth-1:0] data_out_xor_buf;
-  assign data_out_xor = data_out_pre_xor[BusWidth-1:0] ^ addr_xor_muxed;
+  assign data_out_xor =
+      data_out_pre_xor[BusWidth-1:0] ^ {{(BusWidth-BusBankAddrW){1'b0}}, addr_xor_muxed};
 
   // Buffer to ensure that synthesis tool does not optimize the XOR.
   prim_buf #(

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
@@ -38,7 +38,6 @@ module flash_phy_rd
 
   // interface with arbitration unit
   input req_i,
-  input host_req_i,
   input descramble_i,
   input ecc_i,
   input prog_i,
@@ -467,7 +466,6 @@ module flash_phy_rd
 
   logic fifo_data_ready;
   logic fifo_data_valid;
-  logic fifo_addr_xor_valid;
   logic fifo_forward_pop;
   logic rd_and_mask_fifo_pop;
   logic mask_valid;
@@ -568,9 +566,8 @@ module flash_phy_rd
     .err_o   ()
   );
 
-  logic host_req;
   prim_fifo_sync #(
-    .Width   (1+BankAddrW),
+    .Width   (BankAddrW),
     .Pass    (0),
     .Depth   (RspOrderDepth),
     .OutputZeroIfEmpty (1)
@@ -580,12 +577,12 @@ module flash_phy_rd
     .clr_i   (1'b0),
     .wvalid_i(rsp_order_fifo_wr),
     .wready_o(addr_xor_fifo_rdy),
-    .wdata_i ({host_req_i, flash_word_addr}),
+    .wdata_i (flash_word_addr),
     .depth_o (unused_addr_xor_depth),
     .full_o  (),
-    .rvalid_o(fifo_addr_xor_valid),
+    .rvalid_o(),
     .rready_i(data_valid_o),
-    .rdata_o ({host_req, fifo_addr_xor}),
+    .rdata_o (fifo_addr_xor),
     .err_o   ()
   );
 


### PR DESCRIPTION
This PR contains two commits to fix some uncritical lint errors (could also be waived) and some which are rather critical. We better don't rely on tools doing the right thing for those.