### PR TITLE
[entropy_src/dv] Randomize the simulation duration

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -45,13 +45,16 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // When selecting fixed duration, the total simulated duration of the test is approximately
   // equal to cfg.sim_duration
   //
-  // TODO(#18836): Randomize & constrain the following values.
+  // sim_duration_ms is used as a random value to set sim_duration in post_randomize().
   realtime sim_duration;
+  rand int unsigned sim_duration_ms;
 
   // Mean time before hard RNG failure
-  realtime hard_mtbf;
+  // Default: Negative, meaning no random reconfigs.
+  realtime hard_mtbf = -1;
   // Mean time before "soft" RNG failure (still functions but less entropy per bit)
-  realtime soft_mtbf;
+  // Default: Negative, meaning no random reconfigs.
+  realtime soft_mtbf = -1;
 
   // Mean time between unexpected configuration update events
   // Default: Negative, meaning no random reconfigs
@@ -152,6 +155,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   /////////////////
   // Constraints //
   /////////////////
+  constraint sim_duration_ms_c {
+    7 <= sim_duration_ms && sim_duration_ms <= 20;
+  }
+
   constraint which_ht_state_c {
     which_ht_state dist {
       BootHTRunning :/ 25,
@@ -318,6 +325,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   function void post_randomize();
     void'(dut_cfg.randomize());
     super.post_randomize();
+    sim_duration = sim_duration_ms * 1ms;
   endfunction
 
   function void pre_randomize();

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -14,7 +14,6 @@ class entropy_src_fw_ov_test extends entropy_src_base_test;
     cfg.alert_max_delay                     = 5;
     cfg.rng_ignores_backpressure            = 1;
 
-    cfg.sim_duration                        = 5ms;
     cfg.hard_mtbf                           = 100s;
     cfg.mean_rand_reconfig_time             = 1ms;
     cfg.mean_rand_csr_alert_time            = 2ms;

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -14,7 +14,6 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.alert_max_delay             = 5;
     cfg.rng_ignores_backpressure    = 1;
 
-    cfg.sim_duration                = 10ms;
     cfg.hard_mtbf                   = 3ms;
     cfg.mean_rand_reconfig_time     = 3ms;
     // The random alerts only need to happen frequently enough to


### PR DESCRIPTION
This PR randomizes the duration of the simulation and sets the default for the mean time between failures to -1 to turn them off. The time between failures is already randomized for the rng_test and the fw_ov test.

Resolves [#18836](https://github.com/lowRISC/opentitan/issues/18836)

The values below the TODO comment are already random for certain tests.
@andreaskurth please tell me if I am misunderstanding something here.