### PR TITLE
[edn] Move EDN version 2.0.0 verification_stage to V2S

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -20,7 +20,7 @@
   version:            "2.0.0",
   life_stage:         "L1",
   design_stage:       "D2S",
-  verification_stage: "V1",
+  verification_stage: "V2S",
   dif_stage:          "S2",
   clocking: [{clock: "clk_i", reset: "rst_ni"}],
   bus_interfaces: [


### PR DESCRIPTION
This resolves lowRISC/OpenTitan#22468.