### PR TITLE
[rv_dm,dv] Extend ndmreset test to check the reset pins are corrected properly

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -199,6 +199,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
         cfg.m_jtag_agent_cfg.vif.do_trst_n();
       end
       if (kind inside {"HARD", "SCAN"}) apply_scan_reset();
+      cfg.clk_lc_rst_vif.apply_reset();
       super.apply_reset(kind);
     join
   endtask

--- a/hw/ip/rv_dm/dv/tb.sv
+++ b/hw/ip/rv_dm/dv/tb.sv
@@ -78,6 +78,11 @@ module tb;
   assign mon_jtag_if.tdo    = dut.dap.td_o;
 
   initial begin
+    // Copy the clock period from clk_rst_if to clk_lc_rst_if. The clock isn't actually connected to
+    // anything in the design, but we have DV code that asserts the reset and then waits a cycle
+    // before de-asserting it, so the clock must be running.
+    clk_lc_rst_if.set_period_ps(clk_rst_if.clk_period_ps);
+
     clk_rst_if.set_active();
     clk_lc_rst_if.set_active();
 


### PR DESCRIPTION
This is part of what is tracked in #22048, which wanted to make sure we were testing the new behaviour that we have added to rv_dm to make it track ndm resets properly.

The first commit is a "wiring tidyup" which makes sure that the signals are being driven properly. I'm not sure it was strictly needed, but this avoids some X's propagating through the design. The second commit strengthens the vseq and tries to check that the feature works properly.