### PR TITLE
[sw/tests] Fix `rv_dm_access_after_wakeup` in DV

### DIFF
--- a/sw/device/tests/rv_dm_access_after_wakeup.c
+++ b/sw/device/tests/rv_dm_access_after_wakeup.c
@@ -32,7 +32,7 @@ enum {
 };
 
 // This location will be update from SV
-static volatile uint8_t kSoftwareBarrier = 0;
+static volatile const uint8_t kSoftwareBarrier = 0;
 
 // Handle to the plic
 dif_rv_plic_t rv_plic;


### PR DESCRIPTION
The C code kept waiting for `kSoftwareBarrier` to become 1, which the DV code did set via a backdoor memory write but was not visible to SW. This caused a timeout on the DV side (the spinwait on "Entering normal sleep.").

Qualifying `kSoftwareBarrier` with `const` in the C code puts the variable into flash instead of SRAM, which fixes the problem: the value updated from DV is now visible to SW.