### PR TITLE
[rv_dm,dv] Rewrite hard reset vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv
@@ -7,24 +7,45 @@ class rv_dm_jtag_dtm_hard_reset_vseq extends rv_dm_base_vseq;
 
   `uvm_object_new
 
+  // Write value over DMI to abstractdata[0]
+  task set_abstractdata0(bit [31:0] value);
+    csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(value));
+  endtask
+
+  // Write value over DMI to progbuf[0]
+  task set_progbuf0(bit [31:0] value);
+    csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(value));
+  endtask
+
+  // Read abstractdata[0] over DMI and check it has the expected value
+  task check_abstractdata0(bit [31:0] expected);
+    uvm_reg_data_t rdata;
+    csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
+    `DV_CHECK_EQ(rdata, expected)
+  endtask
+
+  // Read progbuf[0] over DMI and check it has the expected value
+  task check_progbuf0(bit [31:0] expected);
+    uvm_reg_data_t rdata;
+    csr_rd(.ptr(jtag_dmi_ral.progbuf[0]), .value(rdata));
+    `DV_CHECK_EQ(rdata, expected)
+  endtask
+
   task body();
-    uvm_reg_data_t wdata;
-    uvm_reg_data_t rdata1;
-    uvm_reg_data_t rdata2;
-    repeat ($urandom_range(1, 10)) begin
-      wdata = $urandom_range(0,31);
-      csr_wr(.ptr(jtag_dmi_ral.abstractdata[0]), .value(wdata));
-      csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(wdata));
-      csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata1));
-      csr_rd(.ptr(jtag_dmi_ral.progbuf[0]), .value(rdata2));
-      `DV_CHECK_EQ(wdata,rdata1);
-      `DV_CHECK_EQ(wdata,rdata2);
-      csr_wr(.ptr(jtag_dtm_ral.dtmcs.dmihardreset), .value(1));
-      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-      csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata1));
-      csr_rd(.ptr(jtag_dmi_ral.progbuf[0]), .value(rdata2));
-      `DV_CHECK_EQ(wdata,rdata1);
-      `DV_CHECK_EQ(wdata,rdata2);
-    end
+    uvm_reg_data_t abstractdata_val = $urandom, progbuf_val = $urandom;
+
+    // Write to a couple of registers over DMI and then read their values back to check they have
+    // been set as expected.
+    set_abstractdata0(abstractdata_val);
+    set_progbuf0(progbuf_val);
+    check_abstractdata0(abstractdata_val);
+    check_progbuf0(progbuf_val);
+
+    // Perform the hard reset
+    csr_wr(.ptr(jtag_dtm_ral.dtmcs.dmihardreset), .value(1));
+
+    // Read the registers again, checking that they haven't lost their values
+    check_abstractdata0(abstractdata_val);
+    check_progbuf0(progbuf_val);
   endtask : body
 endclass : rv_dm_jtag_dtm_hard_reset_vseq


### PR DESCRIPTION
This hasn't really changed what it does, except for dropping an unnecessary loop, using all bits of some registers and dropping a random wait.

But I'm hoping the structure of the code is a bit more obvious now.