### PR TITLE
[csrng] Extend coverage definition for glen

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_item.sv
+++ b/hw/dv/sv/csrng_agent/csrng_item.sv
@@ -33,7 +33,7 @@ class csrng_item extends uvm_sequence_item;
 
   constraint c_glen {
     glen dist {
-      // TODO(#18350): Add a bin for 0 (with 5% chance, like for 4095?).
+      // Note that 0 isn't supported by the implementation, see #23846.
       [1:32]      :/ 75,
       [33:128]    :/ 10,
       [129:1024]  :/ 5,

--- a/hw/ip/csrng/doc/theory_of_operation.md
+++ b/hw/ip/csrng/doc/theory_of_operation.md
@@ -183,7 +183,7 @@ Below is a description of the fields of this header:
          Each unit represents 128 bits of entropy returned.
          This field allows values between 1 and 4095.
          A value of 1 returns 1 * 128 bits of entropy.
-         A value of 4095 returns 4095 * 128 bits of entropy, which is less than the 2<sup>19</sup> bits allowed by NIST (referenced to as <tt>max_number_of_bit_per_request</tt>).
+         A value of 4095 returns 4095 * 128 bits of entropy, which is less than the 2<sup>19</sup> bits allowed by NIST (referenced to as <tt>max_number_of_bits_per_request</tt>).
     </td>
   </tr>
   <tr>

--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -326,9 +326,12 @@ interface csrng_cov_if (
     }
 
     cp_glen: coverpoint glen {
-      bins one         = { 1 };
-      bins multiple    = { [2:$] };
-      ignore_bins zero = { 0 };
+      bins one = { 1 };
+      bins sml = { [2:32] };
+      bins med = { [33:128] };
+      bins lrg = { [129:1024] };
+      bins xtr = { [1025:4094] };
+      bins max = { 4095 };
     }
 
     // Coverpoint for all of the possible transitions of flag0 that can cause a


### PR DESCRIPTION
It turns out that the RTL doesn't handle Generate commands with a glen equal 0 (generate NO randomness) correctly. But this behavior documented already. We could correct the design to signal a error status response instead, but this really isn't a priority as a Generate command that shouldn't generate entropy is a corner case and even the NIST spec isn't fully clear what should happen here. See https://github.com/lowRISC/opentitan/issues/23846 for details.

Thus, this PR simply takes care of extending the coverage definition for the glen coverpoint as outlined  in #18350. This resolves https://github.com/lowRISC/opentitan/issues/18350.