### PR TITLE
[tock] Run Tock tests on both the cw310 and silicon.

### DIFF
--- a/rules/tock.bzl
+++ b/rules/tock.bzl
@@ -18,6 +18,12 @@ load(
 )
 load("@tockloader_deps//:requirements.bzl", "entry_point")
 
+# Exec environments that we can run Tock on, for use with opentitan_test.
+TOCK_ENVS = {
+    "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+    "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
+}
+
 TockApplication = provider(
     fields = {
         "tab": "TAB file for this application",

--- a/sw/device/silicon_owner/tock/apps/hello/BUILD
+++ b/sw/device/silicon_owner/tock/apps/hello/BUILD
@@ -30,8 +30,8 @@ tock_elf2tab(
 )
 
 tock_image(
-    name = "image",
+    name = "image_silicon",
     apps = [":tab"],
     exec_env = "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
-    kernel = "//sw/device/silicon_owner/tock/kernel",
+    kernel = "//sw/device/silicon_owner/tock/tests:test_kernel_silicon",
 )

--- a/sw/device/silicon_owner/tock/kernel/BUILD
+++ b/sw/device/silicon_owner/tock/kernel/BUILD
@@ -31,13 +31,52 @@ cc_library(
 )
 
 rust_binary(
-    name = "kernel",
+    name = "kernel_fpga",
     srcs = [
         "src/io.rs",
         "src/main.rs",
         "src/otbn.rs",
         "src/pinmux_layout.rs",
     ],
+    crate_features = ["fpga"],
+    rustc_flags = [
+        "-g",
+        # TODO(opentitan#19491): determine the appropriate set of linker flags.
+        #"-Clinker=rust-lld",
+        #"-Clinker-flavor=ld.lld",
+        #"-Crelocation-model=static",
+        #"-Clink-arg=-nmagic",
+        #"-Clink-arg=-icf=all",
+        #"-Cforce-frame-pointers=no",
+    ],
+    # We specifically restrict our build target to the OpenTitan
+    # CPU because tock does not support an x86_64 target.
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":layout",
+        ":nostartfiles",
+        "@tock//arch/rv32i",
+        "@tock//boards/components",
+        "@tock//capsules/aes_gcm:capsules-aes-gcm",
+        "@tock//capsules/core:capsules-core",
+        "@tock//capsules/extra:capsules-extra",
+        "@tock//capsules/system:capsules-system",
+        "@tock//chips/earlgrey",
+        "@tock//chips/lowrisc",
+        "@tock//kernel",
+        "@tock//libraries/tock-tbf",
+    ],
+)
+
+rust_binary(
+    name = "kernel_silicon",
+    srcs = [
+        "src/io.rs",
+        "src/main.rs",
+        "src/otbn.rs",
+        "src/pinmux_layout.rs",
+    ],
+    crate_features = ["silicon"],
     rustc_flags = [
         "-g",
         # TODO(opentitan#19491): determine the appropriate set of linker flags.

--- a/sw/device/silicon_owner/tock/kernel/src/main.rs
+++ b/sw/device/silicon_owner/tock/kernel/src/main.rs
@@ -99,6 +99,17 @@ const FAULT_RESPONSE: PanicFaultPolicy = PanicFaultPolicy {};
 pub static mut STACK_MEMORY: [u8; 0x1400] = [0; 0x1400];
 
 enum ChipConfig {}
+
+#[cfg(feature = "fpga")]
+impl EarlGreyConfig for ChipConfig {
+    const NAME: &'static str = "fpga_cw310";
+    const CPU_FREQ: u32 = 24_000_000;
+    const PERIPHERAL_FREQ: u32 = 6_000_000;
+    const AON_TIMER_FREQ: u32 = 250_000;
+    const UART_BAUDRATE: u32 = 115200;
+}
+
+#[cfg(feature = "silicon")]
 impl EarlGreyConfig for ChipConfig {
     const NAME: &'static str = "silicon";
     const CPU_FREQ: u32 = 100_000_000;

--- a/sw/device/silicon_owner/tock/tests/BUILD
+++ b/sw/device/silicon_owner/tock/tests/BUILD
@@ -21,9 +21,14 @@ config_setting(
 )
 
 alias(
-    name = "test_kernel",
+    name = "test_kernel_silicon",
+    actual = "//sw/device/silicon_owner/tock/kernel:kernel_silicon",
+)
+
+alias(
+    name = "test_kernel_fpga",
     actual = select({
         ":upstream_kernel": "//sw/device/silicon_owner/tock/upstream_kernel:kernel",
-        "//conditions:default": "//sw/device/silicon_owner/tock/kernel",
+        "//conditions:default": "//sw/device/silicon_owner/tock/kernel:kernel_fpga",
     }),
 )

--- a/sw/device/silicon_owner/tock/tests/basic/BUILD
+++ b/sw/device/silicon_owner/tock/tests/basic/BUILD
@@ -5,8 +5,8 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//rules:signing.bzl", "sign_bin")
-load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
-load("//rules/opentitan:defs.bzl", "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS", "OPENTITAN_CPU", "cw310_params", "opentitan_test", "silicon_params")
+load("//rules:tock.bzl", "TOCK_ENVS", "tock_elf2tab", "tock_image")
+load("//rules/opentitan:defs.bzl", "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS", "OPENTITAN_CPU", "fpga_params", "opentitan_test", "silicon_params")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -32,17 +32,27 @@ tock_elf2tab(
 )
 
 tock_image(
-    name = "image",
+    name = "image_fpga",
+    testonly = True,
+    apps = [":tab"],
+    exec_env = "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
+    kernel = "//sw/device/silicon_owner/tock/tests:test_kernel_fpga",
+)
+
+tock_image(
+    name = "image_silicon",
     apps = [":tab"],
     exec_env = "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
-    kernel = "//sw/device/silicon_owner/tock/tests:test_kernel",
+    kernel = "//sw/device/silicon_owner/tock/tests:test_kernel_silicon",
 )
 
 opentitan_test(
     name = "basic_test",
-    # Note: tock_image currently create a sival_rom_ext-only image.
-    exec_env = {"//hw/top_earlgrey:silicon_owner_sival_rom_ext": None},
+    exec_env = TOCK_ENVS,
+    fpga = fpga_params(
+        binaries = {":image_fpga": "firmware"},
+    ),
     silicon = silicon_params(
-        binaries = {":image": "firmware"},
+        binaries = {":image_silicon": "firmware"},
     ),
 )

--- a/sw/device/silicon_owner/tock/tests/uart/BUILD
+++ b/sw/device/silicon_owner/tock/tests/uart/BUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//rules/opentitan:defs.bzl", "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS", "OPENTITAN_CPU", "cw310_params", "opentitan_test", "silicon_params")
-load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
+load("//rules/opentitan:defs.bzl", "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS", "OPENTITAN_CPU", "fpga_params", "opentitan_test", "silicon_params")
+load("//rules:tock.bzl", "TOCK_ENVS", "tock_elf2tab", "tock_image")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -30,18 +30,32 @@ tock_elf2tab(
 )
 
 tock_image(
-    name = "image",
+    name = "image_fpga",
+    testonly = True,
+    apps = [":tab"],
+    exec_env = "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
+    kernel = "//sw/device/silicon_owner/tock/tests:test_kernel_fpga",
+)
+
+tock_image(
+    name = "image_silicon",
     apps = [":tab"],
     exec_env = "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
-    kernel = "//sw/device/silicon_owner/tock/kernel",
+    kernel = "//sw/device/silicon_owner/tock/tests:test_kernel_silicon",
 )
 
 opentitan_test(
     name = "uart_test",
-    # Note: tock_image currently create a sival_rom_ext-only image.
-    exec_env = {"//hw/top_earlgrey:silicon_owner_sival_rom_ext": None},
+    exec_env = TOCK_ENVS,
+    fpga = fpga_params(
+        binaries = {":image_fpga": "firmware"},
+        test_cmd = """
+            --bootstrap="{firmware}"
+        """,
+        test_harness = "//sw/host/tests/tock/uart",
+    ),
     silicon = silicon_params(
-        binaries = {":image": "firmware"},
+        binaries = {":image_silicon": "firmware"},
         test_cmd = """
             --bootstrap="{firmware}"
         """,


### PR DESCRIPTION
This builds two Tock kernels: one for the cw310 and one for silicon. Each test app is built once, then combined with both kernels to produce two test images. The `opentitan_test` rule is configured to run image corresponding to its exec environment.

I manually tested this works on silicon.