### PR TITLE
Fix pwrmgr_sleep_all_wake_ups

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -43,6 +43,7 @@ cc_library(
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/base:multibits",
+        "//sw/device/lib/runtime:hart",
     ],
 )
 

--- a/sw/device/lib/dif/dif_adc_ctrl.c
+++ b/sw/device/lib/dif/dif_adc_ctrl.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/runtime/hart.h"
 
 #include "adc_ctrl_regs.h"  // Generated.
 
@@ -511,5 +512,15 @@ dif_result_t dif_adc_ctrl_irq_cause_get_enabled(const dif_adc_ctrl_t *adc_ctrl,
   *enabled_causes =
       mmio_region_read32(adc_ctrl->base_addr, ADC_CTRL_ADC_INTR_CTL_REG_OFFSET);
 
+  return kDifOk;
+}
+
+dif_result_t dif_adc_ctrl_wait_cdc_sync(const dif_adc_ctrl_t *adc_ctrl,
+                                        uint32_t aon_freq_hz) {
+  if (adc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+  // Wait 5 AON ticks.
+  busy_spin_micros(5 * 1000000 / aon_freq_hz);
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_adc_ctrl.h
+++ b/sw/device/lib/dif/dif_adc_ctrl.h
@@ -472,6 +472,21 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_adc_ctrl_irq_cause_get_enabled(const dif_adc_ctrl_t *adc_ctrl,
                                                 uint32_t *enabled_causes);
 
+/**
+ * Wait enough time for CDC synchronization between block and CSRs.
+ *
+ * Wait long enough for any CDC synchronization between the AON part
+ * of the block and the CSRs to be complete. This is particularly important
+ * for the FILTER_STATUS register: this register can be updated by the HW
+ * and any update may take a while to become visible by the SW.
+ *
+ * @param adc_ctrl An adc_ctrl handle.
+ * @param aon_freq_hz Frequency of the AON clock in Hz.
+ * @return The result of the operation.
+ */
+dif_result_t dif_adc_ctrl_wait_cdc_sync(const dif_adc_ctrl_t *adc_ctrl,
+                                        uint32_t aon_freq_hz);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_all_wake_ups_impl.c
@@ -243,6 +243,8 @@ void check_wakeup_reason(uint32_t wakeup_unit) {
     } break;
     case PWRMGR_PARAM_ADC_CTRL_AON_WKUP_REQ_IDX: {
       uint32_t filter_status = 0;
+      CHECK_DIF_OK(
+          dif_adc_ctrl_wait_cdc_sync(&adc_ctrl, (uint32_t)kClockFreqAonHz));
       CHECK_DIF_OK(dif_adc_ctrl_get_filter_status(&adc_ctrl, &filter_status));
       CHECK(filter_status ==
                 ((1 << kDifAdcCtrlFilter5) | (1 << kDifAdcCtrlTrans)),


### PR DESCRIPTION
See #23303 for explanation. In short, the ADC `FILTER_STATUS` register may a take a while to update after wake up due to the hardware writes going through the CDC. This PR fixes this issues by adding a new DIF method to wait long enough for any CDC update to finish and then uses this method in the problematic tests.

Fixes #23303