### PR TITLE
[rom] Enable SRAM readback for RET-RAM

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -232,7 +232,8 @@ otp_json(
                 ),
                 # By default, ROM_EXT's bootstrap feature should be disabled.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(CONST.HARDENED_FALSE),
-                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                # Disable SRAM readback for both ret-ram and main sram.
+                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE << 4 | CONST.MUBI4_FALSE),
                 "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_FALSE),
                 "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
                 # By default, the sensor_ctrl should disable all sensors and mark

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -184,7 +184,8 @@ otp_json(
                 "OWNER_SW_CFG_ROM_RSTMGR_INFO_EN": otp_hex(0x0),
                 # Disable ROM_EXT recovery feature.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
-                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                # Disable SRAM readback for both ret-ram and main sram.
+                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE << 4 | CONST.MUBI4_FALSE),
                 # TODO(#23411): The customer wants this to be HARDENED_TRUE
                 # for production chips.
                 "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_FALSE),

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -184,7 +184,8 @@ otp_json(
                 "OWNER_SW_CFG_ROM_RSTMGR_INFO_EN": otp_hex(0x0),
                 # Disable ROM_EXT recovery feature.
                 "OWNER_SW_CFG_ROM_EXT_BOOTSTRAP_EN": otp_hex(0x0),
-                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE),
+                # Disable SRAM readback for both ret-ram and main sram.
+                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_FALSE << 4 | CONST.MUBI4_FALSE),
                 "OWNER_SW_CFG_ROM_PRESERVE_RESET_REASON_EN": otp_hex(CONST.HARDENED_FALSE),
                 "OWNER_SW_CFG_ROM_FLASH_ECC_EXC_HANDLER_EN": otp_hex(CONST.HARDENED_TRUE),
                 # By default, the sensor_ctrl should disable all sensors and mark

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -334,7 +334,8 @@
                     size: "12" // 2 settings per alert (disabled, fatal), 4 bit per setting, space for 12 alerts (currently 11 used)
                 }
                 {
-                    // Datatype: Mubi4.
+                    // Datatype: Two packed Mubi4s:
+                    // [ret-ram readback enable][main sram readback en].
                     name: "OWNER_SW_CFG_ROM_SRAM_READBACK_EN",
                     size: "4"
                 }

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.c
@@ -33,6 +33,10 @@ void retention_sram_init(void) {
   abs_mmio_write32(kBase + SRAM_CTRL_CTRL_REG_OFFSET, reg);
 }
 
+void retention_sram_readback_enable(uint32_t en) {
+  abs_mmio_write32(kBase + SRAM_CTRL_READBACK_REG_OFFSET, en);
+}
+
 void retention_sram_scramble(void) {
   // Request the renewal of the scrambling key and initialization to random
   // values.

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.h
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.h
@@ -176,6 +176,13 @@ void retention_sram_clear(void);
 void retention_sram_init(void);
 
 /**
+ * Enable or disable the readback feature of the retention SRAM.
+ *
+ * @param en A Mubi4True to enable the feature.
+ */
+void retention_sram_readback_enable(uint32_t en);
+
+/**
  * Start scrambling the retention SRAM.
  *
  * Requests a new scrambling key for the retention SRAM. This operation

--- a/sw/device/silicon_creator/rom/e2e/sram/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sram/BUILD
@@ -28,7 +28,8 @@ otp_json(
         otp_partition(
             name = "OWNER_SW_CFG",
             items = {
-                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_TRUE),
+                # Turn readback on for both retram and sram.
+                "OWNER_SW_CFG_ROM_SRAM_READBACK_EN": otp_hex(CONST.MUBI4_TRUE << 4 | CONST.MUBI4_TRUE),
             },
         ),
     ],

--- a/sw/device/silicon_creator/rom/e2e/sram/sram_readback_test.c
+++ b/sw/device/silicon_creator/rom/e2e/sram/sram_readback_test.c
@@ -17,12 +17,16 @@ OTTF_DEFINE_TEST_CONFIG();
 
 enum {
   kSramCtrlBase = TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR,
+  kRetRamCtrlBase = TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR,
 };
 
 bool test_main(void) {
   uint32_t otp =
       otp_read32(OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SRAM_READBACK_EN_OFFSET);
-  uint32_t cfg = abs_mmio_read32(kSramCtrlBase + SRAM_CTRL_READBACK_REG_OFFSET);
-  LOG_INFO("sram_readback: otp=%x cfg=%x", otp, cfg);
-  return otp == cfg;
+  uint32_t sram =
+      abs_mmio_read32(kSramCtrlBase + SRAM_CTRL_READBACK_REG_OFFSET);
+  uint32_t retram =
+      abs_mmio_read32(kRetRamCtrlBase + SRAM_CTRL_READBACK_REG_OFFSET);
+  LOG_INFO("sram_readback: otp=%x retram=%x sram=%x", otp, retram, sram);
+  return otp == (retram << 4 | sram);
 }

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -225,6 +225,10 @@ static rom_error_t rom_init(void) {
       otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_RET_RAM_RESET_MASK_OFFSET);
   if ((reset_reasons & reset_mask) != 0) {
     retention_sram_init();
+    // The high nybble controls the retram readback enable.
+    retention_sram_readback_enable(
+        otp_read32(OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_SRAM_READBACK_EN_OFFSET) >>
+        4);
     retention_sram_get()->creator.last_shutdown_reason = kErrorOk;
   }
 


### PR DESCRIPTION
1. Use the READBACK_EN OTP word to control both the main SRAM and RET-RAM readback enables.

Addresses #23495