### PR TITLE
[i2c,dv] Override agent sequence for target_tx_stretch_ctrl test

### DIFF
--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_tx_stretch_ctrl_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_tx_stretch_ctrl_vseq.sv
@@ -46,6 +46,9 @@ class i2c_target_tx_stretch_ctrl_vseq extends i2c_target_runtime_base_vseq;
 
     // Disable ACK-Control mode
     cfg.ack_ctrl_en = 0;
+
+    // Use a basic Agent sequence that drives all items it is passed.
+    i2c_base_seq::type_id::set_type_override(i2c_target_base_seq::get_type());
   endtask: pre_start
 
   // Augment the base-class initialization to enable our feature under test.


### PR DESCRIPTION
The base agent sequence is unable to meaningfully drive anything, so we need to override to a sequence which can do meaningful Controller-Mode transfers.

This fixes the "	i2c_target_tx_stretch_ctrl" test, which is currently 0% passing.