### PR TITLE
[hw/pulp_riscv_dbg] Fix reset value of `tap_state_q`

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
@@ -17,9 +17,6 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
   // Length of IR register. Update this field based on the actual width used in the design.
   uint ir_len = JTAG_IRW;
 
-  // TAP FSM state we go to on a TRST_N reset
-  jtag_fsm_state_e tap_reset_state = JtagResetState;
-
   // JTAG debug transport module (DTM) RAL model based off of RISCV spec 0.13.2 (section 6.1.2).
   jtag_dtm_reg_block jtag_dtm_ral;
 

--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -65,10 +65,7 @@ class jtag_monitor extends dv_base_monitor #(
       wait_tck();
 
       if (!cfg.vif.trst_n) begin
-        // Jump to the correct "reset state". I suspect this should always be JtagResetState, but
-        // some hardware jumps elsewhere! In particular, the pulp riscv-dbg TAP jumps to
-        // JtagIdleState.
-        jtag_state = cfg.tap_reset_state;
+        jtag_state = JtagResetState;
         wait(cfg.vif.trst_n == 1);
         continue;
       end

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -54,10 +54,8 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     m_jtag_agent_cfg.is_active = 1'b1;
     m_jtag_agent_cfg.ir_len = JTAG_IR_LEN;
 
-    // Set the 'correct' IDCODE register value to the JTAG DTM RAL, and correctly model the initial
-    // TAP state on a trst_n.
+    // Set the 'correct' IDCODE register value to the JTAG DTM RAL.
     m_jtag_agent_cfg.jtag_dtm_ral.idcode.set_reset(RV_DM_JTAG_IDCODE);
-    m_jtag_agent_cfg.tap_reset_state = JtagIdleState;
 
     // Create TL agent config obj for the SBA port.
     m_tl_sba_agent_cfg = tl_agent_cfg::type_id::create("m_tl_sba_agent_cfg");

--- a/hw/vendor/patches/pulp_riscv_dbg/0008-dmi_jtag_tap-fix-tap_state_q.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0008-dmi_jtag_tap-fix-tap_state_q.patch
@@ -1,0 +1,13 @@
+diff --git a/src/dmi_jtag_tap.sv b/src/dmi_jtag_tap.sv
+index 3f913568a9..b198c2f632 100644
+--- a/src/dmi_jtag_tap.sv
++++ b/src/dmi_jtag_tap.sv
+@@ -300,7 +300,7 @@ module dmi_jtag_tap #(
+ 
+   always_ff @(posedge tck_i or negedge trst_ni) begin : p_regs
+     if (!trst_ni) begin
+-      tap_state_q <= RunTestIdle;
++      tap_state_q <= TestLogicReset;
+       idcode_q    <= IdcodeValue;
+       bypass_q    <= 1'b0;
+     end else begin

--- a/hw/vendor/pulp_riscv_dbg/src/dmi_jtag_tap.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dmi_jtag_tap.sv
@@ -300,7 +300,7 @@ module dmi_jtag_tap #(
 
   always_ff @(posedge tck_i or negedge trst_ni) begin : p_regs
     if (!trst_ni) begin
-      tap_state_q <= RunTestIdle;
+      tap_state_q <= TestLogicReset;
       idcode_q    <= IdcodeValue;
       bypass_q    <= 1'b0;
     end else begin


### PR DESCRIPTION
This fixes upstream issue pulp-platform/riscv-dbg#165 by applying upstream PR pulp-platform/riscv-dbg#169.  The change gets applied in a patch to avoid re-vendoring, which would be inconvenient at the current time.

This also reverts commit bd76d9282f14aad8ddb9ec276948320df59535e3 "[jtag,dv] Allow the jtag monitor to "reset" to a different TAP state" and commit 3b41400f100577e17ab66f18b16677880dc47445 "[rv_dm,dv] Teach environment about TAP's reset FSM state", which together replicated this problem in our DV code.

This fixes #24019.