### PR TITLE
[edn/dv] Add EDN endpoint requests while EDN is in error state

### DIFF
--- a/hw/ip/edn/dv/cov/edn_cov_if.sv
+++ b/hw/ip/edn/dv/cov/edn_cov_if.sv
@@ -305,6 +305,16 @@ interface edn_cov_if (
     }
   endgroup : edn_hw_cmd_sts_cg
 
+  covergroup edn_endpoint_err_req_cg with function sample(uint endpoint);
+    option.name         = "edn_endpoint_err_req_cg";
+    option.per_instance = 1;
+
+    // Create one bin per endpoint of EDN.
+    endpoint_cg: coverpoint endpoint {
+      bins range[MAX_NUM_ENDPOINTS] = {[0:MAX_NUM_ENDPOINTS-1]};
+    }
+  endgroup : edn_endpoint_err_req_cg
+
   `DV_FCOV_INSTANTIATE_CG(edn_cfg_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(edn_endpoints_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(edn_cs_cmds_cg, en_full_cov)
@@ -313,6 +323,7 @@ interface edn_cov_if (
   `DV_FCOV_INSTANTIATE_CG(edn_cs_cmd_response_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(edn_sw_cmd_sts_cg, en_full_cov)
   `DV_FCOV_INSTANTIATE_CG(edn_hw_cmd_sts_cg, en_full_cov)
+  `DV_FCOV_INSTANTIATE_CG(edn_endpoint_err_req_cg, en_full_cov)
 
   // Sample functions needed for xcelium
   function automatic void cg_cfg_sample(edn_env_cfg cfg);
@@ -373,5 +384,9 @@ interface edn_cov_if (
                                                    bit cmd_ack, csrng_pkg::acmd_e acmd);
     edn_hw_cmd_sts_cg_inst.sample(boot_mode, auto_mode, cmd_sts, cmd_ack, acmd);
   endfunction : cg_edn_hw_cmd_sts_sample
+
+  function automatic void cg_edn_endpoint_err_req_sample(uint endpoint);
+    edn_endpoint_err_req_cg_inst.sample(endpoint);
+  endfunction : cg_edn_endpoint_err_req_sample
 
 endinterface : edn_cov_if

--- a/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
@@ -41,7 +41,7 @@ class edn_alert_vseq extends edn_base_vseq;
     bit valid_d;
     bit valid, ready;
     bit [31:0] hw_cmd_sts_prev;
-    bit [CMD_TYPE_SIZE-1:0] cmd_type_prev;
+    csrng_pkg::acmd_e cmd_type_prev;
     bit auto_mode_prev;
     bit precise;
     csrng_pkg::acmd_e exp_cmd_type;
@@ -144,7 +144,8 @@ class edn_alert_vseq extends edn_base_vseq;
         end
         // Back up the previous value of hw_cmd_sts for the prediction.
         csr_rd(.ptr(ral.hw_cmd_sts), .value(hw_cmd_sts_prev), .backdoor(1));
-        cmd_type_prev = hw_cmd_sts_prev[hw_cmd_type+CMD_TYPE_SIZE-1:hw_cmd_type];
+        cmd_type_prev =
+            csrng_pkg::acmd_e'(hw_cmd_sts_prev[hw_cmd_type+CMD_TYPE_SIZE-1:hw_cmd_type]);
         auto_mode_prev = hw_cmd_sts_prev[hw_cmd_auto_mode];
         // The next acknowledgement should return an error status.
         cfg.m_csrng_agent_cfg.rsp_sts_err = cfg.which_cmd_sts_err;


### PR DESCRIPTION
For further information check out the individual commits.

I didn't add multiple requests per endpoint, since lowering the req signal would be a protocol violation.
Furthermore, I could add a more in depth coverage which checks if entropy requests happen in each main SM state.
However, to do this I think I would have to create a proper interface for the endpoint req/res signals, which would be more work.
@vogelpi should we create an issue for this?

Resolves [#19027](https://github.com/lowRISC/opentitan/issues/19027)