### PR TITLE
[rv_dm,dv] Expand the rv_dm_progbuf_read_write_execute test

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_read_write_execute_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_progbuf_read_write_execute_vseq.sv
@@ -6,18 +6,29 @@ class rv_dm_progbuf_read_write_execute_vseq extends rv_dm_base_vseq;
   `uvm_object_utils(rv_dm_progbuf_read_write_execute_vseq)
   `uvm_object_new
 
-  task progbuf_rw(int idx);
-    uvm_reg_data_t data = $urandom;
-    uvm_reg_data_t r_data;
-    csr_wr(.ptr(jtag_dmi_ral.progbuf[idx]), .value(data));
-    csr_rd(.ptr(tl_mem_ral.program_buffer[idx]), .value(r_data));
-    `DV_CHECK_EQ(data, r_data)
-  endtask
-
   task body();
-    // Call the task from base_vseq to halt the hart.
+    uvm_status_e reg_status;
+    bit[31:0]    words[8];
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(words)
+
+    // Ask the debug module to send a halt request, then respond as the hart to say that we are
+    // halted.
     request_halt();
-    for (int i = 0; i < 8; i++) progbuf_rw(i);
+
+    // Fill the program buffer by writing the words to the PROGBUF multiregister. We expect these
+    // writes to be refected on the TL side in PROGRAM_BUFFER, so predict the values there to match.
+    for (int i = 0; i < 8; i++) begin
+      jtag_dmi_ral.progbuf[i].write(.status(reg_status), .value(words[i]));
+      `DV_CHECK_EQ(reg_status, UVM_IS_OK)
+      `DV_CHECK(tl_mem_ral.program_buffer[i].predict(.value(words[i]), .kind(UVM_PREDICT_DIRECT)))
+    end
+
+    // Now read the program buffer back, this time over TL from the PROGRAM_BUFFER multiregister
+    for (int i = 0; i < 8; i++) begin
+      tl_mem_ral.program_buffer[i].mirror(.status(reg_status), .check(UVM_CHECK));
+      `DV_CHECK_EQ(reg_status, UVM_IS_OK)
+    end
   endtask
 
 endclass : rv_dm_progbuf_read_write_execute_vseq


### PR DESCRIPTION
Not much of a functional change, except that I've made it so that now we write all the multiregisters before reading them all back (to make sure that they aren't all backed by a single register).

I've also added comments to make it as clear as possible what's going on.