### PR TITLE
[lc_ctrl] Move LC_CTRL version 2.0.0 design_stage to D3

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -17,7 +17,7 @@
   sw_checklist:       "/sw/device/lib/dif/dif_lc_ctrl",
   version:            "2.0.0",
   life_stage:         "L1",
-  design_stage:       "D2S",
+  design_stage:       "D3",
   verification_stage: "V2S",
   dif_stage:          "S2",
   clocking: [

--- a/hw/ip/lc_ctrl/doc/checklist.md
+++ b/hw/ip/lc_ctrl/doc/checklist.md
@@ -102,15 +102,15 @@ Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Done        |
 --------------|-------------------------|-------------|------------------
 Documentation | [NEW_FEATURES_D3][]     | Done        |
 RTL           | [TODO_COMPLETE][]       | Done        |
-Code Quality  | [LINT_COMPLETE][]       | Done        |
+Code Quality  | [LINT_COMPLETE][]       | Done        | Waiver files approved by TC on 2024-08-08.
 Code Quality  | [CDC_COMPLETE][]        | Waived      | No block-level flow available - waived to top-level signoff.
 Code Quality  | [RDC_COMPLETE][]        | Waived      | No block-level flow available - waived to top-level signoff.
 Review        | [REVIEW_RTL][]          | Done        |
 Review        | [REVIEW_DELETED_FF][]   | Waived      | No block-level flow available - waived to top-level signoff.
 Review        | [REVIEW_SW_CHANGE][]    | Done        |
 Review        | [REVIEW_SW_ERRATA][]    | Done        |
-Review        | Reviewer(s)             | Done        | msf@ rswarbrick@ chencindy@ ttrippel@
-Review        | Signoff date            | Done        | 2022-05-24
+Review        | Reviewer(s)             | Done        | rswarbrick@ vogelpi@
+Review        | Signoff date            | Done        | 2024-08-08
 
 [NEW_FEATURES_D3]:      ../../../../doc/project_governance/checklist/README.md#new_features_d3
 [TODO_COMPLETE]:        ../../../../doc/project_governance/checklist/README.md#todo_complete


### PR DESCRIPTION
This resolves lowRISC/OpenTitan#22480.

For now let's leave this as draft. The TC needs to review the updated lint waiver.