### PR TITLE
[dv,usbdev] Test plan refinements

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -1054,6 +1054,15 @@
       tests: ["usbdev_rand_bus_disconnects"]
     }
     {
+      name: rand_suspends
+      desc: '''
+            Deriving from the sequence 'usbdev_max_usb_traffic' ensure that traffic can be streamed
+            back and forth successfully with the device being randomly suspended and resumed.
+            '''
+      stage: V2
+      tests: ["usbdev_rand_suspends"]
+    }
+    {
       name: max_usb_traffic
       desc: '''
             Verify operation under maximal traffic to maximal endpoints, exercising all transfer
@@ -1163,6 +1172,21 @@
             '''
       stage: V2
       tests: ["usbdev_fifo_rst"]
+    }
+    {
+      name: dpi_config_host
+      desc: '''
+            Using the DPI model run the DUT through a typical configuration sequence consisting of
+            Control Transfers that mimic the behavior of a physical USB host controller.
+
+            - Connect the DUT to the USB and perform a Bus Reset.
+            - Set up endpoint zero and read the Device Descriptor.
+            - Set the device address.
+            - Read the configuration descriptor.
+            - Set the configuration.
+            '''
+      stage: V3
+      tests: ["usbdev_dpi_config_host"]
     }
   ]
 

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -29,6 +29,7 @@
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",


### PR DESCRIPTION
This PR introduces the auto-generated test 'usbdev_alert_test' and maps two existing test points that were not listed in the test plan.