### PR TITLE
[hmac,dv] Increase SHA2 test vector timeout

### DIFF
--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -109,7 +109,7 @@
       name: hmac_test_sha512_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
       // Increase timeout for all test iterations to pass
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_000_000_000 +sha2_digest_size=SHA2_512"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_200_000_000 +sha2_digest_size=SHA2_512"]
     }
 
     {


### PR DESCRIPTION
Regression failed for some seeds due to timeout for SHA2-512 test only:

```
`UVM_FATAL (uvm_phase.svh:1512) [PH_TIMEOUT] Explicit timeout of * ps hit, indicating a probable testbench issue` has 1 failures:
    * Test hmac_test_sha512_vectors has 1 failures.
        * 3.hmac_test_sha512_vectors.108683676871538303991718868438741530266571739654349379393166068314816946587950\
          Line 132586, in log /home/dev/src/scratch/cov_test/hmac-sim-vcs/3.hmac_test_sha512_vectors/latest/run.log

                UVM_FATAL @ 1000000000000 ps: (uvm_phase.svh:1512) [PH_TIMEOUT] Explicit timeout of 1000000000000 ps hit, indicating a probable testbench issue
                UVM_INFO @ 1000000000000 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---

```