### PR TITLE
Earlgrey es sival: Pull shared objects out of Hyperdebug Transport Inner member

### DIFF
--- a/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
-use crate::transport::hyperdebug::{CommandHandler, Flavor, Inner, StandardFlavor, VID_GOOGLE};
+use crate::transport::hyperdebug::{CommandHandler, Flavor, StandardFlavor, VID_GOOGLE};
 use crate::transport::{TransportError, TransportInterfaceType};
+use crate::util::usb::UsbBackend;
 
 /// The C2D2 (Case Closed Debugging Debugger) is used to bring up OT and EC chips sitting
 /// inside a computing device, such that those OT chips can provide Case Closed Debugging
@@ -30,7 +32,7 @@ impl Flavor for C2d2Flavor {
 
     fn spi_index(
         _console: &CommandHandler,
-        _inner: &Rc<Inner>,
+        _usb_device: &Rc<RefCell<UsbBackend>>,
         instance: &str,
     ) -> Result<(u8, u8)> {
         if instance == "0" {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/servo_micro.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/servo_micro.rs
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
-use crate::transport::hyperdebug::{CommandHandler, Flavor, Inner, StandardFlavor, VID_GOOGLE};
+use crate::transport::hyperdebug::{CommandHandler, Flavor, StandardFlavor, VID_GOOGLE};
 use crate::transport::{TransportError, TransportInterfaceType};
+use crate::util::usb::UsbBackend;
 
 /// The Servo Micro is used to bring up GSC and EC chips sitting inside a computing device, such
 /// that those GSC chips can provide Case Closed Debugging support to allow bringup of the rest of
@@ -30,7 +32,7 @@ impl Flavor for ServoMicroFlavor {
 
     fn spi_index(
         _console: &CommandHandler,
-        _inner: &Rc<Inner>,
+        _usb_device: &Rc<RefCell<UsbBackend>>,
         instance: &str,
     ) -> Result<(u8, u8)> {
         bail!(TransportError::InvalidInstance(

--- a/sw/host/opentitanlib/src/transport/hyperdebug/ti50.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/ti50.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use crate::io::gpio::GpioPin;
 use crate::transport::hyperdebug::i2c::Mode;
-use crate::transport::hyperdebug::{Flavor, Inner, StandardFlavor, VID_GOOGLE};
+use crate::transport::hyperdebug::{CommandHandler, Flavor, Inner, StandardFlavor, VID_GOOGLE};
 use crate::transport::{TransportError, TransportInterfaceType};
 
 // The GSC has some capability to control GPIO lines inside a Chromebook, and to program the AP
@@ -19,11 +19,15 @@ impl Ti50Flavor {
 }
 
 impl Flavor for Ti50Flavor {
-    fn gpio_pin(inner: &Rc<Inner>, pinname: &str) -> Result<Rc<dyn GpioPin>> {
-        StandardFlavor::gpio_pin(inner, pinname)
+    fn gpio_pin(console: &CommandHandler, pinname: &str) -> Result<Rc<dyn GpioPin>> {
+        StandardFlavor::gpio_pin(console, pinname)
     }
 
-    fn spi_index(_inner: &Rc<Inner>, instance: &str) -> Result<(u8, u8)> {
+    fn spi_index(
+        _console: &CommandHandler,
+        _inner: &Rc<Inner>,
+        instance: &str,
+    ) -> Result<(u8, u8)> {
         if instance == "AP" {
             return Ok((super::spi::USB_SPI_REQ_ENABLE_AP, 0));
         } else if instance == "EC" {
@@ -35,7 +39,11 @@ impl Flavor for Ti50Flavor {
         ))
     }
 
-    fn i2c_index(_inner: &Rc<Inner>, instance: &str) -> Result<(u8, Mode)> {
+    fn i2c_index(
+        _console: &CommandHandler,
+        _inner: &Rc<Inner>,
+        instance: &str,
+    ) -> Result<(u8, Mode)> {
         if instance == "I2C1" {
             return Ok((0, Mode::Host));
         } else if instance == "I2C2" {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/ti50.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/ti50.rs
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::io::gpio::GpioPin;
 use crate::transport::hyperdebug::i2c::Mode;
-use crate::transport::hyperdebug::{CommandHandler, Flavor, Inner, StandardFlavor, VID_GOOGLE};
+use crate::transport::hyperdebug::{CommandHandler, Flavor, StandardFlavor, VID_GOOGLE};
 use crate::transport::{TransportError, TransportInterfaceType};
+use crate::util::usb::UsbBackend;
 
 // The GSC has some capability to control GPIO lines inside a Chromebook, and to program the AP
 // firmware flash chip via SPI.  This "flavor" allows OpenTitanTool to access those capabilities.
@@ -25,7 +27,7 @@ impl Flavor for Ti50Flavor {
 
     fn spi_index(
         _console: &CommandHandler,
-        _inner: &Rc<Inner>,
+        _usb_device: &Rc<RefCell<UsbBackend>>,
         instance: &str,
     ) -> Result<(u8, u8)> {
         if instance == "AP" {
@@ -41,7 +43,7 @@ impl Flavor for Ti50Flavor {
 
     fn i2c_index(
         _console: &CommandHandler,
-        _inner: &Rc<Inner>,
+        _usb_device: &Rc<RefCell<UsbBackend>>,
         instance: &str,
     ) -> Result<(u8, Mode)> {
         if instance == "I2C1" {


### PR DESCRIPTION
This is to remove the cyclic referenced between Hyperdebug Transport Targets and the Inner struct, allowing for Targets to be dropped if they and the Transport object both go out of scope.

This is useful for creating another Transport object after the previous one has been dropped. Otherwise the target objects stay alive forever preventing equivalents from being created the next a Transport object is created.