### PR TITLE
[csrng/dv] Check RESEED_COUNTER and INT_STATE_READ_ENABLE

### DIFF
--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -251,6 +251,10 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
     bit [csrng_env_pkg::BLOCK_LEN-1:0]   hw_v;
     bit [csrng_env_pkg::RSD_CTR_LEN-1:0] hw_reseed_counter;
 
+    // The dedicated RESEED_COUNTER CSR is always readable.
+    bit [csrng_env_pkg::RSD_CTR_LEN-1:0] csr_reseed_counter;
+    csr_rd(.ptr(ral.reseed_counter[app]), .value(csr_reseed_counter));
+
     csr_wr(.ptr(ral.int_state_num), .value(app));
     // To give the hardware time to update
     clk_rst_vif.wait_clks(1);
@@ -283,6 +287,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
         UVM_DEBUG)
     `uvm_info(`gfn, $sformatf("******************************************\n"), UVM_DEBUG)
     if (compare) begin
+      // The dedicated RESEED_COUNTER CSR is always readable.
+      `DV_CHECK_EQ_FATAL(csr_reseed_counter, reseed_counter[app])
       if ((read_int_state == MuBi4True) && (otp_en_cs_sw_app_read == MuBi8True)) begin
         `DV_CHECK_EQ_FATAL(hw_reseed_counter, reseed_counter[app])
         `DV_CHECK_EQ_FATAL(hw_v, v[app])

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -24,7 +24,7 @@ class csrng_scoreboard extends cip_base_scoreboard #(
   bit [SW_APP:0] genbits_fips_previous;
   bit [SW_APP:0] genbits_fips_received = '0;
   mubi4_t [SW_APP:0] cmd_flag0_previous;
-  csrng_pkg::csrng_cmd_sts_e cmd_sts[NUM_HW_APPS + 1] = {(NUM_HW_APPS+1){CMD_STS_SUCCESS}};
+  csrng_pkg::csrng_cmd_sts_e cmd_sts[NUM_HW_APPS + 1] = '{default: CMD_STS_SUCCESS};
 
   bit [3:0] int_state_num;
   bit [NUM_HW_APPS:0] int_state_read_enable;

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_base_vseq.sv
@@ -60,6 +60,9 @@ class csrng_base_vseq extends cip_base_vseq #(
     ral.ctrl.read_int_state.set(cfg.read_int_state);
     ral.ctrl.fips_force_enable.set(cfg.fips_force_enable);
     csr_update(.csr(ral.ctrl));
+    csr_wr(.ptr(ral.int_state_read_enable_regwen), .value(cfg.int_state_read_enable_regwen));
+    ral.int_state_read_enable.set(cfg.int_state_read_enable);
+    csr_update(.csr(ral.int_state_read_enable));
   endtask
 
   task wait_cmd_req_done(uint exp_sts=CMD_STS_SUCCESS);

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_regwen_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_regwen_vseq.sv
@@ -14,14 +14,18 @@ class csrng_regwen_vseq extends csrng_base_vseq;
   int ctrl_int        = 0;
   int chk_int         = 0;
 
+  rand bit [NUM_HW_APPS:0] int_state_read_enable;
+  bit [NUM_HW_APPS:0] chk_int_state_read_enable;
+
   task body();
 
+    // REGWEN
     csr_wr(.ptr(ral.regwen), .value(ctrl_bit), .blocking(1));
     csr_wr(.ptr(ral.regwen), .value(~ctrl_bit), .blocking(1));
     csr_rd(.ptr(ral.regwen), .value(chk_bit), .blocking(1));
 
     if (chk_bit != ctrl_bit) begin
-      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite REGWEN after being set to 0"))
+      `uvm_fatal(`gfn, "Was able to overwrite REGWEN after being set to 0")
     end
 
     csr_rd(.ptr(ral.ctrl), .value(ctrl_int), .blocking(1));
@@ -31,7 +35,7 @@ class csrng_regwen_vseq extends csrng_base_vseq;
     csr_rd(.ptr(ral.ctrl), .value(chk_int), .blocking(1));
 
     if (ctrl_int != chk_int) begin
-      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite CTRL with REGWEN being set to 0"))
+      `uvm_fatal(`gfn, "Was able to overwrite CTRL with REGWEN being set to 0")
     end
 
     csr_rd(.ptr(ral.err_code_test), .value(ctrl_int), .blocking(1));
@@ -41,7 +45,51 @@ class csrng_regwen_vseq extends csrng_base_vseq;
     csr_rd(.ptr(ral.err_code_test), .value(chk_int), .blocking(1));
 
     if (ctrl_int != chk_int) begin
-      `uvm_fatal(`gfn, $sformatf(" Was able to overwrite ERR_CODE_TEST with REGWEN being set to 0"))
+      `uvm_fatal(`gfn, "Was able to overwrite ERR_CODE_TEST with REGWEN being set to 0")
+    end
+
+    // INT_STATE_READ_ENABLE_REGWEN
+    csr_rd(.ptr(ral.int_state_read_enable_regwen), .value(chk_bit), .blocking(1));
+    if (chk_bit == 1'b1) begin
+      // The register is still writeable. So let's do some writes before disabling write access.
+      `uvm_info(`gfn,
+          $sformatf("Testing INT_STATE_READ_ENABLE[_REGWEN] with value 0x%x",
+              int_state_read_enable),
+          UVM_MEDIUM);
+      csr_wr(.ptr(ral.int_state_read_enable), .value(int_state_read_enable), .blocking(1));
+      csr_rd(.ptr(ral.int_state_read_enable), .value(chk_int_state_read_enable), .blocking(1));
+      if (chk_int_state_read_enable != int_state_read_enable) begin
+        `uvm_fatal(`gfn, "Was unable to write INT_STATE_READ_ENABLE")
+      end
+      csr_wr(.ptr(ral.int_state_read_enable), .value(~int_state_read_enable), .blocking(1));
+      csr_rd(.ptr(ral.int_state_read_enable), .value(chk_int_state_read_enable), .blocking(1));
+      if (chk_int_state_read_enable != ~int_state_read_enable) begin
+        `uvm_fatal(`gfn, "Was unable to flip INT_STATE_READ_ENABLE")
+      end
+
+      csr_wr(.ptr(ral.int_state_read_enable_regwen), .value(1'b0), .blocking(1));
+      csr_rd(.ptr(ral.int_state_read_enable_regwen), .value(chk_bit), .blocking(1));
+      if (chk_bit != 1'b0) begin
+        `uvm_fatal(`gfn, "Was unable to set INT_STATE_READ_ENABLE_REGWEN to 0")
+      end
+    end
+
+    csr_rd(.ptr(ral.int_state_read_enable), .value(chk_int_state_read_enable), .blocking(1));
+    int_state_read_enable = ~chk_int_state_read_enable;
+    `uvm_info(`gfn,
+        $sformatf("Testing INT_STATE_READ_ENABLE[_REGWEN] with value 0x%x", int_state_read_enable),
+        UVM_MEDIUM);
+    csr_wr(.ptr(ral.int_state_read_enable), .value(int_state_read_enable), .blocking(1));
+    csr_rd(.ptr(ral.int_state_read_enable), .value(chk_int_state_read_enable), .blocking(1));
+    if (chk_int_state_read_enable == int_state_read_enable) begin
+      `uvm_fatal(`gfn,
+          "Was able to flip INT_STATE_READ_ENABLE with INT_STATE_READ_ENABLE_REGWEN set to 0")
+    end
+
+    csr_wr(.ptr(ral.int_state_read_enable_regwen), .value(1'b1), .blocking(1));
+    csr_rd(.ptr(ral.int_state_read_enable_regwen), .value(chk_bit), .blocking(1));
+    if (chk_bit == 1'b1) begin
+      `uvm_fatal(`gfn, "Was able to put INT_STATE_READ_ENABLE_REGWEN back to 1")
     end
 
     super.body();

--- a/hw/ip/csrng/dv/tests/csrng_base_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_base_test.sv
@@ -24,15 +24,17 @@ class csrng_base_test extends cip_base_test #(
   // the run_phase; as such, nothing more needs to be done
 
   virtual function void configure_env();
-    cfg.otp_en_cs_sw_app_read_pct       = 80;
-    cfg.otp_en_cs_sw_app_read_inval_pct = 10;
-    cfg.lc_hw_debug_en_pct              = 50;
-    cfg.regwen_pct                      = 100;
-    cfg.enable_pct                      = 100;
-    cfg.sw_app_enable_pct               = 90;
-    cfg.read_int_state_pct              = 90;
-    cfg.fips_force_enable_pct           = 50;
-    cfg.check_int_state_pct             = 100;
+    cfg.otp_en_cs_sw_app_read_pct        = 80;
+    cfg.otp_en_cs_sw_app_read_inval_pct  = 10;
+    cfg.lc_hw_debug_en_pct               = 50;
+    cfg.regwen_pct                       = 100;
+    cfg.enable_pct                       = 100;
+    cfg.sw_app_enable_pct                = 90;
+    cfg.read_int_state_pct               = 95;
+    cfg.fips_force_enable_pct            = 50;
+    cfg.check_int_state_pct              = 100;
+    cfg.int_state_read_enable_pct        = 95;
+    cfg.int_state_read_enable_regwen_pct = 50;
   endfunction
 
 endclass : csrng_base_test


### PR DESCRIPTION
This PR contains a couple of commits to verify some CSRs added close to RTL freeze:
1. INT_STATE_READ_ENABLE[_REGWEN] CSRs, see #23827
2. RESEED_COUNTER CSRs, see #23826

For details, please refer to the commit messages.