### PR TITLE
[verilator, tests] Fix and tag failing & timed-out Verilator test targets

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -500,6 +500,9 @@ opentitan_test(
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         },
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     # This target uses OTBN pointers internally, so it cannot work host-side.
     deps = [
         ":otbn_boot_services",

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -120,6 +120,9 @@ opentitan_test(
     fpga = fpga_params(
         timeout = "long",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         ":mod_exp_ibex",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -317,6 +320,9 @@ opentitan_test(
     fpga = fpga_params(
         timeout = "long",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         ":sigverify",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/weak_straps/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/weak_straps/BUILD
@@ -73,6 +73,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 40 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
         test_cmd = CLEAR_TEST_CMD,
         test_harness = "//sw/host/tests/rom/sw_strap_value",
     ),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1421,7 +1421,7 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
         test_cmd = " ".join([
-            "--firmware-elf=\"{firmware:elf}\"",
+            "\"{firmware:elf}\"",
         ]),
         test_harness = "//sw/host/tests/chip/mem",
     ),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2611,6 +2611,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
+    # FIXME this test is also broken in Verilator for the same reason as in
+    # sival ROM_EXT above. Remove this line when fixed. See #21706.
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -3469,7 +3472,12 @@ opentitan_test(
     name = "spi_host_winbond_flash_test",
     srcs = ["spi_host_winbond_flash_test.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # This test requires an SPI flash on the bus, and therefore
+            # cannot be tested in Verilator where this is not available.
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     deps = [
@@ -5990,7 +5998,10 @@ opentitan_test(
     name = "rv_core_ibex_mem_test_prod",
     srcs = ["rv_core_ibex_mem_test.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     deps = [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -679,6 +679,8 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
+    # Broken on Verilator. See #24182.
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
@@ -3016,6 +3018,8 @@ opentitan_test(
             "//hw/top_earlgrey:fpga_cw310_sival": None,
         },
     ),
+    # Broken on Verilator. See #24182.
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//sw/device/lib/dif:aon_timer",
         "//sw/device/lib/dif:pwrmgr",
@@ -3969,6 +3973,8 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
+    # Broken on Verilator. See #24182.
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -4003,7 +4009,11 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
     ),
-    verilator = verilator_params(timeout = "long"),
+    verilator = verilator_params(
+        timeout = "long",
+        # Broken on Verilator. See #24182.
+        tags = ["broken"],
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -4167,7 +4177,11 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
     ),
-    verilator = verilator_params(timeout = "long"),
+    verilator = verilator_params(
+        timeout = "long",
+        # Broken on Verilator. See #24182.
+        tags = ["broken"],
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:pinmux",
@@ -6095,6 +6109,8 @@ opentitan_test(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
+    # Broken on Verilator. See #24182.
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:pwrmgr",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -239,6 +239,9 @@ opentitan_test(
             "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": "broken",
         },
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey:alert_handler_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -523,6 +526,9 @@ opentitan_test(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -964,7 +970,12 @@ opentitan_test(
     silicon_owner = silicon_params(
         tags = ["broken"],
     ),
-    verilator = verilator_params(timeout = "eternal"),
+    verilator = verilator_params(
+        timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
+    ),
     deps = [
         ":otbn_randomness_impl",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -1044,6 +1055,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//hw/ip/aes:model",
@@ -1318,6 +1332,9 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/ip/entropy_src/data:entropy_src_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2439,6 +2456,9 @@ opentitan_test(
     fpga = fpga_params(
         changes_otp = True,
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
@@ -2627,6 +2647,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -2663,6 +2686,9 @@ opentitan_test(
         test_cmd = "--bootstrap={firmware}",
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -2695,6 +2721,9 @@ opentitan_test(
         test_cmd = "--bootstrap={firmware}",
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -2734,6 +2763,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_por",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -2772,6 +2804,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_por",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -2805,6 +2840,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr:pwrmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2837,6 +2875,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr:pwrmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2877,6 +2918,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr:pwrmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2923,6 +2967,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/ip_autogen/pwrmgr:pwrmgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -2971,7 +3018,12 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
-    verilator = verilator_params(timeout = "long"),
+    verilator = verilator_params(
+        timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -3225,6 +3277,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/spi_device:spi_device_tpm_test",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -3262,6 +3317,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/spi_device:spi_device_flash_smoketest",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -3535,6 +3593,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_c_regs",
@@ -3669,6 +3730,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -3689,6 +3753,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -4509,6 +4576,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/spi_device:spi_passthru",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//sw/device/lib/arch:device",
         "//sw/device/lib/dif:gpio",
@@ -5343,6 +5413,9 @@ opentitan_test(
         ]),
         test_harness = "//sw/host/tests/chip/example_sival",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:ottf_utils",
@@ -5651,6 +5724,9 @@ opentitan_test(
         test_cmd = "--elf={firmware}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:otp_ctrl_testutils",
@@ -5736,6 +5812,9 @@ opentitan_test(
         test_cmd = "--elf={firmware}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:otp_ctrl_testutils",
@@ -5801,6 +5880,9 @@ opentitan_test(
         ]),
         test_harness = "//sw/host/tests/chip/uart:uart_tx_rx",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/ip/lc_ctrl/data:lc_ctrl_c_regs",
         "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_c_regs",
@@ -5855,6 +5937,9 @@ opentitan_test(
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",
@@ -5948,6 +6033,9 @@ opentitan_test(
         ]),
         test_harness = "//sw/host/tests/chip/uart:uart_baud_rate",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -5989,6 +6077,9 @@ opentitan_test(
         ]),
         test_harness = "//sw/host/tests/chip/uart:uart_loopback",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -6012,6 +6103,9 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         ":otbn_randomness_impl",
         "//hw/ip/entropy_src/data:entropy_src_c_regs",
@@ -6065,6 +6159,9 @@ opentitan_test(
         ]),
         test_harness = "//sw/host/tests/chip/uart:uart_parity_break",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -6197,6 +6294,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/gpio:sleep_pin_mio_dio_val",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -6238,6 +6338,9 @@ opentitan_test(
         """,
         test_harness = "//sw/host/tests/chip/gpio:sleep_pin_retention",
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -192,7 +192,7 @@ opentitan_test(
         # be run as part of the DV nightly regression.
         dicts.omit(
             EARLGREY_TEST_ENVS,
-            ["//hw/top_earlgrey:verilator"],
+            ["//hw/top_earlgrey:sim_verilator"],
         ),
         {
             "//hw/top_earlgrey:silicon_creator": None,
@@ -281,7 +281,7 @@ opentitan_test(
         # be run as part of the DV nightly regression.
         dicts.omit(
             EARLGREY_TEST_ENVS,
-            ["//hw/top_earlgrey:verilator"],
+            ["//hw/top_earlgrey:sim_verilator"],
         ),
         {
             "//hw/top_earlgrey:silicon_creator": None,
@@ -333,7 +333,7 @@ opentitan_test(
         # be run as part of the DV nightly regression.
         dicts.omit(
             EARLGREY_TEST_ENVS,
-            ["//hw/top_earlgrey:verilator"],
+            ["//hw/top_earlgrey:sim_verilator"],
         ),
         {
             # See #23038, this test requires a provisioned flash in sival.
@@ -1796,7 +1796,7 @@ opentitan_test(
         # Not compatible with the verilated top level.
         dicts.omit(
             EARLGREY_TEST_ENVS,
-            ["//hw/top_earlgrey:verilator"],
+            ["//hw/top_earlgrey:sim_verilator"],
         ),
         {
             "//hw/top_earlgrey:silicon_creator": None,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3439,7 +3439,12 @@ opentitan_test(
     name = "spi_host_smoketest",
     srcs = ["spi_host_smoketest.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
+        # This test requires a flash connected to the SPI bus,
+        # which is not available in Verilator.
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            ["//hw/top_earlgrey:sim_verilator"],
+        ),
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(timeout = "moderate"),

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3995,7 +3995,13 @@ opentitan_test(
     name = "usbdev_aon_wake_reset_test",
     srcs = ["usbdev_aon_wake_reset_test.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            [
+                "//hw/top_earlgrey:sim_dv",
+                "//hw/top_earlgrey:sim_verilator",
+            ],
+        ),
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(

--- a/sw/device/tests/autogen/BUILD
+++ b/sw/device/tests/autogen/BUILD
@@ -40,7 +40,12 @@ package(default_visibility = ["//visibility:public"])
         ),
         verilator = verilator_params(
             timeout = "eternal",
-            tags = ["flaky"],
+            tags = [
+                "flaky",
+                "manual",
+            ],
+            # This test can take > 60 minutes, so mark it manual as it
+            # shouldn't run in CI/nightlies.
             # often times out in 3600s on 4 cores
         ),
         deps = [

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -36,6 +36,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         ":aes_testvectors",
@@ -125,6 +128,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         ":aes_gcm_testutils",
@@ -218,6 +224,9 @@ opentitan_test(
     exec_env = EARLGREY_TEST_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
@@ -234,6 +243,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
@@ -253,6 +265,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
@@ -309,6 +324,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:otbn",
@@ -328,6 +346,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
@@ -348,6 +369,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
@@ -416,6 +440,9 @@ opentitan_test(
     exec_env = EARLGREY_TEST_ENVS,
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/drivers:entropy",
@@ -431,6 +458,9 @@ opentitan_test(
     exec_env = EARLGREY_TEST_ENVS,
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         ":kdf_testvectors_random_header",
@@ -467,6 +497,9 @@ opentitan_test(
     exec_env = EARLGREY_TEST_ENVS,
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         ":hmac_testvectors_random_header",
@@ -558,6 +591,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
@@ -574,6 +610,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
@@ -590,6 +629,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
@@ -606,6 +648,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
@@ -627,6 +672,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
@@ -645,6 +693,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         "//sw/device/lib/crypto/impl:hash",
@@ -768,6 +819,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         ":rsa_3072_verify_testvectors_wycheproof_header",
@@ -793,6 +847,9 @@ opentitan_test(
     exec_env = CRYPTOTEST_EXEC_ENVS,
     verilator = verilator_params(
         timeout = "long",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         ":rsa_3072_verify_testvectors_hardcoded_header",

--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -10,6 +10,7 @@ load(
     "fpga_params",
     "opentitan_test",
     "silicon_params",
+    "verilator_params",
 )
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
@@ -330,6 +331,9 @@ opentitan_test(
             "pmod",
         ],  # Requires the PMOD::BoB.
     ),
+    # This test can take > 40 minutes, so mark it manual as it shouldn't run
+    # in CI/nightlies.
+    verilator = verilator_params(tags = ["manual"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",

--- a/sw/device/tests/spi_host_irq_test.c
+++ b/sw/device/tests/spi_host_irq_test.c
@@ -371,12 +371,19 @@ static status_t test_init(void) {
   base_addr = mmio_region_from_addr(TOP_EARLGREY_SPI_HOST0_BASE_ADDR);
   TRY(dif_spi_host_init(base_addr, &spi_host));
 
+  uint32_t spi_clock_freq_hz = 1000000;
+  if (kDeviceType == kDeviceSimVerilator) {
+    // On verilator, we reduce the spi clock frequency by a factor of 10
+    // as otherwise we get errors in the SPI host configuration due to
+    // the low high speed peripheral frequency (500 KHz).
+    spi_clock_freq_hz = 100000;
+  }
   CHECK(kClockFreqHiSpeedPeripheralHz <= UINT32_MAX,
         "kClockFreqHiSpeedPeripheralHz must fit in uint32_t");
   TRY(dif_spi_host_configure(
       &spi_host,
       (dif_spi_host_config_t){
-          .spi_clock = 1000000,
+          .spi_clock = spi_clock_freq_hz,
           .peripheral_clock_freq_hz = (uint32_t)kClockFreqHiSpeedPeripheralHz,
           .rx_watermark = kRxWatermark,
           .tx_watermark = kTxWatermark,

--- a/third_party/coremark/top_earlgrey/BUILD
+++ b/third_party/coremark/top_earlgrey/BUILD
@@ -48,6 +48,9 @@ opentitan_test(
     ),
     verilator = verilator_params(
         timeout = "eternal",
+        # This test can take > 60 minutes, so mark it manual as it shouldn't
+        # run in CI/nightlies.
+        tags = ["manual"],
     ),
     deps = [
         ":core_portme",

--- a/util/topgen/templates/BUILD.tpl
+++ b/util/topgen/templates/BUILD.tpl
@@ -40,7 +40,12 @@ package(default_visibility = ["//visibility:public"])
         ),
         verilator = verilator_params(
             timeout = "eternal",
-            tags = ["flaky"],
+            tags = [
+                "flaky",
+                "manual",
+            ],
+            # This test can take > 60 minutes, so mark it manual as it
+            # shouldn't run in CI/nightlies.
             # often times out in 3600s on 4 cores
         ),
         deps = [


### PR DESCRIPTION
This PR partially addresses issues #24182 and #24184.

All Verilator test targets were run using public CI overnight in preparation for the addition of a weekly/nightly Verilator job in PR #24145. Of the 390 targets (at the time of testing), 14 explicitly failed and 67 timed out (when using `--test_timeout=2400,2400,3600,-1`). This PR accordingly:

- Marks all 67 timed-out tests as "manual", as they take at least 40 (and many > 60) minutes to complete when run on our public CI infrastructure and as such are too long to run in any sort of regular CI. The confirmation of whether these tests truly take a long time or should be marked broken and/or fixed is tracked by #24184. All of these tags are documented with the reason for their inclusion, mentioning whether the timeout used was 40 or 60 minutes for future reference.
- Marks all 6 failing Verilator tests tracked in #24182 as `broken`, until they can be looked at further.
- Fixes the `example_mem_ujcmd_test` test for Verilator, which was incorrectly passing in the Firmware ELF as a keyword argument instead of a positional argument. This has been verified (`PASSED in 599.6s`) by running 
```
./bazelisk.sh test -t- --test_output=streamed --test_timeout=3600,3600,3600,3600 \
    //sw/device/tests:example_mem_ujcmd_test_sim_verilator
```
- Fixes the `spi_host_irq_test` target, which was failing on Verilator due to the SPI clock frequency being configured to 1 MHz, whereas Verilator's HiSpeed peripheral frequency is set to just 500 KHz. A conditional check is added and the SPI clock speed is reduced to 100 KHz if running on Verilator. This has been verified (`PASSED in 133.4s`) by running 
```
./bazelisk.sh test -t- --test_output=streamed --test_timeout=3600,3600,3600,3600 \
    //sw/device/tests:spi_host_irq_test_sim_verilator
```
- Correctly excludes the Verilator execution environment from `gpio_smoketest`, which previously erroneously had the `//hw/top_earlgrey:verilator` environment excluded instead of the correct `//hw/top_earlgrey:sim_verilator`. This occurrence is fixed in 3 other places in the `BUILD` file.
- Removes both the `sim_dv` and `sim_verilator` execution environments from the `usbdev_aon_wake_reset_test` Bazel test target, as [the test source already immediately fails if the device type is DV or Verilator](https://github.com/lowRISC/opentitan/blob/70142638925f66eae20f6232b5a7c1ffc51ff0e3/sw/device/tests/usbdev_aon_wake_reset_test.c#L120) - this lack of support for simulator environments is now made explicit in the Bazel parameters.
- Marks the `spi_host_winbond_flash_test` as being `manual` for the Verilator environment, as it requires access to Winbond flash, which is not currently available in CI.
- Removes the Verilator execution environment from `rv_core_ibex_mem_test_prod`, because [the `rv_core_ibex` tests are marked as being incompatible with test_rom](https://github.com/lowRISC/opentitan/blob/70142638925f66eae20f6232b5a7c1ffc51ff0e3/sw/device/tests/BUILD#L5756-L5757), which Verilator uses, and as such this environement should not be supported.
- Marks the `pwrmgr_all_reset_reqs_test` Verilator execution environment as broken alongside the existing broken `fpga_cw310_sival_rom_ext` environment, as the test provides the same error in both cases.
- Removes the Verilator execution environment from `spi_host_smoketest`, as that test requires a flash connected to the SPI bus which is not emulated by Verilator.

Aside from the few fixes, this PR only marks Verilator tests as manual or broken (or removes the Verilator execution environment). Existing Verilator tests that are running in CI are unaffected by this, as currently only `aes_smoketest` is being run on [English breakfast](https://github.com/lowRISC/opentitan/blob/70142638925f66eae20f6232b5a7c1ffc51ff0e3/ci/scripts/run-english-breakfast-verilator-tests.sh#L37), and [16 specific quick tests are being run on top_earlgrey](https://github.com/lowRISC/opentitan/blob/70142638925f66eae20f6232b5a7c1ffc51ff0e3/ci/scripts/run-verilator-tests.sh#L19C2-L34C64).