### PR TITLE
[manuf] add perso extensions feature

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,9 +136,9 @@ sphincsplus_repos()
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")
 
-# Setup for linking in external test hooks for both secure/non-secure
-# manufacturer domains.
-load("//rules:hooks_setup.bzl", "hooks_setup", "secure_hooks_setup")
+# Setup for linking in externally managed test and provisioning customizations
+# for both secure/non-secure manufacturer domains.
+load("//rules:hooks_setup.bzl", "hooks_setup", "secure_hooks_setup", "perso_exts_setup")
 hooks_setup(
     name = "hooks_setup",
     dummy = "sw/device/tests/closed_source",
@@ -147,13 +147,20 @@ secure_hooks_setup(
     name = "secure_hooks_setup",
     dummy = "sw/device/tests/closed_source",
 )
+perso_exts_setup(
+    name = "perso_exts_setup",
+    dummy = "sw/device/silicon_creator/manuf/customization",
+)
 
-# Declare the external test_hooks repositories. One for both manufacturer secure
-# and non-secure domains.
+# Declare the external repositories:
+#  - One for both manufacturer secure and non-secure domains.
+#  - One for personalization firmware extensions.
 load("@hooks_setup//:repos.bzl", "hooks_repo")
 load("@secure_hooks_setup//:repos.bzl", "secure_hooks_repo")
+load("@perso_exts_setup//:repos.bzl", "perso_exts_repo")
 hooks_repo(name = "manufacturer_test_hooks")
 secure_hooks_repo(name = "secure_manufacturer_test_hooks")
+perso_exts_repo(name = "perso_exts")
 
 # The nonhermetic_repo imports environment variables needed to run vivado.
 load("//rules:nonhermetic.bzl", "nonhermetic_repo")

--- a/rules/hooks_setup.bzl
+++ b/rules/hooks_setup.bzl
@@ -18,6 +18,14 @@ def secure_hooks_repo(name):
     )
 """
 
+_PERSO_EXTS_TEMPLATE = """
+def perso_exts_repo(name):
+    native.local_repository(
+        name = name,
+        path = "{perso_exts_dir}",
+    )
+"""
+
 _BUILD = """
 exports_files(glob(["**"]))
 """
@@ -52,4 +60,20 @@ secure_hooks_setup = repository_rule(
         ),
     },
     environ = ["SECURE_MANUFACTURER_HOOKS_DIR"],
+)
+
+def _perso_exts_setup_impl(rctx):
+    perso_exts_dir = rctx.os.environ.get("PERSO_EXTS_DIR", rctx.attr.dummy)
+    rctx.file("repos.bzl", _PERSO_EXTS_TEMPLATE.format(perso_exts_dir = perso_exts_dir))
+    rctx.file("BUILD.bazel", _BUILD)
+
+perso_exts_setup = repository_rule(
+    implementation = _perso_exts_setup_impl,
+    attrs = {
+        "dummy": attr.string(
+            mandatory = True,
+            doc = "Location of the dummy personalization FW extensions directory.",
+        ),
+    },
+    environ = ["PERSO_EXTS_DIR"],
 )

--- a/sw/device/silicon_creator/manuf/customization/BUILD.bazel
+++ b/sw/device/silicon_creator/manuf/customization/BUILD.bazel
@@ -1,0 +1,48 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+bool_flag(
+    name = "use_example_perso_ext",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "example_perso_ext_cfg",
+    flag_values = {
+        ":use_example_perso_ext": "True",
+    },
+)
+
+_PERSO_EXTS = select({
+    "example_perso_ext_cfg": [":example_perso_ext"],
+    "//conditions:default": [":default_perso_ext"],
+})
+
+cc_library(
+    name = "default_perso_ext",
+    srcs = ["default_personalize_ext.c"],
+    deps = [
+        "@//sw/device/lib/testing/test_framework:status",
+        "@//sw/device/lib/testing/test_framework:ujson_ottf",
+    ],
+)
+
+cc_library(
+    name = "example_perso_ext",
+    srcs = ["example_personalize_ext.c"],
+    deps = [
+        "@//sw/device/lib/runtime:log",
+        "@//sw/device/lib/testing/test_framework:status",
+        "@//sw/device/lib/testing/test_framework:ujson_ottf",
+    ],
+)
+
+cc_library(
+    name = "perso_ext",
+    deps = _PERSO_EXTS,
+)

--- a/sw/device/silicon_creator/manuf/customization/README.md
+++ b/sw/device/silicon_creator/manuf/customization/README.md
@@ -1,0 +1,28 @@
+# Personalization Firmware Extensions
+
+The personalization firmware `ft_personalize.c` defines an `extern` extension
+function that is invoked as the final step in the personalization flow.
+
+`status_t personalize_extension(ujson_t *uj)`
+
+The example function provided in this example external Bazel repo does nothing,
+except print a message to the console. However, this provides a mechanism for
+SKU owners / customers to develop closed-source personalization FW extensions,
+that can easily make use of open-source code.
+
+This feature is implemented with the help of some custom Bazel repository rules.
+Specifically, in this directory we define a secondary Bazel
+repository (`@perso_exts`) that is designed to be used in
+conjunction with the main OpenTitan Bazel repository. Within this repository, we
+define a single `perso_ext` library that is linked with the reference
+`ft_personalize` binary. The `perso_ext` library itself just contains an
+implementation of the `personalize_extension(...)` function described above.
+However, the `perso_ext` library is linked with other libraries
+based on a Bazel `config_setting` that allows you to toggle which personalize
+extension library should be used (if you are building binaries for several SKU
+owners).
+
+Note, the Bazel configuration settings and example personalization extension
+library (`perso_ext`) provided in this
+repository are merely examples, as the `personalize_extension(...)` function
+implemented does nothing, except print a message.

--- a/sw/device/silicon_creator/manuf/customization/WORKSPACE.bazel
+++ b/sw/device/silicon_creator/manuf/customization/WORKSPACE.bazel
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+workspace(name = "perso_exts")
+
+# This is a sample workspace to demonstrate how to write custom personalization
+# firmware extensions. This bazel repository is not stand-alone project: it must
+# be connected into the main OpenTitan repository by way of the
+# `perso_exts_setup` call in OpenTitan's WORKSPACE file.
+
+# See this repository's README.md and BUILD.bazel files to understand how to
+# write rules for custom personalization firmware extensions.

--- a/sw/device/silicon_creator/manuf/customization/default_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/customization/default_personalize_ext.c
@@ -1,0 +1,8 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/status.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+
+status_t personalize_extension(ujson_t *uj) { return OK_STATUS(); }

--- a/sw/device/silicon_creator/manuf/customization/example_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/customization/example_personalize_ext.c
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+
+status_t personalize_extension(ujson_t *uj) {
+  LOG_INFO("Running example perso extension ...");
+  return OK_STATUS();
+}

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/BUILD
@@ -254,6 +254,7 @@ opentitan_binary(
         "//sw/device/silicon_creator/lib/drivers:kmac",
         "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_sku_sival",
         "//sw/device/silicon_creator/manuf/lib:personalize",
+        "@perso_exts//:perso_ext",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -493,6 +493,12 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
   return OK_STATUS();
 }
 
+/**
+ * A custom extension to the personalization flow to enable various SKU owners
+ * to customize the provisioning of their devices.
+ */
+extern status_t personalize_extension(ujson_t *uj);
+
 bool test_main(void) {
   CHECK_STATUS_OK(peripheral_handles_init());
   ujson_t uj = ujson_ottf_console();
@@ -501,5 +507,11 @@ bool test_main(void) {
   CHECK_STATUS_OK(personalize_otp_and_flash_secrets(&uj));
   CHECK_STATUS_OK(personalize_dice_certificates(&uj));
   CHECK_STATUS_OK(log_hash_of_all_certs(&uj));
+  CHECK_STATUS_OK(personalize_extension(&uj));
+
+  // DO NOT CHANGE THE BELOW STRING without modifying the host code in
+  // sw/host/provisioning/ft_lib/src/lib.rs
+  LOG_INFO("Personalization done.");
+
   return true;
 }

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -450,7 +450,11 @@ pub fn run_ft_personalize(
     }
 
     let certs: [&Vec<u8>; 3] = [&tpm_ek_cert_bytes, &tpm_cek_cert_bytes, &tpm_cik_cert_bytes];
-    validate_certs_chain(ca_certificate.to_str().unwrap(), &certs)
+    validate_certs_chain(ca_certificate.to_str().unwrap(), &certs)?;
+
+    let _ = UartConsole::wait_for(&*uart, r"Personalization done.", timeout)?;
+
+    Ok(())
 }
 
 // This internal enum provides two different certificate signing key


### PR DESCRIPTION
This partially addresses #23426 by enabling SKU-owners to define their own personalization firmware extensions in separate code repositories. Additionally, this provides an example personalization firmware extension.