### PR TITLE
[hmac,dv] remove invalid assertion

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -928,8 +928,6 @@ module hmac
 
   // Below condition is covered by the design (2020-02-19)
   //`ASSERT(ValidHashStartAssert, hash_start_or_continue |-> !initiated)
-  // `hash_process` or `reg_hash_stop` should be toggled and paired with `hash_start_or_continue`
-  `ASSERT(ValidHashProcessAssert, (hash_process || reg_hash_stop) |-> initiated)
 
   // hmac_en should be modified only when the logic is Idle
   `ASSERT(ValidHmacEnConditionAssert,


### PR DESCRIPTION
This assertion was checking that a `process` or `stop` command happened only after a `start` or `continue` command had been issued. However, it was doing so by checking if the `process` or `stop` signals being high overlapped with the `initiated` signal being high (which simply latches whether a `start` or `continue` had been seen in the past). However, multiple `process` commands may be issued by SW before a `stop` or `done`, and the hardware does support this. Any ROM E2E test that enabled SPX+ signature verification does indeed trigger multiple `process` operations. This was the root cause behind #23954.

Since, what this assertion was checking was too restrictive, we opt for simply removing it.

This fixes #23954.