### PR TITLE
[chip-test,sival] Optimize ENTROPY_SRC config for ast_clk_rst_inputs

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -2111,6 +2111,7 @@
       sw_images: ["//sw/device/tests/sim_dv:ast_clk_rst_inputs:1:new_rules"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=200_000_000"]
+      run_timeout_mins: 90
     }
     {
       name: chip_sw_power_virus

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ast_clk_rst_inputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ast_clk_rst_inputs_vseq.sv
@@ -25,6 +25,10 @@ class chip_sw_ast_clk_rst_inputs_vseq extends chip_sw_base_vseq;
   localparam bit IN_RANGE = 1;
   localparam bit NOT_IN_RANGE = 0;
 
+  // Increase the spinwait timeout. The default is 10ms (see default_spinwait_timeout_ns in
+  // csr_utils_pkg.sv)
+  uint default_spinwait_timeout_ns = 15_000_000; // 15ms
+
   event adc_valid_falling_edge_event;
   event adc_valid_rising_edge_event;
   event adc_channel1_event;


### PR DESCRIPTION
This test previously configured the ENTROPY_SRC in Firmware Override: Extract and Insert mode and erroneously enabled the routing of entropy to firmware (ENTROPY_DATA register). Also the entropy source was reconfigured multiple times during the test.

This commit modifies the test to 1) use the Firmware Override: Observe mode in which entropy is observable from the Observe FIFO but also continues to flow through the pipeline to CSRNG and the EDNs, and 2) to not re-configure the entropy source but just drain the observe FIFO to restart the entropy re-collection.

In addition, the default_spinwait_timeout_ns value in the vseq is updated together with the run_timeout_mins to avoid random timeouts. Also a check that the observe FIFO is empty when we come out of deep sleep is removed. This check doesn't make sense as after deep sleep, a reset is performed which empties the observe FIFO anyway.