### PR TITLE
[dv,flash_ctrl] Fix some block level failures

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_otf_item.sv
@@ -74,7 +74,7 @@ class flash_otf_item extends uvm_object;
     this.cmd.prog_sel = flash_prog_sel_e'(item.req.prog_type);
     this.cmd.addr = item.req.addr;
     // cmd.addr can be modified to call bkdr mem access
-    // So we need to exptra copy of mem interface address
+    // So we need an extra copy of mem interface address.
     this.mem_addr = item.req.addr;
     fq = item.fq;
   endfunction // get_from_phy

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
@@ -4,33 +4,60 @@
 
 // Read fraction of the page.
 // fraction size starts from 1 word (4byte) and increased by 1 word in each round.
+// For error injection to work the data must be initialized, done via mem_bkdr.
+//
+// There are two enhancements needed here:
+// - Initialize the data right before each read
+// - Detect addresses out of partition bounds and terminate within the loop.
 class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_read_word_sweep_vseq)
   `uvm_object_new
 
+  // This is to avoid errors due to the address ending up out-of-bounds as they are incremented.
+  // It begs a better way to handle this, like just stopping the loop below.
+  constraint partition_c {rand_op.partition == FlashPartData;}
+
   virtual task body();
-    flash_op_t ctrl, host;
+    flash_op_t ctrl;
+    addr_t start_addr, max_addr;
+
     int num, bank;
     int mywd;
 
+    `DV_CHECK_RANDOMIZE_FATAL(this)
+
+    // It may be better to initialize the data right before each individual read.
     begin
-      flash_op_t prog_op;
-      int progwd = 16;
-      ctrl_num = 12;
-      ctrl_num.rand_mode(0);
-      fractions = 16;
-      fractions.rand_mode(0);
-      `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
-      prog_op = ctrl;
-      print_flash_op(prog_op, UVM_MEDIUM);
-      prog_flash(prog_op, bank, num, fractions);
+      addr_t addr;
+      addr = rand_op.addr;
+      addr[2] = 1'b0;
+      `uvm_info("read_word_sweep", $sformatf(
+                "Initializing data from addr:0x%x to:0x%x", addr, addr + 256 * 4 - 1),
+                UVM_MEDIUM)
+       for (int w = 0; w < 256; w += 2) begin
+         cfg.update_otf_mem_read_zone(rand_op.partition, rand_op.addr[OTFBankId], addr);
+         addr += 8;
+       end
     end
+
+    ctrl = rand_op;
     num = 1;
     mywd = 1;
+    start_addr = rand_op.addr;
+    max_addr = start_addr;
     repeat(20) begin
+      addr_t end_addr = ctrl.addr + num * mywd - 1;
+      if (end_addr > max_addr) max_addr = end_addr;
+      print_flash_op(ctrl, UVM_MEDIUM);
+      `uvm_info("read_word_sweep", $sformatf(
+                "Reading from addr:0x%x, otf_addr:0x%x, num:%0d, wd:%0d",
+                ctrl.addr, ctrl.otf_addr, num, mywd),
+                UVM_MEDIUM)
       read_flash(ctrl, bank, num, mywd);
       mywd = (mywd % 16) + 1;
     end
+    `uvm_info(`gfn, $sformatf("Total test address span: min 0x%x, max 0x%x", start_addr, max_addr),
+              UVM_MEDIUM)
   endtask
 
 endclass : flash_ctrl_read_word_sweep_vseq

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_otf_item.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_otf_item.sv
@@ -74,7 +74,7 @@ class flash_otf_item extends uvm_object;
     this.cmd.prog_sel = flash_prog_sel_e'(item.req.prog_type);
     this.cmd.addr = item.req.addr;
     // cmd.addr can be modified to call bkdr mem access
-    // So we need to exptra copy of mem interface address
+    // So we need an extra copy of mem interface address.
     this.mem_addr = item.req.addr;
     fq = item.fq;
   endfunction // get_from_phy

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
@@ -4,33 +4,60 @@
 
 // Read fraction of the page.
 // fraction size starts from 1 word (4byte) and increased by 1 word in each round.
+// For error injection to work the data must be initialized, done via mem_bkdr.
+//
+// There are two enhancements needed here:
+// - Initialize the data right before each read
+// - Detect addresses out of partition bounds and terminate within the loop.
 class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   `uvm_object_utils(flash_ctrl_read_word_sweep_vseq)
   `uvm_object_new
 
+  // This is to avoid errors due to the address ending up out-of-bounds as they are incremented.
+  // It begs a better way to handle this, like just stopping the loop below.
+  constraint partition_c {rand_op.partition == FlashPartData;}
+
   virtual task body();
-    flash_op_t ctrl, host;
+    flash_op_t ctrl;
+    addr_t start_addr, max_addr;
+
     int num, bank;
     int mywd;
 
+    `DV_CHECK_RANDOMIZE_FATAL(this)
+
+    // It may be better to initialize the data right before each individual read.
     begin
-      flash_op_t prog_op;
-      int progwd = 16;
-      ctrl_num = 12;
-      ctrl_num.rand_mode(0);
-      fractions = 16;
-      fractions.rand_mode(0);
-      `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
-      prog_op = ctrl;
-      print_flash_op(prog_op, UVM_MEDIUM);
-      prog_flash(prog_op, bank, num, fractions);
+      addr_t addr;
+      addr = rand_op.addr;
+      addr[2] = 1'b0;
+      `uvm_info("read_word_sweep", $sformatf(
+                "Initializing data from addr:0x%x to:0x%x", addr, addr + 256 * 4 - 1),
+                UVM_MEDIUM)
+       for (int w = 0; w < 256; w += 2) begin
+         cfg.update_otf_mem_read_zone(rand_op.partition, rand_op.addr[OTFBankId], addr);
+         addr += 8;
+       end
     end
+
+    ctrl = rand_op;
     num = 1;
     mywd = 1;
+    start_addr = rand_op.addr;
+    max_addr = start_addr;
     repeat(20) begin
+      addr_t end_addr = ctrl.addr + num * mywd - 1;
+      if (end_addr > max_addr) max_addr = end_addr;
+      print_flash_op(ctrl, UVM_MEDIUM);
+      `uvm_info("read_word_sweep", $sformatf(
+                "Reading from addr:0x%x, otf_addr:0x%x, num:%0d, wd:%0d",
+                ctrl.addr, ctrl.otf_addr, num, mywd),
+                UVM_MEDIUM)
       read_flash(ctrl, bank, num, mywd);
       mywd = (mywd % 16) + 1;
     end
+    `uvm_info(`gfn, $sformatf("Total test address span: min 0x%x, max 0x%x", start_addr, max_addr),
+              UVM_MEDIUM)
   endtask
 
 endclass : flash_ctrl_read_word_sweep_vseq


### PR DESCRIPTION
- Improve tracking of words with error injection so only one error of any kind is injected per word.
- Improve initialization of data in flash_ctrl_read_word_sweep. There is still room for improvements.

Addresses #22879