### PR TITLE
[dv, spi_host] Randomization Failure fix

### DIFF
--- a/hw/ip/spi_host/dv/env/spi_segment_item.sv
+++ b/hw/ip/spi_host/dv/env/spi_segment_item.sv
@@ -105,7 +105,7 @@ class spi_segment_item extends uvm_sequence_item;
     }
 
     // ensure we only half or full word writes
-    (command_reg.len + 1) % 2 == 0;
+    !(seg_type == Dummy) -> (command_reg.len + 1) % 2 == 0;
     // default set keep transaction going
     command_reg.csaat == 1;
   }


### PR DESCRIPTION
spi_host tests are still too long for some seeds and that still needs work, but this sorts out the randomisation failure from the nightly regression

This resolves #23938 