### PR TITLE
[i2v,dv] Move TP:target_error_intr / i2c_target_unexp_stop to V3

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -285,7 +285,7 @@
               - Ensure acq_stop is asserted and stay asserted until cleared
               - Ensure IP operation gets back to normal after on-the-fly reset finished
             '''
-      stage: V2
+      stage: V3
       tests: ["i2c_target_unexp_stop"]
     }
     {


### PR DESCRIPTION
This test is currently broken, and the feature is unused by any test software, and only has a cursory mention in the programmers guide. It's purpose was to detect invalid bus driving by the I2C-Controller, when a STOP condition was received at an earlier point that expected during a READ transfer. This is valid I2C bus behaviour, but likely an unexpected early-termination of a transfer.

In short, I believe the logic to generate this IRQ is no longer functional due to the addition of the multi-controller arbitration logic. A comment was made to this effect in the code at the time.
https://github.com/lowRISC/opentitan/blob/44d2f94d7b73b6bdcc85e1bac190bd00e243c160/hw/ip/i2c/rtl/i2c_core.sv#L487-L489

I tried to fix this test as part of #23987, at which point I realized it was unfixable as described in the testplan.

I think this testpoint may possibly be re-written to confirm we can identify an unexpected STOP condition via the arbitration-lost signalling that was added for multi-controller support. But it may end up getting dropped altogether. Either way, this is a feature that has limited uses outside of error detection, and is not used anywhere in our test software. For now, move it to V3.


A fuller description of the problem can be found in this issue : \<LINK\>