### PR TITLE
[pinmux,top_earlgrey] Add ScanClock role to SPI_DEV_CLK and filter from flop inputs during DFT

### DIFF
--- a/hw/ip/pinmux/rtl/pinmux_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_pkg.sv
@@ -30,6 +30,8 @@ package pinmux_pkg;
     integer                   usb_sense_idx;
     pad_type_e [NDioPads-1:0] dio_pad_type;
     pad_type_e [NMioPads-1:0] mio_pad_type;
+    scan_role_e [NDioPads-1:0] dio_scan_role;
+    scan_role_e [NMioPads-1:0] mio_scan_role;
   } target_cfg_t;
 
   parameter target_cfg_t DefaultTargetCfg = '{
@@ -46,7 +48,9 @@ package pinmux_pkg;
     usb_dn_idx:        0,
     usb_sense_idx:     0,
     dio_pad_type:      {NDioPads{BidirStd}},
-    mio_pad_type:      {NMioPads{BidirStd}}
+    mio_pad_type:      {NMioPads{BidirStd}},
+    dio_scan_role:     {NDioPads{NoScan}},
+    mio_scan_role:     {NMioPads{NoScan}}
   };
 
   // Wakeup Detector Modes

--- a/hw/ip/prim/rtl/prim_pad_wrapper_pkg.sv
+++ b/hw/ip/prim/rtl/prim_pad_wrapper_pkg.sv
@@ -17,7 +17,8 @@ package prim_pad_wrapper_pkg;
   typedef enum logic [1:0] {
     NoScan = 2'h0,
     ScanIn = 2'h1,
-    ScanOut = 2'h2
+    ScanOut = 2'h2,
+    ScanClock = 2'h3
   } scan_role_e;
 
   // Pad attributes

--- a/hw/top_earlgrey/chip_earlgrey_cw310.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:systems:ast
       - lowrisc:systems:padring
+      - lowrisc:systems:scan_role_pkg
     files:
       - rtl/clkgen_xil7series.sv
       - rtl/usr_access_xil7series.sv

--- a/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:systems:ast
       - lowrisc:systems:padring
+      - lowrisc:systems:scan_role_pkg
     files:
       - rtl/clkgen_xil7series.sv
       - rtl/usr_access_xil7series.sv

--- a/hw/top_earlgrey/chip_earlgrey_cw340.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw340.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:systems:ast
       - lowrisc:systems:padring
+      - lowrisc:systems:scan_role_pkg
     files:
       - rtl/clkgen_xil_ultrascale.sv
       - rtl/usr_access_xil7series.sv

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -188,6 +188,74 @@ module chip_earlgrey_asic #(
       BidirStd, // MIO Pad 2
       BidirStd, // MIO Pad 1
       BidirStd  // MIO Pad 0
