### PR TITLE
[kmac, dv] Test if KMAC correctly zeroizes the capacity

### DIFF
--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -919,7 +919,7 @@ TEST_F(KmacSqueezeTest, GenerateExtraStatesSuccess) {
                    kOutShares[0].size() - 34);
 
   EXPECT_DIF_OK(dif_kmac_squeeze(&kmac_, &op_state_, out_buffer,
-                                 ARRAYSIZE(out_buffer), nullptr));
+                                 ARRAYSIZE(out_buffer), nullptr, nullptr));
 
   EXPECT_EQ(op_state_, expected_op_state_);
 
@@ -942,7 +942,7 @@ TEST_F(KmacSqueezeTest, FillOutBufferSuccess) {
                    ARRAYSIZE(out_buffer_));
 
   EXPECT_DIF_OK(dif_kmac_squeeze(&kmac_, &op_state_, out_buffer_,
-                                 ARRAYSIZE(out_buffer_), nullptr));
+                                 ARRAYSIZE(out_buffer_), nullptr, nullptr));
 
   EXPECT_EQ(op_state_, expected_op_state_);
 
@@ -964,7 +964,8 @@ TEST_F(KmacSqueezeTest, AppendSizeSuccess) {
   ExpectAppendSize();
   EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
                  {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_PROCESS}});
-  EXPECT_DIF_OK(dif_kmac_squeeze(&kmac_, &op_state_, nullptr, 0, nullptr));
+  EXPECT_DIF_OK(
+      dif_kmac_squeeze(&kmac_, &op_state_, nullptr, 0, nullptr, nullptr));
 
   EXPECT_EQ(op_state_, expected_op_state_);
 }
@@ -976,18 +977,19 @@ TEST_F(KmacSqueezeTest, JustProcessSuccess) {
   EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
                  {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_PROCESS}});
 
-  EXPECT_DIF_OK(dif_kmac_squeeze(&kmac_, &op_state_, nullptr, 0, nullptr));
+  EXPECT_DIF_OK(
+      dif_kmac_squeeze(&kmac_, &op_state_, nullptr, 0, nullptr, nullptr));
   EXPECT_EQ(op_state_, expected_op_state_);
   EXPECT_EQ(op_state_.d, 0);
 }
 
 TEST_F(KmacSqueezeTest, BadArg) {
   EXPECT_DIF_BADARG(dif_kmac_squeeze(NULL, &op_state_, out_buffer_,
-                                     ARRAYSIZE(out_buffer_), nullptr));
+                                     ARRAYSIZE(out_buffer_), nullptr, nullptr));
   EXPECT_DIF_BADARG(dif_kmac_squeeze(&kmac_, nullptr, out_buffer_,
-                                     ARRAYSIZE(out_buffer_), nullptr));
+                                     ARRAYSIZE(out_buffer_), nullptr, nullptr));
   EXPECT_DIF_BADARG(dif_kmac_squeeze(&kmac_, &op_state_, nullptr,
-                                     ARRAYSIZE(out_buffer_), nullptr));
+                                     ARRAYSIZE(out_buffer_), nullptr, nullptr));
 }
 
 TEST_F(KmacSqueezeTest, StarteMachineError) {
@@ -996,7 +998,7 @@ TEST_F(KmacSqueezeTest, StarteMachineError) {
                  {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_PROCESS}});
 
   EXPECT_EQ(dif_kmac_squeeze(&kmac_, &op_state_, out_buffer_,
-                             ARRAYSIZE(out_buffer_), nullptr),
+                             ARRAYSIZE(out_buffer_), nullptr, nullptr),
             kDifError);
 }
 
@@ -1011,7 +1013,7 @@ TEST_F(KmacSqueezeTest, RequestLessDataThanFixedLenError) {
                 {{KMAC_INTR_STATE_KMAC_ERR_BIT, true}});
 
   EXPECT_EQ(dif_kmac_squeeze(&kmac_, &op_state_, out_buffer_,
-                             ARRAYSIZE(out_buffer_), nullptr),
+                             ARRAYSIZE(out_buffer_), nullptr, nullptr),
             kDifError);
 }
 

