### PR TITLE
[rom] Implement and test MGF1 and SHA2-based thash.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
@@ -69,7 +69,6 @@ cc_library(
     ],
 )
 
-
 cc_library(
     name = "thash",
     srcs = ["thash_shake_simple.c"],

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/BUILD
@@ -60,6 +60,17 @@ cc_library(
 )
 
 cc_library(
+    name = "sha2",
+    srcs = ["sha2.c"],
+    hdrs = ["sha2.h"],
+    deps = [
+        ":params",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+    ],
+)
+
+
+cc_library(
     name = "thash",
     srcs = ["thash_shake_simple.c"],
     hdrs = ["thash.h"],

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h
@@ -47,6 +47,10 @@ enum {
    */
   kSpxWotsW = 16,
   /**
+   * Whether SHA-512 is required (boolean).
+   */
+  kSpxSha512 = 0,
+  /**
    * Number of bytes in a hypertree address (for clarity).
    */
   kSpxAddrBytes = 32,

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.c
@@ -1,6 +1,9 @@
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/7ec789ace6874d875f4bb84cb61b81155398167e/ref/sha2.c
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.c
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+
+void mgf1_sha256(const uint32_t *in, size_t in_len, size_t out_len,
+                 uint32_t *out) {
+  // Append SHA256(in || counter) to the output until the requested length is
+  // reached.
+  for (uint32_t ctr = 0; ctr * kHmacDigestNumWords < out_len; ctr++) {
+    hmac_sha256_init_endian(/*big_endian=*/true);
+    hmac_sha256_update_words(in, in_len);
+    uint32_t ctr_be = __builtin_bswap32(ctr);
+    hmac_sha256_update_words(&ctr_be, 1);
+    // If the remaining output needed is less than the full digest size,
+    // truncate.
+    size_t digest_words =
+        (out_len <= kHmacDigestNumWords) ? out_len : kHmacDigestNumWords;
+    hmac_sha256_final_truncated(out, digest_words);
+    out += digest_words;
+  }
+}

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.h
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/7ec789ace6874d875f4bb84cb61b81155398167e/ref/sha2.h
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_SHA2_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_SHA2_H_
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+
+static_assert(kSpxSha512 == 0,
+              "Parameter sets requiring SHA-512 are not supported.");
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  /**
+   * Number of bytes in the SHA256 block size (512 bits).
+   */
+  kSpxSha2BlockNumBytes = 512 / 8,
+  /**
+   * Number of words in the SHA256 block size.
+   */
+  kSpxSha2BlockNumWords = kSpxSha2BlockNumBytes / sizeof(uint32_t),
+  /**
+   * Total number of bytes in the SHA256 address representation.
+   */
+  kSpxSha256AddrBytes = 22,
+};
+
+/**
+ * Mask-generation function (MGF1) using SHA256.
+ *
+ * MGF1 is defined in IETF RFC 8017, section B.2.1. Its inputs are a seed and a
+ * length, and it produces a mask value of that length from the seed using an
+ * underlying hash function (SHA256 in this case).
+ *
+ * The input and output buffers are allowed to overlap in any configuration.
+ *
+ * @param in Input buffer.
+ * @param in_len Input buffer length in 32-bit words.
+ * @param out_len Requested output length in 32-bit words.
+ * @param[out] out Output buffer.
+ */
+void mgf1_sha256(const uint32_t *in, size_t in_len, size_t out_len,
+                 uint32_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_SIGVERIFY_SPHINCSPLUS_SHA2_H_

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
@@ -43,6 +43,26 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "mgf1_test",
+    srcs = ["mgf1_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/sigverify/sphincsplus:sha2",
+    ],
+)
+
 py_binary(
     name = "sphincsplus_set_testvectors",
     srcs = ["sphincsplus_set_testvectors.py"],
@@ -67,7 +87,6 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         },
     ),

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
@@ -63,6 +63,30 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "thash_test",
+    srcs = ["thash_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:profile",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/sigverify/sphincsplus:context",
+        "//sw/device/silicon_creator/lib/sigverify/sphincsplus:hash",
+        "//sw/device/silicon_creator/lib/sigverify/sphincsplus:thash",
+    ],
+)
+
 py_binary(
     name = "sphincsplus_set_testvectors",
     srcs = ["sphincsplus_set_testvectors.py"],

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
@@ -22,7 +22,12 @@ package(default_visibility = ["//visibility:public"])
 opentitan_test(
     name = "fors_test",
     srcs = ["fors_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),
@@ -62,6 +67,7 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         },
     ),
@@ -81,7 +87,12 @@ opentitan_test(
 opentitan_test(
     name = "wots_test",
     srcs = ["wots_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+        },
+    ),
     verilator = verilator_params(
         timeout = "long",
     ),

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/mgf1_test.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/mgf1_test.c
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Length of runtime input and output for SPX+ verify with sha2-128s parameter
+// set.
+enum {
+  kMgf1OutputWords = 8,
+  kMgf1InputWords = 16,
+};
+
+// Test input, same length as runtime input for SPX+ verify.
+static const uint32_t kTestInput[kMgf1InputWords] = {
+    0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c, 0x13121110, 0x17161514,
+    0x1b1a1918, 0x1f1e1d1c, 0x23222120, 0x27262524, 0x2b2a2928, 0x2f2e2d2c,
+    0x33323130, 0x37363534, 0x3b3a3938, 0x3f3e3d3c,
+};
+
+// Expected result, generated with PyCryptoDome as follows:
+// >>> from Crypto.Signature.pss import MGF1
+// >>> from Crypto.Hash import SHA256
+// >>> x = bytearray([i for i in range(0x40)])
+// >>> MGF1(x, 32, SHA256).hex()
+// '926a33148745e412d1b93cfd3829786181935e93ebabb9ae5d42222fd2dfc8a2'
+static const uint32_t kExpectedOutput[kMgf1OutputWords] = {
+    0x14336a92, 0x12e44587, 0xfd3cb9d1, 0x61782938,
+    0x935e9381, 0xaeb9abeb, 0x2f22425d, 0xa2c8dfd2,
+};
+
+OT_WARN_UNUSED_RESULT
+static rom_error_t mgf1_test(void) {
+  uint32_t actual_output[kMgf1OutputWords];
+  mgf1_sha256(kTestInput, ARRAYSIZE(kTestInput), ARRAYSIZE(actual_output),
+              actual_output);
+  CHECK_ARRAYS_EQ(actual_output, kExpectedOutput, ARRAYSIZE(kExpectedOutput));
+  return kErrorOk;
+}
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+  EXECUTE_TEST(result, mgf1_test);
+  return status_ok(result);
+}

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/thash_test.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/thash_test.c
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h"
+
+#include <stdint.h>
+
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/hash.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Test message. Size should always be a multiple of kSpxNWords.
+static uint32_t kTestMsg[2 * kSpxNWords] = {
+    0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c,
+    0x13121110, 0x17161514, 0x1b1a1918, 0x1f1e1d1c,
+};
+
+// Test context.
+static spx_ctx_t kTestCtx = {
+    .pub_seed =
+        {
+            0x23222120,
+            0x27262524,
+            0x2b2a2928,
+            0x2f2e2d2c,
+        },
+};
+
+// Test address. Populate before using.
+static spx_addr_t kTestAddr = {.addr = {0}};
+
+// This test data was generated using a third-party implementation of SPHINCS+
+// (slh-dsa-py).
+static uint32_t kExpectedResult[kSpxNWords] = {
+    0xe8aa6964,
+    0xea613de3,
+    0x6a8c1960,
+    0x657b7527,
+};
+
+OT_WARN_UNUSED_RESULT
+static rom_error_t thash_test(void) {
+  RETURN_IF_ERROR(spx_hash_initialize(&kTestCtx));
+
+  size_t msg_blocks = sizeof(kTestMsg) / kSpxN;
+  uint32_t result[kSpxNWords];
+  RETURN_IF_ERROR(thash(kTestMsg, msg_blocks, &kTestCtx, &kTestAddr, result));
+
+  CHECK_ARRAYS_EQ(result, kExpectedResult, kSpxNWords);
+  return kErrorOk;
+}
+
+bool test_main(void) {
+  status_t result = OK_STATUS();
+
+  spx_addr_layer_set(&kTestAddr, 0xa3);
+  spx_addr_tree_set(&kTestAddr, 0xafaeadacabaaa9a8);
+  spx_addr_type_set(&kTestAddr, kSpxAddrTypeForsTree);
+  spx_addr_keypair_set(&kTestAddr, 0xb4b5b6b7);
+
+  EXECUTE_TEST(result, thash_test);
+  return status_ok(result);
+}

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_sha2_simple.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_sha2_simple.c
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Derived from code in the SPHINCS+ reference implementation (CC0 license):
+// https://github.com/sphincs/sphincsplus/blob/7ec789ace6874d875f4bb84cb61b81155398167e/ref/thash_sha2_simple.h
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/thash.h"
+
+void thash(const uint32_t *in, size_t inblocks, const spx_ctx_t *ctx,
+           const spx_addr_t *addr, uint32_t *out) {
+  hmac_sha256_init_endian(/*big_endian=*/true);
+  hmac_sha256_update_words(ctx->pub_seed, kSpxNWords);
+  uint32_t padding[kSpxSha2BlockNumWords - kSpxNWords];
+  memset(padding, 0, sizeof(padding));
+  hmac_sha256_update_words(padding, ARRAYSIZE(padding));
+  hmac_sha256_update((unsigned char *)addr->addr, kSpxSha256AddrBytes);
+  hmac_sha256_update_words(in, inblocks * kSpxNWords);
+  hmac_sha256_final_truncated(out, kSpxNWords);
+}


### PR DESCRIPTION
Part of https://github.com/lowRISC/opentitan/issues/23144

These are preliminary steps for SHA2-based SPHINCS+; essentially the changes I can make without actually flipping the switch on the whole implementation. I've added an MGF1 implementation and a SHA2 version of the SPHINCS+ `thash` operation, and tests for both that I created using a known-good third-party implementation.

As a side change, I also added `test_rom` targets for all SPHINCS+ subcomponent tests. I found this useful for debugging, especially since it might be helpful to test SPHINCS+ subcomponents on commits/targets where there are issues with the ROM boot flow.