### PR TITLE
[dv,usbdev] OUT side sequences

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -257,8 +257,8 @@ class usb20_monitor extends dv_base_monitor #(
   endtask
 
 //----------------------------------------Classifies Trans----------------------------------------//
-  function classifies_packet(bit valid_sync, bit valid_eop, bit valid_stuffing,
-                             ref bit destuffed_packet[$]);
+  function void classifies_packet(bit valid_sync, bit valid_eop, bit valid_stuffing,
+                                  ref bit destuffed_packet[$]);
     // Read the Packet IDentifier and check its validity.
     pid_type_e pid_e;
     bit [7:0] pid;
@@ -290,8 +290,8 @@ class usb20_monitor extends dv_base_monitor #(
   endfunction
 
 //-------------------------------------------SOF Packet-------------------------------------------//
-  function sof_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
-                      ref bit destuffed_packet[$]);
+  function void sof_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
+                           ref bit destuffed_packet[$]);
     // bits to binary conversion
     m_sof_pkt.m_pid_type = pid;
     m_sof_pkt.valid_sync = valid_sync;
@@ -307,8 +307,8 @@ class usb20_monitor extends dv_base_monitor #(
   endfunction
 
 //------------------------------------------Token Packet------------------------------------------//
-  function token_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
-                        ref bit destuffed_packet[$]);
+  function void token_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
+                             ref bit destuffed_packet[$]);
     // bits to binary conversion
     m_token_pkt.m_pid_type = pid;
     m_token_pkt.valid_sync = valid_sync;
@@ -325,8 +325,8 @@ class usb20_monitor extends dv_base_monitor #(
   endfunction
 
 //------------------------------------------Data Packet-------------------------------------------//
-  function data_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
-                       ref bit destuffed_packet[$]);
+  function void data_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
+                            ref bit destuffed_packet[$]);
     bit data[];
     bit [15:0] data_crc16;
     byte unsigned byte_data[];
@@ -361,8 +361,8 @@ class usb20_monitor extends dv_base_monitor #(
   endfunction
 
 //----------------------------------------Handshake Packet----------------------------------------//
-  function handshake_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
-                            ref bit destuffed_packet[$]);
+  function void handshake_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
+                                 ref bit destuffed_packet[$]);
     // bits to binary conversion
     m_handshake_pkt.m_pid_type = pid;
     m_handshake_pkt.valid_sync = valid_sync;
@@ -377,8 +377,8 @@ class usb20_monitor extends dv_base_monitor #(
   endfunction
 
   //----------------------------------------Invalid Packet----------------------------------------//
-  function invalid_packet_pid(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
-                                  ref bit destuffed_packet[$]);
+  function void invalid_packet_pid(pid_type_e pid, bit valid_sync, bit valid_eop,
+                                   bit valid_stuffing, ref bit destuffed_packet[$]);
     int unsigned size = destuffed_packet.size();
     `uvm_info(`gfn, $sformatf("packet size = %d", size), UVM_HIGH)
     case (size)

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -502,7 +502,7 @@
             - Verify that the interrupt pin goes high indicating an error in the link in OUT transaction.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_link_out_err"]
     }
     {
       name: enable
@@ -558,7 +558,7 @@
               transactions.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_invalid_data1_data0_toggle_test"]
     }
     {
       name: setup_stage
@@ -858,7 +858,7 @@
               responses even though endpoint is enabled.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_nak_to_out_trans_when_avbuffer_empty_rxfifo_full"]
     }
     {
       name: aon_wake_resume

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -464,8 +464,8 @@
       desc: '''
             Verify that if a CRC error occurred then rx_crc_err will raise.
 
-            - send a packet(token/handshake/data) to the device while intentionally corrupting any of the CRC bits.
-            - Verify that the rx_crc_err should go high following the reception of erroneous packet.
+            - Send a token/data packet to the device while intentionally corrupting any of the CRC bits.
+            - Verify that the rx_crc_err goes high following the reception of the invalid packet.
             '''
       stage: V2
       tests: ["usbdev_rx_crc_err"]

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_aon_wake_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_aon_wake_vseq.sv
@@ -14,7 +14,7 @@ class usbdev_aon_wake_vseq extends usbdev_link_suspend_vseq;
     // Weighted to make 'no delay' a more frequent occurrence,
     // by treating all negative values as per zero.
     stim_delay_clks >= -50 && stim_delay_clks <= 2000;
-  };
+  }
 
   // Delay before optional reconnection of VBUS after disconnection.
   rand int disconn_interval_clks;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_device_address_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_device_address_vseq.sv
