### PR TITLE
[hmac,dv] Extend timeout on outstanding accesses for reset test

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -706,4 +706,9 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     key_length_bak  = key_length_tmp;
     key_bak         = key_tmp;
   endtask : save_and_restore_cfg
+
+  // overriding timeout on outstanding accesses for the hmac_stress_test_all_with_rand_reset test
+  virtual function int wait_cycles_with_no_outstanding_accesses();
+    return 1_000_000;
+  endfunction
 endclass : hmac_base_vseq

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -225,9 +225,6 @@ class hmac_smoke_vseq extends hmac_base_vseq;
       `uvm_info(`gfn, $sformatf("reading digest"), UVM_LOW)
       rd_digest();
     end
-    // Ensure that wipe secret flag is cleared for the next sequence, as it may cause digest
-    // comparison issue with the stress tests
-    clear_wipe_secret();
   endtask : body
 
 endclass : hmac_smoke_vseq


### PR DESCRIPTION
This extends the timeout on outstanding accesses when issuing reset for `hmac_stress_all_with_rand_reset` to prevent the test timing out for messages/vectors where there is always outstanding accesses. This change, along with PR https://github.com/lowRISC/opentitan/pull/23848 which excludes the long HMAC/SHA-2 test vectors from this sequence, this should close https://github.com/lowRISC/opentitan/issues/23559.

This reduces to 1 commit 37cdc5fe4bc2a0d3675424be0ae11a1bbfdf541c once a previous PR gets merged.