### PR TITLE
[sw, lib] Add compile-time check for log arg size to prevent undefined behaviour in logging 

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -270,6 +270,153 @@ extern "C++" {
   static_assert(var == expected_value, "Unexpected value for " #var)
 
 /**
+ * A variable-argument macro that expands to the number of arguments passed into
+ * it, between 1 and 32 arguments (1 action and 0-31 others).
+ *
+ * This macro accepts a macro name and a variable list of items, and will then
+ * expand to sequentially call the macro with each provided item in order. This
+ * can be useful for performing compile-time checks on arguments in variadic
+ * functions defined via macros.
+ *
+ * For example, OT_VAR_FOR_EACH(TEST, 5, 19, 32, 1, 4) would expand to be
+ * `do {TEST(5); TEST(19); TEST(32); TEST(1); TEST(4);} while (false)`
+ *
+ * @param action The name of the macro to invoke with each item individually.
+ * @param ... The variable args list to call the macro on.
+ */
+#define OT_VA_FOR_EACH(action, ...)                                        \
+  do {                                                                     \
+    OT_CAT(OT_CAT(OT_VA_FOR_EACH_, OT_VA_ARGS_COUNT(0, ##__VA_ARGS__)), _) \
+    (action, ##__VA_ARGS__)                                                \
+  } while (false)
+
+/**
+ * The following collection of `OT_VA_FOR_EACH` macros are used to construct
+ * the generic "for each" `OT_VA_FOR_EACH` macro.
+ */
+#define OT_VA_FOR_EACH_0_(action)
+#define OT_VA_FOR_EACH_1_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_0_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_2_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_1_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_3_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_2_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_4_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_3_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_5_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_4_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_6_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_5_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_7_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_6_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_8_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_7_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_9_(action, item, ...) \
+  action(item);                              \
+  OT_VA_FOR_EACH_8_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_10_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_9_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_11_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_10_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_12_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_11_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_13_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_12_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_14_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_13_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_15_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_14_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_16_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_15_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_17_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_16_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_18_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_17_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_19_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_18_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_20_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_19_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_21_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_20_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_22_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_21_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_23_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_22_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_24_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_23_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_25_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_24_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_26_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_25_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_27_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_26_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_28_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_27_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_29_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_28_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_30_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_29_(action, ##__VA_ARGS__)
+#define OT_VA_FOR_EACH_31_(action, item, ...) \
+  action(item);                               \
+  OT_VA_FOR_EACH_30_(action, ##__VA_ARGS__)
+
+/**
+ * A macro that checks whether a specified argument is not a standard C integer
+ * type with a width of 64 bits. Useful when assuming that variable arguments
+ * are 32 bits integers.
+ *
+ * @param arg An argument/expression
+ */
+#define OT_CHECK_NOT_INT64(arg) \
+  _Generic((arg), int64_t: false, uint64_t: false, default: true)
+
+/**
+ * A macro that expands to an assertion that wraps the `OT_CHECK_NOT_INT64`
+ * macro, failing with a relevant error message if the provided argument is a
+ * standard C integer type with a width of 64 bits.
+ *
+ * @param arg An argument/expression to check
+ * @param func_name The name of the macro/functionality being invoked, to be
+ * printed in a relevant error if the assertion fails.
+ */
+#define OT_FAIL_IF_64_BIT(arg, func_name)                          \
+  do {                                                             \
+    static_assert(OT_CHECK_NOT_INT64(arg),                         \
+                  "Argument '" #arg "' passed to the " #func_name  \
+                  " function must be no wider than 32 bits. "      \
+                  "Hint: maybe cast with '(uint32_t) " #arg "'?"); \
+  } while (0)
+
+/**
  * A macro representing the OpenTitan execution platform.
  */
 #if __riscv_xlen == 32

--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -218,7 +218,7 @@ inline uint64_t ibex_timeout_elapsed(const ibex_timeout_t *timeout) {
     while (!(expr)) {                                                     \
       CHECK(!ibex_timeout_check(&timeout_),                               \
             "Timed out after %d usec (%d CPU cycles) waiting for " #expr, \
-            timeout_usec, (uint32_t)timeout_.cycles);                     \
+            (uint32_t)timeout_usec, (uint32_t)timeout_.cycles);           \
     }                                                                     \
   } while (0)
 

--- a/sw/device/lib/runtime/log.h
+++ b/sw/device/lib/runtime/log.h
@@ -99,6 +99,25 @@ void base_log_internal_core(const log_fields_t *log, ...);
 void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
 
 /**
+ * A macro that wraps the `OT_FAIL_IF_64_BIT` macro, providing the name
+ * of the LOG macro for better error messages.
+ *
+ * @param arg an arg/expression to check
+ */
+#define OT_FAIL_IF_64_BIT_LOG(arg) OT_FAIL_IF_64_BIT(arg, LOG)
+
+/**
+ * A macro that checks the variable arguments of the `LOG` function are valid
+ * at compile time, by asserting that each of the argument is not a standard
+ * C integer type with a width of 64 bits. Any such invalid argument will
+ * cause a relevant error via a static assertion.
+ *
+ * @param ... the variable args list
+ */
+#define OT_CHECK_VALID_LOG_ARGS(...) \
+  OT_VA_FOR_EACH(OT_FAIL_IF_64_BIT_LOG, ##__VA_ARGS__)
+
+/**
  * Basic logging macro that all other logging macros delegate to.
  *
  * Prefer to use a LOG function with a specified severity, instead.
@@ -110,6 +129,7 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
  */
 #define LOG(severity, format, ...)                               \
   do {                                                           \
+    OT_CHECK_VALID_LOG_ARGS(__VA_ARGS__);                        \
     if (kDeviceLogBypassUartAddress != 0) {                      \
       /* clang-format off */                                     \
       /* Put DV-only log constants in .logs.* sections, which

--- a/sw/device/lib/testing/alert_handler_testutils.c
+++ b/sw/device/lib/testing/alert_handler_testutils.c
@@ -149,7 +149,7 @@ status_t alert_handler_testutils_get_cycles_from_us(uint64_t microseconds,
                                  /*rem_out=*/NULL);
   TRY_CHECK(cycles_ < UINT32_MAX,
             "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
-            (cycles_ >> 32), (uint32_t)cycles_);
+            (uint32_t)(cycles_ >> 32), (uint32_t)cycles_);
   *cycles = (uint32_t)cycles_;
   return OK_STATUS();
 }

--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -23,7 +23,7 @@ status_t aon_timer_testutils_get_aon_cycles_32_from_us(uint64_t microseconds,
                                  /*rem_out=*/NULL);
   TRY_CHECK(cycles_ <= UINT32_MAX,
             "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
-            (cycles_ >> 32), (uint32_t)cycles_);
+            (uint32_t)(cycles_ >> 32), (uint32_t)cycles_);
   *cycles = (uint32_t)cycles_;
   return OK_STATUS();
 }
@@ -41,7 +41,7 @@ status_t aon_timer_testutils_get_us_from_aon_cycles(uint64_t cycles,
                              /*rem_out=*/NULL);
   TRY_CHECK(uss <= UINT32_MAX,
             "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
-            (uss >> 32), (uint32_t)uss);
+            (uint32_t)(uss >> 32), (uint32_t)uss);
   *us = (uint32_t)uss;
   return OK_STATUS();
 }

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -103,7 +103,7 @@ static void execute_test(dif_aon_timer_t *aon_timer, uint64_t irq_time_us,
   CHECK_STATUS_OK(aon_timer_testutils_get_aon_cycles_64_from_us(irq_time_us,
                                                                 &count_cycles));
   LOG_INFO("Setting interrupt for %u us (%u cycles)", (uint32_t)irq_time_us,
-           count_cycles);
+           (uint32_t)count_cycles);
 
   // TRY_CHECK(count_cycles <= UINT32_MAX,
   //           "The desired wake-up count 0x%08x%08x cannot fit into the 32 bits

--- a/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
+++ b/sw/device/tests/sim_dv/otp_ctrl_lc_signals_test.c
@@ -134,12 +134,12 @@ static void otp_read_test(uint32_t address, const uint8_t *buffer,
     CHECK_DIF_OK(dif_otp_ctrl_dai_read64_end(&otp, &got));
     if (exp_result == kExpectFailed) {
       CHECK(got != exp,
-            "0x%x == 0x%x (got == exp) is not expected at address 0x%x", got,
-            exp, address);
+            "0x%x == 0x%x (got == exp) is not expected at address 0x%x",
+            (uint32_t)got, (uint32_t)exp, address);
     } else {
       CHECK(got == exp,
-            "0x%x != 0x%x (got != exp) is not expected at address 0x%x", got,
-            exp, address);
+            "0x%x != 0x%x (got != exp) is not expected at address 0x%x",
+            (uint32_t)got, (uint32_t)exp, address);
     }
   }
 }

--- a/sw/device/tests/sram_ctrl_subword_access_test.c
+++ b/sw/device/tests/sram_ctrl_subword_access_test.c
@@ -67,7 +67,7 @@ static void read_subwords_check(mmio_region_t region) {
   }
 
   // Check uint64_t reads.
-  for (uint64_t i = 0; i < kSramCtrlTestDataSizeBytes - 7; ++i) {
+  for (uint32_t i = 0; i < kSramCtrlTestDataSizeBytes - 7; ++i) {
     uint64_t expected = *(volatile uint64_t *)((uint8_t *)kRandomData + i);
     uint64_t got = *(volatile uint64_t *)((uint8_t *)region.base + i);
     CHECK(expected == got,


### PR DESCRIPTION
When an argument (to be formatted via format specifiers in a given string) is passed to the `LOG` function either directly or indirectly, this value is then later read from the `va_list` using the `va_arg(va_list ap, type)` function. In the case of DV logging via the C->SV backdoor (bypasses UART, speeding up DV simulation) this is always read as a `uint32_t`. In the case of core logging (on Ibex), this is either `uint32_t`, `size_t`, `uintptr_t` or `status_t` (a struct storing an `int32_t`).

As a result, when a 64 bit integer is passed into some debug logging functionality without appropriate explicit casting, no implicit casting is performed as may be expected, and instead the 64 bit integer argument is read as a 32 bit width argument.

As per N1570 7.16.1.1 paragraph 2: 
> ... if type is not compatible with the type of the actual next argument (as promoted according to the default argument promotions), the behaviour is undefined, except for the following cases:
> - one type is a signed integer type, the other type is the corresponding unsigned integer type, and the value is representable in both types.
> - one type is pointer to void and the other is a pointer to a character type.

Because there is no implicit cast, any such invocations of debug printing functionality without casting 64 bit arguments are undefined behaviour, and may cause unreliable and unexpected behaviour in logging. This can compound and mislead separate debugging efforts, and so should not be allowed to occur.

This PR contains a commit that introduces additional macro functionality in order to check the type of each of these variable arguments at compile time. As a result, any code that provides an incorrect argument to debug logging functionality will result in the code not compiling with an appropriate error message via `_Generic` checks and a static assertion. This is all at compile time, with no additional runtime cost added to perform these checks. As part of this functionality, this commit expands the base library of macros to include generic macros for invoking a macro per each argument in a variable list, as well as checking the size of a given argument.

This PR also includes fixes for 8 previous cases of this undefined behaviour that were found in the code base via compiling all software targets. The command `./bazelisk.sh build --keep_going --define bitstream=skip //sw/...` was used to build all possible software targets, and the result of this was then `grep`'d to find these error cases.