+    },
+    // Pad scan roles
+    dio_scan_role: {
+      scan_role_pkg::DioPadSpiHostCsLScanRole, // DIO spi_host0_csb
+      scan_role_pkg::DioPadSpiHostClkScanRole, // DIO spi_host0_sck
+      scan_role_pkg::DioPadSpiDevCsLScanRole, // DIO spi_device_csb
+      scan_role_pkg::DioPadSpiDevClkScanRole, // DIO spi_device_sck
+      scan_role_pkg::DioPadIor9ScanRole, // DIO sysrst_ctrl_aon_flash_wp_l
+      scan_role_pkg::DioPadIor8ScanRole, // DIO sysrst_ctrl_aon_ec_rst_l
+      scan_role_pkg::DioPadSpiDevD3ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD2ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD1ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD0ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiHostD3ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD2ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD1ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD0ScanRole, // DIO spi_host0_sd
+      NoScan, // DIO usbdev_usb_dn
+      NoScan // DIO usbdev_usb_dp
+    },
+    mio_scan_role: {
+      scan_role_pkg::MioPadIor13ScanRole,
+      scan_role_pkg::MioPadIor12ScanRole,
+      scan_role_pkg::MioPadIor11ScanRole,
+      scan_role_pkg::MioPadIor10ScanRole,
+      scan_role_pkg::MioPadIor7ScanRole,
+      scan_role_pkg::MioPadIor6ScanRole,
+      scan_role_pkg::MioPadIor5ScanRole,
+      scan_role_pkg::MioPadIor4ScanRole,
+      scan_role_pkg::MioPadIor3ScanRole,
+      scan_role_pkg::MioPadIor2ScanRole,
+      scan_role_pkg::MioPadIor1ScanRole,
+      scan_role_pkg::MioPadIor0ScanRole,
+      scan_role_pkg::MioPadIoc12ScanRole,
+      scan_role_pkg::MioPadIoc11ScanRole,
+      scan_role_pkg::MioPadIoc10ScanRole,
+      scan_role_pkg::MioPadIoc9ScanRole,
+      scan_role_pkg::MioPadIoc8ScanRole,
+      scan_role_pkg::MioPadIoc7ScanRole,
+      scan_role_pkg::MioPadIoc6ScanRole,
+      scan_role_pkg::MioPadIoc5ScanRole,
+      scan_role_pkg::MioPadIoc4ScanRole,
+      scan_role_pkg::MioPadIoc3ScanRole,
+      scan_role_pkg::MioPadIoc2ScanRole,
+      scan_role_pkg::MioPadIoc1ScanRole,
+      scan_role_pkg::MioPadIoc0ScanRole,
+      scan_role_pkg::MioPadIob12ScanRole,
+      scan_role_pkg::MioPadIob11ScanRole,
+      scan_role_pkg::MioPadIob10ScanRole,
+      scan_role_pkg::MioPadIob9ScanRole,
+      scan_role_pkg::MioPadIob8ScanRole,
+      scan_role_pkg::MioPadIob7ScanRole,
+      scan_role_pkg::MioPadIob6ScanRole,
+      scan_role_pkg::MioPadIob5ScanRole,
+      scan_role_pkg::MioPadIob4ScanRole,
+      scan_role_pkg::MioPadIob3ScanRole,
+      scan_role_pkg::MioPadIob2ScanRole,
+      scan_role_pkg::MioPadIob1ScanRole,
+      scan_role_pkg::MioPadIob0ScanRole,
+      scan_role_pkg::MioPadIoa8ScanRole,
+      scan_role_pkg::MioPadIoa7ScanRole,
+      scan_role_pkg::MioPadIoa6ScanRole,
+      scan_role_pkg::MioPadIoa5ScanRole,
+      scan_role_pkg::MioPadIoa4ScanRole,
+      scan_role_pkg::MioPadIoa3ScanRole,
+      scan_role_pkg::MioPadIoa2ScanRole,
+      scan_role_pkg::MioPadIoa1ScanRole,
+      scan_role_pkg::MioPadIoa0ScanRole
     }
   };
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -198,6 +198,74 @@ module chip_earlgrey_cw310 #(
       BidirStd, // MIO Pad 2
       BidirStd, // MIO Pad 1
       BidirStd  // MIO Pad 0
