### PR TITLE
[entropy_src/dv] Add assertion for rng_fips_o

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -3096,6 +3096,11 @@ module entropy_src_core import entropy_src_pkg::*; #(
 `ifdef INC_ASSERT
 `include "prim_macros.svh"
 
+  // Assert that we request high quality entropy only when the rng_fips field of the conf register
+  // is set to Mubi4True.
+  `ASSERT(RngFipsOutputHighInFipsMode_A,
+          prim_mubi_pkg::mubi4_test_true_loose(mubi4_t'(reg2hw.conf.rng_fips.q)) === rng_fips_o)
+
   // Count number of disables since last reset.
   logic [63:0] disable_cnt_d, disable_cnt_q;
   always_comb begin


### PR DESCRIPTION
This commit adds an assertion for rng_fips_o.
rng_fips_o should only request high quality entropy if mubi_rng_fips is equal to Mubi4True.

Closes [#18842](https://github.com/lowRISC/opentitan/issues/18842)