### PR TITLE
[i2c,dv] I2C agent sequences rework for transfer-level items

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent.sv
@@ -19,7 +19,6 @@ class i2c_agent extends dv_base_agent #(
     if (!uvm_config_db#(virtual i2c_if)::get(this, "", "vif", cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get i2c_if handle from uvm_config_db")
     end
-    cfg.has_req_fifo = 1;
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);

--- a/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_pkg.sv
@@ -76,6 +76,8 @@ package i2c_agent_pkg;
   typedef class i2c_item;
   typedef class i2c_agent_cfg;
 
+  typedef uvm_tlm_analysis_fifo #(i2c_item) i2c_analysis_fifo;
+
   // package sources
   `include "i2c_fdata_item.sv"
   `include "i2c_acqdata_item.sv"

--- a/hw/dv/sv/i2c_agent/i2c_item.sv
+++ b/hw/dv/sv/i2c_agent/i2c_item.sv
@@ -83,7 +83,7 @@ class i2c_item extends uvm_sequence_item;
     `uvm_field_enum(transfer_state_e, state,      UVM_DEFAULT               | UVM_NOCOMPARE)
     `uvm_field_enum(bus_op_e, bus_op,             UVM_DEFAULT)
     `uvm_field_int(addr,                          UVM_DEFAULT)
-    `uvm_field_enum(i2c_pkg::rw_e, dir,           UVM_DEFAULT | UVM_NOPRINT)
+    `uvm_field_enum(i2c_pkg::rw_e, dir,           UVM_DEFAULT               | UVM_NOCOMPARE)
     `uvm_field_enum(i2c_pkg::acknack_e, addr_ack, UVM_DEFAULT)
     `uvm_field_int(num_data,                      UVM_DEFAULT | UVM_NOPRINT)
     `uvm_field_queue_int(data_q,                  UVM_DEFAULT | UVM_NOPRINT)

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -251,11 +251,6 @@ class i2c_monitor extends dv_base_monitor #(
     cfg.stop_perf_monitor.trigger();
 
     mon_dut_item.bus_op = (rw_req) ? BusOpRead : BusOpWrite;
-
-    `uvm_info(`gfn, $sformatf("target_address_thread(): req_analysis_port.write()"), UVM_DEBUG)
-    `downcast(clone_item, mon_dut_item.clone());
-    clone_item.drv_type = DevAck;
-    req_analysis_port.write(clone_item);
     mon_dut_item.state = i2c_agent_pkg::StAddrByteRcvd; // Signal the addr+dir is captured
 
     // get ack after transmitting address
@@ -278,12 +273,6 @@ class i2c_monitor extends dv_base_monitor #(
 
     while (!mon_dut_item.stop && !mon_dut_item.rstart_back) begin
 
-      // Reactive Agent
-      // - Ask driver to transmit rdata bytes (in response to the DUT-initiated READ operation)
-      `uvm_info(`gfn, "target_read_thread(): req_analysis_port.write()", UVM_DEBUG)
-      `downcast(clone_item, mon_dut_item.clone());
-      clone_item.drv_type = RdData;
-      req_analysis_port.write(clone_item);
       mon_dut_item.state = i2c_agent_pkg::StDataByte;
 
       cfg.start_perf_monitor.trigger();
@@ -357,13 +346,6 @@ class i2c_monitor extends dv_base_monitor #(
               `uvm_info(`gfn, $sformatf("target_write_thread() data %2x num_data:%0d",
                                         mon_data, mon_dut_item.num_data), UVM_FULL)
 
