### PR TITLE
[reggen,dv] Remove some unused type: ignore comments

### DIFF
--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -4,7 +4,7 @@
 
 from typing import Dict, List, Optional
 
-from design.mubi import prim_mubi  # type: ignore
+from design.mubi import prim_mubi
 
 from reggen.access import SWAccess, HWAccess
 from reggen.bits import Bits

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -4,7 +4,7 @@
 
 from typing import Dict, List, Optional
 
-from design.mubi import prim_mubi  # type: ignore
+from design.mubi import prim_mubi
 
 from reggen.access import SWAccess, HWAccess
 from reggen.clocking import Clocking


### PR DESCRIPTION
These had no effect but cause errors if you run mypy with

  make -C hw/ip/otbn/dv/otbnsim lint

I think I fixed the original problems with 6e37279.