### PR TITLE
[entropy_src/dv] Fix timeout failure for stress all test

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -341,7 +341,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
 
   // Poll the relevant interrupt bit for accessing either the ENTROPY_DATA or FW_OV_RD_DATA
   // register
-  task poll(tl_data_source_e source = TlSrcEntropyDataReg);
+  task poll(tl_data_source_e source = TlSrcEntropyDataReg, int spinwait_delay_ns = 0);
 
     uvm_reg_field intr_field;
 
@@ -357,7 +357,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
       end
     endcase
 
-    csr_spinwait(.ptr(intr_field), .exp_data(1'b1));
+    csr_spinwait(.ptr(intr_field), .exp_data(1'b1), .spinwait_delay_ns(spinwait_delay_ns));
   endtask
 
 


### PR DESCRIPTION
This PR fixes an issue that arises for the stress all test whenever a ht failure occurs during the smoke vseq. If a HT failure happens the sequence infinitely waits for the DUT to produce a seed even though it will never be produced.
Now the vseq doesn't expect a seed if we get a HT failure.