### PR TITLE
[chip-test] Fix chip_csr_mem_rw_with_rand_reset test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -383,4 +383,11 @@ class chip_base_vseq #(
     cfg.chip_vif.por_n_if.drive(1);
   endtask // assert_por_reset
 
+  // The chip_csr_mem_rw_with_rand_reset test checks all CSRs back to back and without opening a
+  // window for applying a reset. This may take a much longer time than the default 10_000 clock
+  // cycles used in cip_base_vseq.sv.
+  virtual function int wait_cycles_with_no_outstanding_accesses();
+    return 250_000;
+  endfunction
+
 endclass : chip_base_vseq


### PR DESCRIPTION
The `chip_csr_mem_rw_with_rand_reset` has been constantly failing in the nightly regression since early Feb when we've implemented changes in `cip_base_vseq.sv` and `csr_seq_lib.sv`. I am not quite sure why the test has been passing before but all the failures I've seen are due to timeouts inside the sequence. More precisely, the sequence first checks all 2612 CSRs and these checks are done back to back without opening a window for the test to perform a reset. For this to happen, the test expects a window without any outstanding CSR accesses. By default, the test waits for up to 10000 clock cycles until getting such a window without outstanding CSR accesses. Obviously, 10000 clock cycles are not fast enough for write-read-checking 2612 CSRs and that's why the test has had a 100% fail rate since early Feb.

I see four possible options to avoid this issue:
1. Earlier this year, we've added a `stop_transaction_generators()` function to the `dv_base_env_cfg` class. This function allows checking if someone wants to do a reset and can be used to abort loops doing checks. The issue here is that the sequence doing the write-read check lives in `csr_seq_lib.sv` which does know this this configuration class.
2. As outlined [here](https://github.com/lowRISC/opentitan/blob/663be282861048ec1d4eb31abbe8e70d06543220/hw/dv/sv/csr_utils/csr_seq_lib.sv#L15_L19), we could use the `num_test_csrs` parameter or the `num_csr_chunks` plusarg to reduce the number of CSRs (per chunk).
3. We can simply extend the wait timeout for chip-level sequences from 10000 clock cycles to something that's for sure sufficient to check all CSRs. This is the approach taken by this PR.

While 1 and 2 would probably be more elegant, they require more work. More importantly, I see a risk of damaging other DV environments with 1) (this is shared code used also for block level DV). For 2),  I see a risk of lowering chip-level coverage. That's why I went with option 3 for now.

@rswarbrick , @matutem please let me know if you disagree and I can do a follow-up PR or change this one. I would most likely need your help though :-)