### PR TITLE
[dv,usbdev] Fix and extend suspend-related tests

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_aon_wake_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_aon_wake_vseq.sv
@@ -52,7 +52,7 @@ class usbdev_aon_wake_vseq extends usbdev_link_suspend_vseq;
     // Set up the DUT, do some minimal traffic and then check that the USBDEV has detected
     // and reported that it has been Suspended; `usbdev_link_suspend_vseq` supplies the
     // Suspend signaling.
-    super.body();
+    run_and_suspend();
 
     // Report configuration.
     `uvm_info(`gfn, $sformatf("do_resume_signaling %d do_reset_signaling %d do_vbus_disconnects %d",

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_resume_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_resume_vseq.sv
@@ -8,31 +8,82 @@ class usbdev_link_resume_vseq extends usbdev_link_suspend_vseq;
 
   `uvm_object_new
 
-  task body();
+  rand int unsigned link_resume_duration_usecs;
+
+  // Resume Signaling should be at least 20ms according to the protocol specification; there's
+  // really no need for that in simulation every time, though. Just make sure that it's covered.
+  constraint link_resume_duration_usecs_c {
+    (link_resume_duration_usecs >=  1_000 && link_resume_duration_usecs <  5_000) ||
+    (link_resume_duration_usecs >= 18_000 && link_resume_duration_usecs < 24_000);
+  }
+
+  // Check the assertion of the interrupt to indicate the presence of Resume Signaling; since the
+  // timing of this varies with whether we were active previously or just powered up, do it in
+  // parallel with the Resume Signaling itself.
+  task check_interrupt();
     uvm_reg_data_t link_state;
-
-    // Send transaction to make link active
-    super.body();
-
-    // Check that the DUT is presently Suspended.
     csr_rd(.ptr(ral.usbstat.link_state), .value(link_state));
-    `DV_CHECK_EQ(usbdev_link_state_e'(link_state), LinkSuspended)
+    case (link_state)
+      LinkSuspended, LinkResuming: begin
+        // If we're `Suspended` having being active, the interrupt should be asserted at the end of
+        // Resume Signaling to inform software.
+        wait_for_link_state({LinkActiveNoSOF}, .timeout_clks(link_resume_duration_usecs * 48),
+                            .fatal(1));
+      end
+      LinkPoweredSuspended, LinkPowered: begin
+        // If we're resuming having not been active since we powered up (return from Deep Sleep),
+        // the interrupt should occur immediately upon detection of Resume Signaling, to give the
+        // software time to reinstate the configuration and prepare for communication.
+      end
+      default: `uvm_fatal(`gfn, $sformatf("Unexpected link state 0x%0x", link_state))
+    endcase
 
-    // Ensure the interrupt is not presently asserted.
-    csr_wr(.ptr(ral.intr_state), .value(1 << IntrLinkResume));
-
-    // Ask the driver to Resume the DUT; Resume Signaling should be >= 20ms, which the usb20_driver
-    // will normally use by default, so we don't replicate the time delay here.
-    send_resume_signaling();
-
-    // The LinkResume interrupt should be raised at the end of the Resume Signaling, and thus be set
-    // almost immediately if not already.
+    // The interrupt should now have become asserted.
     wait_for_interrupt(1 << IntrLinkResume, .timeout_clks(8), .clear(0), .enforce(1));
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrLinkResume], 1'b1, "Interrupt line not asserted")
+
+    // If we were powered down then the DUT needs a nudge from software at this point before it
+    // will proceed to ActiveNoSOF.
+    if (link_state inside {LinkPoweredSuspended, LinkPowered}) begin
+      // Now prod the DUT into the Resuming state, which should be essentially immediate.
+      ral.usbctrl.resume_link_active.set(1'b1);
+      csr_update(ral.usbctrl);
+      wait_for_link_state({LinkResuming}, .timeout_clks(4), .fatal(1));
+    end
+  endtask
+
+  task body();
+    // Send transaction to make link active
+    run_and_suspend();
+
+    // Check that the DUT is presently (Powered)Suspended.
+    wait_for_link_state({LinkSuspended, LinkPoweredSuspended}, .timeout_clks(1), .fatal(1));
+
+    // Ensure the interrupt is not presently asserted, and then enable it.
+    csr_wr(.ptr(ral.intr_state), .value(1 << IntrLinkResume));
+    csr_wr(.ptr(ral.intr_enable), .value(1 << IntrLinkResume));
+    `DV_CHECK_EQ(cfg.intr_vif.pins[IntrLinkResume], 1'b0, "Interrupt line should not be asserted")
+
+    fork
+      // Ask the driver to Resume the DUT; Resume Signaling should be >= 20ms.
+      send_resume_signaling(link_resume_duration_usecs);
+      // Check for the assertion of the `link_resume` interrupt.
+      check_interrupt();
+    join
 
     // The USB should also be back in the Idle state, with no SOF having yet been transmitted.
-    csr_rd(.ptr(ral.usbstat.link_state), .value(link_state));
-    `DV_CHECK_EQ(usbdev_link_state_e'(link_state), LinkActiveNoSOF)
-    // Disable the interrupt before completing.
+    wait_for_link_state({LinkActiveNoSOF}, .timeout_clks(4), .fatal(1));
+
+    // Disable and clear the interrupt before completing.
     csr_wr(.ptr(ral.intr_enable), .value(0));
+    csr_wr(.ptr(ral.intr_state), .value(1 << IntrLinkResume));
+
+    // Disconnect us from the USB by removing the pullup; the link state change should be almost
+    // immediate.
+    usbdev_disconnect();
+    wait_for_link_state({LinkDisconnected}, .timeout_clks(4), .fatal(1));
+
+    // Disconnect VBUS too and we're done.
+    set_vbus_state(0);
   endtask
 endclass : usbdev_link_resume_vseq

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_suspend_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_link_suspend_vseq.sv
@@ -44,7 +44,8 @@ class usbdev_link_suspend_vseq extends usbdev_pkt_sent_vseq;
   //  (Start Of Frame packets are 1ms apart, and 32 bits in duration like other token packets.)
   uint inter_sof_delay_clks = 1_000 * 48 - (32 * 4);  // 4 times oversampling per bit.
 
-  task body();
+  // Configure, run and suspend the DUT; this task is called by derived sequences.
+  task run_and_suspend();
     // Declare our choices.
     `uvm_info(`gfn, $sformatf("Traffic %0d reset_not_suspended %0d reset_suspended %0d",
                               gen_traffic, gen_reset_not_suspended, gen_reset_suspended), UVM_LOW)
@@ -111,6 +112,10 @@ class usbdev_link_suspend_vseq extends usbdev_pkt_sent_vseq;
     wait_for_interrupt(1 << IntrLinkSuspend, .timeout_clks(1), .clear(1), .enforce(1));
     // Disable the interrupt before completing.
     csr_wr(.ptr(ral.intr_enable), .value(0));
+  endtask
+
+  task body();
+    run_and_suspend();
 
     // Shall we try generating a Bus Reset from the `(Powered)Suspended` state?
     if (gen_reset_suspended) begin

--- a/hw/ip/usbdev/dv/env/usbdev_bfm.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_bfm.sv
@@ -345,13 +345,19 @@ class usbdev_bfm extends uvm_component;
     if (wake_events.module_active) wake_events.bus_not_idle = 1'b1;
     if (powered) begin
       if (completed) begin
-        link_state = LinkActiveNoSOF;
+        if (link_state == LinkResuming) link_state = LinkActiveNoSOF;
         intr_state[IntrLinkResume] = 1'b1;
       end else begin
-        if (link_state == LinkSuspended || link_state == LinkPoweredSuspended) begin
-          link_state = LinkResuming;
-        end
-        if (link_state == LinkPoweredSuspended) intr_state[IntrLinkResume] = 1'b1;
+        case (link_state)
+          LinkSuspended: link_state = LinkResuming;
+          LinkPoweredSuspended: begin
+            link_state = LinkPowered;
+            intr_state[IntrLinkResume] = 1'b1;
+          end
+          default: begin
+            // Nothing to be done.
+          end
+        endcase
       end
     end
   endfunction


### PR DESCRIPTION
Modifications to `usbdev_link_suspend_vseq` induced failures in the derived sequences because it now exercises more functionality and tidies up after itself, disconnecting from the USB. Restructure the sequence so that the derived sequences once again function.

Extend the behavior of `usbdev_link_resume_vseq` to check both resuming when active and resuming from Deep Sleep (since `usbdev_link_suspend_vseq` now offers that), and also improve the interrupt-related checking.