### PR TITLE
[top_earlgrey, conn] Update top-level connectivity specs

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/ast_mem_cfg.csv
@@ -17,10 +17,7 @@
 
 # Dual port RAMs.
 # To spi_device.
-CONNECTION, AST_DFT_SPI_DEVICE_RAM_2P_CFG, u_ast.u_ast_dft, "{10'h0, dpram_rml_o}", top_earlgrey.u_spi_device.u_memory_2p.u_mem, cfg_i
-
-# To usbdev.
-CONNECTION, AST_DFT_USBDEV_RAM_2P_CFG, u_ast.u_ast_dft, "{10'h0, dpram_rmf_o}", top_earlgrey.u_usbdev.gen_no_stubbed_memory.u_memory_2p.i_prim_ram_2p_async_adv.u_mem, cfg_i
+CONNECTION, AST_DFT_SPI_DEVICE_RAM_2P_CFG, u_ast.u_ast_dft, "{12'h0, dpram_rml_o}", top_earlgrey.u_spi_device.u_spid_dpram.gen_ram2p.u_memory_2p.u_mem, cfg_i
 
 # Single port RAMs.
 # To otbn.
@@ -41,3 +38,6 @@ CONNECTION, AST_DFT_SRAM_RET_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm
 
 # To rom.
 CONNECTION, AST_DFT_ROM_CFG, u_ast.u_ast_dft, sprom_rm_o,top_earlgrey.u_rom_ctrl.gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom, cfg_i
+
+# To usbdev.
+CONNECTION, AST_DFT_USBDEV_RAM_1P_CFG, u_ast.u_ast_dft, "{spram_rm_o, sprgf_rm_o}", top_earlgrey.u_usbdev.gen_no_stubbed_memory.u_memory_1p.u_mem, cfg_i

--- a/hw/top_earlgrey/formal/conn_csvs/lc_ctrl_broadcast.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/lc_ctrl_broadcast.csv
@@ -44,8 +44,9 @@ CONNECTION, LC_DFT_EN_AST,    top_earlgrey.u_lc_ctrl, lc_dft_en_o, u_ast,       
 # Verify lc_ctrl's RMA request connections.
 CONNECTION, LC_RMA_SEED_FLASH_CTRL,  top_earlgrey.u_lc_ctrl,    lc_flash_rma_seed_o, top_earlgrey.u_flash_ctrl, rma_seed_i
 CONNECTION, LC_RMA_REQ_FLASH_CTRL,   top_earlgrey.u_lc_ctrl,    lc_flash_rma_req_o,  top_earlgrey.u_flash_ctrl, rma_req_i
-CONNECTION, FLASH_CTRL_RMA_ACK_OTBN, top_earlgrey.u_flash_ctrl, rma_ack_o,           top_earlgrey.u_otbn,       lc_rma_req_i
-CONNECTION, OTBN_RMA_ACK_LC,         top_earlgrey.u_otbn,       lc_rma_ack_o,        top_earlgrey.u_lc_ctrl,    lc_flash_rma_ack_i
+CONNECTION, FLASH_CTRL_RMA_ACK_LC,   top_earlgrey.u_flash_ctrl, rma_ack_o,           top_earlgrey.u_lc_ctrl,    lc_flash_rma_ack_i[0]
+CONNECTION, LC_RMA_REQ_OTBN,         top_earlgrey.u_lc_ctrl,    lc_flash_rma_req_o,  top_earlgrey.u_otbn,       lc_rma_req_i
+CONNECTION, OTBN_RMA_ACK_LC,         top_earlgrey.u_otbn,       lc_rma_ack_o,        top_earlgrey.u_lc_ctrl,    lc_flash_rma_ack_i[1]
 
 # Verify lc_ctrl's clock bypass request connections.
 CONNECTION, LC_CLK_BYP_REQ_CLKMGR,  top_earlgrey.u_lc_ctrl,     lc_clk_byp_req_o,    top_earlgrey.u_clkmgr_aon, lc_clk_byp_req_i


### PR DESCRIPTION
This commit re-aligns the top-level connectivity specs with the RTL updates since Eargrey ES. These are:
- Update SPI_DEVICE and USBDEV memory paths for memory test port connections from AST.
- Update lc_rma_req/ack signals between LC_CTRL, FLASH_CTRL, OTBN. There are now dedicated connections and we no longer daisy chain things.