### PR TITLE
[dv,usbdev] Fix usbdev_rand_suspends sequence

### DIFF
--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -421,7 +421,10 @@
     {
       name: usbdev_rand_suspends
       uvm_test_seq: usbdev_bus_rand_vseq
-      run_opts: ["+do_resume_signaling=1"]
+      // Monitor does not always manage to sample the Resume Signaling and inform the scoreboard
+      // as quickly as the DUT detects it and reports it via an already-issued CSR read; thus the
+      // `usbstat.link_stat` change may sometimes be observed before its prediction.
+      run_opts: ["+do_resume_signaling=1","+en_scb_rdchk_linkstate=0"]
       // Long simulation times
       reseed: 10
     }


### PR DESCRIPTION
For circa 10% of seeds the link state prediction lagged the observation and reporting of Resume Signaling by the DUT (an artefact of the fact that usb20_monitor is sampling on a fixed clock even throughout the Suspend Signaling).