### PR TITLE
[dv,usbdev] Endpoint types sequence

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -633,6 +633,20 @@
       tests: ["usbdev_disable_endpoint"]
     }
     {
+      name: endpoint_types
+      desc: '''
+            Exercise all permutations of endpoint configuration bits with all possible token packets
+            (SETUP, OUT, IN and PRE).
+
+            - Randomize all endpoint configuration bits (ep_out_enable, ep_in_enable,
+              out_stall, in_stall, rxenable_out, rxenable_setup, set_nak_out, out_iso, in_iso).
+            - Targeting only the correct device address with randomized traffic, check that only the
+              expected traffic is received by the DUT and that all other packets are correctly dropped.
+            '''
+      stage: V2
+      tests: ["usbdev_endpoint_types"]
+    }
+    {
       name: out_trans_nak
       desc: '''
             Verify the functionality of OUT transaction when rxenable_out is not set.

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_device_address_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_device_address_vseq.sv
@@ -11,6 +11,18 @@ class usbdev_device_address_vseq extends usbdev_spray_packets_vseq;
     num_trans inside {[256:1024]};
   }
 
+  // We do not wish to test Isochronous transfers in this sequence.
+  constraint in_iso_c {
+    in_iso == 0;
+  }
+  constraint out_iso_c {
+    out_iso == 0;
+  }
+  // Do not complicate things with the `set_nak_out` functionality in this sequence.
+  constraint set_nak_out_c {
+    set_nak_out == 0;
+  }
+
   // Whether to target the correct address?
   bit hit;
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_disable_endpoint_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_disable_endpoint_vseq.sv
@@ -32,6 +32,18 @@ class usbdev_disable_endpoint_vseq extends usbdev_spray_packets_vseq;
     target_addr == dev_addr;
   }
 
+  // We do not wish to test Isochronous transfers in this sequence.
+  constraint in_iso_c {
+    in_iso == 0;
+  }
+  constraint out_iso_c {
+    out_iso == 0;
+  }
+  // Do not complicate things with the `set_nak_out` functionality in this sequence.
+  constraint set_nak_out_c {
+    set_nak_out == 0;
+  }
+
   // Ensure that we choose a disabled endpoint.
   virtual function void choose_target();
     bit [3:0] init_ep;

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_endpoint_types_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_endpoint_types_vseq.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence designed to exercise all endpoint configurations and see that every type of endpoint
+// encounters each of the possible transaction types (SETUP, OUT, IN and PRE).
+class usbdev_endpoint_types_vseq extends usbdev_spray_packets_vseq;
+  `uvm_object_utils(usbdev_endpoint_types_vseq)
+
+  `uvm_object_new
+
+  // For this sequence we are always targeting the DUT address.
+  constraint target_addr_c {
+    target_addr == dev_addr;
+  }
+
+endclass : usbdev_endpoint_types_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -60,6 +60,7 @@
 // These depend on usbdev_spray_packets_vseq, so need to come after it.
 `include "usbdev_device_address_vseq.sv"
 `include "usbdev_disable_endpoint_vseq.sv"
+`include "usbdev_endpoint_types_vseq.sv"
 // This depends on usbdev_stream_len_max_vseq, so needs to come after it.
 `include "usbdev_freq_phase_delta_vseq.sv"
 // These depend on usbdev_random_length_out_transaction, so need to come after it.

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -43,6 +43,7 @@ filesets:
       - seq_lib/usbdev_dpi_config_host_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_enable_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_endpoint_access_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_endpoint_types_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_fifo_rst_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_freq_phase_delta_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_host_lost_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -153,6 +153,15 @@
       uvm_test_seq: usbdev_endpoint_access_vseq
     }
     {
+      name: usbdev_endpoint_types
+      uvm_test_seq: usbdev_endpoint_types_vseq
+      // Model has no concept of elapsed time, and cannot change state in the
+      // absence of a missing USB host controller handshake. (Isochronous IN traffic.)
+      run_opts: ["+en_scb_rdchk_configin=0"]
+      // Short sequence, many possible endpoint configurations.
+      reseed: 200
+    }
+    {
       name: usbdev_fifo_rst
       uvm_test_seq: usbdev_fifo_rst_vseq
     }


### PR DESCRIPTION
This PR modifies the sequence `usbdev_spray_packets` to support Isochronous transfer types and the `set_nak_out` functionality, and then derives a simple, largely-unconstrained sequence `usbdev_endpoint_types` to ensure that all permutations of the configuration bits may be observed in coverage, and each endpoint configuration may see each of the possible token packets.
- Add support for sending PRE token packets (Low Speed traffic).
- Ensure that Isochronous configuration bits are appropriately qualified in the sequence and in the functional model; it is possible to 'misconfigure' an endpoint for _both_ Isochronous traffic and Control Transfers (SETUP packets), so ensure that the behavior is consistent throughout.

~~**This PR is built on 24183 and only the final commit is relevant to this PR; awaiting CI run before merging that PR.**~~