### PR TITLE
[dv + sign-off, spi_device] Bump up verif_stage to V2S

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -37,7 +37,7 @@
     { version:            "2.0.0",
       life_stage:         "L1",
       design_stage:       "D2S",
-      verification_stage: "V1",
+      verification_stage: "V2S",
       dif_stage:          "S1",
       commit_id:          "",
       notes:              ""


### PR DESCRIPTION
This should allow us to close spi-device sign-offs:
- #22473 
- #23489 