### PR TITLE
[otbn,dv] Refactor FSM states in otbn simulator

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -250,13 +250,13 @@ class LW(OTBNInsn):
         base = state.gprs.get_reg(self.grs1).read_unsigned()
         if state.gprs.call_stack_err:
             state.stop_at_end_of_cycle(ErrBits.CALL_STACK)
-            return
+            return None
 
         addr = (base + self.offset) & ((1 << 32) - 1)
 
         if not state.dmem.is_valid_32b_addr(addr):
             state.stop_at_end_of_cycle(ErrBits.BAD_DATA_ADDR)
-            return
+            return None
 
         result = state.dmem.load_u32(addr)
 
@@ -265,9 +265,10 @@ class LW(OTBNInsn):
 
         if result is None:
             state.stop_at_end_of_cycle(ErrBits.DMEM_INTG_VIOLATION)
-            return
+            return None
 
         state.gprs.get_reg(self.grd).write_unsigned(result)
+        return None
 
 
 class SW(OTBNInsn):
@@ -419,12 +420,12 @@ class CSRRS(OTBNInsn):
         if not state.csrs.check_idx(self.csr):
             # Invalid CSR index. Stop with an illegal instruction error.
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         bits_to_set = state.gprs.get_reg(self.grs1).read_unsigned()
         if state.gprs.call_stack_err:
             state.stop_at_end_of_cycle(ErrBits.CALL_STACK)
-            return
+            return None
 
         if self.csr == 0xfc0:
             # A read from RND. If a RND value is not available, request_value()
@@ -441,6 +442,8 @@ class CSRRS(OTBNInsn):
         if self.grs1 != 0:
             state.write_csr(self.csr, new_val)
 
+        return None
+
 
 class CSRRW(OTBNInsn):
     insn = insn_for_mnemonic('csrrw', 3)
@@ -455,12 +458,12 @@ class CSRRW(OTBNInsn):
         if not state.csrs.check_idx(self.csr):
             # Invalid CSR index. Stop with an illegal instruction error.
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         new_val = state.gprs.get_reg(self.grs1).read_unsigned()
         if state.gprs.call_stack_err:
             state.stop_at_end_of_cycle(ErrBits.CALL_STACK)
-            return
+            return None
 
         if self.csr == 0xfc0 and self.grd != 0:
             # A read from RND. If a RND value is not available, request_value()
@@ -478,6 +481,7 @@ class CSRRW(OTBNInsn):
             state.gprs.get_reg(self.grd).write_unsigned(old_val)
 
         state.write_csr(self.csr, new_val)
+        return None
 
 
 class ECALL(OTBNInsn):
@@ -1045,7 +1049,7 @@ class BNLID(OTBNInsn):
 
         if self.grs1_inc and self.grd_inc:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         grs1_val = state.gprs.get_reg(self.grs1).read_unsigned()
         addr = (grs1_val + self.offset) & ((1 << 32) - 1)
@@ -1069,7 +1073,7 @@ class BNLID(OTBNInsn):
             saw_err = True
 
         if saw_err:
-            return
+            return None
 
         wrd = grd_val & 0x1f
         value = state.dmem.load_u256(addr)
@@ -1087,9 +1091,10 @@ class BNLID(OTBNInsn):
 
         if value is None:
             state.stop_at_end_of_cycle(ErrBits.DMEM_INTG_VIOLATION)
-            return
+            return None
 
         state.wdrs.get_reg(wrd).write_unsigned(value)
+        return None
 
 
 class BNSID(OTBNInsn):
@@ -1106,7 +1111,7 @@ class BNSID(OTBNInsn):
     def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         if self.grs1_inc and self.grs2_inc:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         grs1_val = state.gprs.get_reg(self.grs1).read_unsigned()
         addr = (grs1_val + self.offset) & ((1 << 32) - 1)
@@ -1130,7 +1135,7 @@ class BNSID(OTBNInsn):
             saw_err = True
 
         if saw_err:
-            return
+            return None
 
         if self.grs1_inc:
             new_grs1_val = (grs1_val + 32) & ((1 << 32) - 1)
@@ -1146,6 +1151,7 @@ class BNSID(OTBNInsn):
         wrs_val = state.wdrs.get_reg(wrs).read_unsigned()
 
         state.dmem.store_u256(addr, wrs_val)
+        return None
 
 
 class BNMOV(OTBNInsn):
@@ -1174,7 +1180,7 @@ class BNMOVR(OTBNInsn):
     def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         if self.grs_inc and self.grd_inc:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         grd_val = state.gprs.get_reg(self.grd).read_unsigned()
         grs_val = state.gprs.get_reg(self.grs).read_unsigned()
@@ -1197,7 +1203,7 @@ class BNMOVR(OTBNInsn):
             saw_err = True
 
         if saw_err:
-            return
+            return None
 
         wrd = grd_val & 0x1f
         wrs = grs_val & 0x1f
@@ -1214,6 +1220,7 @@ class BNMOVR(OTBNInsn):
 
         value = state.wdrs.get_reg(wrs).read_unsigned()
         state.wdrs.get_reg(wrd).write_unsigned(value)
+        return None
 
 
 class BNWSRR(OTBNInsn):
