### PR TITLE
[otbn,lint] Fix silly Python lint error

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -461,7 +461,7 @@ class OTBNSim:
         self.state.injected_err_bits |= err_val
         self.state.lock_immediately = lock_immediately
 
-    def lock_immediately(self):
+    def lock_immediately(self) -> None:
         '''React to an event that should cause us to immediately jump to the
         locked state.'''
         self.state.set_fsm_state(FsmState.LOCKED)


### PR DESCRIPTION
This was caused by 597247f7614b6dcd661041a161fff19523c87b17 (and causes CI failures)