### PR TITLE
[csrng/dv] Add checks for the cmd sts signal to the scoreboard

### DIFF
--- a/hw/dv/sv/csrng_agent/csrng_item.sv
+++ b/hw/dv/sv/csrng_agent/csrng_item.sv
@@ -15,8 +15,9 @@ class csrng_item extends uvm_sequence_item;
   rand bit [11:0]   glen;
   rand bit [31:0]   cmd_data_q[$];
 
-  bit                                      fips_q[$];
-  bit [csrng_pkg::GENBITS_BUS_WIDTH - 1:0] genbits_q[$];
+  bit [csrng_pkg::CSRNG_CMD_STS_WIDTH - 1:0] status;
+  bit                                        fips_q[$];
+  bit [csrng_pkg::GENBITS_BUS_WIDTH - 1:0]   genbits_q[$];
 
   constraint c_clen {
     clen inside {[0:12]};
@@ -55,6 +56,7 @@ class csrng_item extends uvm_sequence_item;
       this.flags      = rhs_.flags;
       this.glen       = rhs_.glen;
       this.fips_q     = rhs_.fips_q;
+      this.status     = rhs_.status;
       this.cmd_data_q = rhs_.cmd_data_q;
       this.genbits_q  = rhs_.genbits_q;
    endfunction
@@ -70,6 +72,7 @@ class csrng_item extends uvm_sequence_item;
     for (int i = 0; i < cmd_data_q.size(); i++) begin
       str = {str, $sformatf("\n\t |* cmd_data_q [%2d]  : %24s 0x%8h *| \t", i, "", cmd_data_q[i])};
     end
+    str = {str,   $sformatf("\n\t |* status           : %34h *| \t", status)                     };
     for (int i = 0; i < genbits_q.size(); i++) begin
       str = {str, $sformatf("\n\t |* genbits_q[%4d]  : 0x%32h *| \t", i, genbits_q[i])           };
       str = {str, $sformatf("\n\t |* fips_q   [%4d]  : %33s %1b *| \t", i, "", fips_q[i])        };

--- a/hw/dv/sv/csrng_agent/csrng_monitor.sv
+++ b/hw/dv/sv/csrng_agent/csrng_monitor.sv
@@ -86,11 +86,9 @@ class csrng_monitor extends dv_base_monitor #(
                 cs_item.fips_q.push_back(cfg.vif.mon_cb.cmd_rsp.genbits_fips);
               end
             end
-            if (!(cs_item.acmd inside {csrng_pkg::INV, csrng_pkg::GENB,
-                                       csrng_pkg::GENU})) begin
-              cfg.vif.wait_cmd_ack_or_rst_n();
-            end
+            cfg.vif.wait_cmd_ack_or_rst_n();
           join_any
+          cs_item.status = cfg.vif.mon_cb.cmd_rsp.csrng_rsp_sts;
           `uvm_info(`gfn, $sformatf("Writing analysis_port: %s", cs_item.convert2string()),
                     UVM_HIGH)
           analysis_port.write(cs_item);

--- a/hw/ip/csrng/dv/env/csrng_env_pkg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_pkg.sv
@@ -37,6 +37,7 @@ package csrng_env_pkg;
   parameter uint     RSD_CTR_LEN             = 32;
   parameter uint     LC_HW_DEBUG_EN_ON_DATA  = 123456789;
   parameter uint     LC_HW_DEBUG_EN_OFF_DATA = 987654321;
+  parameter uint     CSRNG_CMD_STS_WIDTH     = 3;
 
   // types
   typedef enum int {

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -93,7 +93,7 @@ class csrng_base_vseq extends cip_base_vseq #(
   endtask
 
   task send_cmd_req(uint app, csrng_item cs_item, bit await_response=1'b1, bit edn_rst_as_ack=1'b1,
-                    csrng_cmd_sts_e exp_sts=CMD_STS_SUCCESS, bit await_genbits=1'b1);
+                    csrng_pkg::csrng_cmd_sts_e exp_sts=CMD_STS_SUCCESS, bit await_genbits=1'b1);
     bit [csrng_pkg::CSRNG_CMD_WIDTH-1:0]   cmd;
     // Gen cmd_req
     if ((cs_item.acmd != INS) && (cs_item.acmd != RES)) begin


### PR DESCRIPTION
This PR adds checks for the SW and HW command status signals to the scoreboard.

The error vseq still doesn't use the new checks in the scoreboard since the scoreboard is disabled.
However, I don't think it's a good use of our resources to change this right now.

This resolves [#22219](https://github.com/lowRISC/opentitan/issues/22219)