### PR TITLE
[rom] Extend HMAC driver.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -65,11 +65,36 @@ inline void hmac_sha256_init(void) { hmac_sha256_init_endian(false); }
 void hmac_sha256_update(const void *data, size_t len);
 
 /**
+ * Sends `len` 32-bit words from `data` to the SHA2-256 function.
+ *
+ * This function does not check for the size of the available HMAC
+ * FIFO. Since the this function is meant to run in blocking mode,
+ * polling for FIFO status is equivalent to stalling on FIFO write.
+ *
+ * @param data Buffer to copy data from.
+ * @param len Size of the `data` buffer in words.
+ */
+void hmac_sha256_update_words(const uint32_t *data, size_t len);
+
+/**
+ * Finalizes SHA256 operation and copies truncated output.
+ *
+ * Copies only the first `len` 32-bit words of the digest. The caller must
+ * ensure enough space is available in the buffer.
+ *
+ * @param[out] digest Buffer to copy digest to.
+ * @param[out] len Requested word-length.
+ */
+void hmac_sha256_final_truncated(uint32_t *digest, size_t len);
+
+/**
  * Finalizes SHA256 operation and writes `digest` buffer.
  *
  * @param[out] digest Buffer to copy digest to.
  */
-void hmac_sha256_final(hmac_digest_t *digest);
+inline void hmac_sha256_final(hmac_digest_t *digest) {
+  hmac_sha256_final_truncated(digest->digest, ARRAYSIZE(digest->digest));
+}
 
 /**
  * Convenience function for computing the SHA-256 digest of a contiguous buffer.

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -64,6 +64,22 @@ rom_error_t hmac_test(void) {
   return kErrorOk;
 }
 
+rom_error_t hmac_truncated_test(void) {
+  uint32_t digest[3];
+  hmac_sha256_init();
+  hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1);
+  hmac_sha256_final_truncated(digest, ARRAYSIZE(digest));
+
+  const size_t len = ARRAYSIZE(digest);
+  for (int i = 0; i < len; ++i) {
+    LOG_INFO("word %d = 0x%08x", i, digest[i]);
+    if (digest[i] != kGettysburgDigest[i]) {
+      return kErrorUnknown;
+    }
+  }
+  return kErrorOk;
+}
+
 rom_error_t hmac_bigendian_test(void) {
   uint32_t result[8];
   hexstr_decode(&result, sizeof(result), kGettysburgDigestBigEndian);
@@ -83,11 +99,32 @@ rom_error_t hmac_bigendian_test(void) {
   return kErrorOk;
 }
 
+rom_error_t hmac_bigendian_truncated_test(void) {
+  uint32_t result[8];
+  hexstr_decode(&result, sizeof(result), kGettysburgDigestBigEndian);
+
+  hmac_sha256_init_endian(true);
+  hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1);
+  uint32_t digest[3];
+  hmac_sha256_final_truncated(digest, ARRAYSIZE(digest));
+
+  const size_t len = ARRAYSIZE(digest);
+  for (int i = 0; i < len; ++i) {
+    LOG_INFO("word %d = 0x%08x", i, digest[i]);
+    if (digest[i] != result[i]) {
+      return kErrorUnknown;
+    }
+  }
+  return kErrorOk;
+}
+
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
   status_t result = OK_STATUS();
   EXECUTE_TEST(result, hmac_test);
+  EXECUTE_TEST(result, hmac_truncated_test);
   EXECUTE_TEST(result, hmac_bigendian_test);
+  EXECUTE_TEST(result, hmac_bigendian_truncated_test);
   return status_ok(result);
 }


### PR DESCRIPTION
Add functions for truncated digests and word-aligned input.

This is helpful for SHA2-based SPHINCS+, particularly the word-aligned version of update. Without it, the average of 10 runs is `1739904` cycles, but with the word-aligned update it's `1476997` cycles, so I think the small amount of code size here is worthwhile.