@@ -20,9 +20,9 @@ class usbdev_device_address_vseq extends usbdev_spray_packets_vseq;
     (ep_out_enable & rxenable_setup & ~out_stall) != 0;  // At least one receptive SETUP endpoint.
     (ep_out_enable & rxenable_out &   ~out_stall) != 0;  // At least one receptive OUT endpoint.
     (ep_in_enable  &                   ~in_stall) != 0;  // At least one receptive IN endpoint.
-  };
+  }
 
-  virtual function choose_target();
+  virtual function void choose_target();
     super.choose_target();
     if (hit) target_addr = dev_addr;
     else `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(target_addr, target_addr != dev_addr;)

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_disable_endpoint_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_disable_endpoint_vseq.sv
@@ -33,7 +33,7 @@ class usbdev_disable_endpoint_vseq extends usbdev_spray_packets_vseq;
   }
 
   // Ensure that we choose a disabled endpoint.
-  virtual function choose_target();
+  virtual function void choose_target();
     bit [3:0] init_ep;
     super.choose_target();
     // Choose a disabled endpoint, but start looking from the unconstrained random choice so that

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_out_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_out_err_vseq.sv
@@ -1,0 +1,128 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sequence for testing the 'link_out_err' interrupt.
+class usbdev_link_out_err_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_link_out_err_vseq)
+
+  `uvm_object_new
+
+  // We iterate through each of the possible causes in turn.
+  typedef enum {
+    // First test the behavior when there is no buffer in the 'Available OUT Buffer FIFO.'
+    LinkOutNoAvail,
+    // Supply a buffer at this point, so that the other causes are accessible.
+    LinkOutBadToggle,
+    LinkOutTokenCRC16,
+    LinkOutNoSpace
+  } link_out_cause_e;
+
+  virtual task body();
+    bit [31:0] intr_bit = 1 << IntrLinkOutErr;
+    bit [31:0] ep_mask = 1 << ep_default;
+    link_out_cause_e next_cause, cause;
+    uvm_reg_data_t out_toggles;
+
+    buf_init();
+
+    // Enable the 'link_out_err' interrupt.
+    csr_wr(.ptr(ral.intr_enable), .value(intr_bit));
+
+    // Enable an endpoint for testing, and ensure that there is no buffer available initially.
+    csr_wr(.ptr(ral.ep_out_enable[0]), .value(ep_mask));
+    csr_wr(.ptr(ral.rxenable_out[0]), .value(ep_mask));
+
+    // This interrupt is heavily overloaded and there are many events that may cause it to be
+    // asserted; it is only informative/diagnostic for software, indicating only that an issue
+    // occurred with OUT traffic, rather than anything more specific.
+    //
+    // Iterate through the potential causes...
+    next_cause = cause.first();
+    do begin
+      uvm_reg_data_t intr_state;
+      cause = next_cause;
+      next_cause = next_cause.next();
+
+      // Ensure that the interrupt is not set.
+      csr_rd(.ptr(ral.intr_state), .value(intr_state));
+      `DV_CHECK_EQ(intr_state[IntrLinkOutErr], 0, "Interrupt unexpectedly asserted already")
+      `DV_CHECK_EQ(cfg.intr_vif.pins[IntrLinkOutErr], 0, "Interrupt line unexpected asserted")
+
+      case (cause)
+        LinkOutNoAvail: begin
+          uvm_reg_data_t usbstat;
+          // Check that the Av OUT FIFO is empty.
+          csr_rd(.ptr(ral.usbstat), .value(usbstat));
+          `DV_CHECK_EQ(get_field_val(ral.usbstat.av_out_depth, usbstat), 0, "Av FIFO not empty")
+          send_prnd_out_packet(ep_default, correct_toggle(ep_default, out_toggles));
+          // DUT should be unable to accept the packet right now, so we're expecting a NAK.
+          check_response_matches(PidTypeNak);
+          // Now supply a buffer for subsequent tests.
+          supply_out_buffer();
+        end
+
+        LinkOutBadToggle: begin
+          // Send an OUT data packet with incorrect Data Toggle; to be sure that we get it 'wrong'
+          // we'll read the current toggle.
+          csr_wr(.ptr(ral.out_data_toggle), .value(out_toggles));
+          send_prnd_out_packet(ep_default, bad_toggle(ep_default, out_toggles));
+          // With an invalid Data Toggle the DUT shall still ACK to try to get us to advance to the
+          // next packet/toggle bit, on the premise that its previous ACK was corrupted/lost.
+          check_response_matches(PidTypeAck);
+        end
+
+        LinkOutTokenCRC16: begin
+          inject_bad_data_crc16 = 1'b1;
+          send_prnd_out_packet(ep_default, correct_toggle(ep_default, out_toggles));
+          inject_bad_data_crc16 = 1'b0;
+          // Packets with invalid CRC16 shall simply be ignored; host shall try again.
+          check_no_response();
+        end
+
+        // The final cause is LinkOutNoSpace.
+        LinkOutNoSpace: begin
+          // Expected RX FIFO level; fail as soon as possible if packets are not being stored.
+          int unsigned exp_rx_depth = 0;
+          // At this point we just keep sending packets until the RX FIFO can take no more.
+          uvm_reg_data_t usbstat;
+          bit exp_ack;
+          do begin
+            supply_out_buffer();
+            // Check the level of the RX FIFO and form an expectation of the DUT response;
+            // remember that the last entry of the RX FIFO cannot be populated with an OUT DATA
+            // packet, so the DUT should NAK.
+            csr_rd(.ptr(ral.usbstat), .value(usbstat));
+            `DV_CHECK_EQ(get_field_val(ral.usbstat.rx_depth, usbstat), exp_rx_depth)
+            exp_ack = (get_field_val(ral.usbstat.rx_depth, usbstat) < RxFIFODepth - 1);
+            send_prnd_out_packet(ep_default, correct_toggle(ep_default, out_toggles));
+            check_response_matches(exp_ack ? PidTypeAck : PidTypeNak);
+            // Flip the Data Toggle bit otherwise a subsequent OUT DATA packet shall not be stored.
+            out_toggles[ep_default] ^= 1'b1;
+            exp_rx_depth++;
+          end while (exp_ack);
+        end
+
+        default: `uvm_fatal(`gfn, "Unrecognised/unsupported cause")
+      endcase
+
+      // Interrupt bit should be asserted almost immediately; do not clear it at this point because
+      // we want to check the interrupt line from the DUT too, and not just the status register bit.
+      wait_for_interrupt(intr_bit, .timeout_clks(20), .clear(0), .enforce(1));
+      // Interrupt line may take a little longer.
+      loopback_delay();
+      `DV_CHECK_EQ(cfg.intr_vif.pins[IntrLinkOutErr], 1, "Interrupt line not asserted as expected")
+      // Clear the interrupt
+      csr_wr(.ptr(ral.intr_state), .value(intr_bit));
+      // Interrupt line may take a little longer.
+      loopback_delay();
+      `DV_CHECK_EQ(cfg.intr_vif.pins[IntrLinkOutErr], 0, "Interrupt line still asserted")
+    end while (cause != cause.last());
+
+    // Disable and clear the interrupt.
+    csr_wr(.ptr(ral.intr_enable), .value(0));
+    csr_wr(.ptr(ral.intr_state), .value(intr_bit));
+    // Empty the RX FIFO.
+    flush_rx_fifo();
+  endtask
+endclass : usbdev_link_out_err_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
@@ -35,17 +35,17 @@ class usbdev_max_usb_traffic_vseq extends usbdev_base_vseq;
   constraint in_and_out_c {
     // OUT data is returned as IN data on the same endpoint.
     (ep_in_enabled & ep_out_enabled) != 0;
-  };
+  }
 
   // Ensure that all streams are bidirectional; no OUT endpoints without corresponding IN endpoints
   // and vice-versa.
   constraint bidir_only_c {
     ep_in_enabled == ep_out_enabled;
-  };
+  }
 
   constraint ep_iso_enabled_c {
     ep_iso_enabled == 0;
-  };
+  }
 
   // Bitmap of available buffers that are not presently assigned to the DUT.
   bit [NumBuffers-1:0] buf_avail;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_crc_err_vseq.sv
