### PR TITLE
[rom_e2e,dv] fix ROM self hash test in DV

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -788,8 +788,8 @@
       name: rom_e2e_self_hash
       uvm_test_seq: chip_sw_base_vseq
       sw_images: [
-        "//sw/device/silicon_creator/rom/e2e/release:rom_e2e_self_hash_test:1:new_rules"
-        "//sw/device/silicon_creator/rom/e2e/release:otp_img_sigverify_spx_rma:4",
+        "//sw/device/silicon_creator/rom/e2e/release:rom_e2e_self_hash_test:1:new_rules",
+        "//sw/device/silicon_creator/rom/e2e/release:otp_img_sigverify_spx_prod:4",
       ]
       en_run_modes: ["sw_test_mode_mask_rom"]
       run_opts: [

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -303,6 +303,10 @@ class chip_sw_base_vseq extends chip_base_vseq;
       SwTestStatusFailed: `uvm_error(`gfn, "SW TEST FAILED!")
       default: begin
         // If the SW test has not reached the passed / failed state, then it timed out.
+        `uvm_info(`gfn, $sformatf("Ibex PCs: IF=%0x, ID=%0x, WB=%0x\n",
+            cfg.chip_vif.probed_cpu_pc.pc_if,
+            cfg.chip_vif.probed_cpu_pc.pc_id,
+            cfg.chip_vif.probed_cpu_pc.pc_wb), UVM_LOW)
         `uvm_error(`gfn, $sformatf("SW TEST TIMED OUT. STATE: %0s, TIMEOUT = %0d ns\n",
             cfg.sw_test_status_vif.sw_test_status.name(), cfg.sw_test_timeout_ns))
       end

--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -17,8 +17,8 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 otp_image(
-    name = "otp_img_sigverify_spx_rma",
-    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    name = "otp_img_sigverify_spx_prod",
+    src = "//hw/ip/otp_ctrl/data:otp_json_prod",
     overlays = STD_OTP_OVERLAYS + [
         "//sw/device/silicon_creator/rom/e2e/sigverify_spx:otp_json_sigverify_spx_enabled_true",
     ],
@@ -29,7 +29,6 @@ opentitan_test(
     name = "rom_e2e_self_hash_test",
     srcs = ["rom_e2e_self_hash_test.c"],
     dv = dv_params(
-        otp = ":otp_img_sigverify_spx_rma",
         rom = "//sw/device/silicon_creator/rom:mask_rom",
     ),
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
@@ -39,8 +38,9 @@ opentitan_test(
         "//hw/top_earlgrey:silicon_creator": None,  # This is added to support GLS and bringup environments.
     },
     fpga = fpga_params(
-        otp = ":otp_img_sigverify_spx_rma",
+        otp = ":otp_img_sigverify_spx_prod",
     ),
+    manifest = "//sw/device/silicon_creator/rom_ext:manifest",
     spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",


### PR DESCRIPTION
This changes the ROM self hash test to run in the PROD LC state and increases the timeout.