### PR TITLE
[dv,chip] Delete legacy USBDEV-related test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -85,17 +85,6 @@
       si_stage: NA
       tests: []
     }
-    {
-      name: chip_usb_wake_debug
-      desc: '''Verify that `usb_state_debug_i` can be read from the CSR.
-
-            - Drive random value on `usb_state_debug_i`.
-            - Ensure the CSR `wake_debug` returns correctly value.
-            '''
-      stage: V3
-      si_stage: NA
-      tests: []
-    }
 
     // PINMUX & PADRING (pre-verified IP) integration tests:
     {


### PR DESCRIPTION
Delete testpoint because the functionality that it describes does not exist. There is no such CSR/signal.