### PR TITLE
[dv,flash_ctrl] Avoid double writes in flash_ctrl_rw_evict_vseq

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/README.md.tpl
+++ b/hw/ip_templates/flash_ctrl/dv/README.md.tpl
@@ -99,9 +99,9 @@ Some of the most commonly used tasks / functions are as follows: From `hw/top_${
 * do_direct_read
   Task to read flash from the host interface. Transaction size is 4 byte per transaction.
 * flash_ctrl_intr_read
-  Task to program flash with interrupt mode.
-* flash_ctrl_intr_write
   Task to read flash with interrupt mode.
+* flash_ctrl_intr_write
+  Task to program flash with interrupt mode.
 * send_rma_req
   Task to initiate rma request. Once rma started, task polls `rma ack` until it completes.
 

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -926,7 +926,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     item.clear_qs();
   endfunction
 
-  // Create bit error follwing flash_op and  ecc_mode.
+  // Create bit error following flash_op and ecc_mode.
   // @caller : 0 controller,  1: host
   virtual function void add_bit_err(flash_op_t flash_op, read_task_e caller = ReadTaskCtrl,
                             flash_otf_item item = null);

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Starting from 2 busword (4byte), increases by 2 words each round
+// To avoid program window violation, word size never exceeeds 16.
 class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_write_word_sweep_vseq)
   `uvm_object_new

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/README.md
@@ -99,9 +99,9 @@ Some of the most commonly used tasks / functions are as follows: From `hw/top_ea
 * do_direct_read
   Task to read flash from the host interface. Transaction size is 4 byte per transaction.
 * flash_ctrl_intr_read
-  Task to program flash with interrupt mode.
-* flash_ctrl_intr_write
   Task to read flash with interrupt mode.
+* flash_ctrl_intr_write
+  Task to program flash with interrupt mode.
 * send_rma_req
   Task to initiate rma request. Once rma started, task polls `rma ack` until it completes.
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -926,7 +926,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     item.clear_qs();
   endfunction
 
-  // Create bit error follwing flash_op and  ecc_mode.
+  // Create bit error following flash_op and ecc_mode.
   // @caller : 0 controller,  1: host
   virtual function void add_bit_err(flash_op_t flash_op, read_task_e caller = ReadTaskCtrl,
                             flash_otf_item item = null);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Starting from 2 busword (4byte), increases by 2 words each round
+// To avoid program window violation, word size never exceeeds 16.
 class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_write_word_sweep_vseq)
   `uvm_object_new


### PR DESCRIPTION
The addresses to be programmed cannot repeat to avoid integrity errors.
Fix doc or comment typos in a separate independent commit.

Fixes #23681