### PR TITLE
[dv] Improve debug prints from register aliasing sequence

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -487,8 +487,10 @@ class csr_aliasing_seq extends csr_base_seq;
         continue;
       end
 
-      `uvm_info(`gtn, $sformatf("Verifying register aliasing for %0s",
-                                test_csrs[i].get_full_name()), UVM_MEDIUM)
+      `uvm_info(`gtn,
+                $sformatf("Verifying register aliasing for %0s (register %0d / %0d)",
+                          test_csrs[i].get_full_name(), i + 1, test_csrs.size()),
+                UVM_MEDIUM)
 
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
       wdata = get_csr_wdata_with_write_excl(test_csrs[i], wdata, CsrAliasingTest);
@@ -507,7 +509,7 @@ class csr_aliasing_seq extends csr_base_seq;
         if (is_excl(all_csrs[j], CsrExclInitCheck, CsrAliasingTest) ||
             is_excl(all_csrs[j], CsrExclWriteCheck, CsrAliasingTest)) begin
           `uvm_info(`gtn, $sformatf("Skipping register %0s due to CsrExclInit/WriteCheck exclusion",
-                                    all_csrs[j].get_full_name()), UVM_MEDIUM)
+                                    all_csrs[j].get_full_name()), UVM_HIGH)
           continue;
         end
 

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -708,7 +708,7 @@ package csr_utils_pkg;
         if (m_csr_excl_item.is_excl(flds[i], csr_excl_type, csr_test_type)) begin
           csr_field_t fld_params = decode_csr_or_field(flds[i]);
           `uvm_info(msg_id, $sformatf("Skipping field %0s due to %0s exclusion",
-                                    flds[i].get_full_name(), csr_excl_type.name()), UVM_MEDIUM)
+                                    flds[i].get_full_name(), csr_excl_type.name()), UVM_HIGH)
           get_mask_excl_fields &= ~(fld_params.mask << fld_params.shift);
         end
       end


### PR DESCRIPTION
Add a counter ("register 3 of 10") and lower the verbosity of the "skipping" messages: practically speaking, these messages rather overwhelms the other one when verbosity is medium.