### PR TITLE
[manuf] reactivate CP and FT provisioning flows in CI

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -6,7 +6,6 @@ load("//rules:linker.bzl", "ld_library")
 load(
     "//rules/opentitan:defs.bzl",
     "OPENTITAN_CPU",
-    "cw310_params",
     "fpga_params",
     "opentitan_test",
 )
@@ -264,7 +263,6 @@ cc_library(
 opentitan_test(
     name = "personalize_functest",
     srcs = ["personalize_functest.c"],
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:dev_key_0_ecdsa_p256": "dev_key_0"},
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_sival": None,
     },
@@ -273,9 +271,7 @@ opentitan_test(
         data = ["//sw/device/silicon_creator/manuf/keys/fake:rma_unlock_token_export_key.sk_hsm.der"],
         needs_jtag = True,
         otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_dev_manuf_individualized",
-        # TODO(#22823): Remove "broken" tag once the test is fixed.
         tags = [
-            "broken",
             "lc_dev",
             "manuf",
         ],

--- a/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/provisioning_inputs.bzl
@@ -47,6 +47,3 @@ CLOUD_KMS_CERT_ENDORSEMENT_PARAMS = """
   --ca-key-id="0x40aac5fb_2b1205f9_003f40ab_7f3df784_1d5b59f5"
   --ca-certificate="$(rootpath //sw/device/silicon_creator/manuf/keys/fake:ckms_ca.pem)"
 """
-
-# TODO(#22780): Integrate real keys for A1 flows.
-FT_PERSONALIZE_SIGNING_KEYS = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"}

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load(
     "//rules/opentitan:defs.bzl",
-    "cw310_params",
     "fpga_params",
     "opentitan_binary",
     "opentitan_test",
@@ -20,7 +20,6 @@ load(
     "FT_PROVISIONING_INPUTS",
     "LOCAL_CERT_ENDORSEMENT_PARAMS",
 )
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -124,11 +123,7 @@ opentitan_test(
         changes_otp = True,
         needs_jtag = True,
         otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_test_unlocked0_manuf_empty",
-        # TODO(#22823): Remove "broken" tag once the test is fixed.
-        tags = [
-            "broken",
-            "manuf",
-        ],
+        tags = ["manuf"],
         test_cmd = _CP_PROVISIONING_CMD_ARGS,
         test_harness = _CP_PROVISIONING_HARNESS,
     ),
@@ -291,9 +286,7 @@ opentitan_test(
         data = FT_PERSONALIZE_KEYS,
         needs_jtag = True,
         otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_test_locked0_manuf_initialized",
-        # TODO(#22823): Remove "broken" tag once the test is fixed.
         tags = [
-            "broken",
             "lc_test_locked0",
             "manuf",
         ],

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -16,7 +16,6 @@ load(
     "CP_PROVISIONING_INPUTS",
     "EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS",
     "FT_PERSONALIZE_KEYS",
-    "FT_PERSONALIZE_SIGNING_KEYS",
     "FT_PROVISIONING_INPUTS",
     "LOCAL_CERT_ENDORSEMENT_PARAMS",
 )
@@ -211,12 +210,13 @@ opentitan_binary(
     name = "ft_personalize",
     testonly = True,
     srcs = ["ft_personalize.c"],
-    ecdsa_key = FT_PERSONALIZE_SIGNING_KEYS,
+    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:silicon_creator": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/dif:flash_ctrl",


### PR DESCRIPTION
This updates the CP and FT E2E tests to reactivate them in CI (removing the "broken" label). These were temporarily disabled as #22823 was investigated.

Additionally, the FT flow was fixed (a recent PR #23391 enabled SPX+ signing, but a valid key was not specified here).