### PR TITLE
[Cadence FCOV flow] Cadence FCOV ditched if per_instance=1' not added

### DIFF
--- a/hw/dv/tools/xcelium/common.ccf
+++ b/hw/dv/tools/xcelium/common.ccf
@@ -10,6 +10,9 @@
 // coverage collection on various design elements, that are otherwise turned off by default. We
 // maintain it locally with minor amends.
 
+// Cadence considers covergroups which don't set options.per_instance = 1 to be discarded if below flag not set
+set_covergroup -per_instance_default_one
+
 // Enables expression coverage of various Verilog operators.
 set_expr_coverable_operators -all -event_or
 


### PR DESCRIPTION
Cadence coverage flow has decided not to merge FCOV from covergroups which don't have 'option.per_instance=1' regardless of whether this covergroups are embedded in a class or instantiated.

In order to continue gathering FCOV in the way we intend to, I suggest configuring Cadence tool with a flag so we still collect FCOV from covergroups when per_instance=0.

You can find info from Cadence's solvnet [here](https://support.cadence.com/apex/ArticleAttachmentPortal?id=a1Od0000000nTS9EAM&pageName=ArticleContent).
EDIT: Screenshot:  Removed screenshot since I just saw this disclaimer: Caution: All content on this site is Cadence Confidential and for Cadence customers only. DO NOT DISTRIBUTE.





I've tested Cadence tool to see what happens when the covergroup is embedded in a class VS when is outside and needs instantiating via covergroup type, and the result is the same. If `option.per_instance` isn't set, then Cadence discards that FCOV. 

With the original coverage flow, I've added 2 out-of-class covergroups and 2 embedded in class covergroups: one setting `per_instance=1` the other doesn't. You can see in IMC the coverage is discarded for any that doesn't set per_instance=1:
![Screenshot from 2024-06-27 17-44-43](https://github.com/lowRISC/opentitan/assets/156205999/d83d7363-c04d-4e44-ae8a-c8284109cd8b)

After running some tests and gathering coverage with the suggested flag, I then get all the expected coverage:
![Screenshot from 2024-06-27 17-49-07](https://github.com/lowRISC/opentitan/assets/156205999/a006cb5e-3a41-4935-a589-3afc9973ebc1)
(`dummy_out_cg` is the same covergroup type as `dummy_out_per_instance_cg` only that the second has options.per_instance=1) 


Cadence explains their behaviour based on the LRM, but I interpret the LRM (Table 19.1 - Instance specific coverage options) differently:
![Screenshot from 2024-06-27 17-52-33](https://github.com/lowRISC/opentitan/assets/156205999/279376f6-c17d-4370-b3dd-f9f3cb65f354)
My interpretation is that implementations aren't required to save instance-specific information, as you'd expect with the `option.per_instance=0`, but I'd expect a merged result for each type of covergroup to be saved, not just discarded. 



Note: this may mean the FCOV for blocks running with Xcelium may be worse than we think it is once we incorporate the missing coverage 