### PR TITLE
[otbn,dv] Avoid killing during TL read in otbn_stack_addr_integ_chk

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stack_addr_integ_chk_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stack_addr_integ_chk_vseq.sv
@@ -19,6 +19,8 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
   endtask: body
 
   // Wait until the value at path is nonzero or until OTBN finishes execution.
+  //
+  // This process is safe to kill at any time, because it doesn't start any TL transactions.
   task wait_for_flag(string path);
     fork begin : isolation_fork
       fork
@@ -31,8 +33,9 @@ class otbn_stack_addr_integ_chk_vseq extends otbn_single_vseq;
                        `DV_CHECK_FATAL(uvm_hdl_read(path, value));
                        end while (!value);)
         end
-        // This process waits until OTBN completes execution or until reset.
-        wait_for_run_completion(UVM_HIGH);
+        // This process waits until OTBN completes execution or until reset. Passing backdoor=1
+        // ensures that we won't start any TL reads of the status register.
+        wait_for_run_completion(.verbosity(UVM_HIGH), .backdoor(1'b1));
 
       join_any
       disable fork;


### PR DESCRIPTION
Diagnosing this took me ages! In this situation (with err_type = 1), the vseq works forking into two processes. One injects an error on every stack write. The other waits until it sees a read from the stack, which should trigger an alert, and then tells the model to go into a locked state.

Once the latter process finishes, we can release our forced signals and wait until the RTL and the model raise an alert at the same time. At this point, we use "disable fork"

The first process waited for reads from the stack using the wait_for_flag() task which, in turn, used wait_for_run_completion() to detect the end of a run (at which point, we weren't going to see the flag change, so should stop early).

Unfortunately, wait_for_run_completion would sometimes wait for the end of the run by polling the STATUS register. Doing so would normally involve a TL transaction. The test was failing because we started a TL transaction to read STATUS and then killed a process that was inside the sequencer, in wait_for_item_done(). This meant that the transaction blocked forever and we never passed the response back to the sequence. As a result, the csr_rd task timed out and the test failed.

The fix is rather simple in the end: if you want your process to be disabled, don't do a front-door TL transaction.

Fixes #23691.