### PR TITLE
[rv_dm,dv] Remove unused read_chk task

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -274,23 +274,6 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     join_none
   endtask
 
-  task read_chk (input uvm_object ptr,input int cmderr,input int command);
-    uvm_reg_data_t data;
-    uvm_reg_data_t rdata;
-    repeat ($urandom_range(1, 10)) begin
-      data = $urandom;
-      request_halt();
-      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-      csr_wr(.ptr(jtag_dmi_ral.command), .value(command));
-      csr_rd(.ptr(ptr), .value(data));
-      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-      csr_rd(.ptr(jtag_dmi_ral.abstractcs), .value(rdata));
-      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
-      `DV_CHECK_EQ(cmderr,get_field_val(jtag_dmi_ral.abstractcs.cmderr,rdata));
-      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
-    end
-  endtask
-
   task read_dmcontrol(input bit backdoor, output dmcontrol_t value);
     uvm_reg_data_t raw;
     csr_rd(.ptr(jtag_dmi_ral.dmcontrol), .value(raw));


### PR DESCRIPTION
This was originally added in a0f850982d2 and used in rv_dm_cmderr_busy_vseq. I rewrote that vseq in 85f9684 (tidying things up and adding comments about what it did) but didn't realise that the task was left hanging.

Remove it.