### PR TITLE
[rv_dm,dv] Properly implement the rv_dm_cmderr_not_supported_vseq test

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -366,11 +366,13 @@
     {
       name: jtag_dmi_cmderr_not_supported
       desc: '''
-            Verify that attempt to generate command error result in cmderr field of abstractcs
-            register are set.
+            Generate the "not supported" command error in abstractcs
 
-            - Try to execute abstract command that is not supported like Quick Access & Access Memory command.
-            - Verify that the cmderr field of abstractcs register is set to 2.
+            This command error is generated when trying to run an abstract command that is not
+            supported.
+
+            - Write a command to the command register where cmdtype is definitely not supported.
+            - Check that the cmderr field of abstractcs register is set to 2.
             '''
       stage: V1
       tests: ["rv_dm_cmderr_not_supported"]

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_not_supported_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_cmderr_not_supported_vseq.sv
@@ -10,13 +10,50 @@ class rv_dm_cmderr_not_supported_vseq extends rv_dm_base_vseq;
   constraint lc_hw_debug_en_c {
     lc_hw_debug_en == lc_ctrl_pkg::On;
   }
+
+  // Generate an abstract command that will trigger a "not supported" error because it's cmdtype is
+  // unknown.
+  function command_t gen_bogus_abstract_cmd();
+    command_t cmd;
+    `DV_CHECK_STD_RANDOMIZE_FATAL(cmd)
+
+    if (cmd.cmdtype inside {AccessRegister, QuickAccess, AccessMemory}) begin
+      cmd.cmdtype = cmd_e'(cmd.cmdtype + 3);
+    end
+
+    return cmd;
+  endfunction
+
+  // Check that the cmderr field in abstractcs is as expected
+  task check_cmderr(cmderr_e cmderr_exp);
+    abstractcs_t abstractcs;
+    read_abstractcs(abstractcs);
+    `DV_CHECK_EQ(abstractcs.cmderr, cmderr_exp);
+  endtask
+
   task body();
-    write_chk(.ptr(jtag_dmi_ral.progbuf[0]),.cmderr(2),.command(32'h10231000));
-    write_chk(.ptr(jtag_dmi_ral.command),.cmderr(2),.command(32'h10231000));
-    write_chk(.ptr(jtag_dmi_ral.abstractauto),.cmderr(2),.command(32'h10231000));
-    write_chk(.ptr(jtag_dmi_ral.progbuf[0]),.cmderr(2),.command(32'h20231000));
-    write_chk(.ptr(jtag_dmi_ral.command),.cmderr(2),.command(32'h20231000));
-    write_chk(.ptr(jtag_dmi_ral.abstractauto),.cmderr(2),.command(32'h20231000));
+    // Check that there isn't currently any command error (if there is, it will be sticky and we
+    // won't be able to change it to CmdErrNotSupported)
+    check_cmderr(CmdErrNone);
+
+    // Tell the debug module to request a halt and tell it that we're halted (so that we can accept
+    // the abstract command)
+    request_halt();
+
+    // Ask to start a (bogus) abstract command. This won't actually start, but should cause a
+    // command error flag.
+    csr_wr(.ptr(jtag_dmi_ral.command), .value(gen_bogus_abstract_cmd()));
+
+    // Check that the cmderr field of the abstractcs register is now CmdErrNotSupported
+    check_cmderr(CmdErrNotSupported);
+
+    // Clear the cmderr field. This has access W1C and is 3 bits wide, so writing 3'b111 should
+    // clear all the bits.
+    csr_wr(.ptr(jtag_dmi_ral.abstractcs.cmderr), .value(7));
+
+    // Check that we have managed to clear the command error (to leave things clean for following
+    // sequences)
+    check_cmderr(CmdErrNone);
   endtask
 
 endclass : rv_dm_cmderr_not_supported_vseq


### PR DESCRIPTION
The first commit tidies up the testpoint slightly. The second implements it, replacing a rather nonsensical mess that was there before.