### PR TITLE
[opentitanlib] preprocess the manifest before signing

### DIFF
--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -286,7 +286,7 @@ impl CommandDispatch for ManifestUpdateCommand {
         // Sign with SPX+.
         if let Some(key) = spx_private_key {
             image.add_manifest_extension(ManifestExtEntry::new_spx_signature_entry(
-                &image.map_signed_region(|buf| key.sign(self.domain, buf))??,
+                &image.map_updated_signed_region(|buf| key.sign(self.domain, buf))??,
             )?)?;
         }
 


### PR DESCRIPTION
The manifest usage_constraints field includes values which could be ignored by the signature validator, depending on the selector_bits setting.

This patch makes sure that the signer behaves the same, i.e. replaces the values disabled by the selector with the default value.

Tested by successfully starting the Ti50 image on the Cw310 FPGA board.