### PR TITLE
[prim_esc_receiver] Register esc_req_o to avoid potential CDC issues

### DIFF
--- a/hw/ip/prim/dv/prim_esc/tb/prim_esc_tb.sv
+++ b/hw/ip/prim/dv/prim_esc/tb/prim_esc_tb.sv
@@ -110,6 +110,8 @@ module prim_esc_tb;
     // Drive random length of esc_req and check `esc_req_out` and `integ_fail` outputs.
     main_clk.wait_clks($urandom_range(1, 20));
     if (integ_fail)   test_error("Esc_req unexpected signal integrity error!");
+    // Wait for the escalation request to pass through the output register.
+    main_clk.wait_clks(1);
     if (!esc_req_out) test_error("Esc_req did not set esc_req!");
     esc_req = 0;
 
@@ -148,6 +150,8 @@ module prim_esc_tb;
     `DV_SPINWAIT(wait (integ_fail == 1);, , , "Wait for esc_tx.esc_n integ_fail timeout");
     main_clk.wait_clks(1);
     release esc_tx.esc_n;
+    // Wait for the escalation request to pass through the output register.
+    main_clk.wait_clks(1);
     // Wait #1ps to avoid a race condition on clock edge.
     #1ps;
     if (!esc_req_out) test_error("Signal integrity error should set esc_req!");
@@ -161,6 +165,8 @@ module prim_esc_tb;
     `DV_SPINWAIT(wait (integ_fail == 1);, , , "Wait for esc_rx.resp_n integ_fail timeout");
     main_clk.wait_clks(1);
     release esc_rx.resp_n;
+    // Wait for the escalation request to pass through the output register.
+    main_clk.wait_clks(1);
     // Wait #1ps to avoid a race condition on clock edge.
     #1ps;
     if (!esc_req_out) test_error("Signal integrity error should set esc_req!");
@@ -176,8 +182,12 @@ module prim_esc_tb;
     release esc_tx.esc_n;
     // Wait #1ps to avoid a race condition on clock edge.
     #1ps;
-    if (!esc_req_out) test_error("Signal integrity error should set esc_req!");
     if (ping_ok)      test_error("Ping error!");
+    // Wait for the escalation request to pass through the output register.
+    main_clk.wait_clks(1);
+    // Wait #1ps to avoid a race condition on clock edge.
+    #1ps;
+    if (!esc_req_out) test_error("Signal integrity error should set esc_req!");
     ping_req = 0;
 
     $display("[prim_esc_seq] Escalation esc_p/n integrity sequence during ping request finished!");
@@ -191,7 +201,7 @@ module prim_esc_tb;
         // After one ping_req, esc_receiver will start a counter to expect next ping_req. If the
         // counter reaches its max value but no ping_req has been received, design will set
         // `esc_req_out` signal.
-        main_clk.wait_clks(TIMEOUT_CYCLES + 1);
+        main_clk.wait_clks(TIMEOUT_CYCLES + 2);
         if (!esc_req_out) test_error("Design failed to detect ping request timeout!");
       end
       begin
@@ -200,6 +210,8 @@ module prim_esc_tb;
         main_clk.wait_clks(2);
         ping_req = 0;
         if (integ_fail)  test_error("Ping_req unexpected signal integrity error!");
+        // Wait for the escalation request to pass through the output register.
+        main_clk.wait_clks(1);
         if (esc_req_out) test_error("Ping request should not set esc_req_out!");
       end
     join

--- a/hw/ip/prim/fpv/vip/prim_esc_rxtx_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_esc_rxtx_assert_fpv.sv
@@ -103,11 +103,11 @@ module prim_esc_rxtx_assert_fpv
       !rst_ni ||
       error_present)
 
-  // check correct transmission of escalation within 0-1 cycles
+  // check correct transmission of escalation within 1-2 cycles
   `ASSERT(EscCheck_A,
       ##1 esc_req_i
       |->
-      ##[0:1] esc_req_o,
+      ##[1:2] esc_req_o,
       clk_i,
       !rst_ni ||
       error_present)
@@ -155,7 +155,7 @@ module prim_esc_rxtx_assert_fpv
       !esc_req_o ##1
       !ping_req_i [*0 : 2**TimeoutCntDw - 4]
       |->
-      !esc_req_o,
+      ##1 !esc_req_o,
       clk_i,
       !rst_ni ||
       error_d ||
@@ -169,7 +169,7 @@ module prim_esc_rxtx_assert_fpv
       !esc_req_o ##1
       !ping_req_i [* 2**TimeoutCntDw - 3 : $]
       |->
-      esc_req_o,
+      ##1 esc_req_o,
       clk_i,
       !rst_ni ||
       error_d ||


### PR DESCRIPTION
This is related to lowRISC/OpenTitan#24119.

Note, this is most likely needed on top of flopping the error output of the prim_count instances (#24125) as there is some further combinatorial logic on the counter error output in the escalation receiver. For example, we also check the output value of the counter and AND all bits together. To be safe, we should also latch the escalation request output as done in this PR. Otherwise, you can e.g. get a false escalation request if the counter switches from say 4'b1000 to 4'b0111.