### PR TITLE
[sival, spi_dev] Refactor sleep test to wake up with gpio

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3277,7 +3277,10 @@ opentitan_test(
     srcs = ["spi_device_sleep_test.c"],
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
-        EARLGREY_TEST_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        },
     ),
     fpga = fpga_params(
         test_cmd = """

--- a/sw/device/tests/spi_device_sleep_test.c
+++ b/sw/device/tests/spi_device_sleep_test.c
@@ -24,9 +24,7 @@
 
 OTTF_DEFINE_TEST_CONFIG();
 
-enum {
-  kWakeupTimeMicros = 500000,
-};
+static dif_gpio_t gpio;
 static dif_spi_device_handle_t spid;
 static dif_pwrmgr_t pwrmgr;
 static dif_aon_timer_t aon_timer;
@@ -39,23 +37,34 @@ static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
     .expected_irq = kDifPwrmgrIrqWakeup,
     .is_only_irq = true};
 
-static void enter_low_power(void) {
-  uint64_t wkup_cycles = 0;
-  CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_64_from_us(
-      kWakeupTimeMicros, &wkup_cycles));
-  CHECK_STATUS_OK(aon_timer_testutils_wakeup_config(&aon_timer, wkup_cycles));
-
+static status_t enter_low_power(void) {
   dif_pwrmgr_domain_config_t pwrmgr_domain_cfg =
+      kDifPwrmgrDomainOptionIoClockInLowPower |
       kDifPwrmgrDomainOptionMainPowerInLowPower;
+  // Wait for the host signal that the device can sleep.
+  bool sleep = false;
+  do {
+    CHECK_DIF_OK(dif_gpio_read(&gpio, 0, &sleep));
+  } while (!sleep);
 
-  LOG_INFO("SYNC: Entering lowpower mode");
-  CHECK_STATUS_OK(pwrmgr_testutils_enable_low_power(
-      &pwrmgr, kDifPwrmgrWakeupRequestSourceFive, pwrmgr_domain_cfg));
+  irq_global_ctrl(false);
+  LOG_INFO("SYNC: Sleeping");
+  TRY(pwrmgr_testutils_enable_low_power(
+      &pwrmgr, kDifPwrmgrWakeupRequestSourceThree, pwrmgr_domain_cfg));
   wait_for_interrupt();
-  LOG_INFO("SYNC: Wakening up");
+
+  // Sometimes execution continues after the wfi while the core is preparing to
+  // enter low power mode. In that case we loop checking if the host requested a
+  // sleep. If not we loop until core enters low power mode.
+  do {
+    CHECK_DIF_OK(dif_gpio_read(&gpio, 0, &sleep));
+  } while (sleep);
+  irq_global_ctrl(true);
+  LOG_INFO("SYNC: Awaked");
+  return OK_STATUS();
 }
 
-static status_t spi_flash_mode(void) {
+static status_t configure_spi_flash_mode(void) {
   dif_spi_device_flash_id_t id = {
       .device_id = 0x2298,
       .manufacturer_id = 0x74,
@@ -85,9 +94,6 @@ static status_t spi_flash_mode(void) {
       &spid, kSpiDeviceReadCommandSlotBase + 3, kDifToggleEnabled, cmd));
 
   LOG_INFO("SYNC: Flash mode");
-
-  busy_spin_micros(1 * 1000 * 1000);
-
   return OK_STATUS();
 }
 
@@ -109,36 +115,79 @@ bool test_main(void) {
   addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
   CHECK_DIF_OK(dif_rv_plic_init(addr, &plic));
 
-  // Enable all the AON interrupts used in this test.
+  addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR);
+  CHECK_DIF_OK(dif_gpio_init(addr, &gpio));
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0x1));
+
+  // Enable all the AON interrupts used to wake up the core.
   rv_plic_testutils_irq_range_enable(&plic, kTopEarlgreyPlicTargetIbex0,
                                      kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
                                      kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
-
-  // Enable pwrmgr interrupt
   CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
 
-  // Enable global and external IRQ at Ibex.
   irq_global_ctrl(true);
   irq_external_ctrl(true);
 
+  dif_pinmux_index_t detector = 0;
+  dif_pinmux_wakeup_config_t wakeup_cfg = {
+      .mode = kDifPinmuxWakeupModeNegativeEdge,
+      .signal_filter = false,
+      .pad_type = kDifPinmuxPadKindMio,
+      .pad_select = kTopEarlgreyPinmuxInselIoa8,
+  };
+  CHECK_DIF_OK(
+      dif_pinmux_wakeup_detector_enable(&pinmux, detector, wakeup_cfg));
+
+  // Phase1: spi sleep test
   LOG_INFO("Setting SPI_DIO1 to high when sleeping");
   CHECK_DIF_OK(dif_pinmux_pad_sleep_enable(
       &pinmux, kTopEarlgreyDirectPadsSpiDeviceSd1, kDifPinmuxPadKindDio,
       kDifPinmuxSleepModeHigh));
+  LOG_INFO("Use IOA7 to let host know when sleep is active.");
+  CHECK_DIF_OK(dif_pinmux_input_select(&pinmux,
+                                       kTopEarlgreyPinmuxPeripheralInGpioGpio0,
+                                       kTopEarlgreyPinmuxInselIoa8));
+  CHECK_DIF_OK(dif_pinmux_pad_sleep_enable(&pinmux, kTopEarlgreyMuxedPadsIoa7,
+                                           kDifPinmuxPadKindMio,
+                                           kDifPinmuxSleepModeLow));
   enter_low_power();
+  CHECK_DIF_OK(dif_pinmux_pad_sleep_clear_state(
+      &pinmux, kTopEarlgreyMuxedPadsIoa7, kDifPinmuxPadKindMio));
 
   LOG_INFO("Setting SPI_DIO1 to low when sleeping");
   CHECK_DIF_OK(dif_pinmux_pad_sleep_enable(
       &pinmux, kTopEarlgreyDirectPadsSpiDeviceSd1, kDifPinmuxPadKindDio,
       kDifPinmuxSleepModeLow));
+
+  CHECK_DIF_OK(dif_pinmux_pad_sleep_enable(&pinmux, kTopEarlgreyMuxedPadsIoa7,
+                                           kDifPinmuxPadKindMio,
+                                           kDifPinmuxSleepModeLow));
   enter_low_power();
+  CHECK_DIF_OK(dif_pinmux_pad_sleep_clear_state(
+      &pinmux, kTopEarlgreyMuxedPadsIoa7, kDifPinmuxPadKindMio));
 
   CHECK_DIF_OK(dif_pinmux_pad_sleep_clear_state(
       &pinmux, kTopEarlgreyDirectPadsSpiDeviceSd1, kDifPinmuxPadKindDio));
   CHECK_DIF_OK(dif_pinmux_pad_sleep_disable(
       &pinmux, kTopEarlgreyDirectPadsSpiDeviceSd1, kDifPinmuxPadKindDio));
 
-  return status_ok(spi_flash_mode());
+  // Phase2: spi wake-up test
+  // Configures to wake up when the spi cs goes low.
+  wakeup_cfg = (dif_pinmux_wakeup_config_t){
+      .mode = kDifPinmuxWakeupModeAnyEdge,
+      .signal_filter = false,
+      .pad_type = kDifPinmuxPadKindDio,
+      .pad_select = kTopEarlgreyDirectPadsSpiHost0Csb,
+  };
+  CHECK_DIF_OK(
+      dif_pinmux_wakeup_detector_enable(&pinmux, detector, wakeup_cfg));
+  configure_spi_flash_mode();
+  enter_low_power();
+  CHECK_DIF_OK(dif_pinmux_wakeup_detector_disable(&pinmux, detector));
+
+  busy_spin_micros(2 * 1000 * 1000);
+
+  return true;
 }
 
 /**

--- a/sw/host/tests/chip/spi_device/src/spi_device_sleep_test.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_device_sleep_test.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
+use opentitanlib::io::gpio::{GpioPin, PinMode, PullMode};
 use opentitanlib::io::spi::Transfer;
+use opentitanlib::io::uart::Uart;
 use opentitanlib::spiflash::SpiFlash;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::{ExitStatus, UartConsole};
@@ -28,48 +30,71 @@ struct Opts {
     spi: String,
 }
 
+const SLEEP: bool = true;
+const AWAKE: bool = false;
+
 fn spi_sleep_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     let spi = transport.spi(&opts.spi)?;
+    let sleep_pin = transport.gpio_pin("IOA8")?;
+    sleep_pin.set_mode(PinMode::PushPull)?;
+    let sleep_indicator = transport.gpio_pin("IOA7")?;
+    sleep_indicator.set_mode(PinMode::Input)?;
+    sleep_indicator.set_pull_mode(PullMode::PullUp)?;
+
+    sleep_pin.write(AWAKE)?;
+    transport.pin_strapping("RESET")?.remove()?;
+    while !sleep_indicator.read()? {}
 
     const DATA_SIZE: usize = 10;
-
+    sleep_pin.write(SLEEP)?;
+    wait_sleep(&*sleep_indicator, &*uart, opts.timeout)?;
     /* Test the spi dev in sleep with the SD0 in high. */
-    let _ = UartConsole::wait_for(&*uart, r"SYNC: Entering lowpower mode\r\n", opts.timeout)?;
     let mut buf = [0x55u8; DATA_SIZE];
     spi.run_transaction(&mut [Transfer::Write(&[0x55; 1]), Transfer::Read(&mut buf)])?;
     assert_eq!(&buf, &[0xffu8; DATA_SIZE]);
-    let _ = UartConsole::wait_for(&*uart, r"SYNC: Wakening up\r\n", opts.timeout)?;
+    sleep_pin.write(AWAKE)?;
+    wait_awake(&*sleep_indicator, &*uart, opts.timeout)?;
 
+    sleep_pin.write(SLEEP)?;
+    wait_sleep(&*sleep_indicator, &*uart, opts.timeout)?;
     /* Test the spi dev in sleep with the SD0 in low. */
-    let _ = UartConsole::wait_for(&*uart, r"SYNC: Entering lowpower mode\r\n", opts.timeout)?;
     let mut buf = [0x55u8; DATA_SIZE];
     spi.run_transaction(&mut [Transfer::Write(&[0x55; 1]), Transfer::Read(&mut buf)])?;
     assert_eq!(&buf, &[0x00u8; DATA_SIZE]);
-    let _ = UartConsole::wait_for(&*uart, r"SYNC: Wakening up\r\n", opts.timeout)?;
+    sleep_pin.write(AWAKE)?;
+    wait_awake(&*sleep_indicator, &*uart, opts.timeout)?;
 
     Ok(())
 }
 
-fn spi_flash_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+fn spi_wakeup_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let sleep_pin = transport.gpio_pin("IOA8")?;
+    sleep_pin.set_mode(PinMode::PushPull)?;
+    let sleep_indicator = transport.gpio_pin("IOA7")?;
+    sleep_indicator.set_mode(PinMode::Input)?;
+    sleep_indicator.set_pull_mode(PullMode::PullUp)?;
     let uart = transport.uart("console")?;
     let spi = transport.spi(&opts.spi)?;
+    spi.set_max_speed(100_000)?;
 
-    let _ = UartConsole::wait_for(&*uart, r"SYNC: Flash mode\r\n", opts.timeout)?;
+    sleep_pin.write(SLEEP)?;
+    wait_sleep(&*sleep_indicator, &*uart, opts.timeout)?;
+    println!("Reading jedec id");
+    // Should wakup when the cs goes low.
     let jdec_id = SpiFlash::read_jedec_id(&*spi, 5)?;
-
     assert_eq!(&jdec_id, &[0x17u8, 0x17, 0x74, 0x98, 0x22]);
-
+    sleep_pin.write(AWAKE)?;
     Ok(())
 }
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
     opts.init.init_logging();
-
     let transport = opts.init.init_target()?;
+    transport.pin_strapping("RESET")?.apply()?;
     execute_test!(spi_sleep_test, &opts, &transport,);
-    execute_test!(spi_flash_test, &opts, &transport,);
+    execute_test!(spi_wakeup_test, &opts, &transport,);
 
     let uart = transport.uart("console")?;
     let mut console = UartConsole {
@@ -85,5 +110,17 @@ fn main() -> Result<()> {
         bail!("FAIL: {:?}", result);
     };
 
+    Ok(())
+}
+
+fn wait_sleep(gpio: &dyn GpioPin, uart: &dyn Uart, timeout: Duration) -> Result<()> {
+    let _ = UartConsole::wait_for(uart, r"SYNC: Sleeping\r\n", timeout)?;
+    while gpio.read()? {}
+    Ok(())
+}
+
+fn wait_awake(gpio: &dyn GpioPin, uart: &dyn Uart, timeout: Duration) -> Result<()> {
+    while !gpio.read()? {}
+    let _ = UartConsole::wait_for(uart, r"SYNC: Awaked\r\n", timeout)?;
     Ok(())
 }


### PR DESCRIPTION
This PR makes the spi_sleep test more robust by using gpios to sync between the device and the host.
Fix https://github.com/lowRISC/opentitan/issues/20635