### PR TITLE
[coremark] Increase CoreMark timeout, report CoreMark/MHz, update performance doc

### DIFF
--- a/hw/top_earlgrey/doc/design/README.md
+++ b/hw/top_earlgrey/doc/design/README.md
@@ -123,22 +123,15 @@ See the details in the [rv_plic specification](../../ip_autogen/rv_plic/README.m
 
 #### Performance
 
-Ibex currently achieves a [CoreMark](https://www.eembc.org/coremark/) per MHz of 2.36 on the earlgrey verilator system.
-Performance improvements are ongoing, including the following items being considered:
+Ibex currently achieves a [CoreMark](https://www.eembc.org/coremark/) per MHz of 1.93 on Earl Grey.
+For a detailed analysis of where this number comes from, please refer to this [GitHub issue](https://github.com/lowRISC/opentitan/issues/17370#issuecomment-1453324348).
+In short, by [moving read-only data from Flash into SRAM](https://github.com/lowRISC/opentitan/issues/17370#issuecomment-1446719338) and by playing with optimization flags, A CoreMark/MHz of 2.15 is achievable.
+This number is close to the maximum achievable number for Ibex with an ideal single-cycle access memory system when using the LLVM compiler.
 
-1. Adding a new ALU to calculate branch targets to remove a cycle of latency on taken conditional branches (currently the single ALU is used to compute the branch condition then the branch target the cycle following if the branch is taken).
-2. A 3rd pipeline stage to perform register writeback, this will remove a cycle of latency from all loads and stores and prevent a pipeline stall where a response to a load or store is available the cycle after the request.
-3. Implement a single-cycle multiplier.
-4. Produce an imprecise exception on an error response to a store allowing Ibex to continue executing past a store without waiting for the response.
-
-The method for including these features, e.g. whether they will be configurable options or not, is still being discussed.
+When switching to GCC and combining the Ibex configuration used in OpenTitan Earl Grey with an idealistic single-cycle access Flash memory, a CoreMark/MHz number of 3.07 is achievable.
+To achieve this performance, CoreMark can be compiled with GCC 9.2.0 and with the following flags: `-march=rv32imc -mabi=ilp32 -mcmodel=medany -mtune=sifive-3-series -O3 -falign-functions=16 -funroll-all-loops -finline-functions -falign-jumps=4 -mstrict-align` .
 
 The Ibex documentation has more details on the current pipeline operation, including stall behaviour for each instruction in the [Pipeline Details](https://ibex-core.readthedocs.io/en/latest/03_reference/pipeline_details.html) section.
-
-The CoreMark performance achieved relies in part on single-cycle access to instruction memory.
-An instruction cache is planned to help maintain this performance when using flash memory that will likely not have single-cycle access times.
-
-CoreMark was compiled with GCC 9.2.0 with flags: `-march=rv32imc -mabi=ilp32 -mcmodel=medany -mtune=sifive-3-series -O3 -falign-functions=16 -funroll-all-loops -finline-functions -falign-jumps=4 -mstrict-align`
 
 ### Memory
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -1658,7 +1658,7 @@
       run_opts: ["+en_uart_logger=1",
                  "+sw_test_timeout_ns=200_000_000"]
       reseed: 1
-      run_timeout_mins: 240
+      run_timeout_mins: 300
     }
     {
       name: chip_sw_pwrmgr_b2b_sleep_reset_req

--- a/third_party/coremark/print_coremark_per_mhz.patch
+++ b/third_party/coremark/print_coremark_per_mhz.patch
@@ -1,0 +1,18 @@
+diff --git a/core_main.c b/core_main.c
+index a4beeb6..3b782ad 100644
+--- a/core_main.c
++++ b/core_main.c
+@@ -379,6 +379,13 @@ for (i = 0; i < MULTITHREAD; i++)
+
+     ee_printf("Iterations       : %lu\n",
+               (long unsigned)default_num_contexts * results[0].iterations);
++    ee_u32 coremark_per_100mhz =
++        100000000 * default_num_contexts * results[0].iterations / total_time;
++    ee_u32 coremark_per_mhz = coremark_per_100mhz / 100;
++    ee_u32 coremark_per_mhz_remainder =
++        coremark_per_100mhz - coremark_per_mhz * 100;
++    ee_printf("CoreMark/MHz     : %u.%u\n", coremark_per_mhz,
++              coremark_per_mhz_remainder);
+     ee_printf("Compiler version : %s\n", COMPILER_VERSION);
+     ee_printf("Compiler flags   : %s\n", COMPILER_FLAGS);
+ #if (MULTITHREAD > 1)

--- a/third_party/coremark/repos.bzl
+++ b/third_party/coremark/repos.bzl
@@ -15,6 +15,7 @@ def coremark_repos():
         ],
         patches = [
             Label("//third_party/coremark:use_ottf_main.patch"),
+            Label("//third_party/coremark:print_coremark_per_mhz.patch"),
         ],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
This resolves lowRISC/OpenTitan#14330.

The first commit makes the test print out the CoreMark/MHz number which is what most people actually care about:
```
2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 6193300
Total time (secs): 12
Iterations/Sec   : 1
Iterations       : 12
CoreMark/MHz     : 1.93
Compiler version : GCClowRISC Clang 16.0.2 (https://github.com/lowRISC/llvm-project.git d213f6b2e0bcc561930538ef47b3b5cc900b5b17)
Compiler flags   : Please put compiler flags here (e.g. -o3)
Memory location  : STACK
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x755b
Correct operation validated. See README.md for run and reporting rules.
PASS!
```