### PR TITLE
[dv] Add GUI debug mode for Xcelium

### DIFF
--- a/hw/dv/tools/common.tcl
+++ b/hw/dv/tools/common.tcl
@@ -21,6 +21,12 @@ if {[info exists ::env(GUI)]} {
   set gui "$::env(GUI)"
 }
 
+set gui_debug 0
+# Detect when GUI debug mode has been invoked to build UVM objects by default
+if {[info exists ::env(GUI_DEBUG)]} {
+  set gui_debug "$::env(GUI_DEBUG)"
+}
+
 set tb_top "tb"
 if {[info exists ::env(TB_TOP)]} {
   set tb_top "$::env(TB_TOP)"

--- a/hw/dv/tools/dvsim/common_modes.hjson
+++ b/hw/dv/tools/dvsim/common_modes.hjson
@@ -13,6 +13,11 @@
       en_build_modes: ["{tool}_gui"]
     }
     {
+      name: gui_debug
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_gui_debug"]
+    }
+    {
       name: waves
       is_sim_mode: 1
       en_build_modes: ["{tool}_waves"]

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -77,6 +77,7 @@
     { dv_root: "{dv_root}" },
     { SIMULATOR: "{tool}" },
     { GUI: "{gui}"},
+    { GUI_DEBUG: "{gui_debug}"},
     { WAVES: "{waves}" },
     { DUT_TOP: "{dut}" },
     { TB_TOP: "{tb}" },

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -271,6 +271,13 @@
       run_opts: ["-gui", "-l {run_dir}/simv.log"]
     }
     {
+      name: vcs_gui_debug
+      // TODO as done for Xcelium see PR #24156
+      is_sim_mode: 1
+      build_opts: ["-debug_access+all+reverse"]
+      run_opts: ["-gui", "-l {run_dir}/simv.log"]
+    }
+    {
       name: vcs_waves
       is_sim_mode: 1
       build_opts: [// Enable generating Verdi Knowledge Database

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -203,6 +203,16 @@
       run_opts: ["-gui"]
     }
     {
+      name: xcelium_gui_debug
+      is_sim_mode: 1
+      build_opts: ["-createdebugdb", "-access +c", "-uvmlinedebug", "-linedebug",
+                   "+uvm_set_config_int=*,recording_detail,1"]
+      run_opts: ["-gui",
+                 "-input '@database -open waves -into waves.shm -default; probe -create \n"
+                 "tb -depth all -packed 32k -unpacked 32k -all -dynamic -database waves'",
+                 "+uvm_set_config_int=*,recording_detail,1"]
+    }
+    {
       name: xcelium_waves
       is_sim_mode: 1
       build_opts: ["-access +c"]

--- a/hw/dv/tools/sim.tcl
+++ b/hw/dv/tools/sim.tcl
@@ -38,9 +38,17 @@ if {$simulator eq "xcelium"} {
   assertion -list -depth all -multiline -permoff $tb_top
 }
 
-# In GUI mode, let the user take control of running the simulation.
 global gui
-if {$gui == 0} {
+global gui_debug
+# In GUI mode, let the user take control of running the simulation.
+# In GUI debug mode, run only up until the end of the UVM elaboration phase to have access to the
+# dynamic objects.
+if {$gui_debug == 1} {
+  if {$simulator eq "xcelium"} {
+    uvm_phase -stop_at build -end
+    run
+  }
+} elseif {$gui == 0} {
   run
   if {$simulator eq "xcelium"} {
     # Xcelium provides a `finish` tcl command instead of `quit`. The argument '2' enables the

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -137,7 +137,7 @@ class Deploy():
         """
         self._extract_attrs(self.sim_cfg.__dict__)
 
-        # Enable GUI mode.
+        # Enable GUI mode, also when GUI debug mode has been invoked.
         self.gui = self.sim_cfg.gui
 
         # Output directory where the artifacts go (used by the launcher).

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -52,6 +52,9 @@ class FlowCfg():
         self.branch = args.branch
         self.job_prefix = args.job_prefix
         self.gui = args.gui
+        self.gui_debug = args.gui_debug
+        if self.gui_debug:
+            self.gui = 1
 
         self.interactive = args.interactive
 
@@ -370,8 +373,8 @@ class FlowCfg():
         '''
         self.prune_selected_cfgs()
 
-        # GUI or Interactive mode is allowed only for one cfg.
-        if (self.gui or self.interactive) and len(self.cfgs) > 1:
+        # GUI, GUI debug or Interactive mode is allowed only for one cfg.
+        if (self.gui or self.gui_debug or self.interactive) and len(self.cfgs) > 1:
             log.fatal("In GUI mode, only one cfg can be run.")
             sys.exit(1)
 

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -99,8 +99,8 @@ class LocalLauncher(Launcher):
         elapsed_time = datetime.datetime.now() - self.start_time
         self.job_runtime_secs = elapsed_time.total_seconds()
         if self.process.poll() is None:
-            if self.timeout_secs and (self.job_runtime_secs >
-                                      self.timeout_secs) and not self.deploy.gui:
+            if (self.timeout_secs and (self.job_runtime_secs > self.timeout_secs) and
+                    not (self.deploy.gui or self.deploy.gui_debug)):
                 self._kill()
                 timeout_message = 'Job timed out after {} minutes'.format(
                     self.deploy.get_timeout_mins())

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -82,6 +82,8 @@ class SimCfg(FlowCfg):
         # Set default sim modes for unpacking
         if args.gui:
             self.en_build_modes.append("gui")
+        if args.gui_debug:
+            self.en_build_modes.append("gui_debug")
         if args.waves is not None:
             self.en_build_modes.append("waves")
         else:
@@ -485,11 +487,17 @@ class SimCfg(FlowCfg):
         self.runs = ([]
                      if self.build_only else self._expand_run_list(build_map))
 
-        # In GUI mode, only allow one test to run.
+        # In GUI mode or GUI with debug mode, only allow one test to run.
         if self.gui and len(self.runs) > 1:
             self.runs = self.runs[:1]
             log.warning("In GUI mode, only one test is allowed to run. "
                         "Picking {}".format(self.runs[0].full_name))
+
+        # GUI mode is only available for Xcelium for the moment.
+        if (self.gui_debug) and (self.tool not in ['xcelium']):
+            log.error("GUI debug mode is only available for Xcelium, please remove "
+                      "--gui_debug / -gd option or switch to Xcelium tool.")
+            sys.exit(1)
 
         # Add builds to the list of things to run, only if --run-only switch
         # is not passed.

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -443,6 +443,15 @@ def parse_args():
                       help=('Run the flow in GUI mode instead of the batch '
                             'mode.'))
 
+    disg.add_argument("--gui-debug",
+                      "-gd",
+                      action='store_true',
+                      help=('Run the flow in GUI mode and enable tool debug '
+                            'features such as: breakpoints, live values, '
+                            'transactions recording... (works with Xcelium '
+                            'only for the moment). '
+                            '[!] Has a significant performance impact.'))
+
     disg.add_argument("--interactive",
                       action='store_true',
                       help=('Run the job in non-GUI interactive mode '


### PR DESCRIPTION
Add a GUI debug mode for Xcelium. Turn on debug features:
  - breakpoints
  - live data
  - transaction recording

And run simulation up until the end of the UVM elaboration phase to have access to the dynamic objects.

This mode is available through the dvsim command line arguments: `--gui-debug` or `-gd`