### PR TITLE
[hmac,dv] Extend timeouts

### DIFF
--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -83,7 +83,7 @@
     {
       name: hmac_error
       uvm_test_seq: hmac_error_vseq
-      run_opts: ["+test_timeout_ns=300_000_000"]
+      run_opts: ["+test_timeout_ns=500_000_000"]
     }
 
     {
@@ -103,7 +103,7 @@
       name: hmac_test_sha384_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
       // Increase timeout for all test iterations to pass
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_000_000_000 +sha2_digest_size=SHA2_384"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=3_000_000_000 +sha2_digest_size=SHA2_384"]
       reseed: 5
     }
 
@@ -111,7 +111,7 @@
       name: hmac_test_sha512_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
       // Increase timeout for all test iterations to pass
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=1_200_000_000 +sha2_digest_size=SHA2_512"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=3_000_000_000 +sha2_digest_size=SHA2_512"]
       reseed: 5
     }
 
@@ -125,14 +125,14 @@
     {
       name: hmac_test_hmac384_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=2_000_000_000 +sha2_digest_size=SHA2_384"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=3_000_000_000 +sha2_digest_size=SHA2_384"]
       reseed: 5
     }
 
     {
       name: hmac_test_hmac512_vectors
       uvm_test_seq: hmac_test_vectors_hmac_vseq
-      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=2_000_000_000 +sha2_digest_size=SHA2_512"]
+      run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0 +test_timeout_ns=3_000_000_000 +sha2_digest_size=SHA2_512"]
       reseed: 5
     }
 


### PR DESCRIPTION
This extends the timeout for some HMAC tests that time out and fail in the last nightly regression, and after some local runs by @martin-velay to try and determine the right timeout for the test vector tests.

