### PR TITLE
[entropy_src/dv] Test hardened FIFO errors

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -190,7 +190,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
       es_main_sm_err    :/ 2,
       es_cntr_err       :/ 60,
       fifo_read_err     :/ 4,
-      fifo_state_err    :/ 4};}
+      fifo_state_err    :/ 4,
+      fifo_cntr_err     :/ 4};}
 
   constraint which_cntr_replicate_c {which_cntr_replicate inside {[0:RNG_BUS_WIDTH-1]};}
   int        num_bins = 2**RNG_BUS_WIDTH;
@@ -211,7 +212,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
     which_err_code inside {sfifo_esrng_err, sfifo_distr_err, sfifo_esfinal_err} ->
       which_fifo_err inside {read, state};
     which_err_code == fifo_read_err -> which_fifo_err == read;
-    which_err_code == fifo_state_err -> which_fifo_err == state;
+    which_err_code inside {fifo_state_err, fifo_cntr_err} -> which_fifo_err == state;
   }
 
   constraint which_fifo_c {
@@ -219,6 +220,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
     which_err_code == sfifo_esrng_err -> which_fifo == sfifo_esrng;
     which_err_code == sfifo_distr_err -> which_fifo == sfifo_distr;
     which_err_code == sfifo_esfinal_err -> which_fifo == sfifo_esfinal;
+    which_err_code == fifo_cntr_err -> which_fifo inside {sfifo_observe, sfifo_esrng, sfifo_distr,
+                                                          sfifo_esfinal};
   }
 
   constraint induce_targeted_transition_c {induce_targeted_transition dist {

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -65,15 +65,16 @@ package entropy_src_env_pkg;
     es_cntr_err            = 6,
     fifo_read_err          = 7,
     fifo_state_err         = 8,
-    sfifo_esrng_err_test   = 9,
-    sfifo_distr_err_test   = 10,
-    sfifo_observe_err_test = 11,
-    sfifo_esfinal_err_test = 12,
-    es_ack_sm_err_test     = 13,
-    es_main_sm_err_test    = 14,
-    es_cntr_err_test       = 15,
-    fifo_read_err_test     = 16,
-    fifo_state_err_test    = 17
+    fifo_cntr_err          = 9,
+    sfifo_esrng_err_test   = 10,
+    sfifo_distr_err_test   = 11,
+    sfifo_observe_err_test = 12,
+    sfifo_esfinal_err_test = 13,
+    es_ack_sm_err_test     = 14,
+    es_main_sm_err_test    = 15,
+    es_cntr_err_test       = 16,
+    fifo_read_err_test     = 17,
+    fifo_state_err_test    = 18
   } err_code_e;
 
   typedef enum int {


### PR DESCRIPTION
This PR adds the new hardened FIFO errors to the error test sequence.

This resolves [#22326](https://github.com/lowRISC/opentitan/issues/22326)

While writing the code for this commit I discovered that the hardened counter errors don't cause the error state bits for FIFO state errors to go high. We might want to discuss whether this is intended or not.

Other than that the test results look good.
I also added coverage for the newly covered errors. However I counted them as state errors, so depending on what we decide here I need to change that.