### PR TITLE
[ci, sival] Create a linter for the testplans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         run: ./ci/scripts/python-lint.sh "$GITHUB_BASE_REF"
       - name: Python (mypy)
         run: ./ci/scripts/mypy.sh
+      - name: Validate testplans with schema
+        run: ./ci/scripts/validate_testplans.sh
       - name: C/C++ formatting
         run: ./ci/scripts/clang-format.sh "$GITHUB_BASE_REF"
       - name: Rust formatting

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,10 @@ jobs:
   - bash: ci/scripts/clang-format.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: clang-format (C/C++ lint)
+    # Validate testplans with schema (json schema)
+  - bash: ci/scripts/validate_testplans.sh
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Validate testplans with schema
     # Use clang-format to check C/C++ coding style
   - bash: ci/scripts/rust-format.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -49,6 +49,9 @@ ci/scripts/python-lint.sh $tgt_branch || {
 echo -e "\n### Run Python lint (mypy)"
 ci/scripts/mypy.sh $tgt_branch
 
+echo -e "\n### Validate testplans with schema."
+ci/scripts/validate_testplans.sh
+
 echo -e "\n### Use clang-format to check C/C++ coding style"
 ci/scripts/clang-format.sh $tgt_branch
 

--- a/ci/scripts/validate_testplans.sh
+++ b/ci/scripts/validate_testplans.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Use a JSON schema to validate the testplan hjson files have the correct structure.
+
+set -e
+
+dirs_with_testplan_files=(
+    "hw/top_earlgrey/data"
+    "hw/top_earlgrey/data/ip"
+)
+testplan_schema="hw/lint/sival_testplan_schema.hjson"
+
+for dir in "${dirs_with_testplan_files[@]}"; do
+    echo "Validating testplans under $dir:"
+    util/validate_testplans.py --dir "$dir" --schema "$testplan_schema" || {
+        echo -n "##vso[task.logissue type=error]"
+        echo "Failed testplan validation in ${dir}."
+        echo "::error::Failed testplan validation in ${dir}."
+        exit 1
+    }
+done
+
+exit 0

--- a/hw/lint/sival_testplan_schema.hjson
+++ b/hw/lint/sival_testplan_schema.hjson
@@ -58,6 +58,19 @@
             "type": "array"
           }
         },
+        // If the si_stage is not tagged NA, then require the bazel property be present.
+        "if": {
+          "properties": {
+            "si_stage": {
+              "not": {
+                "const": "NA"
+              }
+            }
+          }
+        },
+        "then": {
+          "required": ["bazel"]
+        },
         "required": ["name", "desc", "stage", "si_stage", "tests"]
       }
     }

--- a/hw/lint/sival_testplan_schema.hjson
+++ b/hw/lint/sival_testplan_schema.hjson
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "additionalProperties": false,
+    "testpoints": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "desc": {
+            "type": "string"
+          },
+          "stage": {
+            "enum": ["V1", "V2", "V2S", "V3"]
+          },
+          "si_stage": {
+            "enum": ["SV1", "SV2", "SV3", "SV4", "SV5", "NA", "None"]
+          },
+          "bazel": {
+            "type": "array"
+          },
+          "boot_stages": {
+            "type": "array",
+            "items": {
+              "enum": ["rom_ext", "silicon_owner"]
+            }
+          },
+          "lc_states": {
+            "type": "array",
+            "items": {
+              "enum": ["PROD", "TEST_UNLOCKED", "RAW", "SCRAP", "TEST_LOCKED",
+                "TEST_LOCKED0", "DEV", "RMA", "TEST_UNLOCKED0", "PROD_END"]
+            }
+          },
+          "features": {
+            "type": "array"
+          },
+          "tests": {
+            "type": "array"
+          },
+          "otp_mutate": {
+            "type": "boolean"
+          },
+          "host_support": {
+            "type": "boolean"
+          },
+          "tags": {
+            "type": "array"
+          }
+        },
+        "required": ["name", "desc", "stage", "si_stage", "tests"]
+      }
+    }
+  }
+}

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -110,6 +110,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
+      bazel: []
     }
     {
       name: chip_padctrl_attributes
@@ -129,6 +130,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
+      bazel: []
     }
     {
       name: chip_sw_sleep_pin_mio_dio_val
@@ -171,6 +173,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_sleep_pin_wake"]
+      bazel: []
     }
     {
       name: chip_sw_sleep_pin_retention
@@ -371,6 +374,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_ast_clk_rst_inputs"]
+      bazel: []
     }
     {
       name: chip_sw_ast_sys_clk_jitter
@@ -391,6 +395,7 @@
               "chip_sw_kmac_mode_kmac_jitter_en",
               "chip_sw_sram_ctrl_scrambled_access_jitter_en",
               "chip_sw_edn_entropy_reqs_jitter"]
+      bazel: []
     }
     {
       name: chip_sw_ast_usb_clk_calib
@@ -411,6 +416,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_usb_ast_clk_calib"]
+      bazel: []
     }
 
     // SENSOR_CTRL tests:
