### PR TITLE
[chip-level/sw] Extend the entropy_src_fw_override_test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -267,6 +267,10 @@
             - The procedure must be run once with ENTROPY_SRC.RNG_BIT_ENABLE disabled (4-bit / sample) and
               four times with the ENTROPY_SRC.RNG_BIT_ENABLE feature being enabled (once for every channel).
             - The procedure must be tested with and without the conditioner (bypass mode).
+            - The procedure must be tested with a significant delay added between extracting and inserting the entropy.
+            - The procedure must be tested with a diablement and a re-enablement of ENTROPY_SRC.
+              - To this end, ENTROPY_SRC must be disabled after it has produced entropy.
+              - Whenever CSRNG has an outstanding entropy request ENTROPY_SRC can be enabled again.
 
             Notes for silicon targets:
             - This test requires access to the ENTROPY_SRC.ROUTE_TO_FIRMWARE and ENTROPY_SRC.FW_OV.EXTRACT_AND_INSERT features, which are gated by OTP.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5926,6 +5926,7 @@ opentitan_test(
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing:hmac_testutils",
         "//sw/device/lib/testing:kmac_testutils",
+        "//sw/device/lib/testing:rand_testutils",
         "//sw/device/lib/testing:rv_core_ibex_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],


### PR DESCRIPTION
This commit extends the entropy_src_fw_override_test to also test whether the entropy can be inserted with a significant delay after reading from the observe FIFO. Another extension is for testing whether the entropy_src can be reenabled without reenabling the rest of the entropy complex.

I tested it on FPGA and the test passes.
`bazel test //sw/device/tests:entropy_src_fw_override_test_fpga_cw310_sival_rom_ext --test_output=streamed --nocache_test_results`

I'm not sure what qualifies as a "significant" delay. I just did 128 micro seconds. For 100Mhz this should be ~12800 cycles.
That should probably be enough but it's still worth discussing.

Resolves [#22705](https://github.com/lowRISC/opentitan/issues/22705)