@@ -8,16 +8,28 @@ class usbdev_rx_crc_err_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   task body();
-    // Configure transaction
+    // Configure transaction.
     configure_out_trans(ep_default);
 
-    // Enable rx_crc_err interrupt
+    // Enable rx_crc_err interrupt.
     csr_wr(.ptr(ral.intr_enable.rx_crc_err), .value(1'b1));
 
-    // Out Token packet with corrupted CRC5
-    inject_bad_token_crc5 = 1'b1;
-    send_token_packet(ep_default, PidTypeOutToken);
-    inject_bad_token_crc5 = 1'b0;
+    randcase
+      // Out Token packet with corrupted CRC5.
+      1: begin
+        `uvm_info(`gfn, "Sending OUT token packet with corrupted CRC5", UVM_LOW)
+        inject_bad_token_crc5 = 1'b1;
+        send_token_packet(ep_default, PidTypeOutToken);
+        inject_bad_token_crc5 = 1'b0;
+      end
+      // Out Data packet with corrupted CRC16.
+      1: begin
+        `uvm_info(`gfn, "Sending OUT DATA packet with corrupted CRC16", UVM_LOW)
+        inject_bad_data_crc16 = 1'b1;
+        send_prnd_out_packet(ep_default, PidTypeData0);
+        inject_bad_data_crc16 = 1'b0;
+      end
+    endcase
 
     // Wait a little while for the interrupt signal to become asserted.
     for (int i = 0; i < 16; i++) begin

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_priority_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_priority_vseq.sv
@@ -25,7 +25,7 @@ class usbdev_setup_priority_vseq extends usbdev_base_vseq;
   endtask
 
   // Retain the packet properties for subsequent checking.
