### PR TITLE
[otbn,dv] Tidy up RMA handling

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -536,9 +536,9 @@ void ISSWrapper::send_err_escalation(uint32_t err_val, bool lock_immediately) {
   run_command(oss.str(), nullptr);
 }
 
-void ISSWrapper::send_rma_req() {
+void ISSWrapper::set_rma_req(uint8_t rma_req) {
   std::ostringstream oss;
-  oss << "send_rma_req\n";
+  oss << "set_rma_req " << std::hex << "0x" << (int)rma_req << "\n";
   run_command(oss.str(), nullptr);
 }
 

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -138,8 +138,8 @@ struct ISSWrapper {
   // Send an error escalation
   void send_err_escalation(uint32_t err_val, bool lock_immediately);
 
-  // Send RMA request
-  void send_rma_req();
+  // Set the RMA request input
+  void set_rma_req(uint8_t rma_req);
 
   const MirroredRegs &get_mirrored() const { return mirrored_; }
 

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -633,13 +633,13 @@ int OtbnModel::send_err_escalation(svBitVecVal *err_val /* bit [31:0] */,
   return 0;
 }
 
-int OtbnModel::send_rma_req() {
+int OtbnModel::set_rma_req(svBitVecVal *rma_req /* bit [3:0] */) {
   ISSWrapper *iss = ensure_wrapper();
   if (!iss)
     return -1;
 
   try {
-    iss->send_rma_req();
+    iss->set_rma_req(rma_req[0] & 0xf);
   } catch (const std::exception &err) {
     std::cerr << "Error when sending RMA req to ISS: " << err.what() << "\n";
     return -1;
@@ -1056,9 +1056,10 @@ int otbn_model_send_err_escalation(OtbnModel *model,
   return model->send_err_escalation(err_val, lock_immediately);
 }
 
-int otbn_model_send_rma_req(OtbnModel *model) {
+int otbn_model_set_rma_req(OtbnModel *model,
+                           svBitVecVal *rma_req /* bit [3:0] */) {
   assert(model);
-  return model->send_rma_req();
+  return model->set_rma_req(rma_req);
 }
 
 int otbn_model_initial_secure_wipe(OtbnModel *model) {

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -123,8 +123,8 @@ class OtbnModel {
   // Trigger initial secure wipe.
   int initial_secure_wipe();
 
-  // Send RMA request to model.
-  int send_rma_req();
+  // Set RMA request input on model.
+  int set_rma_req(svBitVecVal *rma_req /* bit [3:0] */);
 
   // Disable stack integrity checks
   int disable_stack_check();

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -139,8 +139,9 @@ int otbn_model_send_err_escalation(OtbnModel *model,
                                    svBitVecVal *err_val /* bit [31:0] */,
                                    svBit lock_immediately);
 
-// Trigger RMA request in model
-int otbn_model_send_rma_req(OtbnModel *model);
+// Send an RMA request value to the model
+int otbn_model_set_rma_req(OtbnModel *model,
+                           svBitVecVal *rma_req /* bit [3:0] */);
 
 // Trigger initial secure wipe.
 int otbn_model_initial_secure_wipe(OtbnModel *model);

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -70,7 +70,8 @@ import "DPI-C" function int otbn_model_send_err_escalation(chandle    model,
                                                            bit [31:0] err_val,
                                                            bit        lock_immediately);
 
-import "DPI-C" function int otbn_model_send_rma_req(chandle model);
+import "DPI-C" function int otbn_model_set_rma_req(chandle   model,
+                                                   bit [3:0] rma_req);
 
 import "DPI-C" function int otbn_model_initial_secure_wipe(chandle model);
 

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -41,3 +41,20 @@ class ErrBits(IntEnum):
     LIFECYCLE_ESCALATION = 1 << 22
     FATAL_SOFTWARE = 1 << 23
     MASK = (1 << 24) - 1
+
+
+class LcTx(IntEnum):
+    r'''The same encoding as lc_tx_t in the RTL'''
+    ON = 0b0101
+    OFF = 0b1010
+    INVALID = 0
+
+
+def read_lc_tx_t(value: int) -> LcTx:
+    assert 0 <= value <= 15
+    if value == LcTx.ON:
+        return LcTx.ON
+    elif value == LcTx.OFF:
+        return LcTx.OFF
+    else:
+        return LcTx.INVALID

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -234,6 +234,13 @@ class OTBNSim:
 
         changes = self._on_stall(verbose, fetch_next=False)
 
+        # Correctly handle an RMA request when when we're still waiting to
+        # start by jumping immediately to the LOCKED state
+        if self.state.rma_req == LcTx.ON:
+            self.state.set_fsm_state(FsmState.LOCKED)
+            self.state.ext_regs.write('STATUS',
+                                      Status.LOCKED, True, immediately=True)
+
         # Zero INSN_CNT the cycle after we are told to start
         if self.state.ext_regs.read('INSN_CNT', True) != 0:
             self.state.ext_regs.write('INSN_CNT', 0, True)

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -323,6 +323,13 @@ class OTBNSim:
         if self.state.wipe_cycles > 0:
             self.state.wipe_cycles -= 1
 
+        # Correctly handle an RMA request when we're already wiping by ensuring
+        # we're in the WIPING_BAD state (since we're going to lock when we're
+        # done)
+        if ((self.state.get_fsm_state() == FsmState.WIPING_GOOD and
+             self.state.rma_req == LcTx.ON)):
+            self.state.set_fsm_state(FsmState.WIPING_BAD)
+
         # If something bad happened asynchronously (because of an escalation),
         # we want to finish the secure wipe but accept no further commands.  To
         # this end, turn this into a "wipe because something bad happended".

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -170,8 +170,12 @@ class OTBNSim:
     def _step_idle(self, verbose: bool) -> StepRes:
         '''Step the simulation when OTBN is IDLE or LOCKED'''
         self.state.stop_if_pending_halt()
-        if ((self.state._fsm_state == FsmState.LOCKED and
-             self.state.cycles_in_this_state == 0)):
+
+        # If we are locked then zero the INSN_CNT register. It can never change
+        # again, so we only do the write on the first cycle (to avoid sending a
+        # line to stdout on every cycle)
+        is_locked = self.state._fsm_state == FsmState.LOCKED
+        if is_locked and self.state.cycles_in_this_state == 0:
             self.state.ext_regs.write('INSN_CNT', 0, True)
 
         if self.state.init_sec_wipe_is_running():

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -382,9 +382,10 @@ def on_send_err_escalation(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
-def on_send_rma_req(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
-    check_arg_count('send_rma_req', 0, args)
-    sim.send_rma_req()
+def on_set_rma_req(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('set_rma_req', 1, args)
+    rma_req = read_word('rma_req', args[0], 4)
+    sim.set_rma_req(rma_req)
     return None
 
 
@@ -424,7 +425,7 @@ _HANDLERS = {
     'set_keymgr_value': on_set_keymgr_value,
     'step_crc': on_step_crc,
     'send_err_escalation': on_send_err_escalation,
-    'send_rma_req': on_send_rma_req,
+    'set_rma_req': on_set_rma_req,
     'initial_secure_wipe': on_initial_secure_wipe,
     'set_software_errs_fatal': on_set_software_errs_fatal
 }

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -402,8 +402,12 @@ class otbn_scoreboard extends cip_base_scoreboard #(
             pending_start_tl_trans = 1'b0;
           end
 
-          // Has the status changed to locked? This should be accompanied by a fatal alert
-          if (item.status == otbn_pkg::StatusLocked) begin
+          // Has the status changed to locked? This should be accompanied by a fatal alert unless
+          // this is in response to an RMA request (in which case, we shouldn't see an alert).
+          // Assuming that an RMA request won't be dropped after it takes effect, we can just check
+          // the escalation interface to see whether it is still high.
+          if ((item.status == otbn_pkg::StatusLocked) &&
+              (cfg.escalate_vif.req != lc_ctrl_pkg::On)) begin
             expect_alert("fatal");
           end
           // Has the status changed from executing to idle with a nonzero err_bits?


### PR DESCRIPTION
This is still not beautiful, but the pass rate for the `otbn_escalate` test goes from 80% (last night's run) to `87.5%` (running 24 seeds) and the code now has comments that explain why it thinks it is doing the right thing.

There are careful comments on the individual commits. Clearly, this still isn't quite working right (and there's even a TODO message about an ugly workaround in the simulator), but this is much closer to where we want to be.