### PR TITLE
[dv,usbdev] Support Iso transfers in max_usb_traffic

### DIFF
--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -1074,7 +1074,10 @@
             interrupts.
             '''
       stage: V2
-      tests: ["usbdev_max_usb_traffic"]
+      tests: [
+        "usbdev_max_usb_traffic",
+        "usbdev_max_non_iso_usb_traffic"
+      ]
     }
     {
       name: stress_usb_traffic

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_bus_rand_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_bus_rand_vseq.sv
@@ -13,7 +13,7 @@
 // internal state according to the expect DUT changes. (eg. zeroing of device address and resetting
 // of data toggles.)
 
-class usbdev_bus_rand_vseq extends usbdev_max_usb_traffic_vseq;
+class usbdev_bus_rand_vseq extends usbdev_max_non_iso_usb_traffic_vseq;
   `uvm_object_utils(usbdev_bus_rand_vseq)
 
   `uvm_object_new

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_low_speed_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_low_speed_traffic_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class usbdev_low_speed_traffic_vseq extends usbdev_max_usb_traffic_vseq;
+class usbdev_low_speed_traffic_vseq extends usbdev_max_non_iso_usb_traffic_vseq;
   `uvm_object_utils(usbdev_low_speed_traffic_vseq)
 
   `uvm_object_new

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_non_iso_usb_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_max_non_iso_usb_traffic_vseq.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence just adds a couple of additional constraints to prevent the generation of
+// Isochronous transfers with the aim of exercising the more important configurations more
+// thoroughly.
+class usbdev_max_non_iso_usb_traffic_vseq extends usbdev_max_usb_traffic_vseq;
+  `uvm_object_utils(usbdev_max_non_iso_usb_traffic_vseq)
+
+  `uvm_object_new
+
+  constraint out_non_iso_c {
+    out_iso == 0;
+  }
+  constraint in_non_iso_c {
+    in_iso == 0;
+  }
+
+  virtual task body;
+    super.body();
+  endtask
+endclass : usbdev_max_non_iso_usb_traffic_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_streaming_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_streaming_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class usbdev_streaming_vseq extends usbdev_max_usb_traffic_vseq;
+class usbdev_streaming_vseq extends usbdev_max_non_iso_usb_traffic_vseq;
   `uvm_object_utils(usbdev_streaming_vseq)
 
   `uvm_object_new

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -73,6 +73,7 @@
 `include "usbdev_aon_wake_vseq.sv"
 `include "usbdev_link_resume_vseq.sv"
 // These must follow usbdev_max_usb_traffic_vseq.sv
+`include "usbdev_max_non_iso_usb_traffic_vseq.sv"
 `include "usbdev_bus_rand_vseq.sv"
 `include "usbdev_low_speed_traffic_vseq.sv"
 `include "usbdev_streaming_vseq.sv"

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -59,6 +59,7 @@ filesets:
       - seq_lib/usbdev_low_speed_traffic_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_min_length_out_transaction_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_length_out_transaction_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_max_non_iso_usb_traffic_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_max_usb_traffic_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_nak_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_out_iso_vseq.sv: {is_include_file: true}

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -298,8 +298,19 @@
       uvm_test_seq: usbdev_max_length_out_transaction_vseq
     }
     {
+      name: usbdev_max_non_iso_usb_traffic
+      uvm_test_seq: usbdev_max_non_iso_usb_traffic_vseq
+      // More important than Isochronous traffic.
+      reseed: 25
+    }
+    {
       name: usbdev_max_usb_traffic
       uvm_test_seq: usbdev_max_usb_traffic_vseq
+      // Model has no concept of elapsed time, and cannot change state in the
+      // absence of a missing USB host controller handshake (Isochronous IN traffic).
+      run_opts: ["+en_scb_rdchk_configin=0"]
+      // Isochronous transfers are rarely used.
+      reseed: 15
     }
     {
       name: usbdev_min_inter_pkt_delay


### PR DESCRIPTION
Generalize the `usbdev_max_usb_traffic` sequence to support Isochronous transfers/endpoints too.
Introduce a derived sequence that constrains the testing to the much more common non-Isochronous traffic (Iso transfers are rarely used on the USB in practice).

_This PR requires the changes to `usbdev_bfm.sv` in #24185_ so that must be merged first otherwise there will be some test failures when Isochronous transfers are selected oweing to a discrepancy between the model and the DUT.