### PR TITLE
[otbn,dv] Remove some stray debug prints

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -348,7 +348,6 @@ module otbn_core_model
                                != 0);
       end
       if (rma_req_changed) begin
-        $display("%0t: set rma_req to %0x", $time, rma_req_fifo[1]);
         failed_lc_rma_req <= (otbn_model_set_rma_req(model_handle, rma_req_fifo[1]) != 0);
       end
       if (!$stable(keymgr_key_i) || $rose(rst_ni)) begin

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -11,8 +11,6 @@ from .state import OTBNState, FsmState
 from .stats import ExecutionStats
 from .trace import Trace
 
-import sys
-
 # A dictionary that defines a function of the form "address -> from -> to". If
 # PC is the current PC and cnt is the count for the innermost loop then
 # warps[PC][cnt] = new_cnt means that we should warp the current count to
@@ -510,8 +508,6 @@ class OTBNSim:
         effect.
         '''
         self.state.rma_req = read_lc_tx_t(rma_req)
-        # TODO: Remove this debug print
-        print(f'set_rma_req {self.state.rma_req!r}', file=sys.stderr)
 
     def urnd_completed(self) -> None:
         '''An outstanding URND request has just completed.


### PR DESCRIPTION
I added them when developing things recently and didn't notice that I'd left them in place. Oops! Take them out again.