### PR TITLE
[i2c,dv] I2C Controller-Mode NACK modelling, mapping TP:host_mode_halt_on_nak

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -647,7 +647,7 @@
                 reached.
             '''
       stage: V2
-      tests: []
+      tests: ["i2c_host_may_nack"]
     }
     {
       name: target_mode_n_byte_ack_control

--- a/hw/ip/i2c/dv/env/i2c_env.sv
+++ b/hw/ip/i2c/dv/env/i2c_env.sv
@@ -53,6 +53,15 @@ class i2c_env extends cip_base_env #(
         model.target_mode_wr_obs_fifo.analysis_export);
       m_i2c_agent.monitor.controller_mode_rd_item_port.connect(
         model.target_mode_rd_obs_fifo.analysis_export);
+      m_i2c_agent.monitor.target_mode_wr_item_port.connect(
+        model.controller_mode_wr_obs_fifo.analysis_export);
+      m_i2c_agent.monitor.target_mode_rd_item_port.connect(
+        model.controller_mode_rd_obs_fifo.analysis_export);
+
+      m_i2c_agent.monitor.controller_mode_in_progress_port.connect(
+        model.target_mode_in_progress_fifo.analysis_export);
+      m_i2c_agent.monitor.target_mode_in_progress_port.connect(
+        model.controller_mode_in_progress_fifo.analysis_export);
 
       // (EXP) MODEL -> SCOREBOARD
 

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_may_nack_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_may_nack_vseq.sv
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// This vseq generates normal DUT-Controller transactions using the base class routines
+// (from the rx_tx_vseq), except we substitute in an agent sequence which may randomly
+// NACK any bytes transmitted to it.
+//
 class i2c_host_may_nack_vseq extends i2c_rx_tx_vseq;
   `uvm_object_utils(i2c_host_may_nack_vseq)
   `uvm_object_new


### PR DESCRIPTION
> ~~The first two commits in this PR are squashes of other in-flight PRs, which we depend on here. Ignore for reviewing purposes~~.

Build on the changes in #23911 to start modelling and correctly-predicting transfers with a Target that may NACK our bytes.
The modelling in place in this PR is very rudimentary, and cannot yet make predictions when mid-transfer stimulus is applied, such as software clearing fifo state during NACK events which cause the DUT to halt. This modelling will be further fleshed-out in the future.

Map the test "i2c_host_may_nack" to the TP:host_mode_halt_on_nak.

The description and documentation of the "i2c_reference_model.sv" should be significantly fleshed-out in the future, as it will greatly increase in apparent complexity as we amend it to model and predict more and more DUT behaviours. In addition, we should strive to document under what limitations the model can predict, such as bounds for the validity of certain predictions. It would be greatly desirable to be explicit in capturing these model details.