### PR TITLE
[dv, spi_host] Using the factory to create objects

### DIFF
--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -105,7 +105,7 @@ class spi_host_base_vseq extends cip_base_vseq #(
                               cfg.en_scb ? "enable" : "disable"), UVM_DEBUG)
     num_runs.rand_mode(0);
     num_trans_c.constraint_mode(0);
-    transaction = new();
+    transaction = spi_transaction_item::type_id::create("transaction");
     super.pre_start();
   endtask : pre_start
 
@@ -134,7 +134,7 @@ class spi_host_base_vseq extends cip_base_vseq #(
   endtask
 
   function void transaction_init();
-    transaction = new();
+    transaction = spi_transaction_item::type_id::create("transaction");
 
     transaction.read_weight     = cfg.seq_cfg.read_pct;
     transaction.write_weight    = cfg.seq_cfg.write_pct;

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_error_cmd_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_error_cmd_vseq.sv
@@ -26,7 +26,6 @@ class spi_host_error_cmd_vseq extends spi_host_tx_rx_vseq;
 
   virtual task send_cmd();
     generate_transaction();
-    segment = new();
     while (transaction.segments.size() > 0) begin
       segment = transaction.segments.pop_back();
       if (segment.command_reg.direction != RxOnly) begin

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_event_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_event_vseq.sv
@@ -95,7 +95,6 @@ class spi_host_event_vseq extends spi_host_tx_rx_vseq;
 
   virtual task gen_trans();
     generate_transaction();
-    segment = new();
     while (transaction.segments.size() > 0) begin
       segment = transaction.segments.pop_back();
       if (segment.command_reg.direction != RxOnly) begin

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_overflow_underflow_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_overflow_underflow_vseq.sv
@@ -58,7 +58,6 @@ class spi_host_overflow_underflow_vseq extends spi_host_tx_rx_vseq;
 
   virtual task gen_trans();
     generate_transaction();
-    segment = new();
     while (transaction.segments.size() > 0) begin
       segment = transaction.segments.pop_back();
       if (segment.command_reg.direction != RxOnly) begin

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_tx_rx_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_tx_rx_vseq.sv
@@ -64,7 +64,7 @@ class spi_host_tx_rx_vseq extends spi_host_base_vseq;
 
   // Generate the TL-writes needed for the DUT to send all segments of a "spi_transaction_item" transaction.
   virtual task send_trans(spi_transaction_item trans, bit wait_ready = 1'b1);
-    spi_segment_item segment = new();
+    spi_segment_item segment;
     while (trans.segments.size() > 0) begin
       if (wait_ready) wait_ready_for_command();
       // lock fifo to this seq
@@ -83,7 +83,7 @@ class spi_host_tx_rx_vseq extends spi_host_base_vseq;
 
   // Write dummy-data into TxFifo.
   virtual task txfifo_fill();
-    spi_segment_item segment = new();
+    spi_segment_item segment = spi_segment_item::type_id::create("segment");
     spi_host_atomic.get(1);
     access_data_fifo(segment.spi_data, TxFifo);
     spi_host_atomic.put(1);

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -60,9 +60,9 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     plain_data_fifo  = new("plain_data_fifo", this);
-    host_wr_segment  = new("host_wr_segment");
-    host_rd_segment  = new("host_rd_segment");
-    device_item      = new("device_item");
+    host_wr_segment = spi_segment_item::type_id::create("host_wr_segment");
+    host_rd_segment = spi_segment_item::type_id::create("host_rd_segment");
+    device_item = spi_item::type_id::create("device_item");
   endfunction
 
 
@@ -94,7 +94,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
   // Receives spi_segment_item - this is then compared with the value on the bus which is extracted
   // in compare_tx_trans
   virtual task compare_rx_trans();
-    spi_segment_item   tl_segment = new();
+    spi_segment_item   tl_segment = spi_segment_item::type_id::create("tl_segment");
     string             txt = "";
     bit [7:0]          read_data;
 
@@ -185,7 +185,8 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
   // If the written segment's direction is RxOnly or Bidir, this then also populate the `rx_data_q`
   // for further RX comparison in compare_rx_trans
   virtual task compare_tx_trans();
-    spi_segment_item   exp_segment = new();
+    spi_segment_item   exp_segment = spi_segment_item::type_id::create("exp_segment");
+
     spi_item           dut_item, device_item;
     // indication that this is a new transaction
     bit                prev_csaat = 0;
@@ -291,7 +292,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
         `uvm_info(`gfn, $sformatf("Pushed segment:\n%s \nonto 'write_segment_q'",
                                   wr_segment.convert2string), UVM_DEBUG)
         write_segment_q.push_back(wr_segment);
-        host_wr_segment = new();
+        host_wr_segment = spi_segment_item::type_id::create("host_wr_segment");
       end
 
       return;
@@ -316,7 +317,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
         `uvm_info(`gfn, $sformatf("Pushed segment:\n%s \nonto 'read_segment_q'",
                                   rd_segment.convert2string()), UVM_DEBUG)
         read_segment_q.push_back(rd_segment);
-        host_rd_segment = new();
+        host_rd_segment = spi_segment_item::type_id::create("host_rd_segment");
       end
 
       return;
@@ -422,7 +423,7 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
                                           wr_segment.convert2string()), UVM_DEBUG)
               `uvm_info(`gfn, $sformatf("\n  created expeted wr_segment item %s",
                                           wr_segment.convert2string()), UVM_LOW)
-              host_wr_segment = new();
+              host_wr_segment = spi_segment_item::type_id::create("host_wr_segment");
             end
           end
           if (cfg.en_cov) begin
@@ -555,8 +556,8 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
     write_segment_q.delete();
     read_segment_q.delete();
     rx_data_q.delete();
-    host_wr_segment = new();
-    host_rd_segment = new();
+    host_wr_segment = spi_segment_item::type_id::create("host_wr_segment");
+    host_rd_segment = spi_segment_item::type_id::create("host_rd_segment");
     device_item.clear_all();
   endfunction : reset
 

--- a/hw/ip/spi_host/dv/env/spi_transaction_item.sv
+++ b/hw/ip/spi_host/dv/env/spi_transaction_item.sv
@@ -102,7 +102,8 @@ class spi_transaction_item extends uvm_sequence_item;
 
 
   function void segment_init();
-    segment                  = new();
+    segment                  = spi_segment_item::type_id::create("segment");
+
     segment.rx_only_weight   = rx_only_weight;
     segment.tx_only_weight   = tx_only_weight;
     segment.num_dummy        = num_dummy;


### PR DESCRIPTION
The TB was barely using the factory to create objects. In addition there were a few places where a seq_item was created to them be overriden by popping an item from a queue.