### PR TITLE
[rom] Speed up SPHINCS+ computations.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -32,7 +32,7 @@ typedef struct hmac_digest {
 } hmac_digest_t;
 
 /**
- * Initializes the HMAC in SHA256 mode.
+ * Configure the HMAC block in SHA256 mode.
  *
  * This function resets the HMAC module to clear the digest register.
  * It then configures the HMAC block in SHA256 mode with digest output
@@ -41,16 +41,22 @@ typedef struct hmac_digest {
  * @param big_endian Whether or not to initialize the peripheral for big-endian
  *                   results.
  */
-void hmac_sha256_init_endian(bool big_endian_digest);
+void hmac_sha256_configure(bool big_endian_digest);
 
 /**
- * Initializes the HMAC in SHA256 mode with little-endian output.
+ * Starts a new operation on the pre-configured HMAC block.
  *
- * This function resets the HMAC module to clear the digest register.
- * It then configures the HMAC block in SHA256 mode with little endian
- * data input and digest output.
+ * Call `hmac_sha256_configure` first.
  */
-inline void hmac_sha256_init(void) { hmac_sha256_init_endian(false); }
+void hmac_sha256_start(void);
+
+/**
+ * Configures and starts HMAC in SHA256 mode with little-endian output.
+ */
+inline void hmac_sha256_init(void) {
+  hmac_sha256_configure(false);
+  hmac_sha256_start();
+}
 
 /**
  * Sends `len` bytes from `data` to the SHA2-256 function.
@@ -75,6 +81,11 @@ void hmac_sha256_update(const void *data, size_t len);
  * @param len Size of the `data` buffer in words.
  */
 void hmac_sha256_update_words(const uint32_t *data, size_t len);
