### PR TITLE
[rv_dm,dv] Connect up sec_cm_bus_integrity testpoint

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
@@ -27,7 +27,7 @@
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
       stage: V2S
-      tests: []
+      tests: ["rv_dm_tl_intg_err"]
     }
     {
       name: sec_cm_lc_hw_debug_en_intersig_mubi


### PR DESCRIPTION
This is implemented by a generic test (in
cip_base_vseq__tl_errors.svh) and the only work needed for rv_dm is to name it in the testplan. Do so.