### PR TITLE
[hmac,dv] Fix secret wiping issues

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -225,9 +225,6 @@ class hmac_smoke_vseq extends hmac_base_vseq;
       `uvm_info(`gfn, $sformatf("reading digest"), UVM_LOW)
       rd_digest();
     end
-    // Ensure that wipe secret flag is cleared for the next sequence, as it may cause digest
-    // comparison issue with the stress tests
-    clear_wipe_secret();
   endtask : body
 
 endclass : hmac_smoke_vseq


### PR DESCRIPTION
This undoes a minor DV change in https://github.com/lowRISC/opentitan/pull/23817 intended to address rare issues where wipe_secret_triggered is not pulled back to 0. This conflicts with another change that was on master that was meant to do the same, so the digest prediction fails at some points. We can either just merge this fix or unmerge that other PR. 

I am still running `stress_all` and `stress_all_with_rand_reset` at my end locally to make sure though.