### PR TITLE
[flash_ctrl] Increase verification_stage to V2S

### DIFF
--- a/hw/ip_templates/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip_templates/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -44,7 +44,7 @@
           version:            "2.0.0",
           life_stage:         "L1",
           design_stage:       "D2S",
-          verification_stage: "V1",
+          verification_stage: "V2S",
           dif_stage:          "S2",
       },
   ]

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/data/flash_ctrl.hjson
@@ -33,7 +33,7 @@
           version:            "2.0.0",
           life_stage:         "L1",
           design_stage:       "D2S",
-          verification_stage: "V1",
+          verification_stage: "V2S",
           dif_stage:          "S2",
       },
   ]


### PR DESCRIPTION
The V2S signoff for Earlgrey-PROD happened some time ago already (see lowRISC/OpenTitan#21012). This commit just updates the hjson to reflect this.

This resolves lowRISC/OpenTitan#22470.