### PR TITLE
[i2c,dv] I2C SMBus maxlen directed test

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -939,6 +939,18 @@
       stage: V2
       tests: []
     }
+    {
+      name: target_mode_smbus_maxlen
+      desc: '''
+            The I2C ACQFIFO has been sized such that it can absorb a max-length SMBus message (a 255-byte
+            Block-Write) without software intervention.
+            This directed test confirms this use-case is viable by generating a stimulus message of this
+            size, while disabling any interrupt/polling handlers from interacting with the DUT. The
+            message content is checked by the scoreboard to be correct and complete.
+            '''
+      stage: V2
+      tests: ["i2c_target_smbus_maxlen"]
+    }
   ]
   covergroups: [
     {

--- a/hw/ip/i2c/dv/env/i2c_env.core
+++ b/hw/ip/i2c/dv/env/i2c_env.core
@@ -58,6 +58,7 @@ filesets:
       - seq_lib/i2c_target_fifo_watermarks_acq_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_fifo_watermarks_tx_vseq.sv: {is_include_file: true}
       - seq_lib/i2c_target_tx_stretch_ctrl_vseq.sv: {is_include_file: true}
+      - seq_lib/i2c_target_smbus_maxlen_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -37,6 +37,11 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // RSTART injection rate percentage (1-100)
   int        rs_pct = 10;
 
+  // Constrain the number of i2c-transfers within any larger i2c-transaction.
+  // Note. that this specifically refers to transfers & transactions as defined by I2C, which a
+  // transaction is comprised of one or more transfers, where a transfer is between S/Sr -> Sr/P)
+  int        min_num_transfers = 1;
+  int        max_num_transfers = 0; // 0 == unlimited
   // This sets the minimum length of a transfer (START/RSTART -> RSTART/STOP) within
   // any larger transaction. A transfer with no data, where the address byte is NACK'd,
   // is possible with our stimulus approach, and this can break checking in certain

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smbus_maxlen_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smbus_maxlen_vseq.sv
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This directed test aims to check the I2C block can absorb a max-length SMBus message
+// without software intervention mid-message (e.g. to drain the ACQFIFO, or handle interrupts).
+//
+// - Stimulate a max-length transfer (Block-Write of 255 bytes)
+// - Disable all interrupt/polling based handlers
+// - Wait for the command-complete interrupt to signal the end of the transfer
+// - Readback the transfer and check it was received correctly (done via scoreboard)
+//
+class i2c_target_smbus_maxlen_vseq extends i2c_target_runtime_base_vseq;
+  `uvm_object_utils(i2c_target_smbus_maxlen_vseq)
+  `uvm_object_new
+
+  // The maximum number of data-bytes in a SMBus Block Write
+  // 1 - command code
+  // 1 - byte count
+  // 255 - data
+  // 1 - PEC
+  int smbus_maxlen = 258;
+
+  virtual task pre_start();
+    super.pre_start();
+
+    cfg.min_data = smbus_maxlen;
+    cfg.max_data = smbus_maxlen;
+    cfg.rs_pct = 0; // Don't generate any RSTARTs, one single transfer per txn
+    cfg.rd_pct = 0; // Block-Write
+    cfg.min_num_transfers = 1; // Only 1 transfer in the transaction
+    cfg.max_num_transfers = 1;
+
+    // Configure the runtime_base_vseq for just a single transfer before ending.
+    stim_cnt_limit = 1;
+
+    // Disable the ack_ctrl module, as 'TARGET_ACK_CTRL.n_bytes' resets at the beginning of each
+    // new write transaction, so software intervention would, by definition, be required to
+    // increment 'n_bytes' at least once during the transfer.
+    cfg.ack_ctrl_en = 0;
+
+    // Use a basic Agent sequence that drives all items it is passed.
+    i2c_base_seq::type_id::set_type_override(i2c_target_base_seq::get_type());
+  endtask
+
+  virtual task initialization();
+    super.initialization();
+    // The base-class enables all interrupts by default, so override that behaviour here.
+
+    // Mask all target mode interrupts (except CmdComplete). This test is interrupt-driven
+    // (the plusarg '+use_intr_handler=1' is set), so this guarantees no interrupt handler will be
+    // able to respond to the hardware.
+    // If the transfer is able to complete (checked at the scoreboard), we know that the DUT
+    // was able to absorb the entire transaction without software intervention.
+    ral.intr_enable.acq_threshold.set(1'b0);
+    ral.intr_enable.acq_stretch.set(1'b0);
+    ral.intr_enable.tx_threshold.set(1'b0);
+    ral.intr_enable.tx_stretch.set(1'b0);
+    ral.intr_enable.host_timeout.set(1'b0);
+    csr_update(ral.intr_enable);
+  endtask: initialization
+
+endclass : i2c_target_smbus_maxlen_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_vseq_list.sv
@@ -39,3 +39,4 @@
 `include "i2c_target_fifo_watermarks_acq_vseq.sv"
 `include "i2c_target_fifo_watermarks_tx_vseq.sv"
 `include "i2c_target_tx_stretch_ctrl_vseq.sv"
+`include "i2c_target_smbus_maxlen_vseq.sv"

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -267,6 +267,13 @@
                  "+test_timeout_ns=20_000_000",
                  "+use_intr_handler=1"]
     }
+    {
+      name: i2c_target_smbus_maxlen
+      uvm_test_seq: i2c_target_smbus_maxlen_vseq
+      run_opts: ["+i2c_agent_mode=Host",
+                 "+test_timeout_ns=20_000_000",
+                 "+use_intr_handler=1"]
+    }
   ]
 
   // List of regressions.
@@ -292,7 +299,8 @@
               "i2c_target_timeout", "i2c_target_unexp_stop",
               "i2c_target_glitch", "i2c_target_perf",
               "i2c_target_fifo_reset_acq", "i2c_target_fifo_reset_tx",
-              "i2c_target_bad_addr", "i2c_target_hrst"]
+              "i2c_target_bad_addr", "i2c_target_hrst",
+              "i2c_target_smbus_maxlen"]
     }
   ]
 }


### PR DESCRIPTION
> Note. ~~This test depends on changes from #23911, which as been squashed into the first commit. Changes from this commit should be ignored while reviewing, as it will be rebased away when that PR is merged.~~

This directed test aims to check the I2C block can absorb a max-length SMBus message
without software intervention mid-message (e.g. to drain the ACQFIFO, or handle interrupts).

 - Stimulate a max-length transfer (Block-Write of 255 bytes)
 - Disable all interrupt/polling based handlers
 - Wait for the command-complete interrupt to signal the end of the transfer
 - Readback the transfer and check it was received correctly (done via scoreboard)

A new V2 testpoint is added to track this test against.

Closes #22252 

In the future, it might be desirable to confirm the intended behaviour via better constrained randomization and an appropriate coverage bin, rather than a specific vseq.