### PR TITLE
[i2c,dv] I2C regression fixes

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -30,6 +30,7 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
   // test should not update timing parameter.
   // This variable indicates target DUT receives the end of the transaction
   // and allow tb to program a new timing parameter.
+  // TODO(#23920) Remove this.
   bit     got_stop = 0;
 
   int     rcvd_rd_byte = 0; // Increment each time the agent reads a byte.

--- a/hw/dv/sv/i2c_agent/i2c_driver.sv
+++ b/hw/dv/sv/i2c_agent/i2c_driver.sv
@@ -99,8 +99,21 @@ class i2c_driver extends dv_base_driver #(i2c_item, i2c_agent_cfg);
   virtual task drive_host_item(i2c_item req);
     // During pause period, let drive_scl control scl
     `DV_WAIT(scl_pause == 1'b0,, scl_spinwait_timeout_ns, "drive_host_item")
-    `uvm_info(`gfn, $sformatf("drive_host_item() :: drv_type=%s", req.drv_type.name()), UVM_HIGH)
 
+    // Print out what we are about to drive...
+    begin
+      string str = $sformatf("drive_host_item() :: drv_type=%s", req.drv_type.name());
+      case (req.drv_type)
+        HostData: str = {str, $sformatf(" ( byte=8'h%2x )", req.wdata)};
+        HostDataNoWaitForACK: begin
+          str = {str, $sformatf(" ( byte=8'h%2x, wait_cycles=%0d )", req.wdata, req.wait_cycles)};
+        end
+        default:; // Fall-through
+      endcase
+      `uvm_info(`gfn, str, UVM_HIGH)
+    end
+
+    // Now drive the item.
     case (req.drv_type)
       HostStart: begin
         cfg.vif.host_start(cfg.timing_cfg);

--- a/hw/ip/i2c/dv/env/i2c_env_cfg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_cfg.sv
@@ -71,8 +71,8 @@ class i2c_env_cfg extends cip_base_env_cfg #(.RAL_T(i2c_reg_block));
   // given stimulus. This is used by the testbench to know when it should start reading
   // from the ACQFIFO, and also to know when it can stop to end the test.
   // TODO(#23920) REFACTOR
-  int        sent_acq_cnt; // How many ACQFIFO items we expect the be produced
-  int        rcvd_acq_cnt; // How many ACQFIFO items we have observed by reading it
+  int        exp_num_acqfifo_reads; // How many ACQFIFO items we expect the be produced
+  int        obs_num_acqfifo_reads; // How many ACQFIFO items we have observed by reading it
 
   // The i2c_host_fifo_fmt_empty_vseq uses this variable for checking purposes.
   bit [7:0]  lastbyte; // TODO(#23920) Remove

--- a/hw/ip/i2c/dv/env/i2c_reference_model.sv
+++ b/hw/ip/i2c/dv/env/i2c_reference_model.sv
@@ -708,8 +708,10 @@ class i2c_reference_model extends uvm_component;
     exp_rd_item.clear_all();
     exp_wr_item.clear_all();
     rdata_cnt = 0;
-    txdata_wr = '{};
+    txdata_wr = {};
     acqdata_rd = {};
+
+    `uvm_info(`gfn, "i2c_reference_model is reset now.", UVM_LOW)
   endfunction : reset
 
 endclass : i2c_reference_model

--- a/hw/ip/i2c/dv/env/i2c_reference_model.sv
+++ b/hw/ip/i2c/dv/env/i2c_reference_model.sv
@@ -301,7 +301,7 @@ class i2c_reference_model extends uvm_component;
 
       "acqdata": begin
         acqdata_rd.push_back(data[10:0]);
-        cfg.rcvd_acq_cnt++; // Used for stimulus generation purposes #TODO Remove
+        cfg.obs_num_acqfifo_reads++; // Used for stimulus generation purposes #TODO Remove
       end
 
       default:;
@@ -650,7 +650,7 @@ class i2c_reference_model extends uvm_component;
       // the transfer to be accepted, and to become visible at the ACQFIFO.
 
       // Count the number of ACQFIFO items we expect to read to completely observe the transfer.
-      cfg.sent_acq_cnt += 1 /*signal=start/rstart, abyte=addr+dir*/ +
+      cfg.exp_num_acqfifo_reads += 1 /*signal=start/rstart, abyte=addr+dir*/ +
                           obs_xfer.num_data /*signal=none, abyte=data*/ +
                           (obs_xfer.stop ? 1 /*signal=stop, abyte=xx*/ : 0);
 
@@ -681,8 +681,8 @@ class i2c_reference_model extends uvm_component;
       exp_rd_xfer = obs_xfer;
 
       // Count the number of ACQFIFO items we expect to read to completely observe the transfer.
-      cfg.sent_acq_cnt += 1 /*signal=start/rstart, abyte=addr+dir*/ +
-                          (exp_rd_xfer.stop ? 1 /*signal=stop, abyte=xx*/ : 0);
+      cfg.exp_num_acqfifo_reads += 1 /*signal=start/rstart, abyte=addr+dir*/ +
+                                   (exp_rd_xfer.stop ? 1 /*signal=stop, abyte=xx*/ : 0);
 
       // If we received the item from the monitor, that means the transfer must have already
       // ended. Therefore, we know any data in the item has already been written into the

--- a/hw/ip/i2c/dv/env/i2c_reference_model.sv
+++ b/hw/ip/i2c/dv/env/i2c_reference_model.sv
@@ -709,6 +709,7 @@ class i2c_reference_model extends uvm_component;
     exp_wr_item.clear_all();
     rdata_cnt = 0;
     txdata_wr = '{};
+    acqdata_rd = {};
   endfunction : reset
 
 endclass : i2c_reference_model

--- a/hw/ip/i2c/dv/env/i2c_scoreboard.sv
+++ b/hw/ip/i2c/dv/env/i2c_scoreboard.sv
@@ -707,6 +707,8 @@ class i2c_scoreboard extends cip_base_scoreboard #(
 
     // Also reset the model when the scoreboard is reset (such as on dut_init())
     model.reset();
+
+    `uvm_info(`gfn, "i2c_scoreboard is reset now.", UVM_LOW)
   endfunction : reset
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -289,7 +289,7 @@ class i2c_base_vseq extends cip_base_vseq #(
 
   `uvm_object_new
 
-  `define ALL_ACQFIFO_READS_OCCURRED (cfg.rcvd_acq_cnt >= cfg.sent_acq_cnt)
+  `define ALL_ACQFIFO_READS_OCCURRED (cfg.obs_num_acqfifo_reads >= cfg.exp_num_acqfifo_reads)
   `define ALL_READS_OCCURRED (cfg.m_i2c_agent_cfg.rcvd_rd_byte >= sent_rd_byte)
 
   virtual task pre_start();
@@ -302,8 +302,8 @@ class i2c_base_vseq extends cip_base_vseq #(
     num_trans_c.constraint_mode(0);
 
     // Initialize counters for stop_target_interrupt for stress_all test
-    cfg.sent_acq_cnt = 0;
-    cfg.rcvd_acq_cnt = 0;
+    cfg.exp_num_acqfifo_reads = 0;
+    cfg.obs_num_acqfifo_reads = 0;
     sent_txn_cnt = 0;
     sent_rd_byte = 0;
     cfg.m_i2c_agent_cfg.rcvd_rd_byte = 0;
@@ -707,14 +707,14 @@ class i2c_base_vseq extends cip_base_vseq #(
 
   // Polling-based ACQFIFO handler
   //
-  // This routine waits until the sequence (via cfg.sent_acq_cnt) indicates it has created
+  // This routine waits until the sequence (via cfg.exp_num_acqfifo_reads) indicates it has created
   // stimulus that will generate ACQFIFO entires. It then calls read_acq_fifo() until the expected
   // number of ACQFIFO reads have been performed (and checked by the scoreboard).
   //
   virtual task process_acq();
 
     // Wait until at least some stimulus has been created, that will produce ACQFIFO entires.
-    `DV_WAIT(cfg.sent_acq_cnt > 0,, cfg.spinwait_timeout_ns)
+    `DV_WAIT(cfg.exp_num_acqfifo_reads > 0,, cfg.spinwait_timeout_ns)
 
     while (!`ALL_ACQFIFO_READS_OCCURRED || (sent_txn_cnt < num_trans)) begin
       bit read_one;
@@ -1300,11 +1300,11 @@ class i2c_base_vseq extends cip_base_vseq #(
     end
 
     `uvm_info(`gfn, $sformatf(
-      "After read_acq_fifo() : cfg.sent_acq_cnt=%0d cfg.rcvd_acq_cnt=%0d",
-      cfg.sent_acq_cnt, cfg.rcvd_acq_cnt), UVM_HIGH)
+      "After read_acq_fifo() : cfg.exp_num_acqfifo_reads=%0d cfg.obs_num_acqfifo_reads=%0d",
+      cfg.exp_num_acqfifo_reads, cfg.obs_num_acqfifo_reads), UVM_HIGH)
     `uvm_info(`gfn, $sformatf(
       "After read_acq_fifo() : sent_rd_byte=%0d cfg.m_i2c_agent_cfg.rcvd_rd_byte=%0d",
-      cfg.sent_acq_cnt, cfg.rcvd_acq_cnt), UVM_HIGH)
+      sent_rd_byte, cfg.m_i2c_agent_cfg.rcvd_rd_byte), UVM_HIGH)
   endtask : read_acq_fifo
 
   virtual task empty_acqfifo();

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -821,6 +821,7 @@ class i2c_base_vseq extends cip_base_vseq #(
   // This randomized transaction is constrained by a number of 'env_cfg' variables
   // - cfg.min_data/cfg.max_data
   // - cfg.rs_pct
