### PR TITLE
[BLOCKFILE] Block changes to ROM self hash test incl. golden ROM hashes

### DIFF
--- a/BLOCKFILE
+++ b/BLOCKFILE
@@ -91,3 +91,6 @@ hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
 hw/top_earlgrey/data/top_earlgrey.hjson
 hw/top_earlgrey/data/xbar_main.hjson
 hw/top_earlgrey/data/xbar_peri.hjson
+
+# The ROM self hash test including the golden ROM hashes
+sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c


### PR DESCRIPTION
As discussed in the meeting yesterday, we should start to block accidental ROM changes. @timothytrippel @cfrantz , it's probably fine to activate the blocker once the final ROM release tag has been created.

The ROM self hash test itself is run in CI. It fails unless the golden ROM hashes are updated in sync with potential ROM changes. Thus, it's sufficient to block changes to the ROM self hash test and the golden hashes to prevent accidental ROM changes.