### PR TITLE
[dv, aon_timer] Stimulus for wdog_ctrl.pause_in_sleep

### DIFF
--- a/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_scoreboard.sv
@@ -250,6 +250,10 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
     end // compute_num_clks
   endtask
 
+  virtual task wait_for_sleep();
+    wait ( !(wdog_pause_in_sleep & cfg.sleep_vif.sample_pin()));
+  endtask
+
   virtual task run_wkup_timer();
     event sample_coverage;
     forever begin
@@ -339,6 +343,7 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
           // logic.
           cfg.aon_clk_rst_vif.wait_clks(4);
           while (count < wdog_bark_num) begin
+            wait_for_sleep();
             cfg.aon_clk_rst_vif.wait_clks(1);
             // reset the cycle counter when we update the cycle count needed
             count = wdog_num_update_due ? 0 : (count + 1);
@@ -374,7 +379,7 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
       join_any
       disable fork;
     end
-  endtask
+  endtask : run_wdog_bark_timer
 
   virtual task run_wdog_bite_timer();
     event sample_coverage;
@@ -401,6 +406,7 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
           // logic.
           cfg.aon_clk_rst_vif.wait_clks(4);
           while (count < wdog_bite_num) begin
+            wait_for_sleep();
             cfg.aon_clk_rst_vif.wait_clks(1);
             // reset the cycle counter when we update the cycle count needed
             count = wdog_num_update_due ? 0 : (count + 1);
@@ -433,7 +439,7 @@ class aon_timer_scoreboard extends cip_base_scoreboard #(
       join_any
       disable fork;
     end
-  endtask
+  endtask : run_wdog_bite_timer
 
   virtual function void reset(string kind = "HARD");
     super.reset(kind);

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -46,6 +46,9 @@ class aon_timer_base_vseq extends cip_base_vseq #(
   // When set randomisation tries to set the count and threshold so that the bite is likely hit:
   rand bit          aim_bite;
 
+  // Used to randomly configure wdog_ctrl.pause_in_sleep
+  rand bit          wdog_ctrl_pause_in_sleep;
+
   constraint thold_count_c {
     solve wkup_count_gap, wkup_thold before wkup_count;
     solve aim_bite, wdog_count_gap, wdog_bark_thold, wdog_bite_thold before wdog_count;

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_vseq.sv
@@ -20,8 +20,10 @@ class aon_timer_smoke_vseq extends aon_timer_base_vseq;
 
     `uvm_info(`gfn, "Enabling AON Timer. Writing 1 to WKUP_CTRL and WDOG_CTRL", UVM_HIGH)
     csr_utils_pkg::csr_wr(ral.wkup_ctrl.enable, 1'b1);
-    csr_utils_pkg::csr_wr(ral.wdog_ctrl.enable, 1'b1);
-
+    wdog_ctrl_pause_in_sleep = $urandom_range(0, 1);
+    ral.wdog_ctrl.enable.set(1);
+    ral.wdog_ctrl.pause_in_sleep.set(wdog_ctrl_pause_in_sleep);
+    csr_update(ral.wdog_ctrl);
     `uvm_info(`gfn, "\n\t Waiting for AON Timer to finish (interrupt)", UVM_HIGH)
   endtask : smoke_configure
 


### PR DESCRIPTION
* aon_timer TB now randomizes wdog_ctrl.pause_in_sleep in aon_timer_smoke_vseq
* aon_timer SCB now stops WDOG counting in sleep mode when pause_in_sleep is set


I have run a local regression and the passing rate seems the same as the nightly regression. And the failures (2/102) have the same failing signature as the nightly one [(report from 11/06/2024)](https://reports.opentitan.org/hw/ip/aon_timer/dv/2024.06.12_04.38.22/report.html):
```
UVM_ERROR @ 23395289269 ps: (cip_base_vseq.sv:473) [uvm_test_top.env.virtual_sequencer.aon_timer_common_vseq] Check failed exp_val == act_val (0 [0x0] vs 1 [0x1]) when reading the intr CSRaon_timer_reg_block.intr_state
```

I merged the coverage from the local regression (with tweaks to Xcelium coverage config file, [since toggle coverage is only enabled for ports](https://github.com/lowRISC/opentitan/blob/5b17d34ccc8248e791c9d20f054ad52f9d778012/hw/dv/tools/xcelium/common.ccf#L36-L37))

I see the signal `pause_in_sleep` toggling:
![Screenshot from 2024-06-19 16-54-12](https://github.com/lowRISC/opentitan/assets/156205999/b125383d-dbcd-484e-886a-2eee05dd39c3)

 