### PR TITLE
[rv_dm,dv] Rewrite rv_dm_hart_unavail_vseq to make it easier to read

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_hart_unavail_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_hart_unavail_vseq.sv
@@ -2,23 +2,32 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// hart unavail test vseq
 class rv_dm_hart_unavail_vseq extends rv_dm_base_vseq;
   `uvm_object_utils(rv_dm_hart_unavail_vseq)
   `uvm_object_new
 
+  task check_unavailable(bit req_unavailable);
+    uvm_status_e reg_status;
+
+    // Set the unavailable pin for the one and only hart to match req_unavailable.
+    cfg.rv_dm_vif.cb.unavailable <= req_unavailable;
+
+    // Now update the RAL model of the dmstatus register. Do not check that the RAL matches: it
+    // won't do if we have just changed the unavailable status.
+    jtag_dmi_ral.dmstatus.mirror(.status(reg_status), .check(UVM_NO_CHECK));
+    `DV_CHECK_EQ(reg_status, UVM_IS_OK)
+
+    // Since there is just one hart, the anyunavail and allunavail fields should both equal the
+    // unavailable flag that we have set. Check they do.
+    `DV_CHECK_EQ(`gmv(jtag_dmi_ral.dmstatus.anyunavail), req_unavailable)
+    `DV_CHECK_EQ(`gmv(jtag_dmi_ral.dmstatus.allunavail), req_unavailable)
+  endtask
+
   task body();
-    uvm_reg_data_t data;
-    repeat ($urandom_range(1, 10)) begin
-      data = $urandom_range(0, 1);
-      cfg.rv_dm_vif.cb.unavailable <= data;
-      csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(data));
-      `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
-                   get_field_val(jtag_dmi_ral.dmstatus.anyunavail, data))
-      `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
-                   get_field_val(jtag_dmi_ral.dmstatus.allunavail, data))
-      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+    repeat (10) begin
+      check_unavailable($urandom_range(0, 1));
+      cfg.clk_rst_vif.wait_clks(10);
     end
-  endtask : body
+  endtask
 
 endclass : rv_dm_hart_unavail_vseq


### PR DESCRIPTION
No functional change, but it should be a bit simpler to read what's going on.