### PR TITLE
[dv,usbdev] Monitor fixes

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_pkg.sv
@@ -24,11 +24,12 @@ package usb20_agent_pkg;
   //
   // Item Types
   typedef enum bit [2:0] {
-      // Packet objects.
+      // Packet items.
       PktTypeSoF,
       PktTypeToken,
       PktTypeData,
       PktTypeHandshake,
+      PktTypeSpecial,
       // Non-packet items.
       PktTypeEvent} pkt_type_e;
 

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -33,10 +33,10 @@ class usb20_item extends uvm_sequence_item;
   `uvm_object_utils_begin(usb20_item)
   `uvm_object_utils_end
 
-  function new(string name = "", pkt_type_e pkt_type = PktTypeEvent);
+  function new(string name = "");
     super.new(name);
     m_ev_type  = EvPacket;
-    m_pkt_type = pkt_type;
+    m_pkt_type = PktTypeEvent;
     // ALmost all communication shall occur using Full Speed signaling.
     low_speed = 1'b0;
     // When passing requests to the driver the validity bits may be cleared to request fault
@@ -125,12 +125,12 @@ class token_pkt extends usb20_item;
     `uvm_field_int(crc5,                    UVM_DEFAULT)
   `uvm_object_utils_end
 
-  function new(string name = "", pid_type_e pid = PidTypeOutToken, bit [6:0] addr = 0,
-               bit [3:0] ep = 0);
-    super.new(name, PktTypeToken);
-    m_pid_type = pid;
-    address = addr;
-    endpoint = ep;
+  function new(string name = "");
+    super.new(name);
+    m_pkt_type = PktTypeToken;
+    m_pid_type = PidTypeOutToken;
+    address = 0;
+    endpoint = 0;
     crc5 = exp_crc();
   endfunction
 
@@ -161,10 +161,10 @@ class data_pkt extends usb20_item;
     `uvm_field_int(crc16,                   UVM_DEFAULT)
   `uvm_object_utils_end
 
-  function new(string name = "", byte unsigned d[] = {}, pid_type_e pid = PidTypeData0);
-    super.new(name, PktTypeToken);
-    m_pid_type = pid;
-    data = d;
+  function new(string name = "");
+    super.new(name);
+    m_pkt_type = PktTypeData;
+    m_pid_type = PidTypeData0;
     crc16 = exp_crc();
   endfunction
 
@@ -249,10 +249,11 @@ class sof_pkt extends usb20_item;
     `uvm_field_int(crc5,                    UVM_DEFAULT)
   `uvm_object_utils_end
 
-  function new(string name = "", bit [10:0] frame = 0);
-    super.new(name, PktTypeSoF);
+  function new(string name = "");
+    super.new(name);
+    m_pkt_type = PktTypeSoF;
     m_pid_type = PidTypeSofToken;
-    framenum = frame;
+    framenum = 0;
     crc5 = exp_crc();
   endfunction
 
@@ -278,8 +279,9 @@ class handshake_pkt extends usb20_item;
     `uvm_field_enum(pid_type_e, m_pid_type, UVM_DEFAULT)
   `uvm_object_utils_end
 
-  function new(string name = "", pid_type_e pid = PidTypeAck);
-    super.new(name, PktTypeToken);
-    m_pid_type = pid;
+  function new(string name = "");
+    super.new(name);
+    m_pkt_type = PktTypeHandshake;
+    m_pid_type = PidTypeAck;
   endfunction
 endclass

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -76,7 +76,7 @@ class usb20_item extends uvm_sequence_item;
   // Check whether the Packet IDentifier passes its self-check (upper and lower nibbles are bitwise
   // complementary).
   function bit valid_pid();
-    return !(m_pid_type[3:0] ^ m_pid_type[7:4]);
+    return ((m_pid_type[3:0] ^ m_pid_type[7:4]) == 4'hf);
   endfunction
 
   // Check whether any CRC on this item is valid.

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -288,14 +288,13 @@ class usb20_monitor extends dv_base_monitor #(
 //-------------------------------------------SOF Packet-------------------------------------------//
   function void sof_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
                            ref bit destuffed_packet[$]);
-    // bits to binary conversion
     m_sof_pkt.m_pid_type = pid;
     m_sof_pkt.valid_sync = valid_sync;
     m_sof_pkt.valid_eop = valid_eop;
     m_sof_pkt.valid_stuffing = valid_stuffing;
     if (destuffed_packet.size() == 32) begin
-      m_sof_pkt.framenum = {<<{destuffed_packet[8:18]}};
-      m_sof_pkt.crc5 = {<<{destuffed_packet[3:7]}};
+      // Unpack everything following the PID.
+      {m_sof_pkt.crc5, m_sof_pkt.framenum} = {<<{destuffed_packet[16:31]}};
       if (!m_sof_pkt.valid_crc()) begin
         // Informational report; the scoreboard may check this using `valid_crc().`
         `uvm_info(`gfn, $sformatf("Detected SOF packet CRC5 mismatch (0x%0x, expected 0x%0x)",
@@ -310,15 +309,13 @@ class usb20_monitor extends dv_base_monitor #(
 //------------------------------------------Token Packet------------------------------------------//
   function void token_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
                              ref bit destuffed_packet[$]);
-    // bits to binary conversion
     m_token_pkt.m_pid_type = pid;
     m_token_pkt.valid_sync = valid_sync;
     m_token_pkt.valid_eop = valid_eop;
     m_token_pkt.valid_stuffing = valid_stuffing;
     if (destuffed_packet.size() == 32) begin
-      m_token_pkt.address = {<<{destuffed_packet[12:18]}};
-      m_token_pkt.endpoint = {<<{destuffed_packet[8:11]}};
-      m_token_pkt.crc5 = {<<{destuffed_packet[3:7]}};
+      // Unpack everything following the PID.
+      {m_token_pkt.crc5, m_token_pkt.endpoint, m_token_pkt.address} = {<<{destuffed_packet[16:31]}};
       if (!m_token_pkt.valid_crc()) begin
         // Informational report; the scoreboard may check this using `valid_crc().`
         `uvm_info(`gfn, $sformatf("Detected token packet CRC5 mismatch (0x%0x, expected 0x%0x)",
@@ -374,7 +371,6 @@ class usb20_monitor extends dv_base_monitor #(
 //----------------------------------------Handshake Packet----------------------------------------//
   function void handshake_packet(pid_type_e pid, bit valid_sync, bit valid_eop, bit valid_stuffing,
                                  ref bit destuffed_packet[$]);
-    // bits to binary conversion
     m_handshake_pkt.m_pid_type = pid;
     m_handshake_pkt.valid_sync = valid_sync;
     m_handshake_pkt.valid_eop = valid_eop;


### PR DESCRIPTION
This PR fixes decoding of packets in the `usb20_monitor` and tidies up object creation via the UVM factory.
It then simplifies the collection of DATA packets and then ensures that monitor listens to d/se0 only when the DUT is transmitting, because those lines are driven only by the DUT and not `usb20_driver` so the monitor was not seeing all of the traffic.