### PR TITLE
[top, rom_ctrl] Add missing TEST port for ROM macro

### DIFF
--- a/hw/ip/prim/rtl/prim_rom_pkg.sv
+++ b/hw/ip/prim/rtl/prim_rom_pkg.sv
@@ -6,6 +6,7 @@
 package prim_rom_pkg;
 
   typedef struct packed {
+    logic       test;
     logic       cfg_en;
     logic [3:0] cfg;
   } rom_cfg_t;

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -829,8 +829,9 @@ module chip_earlgrey_asic #(
   };
 
   assign rom_cfg = '{
+    test:   ast_rom_cfg.test,
     cfg_en: ast_rom_cfg.marg_en,
-    cfg: ast_rom_cfg.marg
+    cfg:    ast_rom_cfg.marg
   };
 
   // unused cfg bits

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -784,8 +784,9 @@ module chip_earlgrey_cw310 #(
   };
 
   assign rom_cfg = '{
+    test:   ast_rom_cfg.test,
     cfg_en: ast_rom_cfg.marg_en,
-    cfg: ast_rom_cfg.marg
+    cfg:    ast_rom_cfg.marg
   };
 
   // unused cfg bits

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -775,8 +775,9 @@ module chip_earlgrey_cw340 #(
   };
 
   assign rom_cfg = '{
+    test:   ast_rom_cfg.test,
     cfg_en: ast_rom_cfg.marg_en,
-    cfg: ast_rom_cfg.marg
+    cfg:    ast_rom_cfg.marg
   };
 
   // unused cfg bits

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -620,8 +620,9 @@ module chip_${top["name"]}_${target["name"]} #(
   };
 
   assign rom_cfg = '{
+    test:   ast_rom_cfg.test,
     cfg_en: ast_rom_cfg.marg_en,
-    cfg: ast_rom_cfg.marg
+    cfg:    ast_rom_cfg.marg
   };
 
   // unused cfg bits


### PR DESCRIPTION
This is a follow-up of lowRISC/OpenTitan#23547.

This PR supersedes #23716.