### PR TITLE
[hmac,dv] Fix rare issue with wipe_secret

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -152,9 +152,13 @@ constraint key_digest_c {
     bit [TL_DW-1:0] digest[16];
     csr_rd_digest(digest);
     // Clear the wipe_secret flag because the exp digest val in scb will be updated.
+    clear_wipe_secret();
+  endtask : rd_digest
+
+  virtual function clear_wipe_secret();
     `uvm_info(`gfn, "wiping secret untriggered", UVM_LOW)
     cfg.wipe_secret_triggered = 0;
-  endtask
+  endfunction : clear_wipe_secret
 
   // read digest value and output read value
   virtual task csr_rd_digest(output bit [TL_DW-1:0] digest[16]);

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -219,6 +219,9 @@ class hmac_smoke_vseq extends hmac_base_vseq;
       `uvm_info(`gfn, $sformatf("reading digest now"), UVM_HIGH)
       rd_digest();
     end
+    // Ensure that wipe secret flag is cleared for the next sequence, as it may cause digest
+    // comparison issue with the stress tests
+    clear_wipe_secret();
   endtask : body
 
 endclass : hmac_smoke_vseq


### PR DESCRIPTION
- When wipe_secret test is triggered from stress test and if the last
triggered wipe secret type is WipeSecretBeforeStart and HMAC is
enabled then rd_digest is not exercised thus wipe_secret_triggered
is not pulled back to 0.