### PR TITLE
[sensor_ctrl] Renew D3 signoff

### DIFF
--- a/hw/top_earlgrey/ip/sensor_ctrl/doc/checklist.md
+++ b/hw/top_earlgrey/ip/sensor_ctrl/doc/checklist.md
@@ -104,8 +104,8 @@ Review        | [REVIEW_RTL][]          | Done        |
 Review        | [REVIEW_DELETED_FF][]   | Waived      | No block-level flow available - waived to top-level signoff.
 Review        | [REVIEW_SW_CHANGE][]    | Done        |
 Review        | [REVIEW_SW_ERRATA][]    | Done        |
-Review        | Reviewer(s)             | Done        | msf@ sriyer@ tjaychen@ a-will@
-Review        | Signoff date            | Done        | 2022-08-18
+Review        | Reviewer(s)             | Done        | adk@ vogelpi@
+Review        | Signoff date            | Done        | 2024-08-06
 
 [NEW_FEATURES_D3]:      ../../../../../doc/project_governance/checklist/README.md#new_features_d3
 [TODO_COMPLETE]:        ../../../../../doc/project_governance/checklist/README.md#todo_complete


### PR DESCRIPTION
sensor_ctrl's RTL changed since it had previously been signed off at D3.  This renews the D3 signoff, thus closes #22651.

This PR is currently a draft until the lint waiver has been reviewed by the TC and the SW-visible changes by the SW team.