### PR TITLE
[kmac,dv] Increase timeout

### DIFF
--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -168,6 +168,7 @@
     {
       name: "{name}_app_with_partial_data"
       uvm_test_seq: kmac_app_with_partial_data_vseq
+      run_opts: ["+test_timeout_ns=500_000_000"]
       reseed: 10
     }
     {


### PR DESCRIPTION
Similar as https://github.com/lowRISC/opentitan/pull/24083, this issue came up after the merge of this PR during the regression triage meeting.

  - As observed for some other tests: they are going into timeout with 200ms, the worst case seen is running the 126th message when failing over 200. Which leads me to increase the timeout to more than the double to have margin.