+  // - cfg.min_num_transfers/cfg.max_num_transfers
   // - cfg.min_xfer_len
   //
   virtual function i2c_transaction create_txn();
@@ -1263,7 +1264,7 @@ class i2c_base_vseq extends cip_base_vseq #(
           // (ack-stop test) Only write to the txfifo now if there is no pre-feed data
           if (pre_feed_cnt == 0) begin
             csr_wr(.ptr(ral.txdata), .value(wdata));
-            `uvm_info(id, $sformatf("Wrote 0x%0x to txdata", wdata), UVM_HIGH)
+            `uvm_info(id, $sformatf("Wrote 8'h%2x into the TXFIFO.", wdata), UVM_HIGH)
           end else begin
             pre_feed_cnt--;
           end

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_full_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_host_fifo_full_vseq.sv
@@ -8,6 +8,10 @@ class i2c_host_fifo_full_vseq extends i2c_rx_tx_vseq;
   `uvm_object_utils(i2c_host_fifo_full_vseq)
   `uvm_object_new
 
+  /////////////////
+  // CONSTRAINTS //
+  /////////////////
+
   // fast write data to fmt_fifo to quickly trigger fmt_threshold interrupt
   constraint fmt_fifo_access_dly_c { fmt_fifo_access_dly == 0;}
   // fast read data from rd_fifo after it is full in order to quickly finish simulation
@@ -23,6 +27,11 @@ class i2c_host_fifo_full_vseq extends i2c_rx_tx_vseq;
   // read transaction length is equal to rx_fifo
   constraint num_rd_bytes_c { num_rd_bytes == I2C_RX_FIFO_DEPTH; }
 
+  /////////////
+  // METHODS //
+  /////////////
+
+
   virtual task pre_start();
     // hold reading rx_fifo to ensure rx_fifo gets full
     super.pre_start();
@@ -30,55 +39,61 @@ class i2c_host_fifo_full_vseq extends i2c_rx_tx_vseq;
     print_seq_cfg_vars("pre-start");
   endtask : pre_start
 
+
   virtual task body();
-    bit check_fifo_full = 1'b1;
+    bit do_interrupt = 1'b1;
+    bit do_check_fifo_status = 1'b1;
     initialization();
     `uvm_info(`gfn, "\n--> start of i2c_host_fifo_full_vseq", UVM_DEBUG)
     fork
+      // Every-cycle, check the fifo status signals are consistent with the reported levels.
       begin
-        while (!cfg.under_reset && check_fifo_full) process_fifo_full_status();
+        while (!cfg.under_reset && do_check_fifo_status) begin
+          @(posedge cfg.clk_rst_vif.clk);
+          check_fifo_status(); // Backdoor-read and check all fifo status signals. (0-time)
+        end
       end
+      // Process CONTROLLER-Mode interrupts while the stimulus is being generated.
       begin