+    },
+    // Pad scan roles
+    dio_scan_role: {
+      scan_role_pkg::DioPadSpiHostCsLScanRole, // DIO spi_host0_csb
+      scan_role_pkg::DioPadSpiHostClkScanRole, // DIO spi_host0_sck
+      scan_role_pkg::DioPadSpiDevCsLScanRole, // DIO spi_device_csb
+      scan_role_pkg::DioPadSpiDevClkScanRole, // DIO spi_device_sck
+      scan_role_pkg::DioPadIor9ScanRole, // DIO sysrst_ctrl_aon_flash_wp_l
+      scan_role_pkg::DioPadIor8ScanRole, // DIO sysrst_ctrl_aon_ec_rst_l
+      scan_role_pkg::DioPadSpiDevD3ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD2ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD1ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD0ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiHostD3ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD2ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD1ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD0ScanRole, // DIO spi_host0_sd
+      NoScan, // DIO usbdev_usb_dn
+      NoScan // DIO usbdev_usb_dp
+    },
+    mio_scan_role: {
+      scan_role_pkg::MioPadIor13ScanRole,
+      scan_role_pkg::MioPadIor12ScanRole,
+      scan_role_pkg::MioPadIor11ScanRole,
+      scan_role_pkg::MioPadIor10ScanRole,
+      scan_role_pkg::MioPadIor7ScanRole,
+      scan_role_pkg::MioPadIor6ScanRole,
+      scan_role_pkg::MioPadIor5ScanRole,
+      scan_role_pkg::MioPadIor4ScanRole,
+      scan_role_pkg::MioPadIor3ScanRole,
+      scan_role_pkg::MioPadIor2ScanRole,
+      scan_role_pkg::MioPadIor1ScanRole,
+      scan_role_pkg::MioPadIor0ScanRole,
+      scan_role_pkg::MioPadIoc12ScanRole,
+      scan_role_pkg::MioPadIoc11ScanRole,
+      scan_role_pkg::MioPadIoc10ScanRole,
+      scan_role_pkg::MioPadIoc9ScanRole,
+      scan_role_pkg::MioPadIoc8ScanRole,
+      scan_role_pkg::MioPadIoc7ScanRole,
+      scan_role_pkg::MioPadIoc6ScanRole,
+      scan_role_pkg::MioPadIoc5ScanRole,
+      scan_role_pkg::MioPadIoc4ScanRole,
+      scan_role_pkg::MioPadIoc3ScanRole,
+      scan_role_pkg::MioPadIoc2ScanRole,
+      scan_role_pkg::MioPadIoc1ScanRole,
+      scan_role_pkg::MioPadIoc0ScanRole,
+      scan_role_pkg::MioPadIob12ScanRole,
+      scan_role_pkg::MioPadIob11ScanRole,
+      scan_role_pkg::MioPadIob10ScanRole,
+      scan_role_pkg::MioPadIob9ScanRole,
+      scan_role_pkg::MioPadIob8ScanRole,
+      scan_role_pkg::MioPadIob7ScanRole,
+      scan_role_pkg::MioPadIob6ScanRole,
+      scan_role_pkg::MioPadIob5ScanRole,
+      scan_role_pkg::MioPadIob4ScanRole,
+      scan_role_pkg::MioPadIob3ScanRole,
+      scan_role_pkg::MioPadIob2ScanRole,
+      scan_role_pkg::MioPadIob1ScanRole,
+      scan_role_pkg::MioPadIob0ScanRole,
+      scan_role_pkg::MioPadIoa8ScanRole,
+      scan_role_pkg::MioPadIoa7ScanRole,
+      scan_role_pkg::MioPadIoa6ScanRole,
+      scan_role_pkg::MioPadIoa5ScanRole,
+      scan_role_pkg::MioPadIoa4ScanRole,
+      scan_role_pkg::MioPadIoa3ScanRole,
+      scan_role_pkg::MioPadIoa2ScanRole,
+      scan_role_pkg::MioPadIoa1ScanRole,
+      scan_role_pkg::MioPadIoa0ScanRole
     }
   };
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -197,6 +197,74 @@ module chip_earlgrey_cw340 #(
       BidirStd, // MIO Pad 2
       BidirStd, // MIO Pad 1
       BidirStd  // MIO Pad 0
