### PR TITLE
[DV/SPI] updated sleep retention vseq to avoid race condition

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_device_pinmux_sleep_retention_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_device_pinmux_sleep_retention_vseq.sv
@@ -122,7 +122,7 @@ class chip_sw_spi_device_pinmux_sleep_retention_vseq extends chip_sw_base_vseq;
     end join_none
 
 
-    `DV_WAIT(cfg.sw_logger_vif.printed_log == "SYNC: Awaked")
+    `DV_WAIT(cfg.sw_logger_vif.printed_log == "PASS!")
 
     // Check spi transactions work as they should after devide is awoken
   endtask : body


### PR DESCRIPTION
Changed software log printed string in DV_WAIT from "SYNC: Awaked" to "PASS!"
If this DV_WAIT happens after the desired "SYNC: Awaked" is printed the test will fail on timeout.
"PASS!" is the last printed line to the software C log, I choose this line because the desired "SYNC: Awaked" happens almost at the end of the C code.