### PR TITLE
[dv,usbdev] Fix up tri-state related block level tests

### DIFF
--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -1131,6 +1131,8 @@
                 Regardless of the state of this field usb_rx_dp and usb_rx_dn are always used to detect SE0.
                 This bit also feeds the rx_enable pin, activating the receiver when the device is not suspended.
                 '''
+          tags: [// Writing can provoke state changes in the receiver logic and thus raise errors.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         }
         {
           bits: "1",
@@ -1150,6 +1152,8 @@
           desc: '''
                 Recognize a single SE0 bit as an end of packet, otherwise two successive bits are required.
                 '''
+          tags: [// Writing can provoke state changes in the receiver logic and thus raise errors.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         }
         {
           bits: "5",
@@ -1160,6 +1164,8 @@
                 Particularly useful if D+/D- are mapped to SBU1/SBU2 pins of USB-C.
 
                 '''
+          tags: [// Writing can provoke state changes in the receiver logic and thus raise errors.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         }
         {
           bits: "6",
@@ -1181,6 +1187,8 @@
                 The clock might drift off.
 
                 '''
+          tags: [// Writing can provoke state changes in the receiver logic and thus raise errors.
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         }
       ]
     }

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_tx_osc_test_mode_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_tx_osc_test_mode_vseq.sv
@@ -51,6 +51,11 @@ class usbdev_phy_config_tx_osc_test_mode_vseq extends usbdev_base_vseq;
 
     // For the TX OSC test mode to work, the bus must not be in reset.
     set_vbus_state(1);
+
+    // Ensure that the DUT is driving the pull up enable because otherwise the logic will sit in
+    // 'link reset' as both DP and DN are weakly pulled low by the host.
+    usbdev_connect();
+
     // Instruct the driver to perform Bus Reset Signaling; keep this to 100us since there's no
     // point wasting simulation time on all sequences. Full length resets are exercised in
     // usbdev_bus_rand_vseq.

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -487,6 +487,26 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
       "fifo_ctrl": begin
         // TODO
       end
+      "count_out": begin
+        if (!write && channel == DataChannel) begin
+          do_read_check = 1'b0;
+        end
+      end
+      "count_in": begin
+        if (!write && channel == DataChannel) begin
+          do_read_check = 1'b0;
+        end
+      end
+      "count_nodata_in": begin
+        if (!write && channel == DataChannel) begin
+          do_read_check = 1'b0;
+        end
+      end
+      "count_errors": begin
+        if (!write && channel == DataChannel) begin
+          do_read_check = 1'b0;
+        end
+      end
       "buffer": begin
         do_read_check = 1'b1;
       end


### PR DESCRIPTION
This PR just addresses a couple of regressions in the block level DV tests following a change to the usb20_driver module to disable its drivers and let the bus float to the Idle state, rather than actively driving the bus to Idle.

- usbdev_phy_config_tx_osc_test_mode requires the DUT connected to take the USB out of a link reset state and permit the test mode oscillator to drive the bus.
- CSR test was failing because changing the PHY configuration was producing visible input changes to the packet reception logic,  causing it to raise errors. This modified the event counters, causing unexpected register changes in the CSR test(s) (_same_csr_outstanding).