### PR TITLE
[dv] Add "writes_ignore_errors" flag

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -64,6 +64,11 @@ virtual task tl_write_less_than_csr_width(string ral_name);
     `DV_CHECK_FATAL($cast(csr, all_csrs[i]))
     msb_pos = csr.get_msb_pos();
     addr    = csr.get_address();
+
+    // If this is a register that might change on a write that causes an error then we shouldn't
+    // generate writes to it because we might update the register contents unexpectedly.
+    if (csr.writes_ignore_errors) continue;
+
     `create_tl_access_error_case(
         tl_write_less_than_csr_width,
         opcode inside {tlul_pkg::PutFullData, tlul_pkg::PutPartialData};

--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -19,6 +19,13 @@ class dv_base_reg extends uvm_reg;
   local string         update_err_alert_name;
   local string         storage_err_alert_name;
 
+  // This should be set if the register can be affected by a write even if that write also causes an
+  // error (because of an invalid mask, for example).
+  //
+  // TODO: This is really here as a workaround for a minor RTL bug, tracked in issue #24053. Once
+  //       that issue is closed, remove this flag again.
+  bit writes_ignore_errors;
+
   // This is used for get_alias_name
   string alias_name = "";
   // Lookup table for alias fields (used for get_field_by_name)

--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -393,7 +393,8 @@
           { bits: "0",
             resval: "0" // core ID value
           },
-        ]
+        ],
+        writes_ignore_errors: "true"
       },
       { skipto: "0x108" }
       { name: "GOING",
@@ -412,7 +413,8 @@
           { bits: "0",
             resval: "0"
           },
-        ]
+        ],
+        writes_ignore_errors: "true"
       },
       { skipto: "0x110" }
      {  name:  "RESUMING"
@@ -429,7 +431,8 @@
           { bits: "0",
             resval: "0" // core ID value
           },
-        ]
+        ],
+        writes_ignore_errors: "true"
       },
       { skipto: "0x118" }
       { name: "EXCEPTION",
@@ -440,7 +443,8 @@
           { bits: "0",
             resval: "0"
           },
-        ]
+        ],
+        writes_ignore_errors: "true"
       },
       { skipto: "0x300" }
       { name: "WHERETO",
@@ -521,6 +525,7 @@
           ]
           tags: [// TODO: Write-read-check will work after "activating" the debug module via JTAG.
                  "excl:CsrNonInitTests:CsrExclWriteCheck"]
+          writes_ignore_errors: "true"
         }
       },
       { skipto: "0x400" }

--- a/util/reggen/README.md
+++ b/util/reggen/README.md
@@ -168,6 +168,7 @@ tags | optional | string | tags for the register, following the format 'tag_name
 shadowed | optional | string | 'true' if the register is shadowed
 update_err_alert | optional | string | alert that will be triggered if this shadowed register has update error
 storage_err_alert | optional | string | alert that will be triggered if this shadowed register has storage error
+writes_ignore_errors | optional | bitrange | This register may update on a TL write that causes an error response.
 
 
 The basic register definition group will follow this pattern:
@@ -362,6 +363,7 @@ tags | optional | string | tags for the register, following the format 'tag_name
 shadowed | optional | string | 'true' if the register is shadowed
 update_err_alert | optional | string | alert that will be triggered if this shadowed register has update error
 storage_err_alert | optional | string | alert that will be triggered if this shadowed register has storage error
+writes_ignore_errors | optional | bitrange | This register may update on a TL write that causes an error response.
 regwen_multi | optional | python Bool | If true, regwen term increments along with current multireg count.
 compact | optional | python Bool | If true, allow multireg compacting.If false, do not compact.
 cdc | optional | string | indicates the register must cross to a different clock domain before use.  The value shown here should correspond to one of the module's clocks.

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -465,7 +465,8 @@ class RegBlock:
             shadowed=False,
             fields=fields,
             update_err_alert=None,
-            storage_err_alert=None)
+            storage_err_alert=None,
+            writes_ignore_errors=False)
         self.add_register(reg)
 
     def make_intr_regs(self, interrupts: Sequence[Interrupt]) -> None:
@@ -550,7 +551,8 @@ class RegBlock:
                 shadowed=False,
                 fields=fields,
                 update_err_alert=None,
-                storage_err_alert=None))
+                storage_err_alert=None,
+                writes_ignore_errors=False))
 
         self._add_intr_alert_reg(
             interrupts, 'INTR_ENABLE', 'Interrupt Enable Register',

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -94,6 +94,10 @@ OPTIONAL_FIELDS = {
         's',
         "alert that will be triggered if "
         "this shadowed register has storage error"
+    ],
+    'writes_ignore_errors': [
+        'b',
+        "This register may update on a TL write that causes an error response."
     ]
 }
 
@@ -118,7 +122,8 @@ class Register(RegBase):
                  shadowed: bool,
                  fields: List[Field],
                  update_err_alert: Optional[str],
-                 storage_err_alert: Optional[str]):
+                 storage_err_alert: Optional[str],
+                 writes_ignore_errors: bool):
         super().__init__(offset)
         self.alias_target = alias_target
         self.name = name
@@ -240,6 +245,8 @@ class Register(RegBase):
 
         self.update_err_alert = update_err_alert
         self.storage_err_alert = storage_err_alert
+
+        self.writes_ignore_errors = writes_ignore_errors
 
     @staticmethod
     def from_raw(reg_width: int,
@@ -385,11 +392,17 @@ class Register(RegBase):
                                            'storage_err_alert for {} register'
                                            .format(name))
 
+        writes_ignore_errors = \
+            check_bool(rd.get('writes_ignore_errors', False),
+                       'writes_ignore_errors flag for {} register'
+                       .format(name))
+
         return Register(offset, name, alias_target, desc, async_name,
                         async_clk, sync_name, sync_clk,
                         hwext, hwqe, hwre, regwen,
                         tags, resval, shadowed, fields,
-                        update_err_alert, storage_err_alert)
+                        update_err_alert, storage_err_alert,
+                        writes_ignore_errors)
 
     def next_offset(self, addrsep: int) -> int:
         return self.offset + addrsep
@@ -540,7 +553,8 @@ class Register(RegBase):
                         self.sync_name, self.sync_clk,
                         self.hwext, self.hwqe, self.hwre, new_regwen,
                         self.tags, new_resval, self.shadowed, new_fields,
-                        self.update_err_alert, self.storage_err_alert)
+                        self.update_err_alert, self.storage_err_alert,
+                        self.writes_ignore_errors)
 
     def check_valid_regwen(self) -> None:
         '''Check that this register is valid for use as a REGWEN'''

--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -357,6 +357,9 @@ reg_block_path, reg, mr, reg_idx)">\
                  int unsigned n_bits = ${reg_width},
                  int          has_coverage = UVM_NO_COVERAGE);
       super.new(name, n_bits, has_coverage);
+% if reg.writes_ignore_errors:
+      writes_ignore_errors = 1'b1;
+% endif
     endfunction : new
 
     virtual function void build(csr_excl_item csr_excl = null);


### PR DESCRIPTION
This is really for `rv_dm` (see the last commit). But the idea is that we've currently got some code in `cip_base_vseq__tl_errors.svh` that tries to generate bad writes by sending an invalid mask value. The `stress_all_with_rand_reset` sequence is supposed to be checking that those writes won't have any effect.

Unfortunately, they *do* have an effect for some registers in `rv_dm`. I don't *think* this behaviour is disallowed by the TileLink spec, so the correct response is probably to avoid depending on the writes being squashed.