### PR TITLE
[usbdev] Also reject OUT packet internally when STALLing

### DIFF
--- a/hw/ip/usbdev/rtl/usb_fs_nb_out_pe.sv
+++ b/hw/ip/usbdev/rtl/usb_fs_nb_out_pe.sv
@@ -288,6 +288,7 @@ module usb_fs_nb_out_pe #(
           // Non-isochronous OUT transactions end here
           if (out_ep_stall_i[out_ep_index]) begin
             tx_pid_o = {UsbPidStall}; // STALL
+            rollback_data = 1'b1; // Packet not accepted
           end else if (nak_out_transaction | out_ep_full_i[out_ep_index]) begin
             tx_pid_o = {UsbPidNak}; // NAK -- the endpoint could not accept the data at the moment
             rollback_data = 1'b1;


### PR DESCRIPTION
The OUT packet engine was missing a signal to internal blocks about what happened to the just-received packet if it sent a STALL to the host. Fix this so the internal blocks correctly reset counters and free up resources given to the rejected packet.

Fixes #23806 