### PR TITLE
[otbn,dv] Improve RMA handling in model

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -428,7 +428,9 @@ class OTBNSim:
                 # Also, set wipe_cycles to an invalid value to make really sure
                 # we've left the wiping code.
                 self.wipe_cycles = -1
+
                 self.state.first_round_of_wipe = True
+                self.state.incomplete_wipe = False
                 self.state.set_fsm_state(next_state)
 
         return (None, self._on_stall(verbose, fetch_next=False))

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -425,7 +425,7 @@ class OTBNSim:
 
                 # Also, set wipe_cycles to an invalid value to make really sure
                 # we've left the wiping code.
-                self.wipe_cycles = -1
+                self.state.wipe_cycles = -1
 
                 self.state.first_round_of_wipe = True
                 self.state.incomplete_wipe = False

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -148,7 +148,7 @@ def on_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     elif was_wiping:
         # The trailing space is a bit naff but matches the behaviour in the RTL
         # tracer, where it's rather difficult to change.
-        hdr = 'U ' if sim.state.wiping() else 'V '
+        hdr = 'U ' if sim.state.incomplete_wipe else 'V '
     elif sim.state.executing():
         hdr = 'STALL'
     else:

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -317,7 +317,7 @@ def on_edn_flush(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 
 def on_edn_urnd_cdc_done(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     check_arg_count('urnd_cdc_done', 0, args)
-    sim.state.urnd_completed()
+    sim.urnd_completed()
     return None
 
 


### PR DESCRIPTION
These changes massively improve the pass rate of the `otbn_escalate` test. The first commit tracks whether we're in the middle of a secure wipe (rather than waiting for the next seed) and the second commit uses that flag to figure out when we're getting an unexpected URND ack.

The final commit is just a code cleanup which I noticed because I was touching equivalent code. But it collides with the other two commits and I thought it made the most sense to "tailgate" them.