+
+/**
+ * Begin processing the final digest for HMAC.
+ */
+void hmac_sha256_process(void);
 
 /**
  * Finalizes SHA256 operation and copies truncated output.

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.cc
@@ -6,9 +6,11 @@
 
 namespace rom_test {
 extern "C" {
-void hmac_sha256_init_endian(bool big_endian_digest) {
-  MockHmac::Instance().sha256_init_endian(big_endian_digest);
+void hmac_sha256_configure(bool big_endian_digest) {
+  MockHmac::Instance().sha256_configure(big_endian_digest);
 }
+
+void hmac_sha256_start(void) { MockHmac::Instance().sha256_start(); }
 
 void hmac_sha256_init(void) { MockHmac::Instance().sha256_init(); }
 
@@ -20,6 +22,8 @@ void hmac_sha256_update_words(const uint32_t *data, size_t len) {
   MockHmac::Instance().sha256_update_words(data, len);
 }
 
+void hmac_sha256_process(void) { MockHmac::Instance().sha256_process(); }
+
 void hmac_sha256_final_truncated(uint32_t *digest, size_t len) {
   MockHmac::Instance().sha256_final_truncated(digest, len);
 }
@@ -30,6 +34,14 @@ void hmac_sha256_final(hmac_digest_t *digest) {
 
 void hmac_sha256(const void *data, size_t len, hmac_digest_t *digest) {
   MockHmac::Instance().sha256(data, len, digest);
+}
+
+void hmac_sha256_save(hmac_context_t *ctx) {
+  MockHmac::Instance().sha256_save(ctx);
+}
+
+void hmac_sha256_restore(const hmac_context_t *ctx) {
+  MockHmac::Instance().sha256_restore(ctx);
 }
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.h
@@ -17,13 +17,17 @@ namespace internal {
  */
 class MockHmac : public global_mock::GlobalMock<MockHmac> {
  public:
+  MOCK_METHOD(void, sha256_configure, (bool));
+  MOCK_METHOD(void, sha256_start, ());
   MOCK_METHOD(void, sha256_init, ());
-  MOCK_METHOD(void, sha256_init_endian, (bool));
   MOCK_METHOD(void, sha256_update, (const void *, size_t));
   MOCK_METHOD(void, sha256_update_words, (const uint32_t *, size_t));
+  MOCK_METHOD(void, sha256_process, ());
   MOCK_METHOD(void, sha256_final_truncated, (uint32_t *, size_t));
   MOCK_METHOD(void, sha256_final, (hmac_digest_t *));
   MOCK_METHOD(void, sha256, (const void *, size_t, hmac_digest_t *));
+  MOCK_METHOD(void, sha256_save, (hmac_context_t *));
+  MOCK_METHOD(void, sha256_restore, (const hmac_context_t *));
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/context.h
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/context.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
 
 #ifdef __cplusplus
@@ -19,13 +20,18 @@ extern "C" {
 /**
  * Context object for the SPHINCS+ operation.
  *
- * The reference implementation has more fields here: `sk_seed` and
- * hash-specific precomputed values for Haraka and SHA2 hash functions. Since
- * we are only using SHAKE-based SPHINCS+ in this context, and only performing
- * verification, all we need is the public key seed.
+ * The reference implementation stores `sk_seed` here as well, but we only
+ * performing verification so we don't need it.
  */
 typedef struct spx_ctx {
+  /**
+   * Public key seed.
+   */
   uint32_t pub_seed[kSpxNWords];
+  /**
+   * SHA256 state that absorbed pub_seed and padding.
+   */
+  hmac_context_t state_seeded;
 } spx_ctx_t;
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_sha2.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_sha2.c
@@ -49,7 +49,10 @@ static_assert(
     kSpxLeafBits <= 32,
     "For the given height, 32 bits is not large enough for a leaf index.");
 
-inline rom_error_t spx_hash_initialize(spx_ctx_t *ctx) { return kErrorOk; }
+inline rom_error_t spx_hash_initialize(spx_ctx_t *ctx) {
+  hmac_sha256_configure(/*big_endian_digest=*/true);
+  return kErrorOk;
+}
 
 rom_error_t spx_hash_message(const uint32_t *R, const uint32_t *pk,
                              const uint8_t *msg_prefix_1,
@@ -62,7 +65,7 @@ rom_error_t spx_hash_message(const uint32_t *R, const uint32_t *pk,
   // H_msg: MGF1-SHA256(R || PK.seed || SHA256(R || PK.seed || PK.root || M))
   memcpy(seed, R, kSpxN);
   memcpy(&seed[kSpxNWords], pk, kSpxN);
-  hmac_sha256_init_endian(/*big_endian=*/true);
+  hmac_sha256_start();
   hmac_sha256_update_words(R, kSpxNWords);
   hmac_sha256_update_words(pk, kSpxPkWords);
   hmac_sha256_update(msg_prefix_1, msg_prefix_1_len);

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_sha2.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_sha2.c
@@ -51,6 +51,14 @@ static_assert(
 
 inline rom_error_t spx_hash_initialize(spx_ctx_t *ctx) {
   hmac_sha256_configure(/*big_endian_digest=*/true);
+
+  // Save state for the first part of `thash`: public key seed + padding.
+  hmac_sha256_start();
+  hmac_sha256_update_words(ctx->pub_seed, kSpxNWords);
+  uint32_t padding[kSpxSha2BlockNumWords - kSpxNWords];
+  memset(padding, 0, sizeof(padding));
+  hmac_sha256_update_words(padding, ARRAYSIZE(padding));
+  hmac_sha256_save(&ctx->state_seeded);
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.c
@@ -13,7 +13,7 @@ void mgf1_sha256(const uint32_t *in, size_t in_len, size_t out_len,
   // Append SHA256(in || counter) to the output until the requested length is
   // reached.
   for (uint32_t ctr = 0; ctr * kHmacDigestNumWords < out_len; ctr++) {
-    hmac_sha256_init_endian(/*big_endian=*/true);
+    hmac_sha256_start();
     hmac_sha256_update_words(in, in_len);
     uint32_t ctr_be = __builtin_bswap32(ctr);
     hmac_sha256_update_words(&ctr_be, 1);

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/BUILD
@@ -59,6 +59,7 @@ opentitan_test(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/sigverify/sphincsplus:hash",
         "//sw/device/silicon_creator/lib/sigverify/sphincsplus:sha2",
     ],
 )

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/mgf1_test.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/test/mgf1_test.c
@@ -7,6 +7,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/sigverify/sphincsplus/hash.h"
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/params.h"
 #include "sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.h"
 
@@ -39,6 +40,10 @@ static const uint32_t kExpectedOutput[kMgf1OutputWords] = {
 
 OT_WARN_UNUSED_RESULT
 static rom_error_t mgf1_test(void) {
+  // Run spx_hash_initialize() to configure the HMAC block.
+  spx_ctx_t ctx;
+  HARDENED_RETURN_IF_ERROR(spx_hash_initialize(&ctx));
+
   uint32_t actual_output[kMgf1OutputWords];
   mgf1_sha256(kTestInput, ARRAYSIZE(kTestInput), ARRAYSIZE(actual_output),
               actual_output);

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_sha2_simple.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_sha2_simple.c
@@ -13,11 +13,7 @@
 
 void thash(const uint32_t *in, size_t inblocks, const spx_ctx_t *ctx,
            const spx_addr_t *addr, uint32_t *out) {
-  hmac_sha256_start();
-  hmac_sha256_update_words(ctx->pub_seed, kSpxNWords);
-  uint32_t padding[kSpxSha2BlockNumWords - kSpxNWords];
-  memset(padding, 0, sizeof(padding));
-  hmac_sha256_update_words(padding, ARRAYSIZE(padding));
+  hmac_sha256_restore(&ctx->state_seeded);
   hmac_sha256_update((unsigned char *)addr->addr, kSpxSha256AddrBytes);
   hmac_sha256_update_words(in, inblocks * kSpxNWords);
   hmac_sha256_final_truncated(out, kSpxNWords);

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_sha2_simple.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_sha2_simple.c
@@ -13,7 +13,7 @@
 
 void thash(const uint32_t *in, size_t inblocks, const spx_ctx_t *ctx,
            const spx_addr_t *addr, uint32_t *out) {
-  hmac_sha256_init_endian(/*big_endian=*/true);
+  hmac_sha256_start();
   hmac_sha256_update_words(ctx->pub_seed, kSpxNWords);
   uint32_t padding[kSpxSha2BlockNumWords - kSpxNWords];
   memset(padding, 0, sizeof(padding));

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/wots.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/wots.c
@@ -49,12 +49,14 @@ static void gen_chain(const uint32_t *in, uint8_t start, const spx_ctx_t *ctx,
   // performance-critical.
   for (uint8_t i = start; i + 1 < kSpxWotsW; i++) {
     // This loop body is essentially just `thash`, inlined for performance.
-    spx_addr_hash_set(addr, i);
-    hmac_sha256_init_endian(/*big_endian=*/true);
+    hmac_sha256_start();
     hmac_sha256_update_words(ctx->pub_seed, kSpxNWords);
     hmac_sha256_update_words(padding, ARRAYSIZE(padding));
     hmac_sha256_update((unsigned char *)addr->addr, kSpxSha256AddrBytes);
     hmac_sha256_update_words(out, kSpxNWords);
+    hmac_sha256_process();
+    // Update the address while HMAC is processing for performance reasons.
+    spx_addr_hash_set(addr, i+1);
     hmac_sha256_final_truncated(out, kSpxNWords);
   }
 }


### PR DESCRIPTION
Accelerates SPHINCS+ computations by changing the HMAC driver:
1. Separate out `init()` into `configure()` and `start()` so that the code can start a new hash operation of the same type without reconfiguring the hardware.
2. Separate `process()` from `final()` so that we can perform unrelated computations in between letting HMAC know the input is done and actually reading the digest, while HMAC is processing.
3. Use the new save/restore feature of the HMAC block to cache the state of the most performance-relevant computation after ingesting the first message block (the reference implementation also does this; I just didn't include it in #23732 because I wasn't sure we would want to commit to the code size tradeoff).

In terms of performance (average of 10 valid runs from `kat0`) and code size:
| Code  | Performance (cycles) | Code size (bytes) |
| ------------- | ------------- |----------------|
| `master` (a502432bf42811abea7132202bc001c1a9831199)  |  `1482599` | `30400`  |
| change (1)  |  `1428422` | `30420` |
| changes (1) and (2)  |  `1417290` | `30420` |
| changes (1), (2), and (3)  |  `1216347` | `30592` |
 
In summary, the changes together make the average verification speed **2.66ms faster** at the cost of **192 bytes** of code size. Most of both the speed benefit and the code size comes from change (3). With this change, the SHA2 variant becomes slightly faster than the SHAKE variant was before (~12.5ms).