### PR TITLE
[dv,usbdev] Frequency and phase delta sequence

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_block_if.sv
+++ b/hw/dv/sv/usb20_agent/usb20_block_if.sv
@@ -20,8 +20,8 @@ interface usb20_block_if (
   logic usb_tx_se0_o;
   logic usb_tx_d_o;
   // Non-data pins
-  logic usb_dp_pullup_o ;
-  logic usb_dn_pullup_o ;
+  logic usb_dp_pullup_o;
+  logic usb_dn_pullup_o;
   logic usb_rx_enable_o;
   logic usb_tx_use_d_se0_o;
   logic drive_vbus;          // to drive usb_vbus from driver

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -757,7 +757,8 @@
             - Verify that there are no reports of bit stuffing errors or CRC errors.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_freq_loclk",
+              "usbdev_freq_hiclk"]
     }
     {
       name: max_clock_error_tracking
@@ -780,7 +781,8 @@
               the USB device starting at the maximum frequecy.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_freq_loclk_max",
+              "usbdev_freq_hiclk_max"]
     }
     {
       name: max_phase_error
@@ -794,7 +796,7 @@
               of the transaction.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_freq_phase"]
     }
     {
       name: min_inter_pkt_delay

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -223,7 +223,7 @@
               packet data that was transmitted.
             '''
       stage: V2
-      tests: ["usbdev_max_length_out_transaction"]
+      tests: ["usbdev_max_length_out_transaction", "usbdev_stream_len_max"]
     }
     {
       name: max_length_in_transaction

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -872,7 +872,7 @@ endtask
     csr_wr(.ptr(ral.in_stall[0]), .value(stall));
   endtask
 
-  // Send 'Start Of Frame' packet (bus frame/timing referenace).
+  // Send 'Start Of Frame' packet (bus frame/timing reference).
   virtual task send_sof_packet(input pid_type_e pid_type);
     `uvm_create_on(m_sof_pkt, p_sequencer.usb20_sequencer_h)
     start_item(m_sof_pkt);

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_freq_phase_delta_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_freq_phase_delta_vseq.sv
@@ -1,0 +1,278 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Frequency and phase delta between host and device.
+//
+// - Host and DUT frequency may be set independently, to opposite extremes of the permitted
+//   frequency range if desired.
+// - DUT frequency may be adjusted in response to the DUT timing reference signal to match the
+//   frequency of the host.
+// - Host frequency may be configured to drift throughout the test.
+// - Sequence may execute with or without traffic (max length packets to increase the likelihood
+//   of sampling errors from frequency/phase mismatch).
+// - There is a 10ms 'Reset Recovery' period guaranteed within the USB 2.0 protocol specification,
+//   during which the host controller is not permitted to send anything other than SOF packets
+//   to the DUT; this is important in guaranteeing that the DUT has time to measure and track the
+//   frequency of the host.
+class usbdev_freq_phase_delta_vseq extends usbdev_stream_len_max_vseq;
+  `uvm_object_utils(usbdev_freq_phase_delta_vseq)
+
+  `uvm_object_new
+
+  // Min/max DUT clock frequencies (scaled from 12Mbps to 48MHz clock) according to the
+  // USB 2.0 specification; Table 7-9.
+  localparam uint USB_CLK_FREQ_MIN_KHZ = 4 * 11_970;
+  localparam uint USB_CLK_FREQ_MAX_KHZ = 4 * 12_030;
+
+  // Target number of clock cycles per bus frame.
+  localparam int CYCLES_PER_FRAME = 48_000;
+
+  // Duration of test in 1ms bus frames.
+  rand uint num_frames;
+  constraint num_frames_c {
+    num_frames inside {[80:120]};
+  };
+
+  // Target clock frequency of host.
+  rand uint host_target_freq_khz;
+  constraint host_target_freq_khz_c {
+    // Maximum frequency extremes, since the host is using the same oversampling scheme as the DUT.
+    // See USB 2.0 Table 7-9.
+    host_target_freq_khz >= USB_CLK_FREQ_MIN_KHZ && host_target_freq_khz <= USB_CLK_FREQ_MAX_KHZ;
+  };
+
+  // Configured initial frequency deltas from 48Mhz, given in Hz.
+  int host_freq_delta;
+  int usb_freq_delta;
+
+  // Are we required to track the host frequency by adjusting the DUT oscillator?
+  bit osc_tracking = 0;
+
+  // Shall the host clock frequency drift over the duration of the test?
+  bit host_drifting = 0;
+
+  // Shall there be any bus traffic during this test?
+  bit with_traffic = 1;
+
+  // Observe Reset Recovery period; do not transmit anything other than SOF packets within 10ms
+  // of Reset Signaling?
+  bit reset_recovery = 1;
+
+  // Test only SOF reception, not maximum length packets; diagnostic/development switch can make
+  // it easier to study the frequency drifting/tracking.
+  bit sof_only = 0;
+
+  // Indicates that all test frames have completed; the test sequence is terminating.
+  bit all_frames_done = 0;
+
+  // Is transmission of regular bus traffic presently permitted?
+  //   (This prevents collision with the SOF packet at the start of each bus frame.)
+  bit can_transmit = 0;
+
+  // Count of the number of SOF packets sent since the last Bus Reset; this is used to ascertain
+  // when the 'reset recovery' period has elapsed.
+  int unsigned sof_sent = 0;
+
+  // Drift the host clock frequency
+  virtual task host_drift();
+    // Sample the current host frequency and the total intended drift.
+    int initial_freq_khz = cfg.host_clk_freq_khz;
+    int freq_delta = int'(host_target_freq_khz) - initial_freq_khz;
+    // Total cycle count over which to drift; half the expected test duration to leave intervals
+    // at the start (set up) and the end (hopefully 'synchronized' and transfers are successful).
+    uint total_cycles = CYCLES_PER_FRAME * num_frames / 2;
+    uint elapsed_cycles = 0;
+    `uvm_info(`gfn, $sformatf("Driving the host clk from %dkHz to %dkHz",
+                              initial_freq_khz, host_target_freq_khz), UVM_MEDIUM)
+
+    while (!all_frames_done && elapsed_cycles < total_cycles) begin
+      // Decide how many clocks to wait before applying a correction; we must keep this small to
+      // avoid significant step changes in the frequency since they may be expected to produce
+      // transmission errors.
+      uint wait_cycles = $urandom_range(512, 1024);
+      if (wait_cycles > total_cycles - elapsed_cycles) wait_cycles = total_cycles - elapsed_cycles;
+      cfg.host_clk_rst_vif.wait_clks(wait_cycles);
+      elapsed_cycles += wait_cycles;
+      set_host_clk(initial_freq_khz + (freq_delta * int'(elapsed_cycles)) / int'(total_cycles));
+    end
+  endtask
+
+  // Parallel task generates SOF periodically, dividing the bus activity into discrete
+  // bus frames and indicating when transmission of regular bus traffic may occur.
+  virtual task bus_framing();
+    // Whatever the actual host frequency, we want to generate a SOF every 48_000 clock
+    // cycles, since this equates to 1ms in the host's time frame.
+    int unsigned elapsed_cycles = 0;
+    while (!all_frames_done) begin
+      cfg.host_clk_rst_vif.wait_clks(48_000 - elapsed_cycles);
+      elapsed_cycles = 0;
+      fork
+        begin : isolation_fork
+          fork
+            while (1) begin
+              cfg.host_clk_rst_vif.wait_clks(1);
+              elapsed_cycles++;
+            end
+            begin
+              // Use the 'worst possible' frame number to generate a maximal length SOF packet;
+              //  (this is one of a handful of frame numbers that require two bit stuffed zeros,
+              //   experimentally determined).
+              send_sof_packet(PidTypeSofToken, 11'h7fe);
+              can_transmit = 1;
+              // Track the number of SOF packets sent, so that the end of the 'reset recovery'
+              // period can be detected.
+              sof_sent++;
+              if (sof_sent >= 10) reset_recovery = 0;
+            end
+          join_any
+          disable fork;
+        end : isolation_fork
+      join
+    end
+  endtask
+
+  // Await (with timeout) the next USB timing reference pulse from the DUT; this shall be pulsed
+  // every 1ms indicating detection of a Start Of Frame packet from the USB host controller.
+  virtual task wait_ref_pulse();
+    fork
+      begin : isolation_fork
+        fork
+          begin
+            // DUT will declare 'host lost' after just 4 bus frames; we'll wait a little longer
+            // before giving up ourselves in case it recovers.
+            cfg.clk_rst_vif.wait_clks(5 * CYCLES_PER_FRAME);
+            `uvm_fatal(`gfn, "No usb_ref_pulse_i assertion; host lost")
+          end
+          @(posedge cfg.osc_tuning_vif.usb_ref_pulse_i);
+        join_any
+        disable fork;
+      end : isolation_fork
+    join
+  endtask
+
+  // Parallel task receives reference pulses indicating the reception of SOF packets
+  // and allowing the DUT oscillator to be tuned to match that of the USB host.
+  virtual task sof_tracking();
+    // Clock period in picoseconds for a 48MHz oscillator.
+    localparam int CYCLE_PS = 1_000_000 / 48;
+    // The most recent delta measurements
+    localparam int unsigned NDELTAS = 8;
+    int deltas[NDELTAS];
+    int idx = 0;
+
+    while (!all_frames_done) begin
+      int total_delta = 0;
+      int mean_delta_ps;
+      int elapsed_cycles;
+
+      wait_ref_pulse();
+      elapsed_cycles = cfg.osc_tuning_vif.elapsed_dut_cycles();
+
+      // Update the sliding window of delta measurements; we're using a simple weighted average
+      // to provide some robustness whilst tracking a potentially-varying host clock, but we're not
+      // trying to model a realistic variable frequency oscillator too closely.
+      //
+      // The aim is just to achieve convergence upon a static target frequency within a reasonable
+      // number of bus frames. The USB host must guarantee 10ms of post-Bus Reset recovery during
+      // which only SOF packets are transmitted to the DUT, equivalent to 10 bus frames.
+
+      // A positive cycle delta indicates that the DUT is running faster than the host and its
+      // oscillator should be slowed. A negative cycle delta indicates the opposite.
+      elapsed_cycles -= CYCLES_PER_FRAME;
+      `uvm_info(`gfn, $sformatf("Bus frame was measured as %d cycles", elapsed_cycles), UVM_HIGH)
+      deltas[idx] = elapsed_cycles;
+      begin
+        int unsigned i = idx;
+        int n = 1;
+        do begin
+          total_delta += deltas[i] / n;
+          `uvm_info(`gfn, $sformatf("total_delta becoming %d adding %d/%d", total_delta,
+                                    deltas[i], n), UVM_HIGH)
+          i = ((i >= NDELTAS - 1) ? 0 : (i + 1));
+          n = n * 2;  // limit(sum(1/2^n)) for n >= 0 is 2.
+        end while (i != idx);
+      end
+      idx = ((idx > 0) ? idx : NDELTAS) - 1;
+
+      // Convert the average cycle difference to an adjustment in picoseconds, using a clock
+      // frequency of 48MHz; if our cycle count is too high, we need to lengthen the clock period.
+      mean_delta_ps = (total_delta * CYCLE_PS) / 2;  // Div 2 corrects for weighted sum.
+
+      // The mean delta in picoseconds must be amortized over all of the bits in the bus frame.
+      adjust_usb_clk(mean_delta_ps / CYCLES_PER_FRAME);
+    end
+  endtask
+
+  // Transmission of packet data
+  virtual task bus_traffic();
+    repeat (num_frames) begin
+      // Prevent collision between DATA packets and SOF packet at frame start.
+      while (!can_transmit) begin
+        cfg.host_clk_rst_vif.wait_clks(8);
+      end
+      can_transmit = 0;
+      // Transmit enough packets to fill about 2/3 of the bus frame.
+      if (with_traffic & !reset_recovery & !sof_only) transmit_out_packets(10);
+    end
+    // Signal to the other processes that all test frames have been completed and they should stop.
+    all_frames_done = 1;
+  endtask
+
+  virtual task pre_start();
+    // Vary the initial DUT clock frequency in these test sequences.
+    if ($value$plusargs("usb_freq_delta=%0d", usb_freq_delta)) begin
+      cfg.usb_clk_freq_khz = 48_000 + (usb_freq_delta + 500) / 1000;  // round to nearest
+    end else begin
+      // The DUT frequency is kept constant by default in other vseqs, but we want to randomize it
+      // too for freq/phase testing, not just that of the host.
+      cfg.usb_clk_freq_khz = $urandom_range(USB_CLK_FREQ_MIN_KHZ, USB_CLK_FREQ_MAX_KHZ);
+    end
+    // Vary the initial host clock frequency, or let the base class randomize it.
+    if ($value$plusargs("host_freq_delta=%0d", host_freq_delta)) begin
+      cfg.host_clk_freq_khz = 48_000 + (host_freq_delta + 500) / 1000;  // round to nearest
+    end
+
+    // Testpoint settings to control the behavior of this sequence.
+    void'($value$plusargs("host_drifting=%d",  host_drifting));  // Host clk a moving target.
+    void'($value$plusargs("osc_tracking=%d",   osc_tracking));   // DUT clk must track host clk.
+    void'($value$plusargs("with_traffic=%d",   with_traffic));   // Transmit OUT DATA traffic.
+    void'($value$plusargs("reset_recovery=%d", reset_recovery)); // Observe Reset Recovery?
+    void'($value$plusargs("sof_only=%d",       sof_only));       // Diagnostic/development aid.
+
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    // Report test configuration.
+    `uvm_info(`gfn, $sformatf("usb_freq_delta  %0d", usb_freq_delta),  UVM_LOW)
+    `uvm_info(`gfn, $sformatf("host_freq_delta %0d", host_freq_delta), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("host_drifting   %0d", host_drifting),   UVM_LOW)
+    `uvm_info(`gfn, $sformatf("osc_tracking    %0d", osc_tracking),    UVM_LOW)
+    `uvm_info(`gfn, $sformatf("with_traffic    %0d", with_traffic),    UVM_LOW)
+    `uvm_info(`gfn, $sformatf("reset_recovery  %0d", reset_recovery),  UVM_LOW)
+    `uvm_info(`gfn, $sformatf("sof_only        %0d", sof_only),        UVM_LOW)
+
+    configure_out_trans(ep_default);
+
+    // Do not proceed further until the device has exited the Bus Reset signaling of the
+    // usb20_driver module.
+    wait_for_link_state({LinkActive, LinkActiveNoSOF}, 10 * 1000 * 48);  // 10ms timeout, at 48MHz
+
+    // Initialize test state.
+    sof_sent = 0;
+    can_transmit = 0;
+    all_frames_done = 0;
+
+    fork
+      if (host_drifting) host_drift();
+      // Periodic generation of SOF packets by the USB host.
+      bus_framing();
+      // Tracking of bus frames and adjustment of DUT clock frequency.
+      if (osc_tracking) sof_tracking();
+      // Generation of bus traffic, and control of test completion.
+      bus_traffic();
+    join
+  endtask
+
+endclass : usbdev_freq_phase_delta_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_stream_len_max_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_stream_len_max_vseq.sv
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Transmit a stream of maximum length packets to the DUT, aiming to achieve maximal 'Bit Stuffing'
+// throughout at least some of those OUT packets. This is difficult to guarantee because of the
+// interaction between the data bytes and the CRC16 that checksums those bits.
+//
+// This may be used as the basis for testing the rx sampling under conditions of worst case phase
+// and maximal frequency delta.
+class usbdev_stream_len_max_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_stream_len_max_vseq)
+
+  `uvm_object_new
+
+  // Remember the current state of the Data Toggle bit for the selected OUT endpoint.
+  bit data_tog = 0;
+
+  virtual task transmit_out_packets(int unsigned num_packets);
+    byte unsigned data[$];
+    `uvm_info(`gfn, $sformatf("Transmitting %d max length OUT packets", num_packets), UVM_MEDIUM)
+    // To achieve the maximum length of OUT packet we just emit a lot of '1' bits to ensure that
+    // maximal bit stuffing occurs. Although bit stuffing is active throughout the DATA0 PID
+    // and the CRC16 too, it seems as though the maximum packet length is 614 bits and this is
+    // achieved with a simple sequence of 0xff bytes, yielding a CRC16 of 0x40fe.
+    for (int unsigned idx = 0; idx < MaxPktSizeByte; idx++) begin
+      data.push_back(8'hFF);
+    end
+    for (int unsigned txn = 0; txn < num_packets; txn++) begin
+      // TODO: perhaps we want to collect and check the packets in another process?
+      // This would stop the CSR/buffer accesses from affecting the USB traffic timing, which
+      // could be important in exercising all freq/phase extremes.
+      send_out_packet(ep_default, data_tog ? PidTypeData1 : PidTypeData0, data);
+      check_response_matches(PidTypeAck);
+      inter_packet_delay();
+      data_tog ^= 1;
+
+      // Check that the USB device received a packet with the expected properties.
+      check_pkt_received(ep_default, 0, out_buffer_id, m_data_pkt.data);
+      // Return the OUT buffer for reuse.
+      csr_wr(.ptr(ral.avoutbuffer.buffer), .value(out_buffer_id));
+    end
+  endtask
+
+  virtual task body();
+    // Set up an endpoint to receive OUT packets.
+    configure_out_trans(ep_default);
+
+    transmit_out_packets(num_trans);
+  endtask
+
+endclass : usbdev_stream_len_max_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -58,6 +58,8 @@
 // These depend on usbdev_spray_packets_vseq, so need to come after it.
 `include "usbdev_device_address_vseq.sv"
 `include "usbdev_disable_endpoint_vseq.sv"
+// This depends on usbdev_stream_len_max_vseq, so needs to come after it.
+`include "usbdev_freq_phase_delta_vseq.sv"
 // These depend on usbdev_random_length_out_transaction, so need to come after it.
 `include "usbdev_max_length_out_transaction_vseq.sv"
 `include "usbdev_min_length_out_transaction_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -53,6 +53,7 @@
 `include "usbdev_spray_packets_vseq.sv"
 `include "usbdev_stall_priority_over_nak_vseq.sv"
 `include "usbdev_stall_trans_vseq.sv"
+`include "usbdev_stream_len_max_vseq.sv"
 
 // These depend on usbdev_spray_packets_vseq, so need to come after it.
 `include "usbdev_device_address_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:dv:dv_base_reg
     files:
       - usbdev_env_pkg.sv
+      - usbdev_osc_tuning_if.sv
       - usbdev_env_cfg.sv: {is_include_file: true}
       - usbdev_env_cov.sv: {is_include_file: true}
       - usbdev_virtual_sequencer.sv: {is_include_file: true}
@@ -44,6 +45,7 @@ filesets:
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_endpoint_access_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_fifo_rst_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_freq_phase_delta_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_host_lost_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_iso_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_rand_trans_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -86,6 +86,7 @@ filesets:
       - seq_lib/usbdev_stall_priority_over_nak_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_streaming_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_stream_len_max_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/usbdev/dv/env/usbdev_env.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env.sv
@@ -29,22 +29,14 @@ class usbdev_env extends cip_base_env #(
     if (!uvm_config_db#(virtual usb20_if)::get(this, "", "vif", cfg.usb20_usbdpi_vif)) begin
       `uvm_fatal(`gfn, "failed to get usb20_if handle from uvm_config_db")
     end
-
-    // Use the configured USB speed for the main clock
-    cfg.clk_rst_vif.set_freq_khz(cfg.usb_clk_freq_khz);
-
-    // Use a sensible speed for the AON clock
-    cfg.aon_clk_rst_vif.set_freq_khz(cfg.aon_clk_freq_khz);
+    // Access to oscillator tuning/timing reference interface.
+    if (!uvm_config_db#(virtual usbdev_osc_tuning_if)::get(this, "", "usbdev_osc_tuning_vif",
+        cfg.osc_tuning_vif)) begin
+      `uvm_fatal(`gfn, "failed to get usbdev_osc_tuning_if handle from uvm_config_db")
+    end
 
     // Use the selected host clock frequency; this may differ from that of the DUT.
     // The DUT is required to cope with a certain amount of disparity, and adjust itself
-    // to match the frequency of the host over time.
-    cfg.host_clk_rst_vif.set_freq_khz(cfg.host_clk_freq_khz);
-
-    // Report the clock frequencies.
-    `uvm_info(`gfn, $sformatf("usb_clk %dkHz, host_clk %dkHz",
-                              cfg.usb_clk_freq_khz, cfg.host_clk_freq_khz), UVM_MEDIUM)
-
     // create components
     m_usb20_agent = usb20_agent::type_id::create("m_usb20_agent", this);
     uvm_config_db#(usb20_agent_cfg)::set(this, "m_usb20_agent*", "cfg", cfg.m_usb20_agent_cfg);

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -10,6 +10,8 @@ class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
   virtual clk_rst_if host_clk_rst_vif;
   // USB connection to usbdpi host model.
   virtual usb20_if   usb20_usbdpi_vif;
+  // Timing reference for oscillator tuning.
+  virtual usbdev_osc_tuning_if osc_tuning_vif;
 
   // Reset kinds for USB
   string reset_kinds[] = {"HARD", "TL_IF"};

--- a/hw/ip/usbdev/dv/env/usbdev_osc_tuning_if.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_osc_tuning_if.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface usbdev_osc_tuning_if (
+  // Host signals.
+  input     host_clk_i,
+  input     host_rst_ni,
+  // DUT signals.
+  input     usb_clk_i,
+  input     usb_rst_ni,
+  // Reference signal from DUT.
+  input     usb_ref_val_i,
+  input     usb_ref_pulse_i
+);
+
+  // Cycle counters on the host and DUT clocks, to assist with checking of freq/phase vseqs and
+  // oscillator tuning; these elapsed cycle counts may be read directly in the waveforms.
+  logic [31:0] host_clk_cnt;
+  logic [31:0] usb_clk_cnt;
+  always_ff @(posedge host_clk_i or negedge host_rst_ni) begin
+    if (!host_rst_ni) host_clk_cnt <= 0;
+    else host_clk_cnt <= host_clk_cnt + 1'b1;
+  end
+  always_ff @(posedge usb_clk_i or negedge usb_rst_ni) begin
+    if (!usb_rst_ni) usb_clk_cnt <= 0;
+    else usb_clk_cnt <= usb_clk_cnt + 1'b1;
+  end
+
+  // DUT cycle count at the time of the latest reference pulse.
+  bit usb_latest_valid;
+  logic [31:0] usb_latest_cnt;
+
+  // Read the DUT cycle delta since the latest sampling point (one bus frame ago),
+  // and restart the counting in anticipation of the next reference pulse.
+  function automatic integer elapsed_dut_cycles();
+    integer delta;
+    // Elapsed DUT cycles since the last reference pulse.
+    delta = usb_latest_valid ? (usb_clk_cnt - usb_latest_cnt) : 48_000;
+    usb_latest_cnt = usb_clk_cnt;
+    usb_latest_valid = 1;
+    return delta;
+  endfunction
+
+endinterface

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -380,6 +380,10 @@
       uvm_test_seq: usbdev_streaming_vseq
     }
     {
+      name: usbdev_stream_len_max
+      uvm_test_seq: usbdev_stream_len_max_vseq
+    }
+    {
       name: usbdev_stress_all_with_rand_reset
       reseed: 10
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -121,6 +121,66 @@
       uvm_test_seq: usbdev_fifo_rst_vseq
     }
     {
+      name: usbdev_freq_hiclk
+      uvm_test_seq: usbdev_freq_phase_delta_vseq
+      // Run the host slower than the usbdev.
+      // Check that with this small offset, packet reception works without any frequency tracking.
+      run_opts: ["+host_freq_delta=-18500"]
+      // Very long simulation times
+      reseed: 5
+    }
+    {
+      name: usbdev_freq_hiclk_max
+      uvm_test_seq: usbdev_freq_phase_delta_vseq
+      // Run the host slower than the usbdev, at the minimum permissible frequency cf 48MHz.
+      //
+      // Packet reception shall initially be expected to fail, but the SOF reception should be
+      // good enough to track the host frequency by modifying the DUT oscillator.
+      run_opts: [
+        "+cdc_instrumentation_enabled=0",
+        "+host_drifting=1",
+        "+host_freq_delta=-120000",
+        "+osc_tracking=1",
+        "+reset_recovery=1",
+        "+usb_freq_delta=+120000"
+      ]
+      // Very long simulation times
+      reseed: 5
+    }
+    {
+      name: usbdev_freq_loclk
+      uvm_test_seq: usbdev_freq_phase_delta_vseq
+      // Run the host faster than the usbdev.
+      // Check that with this small offset, packet reception works without any frequency tracking.
+      run_opts: ["+host_freq_delta=+18500"]
+      // Very long simulation times
+      reseed: 5
+    }
+    {
+      name: usbdev_freq_loclk_max
+      uvm_test_seq: usbdev_freq_phase_delta_vseq
+      // Run the host faster than the usbdev, at the maximum permissible frequency cf 48MHz.
+      //
+      // Packet reception shall initially be expected to fail, but the SOF reception should be
+      // good enough to track the host frequency by modifying the DUT oscillator.
+      run_opts: [
+        "+cdc_instrumentation_enabled=0",
+        "+osc_tracking=1",
+        "+host_drifting=1",
+        "+host_freq_delta=+120000",
+        "+reset_recovery=1",
+        "+usb_freq_delta=-120000"
+      ]
+      // Very long simulation times
+      reseed: 5
+    }
+    {
+      name: usbdev_freq_phase
+      uvm_test_seq: usbdev_freq_phase_delta_vseq
+      // Very long simulation times
+      reseed: 5
+    }
+    {
       name: usbdev_host_lost
       uvm_test_seq: usbdev_host_lost_vseq
       // No need for randomization.
@@ -403,6 +463,10 @@
                  "+wt_bitstuff_errs=1"]
       // Very long simulation times
       reseed: 5
+    }
+    {
+      name: usbdev_stream_len_max
+      uvm_test_seq: usbdev_stream_len_max_vseq
     }
   ]
 


### PR DESCRIPTION
This PR adds frequency and phase delta testing in two commits:

_Commit 1:_
Adds a sequence for streaming max length packets, taking into consideration USB bit stuffing. Employing maximum length packets is critical in ensuring that the DUT continues to sample the USB signals correctly throughout the packet.

_Commit 2:_
Adds a sequence that employs the 'max length streaming' sequence to operate the DUT and host at different frequencies and phase relationships and check that all data is transferred correctly as expected, without any reliance upon retrying.
- Bus framing is performed by the host, ensuring that the SOF packets form a reliable heart beat signal every 1ms, according to the host clock frequency.
- Traffic may be sent to the DUT during each bus frame, away from the SOF packets, and optionally only once the 'reset recovery' interval has elapsed.
- The 'timing reference' signal from the DUT, in response to detected SOF packets from the host, may be used to adjust the oscillator frequency of the DUT.
- Host frequency may configured to drift during the test, to make the host clock/SOF packets a moving target, rather than tracking and converging only at the start of the sequence.
- For diagnostic/development purposes, the traffic may be disabled entirely, to ensure that the only USB traffic and receiver activity is that of the SOF packets/timing reference.

Passes with 10 seeds each for the 5 new freq/phase tests.