### PR TITLE
[dv,usbdev] Introduce VBUS disconnect/reconnect to `usbdev_link_suspend`

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -292,11 +292,13 @@ class usb20_monitor extends dv_base_monitor #(
     int unsigned bit_cnt = 0;
     usb_symbol_e sym;
     bit valid;
-    collect_symbol(sym);
     // Scoreboard must be notified almost immediately that Resume Signaling has been detected but
     // is not yet completed, so that it can update its prediction of the link state. Resume
     // Signaling typically takes at least 20ms.
+    //
+    // Note that we have already collected a 'K' symbol at this point.
     resume_signaling_detected(1, .completed(1'b0));
+    collect_symbol(sym);
     while (sym == USB20Sym_K) begin
       bit_cnt++;
       collect_symbol(sym);


### PR DESCRIPTION
This PR introduces randomized VBUS disconnection and reconnection to the sequence `usbdev_link_suspend` and its derived sequences to increase the coverage of FSM transitions in the `usbdev_linkstate` module of the DUT.

It also fixes a subtle fault in the Resume Signaling from the monitor to the scoreboard which for some clock frequencies and sampling phases could arrive too late to predict the change in the `usbstat.link_state` field. The result was a test failure for a very small number of seeds; this was observed with one simulator when running a larger number of seeds to check for regressions in the altered sequences.
