### PR TITLE
[dv,usbdev] Exercise all bus configurations

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -419,7 +419,9 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
   function usb_symbol_e current_symbol();
     if (cfg.tx_use_d_se0) begin
       // SE0 takes precedence over the data line.
-      return cfg.bif.usb_tx_se0_o ? USB20Sym_SE0 : (cfg.bif.usb_tx_d_o ? USB20Sym_J : USB20Sym_K);
+      return cfg.bif.usb_tx_se0_o ? USB20Sym_SE0 : // SE0 unaffected by pin flipping.
+           // Pin flipping does affect D/SE0 output too; the sense of 'd' is inverted.
+           ((cfg.bif.usb_tx_d_o ^ cfg.pinflip) ? USB20Sym_J : USB20Sym_K);
     end else if (cfg.pinflip) begin
       // J and K encodings are transposed when the pins are flipped, but SE0 is unaltered.
       case ({cfg.bif.usb_n, cfg.bif.usb_p})

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -136,7 +136,9 @@ class usb20_monitor extends dv_base_monitor #(
     // Return the symbol currently on the bus, according to the pin configuration.
     if (cfg.tx_use_d_se0) begin
       // SE0 takes precedence over the data line.
-      sym = cfg.bif.usb_tx_se0_o ? USB20Sym_SE0 : (cfg.bif.usb_tx_d_o ? USB20Sym_J : USB20Sym_K);
+      sym = cfg.bif.usb_tx_se0_o ? USB20Sym_SE0 : // SE0 unaffected by pin flipping.
+          // Pin flipping does affect D/SE0 output too; the sense of 'd' is inverted.
+          ((cfg.bif.usb_tx_d_o ^ cfg.pinflip) ? USB20Sym_J : USB20Sym_K);
     end else begin
       casez ({cfg.bif.usb_n, cfg.bif.usb_p})
         2'b00:   sym = USB20Sym_SE0;

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -162,6 +162,39 @@
       tests: ["usbdev_phy_config_pinflip"]
     }
     {
+      name: phy_config_rand_bus_type
+      desc: '''
+            Choose a random bus configuration and verify that the smoke sequence still passes.
+            '''
+      stage: V2
+      tests: ["usbdev_phy_config_rand_bus_type"]
+    }
+    {
+      name: phy_config_rx_dp_dn
+      desc: '''
+            Verify that the DP/DN input signals may be used to decode the USB traffic without an
+            external differential receiver.
+            The USBDEV normally relies upon an external differential receiver to ensure USB 2.0
+            specification compliance but it can receive traffic directly using just DP and DN for
+            reduced complexity and/or cost.
+
+            - This just runs the smoke test with modified PHY configuration.
+            '''
+      stage: V2
+      tests: ["usbdev_phy_config_rx_dp_dn"]
+    }
+    {
+      name: phy_config_tx_use_d_se0
+      desc: '''
+            Verify that the D/SE0 outputs can be used to transmit data rather than the DP and DN
+            signals.
+
+            - This just runs the smoke test with modified PHY configuration.
+            '''
+      stage: V2
+      tests: ["usbdev_phy_config_tx_use_d_se0"]
+    }
+    {
       name: phy_config_usb_ref_disable
       desc: '''
             Verify the reference signal generation for clock synchronization may be disabled.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_rand_bus_type_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_rand_bus_type_vseq.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_phy_config_rand_bus_type_vseq extends usbdev_smoke_vseq;
+  `uvm_object_utils(usbdev_phy_config_rand_bus_type_vseq);
+
+  `uvm_object_new
+
+  virtual task pre_start();
+    // Choose a random bus configuration.
+    {phy_pinflip, phy_use_diff_rcvr, phy_tx_use_d_se0} = $urandom_range(0, 7);
+    // Set up and run the test.
+    super.pre_start();
+  endtask
+endclass : usbdev_phy_config_rand_bus_type_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -36,6 +36,7 @@
 `include "usbdev_phy_pins_sense_vseq.sv"
 `include "usbdev_phy_config_eop_single_bit_handling_vseq.sv"
 `include "usbdev_phy_config_pinflip_vseq.sv"
+`include "usbdev_phy_config_rand_bus_type_vseq.sv"
 `include "usbdev_phy_config_tx_osc_test_mode_vseq.sv"
 `include "usbdev_pkt_buffer_vseq.sv"
 `include "usbdev_pkt_received_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -75,6 +75,7 @@ filesets:
       - seq_lib/usbdev_pending_in_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_config_eop_single_bit_handling_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_config_pinflip_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_phy_config_rand_bus_type_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_config_tx_osc_test_mode_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_config_usb_ref_disable_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_phy_pins_sense_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -47,10 +47,6 @@
   // List of test specifications.
   tests: [
     {
-      name: usbdev_smoke
-      uvm_test_seq: usbdev_smoke_vseq
-    }
-    {
       name: usbdev_aon_wake_disconnect
       uvm_test_seq: usbdev_aon_wake_vseq
       run_opts: ["+do_vbus_disconnects=1"]
@@ -213,6 +209,42 @@
       uvm_test_seq: usbdev_out_trans_nak_vseq
     }
     {
+      name: usbdev_phy_config_eop_single_bit_handling
+      uvm_test_seq: usbdev_phy_config_eop_single_bit_handling_vseq
+      reseed: 1
+    }
+    {
+      name: usbdev_phy_config_rand_bus_type
+      uvm_test_seq: usbdev_phy_config_rand_bus_type_vseq
+      reseed: 5
+    }
+    {
+      name: usbdev_phy_config_rx_dp_dn
+      uvm_test_seq: usbdev_smoke_vseq
+      reseed: 1
+      run_opts: ["+en_diff_rcvr=0"]
+    }
+    {
+      name: usbdev_phy_config_tx_osc_test_mode
+      uvm_test_seq: usbdev_phy_config_tx_osc_test_mode_vseq
+      reseed: 1
+    }
+    {
+      name: usbdev_phy_config_tx_use_d_se0
+      uvm_test_seq: usbdev_smoke_vseq
+      reseed: 1
+      run_opts: ["+tx_use_d_se0=1"]
+    }
+    {
+      name: usbdev_phy_config_pinflip
+      uvm_test_seq: usbdev_phy_config_pinflip_vseq
+      run_opts: ["+pin_flip=1"]
+    }
+    {
+      name: usbdev_phy_config_usb_ref_disable
+      uvm_test_seq: usbdev_phy_config_usb_ref_disable_vseq
+    }
+    {
       name: usbdev_pkt_buffer
       uvm_test_seq: usbdev_pkt_buffer_vseq
     }
@@ -268,6 +300,10 @@
       reseed: 5
     }
     {
+      name: usbdev_smoke
+      uvm_test_seq: usbdev_smoke_vseq
+    }
+    {
       name: usbdev_spurious_pids_ignored
       uvm_test_seq: usbdev_bad_traffic_vseq
       run_opts: ["+wt_spurious_pids=1"]
@@ -308,25 +344,6 @@
     {
       name: usbdev_stall_priority_over_nak
       uvm_test_seq: usbdev_stall_priority_over_nak_vseq
-    }
-    {
-      name: usbdev_phy_config_eop_single_bit_handling
-      uvm_test_seq: usbdev_phy_config_eop_single_bit_handling_vseq
-      reseed: 1
-    }
-    {
-      name: usbdev_phy_config_tx_osc_test_mode
-      uvm_test_seq: usbdev_phy_config_tx_osc_test_mode_vseq
-      reseed: 1
-    }
-    {
-      name: usbdev_phy_config_pinflip
-      uvm_test_seq: usbdev_phy_config_pinflip_vseq
-      run_opts: ["+pin_flip=1"]
-    }
-    {
-      name: usbdev_phy_config_usb_ref_disable
-      uvm_test_seq: usbdev_phy_config_usb_ref_disable_vseq
     }
     {
       name: usbdev_setup_stage


### PR DESCRIPTION
There are three bus configuration options, leading to eight possible types of bus. Ensure that all are tested.

Modify the usb20_driver/monitor to be aware of pin-flipping when the TX side is using D/SE0 because this does invert the sense of the 'd' signal, since it is effectively driving DN now.