### PR TITLE
[dv,usbdev] Sequences for testing IN retraction and device timeouts

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_driver.sv
+++ b/hw/dv/sv/usb20_agent/usb20_driver.sv
@@ -102,8 +102,10 @@ class usb20_driver extends dv_base_driver #(usb20_item, usb20_agent_cfg);
     pkt.crc5 = {<<{pkt.crc5}};
     drive_packet("Token", pkt);
     // Attempt to collect a response only to full speed IN transactions; this should be DATA0|1
-    // or ACK/NAK.
-    if (req_item.m_pid_type == PidTypeInToken && !req_item.low_speed) begin
+    // or ACK/NAK. For fault injection purposes we may sometimes want to avoid waiting for any
+    // response.
+    if (req_item.m_pid_type == PidTypeInToken && req_item.await_response &&
+        !req_item.low_speed) begin
       device_response(rsp_item);
       seq_item_port.item_done(rsp_item);
       `uvm_info (`gfn, $sformatf("In drive afer In packet : \n %0s", rsp_item.sprint()), UVM_DEBUG)

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -13,11 +13,15 @@ class usb20_item extends uvm_sequence_item;
   usb_transfer_e m_usb_transfer;
 
   // Indicates that a timeout occurred when awaiting a response from the device.
-  bit timed_out = 1'b0;
+  bit timed_out;
 
   // Indicates that this item is to be transmitted using Low Speed signaling; applicable only to
   // packet items.
   bit low_speed;
+
+  // For an IN token packet, this indicates that a response shall be automatically collected from
+  // the device.
+  bit await_response;
 
   // Validity indicators that apply to all packet types; used by the monitor at metadata for the
   // scoreboard.
@@ -41,6 +45,10 @@ class usb20_item extends uvm_sequence_item;
     valid_length = 1'b1;
     valid_stuffing = 1'b1;
     valid_eop = 1'b1;