@@ -1229,7 +1236,7 @@ class BNWSRR(OTBNInsn):
         if not state.wsrs.check_idx(self.wsr):
             # Invalid WSR index. Stop with an illegal instruction error.
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         if self.wsr == 0x1:
             # A read from RND. If a RND value is not available, request_value()
@@ -1244,11 +1251,12 @@ class BNWSRR(OTBNInsn):
         # provided us with a value). If not, fail with a KEY_INVALID error.
         if not state.wsrs.has_value_at_idx(self.wsr):
             state.stop_at_end_of_cycle(ErrBits.KEY_INVALID)
-            return
+            return None
 
         # The WSR is ready and has a value. Read it.
         val = state.wsrs.read_at_idx(self.wsr)
         state.wdrs.get_reg(self.wrd).write_unsigned(val)
+        return None
 
 
 class BNWSRW(OTBNInsn):

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -344,7 +344,7 @@ class OTBNSim:
         # complex might not be up, so we don't want to wait for a seed. Handle
         # this by jumping straight to the WIPING state and setting the number
         # of rounds to 1 (so that we don't wait again for a seed afterwards)
-        if self.state.rma_req == LcTx.ON and self.state.wipe_rounds_done == 0:
+        if self.state.rma_req == LcTx.ON and not self.state.edn_seen_running:
             self.state.lock_after_wipe = True
             self.state.wipe_rounds_to_do = 1
             self.state.set_fsm_state(FsmState.WIPING)

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -59,8 +59,6 @@ class OTBNSim:
         Use run() or step() to actually execute the program.
 
         '''
-        if self.state.get_fsm_state() != FsmState.IDLE:
-            return
         self.stats = ExecutionStats(self.program) if collect_stats else None
         self._execute_generator = None
         self._next_insn = None

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -385,8 +385,8 @@ class OTBNState:
         self.ext_regs.set_bits('INTR_STATE', 1 << 0)
 
         should_lock = (((self._err_bits >> 16) != 0) or
-                       ((self._err_bits >> 10) & 1) or
-                       (self._err_bits and self.software_errs_fatal) or
+                       ((self._err_bits >> 10) & 1 != 0) or
+                       (self._err_bits != 0 and self.software_errs_fatal) or
                        self.rma_req == LcTx.ON)
         # Make any error bits visible
         self.ext_regs.write('ERR_BITS', self._err_bits, True)

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -170,6 +170,10 @@ class OTBNState:
         # otbn_start_stop_control.sv, which skips a round of secure wiping
         self.has_state_to_wipe = False
 
+        # If this flag is set, jump straight to the LOCKED state when we step
+        # in IDLE.
+        self.delayed_lock = False
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -175,6 +175,13 @@ class OTBNState:
         # in IDLE.
         self.delayed_lock = False
 
+        # We set this flag when the first URND seed comes back from the EDN. If
+        # we get an RMA request before this flag is set, we'll be in the
+        # PRE_WIPE state and the EDN might not actually be running. In that
+        # situation, we do a shortened secure wipe (just one round and no
+        # random data).
+        self.edn_seen_running = False
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override
@@ -216,6 +223,8 @@ class OTBNState:
         # cdc_complete() returned a 256-bit value but we actually need to split
         # it back into four 64-bit words.
         w64s = [(w256 >> (64 * i)) & ((1 << 64) - 1) for i in range(4)]
+
+        self.edn_seen_running = True
 
         self.wsrs.URND.set_seed(w64s)
 

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -148,7 +148,8 @@ def on_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     elif was_wiping:
         # The trailing space is a bit naff but matches the behaviour in the RTL
         # tracer, where it's rather difficult to change.
-        hdr = 'U ' if sim.state.incomplete_wipe else 'V '
+        done_last_round = (sim.state.wipe_rounds_done == 2)
+        hdr = 'V ' if done_last_round else 'U '
     elif sim.state.executing():
         hdr = 'STALL'
     else:

--- a/hw/ip/otbn/dv/otbnsim/test/stats_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/stats_test.py
@@ -137,7 +137,7 @@ def test_general_and_loop(tmpdir: py.path.local) -> None:
     stats = _simulate_asm_file(asm_file, tmpdir)
 
     # General statistics
-    assert stats.stall_count == 3
+    assert stats.stall_count == 4
     assert stats.get_insn_count() == 28
     assert stats.insn_histo == {'addi': 22, 'loop': 4, 'loopi': 1, 'ecall': 1}
     assert stats.func_calls == []


### PR DESCRIPTION
These changes are to get the `otbn_escalate` test working properly: there was a rather "bodged" model of how secure wipe should work and it didn't match the RTL (or make sense!)

The important change is the penultimate one, which splits the "wiping" state into two pieces. This means that we correctly track "waiting for seed" before "performing the wipe", which could end up being tracked backwards in some situations before.

But this doubles the number of "wiping" states and (many years ago) I unwisely differentiated between WIPING_GOOD and WIPING_BAD to distinguish whether we expected to lock when the wipe was complete. Rather than adding *two* more states, I've merged those two states back together (in the "Merge WIPING_GOOD, WIPING_BAD" commit) so the net change is zero!

Fixes #20835 (phew!)