### PR TITLE
[i2c,dv] Move I2C to hardware development stage V2(S)

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -23,9 +23,9 @@
       version:            "2.0.0",
       life_stage:         "L1",
       design_stage:       "D2S",
-      verification_stage: "V1",
+      verification_stage: "V2S",
       dif_stage:          "S2",
-      notes:              ""
+      notes:              "Verification Stage is V2S qualified by the given exceptions in PR#22108. This broadly excludes verif. of multi-controller features."
     }
   ]
   clocking: [{clock: "clk_i", reset: "rst_ni"}],


### PR DESCRIPTION
This moves the I2C HWIP block to V2S, as described in the signoff review issue #22108.

> Note. there are a few in-flight PRs (#23987, #24010) that need to be merged before this one. When they are merged, the lightweight signoff criteria bullets in the signoff issue [comment here](https://github.com/lowRISC/opentitan/issues/22108#issuecomment-2152850795) will be updated to reflect the latest status, particularly related to regression pass rates and coverage numbers.

As detailed in the signoff issue, this is a verification signoff limited to a certain scope of features. 

Signoff review issue : #22108.
V2S checklist : [#22108_checklist_comment](https://github.com/lowRISC/opentitan/issues/22108#issuecomment-2152850795)
V2S qualifying criteria : [#22108_qualif_comment](https://github.com/lowRISC/opentitan/issues/22108#issuecomment-2225759494)

Closes #22108 