### PR TITLE
[rom_ext] Set the boot slot on every boot

### DIFF
--- a/sw/device/silicon_creator/lib/boot_log.c
+++ b/sw/device/silicon_creator/lib/boot_log.c
@@ -71,8 +71,7 @@ rom_error_t boot_log_check(const boot_log_t *boot_log) {
   return kErrorBootLogInvalid;
 }
 
-void boot_log_check_or_init(boot_log_t *boot_log, uint32_t rom_ext_slot,
-                            const chip_info_t *info) {
+void boot_log_check_or_init(boot_log_t *boot_log, const chip_info_t *info) {
   rom_error_t error = boot_log_check(boot_log);
   if (launder32(error) == kErrorOk) {
     HARDENED_CHECK_EQ(error, kErrorOk);
@@ -82,8 +81,8 @@ void boot_log_check_or_init(boot_log_t *boot_log, uint32_t rom_ext_slot,
   boot_log->chip_version.scm_revision_low = info->scm_revision.scm_revision_low;
   boot_log->chip_version.scm_revision_high =
       info->scm_revision.scm_revision_high;
-  boot_log->rom_ext_slot = rom_ext_slot;
-  boot_log->bl0_slot = 0;  // Unknown: no BL0 slot selected yet.
+  boot_log->rom_ext_slot = 0;  // To be filled in by the ROM_EXT.
+  boot_log->bl0_slot = 0;      // Unknown: no BL0 slot selected yet.
   for (size_t i = 0; i < ARRAYSIZE(boot_log->reserved); ++i) {
     boot_log->reserved[i] = 0;
   }

--- a/sw/device/silicon_creator/lib/boot_log.h
+++ b/sw/device/silicon_creator/lib/boot_log.h
@@ -108,11 +108,9 @@ rom_error_t boot_log_check(const boot_log_t *boot_log);
  * Check the boot_log and initialize it if not yet initialized.
  *
  * @param boot_log A buffer that holds the boot_log.
- * @param rom_ext_slot The current ROM_EXT slot.
  * @param info A pointer to the chip_info_t structure in ROM.
  */
-void boot_log_check_or_init(boot_log_t *boot_log, uint32_t rom_ext_slot,
-                            const chip_info_t *info);
+void boot_log_check_or_init(boot_log_t *boot_log, const chip_info_t *info);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -788,7 +788,8 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
 
   // Initialize the boot_log in retention RAM.
   const chip_info_t *rom_chip_info = (const chip_info_t *)_chip_info_start;
-  boot_log_check_or_init(boot_log, rom_ext_current_slot(), rom_chip_info);
+  boot_log_check_or_init(boot_log, rom_chip_info);
+  boot_log->rom_ext_slot = rom_ext_current_slot();
   boot_log->rom_ext_major = self->version_major;
   boot_log->rom_ext_minor = self->version_minor;
   boot_log->rom_ext_size = CHIP_ROM_EXT_SIZE_MAX;


### PR DESCRIPTION
The function `boot_log_check_or_init` is meant to initialize the `boot_log` structure if it hasn't already been initialized.  This is meant to initialize the boot_log if the ROM doesn't (it doesn't on the earlgrey_es chip), however, it will also skip initialization if the boot_log is already initialized from a prior boot.

Initialize only portions of the boot_log that will be constant across boots.  Defer setting the `rom_ext_slot` to `rom_ext_start` and set it to the current boot slot on every boot.

Fixes: #23869