-        host_send_trans(num_trans);
-        check_fifo_full = 1'b0; // gracefully stop process_fifo_full_status()
+        while (!cfg.under_reset && do_interrupt) process_interrupts();
+      end
+      // Generate test stimulus transactions
+      begin
+        host_send_trans(num_trans, .trans_type(WriteOnly));
+        do_check_fifo_status = 1'b0; // gracefully stop check_fifo_status() loop
+        do_interrupt = 1'b0; // gracefully stop process_interrupts() loop
       end
     join
     `uvm_info(`gfn, "\n--> end of i2c_host_fifo_full_vseq", UVM_DEBUG)
   endtask : body
 
-  // ICEBOX(#18979): weicai suggested corner tests: send N + 1 items (N is fifo depth), configure agent
-  // to slow read mode (not able to completely handle one item before N+1 items are written),
-  // then check fifo_full bit is
-  //   - not asserted when N items are written to fifo (fifo_lvl = N-1)
-  //   - asserted once writing one more item to fifo (fifo_lvl = N)
-  //   - clear interrupt, finish processing all the items and check interrupt not asserted
 
-  task process_fifo_full_status();
+  // Backdoor-read the DUT-CONTROLLER fifo status registers, and check that the full and empty
+  // flags are consistent with the reported levels and the known size of the fifos.
+  //
+  task check_fifo_status();
+
     bit fmt_full, rx_full, fmt_empty, rx_empty;
     bit [TL_DW-1:0] status, fmt_lvl, rx_lvl;
 
