### PR TITLE
[dv,usbdev] Low speed traffic sequence

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -15,6 +15,10 @@ class usb20_item extends uvm_sequence_item;
   // Indicates that a timeout occurred when awaiting a response from the device.
   bit timed_out = 1'b0;
 
+  // Indicates that this item is to be transmitted using Low Speed signaling; applicable only to
+  // packet items.
+  bit low_speed;
+
   // Validity indicators that apply to all packet types; used by the monitor at metadata for the
   // scoreboard.
   bit valid_sync;      // SYNC signal properly formed.
@@ -29,6 +33,8 @@ class usb20_item extends uvm_sequence_item;
     super.new(name);
     m_ev_type  = EvPacket;
     m_pkt_type = pkt_type;
+    // ALmost all communication shall occur using Full Speed signaling.
+    low_speed = 1'b0;
     // When passing requests to the driver the validity bits may be cleared to request fault
     // injection; the default behavior shall be to generate valid packets.
     valid_sync = 1'b1;
@@ -49,6 +55,8 @@ class usb20_item extends uvm_sequence_item;
     m_pkt_type          = rhs_.m_pkt_type;
     m_usb_transfer      = rhs_.m_usb_transfer;
     timed_out           = rhs_.timed_out;
+    // Low speed signaling?
+    low_speed           = rhs_.low_speed;
     // Validity indicators; used to instruct the driver to perform fault injection, and completed
     // by the monitor when constructing objects from the observed USB signaling.
     valid_sync          = rhs_.valid_sync;

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -1014,7 +1014,7 @@
               unreliable connections.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_low_speed_traffic"]
     }
     {
       name: rand_bus_resets

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_low_speed_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_low_speed_traffic_vseq.sv
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_low_speed_traffic_vseq extends usbdev_max_usb_traffic_vseq;
+  `uvm_object_utils(usbdev_low_speed_traffic_vseq)
+
+  `uvm_object_new
+
+  // Parallel process that injects low speed traffic in the downstream direction; the streaming
+  // test should continue unimpacted aside from taking longer to transmit and check all of the data.
+  virtual task generate_low_speed_traffic();
+    while (!traffic_stop) begin
+      // Device address and endpoint number for the low speed communication.
+      bit [6:0] ls_dev_addr;
+      bit [3:0] ls_ep;
+      // low speed traffic shall be generated with intermediate frequency; it's less intrusive than
+      // suspend-resume signaling and bus resets, but it is eight times slower than the equivalent
+      // full speed signaling.
+      bit [12:0] ls_delay;
+      // Decide upon a device address and endpoint for the low speed communications.
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(ls_dev_addr, ls_dev_addr != dev_addr;)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(ls_ep, ls_ep < NEndpoints;)
+      // Decide upon the time interval before the next low speed traffic stimulus.
+      `DV_CHECK_STD_RANDOMIZE_FATAL(ls_delay)
+      fork
+        begin : isolation_fork
+          fork
+            cfg.clk_rst_vif.wait_clks(ls_delay);
+            wait (traffic_stop);
+          join_any
+          disable fork;
+        end : isolation_fork
+      join
+      claim_driver();
+      // Try all packet types; IN, OUT and SETUP transactions, as well as handshake packets.
+      // - only the downstream traffic is visible to full speed devices, so the DUT must be able
+      //   to ignore OUT, SETUP and handshake packets, as well as IN token packets but it should
+      //   never encounter IN DATA packets.
+      low_speed_traffic = 1'b1;
+      randcase
+        1: begin
+          // TODO: DATA packets cannot be more than 8 bytes in length.
+          `uvm_info(`gfn, "Generating low speed OUT transaction", UVM_MEDIUM)
+          send_prnd_out_packet(ls_ep, ($urandom & 1) ? PidTypeData1 : PidTypeData0,
+                               .randomize_length(1), .num_of_bytes(0), .isochronous_transfer(0),
+                               .target_addr(ls_dev_addr));
+        end
+        1: begin
+          `uvm_info(`gfn, "Generating low speed IN transaction", UVM_MEDIUM)
+          send_token_packet(ls_ep, PidTypeInToken, ls_dev_addr);
+        end
+        1: begin
+          `uvm_info(`gfn, "Generating low speed SETUP transaction", UVM_MEDIUM)
+          send_prnd_setup_packet(ls_ep, ls_dev_addr);
+        end
+        1: begin
+          `uvm_info(`gfn, "Generating low speed handshake packet", UVM_MEDIUM)
+          send_handshake(($urandom & 1) ? PidTypeNak : PidTypeAck);
+        end
+      endcase
+      low_speed_traffic = 1'b0;
+      release_driver();
+    end
+  endtask
+
+  virtual task body();
+    fork
+      super.body();
+      generate_low_speed_traffic();
+    join
+  endtask
+endclass : usbdev_low_speed_traffic_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_usb_traffic_vseq.sv
@@ -17,7 +17,7 @@ class usbdev_max_usb_traffic_vseq extends usbdev_base_vseq;
   `uvm_object_new
 
   // This is the total number of packets to be transferred, across all endpoints.
-  constraint num_trans_c { num_trans inside {[64:256]}; }
+  constraint num_trans_c { num_trans inside {[64:128]}; }
 
   // Endpoint configuration.
   //

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -68,6 +68,7 @@
 `include "usbdev_link_resume_vseq.sv"
 // These must follow usbdev_max_usb_traffic_vseq.sv
 `include "usbdev_bus_rand_vseq.sv"
+`include "usbdev_low_speed_traffic_vseq.sv"
 `include "usbdev_streaming_vseq.sv"
 // This must follow usbdev_bus_rand_vseq.sv
 `include "usbdev_bad_traffic_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -58,6 +58,7 @@ filesets:
       - seq_lib/usbdev_link_resume_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_suspend_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_low_speed_traffic_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_usb_traffic_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_random_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_resume_link_active_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -165,6 +165,10 @@
       uvm_test_seq: usbdev_link_suspend_vseq
     }
     {
+      name: usbdev_low_speed_traffic
+      uvm_test_seq: usbdev_low_speed_traffic_vseq
+    }
+    {
       name: usbdev_max_length_out_transaction
       uvm_test_seq: usbdev_max_length_out_transaction_vseq
     }


### PR DESCRIPTION
This PR addresses the 'low_speed_traffic' test point by introducing the ability to generate low speed traffic on the USB.

Low speed traffic is propagated in the downstream direction by hubs when operating in a full/low-speed environment, so the DUT must be robust against the presence of such traffic. USBDEV has already been modified to prevent the reporting of spurious 'bit stuffing errors' when subjected to low speed traffic.

This PR also reduces the duration of the stress sequences because they take a long time to complete in the presence of other randomized bus events/stimuli.

For context the pertinent section of the USB 2.0 Protocol Specification is `8.6.5 Low-speed Transactions.`