### PR TITLE
[sw/tests] Fix `rv_dm_access_after_wakeup` on FPGA

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_access_after_wakeup_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rv_dm_access_after_wakeup_vseq.sv
@@ -50,7 +50,7 @@ class chip_sw_rv_dm_access_after_wakeup_vseq extends chip_sw_base_vseq;
     // Allow the software to continue execution.
     software_barrier[0] = 1;
     `uvm_info(`gfn, "SoftwareBarrier = 1", UVM_LOW)
-    sw_symbol_backdoor_overwrite("kSoftwareBarrier", software_barrier);
+    sw_symbol_backdoor_overwrite("kSoftwareBarrierDv", software_barrier);
 
     // Wait for the software to fall asleep.
     `DV_SPINWAIT(wait(cfg.sw_logger_vif.printed_log == "Entering normal sleep.");,
@@ -78,7 +78,7 @@ class chip_sw_rv_dm_access_after_wakeup_vseq extends chip_sw_base_vseq;
     // Allow the software to continue execution.
     software_barrier[0] = 2;
     `uvm_info(`gfn, "SoftwareBarrier = 2", UVM_LOW)
-    sw_symbol_backdoor_overwrite("kSoftwareBarrier", software_barrier);
+    sw_symbol_backdoor_overwrite("kSoftwareBarrierDv", software_barrier);
 
 
     // Wait for the software to fall asleep.
@@ -116,7 +116,7 @@ class chip_sw_rv_dm_access_after_wakeup_vseq extends chip_sw_base_vseq;
     // Allow the software to continue execution.
     software_barrier[0] = 3;
     `uvm_info(`gfn, "SoftwareBarrier = 3", UVM_LOW)
-    sw_symbol_backdoor_overwrite("kSoftwareBarrier", software_barrier);
+    sw_symbol_backdoor_overwrite("kSoftwareBarrierDv", software_barrier);
 
   endtask : body
 

--- a/sw/host/tests/chip/rv_dm/src/access_after_wakeup.rs
+++ b/sw/host/tests/chip/rv_dm/src/access_after_wakeup.rs
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
 
     let elf_file = std::fs::read(&opts.firmware_elf).context("failed to read ELF")?;
     let object = object::File::parse(elf_file.as_ref()).context("failed to parse ELF")?;
-    let software_barrier_addr = test_utils::object::symbol_addr(&object, "kSoftwareBarrier")?;
+    let software_barrier_addr = test_utils::object::symbol_addr(&object, "kSoftwareBarrierHost")?;
 
     execute_test!(
         test_access_after_wakeup,


### PR DESCRIPTION
In #23924, this test got a fix for DV, which unfortunately consistently broke the test on FPGA.  The reason is that `kSoftwareBarrier` got moved to flash, which is read-only for Ibex (enforced by PMP) and thus cannot be updated by OTTF in FPGA tests.

This commit fixes the problem by splitting the software barrier variable into one in flash, which is only used when this test is executed in DV, and one in RAM, which is used when this test is executed outside DV.