### PR TITLE
[jtag,dv] Fix tck acquire/release in jtag_driver.sv

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -164,10 +164,10 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
   task drive_jtag_test_logic_reset();
     `uvm_info(`gfn, "Driving JTAG to Test-Logic-Reset state", UVM_MEDIUM)
     fork begin : isolation_fork
+      enable_tck();
       fork
         begin
           // Enable clock
-          enable_tck();
           `HOST_CB.tms <= 1'b0;
           @(`HOST_CB);
           // Go to Test Logic Reset
@@ -183,15 +183,16 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
         end
       join_any
       disable fork;
+      release_tck();
     end join
   endtask
 
   // drive jtag req and retrieve rsp
   virtual task drive_jtag_req(jtag_item req, jtag_item rsp);
-    enable_tck();
     if (req.reset_tap_fsm) begin
       drive_jtag_test_logic_reset();
     end
+    enable_tck();
     if (exit_to_rti_dr_past & ~cfg.min_rti) begin
       @(`HOST_CB); // wait one cycle to ensure clock is stable. TODO: remove.
     end else begin


### PR DESCRIPTION
There were two bugs in my code!

- The drive_jtag_test_logic_reset function didn't release TCK once the task was finished.

- If a request had the reset_tap_fsm bit set then drive_jtag_req would acquire TCK before calling drive_jtag_test_logic_reset.

Thes bugs were causing the rv_dm_tap_fsm test to fail. Fix them!