### PR TITLE
[sw/pentest] Update SCA library

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/fi/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/drivers:otbn",
         "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/dif:rv_core_ibex",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
@@ -45,6 +46,7 @@ cc_library(
         "//sw/device/tests/penetrationtests/firmware/fi/otbn:otbn_char_hardware_reg_op_loop",
         "//sw/device/tests/penetrationtests/firmware/fi/otbn:otbn_char_unrolled_dmem_op_loop",
         "//sw/device/tests/penetrationtests/firmware/fi/otbn:otbn_char_unrolled_reg_op_loop",
+        "//sw/device/tests/penetrationtests/firmware/lib:sca_lib",
         "//sw/device/tests/penetrationtests/json:otbn_fi_commands",
     ],
 )

--- a/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/fi/ibex_fi.h
@@ -282,7 +282,7 @@ status_t handle_ibex_fi_char_unrolled_reg_op_loop(ujson_t *uj);
  * @param uj An initialized uJSON context.
  * @return OK or error.
  */
-status_t handle_ibex_fi_init_trigger(ujson_t *uj);
+status_t handle_ibex_fi_init(ujson_t *uj);
 
 /**
  * ibex.char.register_file command handler.

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -28,7 +28,7 @@ status_t read_otbn_err_bits(dif_otbn_err_bits_t *err_bits) {
   dif_otbn_t otbn;
   TRY(dif_otbn_init(mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR), &otbn));
   TRY(dif_otbn_get_err_bits(&otbn, err_bits));
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
@@ -72,7 +72,7 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
@@ -116,7 +116,7 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
@@ -160,7 +160,7 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
@@ -204,7 +204,7 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   uj_output.err_ibx = err_ibx;
   memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 status_t handle_otbn_fi_init(ujson_t *uj) {
@@ -259,5 +259,5 @@ status_t handle_otbn_fi(ujson_t *uj) {
       LOG_ERROR("Unrecognized OTBN FI subcommand: %d", cmd);
       return INVALID_ARGUMENT();
   }
-  return OK_STATUS(0);
+  return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -6,16 +6,23 @@
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/entropy_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf_test_config.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"
 #include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/penetrationtests/firmware/lib/sca_lib.h"
 #include "sw/device/tests/penetrationtests/json/otbn_fi_commands.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otbn_regs.h"
+
+// Interface to Ibex.
+static dif_rv_core_ibex_t rv_core_ibex;
+
+static dif_otbn_t otbn;
 
 /**
  * Reat the error bits of the OTBN accelerator.
@@ -44,6 +51,9 @@ status_t read_otbn_err_bits(dif_otbn_err_bits_t *err_bits) {
  * @param uj The received uJSON data.
  */
 status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
+
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_dmem_op_loop);
   OTBN_DECLARE_SYMBOL_ADDR(otbn_char_hardware_dmem_op_loop, lc);
@@ -60,18 +70,26 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   otbn_execute();
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharHardwareDmemOpLoopLC, &loop_counter);
 
   // Read ERR_STATUS register from OTBN.
-  dif_otbn_err_bits_t err_bits;
-  read_otbn_err_bits(&err_bits);
+  dif_otbn_err_bits_t err_otbn;
+  read_otbn_err_bits(&err_otbn);
+
+  // Read ERR_STATUS register from Ibex.
+  dif_rv_core_ibex_error_status_t err_ibx;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &err_ibx));
 
   // Send loop counter & ERR_STATUS to host.
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
-  uj_output.err_status = err_bits;
+  uj_output.err_otbn = err_otbn;
+  uj_output.err_ibx = err_ibx;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -90,6 +108,9 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
+
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_hardware_reg_op_loop);
   OTBN_DECLARE_SYMBOL_ADDR(otbn_char_hardware_reg_op_loop, lc);
@@ -106,18 +127,26 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   otbn_execute();
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharHardwareRegOpLoopLC, &loop_counter);
 
   // Read ERR_STATUS register from OTBN.
-  dif_otbn_err_bits_t err_bits;
-  read_otbn_err_bits(&err_bits);
+  dif_otbn_err_bits_t err_otbn;
+  read_otbn_err_bits(&err_otbn);
+
+  // Read ERR_STATUS register from Ibex.
+  dif_rv_core_ibex_error_status_t err_ibx;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &err_ibx));
 
   // Send loop counter & ERR_STATUS to host.
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
-  uj_output.err_status = err_bits;
+  uj_output.err_otbn = err_otbn;
+  uj_output.err_ibx = err_ibx;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -138,6 +167,9 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
+
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_dmem_op_loop);
   OTBN_DECLARE_SYMBOL_ADDR(otbn_char_unrolled_dmem_op_loop, lc);
@@ -154,18 +186,26 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   otbn_execute();
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharUnrolledDmemOpLoopLC, &loop_counter);
 
   // Read ERR_STATUS register from OTBN.
