### PR TITLE
[hmac,dv] Improve slightly fcov

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cov.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cov.sv
@@ -88,8 +88,10 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
       bins len_2048      = {2048};  // Two blocks in SHA-2 384/512
       bins len_2049      = {2049};  // Two blocks in SHA-2 384/512, +1 byte
       // Any others than the one defined above
-      bins auto_lens[50] = {[0:$]} with (!(item inside {0, 1, 511, 512, 513, 1023, 1024, 1025,
-                                                        2047, 2048, 2049}));
+      bins len_2_510     = {[2:510]};
+      bins len_514_1022  = {[514:1022]};
+      bins len_1026_2046 = {[1026:2046]};
+      bins len_2050_plus = {[2050:$]};
     }
     // Ensure that message length upper register has been used once at least
     msg_len_upper_cp: coverpoint (msg_len_upper) {

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -140,6 +140,8 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
               end else begin
                 update_err_intr_code(SwHashStartWhenActive);
               end
+              // Trigger coverage sampling of CFG register
+              -> sample_cfg;
             end
             // Detect when stop has been triggered to store the current state, for Save and Restore
             // check

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_long_msg_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_long_msg_vseq.sv
@@ -11,12 +11,10 @@ class hmac_long_msg_vseq extends hmac_smoke_vseq;
 
   constraint msg_c {
     msg.size() dist {
-        0               :/ 1,
-        [1    :128]     :/ 1, // 128 bytes is the FIFO depth
-        [129  :999]     :/ 1,
-        [1000 :3000]    :/ 6, // 1KB - 2KB according to SW immediate usage
-        [3001 :10_000]  :/ 1  // temp set to 10KB as max length, spec max size is 2^64 bits
+                  0  :/ 1,  // Empty
+      [   1 :   257] :/ 1,  // Up to two 1024-bit blocks
+      [1000 : 3_000] :/ 5,  // 1KB - 2KB according to SW immediate usage
+      [3001 :10_000] :/ 1   // temp set to 10KB as max length, spec max size is 2^64 bits
     };
   }
-
 endclass : hmac_long_msg_vseq


### PR DESCRIPTION
- replace auto bins by ranges as auto bins were giving coverage mostly on index 0, as this is calculated per seed. Now changed into ranges.
- add sampling of cfg anytime hash_start/hash_continue are triggered to also sample error cases.
- tweak a bit long messages to target more what this test intent is.