### PR TITLE
[dv, chip]: Add pull delay and pad_in_dis_val

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -77,6 +77,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   uint               sw_test_timeout_ns = 12_000_000; // 12ms
   // delay until the pull is propagated, only available in closed-source
   uint               pad_pull_delay = 0;
+  logic              pad_in_dis_val = 1'bz;
   sw_logger_vif      sw_logger_vif;
   sw_test_status_vif sw_test_status_vif;
   ast_supply_vif     ast_supply_vif;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_padctrl_attributes_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_padctrl_attributes_vseq.sv
@@ -456,9 +456,9 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
         InselOne:   exp_in = 1;
         InselPad: begin
           exp_in = cfg.chip_vif.mios_if.pins[pad];
-          if (mio_pad_attr[pad].invert && exp_in !== 1'bz) exp_in = ~exp_in;
           if (exp_in === 1'bz && mio_pad_attr[i].pull_en) exp_in = mio_pad_attr[i].pull_select;
-          exp_in = mio_pad_attr[pad].input_disable ? 1'bz : exp_in;
+          exp_in = mio_pad_attr[pad].input_disable ? cfg.pad_in_dis_val : exp_in;
+          if (mio_pad_attr[pad].invert && exp_in !== 1'bz) exp_in = ~exp_in;
         end
         default: ;
       endcase
@@ -566,7 +566,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
           `DV_CHECK(dio_pad_attr[i].pull_en)
           exp = dio_pad_attr[i].pull_select;
         end
-        if (dio_pad_attr[i].input_disable) exp = 1'bz;
+        if (dio_pad_attr[i].input_disable) exp = cfg.pad_in_dis_val;
         if (dio_pad_attr[i].invert) exp = ~exp;
         if (exp === 1'bz) exp = 1'bx;  // Undriven input treated as x.
         `DV_CHECK_CASE_EQ(exp, cfg.chip_vif.dio_to_periph[i], msg)
@@ -600,7 +600,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
           end
           default: ;
         endcase
-        exp_in = dio_pad_attr[i].input_disable ? 1'bz : exp_in;
+        exp_in = dio_pad_attr[i].input_disable ? cfg.pad_in_dis_val : exp_in;
         if (exp_in === 1'bz) exp_in = 1'bx;  // Undriven input treated as x.
         if (dio_pad_attr[i].invert) exp_in = ~exp_in;
         `DV_CHECK_CASE_EQ(exp_in, cfg.chip_vif.dio_to_periph[i], msg)
@@ -629,6 +629,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
            .predict(1));
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[0].pull_en), .value(1'b1), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.cc_if.pins[0]);
 `ifdef VCS
     // TODO(#18988): Drive strengh seems to be reported incorrectly by VCS.
@@ -639,6 +640,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     // - pull-up
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[0].pull_select), .value(1'b1), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.cc_if.pins[0]);
 `ifdef VCS
     // TODO(#18988): Drive strengh seems to be reported incorrectly by VCS.
@@ -649,6 +651,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     // - pull disabled
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[0].pull_en), .value(1'b0), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.cc_if.pins[0]);
     `DV_CHECK_STREQ(obs_strength, "HiZ", "on CC1")
     // ---------------------------------------------------------------------------------------------
@@ -662,6 +665,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
            .predict(1));
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[1].pull_en), .value(1'b1), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.cc_if.pins[1]);
 `ifdef VCS
     // TODO(#18988): Drive strengh seems to be reported incorrectly by VCS.
@@ -672,6 +676,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     // - pull-up
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[1].pull_select), .value(1'b1), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.cc_if.pins[1]);
 `ifdef VCS
     // TODO(#18988): Drive strengh seems to be reported incorrectly by VCS.
@@ -682,6 +687,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     // - pull disabled
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[1].pull_en), .value(1'b0), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.cc_if.pins[1]);
     `DV_CHECK_STREQ(obs_strength, "HiZ", "on CC2")
     // ---------------------------------------------------------------------------------------------
@@ -695,6 +701,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
            .predict(1));
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[2].pull_en), .value(1'b1), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.flash_test_mode_if.pins[0]);
 `ifdef VCS
     // TODO(#18988): Drive strengh seems to be reported incorrectly by VCS.
@@ -705,6 +712,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     // - pull-up
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[2].pull_select), .value(1'b1), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.flash_test_mode_if.pins[0]);
 `ifdef VCS
     // TODO(#18988): Drive strengh seems to be reported incorrectly by VCS.
@@ -715,6 +723,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     // - pull disabled
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[2].pull_en), .value(1'b0), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.flash_test_mode_if.pins[0]);
     `DV_CHECK_STREQ(obs_strength, "HiZ", "on FLASH_TEST_MODE0")
     // ---------------------------------------------------------------------------------------------
@@ -728,6 +737,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
            .predict(1));
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[3].pull_en), .value(1'b1), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.flash_test_mode_if.pins[1]);
 `ifdef VCS
     // TODO(#18988): Drive strengh seems to be reported incorrectly by VCS.
@@ -738,6 +748,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     // - pull-up
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[3].pull_select), .value(1'b1), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.flash_test_mode_if.pins[1]);
 `ifdef VCS
     // TODO(#18988): Drive strengh seems to be reported incorrectly by VCS.
@@ -748,6 +759,7 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     // - pull disabled
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[3].pull_en), .value(1'b0), .blocking(1),
            .predict(1));
+    #(cfg.pad_pull_delay * 1ns);
     obs_strength = $sformatf("%v", cfg.chip_vif.flash_test_mode_if.pins[1]);
     `DV_CHECK_STREQ(obs_strength, "HiZ", "on FLASH_TEST_MODE1")
     // ---------------------------------------------------------------------------------------------
@@ -761,6 +773,10 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
 
   task check_manual_dios_input_disable();
     logic act;
+    logic lsb_exp_val;
+
+    lsb_exp_val = cfg.pad_in_dis_val;
+    if (cfg.pad_in_dis_val === 1'bz) lsb_exp_val = 1'bx;
 
     cfg.chip_vif.cc_if.drive('1);
     cfg.chip_vif.io_div4_clk_rst_if.wait_clks(1);
@@ -769,13 +785,13 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[0].input_disable), .value(1'b1), .blocking(1),
            .predict(1));
     act = hdl_read_lsb("tb.dut.manual_in_cc1");
-    `DV_CHECK_CASE_EQ(1'bx, act)
+    `DV_CHECK_CASE_EQ(lsb_exp_val, act)
     act = hdl_read_lsb("tb.dut.manual_in_cc2");
     `DV_CHECK_CASE_EQ(1'b1, act)
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[1].input_disable), .value(1'b1), .blocking(1),
            .predict(1));
     act = hdl_read_lsb("tb.dut.manual_in_cc2");
-    `DV_CHECK_CASE_EQ(1'bx, act)
+    `DV_CHECK_CASE_EQ(lsb_exp_val, act)
 
     cfg.chip_vif.flash_test_mode_if.drive('1);
     cfg.chip_vif.io_div4_clk_rst_if.wait_clks(1);
@@ -784,13 +800,13 @@ class chip_padctrl_attributes_vseq extends chip_stub_cpu_base_vseq;
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[2].input_disable), .value(1'b1), .blocking(1),
            .predict(1));
     act = hdl_read_lsb("tb.dut.manual_in_flash_test_mode0");
-    `DV_CHECK_CASE_EQ(1'bx, act)
+    `DV_CHECK_CASE_EQ(lsb_exp_val, act)
     act = hdl_read_lsb("tb.dut.manual_in_flash_test_mode1");
     `DV_CHECK_CASE_EQ(1'b1, act)
     csr_wr(.ptr(ral.sensor_ctrl_aon.manual_pad_attr[3].input_disable), .value(1'b1), .blocking(1),
            .predict(1));
     act = hdl_read_lsb("tb.dut.manual_in_flash_test_mode1");
-    `DV_CHECK_CASE_EQ(1'bx, act)
+    `DV_CHECK_CASE_EQ(lsb_exp_val, act)
   endtask
 
 endclass


### PR DESCRIPTION
Add the following updates to **chip_padctrl_attributes_vseq**:
- Pull delay after configuring the pad pull attributes.
- "pad_in_dis_val": As the value of the pad_in differs between open source and closed source when the input is disabled, with the current configuration we are failing when the pad’s input is disabled.