-              // Send data component of this write to the 'req_analysis_port', for consumption by
-              // reactive-agent sequences.
-
-              `uvm_info(`gfn, "target_write_thread(): req_analysis_port.write()", UVM_DEBUG)
-              `downcast(clone_item, mon_dut_item.clone());
-              clone_item.drv_type = DevAck;
-              req_analysis_port.write(clone_item);
               mon_dut_item.state = i2c_agent_pkg::StDataByteRcvd;
 
               // Sample the ACK/NACK bit

--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -250,7 +250,8 @@ class i2c_monitor extends dv_base_monitor #(
 
     cfg.stop_perf_monitor.trigger();
 
-    mon_dut_item.bus_op = (rw_req) ? BusOpRead : BusOpWrite;
+    mon_dut_item.dir = rw_e'(rw_req);
+    mon_dut_item.bus_op = (mon_dut_item.dir == i2c_pkg::READ) ? BusOpRead : BusOpWrite;
     mon_dut_item.state = i2c_agent_pkg::StAddrByteRcvd; // Signal the addr+dir is captured
 
     // get ack after transmitting address

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_base_seq.sv
@@ -2,66 +2,207 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// This base_vseq contains common subroutines for the agent to drive stimulus as either an
+// I2C-Controller (bus-initiator, or 'Host' in wider OpenTitan verbiage) or as an I2C-Target
+// (bus-receiver, or OpenTitan 'Device').
+//
+// - (cfg.if_mode == Device) As an I2C-Target, the default behaviour is to operate in a
+//   reactive-agent mode, awaiting the monitor to report observations via the
+//   TLM 'p_sequencer.in_progress_ports', and passing items to the driver based on this.
+// - (cfg.if_mode == Host) #FIXME - This configuration appears unused.
+//
 class i2c_base_seq extends dv_base_seq #(
     .REQ         (i2c_item),
     .CFG_T       (i2c_agent_cfg),
     .SEQUENCER_T (i2c_sequencer)
   );
+
+  ///////////////
+  // VARIABLES //
+  ///////////////
+
+  // Store a handle to the in-progress transfer item captured by the monitor.
+  i2c_item inp_xfer;
+
+  // This queue stores a sequence of items to be passed to the driver for stimulus creation.
+  // Typically, this variable is populated by the entity that creates the sequence before starting
+  // it. It is also possible to push_back() new items piecemeal while the sequence is running.
+  REQ req_q[$];
+
+  // Set this bit via. seq_stop() to immediately halt the sequence.
+  protected bit stop;
+
   `uvm_object_utils(i2c_base_seq)
   `uvm_object_new
 
-  // queue monitor requests which ask the re-active driver to response host dut
-  REQ req_q[$];
+  ////////////////////////////////////
+  // RANDOM VARIABLES & CONSTRAINTS //
+  ////////////////////////////////////
 
-  // data to be sent to target dut
-  bit [7:0] data_q[$];
-
-  // Stops running this sequence
-  protected bit stop;
-  // constrain size of data sent/received
+  // Random data, used as payload data for Agent-Controller transactions (if_mode == Host).
+  rand bit [7:0] data_q[$];
+  // Constrain the number of bytes of payload data
   constraint data_q_size_c {
     data_q.size() inside {[cfg.i2c_host_min_data_rw : cfg.i2c_host_max_data_rw]};
   }
 
+  /////////////
+  // METHODS //
+  /////////////
+
+
   virtual task body();
-    if (cfg.if_mode == Device) begin
-      send_device_mode_txn();
-    end else begin
-      send_host_mode_txn();
-    end
+    case (cfg.if_mode)
+      Device: while (!stop) begin // Agent-Target
+        // Get reactive agent items from the i2c_monitor, and use them to monitor the in-progress
+        // transaction and to drive the bus accordingly.
+        inp_xfer = null;
+        get_in_progress_transfer_item(inp_xfer, p_sequencer.target_mode_in_progress_fifo);
+        if (inp_xfer != null) begin
+          `uvm_info(`gfn, $sformatf("i2c_agent_seq: got new in-progress transfer item :\n%s",
+                                    inp_xfer.sprint()), UVM_DEBUG)
+          fork begin : iso_fork
+            fork
+              forever print_inp_xfer_state_changes();
+              send_device_mode_txn();
+            join_any
+            disable fork;
+          end : iso_fork join
+        end
+      end
+      Host: begin // Agent-Controller
+        send_host_mode_txn(); // (NOTE. Unused)
+      end
+      default: `uvm_fatal(`gfn, "Shouldn't get here!")
+    endcase
   endtask : body
 
-  virtual task send_device_mode_txn();
-    // get seq for agent running in Device mode
-    bit [7:0] rdata;
-    forever begin
-      p_sequencer.req_analysis_fifo.get(req);
-      // if it's a read type response, randomize the return data
-      if (req.drv_type == RdData) begin
-        `DV_CHECK_STD_RANDOMIZE_FATAL(rdata)
-        req.rdata = rdata;
-      end
-      start_item(req);
-      finish_item(req);
-    end
-  endtask
 
+  // This task awaits a new item from the i2c_monitor to arrive in the corresponding TLM fifo.
+  //
+  virtual task get_in_progress_transfer_item(output i2c_item inp_xfer,
+                                             input i2c_analysis_fifo fifo);
+    fork begin: iso_fork
+      fork
+        // Block until a new item arrives from the monitor
+        begin
+          i2c_item item;
+          fifo.get(item);
+          `downcast(inp_xfer, item)
+        end
+        // If seq_stop() is called, break out of the above wait-state immediately.
+        wait (stop);
+      join_any
+      #0;
+      disable fork;
+    end: iso_fork join
+  endtask : get_in_progress_transfer_item
+
+
+  virtual task print_inp_xfer_state_changes();
+    @(inp_xfer.state);
+    `uvm_info(`gfn, $sformatf("inp_xfer.state moved to %0s.", inp_xfer.state.name()), UVM_DEBUG)
+  endtask : print_inp_xfer_state_changes
+
+
+  // As an Agent-Target, drive the bus based on the reactive-agent item passed from the i2c_monitor
+  //
+  virtual task send_device_mode_txn();
+
+    while (!(inp_xfer.state inside {StStopped, StAborted})) begin
+
+      @(inp_xfer.state);
+      case (inp_xfer.state)
+        StAddrByteRcvd: begin
+          // Drive an ACK/NACK to the address byte
+          drive_addr_byte_ack();
+        end
+        StDataByte: begin
+          if (inp_xfer.dir == i2c_pkg::READ) begin
+            // The agent drives the read bytes as target-transmitter.
+            drive_read_byte();
+          end
+        end
+        StDataByteRcvd: begin
+          if (inp_xfer.dir == i2c_pkg::WRITE) begin
+            // The agent now needs to ACK or NACK the received write data byte.
+            drive_write_byte_ack();
+          end
+        end
+        default:; // We want to fall through for all other states.
+      endcase
+
+    end // while(!stopped)
+
+    `uvm_info(`gfn, "Got to end of Agent-Target transfer. Now awaiting new transfer.", UVM_DEBUG)
+  endtask : send_device_mode_txn
+
+
+  virtual task drive_addr_byte_ack();
+    `uvm_create_obj(REQ, req);
+    start_item(req);
+    req.drv_type = DevAck;
+    finish_item(req);
+    `uvm_info(`gfn, "drive_addr_byte_ack()::finish_item()", UVM_DEBUG)
+  endtask : drive_addr_byte_ack
+
+
+  virtual task drive_read_byte();
+    `uvm_create_obj(REQ, req);
+    start_item(req);
+    req.drv_type = RdData;
+    req.rdata = $urandom;
+    finish_item(req);
+    `uvm_info(`gfn, "drive_read_byte()::finish_item()", UVM_DEBUG)
+  endtask : drive_read_byte
+
+
+  virtual task drive_write_byte_ack();
+    `uvm_create_obj(REQ, req);
+    start_item(req);
+    req.drv_type = DevAck;
+    finish_item(req);
+    `uvm_info(`gfn, "drive_write_byte_ack()::finish_item()", UVM_DEBUG)
+  endtask : drive_write_byte_ack
+
+
+  // As an Agent-Controller, drive the bus with a single randomized seq_item
+  // - Use data from the class randomized variable 'data_q[$]'
+  //
   virtual task send_host_mode_txn();
-    // get seq for agent running in Host mode
     req = REQ::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-                                   data_q.size() == local::data_q.size();
-                                   foreach (data_q[i]) {
-                                     data_q[i] == local::data_q[i];
-                                   })
+      data_q.size() == local::data_q.size();
+      foreach (data_q[i]) {
+        data_q[i] == local::data_q[i];
+      }
+    )
     finish_item(req);
     get_response(rsp);
-  endtask
+  endtask : send_host_mode_txn
 
+
+  // This routine can be called to gracefully end the sequence immediately
+  //
   virtual task seq_stop();
     stop = 1'b1;
     wait_for_sequence_state(UVM_FINISHED);
   endtask : seq_stop
+
+
+  // Override the uvm print implementation to only show the '.drv_type' and any associated data
+  // of each item in the 'req_q'.
+  //
+  virtual function void do_print(uvm_printer printer);
+    super.do_print(printer);
+    foreach (req_q[i]) begin
+      printer.print_string($sformatf("req_q[%0d].drv_type", i), req_q[i].drv_type.name());
+      if (req_q[i].drv_type == RdData) begin
+        printer.print_field("  rdata", req_q[i].rdata, 8);
+      end
+    end
+  endfunction: do_print
+
 
 endclass : i2c_base_seq

--- a/hw/dv/sv/i2c_agent/seq_lib/i2c_device_response_seq.sv
+++ b/hw/dv/sv/i2c_agent/seq_lib/i2c_device_response_seq.sv
@@ -2,60 +2,104 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Agent-Target sequence which accepts all write-transfer data and returns it in read-transfers.
+// aka. 'autoresponder'
+// - Write transfers to any address are accepted, and data is stored in a queue such that response
+//   data to reads is returned in the same order it was written to that address.
+//
 class i2c_device_response_seq extends i2c_base_seq;
+
+  ///////////////
+  // VARIABLES //
+  ///////////////
+
+  typedef bit [7:0] data_q[$];
+
+  // Only 7-bit addresses are supported
+  data_q response_mem[2**Addr7BitMode]; // One queue per 7-bit address.
+
   `uvm_object_utils(i2c_device_response_seq)
   `uvm_object_new
 
-  REQ w_q[256][$];
+  /////////////
+  // METHODS //
+  /////////////
 
-  protected virtual task get_dev_req(output REQ req);
+
+  virtual task body();
     fork
-      begin: isolation_thread
-        fork
-          begin
-            REQ item;
-            p_sequencer.req_analysis_fifo.get(item);
-            `downcast(req, item)
-          end
-          wait (stop);
-        join_any
-        #0;
-        disable fork;
-      end
-    join
-  endtask
-
-  task send_device_mode_txn();
-    // get seq for agent running in Device mode
-    fork
-      forever begin
-        REQ req;
-        get_dev_req(req);
-        if (req != null) begin
-          `uvm_info(`gfn, $sformatf("bus_op:%s drv_type:%s data_q:%p",req.bus_op.name,
-                                    req.drv_type.name, req.data_q), UVM_HIGH)
-          if (req.bus_op == BusOpWrite && req.drv_type == DevAck && req.data_q.size() > 0) begin
-            w_q[req.addr].push_back(req);
-          end else if (req.bus_op == BusOpRead && req.drv_type == RdData) begin
-            if (w_q[req.addr].size() == 0) begin
-              `uvm_fatal(`gfn, $sformatf("Read requested on empty Write queue"))
-            end else begin
-              rsp = w_q[req.addr].pop_front();
-              req.rdata = rsp.wdata;
-            end
-          end
-          start_item(req);
-          finish_item(req);
+      // The base_seq body behaviour for Target operations captures in-progress transfers from
+      // the monitor, then calls a number of hooks methods where we may wish to drive traffic or
+      // capture data. For this sequence, we just need to override the hooks to achieve the
+      // intended autoresponder function.
+      super.body();
+      // Spawn some background processes that run the entire length of the sequence
+      fork
+        // This task clears out the response memory upon each reset assertion
+        forever begin
+          @(negedge cfg.vif.rst_ni);
+          foreach (response_mem[i]) response_mem[i].delete();
         end
-        if (stop) break;
-      end // forever begin
-      forever begin
-        @(negedge cfg.vif.rst_ni);
-        foreach (w_q[i]) begin
-          w_q[i].delete();
+        // The cfg field 'got_stop' is used in block-level DV to prevent new stimulus from being
+        // generated before the previous transaction has completed. When used at chip-level, when
+        // the block-level sequences are not running, we need to handle this field differently.
+        // Simply clear this field here whenever it is set.
+        // TODO(#) Remove this hacky-hack, hopefully along with the cfg.got_stop field altogether.
+        forever begin
+          wait(cfg.got_stop == 1);
+          cfg.got_stop = 0;
         end
-      end
+      join_none
     join
-  endtask // send_device_mode
+  endtask : body
 
-endclass // i2c_device_response_seq
+
+  // We don't need to hook the address-byte ACK here (drive_addr_byte_ack()), as the base class
+  // will ACK to accept all transfers by default, which matches the behaviour we want for this
+  // sequence.
+
+
+  // This method hooks the end of every data byte in an in-progress WRITE transfer.
+  // Store the data byte into the local memory, for recall by the next read operation.
+  virtual task drive_write_byte_ack();
+    bit[Addr7BitMode-1:0] xfer_addr = inp_xfer.addr[Addr7BitMode-1:0];
+
+    response_mem[xfer_addr].push_back(inp_xfer.data_q[$]);
+    `uvm_info(`gfn, $sformatf(
+      "Autoresponder sequence storing the following write : addr:8'h%2x byte:8'h%2x",
+      xfer_addr, inp_xfer.data_q[$]), UVM_DEBUG)
+
+    // Drive the ACK to this write byte.
+    // This sequence will always ACK all write bytes.
+    super.drive_write_byte_ack();
+  endtask : drive_write_byte_ack
+
+
+  // This method hooks the start of every data byte in an inprogress READ transfer.
+  // Fetch any read data from the local memory, and drive the data byte with this value.
+  virtual task drive_read_byte();
+    bit[Addr7BitMode-1:0] xfer_addr = inp_xfer.addr[Addr7BitMode-1:0];
+    bit [7:0]             rdata;
+
+    if (response_mem[xfer_addr].size() == 0) begin
+      // We haven't previously seen a write transfer at this address. There is no data to return.
+      `uvm_fatal(`gfn, $sformatf("Read requested, but write-queue at this address is empty!"))
+    end
+
+    // Fetch the data written to this address, and use it to populate the drive item.
+    rdata = response_mem[xfer_addr].pop_front();
+
+    `uvm_info(`gfn, $sformatf(
+      "Autoresponder sequence transmitting based byte based on read : addr:8'h%2x byte:8'h%2x",
+      xfer_addr, rdata), UVM_DEBUG)
+
+    // Drive the data byte
+    `uvm_create_obj(REQ, req);
+    start_item(req);
+    req.drv_type = RdData;
+    req.rdata = rdata;
+    finish_item(req);
+  endtask : drive_read_byte
+
+
+endclass : i2c_device_response_seq


### PR DESCRIPTION
> ~~The first two commits in this PR are squashes of other PRs, on which we are dependent. They should both be ignored for reviewing purposes, and will be rebased away when they land.~~
> Without these two commits : 313 insertions(+), 126 deletions(-)

Fixup the i2c_agent's target-mode sequences to use the new transfer-level TLM items from the i2c_monitor (functionality added in #23955). This removes the strange partial-item messages that were passed from monitor to seqr via the 'req_analysis_port', which was inflexible and used the existing i2c_item for yet another alternate purpose. With this change, the sequences can pickup the 'in-progress' transfer item from the monitor, and observe the state of the transaction as it progresses via the `i2c_item.state` field.

The base_seq has been amended to add this monitor-tracking behaviour, and now provides a number of callback routines that derived sequences can use to drive the bus at the correct time. 
The derived target-mode sequences have been cleaned up and reworked to use these new callbacks.

A significant fraction of the LoC changes are comments, to help me and the next person remember what is going on here.