### PR TITLE
[conn,alert_esc] Check escalation sender/receiver connectivity

### DIFF
--- a/hw/top_earlgrey/formal/chip_conn_cfg.hjson
+++ b/hw/top_earlgrey/formal/chip_conn_cfg.hjson
@@ -11,7 +11,8 @@
 
   bbox_cmd: "[list aon_osc io_osc sys_osc usb_osc]"
   conn_csvs_dir: "{proj_root}/hw/top_earlgrey/formal/conn_csvs"
-  conn_csvs: ["{conn_csvs_dir}/analog_sigs.csv",
+  conn_csvs: ["{conn_csvs_dir}/alert_handler_esc.csv",
+              "{conn_csvs_dir}/analog_sigs.csv",
               "{conn_csvs_dir}/aon_timer_rst.csv",
               "{conn_csvs_dir}/ast_infra.csv",
               "{conn_csvs_dir}/ast_entropy_src_cfg.csv",

--- a/hw/top_earlgrey/formal/conn_csvs/alert_handler_esc.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/alert_handler_esc.csv
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run these checks with:
+#  ./util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfg.hjson
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+# escalation sender and receivers
+CONNECTION, ALERT_HANDLER_PWRMGR_ESC_CLK, top_earlgrey.u_alert_handler, clk_i, top_earlgrey.u_pwrmgr_aon.u_esc_rx, clk_i
+# TODO(lowrisc/opentitan#23888) Enable this check once this issue is fixed.
+# CONNECTION, ALERT_HANDLER_PWRMGR_ESC_RST, top_earlgrey.u_alert_handler, rst_ni, top_earlgrey.u_pwrmgr_aon.u_esc_rx, rst_ni
+CONNECTION, ALERT_HANDLER_LC_CTRL_ESC0_CLK, top_earlgrey.u_alert_handler, clk_i, top_earlgrey.u_lc_ctrl.u_prim_esc_receiver0, clk_i
+CONNECTION, ALERT_HANDLER_LC_CTRL_ESC0_RST, top_earlgrey.u_alert_handler, rst_ni, top_earlgrey.u_lc_ctrl.u_prim_esc_receiver0, rst_ni
+CONNECTION, ALERT_HANDLER_LC_CTRL_ESC1_CLK, top_earlgrey.u_alert_handler, clk_i, top_earlgrey.u_lc_ctrl.u_prim_esc_receiver1, clk_i
+CONNECTION, ALERT_HANDLER_LC_CTRL_ESC1_RST, top_earlgrey.u_alert_handler, rst_ni, top_earlgrey.u_lc_ctrl.u_prim_esc_receiver1, rst_ni
+CONNECTION, ALERT_HANDLER_RV_CORE_IBEX_ESC_CLK, top_earlgrey.u_alert_handler, clk_i, top_earlgrey.u_rv_core_ibex.u_prim_esc_receiver, clk_i
+CONNECTION, ALERT_HANDLER_RV_CORE_IBEX_ESC_RST, top_earlgrey.u_alert_handler, rst_ni, top_earlgrey.u_rv_core_ibex.u_prim_esc_receiver, rst_ni


### PR DESCRIPTION
The escalation sender and receiver pairs need to connect to the same clock and reset signals, or they can malfunction.

This adds a connectivity configuration for these tests, but it is expected to fail due to the mis-connection of pwrmgr rst_ni described in #23888.

Fixes #14887