### PR TITLE
[otbn] Mark verification stage as V2S

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -35,7 +35,7 @@
           version:            "1.0.0",
           life_stage:         "L1",
           design_stage:       "D2S",
-          verification_stage: "V2",
+          verification_stage: "V2S",
           dif_stage:          "S2",
           commit_id:          "a6b908283fccba3f8b6b44052c6ad87276dc21e8",
           notes:              ""


### PR DESCRIPTION
This follows the discussion on issue #22077.

Fixes #22077.