### PR TITLE
Fix i2c testutils

### DIFF
--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -234,6 +234,17 @@ dif_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
     config->scl_time_high_cycles = (uint16_t)lengthened_high_cycles;
   }
 
+  // For clock stretching detection to work, the SCL high and low time must be
+  // at leats 4 cycles.
+  // TODO The i2c IP has a parameter (InputDelayCycles) for that, use this when
+  // topgen supports exposing it in the headers (Issue#23786).
+  if (config->scl_time_high_cycles < 4) {
+    config->scl_time_high_cycles = 4;
+  }
+  if (config->scl_time_low_cycles < 4) {
+    config->scl_time_low_cycles = 4;
+  }
+
   return kDifOk;
 }
 

--- a/sw/device/lib/testing/i2c_testutils.c
+++ b/sw/device/lib/testing/i2c_testutils.c
@@ -434,9 +434,12 @@ status_t i2c_testutils_wait_transaction_finish(const dif_i2c_t *i2c) {
   dif_i2c_status_t status;
   bool controller_halted = false;
   do {
-    TRY(dif_i2c_get_status(i2c, &status));
     TRY(dif_i2c_irq_is_pending(i2c, kDifI2cIrqControllerHalt,
                                &controller_halted));
-  } while (!status.fmt_fifo_empty || controller_halted);
-  return OK_STATUS();
+    if (controller_halted) {
+      return OK_STATUS(1);
+    }
+    TRY(dif_i2c_get_status(i2c, &status));
+  } while (!status.fmt_fifo_empty);
+  return OK_STATUS(0);
 }

--- a/sw/device/lib/testing/i2c_testutils.h
+++ b/sw/device/lib/testing/i2c_testutils.h
@@ -244,11 +244,13 @@ OT_WARN_UNUSED_RESULT
 status_t i2c_testutils_wait_host_idle(const dif_i2c_t *i2c);
 
 /**
- * Busy spin until the fmt_fifo gets empty meaning that it has finished the all
- * the transactions issued.
+ * Busy spin until the fmt_fifo gets empty (meaning that it has finished the all
+ * the transactions issued) or until a controller halted event is detected.
+ * In the latter case, it will not clear the controller halt event.
  *
  * @param i2c An I2C DIF handle.
- * @return The result of the operation.
+ * @return Return an error code if something went wrong, otherwise `kOk(halted)`
+ * where `halted` is 1 if the controller was halted and 0 if fmt_fifo was empty.
  */
 status_t i2c_testutils_wait_transaction_finish(const dif_i2c_t *i2c);
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_I2C_TESTUTILS_H_

--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -292,7 +292,6 @@ opentitan_test(
         tags = [
             "manual",
             "pmod",
-            "skip_in_ci",
         ],  # Requires the PMOD::BoB.
     ),
     deps = [

--- a/sw/device/tests/pmod/i2c_host_fram_test.c
+++ b/sw/device/tests/pmod/i2c_host_fram_test.c
@@ -212,7 +212,7 @@ const test_setup_t kSetup[] = {
     // approaches the peripheral clock.
     {.speed = kDifI2cSpeedStandard, .kbps = (uint32_t)(100 * 0.984 * 0.85)},
     {.speed = kDifI2cSpeedFast, .kbps = (uint32_t)(400 * 0.92 * 0.85)},
-    {.speed = kDifI2cSpeedFastPlus, .kbps = (uint32_t)(1000 * 0.55 * 0.85)}};
+    {.speed = kDifI2cSpeedFastPlus, .kbps = (uint32_t)(1000 * 0.55 * 0.75)}};
 
 bool test_main(void) {
   dif_pinmux_t pinmux;

--- a/sw/device/tests/pmod/i2c_host_irq_test.c
+++ b/sw/device/tests/pmod/i2c_host_irq_test.c
@@ -133,11 +133,11 @@ static status_t nak_irq(void) {
   TRY(dif_i2c_get_controller_halt_events(&i2c, &halt_events));
   CHECK(halt_events.nack_received == true);
   CHECK(halt_events.unhandled_nack_timeout == false);
-  TRY(dif_i2c_reset_fmt_fifo(i2c));
-  TRY(dif_i2c_clear_controller_halt_events(i2c, halt_events));
+  TRY(dif_i2c_reset_fmt_fifo(&i2c));
+  TRY(dif_i2c_clear_controller_halt_events(&i2c, halt_events));
   // Force Stop to be sent after the unexpected NACK.
-  TRY(dif_i2c_host_set_enabled(i2c, kDifToggleDisabled));
-  TRY(dif_i2c_host_set_enabled(i2c, kDifToggleEnabled));
+  TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleDisabled));
+  TRY(dif_i2c_host_set_enabled(&i2c, kDifToggleEnabled));
   return OK_STATUS();
 }
 


### PR DESCRIPTION
The PR fixes the following tests:
- `i2c_host_eeprom_test`
- `i2c_host_hdc1080_humidity_temp_test`
- `i2c_host_gas_sensor_test`
- `i2c_host_irq_test`

This is done by updating the `i2c_testutils_wait_transaction_finish` to handle halt events correctly. The test `i2c_host_irq_test` was completely broken since it didn't compile and required a small change (see commit).

TODO:
- [ ] `i2c_host_irq_test` is not part of any testplan: add it
- [ ] `i2c_host_fram_test` is still broken