-  dif_otbn_err_bits_t err_bits;
-  read_otbn_err_bits(&err_bits);
+  dif_otbn_err_bits_t err_otbn;
+  read_otbn_err_bits(&err_otbn);
+
+  // Read ERR_STATUS register from Ibex.
+  dif_rv_core_ibex_error_status_t err_ibx;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &err_ibx));
 
   // Send loop counter & ERR_STATUS to host.
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
-  uj_output.err_status = err_bits;
+  uj_output.err_otbn = err_otbn;
+  uj_output.err_ibx = err_ibx;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
@@ -184,6 +224,9 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
  * @param uj The received uJSON data.
  */
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
+
   // Initialize OTBN app, load it, and get interface to OTBN data memory.
   OTBN_DECLARE_APP_SYMBOLS(otbn_char_unrolled_reg_op_loop);
   OTBN_DECLARE_SYMBOL_ADDR(otbn_char_unrolled_reg_op_loop, lc);
@@ -200,34 +243,71 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   otbn_execute();
   otbn_busy_wait_for_done();
   sca_set_trigger_low();
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
 
   // Read loop counter from OTBN data memory.
   otbn_dmem_read(1, kOtbnAppCharUnrolledRegOpLoopLC, &loop_counter);
 
   // Read ERR_STATUS register from OTBN.
-  dif_otbn_err_bits_t err_bits;
-  read_otbn_err_bits(&err_bits);
+  dif_otbn_err_bits_t err_otbn;
+  read_otbn_err_bits(&err_otbn);
+
+  // Read ERR_STATUS register from Ibex.
+  dif_rv_core_ibex_error_status_t err_ibx;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &err_ibx));
 
   // Send loop counter & ERR_STATUS to host.
   otbn_fi_loop_counter_t uj_output;
   uj_output.loop_counter = loop_counter;
-  uj_output.err_status = err_bits;
+  uj_output.err_otbn = err_otbn;
+  uj_output.err_ibx = err_ibx;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
   RESP_OK(ujson_serialize_otbn_fi_loop_counter_t, uj, &uj_output);
   return OK_STATUS(0);
 }
 
 /**
- * Initializes the SCA trigger.
+ * Initializes the OTBN FI test.
  *
- * @param uj The received uJSON data.
+ * Setup the trigger and alert handler. Disable dummy instructions and the
+ * iCache.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
  */
-status_t handle_otbn_fi_init_trigger(ujson_t *uj) {
-  status_t err = entropy_testutils_auto_mode_init();
+status_t handle_otbn_fi_init(ujson_t *uj) {
+  // Configure the entropy complex for OTBN. Set the reseed interval to max
+  // to avoid a non-constant trigger window.
+  TRY(sca_configure_entropy_source_max_reseed_interval());
+
   sca_select_trigger_type(kScaTriggerTypeSw);
-  sca_init(kScaTriggerSourceOtbn, kScaPeripheralEntropy | kScaPeripheralIoDiv4 |
-                                      kScaPeripheralOtbn | kScaPeripheralCsrng |
-                                      kScaPeripheralEdn | kScaPeripheralHmac);
-  return err;
+  sca_init(kScaTriggerSourceOtbn,
+           kScaPeripheralIoDiv4 | kScaPeripheralEdn | kScaPeripheralCsrng |
+               kScaPeripheralEntropy | kScaPeripheralAes | kScaPeripheralHmac |
+               kScaPeripheralKmac | kScaPeripheralOtbn);
+
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // Init the OTBN core.
+  TRY(dif_otbn_init(mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR), &otbn));
+
+  // Configure the alert handler. Alerts triggered by IP blocks are captured
+  // and reported to the test.
+  sca_configure_alert_handler();
+
+  // Disable the instruction cache and dummy instructions for FI attacks.
+  sca_configure_cpu();
+
+  // Read device ID and return to host.
+  penetrationtest_device_id_t uj_output;
+  TRY(sca_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+
+  return OK_STATUS();
 }
 
 /**
@@ -241,8 +321,8 @@ status_t handle_otbn_fi(ujson_t *uj) {
   otbn_fi_subcommand_t cmd;
   TRY(ujson_deserialize_otbn_fi_subcommand_t(uj, &cmd));
   switch (cmd) {
-    case kOtbnFiSubcommandInitTrigger:
-      return handle_otbn_fi_init_trigger(uj);
+    case kOtbnFiSubcommandInit:
+      return handle_otbn_fi_init(uj);
     case kOtbnFiSubcommandCharUnrolledRegOpLoop:
       return handle_otbn_fi_char_unrolled_reg_op_loop(uj);
     case kOtbnFiSubcommandCharUnrolledDmemOpLoop:

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -24,11 +24,6 @@ static dif_rv_core_ibex_t rv_core_ibex;
 
 static dif_otbn_t otbn;
 
-/**
- * Reat the error bits of the OTBN accelerator.
- *
- * @returns Error bits.
- */
 status_t read_otbn_err_bits(dif_otbn_err_bits_t *err_bits) {
   dif_otbn_t otbn;
   TRY(dif_otbn_init(mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR), &otbn));
@@ -36,20 +31,6 @@ status_t read_otbn_err_bits(dif_otbn_err_bits_t *err_bits) {
   return OK_STATUS(0);
 }
 
-/**
- * otbn.fi.char.hardware.dmem.op.loop command handler.
- *
- * This FI penetration tests executes the following instructions on OTBN:
- * - Initialize register x3=0
- * - Perform 10000 x3 = x3 + 1 additions using hardware loop instructions.
- *   Load loop counter from memory and write back after increment.
- * - Return the value over UART.
- *
- * Faults are injected during the trigger_high & trigger_low.
- * It needs to be ensured that the compiler does not optimize this code.
- *
- * @param uj The received uJSON data.
- */
 status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
@@ -94,19 +75,6 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   return OK_STATUS(0);
 }
 