@@ -442,6 +448,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_sensor_ctrl_status"]
+      bazel: []
     }
     {
       name: chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup
@@ -453,6 +460,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup"]
+      bazel: []
     }
 
     ////////////////////////////
@@ -735,6 +743,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_power_sleep_load"]
+      bazel: []
     }
 
     {

--- a/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
@@ -29,6 +29,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_sleep_debug_cable_wakeup
@@ -54,6 +55,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_normal
@@ -63,6 +65,7 @@
       si_stage: SV2
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_oneshot
@@ -72,6 +75,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -112,6 +112,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_aes_entropy
@@ -180,6 +181,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_aes_prng_reseed"]
+      bazel: []
     }
     {
       name: chip_sw_aes_force_prng_reseed
@@ -213,6 +215,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_aes_force_prng_reseed"]
+      bazel: []
     }
     {
       name: chip_sw_aes_idle

--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -43,6 +43,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_escalation"]
+      bazel: []
       otp_mutate: true
       host_support: true
     }
@@ -67,6 +68,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
       otp_mutate: false
     }
     {
@@ -85,6 +87,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_all_escalation_resets
@@ -190,6 +193,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_lpg_sleep_mode_alerts"]
+      bazel: []
     }
     {
       name: chip_sw_alert_handler_lpg_sleep_mode_pings

--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -94,6 +94,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_flash_rma_unlocked"]
+      bazel: []
     }
     {
       name: chip_sw_flash_scramble
@@ -251,6 +252,7 @@
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       boot_stages: ["rom_ext"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      bazel: []
     }
     {
       name: chip_sw_flash_lc_escalate_en

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -43,6 +43,7 @@
         "chip_sw_keymgr_key_derivation",
         "chip_sw_keymgr_key_derivation_jitter_en",
       ]
+      bazel: []
     }
     {
       name: chip_sw_keymgr_sideload_kmac_error

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -96,6 +96,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_kmac_entropy"]
+      bazel: []
     }
     {
       name: chip_sw_kmac_idle

--- a/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
@@ -288,11 +288,13 @@
              Verify that the features that should indeed be disabled are indeed disabled.
              '''
       stage: V2
+      si_stage: None
       tests: ["chip_sw_lc_walkthrough_dev",
               "chip_sw_lc_walkthrough_prod",
               "chip_sw_lc_walkthrough_prodend",
               "chip_sw_lc_walkthrough_rma",
               "chip_sw_lc_walkthrough_testunlocks"]
+      bazel: []
     }
     {
       name: chip_sw_lc_ctrl_volatile_raw_unlock

--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -48,6 +48,7 @@
               "chip_sw_keymgr_key_derivation",
               "chip_sw_otbn_mem_scramble",
               "chip_sw_rv_core_ibex_icache_invalidate"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_entropy
@@ -68,6 +69,7 @@
               "chip_sw_keymgr_key_derivation",
               "chip_sw_otbn_mem_scramble",
               "chip_sw_rv_core_ibex_icache_invalidate"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_program
@@ -90,6 +92,7 @@
       si_stage: SV1
       lc_states: ["PROD"]
       tests: ["chip_sw_lc_ctrl_transition"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_program_error
@@ -180,6 +183,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "RMA"]
       tests: ["chip_prim_tl_access"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_vendor_test_csr_access
@@ -232,6 +236,7 @@
       si_stage: SV1
       lc_states: ["TEST_UNLOCKED"]
       tests: []
+      bazel: []
     }
     {
       name: otp_ctrl_partition_access_locked

--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -77,6 +77,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -222,6 +222,7 @@
      stage: V2S
      si_stage: None
      tests: ["chip_sw_rv_core_ibex_lockstep_glitch"]
+     bazel: []
     }
     {
       name: chip_sw_rv_core_ibex_alerts

--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -24,7 +24,7 @@
       tests: ["chip_jtag_csr_rw"]
       bazel: ["//sw/device/tests:rv_dm_csr_rw"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -55,7 +55,7 @@
       tests: ["chip_jtag_mem_access"]
       bazel: ["//sw/device/tests:rv_dm_mem_access"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -95,7 +95,7 @@
               "rom_e2e_jtag_debug_rma"]
       bazel: ["//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -119,7 +119,7 @@
       tests: ["chip_rv_dm_ndm_reset_req"]
       bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -151,7 +151,7 @@
       tests: ["chip_sw_rv_dm_ndm_reset_req_when_cpu_halted"]
       bazel: ["//sw/device/tests:rv_dm_ndm_reset_req_when_cpu_halted"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -172,7 +172,7 @@
       tests: ["chip_sw_rv_dm_access_after_wakeup"]
       bazel: ["//sw/device/tests:rv_dm_access_after_wakeup"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -209,7 +209,7 @@
       tests: ["chip_tap_straps_rma"]
       bazel: ["//sw/device/tests:rv_dm_jtag_tap_sel"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -255,7 +255,7 @@
       ],
       lc_states: ["RAW", "TEST_LOCKED", "TEST_UNLOCKED", "DEV", "RMA", "PROD",
         "PROD_END", "SCRAP"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -275,7 +275,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_jtag"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
       ]
@@ -294,7 +294,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_dtm"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -323,7 +323,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_control_status"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -54,6 +54,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["//sw/device/tests:spi_passthru_test"]
+      bazel: []
     }
     {
       name: chip_sw_spi_host_configuration
@@ -70,6 +71,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["//sw/device/tests:spi_host_config_test"]
+      bazel: []
     }
     {
       name: chip_sw_spi_host_events

--- a/hw/top_earlgrey/data/standalone_sw_testplan.hjson
+++ b/hw/top_earlgrey/data/standalone_sw_testplan.hjson
@@ -12,7 +12,9 @@
             It also performs a sanity region protection check to make sure a protected page cannot be modified.
             When the test passes, it will output "PASS!".'''
       stage: V1
+      si_stage: SV4
       tests: ["flash_test"]
+      bazel: []
     }
     {
       name: hmac
@@ -20,7 +22,9 @@
             It computes the hash of a known input and compares it against the known digest.
             When the test passes, it will output "PASS!".'''
       stage: V1
+      si_stage: SV4
       tests: ["sha256_test"]
+      bazel: []
     }
     {
       name: rv_timer
@@ -29,7 +33,9 @@
             If the interrupt handling is incorrect, the test will never complete.
             When the test passes, it will output "PASS!".'''
       stage: V1
+      si_stage: SV4
       tests: ["rv_timer_test"]
+      bazel: []
     }
   ]
 }

