### PR TITLE
[rv_dm,dv] Get rid of unnecessary re-randomisation in base vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -31,6 +31,11 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   //
   // A vseq that actually wants to exercise scanmode should override this constraint and turn it
   // back on.
+  //
+  // TODO(#23763): This currently avoids setting scanmode to true. This is because doing so changes
+  // the internal JTAG interface so that it is clocked from the main clock instead of the jtag_if
+  // TCK. Muxing the tck signal in jtag_if isn't all that easy because the jtag driver expects to be
+  // able to control it.
   constraint no_scanmode_c {
     scanmode != prim_mubi_pkg::MuBi4True;
   }
@@ -54,15 +59,6 @@ class rv_dm_base_vseq extends cip_base_vseq #(
 
   task pre_start();
     // Initialize the input signals with defaults at the start of the sim.
-    //
-    // TODO(#23763): This currently avoids setting scanmode to true. This is because doing so
-    // changes the internal JTAG interface so that it is clocked from the main clock instead of the
-    // jtag_if TCK. Muxing the tck signal in jtag_if isn't all that easy because the jtag driver
-    // expects to be able to control it.
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(lc_hw_debug_en)
-    `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(scanmode, scanmode != prim_mubi_pkg::MuBi4True;)
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(unavailable)
-
     cfg.rv_dm_vif.lc_hw_debug_en <= lc_hw_debug_en;
     cfg.rv_dm_vif.scanmode <= scanmode;
     cfg.rv_dm_vif.unavailable <= unavailable;


### PR DESCRIPTION
UVM sequences get randomized before calling pre_start, so these
repeated calls to DV_CHECK_MEMBER_RANDOMIZE_FATAL are a bit pointless.
I tested that by implementing pre_randomize like this and looking at
the logs:

    function void pre_randomize();
      $display("pre_randomize()");
      super.pre_randomize();
    endfunction

The pre_randomize call comes out once before pre_start and then once
for each call we were doing to DV_CHECK_MEMBER_RANDOMIZE_FATAL.