+    // Await response to IN token packet?
+    await_response = 1'b1;
+    // Timed out awaiting a response from the device?
+    timed_out = 1'b0;
   endfunction
 
   // Copy the common fields that are not declared as uvm object fields because of the way that

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -840,7 +840,7 @@
               'in_sent' register bit indicates successful transmission of the packet.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_timeout_missing_host_handshake"]
     }
     {
       name: device_timeout
@@ -860,7 +860,7 @@
               'in_sent' register bit indicates successful transmission of the packet.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_device_timeout"]
     }
     {
       name: packet_buffer

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -1103,7 +1103,7 @@
               transmitted from the device to the host.
             '''
       stage: V2
-      tests: []
+      tests: ["usbdev_iso_retraction"]
     }
     {
       name: data_toggle_restore

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_device_timeout_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_device_timeout_vseq.sv
@@ -1,0 +1,168 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_device_timeout_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_device_timeout_vseq)
+
+  `uvm_object_new
+
+  // Types of response to IN DATA packet.
+  typedef enum {
+    // Host ignores the IN Data packet and sends no handshake within the timeout period; the DUT
+    // shall not mark it as sent.
+    ResponseNone,
+    // This indicates that the host has successfully received the IN DATA packet and the DUT shall
+    // mark it as sent.
+    ResponseAck,
+    // The following packets should be taken as indication that the handshake response from the host
+    // has been missed; DUT shall not mark it as sent.
+    ResponseSETUP,
+    ResponseOUT,
+    ResponseIN
+  } response_type_e;
+
+  // Check that the IN configuration of the specified endpoint matches expectations.
+  task check_configin(bit [3:0] ep, bit exp_rdy, bit exp_sending, bit exp_pend);
+    uvm_reg_data_t configin;
+    csr_rd(.ptr(ral.configin[ep]), .value(configin));
+    `DV_CHECK_EQ(get_field_val(ral.configin[0].rdy, configin), exp_rdy, "rdy not as expected")
+    `DV_CHECK_EQ(get_field_val(ral.configin[0].pend, configin), exp_pend, "pend not as expected")
+    `DV_CHECK_EQ(get_field_val(ral.configin[0].sending, configin), exp_sending,
+                 "sending not as expected")
+  endtask
+
+  // Reset IN configuration in preparation for the next transaction.
+  task reset_configin(bit [3:0] ep);
+    uvm_reg_data_t configin;
+    csr_rd(.ptr(ral.configin[ep]), .value(configin));
+    if (get_field_val(ral.configin[ep].rdy, configin)) begin
+      // The packet is still marked as 'rdy' so we need to remove it properly.
+      int unsigned retracted_buf;
+      bit sent, pend, retracted;
+      retract_in_packet(ep, configin, sent, pend, retracted, retracted_buf);
+      // Retraction should always occur at this point because there is nothing that can collect
+      // it via an IN transaction.
+      `DV_CHECK_EQ(retracted, 1, "Could not retract packet as expected")
+      // We use only a single buffer in this test.
+      `DV_CHECK_EQ(retracted_buf, in_buffer_id, "Buffer ID not as expected")
+    end
+  endtask
+
+  // Check that the Data Toggle bit for the given IN endpoint is as expected.
+  task check_in_toggle(bit [3:0] ep, bit exp_toggle);
+    uvm_reg_data_t act_toggles;
+    csr_rd(.ptr(ral.in_data_toggle.status), .value(act_toggles));
+    `DV_CHECK_EQ(act_toggles[ep], exp_toggle, "IN data toggle not as expected")
+  endtask
+
+  // Check that the 'in_sent' bit for the given endpoint is as expected.
+  task check_in_sent(bit [3:0] ep, bit exp_sent);
+    uvm_reg_data_t in_sent;
+    csr_rd(.ptr(ral.in_sent[0]), .value(in_sent));
+    `DV_CHECK_EQ(in_sent[ep], exp_sent, "in_sent bit not as expected")
+  endtask
+
+  // Supply a buffer to the Available SETUP Buffer FIFO.
+  task supply_buffer(int unsigned b);
+    csr_wr(.ptr(ral.avsetupbuffer), .value(b));
+  endtask
+
+  virtual task body();
+    // Expected DUT time out interval in terms of clock ticks.
+    int unsigned dut_timeout = 18 * 4;
+    bit exp_in_toggle = 1'b0;
+
+    // Use the randomized default endpoint and buffer ID chosen by the base sequence.
+    for (int unsigned txn = 0; txn < num_trans; txn++) begin
+      // How shall we respond to the IN data packet?
+      response_type_e response;
+      // After how many bit intervals shall we respond?
+      bit [4:0] response_delay;
+      // Expectations for an unsuccessful transfer.
+      bit exp_sending = 1'b1;
+      bit exp_sent = 1'b0;
+      bit exp_pend = 1'b0;
+      bit exp_rdy = 1'b1;
+      // Do we need to delay after this transaction?
+      bit delay = 0;
+
+      `DV_CHECK_STD_RANDOMIZE_FATAL(response)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(response_delay)
+
+      `uvm_info(`gfn, $sformatf("Response type %0d delay %0d clocks", response, response_delay),
+                UVM_MEDIUM)
+
+      configure_in_trans(ep_default, in_buffer_id, .num_of_bytes(0));
+      // The IN packet should be marked as 'rdy' at this point since it is available for collection.
+      check_configin(ep_default, .exp_rdy(1'b1), .exp_sending(1'b0), .exp_pend(1'b0));
+      check_in_toggle(ep_default, .exp_toggle(exp_in_toggle));
+
+      // Initiate collection of the IN packet.
+      `uvm_info(`gfn, $sformatf("Sending IN token to endpoint %0d", ep_default), UVM_MEDIUM)
+      send_token_packet(ep_default, PidTypeInToken);
+      // Collect and check the IN data packet.
+      check_response_matches(exp_in_toggle ? PidTypeData1 : PidTypeData0);
+      // Wait for a randomized number of bit intervals, and predict whether the DUT shall yet
+      // have timed-out the IN transaction; we use the DUT clock to measure the bit intervals at the
+      // device, and observe that the clock is 4 x the bit rate.
+      if (response_delay) cfg.clk_rst_vif.wait_clks(response_delay);
+
+      // How are we going to respond?
+      case (response)
+        ResponseSETUP, ResponseIN, ResponseOUT: begin
+          // Send an unexpected SETUP/IN/OUT
+          pid_type_e pid = (response == ResponseSETUP) ? PidTypeSetupToken :
+                          ((response == ResponseOUT)   ? PidTypeOutToken   : PidTypeInToken);
+          send_token_packet(ep_default, pid, .target_addr(dev_addr),
+                            .await_response(response != ResponseIN));
+          // Wait long enough for the effects of the SETUP packet to be visible in the CSRs.
+          loopback_delay();
+          // Having chosen to send a SETUP packet we'll have caused the IN packet to be retired from
+          // 'rdy' to 'pend' to prevent interference with the ensuing Control Transfer.
+          if (response == ResponseSETUP) begin
+            // IN side toggle becomes set in response to SETUP token packet.
+            exp_in_toggle = 1'b1;
+          end
+          // TODO: This relies upon a proposed RTL change #23717 which deasserts 'sending' in the
+          // event of rollback.
+          exp_sending = 1'b0;
+          delay = 1;
+        end
+        ResponseAck: begin
+          bit acked_promptly = (response_delay < dut_timeout);
+          send_handshake(PidTypeAck, .delay_first(0));
+          // IN packet successfully received if ACKed promptly; flip the data toggle bit.
+          exp_in_toggle ^= acked_promptly;
+          // Update expectations; the behavior here depends upon our tardiness.
+          exp_sending = 1'b0;
+          exp_pend = 1'b0;
+          exp_sent = acked_promptly;
+          exp_rdy  = !acked_promptly;
+        end
+        default: `DV_CHECK_EQ(response, ResponseNone)  // Nothing more to do.
+      endcase
+
+      // Check that the packet has the expected 'rdy' and 'pend' indications, according to whether
+      // we acknowledged successful receipt of the packet within the DUT timeout interval.
+      check_configin(ep_default, .exp_rdy(exp_rdy), .exp_sending(exp_sending), .exp_pend(exp_pend));
+      if (exp_pend) begin
+        ral.configin[ep_default].pend.set(1'b1);
+        csr_update(ral.configin[ep_default]);
+      end
+      check_in_toggle(ep_default, .exp_toggle(exp_in_toggle));
+      // Check that 'in_sent' indicates whether or not the packet has been sent as per expectations.
+      check_in_sent(ep_default, .exp_sent(exp_sent));
+      // Clear the sent bit
+      if (exp_sent) csr_wr(.ptr(ral.in_sent[0]), .value(exp_sent << ep_default));
+
+      // If we sent a SETUP/IN/OUT packet in place of the usual handshake then we need to wait long
+      // enough here for the device to time out, because otherwise the next transaction could become
+      // confused by this one.
+      if (delay) begin
+        cfg.clk_rst_vif.wait_clks(dut_timeout * 4);
+      end
+      reset_configin(ep_default);
+    end
+  endtask
+endclass : usbdev_device_timeout_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_iso_retraction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_iso_retraction_vseq.sv
@@ -1,0 +1,184 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_iso_retraction_vseq extends usbdev_base_vseq;
+  `uvm_object_utils(usbdev_iso_retraction_vseq)
+
+  `uvm_object_new
+
+  constraint num_trans_c {
+    num_trans inside {[64:256]};
+  }
+
+  // Packets retrieved, from the perspective of the host side.
+  bit pkts_rcvd[];
+  // Packets sent, from the perspective of the device side.
+  bit pkts_sent[];
+
+  // Indication that the device side has completed.
+  bit complete = 1'b0;
+
+  // Choose min/max delays to try to ensure a good probability of collisions between host-side
+  // collection attempts and device-side retractions.
+  // We used max length packets, which take ca. 4 x 550-700 clock ticks to transmit.
+  int unsigned min_delay = 320;
+  int unsigned max_delay = 3200;
+
+  // Host side collected IN packets until instructed to stop.
+  task host_side();
+    int prev_seq = -1;
+    do begin
+      // TODO: experiment/justify. See #23932.
+      int unsigned delay = $urandom_range(1, max_delay - min_delay);
+      usb20_item reply;
+      // Randomized delay, to ensure that we miss some of the packets.
+      // TODO: we should really be using the host clock here; see #23932.
+      cfg.clk_rst_vif.wait_clks(delay);
+      // Isochronous packets are not ACKnowledged.
+      retrieve_in_packet(ep_default, reply, .ack(1'b0));
+      `DV_CHECK_EQ(reply.m_ev_type, EvPacket)
+      case (reply.m_pid_type)
+        PidTypeData0, PidTypeData1: begin
+          // Packets shall arrive in order, because it's a single endpoint.
+          data_pkt data;
+          $cast(data, reply);
+          // Isochronous endpoints without pending data shall return a Zero Length Packet, because
+          // there is no handshake mechanism and a response must be returned to the USB host.
+          if (data.data.size() > 0) begin
+            bit [31:0] seq;
+            `DV_CHECK_EQ(data.data.size, MaxPktSizeByte)
+            seq = {data.data[3], data.data[2], data.data[1], data.data[0]};
+            `uvm_info(`gfn, $sformatf("Retrieved IN packet (seq %0d)", seq), UVM_MEDIUM)
+            `DV_CHECK_GT(int'(seq), prev_seq)
+            `DV_CHECK_LT(seq, num_trans)
+            pkts_rcvd[seq] = 1'b1;
+            prev_seq = seq;
+          end
+        end
+        // Since we deal only with Isochronous endpoints presently, we should always get a DATA
+        // packet in response.
+        default: `uvm_fatal(`gfn, "Unexpected response")
+      endcase
+    end while (!complete);
+  endtask
+
+  // Introduce a random delay on the device side before attempting to present a new packet
+  // (and thus possibly retracting its predecessor).
+  task device_rand_delay();
+    int unsigned delay = $urandom_range(min_delay, max_delay);
+    cfg.clk_rst_vif.wait_clks(delay);
+  endtask
+
+  // Record a verdict on whether the previous packet was successfully sent (ie. not retracted),
+  // and release its associated buffer for reuse.
+  function void device_pkt_verdict(int prev_seq, int prev_buf, bit retracted,
+                                   int unsigned retracted_buf);
+    // Was a packet retracted?
+    if (retracted) begin
+      // Just check that it was the buffer we last supplied.
+      `DV_CHECK_EQ(retracted_buf, prev_buf)
+      `uvm_info(`gfn, $sformatf(" - seq %0d retracted", prev_seq), UVM_MEDIUM)
+    end else if (prev_seq >= 0) begin
+      `uvm_info(`gfn, $sformatf(" - seq %0d sent", prev_seq), UVM_MEDIUM)
+      pkts_sent[prev_seq] = 1'b1;
+    end
+    // Release the buffer holding the previous packet, so that we don't run out of available
+    // buffers.
+    if (prev_buf >= 0) begin
+      `uvm_info(`gfn, $sformatf(" - releasing buffer %0d", prev_buf), UVM_MEDIUM)
+      buf_release(prev_buf);
+    end
+  endfunction
+
+  // Device side presents IN packets for collection; if a packet has not been collected then it
+  // will be retracted when the next is presented.
+  task device_side();
+    int unsigned retracted_buf;
+    uvm_reg_data_t configin;
+    int prev_seq = -1;
+    int prev_buf = -1;
+    bit retracted;
+    int seq = 0;
+
+    repeat (num_trans) begin
+      byte unsigned pkt_data[$];
+      int unsigned nwords;
+      int buf_num;
+
+      // Collect and populate a buffer; we use the sequence number as the packet content so that
+      // the host side can identify which packet it has collected.
+      buf_num = buf_alloc();
+      `DV_CHECK_GE(buf_num, 0, "No buffer available")
+
+      // Repeat the sequence number throughout the buffer to create a longer packet.
+      // TODO: investigate whether there's any benefit to varying this. See #23932.
+      nwords = MaxPktSizeByte / 4;
+      repeat (nwords) begin
+        bit [31:0] pkt_seq = seq;
+        repeat (4) begin
+          pkt_data.push_back(pkt_seq[7:0]);
+          pkt_seq >>= 8;
+        end
+      end
+      write_buffer(buf_num, pkt_data);
+
+      // After a randomized short delay, present the new IN packet for collection; we may or may
+      // not thus be required to retract and replace the previous IN packet.
+      device_rand_delay();
+      `uvm_info(`gfn, $sformatf("Presenting IN packet (seq %0d) via buf %0d", seq, buf_num),
+                UVM_MEDIUM)
+      present_in_packet(ep_default, buf_num, pkt_data.size(), .may_retract(1'b1),
+                        .retracted(retracted), .retracted_buf(retracted_buf));
+      device_pkt_verdict(prev_seq, prev_buf, retracted, retracted_buf);
+
+      // Remember properties of this presented IN packet.
+      prev_buf = buf_num;
+      prev_seq = seq;
+      // Next packet.
+      seq++;
+    end
+
+    // We must reach a verdict on the final packet that we presented.
+    device_rand_delay();
+    csr_rd(.ptr(ral.configin[ep_default]), .value(configin));
+    if (get_field_val(ral.configin[0].rdy, configin)) begin
+      bit sent, pend;
+      retract_in_packet(ep_default, configin, sent, pend, retracted, retracted_buf);
+    end else retracted = 1'b0;
+    device_pkt_verdict(prev_seq, prev_buf, retracted, retracted_buf);
+
+    // We have now reached a verdict on all the packets that we have tried to send.
+    complete = 1'b1;
+  endtask
+
+  virtual task body();
+    // Initialize buffer allocation.
+    buf_init();
+
+    // Size the packets sent and packets received bitmaps appropriately; all bits are initially
+    // reset, indicating that the corresponding packet has neither been sent not received.
+    pkts_rcvd = new [num_trans];
+    pkts_sent = new [num_trans];
+
+    // Enable endpoint for IN traffic.
+    csr_wr(.ptr(ral.ep_in_enable[0].enable[ep_default]),  .value(1'b1));
+    csr_wr(.ptr(ral.in_iso[0].iso[ep_default]), .value(1'b1));
+
+    fork
+      host_side();
+      device_side();
+    join
+
+    // Check that the two parties agree on which packets were actually transferred successfully.
+    `uvm_info(`gfn, $sformatf("device side sent   %p", pkts_sent), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("host side received %p", pkts_rcvd), UVM_LOW)
+    for (int unsigned seq = 0; seq < num_trans; seq++) begin
+      if (pkts_sent[seq] != pkts_rcvd[seq]) begin
+        `uvm_info(`gfn, $sformatf("mismatched seq %0d - sent %0d rcvd %0d", seq,
+                                  pkts_sent[seq], pkts_rcvd[seq]), UVM_MEDIUM)
+      end
+    end
+    if (pkts_rcvd != pkts_sent) `uvm_fatal(`gfn, "Device- and host-side do not agree")
+  endtask
+endclass : usbdev_iso_retraction_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_rand_bus_type_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_rand_bus_type_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class usbdev_phy_config_rand_bus_type_vseq extends usbdev_smoke_vseq;
-  `uvm_object_utils(usbdev_phy_config_rand_bus_type_vseq);
+  `uvm_object_utils(usbdev_phy_config_rand_bus_type_vseq)
 
   `uvm_object_new
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -14,6 +14,7 @@
 `include "usbdev_csr_test_vseq.sv"
 `include "usbdev_data_toggle_clear_vseq.sv"
 `include "usbdev_data_toggle_restore_vseq.sv"
+`include "usbdev_device_timeout_vseq.sv"
 `include "usbdev_disconnected_vseq.sv"
 `include "usbdev_dpi_config_host_vseq.sv"
 `include "usbdev_enable_vseq.sv"

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -23,6 +23,7 @@
 `include "usbdev_in_rand_trans_vseq.sv"
 `include "usbdev_in_stall_vseq.sv"
 `include "usbdev_in_trans_vseq.sv"
+`include "usbdev_iso_retraction_vseq.sv"
 `include "usbdev_link_in_err_vseq.sv"
 `include "usbdev_link_out_err_vseq.sv"
 `include "usbdev_link_reset_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -39,6 +39,7 @@ filesets:
       - seq_lib/usbdev_data_toggle_clear_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_data_toggle_restore_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_device_address_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_device_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_disable_endpoint_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_disconnected_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_dpi_config_host_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -51,6 +51,7 @@ filesets:
       - seq_lib/usbdev_in_rand_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_stall_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_in_trans_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_iso_retraction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_in_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_out_err_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_link_suspend_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -210,6 +210,10 @@
       uvm_test_seq: usbdev_in_trans_vseq
     }
     {
+      name: usbdev_iso_retraction
+      uvm_test_seq: usbdev_iso_retraction_vseq
+    }
+    {
       name: usbdev_link_in_err
       uvm_test_seq: usbdev_link_in_err_vseq
     }

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -95,6 +95,14 @@
       uvm_test_seq: usbdev_device_address_vseq
     }
     {
+      name: usbdev_device_timeout
+      uvm_test_seq: usbdev_device_timeout_vseq
+    }
+    {
+      name: usbdev_timeout_missing_host_handshake
+      uvm_test_seq: usbdev_device_timeout_vseq
+    }
+    {
       name: usbdev_disable_endpoint
       uvm_test_seq: usbdev_disable_endpoint_vseq
     }


### PR DESCRIPTION
This PR adds two sequences for the remaining test points:

- IN packet retraction, for Isochronous IN traffic primarily.
- Device timeout; checks that the device recovers from missing host handshake, corruption to/loss of DATA packet and delayed host handshake; USB 2.0 protocol specification stipulates the time window within which the device must timeout and become receptive to subsequent transactions, as part of the recovery mechanism.

Note that the first of these sequences relies upon RTL changes and is not yet expected to pass on the current RTL; the RTL change is yet to be soak-tested and ratified, but this is a refinement to the behavior of a feature not presently requested or required.
