### PR TITLE
[rom] Refactor ECDSA pub key and signature structs.

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -12,7 +12,6 @@ load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
-    "cw310_params",
     "fpga_params",
     "opentitan_test",
     "verilator_params",
@@ -487,6 +486,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:otbn",
+        "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
         "//sw/device/silicon_creator/lib/sigverify:rsa_key",
         "//sw/otbn/crypto:boot",
     ],
@@ -564,5 +564,6 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:otp",
+        "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
     ],
 )

--- a/sw/device/silicon_creator/lib/attestation.h
+++ b/sw/device/silicon_creator/lib/attestation.h
@@ -22,44 +22,6 @@ enum {
    * Size of the additional seed for attestation key generation in 32b words.
    */
   kAttestationSeedWords = kAttestationSeedBytes / sizeof(uint32_t),
-  /**
-   * Size of a coordinate for an attestation public key in bits.
-   */
-  kAttestationPublicKeyCoordBits = 256,
-  /**
-   * Size of a coordinate for an attestation public key in bytes.
-   */
-  kAttestationPublicKeyCoordBytes = kAttestationPublicKeyCoordBits / 8,
-  /**
-   * Size of a coordinate for an attestation public key in 32b words.
-   */
-  kAttestationPublicKeyCoordWords =
-      kAttestationPublicKeyCoordBytes / sizeof(uint32_t),
-  /**
-   * Size of an attestation signature component in bits.
-   */
-  kAttestationSignatureComponentBits = 256,
-  /**
-   * Size of an attestation signature component in bytes.
-   */
-  kAttestationSignatureComponentBytes = kAttestationSignatureComponentBits / 8,
-  /**
-   * Size of an attestation signature component in 32b words.
-   */
-  kAttestationSignatureComponentWords =
-      kAttestationSignatureComponentBytes / sizeof(uint32_t),
-  /**
-   * Size of an attestation signature in bits.
-   */
-  kAttestationSignatureBits = kAttestationSignatureComponentBits * 2,
-  /**
-   * Size of an attestation signature in bytes.
-   */
-  kAttestationSignatureBytes = kAttestationSignatureBits / 8,
-  /**
-   * Size of an attestation signature in 32b words.
-   */
-  kAttestationSignatureWords = kAttestationSignatureBytes / sizeof(uint32_t),
 };
 
 typedef enum {
@@ -95,28 +57,6 @@ typedef enum {
 enum {
   kAttestationKeyGenVersion0 = 0,
 };
-
-/**
- * Holds an attestation public key (ECDSA-P256).
- */
-typedef struct attestation_public_key {
-  /**
-   * Affine x-coordinate of the point.
-   */
-  uint32_t x[kAttestationPublicKeyCoordWords];
-  /**
-   * Affine y-coordinate of the point.
-   */
-  uint32_t y[kAttestationPublicKeyCoordWords];
-} attestation_public_key_t;
-
-/**
- * Holds an attestation signature (ECDSA-P256).
- */
-typedef struct attestation_signature {
-  uint32_t r[kAttestationSignatureComponentWords];
-  uint32_t s[kAttestationSignatureComponentWords];
-} attestation_signature_t;
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/dice.h
+++ b/sw/device/silicon_creator/lib/dice.h
@@ -11,6 +11,7 @@
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 
 enum {
   /**
@@ -83,7 +84,7 @@ typedef struct dice_cert_key_id_pair {
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_attestation_keygen(dice_key_t desired_key,
                                     hmac_digest_t *pubkey_id,
-                                    attestation_public_key_t *pubkey);
+                                    ecdsa_p256_public_key_t *pubkey);
 
 /**
  * Generates the UDS attestation keypair and (unendorsed) X.509 TBS certificate.
@@ -98,7 +99,7 @@ rom_error_t dice_attestation_keygen(dice_key_t desired_key,
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_uds_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
-                                    attestation_public_key_t *uds_pubkey,
+                                    ecdsa_p256_public_key_t *uds_pubkey,
                                     uint8_t *tbs_cert, size_t *tbs_cert_size);
 
 /**
@@ -118,7 +119,7 @@ OT_WARN_UNUSED_RESULT
 rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
                                   uint32_t rom_ext_security_version,
                                   dice_cert_key_id_pair_t *key_ids,
-                                  attestation_public_key_t *cdi_0_pubkey,
+                                  ecdsa_p256_public_key_t *cdi_0_pubkey,
                                   uint8_t *cert, size_t *cert_size);
 
 /**
@@ -140,7 +141,7 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
                                   hmac_digest_t *owner_manifest_measurement,
                                   uint32_t owner_security_version,
                                   dice_cert_key_id_pair_t *key_ids,
-                                  attestation_public_key_t *cdi_1_pubkey,
+                                  ecdsa_p256_public_key_t *cdi_1_pubkey,
                                   uint8_t *cert, size_t *cert_size);
 
 /**
@@ -156,7 +157,7 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t dice_tpm_ek_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
-                                       attestation_public_key_t *tpm_ek_pubkey,
+                                       ecdsa_p256_public_key_t *tpm_ek_pubkey,
                                        uint8_t *tbs_cert,
                                        size_t *tbs_cert_size);
 
@@ -172,9 +173,10 @@ rom_error_t dice_tpm_ek_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t dice_tpm_cek_tbs_cert_build(
-    dice_cert_key_id_pair_t *key_ids, attestation_public_key_t *tpm_cek_pubkey,
-    uint8_t *tbs_cert, size_t *tbs_cert_size);
+rom_error_t dice_tpm_cek_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
+                                        ecdsa_p256_public_key_t *tpm_cek_pubkey,
+                                        uint8_t *tbs_cert,
+                                        size_t *tbs_cert_size);
 
 /**
  * Generates an X.509 TBS section of a TPM CIK certificate.
@@ -188,7 +190,8 @@ rom_error_t dice_tpm_cek_tbs_cert_build(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t dice_tpm_cik_tbs_cert_build(
-    dice_cert_key_id_pair_t *key_ids, attestation_public_key_t *tpm_cik_pubkey,
-    uint8_t *tbs_cert, size_t *tbs_cert_size);
+rom_error_t dice_tpm_cik_tbs_cert_build(dice_cert_key_id_pair_t *key_ids,
+                                        ecdsa_p256_public_key_t *tpm_cik_pubkey,
+                                        uint8_t *tbs_cert,
+                                        size_t *tbs_cert_size);
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DICE_H_

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -231,7 +231,7 @@ typedef struct manifest {
      * immediately after the end of the union encapsulating this field and ends
      * at the end of the image.
      */
-    sigverify_ecdsa_p256_buffer_t ecdsa_signature;
+    ecdsa_p256_signature_t ecdsa_signature;
   };
   /**
    * Usage constraints.
@@ -251,7 +251,7 @@ typedef struct manifest {
     /**
      * Signer's ECDSA NIST P256 ECC public key.
      */
-    sigverify_ecdsa_p256_buffer_t ecdsa_public_key;
+    ecdsa_p256_public_key_t ecdsa_public_key;
   };
   /**
    * Address translation (hardened boolean).

--- a/sw/device/silicon_creator/lib/otbn_boot_services.h
+++ b/sw/device/silicon_creator/lib/otbn_boot_services.h
@@ -11,6 +11,7 @@
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 #include "sw/device/silicon_creator/lib/sigverify/rsa_key.h"
 
 #ifdef __cplusplus
@@ -67,7 +68,7 @@ rom_error_t otbn_boot_attestation_keygen(
     attestation_key_seed_t additional_seed,
     otbn_boot_attestation_key_type_t key_type,
     sc_keymgr_diversification_t diversification,
-    attestation_public_key_t *public_key);
+    ecdsa_p256_public_key_t *public_key);
 
 /**
  * Saves an attestation private key to OTBN's scratchpad.
@@ -127,7 +128,7 @@ rom_error_t otbn_boot_attestation_key_clear(void);
  */
 OT_WARN_UNUSED_RESULT
 rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
-                                          attestation_signature_t *sig);
+                                          ecdsa_p256_signature_t *sig);
 
 /**
  * Computes an ECDSA-P256 signature verification on OTBN.
@@ -147,8 +148,8 @@ rom_error_t otbn_boot_attestation_endorse(const hmac_digest_t *digest,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t otbn_boot_sigverify(const attestation_public_key_t *key,
-                                const attestation_signature_t *sig,
+rom_error_t otbn_boot_sigverify(const ecdsa_p256_public_key_t *key,
+                                const ecdsa_p256_signature_t *sig,
                                 const hmac_digest_t *digest,
                                 uint32_t *recovered_r);
 

--- a/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
+++ b/sw/device/silicon_creator/lib/otbn_boot_services_functest.c
@@ -25,7 +25,7 @@ const char kTestMessage[] = "Test message.";
 const size_t kTestMessageLen = sizeof(kTestMessage) - 1;
 
 // Valid ECDSA-P256 public key.
-static const attestation_public_key_t kEcdsaKey = {
+static const ecdsa_p256_public_key_t kEcdsaKey = {
     .x = {0x1ceb402b, 0x9dc600d1, 0x182ec21b, 0x5ede3640, 0x3566bdac,
           0x1debf94b, 0x1a286a75, 0x8904d749},
     .y = {0x63eab6dc, 0x0c53bf99, 0x086d3ee7, 0x1076efa6, 0x8dd8ece2,
@@ -33,7 +33,7 @@ static const attestation_public_key_t kEcdsaKey = {
 };
 
 // Valid ECDSA-P256 signature for `kTestMessage`.
-static const attestation_signature_t kEcdsaSignature = {
+static const ecdsa_p256_signature_t kEcdsaSignature = {
     .r = {0x4811545a, 0x088d927b, 0x5d8624b5, 0x2ef1f329, 0x184ba14a,
           0xf655eede, 0xaaed0d54, 0xa20e1ac7},
     .s = {0x729b945d, 0x181dc116, 0x1025dba4, 0xb99828a0, 0xe7225df3,
@@ -63,7 +63,7 @@ rom_error_t sigverify_test(void) {
 
   // The recovered `r` value from sigverify should be equal to the signature
   // `r` value.
-  uint32_t recovered_r[kAttestationSignatureComponentWords];
+  uint32_t recovered_r[kEcdsaP256SignatureComponentWords];
   RETURN_IF_ERROR(
       otbn_boot_sigverify(&kEcdsaKey, &kEcdsaSignature, &digest, recovered_r));
   CHECK_ARRAYS_EQ(recovered_r, kEcdsaSignature.r, ARRAYSIZE(kEcdsaSignature.r));
@@ -72,19 +72,19 @@ rom_error_t sigverify_test(void) {
 
 rom_error_t attestation_keygen_test(void) {
   // Check that key generations with different seeds result in different keys.
-  attestation_public_key_t pk_uds;
+  ecdsa_p256_public_key_t pk_uds;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kUdsAttestationKeySeed,
                                                kOtbnBootAttestationKeyTypeDice,
                                                kDiversification, &pk_uds));
-  attestation_public_key_t pk_cdi0;
+  ecdsa_p256_public_key_t pk_cdi0;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kCdi0AttestationKeySeed,
                                                kOtbnBootAttestationKeyTypeDice,
                                                kDiversification, &pk_cdi0));
-  attestation_public_key_t pk_cdi1;
+  ecdsa_p256_public_key_t pk_cdi1;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kCdi1AttestationKeySeed,
                                                kOtbnBootAttestationKeyTypeDice,
                                                kDiversification, &pk_cdi1));
-  attestation_public_key_t pk_tpm_ek;
+  ecdsa_p256_public_key_t pk_tpm_ek;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kTpmEkAttestationKeySeed,
                                                kOtbnBootAttestationKeyTypeTpm,
                                                kDiversification, &pk_tpm_ek));
@@ -98,7 +98,7 @@ rom_error_t attestation_keygen_test(void) {
                   sizeof(pk_uds));
 
   // Check that running the same key generation twice results in the same key.
-  attestation_public_key_t pk_uds_again;
+  ecdsa_p256_public_key_t pk_uds_again;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(
       kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice, kDiversification,
       &pk_uds_again));
@@ -111,7 +111,7 @@ rom_error_t attestation_keygen_test(void) {
   memcpy(&diversification_modified, &kDiversification,
          sizeof(diversification_modified));
   diversification_modified.salt[0] ^= 1;
-  attestation_public_key_t pk_uds_div;
+  ecdsa_p256_public_key_t pk_uds_div;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(
       kUdsAttestationKeySeed, kOtbnBootAttestationKeyTypeDice,
       diversification_modified, &pk_uds_div));
@@ -122,7 +122,7 @@ rom_error_t attestation_keygen_test(void) {
 
 rom_error_t attestation_advance_and_endorse_test(void) {
   // Generate and save the a keypair.
-  attestation_public_key_t pk;
+  ecdsa_p256_public_key_t pk;
   RETURN_IF_ERROR(otbn_boot_attestation_keygen(kUdsAttestationKeySeed,
                                                kOtbnBootAttestationKeyTypeDice,
                                                kDiversification, &pk));
@@ -138,11 +138,11 @@ rom_error_t attestation_advance_and_endorse_test(void) {
   // Run endorsement (should overwrite the key with randomness when done).
   hmac_digest_t digest;
   hmac_sha256(kTestMessage, kTestMessageLen, &digest);
-  attestation_signature_t sig;
+  ecdsa_p256_signature_t sig;
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
 
   // Check that the signature is valid (recovered r == r).
-  uint32_t recovered_r[kAttestationSignatureComponentWords];
+  uint32_t recovered_r[kEcdsaP256SignatureComponentWords];
   RETURN_IF_ERROR(otbn_boot_sigverify(&pk, &sig, &digest, recovered_r));
   CHECK_ARRAYS_EQ(recovered_r, sig.r, ARRAYSIZE(sig.r));
 
@@ -171,7 +171,7 @@ rom_error_t attestation_save_clear_key_test(void) {
       kDiversification));
   hmac_digest_t digest;
   hmac_sha256(kTestMessage, kTestMessageLen, &digest);
-  attestation_signature_t sig;
+  ecdsa_p256_signature_t sig;
   RETURN_IF_ERROR(otbn_boot_attestation_endorse(&digest, &sig));
 
   // Clear the key and check that endorsing now fails (it should even lock

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -4,13 +4,10 @@
 
 load(
     "//rules/opentitan:defs.bzl",
-    "EARLGREY_TEST_ENVS",
     "opentitan_test",
-    "verilator_params",
 )
 load(
     "//rules:cross_platform.bzl",
-    "dual_cc_device_library_of",
     "dual_cc_library",
     "dual_inputs",
 )

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -170,7 +170,7 @@ typedef struct owner_application_key {
     uint32_t id;
     sigverify_rsa_key_t rsa;
     sigverify_spx_key_t spx;
-    sigverify_ecdsa_p256_buffer_t ecdsa;
+    ecdsa_p256_public_key_t ecdsa;
   } data;
 } owner_application_key_t;
 

--- a/sw/device/silicon_creator/lib/ownership/ecdsa.c
+++ b/sw/device/silicon_creator/lib/ownership/ecdsa.c
@@ -40,10 +40,8 @@ hardened_bool_t ecdsa_verify_digest(const owner_key_t *pubkey,
                                     const owner_signature_t *signature,
                                     const hmac_digest_t *digest) {
 #if USE_OTBN == 1
-  const attestation_public_key_t *key =
-      (const attestation_public_key_t *)pubkey;
-  const attestation_signature_t *sig =
-      (const attestation_signature_t *)signature;
+  const ecdsa_p256_public_key_t *key = (const ecdsa_p256_public_key_t *)pubkey;
+  const ecdsa_p256_signature_t *sig = (const ecdsa_p256_signature_t *)signature;
   uint32_t rr[8];
   rom_error_t error = otbn_boot_sigverify(key, sig, digest, rr);
   if (error != kErrorOk) {

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -11,7 +11,6 @@ load(
 load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",
-    "cw310_params",
     "fpga_params",
     "opentitan_test",
     "verilator_params",

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.c
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.c
@@ -5,4 +5,4 @@
 
 // `extern` declarations for `inline` functions in the header.
 extern uint32_t sigverify_ecdsa_p256_key_id_get(
-    const sigverify_ecdsa_p256_buffer_t *pub_key);
+    const ecdsa_p256_public_key_t *pub_key);

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h
@@ -14,18 +14,67 @@ extern "C" {
 #endif  // __cplusplus
 
 enum {
-  /** Number of 32-bit words in a P-256 public key. */
-  kP256PublicKeyWords = 512 / 32,
+  /**
+   * Size of a coordinate for an attestation public key in bits.
+   */
+  kEcdsaP256PublicKeyCoordBits = 256,
+  /**
+   * Size of a coordinate for an attestation public key in bytes.
+   */
+  kEcdsaP256PublicKeyCoordBytes = kEcdsaP256PublicKeyCoordBits / 8,
+  /**
+   * Size of a coordinate for an attestation public key in 32b words.
+   */
+  kEcdsaP256PublicKeyCoordWords =
+      kEcdsaP256PublicKeyCoordBytes / sizeof(uint32_t),
+  /**
+   * Size of an attestation signature component in bits.
+   */
+  kEcdsaP256SignatureComponentBits = 256,
+  /**
+   * Size of an attestation signature component in bytes.
+   */
+  kEcdsaP256SignatureComponentBytes = kEcdsaP256SignatureComponentBits / 8,
+  /**
+   * Size of an attestation signature component in 32b words.
+   */
+  kEcdsaP256SignatureComponentWords =
+      kEcdsaP256SignatureComponentBytes / sizeof(uint32_t),
+  /**
+   * Size of an attestation signature in bits.
+   */
+  kAttestationSignatureBits = kEcdsaP256SignatureComponentBits * 2,
+  /**
+   * Size of an attestation signature in bytes.
+   */
+  kAttestationSignatureBytes = kAttestationSignatureBits / 8,
+  /**
+   * Size of an attestation signature in 32b words.
+   */
+  kAttestationSignatureWords = kAttestationSignatureBytes / sizeof(uint32_t),
 };
 
 /**
- * A type that holds `kP256PublicKeyWords` words.
- *
- * This can be used to store ECDSA P256 public keys or signatures.
+ * Holds an attestation public key (ECDSA-P256).
  */