-/**
- * otbn.fi.char.hardware.reg.op.loop command handler.
- *
- * This FI penetration tests executes the following instructions on OTBN:
- * - Initialize register x3=0
- * - Perform 10000 x3 = x3 + 1 additions using hardware loop instructions
- * - Return the value over UART.
- *
- * Faults are injected during the trigger_high & trigger_low.
- * It needs to be ensured that the compiler does not optimize this code.
- *
- * @param uj The received uJSON data.
- */
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
@@ -151,21 +119,6 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   return OK_STATUS(0);
 }
 
-/**
- * otbn.fi.char.unrolled.dmem.op.loop command handler.
- *
- * This FI penetration tests executes the following instructions on OTBN:
- * - Perform 100 times:
- *  - Load loop counter from memory
- *  - Increment loop counter
- *  - Store back to memory
- * - Return the value over UART.
- *
- * Faults are injected during the trigger_high & trigger_low.
- * It needs to be ensured that the compiler does not optimize this code.
- *
- * @param uj The received uJSON data.
- */
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
@@ -210,19 +163,6 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   return OK_STATUS(0);
 }
 
-/**
- * otbn.char.unrolled.reg.op.loop command handler.
- *
- * This FI penetration tests executes the following instructions on OTBN:
- * - Initialize register x2=0
- * - Perform 100 x2 = x2 + 1 additions
- * - Return the value over UART.
- *
- * Faults are injected during the trigger_high & trigger_low.
- * It needs to be ensured that the compiler does not optimize this code.
- *
- * @param uj The received uJSON data.
- */
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   // Clear registered alerts in alert handler.
   sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
@@ -267,15 +207,6 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   return OK_STATUS(0);
 }
 
-/**
- * Initializes the OTBN FI test.
- *
- * Setup the trigger and alert handler. Disable dummy instructions and the
- * iCache.
- *
- * @param uj An initialized uJSON context.
- * @return OK or error.
- */
 status_t handle_otbn_fi_init(ujson_t *uj) {
   // Configure the entropy complex for OTBN. Set the reseed interval to max
   // to avoid a non-constant trigger window.
@@ -310,13 +241,6 @@ status_t handle_otbn_fi_init(ujson_t *uj) {
   return OK_STATUS();
 }
 
-/**
- * OTBN FI command handler.
- *
- * Command handler for the OTBN FI command.
- *
- * @param uj The received uJSON data.
- */
 status_t handle_otbn_fi(ujson_t *uj) {
   otbn_fi_subcommand_t cmd;
   TRY(ujson_deserialize_otbn_fi_subcommand_t(uj, &cmd));

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.h
@@ -16,7 +16,7 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj);
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj);
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj);
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj);
-status_t handle_otbn_init_trigger(ujson_t *uj);
+status_t handle_otbn_init(ujson_t *uj);
 status_t handle_otbn_fi(ujson_t *uj);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_FI_OTBN_FI_H_

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.h
@@ -10,13 +10,99 @@
 #include "sw/device/lib/dif/dif_otbn.h"
 #include "sw/device/lib/ujson/ujson.h"
 
+/**
+ * Read the error bits of the OTBN accelerator.
+ *
+ * @returns Error bits.
+ */
 status_t read_otbn_err_bits(dif_otbn_err_bits_t *err_bits);
 
