### PR TITLE
[dv,usbdev] Setup priority over STALL response vseq

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -687,16 +687,17 @@
     {
       name: setup_priority_over_stall_response
       desc: '''
-            Verify that by enabling STALL response shall not prevent the reception of a SETUP
-            transaction/packet.SETUP shall clear both in_stall and out_stall bits for the endpoint.
+            Verify that enabling STALL response does not prevent the reception of a SETUP
+            transaction/packet. Receipt of the SETUP packet shall clear both the `in_stall` and
+            the `out_stall` bits for that endpoint.
 
-            - Configure an endpoint for stall response to out transactions then send a setup
-              transaction to the device on stalled endpoint.
-            - Verify that the SETUP being higher in priority shall clear both in_stall and out_stall
-              bits for that endpoint
+            - Configure an endpoint for stall response to OUT transactions and then send a SETUP
+              transaction to the device on the stalled endpoint.
+            - Verify that the SETUP transaction, being higher in priority, clears both in_stall and
+              out_stall bits for that endpoint.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_setup_priority_over_stall_response"]
     }
     {
       name: stall_priority_over_nak

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -417,7 +417,7 @@ endtask
           send_handshake(PidTypeAck);
         default: begin
           // We leave the caller to deal appropriately with any other response;
-          // could be a time out (invalid device/endpoint) or could be a NAK.
+          // could be a time out (invalid device/endpoint), a NAK or a STALL, for example.
         end
       endcase
     end
@@ -854,6 +854,22 @@ endtask
     ral.configin[ep].size.set(num_of_bytes);
     ral.configin[ep].buffer.set(buffer_id);
     csr_update(ral.configin[ep]);
+  endtask
+
+  // Enable/disable the STALL response to OUT transactions for a given endpoint.
+  virtual task configure_out_stall(bit [3:0] ep, bit out_stall = 1'b1);
+    uvm_reg_data_t stall;
+    csr_rd(.ptr(ral.out_stall[0]), .value(stall));
+    stall[ep] = out_stall;
+    csr_wr(.ptr(ral.out_stall[0]), .value(stall));
+  endtask
+
+  // Enable/disable the STALL response to IN transactions for a given endpoint.
+  virtual task configure_in_stall(bit [3:0] ep, bit in_stall = 1'b1);
+    uvm_reg_data_t stall;
+    csr_rd(.ptr(ral.in_stall[0]), .value(stall));
+    stall[ep] = in_stall;
+    csr_wr(.ptr(ral.in_stall[0]), .value(stall));
   endtask
 
   // Send 'Start Of Frame' packet (bus frame/timing referenace).

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_priority_over_stall_response_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_setup_priority_over_stall_response_vseq.sv
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_setup_priority_over_stall_response_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_setup_priority_over_stall_response_vseq)
+
+  `uvm_object_new
+
+  // Check the STALL state is as expected for the given endpoint.
+  task check_stall_state(bit [3:0] ep, bit exp_out_stall, bit exp_in_stall);
+    uvm_reg_data_t act_out_stall;
+    uvm_reg_data_t act_in_stall;
+    csr_rd(.ptr(ral.out_stall[0]), .value(act_out_stall));
+    `DV_CHECK_EQ(act_out_stall[ep], exp_out_stall, "OUT STALL bit not as expected")
+    csr_rd(.ptr(ral.in_stall[0]), .value(act_in_stall));
+    `DV_CHECK_EQ(act_in_stall[ep], exp_in_stall, "IN STALL bit not as expected")
+  endtask
+
+  virtual task body();
+    // Properties of OUT transaction.
+    int unsigned num_of_bytes = 0;
+    bit randomize_length = 1'b1;
+    // Stimulus after OUT transaction.
+    bit bus_reset = 1'b0;
+
+    // Related to closed issue #23806 we need to be sure that we generate long packets that yield a
+    // STALL response, and ideally long packets for which we then issue a bus reset before the
+    // ACK/NAK.
+    //
+    // Note: unfortunately with the present driver structure we cannot generate a link reset
+    // part-way through transmitting an OUT packet to the device, and ideally we need to hit the
+    // point at which 62-64 bytes have been transmitted but there has been no ACK/NAK response.
+    randcase
+      1: begin
+        // Nothing to do...default configuration suffices.
+      end
+      1: begin
+        randomize_length = 1'b0;
+        num_of_bytes = 62;
+      end
+      // Don't STALL the OUT packet, but DO ensure that it's a long packet and _then_ issue a
+      // Bus Reset.
+      1: begin
+        randomize_length = 1'b0;
+        bus_reset = 1'b1;
+        num_of_bytes = 63;
+      end
+    endcase
+    // Report chosen stimulus.
+    `uvm_info(`gfn, $sformatf("Decided to send OUT transaction of %0d byte(s), bus reset %0d",
+                              num_of_bytes, bus_reset), UVM_MEDIUM)
+
+    // Enable the endpoint for all transaction types.
+    configure_out_trans(ep_default);
+    configure_in_trans(ep_default, in_buffer_id, .num_of_bytes(0));
+    // Note: this also supplies a buffer to the SETUP DATA packet.
+    configure_setup_trans(ep_default);
+
+    // Configure an endpoint to generate a STALL handshake in response to IN or OUT transactions.
+    configure_out_stall(ep_default);
+    configure_in_stall(ep_default);
+
+    check_stall_state(ep_default, .exp_out_stall(1'b1), .exp_in_stall(1'b1));
+
+    // Check that an OUT transaction is not accepted now that we have enabled STALLing.
+    send_prnd_out_packet(ep_default, PidTypeData0, randomize_length, num_of_bytes);
+    check_response_matches(PidTypeStall);
+    // Issue a Bus Reset at this point? See the note above; ideally we'd send the bus reset
+    // overlapped with the OUT transaction.
+    if (bus_reset) begin
+      send_bus_reset(100);
+      // Following a Bus Reset we need to reinstate the device address.
+      usbdev_set_address(dev_addr);
+    end else begin
+      // Check that an IN transaction is not accepted either.
+      usb20_item item;
+      retrieve_in_packet(ep_default, item, .ack(0));
+      item.check_pid_type(PidTypeStall);
+    end
+
+    // Attempt to send a SETUP transaction to this endpoint.
+    send_prnd_setup_packet(ep_default);
+    // We should get no STALL at this point; the receipt of SETUP transactions is more important,
+    // so it should be ACKnowledged.
+    check_response_matches(PidTypeAck);
+
+    check_stall_state(ep_default, .exp_out_stall(1'b0), .exp_in_stall(1'b0));
+    // We may as well check the received packet too; this also empties the RX FIFO.
+    check_rx_packet(ep_default, .setup(1), .exp_buffer_id(setup_buffer_id),
+                    .exp_byte_data(m_data_pkt.data), .buffer_known(1));
+  endtask
+endclass : usbdev_setup_priority_over_stall_response_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -46,6 +46,7 @@
 `include "usbdev_rx_crc_err_vseq.sv"
 `include "usbdev_rx_full_vseq.sv"
 `include "usbdev_rx_pid_err_vseq.sv"
+`include "usbdev_setup_priority_over_stall_response_vseq.sv"
 `include "usbdev_setup_priority_vseq.sv"
 `include "usbdev_setup_stage_vseq.sv"
 `include "usbdev_setup_trans_ignored_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -77,6 +77,7 @@ filesets:
       - seq_lib/usbdev_rx_crc_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_rx_full_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_rx_pid_err_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_setup_priority_over_stall_response_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_setup_priority_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_setup_stage_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_setup_trans_ignored_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -345,6 +345,12 @@
       reseed: 5
     }
     {
+      name: usbdev_setup_priority_over_stall_response
+      uvm_test_seq: usbdev_setup_priority_over_stall_response_vseq
+      // Simple sequence, limited need of randomization.
+      reseed: 5
+    }
+    {
       name: usbdev_setup_stage
       uvm_test_seq: usbdev_setup_stage_vseq
     }


### PR DESCRIPTION
Ensure that transmission of SETUP to a STALLed endpoint clears the STALL condition. This is important in clearing protocol stall and permitting Control Transfers to the endpoint to continue.

This relates to issue #23806 and RTL changes in #23807 and #23812.