### PR TITLE
[rom] Make the banner message non-blocking

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/uart.h
+++ b/sw/device/silicon_creator/lib/drivers/uart.h
@@ -56,6 +56,8 @@ void uart_write(const void *data, size_t len);
 /**
  * Write an unsigned integer as hex to the UART.
  *
+ * Note: this function does not block waiting for the transmitter to finish.
+ *
  * @param val The value to write to the UART.
  * @param len The length of the value in bytes (1, 2, or 4 bytes).
  * @param after Packed ASCII values to write after the hex value.
@@ -71,14 +73,11 @@ void uart_write_hex(uint32_t val, size_t len, uint32_t after);
  * order (ie: the string is reversed).  A maximum of eight bytes can be printed
  * in this way.  A zero byte in the value terminates the output.
  *
+ * Note: this function does not block waiting for the transmitter to finish.
+ *
  * @param val The bytes to print.
  */
 void uart_write_imm(uint64_t val);
-
-inline void uart_write_newline(void) {
-  //               \n\r
-  uart_write_imm(0x0a0d);
-}
 
 /**
  * Read from the UART into a buffer.

--- a/sw/device/silicon_creator/lib/stack_utilization.c
+++ b/sw/device/silicon_creator/lib/stack_utilization.c
@@ -22,10 +22,11 @@ void stack_utilization_print(void) {
   uint32_t used = total - free;
   //                          : K T S
   const uint32_t kPrefix = 0x3a4b5453;
-  //                          \n\r
-  const uint32_t kNewline = 0x0a0d;
   uart_write_imm(kPrefix);
   uart_write_hex(used, sizeof(used), '/');
-  uart_write_hex(total, sizeof(total), kNewline);
+  uart_write_hex(total, sizeof(total), '\r');
+  // Send the last char with putchar so we'll wait for the
+  // transmitter to finish.
+  uart_putchar('\n');
 }
 #endif


### PR DESCRIPTION
1. The ROM banner takes about 2 ms to be sent from the UART at 115200 bps.  Rather than wait for it to complete transmission, emit the characters into the UART FIFO and proceed with boot.  Hashing the FLASH contents and performing signature verification typically will take an additional 2.4 + 4.2 ms.  There is no need to delay boot waiting for the UART.
2. Fix the ROM's terminal states to wait for UART output to complete.