### PR TITLE
[silicon_creator,hmac] ensure `process` cmd is only invoked once

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -92,9 +92,6 @@ static void wait_for_done(void) {
 }
 
 void hmac_sha256_final_truncated(uint32_t *digest, size_t len) {
-  // Send the process command in case it hasn't been sent yet (it's harmless to
-  // send it twice).
-  hmac_sha256_process();
   wait_for_done();
 
   uint32_t result, incr;
@@ -124,6 +121,7 @@ void hmac_sha256_final_truncated(uint32_t *digest, size_t len) {
 void hmac_sha256(const void *data, size_t len, hmac_digest_t *digest) {
   hmac_sha256_init();
   hmac_sha256_update(data, len);
+  hmac_sha256_process();
   hmac_sha256_final(digest);
 }
 

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -106,6 +106,8 @@ void hmac_sha256_process(void);
  * Copies only the first `len` 32-bit words of the digest. The caller must
  * ensure enough space is available in the buffer.
  *
+ * Note: the caller must call `hmac_sha256_process()` before calling this.
+ *
  * @param[out] digest Buffer to copy digest to.
  * @param[out] len Requested word-length.
  */
@@ -114,6 +116,8 @@ void hmac_sha256_final_truncated(uint32_t *digest, size_t len);
 /**
  * Finalizes SHA256 operation and writes `digest` buffer.
  *
+ * Note: the caller must call `hmac_sha256_process()` before calling this.
+ *
  * @param[out] digest Buffer to copy digest to.
  */
 inline void hmac_sha256_final(hmac_digest_t *digest) {
@@ -121,7 +125,8 @@ inline void hmac_sha256_final(hmac_digest_t *digest) {
 }
 
 /**
- * Convenience function for computing the SHA-256 digest of a contiguous buffer.
+ * Convenience single-shot function for computing the SHA-256 digest of a
+ * contiguous buffer.
  *
  * @param data Buffer to copy data from.
  * @param len Size of the `data` buffer in bytes.

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -110,6 +110,7 @@ rom_error_t hmac_truncated_test(void) {
   uint32_t digest[3];
   hmac_sha256_init();
   hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1);
+  hmac_sha256_process();
   hmac_sha256_final_truncated(digest, ARRAYSIZE(digest));
 
   const size_t len = ARRAYSIZE(digest);
@@ -130,6 +131,7 @@ rom_error_t hmac_bigendian_test(void) {
   hmac_sha256_configure(true);
   hmac_sha256_start();
   hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1);
+  hmac_sha256_process();
   hmac_sha256_final(&digest);
 
   const size_t len = ARRAYSIZE(digest.digest);
@@ -149,6 +151,7 @@ rom_error_t hmac_bigendian_truncated_test(void) {
   hmac_sha256_configure(true);
   hmac_sha256_start();
   hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1);
+  hmac_sha256_process();
   uint32_t digest[3];
   hmac_sha256_final_truncated(digest, ARRAYSIZE(digest));
 
@@ -182,6 +185,7 @@ rom_error_t hmac_save_restore_test(void) {
   hmac_sha256_configure(true);
   hmac_sha256_start();
   hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1);
+  hmac_sha256_process();
   hmac_digest_t digest_be;
   hmac_sha256_final(&digest_be);
 
@@ -189,6 +193,7 @@ rom_error_t hmac_save_restore_test(void) {
   hmac_sha256_configure(false);
   hmac_sha256_restore(&ctx);
   hmac_sha256_update(input, remaining_input_len);
+  hmac_sha256_process();
   hmac_digest_t digest_le;
   hmac_sha256_final(&digest_le);
 
@@ -235,6 +240,7 @@ rom_error_t hmac_save_restore_repeated_test(void) {
   hmac_sha256_save(&ctx);
   hmac_sha256_restore(&ctx);
   hmac_sha256_update(input, remaining_input_len);
+  hmac_sha256_process();
   hmac_digest_t digest_le;
   hmac_sha256_final(&digest_le);
 

--- a/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
@@ -126,6 +126,7 @@ TEST_F(Sha256FinalTest, GetDigest) {
   };
   ExpectDigest(kExpectedDigest);
 
+  hmac_sha256_process();
   hmac_digest_t got_digest;
   hmac_sha256_final(&got_digest);
   EXPECT_THAT(got_digest.digest, ElementsAreArray(kExpectedDigest));

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_sha2.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_sha2.c
@@ -79,6 +79,7 @@ rom_error_t spx_hash_message(
   hmac_sha256_update(msg_prefix_2, msg_prefix_2_len);
   hmac_sha256_update(msg_prefix_3, msg_prefix_3_len);
   hmac_sha256_update(msg, msg_len);
+  hmac_sha256_process();
   hmac_sha256_final_truncated(&seed[2 * kSpxNWords], kSpxDigestWords);
 
   uint32_t buf[kSpxDigestWords] = {0};

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/sha2.c
@@ -17,6 +17,7 @@ void mgf1_sha256(const uint32_t *in, size_t in_len, size_t out_len,
     hmac_sha256_update_words(in, in_len);
     uint32_t ctr_be = __builtin_bswap32(ctr);
     hmac_sha256_update_words(&ctr_be, 1);
+    hmac_sha256_process();
     // If the remaining output needed is less than the full digest size,
     // truncate.
     size_t digest_words =

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_sha2_simple.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/thash_sha2_simple.c
@@ -16,5 +16,6 @@ void thash(const uint32_t *in, size_t inblocks, const spx_ctx_t *ctx,
   hmac_sha256_restore(&ctx->state_seeded);
   hmac_sha256_update((unsigned char *)addr->addr, kSpxSha256AddrBytes);
   hmac_sha256_update_words(in, inblocks * kSpxNWords);
+  hmac_sha256_process();
   hmac_sha256_final_truncated(out, kSpxNWords);
 }

--- a/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c
@@ -336,6 +336,7 @@ static status_t log_hash_of_all_certs(ujson_t *uj) {
   }
 
   // Log the final hash of all certificates to the host and console.
+  hmac_sha256_process();
   hmac_sha256_final((hmac_digest_t *)&hash);
   RESP_OK(ujson_serialize_serdes_sha256_hash_t, uj, &hash);
   LOG_INFO("SHA256 hash of all certificates: %08x%08x%08x%08x%08x%08x%08x%08x",

--- a/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
@@ -39,26 +39,25 @@ enum {
 
 const size_t kGoldenRomSizeBytes = 32652 - sizeof(chip_info_t);
 const uint32_t kSimDvGoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0x5559e17d, 0xd920f2a7, 0x98afda37, 0x5380eed1,
-    0x7549a52e, 0x26f0a4a9, 0x917888e5, 0x5a76bd3d,
+    0x953cca70, 0x018fb4c7, 0xcd2ebc02, 0x95680df3,
+    0x220ca956, 0xe890a35d, 0xe8b62c21, 0x15bfa5e0,
 };
 const uint32_t kFpgaCw310GoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0xb1ebe528, 0xe461696b, 0x55d795e8, 0x5e57a7da,
-    0x04007623, 0xb4b121cb, 0x572fcc0a, 0x76c45aea,
+    0x876747cf, 0xec01137f, 0x159bdc7f, 0x8177d11c,
+    0xcad1fb4e, 0xc0d3ccd0, 0xc7cb8699, 0x99c8a56b,
 };
 const uint32_t kSiliconGoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0x0ad1f73d, 0xf1c010da, 0x2dd0186a, 0x78f1be69,
-    0x0f01949c, 0xf61ec134, 0x14d56198, 0x8d971279,
+    0x5d02eeae, 0x76d7386c, 0x063a84ea, 0x279865f6,
+    0xf05b04e8, 0x06a569e0, 0xa8f2053b, 0x66c2cb77,
 };
 
 extern const char _chip_info_start[];
 
 // We hash the ROM using the SHA256 algorithm and print the hash to the console.
 status_t hash_rom(void) {
-  hmac_sha256_init();
-  hmac_sha256_update((void *)TOP_EARLGREY_ROM_BASE_ADDR, kGoldenRomSizeBytes);
   hmac_digest_t rom_hash;
-  hmac_sha256_final(&rom_hash);
+  hmac_sha256((void *)TOP_EARLGREY_ROM_BASE_ADDR, kGoldenRomSizeBytes,
+              &rom_hash);
   LOG_INFO("ROM Hash: 0x%08x%08x%08x%08x%08x%08x%08x%08x", rom_hash.digest[7],
            rom_hash.digest[6], rom_hash.digest[5], rom_hash.digest[4],
            rom_hash.digest[3], rom_hash.digest[2], rom_hash.digest[1],

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -377,6 +377,7 @@ static rom_error_t rom_verify(const manifest_t *manifest,
   manifest_digest_region_t digest_region = manifest_digest_region_get(manifest);
   // Add remaining part of manifest / ROM_EXT image to the measurement.
   hmac_sha256_update(digest_region.start, digest_region.length);
+  hmac_sha256_process();
   hmac_digest_t act_digest;
   hmac_sha256_final(&act_digest);
   // Copy the ROM_EXT measurement to the .static_critical section.
@@ -523,6 +524,7 @@ static rom_error_t rom_measure_otp_partitions(
       sizeof(uint64_t));
   hmac_sha256_update(sigverify_ctx.keys.integrity_measurement.digest,
                      kHmacDigestNumBytes);
+  hmac_sha256_process();
   hmac_digest_t otp_measurement;
   hmac_sha256_final(&otp_measurement);
   memcpy(measurement->data, otp_measurement.digest, kHmacDigestNumBytes);
@@ -686,6 +688,7 @@ static rom_error_t rom_boot(const manifest_t *manifest, uint32_t flash_exec) {
     hmac_sha256_update(&immutable_rom_ext_length, /*len=*/sizeof(size_t));
     hmac_sha256_update((const void *)immutable_rom_ext_entry_point,
                        immutable_rom_ext_length);
+    hmac_sha256_process();
     hmac_digest_t actual_immutable_section_digest;
     hmac_sha256_final(&actual_immutable_section_digest);
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -255,6 +255,7 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
   hmac_sha256_update(digest_region.start, digest_region.length);
   // TODO(#19596): add owner configuration block to measurement.
   // Verify signature
+  hmac_sha256_process();
   hmac_digest_t act_digest;
   hmac_sha256_final(&act_digest);
 


### PR DESCRIPTION
This updates the HMAC silicon_creator driver to separate out the `hmac_sha256_process()` call from the `hmac_sha256_final...()` calls to avoid sending multiple process commands to the hardware, and thus triggering an SVA in sim (see #23954). While the consensus in #24022 was that the hardware can handle multiple `process` commands, this path is less tested. Hence, we make this update to minimize risk in the ROM code that drives the HMAC SHA2 engine.

This updates the ROM, and fixes #23954. A new rom release candidate will tagged after this merges.