### PR TITLE
[i2c,dv] Capture progress of transfer into i2c_item.state field

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent.sv
@@ -22,4 +22,17 @@ class i2c_agent extends dv_base_agent #(
     cfg.has_req_fifo = 1;
   endfunction : build_phase
 
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    // If the monitor is active, connect the in-progress transfer ports from the monitor through
+    // to the sequencer. This allows agent sequences to monitor the state of any in-progress
+    // i2c transfer, and drive accordingly.
+    if (cfg.is_active) begin
+      monitor.controller_mode_in_progress_port.connect(
+        sequencer.controller_mode_in_progress_fifo.analysis_export);
+      monitor.target_mode_in_progress_port.connect(
+        sequencer.target_mode_in_progress_fifo.analysis_export);
+    end
+  endfunction : connect_phase
+
 endclass

--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -25,6 +25,20 @@ package i2c_agent_pkg;
     HostWait
   } drv_type_e;
 
+  // This enum is used to model the current state of an in-progress i2c transfer
+  typedef enum int {
+    StNone,
+    StStarted,
+    StAddrByte,
+    StAddrByteRcvd,
+    StAddrByteAckRcvd,
+    StDataByte,
+    StDataByteRcvd,
+    StDataByteAckRcvd,
+    StStopped,
+    StAborted
+  } transfer_state_e;
+
   // register values
   typedef struct {
     // derived parameters

--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -10,6 +10,11 @@ class i2c_item extends uvm_sequence_item;
   // Transfer ID
   int                      tran_id;
 
+  // Model the state of an in-progress i2c transfer. This can be used as a cheap proxy for
+  // breaking up the transfer into smaller sequence items (bytes, bits, etc.) when we need to
+  // update our predictions mid-transfer.
+  transfer_state_e         state;
+
   // Address / Direction
   bit [9:0]                addr; // enough to support both 7 & 10-bit target address
   rw_e                     dir; // Transfer direction bit
@@ -75,6 +80,7 @@ class i2c_item extends uvm_sequence_item;
   `uvm_object_utils_begin(i2c_item)
     `uvm_field_int(stim_id,                       UVM_DEFAULT | UVM_DEC)
     `uvm_field_int(tran_id,                       UVM_DEFAULT | UVM_DEC)
+    `uvm_field_enum(transfer_state_e, state,      UVM_DEFAULT               | UVM_NOCOMPARE)
     `uvm_field_enum(bus_op_e, bus_op,             UVM_DEFAULT)
     `uvm_field_int(addr,                          UVM_DEFAULT)
     `uvm_field_enum(i2c_pkg::rw_e, dir,           UVM_DEFAULT | UVM_NOPRINT)

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -228,11 +228,6 @@ class i2c_monitor extends dv_base_monitor #(
       prev_item = full_item;
     end
 
-    // Clear any data leftover in the temporary item (but don't clear the flags)
-    mon_dut_item.clear_data();
-    // Clear flags (start/stop/rstart/read/rcont/nakok)
-    mon_dut_item.clear_flags();
-
   endtask: target_collect_thread
 
 
@@ -531,11 +526,6 @@ class i2c_monitor extends dv_base_monitor #(
       // This is then used to determine how the previous transfer ended (STOP or RSTART)
       prev_item = full_item;
     end
-
-    // Clear any data leftover in the temporary item (but don't clear the flags)
-    mon_dut_item.clear_data();
-    // Clear flags (start/stop/rstart/read/rcont/nakok)
-    mon_dut_item.clear_flags();
 
   endtask: controller_collect_thread
 

--- a/hw/dv/sv/i2c_agent/i2c_sequencer.sv
+++ b/hw/dv/sv/i2c_agent/i2c_sequencer.sv
@@ -6,4 +6,18 @@ class i2c_sequencer extends dv_base_sequencer#(i2c_item, i2c_agent_cfg);
   `uvm_component_utils(i2c_sequencer)
   `uvm_component_new
 
+  // These ports capture in-progress transfer items published by the i2c_monitor.
+  // Agent sequences can then monitor these transfers by accessing the fifos via 'p_sequencer'.
+  // Note. that as these items represent in-progress transfers, they are valid and expected to
+  // be continuously updated by the monitor until the state variable reaches "StStopped | StAborted"
+  // Consumers of these items should not modify them.
+  uvm_tlm_analysis_fifo #(i2c_item) controller_mode_in_progress_fifo;
+  uvm_tlm_analysis_fifo #(i2c_item) target_mode_in_progress_fifo;
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    controller_mode_in_progress_fifo = new("controller_mode_in_progress_fifo", this);
+    target_mode_in_progress_fifo = new("target_mode_in_progress_fifo", this);
+  endfunction : build_phase
+
 endclass : i2c_sequencer


### PR DESCRIPTION
> For reviewing purposes, ignore the first commit. It is part of #23911, and will be rebased away when that PR is merged.

This change adds more granular transaction tracking into the i2c_item type. A new `.state` field is added, which is updated by the i2c_monitor as a transfer progresses.
This more-granular measurement allows:
1) For the agent's reactive sequences to monitor in-progress transfers directly, and to drive at the appropriate points.
2) For the I2C predictor/ref_model to make more accurate predictions about inputs to the system mid-transfer. Currently we make no use of this, but it will be built upon to start modelling DUT features more precisely. 