### PR TITLE
[rv_dm, sival] test WARL hartsel and anyhavereset

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -310,9 +310,7 @@
                 - Write 1 to ackhavereset
                 - Check dmstatus does not indicate havereset for Ibex
                 - Write all 1s to hartsel
-                - Read back hartsel and check value is all 1s
-                - Write 0 to hartsel
-                - Read back hartsel and check value is 0 (Ibex core selected)
+                - Read back hartsel and check value is 0 (hartsel is WARL)
                 - Halt Ibex with a write to haltreq
                 - Check dmstatus reflects halted status
                 - Resume Ibex for a write to resumereq

--- a/sw/host/opentitanlib/src/debug/dmi.rs
+++ b/sw/host/opentitanlib/src/debug/dmi.rs
@@ -47,6 +47,7 @@ pub mod consts {
     pub const DMSTATUS_ANYNONEXISTENT_MASK: u32 = 1 << 14;
     pub const DMSTATUS_ANYRESUMEACK_MASK: u32 = 1 << 16;
     pub const DMSTATUS_ANYHAVERESET_MASK: u32 = 1 << 18;
+    pub const DMSTATUS_ALLHAVERESET_MASK: u32 = 1 << 19;
 
     pub const DMCONTROL_HASEL_SHIFT: u32 = 26;
     pub const DMCONTROL_HARTSELHI_SHIFT: u32 = 6;

--- a/sw/host/tests/chip/rv_dm/src/ndm_reset_req.rs
+++ b/sw/host/tests/chip/rv_dm/src/ndm_reset_req.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use clap::Parser;
 
 use opentitanlib::app::TransportWrapper;
+use opentitanlib::debug::dmi::{consts, DmiDebugger, OpenOcdDmi};
 use opentitanlib::execute_test;
-use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
 
@@ -23,6 +23,9 @@ struct Opts {
     timeout: Duration,
 }
 
+// Needs to match util/openocd/target
+const RISCV_IDCODE: u32 = 0x10001cdf;
+
 fn test_ndm_reset_req(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     // This test requires RV_DM access so first strap and reset.
     transport.pin_strapping("PINMUX_TAP_RISCV")?.apply()?;
@@ -33,16 +36,57 @@ fn test_ndm_reset_req(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     uart.set_flow_control(true)?;
     let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
 
-    log::info!("Waiting for \"wait for ndm reset\" message");
-    let _ = UartConsole::wait_for(&*uart, "wait for ndm reset", opts.timeout)?;
-
     // Connect via JTAG and trigger a NDM reset
     let mut jtag = opts
         .init
         .jtag_params
         .create(transport)?
-        .connect(JtagTap::RiscvTap)?;
-    jtag.reset(true)?;
+        // .connect(JtagTap::RiscvTap)?;
+        .into_raw()?;
+
+    // Configure OpenOCD to expect RISC-V tap and initialize JTAG.
+    assert_eq!(
+        jtag.execute(&format!(
+            "jtag newtap riscv tap -irlen 5 -expected-id {RISCV_IDCODE:#x}"
+        ))?,
+        ""
+    );
+    assert_eq!(jtag.execute("init")?, "");
+
+    let mut dmi = DmiDebugger::new(OpenOcdDmi::new(jtag, "riscv.tap")?);
+
+    // Check dmstatus indicates havereset for Ibex (power-on reset) and set ackhavereset to clear it.
+    let mut hart = dmi.select_hart(0)?;
+    let dmstatus = hart.dmstatus()?;
+    assert!(dmstatus & consts::DMSTATUS_ANYHAVERESET_MASK != 0);
+    assert!(dmstatus & consts::DMSTATUS_ALLHAVERESET_MASK != 0);
+    hart.set_dmcontrol(consts::DMCONTROL_ACKHAVERESET_MASK)?;
+
+    // Check that anyhavereset is now low.
+    let dmstatus = hart.dmstatus()?;
+    assert!(dmstatus & consts::DMSTATUS_ANYHAVERESET_MASK == 0);
+    assert!(dmstatus & consts::DMSTATUS_ALLHAVERESET_MASK == 0);
+
+    log::info!("Waiting for \"wait for ndm reset\" message");
+    let _ = UartConsole::wait_for(&*uart, "wait for ndm reset", opts.timeout)?;
+
+    log::info!("Issuing an NDM reset request");
+    hart.set_dmcontrol(consts::DMCONTROL_NDMRESET_MASK)?;
+
+    // Read anyhavereset to ensure that it stays low.
+    let dmstatus = hart.dmstatus()?;
+    assert!(dmstatus & consts::DMSTATUS_ANYHAVERESET_MASK == 0);
+    assert!(dmstatus & consts::DMSTATUS_ALLHAVERESET_MASK == 0);
+
+    log::info!("Clearing NDM reset request");
+    hart.set_dmcontrol(0)?;
+
+    // Read anyhavereset again, it now should have been set.
+    // Note that there is a brief period of time between clearing ndmreset and anyhavereset going high, but
+    // JTAG speed is too slow compared to system reset and we cannot observe it.
+    let dmstatus = hart.dmstatus()?;
+    assert!(dmstatus & consts::DMSTATUS_ANYHAVERESET_MASK != 0);
+    assert!(dmstatus & consts::DMSTATUS_ALLHAVERESET_MASK != 0);
 
     UartConsole::wait_for(&*uart, r"PASS!", opts.timeout)?;
     Ok(())


### PR DESCRIPTION
Fix #22044

For the WARL `hartsel`:
* The existing code already tests the WARL behaviour, update the testplan to match.
* The hartsel mask retrieval code is moved to a dedicated function for clarity.

For the anyhavereset:
* Replace OpenOCD reset command with explicit manipulation of `ndmreset` in dmcontrol
* Check `anyhavereset` stays low before releasing ndmreset
* Check that it goes have after releasing `ndmreset`
* Note that it's not feasible to observe the period between `ndmreset` release and `anyhavereset` going high, because JTAG is too slow compared to reset.
