### PR TITLE
[rv_dm,dv] Remove the "good prefix" of sba_debug_disabled testpoint

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -288,8 +288,6 @@
             Verify that access to SBA interface is disabled if lc_hw_debug_en is set to a value
             other than lc_ctrl_pkg::On.
 
-            - Set lc_hw_debug_en to true and activate the dm.
-            - Attempt to inject a legal randomized SBA access - verify that it comes through.
             - Set lc_hw_debug_en to non-true value and activate the dm.
             - Attempt to send some legal randomized SBA accesses. Checks in the scoreboard will
               assert that no SBA TL accesses appear on the TL interface.


### PR DESCRIPTION
This is already tested by the two tests that implement the SBA testpoint. I don't believe that repeating the implementation here will gain us any confidence.