### PR TITLE
[BLOCKFILE] Add top_earlgrey.sv and chip_earlgrey_asic.sv files

### DIFF
--- a/BLOCKFILE
+++ b/BLOCKFILE
@@ -25,6 +25,8 @@ hw/ip/*/rtl/*
 hw/ip_templates/*/rtl/*
 hw/top_earlgrey/ip/*/rtl/*
 hw/top_earlgrey/ip_autogen/*/rtl/*
+hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
 
 # Vendored IP
 hw/vendor/lowrisc_ibex/rtl/*


### PR DESCRIPTION
For some reason, we did not have `chip_earlgrey_asic.sv` in the BLOCKFILE nor the template used to generate it. Including the template is not needed as this also impacts the FPGA chip-level files. But we should at least include the generated ASIC file.