--- a/sw/device/lib/testing/kmac_testutils.c
+++ b/sw/device/lib/testing/kmac_testutils.c
@@ -39,7 +39,8 @@ status_t kmac_testutils_kmac(const dif_kmac_t *kmac,
                              const char *custom_string,
                              const size_t custom_string_len,
                              const char *message, const size_t message_len,
-                             const size_t output_len, uint32_t *output) {
+                             const size_t output_len, uint32_t *output,
+                             uint32_t *capacity) {
   // Initialize customization string.
   dif_kmac_customization_string_t kmac_custom_string;
   TRY(dif_kmac_customization_string_init(custom_string, custom_string_len,
@@ -58,7 +59,8 @@ status_t kmac_testutils_kmac(const dif_kmac_t *kmac,
 
   // Get the output ("squeeze" stage) and check that KMAC doesn't report an
   // error.
-  TRY(dif_kmac_squeeze(kmac, &operation_state, output, output_len, NULL));
+  TRY(dif_kmac_squeeze(kmac, &operation_state, output, output_len, NULL,
+                       capacity));
   TRY(kmac_testutils_check_error(kmac));
 
   // End the operation and check that KMAC doesn't report an error.

--- a/sw/device/lib/testing/kmac_testutils.h
+++ b/sw/device/lib/testing/kmac_testutils.h
@@ -39,6 +39,7 @@ status_t kmac_testutils_config(dif_kmac_t *kmac, bool sideload);
  * @param output_len Requested length of output in words.
  * @param[out] output Pre-allocated output buffer (length must match
  * output_len).
+ * @param[out] capacity Optional buffer to read the capacity of Keccak state.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -47,7 +48,8 @@ status_t kmac_testutils_kmac(const dif_kmac_t *kmac, dif_kmac_mode_kmac_t mode,
                              const char *custom_string,
                              const size_t custom_string_len,
                              const char *message, const size_t message_len,
-                             const size_t output_len, uint32_t *output);
+                             const size_t output_len, uint32_t *output,
+                             uint32_t *capacity);
 
 /**
  * Check if the KMAC HW has flagged any errors and acknowledge them.

--- a/sw/device/tests/entropy_src_fw_override_test.c
+++ b/sw/device/tests/entropy_src_fw_override_test.c
@@ -324,7 +324,7 @@ status_t firmware_override_extract_insert(
   TRY(kmac_testutils_kmac(&kmac, kDifKmacModeKmacLen128, &software_key,
                           /*custom_string=*/NULL, /*custom_string_len=*/0,
                           /*message=*/"hello", /*message_len=*/6,
-                          ARRAYSIZE(output), output));
+                          ARRAYSIZE(output), output, /*capacity=*/NULL));
 
   LOG_INFO("Running OTBN...");
   otbn_randomness_test_start(&otbn, /*iters=*/10);

--- a/sw/device/tests/kmac_entropy_test.c
+++ b/sw/device/tests/kmac_entropy_test.c
@@ -167,9 +167,9 @@ bool test_main(void) {
 
     // This is where timeout might happen, so we handle dif return manually
     uint32_t out[kKmacDigestLenMax];
-    dif_result_t res =
-        dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
-                         kKmacTestVector.digest_len, /*processed=*/NULL);
+    dif_result_t res = dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
+                                        kKmacTestVector.digest_len,
+                                        /*processed=*/NULL, /*capacity=*/NULL);
 
     // It is OK to get kDifError at this point because of possible timeout
     CHECK(res == kDifOk || res == kDifError);

--- a/sw/device/tests/kmac_idle_test.c
+++ b/sw/device/tests/kmac_idle_test.c
@@ -82,7 +82,8 @@ static void do_sha3_test(void) {
 
   uint32_t out[DIGEST_LEN_SHA3_MAX];
   CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
-                                sha3_256_test.digest_len, NULL));
+                                sha3_256_test.digest_len, /*processed=*/NULL,
+                                /*capacity=*/NULL));
 
   // Check clock state again which should still be enabled.
   check_clock_state(kDifToggleEnabled);

