### PR TITLE
[rv_dm,dv] Add late_debug_enable_regwen to scoreboard list of regs

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -335,6 +335,8 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
           end
           "late_debug_enable": begin
           end
+          "late_debug_enable_regwen": begin
+          end
           default: `uvm_fatal(`gfn, $sformatf("Unknown regs CSR: %0s", csr.get_name()))
         endcase
       end


### PR DESCRIPTION
This doesn't actually add any testing, but it avoids a quick error path when a stress test tries to write the late_debug_enable_regwen register.

Eventually, we should probably check that the register *does* something useful. This change is much simpler than that: it just stops the random write from causing the test to fail for a silly reason.