### PR TITLE
[bazel] Add default flags for cquery

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -145,3 +145,6 @@ try-import .bazelrc-site
 
 # Shortcut for enabling Cloud KMS certificate endorsement during test
 build --flag_alias=ckms_cert_endorsement=//sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup:endorse_certs_with_ckms
+
+# cquery output option.
+cquery --output=files


### PR DESCRIPTION
This sets the default flags for `cquery` to `--output=files`.  This is a convenience for finding the outputs of a given target with:

```
bazel cquery <some-label>
```