### PR TITLE
[dv,flash_ctrl] Fix word sweep tests

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -1146,9 +1146,8 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Increase outstanding table entry.
   function void inc_otd_tbl(bit bank, addr_t addr, flash_dv_part_e part);
     rd_cache_t ent;
-    addr[2:0] = 3'h0;
     ent.bank = bank;
-    ent.addr = addr;
+    ent.addr = align_to_flash_word(addr);
     ent.part = part;
     if (!derr_otd.exists(ent)) begin
       derr_otd[ent] = 1;
@@ -1160,9 +1159,8 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Descrease outstanding table entry.
   function void dec_otd_tbl(bit bank, addr_t addr, flash_dv_part_e part);
     rd_cache_t ent;
-    addr[2:0] = 3'h0;
     ent.bank = bank;
-    ent.addr = addr;
+    ent.addr = align_to_flash_word(addr);
     ent.part = part;
     if (!derr_otd.exists(ent)) begin
       `uvm_error("dec_otd_tbl", $sformatf("addr %x %s doesn't exits", addr, part.name))

--- a/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -543,6 +543,10 @@ package flash_ctrl_env_pkg;
     end
   endfunction
 
+  function automatic addr_t align_to_flash_word(addr_t addr);
+     return {addr[$bits(addr_t) - 1 : FlashDataByteWidth], {FlashDataByteWidth{1'b0}}};
+  endfunction
+
   // Round an address down to a program resolution window.
   function automatic addr_t round_to_prog_resolution(addr_t addr);
     return addr - (addr & (BusPgmResBytes - 1));

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -1139,8 +1139,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end // for (int i = 0; i < num; i++)
   endtask
 
-   task direct_readback(bit [OTFBankId-1:0] addr, int bank, int num);
-     bit[TL_AW-1:0] tl_addr, st_addr, end_addr;
+  task direct_readback(bit [OTFBankId-1:0] addr, int bank, int num);
+    bit[TL_AW-1:0] tl_addr, st_addr, end_addr;
     data_4s_t rdata;
     flash_otf_item exp_item;
     int page;
@@ -1161,7 +1161,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     // Capture for the print in sb.
     st_addr = tl_addr;
 
-     for (int i = 0; i < num ; i++) begin
+    for (int i = 0; i < num ; i++) begin
       drop = 0;
       derr = 0;
 
@@ -1183,48 +1183,48 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       rd_entry.addr[2:0] = 'h0;
       rd_entry.part = FlashPartData;
 
-        if (cfg.ecc_mode > FlashEccEnabled) begin
-          if (exp_item.region.ecc_en == MuBi4True) begin
-            flash_op.addr = tl_addr;
-            // host can only access data partitions.
-            flash_op.partition = FlashPartData;
-            flash_op.num_words = 1;
-            if (cfg.ecc_mode == FlashSerrTestMode || tl_addr[2] == 0) begin
-              cfg.add_bit_err(flash_op, ReadTaskHost, exp_item);
-              derr_is_set = cfg.address_has_derr(flash_op.addr, flash_op.partition);
-            end
-            if (derr_is_set) begin
-              `uvm_info("direct_readback", $sformatf("assert_derr 0x%x", tl_addr), UVM_MEDIUM)
-              cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
-              global_derr_is_set = 1;
-            end
-            if (cfg.derr_once == 0) cfg.derr_created[ReadTaskHost] = 0;
-            `uvm_info("direct_readback",
-                      $sformatf("ierr_created[ReadTaskHost]:%0d  derr_is_set:%0d exists:%0d",
-                                cfg.ierr_created[ReadTaskHost], derr_is_set,
-                                cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0})),
-                      UVM_MEDIUM)
-            cfg.ierr_created[ReadTaskHost] = 0;
+      if (cfg.ecc_mode > FlashEccEnabled) begin
+        if (exp_item.region.ecc_en == MuBi4True) begin
+          flash_op.addr = tl_addr;
+          // host can only access data partitions.
+          flash_op.partition = FlashPartData;
+          flash_op.num_words = 1;
+          if (cfg.ecc_mode == FlashSerrTestMode || tl_addr[2] == 0) begin
+            cfg.add_bit_err(flash_op, ReadTaskHost, exp_item);
+            derr_is_set = cfg.address_has_derr(flash_op.addr, flash_op.partition);
           end
-          if (cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0}) | derr_is_set) begin
-            derr = 1;
+          if (derr_is_set) begin
+            `uvm_info("direct_readback", $sformatf("assert_derr 0x%x", tl_addr), UVM_MEDIUM)
+            cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
+            global_derr_is_set = 1;
           end
