### PR TITLE
[dv,usbdev] Sequence to disrupt packet tx/rx with USB Bus Reset or IP block reset

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -52,6 +52,9 @@ class usb20_agent_cfg extends dv_base_agent_cfg;
   // ACKnowledged an IN packet or it has been marked as `pend` by the hardware.
   bit rtl_sending_clear_requires_ack = 1'b1;
 
+  // RTL will report CRC errors even if the PID is truncated, for DATA packets.
+  bit rtl_limited_crc_checking = 1'b1;
+
   // --------------------------------------------------------------------------
 
 endclass

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -26,6 +26,14 @@ class usb20_item extends uvm_sequence_item;
   // the device.
   bit await_response;
 
+  // For a SETUP/OUT token packet, OUT DATA packet or an IN DATA request, this indicates how many
+  // bits shall be transmitted, as a precursor to then issuing a bus-level event such as a Bus Reset
+  // to test the DUT's recovery logic. (0 = default; transmit the entire packet.)
+  int unsigned bits_to_transmit;
+  // For an IN DATA request, this indicates how many bits of any responses shall be received.
+  // (0 = default; receive the entire response.)
+  int unsigned bits_to_receive;
+
   // Validity indicators that apply to all packet types; used by the monitor at metadata for the
   // scoreboard.
   bit valid_sync;      // SYNC signal properly formed.
@@ -51,6 +59,12 @@ class usb20_item extends uvm_sequence_item;
     valid_eop = 1'b1;
     // Await response to IN token packet?
     await_response = 1'b1;
+    // Normally the entire packet will be transmitted; this field may be used to truncate a packet
+    // transfer prematurely to test recovery behavior.
+    bits_to_transmit = 0;
+    // Normally the entirety of any response will be received; this field may be used to truncate
+    // collect only part of the response, to test recovery behavior.
+    bits_to_receive = 0;
     // Timed out awaiting a response from the device?
     timed_out = 1'b0;
   endfunction
@@ -68,6 +82,12 @@ class usb20_item extends uvm_sequence_item;
     m_pkt_type          = rhs_.m_pkt_type;
     m_usb_transfer      = rhs_.m_usb_transfer;
     timed_out           = rhs_.timed_out;
+    // Await response to IN packet?
+    await_response      = rhs_.await_response;
+    // Number of bits to transmit, if truncating.
+    bits_to_transmit    = rhs_.bits_to_transmit;
+    // Number of response bits to receive, if truncating.
+    bits_to_receive     = rhs_.bits_to_receive;
     // Low speed signaling?
     low_speed           = rhs_.low_speed;
     // Validity indicators; used to instruct the driver to perform fault injection, and completed

--- a/hw/dv/sv/usb20_agent/usb20_item.sv
+++ b/hw/dv/sv/usb20_agent/usb20_item.sv
@@ -30,7 +30,7 @@ class usb20_item extends uvm_sequence_item;
   // bits shall be transmitted, as a precursor to then issuing a bus-level event such as a Bus Reset
   // to test the DUT's recovery logic. (0 = default; transmit the entire packet.)
   int unsigned bits_to_transmit;
-  // For an IN DATA request, this indicates how many bits of any responses shall be received.
+  // For an IN DATA request, this indicates how many bits of any response shall be received.
   // (0 = default; receive the entire response.)
   int unsigned bits_to_receive;
 
@@ -62,8 +62,8 @@ class usb20_item extends uvm_sequence_item;
     // Normally the entire packet will be transmitted; this field may be used to truncate a packet
     // transfer prematurely to test recovery behavior.
     bits_to_transmit = 0;
