### PR TITLE
[rom,e2e,dv] fix UART message check

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq.sv
@@ -13,6 +13,7 @@ class chip_sw_rom_e2e_sigverify_always_a_bad_b_bad_vseq extends
     super.body();
     connect_rom_uart_agent();
     lc_state = cfg.mem_bkdr_util_h[Otp].otp_read_lc_partition_state();
+    check_uart_output_msg($sformatf("%0s\x0d\n", ROM_BANNER));
     check_uart_output_msg(
       $sformatf("BFV:%0s\x0d\nLCV:%0s\x0d\n", ROM_BFV_BAD_ECDSA_SIGNATURE,
       lc_state_2_rom_lcv[lc_state]));


### PR DESCRIPTION
This updates the ROM E2E `sigverify_always` test to check for the correct UART message, since the ROM prints a banner message since #23521 merged.