### PR TITLE
[dv/otp_ctrl] diconnecting external VPP when reset is asserted

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_if.sv.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_if.sv.tpl
@@ -264,6 +264,11 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     release tb.dut.part_access_dai;
   endtask
 
+  // everytime we reset, disconnect EXT_VPP
+  always_ff @( negedge rst_ni ) begin : disconnect_ext_vpp
+    drive_ext_voltage_h_io(1'bz);
+  end
+
   // Connectivity assertions for test related I/Os.
   `ASSERT(LcOtpTestStatusO_A, otp_vendor_test_status_o == `PRIM_GENERIC_OTP_PATH.test_status_o)
   `ASSERT(LcOtpTestCtrlI_A, otp_vendor_test_ctrl_i == `PRIM_GENERIC_OTP_PATH.test_ctrl_i)

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -283,6 +283,11 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     release tb.dut.part_access_dai;
   endtask
 
+  // everytime we reset, disconnect EXT_VPP
+  always_ff @( negedge rst_ni ) begin : disconnect_ext_vpp
+    drive_ext_voltage_h_io(1'bz);
+  end
+
   // Connectivity assertions for test related I/Os.
   `ASSERT(LcOtpTestStatusO_A, otp_vendor_test_status_o == `PRIM_GENERIC_OTP_PATH.test_status_o)
   `ASSERT(LcOtpTestCtrlI_A, otp_vendor_test_ctrl_i == `PRIM_GENERIC_OTP_PATH.test_ctrl_i)


### PR DESCRIPTION
This PR solve an issue in CS where using EXT_VPP, some assertions in CS implementation will throw when reset is asserted and EXT_VPP is still active.

The PR is suggested in OS code and not in CS because adding another driving point for [`otp_ext_voltage_h_io`](https://github.com/lowRISC/opentitan/blob/8a6f1d44a8107ec7b80f0e476e7018c5d657b881/hw/ip/otp_ctrl/dv/tb.sv#L88) via DV will potentially result in a race condition.


