### PR TITLE
[rom_e2e,dv] fix ROM E2E DV test cases due to new ROM banner

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_common_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_common_pkg.sv
@@ -24,6 +24,9 @@ package chip_common_pkg;
 
   parameter uint ROM_CONSOLE_UART = 0;
 
+  // ROM banner values.
+  parameter string ROM_BANNER   = "OpenTitan:4001-0002-01";
+
   // ROM Boot Fault Values, matches definitions in `rules/const.bzl`.
   parameter string ROM_BFV_BAD_IDENTIFIER       = "0142500d";
   parameter string ROM_BFV_BAD_ECDSA_SIGNATURE  = "07535603";

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_exception_c_vseq.sv
@@ -9,7 +9,8 @@ class chip_sw_rom_e2e_shutdown_exception_c_vseq extends chip_sw_rom_e2e_base_vse
   virtual task body();
     super.body();
     connect_rom_uart_agent();
-    check_uart_output_msg($sformatf("BFV:%0s\x0d\nLCV:%0s\x0d\n",
+    check_uart_output_msg($sformatf("%0s\x0d\n", ROM_BANNER));
+    check_uart_output_msg($sformatf("BFV:%0s\x0d\nLCV:%0s\x0d",
       ROM_BFV_INSTRUCTION_ACCESS, ROM_LCV_RMA));
     disconnect_rom_uart_agent();
     rom_e2e_test_boot_fault_success();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_shutdown_output_vseq.sv
@@ -23,9 +23,10 @@ class chip_sw_rom_e2e_shutdown_output_vseq extends
       `DV_WAIT(cfg.chip_vif.sram_ret_init_done == 1)
       connect_rom_uart_agent();
 
+      check_uart_output_msg($sformatf("%0s\x0d\n", ROM_BANNER));
       check_uart_output_msg(
-        $sformatf("BFV:%0s\x0d\nLCV:%0s\x0d\n", ROM_BFV_BAD_IDENTIFIER,
-        lc_state_2_rom_lcv[lc_state]));
+        $sformatf("BFV:%0s\x0d\nLCV:%0s\x0d", ROM_BFV_BAD_IDENTIFIER,
+          lc_state_2_rom_lcv[lc_state]));
 
       disconnect_rom_uart_agent();
     end


### PR DESCRIPTION
A new ROM UART banner was added to print chip version information to the UART. This broke some DV E2E test cases that did not expect such information to be printed.

Note: this depends on #23802.