### PR TITLE
[rv_dm,dv] Add WARL check for hartsel

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -534,6 +534,17 @@
       tests: ["rv_dm_rom_read_access"]
     }
     {
+      name: hartsel_warl
+      desc: '''
+        Check the WARL behaviour of the hartsel field in dmcontrol
+
+        - Write '1 to hartsel and then read dmcontrol back again.
+        - Check resulting value of hartsel equals the maximum hart index.
+      '''
+      stage: V2
+      tests: ["rv_dm_hartsel_warl"]
+    }
+    {
       name: stress_all
       desc: '''
             A 'bug hunt' test that stresses the DUT to its limits.

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -54,6 +54,7 @@ filesets:
       - seq_lib/rv_dm_rom_read_access_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_progbuf_read_write_execute_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_dmi_failed_op_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_hartsel_warl_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -165,15 +165,15 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
         end
         default: `uvm_fatal(`gfn, $sformatf("Unknown DMI CSR: %0s", csr.get_name()))
       endcase
-    end
 
-    // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
-    if (item.req_op == DmiOpRead) begin
-      if (do_read_check) begin
-        `DV_CHECK_EQ(csr.get_mirrored_value(), item.rdata,
-                     $sformatf("reg name: %0s", csr.get_full_name()))
+      // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
+      if (item.req_op == DmiOpRead) begin
+        if (do_read_check) begin
+          `DV_CHECK_EQ(csr.get_mirrored_value(), item.rdata,
+                       $sformatf("reg name: %0s", csr.get_full_name()))
+        end
+        void'(csr.predict(.value(item.rdata), .kind(UVM_PREDICT_READ)));
       end
-      void'(csr.predict(.value(item.rdata), .kind(UVM_PREDICT_READ)));
     end
   endtask
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_hartsel_warl_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_hartsel_warl_vseq.sv
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class rv_dm_hartsel_warl_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_hartsel_warl_vseq)
+  `uvm_object_new
+
+  task body();
+    bit [19:0] hartsel;
+
+    // Write '1 to the hartsel fields
+    jtag_dmi_ral.dmcontrol.hartselhi.set(1023);
+    jtag_dmi_ral.dmcontrol.hartsello.set(1023);
+    csr_update(.csr(jtag_dmi_ral.dmcontrol));
+
+    // Now read back the dmcontrol register, which should be clipped to NrHarts-1
+    begin
+      uvm_reg_data_t rdata;
+      csr_rd(.ptr(jtag_dmi_ral.dmcontrol), .value(rdata));
+    end
+
+    hartsel = {`gmv(jtag_dmi_ral.dmcontrol.hartselhi), `gmv(jtag_dmi_ral.dmcontrol.hartsello)};
+
+    // Check that we got the clipped value that we expect. This should be NrHarts - 1
+    `DV_CHECK_EQ(hartsel, rv_dm_reg_pkg::NrHarts - 1)
+  endtask : body
+
+endclass

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -31,3 +31,4 @@
 `include "rv_dm_sba_debug_disabled_vseq.sv"
 `include "rv_dm_debug_disabled_vseq.sv"
 `include "rv_dm_dmi_failed_op_vseq.sv"
+`include "rv_dm_hartsel_warl_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -293,6 +293,11 @@
       reseed: 2
     }
     {
+      name: rv_dm_hartsel_warl
+      uvm_test_seq: rv_dm_hartsel_warl_vseq
+      reseed: 1
+    }
+    {
       name: rv_dm_stress_all
       uvm_test_seq: rv_dm_stress_all_vseq
     }


### PR DESCRIPTION
This is the extra check discussed in #22048. The second commit adds the check, but it didn't work at first! This turned out to be a silly DV bug, fixed in the first commit.