### PR TITLE
[dv,usbdev] Coverage improvements

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_full_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_rx_full_vseq.sv
@@ -7,47 +7,76 @@ class usbdev_rx_full_vseq extends usbdev_base_vseq;
 
   `uvm_object_new
 
+  // Use SETUP packets rather than OUT?
+  rand bit use_setup;
+
   // Supply a buffer to the selected FIFO.
   task supply_buffer(int unsigned b);
-    csr_wr(.ptr(ral.avsetupbuffer), .value(b));
+    if (use_setup) csr_wr(.ptr(ral.avsetupbuffer), .value(b));
+    else csr_wr(.ptr(ral.avoutbuffer), .value(b));
   endtask
 
   virtual task body();
+    int unsigned max_av_level = use_setup ? AvSetupFIFODepth : AvOutFIFODepth;
+    int unsigned exp_av_level = 0;
+    int unsigned buffer_id = 0;
+    int unsigned exp_rx_level;
+    uvm_reg_data_t rx_level;
     uvm_reg_data_t rx_full;
 
     clear_all_interrupts();
     // Enable the Rx Full interrupt.
     csr_wr(.ptr(ral.intr_enable), .value(1 << IntrRxFull));
 
+    `uvm_info(`gfn, $sformatf("Using SETUP packets %0d", use_setup), UVM_LOW)
+
     // Make all endpoints accept SETUP packets; `ep_default` is randomized.
-    configure_setup_all();
+    if (use_setup) configure_setup_all();
+    else configure_out_all();
 
     // Keep sending packets until we expect to see the Rx Full interrupt.
-    for (int unsigned b = 0; b < RxFIFODepth; b++) begin
-      // Make a single buffer available; the buffer number does not matter.
-      supply_buffer(b);
-
+    exp_rx_level = RxFIFODepth - !use_setup;
+    for (int unsigned b = 0; b < exp_rx_level; b++) begin
+      // Ensure one or more buffers if available.
+      int unsigned desired_av_level = $urandom_range(1, max_av_level);
+      while (exp_av_level < desired_av_level) begin
+        // Buffer numbers increase monotonically so that we can check them below.
+        supply_buffer(buffer_id);
+        buffer_id++;
+        exp_av_level++;
+      end
       // There should be no interrupt at present.
       csr_rd(.ptr(ral.intr_state.rx_full), .value(rx_full));
       `DV_CHECK_EQ(rx_full, 0, "RX Full interrupt unexpectedly asserted")
 
-      send_prnd_setup_packet(ep_default);
+      if (use_setup) send_prnd_setup_packet(ep_default);
+      else send_prnd_out_packet(ep_default, b[0] ? PidTypeData1 : PidTypeData0);
+      exp_av_level--;
     end
 
     csr_rd(.ptr(ral.intr_state.rx_full), .value(rx_full));
-    `DV_CHECK_EQ(rx_full, 1, "RX Full interrupt not asserted when expected")
+    `DV_CHECK_EQ(rx_full, use_setup, "RX Full interrupt not as expected")
+    csr_rd(.ptr(ral.usbstat.rx_depth), .value(rx_level));
+    `DV_CHECK_EQ(rx_level, exp_rx_level, "RX FIFO level not as expected")
 
-    // Check that the interrupt line is asserted.
-    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrRxFull], 1'b1, "Interrupt signal not asserted")
+    // Check that the interrupt line has the expected state.
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrRxFull], use_setup, "Interrupt signal not asserted")
 
     // Remove the packets to remove the interrupt.
-    for (int unsigned b = 0; b < RxFIFODepth; b++) begin
+    for (int unsigned b = 0; b < exp_rx_level; b++) begin
       uvm_reg_data_t rx_fifo_read;
       csr_rd(.ptr(ral.rxfifo), .value(rx_fifo_read));
       // Just check the buffer numbers as we do so.
       `DV_CHECK_EQ(get_field_val(ral.rxfifo.buffer, rx_fifo_read), b)
+      // Check the updated FIFO level.
+      csr_rd(.ptr(ral.usbstat.rx_depth), .value(rx_level));
+      `DV_CHECK_EQ(rx_level, exp_rx_level - 1 - b)
     end
-    clear_all_interrupts();
+
+    // Check that the `rx_full` Status interrupt has become deasserted.
+    csr_rd(.ptr(ral.intr_state.rx_full), .value(rx_full));
+    `DV_CHECK_EQ(rx_full, 1'b0, "RX Full interrupt not deasserted when expected")
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrRxFull], 1'b0, "Interrupt signal not deasserted")
   endtask
 
 endclass : usbdev_rx_full_vseq

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -70,6 +70,10 @@ class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     list_of_alerts = usbdev_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
+
+    // The DUT supports only a single outstanding request.
+    m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;
+
     // create usb20 agent config obj
     m_usb20_agent_cfg = usb20_agent_cfg::type_id::create("m_usb20_agent_cfg");
 

--- a/hw/ip/usbdev/dv/env/usbdev_env_cov.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cov.sv
@@ -194,10 +194,10 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       bins five  = {5};
       // Plus those where the additional bytes of the CRC16 cause the total byte count to near or
       // exceed 64.
-      bins sixty_one   = {61};
-      bins sixty_two   = {62};
-      bins sixty_three = {63};
-      bins sixty_four  = {64};
+      bins max_len_m3 = {MaxPktSizeByte-3};
+      bins max_len_m2 = {MaxPktSizeByte-2};
+      bins max_len_m1 = {MaxPktSizeByte-1};
+      bins max_len    = {MaxPktSizeByte};
     }
     // Directions
     cp_dir: coverpoint dir_in;
@@ -215,7 +215,10 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       bins nak = {PidTypeNak};
     }
     cp_dir: coverpoint dir_in;  // 'dir_in' is set to indicate IN
-    cp_endp: coverpoint endp;
+    cp_endp: coverpoint endp {
+      // Device supports only 12 endpoints.
+      bins endpoints[] = {[0:NEndpoints-1]};
+    }
 
     cr_pid_X_dir_X_endp: cross
       cp_pid,
@@ -228,9 +231,9 @@ class usbdev_env_cov extends cip_base_env_cov #(.CFG_T(usbdev_env_cfg));
       bins pkt_types[] = {PidTypeSetupToken, PidTypeOutToken, PidTypeInToken};
     }
     cp_endp: coverpoint endp {
-      bins endpoints[] = {[0:11]};
+      bins endpoints[] = {[0:NEndpoints-1]};
       // Device should ignore all packets to unimplemented endpoints.
-      bins invalid_ep[] = {[12:15]};
+      bins invalid_ep[] = {[NEndpoints:15]};
     }
 
     cr_pid_X_endp: cross


### PR DESCRIPTION
This PR addresses a couple of small oversights in the coverage collection and extends two sequences to provide more extensive testing.
In changing the sequence `usbdev_data_toggle_restore` a subtle discrepancy between the functional model and the DUT was also discovered; the DUT routinely collects packet data into the buffer memory before deciding whether or not the packet can be accepted. This is because of the serial nature of the USB transmission and the absence of any internal storage beyond a few flip-flops and the packet buffer memory itself.