### PR TITLE
[i2c,dv] I2C cleanups for nack generation tests

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent.core
+++ b/hw/dv/sv/i2c_agent/i2c_agent.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/i2c_device_response_seq.sv: {is_include_file: true}
       - seq_lib/i2c_target_base_seq.sv: {is_include_file: true}
       - seq_lib/i2c_target_may_nack_seq.sv: {is_include_file: true}
+      - seq_lib/i2c_controller_base_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -15,6 +15,8 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   // bit. If 0, perform stretching during the ACK / NACK bit.
   bit stretch_after_ack = 0;
 
+  uvm_event got_nack;
+
   virtual i2c_if  vif;
 
   // Performance Monitoring Variables
@@ -107,6 +109,7 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
 
   function new(string name = "");
     super.new(name);
+    got_nack = new("got_nack");
     start_perf_monitor = new("start_perf_monitor");
     stop_perf_monitor = new("stop_perf_monitor");
   endfunction

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_controller_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_controller_base_seq.sv
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A basic reactive agent sequence which drives a controller transaction, and automatically ends
+// the transaction with a STOP condition if a target NACK is seen in response to any write-byte.
+//
+class i2c_controller_base_seq extends i2c_base_seq;
+  `uvm_object_utils(i2c_controller_base_seq)
+  `uvm_object_new
+
+  virtual task send_controller_txn();
+
+    // Set this bit when the monitor observes a NACK from the target device.
+    bit got_nack;
+
+    // Wait until we get stimulus from the vseq.
+    wait (req_q.size() > 0);
+
+    fork
+      begin
+        // Spawn a task that watches for NACK.
+
+        cfg.got_nack.wait_trigger();
+        `uvm_info(`gfn, "Monitor triggered the 'got_nack' event!", UVM_MEDIUM)
+        got_nack = 1;
+      end
+      begin
+        // Drive the stimulus items, either until all items have been sent or
+        // until we see a NACK from the DUT-Target.
+
+        while (req_q.size() > 0 && !got_nack) begin
+          req = req_q.pop_front();
+          start_item(req);
+          finish_item(req);
+        end
+
+        if (got_nack) begin
+          `uvm_info(`gfn, "Got a NACK, driving a STOP symbol now to end the txn.", UVM_MEDIUM)
+          `uvm_create_obj(REQ, req)
+          req.drv_type = HostStop;
+          start_item(req);
+          finish_item(req);
+        end
+      end
+    join
+
+  endtask
+
+  virtual task send_host_mode_txn();
+    send_controller_txn();
+  endtask
+
+endclass: i2c_controller_base_seq

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_seq_list.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_seq_list.sv
@@ -6,3 +6,4 @@
 `include "i2c_device_response_seq.sv"
 `include "i2c_target_base_seq.sv"
 `include "i2c_target_may_nack_seq.sv"
+`include "i2c_controller_base_seq.sv"

--- a/hw/ip/i2c/dv/env/i2c_reference_model.sv
+++ b/hw/ip/i2c/dv/env/i2c_reference_model.sv
@@ -289,15 +289,13 @@ class i2c_reference_model extends uvm_component;
 
       "acqdata": begin
         i2c_item obs;
-        `uvm_create_obj(i2c_item, obs);
-
         obs = acq2item(data);
-        cfg.rcvd_acq_cnt++;
-
         `uvm_info(`gfn, $sformatf("Pushing obs[%0d] to target_mode_wr_obs_port now!",
                                   obs.tran_id), UVM_MEDIUM)
 
         target_mode_wr_obs_port.write(obs);
+
+        cfg.rcvd_acq_cnt++;
       end
 
       default:;

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -456,6 +456,8 @@ class i2c_scoreboard extends cip_base_scoreboard #(
       cov.sample_i2c_b2b_cg(obs_wr.addr, `gmv(ral.ctrl.enablehost));
     end
 
+    if (!cfg.en_scb) return; // Skip comparison
+
     target_wr_comp(obs_wr, exp_wr);
   endtask: compare_target_write_trans
 
@@ -492,6 +494,8 @@ class i2c_scoreboard extends cip_base_scoreboard #(
     if (cfg.en_cov) begin
       cov.sample_i2c_b2b_cg(obs_rd.addr, `gmv(ral.ctrl.enablehost));
     end
+
+    if (!cfg.en_scb) return; // Skip comparison
 
     obs_rd.pname = "obs_rd";
     exp_rd.pname = "exp_rd";

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -1111,7 +1111,7 @@ class i2c_base_vseq extends cip_base_vseq #(
     repeat(read_data) begin
       // read one entry and compare
       csr_rd(.ptr(ral.acqdata), .value(read_data));
-      `uvm_info("process_acq", $sformatf("acq data %x", read_data), UVM_MEDIUM)
+      `uvm_info("process_acq", $sformatf("acq data %x", read_data), UVM_HIGH)
       // Capture the same read data from 'process_tl_access' sb
       obs = acq2item(read_data);
     end
