### PR TITLE
[ci] Disable hyperdebug job in nightlies

### DIFF
--- a/ci/azure-pipelines-nightly.yml
+++ b/ci/azure-pipelines-nightly.yml
@@ -48,43 +48,6 @@ jobs:
     artifact: opentitan-repo
     displayName: "Upload repository"
 
-- job: hyperdebug
-  displayName: "Hyperdebug tests"
-  timeoutInMinutes: 30
-  dependsOn: checkout
-  pool:
-    name: FPGA
-    demands: BOARD -equals cw310
-  steps:
-  - template: ../ci/checkout-template.yml
-  - template: ../ci/install-package-dependencies.yml
-  # We run the update command twice to workaround an issue with udev on the container.
-  # Where rusb cannot dynamically update its device list in CI (udev is not completely
-  # functional). If the device is in normal mode, the first thing that opentitantool
-  # does is to switch it to DFU mode and wait until it reconnects. This reconnection is
-  # never detected. But if we run the tool another time, the device list is queried again
-  # and opentitantool can finish the update. The device will now reboot in normal mode
-  # and work for the hyperdebug job.
-  - bash: |
-      ci/bazelisk.sh run \
-        //sw/host/opentitantool:opentitantool -- \
-        --interface=hyperdebug_dfu transport update-firmware \
-      || ci/bazelisk.sh run \
-        //sw/host/opentitantool:opentitantool -- \
-        --interface=hyperdebug_dfu transport update-firmware || true
-    displayName: "Update the hyperdebug firmware"
-  - bash: |
-      set -x
-      module load "xilinx/vivado/$(VIVADO_VERSION)"
-      ci/bazelisk.sh test \
-        --define DISABLE_VERILATOR_BUILD=true \
-        --define bitstream=gcp_splice \
-        --build_tests_only \
-        --test_tag_filters=-broken \
-        --test_output=errors \
-        $(bash ./bazelisk.sh query 'attr("tags", "cw310_sival", tests(//...))')
-    displayName: "Run all the hyperdebug tests"
-
 - job: rom_e2e
   displayName: "ROM E2E Tests"
   timeoutInMinutes: 180


### PR DESCRIPTION
This is contributing to nightly failures due to its timeout being too short. The tests it runs are already covered by regular CI run on every pull request, so this is redundant.