### PR TITLE
[silicon_creator,flash_ctrl] decouple cert page configs

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -99,11 +99,11 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
  * DICE certificates exported during personalization.
  *
  * See the `OT_ASSERT_MEMBER_SIZE_AS_ENUM` calls in
- * `sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c`
+ * `sw/device/silicon_creator/manuf/base/ft_personalize.c`
  * for how these sizes are chosen.
  */
 // clang-format off
-#define STRUCT_MANUF_PERSO_CERTS(field, string) \
+#define STRUCT_MANUF_CERTS(field, string) \
     field(uds_tbs_certificate, uint8_t, 680) \
     field(uds_tbs_certificate_size, size_t) \
     field(cdi_0_certificate, uint8_t, 580) \
@@ -118,14 +118,14 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
     field(tpm_cik_tbs_certificate_size, size_t)
 UJSON_SERDE_STRUCT(ManufCerts, \
                    manuf_certs_t, \
-                   STRUCT_MANUF_PERSO_CERTS);
+                   STRUCT_MANUF_CERTS);
 // clang-format on
 
 /**
- * Endorsed certificates imported during personalization.
+ * Endorsed DICE certificates imported during personalization.
  *
  * See the `OT_ASSERT_MEMBER_SIZE_AS_ENUM` calls in
- * `sw/device/silicon_creator/manuf/skus/earlgrey_a0/sival_bringup/ft_personalize.c`
+ * `sw/device/silicon_creator/manuf/base/ft_personalize.c`
  * for how these sizes are chosen.
  */
 // clang-format off

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -728,53 +728,32 @@ void flash_ctrl_creator_info_pages_lockdown(void) {
   HARDENED_CHECK_EQ(r, SIZE_MAX);
 }
 
