### PR TITLE
[rv_dm,dv] Improve the coverage we get from reading WhereTo address

### DIFF
--- a/hw/ip/rv_dm/dv/cov/rv_dm_cov_excl.el
+++ b/hw/ip/rv_dm/dv/cov/rv_dm_cov_excl.el
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// In dm_mem.sv, a location that can be read is at WhereToAddr. This is supposed to contain a JAL
+// instruction that points at the first instruction of the current abstract command. This location
+// is either the start of the program buffer or the start of the abstract command. Deciding which is
+// done with the current command's cmdtype. But it turns out that this is always dm::AccessRegister,
+// because this is the only supported command. Waive coverage of a situation where the command is
+// not that value.
+INSTANCE: tb.dut.u_dm_top.i_dm_mem
+ANNOTATION: "Cannot have running command other than AccessRegister"
+Condition 5 "3588663374" "((cmd_i.cmdtype == AccessRegister) && ((!ac_ar.transfer)) && ac_ar.postexec) 1 -1" (1 "011")
+Condition 6 "3885215629" "(cmd_i.cmdtype == AccessRegister) 1 -1" (1 "0")

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_halt_resume_whereto_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_halt_resume_whereto_vseq.sv
@@ -59,7 +59,8 @@ class rv_dm_halt_resume_whereto_vseq extends rv_dm_base_vseq;
     dm::command_t cmd;
 
     ar_cmd.aarsize  = 3'h2;
-    ar_cmd.postexec = 1'b1;
+    ar_cmd.postexec = $urandom_range(0, 1);
+    ar_cmd.transfer = $urandom_range(0, 1);
     ar_cmd.regno    = regno;
 
     cmd.cmdtype = dm::AccessRegister;

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -43,6 +43,8 @@
   // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
+  vcs_cov_excl_files: ["{proj_root}/hw/ip/rv_dm/dv/cov/rv_dm_cov_excl.el"]
+
   overrides: [
     {
       // This sets the width of UVM data (UVM_REG_DATA_WIDTH) to sufficiently large value. RV_DM DV

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -232,7 +232,7 @@
     {
       name: rv_dm_halt_resume_whereto
       uvm_test_seq: rv_dm_halt_resume_whereto_vseq
-      reseed: 2
+      reseed: 8
     }
     {
       name: rv_dm_sba_debug_disabled


### PR DESCRIPTION
These are minor tweaks in `rv_dm_halt_resume_whereto_vseq` to try to improve condition coverage numbers.

It feels a little bit silly to go much further, because the conditions and branches in `dm_mem` are all about deciding what instruction to manufacture for the core to execute. I don't think it would make much sense to put more effort into seeing lots of those instructions, only to ignore the values that come out (since `rv_dm` testing doesn't really care about what instructions get generated by the debug module).

A sensible approach might be to waive a large tract of the relevant conditional coverage and note that we're not really trying to test the internals of the pulp debug module. But that's definitely a problem for a different PR.