### PR TITLE
[rv_dm,dv] Minor tweaks to rv_dm dv code to work with stress_all_with_rand_reset

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_debug_disabled_vseq.sv
@@ -13,7 +13,7 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
   task automatic read_abstractdata(uvm_reg_data_t expected_value);
     uvm_reg_data_t rdata;
     csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
-    `DV_CHECK_EQ(rdata, expected_value);
+    if (cfg.clk_rst_vif.rst_n) `DV_CHECK_EQ(rdata, expected_value);
   endtask
 
   // Possibly wait a short time.
@@ -47,6 +47,7 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
     // working DMI connection. Write some arbitrary value to abstractdata 0.
     write_abstractdata(value0);
     read_abstractdata(value0);
+    if (!cfg.clk_rst_vif.rst_n) return;
 
     // Possibly wait a bit
     maybe_delay();
@@ -59,6 +60,7 @@ class rv_dm_jtag_dmi_debug_disabled_vseq extends rv_dm_base_vseq;
     // and the register should read as zero (because the JTAG connection isn't actually up).
     write_abstractdata(value1);
     read_abstractdata(0);
+    if (!cfg.clk_rst_vif.rst_n) return;
 
     // Possibly wait a bit
     maybe_delay();

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_dm_inactive_vseq.sv
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-//rv_dm_jtag_dmi_dm_inactive_vseq
 class rv_dm_jtag_dmi_dm_inactive_vseq extends rv_dm_common_vseq;
   `uvm_object_utils(rv_dm_jtag_dmi_dm_inactive_vseq)
   `uvm_object_new
@@ -46,6 +45,8 @@ class rv_dm_jtag_dmi_dm_inactive_vseq extends rv_dm_common_vseq;
                  .value(is_active), .blocking(1), .predict(1));
         end
       endcase
+
+      if (cfg.stop_transaction_generators()) return;
     end
   endtask
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_stress_all_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_stress_all_vseq.sv
@@ -31,6 +31,8 @@ class rv_dm_stress_all_vseq extends rv_dm_base_vseq;
       rv_dm_base_vseq rv_dm_vseq;
       uint            seq_idx = $urandom_range(0, seq_names.size - 1);
 
+      if (cfg.stop_transaction_generators()) return;
+
       `uvm_info(`gfn,
                 $sformatf("Starting sequence %0s (trans %0d / %0d)",
                           seq_names[seq_idx], i, num_trans),


### PR DESCRIPTION
These are small changes. The first one handles a situation where we've issued a CSR read which has stopped early because we are in reset (and obviously won't have seen the right value).

The other two concentrate on stopping the sequence if we wish to issue a reset. Honestly, I think the correct behaviour will be for the base classes to issue the resets unconditionally and for the IP classes to handle this. But that's a much bigger change and these are minimal tweaks to make the vseq work at all with the current structure.