### PR TITLE
[otbn,dv] Add -j$(nproc) to --make_options in run_smoke.sh

### DIFF
--- a/hw/ip/otbn/dv/smoke/run_smoke.sh
+++ b/hw/ip/otbn/dv/smoke/run_smoke.sh
@@ -34,7 +34,7 @@ $OTBN_UTIL/otbn_ld.py -o $SMOKE_BIN_DIR/smoke.elf $SMOKE_BIN_DIR/smoke_test.o ||
 
 (cd $REPO_TOP;
  fusesoc --cores-root=. run --target=sim --setup --build \
-         lowrisc:ip:otbn_top_sim || fail "HW Sim build failed")
+         lowrisc:ip:otbn_top_sim --make_options=-j$(nproc) || fail "HW Sim build failed")
 
 RUN_LOG=`mktemp`
 readonly RUN_LOG


### PR DESCRIPTION
We're doing a build using fusesoc, which uses Verilator as the backend. The compilation takes quite a while and I realised that I was essentially compiling a big load of C++ with one thread. Oops! This makes things a bit snappier.