### PR TITLE
[sival] Test inverted pads with GPIO

### DIFF
--- a/sw/device/lib/testing/json/command.h
+++ b/sw/device/lib/testing/json/command.h
@@ -27,6 +27,7 @@ extern "C" {
     value(_, MemWrite) \
     value(_, MemWrite32) \
     value(_, PinmuxConfig) \
+    value(_, PinmuxAttrConfig) \
     value(_, SpiConfigureJedecId) \
     value(_, SpiReadStatus) \
     value(_, SpiWaitForUpload) \

--- a/sw/device/lib/testing/json/pinmux_config.c
+++ b/sw/device/lib/testing/json/pinmux_config.c
@@ -12,6 +12,8 @@
 #include "sw/device/lib/testing/json/pinmux_config.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
 status_t pinmux_config(ujson_t *uj, dif_pinmux_t *pinmux) {
   pinmux_config_t config;
   TRY(ujson_deserialize_pinmux_config_t(uj, &config));
@@ -29,6 +31,15 @@ status_t pinmux_config(ujson_t *uj, dif_pinmux_t *pinmux) {
     }
     TRY(dif_pinmux_output_select(pinmux, config.output.mio[i],
                                  config.output.selector[i]));
+  }
+  for (size_t i = 0; i < ARRAYSIZE(config.attrs.mio); ++i) {
+    if (config.attrs.mio[i] == kPinmuxMioOutEnd) {
+      break;
+    }
+    dif_pinmux_pad_attr_t pad_attr = {.flags = config.attrs.flags[i]};
+    dif_pinmux_pad_attr_t attrs_out;
+    TRY(dif_pinmux_pad_write_attrs(pinmux, config.attrs.mio[i],
+                                   kDifPinmuxPadKindMio, pad_attr, &attrs_out));
   }
   return RESP_OK_STATUS(uj);
 }

--- a/sw/device/lib/testing/json/pinmux_config.h
+++ b/sw/device/lib/testing/json/pinmux_config.h
@@ -22,22 +22,26 @@ extern "C" {
 #endif
 // clang-format off
 
+// Derive `Default` on top of the default derives.
+#define RUST_DERIVE RUST_DEFAULT_DERIVE, Default
+
 #define STRUCT_PINMUX_INPUT_SELECTION(field, string) \
     field(peripheral, pinmux_peripheral_in_t, 16)    \
     field(selector, pinmux_insel_t, 16)
 UJSON_SERDE_STRUCT(PinmuxInputSelection, pinmux_input_selection_t,
-                   STRUCT_PINMUX_INPUT_SELECTION);
+                   STRUCT_PINMUX_INPUT_SELECTION, RUST_DERIVE);
 
 #define STRUCT_PINMUX_OUTPUT_SELECTION(field, string) \
     field(mio, pinmux_mio_out_t, 16)                  \
     field(selector, pinmux_outsel_t, 16)
 UJSON_SERDE_STRUCT(PinmuxOutputSelection, pinmux_output_selection_t,
-                   STRUCT_PINMUX_OUTPUT_SELECTION);
+                   STRUCT_PINMUX_OUTPUT_SELECTION, RUST_DERIVE);
 
 #define STRUCT_PINMUX_CONFIG(field, string) \
     field(input, pinmux_input_selection_t)  \
     field(output, pinmux_output_selection_t)
-UJSON_SERDE_STRUCT(PinmuxConfig, pinmux_config_t, STRUCT_PINMUX_CONFIG);
+UJSON_SERDE_STRUCT(PinmuxConfig, pinmux_config_t,
+                   STRUCT_PINMUX_CONFIG, RUST_DERIVE);
 
 #undef MODULE_ID
 

