### PR TITLE
[i2c,dv] Add csr test exclusions for CSR.{target,controller}_event

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -1035,6 +1035,7 @@
           desc: "A Host-Mode active transaction has terminated due to lost arbitration."
         }
       ]
+      tags: ["excl:CsrAllTests:CsrExclCheck"]
     }
     { name: "TARGET_EVENTS"
       desc: '''
@@ -1068,6 +1069,7 @@
           desc: "A Target-Mode read transfer has terminated due to lost arbitration."
         }
       ]
+      tags: ["excl:CsrAllTests:CsrExclCheck"]
     }
   ]
 }


### PR DESCRIPTION
Both of these registers are sw:"rw1c"/hw:"hrw".

Fixes #22761 