### PR TITLE
[sw] Remove `device_id` checks from spi host tests

### DIFF
--- a/sw/device/tests/pmod/spi_host_gigadevice1Gb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_gigadevice1Gb_flash_test.c
@@ -80,7 +80,6 @@ bool test_main(void) {
    * the Quad SPI.
    */
   enum GigadeviceVendorSpecific {
-    kDeviceId = 0x1b47,
     kManufactureId = 0xC8,
     kPageQuadProgramOpcode = 0xC2,
   };
@@ -89,7 +88,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_software_reset, &spi_host);
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
-  EXECUTE_TEST(result, test_read_jedec, &spi_host, kDeviceId, kManufactureId);
+  EXECUTE_TEST(result, test_read_jedec, &spi_host, kManufactureId);
   EXECUTE_TEST(result, test_page_program, &spi_host);
   if (is_4_bytes_address_mode_supported()) {
     EXECUTE_TEST(result, test_4bytes_address, &spi_host);

--- a/sw/device/tests/pmod/spi_host_gigadevice256Mb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_gigadevice256Mb_flash_test.c
@@ -72,7 +72,6 @@ bool test_main(void) {
 
   init_test(&spi_host);
   enum GigadeviceVendorSpecific {
-    kDeviceId = 0x1940,
     kManufactureId = 0xC8,
     kPageQuadProgramOpcode = 0x32,
   };
@@ -81,7 +80,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_software_reset, &spi_host);
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
-  EXECUTE_TEST(result, test_read_jedec, &spi_host, kDeviceId, kManufactureId);
+  EXECUTE_TEST(result, test_read_jedec, &spi_host, kManufactureId);
   EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
   EXECUTE_TEST(result, test_page_program, &spi_host);
   if (is_4_bytes_address_mode_supported()) {

--- a/sw/device/tests/pmod/spi_host_macronix_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_macronix_flash_test.c
@@ -70,7 +70,6 @@ bool test_main(void) {
 
   init_test(&spi_host);
   enum MacronixVendorSpecific {
-    kDeviceId = 0x1B20,
     kManufactureId = 0xC2,
     kPageQuadProgramOpcode = 0x38,
   };
@@ -79,7 +78,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_software_reset, &spi_host);
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
-  EXECUTE_TEST(result, test_read_jedec, &spi_host, kDeviceId, kManufactureId);
+  EXECUTE_TEST(result, test_read_jedec, &spi_host, kManufactureId);
   EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
   EXECUTE_TEST(result, test_page_program, &spi_host);
   if (is_4_bytes_address_mode_supported()) {

--- a/sw/device/tests/pmod/spi_host_micron512Mb_flash_test.c
+++ b/sw/device/tests/pmod/spi_host_micron512Mb_flash_test.c
@@ -79,7 +79,6 @@ bool test_main(void) {
    * here.
    */
   enum MicronVendorSpecific {
-    kDeviceId = 0x20ba,
     kManufactureId = 0x20,
   };
 
@@ -87,7 +86,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_software_reset, &spi_host);
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
-  EXECUTE_TEST(result, test_read_jedec, &spi_host, kDeviceId, kManufactureId);
+  EXECUTE_TEST(result, test_read_jedec, &spi_host, kManufactureId);
   EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
   EXECUTE_TEST(result, test_page_program, &spi_host);
   if (is_4_bytes_address_mode_supported()) {

--- a/sw/device/tests/spi_host_flash_test_impl.c
+++ b/sw/device/tests/spi_host_flash_test_impl.c
@@ -65,12 +65,9 @@ status_t test_read_sfdp(dif_spi_host_t *spi) {
   return OK_STATUS();
 }
 
-status_t test_read_jedec(dif_spi_host_t *spi, uint16_t device_id,
-                         uint8_t manufacture_id) {
+status_t test_read_jedec(dif_spi_host_t *spi, uint8_t manufacture_id) {
   spi_flash_testutils_jedec_id_t jdec;
   TRY(spi_flash_testutils_read_id(spi, &jdec));
-  TRY_CHECK(jdec.device_id == device_id, "Expected %x, got %x!", device_id,
-            jdec.device_id);
   TRY_CHECK(jdec.manufacturer_id == manufacture_id, "Expected %x, got %x!",
             manufacture_id, jdec.manufacturer_id);
   return OK_STATUS();

--- a/sw/device/tests/spi_host_flash_test_impl.h
+++ b/sw/device/tests/spi_host_flash_test_impl.h
@@ -41,8 +41,7 @@ status_t test_sector_erase(dif_spi_host_t *spi);
  * @param manufacture_id The expected manufacture_id.
  * @return status_t containing either OK or an error.
  */
-status_t test_read_jedec(dif_spi_host_t *spi, uint16_t device_id,
-                         uint16_t manufacture_id);
+status_t test_read_jedec(dif_spi_host_t *spi, uint16_t manufacture_id);
 
 /**
  * Send the enable quad mode command.

--- a/sw/device/tests/spi_host_winbond_flash_test.c
+++ b/sw/device/tests/spi_host_winbond_flash_test.c
@@ -30,10 +30,8 @@ bool test_main(void) {
   CHECK_DIF_OK(dif_spi_host_init(
       mmio_region_from_addr(TOP_EARLGREY_SPI_HOST0_BASE_ADDR), &spi_host));
 
-  uint16_t device_id = 0x2180;
   uint32_t spi_speed = 10000000;  // 10MHz
   if (kDeviceType == kDeviceSilicon) {
-    device_id = 0x1870;
     spi_speed = 16000000;  // 16MHz
 
     dif_pinmux_t pinmux;
@@ -78,7 +76,7 @@ bool test_main(void) {
   EXECUTE_TEST(result, test_software_reset, &spi_host);
   EXECUTE_TEST(result, test_read_sfdp, &spi_host);
   EXECUTE_TEST(result, test_sector_erase, &spi_host);
-  EXECUTE_TEST(result, test_read_jedec, &spi_host, device_id, kManufactureId);
+  EXECUTE_TEST(result, test_read_jedec, &spi_host, kManufactureId);
   EXECUTE_TEST(result, test_enable_quad_mode, &spi_host);
   EXECUTE_TEST(result, test_page_program, &spi_host);
   if (is_4_bytes_address_mode_supported()) {


### PR DESCRIPTION
We would like more flexibility to change flash parts in CI without breaking these tests.

Removed the `device_id` check, but retain the manufacturer ID check.

I have not checked for `0x00` or `0xff` as signs of failure since these are legitimate device IDs.