### PR TITLE
[kmac/dv] Extend timeout values for long running tests

### DIFF
--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -95,6 +95,7 @@
       name: "{name}_long_msg_and_output"
       uvm_test_seq: kmac_long_msg_and_output_vseq
       run_opts: ["+test_timeout_ns=10_000_000_000"]
+      run_timeout_mins: 90
     }
     {
       name: "{name}_sideload"
@@ -112,6 +113,7 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_sha3_variant=224"]
+      run_timeout_mins: 90
     }
     {
       name: "{name}_test_vectors_sha3_256"
@@ -119,6 +121,7 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_sha3_variant=256"]
+      run_timeout_mins: 90
     }
     {
       name: "{name}_test_vectors_sha3_384"
@@ -140,7 +143,7 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_shake_variant=128"]
-      run_timeout_mins: 120
+      run_timeout_mins: 180
     }
     {
       name: "{name}_test_vectors_shake_256"
@@ -148,7 +151,7 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_shake_variant=256"]
-      run_timeout_mins: 120
+      run_timeout_mins: 180
     }
     {
       name: "{name}_test_vectors_kmac"


### PR DESCRIPTION
As of lowRISC/OpenTitan#23942, the FIFO empty status-type interrupt is predicted and verified which unfortunately negatively impacts the simulation performance in some cases. Most tests are not notably impacted but for some rather long running tests, the maximum observed job runtime increased by up to 50%. As a result, we started seeing timeouts for some of these tests in the nightly regressions after merging the FIFO empty interrupt verification PR.

Therefore, this commit increases the timeout for those long running tests where we observed timeouts.

This resolves lowRISC/OpenTitan#24225.