### PR TITLE
[dv] Add a quick exit in csr_rd_sub when in reset

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -348,6 +348,16 @@ package csr_utils_pkg;
       status = UVM_IS_OK;
       return;
     end
+
+    // If we are under reset then we want to respond instantly with a bad return value and
+    // UVM_NOT_OK, rather than blocking indefinitely on the bus.
+    if (under_reset) begin
+      `uvm_info(msg_id, "Early-exit from csr_rd_sub because we are in reset", UVM_LOW)
+      value = '1;
+      status = UVM_NOT_OK;
+      return;
+    end
+
     fork
       begin : isolation_fork
         csr_field_t   csr_or_fld;


### PR DESCRIPTION
If we are trying to read a CSR and are in reset, the operation isn't going to work. This change makes it so that we exit immediately (setting the status to UVM_NOT_OK) rather than blocking indefinitely.