### PR TITLE
[flash/dv] Make the info_ro to be controlled by plusarg

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -219,9 +219,19 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
     max_flash_ops_per_cfg = 50;
 
-    op_readonly_on_info_partition = 0;
-    // info1 partition will be read-only by default
-    op_readonly_on_info1_partition = 1;
+    if (!$value$plusargs("op_readonly_on_info_partition=%0d",
+                         op_readonly_on_info_partition)) begin
+      op_readonly_on_info_partition = 0;
+    end
+    if (!$value$plusargs("op_readonly_on_info1_partition=%0d",
+                         op_readonly_on_info1_partition)) begin
+      // info1 partition will be read-only by default
+      op_readonly_on_info1_partition = 1;
+    end
+    if (!$value$plusargs("op_readonly_on_info2_partition=%0d",
+                         op_readonly_on_info2_partition)) begin
+      op_readonly_on_info2_partition = 0;
+    end
 
     avoid_ro_partitions = 0;
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -199,11 +199,6 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
     // Configure MP Region Enable Prob
     cfg.seq_cfg.mp_region_en_pc = 70;
 
-    // Disable Read Only on the Info Partitions
-    cfg.seq_cfg.op_readonly_on_info_partition  = 0;
-    cfg.seq_cfg.op_readonly_on_info1_partition = 0;
-    cfg.seq_cfg.op_readonly_on_info2_partition = 0;
-
     // Scoreboard knob for blocking host reads
     cfg.block_host_rd = 1;
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -159,10 +159,6 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
     cfg.seq_cfg.mp_region_he_en_pc = 50;
     cfg.seq_cfg.default_region_he_en_pc = 50;
 
-    // Enable Read Only on Info Partitions
-    cfg.seq_cfg.op_readonly_on_info_partition = 1;
-    cfg.seq_cfg.op_readonly_on_info1_partition = 1;
-
     // MAX Delay for an Expected Alert
     cfg.alert_max_delay = cfg.seq_cfg.prog_timeout_ns;
 

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -201,10 +201,6 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
     cfg.seq_cfg.mp_region_he_en_pc = 50;
     cfg.seq_cfg.default_region_he_en_pc = 50;
 
-    // Enable Read Only on Info Partitions
-    cfg.seq_cfg.op_readonly_on_info_partition  = 1;
-    cfg.seq_cfg.op_readonly_on_info1_partition = 1;
-
   endfunction : configure_vseq
 
   // Body

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -19,9 +19,6 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     // enable high endurance
     cfg.seq_cfg.mp_region_he_en_pc             = 50;
     cfg.seq_cfg.default_region_he_en_pc        = 50;
-
-    // info1 partition is not read only
-    cfg.seq_cfg.op_readonly_on_info1_partition = 0;
   endfunction
 
   rand flash_op_t flash_op;

