### PR TITLE
[rv_dm,dv] Avoid repetition in rv_dm_mem_tl_access_halted_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
@@ -18,14 +18,11 @@ class rv_dm_mem_tl_access_halted_vseq extends rv_dm_base_vseq;
     // the flush state.
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(0));
 
-    repeat ($urandom_range(1, 10)) begin
-      // Verify that writing to HALTED results in anyhalted and allhalted to be set.
-      request_halt();
-      csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(r_data));
-      `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.dmstatus.anyhalted, r_data))
-      `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.dmstatus.allhalted, r_data))
-      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
-    end
+    // Verify that writing to HALTED causes anyhalted and allhalted to be set.
+    request_halt();
+    csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(r_data));
+    `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.dmstatus.anyhalted, r_data))
+    `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.dmstatus.allhalted, r_data))
   endtask : body
 
 endclass : rv_dm_mem_tl_access_halted_vseq


### PR DESCRIPTION
This isn't really needed for the testpoint and I don't believe it strengthens our confidence in the design. Drop the repetition.