### PR TITLE
[dv,chip_level] Fix chip_sw_lc_ctrl_program_error

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -609,7 +609,7 @@
 //
 // If there is a need to sample / force an internal signal, then it must be done in the testbench,
 // or in an interface bound to the DUT. This macro creates a standardized signal probe function
-// meant to be invoked an interface. The generated function can then be invoked in test sequences
+// to be defined in an interface. The generated function can then be invoked in test sequences
 // or other UVM classes. The macro takes 2 arguments - name of the function and the hierarchical
 // path to the signal. If invoked in an interface which is bound to the DUT, the signal can be a
 // partial hierarchical path within the DUT. The generated function accepts 2 arguments - the first

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_program_error_vseq.sv
@@ -2,19 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Injects an error in the lc program request received by the OTP.
 class chip_sw_lc_ctrl_program_error_vseq extends chip_sw_base_vseq;
   `uvm_object_utils(chip_sw_lc_ctrl_program_error_vseq)
 
   `uvm_object_new
 
-  virtual task pre_start();
-    cfg.chip_vif.tap_straps_if.drive(JtagTapLc);
-    super.pre_start();
-  endtask
-
   virtual task body();
-    bit [TL_DW-1:0] status_val;
-
     super.body();
 
     // Wait for C side to fully stabilize
@@ -22,27 +16,8 @@ class chip_sw_lc_ctrl_program_error_vseq extends chip_sw_base_vseq;
              "timeout waiting for C side acknowledgement",
              cfg.sw_test_timeout_ns)
 
-    // force lc_ctrl program path to error
-    void'(cfg.chip_vif.signal_probe_otp_ctrl_lc_err_o(SignalProbeForce, 1));
-
-    // poll for state to transition to post transition state
-    jtag_csr_spinwait(ral.lc_ctrl.lc_state.get_offset(),
-      p_sequencer.jtag_sequencer_h,
-      {DecLcStateNumRep{DecLcStEscalate}},
-      cfg.sw_test_timeout_ns);
-
-    `uvm_info(`gfn, $sformatf("post trans observed"), UVM_LOW)
-
-    // This is used for toggle coverage collection purpose to cover the `lc_err_o` transition from
-    // 1 to 0.
-    void'(cfg.chip_vif.signal_probe_otp_ctrl_lc_err_o(SignalProbeRelease));
-
-    // check to ensure that we see an otp error
-    jtag_read_csr(ral.lc_ctrl.status.get_offset(),
-      p_sequencer.jtag_sequencer_h,
-      status_val);
-
-    `DV_CHECK_FATAL(status_val & (1 << LcOtpError));
-
+    `DV_SPINWAIT(cfg.chip_vif.create_illegal_lc_request_for_otp();,
+                 "timeout waiting for an lc_program request for otp_ctrl",
+                 cfg.sw_test_timeout_ns)
   endtask
 endclass

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -190,8 +190,6 @@ module tb;
     .IOR13(dut.chip_if.mios[top_earlgrey_pkg::MioPadIor13])
   );
 
-  `define SIM_SRAM_IF u_sim_sram.u_sim_sram_if
-
   // Knob to skip ROM backdoor logging (for sims that use ROM macro). Set below.
   logic skip_rom_bkdr_load;
 
@@ -366,6 +364,8 @@ module tb;
     .tl_out_i ()
   );
 
+  `define SIM_SRAM_IF u_sim_sram.u_sim_sram_if
+
   initial begin
     void'($value$plusargs("en_sim_sram=%0b", en_sim_sram));
     if (!dut.chip_if.stub_cpu && en_sim_sram) begin
@@ -427,14 +427,14 @@ module tb;
     run_test();
   end
 
+  `undef SIM_SRAM_IF
+
   for (genvar i = 0; i < NUM_ALERTS; i++) begin : gen_alert_vif
     initial begin
       uvm_config_db#(virtual alert_esc_if)::set(null, $sformatf("*.env.m_alert_agent_%0s",
           LIST_OF_ALERTS[i]), "vif", alert_if[i]);
     end
   end
-
-  `undef SIM_SRAM_IF
 
   // Instantitate the memory backdoor util instances.
   if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_generic


### PR DESCRIPTION
Inject an error by tampering with the state field in an otherwise valid lc program request. If a bit needs to be cleared the otp will flag an error and won't perform the update. The previous approach was flawed.

Fixes #23631