### PR TITLE
[hmac,dv] Improve feature coverage

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cov.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cov.sv
@@ -74,8 +74,7 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
                                               logic [TL_DW-1:0] msg_len_upper,
                                               logic [TL_DW-1:0] cfg          );
     hmac_en: coverpoint cfg[HmacEn];
-    // Register is in bits but we are interested in the number of bytes => /8
-    msg_len_lower_cp: coverpoint (msg_len_lower / 8) {
+    msg_len_lower_cp: coverpoint (msg_len_lower) {
       bins len_0         = {0};     // Empty message
       bins len_1         = {1};     // One byte message
       bins len_511       = {511};   // One block in SHA-2 256, -1 byte

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -319,8 +319,12 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
             end
             // randomly change key, config regs during msg wr, should trigger error or be discarded
             write_discard_config_and_key(wr_config_during_hash, wr_key_during_hash);
+            // Randomly trigger error code read also when no error is supposed to happen
+            if ($urandom_range(0, 1)) begin
+              check_error_code(0);
+            end
           end else begin
-            check_error_code();
+            check_error_code(1);
           end
         end
         // Keep it alive only if needed


### PR DESCRIPTION
  - sample reg CFG from seq as cannot be done from the SCB, otherwise the sha2/key_invalid are never seen
  - sample properly msg_length: the divide by 8 was not needed as we got a number of bits and that's what we need to sample actually
  - add a check on error even when no error is supposed to be triggered