### PR TITLE
[dv,jtag] Don't constrain wait for trst_n to be de-asserted

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -121,7 +121,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
       join
 
       if (!cfg.vif.trst_n) begin
-        `DV_WAIT(cfg.vif.trst_n)
+        @(posedge cfg.vif.trst_n);
       end else begin
         // Since trst_n is not 0, the get_next_item() task must have completed and has written the
         // request to req


### PR DESCRIPTION
Using the DV_WAIT macro causes a failure if the signal doesn't go high again in time. The driver shouldn't really be checking for things like this: it should just wait until we come out of reset.