### PR TITLE
[rv_dm,dv] Use the "right enable" in *_jtag_dmi_debug_disabled_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -171,7 +171,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
 
     // TODO: Randomize the contents of the debug ROM & the program buffer once out of reset.
 
-    if (lc_hw_debug_en) begin
+    if (pinmux_hw_debug_en) begin
       // We would like to do a DMI transaction here. If this vseq is the first with debug enabled,
       // the "enable" signal will need to make it through the a prim_lc_sync in the design before it
       // takes effect. Fortunately, we can see that this has happened by looking at the trst_n

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -135,7 +135,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
 
     // Drive the pinmux_hw_debug_en_i pin to match the pinmux_hw_debug_en bit, avoiding assertions
     // that get triggered in prim_lc_sync if the input is 'x.
-    cfg.rv_dm_vif.pinmux_hw_debug_en <= bool_to_lc_tx_t(pinmux_hw_debug_en);
+    upd_pinmux_hw_debug_en();
 
     // Drive the lc_hw_debug_en_i pin to match the lc_hw_debug_en bit, avoiding assertions that get
     // triggered in prim_lc_sync if the input is 'x.
@@ -389,6 +389,11 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   virtual task set_late_debug_enable_with_reg(bit bool_val);
     csr_wr(.ptr(ral.late_debug_enable), .value(bool_to_mubi32_t(bool_val)));
   endtask
+
+  // Update the pinmux_hw_debug_en_i pin to match the bit in pinmux_hw_debug_en
+  function void upd_pinmux_hw_debug_en();
+    cfg.rv_dm_vif.pinmux_hw_debug_en <= bool_to_lc_tx_t(pinmux_hw_debug_en);
+  endfunction
 
   // Update the lc_hw_debug_en_i pin to match the bit in lc_hw_debug_en
   function void upd_lc_hw_debug_en();


### PR DESCRIPTION
This PR looks reasonably large because it depends on #23799. Once that has been merged, there are two remaining commits:
- *[rv_dm,dv] Make DMI bringup in base vseq depend on pinmux connection*
- *[rv_dm,dv] Use the "right enable" in \*_jtag_dmi_debug_disabled_vseq*

The first commit is a tidyup in the base vseq (which I noticed when trying to fix the vseq for the second commit). The second commit is the main point of this PR. Its commit message is as follows:

*[rv_dm,dv] Use the "right enable" in \*_jtag_dmi_debug_disabled_vseq*

The code here was a bit broken and I clearly hadn't previously
understood the difference between "pinmux enabled" and "debug
enabled".

The *whole point* of this test is supposed to be that DMI transactions
get blocked when pinmux is not enabled. After the changes here, we
actually test that property!