### PR TITLE
[dv,ast] Add timeunit for correct execution of delays in AST IF

### DIFF
--- a/hw/top_earlgrey/dv/env/ast_supply_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_supply_if.sv
@@ -15,6 +15,10 @@ interface ast_supply_if (
   input logic core_sleeping_trigger,
   input logic low_power_trigger
 );
+
+  timeunit 1ps;
+  timeprecision 1ps;
+
   import uvm_pkg::*;
 
   // The amount of time to hold the glitch. Should be enough to span more than one aon_clk cycles


### PR DESCRIPTION
Adding \`timeunit and \`timeprecision to allow proper execution of '#1ps' inside 'GLITCH_VCMAIN_POK'.
Otherwise #1ps might be executed as 0 in certain cases.