### PR TITLE
[csrng/dv] Properly trigger the status error responses

### DIFF
--- a/hw/ip/csrng/dv/cov/csrng_cov_if.sv
+++ b/hw/ip/csrng/dv/cov/csrng_cov_if.sv
@@ -212,8 +212,12 @@ interface csrng_cov_if (
     }
 
     cp_sw_cmd_sts_cmd_sts: coverpoint u_reg.sw_cmd_sts_cmd_sts_qs {
-      bins success = { 1'b0 };
-      bins error   = { 1'b1 };
+      bins success             = { CMD_STS_SUCCESS };
+      bins invalid_acmd        = { CMD_STS_INVALID_ACMD };
+      // TODO(#24224): Uncomment or delete this line based on the decision in the issue.
+      // bins invalid_gen_cmd     = { CMD_STS_INVALID_GEN_CMD };
+      bins invalid_cmd_seq     = { CMD_STS_INVALID_CMD_SEQ };
+      bins reseed_cnt_exceeded = { CMD_STS_RESEED_CNT_EXCEEDED };
     }
 
   endgroup : csrng_sts_cg

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -66,6 +66,15 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   int NApps = NHwApps + 1;
   int Sp2VWidth = 3;
 
+  rand csrng_pkg::acmd_e which_cmd_inv_seq;
+  constraint  which_cmd_inv_seq_c { which_cmd_inv_seq inside {INS, RES, GEN, UPD};}
+
+  rand csrng_pkg::acmd_e which_invalid_acmd;
+  constraint  which_invalid_acmd_c { which_invalid_acmd inside {INV, GENB, GENU};}
+
+  rand bit [31:0] reseed_interval;
+  constraint  reseed_interval_c { reseed_interval inside {[1:10]};}
+
   rand uint   which_app_err_alert;
   constraint  which_app_err_alert_c { which_app_err_alert inside {[0:NApps-1]};}
 

--- a/hw/ip/edn/dv/cov/edn_cov_if.sv
+++ b/hw/ip/edn/dv/cov/edn_cov_if.sv
@@ -227,14 +227,11 @@ interface edn_cov_if (
     cp_recov_alert_cg: coverpoint recov_alert;
   endgroup : edn_alert_cg
 
-  covergroup edn_cs_cmd_response_cg with function sample(bit csrng_rsp_sts);
+  covergroup edn_cs_cmd_response_cg with function sample(csrng_pkg::csrng_cmd_sts_e csrng_rsp_sts);
     option.name         = "edn_cs_cmd_response_cg";
     option.per_instance = 1;
 
-    cp_csrng_rsp_sts_cg: coverpoint csrng_rsp_sts {
-      bins error   = { 1'b1 };
-      bins success = { 1'b0 };
-    }
+    cp_csrng_rsp_sts_cg: coverpoint csrng_rsp_sts;
   endgroup : edn_cs_cmd_response_cg
 
   covergroup edn_sw_cmd_sts_cg with function sample(bit cmd_rdy, bit cmd_reg_rdy,
@@ -356,7 +353,8 @@ interface edn_cov_if (
     end
   endfunction : cg_alert_sample
 
-  function automatic void cg_cs_cmd_response_sample(bit csrng_rsp_sts, bit csrng_rsp_ack);
+  function automatic void cg_cs_cmd_response_sample(csrng_pkg::csrng_cmd_sts_e csrng_rsp_sts,
+                                                    bit csrng_rsp_ack);
     if (csrng_rsp_ack) begin
       edn_cs_cmd_response_cg_inst.sample(csrng_rsp_sts);
     end


### PR DESCRIPTION
This PR changes the interrupt vseq to properly trigger the command error status responses instead of forcing the signals.

One thing we might need to discuss is that we run into issues where if a command with clen > 0 fails we don't absorb the whole command. This might be completely fine but still worth discussing.

Resolves #22869