### PR TITLE
[entropy_src/dv] Ignore outstanding alerts after disablement

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -40,6 +40,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   // This event is used to notify process_set_exp_alerts there are alerts to be handled.
   event new_exp_alert;
+  bit ignore_exp_alert = 0;
 
   // alert checking related parameters
   bit do_alert_check = 1;
@@ -297,7 +298,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       cfg.clk_rst_vif.wait_n_clks(1);
       if (under_alert_handshake[alert_name] || cfg.under_reset) return;
     end
-    if (!cfg.en_scb) return;
+    // Ignore the alert if the scoreboard is disabled or if the alert is not fatal and the ignore
+    // alert bit is set.
+    if (!cfg.en_scb || (ignore_exp_alert && !expected_alert[alert_name].is_fatal)) return;
     `uvm_error(`gfn, $sformatf("alert %0s did not trigger max_delay:%0d",
                                alert_name, expected_alert[alert_name].max_delay))
   endtask

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1076,6 +1076,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
                    (`gmv(ral.fw_ov_control.fw_ov_entropy_insert) == MuBi4True);
 
     if (rst_type == Enable) begin
+      // Stop ignoring alerts as soon as ENTROPY_SRC is turned on.
+      ignore_exp_alert = 0;
       clear_ht_stat_predictions();
       seeds_out = 0;
       health_test_data_q.delete();
@@ -1111,6 +1113,8 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       // fw_ov_wr_fifo_full goes high when the module is disabled.
       precon_fifo_full = 1;
       precon_fifo_cnt = 1;
+      // Ignore any outstanding alerts.
+      ignore_exp_alert = 1;
     end
 
     // Internal repetition counters and watermark registers are cleared on enable.


### PR DESCRIPTION
Some tests were failing because the scoreboard was expecting an alert after disabling the DUT. This PR adds a variable that when set leads the scoreboard to ignore any outstanding alerts.

Closes [#18797](https://github.com/lowRISC/opentitan/issues/18797)