### PR TITLE
[crypto] Add a counter to the main loop of ECDSA-P256 verify.

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
@@ -39,12 +39,12 @@ enum {
 
 const size_t kGoldenRomSizeBytes = 32652 - sizeof(chip_info_t);
 const uint32_t kSimDvGoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0xdc9a2c64, 0xcf6c75b2, 0x450cb695, 0x2a02780e,
-    0x88df3501, 0x89c24073, 0x7d5baa94, 0xc8bbca20,
+    0x5559e17d, 0xd920f2a7, 0x98afda37, 0x5380eed1,
+    0x7549a52e, 0x26f0a4a9, 0x917888e5, 0x5a76bd3d,
 };
 const uint32_t kFpgaCw310GoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0x25fdea26, 0x8dbcfe81, 0x32a3b4ff, 0x059d3837,
-    0xef644919, 0xf7a5f401, 0x0f53a45d, 0xc678ecd9,
+    0xb1ebe528, 0xe461696b, 0x55d795e8, 0x5e57a7da,
+    0x04007623, 0xb4b121cb, 0x572fcc0a, 0x76c45aea,
 };
 
 extern const char _chip_info_start[];


### PR DESCRIPTION
This is a simple, lightweight hardening measure against fault-injection attacks on the loop control flow in OTBN, just in case the hardware hardening measures don't hold up as well as we'd like.

The OTBN ECDSA-P256 verification program returns two results: an "OK" value that's either `kHardenedBoolTrue` or `kHardenedBoolFalse`, and the recovered "r" value that should be equal to "r" from the signature if the signature was valid. Ibex needs to check both values.

The new counter basically just piggybacks on the existing "OK" value; instead of directly writing `kHardenedBoolTrue` into the "OK" buffer, we load the constant `kHardenedBoolTrue ^ 256` and then XOR it with a counter that gets incremented on every loop iteration. If the counter says 256 iterations, we get the right value, but if not we'll get something else and Ibex will detect that something is wrong in the code here:
https://github.com/lowRISC/opentitan/blob/5655312fae6a6d92ce18f9f87aceffdb454b4f76/sw/device/silicon_creator/lib/otbn_boot_services.c#L269-L278

If we wanted to be even more strict, we could cause a more catastrophic error if `ok != kHardenedBoolFalse`. We could also consider starting the counter at `2^32-1` instead of 0, so that the expected value is 255, which would just give us more bits that the counter flips. Open to opinions on more advanced strategies, but for now I just went with the simplest version.