### PR TITLE
[flash_ctrl,dv] Drop some unused stuff from the smoke sequence

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_claim_transition_if_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_claim_transition_if_vseq.sv
@@ -25,7 +25,7 @@ class lc_ctrl_claim_transition_if_vseq extends lc_ctrl_smoke_vseq;
 
   task body();
     fork
-      run_clk_byp_rsp(clk_byp_error_rsp);
+      run_clk_byp_rsp(1'b0);
       run_flash_rma_rsp(flash_rma_error_rsp);
     join_none
 

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_claim_transition_if_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_claim_transition_if_vseq.sv
@@ -26,7 +26,7 @@ class lc_ctrl_claim_transition_if_vseq extends lc_ctrl_smoke_vseq;
   task body();
     fork
       run_clk_byp_rsp(1'b0);
-      run_flash_rma_rsp(flash_rma_error_rsp);
+      run_flash_rma_rsp(1'b0);
     join_none
 
     csr_wr(ral.claim_transition_if, rand_claim_trans_val);

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -8,14 +8,9 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
   `uvm_object_new
 
-  rand bit flash_rma_error_rsp;
   rand bit otp_prog_err, token_mismatch_err;
   dec_lc_state_e next_lc_state;
   rand lc_token_t token_scramble;
-
-  constraint no_err_rsps_c {
-    flash_rma_error_rsp == 0;
-  }
 
   constraint otp_prog_err_c {otp_prog_err == 0;}
 
@@ -39,7 +34,7 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
     fork
       run_clk_byp_rsp(1'b0);
-      run_flash_rma_rsp(flash_rma_error_rsp);
+      run_flash_rma_rsp(1'b0);
     join_none
 
     //

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -8,13 +8,11 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
   `uvm_object_new
 
-  rand bit otp_prog_err, token_mismatch_err;
+  rand bit otp_prog_err;
   dec_lc_state_e next_lc_state;
   rand lc_token_t token_scramble;
 
   constraint otp_prog_err_c {otp_prog_err == 0;}
-
-  constraint token_mismatch_err_c {token_mismatch_err == 0;}
 
   virtual task pre_start();
     super.pre_start();

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -8,13 +8,12 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
   `uvm_object_new
 
-  rand bit clk_byp_error_rsp, flash_rma_error_rsp;
+  rand bit flash_rma_error_rsp;
   rand bit otp_prog_err, token_mismatch_err;
   dec_lc_state_e next_lc_state;
   rand lc_token_t token_scramble;
 
   constraint no_err_rsps_c {
-    clk_byp_error_rsp == 0;
     flash_rma_error_rsp == 0;
   }
 
@@ -39,7 +38,7 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
   task body();
 
     fork
-      run_clk_byp_rsp(clk_byp_error_rsp);
+      run_clk_byp_rsp(1'b0);
       run_flash_rma_rsp(flash_rma_error_rsp);
     join_none
 

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
@@ -30,7 +30,7 @@ class lc_ctrl_volatile_unlock_smoke_vseq extends lc_ctrl_smoke_vseq;
     int lc_cnt_int;
     fork
       run_clk_byp_rsp(1'b0);
-      run_flash_rma_rsp(flash_rma_error_rsp);
+      run_flash_rma_rsp(1'b0);
     join_none
 
     `DV_CHECK_RANDOMIZE_FATAL(this)

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_volatile_unlock_smoke_vseq.sv
@@ -29,7 +29,7 @@ class lc_ctrl_volatile_unlock_smoke_vseq extends lc_ctrl_smoke_vseq;
   task body();
     int lc_cnt_int;
     fork
-      run_clk_byp_rsp(clk_byp_error_rsp);
+      run_clk_byp_rsp(1'b0);
       run_flash_rma_rsp(flash_rma_error_rsp);
     join_none
 


### PR DESCRIPTION
I think this predates the infrastructure that's now in `lc_ctrl_errors_vseq.sv`. When that was merged, the stuff in the smoke sequence seems to have been disabled but left in place unused. Remove it.