### PR TITLE
[rv_dm,dv] Tidy up reset length calculation

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -216,8 +216,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
-    int trst_n_duration_ps = cfg.m_jtag_agent_cfg.vif.tck_period_ps * $urandom_range(5, 20) *
-        1000_000;
+    int trst_n_duration_ps = cfg.m_jtag_agent_cfg.vif.tck_period_ps * $urandom_range(5, 20);
     cfg.rv_dm_vif.cb.scan_rst_n <= 1'b0;
     cfg.m_jtag_agent_cfg.vif.trst_n <= 1'b0;
     super.apply_resets_concurrently(dv_utils_pkg::max2(reset_duration_ps, trst_n_duration_ps));


### PR DESCRIPTION
This was wrong twice in the same direction. The first commit tidies up a factor of 1000 in the rv_dm code, then the second commit tidies up another factor of up to 10 in the base dv code.