### PR TITLE
[rv_dm,dv] Fix port name typo in rv_dm_enable_checker

### DIFF
--- a/hw/ip/rv_dm/dv/sva/rv_dm_enable_checker.sv
+++ b/hw/ip/rv_dm/dv/sva/rv_dm_enable_checker.sv
@@ -35,5 +35,5 @@ module rv_dm_enable_checker
   // If debug is not enabled then the SBA TL interface is disabled and we will never generate a new
   // TL transaction. As such, the a_valid signal will always be false.
   `ASSERT(SbaTLRequestNeedsDebug_A,
-          sba_tl_h_o.a_valid |-> lc_tx_test_true_strict(lc_hw_debug_en_i))
+          sba_tl_h_o_i.a_valid |-> lc_tx_test_true_strict(lc_hw_debug_en_i))
 endmodule


### PR DESCRIPTION
The assertion referenced a non-existent port and was missing the direction suffix. Fix that up.

Fixes a typo from #23788 