### PR TITLE
[opentitantool]: add command line option for setting manifest timestamp

### DIFF
--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -506,6 +506,14 @@ impl Image {
     pub fn compute_digest(&self) -> Result<sha256::Sha256Digest> {
         self.map_signed_region(|v| sha256::sha256(v))
     }
+
+    pub fn update_timestamp(&mut self, timestamp:u64)->Result<()> {
+        let manifest = self.borrow_manifest_mut()?;
+
+        manifest.timestamp.timestamp_high = (timestamp >> 32) as u32;
+        manifest.timestamp.timestamp_low = timestamp as u32;
+        Ok(())
+    }
 }
 
 impl ImageAssembler {

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -150,6 +150,9 @@ pub struct ManifestUpdateCommand {
     /// Filename to write the output to instead of updating the input file.
     #[arg(short, long)]
     output: Option<PathBuf>,
+    /// Set manifest timestamp field to this u64 value.
+    #[arg(long)]
+    timestamp: Option<u64>,
 }
 
 fn load_rsa_key(key_file: &Path) -> Result<(RsaPublicKey, Option<RsaPrivateKey>)> {
@@ -214,6 +217,11 @@ impl CommandDispatch for ManifestUpdateCommand {
             if let Some(private) = private {
                 rsa_private_key = Some(private);
             }
+        }
+
+        // If requested, set the timestamp field first, before any signing.
+        if let Some(timestamp) = &self.timestamp {
+            image.update_timestamp(*timestamp)?;
         }
 
         // Load / write ECDSA public key.


### PR DESCRIPTION
The new command line option given to 'image manifest update' allows the user to set the manifest 'timestamp' field to the passed in 64 bit integer value.

Veified by invoking opentitantool with the new command line option and examining the resulting manifest header contents.