### PR TITLE
[otbn,util] Add clobbered-register print mode for analyzer.

### DIFF
--- a/hw/ip/otbn/util/analyze_information_flow.py
+++ b/hw/ip/otbn/util/analyze_information_flow.py
@@ -25,6 +25,11 @@ def main() -> int:
         action='store_true',
         help=('Print full control-flow and information-flow graphs.'))
     parser.add_argument(
+        '--clobbered',
+        action='store_true',
+        help=('Print the clobbered registers as they would be in a docstring. '
+              'Unless --verbose is set, will not print full graph.'))
+    parser.add_argument(
         '--subroutine',
         required=False,
         help=(
@@ -91,7 +96,7 @@ def main() -> int:
 
     # If no secrets were given or the --verbose flag is set, then print the
     # full information-flow graphs.
-    if (args.verbose or args.secrets is None):
+    if (args.verbose or (args.secrets is None and not args.clobbered)):
         if ret_iflow.exists:
             print(
                 'Information flow for paths ending in a return to the caller:')
@@ -102,6 +107,13 @@ def main() -> int:
         if end_iflow.exists:
             print('Information flow for paths ending the program:')
             print(end_iflow.pretty(indent=2))
+
+    if args.clobbered:
+        if ret_iflow.exists:
+            print(ret_iflow.clobbered())
+        # If we have no secrets listed, then just finish here.
+        if args.secrets is None:
+            return 0
 
     if args.secrets is None:
         # If no initial secrets were provided, we will print all nodes that

--- a/hw/ip/otbn/util/shared/information_flow.py
+++ b/hw/ip/otbn/util/shared/information_flow.py
@@ -248,6 +248,77 @@ class InformationFlowGraph:
             'information-flow graph. Is the set of possible nodes larger '
             'than the maximum iterations?'.format(max_iterations))
 
+    def clobbered(self) -> str:
+        '''Return a human-readable description of clobbered registers and flags.
+
+        For example:
+        clobbered registers: x3 to x5, w2 to w10, acc
+        clobbered flag groups: FG0
+        '''
+        if not self.exists:
+            return 'Nonexistent information-flow graph (no possible paths).'
+
+        def _combine_ranges(nums):
+            '''Convert a list of numbers into a list of ranges.
+
+            For example, [1, 3, 4, 5] would become [(1, 1), (3,5)].
+            '''
+            if len(nums) == 0:
+                return []
+
+            ranges = []
+            start = nums[0]
+            end = nums[0]
+            for n in nums[1:]:
+                if n == end + 1:
+                    end = n
+                else:
+                    ranges.append((start, end))
+                    start = n
+                    end = n
+            ranges.append((start, end))
+            return ranges
+
+        def _stringify_range(prefix, r):
+            start, end = r
+            if start == end:
+                return f'{prefix}{start}'
+            return f'{prefix}{start} to {prefix}{end}'
+
+        # First transform the nodes into a list of special registers plus
+        # registers that may get represented as a range, stored as numbers.
+        special = []
+        flag_groups = set()
+        wregs = []
+        xregs = []
+        for sink in sorted(self.flow.keys()):
+            if sink == 'dmem' or sink == 'x1':
+                # Not real registers or flags, ignore
+                continue
+            elif sink.startswith('w') and sink[1:].isdigit():
+                wregs.append(int(sink[1:]))
+            elif sink.startswith('x') and sink[1:].isdigit():
+                xregs.append(int(sink[1:]))
+            elif sink.startswith('fg0'):
+                flag_groups.add('FG0')
+            elif sink.startswith('fg1'):
+                flag_groups.add('FG1')
+            else:
+                special.append(sink)
+
+        # Combine the ranges.
+        w_ranges = _combine_ranges(sorted(wregs))
+        x_ranges = _combine_ranges(sorted(xregs))
+
+        # Stringify ranges
+        regs = [_stringify_range('x', r) for r in x_ranges]
+        regs += [_stringify_range('w', r) for r in w_ranges]
+        regs += special
+        regs_line = '* clobbered registers: ' + ', '.join(regs)
+        flags_str = 'none' if len(flag_groups) == 0 else ', '.join(sorted(list(flag_groups)))
+        flags_line = '* clobbered flag groups: ' + flags_str
+        return regs_line + '\n' + flags_line
+
     def pretty(self, indent: int = 0) -> str:
         '''Return a human-readable representation of the graph.'''
         if not self.exists:


### PR DESCRIPTION
Convenience mode that prints the "clobbered register:" and "clobbered flag groups:" lines as they should appear in the docstring for OTBN functions.

Usage looks like:
```
 $ hw/ip/otbn/util/analyze_information_flow.py p256_ecdsa.elf --subroutine p256_sign --clobbered
* clobbered registers: x2 to x3, x10, x16, x18 to x22, w0 to w31, acc, mod
* clobbered flag groups: FG0
```

I've been meaning to do this for a long while, since it's a straightforward extension of the information-flow analyzer we already have and is helpful for writing and checking OTBN docstrings :slightly_smiling_face: 