--- a/sw/device/lib/testing/json/pinmux_config.h
+++ b/sw/device/lib/testing/json/pinmux_config.h
@@ -37,9 +37,16 @@ UJSON_SERDE_STRUCT(PinmuxInputSelection, pinmux_input_selection_t,
 UJSON_SERDE_STRUCT(PinmuxOutputSelection, pinmux_output_selection_t,
                    STRUCT_PINMUX_OUTPUT_SELECTION, RUST_DERIVE);
 
-#define STRUCT_PINMUX_CONFIG(field, string) \
-    field(input, pinmux_input_selection_t)  \
-    field(output, pinmux_output_selection_t)
+# define STRUCT_PINMUX_ATTR_CONFIG(field, string) \
+    field(mio, pinmux_mio_out_t, 16)              \
+    field(flags, uint32_t, 16)
+UJSON_SERDE_STRUCT(PinmuxAttrConfig, pinmux_attr_config_t,
+                   STRUCT_PINMUX_ATTR_CONFIG, RUST_DERIVE);
+
+#define STRUCT_PINMUX_CONFIG(field, string)  \
+    field(input, pinmux_input_selection_t)   \
+    field(output, pinmux_output_selection_t) \
+    field(attrs, pinmux_attr_config_t)
 UJSON_SERDE_STRUCT(PinmuxConfig, pinmux_config_t,
                    STRUCT_PINMUX_CONFIG, RUST_DERIVE);
 

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -242,6 +242,7 @@ rust_library(
         "//sw/device:is_english_breakfast": [],
         "//conditions:default": [
             "src/chip/autogen/earlgrey.rs",
+            "src/dif/pinmux.rs",
             "src/test_utils/pinmux_config.rs",
         ],
     }),

