### PR TITLE
[entropy_src/dv] Improve the group coverage

### DIFF
--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -208,17 +208,31 @@ interface entropy_src_cov_if
 
     // Large cross covering entropy data interface over all valid configurations
     cr_config: cross cp_fips_enable, cp_fips_flag, cp_rng_fips, cp_threshold_scope, cp_rng_bit,
-                     cp_es_type;
+                     cp_es_type {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
 
     // Finer crosses
     cr_fips_scope: cross cp_fips_enable, cp_threshold_scope;
     cr_fips_bit: cross cp_fips_enable, cp_rng_bit;
     cr_fips_type: cross cp_fips_enable, cp_es_type;
-    cr_scope_bit: cross cp_threshold_scope, cp_rng_bit;
-    cr_fips_scope_bit: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit;
+    cr_fips_scope_bit: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
     cr_fips_scope_type: cross cp_fips_enable, cp_threshold_scope, cp_es_type;
     cr_fips_bit_type: cross cp_fips_enable, cp_rng_bit, cp_es_type;
-    cr_scope_bit_type: cross cp_threshold_scope, cp_rng_bit, cp_es_type;
+    cr_scope_bit_type: cross cp_threshold_scope, cp_rng_bit, cp_es_type {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
 
     // Entropy data interface functions despite any changes to the fw_ov settings
     cr_fw_ov: cross cp_fw_ov_mode, cp_entropy_insert;
@@ -263,6 +277,11 @@ interface entropy_src_cov_if
     cp_threshold_scope: coverpoint threshold_scope {
       bins        mubi_true  = { MuBi4True };
       bins        mubi_false = { MuBi4False };
+    }
+
+    cp_rng_bit_enable: coverpoint rng_bit_enable{
+      bins        enabled  = { MuBi4True };
+      bins        disabled = { MuBi4False };
     }
 
     cp_rng_bit: coverpoint {rng_bit_enable == MuBi4True, rng_bit_sel} {
@@ -321,9 +340,20 @@ interface entropy_src_cov_if
     // Cross coverage points
 
     // CSRNG HW interface is tested with all valid configurations
-    cr_config: cross cp_fips_enable, cp_fips_flag, cp_rng_fips, cp_threshold_scope, cp_rng_bit,
+    cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit_enable,
                      cp_es_type, cp_entropy_data_reg_enable, cp_otp_en_es_fw_read,
-                     cp_otp_en_es_fw_over;
+                     cp_otp_en_es_fw_over
+    {
+      // Ignore the invalid mubi values.
+      ignore_bins otp_en_es_fw_read_inval =
+          ! binsof(cp_otp_en_es_fw_read) intersect {MuBi8True, MuBi8False};
+      ignore_bins otp_en_es_fw_over_inval =
+          ! binsof(cp_otp_en_es_fw_over) intersect {MuBi8True, MuBi8False};
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit_enable) intersect {MuBi4True};
+    }
 
     // Smaller crosses
     cr_fips_scope_type: cross cp_fips_enable, cp_threshold_scope, cp_es_type;
@@ -334,14 +364,41 @@ interface entropy_src_cov_if
 
     cr_fips_bit_type: cross cp_fips_enable, cp_rng_bit, cp_es_type;
     cr_fips_bit_data_enable: cross cp_fips_enable, cp_rng_bit, cp_entropy_data_reg_enable;
-    cr_fips_bit_otp: cross cp_fips_enable, cp_rng_bit, cp_otp_en_es_fw_read, cp_otp_en_es_fw_over;
+    cr_fips_bit_otp: cross cp_fips_enable, cp_rng_bit, cp_otp_en_es_fw_read, cp_otp_en_es_fw_over
+    {
+      // Ignore the invalid mubi values.
+      ignore_bins otp_en_es_fw_read_inval =
+          ! binsof(cp_otp_en_es_fw_read) intersect {MuBi8True, MuBi8False};
+      ignore_bins otp_en_es_fw_over_inval =
+          ! binsof(cp_otp_en_es_fw_over) intersect {MuBi8True, MuBi8False};
+    }
     cr_fips_bit_fw_ov: cross cp_fips_enable, cp_rng_bit, cp_fw_ov_mode, cp_entropy_insert;
 
-    cr_scope_bit_type:  cross cp_threshold_scope, cp_rng_bit, cp_es_type;
-    cr_scope_bit_data_enable:  cross cp_threshold_scope, cp_rng_bit, cp_entropy_data_reg_enable;
+    cr_scope_bit_type:  cross cp_threshold_scope, cp_rng_bit, cp_es_type {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
+    cr_scope_bit_data_enable:  cross cp_threshold_scope, cp_rng_bit, cp_entropy_data_reg_enable {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
     cr_scope_bit_otp:  cross cp_threshold_scope, cp_rng_bit, cp_otp_en_es_fw_read,
-                             cp_otp_en_es_fw_over;
-    cr_scope_bit_fw_ov:  cross cp_threshold_scope, cp_rng_bit, cp_fw_ov_mode, cp_entropy_insert;
+                             cp_otp_en_es_fw_over {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
+    cr_scope_bit_fw_ov:  cross cp_threshold_scope, cp_rng_bit, cp_fw_ov_mode, cp_entropy_insert {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
 
     // CSRNG HW interface functions despite any changes to the fw_ov settings
     cr_fw_ov: cross cp_fw_ov_mode, cp_entropy_insert;
@@ -452,13 +509,22 @@ interface entropy_src_cov_if
     // Cross coverage points
 
     // Entropy data interface is tested with all valid configurations
-    cr_config: cross cp_fips_enable, cp_fips_flag, cp_rng_fips, cp_threshold_scope, cp_rng_bit,
-                     cp_es_route, cp_es_type, cp_entropy_data_reg_enable, cp_otp_en_es_fw_read,
-                     cp_otp_en_es_fw_over;
+    cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit, cp_es_route, cp_es_type,
+                     cp_entropy_data_reg_enable, cp_otp_en_es_fw_read, cp_otp_en_es_fw_over {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
 
     // Smaller cross-points
     cr_rng_insert_fips: cross cp_rng_bit, cp_entropy_insert, cp_fips_enable;
-    cr_rng_insert_scope: cross cp_rng_bit, cp_entropy_insert, cp_threshold_scope;
+    cr_rng_insert_scope: cross cp_rng_bit, cp_entropy_insert, cp_threshold_scope {
+      // The threshold scope needs to be set to false if we are in the single lane mode.
+      ignore_bins thresh_scope_true_rng_bit_true =
+          binsof(cp_threshold_scope) intersect {MuBi4True} &&
+          binsof(cp_rng_bit) intersect { [3'b100 : 3'b111] };
+    }
     cr_rng_insert_route: cross cp_rng_bit, cp_entropy_insert, cp_es_route;
     cr_rng_insert_type: cross cp_rng_bit, cp_entropy_insert, cp_es_type;
     cr_rng_insert_reg_en: cross cp_rng_bit, cp_entropy_insert, cp_entropy_data_reg_enable;

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -577,6 +577,11 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     int window_size = fips_mode ? `gmv(ral.health_test_windows.fips_window) :
                                   `gmv(ral.health_test_windows.bypass_window);
 
+    // If rng_bit_enable is set to MuBi4True, the window size is 4 times as large.
+    // We need the same number of bits but only have a single lane.
+    int window_size_scaled = (`gmv(ral.conf.rng_bit_enable) == MuBi4True) ? 4*window_size :
+                                                                            window_size;
+
     threshold_hi = fips_mode ? `gmv(ral.adaptp_hi_thresholds.fips_thresh) :
                                `gmv(ral.adaptp_hi_thresholds.bypass_thresh);
 
@@ -585,9 +590,9 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
 
     total_scope = (ral.conf.threshold_scope.get_mirrored_value() == MuBi4True);
 
-    sigma_hi = ideal_threshold_to_sigma(window_size, adaptp_ht, !total_scope,
+    sigma_hi = ideal_threshold_to_sigma(window_size_scaled, adaptp_ht, !total_scope,
                                         high_test, threshold_hi);
-    sigma_lo = ideal_threshold_to_sigma(window_size, adaptp_ht, !total_scope,
+    sigma_lo = ideal_threshold_to_sigma(window_size_scaled, adaptp_ht, !total_scope,
                                         low_test, threshold_lo);
 
     value = calc_adaptp_test(window, maxval, minval);
@@ -603,11 +608,13 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
 
 
     if (ht_is_active()) begin
-      cov_vif.cg_win_ht_sample(adaptp_ht, high_test, window_size * RNG_BUS_WIDTH, fail_hi);
-      cov_vif.cg_win_ht_sample(adaptp_ht, low_test, window_size * RNG_BUS_WIDTH, fail_lo);
-      cov_vif.cg_win_ht_deep_threshold_sample(adaptp_ht, high_test, window_size * RNG_BUS_WIDTH,
+      cov_vif.cg_win_ht_sample(adaptp_ht, high_test, window_size_scaled * RNG_BUS_WIDTH, fail_hi);
+      cov_vif.cg_win_ht_sample(adaptp_ht, low_test, window_size_scaled * RNG_BUS_WIDTH, fail_lo);
+      cov_vif.cg_win_ht_deep_threshold_sample(adaptp_ht, high_test,
+                                              window_size_scaled * RNG_BUS_WIDTH,
                                               !total_scope, sigma_hi, fail_hi);
-      cov_vif.cg_win_ht_deep_threshold_sample(adaptp_ht, low_test, window_size * RNG_BUS_WIDTH,
+      cov_vif.cg_win_ht_deep_threshold_sample(adaptp_ht, low_test,
+                                              window_size_scaled * RNG_BUS_WIDTH,
                                               !total_scope, sigma_lo, fail_lo);
     end
 
@@ -623,10 +630,15 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     int window_size = fips_mode ? `gmv(ral.health_test_windows.fips_window) :
                                   `gmv(ral.health_test_windows.bypass_window);
 
+    // If rng_bit_enable is set to MuBi4True, the window size is 4 times as large.
+    // We need the same number of bits but only have a single lane.
+    int window_size_scaled = (`gmv(ral.conf.rng_bit_enable) == MuBi4True) ? 4*window_size :
+                                                                            window_size;
+
     threshold = fips_mode ? `gmv(ral.bucket_thresholds.fips_thresh) :
                             `gmv(ral.bucket_thresholds.bypass_thresh);
 
-    sigma = ideal_threshold_to_sigma(window_size, bucket_ht, 0, high_test, threshold);
+    sigma = ideal_threshold_to_sigma(window_size_scaled, bucket_ht, 0, high_test, threshold);
 
     value = calc_bucket_test(window);
 
@@ -636,8 +648,9 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     if (fail) predict_failure_logs("bucket");
 
     if (ht_is_active()) begin
-      cov_vif.cg_win_ht_sample(bucket_ht, high_test, window_size*RNG_BUS_WIDTH, fail);
-      cov_vif.cg_win_ht_deep_threshold_sample(bucket_ht, high_test, window_size*RNG_BUS_WIDTH,
+      cov_vif.cg_win_ht_sample(bucket_ht, high_test, window_size_scaled*RNG_BUS_WIDTH, fail);
+      cov_vif.cg_win_ht_deep_threshold_sample(bucket_ht, high_test,
+                                              window_size_scaled*RNG_BUS_WIDTH,
                                               1'b0, sigma, fail);
     end
 
@@ -654,6 +667,11 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     int window_size = fips_mode ? `gmv(ral.health_test_windows.fips_window) :
                                   `gmv(ral.health_test_windows.bypass_window);
 
+    // If rng_bit_enable is set to MuBi4True, the window size is 4 times as large.
+    // We need the same number of bits but only have a single lane.
+    int window_size_scaled = (`gmv(ral.conf.rng_bit_enable) == MuBi4True) ? 4*window_size :
+                                                                            window_size;
+
     threshold_hi = fips_mode ? `gmv(ral.markov_hi_thresholds.fips_thresh) :
                                `gmv(ral.markov_hi_thresholds.bypass_thresh);
 
@@ -662,9 +680,9 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
 
     total_scope = (ral.conf.threshold_scope.get_mirrored_value() == MuBi4True);
 
-    sigma_hi = ideal_threshold_to_sigma(window_size, markov_ht, !total_scope,
+    sigma_hi = ideal_threshold_to_sigma(window_size_scaled, markov_ht, !total_scope,
                                         high_test, threshold_hi);
-    sigma_lo = ideal_threshold_to_sigma(window_size, markov_ht, !total_scope,
+    sigma_lo = ideal_threshold_to_sigma(window_size_scaled, markov_ht, !total_scope,
                                         low_test, threshold_lo);
 
     value = calc_markov_test(window, maxval, minval);
@@ -679,11 +697,13 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
     if (fail_hi) predict_failure_logs("markov_hi");
 
     if (ht_is_active()) begin
-      cov_vif.cg_win_ht_sample(markov_ht, high_test, window_size*RNG_BUS_WIDTH, fail_hi);
-      cov_vif.cg_win_ht_sample(markov_ht, low_test, window_size*RNG_BUS_WIDTH, fail_lo);
-      cov_vif.cg_win_ht_deep_threshold_sample(markov_ht, high_test, window_size*RNG_BUS_WIDTH,
+      cov_vif.cg_win_ht_sample(markov_ht, high_test, window_size_scaled*RNG_BUS_WIDTH, fail_hi);
+      cov_vif.cg_win_ht_sample(markov_ht, low_test, window_size_scaled*RNG_BUS_WIDTH, fail_lo);
+      cov_vif.cg_win_ht_deep_threshold_sample(markov_ht, high_test,
+                                              window_size_scaled*RNG_BUS_WIDTH,
                                               !total_scope, sigma_hi, fail_hi);
-      cov_vif.cg_win_ht_deep_threshold_sample(markov_ht, low_test, window_size*RNG_BUS_WIDTH,
+      cov_vif.cg_win_ht_deep_threshold_sample(markov_ht, low_test,
+                                              window_size_scaled*RNG_BUS_WIDTH,
                                               !total_scope, sigma_hi, fail_lo);
     end
 


### PR DESCRIPTION
This PR raises the group coverage to ~85%. Could be even more potentially.
For more information please have a look at the individual commit messages.
I had to leave in the first commit which contains an RTL fix (#23775) because without it a lot of the tests are failing (>10%).

This PR could potentially also be related to #18797.

This PR is related to [#21888](https://github.com/lowRISC/opentitan/issues/21888)
