### PR TITLE
[rv_dm,dv] Implement sec_cm_lc_hw_debug_en_intersig_mubi testpoint

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
@@ -31,9 +31,22 @@
     }
     {
       name: sec_cm_lc_hw_debug_en_intersig_mubi
-      desc: "Verify the countermeasure(s) LC_HW_DEBUG_EN.INTERSIG.MUBI."
+      desc: '''
+        Verify the countermeasure(s) LC_HW_DEBUG_EN.INTERSIG.MUBI.
+
+        The lc_hw_debug_en_i signal is encoded as lc_tx_t and is used through the
+        lc_hw_debug_en_gated signal. Bad values of this signal should be interpreted as "Off",
+        disabling debug and also memory/sba TL access.
+
+        Set this to a value other than On and check:
+
+        - No ndmreset is possible (true because the ndmreset_ack signal is gated)
+        - No debug request can be sent to the core through debug_req_o
+        - Instruction fetch requests through the memory window are not successful.
+        - The "mem" and "sba" TL interfaces are both disabled.
+      '''
       stage: V2S
-      tests: []
+      tests: ["rv_dm_debug_disabled", "rv_dm_sba_debug_disabled"]
     }
     {
       name: sec_cm_lc_dft_en_intersig_mubi

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/rv_dm_dataaddr_rw_access_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_halt_resume_whereto_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_sba_debug_disabled_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_debug_disabled_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_ndmreset_req_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dtm_idle_hint_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv: {is_include_file: true}

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -393,4 +393,20 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     `DV_EOT_PRINT_Q_CONTENTS(tl_seq_item, sba_tl_access_q)
   endfunction
 
+  // This overrides a function in cip_base_scoreboard. The problem is that when debug is not
+  // enabled, any TL request will respond with an error. This is what we expect, but the code in
+  // cip_base_scoreboard fails because we're responding with an error to an access that would
+  // otherwise be perfectly reasonable.
+  function bit predict_tl_err(tl_seq_item item, tl_channels_e channel, string ral_name);
+    if ((ral_name == "rv_dm_mem_reg_block") &&
+        (channel == DataChannel) &&
+        (cfg.rv_dm_vif.lc_hw_debug_en != lc_ctrl_pkg::On)) begin
+
+      `DV_CHECK(item.d_error)
+      return 1'b1;
+    end
+
+    return super.predict_tl_err(item, channel, ral_name);
+  endfunction
+
 endclass

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_debug_disabled_vseq.sv
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_debug_disabled_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_debug_disabled_vseq)
+  `uvm_object_new
+
+  // Check that the "mem" TL interface is disabled as expected
+  task check_no_mem_if();
+    // Try to do an arbitrary TL access to the interface. We don't expect it to work, which is
+    // checked in the scoreboard (in predict_tl_err).
+    csr_wr(.ptr(tl_mem_ral.halted), .value(0));
+  endtask
+
+  // Check that some signal that comes out of dm_top doesn't make it as far as the rv_dm toplevel
+  task check_no_dm_output(string         dm_top_port,
+                          string         rv_dm_port,
+                          uvm_reg_data_t forced_input,
+                          uvm_reg_data_t expected_output);
+    string in_path = {"tb.dut.u_dm_top.", dm_top_port};
+    string out_path = {"tb.dut.", rv_dm_port};
+
+    `DV_CHECK(uvm_hdl_force(in_path, forced_input))
+    repeat (100) begin
+      uvm_reg_data_t rvalue;
+      `DV_CHECK(uvm_hdl_read(out_path, rvalue));
+      `DV_CHECK(rvalue == expected_output)
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+    `DV_CHECK(uvm_hdl_release(in_path))
+  endtask
+
+  // Check that an ndmreset signal can't come out of rv_dm.
+  task check_no_ndmreset();
+    check_no_dm_output("ndmreset_o", "ndmreset_req_o", 1'b1, 1'b0);
+  endtask
+
+  // Check that a debug_req signal can't come out of rv_dm.
+  task check_no_debug_req();
+    check_no_dm_output("debug_req_o", "debug_req_o", 1'b1, 1'b0);
+  endtask
+
+
+  task body();
+    // Disable TL error checks in tl_reg_adapter. It doesn't expect to see TL errors (since it's not
+    // doing anything untoward), but we've configured rv_dm to respond with an error to *every*
+    // request.
+    cfg.m_tl_agent_cfgs["rv_dm_mem_reg_block"].check_tl_errs = 0;
+
+    repeat (4) begin
+      // Pick an arbitrary value for lc_hw_debug_en other than On. Drive the signal appropriately
+      // and then wait a short time to make sure it has had an effect.
+      bit [3:0] raw_dbg_enable;
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(raw_dbg_enable, raw_dbg_enable != lc_ctrl_pkg::On;)
+      lc_hw_debug_en = lc_ctrl_pkg::lc_tx_t'(raw_dbg_enable);
+      `uvm_info(`gfn, $sformatf("Setting lc_hw_debug_en to %0x", lc_hw_debug_en), UVM_LOW)
+      cfg.rv_dm_vif.lc_hw_debug_en <= lc_hw_debug_en;
+
+      cfg.clk_rst_vif.wait_clks(10);
+
+      randcase
+        1: check_no_mem_if();
+        1: check_no_ndmreset();
+        1: check_no_debug_req();
+      endcase
+    end
+  endtask
+
+endclass

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -29,3 +29,4 @@
 `include "rv_dm_rom_read_access_vseq.sv"
 `include "rv_dm_progbuf_read_write_execute_vseq.sv"
 `include "rv_dm_sba_debug_disabled_vseq.sv"
+`include "rv_dm_debug_disabled_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -283,6 +283,11 @@
       reseed: 2
     }
     {
+      name: rv_dm_debug_disabled
+      uvm_test_seq: rv_dm_debug_disabled_vseq
+      reseed: 2
+    }
+    {
       name: rv_dm_stress_all
       uvm_test_seq: rv_dm_stress_all_vseq
     }

--- a/hw/ip/rv_dm/dv/sva/rv_dm_bind.sv
+++ b/hw/ip/rv_dm/dv/sva/rv_dm_bind.sv
@@ -40,4 +40,14 @@ module rv_dm_bind;
 
   // TODO: What about 'rv_dm_mem_csr_assert_fpv?
 
+  bind rv_dm rv_dm_enable_checker enable_checker (
+    .clk_i (clk_i),
+    .rst_ni (rst_ni),
+    .lc_hw_debug_en_i(lc_hw_debug_en_i),
+    .debug_req_o_i(debug_req_o),
+    .mem_tl_d_o_i(mem_tl_d_o),
+    .sba_tl_h_o_i(sba_tl_h_o),
+    .ndmreset_ack
+  );
+
 endmodule

--- a/hw/ip/rv_dm/dv/sva/rv_dm_enable_checker.sv
+++ b/hw/ip/rv_dm/dv/sva/rv_dm_enable_checker.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module rv_dm_enable_checker
+  import rv_dm_reg_pkg::NrHarts;
+(
+  input logic         clk_i,
+  input logic         rst_ni,
+
+  input lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,
+  input logic [NrHarts-1:0]  debug_req_o_i,
+  input tlul_pkg::tl_d2h_t   mem_tl_d_o_i,
+  input tlul_pkg::tl_h2d_t   sba_tl_h_o_i,
+
+  input logic                ndmreset_ack
+);
+
+  import lc_ctrl_pkg::lc_tx_test_true_strict;
+
+  // An ndmreset ack is only passed to the debug module if debug is enabled.
+  `ASSERT(NdmResetAckNeedsDebug_A,
+          ndmreset_ack |-> lc_tx_test_true_strict(lc_hw_debug_en_i))
+
+  // A debug request can only be passed from the debug module to the hart if debug is enabled
+  `ASSERT(DebugRequestNeedsDebug_A,
+          debug_req_o_i |-> lc_tx_test_true_strict(lc_hw_debug_en_i))
+
+  // If debug is not enabled then the mem TL interface is disabled and will respond to everything
+  // with an error. This means that any response will have d_error=1.
+  `ASSERT(MemTLResponseWithoutDebugIsError_A,
+          mem_tl_d_o_i.d_valid && !lc_tx_test_true_strict(lc_hw_debug_en_i) |->
+          mem_tl_d_o_i.d_error)
+
+  // If debug is not enabled then the SBA TL interface is disabled and we will never generate a new
+  // TL transaction. As such, the a_valid signal will always be false.
+  `ASSERT(SbaTLRequestNeedsDebug_A,
+          sba_tl_h_o.a_valid |-> lc_tx_test_true_strict(lc_hw_debug_en_i))
+endmodule

--- a/hw/ip/rv_dm/dv/sva/rv_dm_sva.core
+++ b/hw/ip/rv_dm/dv/sva/rv_dm_sva.core
@@ -9,8 +9,10 @@ filesets:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
+      - lowrisc:ip:rv_dm
     files:
       - rv_dm_bind.sv
+      - rv_dm_enable_checker.sv
     file_type: systemVerilogSource
 
   files_formal:


### PR DESCRIPTION
This builds on #23766, which is the first 4 commits. Only the final 3 commits are unique to this PR.

The first two commits are about strengthening the scoreboard slightly so that it can check the properties we want to test in the testpoint. The final commit implements most of the testpoint, falling back to rv_dm_sba_debug_disabled (which was implemented in commit 4) for one of the properties we want to assert.