@@ -1121,7 +1121,12 @@ class i2c_base_vseq extends cip_base_vseq #(
       `uvm_info("process_acq", $sformatf("acq_dbg: sent:%0d rcvd:%0d acq_is_empty",
                                          cfg.sent_acq_cnt, cfg.rcvd_acq_cnt), UVM_HIGH)
     end
-  endtask // read_acq_fifo
+  endtask : read_acq_fifo
+
+  virtual task empty_acqfifo();
+    bit acq_fifo_empty;
+    read_acq_fifo(.read_one(0), .acq_fifo_empty(acq_fifo_empty));
+  endtask : empty_acqfifo
 
   // is_stop: Whether the next symbol is to be a Stop
   function drv_type_e get_ack_nack(bit is_stop = 0);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_acq_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_acq_vseq.sv
@@ -14,6 +14,9 @@ class i2c_target_fifo_reset_acq_vseq extends i2c_target_runtime_base_vseq;
 
     cfg.read_rnd_data = 1;
     seq_runtime_us = 10000;
+
+    // Use a basic Agent sequence that drives all items it is passed.
+    i2c_base_seq::type_id::set_type_override(i2c_target_base_seq::get_type());
   endtask
 
   virtual task body();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_reset_tx_vseq.sv
@@ -15,6 +15,9 @@ class i2c_target_fifo_reset_tx_vseq extends i2c_target_runtime_base_vseq;
     cfg.read_rnd_data = 1;
     cfg.rd_pct = 3;
     seq_runtime_us = 10000;
+
+    // Use a basic Agent sequence that drives all items it is passed.
+    i2c_base_seq::type_id::set_type_override(i2c_target_base_seq::get_type());
   endtask
 
   virtual task body();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_watermarks_acq_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_watermarks_acq_vseq.sv
@@ -35,6 +35,9 @@ class i2c_target_fifo_watermarks_acq_vseq extends i2c_target_runtime_base_vseq;
 
     // Disable ACK-Control mode ('acqstretch' can only be due to acqfull)
     cfg.ack_ctrl_en = 0;
+
+    // Use a basic Agent sequence that drives all items it is passed.
+    i2c_base_seq::type_id::set_type_override(i2c_target_base_seq::get_type());
   endtask: pre_start
 
   virtual task body();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_watermarks_tx_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_fifo_watermarks_tx_vseq.sv
@@ -42,6 +42,9 @@ class i2c_target_fifo_watermarks_tx_vseq extends i2c_target_runtime_base_vseq;
 
     // Disable ACK-Control mode ('acqstretch' can only be due to acqfull)
     cfg.ack_ctrl_en = 0;
+
+    // Use a basic Agent sequence that drives all items it is passed.
+    i2c_base_seq::type_id::set_type_override(i2c_target_base_seq::get_type());
   endtask: pre_start
 
   virtual task body();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_runtime_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_runtime_base_vseq.sv
@@ -62,8 +62,8 @@ class i2c_target_runtime_base_vseq extends i2c_target_smoke_vseq;
 
   // The stimulus sequence that will be run on the agent.
   // Derived testcases can observe the generated stimulus before it is driven by the agent
-  // by examining the items in 'm_i2c_host_seq.req_q' during the start_of_stim_hook().
-  protected i2c_target_base_seq m_i2c_host_seq;
+  // by examining the items in 'm_i2c_controller_seq.req_q' during the start_of_stim_hook().
+  protected i2c_base_seq m_i2c_controller_seq;
 
   ///////////////////
   // CLASS METHODS //
@@ -126,16 +126,16 @@ class i2c_target_runtime_base_vseq extends i2c_target_smoke_vseq;
     // for this test.
     begin
       i2c_item txn_q[$];
-      `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
+      `uvm_create_obj(i2c_base_seq, m_i2c_controller_seq)
       create_txn(txn_q);
-      fetch_txn(txn_q, m_i2c_host_seq.req_q);
+      fetch_txn(txn_q, m_i2c_controller_seq.req_q);
     end
 
     advance_runtime_state(.to(StPreHook));
     wait_for_runtime_state(.await(StStim));
 
     // Run the stimulus sequence on the agent
-    m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
+    m_i2c_controller_seq.start(p_sequencer.i2c_sequencer_h);
     stim_cnt++;
   endtask
 


### PR DESCRIPTION
This PR is a precursor for #23192, split out to hopefully make reviewing a bit easier.

This changeset includes the less interesting stuff, cleanups and utility code to prepare for adding the new testcases in the coming PR. Hopefully each commit is comprehensible on its own. Probably the most interesting and weighty commit is the first, which adds new functionality to the I2C Agent to allow it to run NACK-aware sequences which can, for example, terminate with a stop condition when they observe a Target-driven NACK on the bus. 