### PR TITLE
[hmac,dv] FIFO empty interrupt and test mode pins

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -35,18 +35,35 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-  endfunction
+  endfunction : build_phase
 
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
-    fork
-      hmac_process_fifo_status();
-      hmac_process_fifo_wr();
-      hmac_process_fifo_rd();
-      hmac_intr_test();
-      monitor_cov();
-    join_none
-  endtask
+    wait(cfg.under_reset);
+    forever begin
+      wait(!cfg.under_reset);
+      // This isolation fork is needed to ensure that "disable fork" call won't kill any other
+      // processes at the same level from the base classes
+      fork begin : isolation_fork
+        fork
+          begin : main_thread
+            fork
+              hmac_process_fifo_status();
+              hmac_process_fifo_wr();
+              hmac_process_fifo_rd();
+              hmac_intr_test();
+              monitor_cov();
+            join
+            wait fork;  // To ensure it will be killed only when the reset will occur
+          end
+          begin : reset_thread
+            wait(cfg.under_reset);
+          end
+        join_any
+        disable fork;   // Terminates all descendants and sub-descendants of isolation_fork
+      end join
+    end
+  endtask : run_phase
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
@@ -467,7 +484,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
       end
       void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
     end
-  endtask
+  endtask : process_tl_access
 
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
@@ -489,7 +506,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     msg_q.delete();
     msg_part_q.delete();
     cfg.wipe_secret_triggered = 0;
-  endfunction
+  endfunction : reset
 
   // clear variables after hmac_done
   virtual function void flush();
@@ -510,56 +527,44 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
     fifo_empty_intr     = 0;
     void'(ral.intr_state.fifo_empty.predict(.value(fifo_empty_intr | intr_test[HmacMsgFifoEmpty]),
                                             .kind(UVM_PREDICT_READ)));
-  endfunction
+  endfunction : flush
 
   // hmac_wr_cnt was incremented every time when msg_q has 4 bytes streamed in
   // or when hash_process is triggered, and there are some remaining bytes
   // this task will also clear the msg_q queue once hmac_process is set
   virtual task hmac_process_fifo_wr();
-    fork
-      begin : insolation_fork_process_fifo_wr
-        forever begin
-          wait(!cfg.under_reset);
-          fork
-            begin : increase_wr_cnt
-              bit has_unprocessed_msg = 1;
-              wait(msg_q.size() >= (hmac_wr_cnt + 1) * 4 || (hmac_process && msg_q.size() > 0));
-              // Ensure that current context has to be taken into account or skipped
-              if (cfg.sar_skip_ctxt) begin
-                wait(!cfg.sar_skip_ctxt);
-              end
-              // if hmac process is issued and there are still unprocessed word (can hold up to at
-              // most one word), then the hmac_wr_cnt will increment
-              // if all the written msgs have been process, will skip the counter incrementation
-              if (hmac_process) begin
-                if (msg_q.size() <= hmac_wr_cnt * 4) begin
-                  has_unprocessed_msg = 0;
-                end
-                msg_q.delete();
-                msg_part_q.delete();
-              end
-              if (sha_en && has_unprocessed_msg) begin
-                // if fifo full, tlul will not write next data until fifo has space again
-                if ((hmac_wr_cnt - hmac_rd_cnt) == HMAC_MSG_FIFO_DEPTH_WR) begin
-                  wait((hmac_wr_cnt - hmac_rd_cnt) < HMAC_MSG_FIFO_DEPTH_WR);
-                end
-                @(negedge cfg.clk_rst_vif.clk);
-                if (!hmac_stopped) begin
-                  hmac_wr_cnt++;
-                  `uvm_info(`gfn, $sformatf("increase wr cnt %0d", hmac_wr_cnt), UVM_HIGH)
-                  cfg.clk_rst_vif.wait_clks(HMAC_WR_WORD_CYCLE);
-                end
-              end
-            end
-            begin : reset_increase_wr_cnt
-              wait(cfg.under_reset);
-            end
-          join_any
-          disable fork;
-        end // end forever
+    bit has_unprocessed_msg;
+    forever begin
+      has_unprocessed_msg = 1;
+      wait(msg_q.size() >= (hmac_wr_cnt + 1) * 4 || (hmac_process && msg_q.size() > 0));
+      // Ensure that current context has to be taken into account or skipped
+      if (cfg.sar_skip_ctxt) begin
+        wait(!cfg.sar_skip_ctxt);
       end
