### PR TITLE
[top, pinmux] Update AscentLint waivers

### DIFF
--- a/hw/ip/pinmux/lint/pinmux.waiver
+++ b/hw/ip/pinmux/lint/pinmux.waiver
@@ -33,3 +33,9 @@ waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_strap_sampling.sv} -rege
 
 waive -rules CLOCK_MUX -location {pinmux_strap_sampling.sv pinmux.sv} -regexp {Clock '(in_padring_i\[38\]|mio_in_i\[38\]|jtag_req.tck)' reaches a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "The 'mio_in_i[TckPadIdx]' input signal is connected to 'jtag_req.tck' which eventually feeds into the JTAG Selection Mux."
+
+waive -rules CLOCK_DRIVER -location {pinmux.sv} -regexp {'mio_attr\[28\].pull_select' is driven here, and used as a clock} \
+      -comment "'MioPadIoc6' at index 28 may also serve as an external clock input. The 'pull_select' signal impacts the actual value obtained from the pad simulation model."
+
+waive -rules CLOCK_USE -location {pinmux.sv} -regexp {'hw2reg.mio_pad_attr\[28\].pull_select.d' is connected to 'pinmux_reg_top' port 'hw2reg.mio_pad_attr\[28\].pull_select.d', and used as a clock} \
+      -comment "'MioPadIoc6' at index 28 may also serve as an external clock input. The 'pull_select' signal impacts the actual value obtained from the pad simulation model."

--- a/hw/ip/pinmux/lint/pinmux.waiver
+++ b/hw/ip/pinmux/lint/pinmux.waiver
@@ -20,14 +20,6 @@ waive -rules RESET_USE -location {pinmux_strap_sampling.sv} -regexp {'rst_ni' is
 waive -rules RESET_MUX -location {pinmux_strap_sampling.sv} -regexp {Asynchronous reset 'rst_ni' reaches a multiplexer here, used as a reset at pinmux_strap_sampling} \
       -comment "This is a clock mux for DFT."
 
-# temporary waiver for #15602. This waiver needs to be removed once rst_sys_n is connected in pinmux_strap_sampling
-waive -rules HIER_NET_NOT_READ -location {pinmux.sv} -regexp {.*'rst_sys_ni'.*is not read from.*'} \
-      -comment "Temporary waiver for #15602. This waiver needs to be removed once rst_sys_n is connected in pinmux_strap_sampling"
-
-waive -rules INPUT_NOT_READ -location {pinmux_strap_sampling.sv} -regexp {Input port 'rst_sys_ni' is not read from in module 'pinmux_strap_sampling'} \
-      -comment "Temporary waiver for #15602. This waiver needs to be removed once rst_sys_n is connected in pinmux_strap_sampling"
-'rst_sys_ni' is not read from in module 'pinmux_strap_sampling'
-
 waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_strap_sampling.sv} -regexp {'(lc|rv)_jtag_req.tck' is driven( by a multiplexer)? here,( and)? used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "These signals are muxed using the JTAG Selection Mux."
 

--- a/hw/ip/pinmux/lint/pinmux.waiver
+++ b/hw/ip/pinmux/lint/pinmux.waiver
@@ -27,3 +27,9 @@ waive -rules HIER_NET_NOT_READ -location {pinmux.sv} -regexp {.*'rst_sys_ni'.*is
 waive -rules INPUT_NOT_READ -location {pinmux_strap_sampling.sv} -regexp {Input port 'rst_sys_ni' is not read from in module 'pinmux_strap_sampling'} \
       -comment "Temporary waiver for #15602. This waiver needs to be removed once rst_sys_n is connected in pinmux_strap_sampling"
 'rst_sys_ni' is not read from in module 'pinmux_strap_sampling'
+
+waive -rules {CLOCK_DRIVER CLOCK_MUX} -location {pinmux_strap_sampling.sv} -regexp {'(lc|rv)_jtag_req.tck' is driven( by a multiplexer)? here,( and)? used as a clock 'tck_i' at dmi_jtag_tap.sv} \
+      -comment "These signals are muxed using the JTAG Selection Mux."
+
+waive -rules CLOCK_MUX -location {pinmux_strap_sampling.sv pinmux.sv} -regexp {Clock '(in_padring_i\[38\]|mio_in_i\[38\]|jtag_req.tck)' reaches a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} \
+      -comment "The 'mio_in_i[TckPadIdx]' input signal is connected to 'jtag_req.tck' which eventually feeds into the JTAG Selection Mux."

--- a/hw/ip/pinmux/lint/pinmux.waiver
+++ b/hw/ip/pinmux/lint/pinmux.waiver
@@ -39,3 +39,6 @@ waive -rules CLOCK_DRIVER -location {pinmux.sv} -regexp {'mio_attr\[28\].pull_se
 
 waive -rules CLOCK_USE -location {pinmux.sv} -regexp {'hw2reg.mio_pad_attr\[28\].pull_select.d' is connected to 'pinmux_reg_top' port 'hw2reg.mio_pad_attr\[28\].pull_select.d', and used as a clock} \
       -comment "'MioPadIoc6' at index 28 may also serve as an external clock input. The 'pull_select' signal impacts the actual value obtained from the pad simulation model."
+
+waive -rules CLOCK_USE -location {pinmux.sv} -regexp {'(dio_wkup_mux\[12\]|dio_wkup_mux\[13\]|mio_wkup_mux\[40\])' is used for some other purpose, and as clock} \
+      -comment "The wakeup detectors can be configured to observe any MIO / DIO pins. 'DioSpiDeviceSck' (index 12) is the spi_device clock, 'DioSpiDeviceCsb' (index 13) is the spi_device chip select (used as a clock for detecting toggles inside spi_device), and 'Dft0PadIdx' (index 40) controls the first TAP strap and thus the TAP selection mux driving the JTAG clocks."

--- a/hw/top_earlgrey/lint/padring.waiver
+++ b/hw/top_earlgrey/lint/padring.waiver
@@ -23,3 +23,8 @@ waive -rules {CLOCK_DRIVER} \
       -location {padring.sv} \
       -regexp {'gen_mio_pads\[38\].mio_in' is driven by instance 'gen_mio_pads\[38\]\^u_mio_pad' of module 'prim_pad_wrapper', and used as a clock 'tck_i' at dmi_jtag_tap.sv} \
       -comment "The 'mio_in[TckPadIdx]' input signal driven by a prim_pad_wrapper eventually feeds in to the JTAG Selection Mux."
+
+waive -rules {CLOCK_DRIVER} \
+      -location {padring.sv} \
+      -regexp {'gen_mio_pads\[28\].mio_in_raw' is driven by instance 'gen_mio_pads\[28\]\^u_mio_pad' of module 'prim_pad_wrapper', and used as a clock} \
+      -comment "'MioPadIoc6' at index 28 may also serve as an external clock input."

--- a/hw/top_earlgrey/lint/padring.waiver
+++ b/hw/top_earlgrey/lint/padring.waiver
@@ -18,3 +18,8 @@ waive -rules {HIER_BRANCH_NOT_READ} \
       -location {padring.sv} \
       -regexp   {Net 'clk_scan_i' in module 'padring'.*} \
       -comment "This net is not read from if no scan role is defined for the pads (which is the case in the opensource view)."
+
+waive -rules {CLOCK_DRIVER} \
+      -location {padring.sv} \
+      -regexp {'gen_mio_pads\[38\].mio_in' is driven by instance 'gen_mio_pads\[38\]\^u_mio_pad' of module 'prim_pad_wrapper', and used as a clock 'tck_i' at dmi_jtag_tap.sv} \
+      -comment "The 'mio_in[TckPadIdx]' input signal driven by a prim_pad_wrapper eventually feeds in to the JTAG Selection Mux."

--- a/hw/top_earlgrey/lint/top_earlgrey.waiver
+++ b/hw/top_earlgrey/lint/top_earlgrey.waiver
@@ -27,6 +27,15 @@ waive -rules CLOCK_USE -location {top_earlgrey.sv} -regexp {'clkmgr_aon_clocks.c
 waive -rules CLOCK_MUX -location {clkmgr.sv top_earlgrey.sv} -regexp {.*clk_io_div.* is driven by a multiplexer here} \
       -comment "Divided clocks go through prim_clock_div, which use muxes for scan bypass and clock step down"
 
+waive -rules CLOCK_MUX -location {top_earlgrey.sv} -regexp {Clock 'spi_device_passthrough_req.sck' reaches a multiplexer here, used as a clock} \
+      -comment "In passthrough mode, spi_host muxes 'spi_device_passthrough_req.sck' to the `cio_sck_o` output."
+
+waive -rules CLOCK_MUX -location {top_earlgrey.sv} -regexp {Clock 'pinmux_aon_(lc|rv)_jtag_req.tck' is driven by a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} \
+      -comment "Inside lc_ctrl/rv_dm, either the JTAG clock is muxed and forward to the DMI JTAG TAP depending on the scanmode/testmode signals."
+
+waive -rules CLOCK_MUX -location {top_earlgrey.sv} -regexp {Clock 'mio_in_i\[38\]' reaches a multiplexer here, used as a clock 'tck_i' at dmi_jtag_tap.sv} \
+      -comment "Inside pinmux_strap_sampling.sv, 'mio_in_i[TckPadIdx]' is connected to 'jtag_req' which is then muxed in the JTAG Selection Mux."
+
 # scan reset is a legal asynchronous reset
 waive -rules RESET_USE -location {top_earlgrey.sv} -regexp {'scan_rst_ni' is connected to .* port 'scan_rst_ni', and used as an asynchronous reset or set 'rst_.*ni' at} \
       -comment "Scan reset is a legal asynchronous reset"


### PR DESCRIPTION
This PR contains the last AscentLint waiver updates for Earlgrey. Once this PR is merged together with either https://github.com/lowRISC/opentitan/pull/23718 or https://github.com/lowRISC/opentitan/pull/23716, Earlgrey is lint clean.