### PR TITLE
[entropy_src] Max rate test fixes

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.sv
@@ -77,6 +77,13 @@ class entropy_src_env extends cip_base_env #(
     cfg.m_xht_agent_cfg.en_cov            = cfg.en_cov;
     cfg.m_xht_agent_cfg.is_active         = 1'b1;
 
+    // When running ast/rng at the maximum rate (this is an unrealistic scenario primarily used for
+    // reaching coverage metrics) we reduce the maximum d_ready delay of the TL-UL host to speed up
+    // e.g. the reading out of the Observe FIFO.
+    if (cfg.rng_max_delay == 1) begin
+      cfg.m_tl_agent_cfg.d_ready_delay_max = 5;
+    end
+
     if (!uvm_config_db#(virtual entropy_subsys_fifo_exception_if#(1))::get(this, "",
                         "precon_fifo_vif", cfg.precon_fifo_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get precon_fifo_vif from uvm_config_db")

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -385,6 +385,8 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     m_csrng_pull_seq.stop(.hard(0));
     `uvm_info(`gfn, "Stopping RNG seq", UVM_LOW)
     m_rng_push_seq.stop(.hard(0));
+    `uvm_info(`gfn, "Waiting for CS AES Halt interface to become idle", UVM_MEDIUM)
+    `DV_SPINWAIT(wait(cfg.m_aes_halt_agent_cfg.vif.req == 1'b0);)
     `uvm_info(`gfn, "SEQs SHUTDOWN applying CSRNG reset", UVM_MEDIUM)
     apply_reset(.kind("CSRNG_ONLY"));
     `uvm_info(`gfn, "Waiting for SEQs finished", UVM_MEDIUM)

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -312,9 +312,19 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     // handle the Observe FIFO first as that will have no impact on other features
     if (intr_status[ObserveFifoReady]) begin
       int bundles_found;
+      // When running ast/rng at the maximum rate (this is an unrealistic scenario primarily used
+      // for reaching coverage metrics), we limit the number of bits read from the Observe FIFO per
+      // call to 2 health test windows.
+      //
+      // Without a limit, the read function might keep reading the Observe FIFO forever and time
+      // out as the Observe FIFO potentially never runs empty when ast/rng runs at such
+      // unrealistically high rates.
+      int max_bundles =
+          (cfg.rng_max_delay == 1) ? 2 * (4 * `gmv(ral.health_test_windows.fips_window)) / 32 : -1;
       `uvm_info(`gfn, "Reading observe FIFO", UVM_DEBUG)
       // Read all currently available data
       do_entropy_data_read(.source(TlSrcObserveFIFO),
+                           .max_bundles(max_bundles),
                            .bundles_found(bundles_found));
       `uvm_info(`gfn, $sformatf("Found %d observe FIFO bundles", bundles_found), UVM_FULL)
     end

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -3273,7 +3273,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
       default: bsc_state_d = BscStIncomplete;
     endcase
     // If not enabled, always clear to incomplete.
-    if (!mubi4_test_true_strict(mubi_es_enable)) begin
+    if (!es_delayed_enable) begin
       bsc_state_d = BscStIncomplete;
     end
   end
@@ -3339,7 +3339,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
       end
     end
     // If not enabled, always clear to no result.
-    if (!mubi4_test_true_strict(mubi_es_enable)) begin
+    if (!es_delayed_enable) begin
       ht_state_d = HtStNoResult;
     end
   end
@@ -3426,7 +3426,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
       precon_post_startup_push_bit_cnt_q  <= '0;
       precon_push_bit_cnt_q               <= '0;
       rng_valid_bit_cnt_q                 <= '0;
-    end else if (mubi4_test_true_strict(mubi_es_enable) & !fw_ov_mode_entropy_insert) begin
+    end else if (es_delayed_enable & !fw_ov_mode_entropy_insert) begin
       // All these counters get updated if and only if entropy_src is enabled and the firmware
       // override entropy insertion mode is disabled.  Otherwise, there are no guarantees on how
       // much entropy from the noise source gets dropped due to backpressure.

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -3344,13 +3344,11 @@ module entropy_src_core import entropy_src_pkg::*; #(
     end
   end
 
-  // Track when entropy is expected to get dropped instead of pushed into the esfinal FIFO: when the
-  // esfinal FIFO is full and either routing to SW and the SW read isn't done or not routing to SW
-  // and no request on the hardware interface.
+  // Track when entropy is expected to get dropped instead of pushed into the esfinal FIFO. This is
+  // the case whenever the esfinal FIFO is full. When routing to SW and the SW read finished at the
+  // same time, the entropy isn't dropped.
   logic esfinal_exp_drop;
-  assign esfinal_exp_drop = sfifo_esfinal_full & (es_route_to_sw ?
-                                                  ~swread_done :                // SW read not done
-                                                  ~entropy_src_hw_if_i.es_req); // no HW request
+  assign esfinal_exp_drop = sfifo_esfinal_full & (es_route_to_sw ? ~swread_done : 1'b1);
 
   // Count number of bits that are expected to have gotten pushed into precon FIFO and into esfinal
   // FIFO after boot and startup checks and while bypass mode was disabled.


### PR DESCRIPTION
This PR contains a couple of fixes mostly relevant for the max rate test. I recommend reviewing the commits individually.

The first two commits just fix failing tests whereas the third commit changes the behavior of the DV environment which triggers Observe FIFO overflows. The DV environment can handle these overflows correctly but it may have an impact on coverage. I am currently running a full regression with coverage.

This PR is the last missing item for and resolves #21855.