### PR TITLE
[Sival, Spi host]  Config test CPOL and CPHA

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -57,13 +57,10 @@
     }
     {
       name: chip_sw_spi_host_configuration
-      desc: ''' Verifiy that the polarity and clock divider configurations work appropriately.
+      desc: ''' Verifiy that the polarity configurations work appropriately.
 
-            1. Send a packet with no clock division and no polarity switch.
-            2. Send a packet with no clock division and a polarity switch.
-            3. Send a packet with clock divided by two and a polarity switch.
-
-            The testbench should compare the three packets that are received; the second packet should be inverted from the first and the third should be send half as fast as the second.
+            1. Send four packets from the host to the device, each one with a different configuration for cpol and cpha.
+            2. The device should receive the packets and be able to decode them with the appropriated configuration.
             '''
       features: [
         "SPIHOST.CONFIG.CPOL",
@@ -72,7 +69,7 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: []
+      tests: ["//sw/device/tests:spi_host_config_test"]
     }
     {
       name: chip_sw_spi_host_events

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3389,6 +3389,41 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "spi_host_config_test",
+    srcs = ["spi_host_config_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_CW340_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+        },
+    ),
+    fpga = fpga_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            "{firmware:elf}"
+        """,
+        test_harness = "//sw/host/tests/chip/spi_device:spi_host_config_test",
+    ),
+    deps = [
+        ":spi_host_flash_test_impl",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:spi_host",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:spi_device_testutils",
+        "//sw/device/lib/testing:spi_flash_testutils",
+        "//sw/device/lib/testing:spi_host_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ottf_utils",
+    ],
+)
+
+opentitan_test(
     name = "spi_host_irq_test",
     srcs = ["spi_host_irq_test.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/spi_host_config_test.c
+++ b/sw/device/tests/spi_host_config_test.c
@@ -1,0 +1,105 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include <assert.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/dif_spi_host.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/spi_flash_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ottf_utils.h"
+#include "sw/device/tests/spi_host_flash_test_impl.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+              "This test assumes the target platform is little endian.");
+
+OTTF_DEFINE_TEST_CONFIG();
+
+enum {
+  kDefaultTimeoutMicros = 50000,
+};
+
+uint8_t backdoor_cpha = UINT8_MAX;
+uint8_t backdoor_cpol = UINT8_MAX;
+uint32_t backdoor_data = UINT32_MAX;
+
+static status_t spi_config_test(dif_spi_host_t *spi);
+
+static status_t configure_pinmux(const dif_pinmux_t *pinmux);
+
+bool test_main(void) {
+  dif_spi_host_t spi_host;
+  mmio_region_t base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR);
+
+  dif_pinmux_t pinmux;
+  CHECK_DIF_OK(dif_pinmux_init(base_addr, &pinmux));
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST1_BASE_ADDR);
+  CHECK_DIF_OK(dif_spi_host_init(base_addr, &spi_host));
+
+  configure_pinmux(&pinmux);
+  for (size_t i = 0; i < 4; ++i) {
+    CHECK_STATUS_OK(spi_config_test(&spi_host));
+  }
+  return true;
+}
+
+static status_t spi_config_test(dif_spi_host_t *spi) {
+  dif_spi_host_config_t config = {
+      .spi_clock = 40000,
+      .peripheral_clock_freq_hz = (uint32_t)kClockFreqUsbHz,
+  };
+  backdoor_cpha = UINT8_MAX;
+  backdoor_cpol = UINT8_MAX;
+  backdoor_data = UINT32_MAX;
+
+  OTTF_WAIT_FOR(backdoor_cpha != UINT8_MAX, kDefaultTimeoutMicros);
+  config.cpha = backdoor_cpha;
+  OTTF_WAIT_FOR(backdoor_cpol != UINT8_MAX, kDefaultTimeoutMicros);
+  config.cpol = backdoor_cpol;
+  TRY(dif_spi_host_output_set_enabled(spi, false));
+  TRY(dif_spi_host_configure(spi, config));
+  TRY(dif_spi_host_output_set_enabled(spi, true));
+  LOG_INFO("Mode : CPOL=%d,CPHA=%d", config.cpol, config.cpha);
+
+  static uint32_t address = 0;
+  OTTF_WAIT_FOR(backdoor_data != UINT32_MAX, kDefaultTimeoutMicros);
+  uint8_t data[sizeof(backdoor_data)];
+  memcpy(data, &backdoor_data, sizeof(data));
+  busy_spin_micros(70000);
+  TRY(spi_flash_testutils_program_page(spi, data, sizeof(data), address,
+                                       false));
+  return OK_STATUS();
+}
+
+static status_t configure_pinmux(const dif_pinmux_t *pinmux) {
+  // CSB.
+  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIor10,
+                               kTopEarlgreyPinmuxOutselSpiHost1Csb));
+  // SCLK.
+  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIor11,
+                               kTopEarlgreyPinmuxOutselSpiHost1Sck));
+  // SD0.
+  TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd0,
+                              kTopEarlgreyPinmuxInselIor12));
+  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIor12,
+                               kTopEarlgreyPinmuxOutselSpiHost1Sd0));
+
+  // SD1.
+  TRY(dif_pinmux_input_select(pinmux, kTopEarlgreyPinmuxPeripheralInSpiHost1Sd1,
+                              kTopEarlgreyPinmuxInselIor13));
+  TRY(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIor13,
+                               kTopEarlgreyPinmuxOutselSpiHost1Sd1));
+  return OK_STATUS();
+}

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -142,6 +142,7 @@ rust_library(
         "src/spiflash/mod.rs",
         "src/spiflash/sfdp.rs",
         "src/test_utils/bitbanging/i2c.rs",
+        "src/test_utils/bitbanging/spi.rs",
         "src/test_utils/bitbanging/mod.rs",
         "src/test_utils/bootstrap.rs",
         "src/test_utils/e2e_command.rs",

--- a/sw/host/opentitanlib/src/test_utils/bitbanging/i2c.rs
+++ b/sw/host/opentitanlib/src/test_utils/bitbanging/i2c.rs
@@ -2,24 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::Bit;
 use anyhow::{bail, Context, Result};
 use arrayvec::ArrayVec;
-
-#[repr(u8)]
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum Bit {
-    Low = 0,
-    High = 1,
-}
-
-impl From<u8> for Bit {
-    fn from(val: u8) -> Self {
-        match val {
-            0x00 => Self::Low,
-            _ => Self::High,
-        }
-    }
-}
 
 #[derive(Debug, PartialEq)]
 enum Symbol {

--- a/sw/host/opentitanlib/src/test_utils/bitbanging/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/bitbanging/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod i2c;
+pub mod spi;
 
 #[repr(u8)]
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/sw/host/opentitanlib/src/test_utils/bitbanging/mod.rs
+++ b/sw/host/opentitanlib/src/test_utils/bitbanging/mod.rs
@@ -3,3 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod i2c;
+
+#[repr(u8)]
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Bit {
+    Low = 0,
+    High = 1,
+}
+
+impl From<u8> for Bit {
+    fn from(val: u8) -> Self {
+        match val {
+            0x00 => Self::Low,
+            _ => Self::High,
+        }
+    }
+}

--- a/sw/host/opentitanlib/src/test_utils/bitbanging/spi.rs
+++ b/sw/host/opentitanlib/src/test_utils/bitbanging/spi.rs
@@ -1,0 +1,155 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Bit;
+use anyhow::{bail, Context, Result};
+
+pub enum SpiDataMode {
+    Single,
+    Dual,
+    Quad,
+}
+
+pub mod encoder {}
+
+pub mod decoder {
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct Sample<
+        const D0: u8,
+        const D1: u8,
+        const D2: u8,
+        const D3: u8,
+        const CLK: u8,
+        const CS: u8,
+    > {
+        raw: u8,
+    }
+
+    impl<const D0: u8, const D1: u8, const D2: u8, const D3: u8, const CLK: u8, const CS: u8>
+        Sample<D0, D1, D2, D3, CLK, CS>
+    {
+        fn d0(&self) -> Bit {
+            ((self.raw >> D0) & 0x01).into()
+        }
+        fn d1(&self) -> Bit {
+            ((self.raw >> D1) & 0x01).into()
+        }
+        fn d2(&self) -> Bit {
+            ((self.raw >> D2) & 0x01).into()
+        }
+        fn d3(&self) -> Bit {
+            ((self.raw >> D3) & 0x01).into()
+        }
+        fn clk(&self) -> Bit {
+            ((self.raw >> CLK) & 0x01).into()
+        }
+        fn cs(&self) -> Bit {
+            ((self.raw >> CS) & 0x01).into()
+        }
+    }
+
+    pub struct Decoder<
+        const D0: u8,
+        const D1: u8,
+        const D2: u8,
+        const D3: u8,
+        const CLK: u8,
+        const CS: u8,
+    > {
+        pub cpol: bool,
+        pub cpha: bool,
+        pub data_mode: SpiDataMode,
+    }
+
+    impl<const D0: u8, const D1: u8, const D2: u8, const D3: u8, const CLK: u8, const CS: u8>
+        Decoder<D0, D1, D2, D3, CLK, CS>
+    {
+        /// Returns a sample when a raise or fall clock edge is detected depending on the cpol and cpha configuration.
+        fn wait_cs<I>(&self, samples: &mut I) -> Result<()>
+        where
+            I: Iterator<Item = Sample<D0, D1, D2, D3, CLK, CS>>,
+        {
+            let clk_idle_level = if self.cpol { Bit::High } else { Bit::Low };
+
+            let sample = samples
+                .by_ref()
+                .find(|sample| sample.cs() == Bit::Low)
+                .expect("Exhausted the samples");
+            if sample.clk() == clk_idle_level {
+                Ok(())
+            } else {
+                bail!(
+                    "Settings mismatch: Clock level when idle is {:?}, but cpol is {:?}",
+                    sample.clk(),
+                    self.cpol
+                )
+            }
+        }
+        /// Returns a sample when a raise or fall clock edge is detected depending on the cpol and cpha configuration.
+        fn sample_on_edge<I>(&self, samples: &mut I) -> Option<Sample<D0, D1, D2, D3, CLK, CS>>
+        where
+            I: Iterator<Item = Sample<D0, D1, D2, D3, CLK, CS>>,
+        {
+            let (sample_level, wait_level) = if self.cpol == self.cpha {
+                (Bit::High, Bit::Low)
+            } else {
+                (Bit::Low, Bit::High)
+            };
+            samples.by_ref().find(|sample| sample.clk() == wait_level);
+            samples.by_ref().find(|sample| sample.clk() == sample_level)
+        }
+
+        fn decode_byte<I>(&self, samples: &mut I) -> Result<u8>
+        where
+            I: Iterator<Item = Sample<D0, D1, D2, D3, CLK, CS>>,
+        {
+            let mut byte = 0u16;
+            let mut bits = 8;
+            while bits > 0 {
+                let sample = self.sample_on_edge(samples).context("Run out of samples")?;
+                match self.data_mode {
+                    SpiDataMode::Single => {
+                        byte <<= 1;
+                        byte |= sample.d0() as u16;
+                        bits -= 1;
+                    }
+                    SpiDataMode::Dual => {
+                        byte <<= 1;
+                        byte |= sample.d1() as u16;
+                        byte <<= 1;
+                        byte |= sample.d0() as u16;
+                        bits -= 2;
+                    }
+                    SpiDataMode::Quad => {
+                        byte <<= 1;
+                        byte |= sample.d3() as u16;
+                        byte <<= 1;
+                        byte |= sample.d2() as u16;
+                        byte <<= 1;
+                        byte |= sample.d1() as u16;
+                        byte <<= 1;
+                        byte |= sample.d0() as u16;
+                        bits -= 4;
+                    }
+                }
+            }
+
+            Ok(byte as u8)
+        }
+
+        pub fn run(&mut self, samples: Vec<u8>) -> Result<Vec<u8>> {
+            let mut samples = samples
+                .into_iter()
+                .map(|raw| Sample::<D0, D1, D2, D3, CLK, CS> { raw });
+            self.wait_cs(&mut samples)?;
+            let mut bytes = Vec::new();
+            while let Ok(byte) = self.decode_byte(&mut samples) {
+                bytes.push(byte);
+            }
+            Ok(bytes)
+        }
+    }
+}

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -177,10 +177,10 @@ fn test_write_repeated_start(
 
     const REFERENCE_DATA: &[u8] = b"Hello World!";
     let broken_byte = [
-        test_utils::bitbanging::i2c::Bit::High,
-        test_utils::bitbanging::i2c::Bit::Low,
-        test_utils::bitbanging::i2c::Bit::Low,
-        test_utils::bitbanging::i2c::Bit::High,
+        test_utils::bitbanging::Bit::High,
+        test_utils::bitbanging::Bit::Low,
+        test_utils::bitbanging::Bit::Low,
+        test_utils::bitbanging::Bit::High,
     ]
     .into_iter()
     .collect();

--- a/sw/host/tests/chip/spi_device/BUILD
+++ b/sw/host/tests/chip/spi_device/BUILD
@@ -71,3 +71,20 @@ rust_binary(
         "@crate_index//:serde_json",
     ],
 )
+
+rust_binary(
+    name = "spi_host_config_test",
+    srcs = [
+        "src/spi_host_config_test.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//third_party/rust/crates:regex",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:object",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/spi_device/src/spi_host_config_test.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_host_config_test.rs
@@ -1,0 +1,164 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use clap::Parser;
+use regex::Regex;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::execute_test;
+use opentitanlib::io::gpio::BitbangEntry;
+use opentitanlib::io::gpio::{GpioPin, PinMode, PullMode};
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::{self, mem::MemWriteReq};
+use opentitanlib::uart::console::{ExitStatus, UartConsole};
+use std::borrow::Borrow;
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
+    timeout: Duration,
+
+    /// Name of the SPI interface to connect to the OTTF console.
+    #[arg(long, default_value = "BOOTSTRAP")]
+    spi: String,
+
+    /// Path to the firmware's ELF file, for querying symbol addresses.
+    #[arg(value_name = "FIRMWARE_ELF")]
+    firmware_elf: PathBuf,
+}
+
+struct TestContext<'a> {
+    backdoor_cpha: u32,
+    backdoor_cpol: u32,
+    backdoor_data: u32,
+    gpio_pins: &'a [Rc<dyn GpioPin>],
+    cpol: u8,
+    cpha: u8,
+}
+const SPI_PIN_CS: u8 = 0;
+const SPI_PIN_SCL: u8 = 1;
+const SPI_PIN_D0: u8 = 2;
+const SPI_PIN_D1: u8 = 3;
+
+fn spi_host_config_test(opts: &Opts, transport: &TransportWrapper, ctx: &TestContext) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let gpio_bitbanging = transport.gpio_bitbanging()?;
+
+    const SAMPLES: usize = 5000;
+    let mut samples = vec![0x00; SAMPLES];
+    let output = &mut [0x7; SAMPLES];
+    output[1] = 0x0f; // A rising edge on the D1 to indicate when the sampling started, which is helpfull when debugging.
+    let waveform = Box::new([BitbangEntry::Both(output, &mut samples)]);
+
+    UartConsole::wait_for(
+        &*uart,
+        r".*SiVal: waiting for commands.*?[^\r\n]*",
+        opts.timeout,
+    )?;
+    MemWriteReq::execute(&*uart, ctx.backdoor_cpha, &[ctx.cpha])?;
+
+    UartConsole::wait_for(
+        &*uart,
+        r".*SiVal: waiting for commands.*?[^\r\n]*",
+        opts.timeout,
+    )?;
+    MemWriteReq::execute(&*uart, ctx.backdoor_cpol, &[ctx.cpol])?;
+
+    UartConsole::wait_for(
+        &*uart,
+        r".*SiVal: waiting for commands.*?[^\r\n]*",
+        opts.timeout,
+    )?;
+    MemWriteReq::execute(&*uart, ctx.backdoor_data, &[0xAB, 0xCD, 0xEF, 0xAB])?;
+    gpio_bitbanging.run(
+        &ctx.gpio_pins
+            .iter()
+            .map(Rc::borrow)
+            .collect::<Vec<&dyn GpioPin>>(),
+        Duration::from_micros(20),
+        waveform,
+    )?;
+
+    let mut decoder = test_utils::bitbanging::spi::decoder::Decoder::<
+        SPI_PIN_D0,
+        SPI_PIN_D1,
+        0, // D2, not in use.
+        0, // D3, not in use.
+        SPI_PIN_SCL,
+        SPI_PIN_CS,
+    > {
+        cpol: ctx.cpol == 1,
+        cpha: ctx.cpha == 1,
+        data_mode: test_utils::bitbanging::spi::SpiDataMode::Single,
+    };
+    let decoded = decoder.run(samples.to_owned())?;
+    assert_eq!(
+        decoded,
+        vec![0x06, 0x02, 0x00, 0x00, 0x00, 0xab, 0xcd, 0xef, 0xab, 0x05, 0x80,]
+    );
+    println!("decoded: {:?}", decoded);
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    println!("starting test");
+    let transport = opts.init.init_target()?;
+
+    /* Load the ELF binary and get the expect data.*/
+    let elf_binary = fs::read(&opts.firmware_elf)?;
+    let object = object::File::parse(&*elf_binary)?;
+    let mut ctx = TestContext {
+        backdoor_cpha: test_utils::object::symbol_addr(&object, "backdoor_cpha")?,
+        backdoor_cpol: test_utils::object::symbol_addr(&object, "backdoor_cpol")?,
+        backdoor_data: test_utils::object::symbol_addr(&object, "backdoor_data")?,
+        gpio_pins: &transport
+            .gpio_pins(&["IOR10", "IOR11", "IOR12", "IOR13"].map(str::to_owned))?,
+        cpol: 0,
+        cpha: 0,
+    };
+    for pin in ctx.gpio_pins {
+        pin.set_mode(PinMode::OpenDrain)?;
+        pin.set_pull_mode(PullMode::PullUp)?;
+    }
+    ctx.cpol = 0;
+    ctx.cpha = 0;
+    execute_test!(spi_host_config_test, &opts, &transport, &ctx);
+    ctx.cpol = 0;
+    ctx.cpha = 1;
+    execute_test!(spi_host_config_test, &opts, &transport, &ctx);
+    ctx.cpol = 1;
+    ctx.cpha = 0;
+    execute_test!(spi_host_config_test, &opts, &transport, &ctx);
+    ctx.cpol = 1;
+    ctx.cpha = 1;
+    execute_test!(spi_host_config_test, &opts, &transport, &ctx);
+
+    let uart = transport.uart("console")?;
+    let mut console = UartConsole {
+        timeout: Some(opts.timeout),
+        exit_success: Some(Regex::new(r"PASS!\r\n")?),
+        exit_failure: Some(Regex::new(r"FAIL:")?),
+        ..Default::default()
+    };
+
+    // Now watch the console for the exit conditions.
+    let result = console.interact(&*uart, None, Some(&mut std::io::stdout()))?;
+    if result != ExitStatus::ExitSuccess {
+        bail!("FAIL: {:?}", result);
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
## This PR implements the spi host config test. As we don't have spi device implemented on opentitanlib via hyperdebug, I used the bitbanging feature.  
### test:
1. Send four packets from the host to the device, each one with a different configuration for cpol and cpha.
2. The device should receive the packets and be able to decode them with the appropriated configuration.

Fix https://github.com/lowRISC/opentitan/issues/19036
Fix https://github.com/lowRISC/opentitan/issues/19844