### PR TITLE
[sival] Assign `kmac_app_rom_test` to `rom_ctrl_digest` test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -76,6 +76,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: ["//sw/device/tests:kmac_app_rom_test"]
     }
   ]
 }


### PR DESCRIPTION
This was called out in https://github.com/lowRISC/opentitan/pull/22604 to satisfy both tests, so adding the `bazel` label here. There was also discussion of merging the testpoints in the two plans into one, but for now I'm just going to assign the test to both.