### PR TITLE
[rv_dm,dv] Tidy up randomisation of "enable signals" in base vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -29,6 +29,10 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   // enabled (controlled by late_debug_enable), this controls whether debug is enabled.
   rand bit lc_hw_debug_en;
 
+  // This flag controls whether the lc_dft_en_i signal is set to On. When late debug mode is
+  // disabled (controlled by late_debug_enable), this controls whether debug is enabled.
+  rand bit lc_dft_en;
+
   // This flag controls whether the scanmode_i signal is set to On, putting the JTAG TAP in the
   // debug module into testmode and controlling TCK and TRST_N with the system clock and reset,
   // instead of the signals in jtag_if
@@ -74,6 +78,12 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     pinmux_hw_debug_en == 1'b1;
   }
 
+  // TODO(#23096): Currently, the dft enable (used when late debug is enable is false) is hard-coded
+  //               to match lc_hw_debug_en. This eventually needs to be separately controlled.
+  constraint lc_dft_en_c {
+    lc_dft_en == lc_hw_debug_en;
+  }
+
   // TODO(#23096): We don't currently test the situation where late debug enable is false. We
   // should.
   constraint late_debug_enable_c {
@@ -116,10 +126,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
 
     cfg.rv_dm_vif.unavailable <= unavailable;
 
-    // TODO(#23096): We're currently wiring all the enable signals to match lc_hw_debug_en and
-    //               hard-coding the late debug enable flag to be true. These eventually need to be
-    //               separately controlled.
-    cfg.rv_dm_vif.lc_dft_en <= bool_to_lc_tx_t(lc_hw_debug_en);
+    cfg.rv_dm_vif.lc_dft_en <= bool_to_lc_tx_t(lc_dft_en);
 
     // Drive the otp_dis_rv_dm_late_debug_i pin to match pin_late_debug_enable (to avoid assertions
     // that get triggered in prim_lc_sync/prim_mubi8_sync if the input is 'x). We will configure the

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
@@ -6,6 +6,11 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
   `uvm_object_utils(rv_dm_jtag_dmi_debug_disabled_vseq)
   `uvm_object_new
 
+  // Override the constraint in rv_dm_base_vseq that enables debug (to disable it instead)
+  constraint debug_enabled_c {
+    lc_hw_debug_en == 1'b0;
+  }
+
   task automatic write_abstractdata(uvm_reg_data_t value);
     csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(value));
   endtask
@@ -40,13 +45,8 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
       // Possibly wait a bit
       maybe_delay();
 
-      // Set lc_hw_debug_en to some value other than On.
-      begin
-        lc_ctrl_pkg::lc_tx_t pinmux_hw_debug_en;
-        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(pinmux_hw_debug_en,
-                                           pinmux_hw_debug_en != lc_ctrl_pkg::On;)
-        cfg.rv_dm_vif.cb.pinmux_hw_debug_en <= pinmux_hw_debug_en;
-      end
+      // Pick an arbitrary value for lc_hw_debug_en_i other than On
+      upd_lc_hw_debug_en();
 
       // Wait a few cycles to make sure that the changed enable signal has made it through a
       // prim_lc_sync. If we start the next operation too early, things will get rather confused

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_ndmreset_req_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_ndmreset_req_vseq.sv
@@ -53,8 +53,8 @@ class rv_dm_ndmreset_req_vseq extends rv_dm_base_vseq;
     // At this point, "normal debug operation" is not going to be available in the chip. Set
     // lc_hw_debug_en to something other than On. But keep pinmux_hw_debug_en equal to On, so that
     // JTAG access to the debug module is maintained.
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(lc_hw_debug_en, lc_hw_debug_en != lc_ctrl_pkg::On;)
-    cfg.rv_dm_vif.lc_hw_debug_en <= lc_hw_debug_en;
+    lc_hw_debug_en = 1'b0;
+    upd_lc_hw_debug_en();
 
     // Make sure that dmstatus does indeed reflect the unavailable signals.
     check_unavail();
@@ -67,8 +67,8 @@ class rv_dm_ndmreset_req_vseq extends rv_dm_base_vseq;
     // At this point, we want to mimic the system coming back up. De-assert the unavailable_i signal
     // to show that the CPU is back. Also behave as lc_ctrl and re-enable debug.
     cfg.rv_dm_vif.cb.unavailable <= 0;
-    lc_hw_debug_en = lc_ctrl_pkg::On;
-    cfg.rv_dm_vif.lc_hw_debug_en <= lc_hw_debug_en;
+    lc_hw_debug_en = 1'b1;
+    upd_lc_hw_debug_en();
 
     // Read back progbuf[0] and dataddr[0]. They should still have the values that we wrote earlier
     // because the ndmreset shouldn't have reset any state inside the debug module itself.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_sba_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_sba_debug_disabled_vseq.sv
@@ -9,7 +9,7 @@ class rv_dm_sba_debug_disabled_vseq extends rv_dm_base_vseq;
   // This overrides a constraint in the base vseq: we want to ensure that debug is *not* enabled for
   // this vseq.
   constraint debug_enabled_c {
-    lc_hw_debug_en != lc_ctrl_pkg::On;
+    lc_hw_debug_en == 1'b0;
   }
 
   task body();


### PR DESCRIPTION
This PR looks a bit massive, but it actually builds on some existing PRs.
- #23750: This contains commits 1,2
- #23792: This contains commits 3,4
- #23793: This contains commit 5

The remaining commits are:
- [rv_dm,dv] Explicitly control lc_dft_en_i
- [rv_dm,dv] Configure scanmode as a bit instead of a mubi4_t
- [rv_dm,dv] Config lc_hw_debug_en as a bit, not a 4-bit variable
- [rv_dm,dv] Get rid of unnecessary re-randomisation in base vseq

They have detailed commit messages, but the overriding aim is to simplify the way the underlying `rv_dm_base_vseq` controls the enable/disable of debug features.