### PR TITLE
[manuf] export/import certs as a single blob during perso

### DIFF
--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -96,48 +96,41 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
 // clang-format on
 
 /**
- * DICE certificates exported during personalization.
+ * All certificates exported during personalization.
  *
- * See the `OT_ASSERT_MEMBER_SIZE_AS_ENUM` calls in
- * `sw/device/silicon_creator/manuf/base/ft_personalize.c`
- * for how these sizes are chosen.
+ * This struct may hold up to eight different certificate blobs, the cumulative
+ * size of which must be <= 4k. The layout is such that the first three slots
+ * contain the following DICE certificates, and the remaining slots may be used
+ * by provisioning extensions.
+ *
+ * First three slots:
+ * 1. UDS TBS certificate.
+ * 2. CDI_0 certificate.
+ * 3. CDI_1 certificate.
  */
 // clang-format off
 #define STRUCT_MANUF_CERTS(field, string) \
-    field(uds_tbs_certificate, uint8_t, 680) \
-    field(uds_tbs_certificate_size, size_t) \
-    field(cdi_0_certificate, uint8_t, 580) \
-    field(cdi_0_certificate_size, size_t) \
-    field(cdi_1_certificate, uint8_t, 632) \
-    field(cdi_1_certificate_size, size_t) \
-    field(tpm_ek_tbs_certificate, uint8_t, 844) \
-    field(tpm_ek_tbs_certificate_size, size_t) \
-    field(tpm_cek_tbs_certificate, uint8_t, 456) \
-    field(tpm_cek_tbs_certificate_size, size_t) \
-    field(tpm_cik_tbs_certificate, uint8_t, 456) \
-    field(tpm_cik_tbs_certificate_size, size_t)
+    field(sizes, uint32_t, 8) \
+    field(offsets, uint32_t, 8) \
+    field(certs, uint8_t, 4096)
 UJSON_SERDE_STRUCT(ManufCerts, \
                    manuf_certs_t, \
                    STRUCT_MANUF_CERTS);
 // clang-format on
 
 /**
- * Endorsed DICE certificates imported during personalization.
+ * All endorsed certificates imported during personalization.
  *
- * See the `OT_ASSERT_MEMBER_SIZE_AS_ENUM` calls in
- * `sw/device/silicon_creator/manuf/base/ft_personalize.c`
- * for how these sizes are chosen.
+ * This struct may hold up to eight different certificate blobs, the cumulative
+ * size of which must be <= 4k. The layout is such that the first slot contains
+ * the endorsed UDS certificate, and the remaining slots may be used by
+ * provisioning extensions.
  */
 // clang-format off
 #define STRUCT_MANUF_ENDORSED_CERTS(field, string) \
-    field(uds_certificate, uint8_t, 768) \
-    field(uds_certificate_size, size_t) \
-    field(tpm_ek_certificate, uint8_t, 936) \
-    field(tpm_ek_certificate_size, size_t) \
-    field(tpm_cek_certificate, uint8_t, 548) \
-    field(tpm_cek_certificate_size, size_t) \
-    field(tpm_cik_certificate, uint8_t, 548) \
-    field(tpm_cik_certificate_size, size_t)
+    field(sizes, uint32_t, 8) \
+    field(offsets, uint32_t, 8) \
+    field(certs, uint8_t, 4096)
 UJSON_SERDE_STRUCT(ManufEndorsedCerts, \
                    manuf_endorsed_certs_t, \
                    STRUCT_MANUF_ENDORSED_CERTS);

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -96,17 +96,21 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
 // clang-format on
 
 /**
- * All certificates exported during personalization.
+ * All certificates exported/imported during personalization.
  *
  * This struct may hold up to eight different certificate blobs, the cumulative
- * size of which must be <= 4k. The layout is such that the first three slots
- * contain the following DICE certificates, and the remaining slots may be used
- * by provisioning extensions.
+ * size of which must be <= 4k. The layout is such that the cumulative blob
+ * array can hold several concatenated TBS and/or endorsed certificates.
  *
- * First three slots:
+ * The `tbs` value indicates if the certificate needs be endorsed or not.
+ *
+ * During certificate export, the first three slots are:
  * 1. UDS TBS certificate.
  * 2. CDI_0 certificate.
  * 3. CDI_1 certificate.
+ *
+ * During certificate import, the first slot is:
+ * 1. UDS certificate.
  */
 // clang-format off
 #define STRUCT_MANUF_CERTS(field, string) \
