### PR TITLE
[rv_dm,dv] Rewrite and simplify rv_dm_dataaddr_rw_access_vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_dataaddr_rw_access_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_dataaddr_rw_access_vseq.sv
@@ -2,24 +2,31 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-//Dataaddr_RW_access_Test
 class rv_dm_dataaddr_rw_access_vseq extends rv_dm_base_vseq;
   `uvm_object_utils(rv_dm_dataaddr_rw_access_vseq)
   `uvm_object_new
 
-  task write_and_verify(input uvm_object ptr,int idx);
-    uvm_reg_data_t data;
-    uvm_reg_data_t rdata;
-     data = $urandom;
-     csr_wr(.ptr(ptr), .value(data));
-     cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-     csr_rd(.ptr(jtag_dmi_ral.abstractdata[idx]), .value(rdata));
-     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
-     `DV_CHECK_EQ(rdata,data);
+  task test_reg(int unsigned reg_idx);
+    uvm_status_e   reg_status;
+    uvm_reg_data_t value = $urandom;
+
+    `DV_CHECK_FATAL(reg_idx <= 1)
+
+    // Write the random value on the TL side
+    tl_mem_ral.dataaddr[reg_idx].write(.status(reg_status), .value(value));
+    `DV_CHECK_EQ(reg_status, UVM_IS_OK)
+
+    // The scoreboard doesn't know about the connection between the two registers, so we perform it
+    // on the RAL side by hand.
+    `DV_CHECK(jtag_dmi_ral.abstractdata[reg_idx].predict(.value(value), .kind(UVM_PREDICT_DIRECT)))
+
+    // Now read the DMI register and check it matches the prediction we just made.
+    jtag_dmi_ral.abstractdata[reg_idx].mirror(.status(reg_status), .check(UVM_CHECK));
   endtask
+
   task body();
-     write_and_verify(.ptr(tl_mem_ral.dataaddr[0]),.idx(0));
-     write_and_verify(.ptr(tl_mem_ral.dataaddr[1]),.idx(1));
+    test_reg(0);
+    test_reg(1);
   endtask
 
 endclass : rv_dm_dataaddr_rw_access_vseq


### PR DESCRIPTION
This test is pretty trivial: it's just supposed to be checking that values written over TL to a certain pair of registers are visible over DMI.

This rewrite makes the code a bit easier to read. The behaviour is still the same.