### PR TITLE
[rv_dm,dv] Tidy up implementation of the ndmreset_req vseq

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -306,8 +306,8 @@
             Verify that the debugger can issue a non-debug reset to the rest of the system.
 
             - Set lc_hw_debug_en / pinmux_hw_debug_en to true value and activate the dm.
-            - Pick a random set of write/readable CSRs in all 3 RALs (JTAG DMI, regs RAL and debug
-              mem RAL). Write known values to them.
+            - Pick a random set of write/readable CSRs in the debug RALs (JTAG DMI and debug
+              memory). Write known values to them.
             - Write the dmcontrol register to assert ndmreset - verify that the ndmreset output
               is asserted.
             - Mimic the CPU going into reset by asserting the unavailable input.

--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -309,10 +309,11 @@
             - Pick a random set of write/readable CSRs in all 3 RALs (JTAG DMI, regs RAL and debug
               mem RAL). Write known values to them.
             - Write the dmcontrol register to assert ndmreset - verify that the ndmreset output
-              stays asserted.
-            - Mimic the CPU going into reset by asserting unavailable input,
-              setting lc_hw_debug_en to false. Keep pinmux_hw_debug_en set to true to keep
-              the JTAG side open while the ndmreset is in progress.
+              is asserted.
+            - Mimic the CPU going into reset by asserting the unavailable input.
+            - Set lc_hw_debug_en to something other than On (since it should no longer be needed).
+              At this point the ndmreset output signal will drop. Keep pinmux_hw_debug_en set to On
+              to keep the JTAG side open while the ndmreset is in progress.
             - Read the dmstatus register to verify allunavail is asserted.
             - De-assert the ndmreset by writing 0 to the dmcontrol register field, verify the
               ndmreset output deasserted as well.


### PR DESCRIPTION
The testpoint description can be improved slightly (first two commits). Then the implementation needs re-doing, so that it gives us some confidence! That's the third commit.