-    join
-  endtask
+      // if hmac process is issued and there are still unprocessed word (can hold up to at
+      // most one word), then the hmac_wr_cnt will increment
+      // if all the written msgs have been process, will skip the counter incrementation
+      if (hmac_process) begin
+        if (msg_q.size() <= hmac_wr_cnt * 4) begin
+          has_unprocessed_msg = 0;
+        end
+        msg_q.delete();
+        msg_part_q.delete();
+      end
+      if (sha_en && has_unprocessed_msg) begin
+        // if fifo full, tlul will not write next data until fifo has space again
+        if ((hmac_wr_cnt - hmac_rd_cnt) == HMAC_MSG_FIFO_DEPTH_WR) begin
+          wait((hmac_wr_cnt - hmac_rd_cnt) < HMAC_MSG_FIFO_DEPTH_WR);
+        end
+        @(negedge cfg.clk_rst_vif.clk);
+        if (!hmac_stopped) begin
+          hmac_wr_cnt++;
+          `uvm_info(`gfn, $sformatf("increase wr cnt %0d", hmac_wr_cnt), UVM_HIGH)
+          cfg.clk_rst_vif.wait_clks(HMAC_WR_WORD_CYCLE);
+        end
+      end
+    end
+  endtask : hmac_process_fifo_wr
 
   virtual task hmac_process_fifo_status();
     bit pre_fifo_empty_intr;
@@ -632,11 +637,13 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
 
   // Check interrupt pins in test mode
   virtual task hmac_intr_test_pin(int intr_i);
-    hmac_intr_e intr = hmac_intr_e'(intr_i);
+    bit [TL_DW-1:0] intr_en;
+    hmac_intr_e     intr = hmac_intr_e'(intr_i);
     forever @(intr_test[intr_i]) begin
+      intr_en = `gmv(ral.intr_enable);
       if (intr_test[intr_i]) begin
         // Check interrupt state pins only if enabled
-        if (`gmv(ral.intr_enable)[intr_i]) begin
+        if (intr_en[intr_i]) begin
           fork: intr_pins
             begin
               wait(cfg.intr_vif.pins[intr_i]);
@@ -659,104 +666,80 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
   // 1). hmac process key: DUT will process the key first
   // 2). read cnt reaches FIFO_MAX: DUT will process msg in the FIFO
   virtual task hmac_process_fifo_rd();
-    bit key_processed;
+    bit key_processed = 0;
     fork
       begin : process_hmac_key_pad
         forever begin
-          if (cfg.under_reset) begin
-            wait(!cfg.under_reset);
+          cfg.clk_rst_vif.wait_clks(1);
+          // Key padding
+          wait(hmac_start && sha_en);
+          if (`gmv(ral.cfg.hmac_en) && hmac_rd_cnt == 0 && !invalid_cfg) begin
+            if (`gmv(ral.cfg.digest_size) == SHA2_256) begin
+              key_process_cycles = HMAC_KEY_PROCESS_CYCLES_256;
+            end else begin
+              key_process_cycles = HMAC_KEY_PROCESS_CYCLES_512;
+            end
+            // key_process_cycles for hmac key padding + 1 cycle for hash_start reg to reset
+            cfg.clk_rst_vif.wait_clks(key_process_cycles + 1);
+            @(negedge cfg.clk_rst_vif.clk);
+            key_processed = 1;
           end
