### PR TITLE
[top_earlgrey/dv] Fix `rom_raw_unlock` test

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -778,6 +778,7 @@
         "+use_otp_image=OtpTypeLcStRaw",
         "+chip_clock_source=ChipClockSourceExternal48Mhz",
         "+rom_prod_mode=1",
+        "+use_jtag_dmi=1",
       ]
       run_timeout_mins: 480
     }

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_raw_unlock_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_raw_unlock_vseq.sv
@@ -38,14 +38,16 @@ class chip_sw_lc_raw_unlock_vseq extends chip_sw_base_vseq;
                                          p_sequencer.jtag_sequencer_h, extcl_en);
 
     `uvm_info(`gfn, "Waiting for extclk transition", UVM_LOW)
-    while (!ack) begin
-      jtag_riscv_agent_pkg::jtag_read_csr(base_addr + ral.clkmgr_aon.extclk_status.get_offset(),
-                                          p_sequencer.jtag_sequencer_h, status);
+    `DV_SPINWAIT(
+      while (!ack) begin
+        jtag_riscv_agent_pkg::jtag_read_csr(base_addr + ral.clkmgr_aon.extclk_status.get_offset(),
+                                            p_sequencer.jtag_sequencer_h, status);
 
-      ack = dv_base_reg_pkg::get_field_val(
-          ral.clkmgr_aon.extclk_status.ack, status
-      ) == prim_mubi_pkg::MuBi4True;
-    end
+        ack = dv_base_reg_pkg::get_field_val(
+            ral.clkmgr_aon.extclk_status.ack, status
+        ) == prim_mubi_pkg::MuBi4True;
+      end,
+      "Timed out waiting for clkmgr to confirm extclk enablement")
   endtask
 
   virtual task body();


### PR DESCRIPTION
Prior to this PR, `chip_sw_lc_raw_unlock_vseq` would try to read a CSR via JTAG without checking if SBA is non-busy.  The `rom_raw_unlock` test failed (for some seeds) because the SBA was indeed busy, which caused an `sbbusyerror` that never got cleared.

With this, the pass rate of `rom_raw_unlock` is 100% (tested with `-rx 10`).