--- a/sw/host/opentitanlib/bindgen/BUILD
+++ b/sw/host/opentitanlib/bindgen/BUILD
@@ -106,6 +106,7 @@ rust_bindgen_library(
         "--allowlist-var=OTP_CTRL_.*_SIZE",
         "--allowlist-var=PATTGEN_.*_REG_OFFSET",
         "--allowlist-var=PINMUX_.*_REG_OFFSET",
+        "--allowlist-var=PINMUX_.*_BIT",
         "--allowlist-var=PWM_.*_REG_OFFSET",
         "--allowlist-var=PWRMGR_.*_REG_OFFSET",
         "--allowlist-type=dif_rstmgr_reset_info",

--- a/sw/host/opentitanlib/src/dif/mod.rs
+++ b/sw/host/opentitanlib/src/dif/mod.rs
@@ -8,3 +8,6 @@ pub mod lc_ctrl;
 pub mod otp_ctrl;
 pub mod rstmgr;
 pub mod uart;
+
+#[cfg(not(feature = "english_breakfast"))]
+pub mod pinmux;

--- a/sw/host/opentitanlib/src/dif/pinmux.rs
+++ b/sw/host/opentitanlib/src/dif/pinmux.rs
@@ -6,7 +6,7 @@ use bindgen::dif;
 use bitflags::bitflags;
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct PinmuxPadAttr: u32 {
         const OD_EN = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_OD_EN_1_BIT;
         const SCHMITT_EN = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_SCHMITT_EN_1_BIT;

--- a/sw/host/opentitanlib/src/dif/pinmux.rs
+++ b/sw/host/opentitanlib/src/dif/pinmux.rs
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use bindgen::dif;
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct PinmuxPadAttr: u32 {
+        const OD_EN = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_OD_EN_1_BIT;
+        const SCHMITT_EN = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_SCHMITT_EN_1_BIT;
+        const KEEPER_EN = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_KEEPER_EN_1_BIT;
+        const PULL_SELECT = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_PULL_SELECT_1_BIT;
+        const PULL_EN = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_PULL_EN_1_BIT;
+        const VIRTUAL_OD_EN = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_VIRTUAL_OD_EN_1_BIT;
+        const INVERT = 0b1 << dif::PINMUX_MIO_PAD_ATTR_1_INVERT_1_BIT;
+    }
+}

--- a/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
+++ b/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use anyhow::Result;
 
 use crate::chip::autogen::earlgrey::{PinmuxInsel, PinmuxMioOut, PinmuxOutsel, PinmuxPeripheralIn};
+use crate::dif::pinmux::PinmuxPadAttr;
 use crate::io::uart::Uart;
 use crate::test_utils::e2e_command::TestCommand;
 use crate::test_utils::rpc::{UartRecv, UartSend};
@@ -26,6 +27,7 @@ impl PinmuxConfig {
         uart: &dyn Uart,
         inputs: Option<&HashMap<PinmuxPeripheralIn, PinmuxInsel>>,
         outputs: Option<&HashMap<PinmuxMioOut, PinmuxOutsel>>,
+        attrs: Option<&HashMap<PinmuxMioOut, PinmuxPadAttr>>,
     ) -> Result<()> {
         // The PinmuxConfig struct can carry a limited number of input
         // and output configurations.  We'll take the whole config and
@@ -41,16 +43,23 @@ impl PinmuxConfig {
             .flat_map(HashMap::iter)
             .map(|(&key, &value)| (key, value))
             .collect();
+        let mut attrs: Vec<_> = attrs
+            .into_iter()
+            .flat_map(HashMap::iter)
+            .map(|(&key, &value)| (key, value.bits()))
+            .collect();
 
-        let len = cmp::max(inputs.len(), outputs.len())
+        let len = cmp::max(cmp::max(inputs.len(), outputs.len()), attrs.len())
             .next_multiple_of(CONFIG_CAP);
 
         inputs.resize_with(len, Default::default);
         outputs.resize_with(len, Default::default);
+        attrs.resize_with(len, Default::default);
 
-        while !inputs.is_empty() && !outputs.is_empty() {
+        while !inputs.is_empty() && !outputs.is_empty() && !attrs.is_empty() {
             let (in_peripherals, in_selectors) = inputs.drain(..CONFIG_CAP).unzip();
             let (out_mios, out_selectors) = outputs.drain(..CONFIG_CAP).unzip();
+            let (attr_mios, attr_flags) = attrs.drain(..CONFIG_CAP).unzip();
 
             let config = PinmuxConfig {
                 input: PinmuxInputSelection {
@@ -60,6 +69,10 @@ impl PinmuxConfig {
                 output: PinmuxOutputSelection {
                     mio: out_mios,
                     selector: out_selectors,
+                },
+                attrs: PinmuxAttrConfig {
+                    mio: attr_mios,
+                    flags: attr_flags,
                 },
             };
 

--- a/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
+++ b/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use std::cmp;
 use std::collections::HashMap;
 use std::time::Duration;
+
+use anyhow::Result;
 
 use crate::chip::autogen::earlgrey::{PinmuxInsel, PinmuxMioOut, PinmuxOutsel, PinmuxPeripheralIn};
 use crate::io::uart::Uart;
@@ -16,20 +18,8 @@ use crate::test_utils::status::Status;
 use crate::chip::autogen::earlgrey::ujson_alias::*;
 include!(env!("pinmux_config"));
 
-impl Default for PinmuxConfig {
-    fn default() -> Self {
-        Self {
-            input: PinmuxInputSelection {
-                peripheral: Default::default(),
-                selector: Default::default(),
-            },
-            output: PinmuxOutputSelection {
-                mio: Default::default(),
-                selector: Default::default(),
-            },
-        }
-    }
-}
+/// Capacity of a single configuration message.
+const CONFIG_CAP: usize = 16;
 
 impl PinmuxConfig {
     pub fn configure(
@@ -41,40 +31,43 @@ impl PinmuxConfig {
         // and output configurations.  We'll take the whole config and
         // chunk it into as many PinmuxConfig commands as necessary.
 
-        let len = std::cmp::max(
-            inputs.map(|h| h.len()).unwrap_or(0),
-            outputs.map(|h| h.len()).unwrap_or(0),
-        );
+        let mut inputs: Vec<_> = inputs
+            .into_iter()
+            .flat_map(HashMap::iter)
+            .map(|(&key, &value)| (key, value))
+            .collect();
+        let mut outputs: Vec<_> = outputs
+            .into_iter()
+            .flat_map(HashMap::iter)
+            .map(|(&key, &value)| (key, value))
+            .collect();
 
-        let df_ik = PinmuxPeripheralIn::default();
-        let df_iv = PinmuxInsel::default();
-        let df_ok = PinmuxMioOut::default();
-        let df_ov = PinmuxOutsel::default();
+        let len = cmp::max(inputs.len(), outputs.len())
+            .next_multiple_of(CONFIG_CAP);
 
-        let mut inputs = inputs.map(|h| h.iter());
-        let mut outputs = outputs.map(|h| h.iter());
-        let mut i = 0;
-        while i < len {
-            let mut config = Self::default();
-            for _ in 0..config.input.peripheral.capacity() {
-                let (ik, iv) = inputs
-                    .as_mut()
-                    .and_then(|i| i.next())
-                    .unwrap_or((&df_ik, &df_iv));
-                let (ok, ov) = outputs
-                    .as_mut()
-                    .and_then(|i| i.next())
-                    .unwrap_or((&df_ok, &df_ov));
-                config.input.peripheral.push(*ik);
-                config.input.selector.push(*iv);
-                config.output.mio.push(*ok);
-                config.output.selector.push(*ov);
-                i += 1;
-            }
+        inputs.resize_with(len, Default::default);
+        outputs.resize_with(len, Default::default);
+
+        while !inputs.is_empty() && !outputs.is_empty() {
+            let (in_peripherals, in_selectors) = inputs.drain(..CONFIG_CAP).unzip();
+            let (out_mios, out_selectors) = outputs.drain(..CONFIG_CAP).unzip();
+
+            let config = PinmuxConfig {
+                input: PinmuxInputSelection {
+                    peripheral: in_peripherals,
+                    selector: in_selectors,
+                },
+                output: PinmuxOutputSelection {
+                    mio: out_mios,
+                    selector: out_selectors,
+                },
+            };
+
             TestCommand::PinmuxConfig.send(uart)?;
             config.send(uart)?;
             Status::recv(uart, Duration::from_secs(300), false)?;
         }
+
         Ok(())
     }
 }

--- a/sw/host/tests/chip/gpio/src/main.rs
+++ b/sw/host/tests/chip/gpio/src/main.rs
@@ -2,13 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
-use clap::Parser;
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::time::Duration;
 
+use anyhow::{Context, Result};
+use clap::Parser;
+use once_cell::sync::Lazy;
+
 use opentitanlib::app::TransportWrapper;
+use opentitanlib::dif::pinmux::PinmuxPadAttr;
 use opentitanlib::io::gpio::PinMode;
 use opentitanlib::io::uart::Uart;
 use opentitanlib::test_utils::gpio::{GpioGet, GpioSet};
@@ -316,12 +318,14 @@ fn test_gpio_outputs(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart)
 
     log::info!("Enabling outputs on the DUT");
     GpioSet::set_enabled_all(uart, 0xFFFFFFFF)?;
+
     write_all_verify(transport, uart, 0x5555_5555, 0x5555_5555, &config.output)?;
     write_all_verify(transport, uart, 0xAAAA_AAAA, 0xAAAA_AAAA, &config.output)?;
 
     for i in 0..32 {
         write_all_verify(transport, uart, 1 << i, 1 << i, &config.output)?;
     }
+
     Ok(())
 }
 
@@ -355,6 +359,67 @@ fn test_gpio_inputs(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) 
     Ok(())
 }
 
+fn test_pad_inversion(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) -> Result<()> {
+    let interface = opts.init.backend_opts.interface.as_str();
+    log::info!("Configuring pinmux for {interface}");
+
+    let config = CONFIG
+        .get(interface)
+        .with_context(|| format!("interface '{interface}' is not yet supported"))?;
+
+    let invert_all: HashMap<_, _> = config
+        .output
+        .keys()
+        .map(|&mio| (mio, PinmuxPadAttr::INVERT))
+        .collect();
+
+    log::info!("Configuring pads as inverted inputs");
+    PinmuxConfig::configure(uart, Some(&config.input), None, Some(&invert_all))?;
+
+    log::info!("Configuring debugger GPIOs as outputs");
+    // The inputs (with respect to pinmux config) correspond to the output pins on the debug board.
+    for pin in config.input.values() {
+        transport
+            .gpio_pin(&pin.to_string())?
+            .set_mode(PinMode::PushPull)?;
+    }
+
+    log::info!("Disabling outputs on the DUT");
+    GpioSet::set_enabled_all(uart, 0x0)?;
+
+    log::info!("Testing inverted device inputs");
+    read_all_verify(transport, uart, 0x5555_5555, !0x5555_5555, &config.input)?;
+    read_all_verify(transport, uart, 0xAAAA_AAAA, !0xAAAA_AAAA, &config.input)?;
+
+    for i in 0..32 {
+        read_all_verify(transport, uart, 1 << i, !(1 << i), &config.input)?;
+    }
+
+    log::info!("Configuring pads as inverted outputs");
+    PinmuxConfig::configure(uart, None, Some(&config.output), Some(&invert_all))?;
+
+    log::info!("Configuring debugger GPIOs as inputs");
+    // The outputs (with respect to pinmux config) correspond to the input pins on the debug board.
+    for pin in config.output.keys() {
+        transport
+            .gpio_pin(&pin.to_string())?
+            .set_mode(PinMode::Input)?;
+    }
+
+    log::info!("Enabling outputs on the DUT");
+    GpioSet::set_enabled_all(uart, 0xFFFFFFFF)?;
+
+    log::info!("Testing inverted device outputs");
+    write_all_verify(transport, uart, 0x5555_5555, !0x5555_5555, &config.output)?;
+    write_all_verify(transport, uart, 0xAAAA_AAAA, !0xAAAA_AAAA, &config.output)?;
+
+    for i in 0..32 {
+        write_all_verify(transport, uart, 1 << i, !(1 << i), &config.output)?;
+    }
+
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let opts = Opts::parse();
     opts.init.init_logging();
@@ -366,5 +431,7 @@ fn main() -> Result<()> {
 
     execute_test!(test_gpio_outputs, &opts, &transport, &*uart);
     execute_test!(test_gpio_inputs, &opts, &transport, &*uart);
+    execute_test!(test_pad_inversion, &opts, &transport, &*uart);
+
     Ok(())
 }

--- a/sw/host/tests/chip/gpio/src/main.rs
+++ b/sw/host/tests/chip/gpio/src/main.rs
@@ -305,7 +305,7 @@ fn test_gpio_outputs(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart)
     let config = CONFIG
         .get(opts.init.backend_opts.interface.as_str())
         .expect("interface");
-    PinmuxConfig::configure(uart, None, Some(&config.output))?;
+    PinmuxConfig::configure(uart, None, Some(&config.output), None)?;
 
     log::info!("Configuring debugger GPIOs as inputs");
     // The outputs (with respect to pinmux config) correspond to the input pins on the debug board.
@@ -334,7 +334,7 @@ fn test_gpio_inputs(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) 
     let config = CONFIG
         .get(opts.init.backend_opts.interface.as_str())
         .expect("interface");
-    PinmuxConfig::configure(uart, Some(&config.input), None)?;
+    PinmuxConfig::configure(uart, Some(&config.input), None, None)?;
 
     log::info!("Configuring debugger GPIOs as outputs");
     // The inputs (with respect to pinmux config) correspond to the output pins on the debug board.

--- a/sw/host/tests/chip/gpio_intr/src/main.rs
+++ b/sw/host/tests/chip/gpio_intr/src/main.rs
@@ -216,7 +216,7 @@ fn test_gpio_outputs(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart)
     let config = CONFIG
         .get(opts.init.backend_opts.interface.as_str())
         .expect("interface");
-    PinmuxConfig::configure(uart, Some(&config.input), Some(&config.output))?;
+    PinmuxConfig::configure(uart, Some(&config.input), Some(&config.output), None)?;
 
     log::info!("Configuring debugger GPIOs as inputs");
     // The outputs (with respect to pinmux config) correspond to the input pins on the debug board.
@@ -290,7 +290,7 @@ fn test_gpio_inputs(opts: &Opts, transport: &TransportWrapper, uart: &dyn Uart) 
     let config = CONFIG
         .get(opts.init.backend_opts.interface.as_str())
         .expect("interface");
-    PinmuxConfig::configure(uart, Some(&config.input), None)?;
+    PinmuxConfig::configure(uart, Some(&config.input), None, None)?;
 
     log::info!("Configuring debugger GPIOs as outputs");
     // The inputs (with respect to pinmux config) correspond to the output pins on the debug board.


### PR DESCRIPTION
This PR adds support for `opentitanlib` to configure the pad attributes of the device under test and extends the `gpio_pinmux` test to check inverted pads.

Only MIOs are tested. The DIOs could in theory be tested but it might be a bit harder.