+    },
+    // Pad scan roles
+    dio_scan_role: {
+      scan_role_pkg::DioPadSpiHostCsLScanRole, // DIO spi_host0_csb
+      scan_role_pkg::DioPadSpiHostClkScanRole, // DIO spi_host0_sck
+      scan_role_pkg::DioPadSpiDevCsLScanRole, // DIO spi_device_csb
+      scan_role_pkg::DioPadSpiDevClkScanRole, // DIO spi_device_sck
+      scan_role_pkg::DioPadIor9ScanRole, // DIO sysrst_ctrl_aon_flash_wp_l
+      scan_role_pkg::DioPadIor8ScanRole, // DIO sysrst_ctrl_aon_ec_rst_l
+      scan_role_pkg::DioPadSpiDevD3ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD2ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD1ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiDevD0ScanRole, // DIO spi_device_sd
+      scan_role_pkg::DioPadSpiHostD3ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD2ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD1ScanRole, // DIO spi_host0_sd
+      scan_role_pkg::DioPadSpiHostD0ScanRole, // DIO spi_host0_sd
+      NoScan, // DIO usbdev_usb_dn
+      NoScan // DIO usbdev_usb_dp
+    },
+    mio_scan_role: {
+      scan_role_pkg::MioPadIor13ScanRole,
+      scan_role_pkg::MioPadIor12ScanRole,
+      scan_role_pkg::MioPadIor11ScanRole,
+      scan_role_pkg::MioPadIor10ScanRole,
+      scan_role_pkg::MioPadIor7ScanRole,
+      scan_role_pkg::MioPadIor6ScanRole,
+      scan_role_pkg::MioPadIor5ScanRole,
+      scan_role_pkg::MioPadIor4ScanRole,
+      scan_role_pkg::MioPadIor3ScanRole,
+      scan_role_pkg::MioPadIor2ScanRole,
+      scan_role_pkg::MioPadIor1ScanRole,
+      scan_role_pkg::MioPadIor0ScanRole,
+      scan_role_pkg::MioPadIoc12ScanRole,
+      scan_role_pkg::MioPadIoc11ScanRole,
+      scan_role_pkg::MioPadIoc10ScanRole,
+      scan_role_pkg::MioPadIoc9ScanRole,
+      scan_role_pkg::MioPadIoc8ScanRole,
+      scan_role_pkg::MioPadIoc7ScanRole,
+      scan_role_pkg::MioPadIoc6ScanRole,
+      scan_role_pkg::MioPadIoc5ScanRole,
+      scan_role_pkg::MioPadIoc4ScanRole,
+      scan_role_pkg::MioPadIoc3ScanRole,
+      scan_role_pkg::MioPadIoc2ScanRole,
+      scan_role_pkg::MioPadIoc1ScanRole,
+      scan_role_pkg::MioPadIoc0ScanRole,
+      scan_role_pkg::MioPadIob12ScanRole,
+      scan_role_pkg::MioPadIob11ScanRole,
+      scan_role_pkg::MioPadIob10ScanRole,
+      scan_role_pkg::MioPadIob9ScanRole,
+      scan_role_pkg::MioPadIob8ScanRole,
+      scan_role_pkg::MioPadIob7ScanRole,
+      scan_role_pkg::MioPadIob6ScanRole,
+      scan_role_pkg::MioPadIob5ScanRole,
+      scan_role_pkg::MioPadIob4ScanRole,
+      scan_role_pkg::MioPadIob3ScanRole,
+      scan_role_pkg::MioPadIob2ScanRole,
+      scan_role_pkg::MioPadIob1ScanRole,
+      scan_role_pkg::MioPadIob0ScanRole,
+      scan_role_pkg::MioPadIoa8ScanRole,
+      scan_role_pkg::MioPadIoa7ScanRole,
+      scan_role_pkg::MioPadIoa6ScanRole,
+      scan_role_pkg::MioPadIoa5ScanRole,
+      scan_role_pkg::MioPadIoa4ScanRole,
+      scan_role_pkg::MioPadIoa3ScanRole,
+      scan_role_pkg::MioPadIoa2ScanRole,
+      scan_role_pkg::MioPadIoa1ScanRole,
+      scan_role_pkg::MioPadIoa0ScanRole
     }
   };
 

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -488,7 +488,9 @@ module chip_earlgrey_verilator (
     usb_sense_idx:     MioInUsbdevSense,
     // TODO: connect these once the verilator chip-level has been merged with the chiplevel.sv.tpl
     dio_pad_type: {pinmux_reg_pkg::NDioPads{prim_pad_wrapper_pkg::BidirStd}},
-    mio_pad_type: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::BidirStd}}
+    mio_pad_type: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::BidirStd}},
+    dio_scan_role: {pinmux_reg_pkg::NDioPads{prim_pad_wrapper_pkg::NoScan}},
+    mio_scan_role: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::NoScan}}
   };
 
   prim_mubi_pkg::mubi4_t lc_clk_bypass;