-const flash_ctrl_info_page_t
-    *kCertificateInfoPages[kFlashCtrlNumCertInfoPages] = {
-        &kFlashCtrlInfoPageAttestationKeySeeds,
-        &kFlashCtrlInfoPageDiceCerts,
-        &kFlashCtrlInfoPageTpmCerts,
-};
-const flash_ctrl_cfg_t kCertificateInfoPagesCfg = {
+const flash_ctrl_cfg_t kCertificateInfoPageCfg = {
     .scrambling = kMultiBitBool4True,
     .ecc = kMultiBitBool4True,
     .he = kMultiBitBool4False,
 };
-const flash_ctrl_perms_t kCertificateInfoPagesCreatorAccess = {
+const flash_ctrl_perms_t kCertificateInfoPageCreatorAccess = {
     .read = kMultiBitBool4True,
     .write = kMultiBitBool4True,
     .erase = kMultiBitBool4True,
 };
-const flash_ctrl_perms_t kCertificateInfoPagesOwnerAccess = {
+const flash_ctrl_perms_t kCertificateInfoPageOwnerAccess = {
     .read = kMultiBitBool4True,
     .write = kMultiBitBool4False,
     .erase = kMultiBitBool4False,
 };
 
-void flash_ctrl_cert_info_pages_creator_cfg(void) {
-  SEC_MMIO_ASSERT_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPagesCreatorCfg,
-                                  2 * kFlashCtrlNumCertInfoPages);
-  size_t i = 0, r = kFlashCtrlNumCertInfoPages - 1;
-  for (; launder32(i) < kFlashCtrlNumCertInfoPages &&
-         launder32(r) < kFlashCtrlNumCertInfoPages;
-       ++i, --r) {
-    flash_ctrl_info_cfg_set(kCertificateInfoPages[i], kCertificateInfoPagesCfg);
-    flash_ctrl_info_perms_set(kCertificateInfoPages[i],
-                              kCertificateInfoPagesCreatorAccess);
-  }
-  HARDENED_CHECK_EQ(i, kFlashCtrlNumCertInfoPages);
-  HARDENED_CHECK_EQ(r, SIZE_MAX);
+void flash_ctrl_cert_info_page_creator_cfg(
+    const flash_ctrl_info_page_t *info_page) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPageCreatorCfg, 2);
+  flash_ctrl_info_cfg_set(info_page, kCertificateInfoPageCfg);
+  flash_ctrl_info_perms_set(info_page, kCertificateInfoPageCreatorAccess);
 }
 
-void flash_ctrl_cert_info_pages_owner_restrict(void) {
-  SEC_MMIO_ASSERT_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPagesOwnerRestrict,
-                                  kFlashCtrlNumCertInfoPages);
-  size_t i = 0, r = kFlashCtrlNumCertInfoPages - 1;
-  for (; launder32(i) < kFlashCtrlNumCertInfoPages &&
-         launder32(r) < kFlashCtrlNumCertInfoPages;
-       ++i, --r) {
-    flash_ctrl_info_perms_set(kCertificateInfoPages[i],
-                              kCertificateInfoPagesOwnerAccess);
-  }
-  HARDENED_CHECK_EQ(i, kFlashCtrlNumCertInfoPages);
-  HARDENED_CHECK_EQ(r, SIZE_MAX);
+void flash_ctrl_cert_info_page_owner_restrict(
+    const flash_ctrl_info_page_t *info_page) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPageOwnerRestrict,
+                                  1);
+  flash_ctrl_info_perms_set(info_page, kCertificateInfoPageOwnerAccess);
 }

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -166,8 +166,8 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  */
 enum {
   kFlashCtrlSecMmioCreatorInfoPagesLockdown = 16,
-  kFlashCtrlSecMmioCertInfoPagesCreatorCfg = 6,
-  kFlashCtrlSecMmioCertInfoPagesOwnerRestrict = 3,
+  kFlashCtrlSecMmioCertInfoPageCreatorCfg = 2,
+  kFlashCtrlSecMmioCertInfoPageOwnerRestrict = 1,
   kFlashCtrlSecMmioDataDefaultCfgSet = 1,
   kFlashCtrlSecMmioDataDefaultPermsSet = 1,
   kFlashCtrlSecMmioExecSet = 1,
@@ -588,30 +588,14 @@ void flash_ctrl_exec_set(uint32_t exec_val);
 void flash_ctrl_creator_info_pages_lockdown(void);
 
 /**
- * Number of flash info pages reserved for storing:
- *
- * 1. any DRBG seed material needed to reproduce private keys, and
- * 2. the certificates themselves.
- */
-enum {
-  kFlashCtrlNumCertInfoPages = 3,
-};
-
-/**
- * Info pages that contain device certificates.
- */
-extern const flash_ctrl_info_page_t
-    *kCertificateInfoPages[kFlashCtrlNumCertInfoPages];
-
-/**
  * Certificate info page configurations and permissions.
  *
  * Certificate info pages are fully accessable by the creator code (ROM +
  * ROM_EXT), but read-only for owner code.
  */
-extern const flash_ctrl_cfg_t kCertificateInfoPagesCfg;
-extern const flash_ctrl_perms_t kCertificateInfoPagesCreatorAccess;
-extern const flash_ctrl_perms_t kCertificateInfoPagesOwnerAccess;
+extern const flash_ctrl_cfg_t kCertificateInfoPageCfg;
+extern const flash_ctrl_perms_t kCertificateInfoPageCreatorAccess;
+extern const flash_ctrl_perms_t kCertificateInfoPageOwnerAccess;
 
 /**
  * Configures certificate flash info pages for access by the silicon creator.
@@ -624,7 +608,8 @@ extern const flash_ctrl_perms_t kCertificateInfoPagesOwnerAccess;
  * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPagesCreatorCfg)`
  * when sec_mmio is being used to check expectations.
  */
-void flash_ctrl_cert_info_pages_creator_cfg(void);
+void flash_ctrl_cert_info_page_creator_cfg(
+    const flash_ctrl_info_page_t *info_page);
 
 /**
  * Restricts access of certificate flash info pages to read-only for the silicon
@@ -634,7 +619,8 @@ void flash_ctrl_cert_info_pages_creator_cfg(void);
  * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPagesOwnerRestrict)`
  * when sec_mmio is being used to check expectations.
  */
-void flash_ctrl_cert_info_pages_owner_restrict(void);
+void flash_ctrl_cert_info_page_owner_restrict(
+    const flash_ctrl_info_page_t *info_page);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -712,10 +712,9 @@ TEST_F(FlashCtrlTest, BankErasePermsSet) {
 }
 
 TEST_F(FlashCtrlTest, CertInfoCreatorCfg) {
-  std::array<const flash_ctrl_info_page_t *, 3> cert_pages = {
+  std::array<const flash_ctrl_info_page_t *, 2> cert_pages = {
       &kFlashCtrlInfoPageAttestationKeySeeds,
       &kFlashCtrlInfoPageDiceCerts,
-      &kFlashCtrlInfoPageTpmCerts,
   };
   for (auto page : cert_pages) {
     auto info_page = InfoPages().at(page);
@@ -726,14 +725,14 @@ TEST_F(FlashCtrlTest, CertInfoCreatorCfg) {
     EXPECT_SEC_WRITE32(base_ + info_page.cfg_offset, 0x9666666);
   }
 
-  flash_ctrl_cert_info_pages_creator_cfg();
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageAttestationKeySeeds);
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageDiceCerts);
 }
 
 TEST_F(FlashCtrlTest, CertInfoOwnerRestrict) {
-  std::array<const flash_ctrl_info_page_t *, 3> cert_pages = {
+  std::array<const flash_ctrl_info_page_t *, 2> cert_pages = {
       &kFlashCtrlInfoPageAttestationKeySeeds,
       &kFlashCtrlInfoPageDiceCerts,
-      &kFlashCtrlInfoPageTpmCerts,
   };
   for (auto page : cert_pages) {
     auto info_page = InfoPages().at(page);
@@ -741,7 +740,9 @@ TEST_F(FlashCtrlTest, CertInfoOwnerRestrict) {
     EXPECT_SEC_WRITE32(base_ + info_page.cfg_offset, 0x9669966);
   }
 
-  flash_ctrl_cert_info_pages_owner_restrict();
+  flash_ctrl_cert_info_page_owner_restrict(
+      &kFlashCtrlInfoPageAttestationKeySeeds);
+  flash_ctrl_cert_info_page_owner_restrict(&kFlashCtrlInfoPageDiceCerts);
 }
 
 struct EraseVerifyCase {

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -203,7 +203,9 @@ static void sw_reset(void) {
  * Configures flash info pages to store device certificates.
  */
 static status_t config_and_erase_certificate_flash_pages(void) {
-  flash_ctrl_cert_info_pages_creator_cfg();
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageAttestationKeySeeds);
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageDiceCerts);
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageTpmCerts);
   TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageDiceCerts,
                             kFlashCtrlEraseTypePage));
   TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageTpmCerts,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -493,7 +493,9 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
 
   // Remove write and erase access to the certificate pages before handing over
   // execution to the owner firmware (owner firmware can still read).
-  flash_ctrl_cert_info_pages_owner_restrict();
+  flash_ctrl_cert_info_page_owner_restrict(
+      &kFlashCtrlInfoPageAttestationKeySeeds);
+  flash_ctrl_cert_info_page_owner_restrict(&kFlashCtrlInfoPageDiceCerts);
 
   // Disable access to silicon creator info pages, the OTP creator partition
   // and the OTP direct access interface until the next reset.
@@ -819,7 +821,8 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
              self->version_minor);
 
   // Configure DICE certificate flash info page and buffer it into RAM.
-  flash_ctrl_cert_info_pages_creator_cfg();
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageAttestationKeySeeds);
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageDiceCerts);
   HARDENED_RETURN_IF_ERROR(rom_ext_buffer_dice_certs_into_ram());
 
   // Establish our identity.


### PR DESCRIPTION
This decouples the flash info certificate page configuration functions from the specific certificate pages to enable configuring different personalization flows for different SKUs, where different SKUs may have a different number of certificates. This partially addresses #23426.