### PR TITLE
[prim/lint] Move AscentLint waiver rules for prim_gf_mult into own file

### DIFF
--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -19,9 +19,3 @@ waive -rules CONST_OUTPUT -location {prim_sram_arbiter.sv} -regexp {rsp_error.* 
 # prim_fifo_async_simple
 waive -rules CONST_FF -location {prim_fifo_async_simple.sv} -msg {Flip-flop 'not_in_reset_q' is driven by constant one in module 'prim_fifo_async_simple'} \
       -comment "The flop input and reset values are constants."
-
-# prim_gf_mult
-waive -rules USE_BEFORE_DECL -location {prim_gf_mult.sv} -msg {'gf_mult' is referenced before its declaration at prim_gf_mult.sv} \
-      -comment "gf_mult is a function defined towards the end of the file."
-waive -rules USE_BEFORE_DECL -location {prim_gf_mult.sv} -msg {'gen_matrix' is referenced before its declaration at prim_gf_mult.sv} \
-      -comment "gen_matrix is a function defined towards the end of the file."

--- a/hw/ip/prim/lint/prim_gf_mult.waiver
+++ b/hw/ip/prim/lint/prim_gf_mult.waiver
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_gf_mult
+
+waive -rules USE_BEFORE_DECL -location {prim_gf_mult.sv} -msg {'gf_mult' is referenced before its declaration at prim_gf_mult.sv} \
+      -comment "gf_mult is a function defined towards the end of the file."
+waive -rules USE_BEFORE_DECL -location {prim_gf_mult.sv} -msg {'gen_matrix' is referenced before its declaration at prim_gf_mult.sv} \
+      -comment "gen_matrix is a function defined towards the end of the file."

--- a/hw/ip/prim/prim_gf_mult.core
+++ b/hw/ip/prim/prim_gf_mult.core
@@ -13,7 +13,17 @@ filesets:
       - rtl/prim_gf_mult.sv
     file_type: systemVerilogSource
 
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_gf_mult.waiver
+    file_type: waiver
+
+
 targets:
   default:
     filesets:
+      - tool_ascentlint  ? (files_ascentlint_waiver)
       - files_rtl


### PR DESCRIPTION
prim_gf_mult is a primitive with it's own core file. Having the waiver rules inside the shared prim.waiver file may cause Flow warnings.