### PR TITLE
[dv/chip] fixed chip_sw_lc_ctrl_scrap_vseq

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -1125,7 +1125,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     // Wait for LC to be ready, acquire the transition interface mutex
     wait_lc_ready();
 
-    // enable external clock.
+    // claim the transition interface mutex
     claim_transition_interface();
 
     // Switch to external clock via LC controller.
@@ -1134,6 +1134,9 @@ class chip_sw_base_vseq extends chip_base_vseq;
       ral.lc_ctrl.transition_ctrl.get_offset(),
       p_sequencer.jtag_sequencer_h,
       1);
+
+    // wait until external clock is actually switched
+    wait_lc_ext_clk_switched();
   endtask : switch_to_external_clock
 
   // Use JTAG interface to program OTP fields.


### PR DESCRIPTION
This PR solves a problem in CS where external clock transition request might complete in the middle of booter operations, where the booter will read values from the OTP and write them to AST registers upon startup. 

Changes:
- Waiting for the boot process to end (`sync_with_sw`) before changing to external clock and performing a LC state transition
- Waiting for`LC_CTRL.STATUS.EXT_CLOCK_SWITCHED == 1` in order to be sure the external clock is switched and stable 