-  function retain_packet(bit [3:0] ep, bit setup, ref byte unsigned data[]);
+  function void retain_packet(bit [3:0] ep, bit setup, ref byte unsigned data[]);
     rx_packet_t rx;
     // The randomized packet data that was transmitted to the DUT.
     rx.ep = ep;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_spray_packets_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_spray_packets_vseq.sv
@@ -80,7 +80,7 @@ class usbdev_spray_packets_vseq extends usbdev_base_vseq;
   // transaction.
   // To be overridden by any child sequence that wishes to constrain the choice of target, endpoint
   // and/or transaction type, and/or constraints may be added to their randomization.
-  virtual function choose_target();
+  virtual function void choose_target();
     `DV_CHECK_STD_RANDOMIZE_FATAL(target_addr)
     `DV_CHECK_STD_RANDOMIZE_FATAL(target_ep)
     `DV_CHECK_STD_RANDOMIZE_FATAL(txn_type)
@@ -225,7 +225,7 @@ class usbdev_spray_packets_vseq extends usbdev_base_vseq;
       // Check the properties and content of the received packet, observing that we do not know
       // into which buffer the packet will have been received.
       check_rxfifo_packet(exp_rx[0].ep, exp_rx[0].setup, exp_rx[0].data, rx_fifo_read);
-      exp_rx.pop_front();
+      void'(exp_rx.pop_front());
       rx_cnt++;
       // Release the buffer that was used.
       buf_release(act_buffer_id);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_streaming_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_streaming_vseq.sv
@@ -10,6 +10,6 @@ class usbdev_streaming_vseq extends usbdev_max_usb_traffic_vseq;
   // Ensure that a single endpoint pair (IN and OUT) is selected.
   constraint single_endpoint_c {
     ep_in_enabled != 0 && (ep_in_enabled & (ep_in_enabled - 1)) == 0;
-  };
+  }
 
 endclass : usbdev_streaming_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -24,6 +24,7 @@
 `include "usbdev_in_trans_vseq.sv"
 `include "usbdev_in_iso_vseq.sv"
 `include "usbdev_link_in_err_vseq.sv"