-          // delay 1ps to make sure all variables are being reset, before moving to the next
-          // forever loop
-          #1ps;
-          fork
-            begin : key_padding
-              wait(hmac_start && sha_en);
-              if (`gmv(ral.cfg.hmac_en) && hmac_rd_cnt == 0 && !invalid_cfg) begin
-                if (`gmv(ral.cfg.digest_size) == SHA2_256) begin
-                  key_process_cycles = HMAC_KEY_PROCESS_CYCLES_256;
-                end else begin
-                  key_process_cycles = HMAC_KEY_PROCESS_CYCLES_512;
-                end
-                // key_process_cycles for hmac key padding + 1 cycle for hash_start reg to reset
-                cfg.clk_rst_vif.wait_clks(key_process_cycles + 1);
-                @(negedge cfg.clk_rst_vif.clk);
-                key_processed = 1;
-              end
-              while (1) begin
-                // TODO: check if we need the error checking here - might not be necessary
-                // break if hmac is done or if invalid config error is triggered or if SHA is
-                // being disabled as HMAC enable configuration could be changed and thus
-                // key_process_cycles might need to be updated
-                if (`gmv(ral.intr_state.hmac_done) ||
-                   (`gmv(ral.intr_state.hmac_err) && `gmv(ral.err_code) == SwInvalidConfig) ||
-                    !sha_en) begin
-                  break;
-                end
-                cfg.clk_rst_vif.wait_clks(1);
-              end
+          while (1) begin
+            // TODO: check if we need the error checking here - might not be necessary
+            // break if hmac is done or if invalid config error is triggered or if SHA is
+            // being disabled as HMAC enable configuration could be changed and thus
+            // key_process_cycles might need to be updated
+            if (`gmv(ral.intr_state.hmac_done) ||
+                (`gmv(ral.intr_state.hmac_err) && `gmv(ral.err_code) == SwInvalidConfig) ||
+                !sha_en) begin
+              break;
             end
-            begin : reset_key_padding
-              wait(cfg.under_reset);
-            end
-          join_any
-          disable fork;
+            cfg.clk_rst_vif.wait_clks(1);
+          end
           key_processed = 0;
-        end // end forever
+        end
       end
 
       begin : process_internal_fifo_rd
         forever begin