-typedef struct sigverify_ecdsa_p256_buffer {
-  uint32_t data[kP256PublicKeyWords];
-} sigverify_ecdsa_p256_buffer_t;
+typedef struct ecdsa_p256_public_key {
+  /**
+   * Affine x-coordinate of the point.
+   */
+  uint32_t x[kEcdsaP256PublicKeyCoordWords];
+  /**
+   * Affine y-coordinate of the point.
+   */
+  uint32_t y[kEcdsaP256PublicKeyCoordWords];
+} ecdsa_p256_public_key_t;
+
+/**
+ * Holds an attestation signature (ECDSA-P256).
+ */
+typedef struct ecdsa_p256_signature {
+  uint32_t r[kEcdsaP256SignatureComponentWords];
+  uint32_t s[kEcdsaP256SignatureComponentWords];
+} ecdsa_p256_signature_t;
 
 /**
  * Gets the ID of an ECDSA public key.
@@ -38,8 +87,8 @@ typedef struct sigverify_ecdsa_p256_buffer {
  */
 OT_WARN_UNUSED_RESULT
 inline uint32_t sigverify_ecdsa_p256_key_id_get(
-    const sigverify_ecdsa_p256_buffer_t *pub_key) {
-  return pub_key->data[0];
+    const ecdsa_p256_public_key_t *pub_key) {
+  return pub_key->x[0];
 }
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify.h
@@ -34,10 +34,10 @@ enum {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t sigverify_ecdsa_p256_verify(
-    const sigverify_ecdsa_p256_buffer_t *signature,
-    const sigverify_ecdsa_p256_buffer_t *key, const hmac_digest_t *act_digest,
-    uint32_t *flash_exec);
+rom_error_t sigverify_ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
+                                        const ecdsa_p256_public_key_t *key,
+                                        const hmac_digest_t *act_digest,
+                                        uint32_t *flash_exec);
 
 /**
  * Transforms `kSigverifyEcdsaSuccess` into `kErrorOk`.

--- a/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify/ecdsa_p256_verify_functest.c
@@ -17,26 +17,80 @@ const size_t kTestMessageLen = sizeof(kTestMessage) - 1;
 hmac_digest_t digest;
 
 // Valid ECDSA-P256 public key.
-static const sigverify_ecdsa_p256_buffer_t kEcdsaKey = {
-    .data = {0x1ceb402b, 0x9dc600d1, 0x182ec21b, 0x5ede3640, 0x3566bdac,
-             0x1debf94b, 0x1a286a75, 0x8904d749, 0x63eab6dc, 0x0c53bf99,
-             0x086d3ee7, 0x1076efa6, 0x8dd8ece2, 0xbfececf0, 0x9b94e34d,
-             0x59b12f3c},
+static const ecdsa_p256_public_key_t kEcdsaKey = {
+    .x =
+        {
+            0x1ceb402b,
+            0x9dc600d1,
+            0x182ec21b,
+            0x5ede3640,
+            0x3566bdac,
+            0x1debf94b,
+            0x1a286a75,
+            0x8904d749,
+        },
+    .y =
+        {
+            0x63eab6dc,
+            0x0c53bf99,
+            0x086d3ee7,
+            0x1076efa6,
+            0x8dd8ece2,
+            0xbfececf0,
+            0x9b94e34d,
+            0x59b12f3c,
+        },
 };
 
 // Valid ECDSA-P256 signature for `kTestMessage`.
-static const sigverify_ecdsa_p256_buffer_t kEcdsaSignature = {
-    .data = {0x4811545a, 0x088d927b, 0x5d8624b5, 0x2ef1f329, 0x184ba14a,
-             0xf655eede, 0xaaed0d54, 0xa20e1ac7, 0x729b945d, 0x181dc116,
-             0x1025dba4, 0xb99828a0, 0xe7225df3, 0x0e200e9b, 0x785690b4,
-             0xf47efe98},
+static const ecdsa_p256_signature_t kEcdsaSignature = {
+    .r =
+        {
+            0x4811545a,
+            0x088d927b,
+            0x5d8624b5,
+            0x2ef1f329,
+            0x184ba14a,
+            0xf655eede,
+            0xaaed0d54,
+            0xa20e1ac7,
+        },
+    .s =
+        {
+            0x729b945d,
+            0x181dc116,
+            0x1025dba4,
+            0xb99828a0,
+            0xe7225df3,
+            0x0e200e9b,
+            0x785690b4,
+            0xf47efe98,
+        },
 };
 
-static const sigverify_ecdsa_p256_buffer_t kEcdsaSignatureBad = {
-    .data = {0x481154ff, 0x088d92ff, 0x5d8624b5, 0x2ef1f329, 0x184ba14a,
-             0xf655eede, 0xaaed0d54, 0xa20e1ac7, 0x729b945d, 0x181dc116,
-             0x1025dba4, 0xb99828a0, 0xe7225df3, 0x0e200e9b, 0x785690b4,
-             0xf47efe98},
+static const ecdsa_p256_signature_t kEcdsaSignatureBad = {
+    .r =
+        {
+            0x481154ff,
+            0x088d92ff,
+            0x5d8624b5,
+            0x2ef1f329,
+            0x184ba14a,
+            0xf655eede,
+            0xaaed0d54,
+            0xa20e1ac7,
+        },
+    .s =
+        {
+            0x729b945d,
+            0x181dc116,
+            0x1025dba4,
+            0xb99828a0,
+            0xe7225df3,
+            0x0e200e9b,
+            0x785690b4,
+            0xf47efe98,
+        },
 };
 
 rom_error_t ecdsa_p256_verify_ok_test(void) {
@@ -50,8 +104,8 @@ rom_error_t ecdsa_p256_verify_ok_test(void) {
 rom_error_t ecdsa_p256_verify_negative_test(void) {
   uint32_t flash_exec = 0;
   // Signature verification should fail when using the wrong signature.
-  if (sigverify_ecdsa_p256_verify(&kEcdsaSignature, &kEcdsaSignatureBad,
-                                  &digest, &flash_exec) == kErrorOk) {
+  if (sigverify_ecdsa_p256_verify(&kEcdsaSignatureBad, &kEcdsaKey, &digest,
+                                  &flash_exec) == kErrorOk) {
     return kErrorUnknown;
   }
   CHECK(flash_exec == UINT32_MAX);

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -109,7 +109,7 @@ static hmac_digest_t tpm_endorsement_key_id;
 static hmac_digest_t tpm_pubkey_id;
 static dice_cert_key_id_pair_t tpm_key_ids = {
     .endorsement = &tpm_endorsement_key_id, .cert = &tpm_pubkey_id};
-static attestation_public_key_t curr_pubkey = {.x = {0}, .y = {0}};
+static ecdsa_p256_public_key_t curr_pubkey = {.x = {0}, .y = {0}};
 static manuf_certs_t tbs_certs = {
     .uds_tbs_certificate = {0},
     .uds_tbs_certificate_size = kUdsMaxTbsSizeBytes,

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -256,7 +256,7 @@ static rom_error_t rom_verify(const manifest_t *manifest,
   // Load secure boot keys from OTP into RAM.
   HARDENED_RETURN_IF_ERROR(sigverify_otp_keys_init(&sigverify_ctx));
   // ECDSA key.
-  const sigverify_ecdsa_p256_buffer_t *ecdsa_key = NULL;
+  const ecdsa_p256_public_key_t *ecdsa_key = NULL;
   HARDENED_RETURN_IF_ERROR(sigverify_ecdsa_p256_key_get(
       &sigverify_ctx,
       sigverify_ecdsa_p256_key_id_get(&manifest->ecdsa_public_key), lc_state,

--- a/sw/device/silicon_creator/rom/sigverify_key_types.h
+++ b/sw/device/silicon_creator/rom/sigverify_key_types.h
@@ -139,15 +139,15 @@ typedef struct sigverify_rom_ecdsa_p256_key_entry {
   /**
    * An ECDSA P256 public key.
    */
