### PR TITLE
[rv_dm,dv] Correctly set pinmux_hw_debug_en_i in rv_dm_ndmreset_req

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_ndmreset_req_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_ndmreset_req_vseq.sv
@@ -10,11 +10,6 @@ class rv_dm_ndmreset_req_vseq extends rv_dm_base_vseq;
   `uvm_object_utils(rv_dm_ndmreset_req_vseq)
   `uvm_object_new
 
-  rand lc_ctrl_pkg::lc_tx_t pinmux_hw_debug_en;
-  constraint pinmux_hw_debug_en_c {
-    pinmux_hw_debug_en == lc_ctrl_pkg::On;
-  }
-
   // Read the dmstatus register over DMI
   task read_dmstatus(output dmstatus_t value);
     logic [31:0] rdata;


### PR DESCRIPTION
I messed this up with a recent refactor and the constraint ended up overriding the (correct) pinmux_hw_debug_en_c constraint in the base class with a no-op constraint in the derived class.

Fortunately, the fix is trivial: delete the bogus override.