### PR TITLE
[rv_dm,dv] Avoid failures in stress sequence from ndmreset signal

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -221,9 +221,21 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     end
   endtask
 
+  task read_dmcontrol(input bit backdoor, output dmcontrol_t value);
+    uvm_reg_data_t raw;
+    csr_rd(.ptr(jtag_dmi_ral.dmcontrol), .value(raw));
+    value = dmcontrol_t'(raw);
+  endtask
+
   // Tell rv_dm to request a halt, then "acknowledge" its forwarded request as the CPU after a few
   // cycles (hartsel=0 give a hart ID of 0 as we only have one hart).
   task request_halt();
+    // The TLUL connection gets blocked by u_tlul_lc_gate_rom if there is an ndmreset signal. This
+    // is confusing to debug, so use a backdoor read to check that it isn't currently set.
+    dmcontrol_t dmcontrol_val;
+    read_dmcontrol(.backdoor(1), .value(dmcontrol_val));
+    `DV_CHECK(!dmcontrol_val.ndmreset);
+
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(1));
     `DV_CHECK_EQ(cfg.rv_dm_vif.cb.debug_req, 1)
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
@@ -17,6 +17,12 @@ class rv_dm_mem_tl_access_halted_vseq extends rv_dm_base_vseq;
     // Disable unavailable signal to make sure that hart should be in known state. if hart
     // is unavailable then it could not halted.
     cfg.rv_dm_vif.unavailable <= 0;
+
+    // Make sure that the ndmreset signal is not currently asserted. If it is asserted then DMI
+    // operations work but the TLUL connection is blocked by u_tlul_lc_gate_rom, which is held in
+    // the flush state.
+    csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(0));
+
     repeat ($urandom_range(1, 10)) begin
       // Verify that writing to HALTED results in anyhalted and allhalted to be set.
       request_halt();


### PR DESCRIPTION
This happens because we run a DMI stress sequence which happens to set the ndmreset signal and follow it up with `rv_dm_mem_tl_access_halted_vseq`. The latter sequence times out because the TL connection is gated by ndmreset.

The first commit here fixes the problem by setting the signal back to zero. The second commit adds a check in the `request_halt` task (the one that was timing out) to die immediately and informatively if this happens again.