### PR TITLE
[dv] Remove pre_reset_dly_clks argument from clk_rst_if.apply_reset

### DIFF
--- a/hw/dv/sv/common_ifs/clk_rst_if.sv
+++ b/hw/dv/sv/common_ifs/clk_rst_if.sv
@@ -257,15 +257,12 @@ interface clk_rst_if #(
   endtask
 
   // apply reset with specified scheme
-  // Note: for power on reset, please ensure pre_reset_dly_clks is set to 0
-  task automatic apply_reset(int pre_reset_dly_clks   = 0,
-                             int reset_width_clks = $urandom_range(50, 100),
+  task automatic apply_reset(int reset_width_clks = $urandom_range(50, 100),
                              int post_reset_dly_clks  = 0,
                              rst_scheme_e rst_n_scheme  = RstAssertAsyncDeassertSync);
     if (drive_rst_n) begin
       int dly_ps;
       dly_ps = $urandom_range(0, clk_period_ps);
-      wait_clks(pre_reset_dly_clks);
       case (rst_n_scheme)
         RstAssertSyncDeassertSync: begin
           o_rst_n <= 1'b0;

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
@@ -143,8 +143,7 @@ class sysrst_ctrl_base_vseq extends cip_base_vseq #(
         super.apply_reset(kind);
         // Aon domain has very slow clock so uses scheme 0 to make sure the `rst_ni` and
         // `rst_aon_ni` will be asserted together within one clk_i cycle.
-        cfg.clk_aon_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                        .reset_width_clks(400),
+        cfg.clk_aon_rst_vif.apply_reset(.reset_width_clks(400),
                                         .post_reset_dly_clks(0),
                                         .rst_n_scheme(common_ifs_pkg::RstAssertSyncDeassertSync));
       join

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -204,7 +204,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
       super.apply_reset(kind);
       if (kind == "HARD") begin
         // A short slow clock reset should suffice.
-        cfg.slow_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0), .reset_width_clks(5));
+        cfg.slow_clk_rst_vif.apply_reset(.reset_width_clks(5));
       end
       cfg.esc_clk_rst_vif.apply_reset();
       cfg.lc_clk_rst_vif.apply_reset();

--- a/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -462,18 +462,12 @@ class rstmgr_base_vseq extends cip_base_vseq #(
   local task start_clocks();
     control_all_clocks(.enable(1));
     fork
-      cfg.aon_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                      .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.io_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                     .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.io_div2_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                          .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.io_div4_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                          .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.main_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                       .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.usb_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                      .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.aon_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.io_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.io_div2_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.io_div4_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.main_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.usb_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
     join
   endtask
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -204,7 +204,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
       super.apply_reset(kind);
       if (kind == "HARD") begin
         // A short slow clock reset should suffice.
-        cfg.slow_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0), .reset_width_clks(5));
+        cfg.slow_clk_rst_vif.apply_reset(.reset_width_clks(5));
       end
       cfg.esc_clk_rst_vif.apply_reset();
       cfg.lc_clk_rst_vif.apply_reset();

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -462,18 +462,12 @@ class rstmgr_base_vseq extends cip_base_vseq #(
   local task start_clocks();
     control_all_clocks(.enable(1));
     fork
-      cfg.aon_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                      .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.io_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                     .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.io_div2_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                          .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.io_div4_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                          .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.main_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                       .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
-      cfg.usb_clk_rst_vif.apply_reset(.pre_reset_dly_clks(0),
-                                      .reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.aon_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.io_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.io_div2_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.io_div4_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.main_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
+      cfg.usb_clk_rst_vif.apply_reset(.reset_width_clks(BOGUS_RESET_CLK_CYCLES));
     join
   endtask
 


### PR DESCRIPTION
This is never given a positive value and dates back to the initial import in 2019. Probably no benefit to keeping the implementation.