### PR TITLE
[usbdev] Link reset must clear packet reception state.

### DIFF
--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -199,6 +199,9 @@ module usbdev_usbif  #(
       out_max_used_q <= '0;
       wdata_q        <= '0;
       std_write_q    <= 1'b0;
+    end else if (link_reset) begin
+      out_max_used_q <= '0;
+      std_write_q    <= 1'b0;
     end else begin
       out_max_used_q <= out_max_used_d;
       std_write_q    <= std_write_d;


### PR DESCRIPTION
In the event that a link reset occurs at the end of receiving an OUT packet of 62 or more bytes, the same fault as observed with the OUT STALL behavior would occur, causing reception failure of the first packet post-reset.

Related to issue #23806 and the RTL change in #23807, but this additional change is from inspection/reasoning rather than (yet) being demonstrated in DV.