### PR TITLE
[hmac,dv] Optimize regression duration

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
@@ -17,9 +17,7 @@ class hmac_stress_all_vseq extends hmac_base_vseq;
                           "hmac_datapath_stress_vseq",
                           "hmac_long_msg_vseq",
                           "hmac_error_vseq",
-                          "hmac_wipe_secret_vseq",
-                          "hmac_test_vectors_sha_vseq",
-                          "hmac_test_vectors_hmac_vseq"};
+                          "hmac_wipe_secret_vseq"};
     for (int i = 1; i <= num_trans; i++) begin
       uvm_sequence   seq;
       hmac_base_vseq hmac_vseq;

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -96,6 +96,7 @@
       uvm_test_seq: hmac_test_vectors_sha_vseq
       // Increase timeout for all test iterations to pass
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=800_000_000 +sha2_digest_size=SHA2_256"]
+      reseed: 5
     }
 
     {
@@ -103,6 +104,7 @@
       uvm_test_seq: hmac_test_vectors_sha_vseq
       // Increase timeout for all test iterations to pass
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_000_000_000 +sha2_digest_size=SHA2_384"]
+      reseed: 5
     }
 
     {
@@ -110,24 +112,28 @@
       uvm_test_seq: hmac_test_vectors_sha_vseq
       // Increase timeout for all test iterations to pass
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_200_000_000 +sha2_digest_size=SHA2_512"]
+      reseed: 5
     }
 
     {
       name: hmac_test_hmac256_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_000_000_000 +sha2_digest_size=SHA2_256"]
+      reseed: 5
     }
 
     {
       name: hmac_test_hmac384_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=2_000_000_000 +sha2_digest_size=SHA2_384"]
+      reseed: 5
     }
 
     {
       name: hmac_test_hmac512_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=2_000_000_000 +sha2_digest_size=SHA2_512"]
+      reseed: 5
     }
 
     {


### PR DESCRIPTION
  - reduce reseeding for HMAC SHA-2/HMAC vectors tests as the randomization space is quite narrow
  - remove these tests from the stress test as it doesn't bring anything
  - related to this issue #23844