### PR TITLE
[otbn,bazel] Add a way to generate random-ish tests for OTBN.

### DIFF
--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -198,6 +198,11 @@ py_library(
 )
 
 py_library(
+    name = "testgen",
+    srcs = ["testgen.py"],
+)
+
+py_library(
     name = "toolchain",
     srcs = ["toolchain.py"],
 )

--- a/hw/ip/otbn/util/shared/testgen.py
+++ b/hw/ip/otbn/util/shared/testgen.py
@@ -1,0 +1,45 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, TextIO
+
+_GPR_NAMES = [f'x{i}' for i in range(32)]
+_WDR_NAMES = [f'w{i}' for i in range(32)]
+
+
+def write_test_data(inputs: Dict[str, bytes], data_file: TextIO) -> None:
+    '''Write the test input data to DMEM.'''
+    data_file.write('.data\n')
+    for name in inputs:
+        data_file.write('\n')
+        if len(inputs[name]) <= 4:
+            # Buffer should be read as a 32-bit (4-byte) value.
+            align = 4
+            length = 4
+        else:
+            # Buffer should be read as a (sequence of) 256-bit (32-byte) values.
+            align = 32
+            length = ((len(inputs[name]) + 31) // 32) * 32
+        data_file.write(f'.balign {align}\n')
+        data_file.write(f'.globl {name}\n')
+        data_file.write(f'{name}:\n')
+        for i in range(0, length, 4):
+            word = int.from_bytes(inputs[name][i:i + 4], byteorder='little')
+            data_file.write(f'.word {word:#010x}\n')
+
+
+def write_test_exp(exp: Dict[str, bytes], exp_file: TextIO) -> None:
+    '''Write the expected-values file for the test.'''
+    for name in exp:
+        value = int.from_bytes(exp[name], byteorder='little')
+        if name in _GPR_NAMES or name == 'ERR_BITS':
+            if len(exp[name]) > 8:
+                raise ValueError(f'Expected value for {name} is too large: {value}')
+            exp_file.write(f'{name} = {value:#010x}\n')
+        elif name in _WDR_NAMES:
+            if len(exp[name]) > 32:
+                raise ValueError(f'Expected value for {name} is too large: {value}')
+            exp_file.write(f'{name} = {value:#066x}\n')
+        else:
+            raise ValueError(f'Register name {name} not recognized.')

--- a/sw/otbn/crypto/tests/generated/BUILD
+++ b/sw/otbn/crypto/tests/generated/BUILD
@@ -1,0 +1,35 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_binary")
+load("//rules:otbn.bzl", "otbn_autogen_sim_test")
+
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "mul_testgen",
+    srcs = ["mul_testgen.py"],
+    imports = [
+        "../../../../../hw/ip/otbn/util",
+    ],
+    deps = [
+        "//hw/ip/otbn/util/shared:testgen",
+    ],
+)
+
+# Run randomly generated tests. Note that the random test data will be the same
+# for the same seed every time, because Bazel always builds "hermetically" and
+# therefore cannot generate any actually random values at build time.
+[
+    otbn_autogen_sim_test(
+        name = "mul_test" + str(i),
+        srcs = ["mul_test.s"],
+        seed = i,
+        testgen = ":mul_testgen",
+        deps = [
+            "//sw/otbn/crypto:mul",
+        ],
+    )
+    for i in range(10)
+]

--- a/sw/otbn/crypto/tests/generated/mul_test.s
+++ b/sw/otbn/crypto/tests/generated/mul_test.s
@@ -1,0 +1,47 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+
+/**
+ * Randomizable bignum multiply test.
+ *
+ * The following buffers are generated separately by the test infrastructure:
+ *   x: 64 bytes
+ *   y: 64 bytes
+ */
+
+.section .text.start
+main:
+  /* Init all-zero register. */
+  bn.xor  w31, w31, w31
+
+  /* Operand limb count (2). */
+  li      x30, 2
+
+  /* dmem[result] <= mul(dmem[x], dmem[y]) */
+  la      x10, x
+  la      x11, y
+  la      x12, result
+  jal     x1, bignum_mul
+
+  /* Load result into w0 through w3.
+       [w0..w3] <= dmem[result] */
+  la      x2, result
+  li      x3, 0
+  bn.lid  x3, 0(x2++)
+  addi    x3, x3, 1
+  bn.lid  x3, 0(x2++)
+  addi    x3, x3, 1
+  bn.lid  x3, 0(x2++)
+  addi    x3, x3, 1
+  bn.lid  x3, 0(x2)
+
+  ecall
+
+.data
+
+/* Buffer to hold the multiplication result. */
+.balign 32
+result:
+.zero 128

--- a/sw/otbn/crypto/tests/generated/mul_testgen.py
+++ b/sw/otbn/crypto/tests/generated/mul_testgen.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import random
+from typing import TextIO, Optional
+
+from shared.testgen import write_test_data, write_test_exp
+
+OPERAND_LIMBS = 2
+LIMB_NBYTES = 32
+
+
+def gen_mul_test(seed: Optional[int], data_file: TextIO, exp_file: TextIO):
+    # Generate random operands.
+    if seed is not None:
+        random.seed(seed)
+    operand_nbytes = LIMB_NBYTES * OPERAND_LIMBS
+    x = random.getrandbits(8 * operand_nbytes)
+    y = random.getrandbits(8 * operand_nbytes)
+    x_bytes = int.to_bytes(x, byteorder='little', length=operand_nbytes)
+    y_bytes = int.to_bytes(y, byteorder='little', length=operand_nbytes)
+
+    # Write input values.
+    inputs = {'x': x_bytes, 'y': y_bytes}
+    write_test_data(inputs, data_file)
+
+    # Write expected output values.
+    xy_bytes = int.to_bytes(x * y, byteorder='little', length=operand_nbytes * 2)
+    exp = {}
+    for i in range(OPERAND_LIMBS * 2):
+        exp[f'w{i}'] = xy_bytes[i * LIMB_NBYTES:(i + 1) * LIMB_NBYTES]
+    write_test_exp(exp, exp_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--seed',
+                        type=int,
+                        required=False,
+                        help=('Seed value for pseudorandomness.'))
+    parser.add_argument('data',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for input DMEM values.'))
+    parser.add_argument('exp',
+                        metavar='FILE',
+                        type=argparse.FileType('w'),
+                        help=('Output file for expected register values.'))
+    args = parser.parse_args()
+
+    gen_mul_test(args.seed, args.data, args.exp)


### PR DESCRIPTION
This is a slight expansion of the existing OTBN test infrastructure that allows us to generate test data based on a known-good implementation. This PR includes both the infrastructure and an example that tests our bignum `mul` implementation against test data that generates some numbers and then multiplies them in Python.

Since Bazel doesn't allow _actually_ random generation of numbers at build time, I included a "seed" argument that gets passed through from the `BUILD` file to seed the pseudorandom test-data generation. The test data for the first test (seed = 0) will always be the same on every build, and so will the test data for the second test, etc, as long as the test-generation script is the same. But they will be different from each other, so by repeating the target 10 times like in the example, you can get 10 different sets of generated data.

If there's a better way of increasing coverage here to run more truly random tests, I'm all ears -- I considered trying to e.g. get the digest of the OTBN binary so that changing the binary would trigger new data, but in the end I decided that this was too likely to lead to a situation where there's a failure in some corner case that's triggered by a specific seed value, and then someone updates the binary in a trivial way and thinks the bug is "fixed". So I decided to resist the temptation to over-engineer and just go with the dumb but transparent integer seed.