-          wait(!cfg.under_reset);
-          // delay 1ps to make sure all variables are being reset, before moving to the next
-          // forever loop
-          #1ps;
-          fork
-            begin : hmac_fifo_rd
-              // Ensure that current context has to be taken into account or skipped
-              if (cfg.sar_skip_ctxt) begin
-                wait(!cfg.sar_skip_ctxt);
-              end
-              wait((hmac_wr_cnt > hmac_rd_cnt) && (sha_en));
-              if (`gmv(ral.cfg.hmac_en) && hmac_rd_cnt == 0) begin
-                `uvm_info(`gfn, $sformatf("waiting on key processing to complete"), UVM_HIGH)
-                wait(key_processed);
-                `uvm_info(`gfn, $sformatf("key processing has completed"), UVM_HIGH)
-              end
-              #1ps; // delay 1 ps to make sure did not sample right at negedge clk
-              cfg.clk_rst_vif.wait_n_clks(1);
-              hmac_rd_cnt++;
-              `uvm_info(`gfn, $sformatf("increase rd cnt %0d", hmac_rd_cnt), UVM_HIGH)
-              // select correct FIFO read depth and message processing cycles
-              if (`gmv(ral.cfg.digest_size) == SHA2_256) begin
-                fifo_rd_depth        = HMAC_MSG_FIFO_DEPTH_RD_256;
-                block_process_cycles = HMAC_MSG_PROCESS_CYCLES_256;
-              end else begin
-                fifo_rd_depth        = HMAC_MSG_FIFO_DEPTH_RD_512;
-                block_process_cycles = HMAC_MSG_PROCESS_CYCLES_512;
-              end
-              if (hmac_rd_cnt % fifo_rd_depth == 0) begin
-                `uvm_info(`gfn, $sformatf("start waiting on message processing now"), UVM_HIGH)
-                cfg.clk_rst_vif.wait_n_clks(block_process_cycles);
-                `uvm_info(`gfn, $sformatf("message processing has completed"), UVM_HIGH)
-              end
-            end
-            begin : reset_hmac_fifo_rd
-              wait(cfg.under_reset);
-            end
-          join_any
-          disable fork;
-        end // end forever
+          // Ensure that current context has to be taken into account or skipped
+          if (cfg.sar_skip_ctxt) begin
+            wait(!cfg.sar_skip_ctxt);
+          end
+          wait((hmac_wr_cnt > hmac_rd_cnt) && (sha_en));
+          if (`gmv(ral.cfg.hmac_en) && hmac_rd_cnt == 0) begin
+            `uvm_info(`gfn, $sformatf("waiting on key processing to complete"), UVM_HIGH)
+            wait(key_processed);
+            `uvm_info(`gfn, $sformatf("key processing has completed"), UVM_HIGH)
+          end
+          #1ps; // delay 1 ps to make sure did not sample right at negedge clk
+          cfg.clk_rst_vif.wait_n_clks(1);
+          hmac_rd_cnt++;
+          `uvm_info(`gfn, $sformatf("increase rd cnt %0d", hmac_rd_cnt), UVM_HIGH)
+          // select correct FIFO read depth and message processing cycles
+          if (`gmv(ral.cfg.digest_size) == SHA2_256) begin
+            fifo_rd_depth        = HMAC_MSG_FIFO_DEPTH_RD_256;
+            block_process_cycles = HMAC_MSG_PROCESS_CYCLES_256;
+          end else begin
+            fifo_rd_depth        = HMAC_MSG_FIFO_DEPTH_RD_512;
+            block_process_cycles = HMAC_MSG_PROCESS_CYCLES_512;
+          end
+          if (hmac_rd_cnt % fifo_rd_depth == 0) begin
+            `uvm_info(`gfn, $sformatf("start waiting on message processing now"), UVM_HIGH)
+            cfg.clk_rst_vif.wait_n_clks(block_process_cycles);
+            `uvm_info(`gfn, $sformatf("message processing has completed"), UVM_HIGH)
+          end
+        end
       end
     join_none
-  endtask
+  endtask : hmac_process_fifo_rd
 
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
     `DV_CHECK_EQ(cfg.intr_vif.pins[HmacMsgFifoEmpty], 1'b0)
     `DV_CHECK_EQ(cfg.intr_vif.pins[HmacDone], 1'b0)
     `DV_CHECK_EQ(cfg.intr_vif.pins[HmacErr], 1'b0)
-  endfunction
+  endfunction : check_phase
 
   // query the sha / hmac c model to get expected digest
   // update predicted digest to ral mirrored value
@@ -840,13 +823,13 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
         exp_digest = '{default:0};
       end
     endcase
-  endfunction
+  endfunction : predict_digest
 
   virtual function void update_wr_msg_length(int size_bytes);
     uint64 size_bits = size_bytes * 8;
     void'(ral.msg_length_upper.predict(size_bits[TL_DW*2-1:TL_DW]));
     void'(ral.msg_length_lower.predict(size_bits[TL_DW-1:0]));
-  endfunction
+  endfunction : update_wr_msg_length
 
   virtual task update_err_intr_code(err_code_e err_code_val);
     if (!`gmv(ral.intr_state.hmac_err)) begin
@@ -864,11 +847,11 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
       end
       void'(ral.err_code.predict(.value(err_code_val), .kind(UVM_PREDICT_DIRECT)));
     end
-  endtask
+  endtask : update_err_intr_code
 
   virtual function void check_idle_o(bit val);
     if (cfg.under_reset == 0) `DV_CHECK_EQ(cfg.hmac_vif.is_idle(), val)
-  endfunction
+  endfunction : check_idle_o
 
   virtual task monitor_cov();
     save_and_restore_e  sar_ctxt;
@@ -906,4 +889,4 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
       end
     join_none
   endtask : monitor_cov
-endclass
+endclass : hmac_scoreboard


### PR DESCRIPTION
  - Verify FIFO empty interrupt register to tackle issue #21815
  - Add checks on interrupt pins when test mode is triggered via the dedicated register INTR_TEST