-        end // if (cfg.ecc_mode > FlashEccEnabled)
+          if (cfg.derr_once == 0) cfg.derr_created[ReadTaskHost] = 0;
+          `uvm_info("direct_readback",
+                    $sformatf("ierr_created[ReadTaskHost]:%0d  derr_is_set:%0d exists:%0d",
+                              cfg.ierr_created[ReadTaskHost], derr_is_set,
+                              cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0})),
+                    UVM_MEDIUM)
+          cfg.ierr_created[ReadTaskHost] = 0;
+        end
+        if (cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0}) | derr_is_set) begin
+          derr = 1;
+        end
+      end // if (cfg.ecc_mode > FlashEccEnabled)
 
-       cfg.otf_read_entry.insert(rd_entry, flash_op);
-       if (my_region.ecc_en == MuBi4True && cfg.otf_scb_h.corrupt_entry.exists(rd_entry) == 1) begin
-         bit local_derr = 0;
-         check_mem_intg(exp_item, bank, local_derr);
-         if (local_derr) begin
-           exp_item.derr = 1;
-           derr = 1;
-           cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
-           if (derr & cfg.scb_h.do_alert_check) begin
-             cfg.scb_h.expected_alert["fatal_err"].expected = 1;
-             cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
-             cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
-           end
-         end
+      cfg.otf_read_entry.insert(rd_entry, flash_op);
+      if (my_region.ecc_en == MuBi4True && cfg.otf_scb_h.corrupt_entry.exists(rd_entry) == 1) begin
+        bit local_derr = 0;
+        check_mem_intg(exp_item, bank, local_derr);
+        if (local_derr) begin
+          exp_item.derr = 1;
+          derr = 1;
+          cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
+          if (derr & cfg.scb_h.do_alert_check) begin
+            cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+            cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
+            cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
+          end
+        end
       end
 
       `uvm_info("direct_readback", $sformatf("idx:%0d: bank:%0d exec: 0x%x page:%0d derr:%0d",
@@ -1250,8 +1250,6 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       cfg.otf_host_rd_rcvd++;
       tl_addr += 4;
      end // for (int i = 0; i < num ; i++)
-
-
    endtask
 
    task erase_flash(flash_op_t flash_op, int bank, bit in_err = 0);

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -1311,9 +1311,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
             st_addr = 'h0;
             st_addr[18:17] = cfg.tgt_pre[part][j];
             ed_addr = st_addr + byte_size - 1;
-            for (addr_t addr = st_addr; addr <= ed_addr; addr += 8) begin
-              cfg.update_otf_mem_read_zone(part, i, addr);
-            end
+            cfg.update_otf_mem_read_zone(part, i, st_addr, ed_addr);
             add_address_range(i, part, st_addr, ed_addr);
             `uvm_info("flash_otf_init",
                       $sformatf("part:%s pre:%s bank:%0d st:%x ed:%x",
@@ -1333,9 +1331,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
             for (int k = 0; k < InfoTypeSize[part>>1]; k++) begin : pages
               st_addr[DVPageMSB:DVPageLSB] = k; // page
               ed_addr = st_addr + byte_size - 1;
-              for (addr_t addr = st_addr; addr <= ed_addr; addr += 8) begin
-                cfg.update_otf_mem_read_zone(part, i, addr);
-              end
+              cfg.update_otf_mem_read_zone(part, i, st_addr, ed_addr);
               add_address_range(i, part, st_addr, ed_addr);
               `uvm_info("flash_otf_init",
                         $sformatf("part:%s pre:%s bank:%0d page:%0d st:%x ed:%x",

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
@@ -19,6 +19,15 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
 
   localparam int InitializedMemBytes = 1024;
 
+  local function void initialize_memory(flash_dv_part_e partition, int bank,
+                                        otf_addr_t start_addr, otf_addr_t end_addr);
+    `uvm_info("read_word_sweep", $sformatf(
+              "Initializing bank:%0d %s from addr:0x%x to:0x%x",
+              bank, partition.name, start_addr, end_addr),
+              UVM_MEDIUM)
+    cfg.update_otf_mem_read_zone(partition, bank, start_addr, end_addr);
+  endfunction
+
   virtual task body();
     flash_op_t ctrl;
     addr_t start_addr, max_addr;
@@ -34,10 +43,7 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
     max_addr = start_addr + InitializedMemBytes - 1;
 
     // It may be better to initialize the data right before each individual read.
-    `uvm_info("read_word_sweep", $sformatf(
-              "Initializing data from addr:0x%x to:0x%x", start_addr, max_addr),
-              UVM_MEDIUM)
-    cfg.update_otf_mem_read_zone(rand_op.partition, bank, start_addr, max_addr);
+    initialize_memory(rand_op.partition, bank, start_addr, max_addr);
 
     ctrl = rand_op;
     num = 1;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
@@ -29,19 +29,15 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
 
     `DV_CHECK_RANDOMIZE_FATAL(this)
 
+    bank = rand_op.addr[OTFBankId];
     start_addr = rand_op.addr;
     max_addr = start_addr + InitializedMemBytes - 1;
+
     // It may be better to initialize the data right before each individual read.
-    begin
-      addr_t addr = start_addr;
-      addr[2] = 1'b0;
-      `uvm_info("read_word_sweep", $sformatf(
-                "Initializing data from addr:0x%x to:0x%x", addr, addr + InitializedMemBytes - 1),
-                UVM_MEDIUM)
-       for (; addr <= max_addr; addr += 8) begin
-         cfg.update_otf_mem_read_zone(rand_op.partition, rand_op.addr[OTFBankId], addr);
-       end
-    end
+    `uvm_info("read_word_sweep", $sformatf(
+              "Initializing data from addr:0x%x to:0x%x", start_addr, max_addr),
+              UVM_MEDIUM)
+    cfg.update_otf_mem_read_zone(rand_op.partition, bank, start_addr, max_addr);
 
     ctrl = rand_op;
     num = 1;
@@ -49,6 +45,7 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
     addr = start_addr;
     repeat(20) begin
       addr_t end_addr = addr + num * mywd * 4 - 1;
+      // Don't read uninitialized memory to avoid trouble.
       if (end_addr > max_addr) break;
       ctrl.addr = addr;
       ctrl.otf_addr = addr;

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
@@ -17,47 +17,50 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   // It begs a better way to handle this, like just stopping the loop below.
   constraint partition_c {rand_op.partition == FlashPartData;}
 
+  localparam int InitializedMemBytes = 1024;
+
   virtual task body();
     flash_op_t ctrl;
     addr_t start_addr, max_addr;
+    addr_t addr;
 
     int num, bank;
     int mywd;
 
     `DV_CHECK_RANDOMIZE_FATAL(this)
 
+    start_addr = rand_op.addr;
+    max_addr = start_addr + InitializedMemBytes - 1;
     // It may be better to initialize the data right before each individual read.
     begin
-      addr_t addr;
-      addr = rand_op.addr;
+      addr_t addr = start_addr;
       addr[2] = 1'b0;
       `uvm_info("read_word_sweep", $sformatf(
-                "Initializing data from addr:0x%x to:0x%x", addr, addr + 256 * 4 - 1),
+                "Initializing data from addr:0x%x to:0x%x", addr, addr + InitializedMemBytes - 1),
                 UVM_MEDIUM)
-       for (int w = 0; w < 256; w += 2) begin
+       for (; addr <= max_addr; addr += 8) begin
          cfg.update_otf_mem_read_zone(rand_op.partition, rand_op.addr[OTFBankId], addr);
-         addr += 8;
        end
     end
 
     ctrl = rand_op;
     num = 1;
     mywd = 1;
-    start_addr = rand_op.addr;
-    max_addr = start_addr;
+    addr = start_addr;
     repeat(20) begin
-      addr_t end_addr = ctrl.addr + num * mywd - 1;
-      if (end_addr > max_addr) max_addr = end_addr;
+      addr_t end_addr = addr + num * mywd * 4 - 1;
+      if (end_addr > max_addr) break;
+      ctrl.addr = addr;
+      ctrl.otf_addr = addr;
       print_flash_op(ctrl, UVM_MEDIUM);
       `uvm_info("read_word_sweep", $sformatf(
                 "Reading from addr:0x%x, otf_addr:0x%x, num:%0d, wd:%0d",
                 ctrl.addr, ctrl.otf_addr, num, mywd),
                 UVM_MEDIUM)
       read_flash(ctrl, bank, num, mywd);
+      addr += num * mywd * 4;
       mywd = (mywd % 16) + 1;
     end
-    `uvm_info(`gfn, $sformatf("Total test address span: min 0x%x, max 0x%x", start_addr, max_addr),
-              UVM_MEDIUM)
   endtask
 
 endclass : flash_ctrl_read_word_sweep_vseq

--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
@@ -14,14 +14,20 @@ class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
     flash_op_t ctrl;
     int num, bank;
     int mywd;
+    addr_t addr;
 
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
     `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+    num = 1;
     mywd = fractions;
     `DV_CHECK_EQ(mywd, 2)
+    addr = ctrl.addr;
     repeat(10) begin
+      ctrl.addr = addr;
+      ctrl.otf_addr = addr;
       prog_flash(ctrl, bank, num, mywd);
+      addr += num * mywd * 4;
       mywd = (mywd % 16) + 2;
     end
   endtask

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -1146,9 +1146,8 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Increase outstanding table entry.
   function void inc_otd_tbl(bit bank, addr_t addr, flash_dv_part_e part);
     rd_cache_t ent;
-    addr[2:0] = 3'h0;
     ent.bank = bank;
-    ent.addr = addr;
+    ent.addr = align_to_flash_word(addr);
     ent.part = part;
     if (!derr_otd.exists(ent)) begin
       derr_otd[ent] = 1;
@@ -1160,9 +1159,8 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Descrease outstanding table entry.
   function void dec_otd_tbl(bit bank, addr_t addr, flash_dv_part_e part);
     rd_cache_t ent;
-    addr[2:0] = 3'h0;
     ent.bank = bank;
-    ent.addr = addr;
+    ent.addr = align_to_flash_word(addr);
     ent.part = part;
     if (!derr_otd.exists(ent)) begin
       `uvm_error("dec_otd_tbl", $sformatf("addr %x %s doesn't exits", addr, part.name))

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -543,6 +543,10 @@ package flash_ctrl_env_pkg;
     end
   endfunction
 
+  function automatic addr_t align_to_flash_word(addr_t addr);
+     return {addr[$bits(addr_t) - 1 : FlashDataByteWidth], {FlashDataByteWidth{1'b0}}};
+  endfunction
+
   // Round an address down to a program resolution window.
   function automatic addr_t round_to_prog_resolution(addr_t addr);
     return addr - (addr & (BusPgmResBytes - 1));

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -1139,8 +1139,8 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     end // for (int i = 0; i < num; i++)
   endtask
 
-   task direct_readback(bit [OTFBankId-1:0] addr, int bank, int num);
-     bit[TL_AW-1:0] tl_addr, st_addr, end_addr;
+  task direct_readback(bit [OTFBankId-1:0] addr, int bank, int num);
+    bit[TL_AW-1:0] tl_addr, st_addr, end_addr;
     data_4s_t rdata;
     flash_otf_item exp_item;
     int page;
@@ -1161,7 +1161,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
     // Capture for the print in sb.
     st_addr = tl_addr;
 
-     for (int i = 0; i < num ; i++) begin
+    for (int i = 0; i < num ; i++) begin
       drop = 0;
       derr = 0;
 
@@ -1183,48 +1183,48 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       rd_entry.addr[2:0] = 'h0;
       rd_entry.part = FlashPartData;
 
-        if (cfg.ecc_mode > FlashEccEnabled) begin
-          if (exp_item.region.ecc_en == MuBi4True) begin
-            flash_op.addr = tl_addr;
-            // host can only access data partitions.
-            flash_op.partition = FlashPartData;
-            flash_op.num_words = 1;
-            if (cfg.ecc_mode == FlashSerrTestMode || tl_addr[2] == 0) begin
-              cfg.add_bit_err(flash_op, ReadTaskHost, exp_item);
-              derr_is_set = cfg.address_has_derr(flash_op.addr, flash_op.partition);
-            end
-            if (derr_is_set) begin
-              `uvm_info("direct_readback", $sformatf("assert_derr 0x%x", tl_addr), UVM_MEDIUM)
-              cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
-              global_derr_is_set = 1;
-            end
-            if (cfg.derr_once == 0) cfg.derr_created[ReadTaskHost] = 0;
-            `uvm_info("direct_readback",
-                      $sformatf("ierr_created[ReadTaskHost]:%0d  derr_is_set:%0d exists:%0d",
-                                cfg.ierr_created[ReadTaskHost], derr_is_set,
-                                cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0})),
-                      UVM_MEDIUM)
-            cfg.ierr_created[ReadTaskHost] = 0;
+      if (cfg.ecc_mode > FlashEccEnabled) begin
+        if (exp_item.region.ecc_en == MuBi4True) begin
+          flash_op.addr = tl_addr;
+          // host can only access data partitions.
+          flash_op.partition = FlashPartData;
+          flash_op.num_words = 1;
+          if (cfg.ecc_mode == FlashSerrTestMode || tl_addr[2] == 0) begin
+            cfg.add_bit_err(flash_op, ReadTaskHost, exp_item);
+            derr_is_set = cfg.address_has_derr(flash_op.addr, flash_op.partition);
           end
-          if (cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0}) | derr_is_set) begin
-            derr = 1;
+          if (derr_is_set) begin
+            `uvm_info("direct_readback", $sformatf("assert_derr 0x%x", tl_addr), UVM_MEDIUM)
+            cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
+            global_derr_is_set = 1;
           end
-        end // if (cfg.ecc_mode > FlashEccEnabled)
+          if (cfg.derr_once == 0) cfg.derr_created[ReadTaskHost] = 0;
+          `uvm_info("direct_readback",
+                    $sformatf("ierr_created[ReadTaskHost]:%0d  derr_is_set:%0d exists:%0d",
+                              cfg.ierr_created[ReadTaskHost], derr_is_set,
+                              cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0})),
+                    UVM_MEDIUM)
+          cfg.ierr_created[ReadTaskHost] = 0;
+        end
+        if (cfg.scb_h.ecc_error_addr.exists({tl_addr[31:3],3'h0}) | derr_is_set) begin
+          derr = 1;
+        end
+      end // if (cfg.ecc_mode > FlashEccEnabled)
 
-       cfg.otf_read_entry.insert(rd_entry, flash_op);
-       if (my_region.ecc_en == MuBi4True && cfg.otf_scb_h.corrupt_entry.exists(rd_entry) == 1) begin
-         bit local_derr = 0;
-         check_mem_intg(exp_item, bank, local_derr);
-         if (local_derr) begin
-           exp_item.derr = 1;
-           derr = 1;
-           cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
-           if (derr & cfg.scb_h.do_alert_check) begin
-             cfg.scb_h.expected_alert["fatal_err"].expected = 1;
-             cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
-             cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
-           end
-         end
+      cfg.otf_read_entry.insert(rd_entry, flash_op);
+      if (my_region.ecc_en == MuBi4True && cfg.otf_scb_h.corrupt_entry.exists(rd_entry) == 1) begin
+        bit local_derr = 0;
+        check_mem_intg(exp_item, bank, local_derr);
+        if (local_derr) begin
+          exp_item.derr = 1;
+          derr = 1;
+          cfg.scb_h.ecc_error_addr[{tl_addr[31:3],3'h0}] = 1;
+          if (derr & cfg.scb_h.do_alert_check) begin
+            cfg.scb_h.expected_alert["fatal_err"].expected = 1;
+            cfg.scb_h.expected_alert["fatal_err"].max_delay = 2000;
+            cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
+          end
+        end
       end
 
       `uvm_info("direct_readback", $sformatf("idx:%0d: bank:%0d exec: 0x%x page:%0d derr:%0d",
@@ -1250,8 +1250,6 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
       cfg.otf_host_rd_rcvd++;
       tl_addr += 4;
      end // for (int i = 0; i < num ; i++)
-
-
    endtask
 
    task erase_flash(flash_op_t flash_op, int bank, bit in_err = 0);

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_otf_base_vseq.sv
@@ -1311,9 +1311,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
             st_addr = 'h0;
             st_addr[18:17] = cfg.tgt_pre[part][j];
             ed_addr = st_addr + byte_size - 1;
-            for (addr_t addr = st_addr; addr <= ed_addr; addr += 8) begin
-              cfg.update_otf_mem_read_zone(part, i, addr);
-            end
+            cfg.update_otf_mem_read_zone(part, i, st_addr, ed_addr);
             add_address_range(i, part, st_addr, ed_addr);
             `uvm_info("flash_otf_init",
                       $sformatf("part:%s pre:%s bank:%0d st:%x ed:%x",
@@ -1333,9 +1331,7 @@ class flash_ctrl_otf_base_vseq extends flash_ctrl_base_vseq;
             for (int k = 0; k < InfoTypeSize[part>>1]; k++) begin : pages
               st_addr[DVPageMSB:DVPageLSB] = k; // page
               ed_addr = st_addr + byte_size - 1;
-              for (addr_t addr = st_addr; addr <= ed_addr; addr += 8) begin
-                cfg.update_otf_mem_read_zone(part, i, addr);
-              end
+              cfg.update_otf_mem_read_zone(part, i, st_addr, ed_addr);
               add_address_range(i, part, st_addr, ed_addr);
               `uvm_info("flash_otf_init",
                         $sformatf("part:%s pre:%s bank:%0d page:%0d st:%x ed:%x",

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
@@ -19,6 +19,15 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
 
   localparam int InitializedMemBytes = 1024;
 
+  local function void initialize_memory(flash_dv_part_e partition, int bank,
+                                        otf_addr_t start_addr, otf_addr_t end_addr);
+    `uvm_info("read_word_sweep", $sformatf(
+              "Initializing bank:%0d %s from addr:0x%x to:0x%x",
+              bank, partition.name, start_addr, end_addr),
+              UVM_MEDIUM)
+    cfg.update_otf_mem_read_zone(partition, bank, start_addr, end_addr);
+  endfunction
+
   virtual task body();
     flash_op_t ctrl;
     addr_t start_addr, max_addr;
@@ -34,10 +43,7 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
     max_addr = start_addr + InitializedMemBytes - 1;
 
     // It may be better to initialize the data right before each individual read.
-    `uvm_info("read_word_sweep", $sformatf(
-              "Initializing data from addr:0x%x to:0x%x", start_addr, max_addr),
-              UVM_MEDIUM)
-    cfg.update_otf_mem_read_zone(rand_op.partition, bank, start_addr, max_addr);
+    initialize_memory(rand_op.partition, bank, start_addr, max_addr);
 
     ctrl = rand_op;
     num = 1;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
@@ -29,19 +29,15 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
 
     `DV_CHECK_RANDOMIZE_FATAL(this)
 
+    bank = rand_op.addr[OTFBankId];
     start_addr = rand_op.addr;
     max_addr = start_addr + InitializedMemBytes - 1;
+
     // It may be better to initialize the data right before each individual read.
-    begin
-      addr_t addr = start_addr;
-      addr[2] = 1'b0;
-      `uvm_info("read_word_sweep", $sformatf(
-                "Initializing data from addr:0x%x to:0x%x", addr, addr + InitializedMemBytes - 1),
-                UVM_MEDIUM)
-       for (; addr <= max_addr; addr += 8) begin
-         cfg.update_otf_mem_read_zone(rand_op.partition, rand_op.addr[OTFBankId], addr);
-       end
-    end
+    `uvm_info("read_word_sweep", $sformatf(
+              "Initializing data from addr:0x%x to:0x%x", start_addr, max_addr),
+              UVM_MEDIUM)
+    cfg.update_otf_mem_read_zone(rand_op.partition, bank, start_addr, max_addr);
 
     ctrl = rand_op;
     num = 1;
@@ -49,6 +45,7 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
     addr = start_addr;
     repeat(20) begin
       addr_t end_addr = addr + num * mywd * 4 - 1;
+      // Don't read uninitialized memory to avoid trouble.
       if (end_addr > max_addr) break;
       ctrl.addr = addr;
       ctrl.otf_addr = addr;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_read_word_sweep_vseq.sv
@@ -17,47 +17,50 @@ class flash_ctrl_read_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
   // It begs a better way to handle this, like just stopping the loop below.
   constraint partition_c {rand_op.partition == FlashPartData;}
 
+  localparam int InitializedMemBytes = 1024;
+
   virtual task body();
     flash_op_t ctrl;
     addr_t start_addr, max_addr;
+    addr_t addr;
 
     int num, bank;
     int mywd;
 
     `DV_CHECK_RANDOMIZE_FATAL(this)
 
+    start_addr = rand_op.addr;
+    max_addr = start_addr + InitializedMemBytes - 1;
     // It may be better to initialize the data right before each individual read.
     begin
-      addr_t addr;
-      addr = rand_op.addr;
+      addr_t addr = start_addr;
       addr[2] = 1'b0;
       `uvm_info("read_word_sweep", $sformatf(
-                "Initializing data from addr:0x%x to:0x%x", addr, addr + 256 * 4 - 1),
+                "Initializing data from addr:0x%x to:0x%x", addr, addr + InitializedMemBytes - 1),
                 UVM_MEDIUM)
-       for (int w = 0; w < 256; w += 2) begin
+       for (; addr <= max_addr; addr += 8) begin
          cfg.update_otf_mem_read_zone(rand_op.partition, rand_op.addr[OTFBankId], addr);
-         addr += 8;
        end
     end
 
     ctrl = rand_op;
     num = 1;
     mywd = 1;
-    start_addr = rand_op.addr;
-    max_addr = start_addr;
+    addr = start_addr;
     repeat(20) begin
-      addr_t end_addr = ctrl.addr + num * mywd - 1;
-      if (end_addr > max_addr) max_addr = end_addr;
+      addr_t end_addr = addr + num * mywd * 4 - 1;
+      if (end_addr > max_addr) break;
+      ctrl.addr = addr;
+      ctrl.otf_addr = addr;
       print_flash_op(ctrl, UVM_MEDIUM);
       `uvm_info("read_word_sweep", $sformatf(
                 "Reading from addr:0x%x, otf_addr:0x%x, num:%0d, wd:%0d",
                 ctrl.addr, ctrl.otf_addr, num, mywd),
                 UVM_MEDIUM)
       read_flash(ctrl, bank, num, mywd);
+      addr += num * mywd * 4;
       mywd = (mywd % 16) + 1;
     end
-    `uvm_info(`gfn, $sformatf("Total test address span: min 0x%x, max 0x%x", start_addr, max_addr),
-              UVM_MEDIUM)
   endtask
 
 endclass : flash_ctrl_read_word_sweep_vseq

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_write_word_sweep_vseq.sv
@@ -14,14 +14,20 @@ class flash_ctrl_write_word_sweep_vseq extends flash_ctrl_otf_base_vseq;
     flash_op_t ctrl;
     int num, bank;
     int mywd;
+    addr_t addr;
 
     // Don't select a partition defined as read-only
     cfg.seq_cfg.avoid_ro_partitions = 1'b1;
     `DV_CHECK(try_create_prog_op(ctrl, bank, num), "Could not create a prog flash op")
+    num = 1;
     mywd = fractions;
     `DV_CHECK_EQ(mywd, 2)
+    addr = ctrl.addr;
     repeat(10) begin
+      ctrl.addr = addr;
+      ctrl.otf_addr = addr;
       prog_flash(ctrl, bank, num, mywd);
+      addr += num * mywd * 4;
       mywd = (mywd % 16) + 2;
     end
   endtask


### PR DESCRIPTION
This has 4 commits. The first is a fix for two test sequences, the remaining changes are
code simplifications and formatting changes.