### PR TITLE
[entropy_src/dv] Verify firmware override CSRs

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -24,10 +24,11 @@ package entropy_src_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter bit [TL_DW-1:0]   INCR_ENTROPY_LO  = 32'h76543210;
-  parameter bit [TL_DW-1:0]   INCR_ENTROPY_HI  = 32'hfedcba98;
-  parameter string            LIST_OF_ALERTS[] = {"recov_alert","fatal_alert"};
-  parameter uint              NUM_ALERTS       = 2;
+  parameter bit [TL_DW-1:0]   INCR_ENTROPY_LO    = 32'h76543210;
+  parameter bit [TL_DW-1:0]   INCR_ENTROPY_HI    = 32'hfedcba98;
+  parameter string            LIST_OF_ALERTS[]   = {"recov_alert","fatal_alert"};
+  parameter uint              NUM_ALERTS         = 2;
+  parameter uint              OBSERVE_FIFO_DEPTH = 32;
 
   // types
   typedef enum int {

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1055,6 +1055,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       fips_csrng_q.delete();
       repacked_entropy_release_q.delete();
       overflow_condition = 0;
+      `DV_CHECK_FATAL(ral.observe_fifo_depth.observe_fifo_depth.predict('b0))
     end
 
     // Internal repetition counters and watermark registers are cleared on enable.
@@ -1465,6 +1466,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
           // by allowing our observe FIFO queue in the scoreboard to hold one additional
           // word.
           observe_read_incoming = 1;
+          `DV_CHECK_FATAL(ral.observe_fifo_depth.observe_fifo_depth.predict(
+              `gmv(ral.observe_fifo_depth.observe_fifo_depth)-1, .kind(UVM_PREDICT_DIRECT)))
           // If there's an overflow condition and we only have one word left in the observe FIFO,
           // this means that the overflow condition ends here. Here we signal the end of the
           // overflow condition and update the predictions.
@@ -1475,12 +1478,12 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
         end
       end
       "fw_ov_wr_data": begin
+        // TODO(#18837): need to predict this
       end
       "fw_ov_wr_fifo_full": begin
         // TODO(#18837): need to predict this
       end
       "fw_ov_rd_fifo_overflow": begin
-        // TODO(#18837): need to predict this
       end
       "observe_fifo_thresh": begin
         locked_reg_access = dut_reg_locked;
@@ -2216,6 +2219,9 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
               end else begin
                 observe_fifo_q.push_back(repacked_entropy_release);
               end
+              wait(!ral.observe_fifo_depth.is_busy());
+              `DV_CHECK_FATAL(ral.observe_fifo_depth.observe_fifo_depth.predict(
+                  `gmv(ral.observe_fifo_depth.observe_fifo_depth)+1, .kind(UVM_PREDICT_DIRECT)))
             end
           join_none
 

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_fw_ov_contiguous_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_fw_ov_contiguous_vseq.sv
@@ -22,8 +22,9 @@ class entropy_src_fw_ov_contiguous_vseq extends entropy_src_base_vseq;
     fork
       m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
       begin
+        int available_bundles;
+        bit [TL_DW-1:0] observe_fifo_depth;
         do begin
-          int available_bundles;
           // Wait for data to arrive for TL consumption via the ENTROPY_DATA register
           poll(.source(TlSrcObserveFIFO));
           // Read all currently available data (but no more than bundle_cnt)
@@ -32,6 +33,8 @@ class entropy_src_fw_ov_contiguous_vseq extends entropy_src_base_vseq;
           // Update the count of remaining seeds to read
           bundle_cnt -= available_bundles;
         end while (bundle_cnt > 0);
+        csr_rd(.ptr(ral.observe_fifo_depth.observe_fifo_depth), .value(observe_fifo_depth),
+                .blocking(1'b1));
         m_rng_push_seq.stop(.hard(0));
         m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
       end


### PR DESCRIPTION
This commit adds some checks for the CSRs relevant for the
firmware override mode. For further information check out the 
individual commit messages and the added comments.

There is still some work to be done here.
I need to:
- add coverage for the fill state or come up with a clever way to check if the behavior for reading from the observe FIFO is as intended.
- Debug failing test sequences.

**Update** by @vogelpi: we've decided to split the work for #18837 into two parts. This PR covers the first part around the extract part / observe FIFO (FW_OV_RD_DATA) while a follow-up PR will cover the insert part (FW_OV_WR_DATA).

~~This resolves #18837~~