### PR TITLE
[rom_ctrl,dv] Minor tidy-ups in smoke vseq

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -116,14 +116,8 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
   // Update the RAL model with expected values for the digest registers
   virtual function void update_ral_digests();
     for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
-      string digest_name = $sformatf("digest_%0d", i);
-      uvm_reg csr = ral.get_reg_by_name(digest_name);
-      void'(csr.predict(.value(kmac_digest[i*TL_DW+:TL_DW]), .kind(UVM_PREDICT_READ)));
-    end
-    for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
-      string digest_name = $sformatf("exp_digest_%0d", i);
-      uvm_reg csr = ral.get_reg_by_name(digest_name);
-      void'(csr.predict(.value(expected_digest[i*TL_DW+:TL_DW]), .kind(UVM_PREDICT_READ)));
+      `DV_CHECK(ral.digest[i].predict(kmac_digest[i*TL_DW+:TL_DW]))
+      `DV_CHECK(ral.exp_digest[i].predict(expected_digest[i*TL_DW+:TL_DW]))
     end
   endfunction
 

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -82,17 +82,17 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
     csr_utils_pkg::wait_no_outstanding_access();
   endtask
 
+  // Read the digest[i] registers (computed by kmac) and the exp_digest[i] registers (which rom_ctrl
+  // read from the top of the ROM). Check these registers all have their expected values.
   virtual task read_digest_regs();
-    bit [TL_DW-1:0] rdata;
+    uvm_status_e status;
     for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
-      string digest_name = $sformatf("digest_%0d", i);
-      uvm_reg csr = ral.get_reg_by_name(digest_name);
-      csr_rd(.ptr(csr), .value(rdata));
+      ral.digest[i].mirror(.status(status), .check(UVM_CHECK));
+      `DV_CHECK_EQ(status, UVM_IS_OK)
     end
     for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
-      string digest_name = $sformatf("exp_digest_%0d", i);
-      uvm_reg csr = ral.get_reg_by_name(digest_name);
-      csr_rd(.ptr(csr), .value(rdata));
+      ral.exp_digest[i].mirror(.status(status), .check(UVM_CHECK));
+      `DV_CHECK_EQ(status, UVM_IS_OK)
     end
   endtask
 

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_smoke_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_smoke_vseq.sv
@@ -12,7 +12,7 @@ class rom_ctrl_smoke_vseq extends rom_ctrl_base_vseq;
     do_rand_ops($urandom_range(20, 50));
     read_digest_regs();
     dut_init();
-    set_kmac_digest();
+    configure_kmac_digest(1'b1);
     do_rand_ops($urandom_range(20, 50));
     read_digest_regs();
   endtask : body

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_smoke_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_smoke_vseq.sv
@@ -2,18 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// smoke test vseq
 class rom_ctrl_smoke_vseq extends rom_ctrl_base_vseq;
   `uvm_object_utils(rom_ctrl_smoke_vseq)
-
   `uvm_object_new
 
   task body();
+    bit send_expected = $urandom_range(0, 1);
+
+    // Tell the KMAC app agent whether generate the digest that was expected in the ROM.
+    configure_kmac_digest(send_expected);
+
+    // Queue up some memory operations. These will block until the rom check completes.
     do_rand_ops($urandom_range(20, 50));
-    read_digest_regs();
-    dut_init();
-    configure_kmac_digest(1'b1);
-    do_rand_ops($urandom_range(20, 50));
+
+    // Read all the digest and exp_digest registers, checking they match the values we expect.
     read_digest_regs();
   endtask : body
 

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_smoke_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_smoke_vseq.sv
@@ -8,21 +8,12 @@ class rom_ctrl_smoke_vseq extends rom_ctrl_base_vseq;
 
   `uvm_object_new
 
-  // Indicates the number of memory accesses to be performed
-  rand int num_mem_reads;
-
-  constraint num_mem_reads_c {
-    num_mem_reads inside {[20 : 50]};
-  }
-
   task body();
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
-    do_rand_ops(num_mem_reads);
+    do_rand_ops($urandom_range(20, 50));
     read_digest_regs();
     dut_init();
     set_kmac_digest();
-    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
-    do_rand_ops(num_mem_reads);
+    do_rand_ops($urandom_range(20, 50));
     read_digest_regs();
   endtask : body
 

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -74,6 +74,7 @@
     {
       name: rom_ctrl_smoke
       uvm_test_seq: rom_ctrl_smoke_vseq
+      reseed: 10
     }
     {
       name: rom_ctrl_stress_all


### PR DESCRIPTION
This was driven by me trying to fix (very sporadic) smoke test failures. Annoyingly, they still happen very sporadically after this change, but the test has got rather quicker and is slightly easier to read.