+/**
+ * otbn.fi.char.hardware.dmem.op.loop command handler.
+ *
+ * This FI penetration tests executes the following instructions on OTBN:
+ * - Initialize register x3=0
+ * - Perform 10000 x3 = x3 + 1 additions using hardware loop instructions.
+ *   Load loop counter from memory and write back after increment.
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
 status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj);
+
+/**
+ * otbn.fi.char.hardware.reg.op.loop command handler.
+ *
+ * This FI penetration tests executes the following instructions on OTBN:
+ * - Initialize register x3=0
+ * - Perform 10000 x3 = x3 + 1 additions using hardware loop instructions
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
 status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj);
+
+/**
+ * otbn.fi.char.unrolled.dmem.op.loop command handler.
+ *
+ * This FI penetration tests executes the following instructions on OTBN:
+ * - Perform 100 times:
+ *  - Load loop counter from memory
+ *  - Increment loop counter
+ *  - Store back to memory
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
 status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj);
+
+/**
+ * otbn.char.unrolled.reg.op.loop command handler.
+ *
+ * This FI penetration tests executes the following instructions on OTBN:
+ * - Initialize register x2=0
+ * - Perform 100 x2 = x2 + 1 additions
+ * - Return the value over UART.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ * It needs to be ensured that the compiler does not optimize this code.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
 status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj);
+
+/**
+ * Initializes the OTBN FI test.
+ *
+ * Setup the trigger and alert handler. Disable dummy instructions and the
+ * iCache.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
 status_t handle_otbn_init(ujson_t *uj);
+
+/**
+ * OTBN FI command handler.
+ *
+ * Command handler for the OTBN FI command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
 status_t handle_otbn_fi(ujson_t *uj);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_FI_OTBN_FI_H_

--- a/sw/device/tests/penetrationtests/firmware/firmware.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware.c
@@ -73,7 +73,7 @@ status_t process_cmd(ujson_t *uj) {
     }
   }
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 bool test_main(void) {

--- a/sw/device/tests/penetrationtests/firmware/firmware_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_fi.c
@@ -42,7 +42,7 @@ status_t process_cmd(ujson_t *uj) {
     }
   }
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 bool test_main(void) {

--- a/sw/device/tests/penetrationtests/firmware/firmware_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_sca.c
@@ -62,7 +62,7 @@ status_t process_cmd(ujson_t *uj) {
     }
   }
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 bool test_main(void) {

--- a/sw/device/tests/penetrationtests/firmware/lib/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/lib/BUILD
@@ -42,5 +42,6 @@ cc_library(
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ujson_ottf",
         "//sw/device/lib/ujson",
+        "//sw/device/tests/penetrationtests/json:sca_lib_commands",
     ],
 )

--- a/sw/device/tests/penetrationtests/firmware/lib/extclk_sca_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/extclk_sca_fi.c
@@ -32,8 +32,8 @@ static bool did_extclk_settle(const dif_clkmgr_t *clkmgr) {
 }
 
 status_t handle_extclk_sca_fi_configure(ujson_t *uj) {
-  cryptotest_extclk_sca_fi_cfg_t uj_data;
-  TRY(ujson_deserialize_cryptotest_extclk_sca_fi_cfg_t(uj, &uj_data));
+  penetrationtest_extclk_sca_fi_cfg_t uj_data;
+  TRY(ujson_deserialize_penetrationtest_extclk_sca_fi_cfg_t(uj, &uj_data));
 
   TRY(dif_clkmgr_init(mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
                       &clkmgr));

--- a/sw/device/tests/penetrationtests/firmware/lib/sca_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/sca_lib.c
@@ -2,16 +2,236 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/tests/penetrationtests/firmware/lib/sca_lib.h"
+
 #include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_csrng_shared.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/runtime/irq.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
-/**
- * Configures Ibex for SCA and FI.
- *
- * This function disables the iCache and the dummy instructions using the
- * CPU Control and Status Register (cpuctrlsts).
- *
- */
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_rv_plic_t plic;
+static dif_rstmgr_t rstmgr;
+static dif_alert_handler_t alert_handler;
+static dif_lc_ctrl_t lc;
+
+status_t sca_configure_entropy_source_max_reseed_interval(void) {
+  const dif_entropy_src_t entropy_src = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR)};
+  const dif_csrng_t csrng = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR)};
+  const dif_edn_t edn0 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR)};
+  const dif_edn_t edn1 = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR)};
+
+  TRY(entropy_testutils_stop_all());
+
+  // Re-eanble entropy src and csrng.
+  TRY(dif_entropy_src_configure(
+      &entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));
+  TRY(dif_csrng_configure(&csrng));
+
+  // Re-enable EDN0 in auto mode.
+  TRY(dif_edn_set_auto_mode(
+      &edn0,
+      (dif_edn_auto_params_t){
+          // EDN0 provides lower-quality entropy.  Let one generate command
+          // return 8
+          // blocks, and reseed every 32 generates.
+          .instantiate_cmd =
+              {
+                  .cmd = csrng_cmd_header_build(kCsrngAppCmdInstantiate,
+                                                kDifCsrngEntropySrcToggleEnable,
+                                                /*cmd_len=*/0,
+                                                /*generate_len=*/0),
+                  .seed_material =
+                      {
+                          .len = 0,
+                      },
+              },
+          .reseed_cmd =
+              {
+                  .cmd = csrng_cmd_header_build(
+                      kCsrngAppCmdReseed, kDifCsrngEntropySrcToggleEnable,
+                      /*cmd_len=*/0, /*generate_len=*/0),
+                  .seed_material =
+                      {
+                          .len = 0,
+                      },
+              },
+          .generate_cmd =
+              {
+                  // Generate 8 128-bit blocks.
+                  .cmd = csrng_cmd_header_build(kCsrngAppCmdGenerate,
+                                                kDifCsrngEntropySrcToggleEnable,
+                                                /*cmd_len=*/0,
+                                                /*generate_len=*/8),
+                  .seed_material =
+                      {
+                          .len = 0,
+                      },
+              },
+          // Reseed every 0xffffffff generates.
+          .reseed_interval = 0xffffffff,
+      }));
+
+  // Re-enable EDN1 in auto mode.
+  TRY(dif_edn_set_auto_mode(
+      &edn1,
+      (dif_edn_auto_params_t){
+          // EDN1 provides highest-quality entropy.  Let one generate command
+          // return 1 block, and reseed after every generate.
+          .instantiate_cmd =
+              {
+                  .cmd = csrng_cmd_header_build(kCsrngAppCmdInstantiate,
+                                                kDifCsrngEntropySrcToggleEnable,
+                                                /*cmd_len=*/0,
+                                                /*generate_len=*/0),
+                  .seed_material =
+                      {
+                          .len = 0,
+                      },
+              },
+          .reseed_cmd =
+              {
+                  .cmd = csrng_cmd_header_build(
+                      kCsrngAppCmdReseed, kDifCsrngEntropySrcToggleEnable,
+                      /*cmd_len=*/0, /*generate_len=*/0),
+                  .seed_material =
+                      {
+                          .len = 0,
+                      },
+              },
+          .generate_cmd =
+              {
+                  // Generate 1 128-bit block.
+                  .cmd = csrng_cmd_header_build(kCsrngAppCmdGenerate,
+                                                kDifCsrngEntropySrcToggleEnable,
+                                                /*cmd_len=*/0,
+                                                /*generate_len=*/1),
+                  .seed_material =
+                      {
+                          .len = 0,
+                      },
+              },
+          // Reseed after every 0xffffffff generates.
+          .reseed_interval = 0xffffffff,
+      }));
+  return OK_STATUS();
+}
+
+sca_registered_alerts_t sca_get_triggered_alerts(void) {
+  bool is_cause;
+
+  sca_registered_alerts_t registered;
+  memset(registered.alerts, 0, sizeof(registered.alerts));
+
+  // Loop over all alert_cause regs
+  for (size_t alert = 0; alert < ALERT_HANDLER_PARAM_N_ALERTS; alert++) {
+    CHECK_DIF_OK(
+        dif_alert_handler_alert_is_cause(&alert_handler, alert, &is_cause));
+    if (is_cause) {
+      if (alert < 32) {
+        registered.alerts[0] |= (1 << alert);
+      } else if (alert < 64) {
+        registered.alerts[1] |= (1 << (alert - 32));
+      } else {
+        registered.alerts[2] |= (1 << (alert - 64));
+      }
+    }
+  }
+
+  // Loop over all alert_cause regs.
+  for (dif_alert_handler_alert_t i = 0; i < ALERT_HANDLER_PARAM_N_ALERTS; i++) {
+    CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(&alert_handler, i));
+  }
+
+  return registered;
+}
+
+void sca_configure_alert_handler(void) {
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  mmio_region_t base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  CHECK_DIF_OK(dif_rv_plic_init(base_addr, &plic));
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR);
+  CHECK_DIF_OK(dif_alert_handler_init(base_addr, &alert_handler));
+
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  dif_alert_handler_alert_t alerts[ALERT_HANDLER_PARAM_N_ALERTS];
+  dif_alert_handler_class_t alert_classes[ALERT_HANDLER_PARAM_N_ALERTS];
+
+  // Enable all incoming alerts and configure them to classa.
+  for (dif_alert_handler_alert_t i = 0; i < ALERT_HANDLER_PARAM_N_ALERTS; ++i) {
+    alerts[i] = i;
+    alert_classes[i] = kDifAlertHandlerClassA;
+  }
+
+  dif_alert_handler_escalation_phase_t esc_phases[] = {
+      {.phase = kDifAlertHandlerClassStatePhase0,
+       .signal = 0,
+       .duration_cycles = 2000}};
+
+  dif_alert_handler_class_config_t class_config = {
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = 0,
+      .irq_deadline_cycles = 10000,
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase1,
+  };
+
+  dif_alert_handler_class_config_t class_configs[] = {class_config};
+
+  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassA};
+  dif_alert_handler_config_t config = {
+      .alerts = alerts,
+      .alert_classes = alert_classes,
+      .alerts_len = ARRAYSIZE(alerts),
+      .classes = classes,
+      .class_configs = class_configs,
+      .classes_len = ARRAYSIZE(class_configs),
+      .ping_timeout = 256,
+  };
+
+  CHECK_STATUS_OK(alert_handler_testutils_configure_all(&alert_handler, config,
+                                                        kDifToggleEnabled));
+  // Enables alert handler irq.
+  CHECK_DIF_OK(dif_alert_handler_irq_set_enabled(
+      &alert_handler, kDifAlertHandlerIrqClassa, kDifToggleEnabled));
+}
+
+status_t sca_read_device_id(uint32_t device_id[]) {
+  mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
+  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
+
+  dif_lc_ctrl_device_id_t lc_device_id;
+  CHECK_DIF_OK(dif_lc_ctrl_get_device_id(&lc, &lc_device_id));
+  memcpy(device_id, lc_device_id.data, 8 * sizeof(uint32_t));
+
+  return OK_STATUS();
+}
+
 void sca_configure_cpu(void) {
   uint32_t cpuctrl_csr;
   // Get current config.

--- a/sw/device/tests/penetrationtests/firmware/lib/sca_lib.h
+++ b/sw/device/tests/penetrationtests/firmware/lib/sca_lib.h
@@ -5,6 +5,59 @@
 #ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_LIB_SCA_LIB_H_
 #define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_LIB_SCA_LIB_H_
 
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/penetrationtests/json/sca_lib_commands.h"
+
+typedef struct sca_registered_alerts {
+  uint32_t alerts[3];
+} sca_registered_alerts_t;
+
+/**
+ * Configures the entropy complex for OTBN tests.
+ *
+ * Similar to entropy_testutils_auto_mode_init(), this function inits the
+ * entropy complex. However, in comparison to the function available in the
+ * testutils, this function maximizes the reseed intervall to 0xffffffff.
+ * This is necessary to guarantee a fixed trigger window for OTBN tests.
+ *
+ * @return OK or error.
+ */
+status_t sca_configure_entropy_source_max_reseed_interval(void);
+
+/**
+ * Returns the registered alerts.
+ *
+ * If a fault injection triggered an alert, this function returns the alert ID
+ * back to the host. Afterwards, the alert is cleared.
+ *
+ * @return A struct containing which of the alerts were triggered during the
+ * test.
+ */
+sca_registered_alerts_t sca_get_triggered_alerts(void);
+
+/**
+ * Configures the alert handler for FI.
+ *
+ * Register all alerts and let them escalate to Phase0 only.
+ */
+void sca_configure_alert_handler(void);
+
+/**
+ * Reads the device ID from the LC.
+ *
+ * Can be used to categorize different SCA and FI runs.
+ *
+ * @param device_id A buffer available to store the device id.
+ * @return OK or error.
+ */
+status_t sca_read_device_id(uint32_t device_id[]);
+
+/**
+ * Configures CPU for SCA and FI penetration tests.
+ *
+ * This function disables the iCache and the dummy instructions using the
+ * CPU Control and Status Register (cpuctrlsts).
+ */
 void sca_configure_cpu(void);
 
 #endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_LIB_SCA_LIB_H_

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -215,7 +215,7 @@ status_t handle_aes_sca_key_set(ujson_t *uj) {
   if (aes_key_mask_and_config(key_fixed, uj_key_data.key_length) != aesScaOk) {
     return ABORTED();
   }
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -285,7 +285,7 @@ static status_t aes_send_ciphertext(bool only_first_word, ujson_t *uj) {
   memcpy(uj_output.ciphertext, (uint8_t *)ciphertext.data,
          uj_output.ciphertext_length);
   RESP_OK(ujson_serialize_cryptotest_aes_sca_ciphertext_t, uj, &uj_output);
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -330,7 +330,7 @@ status_t handle_aes_sca_single_encrypt(ujson_t *uj) {
   }
 
   TRY(aes_send_ciphertext(false, uj));
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -427,7 +427,7 @@ status_t handle_aes_sca_batch_encrypt(ujson_t *uj) {
 
   TRY(aes_send_ciphertext(true, uj));
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -508,7 +508,7 @@ status_t handle_aes_sca_batch_alternative_encrypt(ujson_t *uj) {
   memcpy(uj_output.ciphertext, (uint8_t *)ciphertext.data, kAesTextLength);
   RESP_OK(ujson_serialize_cryptotest_aes_sca_ciphertext_t, uj, &uj_output);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -534,7 +534,7 @@ status_t handle_aes_sca_batch_plaintext_set(ujson_t *uj) {
   }
   memcpy(batch_plaintext, uj_data.text, uj_data.text_length);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -559,7 +559,7 @@ status_t handle_aes_sca_fvsr_key_set(ujson_t *uj) {
     return OUT_OF_RANGE();
   }
   memcpy(key_fixed, uj_key_data.key, uj_key_data.key_length);
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -609,7 +609,7 @@ status_t aes_sca_fvsr_key_batch_generate(cryptotest_aes_sca_data_t uj_data) {
     sample_fixed = batch_plaintexts[i][0] & 0x1;
   }
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -755,7 +755,7 @@ status_t handle_aes_sca_fvsr_data_batch_encrypt(ujson_t *uj) {
 
   TRY(aes_send_ciphertext(false, uj));
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -802,7 +802,7 @@ status_t handle_aes_sca_seed_lfsr(ujson_t *uj) {
   }
 #endif
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -824,7 +824,7 @@ status_t handle_aes_sca_seed_lfsr_order(ujson_t *uj) {
   uint32_t seed_local = read_32(uj_lfsr_data.seed);
   sca_seed_lfsr(seed_local, kScaLfsrOrder);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -888,7 +888,7 @@ status_t handle_aes_sca_fvsr_key_start_batch_generate(ujson_t *uj) {
 
   sca_seed_lfsr(kPrngInitialState, kScaLfsrOrder);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -925,7 +925,7 @@ status_t handle_aes_sca_init(ujson_t *uj) {
   TRY(sca_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 status_t handle_aes_sca(ujson_t *uj) {
@@ -975,5 +975,5 @@ status_t handle_aes_sca(ujson_t *uj) {
       LOG_ERROR("Unrecognized AES SCA subcommand: %d", cmd);
       return INVALID_ARGUMENT();
   }
-  return OK_STATUS(0);
+  return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/aes_sca.c
@@ -920,6 +920,11 @@ status_t handle_aes_sca_init(ujson_t *uj) {
   // measurements.
   sca_configure_cpu();
 
+  // Read device ID and return to host.
+  penetrationtest_device_id_t uj_output;
+  TRY(sca_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/ibex_sca.c
@@ -194,6 +194,11 @@ status_t handle_ibex_sca_init(ujson_t *uj) {
   // Disable the instruction cache and dummy instructions for SCA.
   sca_configure_cpu();
 
+  // Read device ID and return to host.
+  penetrationtest_device_id_t uj_output;
+  TRY(sca_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+
   return OK_STATUS();
 }
 

--- a/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
@@ -479,7 +479,7 @@ status_t handle_kmac_sca_init(ujson_t *uj) {
   TRY(sca_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -509,7 +509,7 @@ status_t handle_kmac_sca_set_key(ujson_t *uj) {
   };
   memcpy(kmac_key.share0, uj_key.key, kKeyLength);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -616,7 +616,7 @@ status_t handle_kmac_sca_single_absorb(ujson_t *uj) {
   // another absorb.
   kmac_reset();
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -638,7 +638,7 @@ status_t handle_kmac_sca_fixed_key_set(ujson_t *uj) {
 
   memcpy(key_fixed, uj_key.key, uj_key.key_length);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -702,7 +702,7 @@ status_t handle_kmac_sca_batch(ujson_t *uj) {
   memcpy(uj_output.batch_digest, (uint8_t *)batch_digest, kDigestLength * 4);
   RESP_OK(ujson_serialize_cryptotest_kmac_sca_batch_digest_t, uj, &uj_output);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -720,7 +720,7 @@ status_t handle_kmac_sca_seed_lfsr(ujson_t *uj) {
   TRY(ujson_deserialize_cryptotest_kmac_sca_lfsr_t(uj, &uj_lfsr_data));
   sca_seed_lfsr(read_32(uj_lfsr_data.seed), kScaLfsrMasking);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -750,5 +750,5 @@ status_t handle_kmac_sca(ujson_t *uj) {
       LOG_ERROR("Unrecognized KMAC SCA FI subcommand: %d", cmd);
       return INVALID_ARGUMENT();
   }
-  return OK_STATUS(0);
+  return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/kmac_sca.c
@@ -474,6 +474,11 @@ status_t handle_kmac_sca_init(ujson_t *uj) {
   // measurements.
   sca_configure_cpu();
 
+  // Read device ID and return to host.
+  penetrationtest_device_id_t uj_output;
+  TRY(sca_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/penetrationtests/firmware/sca/prng_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/prng_sca.c
@@ -32,7 +32,7 @@ status_t handle_prng_sca_seed_prng(ujson_t *uj) {
   }
   prng_seed(read_32(uj_data.seed));
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -53,5 +53,5 @@ status_t handle_prng_sca(ujson_t *uj) {
       LOG_ERROR("Unrecognized PRNG SCA subcommand: %d", cmd);
       return INVALID_ARGUMENT();
   }
-  return OK_STATUS(0);
+  return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -605,6 +605,11 @@ status_t handle_sha3_sca_init(ujson_t *uj) {
   // measurements.
   sca_configure_cpu();
 
+  // Read device ID and return to host.
+  penetrationtest_device_id_t uj_output;
+  TRY(sca_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+
   return OK_STATUS(0);
 }
 

--- a/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/sha3_sca.c
@@ -383,7 +383,7 @@ status_t handle_sha3_sca_disable_masking(ujson_t *uj) {
   uj_status.status = 0;
   RESP_OK(ujson_serialize_cryptotest_sha3_sca_status_t, uj, &uj_status);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -465,7 +465,7 @@ status_t handle_sha3_sca_single_absorb(ujson_t *uj) {
   // another absorb.
   kmac_reset();
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -489,7 +489,7 @@ status_t handle_sha3_sca_fixed_message_set(ujson_t *uj) {
 
   memcpy(message_fixed, uj_msg.msg, uj_msg.msg_length);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -556,7 +556,7 @@ status_t handle_sha3_sca_batch(ujson_t *uj) {
   memcpy(uj_output.batch_digest, (uint8_t *)batch_digest, kDigestLength * 4);
   RESP_OK(ujson_serialize_cryptotest_sha3_sca_batch_digest_t, uj, &uj_output);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -574,7 +574,7 @@ status_t handle_sha3_sca_seed_lfsr(ujson_t *uj) {
   TRY(ujson_deserialize_cryptotest_sha3_sca_lfsr_t(uj, &uj_lfsr_data));
   sca_seed_lfsr(read_32(uj_lfsr_data.seed), kScaLfsrMasking);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -610,7 +610,7 @@ status_t handle_sha3_sca_init(ujson_t *uj) {
   TRY(sca_read_device_id(uj_output.device_id));
   RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 /**
@@ -640,5 +640,5 @@ status_t handle_sha3_sca(ujson_t *uj) {
       LOG_ERROR("Unrecognized SHA SCA FI subcommand: %d", cmd);
       return INVALID_ARGUMENT();
   }
-  return OK_STATUS(0);
+  return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/firmware/sca/trigger_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/trigger_sca.c
@@ -29,7 +29,7 @@ status_t handle_trigger_sca_select_source(ujson_t *uj) {
 
   sca_select_trigger_type(uj_trigger.source);
 
-  return OK_STATUS(0);
+  return OK_STATUS();
 }
 
 status_t handle_trigger_sca(ujson_t *uj) {
@@ -43,5 +43,5 @@ status_t handle_trigger_sca(ujson_t *uj) {
       LOG_ERROR("Unrecognized TRIGGER SCA subcommand: %d", cmd);
       return INVALID_ARGUMENT();
   }
-  return OK_STATUS(0);
+  return OK_STATUS();
 }

--- a/sw/device/tests/penetrationtests/json/BUILD
+++ b/sw/device/tests/penetrationtests/json/BUILD
@@ -71,6 +71,13 @@ cc_library(
 )
 
 cc_library(
+    name = "sca_lib_commands",
+    srcs = ["sca_lib_commands.c"],
+    hdrs = ["sca_lib_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
     name = "sha3_sca_commands",
     srcs = ["sha3_sca_commands.c"],
     hdrs = ["sha3_sca_commands.h"],

--- a/sw/device/tests/penetrationtests/json/extclk_sca_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/extclk_sca_fi_commands.h
@@ -20,7 +20,7 @@ UJSON_SERDE_ENUM(ExtClkScaFiSubcommand, extclk_sca_fi_subcommand_t, EXTCLK_SCA_F
 #define EXTCLK_SCA_FI_CFG(field, string) \
     field(sel, bool) \
     field(hi_speed_sel, bool)
-UJSON_SERDE_STRUCT(CryptotestExtClkScaFiCfg, cryptotest_extclk_sca_fi_cfg_t, EXTCLK_SCA_FI_CFG);
+UJSON_SERDE_STRUCT(PenetrationtestExtClkScaFiCfg, penetrationtest_extclk_sca_fi_cfg_t, EXTCLK_SCA_FI_CFG);
 
 // clang-format on
 

--- a/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/ibex_fi_commands.h
@@ -12,7 +12,7 @@ extern "C" {
 // clang-format off
 
 #define IBEXFI_SUBCOMMAND(_, value) \
-    value(_, InitTrigger) \
+    value(_, Init) \
     value(_, CharUnrolledRegOpLoop) \
     value(_, CharRegOpLoop) \
     value(_, CharUnrolledMemOpLoop) \
@@ -33,24 +33,28 @@ UJSON_SERDE_ENUM(IbexFiSubcommand, ibex_fi_subcommand_t, IBEXFI_SUBCOMMAND);
 
 #define IBEXFI_TEST_RESULT(field, string) \
     field(result, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiTestResult, ibex_fi_test_result_t, IBEXFI_TEST_RESULT);
 
 #define IBEXFI_TEST_RESULT_MULT(field, string) \
     field(result1, uint32_t) \
     field(result2, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiTestResultMult, ibex_fi_test_result_mult_t, IBEXFI_TEST_RESULT_MULT);
 
 #define IBEXFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t) \
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterOutput, ibex_fi_loop_counter_t, IBEXFI_LOOP_COUNTER_OUTPUT);
 
 #define IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT(field, string) \
     field(loop_counter1, uint32_t) \
     field(loop_counter2, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_status, uint32_t)  \
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(IbexFiLoopCounterMirroredOutput, ibex_fi_loop_counter_mirrored_t, IBEXFI_LOOP_COUNTER_MIRRORED_OUTPUT);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/otbn_fi_commands.h
@@ -12,7 +12,7 @@ extern "C" {
 // clang-format off
 
 #define OTBNFI_SUBCOMMAND(_, value) \
-    value(_, InitTrigger) \
+    value(_, Init) \
     value(_, CharUnrolledRegOpLoop) \
     value(_, CharUnrolledDmemOpLoop) \
     value(_, CharHardwareRegOpLoop) \
@@ -21,7 +21,9 @@ UJSON_SERDE_ENUM(OtbnFiSubcommand, otbn_fi_subcommand_t, OTBNFI_SUBCOMMAND);
 
 #define OTBNFI_LOOP_COUNTER_OUTPUT(field, string) \
     field(loop_counter, uint32_t) \
-    field(err_status, uint32_t)
+    field(err_otbn, uint32_t) \
+    field(err_ibx, uint32_t) \
+    field(alerts, uint32_t, 3)
 UJSON_SERDE_STRUCT(OtbnFiLoopCounterOutput, otbn_fi_loop_counter_t, OTBNFI_LOOP_COUNTER_OUTPUT);
 
 // clang-format on

--- a/sw/device/tests/penetrationtests/json/sca_lib_commands.c
+++ b/sw/device/tests/penetrationtests/json/sca_lib_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "sca_lib_commands.h"

--- a/sw/device/tests/penetrationtests/json/sca_lib_commands.h
+++ b/sw/device/tests/penetrationtests/json/sca_lib_commands.h
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_SCA_LIB_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_SCA_LIB_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define PENETRATIONTEST_DEVICE_ID(field, string) \
+    field(device_id, uint32_t, 8)
+UJSON_SERDE_STRUCT(PenetrationtestDeviceId, penetrationtest_device_id_t, PENETRATIONTEST_DEVICE_ID);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_SCA_LIB_COMMANDS_H_


### PR DESCRIPTION
This PR consists of several commits that update and use the new SCA lib that is utilized by the penetration testing framework. This PR moves code from my fork used in the testing to the upstream project.

New functionalities include:
- Returning the device ID. This allows the tester to differentiate between different chips/fpga used in the setup
- Configure and return the triggered alerts for FI tests

Moreover, this PR consists of the following cosmetical changes:
- Move function description from source file into header file to comply with the coding standard
- Remove 0 from OK_STATUS(0) as this is unnecessary
- Rename cryptotest to penetrationtest