### PR TITLE
[sival] Assign `gpio_pinmux_test` to padctrl tests

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -121,6 +121,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
+      bazel: ["//sw/device/tests:gpio_pinmux_test"]
     }
     {
       name: chip_padctrl_attributes
@@ -140,6 +141,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
+      bazel: ["//sw/device/tests:gpio_pinmux_test"]
     }
     {
       name: chip_sw_sleep_pin_mio_dio_val


### PR DESCRIPTION
The `gpio_pinmux_test` mostly covers the `chip_pin_mux` testpoint since it systematically tests muxing all the MIOs to GPIO. It does not test the DIOs.

The test also mostly covers the `chip_padctrl_attributes` testpoint by testing the `invert` attribute on all MIOs. It does not test this on the DIOs and it does not test other attributes such as drive strength, slew, etc.

@moidx is this enough to assign the test to these two points?