@@ -117,24 +121,6 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
 UJSON_SERDE_STRUCT(ManufCerts, \
                    manuf_certs_t, \
                    STRUCT_MANUF_CERTS);
-// clang-format on
-
-/**
- * All endorsed certificates imported during personalization.
- *
- * This struct may hold up to eight different certificate blobs, the cumulative
- * size of which must be <= 4k. The layout is such that the first slot contains
- * the endorsed UDS certificate, and the remaining slots may be used by
- * provisioning extensions.
- */
-// clang-format off
-#define STRUCT_MANUF_ENDORSED_CERTS(field, string) \
-    field(sizes, uint32_t, 8) \
-    field(offsets, uint32_t, 8) \
-    field(certs, uint8_t, 4096)
-UJSON_SERDE_STRUCT(ManufEndorsedCerts, \
-                   manuf_endorsed_certs_t, \
-                   STRUCT_MANUF_ENDORSED_CERTS);
 // clang-format on
 
 /**

--- a/sw/device/lib/testing/json/provisioning_data.h
+++ b/sw/device/lib/testing/json/provisioning_data.h
@@ -112,6 +112,7 @@ UJSON_SERDE_STRUCT(ManufCertgenInputs, \
 #define STRUCT_MANUF_CERTS(field, string) \
     field(sizes, uint32_t, 8) \
     field(offsets, uint32_t, 8) \
+    field(tbs, bool, 8) \
     field(certs, uint8_t, 4096)
 UJSON_SERDE_STRUCT(ManufCerts, \
                    manuf_certs_t, \

--- a/sw/device/silicon_creator/lib/cert/cert.h
+++ b/sw/device/silicon_creator/lib/cert/cert.h
@@ -64,9 +64,19 @@ typedef struct cert_flash_info_layout {
    */
   const char **names;
   /**
-   * An array of buffer pointers, where each buffer holds a single certificate.
+   * An array of buffer pointers, where each buffer holds a contiguous buffer of
+   * certificates from the host.
    */
   const unsigned char **certs;
+  /**
+   * An array of cert buffer offset arrays.
+   */
+  const uint32_t **cert_offsets;
+  /**
+   * An array of buffer offset indices to use to retrieve the certificate buffer
+   * offset from the buffer above.
+   */
+  const int *cert_offset_idxs;
 } cert_flash_info_layout_t;
 
 /**

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -103,12 +103,10 @@ static manuf_certs_t tbs_certs = {
             kTpmCikMaxTbsSizeBytes,
         },
     .offsets = {0},
-    // Indicates if the embedded certificate blob is a TBS certificate and needs
-    // to be endorsed by the host.
     .tbs = {true, false, false, true, true, true},
     .certs = {0},
 };
-static manuf_endorsed_certs_t endorsed_certs;
+static manuf_certs_t endorsed_certs;
 
 /**
  * Certificates flash info page layout.
@@ -533,7 +531,7 @@ static status_t personalize_dice_certificates(ujson_t *uj) {
   // DO NOT CHANGE THE BELOW STRING without modifying the host code in
   // sw/host/provisioning/ft_lib/src/lib.rs
   LOG_INFO("Importing endorsed certificates ...");
-  TRY(ujson_deserialize_manuf_endorsed_certs_t(uj, &endorsed_certs));
+  TRY(ujson_deserialize_manuf_certs_t(uj, &endorsed_certs));
 
   /*****************************************************************************
    * Save Certificates to Flash.

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -103,6 +103,9 @@ static manuf_certs_t tbs_certs = {
             kTpmCikMaxTbsSizeBytes,
         },
     .offsets = {0},
+    // Indicates if the embedded certificate blob is a TBS certificate and needs
+    // to be endorsed by the host.
+    .tbs = {true, false, false, true, true, true},
     .certs = {0},
 };
 static manuf_endorsed_certs_t endorsed_certs;


### PR DESCRIPTION
This updates the personalization flow to export/import certificates as continuous blobs to enable easily adding additional certificates in extensions for various SKUs.

This partially addresses #23426.