### PR TITLE
[dv,usbdev] Testing of inter-packet delays

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -771,7 +771,7 @@
             - Verify that the packet is received, decoded correctly and ACKnowledged by the DUT.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_min_inter_pkt_delay"]
     }
     {
       name: max_inter_pkt_delay
@@ -784,7 +784,7 @@
             - Verify that the packet is received, decoded correctly and ACKnowledged by the DUT.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_max_inter_pkt_delay"]
     }
     {
       name: device_timeout_missing_host_handshake

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
@@ -144,11 +144,14 @@ class usbdev_max_usb_traffic_vseq extends usbdev_base_vseq;
       // Choose the packet length and content pseudo-randomly.
       send_prnd_out_packet(ep, exp_out_toggle[ep] ? PidTypeData1 : PidTypeData0,
                            1'b1, 0, ep_iso_enabled[ep]);
-      inter_packet_delay();
     end
     // Check that the packet was accepted (ACKnowledged) by the USB device.
     // An Isochronous endpoint returns no handshake and no data toggle bit, so do not wait.
-    if (!ep_iso_enabled[ep]) begin
+    if (ep_iso_enabled[ep]) begin
+      // Ensure a sufficient gap before the next transaction.
+      // TODO: this should probably be guaranteed within the driver.
+      inter_packet_delay();
+    end else begin
       check_response_matches(PidTypeAck);
       // Packet successfully received and ACKnowledged; flip the data toggle.
       exp_out_toggle[ep] ^= 1'b1;

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -124,6 +124,16 @@
       uvm_test_seq: usbdev_max_usb_traffic_vseq
     }
     {
+      name: usbdev_min_inter_pkt_delay
+      uvm_test_seq: usbdev_streaming_vseq
+      run_opts: ["+setup_data_delay=8", "+out_data_delay=8"]
+    }
+    {
+      name: usbdev_max_inter_pkt_delay
+      uvm_test_seq: usbdev_streaming_vseq
+      run_opts: ["+setup_data_delay=26", "+out_data_delay=26"]
+    }
+    {
       name: usbdev_nak_trans
       uvm_test_seq: usbdev_nak_trans_vseq
     }


### PR DESCRIPTION
Ensure that minimum and maximmum inter-packet delays are exercised by introducing the ability to set these delays explicitly on existing sequences rather than have them randomized.