### PR TITLE
[tock] Enable Tock in ROM_EXT environments.

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -357,7 +357,6 @@ silicon(
 
 silicon(
     name = "silicon_owner_sival_rom_ext",
-    testonly = True,
     args = [
         "--rcfile=",
         "--logging=info",

--- a/rules/tock.bzl
+++ b/rules/tock.bzl
@@ -5,7 +5,11 @@
 """Rules for assembling Tock binaries.
 """
 
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
+load("//rules:signing.bzl", "sign_binary")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
+load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback")
 load(
     "//rules:rv.bzl",
     "rv_rule",
@@ -19,6 +23,7 @@ TockApplication = provider(
         "tab": "TAB file for this application",
         "tbf": "TBF file for this application",
         "elf": "ELF file for this application",
+        "flash_start": "Address at which the app image must start in flash",
     },
 )
 
@@ -58,7 +63,7 @@ def _tock_elf2tab_impl(ctx):
 
     outputs.append(elffile)
     return [
-        TockApplication(tab = tabfile, tbf = tbffile, elf = elffile),
+        TockApplication(tab = tabfile, tbf = tbffile, elf = elffile, flash_start = ctx.attr.flash_start),
         DefaultInfo(
             files = depset(outputs),
             data_runfiles = ctx.runfiles(files = outputs),
@@ -77,6 +82,7 @@ tock_elf2tab = rule(
         "src": attr.label(mandatory = True, allow_single_file = True, doc = "ELF binary to convert"),
         "disable": attr.bool(default = False, doc = "Mark the application as disabled"),
         "arch": attr.string(mandatory = True, doc = "Target architecture for the ELF binary (e.g., `rv32imc`)"),
+        "flash_start": attr.int(mandatory = True, doc = "Application starting address in flash"),
         "_elf2tab": attr.label(
             default = "@elf2tab//:bin",
             executable = True,
@@ -101,7 +107,7 @@ def _tock_image_impl(ctx):
     cc_toolchain = find_cc_toolchain(ctx).cc
 
     kernel_binary = ctx.actions.declare_file("{}_kernel.bin".format(ctx.attr.name))
-    images = [ctx.actions.declare_file("{}0.bin".format(ctx.attr.name))]
+    image = ctx.actions.declare_file("{}.bin".format(ctx.attr.name))
 
     ctx.actions.run(
         outputs = [kernel_binary],
@@ -115,56 +121,35 @@ def _tock_image_impl(ctx):
     )
 
     ctx.actions.run(
-        outputs = [images[0]],
-        inputs = [kernel_binary],
+        outputs = [image],
+        inputs = [kernel_binary] + [app[TockApplication].tbf for app in ctx.attr.apps],
         arguments = [
-            "flash",
-            "--board",
-            "opentitan_earlgrey",
-            "--flash-file",
-            images[0].path,
-            "--address",
-            "0x20000000",
-            kernel_binary.path,
-        ],
-        executable = ctx.executable._tockloader,
+            "--rcfile=",
+            "image",
+            "assemble",
+            "--mirror=false",
+            "--output={}".format(image.path),
+            "--size={}".format(ctx.attr.image_end - ctx.attr.image_start),
+            "{}@0".format(kernel_binary.path),
+        ] + ["{}@{}".format(app[TockApplication].tbf.path, app[TockApplication].flash_start - ctx.attr.image_start) for app in ctx.attr.apps],
+        executable = ctx.toolchains[LOCALTOOLS_TOOLCHAIN].tools.opentitantool,
     )
 
-    for app in ctx.attr.apps:
-        tab = app[TockApplication].tab
-        input_image = images[-1]
-        output_image = ctx.actions.declare_file("{}{}.bin".format(ctx.attr.name, len(images)))
-        images += [output_image]
-
-        ctx.actions.run_shell(
-            outputs = [output_image],
-            inputs = [input_image, tab, ctx.executable._tockloader],
-            command = "\
-              cp {} {} &&\
-              chmod +rw {} &&\
-              {} install\
-                --board opentitan_earlgrey\
-                --flash-file {}\
-                --app-address {}\
-                {}\
-                {}\
-            ".format(
-                input_image.path,
-                output_image.path,
-                output_image.path,
-                ctx.executable._tockloader.path,
-                output_image.path,
-                ctx.attr.app_flash_start,
-                "--debug" if ctx.attr.debug else "",
-                tab.path,
-            ),
-        )
-
-    output = ctx.actions.declare_file("{}.bin".format(ctx.attr.name))
-    ctx.actions.symlink(
-        output = output,
-        target_file = images[-1],
+    exec_env = ctx.attr.exec_env[ExecEnvInfo]
+    manifest = get_fallback(ctx, "file.manifest", exec_env)
+    ecdsa_key = get_fallback(ctx, "attr.ecdsa_key", exec_env)
+    rsa_key = get_fallback(ctx, "attr.rsa_key", exec_env)
+    spx_key = get_fallback(ctx, "attr.spx_key", exec_env)
+    signed = sign_binary(
+        ctx,
+        ctx.toolchains[LOCALTOOLS_TOOLCHAIN].tools.opentitantool,
+        bin = image,
+        ecdsa_key = ecdsa_key,
+        rsa_key = rsa_key,
+        spx_key = spx_key,
+        manifest = manifest,
     )
+    output = signed.get("signed")
 
     return [
         DefaultInfo(files = depset([output]), data_runfiles = ctx.runfiles(files = [output])),
@@ -177,18 +162,31 @@ tock_image = rv_rule(
     implementation = _tock_image_impl,
     attrs = {
         "kernel": attr.label(mandatory = True, allow_single_file = True, doc = "Kernel ELF file", cfg = opt_mode),
-        "app_flash_start": attr.int(mandatory = True, doc = "Start of flash region for applications"),
         "apps": attr.label_list(mandatory = True, providers = [TockApplication], doc = "Application TAB labels", cfg = opt_mode),
-        "debug": attr.bool(default = True, doc = "Tockloader debug output"),
-        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
-        "_tockloader": attr.label(
-            default = entry_point(
-                pkg = "tockloader",
-                script = "tockloader",
-            ),
-            executable = True,
-            cfg = "exec",
+        "ecdsa_key": attr.label_keyed_string_dict(
+            allow_files = True,
+            doc = "ECDSA public key to validate this image",
         ),
+        "exec_env": attr.label(
+            providers = [ExecEnvInfo],
+            doc = "Execution environment for this target.",
+        ),
+        "image_start": attr.int(default = 0x20010000, doc = "Start of Tock's flash region (beginning of the kernel image)"),
+        "image_end": attr.int(default = 0x20080000, doc = "End of Tock's flash region (end of applications)"),
+        "manifest": attr.label(allow_single_file = True),
+        "rsa_key": attr.label_keyed_string_dict(
+            allow_files = True,
+            doc = "RSA public key to validate this image",
+        ),
+        "secver_write": attr.bool(
+            doc = "Commit the security version to boot_data",
+            default = True,
+        ),
+        "spx_key": attr.label_keyed_string_dict(
+            allow_files = True,
+            doc = "SPX public key to validate this image",
+        ),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
-    toolchains = ["@rules_cc//cc:toolchain_type"],
+    toolchains = ["@rules_cc//cc:toolchain_type", LOCALTOOLS_TOOLCHAIN],
 )

--- a/sw/device/silicon_owner/tock/apps/hello/BUILD
+++ b/sw/device/silicon_owner/tock/apps/hello/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS", "OPENTITAN_CPU", "cw310_params", "opentitan_test", "silicon_params")
 load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
 
 package(default_visibility = ["//visibility:public"])
@@ -26,11 +26,12 @@ tock_elf2tab(
     name = "tab",
     src = ":hello",
     arch = "rv32imc",
+    flash_start = 0x20040000,
 )
 
 tock_image(
     name = "image",
-    app_flash_start = 0x20040000,
     apps = [":tab"],
+    exec_env = "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
     kernel = "//sw/device/silicon_owner/tock/kernel",
 )

--- a/sw/device/silicon_owner/tock/kernel/BUILD
+++ b/sw/device/silicon_owner/tock/kernel/BUILD
@@ -59,6 +59,7 @@ rust_binary(
         "@tock//capsules/aes_gcm:capsules-aes-gcm",
         "@tock//capsules/core:capsules-core",
         "@tock//capsules/extra:capsules-extra",
+        "@tock//capsules/system:capsules-system",
         "@tock//chips/earlgrey",
         "@tock//chips/lowrisc",
         "@tock//kernel",

--- a/sw/device/silicon_owner/tock/kernel/layout.ld
+++ b/sw/device/silicon_owner/tock/kernel/layout.ld
@@ -9,9 +9,14 @@
 
 MEMORY
 {
-  rom   (rx)  : ORIGIN = 0x20000000, LENGTH = 0x40000
-  /* Support up to 0x2009_0000 for apps
-   * and 0x2009_0000 to 0x2010_0000 is for flash storage.
+  rom_ext (r) : ORIGIN = 0x20000000, LENGTH = 0x10000
+  /* rom is the region the kernel image occupies (a Tock convention required by
+   * tock/boards/kernel_layout.ld) -- it is not the region the chip's ROM exists
+   * in.
+   */
+  rom   (rx)  : ORIGIN = 0x20010000, LENGTH = 0x30000
+  /* Support up to 0x200a_0000 for apps
+   * and 0x200a_0000 to 0x2010_0000 is for flash storage.
    */
   prog  (rx)  : ORIGIN = 0x20040000, LENGTH = 0x60000
   fs    (r)   : ORIGIN = 0x200a0000, LENGTH = 0x60000
@@ -29,7 +34,8 @@ SECTIONS {
      * that we can use a single NAPOT region. The .text section will
      * be made executable by a separate PMP region.
      */
-    _sflash = ORIGIN(rom);
+    _sflash = ORIGIN(rom_ext);
+    _skernel = ORIGIN(rom);
     _eflash = ORIGIN(fs) + LENGTH(fs);
 
     _ssram  = ORIGIN(ram) - 0x650;
@@ -46,9 +52,10 @@ SECTIONS {
         . += 4;   /* usage_constraints.manuf_state_owner */
         . += 4;   /* usage_constraints.life_cycle_state */
         . += 384; /* rsa_modulus */
-        . += 4;   /* address_translation */
+        LONG(0x1d4); /* . = . + 4; address_translation (HardenedFalse) */
         . += 4;   /* identifier */
-        . += 4;   /* manifest_version */
+        SHORT(0x6c47); /* . = . + 2; manifest_version.minor */
+        SHORT(0x71c3); /* . = . + 2; manifest_version.major */
         . += 4;   /* signed_region_end */
         . += 4;   /* length */
         . += 4;   /* version_major */
@@ -57,8 +64,8 @@ SECTIONS {
         . += 8;   /* timestamp */
         . += 32;  /* binding_value */
         . += 4;   /* max_key_version */
-        . += 4;   /* code_start */
-        . += 4;   /* code_end */
+        LONG(_stext - ORIGIN(rom)); /* . = . + 4; code_start */
+        LONG(_etext - ORIGIN(rom)); /* . = . + 4; code_end */
         LONG(_stext - ORIGIN(rom)); /* . = . + 4; entry_point */
         /* manifest extension table */
         /* see: sw/device/silicon_creator/lib/base/chip.h */

--- a/sw/device/silicon_owner/tock/tests/basic/BUILD
+++ b/sw/device/silicon_owner/tock/tests/basic/BUILD
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//rules:signing.bzl", "sign_bin")
 load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
-load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "cw310_params", "fpga_params", "opentitan_test")
+load("//rules/opentitan:defs.bzl", "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS", "OPENTITAN_CPU", "cw310_params", "opentitan_test", "silicon_params")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,21 +28,21 @@ tock_elf2tab(
     name = "tab",
     src = ":basic",
     arch = "rv32imc",
+    flash_start = 0x20040000,
 )
 
 tock_image(
     name = "image",
-    app_flash_start = 0x20040000,
     apps = [":tab"],
+    exec_env = "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
     kernel = "//sw/device/silicon_owner/tock/tests:test_kernel",
 )
 
 opentitan_test(
     name = "basic_test",
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
-    fpga = fpga_params(
+    # Note: tock_image currently create a sival_rom_ext-only image.
+    exec_env = {"//hw/top_earlgrey:silicon_owner_sival_rom_ext": None},
+    silicon = silicon_params(
         binaries = {":image": "firmware"},
     ),
 )

--- a/sw/device/silicon_owner/tock/tests/uart/BUILD
+++ b/sw/device/silicon_owner/tock/tests/uart/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "cw310_params", "fpga_params", "opentitan_test")
+load("//rules/opentitan:defs.bzl", "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS", "OPENTITAN_CPU", "cw310_params", "opentitan_test", "silicon_params")
 load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
 
 package(default_visibility = ["//visibility:public"])
@@ -26,23 +26,21 @@ tock_elf2tab(
     name = "tab",
     src = ":uart",
     arch = "rv32imc",
+    flash_start = 0x20040000,
 )
 
 tock_image(
     name = "image",
-    app_flash_start = 0x20040000,
     apps = [":tab"],
+    exec_env = "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
     kernel = "//sw/device/silicon_owner/tock/kernel",
 )
 
 opentitan_test(
     name = "uart_test",
-    exec_env = {
-        # TODO: Migrate to a _rom_ext environment once we have Tock successfully
-        # booting in one.
-        "//hw/top_earlgrey:fpga_cw310_test_rom": None,
-    },
-    fpga = fpga_params(
+    # Note: tock_image currently create a sival_rom_ext-only image.
+    exec_env = {"//hw/top_earlgrey:silicon_owner_sival_rom_ext": None},
+    silicon = silicon_params(
         binaries = {":image": "firmware"},
         test_cmd = """
             --bootstrap="{firmware}"

--- a/third_party/tock/repos.bzl
+++ b/third_party/tock/repos.bzl
@@ -40,9 +40,9 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
     bare_repository(
         name = "tock",
         local = tock,
-        strip_prefix = "tock-25d9f42c9f4672c54840e4623d79279ff6abd820",
-        url = "https://github.com/tock/tock/archive/25d9f42c9f4672c54840e4623d79279ff6abd820.tar.gz",
-        sha256 = "56b528ad0da04e05053f2c8220b8a0bb44bc1233b51d742f05e05f5c950787b9",
+        strip_prefix = "tock-5a65d681489d30a4b88b5d1a7d2a0e8273cbf027",
+        url = "https://github.com/tock/tock/archive/5a65d681489d30a4b88b5d1a7d2a0e8273cbf027.tar.gz",
+        sha256 = "38f3efcaaa6c4e22a7c4fa8f2befa651ec1a9f730089434696ad781f6b479c79",
         additional_files_content = {
             "BUILD": """exports_files(glob(["**"]))""",
             "arch/riscv/BUILD": crate_build(
@@ -69,6 +69,7 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
                     "//kernel",
                     "//capsules/core:capsules-core",
                     "//capsules/extra:capsules-extra",
+                    "//capsules/system:capsules-system",
                 ],
             ),
             "boards/opentitan/earlgrey-cw310/BUILD": _EARLGREY_CW310_BUILD,
@@ -96,6 +97,13 @@ def tock_repos(tock = None, libtock = None, elf2tab = None):
                     "//libraries/enum_primitive",
                     "//libraries/tickv",
                     "//capsules/core:capsules-core",
+                ],
+            ),
+            "capsules/system/BUILD": crate_build(
+                name = "capsules-system",
+                deps = [
+                    "//kernel",
+                    "//libraries/tock-tbf",
                 ],
             ),
             "chips/earlgrey/BUILD": crate_build(


### PR DESCRIPTION
This makes several changes:

1. Update Tock to the merge commit for PR 4034 (which makes its ePMP setup compatible with the ROM_EXT).
2. tock_image uses opentitantool to assemble the final Tock image, because tockloader was hardcoded to assume Tock is at address 0x20000000.
3. tock_image now produces a signed image.
4. The kernel linker script sets separate symbols for "start of flash" and "start of the Tock image", as required by the new ePMP setup logic.
5. The kernel linker script now fills in all the required manifest fields.
6. Removes TicKV from the Tock kernel as well as the flash controller reconfiguration, as they are not working on silicon. TicKV is unlikely to suit our needs.
7. Changes the Tock chip config to one that matches silicon.