--- a/util/validate_testplans.py
+++ b/util/validate_testplans.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script validates the various opentitan testplan.hjson files.
+Usage:
+    ./util/validate_testplans.py --schema hw/lint/sival_testplan_schema.hjson \
+                                 --dir hw/top_earlgrey/data/
+    ./util/validate_testplans.py --schema hw/lint/sival_testplan_schema.hjson \
+                                 --dir hw/top_earlgrey/data/ip/
+"""
+
+import argparse
+import glob
+import logging
+import sys
+import pathlib
+import hjson
+import jsonschema
+
+
+def main(args: argparse.Namespace) -> int:
+    files = [f for f in glob.glob(f"{args.dir}/*.hjson")]
+
+    assert args.schema
+    return SchemaValidator(args.schema).check(files)
+
+
+class SchemaValidator:
+    def __init__(self, schema_file: str):
+        self.schema = hjson.load(open(schema_file, "r", encoding="utf-8"))
+
+    def check(self, files: str) -> int:
+        res: int = 0
+        for f in files:
+            try:
+                testplan = hjson.load(open(f, "r", encoding="utf-8"))
+                jsonschema.validate(testplan, schema=self.schema)
+
+            except jsonschema.ValidationError as e:
+                logging.info("Validation failed on file %s: %s", f, e)
+                res = -1
+            except hjson.scanner.HjsonDecodeError as e:
+                logging.info("Failed to decode file %s: %s", f, e)
+                res = -1
+                break
+
+        if res == 0:
+            logging.info("No errors found!")
+        else:
+            logging.info("Errors found - run validation locally with %s", " ".join(sys.argv))
+        return res
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--logging",
+        default="info",
+        choices=["debug", "info", "warning", "error", "critical"],
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--dir",
+        required=True,
+        help="A directory containing testplan.hjson files.",
+    )
+    parser.add_argument(
+        "--schema",
+        required=True,
+        type=pathlib.Path,
+        help="A hjson file with the validation rules to be used.",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(level=args.logging.upper())
+    sys.exit(main(args))


### PR DESCRIPTION
This PR is an updated version of a previous PR by @engdoreis found at https://github.com/lowRISC/opentitan/pull/20265, with merge conflicts resolved and with support for the `bazel` property of a testplan to be conditionally missing if the `si_stage` property is set to `NA`, as discussed [here](https://github.com/lowRISC/opentitan/pull/20265#discussion_r1541901278). That PR can be closed when this is merged. 

A JSON schema is used with the relevant python library to lint the testplans appropriately. This can be run using the below commands to verify that all testplans pass the linting.

```bash
./util/lint_testplan.py --schema hw/lint/sival_testplan_schema.json --dir hw/top_earlgrey/data/
```
```bash
./util/lint_testplan.py --schema hw/lint/sival_testplan_schema.json --dir hw/top_earlgrey/data/ip
```

Edit: The missing `si_stage` properties in `hw/top_earlgrey/data/standalone_sw_testplan.hjson` have been set to SV4 as suggested by @engdoreis, and support for SV4 and SV5 in the json schema has now been added.

I've also now added a Github actions CI Job to run the linting check on these two directories on any PR that is made to OpenTitan.