### PR TITLE
[dv,usbdev] usbdev_resume_link_active uses randomization

### DIFF
--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -451,8 +451,7 @@
     {
       name: usbdev_resume_link_active
       uvm_test_seq: usbdev_resume_link_active_vseq
-      // No need for randomization.
-      reseed: 1
+      reseed: 20
     }
     {
       name: usbdev_rx_crc_err


### PR DESCRIPTION
The sequence `usbdev_resume_link_active` was recently modified and does now use randomization to control timing and state transitions.