-    @(posedge cfg.clk_rst_vif.clk);
+    // Backdoor-read all of the CONTROLLER-Mode fifo status registers.
+    csr_rd(.ptr(ral.host_fifo_status.fmtlvl), .value(fmt_lvl), .backdoor(1'b1));
+    csr_rd(.ptr(ral.host_fifo_status.rxlvl), .value(rx_lvl), .backdoor(1'b1));
     csr_rd(.ptr(ral.status), .value(status), .backdoor(1'b1));
     fmt_full  = bit'(get_field_val(ral.status.fmtfull, status));
     fmt_empty = bit'(get_field_val(ral.status.fmtempty, status));
     rx_full   = bit'(get_field_val(ral.status.rxfull, status));
     rx_empty  = bit'(get_field_val(ral.status.rxempty, status));
-    csr_rd(.ptr(ral.host_fifo_status.fmtlvl), .value(fmt_lvl), .backdoor(1'b1));
-    csr_rd(.ptr(ral.host_fifo_status.rxlvl), .value(rx_lvl), .backdoor(1'b1));
-    if (!cfg.under_reset) begin
-      if (fmt_full)  begin
-        `DV_CHECK_EQ(fmt_lvl, I2C_FMT_FIFO_DEPTH);
-      end else begin
-        `DV_CHECK_LT(fmt_lvl, I2C_FMT_FIFO_DEPTH);
-      end
-      if (rx_full)   begin
-        `DV_CHECK_EQ(rx_lvl, I2C_RX_FIFO_DEPTH);
-      end else begin
-        `DV_CHECK_LT(rx_lvl, I2C_RX_FIFO_DEPTH);
-      end
-      if (fmt_empty) `DV_CHECK_EQ(fmt_lvl, 0);
-      if (rx_empty)  `DV_CHECK_EQ(rx_lvl, 0);
-    end
-  endtask : process_fifo_full_status
+
+    // Check the reported levels and status bits are consistent with the known fifo sizes.
+    if (fmt_full)  `DV_CHECK_EQ(fmt_lvl, I2C_FMT_FIFO_DEPTH)
+    else           `DV_CHECK_LT(fmt_lvl, I2C_FMT_FIFO_DEPTH)
+    if (rx_full)   `DV_CHECK_EQ(rx_lvl,  I2C_RX_FIFO_DEPTH)
+    else           `DV_CHECK_LT(rx_lvl,  I2C_RX_FIFO_DEPTH)
+    if (fmt_empty) `DV_CHECK_EQ(fmt_lvl, 0)
+    if (rx_empty)  `DV_CHECK_EQ(rx_lvl,  0)
+
+  endtask : check_fifo_status
+
 
 endclass : i2c_host_fifo_full_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_hrst_vseq.sv
@@ -2,36 +2,39 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Test to check the DUT-Target behaviour with early assertion of RSTART or STOP
-// (We refer to this behaviour as 'glitches' in within this vseq)
+// This vseq stimulates mid-transfer START and STOP conditions to test DUT-Target responses to
+// these non-protocol but valid bus events.
+// (We refer to this stimulus as 'glitches' within this vseq).
 //
 // The main function of this vseq is to increase coverage of FSM state transitions
 // back to the idle/acquire states upon the early Sr/P conditions short-circuiting the
 // normal transfer/transaction process.
 //
 // Test Procedure:
-// > Initialize DUT in Target mode
-// > Randomly introduce glitches specified by enum `glitch_e`
-//   > For each glitch type, byte transmission will be interrupted causing the internal FSM to
+// - Initialize DUT-Target mode
+// - Begin stimulating an i2c transaction using the Agent-Controller.
+// - Randomly introduce glitches specified by enum `glitch_e`
+//   - For each glitch type, byte transmission will be interrupted causing the internal FSM to
 //     go to Idle/AcquireStart state
-// > Issue new transactions after glitch to check if DUT is processing transactions as expected
+// - Issue new transactions after glitch to check if DUT is processing transactions as expected
 
 class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
 
-  // Control-flags used to sequence tasks
+  ///////////////
+  // VARIABLES //
+  ///////////////
 
-  // Used to track which call to fetch_txn should avoid appending Start
-  bit skip_start = 0;
-
-  rand uint glitch_txn_num; // This indicates the index of the transaction we will glitch
+  // This indicates the index of the transaction we will glitch
+  rand uint glitch_txn_num;
 
   // Protocol glitch type
   rand glitch_e glitch;
-  // 0 - Indicates Start/Stop glitch in Write transaction
-  // 1 - Indicates Start/Stop glitch in Read transaction
-  rand tran_type_e rw_bit;
 
-  `uvm_object_utils(i2c_target_hrst_vseq)
+  `uvm_object_utils_begin(i2c_target_hrst_vseq)
+    `uvm_field_int(glitch_txn_num,           UVM_DEFAULT)
+    `uvm_field_enum(glitch_e, glitch,        UVM_DEFAULT)
+  `uvm_object_utils_end
+
   `uvm_object_new
 
   /////////////////
@@ -39,37 +42,32 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
   /////////////////
 
   constraint num_trans_c {num_trans == 5;}
-  // Constrain the glitched transaction to allow a number of post-glitch normal
-  // transactions to test recovery.
-  constraint glitch_txn_num_c {glitch_txn_num < num_trans - 2;}
 
-  constraint rw_bit_c {
-    // Read state glitches covered in i2c_glitch_vseq
-    rw_bit dist {ReadOnly := 0, WriteOnly := 1};
+  // This sequence only tests "glitches" in DUT-Target WRITE Transfers.
+  // - i2c_glitch_vseq is a directed-test which is responsible for stimulating "glitches" into
+  //   primarily READ Transfers.
+  constraint rw_bit_c {rw_bit == WriteOnly;}
+
+  // Constrain the glitched transaction position to ensure a number of post-glitch normal
+  // transactions can test recovery.
+  constraint glitch_txn_num_c {
+    glitch_txn_num inside {[0 : num_trans - 2]};
   }
-  // Randomize type of glitch based on rw_bit with equal probability
+
+  // Randomize type of glitch
   constraint glitch_c {
-     if (rw_bit == ReadOnly) {
-       glitch dist {
-         ReadDataByteStart := 1,
-         ReadDataAckStart := 1,
-         ReadDataAckStop := 1
-       };
-     }
-     else{
-       glitch dist {
-         AddressByteStart := 1,
-         AddressByteStop := 1 ,
-         WriteDataByteStart := 1 ,
-         WriteDataByteStop := 1
-       };
-     }
-     solve rw_bit before glitch;
+    glitch dist {
+      AddressByteStart := 1,
+      AddressByteStop := 1 ,
+      WriteDataByteStart := 1 ,
+      WriteDataByteStop := 1
+    };
   }
 
   ///////////////////
   // CLASS METHODS //
   ///////////////////
+
 
   virtual task pre_start();
     super.pre_start();
@@ -84,13 +82,18 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
     `uvm_info("cfg_summary",
               $sformatf("target_addr0:0x%x target_addr1:0x%x illegal_addr:0x%x num_trans:%0d",
                         target_addr0, target_addr1, illegal_addr, num_trans), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("vseq summary:\n%s", this.sprint()), UVM_MEDIUM)
 
     fork
       // Send all transaction stimulus
+      // - This includes all the normal transactions, plus the one special one where we apply the
+      //   glitch.
       for (uint i = 0; i < num_trans; i++) send_trans(i);
-      // Handle normal interrupts, and gracefully stop interrupt handlers at end of test
-      while (!cfg.stop_intr_handler) process_target_interrupts();
-      stop_target_interrupt_handler();
+      // Handle all DUT-Controller interrupts, and gracefully stop handlers at end of test
+      fork
+        while (!cfg.stop_intr_handler) process_target_interrupts();
+        stop_target_interrupt_handler();
+      join
     join
   endtask : body
 
@@ -99,21 +102,22 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
     // Agent-Controller sequence to generate stimulus
     i2c_target_base_seq m_i2c_host_seq;
 
-    `uvm_info(`gfn, $sformatf("start of round %0d/%0d (glitch_txn:%0d)",
-                              i + 1, num_trans, glitch_txn_num + 1), UVM_MEDIUM)
-
     // Wait for previous stop-condition before proceeding with next transaction.
     if (i > 0) begin
       `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop,, cfg.spinwait_timeout_ns, "target_hrst_vseq")
       cfg.m_i2c_agent_cfg.got_stop = 0;
     end
 
-    // If the glitched transaction was a Read, reset the DUT's TXFIFO after completion.
-    // This ensures there is no stale data left in the fifo for the next read transaction.
-    if (i == (glitch_txn_num + 1) && rw_bit == ReadOnly) begin
-      ral.fifo_ctrl.txrst.set(1'b1);
-      csr_update(ral.fifo_ctrl);
-    end
+    `DV_WAIT(cfg.intr_vif.pins[CmdComplete] == 1'b0, "cmd_complete interrupt did not de-assert!")
+    // Cleanup for next iteration.
+    empty_acqfifo();
+
+    // Check all acqfifo entries have been read before beginning the next transfer.
+    `DV_WAIT(`ALL_READS_OCCURRED,,, "Failed check for ALL_READS_OCCURRED")
+    `DV_WAIT(`ALL_ACQFIFO_READS_OCCURRED,,, "Failed check for ALL_ACQFIFO_READS_OCCURRED")
+
+    `uvm_info(`gfn, $sformatf("Starting trans(%0d)/num_trans(%0d) (glitch_txn_num=%0d)",
+                              i + 1, num_trans, glitch_txn_num + 1), UVM_MEDIUM)
 
     // Apply a new set of timing parameters for the next transaction.
     // However, don't update new timing params during and right after the glitched runt transaction
@@ -125,278 +129,101 @@ class i2c_target_hrst_vseq extends i2c_target_smoke_vseq;
     // Populate item queue that defines the upcoming transaction
     `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
     if (i == glitch_txn_num) begin
-      `uvm_info(`gfn, $sformatf("Creating glitched transaction stimulus as trans %0d/%0d",
-        i+1, num_trans), UVM_MEDIUM)
-      // This special routine creates the glitched transaction
-      fetch_no_tb_txn(m_i2c_host_seq.req_q);
+      // Disable address randomization for the glitch txn
+      cfg.bad_addr_pct = 0;
+      // Create the special glitches txn
+      create_write_glitch(m_i2c_host_seq.req_q);
+      `uvm_info(`gfn, "Generated glitched transaction stimulus now.", UVM_MEDIUM)
     end else begin
       // Create a normal transaction
       generate_agent_controller_stimulus(m_i2c_host_seq.req_q);
     end
 
     fork
-      // Start stimulus sequence
+      // Start the agent driving the stimulus sequence
       m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
-      if (i == glitch_txn_num) fork
-        // Reset the monitor state just before the glitch is introduced.
-        reset_monitor();
-        // Wait for completion of the glitch transaction, and cleanup the scoreboard for further
-        // transactions to test recovery.
-        cleanup_scoreboard();
-      join
-    join_any
+    join
 
-    `uvm_info("seq", $sformatf("End of round %0d/%0d", i + 1, num_trans), UVM_MEDIUM)
-
-    // Reset 'skip_start' the iteration after the glitched transaction
-    if (i == (glitch_txn_num + 1)) skip_start = 0;
+    `uvm_info("seq", $sformatf("End of trans %0d/%0d", i + 1, num_trans), UVM_MEDIUM)
 
     sent_txn_cnt++;
   endtask: send_trans
 
 
-  // We need to reset some of the monitor state just before introducing the 'glitch' condition,
-  // as the environment is currently incapable of modelling this behaviour precisely.
-  // During data transmission, the glitch is introduced on a random bit using the
-  // <i2c_item>.wait_cycles field. The monitor state should be reset before the earliest
-  // possible cycle a glitch may be introduced.
-  //
-  task reset_monitor();
-    // The 'wait_cycles' variable indicates at which point the monitor should be reset.
-    // - For AddressByteStart the minimum is 1 cycle
-    // - For AddressByteStop, the minimum is 9 cycles (Start+Address+ACK).
-    // To prevent TB side races, +1 is added to these limits.
-
-    int wait_cycles = glitch inside {AddressByteStart, AddressByteStop} ? 2 : 10;
-    repeat(wait_cycles) @(posedge cfg.m_i2c_agent_cfg.vif.scl_i);
-
-    `uvm_info(`gfn, "Issuing monitor_rst now.", UVM_MEDIUM)
-    cfg.m_i2c_agent_cfg.monitor_rst = 1;
-
-    cfg.clk_rst_vif.wait_clks(2);
-
-    `uvm_info(`gfn, "Clearing monitor_rst now.", UVM_MEDIUM)
-    cfg.m_i2c_agent_cfg.monitor_rst = 0;
-  endtask: reset_monitor
-
-
-  task cleanup_scoreboard();
-    // We're now driving the glitched transaction. After the expected item is sent
-    // to the scoreboard, wait until the queue becomes empty, indicating the scoreboard has
-    // popped the item for comparison.
-
-    fork
-      if (!cfg.scoreboard.target_mode_wr_exp_fifo.is_empty()) begin
-        `uvm_info(`gfn, "Waiting for target_mode_wr_exp_fifo to become empty.", UVM_MEDIUM)
-        `DV_SPINWAIT(// WAIT_
-                     cfg.wait_fifo_not_empty(cfg.scoreboard.target_mode_wr_exp_fifo);,
-                     // MSG_
-                     "Timed-out waiting for target_mode_wr_exp_fifo to become empty.",
-                     // TIMEOUT_NS_
-                     cfg.spinwait_timeout_ns)
-
-        // Reset the scoreboard checking routine
-        `uvm_info(`gfn, "target_mode_wr_exp_fifo is empty. Resetting the scb checking routine now.",
-                  UVM_MEDIUM)
-        cfg.scoreboard.reset_dut_target_wr_compare.trigger();
-      end
-      if (!cfg.scoreboard.target_mode_rd_exp_fifo.is_empty()) begin
-        `uvm_info(`gfn, "Waiting for target_mode_rd_exp_fifo to become empty.", UVM_MEDIUM)
-        `DV_SPINWAIT(// WAIT_
-                     cfg.wait_fifo_not_empty(cfg.scoreboard.target_mode_rd_exp_fifo);,
-                     // MSG_
-                     "Timed-out waiting for target_mode_rd_exp_fifo to become empty.",
-                     // TIMEOUT_NS_
-                     cfg.spinwait_timeout_ns)
-
-        // Reset the scoreboard checking routine
-        `uvm_info(`gfn, "target_mode_rd_exp_fifo is empty. Resetting the scb checking routine now.",
-                  UVM_MEDIUM)
-        cfg.scoreboard.reset_dut_target_rd_compare.trigger();
-      end
-    join
-
-  endtask: cleanup_scoreboard
-
-
-  // Populate transaction queue with glitches based on glitch variable
-  task fetch_no_tb_txn(ref i2c_item dst_q[$]);
-
-    // Make sure error txn is long enough to have various different transaction segments
-    cfg.min_data = 20;
-    // Disable address randomization for the glitch txn
-    cfg.bad_addr_pct = 0;
-
-    // Add 'START' to the front
-    begin
-      i2c_item txn;
-      `uvm_create_obj(i2c_item, txn)
-      txn.drv_type = HostStart;
-      dst_q.push_back(txn);
-    end
-
-    `uvm_info(`gfn, $sformatf("Glitching a %0s transaction", rw_bit ? "Read" : "Write"), UVM_MEDIUM)
-    case (rw_bit)
-      ReadOnly: create_read_glitch(dst_q);
-      WriteOnly: create_write_glitch(dst_q);
-      default:;
-    endcase
-
-    // If we glitched with an unexpected start condition, we don't need to create
-    // a start condition for the next stimulus transaction that tests recovery. So skip it.
-    if (glitch == AddressByteStart) skip_start = 1;
-
-  endtask
-
-
-  // Populate transaction queue to introduce Start/Stop conditions in Write Data/Address byte
+  // Populate transaction queue to introduce Start/Stop conditions in Data or Address byte
   function void create_write_glitch(ref i2c_item driver_q[$]);
-    i2c_item txn;
     `uvm_info(`gfn, $sformatf("Introducing %s glitch", glitch.name()), UVM_LOW)
 
-    // Address byte
-    `uvm_create_obj(i2c_item, txn)
-    txn.wdata[7:1] = get_target_addr(); // target_addr0;
-    txn.wdata[0] = (rw_bit == ReadOnly); // dir
-    txn.drv_type = HostData;
-    driver_q.push_back(txn);
+    // First drive a START condition to begin the transactiona.
+    begin
+      i2c_item start_txn;
+      `uvm_create_obj(i2c_item, start_txn)
+      start_txn.drv_type = HostStart;
+      driver_q.push_back(start_txn);
+    end
 
-    // Add entry for Address glitch
+    // Address byte
+    begin
+      i2c_item addr_txn;
+      `uvm_create_obj(i2c_item, addr_txn)
+      addr_txn.wdata[7:1] = get_target_addr(); // Get one of the two (valid) addresses
+      addr_txn.wdata[0] = (rw_bit == ReadOnly) ? i2c_pkg::READ : i2c_pkg::WRITE; // direction bit
+      addr_txn.drv_type = HostData;
+      driver_q.push_back(addr_txn);
+    end
+
+    // If we're adding the glitch into the Addr+Dir byte, create the special driver item now.
     if (glitch inside {AddressByteStart, AddressByteStop}) begin
 
       i2c_item glitch_txn;
       `uvm_create_obj(i2c_item, glitch_txn)
       case (glitch)
-        AddressByteStart: glitch_txn.drv_type = HostRStart; // Add Start glitch
-        AddressByteStop: glitch_txn.drv_type = HostStop; // Add Stop glitch
+        AddressByteStart: glitch_txn.drv_type = HostRStart; // START glitch
+        AddressByteStop: glitch_txn.drv_type = HostStop; // STOP glitch
         default:;
       endcase
       driver_q.push_back(glitch_txn);
 
-      // There should be no entry in the ACQ FIFO for an AddressByte*
-      // glitch, since this is a new transaction that never completes
-      // addressing the target.
-      return; // return, since glitch entry is done
+      // There should be no entry in the ACQFIFO for an Address byte glitch, since this is a
+      // new transaction that never completes addressing the target.
+      // Therefore, we don't need to add any further drive stimulus items.
+      return;
     end
 
-    // Data byte
-    `uvm_create_obj(i2c_item, txn)
-    txn.wdata = $urandom_range(1, 127);
+    // If we're not glitching the address byte, we must be glitching one of the data bytes.
+    `DV_CHECK(glitch inside {WriteDataByteStart, WriteDataByteStop}, "Invalid glitch type!")
 
-    // Glitch in Data byte
-    if (glitch inside {WriteDataByteStart, WriteDataByteStop}) begin
-      txn.drv_type = HostDataNoWaitForACK;
-      txn.wait_cycles = $urandom_range(2, 6);
-      if (glitch == WriteDataByteStart) begin
-        txn.wdata = 8'hFF;
-      end else if (glitch == WriteDataByteStop) begin
-        txn.wdata = 8'h00;
-      end
-      // Push transaction to driver queue
-      driver_q.push_back(txn);
-      // Add glitch transaction
-      `uvm_create_obj(i2c_item, txn)
-      if (glitch == WriteDataByteStart) begin
-        txn.drv_type = HostRStart;
-        txn.rstart_front = 1;
-        skip_start = 1;
-      end else begin
-        txn.drv_type = HostStop;
-        txn.stop = 1;
-      end
-      // Push transaction for driver
-      driver_q.push_back(txn);
+    // Add glitch in Data byte
+
+    // First add the drive item for the first part of the data byte, which is normal.
+    // This special data bytes driver terminates early, allowing us to then drive the glitch
+    // condition afterwards.
+    begin
+      i2c_item data_txn;
+      `uvm_create_obj(i2c_item, data_txn)
+      data_txn.drv_type = HostDataNoWaitForACK;
+      data_txn.wait_cycles = $urandom_range(2, 6); // This makes us only drive a partial byte
+      case(glitch)
+        WriteDataByteStart: data_txn.wdata = 8'hFF;
+        WriteDataByteStop: data_txn.wdata = 8'h00;
+        default: `uvm_fatal(`gfn, "Shouldn't get here!")
+      endcase
+      driver_q.push_back(data_txn);
     end
+
+    // Now drive the glitch itself
+    begin
+      i2c_item glitch_txn;
+      `uvm_create_obj(i2c_item, glitch_txn)
+      case(glitch)
+        WriteDataByteStart: glitch_txn.drv_type = HostRStart;
+        WriteDataByteStop:  glitch_txn.drv_type = HostStop;
+        default: `uvm_fatal(`gfn, "Shouldn't get here!")
+      endcase
+      driver_q.push_back(glitch_txn);
+    end
+
   endfunction
 
-
-  task create_read_glitch(ref i2c_item driver_q[$]);
-    i2c_item txn;
-    bit valid_addr;
-    bit got_valid;
-    `uvm_info(`gfn, $sformatf("Introducing %s glitch", glitch.name()), UVM_LOW)
-    // Address byte
-    `uvm_create_obj(i2c_item, txn)
-    txn.wdata[7:1] = get_target_addr(); //target_addr0;
-    txn.wdata[0] = rw_bit == ReadOnly;
-    txn.read = rw_bit == ReadOnly;
-    txn.drv_type = HostData;
-    valid_addr = is_target_addr(txn.wdata[7:1]);
-    // Push transaction for driver
-    driver_q.push_back(txn);
-
-    // Update read transaction of DUT
-    begin
-      i2c_item read_txn;
-      `uvm_create_obj(i2c_item, read_txn)
-      read_txn.wdata = 8'hFF;
-      read_rcvd_q.push_back(1); // add one entry for txfifo
-      read_byte_q.push_back(read_txn.wdata);
-    end
-
-    // Data byte
-    if(glitch inside {ReadDataByteStart}) begin
-      // Update driver transaction
-      `uvm_create_obj(i2c_item, txn)
-      txn.drv_type = HostWait;
-      txn.wait_cycles = $urandom_range(1, 6);
-      // Clear TXDATA FIFO
-      ral.fifo_ctrl.txrst.set(1'b1);
-      csr_update(ral.fifo_ctrl);
-      cfg.clk_rst_vif.wait_clks(1);
-      // Write 'hFF to TXDATA FIFO so that SDA is driven high
-      csr_wr(.ptr(ral.txdata), .value('hFF));
-      cfg.clk_rst_vif.wait_clks(1);
-      // Push transaction to driver
-      driver_q.push_back(txn);
-      // Introduce Start glitch
-      `uvm_create_obj(i2c_item, txn)
-      txn.drv_type = HostRStart;
-      // Push glitch transaction to driver
-      driver_q.push_back(txn);
-      skip_start = 1;
-      return;
-    end else if (glitch inside {ReadDataAckStart, ReadDataAckStop}) begin
-      // Update driver transaction
-      `uvm_create_obj(i2c_item, txn)
-      txn.drv_type = HostWait;
-      txn.wait_cycles = 8; // Wait for full byte transmission
-      // Push transaction to driver
-      driver_q.push_back(txn);
-      // Introduce Start glitch
-      `uvm_create_obj(i2c_item, txn)
-      if (glitch inside {ReadDataAckStart}) begin
-        txn.drv_type = HostRStart;
-        skip_start = 1;
-      end else begin
-        txn.drv_type = HostStop;
-      end
-      // Push glitch transaction to driver
-      driver_q.push_back(txn);
-    end
-  endtask
-
-
-  task stop_target_interrupt_handler();
-    string id = "stop_interrupt_handler";
-    int    acq_rd_cyc;
-    acq_rd_cyc = 9 * (thigh + tlow);
-    `DV_WAIT(cfg.sent_acq_cnt > 0,, cfg.spinwait_timeout_ns, id)
-    `DV_WAIT(sent_txn_cnt == num_trans,, cfg.long_spinwait_timeout_ns, id)
-    cfg.read_all_acq_entries = 1;
-    if (cfg.rd_pct != 0) begin
-      `DV_WAIT(sent_rd_byte > 0,, cfg.spinwait_timeout_ns, id)
-      `uvm_info(id, $sformatf("st3 sent_acq:%0d rcvd_acq:%0d",
-                              cfg.sent_acq_cnt, cfg.rcvd_acq_cnt), UVM_HIGH)
-    end
-    `DV_WAIT(cfg.sent_acq_cnt <= cfg.rcvd_acq_cnt,, cfg.spinwait_timeout_ns, id)
-    csr_spinwait(.ptr(ral.status.acqempty), .exp_data(1'b1));
-
-    // add drain time before stop interrupt handler
-    cfg.clk_rst_vif.wait_clks(1000);
-    // Add extra draintime for tx overflow test
-    cfg.stop_intr_handler = 1;
-    `uvm_info(id, "called stop_intr_handler", UVM_MEDIUM)
-  endtask // stop_target_interrupt_handler
 
 endclass : i2c_target_hrst_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_perf_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_perf_vseq.sv
@@ -20,7 +20,7 @@ class i2c_target_perf_vseq extends i2c_target_smoke_vseq;
     e_timeout == 1;
     tsu_sta   == 1;
 
-    thigh     == 3;
+    thigh     == 4;
     tlow      == 8;
     // tHoldStop must be at least 2 cycles which implies, t_r + t_buf - tsu_sta >= 2
     // in order for stop condition to propogate to internal FSM via prim flop

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_smoke_vseq.sv
@@ -96,14 +96,15 @@ class i2c_target_smoke_vseq extends i2c_base_vseq;
             // Wait for the STOP-condition (the end of the previous transaction) before
             // programming new timing parameters.
             `DV_WAIT(cfg.m_i2c_agent_cfg.got_stop,, cfg.spinwait_timeout_ns, "target_smoke_vseq")
-            cfg.m_i2c_agent_cfg.got_stop = 0;
           end
+          cfg.m_i2c_agent_cfg.got_stop = 0;
           get_timing_values();
           program_registers();
 
           `uvm_create_obj(i2c_target_base_seq, m_i2c_host_seq)
           m_i2c_host_seq.req_q = txn_stimulus[i];
           m_i2c_host_seq.start(p_sequencer.i2c_sequencer_h);
+
           sent_txn_cnt++;
           `uvm_info(`gfn, $sformatf("Finished stimulus transaction %0d/%0d.",
             i+1, num_trans), UVM_HIGH)

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_all_vseq.sv
@@ -2,20 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// combine all i2c seqs (except below vseqs) in one seq to run sequentially
-// 1. override_vseq requires scb and monitor to be disabled
-// 2. csr seq, which requires scb to be disabled
-// 3. i2c_error_intr_vseq can issue internal reset
-//    so it is excluded/included w.r.t stress_all_with_rand_reset/stress_all test
+// This test runs a number of different virtual sequences back-to-back to cover a wider
+// gamut of stimulus.
+//
+class i2c_target_stress_all_vseq extends i2c_base_vseq;
 
-class i2c_target_stress_all_vseq extends i2c_target_smoke_vseq;
-  `uvm_object_utils(i2c_target_stress_all_vseq)
+  ///////////////
+  // VARIABLES //
+  ///////////////
 
-  `uvm_object_new
+  local int seq_run_hist[string];
 
-  local string str, seq_name;
-  local int    seq_run_hist[string];
-
+  // The following sequence names are all candidates to be run as part of the stress test.
   string seq_names[$] = {
     "i2c_target_smoke_vseq",
     "i2c_target_stress_wr_vseq",
@@ -24,70 +22,105 @@ class i2c_target_stress_all_vseq extends i2c_target_smoke_vseq;
     "i2c_target_perf_vseq"
   };
 
-  virtual task body();
-    `uvm_info(`gfn, "\n\n=> start i2c_target_stress_all_vseq", UVM_DEBUG)
-    print_seq_names(seq_names);
-    initialization();
-    for (int i = 1; i <= seq_names.size(); i++) begin
-      seq_run_hist[seq_names[i-1]] = 0;
-    end
+  `uvm_object_utils(i2c_target_stress_all_vseq)
+  `uvm_object_new
 
+  /////////////
+  // METHODS //
+  /////////////
+
+
+  virtual task pre_start();
+    super.pre_start();
+
+    // Initialize the sequence history map
+    for (int i = 1; i <= seq_names.size(); i++) seq_run_hist[seq_names[i-1]] = 0;
+
+    // Disable reset-application between sequences
+    // This may be re-enabled in the future if there is any test coverage to be achieved by it,
+    // so it can remain for now. However, the stress_all_with_rand_reset tests are likely to be
+    // better for closing coverage around resets.
+    do_apply_reset = 1'b0;
+    `uvm_info(`gfn, $sformatf("stress_all_vseq.do_apply_reset=1'b%1b", do_apply_reset), UVM_MEDIUM)
+
+    // Print out any sequences we may run as part of the stress test.
+    print_seq_names(seq_names);
+  endtask : pre_start
+
+
+  virtual task body();
+    // Initialize the DUT/Agent as Target/Controller respectively.
+    // This provides an initial configuration of the DUT's CSRs, as well as configuring both DUT
+    // and Agent with a compatible set of timing parameters.
+    initialization();
+
+    `uvm_info(`gfn, "i2c_target_stress_all_vseq : Initialization completed.", UVM_HIGH)
+
+    // Drive the stimulus sequences.
     for (int i = 1; i <= num_runs; i++) begin
-      uvm_sequence   seq;
-      i2c_base_vseq  i2c_vseq;
-      uint           seq_idx = $urandom_range(0, seq_names.size() - 1);
-      cfg.stop_intr_handler = 0;
+      string seq_name; // The name of the current stimulus sequence
+      uint seq_idx = $urandom_range(0, seq_names.size() - 1);
+
+      `uvm_info(`gfn, $sformatf("-> (%0d/%0d) Start of stimulus vseq '%0s'",
+        i, num_runs, seq_names[seq_idx]), UVM_LOW)
 
       seq_name = seq_names[seq_idx];
-      `uvm_info(`gfn, $sformatf("\n  -> start stressing vseq %s (%0d/%0d)",
-                                seq_name, i, num_runs), UVM_LOW)
-      seq = create_seq_by_name(seq_name);
-      `downcast(i2c_vseq, seq)
-      // do_apply_reset is defined in dv_base_vseq
-      // if upper seq disables do_apply_reset for this seq, then can't issue reset
-      // as upper seq may drive reset
-      `uvm_info(`gfn, $sformatf("\n  do_apply_reset %b", do_apply_reset), UVM_MEDIUM)
-      if (do_apply_reset) begin
-        i2c_vseq.do_apply_reset = $urandom_range(0, 1);
-        if (i2c_vseq.do_apply_reset) begin
-          `uvm_info(`gfn, "\n  stressing reset is randomly issued with stress_test", UVM_MEDIUM)
-        end
-      end else begin
-        i2c_vseq.do_apply_reset = 0;
-        `uvm_info(`gfn, "\n  reset may be driven by upper_seq thus not be issued", UVM_DEBUG)
-      end
-      // Need to reset scoreboard whenever sequence start over regardless of dut reset
-      cfg.scoreboard.reset("SOFT");
 
-      i2c_vseq.set_sequencer(p_sequencer);
-      `DV_CHECK_RANDOMIZE_FATAL(i2c_vseq)
-      // run vseq
-      i2c_vseq.start(p_sequencer);
+      begin
+        i2c_base_vseq i2c_vseq;
+        begin
+          uvm_sequence seq;
+          seq = create_seq_by_name(seq_name);
+          `downcast(i2c_vseq, seq)
+        end
+        i2c_vseq.do_apply_reset = (do_apply_reset) ? $urandom_range(0, 1) :
+                                                     0;
+
+        `uvm_info(`gfn, $sformatf("For the following vseq, %0s.do_apply_reset=1'b%1b",
+          seq_name, i2c_vseq.do_apply_reset), UVM_MEDIUM)
+
+        i2c_vseq.set_sequencer(p_sequencer);
+        `DV_CHECK_RANDOMIZE_FATAL(i2c_vseq)
+        i2c_vseq.start(p_sequencer);
+      end
+
+      `uvm_info(`gfn, $sformatf("-> (%0d/%0d) End of stimulus vseq '%0s'",
+        i, num_runs, seq_name), UVM_LOW)
       seq_run_hist[seq_name]++;
 
-      `uvm_info(`gfn, $sformatf("\n  -> end stressing vseq %s\n", seq_name), UVM_LOW)
-      wait(cfg.m_i2c_agent_cfg.vif.rst_ni);
+      // Reset the flag for the next sequence
+      cfg.stop_intr_handler = 0;
     end
-    wait_for_target_idle();
-    `uvm_info(`gfn, "\n=> end of i2c_target_stress_all_vseq", UVM_MEDIUM)
 
-    // get the histogram of vseq running
-    str = {str, "\n\n=> vseq run histogram:"};
-    for (int i = 0; i < seq_names.size(); i++) begin
-      seq_name = seq_names[i];
-      str = {str, $sformatf("\n  %-25s  %2d / %2d", seq_name, seq_run_hist[seq_name], num_runs)};
-    end
-    `uvm_info(`gfn, $sformatf("%s\n", str), UVM_DEBUG)
+    // We've now finished running all the stimulus sequences
+    // Wait for the DUT's target-module to return to idle, given there is no more stimulus.
+    wait_for_target_idle();
+
+    // Print a histogram/summary of the vseq's we ran
+    print_seq_histogram_summary();
+
+    `uvm_info(`gfn, "End of i2c_target_stress_all_vseq.", UVM_MEDIUM)
   endtask : body
+
 
   virtual function void print_seq_names(string seq_names[]);
     string str;
-
-    `uvm_info(`gfn, $sformatf("\n  list of %0d vseqs are stressed", seq_names.size()), UVM_DEBUG)
-    for (int i = 1; i <= seq_names.size(); i++) begin
-      str = {str, $sformatf("\n    %s", seq_names[i-1])};
+    str = $sformatf("\nThe following list of %0d vseqs will be stressed:", seq_names.size());
+    for (int i = 0; i < seq_names.size(); i++) begin
+      str = {str, $sformatf("\n - %s", seq_names[i])};
     end
-    `uvm_info(`gfn, $sformatf("%s", str), UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("%s", str), UVM_MEDIUM)
   endfunction : print_seq_names
+
+
+  virtual function void print_seq_histogram_summary();
+    string str = "\ni2c_target_stress_all_vseq -> run histogram:";
+    for (int i = 0; i < seq_names.size(); i++) begin
+      string seq_name = seq_names[i];
+      str = {str, $sformatf("\n  %-25s  %2d / %2d", seq_name, seq_run_hist[seq_name], num_runs)};
+    end
+    `uvm_info(`gfn, $sformatf("%s", str), UVM_MEDIUM)
+  endfunction : print_seq_histogram_summary
+
 
 endclass : i2c_target_stress_all_vseq

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_all_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_target_stress_all_vseq.sv
@@ -18,7 +18,6 @@ class i2c_target_stress_all_vseq extends i2c_base_vseq;
     "i2c_target_smoke_vseq",
     "i2c_target_stress_wr_vseq",
     "i2c_target_timeout_vseq",
-    "i2c_target_ack_stop_vseq",
     "i2c_target_perf_vseq"
   };
 


### PR DESCRIPTION
This is a bunch of smaller fixes, and cleanups that happened along the way, to get the overall I2C block-level regression back up to V2(S) levels.
Review commit-by-commit, see commit messages for more details about each failure. Most of these failures just came about from previous DV changes to model I2C transfers properly, but some are stragglers due to previous RTL changes.

The final commit removes the `i2c_target_ack_stop_vseq` from the target_stress_all test, as I believe this test is no longer functional due to a small RTL bug. See #24010 for more details.

--- 

`./util/dvsim/dvsim.py hw/ip/i2c/dv/i2c_sim_cfg.hjson -i all_once --tool vcs --reseed 10 --cov`

![_home_harry_projects_opentitan_scratch_dev4_tmp_reports_hw_ip_i2c_dv_latest_report html](https://github.com/user-attachments/assets/5748fd72-f01d-44a0-a429-9d839e610fbb)

