### PR TITLE
[kmac,dv] Check FIFO empty interrupt

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -233,7 +233,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
           // does as many EDN fetches as necessary to fill up the required data bus size
           // of the "host".
           repeat (kmac_reg_pkg::NumSeedsEntropy) begin
-            `DV_SPINWAIT(edn_fifos[0].get(edn_item);, "Wait EDN request")
+            edn_fifos[0].get(edn_item);
           end
           `uvm_info(`gfn, "got all edn transactions", UVM_HIGH)
           set_entropy_fetch(0);

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_kmac_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_kmac_vseq.sv
@@ -17,6 +17,7 @@ class kmac_test_vectors_kmac_vseq extends kmac_test_vectors_base_vseq;
   endtask
 
   virtual function void randomize_cfg(test_vectors_pkg::test_vectors_t vector);
+    int vector_len = vector.customization_str.len();
     `DV_CHECK_RANDOMIZE_WITH_FATAL(this,
       hash_mode == sha3_pkg::CShake;
       kmac_en == 1;
@@ -39,7 +40,7 @@ class kmac_test_vectors_kmac_vseq extends kmac_test_vectors_base_vseq;
       } else if (vector.key_length_word * 32 == 512) {
         key_len == Key512;
       }
-      custom_str_len == vector.customization_str.len();
+      custom_str_len == vector_len;
     )
   endfunction
 


### PR DESCRIPTION
Linked to this issue #22341

I am not sure it works well yet. I have only checked it for one test, and it seems good from what I've seen.
This check is not modeling the FIFO level, instead it is using the FIFO empty/full from the DUT through a backdoor access. Then it does a prediction on the FIFO empty interrupt as described in the [KMAC register doc](https://opentitan.org/book/hw/ip/kmac/doc/registers.html#intr_state--fifo_empty).