-    // Normally the entirety of any response will be received; this field may be used to truncate
-    // collect only part of the response, to test recovery behavior.
+    // Normally the entirety of any response will be received; this field may be used to collect
+    // only part of the response, to test recovery behavior.
     bits_to_receive = 0;
     // Timed out awaiting a response from the device?
     timed_out = 1'b0;

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -1194,6 +1194,30 @@
       tests: ["usbdev_fifo_rst"]
     }
     {
+      name: usbdev_tx_rx_disruption
+      desc: '''
+            Verify that the DUT is still capable of transmitting and receiving after a spontaneous
+            disruption to the connection during transmission or reception, without requiring an
+            IP block reset. On some implementations resetting of individual IP blocks may not be
+            an option.
+
+            Note that after a Bus Reset the USB host must restart the entire device addressing and
+            configuration sequence, so the first transmissions will be SOF and SETUP packets.
+
+            - Configure the device, choosing an endpoint and choose whether to transmit or receive.
+            - Choose the moment at which the link reset shall occur.
+            - Transmit/receive a partial transaction before instructing the driver to perform a
+              USB Bus Reset.
+            - Reconfigure the device _without_ resetting the block or even the FIFO state, since
+              normally the software will rely upon its knowledge of the device state in handling
+              a Bus Reset.
+            - Retry transmission or reception to/from the device both to the previously-active
+              endpoint and to a different endpoint to guard against persistent internal state.
+            '''
+      stage: V2
+      tests: ["usbdev_tx_rx_disruption"]
+    }
+    {
       name: dpi_config_host
       desc: '''
             Using the DPI model run the DUT through a typical configuration sequence consisting of

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_tx_rx_disruption_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_tx_rx_disruption_vseq.sv
@@ -46,8 +46,6 @@ class usbdev_tx_rx_disruption_vseq extends usbdev_smoke_vseq;
     uint data_bytes = ($urandom & 1) ? MaxPktSizeByte : 8;
     // Report choices.
     string stim_desc;
-    // TODO: Only BusReset is expected to work presently; scoreboard/BFM not hooked up for IP reset.
-    stim_type = StimType_BusReset;
     case (stim_type)
       StimType_IPReset:    stim_desc = "IP Reset";
       StimType_BusReset:   stim_desc = "Bus Reset";

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_tx_rx_disruption_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_tx_rx_disruption_vseq.sv
@@ -1,0 +1,147 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class usbdev_tx_rx_disruption_vseq extends usbdev_smoke_vseq;
+  `uvm_object_utils(usbdev_tx_rx_disruption_vseq)
+
+  `uvm_object_new
+
+  // The type of disruption stimulus to generate.
+  typedef enum {
+    StimType_IPReset,
+    StimType_BusReset,
+    StimType_Disconnect
+  } stim_type_e;
+
+  // The type of transaction to interrupt.
+  typedef enum {
+    TxnType_SETUP,
+    TxnType_OUT,
+    TxnType_IN
+  } txn_type_e;
+
+  rand txn_type_e txn_type;   // The type of transaction to disrupt.
+  rand bit disrupt_data;      // Disrupt the DATA packet rather than the token packet?
+  rand stim_type_e stim_type; // Type of stimulus to be applied.
+
+  // We run this sequence in normal differential mode (DP/DN for both IN and OUT) as well as
+  // using 'd_se0' for transmission to help with coverage numbers.
+  virtual task pre_start();
+    phy_tx_use_d_se0 = $urandom & 1;
+    super.pre_start();
+  endtask
+
+  virtual task body;
+    // It can take 3-4 microseconds for the DUT to spot a link reset condition and we wish to be
+    // able to induce one whilst it is still within what it thinks is the data field of a DATA
+    // packet, so that must take at least 4 microseconds to transmit; this is 4 x 12 = 48 bit
+    // intervals, or 6 bytes; making them appreciably longer just makes it less likely that we hit
+    // the CRC bytes.
+    byte unsigned data[$];
+    // For attaining coverage numbers, however, we also want to ensure the 'out_state_q' FSM in
+    // `usb_fs_tx` is observed moving through each of its 4 transitions, and there's only a 1/32
+    // probability of a `link_reset` starting in the single cycle of fetch a new byte from the
+    // packet buffer RAM, so use some longer packets too.
+    uint data_bytes = ($urandom & 1) ? MaxPktSizeByte : 8;
+    // Report choices.
+    string stim_desc;
+    // TODO: Only BusReset is expected to work presently; scoreboard/BFM not hooked up for IP reset.
+    stim_type = StimType_BusReset;
+    case (stim_type)
+      StimType_IPReset:    stim_desc = "IP Reset";
+      StimType_BusReset:   stim_desc = "Bus Reset";
+      StimType_Disconnect: stim_desc = "Disconnect";
+      default:             `uvm_fatal(`gfn, $sformatf("Invalid/unsupported stimulus %p", stim_type))
+    endcase
+    `uvm_info(`gfn, $sformatf("Disrupting %p data %0d with %s", txn_type, disrupt_data, stim_desc),
+              UVM_LOW)
+    // Use zeros for transferred data to avoid bit stuffing; we then guarantee that the tx/rx
+    // _can_ be disrupted in the CRC at the packet end.
+    repeat (data_bytes) data.push_back(0);
+
+    // Set up the device and run the smoke sequence.
+    super.body();
+
+    // Initiate the transaction that we are going to disrupt.
+    //
+    // Keep the packets short; greater likelihood of disruption within the packet overhead (SYNC,
+    // PID, CRC...), and it's also compatible with standard SETUP DATA packets.
+    case (txn_type)
+      TxnType_SETUP, TxnType_OUT: begin
+        disrupt_tx_bits = disrupt_data ? 0 : $urandom_range(1, 31);  // Token packets are 32 bits.
+        if (txn_type == TxnType_SETUP) send_token_packet(ep_default, PidTypeSetupToken);
+        else send_token_packet(ep_default, PidTypeOutToken);
+        if (disrupt_data) begin
+          // Variable delay between OUT token packet and the ensuing DATA packet.
+          inter_packet_delay();
+          // Minimum length, with no bit stuffing, minus 1 becomes the upper bound.
+          disrupt_tx_bits = $urandom_range(1, 31 + data_bytes * 8);
+          // The selected PID type does not matter, for once; we're about to interrupt the
+          // transmission.
+          send_data_packet(PidTypeData0, data);
+        end
+      end
+      TxnType_IN: begin
+        configure_in_trans(ep_default, in_buffer_id, data_bytes);
+        write_buffer(in_buffer_id, data);
+        disrupt_tx_bits = disrupt_data ? 0 : $urandom_range(1, 31);  // Token packets are 32 bits.
+        // Minimum length, with no bit stuffing, minus 1 becomes the upper bound.
+        disrupt_rx_bits = disrupt_data ? $urandom_range(1, 31 + data_bytes * 8) : 0;
+        send_token_packet(ep_default, PidTypeInToken);
+        if (disrupt_data) begin
+          RSP rsp;
+          get_response(rsp);
+        end
+      end
+      default: `uvm_fatal(`gfn, "Invalid/unrecognised transaction type")
+    endcase
+    // Switch off disruption before causing any further confusion.
+    disrupt_tx_bits = 0;
+    disrupt_rx_bits = 0;
+    // Apply the disruption stimulus immediately.
+    `uvm_info(`gfn, $sformatf("Applying %s stimulus to disrupt traffic", stim_desc), UVM_LOW)
+    case (stim_type)
+      StimType_BusReset: begin
+        send_bus_reset(100);
+        // After the Bus Reset we must reinstate the device address.
+        `uvm_info(`gfn, $sformatf("Setting device address to 0x%02x", dev_addr), UVM_MEDIUM)
+        usbdev_set_address(dev_addr);
+      end
+      StimType_IPReset: begin
+        apply_reset();
+        // After an IP block reset the entire device configuration must be reinstated.
+        usbdev_init(dev_addr, phy_use_diff_rcvr, phy_tx_use_d_se0, phy_pinflip);
+      end
+      StimType_Disconnect: begin
+        bit remove_pullup = $urandom & 1;
+        set_vbus_state(0);
+        // Wait for 100 microseconds; a pretty arbitrary choice. VBUS disconnections would usually
+        // be longer in practice.
+        cfg.clk_rst_vif.wait_clks(100 * 48);
+        if (remove_pullup) begin
+          usbdev_disconnect();
+          set_vbus_state(1);
+          // Wait a little before reinstating pull up
+          cfg.clk_rst_vif.wait_clks(4 * 48);
+          usbdev_connect();
+        end else set_vbus_state(1);
+        // Allow a little time before VBUS connection and the host supplying the Bus Reset.
+        cfg.clk_rst_vif.wait_clks(10 * 48);
+        send_bus_reset(100);
+        // After the Bus Reset we must reinstate the device address.
+        `uvm_info(`gfn, $sformatf("Setting device address to 0x%02x", dev_addr), UVM_MEDIUM)
+        usbdev_set_address(dev_addr);
+      end
+      default: `uvm_fatal(`gfn, $sformatf("Unexpected stimulus %p", stim_type))
+    endcase
+
+    // Try the smoke sequence again.
+    super.body();
+    // Choose another endpoint.
+    ep_default = (|ep_default ? ep_default : NEndpoints) - 1;
+    // Retry the smoke sequence.
+    super.body();
+  endtask
+
+endclass : usbdev_tx_rx_disruption_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_vseq_list.sv
@@ -56,6 +56,7 @@
 `include "usbdev_stall_priority_over_nak_vseq.sv"
 `include "usbdev_stall_trans_vseq.sv"
 `include "usbdev_stream_len_max_vseq.sv"
+`include "usbdev_tx_rx_disruption_vseq.sv"
 
 // These depend on usbdev_spray_packets_vseq, so need to come after it.
 `include "usbdev_device_address_vseq.sv"

--- a/hw/ip/usbdev/dv/env/timed_reg.sv
+++ b/hw/ip/usbdev/dv/env/timed_reg.sv
@@ -137,16 +137,20 @@ class timed_reg_field extends uvm_object;
                                   field.get_name(), pred.id, pred.val_new), UVM_HIGH)
         void'(pred_q.pop_front());
         obs_latest = act_val;
-      end else if (!(pred.latest_time - time_now > 0)) begin
-        `uvm_info(`gfn, $sformatf("Reg %p field %s (ID 0x%0x) did NOT meet expectation 0x%0x",
-                                  reg_name, field.get_name(), pred.id, pred.val_new), UVM_MEDIUM)
-        `uvm_info(`gfn, $sformatf(" (time_now 0x%0x)", time_now), UVM_MEDIUM)
-        // Report the mismatched value.
-        `DV_CHECK_EQ(act_val, pred.val_new);
       end else begin
-        // Check that it still matches the previous value.
-        `DV_CHECK_EQ(act_val, pred.val_prev);
-        break;
+        // Check that the latest time on this prediction has not yet passed; the expression of the
+        // comparison copes with timer wraparound too.
+        if (!(pred.latest_time - time_now > 0)) begin
+          `uvm_info(`gfn, $sformatf("Reg %p field %s (ID 0x%0x) did NOT meet expectation 0x%0x",
+                                    reg_name, field.get_name(), pred.id, pred.val_new), UVM_MEDIUM)
+          `uvm_info(`gfn, $sformatf(" (time_now 0x%0x)", time_now), UVM_MEDIUM)
+          // Report the mismatched value.
+          `DV_CHECK_EQ(act_val, pred.val_new);
+        end else begin
+          // Check that it still matches the previous value.
+          `DV_CHECK_EQ(act_val, pred.val_prev);
+          break;
+        end
       end
     end while (pred_q.size() > 0);
   endfunction

--- a/hw/ip/usbdev/dv/env/usbdev_bfm.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_bfm.sv
@@ -130,6 +130,8 @@ class usbdev_bfm extends uvm_component;
 
   // Reset assertion to the DUT; this is a reset of the IP block; not a Bus Reset on the USB.
   function void dut_reset();
+    configin_t configin_rst;  // Defaults to zeros throughout.
+    `uvm_info(`gfn, "Modeling DUT reset", UVM_LOW)
     powered = 1'b1;
     // Assigned device address is discarded and the DUT returns to the disconnected state.
     dev_address = 0;
@@ -163,8 +165,12 @@ class usbdev_bfm extends uvm_component;
     // Note: packet buffer contents are unmodified by DUT reset, but the bank of 32 flops is reset.
     wdata_q <= 32'b0;
     // Note: AON/Wake state also unaffected.
-    // Record that there is no IN transmission in progress.
+    // Note: `sense` line is unaffected; it's an external input to the DUT.
+    // Record that there is no IN transmission configured or in progress.
+    for (int unsigned ep = 0; ep < NEndpoints; ep++) configin[ep] = configin_rst;
     tx_ep = InvalidEP;
+    // Nor any in-progress reception.
+    rx_token = null;
   endfunction
 
   //------------------------------------------------------------------------------------------------

--- a/hw/ip/usbdev/dv/env/usbdev_env.core
+++ b/hw/ip/usbdev/dv/env/usbdev_env.core
@@ -91,6 +91,7 @@ filesets:
       - seq_lib/usbdev_stall_trans_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_streaming_vseq.sv: {is_include_file: true}
       - seq_lib/usbdev_stream_len_max_vseq.sv: {is_include_file: true}
+      - seq_lib/usbdev_tx_rx_disruption_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -58,6 +58,10 @@ class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
   bit en_scb_rdchk_link_in_err = 1'b1;
   // Enable checking of `intr_state.link_resume` register field?
   bit en_scb_rdchk_link_resume = 1'b1;
+  // Enable checking of `intr_state.rx_pid_err` register field?
+  bit en_scb_rdchk_rx_pid_err = 1'b1;
+  // Enable checking of `intr_state.rx_crc_err` register field?
+  bit en_scb_rdchk_rx_crc_err = 1'b1;
 
   `uvm_object_utils_begin(usbdev_env_cfg)
     `uvm_field_object(m_usb20_agent_cfg,  UVM_DEFAULT)

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -62,6 +62,8 @@ class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
   bit en_scb_rdchk_rx_pid_err = 1'b1;
   // Enable checking of `intr_state.rx_crc_err` register field?
   bit en_scb_rdchk_rx_crc_err = 1'b1;
+  // Enable checking of `intr_state.rx_bitstuff_err` register field?
+  bit en_scb_rdchk_rx_bitstuff_err = 1'b1;
 
   `uvm_object_utils_begin(usbdev_env_cfg)
     `uvm_field_object(m_usb20_agent_cfg,  UVM_DEFAULT)

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -72,10 +72,14 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
     // sample the SE0 state of a spontaneous Bus Reset and complete the PID even though not all
     // of the PID bits were transmitted. The CRC can simply be a false positive match,
     // particularly the CRC5 of a token packet.
+    // Reporting of bit stuffing violations is a similar situation to that with PID bits; whether or
+    // not they will be detected and reported is data-dependent.
     cfg.en_scb_rdchk_rx_pid_err = 1'b1;
     void'($value$plusargs("en_scb_rdchk_rx_pid_err=%0b", cfg.en_scb_rdchk_rx_pid_err));
     cfg.en_scb_rdchk_rx_crc_err = 1'b1;
     void'($value$plusargs("en_scb_rdchk_rx_crc_err=%0b", cfg.en_scb_rdchk_rx_crc_err));
+    cfg.en_scb_rdchk_rx_bitstuff_err = 1'b1;
+    void'($value$plusargs("en_scb_rdchk_rx_bitstuff_err=%0b", cfg.en_scb_rdchk_rx_bitstuff_err));
 
     super.build_phase(phase);
     // Bus Functional Model of USBDEV.
@@ -421,11 +425,17 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
                 // because `usb_fs_rx` can sample the SE0 state of a spontaneous Bus Reset and
                 // complete the PID even though not all of the PID bits were transmitted. The CRC
                 // can simply be a false positive match, particularly the CRC5 of a token packet.
+                // Reporting of bit stuffing violations is a similar situation to that with PID
+                // bits; whether or not they will be detected and reported is data-dependent.
                 if (!cfg.en_scb_rdchk_rx_crc_err) include_field = 1'b0;
               end
               "rx_pid_err": begin
                 // See `rx_crc_err` above.
                 if (!cfg.en_scb_rdchk_rx_pid_err) include_field = 1'b0;
+              end
+              "rx_bitstuff_err": begin
+                // See `rx_crc_err` above.
+                if (!cfg.en_scb_rdchk_rx_bitstuff_err) include_field = 1'b0;
               end
               // Most interrupts should be reflected almost immediately.
               default: begin

--- a/hw/ip/usbdev/dv/env/usbdev_timed_regs.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_timed_regs.sv
@@ -80,7 +80,7 @@ class usbdev_timed_regs extends uvm_object;
 
   // This process checks every prediction that is made, using backdoor csr_rd in zero time to avoid
   // interfering with actual CSR reads and the timing of the simulation.
-  task check_predictions();
+  task check_predictions(ref bit under_reset);
     // Collect the initial values post-reset.
     wait (clk_rst_vif.rst_n === 1'b1);
     forever begin
@@ -92,7 +92,11 @@ class usbdev_timed_regs extends uvm_object;
       // Check each of the timed registers for expired expectations.
       r = r.first();
       forever begin
-        if (timed[r].preds_pending()) begin
+        if (under_reset) begin
+          `uvm_info(`gfn, $sformatf("Resetting timed register predictions at 0x%0x", time_now),
+                    UVM_LOW)
+          timed[r].reset();
+        end else if (timed[r].preds_pending()) begin
           uvm_reg_data_t act_data;
           // Something is expected to happen to this register field.
           read_act_data(r, act_data);

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -541,6 +541,23 @@
       name: usbdev_stream_len_max
       uvm_test_seq: usbdev_stream_len_max_vseq
     }
+    {
+      name: usbdev_tx_rx_disruption
+      uvm_test_seq: usbdev_tx_rx_disruption_vseq
+      // Monitor and model cannot be used to predict with absolute certainty when a PID/CRC error
+      // will be reported when truncating a packet transmission to the DUT because `usb_fs_rx` can
+      // sample the SE0 state of a spontaneous Bus Reset and complete the PID even though not all
+      // of the PID bits were transmitted. The CRC can simply be a false positive match,
+      // particularly the CRC5 of a token packet.
+      // We also cannot readily predict whether we shall raise a `link_in_err` by issuing a bus
+      // reset during an IN DATA packet.
+      run_opts: [
+        "+en_scb_rdchk_rx_pid_err=0",
+        "+en_scb_rdchk_rx_crc_err=0",
+        "+en_scb_rdchk_link_in_err=0"
+      ]
+      reseed: 500
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -551,10 +551,14 @@
       // particularly the CRC5 of a token packet.
       // We also cannot readily predict whether we shall raise a `link_in_err` by issuing a bus
       // reset during an IN DATA packet.
+      // Reliable prediction of reported bit stuffing violations would require examination of the
+      // OUT traffic to the device prior to the instant of a Bus Reset or VBUS Disconnection.
+      // These notifications are just informative in any case.
       run_opts: [
         "+en_scb_rdchk_rx_pid_err=0",
         "+en_scb_rdchk_rx_crc_err=0",
-        "+en_scb_rdchk_link_in_err=0"
+        "+en_scb_rdchk_link_in_err=0",
+        "+en_scb_rdchk_rx_bitstuff_err=0"
       ]
       reseed: 500
     }


### PR DESCRIPTION
This PR adds a sequence that subjects the DUT to USB Bus Resets or IP block resets during the transmission or reception of packet data. Although the relevant logic in the module `usb_fs_tx.sv` is very simple the fact that bus resets were disjoint with packet transmission meant that a number of state transitions were not observed in coverage collection.

The sequence additionally uses the IP block reset and then reconfigures the DUT to ensure that it is possible to resume communication by receiving and transmitting packets. This is less of a concern than the idea that an inopportunely-timed USB Bus Reset might break packet reception/transmission logic or the OUT/IN packet engine state machines.

~~**The first commit belongs to PR #24206**~~