### PR TITLE
[uart,dv] Fix string line break

### DIFF
--- a/hw/ip/uart/dv/env/seq_lib/uart_noise_filter_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_noise_filter_vseq.sv
@@ -8,8 +8,8 @@ class uart_noise_filter_vseq extends uart_tx_rx_vseq;
 
   `uvm_object_new
 
-  string cdc_sel_path = "tb.dut.uart_core.sync_rx.gen_generic.u_impl_generic" +
-                        ".u_prim_cdc_rand_delay.gen_enable.data_sel";
+  string cdc_sel_path = {"tb.dut.uart_core.sync_rx.gen_generic.u_impl_generic",
+                         ".u_prim_cdc_rand_delay.gen_enable.data_sel"};
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);


### PR DESCRIPTION
This commit fixes a string line break that was causing the `uart_noise_filter` test to fail.

Closes lowRISC/opentitan#23639