### PR TITLE
[hsmtool] Fix endianness reversal for ECDSA

### DIFF
--- a/sw/host/hsmtool/src/commands/ecdsa/verify.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/verify.rs
@@ -48,13 +48,19 @@ impl Dispatch for Verify {
 
         let mut data = helper::read_file(&self.input)?;
         if self.little_endian {
+            // OpenTitanTool writes digest files in little-endian byte order,
+            // (same as the hmac peripheral's default output mode).  The ECDSA
+            // implementation performs the signature calculation with the bytes in
+            // big-endian order.
             data.reverse();
         }
         let data = self.format.prepare(KeyType::Ec, &data)?;
         let mechanism = self.format.mechanism(KeyType::Ec)?;
         let mut signature = helper::read_file(&self.signature)?;
         if self.little_endian {
-            signature.reverse();
+            let half = signature.len() / 2;
+            signature[..half].reverse();
+            signature[half..].reverse();
         }
         session.verify(&mechanism, object, &data, &signature)?;
         Ok(Box::<BasicResult>::default())


### PR DESCRIPTION
OpenTitan's ECDSA implementation expects the R and S components of an ECDSA signature to be in little-endian order.

1. Reverse the R and S components individually rather than reversing the entire signature.