--- a/sw/device/tests/kmac_mode_cshake_test.c
+++ b/sw/device/tests/kmac_mode_cshake_test.c
@@ -129,7 +129,8 @@ bool test_main(void) {
     uint32_t out[DIGEST_LEN_CSHAKE_MAX];
     CHECK(DIGEST_LEN_CSHAKE_MAX >= test.digest_len);
     CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
-                                  test.digest_len, NULL));
+                                  test.digest_len, /*processed=*/NULL,
+                                  /*capacity=*/NULL));
     CHECK_DIF_OK(dif_kmac_end(&kmac, &kmac_operation_state));
 
     for (int j = 0; j < test.digest_len; ++j) {

--- a/sw/device/tests/kmac_mode_kmac_test.c
+++ b/sw/device/tests/kmac_mode_kmac_test.c
@@ -227,7 +227,8 @@ bool test_main(void) {
     uint32_t out[DIGEST_LEN_KMAC_MAX];
     CHECK(DIGEST_LEN_KMAC_MAX >= test.digest_len);
     CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
-                                  test.digest_len, NULL));
+                                  test.digest_len, /*processed=*/NULL,
+                                  /*capacity=*/NULL));
     CHECK_DIF_OK(dif_kmac_end(&kmac, &kmac_operation_state));
 
     for (int j = 0; j < test.digest_len; ++j) {

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -171,8 +171,8 @@ void run_sha3_test(dif_kmac_t *kmac) {
     }
     uint32_t out[DIGEST_LEN_SHA3_MAX];
     CHECK(DIGEST_LEN_SHA3_MAX >= test.digest_len);
-    CHECK_DIF_OK(
-        dif_kmac_squeeze(kmac, &operation_state, out, test.digest_len, NULL));
+    CHECK_DIF_OK(dif_kmac_squeeze(kmac, &operation_state, out, test.digest_len,
+                                  /*processed=*/NULL, /*capacity=*/NULL));
     CHECK_DIF_OK(dif_kmac_end(kmac, &operation_state));
 
     // Wait for the hardware engine to actually finish. On FPGA, it may take
@@ -212,8 +212,9 @@ void run_sha3_alignment_test(dif_kmac_t *kmac) {
 
     // Checking the first 32-bits of the digest is sufficient.
     uint32_t out;
-    CHECK_DIF_OK(
-        dif_kmac_squeeze(kmac, &operation_state, &out, sizeof(uint32_t), NULL));
+    CHECK_DIF_OK(dif_kmac_squeeze(kmac, &operation_state, &out,
+                                  sizeof(uint32_t), /*processed=*/NULL,
+                                  /*capacity=*/NULL));
     CHECK_DIF_OK(dif_kmac_end(kmac, &operation_state));
 
     // Wait for the hardware engine to actually finish. On FPGA, it may take
@@ -238,8 +239,9 @@ void run_sha3_alignment_test(dif_kmac_t *kmac) {
 
     // Checking the first 32-bits of the digest is sufficient.
     uint32_t out;
-    CHECK_DIF_OK(
-        dif_kmac_squeeze(kmac, &operation_state, &out, sizeof(uint32_t), NULL));
+    CHECK_DIF_OK(dif_kmac_squeeze(kmac, &operation_state, &out,
+                                  sizeof(uint32_t), /*processed=*/NULL,
+                                  /*capacity=*/NULL));
     CHECK_DIF_OK(dif_kmac_end(kmac, &operation_state));
 
     // Wait for the hardware engine to actually finish. On FPGA, it may take
@@ -267,8 +269,8 @@ void run_shake_test(dif_kmac_t *kmac) {
     }
     uint32_t out[DIGEST_LEN_SHAKE_MAX];
     CHECK(DIGEST_LEN_SHAKE_MAX >= test.digest_len);
-    CHECK_DIF_OK(
-        dif_kmac_squeeze(kmac, &operation_state, out, test.digest_len, NULL));
+    CHECK_DIF_OK(dif_kmac_squeeze(kmac, &operation_state, out, test.digest_len,
+                                  /*processed=*/NULL, /*capacity=*/NULL));
     CHECK_DIF_OK(dif_kmac_end(kmac, &operation_state));
 
     // Wait for the hardware engine to actually finish. On FPGA, it may take

--- a/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
+++ b/sw/device/tests/sim_dv/csrng_lc_hw_debug_en_test.c
@@ -142,7 +142,8 @@ static void exit_token_cshake_hash(uint64_t *otp_token_l,
 
   uint32_t token_hash[kExitTokenSizeInWords];
   CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &op_state, token_hash,
-                                kExitTokenSizeInWords, /*processed=*/NULL));
+                                kExitTokenSizeInWords, /*processed=*/NULL,
+                                /*capacity=*/NULL));
   CHECK_DIF_OK(dif_kmac_end(&kmac, &op_state));
 
   *otp_token_l = 0;


### PR DESCRIPTION
Related to #17759.

The key change in this PR is the test `sw/device/tests/keymgr_sideload_kmac_test.c`, so I find that to be the most review-worthy change of this PR.

- Extend `keymgr_sideload_kmac` test so that:'
  - For KMAC op with sideloaded key, check that the capacity reads as 0.
  - For SW-keyed KMAC op, check that the capacity does not read as 0. This test **does not** check that this capacity value is correct. I think that is not very important to check its correctness, because we do check the correct digest.
- Further changes required in DIF/testutils to enable above change:
  - Update `dif_kmac_squeeze` so that it can also return `capacity` buffer.
  - Update `kmac_testutils_kmac` so that it also accepts `capacity` buffer.
  - Fix these function references in other tests.