### PR TITLE
[dv,tlt,i2c] Fixup i2c_agent timing parameters in power_virus test

### DIFF
--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -132,6 +132,7 @@ enum {
   /**
    * I2C parameters.
    */
+  kI2CSpeedMode = kDifI2cSpeedFastPlus,
   kI2cSclPeriodNs = 1000,
   kI2cSdaRiseFallTimeNs = 10,
   kI2cDeviceMask = 0x7f,
@@ -937,7 +938,7 @@ static void configure_i2c(dif_i2c_t *i2c, uint8_t device_addr_0,
 
   CHECK_DIF_OK(dif_i2c_compute_timing(
       (dif_i2c_timing_config_t){
-          .lowest_target_device_speed = kDifI2cSpeedFastPlus,
+          .lowest_target_device_speed = kI2CSpeedMode,
           .clock_period_nanos = peripheral_clock_period_ns,
           .sda_rise_nanos = kI2cSdaRiseFallTimeNs,
           .sda_fall_nanos = kI2cSdaRiseFallTimeNs,


### PR DESCRIPTION
Bad i2c_agent timing parameters have been causing the power_virus test to fail. This commit fixes this, by using the algorithm in `chip_sw_i2c_host_tx_rx_vseq.sv` to create a derived timing configuration for the agent.

In the future, we shouldn't be handcrafting a set of timing parameters like this. Hopefully this sort of calculation will be centralized into a library of-sorts. That future improvement is already tracked in #23920.

Tested locally with the following command, which passes. This is what is run by the nightly regression.
```
./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_sw_power_virus --tool vcs --fi 1
```