### PR TITLE
[flash_ctrl] Fix read buffer re-allocation for even buffers

### DIFF
--- a/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip_templates/flash_ctrl/rtl/flash_phy_rd.sv
@@ -179,7 +179,7 @@ module flash_phy_rd
     .idx_o(),
     .valid_o(),
     .data_o(),
-    .ready_i(req_o & no_match)
+    .ready_i(req_o & ack_i & no_match)
   );
 
   // which buffer to allocate upon a new transaction

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/rtl/flash_phy_rd.sv
@@ -179,7 +179,7 @@ module flash_phy_rd
     .idx_o(),
     .valid_o(),
     .data_o(),
-    .ready_i(req_o & no_match)
+    .ready_i(req_o & ack_i & no_match)
   );
 
   // which buffer to allocate upon a new transaction


### PR DESCRIPTION
Previously, the read buffer re-allocation arbiter erroneously did not factor in the `ack_i` signal coming from the Flash macro. While the open source simulation model never really de-asserts `ack_i`, some real Flash macros may do so. As a result, `req_o` might be high for multiple clock cycles and the read buffer re-allocation may skip even read buffers. This effectively halves the number of usable read buffers which may have a negative performance impact.

The fix is easy and just involves factoring in `ack_i` to take the actual Flash macro request handshake for doing allocations.

This resolves lowRISC/OpenTitan#23797.