--- a/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip_templates/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -150,12 +150,14 @@
       name: flash_ctrl_mp_regions
       uvm_test_seq: flash_ctrl_mp_regions_vseq
       run_opts: ["+multi_alert=1", "+test_timeout_ns=300_000_000_000",
-                 "+fast_rcvr_recov_err"]
+                 "+fast_rcvr_recov_err", "+op_readonly_on_info1_partition=0"]
       reseed: 20
     }
     {
       name: flash_ctrl_fetch_code
       uvm_test_seq: flash_ctrl_fetch_code_vseq
+      run_opts: ["+op_readonly_on_info_partition=1",
+                 "+op_readonly_on_info1_partition=1"]
       reseed: 10
     }
     {
@@ -168,6 +170,8 @@
     {
       name: flash_ctrl_error_prog_type
       uvm_test_seq: flash_ctrl_error_prog_type_vseq
+      run_opts: ["+op_readonly_on_info_partition=1",
+                 "+op_readonly_on_info1_partition=1"]
       reseed: 5
     }
     {
@@ -178,7 +182,8 @@
     {
       name: flash_ctrl_error_mp
       uvm_test_seq: flash_ctrl_error_mp_vseq
-      run_opts: ["+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+test_timeout_ns=300_000_000_000", "+op_readonly_on_info_partition=0",
+                 "+op_readonly_on_info1_partition=0", "+op_readonly_on_info2_partition=0"]
       reseed: 10
     }
     {

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -219,9 +219,19 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
     max_flash_ops_per_cfg = 50;
 
-    op_readonly_on_info_partition = 0;
-    // info1 partition will be read-only by default
-    op_readonly_on_info1_partition = 1;
+    if (!$value$plusargs("op_readonly_on_info_partition=%0d",
+                         op_readonly_on_info_partition)) begin
+      op_readonly_on_info_partition = 0;
+    end
+    if (!$value$plusargs("op_readonly_on_info1_partition=%0d",
+                         op_readonly_on_info1_partition)) begin
+      // info1 partition will be read-only by default
+      op_readonly_on_info1_partition = 1;
+    end
+    if (!$value$plusargs("op_readonly_on_info2_partition=%0d",
+                         op_readonly_on_info2_partition)) begin
+      op_readonly_on_info2_partition = 0;
+    end
 
     avoid_ro_partitions = 0;
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_mp_vseq.sv
@@ -199,11 +199,6 @@ class flash_ctrl_error_mp_vseq extends flash_ctrl_base_vseq;
     // Configure MP Region Enable Prob
     cfg.seq_cfg.mp_region_en_pc = 70;
 
-    // Disable Read Only on the Info Partitions
-    cfg.seq_cfg.op_readonly_on_info_partition  = 0;
-    cfg.seq_cfg.op_readonly_on_info1_partition = 0;
-    cfg.seq_cfg.op_readonly_on_info2_partition = 0;
-
     // Scoreboard knob for blocking host reads
     cfg.block_host_rd = 1;
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_error_prog_type_vseq.sv
@@ -159,10 +159,6 @@ class flash_ctrl_error_prog_type_vseq extends flash_ctrl_base_vseq;
     cfg.seq_cfg.mp_region_he_en_pc = 50;
     cfg.seq_cfg.default_region_he_en_pc = 50;
 
-    // Enable Read Only on Info Partitions
-    cfg.seq_cfg.op_readonly_on_info_partition = 1;
-    cfg.seq_cfg.op_readonly_on_info1_partition = 1;
-
     // MAX Delay for an Expected Alert
     cfg.alert_max_delay = cfg.seq_cfg.prog_timeout_ns;
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_fetch_code_vseq.sv
@@ -201,10 +201,6 @@ class flash_ctrl_fetch_code_vseq extends flash_ctrl_base_vseq;
     cfg.seq_cfg.mp_region_he_en_pc = 50;
     cfg.seq_cfg.default_region_he_en_pc = 50;
 
-    // Enable Read Only on Info Partitions
-    cfg.seq_cfg.op_readonly_on_info_partition  = 1;
-    cfg.seq_cfg.op_readonly_on_info1_partition = 1;
-
   endfunction : configure_vseq
 
   // Body

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -19,9 +19,6 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     // enable high endurance
     cfg.seq_cfg.mp_region_he_en_pc             = 50;
     cfg.seq_cfg.default_region_he_en_pc        = 50;
-
-    // info1 partition is not read only
-    cfg.seq_cfg.op_readonly_on_info1_partition = 0;
   endfunction
 
   rand flash_op_t flash_op;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -150,12 +150,14 @@
       name: flash_ctrl_mp_regions
       uvm_test_seq: flash_ctrl_mp_regions_vseq
       run_opts: ["+multi_alert=1", "+test_timeout_ns=300_000_000_000",
-                 "+fast_rcvr_recov_err"]
+                 "+fast_rcvr_recov_err", "+op_readonly_on_info1_partition=0"]
       reseed: 20
     }
     {
       name: flash_ctrl_fetch_code
       uvm_test_seq: flash_ctrl_fetch_code_vseq
+      run_opts: ["+op_readonly_on_info_partition=1",
+                 "+op_readonly_on_info1_partition=1"]
       reseed: 10
     }
     {
@@ -168,6 +170,8 @@
     {
       name: flash_ctrl_error_prog_type
       uvm_test_seq: flash_ctrl_error_prog_type_vseq
+      run_opts: ["+op_readonly_on_info_partition=1",
+                 "+op_readonly_on_info1_partition=1"]
       reseed: 5
     }
     {
@@ -178,7 +182,8 @@
     {
       name: flash_ctrl_error_mp
       uvm_test_seq: flash_ctrl_error_mp_vseq
-      run_opts: ["+test_timeout_ns=300_000_000_000"]
+      run_opts: ["+test_timeout_ns=300_000_000_000", "+op_readonly_on_info_partition=0",
+                 "+op_readonly_on_info1_partition=0", "+op_readonly_on_info2_partition=0"]
       reseed: 10
     }
     {


### PR DESCRIPTION
This PR is making the op_readonly_on_info in the flash_ctrl env to be controllable by plusargs.