### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@96a1c02b

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 668233699df9ec2a40413e69e0de0a5b10185980
+    rev: 96a1c02ba03400a8b0d69f08b97004adc436dfb7
   }
 }

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/env/core_ibex_dut_probe_if.sv
@@ -34,6 +34,7 @@ interface core_ibex_dut_probe_if(input logic clk);
   logic                              rf_ren_b;
   logic                              rf_rd_a_wb_match;
   logic                              rf_rd_b_wb_match;
+  logic                              rf_write_wb;
   logic                              sync_exc_seen;
   logic                              irq_exc_seen;
   logic                              csr_save_cause;
@@ -80,6 +81,7 @@ interface core_ibex_dut_probe_if(input logic clk);
     input rf_ren_b;
     input rf_rd_a_wb_match;
     input rf_rd_b_wb_match;
+    input rf_write_wb;
     input sync_exc_seen;
     input irq_exc_seen;
     input wb_exception;
@@ -93,6 +95,7 @@ interface core_ibex_dut_probe_if(input logic clk);
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_rf_ren_b, rf_ren_b)
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_rf_rd_a_wb_match, rf_rd_a_wb_match)
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_rf_rd_b_wb_match, rf_rd_b_wb_match)
+  `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_rf_write_wb, rf_write_wb)
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_alert_minor, alert_minor)
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_ic_tag_req, ic_tag_req)
   `DV_CREATE_SIGNAL_PROBE_FUNCTION(signal_probe_ic_tag_write, ic_tag_write)

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/riscv_dv_extension/testlist.yaml
@@ -683,8 +683,14 @@
 - test: riscv_rf_intg_test
   description: >
     Randomly corrupt the register file read port once in the middle of program execution
-  iterations: 15
+  iterations: 100
   gen_test: riscv_rand_instr_test
+  gen_opts: >
+    +instr_cnt=10000
+    +num_of_sub_program=5
+    +gen_all_csrs_by_default=1
+    +add_csr_write=MSTATUS,MEPC,MCAUSE,MTVAL,0x7c0,0x7c1
+    +no_csr_instr=0
   rtl_test: core_ibex_rf_intg_test
   rtl_params:
     SecureIbex: 1

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -250,6 +250,7 @@ module core_ibex_tb_top;
   assign dut_if.rf_ren_b         = dut.u_ibex_top.u_ibex_core.rf_ren_b;
   assign dut_if.rf_rd_a_wb_match = dut.u_ibex_top.u_ibex_core.rf_rd_a_wb_match;
   assign dut_if.rf_rd_b_wb_match = dut.u_ibex_top.u_ibex_core.rf_rd_b_wb_match;
+  assign dut_if.rf_write_wb      = dut.u_ibex_top.u_ibex_core.rf_write_wb;
   assign dut_if.sync_exc_seen    = dut.u_ibex_top.u_ibex_core.cs_registers_i.cpuctrlsts_part_q.sync_exc_seen;
   assign dut_if.csr_save_cause   = dut.u_ibex_top.u_ibex_core.csr_save_cause;
   assign dut_if.exc_cause        = dut.u_ibex_top.u_ibex_core.exc_cause;

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
@@ -916,8 +916,8 @@ module ibex_core import ibex_pkg::*; #(
     assign rf_rdata_b = rf_rdata_b_ecc_i[31:0];
 
     // Calculate errors - qualify with WB forwarding to avoid xprop into the alert signal
-    assign rf_ecc_err_a_id = |rf_ecc_err_a & rf_ren_a & ~rf_rd_a_wb_match;
-    assign rf_ecc_err_b_id = |rf_ecc_err_b & rf_ren_b & ~rf_rd_b_wb_match;
+    assign rf_ecc_err_a_id = |rf_ecc_err_a & rf_ren_a & ~(rf_rd_a_wb_match & rf_write_wb);
+    assign rf_ecc_err_b_id = |rf_ecc_err_b & rf_ren_b & ~(rf_rd_b_wb_match & rf_write_wb);
 
     // Combined error
     assign rf_ecc_err_comb = instr_valid_id & (rf_ecc_err_a_id | rf_ecc_err_b_id);


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
96a1c02ba03400a8b0d69f08b97004adc436dfb7

* [dv] Increase iterations and instructions in riscv_rf_intg_test (Greg Chadwick)
* [dv] Alter riscv_rf_intg_test to cover more scenarios (Greg Chadwick)
* [rtl] Fix logic for generating ECC related alerts (Greg Chadwick)