### PR TITLE
[flash/dv] Add back the exclude_info2 condition to legacy_base_vseq

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -29,7 +29,12 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
         rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
       }
     }
-    rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
+    // This added because in some extending env the info2 has special use.
+    if (cfg.seq_cfg.exclude_info2) {
+        rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo1] :/ 1};
+     } else {
+        rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
+     }
     rand_op.addr[TL_AW-1:BusAddrByteW] == 'h0;
     rand_op.addr[1:0] == 'h0;
     cfg.seq_cfg.addr_flash_word_aligned -> rand_op.addr[2] == 1'b0;

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_legacy_base_vseq.sv
@@ -29,7 +29,12 @@ class flash_ctrl_legacy_base_vseq extends flash_ctrl_otf_base_vseq;
         rand_op.partition == FlashPartInfo1 -> rand_op.op == flash_ctrl_pkg::FlashOpRead;
       }
     }
-    rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
+    // This added because in some extending env the info2 has special use.
+    if (cfg.seq_cfg.exclude_info2) {
+        rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo1] :/ 1};
+     } else {
+        rand_op.partition dist { FlashPartData := 1, [FlashPartInfo:FlashPartInfo2] :/ 1};
+     }
     rand_op.addr[TL_AW-1:BusAddrByteW] == 'h0;
     rand_op.addr[1:0] == 'h0;
     cfg.seq_cfg.addr_flash_word_aligned -> rand_op.addr[2] == 1'b0;


### PR DESCRIPTION
Hi,
This PR added back the recently removed exclude_info2 condition to flash_ctrl_legacy_base_vseq.
This condition is required because info2 has special use in the extending environment in which it can't be tested in those tests, so the flag added to allow running those tests without using info2 partition.
Thanks!