-  sigverify_ecdsa_p256_buffer_t key;
+  ecdsa_p256_public_key_t key;
 } sigverify_rom_ecdsa_p256_key_entry_t;
 OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key_type, 0);
-OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key.data[0], 4);
+OT_ASSERT_MEMBER_OFFSET(sigverify_rom_ecdsa_p256_key_entry_t, key.x[0], 4);
 static_assert(offsetof(sigverify_rom_key_header_t, key_type) ==
                   offsetof(sigverify_rom_ecdsa_p256_key_entry_t, key_type),
               "Invalid key_type offset.");
 static_assert(offsetof(sigverify_rom_key_header_t, key_id) ==
-                  offsetof(sigverify_rom_ecdsa_p256_key_entry_t, key.data[0]),
+                  offsetof(sigverify_rom_ecdsa_p256_key_entry_t, key.x[0]),
               "Invalid key_id offset.");
 
 /**

--- a/sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.c
+++ b/sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.c
@@ -10,7 +10,7 @@
 
 rom_error_t sigverify_ecdsa_p256_key_get(
     const sigverify_otp_key_ctx_t *sigverify_ctx, uint32_t key_id,
-    lifecycle_state_t lc_state, const sigverify_ecdsa_p256_buffer_t **key) {
+    lifecycle_state_t lc_state, const ecdsa_p256_public_key_t **key) {
   *key = NULL;
   rom_error_t error = kErrorSigverifyBadEcdsaKey;
 

--- a/sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.h
+++ b/sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.h
@@ -32,7 +32,7 @@ extern "C" {
 OT_WARN_UNUSED_RESULT
 rom_error_t sigverify_ecdsa_p256_key_get(
     const sigverify_otp_key_ctx_t *sigverify_ctx, uint32_t key_id,
-    lifecycle_state_t lc_state, const sigverify_ecdsa_p256_buffer_t **key);
+    lifecycle_state_t lc_state, const ecdsa_p256_public_key_t **key);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -44,6 +44,7 @@
 #include "sw/device/silicon_creator/lib/ownership/ownership.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_unlock.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 #include "sw/device/silicon_creator/lib/sigverify/rsa_verify.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
 #include "sw/device/silicon_creator/rom_ext/rescue.h"
@@ -100,7 +101,7 @@ static dice_cert_key_id_pair_t cdi_1_key_ids = {
     .endorsement = &cdi_0_pubkey_id,
     .cert = &cdi_1_pubkey_id,
 };
-static attestation_public_key_t curr_attestation_pubkey = {.x = {0}, .y = {0}};
+static ecdsa_p256_public_key_t curr_attestation_pubkey = {.x = {0}, .y = {0}};
 static uint8_t cdi_0_cert[kCdi0MaxCertSizeBytes] = {0};
 static uint8_t cdi_1_cert[kCdi1MaxCertSizeBytes] = {0};
 


### PR DESCRIPTION
Align secure boot and attestation implementations to use the same ECDSA types.

Part of https://github.com/lowRISC/opentitan/issues/22134. 
