### PR TITLE
[opentitantool] Treat empty timestamp manifest field as now

### DIFF
--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::mem::{align_of, size_of};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 use crate::crypto::ecdsa::{EcdsaPublicKey, EcdsaRawPublicKey, EcdsaRawSignature};
@@ -372,6 +373,18 @@ impl Image {
             rsa_modulus.to_le_bytes(),
         )?);
         *manifest = manifest_def.try_into()?;
+        Ok(())
+    }
+
+    /// Updates the timestamp field to the current UTC time in milliseconds.
+    pub fn update_timestamp_to_now(&mut self) -> Result<()> {
+        let now: u64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time since unix epoch")
+            .as_millis()
+            .try_into()?;
+
+        self.borrow_manifest_mut()?.timestamp = now.into();
         Ok(())
     }
 

--- a/sw/host/opentitanlib/src/image/manifest.rs
+++ b/sw/host/opentitanlib/src/image/manifest.rs
@@ -184,6 +184,15 @@ pub struct Timestamp {
     pub timestamp_high: u32,
 }
 
+impl From<u64> for Timestamp {
+    fn from(value: u64) -> Self {
+        Self {
+            timestamp_low: value as u32,
+            timestamp_high: (value >> 32) as u32,
+        }
+    }
+}
+
 #[repr(C)]
 #[derive(AsBytes, FromBytes, FromZeroes, Debug, Default)]
 pub struct KeymgrBindingValue {

--- a/sw/host/opentitanlib/src/image/manifest_def.rs
+++ b/sw/host/opentitanlib/src/image/manifest_def.rs
@@ -122,6 +122,10 @@ impl ManifestSpec {
     pub fn has_length(&self) -> bool {
         self.length.0.is_some()
     }
+
+    pub fn has_timestamp(&self) -> bool {
+        self.timestamp[0].0.is_some() || self.timestamp[1].0.is_some()
+    }
 }
 
 trait ManifestPacked<T> {

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -120,6 +120,9 @@ pub struct ManifestUpdateCommand {
     /// Update the length field of the manifest automatically.
     #[arg(long, action = clap::ArgAction::Set, default_value = "true")]
     update_length: bool,
+    /// Treat an unspecified timestamp field in manifest file as current UTC value.
+    #[arg(long, action = clap::ArgAction::Set, default_value = "true")]
+    empty_manifest_timestamp_is_now: bool,
     /// Filename for an external ECDSA signature file.
     #[arg(long)]
     ecdsa_signature: Option<PathBuf>,
@@ -190,7 +193,11 @@ impl CommandDispatch for ManifestUpdateCommand {
         if let Some(manifest) = &self.manifest {
             let def = ManifestSpec::read_from_file(manifest)?;
             update_length = !def.has_length();
+            let update_timestamp = self.empty_manifest_timestamp_is_now && !def.has_timestamp();
             image.overwrite_manifest(def)?;
+            if update_timestamp {
+                image.update_timestamp_to_now()?;
+            }
         }
 
         // Load the manifest extension HJSON definition and update the image.


### PR DESCRIPTION
When updating an image with a manifest file, treat a non-present timestamp field as the current UTC time by default. This behavior can be overridden with `--empty_manifest_timestamp_is_now==false`