### PR TITLE
[dv,usbdev] Initial minor changes to improve coverage results

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_tx_osc_test_mode_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_phy_config_tx_osc_test_mode_vseq.sv
@@ -97,6 +97,9 @@ class usbdev_phy_config_tx_osc_test_mode_vseq extends usbdev_base_vseq;
       end
     end
 
+    // Disable TX OSC test mode.
+    csr_wr(.ptr(ral.phy_config.tx_osc_test_mode), .value(1'b0));
+
     // Check the mean phase duration; expect to see 4 cycles for each phase, allow a little error
     // for sampling phase issues.
     `DV_CHECK(total_duration >= 4 * (num_phases - 1) && total_duration <= 4 * (num_phases + 1),

--- a/hw/ip/usbdev/dv/env/timed_reg.sv
+++ b/hw/ip/usbdev/dv/env/timed_reg.sv
@@ -82,13 +82,13 @@ class timed_reg_field extends uvm_object;
     uvm_reg_data_t pred_val;
     `uvm_info(`gfn, $sformatf(" - field %s : pred valid %d prev 0x%0x new 0x%0x",
                               field.get_name(), pred_valid, pred_latest.val_prev,
-                              pred_latest.val_new), UVM_MEDIUM)
+                              pred_latest.val_new), UVM_HIGH)
     if (pred_valid) begin
       uvm_reg_data_t act_val = (act_data >> lsb) & f_mask;
       `uvm_info(`gfn, $sformatf("   (time_now 0x%0x latest_time 0x%0x)", pred_latest.latest_time,
-                                time_now), UVM_MEDIUM)
+                                time_now), UVM_HIGH)
       if (act_val == pred_latest.val_new) begin
-        `uvm_info(`gfn, "   Prediction met", UVM_MEDIUM)
+        `uvm_info(`gfn, "   Prediction met", UVM_HIGH)
         pred_val = pred_latest.val_new;
         // Prediction met; no longer required.
         pred_valid = 1'b0;
@@ -104,7 +104,7 @@ class timed_reg_field extends uvm_object;
       // We have no new prediction, use the most recent prediction.
       pred_val = read_latest;
     end
-    `uvm_info(`gfn, $sformatf("   (predicted as 0x%0x)", pred_val), UVM_MEDIUM)
+    `uvm_info(`gfn, $sformatf("   (predicted as 0x%0x)", pred_val), UVM_HIGH)
     // Return the predicted value pre-shifted to be merged into the register-level prediction.
     return pred_val << lsb;
   endfunction


### PR DESCRIPTION
This PR just implements a few initial minor changes to improve the coverage results:

- Disabling the tx oscillator test mode was not being performed at sequence end, so that state transition was never observed.
- Low Speed traffic would have been collected as per Full Speed traffic, when in reality all Low Speed packets have a PREamble PID and shall be ignored entirely by the device. This is just because the usb20_monitor is actually capable of decoding Low Speed traffic.
