### PR TITLE
fix format to keep rustfmt happy

### DIFF
--- a/sw/host/tests/chip/gpio/src/sleep_pin_retention.rs
+++ b/sw/host/tests/chip/gpio/src/sleep_pin_retention.rs
@@ -45,9 +45,7 @@ fn sleep_pin_retention_test(opts: &Opts, transport: &TransportWrapper) -> Result
     transport
         .gpio_pin(WAKEUP_PIN)?
         .set_mode(PinMode::PushPull)?;
-    transport
-        .gpio_pin(SYNC_PIN)?
-        .set_mode(PinMode::PushPull)?;
+    transport.gpio_pin(SYNC_PIN)?.set_mode(PinMode::PushPull)?;
     for pin in GPIO_PINS {
         transport.gpio_pin(pin)?.set_mode(PinMode::Input)?;
     }

--- a/sw/host/tests/chip/spi_device/src/spi_host_config_test.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_host_config_test.rs
@@ -50,7 +50,11 @@ const SPI_PIN_SCL: u8 = 1;
 const SPI_PIN_D0: u8 = 2;
 const SPI_PIN_D1: u8 = 3;
 
-fn spi_host_config_test(opts: &Opts, transport: &TransportWrapper, ctx: &TestContext) -> Result<()> {
+fn spi_host_config_test(
+    opts: &Opts,
+    transport: &TransportWrapper,
+    ctx: &TestContext,
+) -> Result<()> {
     let uart = transport.uart("console")?;
     let gpio_bitbanging = transport.gpio_bitbanging()?;
 


### PR DESCRIPTION
A noop change, the result of executing

  bazel run //quality:rustfmt_fix'