### PR TITLE
[hw,dma,rtl] Add STATUS.chunk_done bit

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -100,9 +100,11 @@
   interrupt_list: [
     { name: "dma_done"
       desc: "DMA operation has been completed."
+      type: "status"
     }
     { name: "dma_error"
       desc: "DMA error has occurred. DMA_STATUS.error_code register shows the details."
+      type: "status"
     }
   ]
   alert_list: [

--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -541,7 +541,6 @@
           resval: 0x0
           hwaccess: "hrw"
           swaccess: "ro"
-          hwaccess: "hrw"
           desc: '''
                 DMA operation is active if this bit is set.
                 DMA engine clears this bit when operation is complete.
@@ -581,6 +580,16 @@
           desc: '''
                 Indicates whether the SHA2_DIGEST register contains a valid digest.
                 This value is cleared on the initial transfer and set when the digest is written.
+                '''
+        }
+        { bits: "5"
+          name: "chunk_done"
+          resval: 0x0
+          hwaccess: "hrw"
+          desc: '''
+                Transfer of a single chunk is complete.
+                Only raised for multi-chunk memory-to-memory transfers.
+                Cleared automatically by the hardware when starting the transfer of a new chunk.
                 '''
         }
       ]

--- a/hw/ip/dma/doc/registers.md
+++ b/hw/ip/dma/doc/registers.md
@@ -532,17 +532,18 @@ Other values are reserved.
 Status indication for DMA data movement.
 - Offset: `0x48`
 - Reset default: `0x0`
-- Reset mask: `0x1f`
+- Reset mask: `0x3f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "busy", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "aborted", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "error", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "sha2_digest_valid", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 27}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
+{"reg": [{"name": "busy", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "aborted", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "error", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "sha2_digest_valid", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "chunk_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 190}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name              | Description                                                                                                                                                                        |
 |:------:|:------:|:-------:|:------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:5  |        |         |                   | Reserved                                                                                                                                                                           |
+|  31:6  |        |         |                   | Reserved                                                                                                                                                                           |
+|   5    |  rw1c  |   0x0   | chunk_done        | Transfer of a single chunk is complete. Only raised for multi-chunk memory-to-memory transfers. Cleared automatically by the hardware when starting the transfer of a new chunk.   |
 |   4    |   ro   |   0x0   | sha2_digest_valid | Indicates whether the SHA2_DIGEST register contains a valid digest. This value is cleared on the initial transfer and set when the digest is written.                              |
 |   3    |  rw1c  |   0x0   | error             | Error occurred during the operation. ERROR_CODE register denotes the source of the error.                                                                                          |
 |   2    |  rw1c  |   0x0   | aborted           | Set once aborted operation drains.                                                                                                                                                 |

--- a/hw/ip/dma/doc/registers.md
+++ b/hw/ip/dma/doc/registers.md
@@ -76,14 +76,14 @@ Interrupt State Register
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "dma_done", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"name": "dma_error", "bits": 1, "attr": ["rw1c"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
+{"reg": [{"name": "dma_done", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "dma_error", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name      | Description                                                               |
 |:------:|:------:|:-------:|:----------|:--------------------------------------------------------------------------|
 |  31:2  |        |         |           | Reserved                                                                  |
-|   1    |  rw1c  |   0x0   | dma_error | DMA error has occurred. DMA_STATUS.error_code register shows the details. |
-|   0    |  rw1c  |   0x0   | dma_done  | DMA operation has been completed.                                         |
+|   1    |   ro   |   0x0   | dma_error | DMA error has occurred. DMA_STATUS.error_code register shows the details. |
+|   0    |   ro   |   0x0   | dma_done  | DMA operation has been completed.                                         |
 
 ## INTR_ENABLE
 Interrupt Enable Register

--- a/hw/ip/dma/dv/env/dma_env_cov.sv
+++ b/hw/ip/dma/dv/env/dma_env_cov.sv
@@ -192,6 +192,7 @@ endgroup
 covergroup dma_status_cg with function sample(
   bit busy,
   bit done,
+  bit chunk_done,
   bit aborted,
   bit error,
   bit sha2_digest_valid
@@ -200,6 +201,7 @@ covergroup dma_status_cg with function sample(
   option.name = "dma_status_cg";
   cp_status_busy: coverpoint busy;
   cp_status_done: coverpoint done;
+  cp_status_chunk_done: coverpoint chunk_done;
   cp_status_aborted: coverpoint aborted;
   cp_status_error: coverpoint error;
   cp_sha2_digest_valid: coverpoint sha2_digest_valid;

--- a/hw/ip/dma/dv/env/dma_env_pkg.sv
+++ b/hw/ip/dma/dv/env/dma_env_pkg.sv
@@ -33,8 +33,10 @@ package dma_env_pkg;
   parameter uint SYS_ADDR_WIDTH = 64;
 
   // Index of interrupt in intf_vif
+  // TODO: rename `DMA_x` to indicate that they are interrupt numbers.
   parameter uint DMA_DONE = 0;
   parameter uint DMA_ERROR = 1;
+  parameter uint NumDmaInterrupts = 2;
 
   // Completion status bits (DV-internal)
   typedef enum {

--- a/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_base_vseq.sv
@@ -386,12 +386,6 @@ class dma_base_vseq extends cip_base_vseq #(
     cfg_interrupts(interrupts, enable);
   endtask : enable_interrupts
 
-  // Clear one or more interrupts
-  task clear_interrupts(bit [31:0] clear);
-    `uvm_info(`gfn, $sformatf("DMA: Clear Interrupt(s) 0x%0x", clear), UVM_HIGH)
-    csr_wr(ral.intr_state, clear);
-  endtask : clear_interrupts
-
   // Task: Enable Handshake Interrupt Enable
   task enable_handshake_interrupt();
     `uvm_info(`gfn, "DMA: Assert Interrupt Enable", UVM_HIGH)

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -120,8 +120,6 @@ class dma_generic_vseq extends dma_base_vseq;
       ral.status.error.set(1'b1);
       csr_update(ral.status);
     end
-    // Clear the Error interrupt if set
-    clear_interrupts(1 << DMA_ERROR);
   endtask
 
   virtual task body();
@@ -276,7 +274,6 @@ class dma_generic_vseq extends dma_base_vseq;
         if (status[StatusDone]) begin
           // Clear STATUS.done bit and then clear the interrupt, if enabled.
           clear_done();
-          clear_interrupts(1 << DMA_DONE);
           status[StatusDone] = 1'b0;
         end
         if (status[StatusError]) begin

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -137,6 +137,9 @@ package dma_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } chunk_done;
+    struct packed {
+      logic        q;
       logic        qe;
     } sha2_digest_valid;
     struct packed {
@@ -242,6 +245,10 @@ package dma_reg_pkg;
       logic        d;
       logic        de;
     } sha2_digest_valid;
+    struct packed {
+      logic        d;
+      logic        de;
+    } chunk_done;
   } dma_hw2reg_status_reg_t;
 
   typedef struct packed {
@@ -286,24 +293,24 @@ package dma_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    dma_reg2hw_intr_state_reg_t intr_state; // [1037:1036]
-    dma_reg2hw_intr_enable_reg_t intr_enable; // [1035:1034]
-    dma_reg2hw_intr_test_reg_t intr_test; // [1033:1030]
-    dma_reg2hw_alert_test_reg_t alert_test; // [1029:1028]
-    dma_reg2hw_src_addr_lo_reg_t src_addr_lo; // [1027:996]
-    dma_reg2hw_src_addr_hi_reg_t src_addr_hi; // [995:964]
-    dma_reg2hw_dst_addr_lo_reg_t dst_addr_lo; // [963:932]
-    dma_reg2hw_dst_addr_hi_reg_t dst_addr_hi; // [931:900]
-    dma_reg2hw_addr_space_id_reg_t addr_space_id; // [899:892]
-    dma_reg2hw_enabled_memory_range_base_reg_t enabled_memory_range_base; // [891:859]
-    dma_reg2hw_enabled_memory_range_limit_reg_t enabled_memory_range_limit; // [858:826]
-    dma_reg2hw_range_valid_reg_t range_valid; // [825:825]
-    dma_reg2hw_range_regwen_reg_t range_regwen; // [824:821]
-    dma_reg2hw_total_data_size_reg_t total_data_size; // [820:789]
-    dma_reg2hw_chunk_data_size_reg_t chunk_data_size; // [788:757]
-    dma_reg2hw_transfer_width_reg_t transfer_width; // [756:755]
-    dma_reg2hw_control_reg_t control; // [754:743]
-    dma_reg2hw_status_reg_t status; // [742:737]
+    dma_reg2hw_intr_state_reg_t intr_state; // [1038:1037]
+    dma_reg2hw_intr_enable_reg_t intr_enable; // [1036:1035]
+    dma_reg2hw_intr_test_reg_t intr_test; // [1034:1031]
+    dma_reg2hw_alert_test_reg_t alert_test; // [1030:1029]
+    dma_reg2hw_src_addr_lo_reg_t src_addr_lo; // [1028:997]
+    dma_reg2hw_src_addr_hi_reg_t src_addr_hi; // [996:965]
+    dma_reg2hw_dst_addr_lo_reg_t dst_addr_lo; // [964:933]
+    dma_reg2hw_dst_addr_hi_reg_t dst_addr_hi; // [932:901]
+    dma_reg2hw_addr_space_id_reg_t addr_space_id; // [900:893]
+    dma_reg2hw_enabled_memory_range_base_reg_t enabled_memory_range_base; // [892:860]
+    dma_reg2hw_enabled_memory_range_limit_reg_t enabled_memory_range_limit; // [859:827]
+    dma_reg2hw_range_valid_reg_t range_valid; // [826:826]
+    dma_reg2hw_range_regwen_reg_t range_regwen; // [825:822]
+    dma_reg2hw_total_data_size_reg_t total_data_size; // [821:790]
+    dma_reg2hw_chunk_data_size_reg_t chunk_data_size; // [789:758]
+    dma_reg2hw_transfer_width_reg_t transfer_width; // [757:756]
+    dma_reg2hw_control_reg_t control; // [755:744]
+    dma_reg2hw_status_reg_t status; // [743:737]
     dma_reg2hw_handshake_intr_enable_reg_t handshake_intr_enable; // [736:726]
     dma_reg2hw_clear_intr_src_reg_t clear_intr_src; // [725:715]
     dma_reg2hw_clear_intr_bus_reg_t clear_intr_bus; // [714:704]
@@ -313,14 +320,14 @@ package dma_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    dma_hw2reg_intr_state_reg_t intr_state; // [699:696]
-    dma_hw2reg_src_addr_lo_reg_t src_addr_lo; // [695:663]
-    dma_hw2reg_src_addr_hi_reg_t src_addr_hi; // [662:630]
-    dma_hw2reg_dst_addr_lo_reg_t dst_addr_lo; // [629:597]
-    dma_hw2reg_dst_addr_hi_reg_t dst_addr_hi; // [596:564]
-    dma_hw2reg_cfg_regwen_reg_t cfg_regwen; // [563:560]
-    dma_hw2reg_control_reg_t control; // [559:554]
-    dma_hw2reg_status_reg_t status; // [553:544]
+    dma_hw2reg_intr_state_reg_t intr_state; // [701:698]
+    dma_hw2reg_src_addr_lo_reg_t src_addr_lo; // [697:665]
+    dma_hw2reg_src_addr_hi_reg_t src_addr_hi; // [664:632]
+    dma_hw2reg_dst_addr_lo_reg_t dst_addr_lo; // [631:599]
+    dma_hw2reg_dst_addr_hi_reg_t dst_addr_hi; // [598:566]
+    dma_hw2reg_cfg_regwen_reg_t cfg_regwen; // [565:562]
+    dma_hw2reg_control_reg_t control; // [561:556]
+    dma_hw2reg_status_reg_t status; // [555:544]
     dma_hw2reg_error_code_reg_t error_code; // [543:528]
     dma_hw2reg_sha2_digest_mreg_t [15:0] sha2_digest; // [527:0]
   } dma_hw2reg_t;

--- a/hw/ip/dma/rtl/dma_reg_top.sv
+++ b/hw/ip/dma/rtl/dma_reg_top.sv
@@ -121,11 +121,8 @@ module dma_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic intr_state_we;
   logic intr_state_dma_done_qs;
-  logic intr_state_dma_done_wd;
   logic intr_state_dma_error_qs;
-  logic intr_state_dma_error_wd;
   logic intr_enable_we;
   logic intr_enable_dma_done_qs;
   logic intr_enable_dma_done_wd;
@@ -308,7 +305,7 @@ module dma_reg_top (
   //   F[dma_done]: 0:0
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_dma_done (
@@ -316,8 +313,8 @@ module dma_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_dma_done_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.dma_done.de),
@@ -335,7 +332,7 @@ module dma_reg_top (
   //   F[dma_error]: 1:1
   prim_subreg #(
     .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (1'h0),
     .Mubi    (1'b0)
   ) u_intr_state_dma_error (
@@ -343,8 +340,8 @@ module dma_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_we),
-    .wd     (intr_state_dma_error_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (hw2reg.intr_state.dma_error.de),
@@ -3004,11 +3001,6 @@ module dma_reg_top (
   end
 
   // Generate write-enables
-  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
-
-  assign intr_state_dma_done_wd = reg_wdata[0];
-
-  assign intr_state_dma_error_wd = reg_wdata[1];
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
   assign intr_enable_dma_done_wd = reg_wdata[0];
@@ -3166,7 +3158,7 @@ module dma_reg_top (
   // Assign write-enables to checker logic vector.
   always_comb begin
     reg_we_check = '0;
-    reg_we_check[0] = intr_state_we;
+    reg_we_check[0] = 1'b0;
     reg_we_check[1] = intr_enable_we;
     reg_we_check[2] = intr_test_we;
     reg_we_check[3] = alert_test_we;

--- a/sw/device/lib/dif/autogen/dif_dma_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_dma_autogen.c
@@ -65,8 +65,8 @@ static bool dma_get_irq_bit_index(dif_dma_irq_t irq,
 }
 
 static dif_irq_type_t irq_types[] = {
-    kDifIrqTypeEvent,
-    kDifIrqTypeEvent,
+    kDifIrqTypeStatus,
+    kDifIrqTypeStatus,
 };
 
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_dma_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_dma_autogen_unittest.cc
@@ -77,7 +77,7 @@ TEST_F(IrqGetTypeTest, Success) {
   dif_irq_type_t type;
 
   EXPECT_DIF_OK(dif_dma_irq_get_type(&dma_, kDifDmaIrqDmaDone, &type));
-  EXPECT_EQ(type, kDifIrqTypeEvent);
+  EXPECT_EQ(type, kDifIrqTypeStatus);
 }
 
 class IrqGetStateTest : public DmaTest {};

--- a/sw/device/lib/dif/dif_dma.h
+++ b/sw/device/lib/dif/dif_dma.h
@@ -226,6 +226,8 @@ typedef enum dif_dma_status_code {
   kDifDmaStatusError = 0x01 << DMA_STATUS_ERROR_BIT,
   // Set once the SHA2 digest is valid after finishing a transfer
   kDifDmaStatusSha2DigestValid = 0x01 << DMA_STATUS_SHA2_DIGEST_VALID_BIT,
+  // Transfer of a single chunk is complete.
+  kDifDmaStatusChunkDone = 0x01 << DMA_STATUS_CHUNK_DONE_BIT,
 } dif_dma_status_code_t;
 
 /**

--- a/sw/device/lib/dif/dif_dma_unittest.cc
+++ b/sw/device/lib/dif/dif_dma_unittest.cc
@@ -324,6 +324,7 @@ INSTANTIATE_TEST_SUITE_P(
         {1 << DMA_STATUS_ABORTED_BIT, kDifDmaStatusAborted},
         {1 << DMA_STATUS_ERROR_BIT, kDifDmaStatusError},
         {1 << DMA_STATUS_SHA2_DIGEST_VALID_BIT, kDifDmaStatusSha2DigestValid},
+        {1 << DMA_STATUS_CHUNK_DONE_BIT, kDifDmaStatusChunkDone},
     }}));
 
 TEST_F(StatusGetTest, GetBadArg) {
@@ -350,6 +351,7 @@ INSTANTIATE_TEST_SUITE_P(
         {1 << DMA_STATUS_ABORTED_BIT, kDifDmaStatusAborted},
         {1 << DMA_STATUS_ERROR_BIT, kDifDmaStatusError},
         {1 << DMA_STATUS_SHA2_DIGEST_VALID_BIT, kDifDmaStatusSha2DigestValid},
+        {1 << DMA_STATUS_CHUNK_DONE_BIT, kDifDmaStatusChunkDone},
     }}));
 
 TEST_F(StatusWriteTest, GetBadArg) {

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -213,6 +213,7 @@ void isr_testutils_csrng_isr(
 }
 
 void isr_testutils_dma_isr(plic_isr_ctx_t plic_ctx, dma_isr_ctx_t dma_ctx,
+                           bool mute_status_irq,
                            top_earlgrey_plic_peripheral_t *peripheral_serviced,
                            dif_dma_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -243,6 +244,8 @@ void isr_testutils_dma_isr(plic_isr_ctx_t plic_ctx, dma_isr_ctx_t dma_ctx,
   CHECK_DIF_OK(dif_dma_irq_get_type(dma_ctx.dma, irq, &type));
   if (type == kDifIrqTypeEvent) {
     CHECK_DIF_OK(dif_dma_irq_acknowledge(dma_ctx.dma, irq));
+  } else if (mute_status_irq) {
+    CHECK_DIF_OK(dif_dma_irq_set_enabled(dma_ctx.dma, irq, kDifToggleDisabled));
   }
 
   // Complete the IRQ at the PLIC.

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -691,11 +691,13 @@ void isr_testutils_csrng_isr(
  *
  * @param plic_ctx A PLIC ISR context handle.
  * @param dma_ctx A(n) dma ISR context handle.
+ * @param mute_status_irq set to true to disable the serviced status type IRQ.
  * @param[out] peripheral_serviced Out param for the peripheral that was
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_dma_isr(plic_isr_ctx_t plic_ctx, dma_isr_ctx_t dma_ctx,
+                           bool mute_status_irq,
                            top_earlgrey_plic_peripheral_t *peripheral_serviced,
                            dif_dma_irq_t *irq_serviced);
 


### PR DESCRIPTION
This PR adds a new STATUS.chunk_done bit to the status register to determine the cause when the DMA stopped an operation. In multi-chunk mem2mem transfers, where each chunk is transferred with a separate SW-go, `chunk_done` goes high when finishing every chunk, except the last chunk, where `done` goes high. The `done` interrupt fires for every chunk for now.