+`include "usbdev_link_out_err_vseq.sv"
 `include "usbdev_link_reset_vseq.sv"
 `include "usbdev_max_usb_traffic_vseq.sv"
 `include "usbdev_nak_trans_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -54,6 +54,7 @@ filesets:
       - seq_lib/usbdev_in_rand_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_in_err_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_link_out_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_resume_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_suspend_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_reset_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -147,8 +147,8 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
   // -------------------------------
   virtual task compare_usb20_pkt(usb20_item item);
     if (predict_errors(item)) begin
-      actual_pkt_q.pop_front();
-      expected_pkt_q.pop_front();
+      void'(actual_pkt_q.pop_front());
+      void'(expected_pkt_q.pop_front());
       return;
     end
     if (actual_pkt_q.size() > 0) begin

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -108,6 +108,10 @@
       uvm_test_seq: usbdev_disable_endpoint_vseq
     }
     {
+      name: usbdev_disconnected
+      uvm_test_seq: usbdev_disconnected_vseq
+    }
+    {
       name: usbdev_endpoint_access
       uvm_test_seq: usbdev_endpoint_access_vseq
     }
@@ -130,6 +134,12 @@
       uvm_test_seq: usbdev_in_trans_vseq
     }
     {
+      name: usbdev_invalid_data1_data0_toggle_test
+      uvm_test_seq: usbdev_link_out_err_vseq
+      // No need for randomization.
+      reseed: 1
+    }
+    {
       name: usbdev_invalid_sync
       uvm_test_seq: usbdev_bad_traffic_vseq
       run_opts: ["+wt_bad_syncs=1"]
@@ -137,6 +147,12 @@
     {
       name: usbdev_link_in_err
       uvm_test_seq: usbdev_link_in_err_vseq
+    }
+    {
+      name: usbdev_link_out_err
+      uvm_test_seq: usbdev_link_out_err_vseq
+      // No need for randomization.
+      reseed: 1
     }
     {
       name: usbdev_link_reset
@@ -161,10 +177,6 @@
       uvm_test_seq: usbdev_min_length_out_transaction_vseq
     }
     {
-      name: usbdev_disconnected
-      uvm_test_seq: usbdev_disconnected_vseq
-    }
-    {
       name: usbdev_max_usb_traffic
       uvm_test_seq: usbdev_max_usb_traffic_vseq
     }
@@ -177,6 +189,12 @@
       name: usbdev_max_inter_pkt_delay
       uvm_test_seq: usbdev_streaming_vseq
       run_opts: ["+setup_data_delay=26", "+out_data_delay=26"]
+    }
+    {
+      name: usbdev_nak_to_out_trans_when_avbuffer_empty_rxfifo_full
+      uvm_test_seq: usbdev_link_out_err_vseq
+      // No need for randomization.
+      reseed: 1
     }
     {
       name: usbdev_nak_trans


### PR DESCRIPTION
This PR addresses a number of uncovered test points with a single sequence `usbdev_link_out_err` that iterates through the possible causes of a 'link out error' interrupt.

It additionally improves the existing 'usbdev_rx_crc_err' sequence to meet the test plan description, which is refined for correctness.

This PR is built on #23725 because that is still suffering from unrelated CI failures, but only the **last 3 commits are relevant to this PR** and the earlier commits are unmodified and already reviewed.