--- a/hw/top_earlgrey/rtl/scan_role_pkg.sv
+++ b/hw/top_earlgrey/rtl/scan_role_pkg.sv
@@ -21,7 +21,7 @@ package scan_role_pkg;
   parameter scan_role_e DioPadSpiDevD1ScanRole        = NoScan;
   parameter scan_role_e DioPadSpiDevD2ScanRole        = NoScan;
   parameter scan_role_e DioPadSpiDevD3ScanRole        = NoScan;
-  parameter scan_role_e DioPadSpiDevClkScanRole       = NoScan;
+  parameter scan_role_e DioPadSpiDevClkScanRole       = ScanClock;
   parameter scan_role_e DioPadSpiDevCsLScanRole       = NoScan;
   parameter scan_role_e DioPadUsbPScanRole            = NoScan;
   parameter scan_role_e DioPadUsbNScanRole            = NoScan;

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -150,7 +150,9 @@ module chip_englishbreakfast_verilator (
     usb_sense_idx:     MioInUsbdevSense,
     // TODO: connect these once the verilator chip-level has been merged with the chiplevel.sv.tpl
     dio_pad_type: {pinmux_reg_pkg::NDioPads{prim_pad_wrapper_pkg::BidirStd}},
-    mio_pad_type: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::BidirStd}}
+    mio_pad_type: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::BidirStd}},
+    dio_scan_role: {pinmux_reg_pkg::NDioPads{prim_pad_wrapper_pkg::NoScan}},
+    mio_scan_role: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::NoScan}}
   };
 
 

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -168,6 +168,37 @@ module chip_${top["name"]}_${target["name"]} #(
 % for attr in pad_attr:
       ${attr}${" " if loop.last else ","} // MIO Pad ${len(pad_attr) - loop.index - 1}
 % endfor
+    },
+    // Pad scan roles
+    dio_scan_role: {
+<%
+  scan_roles = []
+  for sig in list(reversed(top["pinmux"]["ios"])):
+    if sig["connection"] != "muxed":
+      if (len(sig['pad']) > 0) and (target["name"] != "cw305"):
+        scan_string = lib.Name.from_snake_case('dio_pad_' + sig['pad'] + '_scan_role')
+        scan_roles.append((f'scan_role_pkg::{scan_string.as_camel_case()}', sig['name']))
+      else:
+        scan_roles.append(('NoScan', sig['name']))
+%>\
+% for scan_role, name in list(scan_roles):
+      ${scan_role}${"" if loop.last else ","} // DIO ${name}
+% endfor
+    },
+    mio_scan_role: {
+<%
+  scan_roles = []
+  for pad in list(reversed(pinout["pads"])):
+    if pad["connection"] == "muxed":
+      if target["name"] != "cw305":
+        scan_string = lib.Name.from_snake_case('mio_pad_' + pad['name'] + '_scan_role')
+        scan_roles.append(f'scan_role_pkg::{scan_string.as_camel_case()}')
+      else:
+        scan_roles.append('NoScan')
+%>\
+% for scan_role in list(scan_roles):
+      ${scan_role}${"" if loop.last else ","}
+% endfor
     }
   };
 


### PR DESCRIPTION
Add a ScanClock role to the scan_role_e enum, then add the scan roles of all pinmux-connected DIOs and MIOs to the pinmux. Filter any DIO or MIO with the ScanClock role from connecting to the wakeup detector flops when scanmode is active.

Use SPI_DEV_CLK as the scan clock.