### PR TITLE
[rom] Miscellaneous test fixups

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
@@ -55,7 +55,7 @@ SHUTDOWN_WATCHDOG_CASES = [
     {
         "lc_state": lc_state[0],
         "lc_state_val": lc_state[1],
-        "exit_success": "Wait done: after [0-9]+ ms, watchdog count=0" if bite_threshold == 0 else "I0000[^\r\n]*\r\nROM:[0-9a-f]{8}\r\n",
+        "exit_success": "Wait done: after [0-9]+ ms, watchdog count=0" if bite_threshold == 0 else "I0000[^\r\n]*\r\nOpenTitan:[0-9a-f-]{12}\r\n",
         "bite_threshold": bite_threshold,
     }
     for lc_state in get_lc_items(

--- a/sw/host/opentitanlib/src/transport/verilator/transport.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/transport.rs
@@ -105,7 +105,10 @@ impl Transport for Verilator {
         );
         let mut inner = self.inner.borrow_mut();
         if inner.uart.is_none() {
-            inner.uart = Some(Rc::new(SerialPortUart::open(&self.uart_tty, UART_BAUD)?));
+            inner.uart = Some(Rc::new(SerialPortUart::open_pseudo(
+                &self.uart_tty,
+                UART_BAUD,
+            )?));
         }
         Ok(Rc::clone(inner.uart.as_ref().unwrap()))
     }


### PR DESCRIPTION
1. Recognize the ROM banner in the watchdog shutdown tests.
2. Be permissive about UART baudrates in tests that communicate via a pseudo-uart.