### PR TITLE
[csrng/doc] Adapt the command status response documentation

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -404,6 +404,7 @@
                 The field is set to high once a SW command request has been acknowledged by the CSRNG.
                 0b0: The last SW command has not been acknowledged yet.
                 0b1: The last SW command has been acknowledged.
+                In case of a generate command the acknowledgement goes high after all of the requested entropy is consumed.
                 '''
           resval: "0"
         }
@@ -467,7 +468,7 @@
       fields: [
         { bits: "0",
           name: "GENBITS_VLD",
-          desc: "This bit is set when genbits are available on this application interface."
+          desc: "This bit is set when genbits are available on this application interface after a generate command has been issued."
         }
         { bits: "1",
           name: "GENBITS_FIPS",

--- a/hw/ip/csrng/doc/registers.md
+++ b/hw/ip/csrng/doc/registers.md
@@ -276,6 +276,7 @@ It is set to low each time a new command is written to [`CMD_REQ.`](#cmd_req)
 The field is set to high once a SW command request has been acknowledged by the CSRNG.
 0b0: The last SW command has not been acknowledged yet.
 0b1: The last SW command has been acknowledged.
+In case of a generate command the acknowledgement goes high after all of the requested entropy is consumed.
 
 ### SW_CMD_STS . CMD_RDY
 This bit indicates when the command interface is ready to accept commands.
@@ -295,11 +296,11 @@ Generate bits returned valid register
 {"reg": [{"name": "GENBITS_VLD", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "GENBITS_FIPS", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 140}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name         | Description                                                               |
-|:------:|:------:|:-------:|:-------------|:--------------------------------------------------------------------------|
-|  31:2  |        |         |              | Reserved                                                                  |
-|   1    |   ro   |    x    | GENBITS_FIPS | This bit is set when genbits are FIPS/CC compliant.                       |
-|   0    |   ro   |    x    | GENBITS_VLD  | This bit is set when genbits are available on this application interface. |
+|  Bits  |  Type  |  Reset  | Name         | Description                                                                                                        |
+|:------:|:------:|:-------:|:-------------|:-------------------------------------------------------------------------------------------------------------------|
+|  31:2  |        |         |              | Reserved                                                                                                           |
+|   1    |   ro   |    x    | GENBITS_FIPS | This bit is set when genbits are FIPS/CC compliant.                                                                |
+|   0    |   ro   |    x    | GENBITS_VLD  | This bit is set when genbits are available on this application interface after a generate command has been issued. |
 
 ## GENBITS
 Generate bits returned register

--- a/hw/ip/csrng/doc/theory_of_operation.md
+++ b/hw/ip/csrng/doc/theory_of_operation.md
@@ -284,8 +284,8 @@ The actions performed by each command, as well as which flags are supported, are
 #### Command Response
 
 Once a command has been completed, successfully or unsuccessfully, the CSRNG responds with a single cycle pulse on the `csrng_rsp_ack` signal associated with the same application interface port.
-If the command is successful, the `csrng_rsp_sts` signal will indicate the value 0 (`CSRNG_OK`) in the same cycle.
-Otherwise the application will receive the value 1 (`CSRNG_ERROR`) on the `csrng_rsp_sts` signal.
+If the command is successful, the `csrng_rsp_sts` signal will indicate the value 0 (`SUCCESS`) in the same cycle.
+Otherwise the application will receive an error value on the `csrng_rsp_sts` signal as described in [`SW_CMD_STS.CMD_STS`](registers.md#sw_cmd_sts).
 A number of exception cases to be considered are enumerated in NIST SP 800-90A, and may include events such as:
 * Failure of the entropy source
 * Attempts to use an instance which has not been properly instantiated, or


### PR DESCRIPTION
As discussed in #24193 this is the PR to adapt the documentation.