### PR TITLE
[jtag,dv] Keep TCK running a short time after a transaction

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
@@ -28,6 +28,16 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
   // This knob can bypass default 1 cycle initial delay of 'driver.drive_jtag_req()' task.
   // Use this knob only for the necessary tests.
   bit     min_rti = 0;
+
+  // This JTAG driver expects to control the JTAG interface clock (TCK), which it does by setting
+  // tck_en to 0 or 1. If rtc_length is positive, it gives a number of TCK cycles to "run to clear"
+  // (where we expect to be in the RunTest/IDLE state) before disabling the clock.
+  //
+  // This allows safe interactions with things like DMI operations, where we expect CDC to convert
+  // between the JTAG clock and a system clock. This only works when TCK is running!
+  int unsigned rtc_length = 0;
+
+
   `uvm_object_utils_begin(jtag_agent_cfg)
     `uvm_field_object(jtag_dtm_ral, UVM_DEFAULT)
   `uvm_object_utils_end

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_frontdoor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_frontdoor.sv
@@ -26,6 +26,10 @@ class jtag_dmi_reg_frontdoor extends uvm_reg_frontdoor;
     jtag_dtm_reg_block  jtag_dtm_ral = jtag_agent_cfg_h.jtag_dtm_ral;
     jtag_dmi_op_rsp_e   op_rsp;
 
+    // Configure the JTAG agent to have a positive run-to-clear length, ensuring that DMI operations
+    // make it from dmi_jtag to dm_top and back again before TCK stops.
+    jtag_agent_cfg_h.rtc_length = 4;
+
     // If the JTAG agent is sitting in reset, print a debug message and exit early
     if (jtag_agent_cfg_h.in_reset) begin
       `uvm_info(`gfn, "DMI CSR req skipped due to reset", UVM_HIGH)


### PR DESCRIPTION
This handles a rather confusing situation in the DMI frontdoor. The problem is that a DMI request has to travel from dmi_jtag to dm_top (involving a CDC from TCK to the main clock) and then back again (involving a CDC from the main clock back to TCK).

If we stop sending JTAG operations in that time, the CDC doesn't actually get anywhere. The wait is jtag_agent_cfg_h.vif.wait_tck(10), which ends up waiting based on elapsed time rather than clock edges.

The result is that when we send another JTAG operation to find out the result of the operation, the "busy" status only makes it through the CDC *after* the JTAG operation has finished and reported that the dm is idle.

Things then get rather confused when the "busy" status appears, which the agent interprets as a mysterious operation that has just come into being.
