### PR TITLE
[dif,sensor_ctrl] Fix incorrect AST event validity range check

### DIFF
--- a/sw/device/lib/dif/dif_sensor_ctrl.c
+++ b/sw/device/lib/dif/dif_sensor_ctrl.c
@@ -18,8 +18,8 @@
  * as an argument.  This check is used in multiple places so use a helper
  * function.
  */
-static inline bool is_ast_event_invalid(dif_sensor_ctrl_event_idx_t event_idx) {
-  return event_idx > SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS;
+static inline bool is_ast_event_valid(dif_sensor_ctrl_event_idx_t event_idx) {
+  return event_idx < SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS;
 }
 
 /**
@@ -46,8 +46,7 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_sensor_ctrl_get_ast_event_trigger(
     const dif_sensor_ctrl_t *sensor_ctrl, dif_sensor_ctrl_event_idx_t event_idx,
     dif_toggle_t *enable) {
-  if (sensor_ctrl == NULL || is_ast_event_invalid(event_idx) ||
-      enable == NULL) {
+  if (sensor_ctrl == NULL || !is_ast_event_valid(event_idx) || enable == NULL) {
     return kDifBadArg;
   };
 
@@ -62,7 +61,7 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_sensor_ctrl_set_ast_event_trigger(
     const dif_sensor_ctrl_t *sensor_ctrl, dif_sensor_ctrl_event_idx_t event_idx,
     dif_toggle_t enable) {
-  if (sensor_ctrl == NULL || is_ast_event_invalid(event_idx)) {
+  if (sensor_ctrl == NULL || !is_ast_event_valid(event_idx)) {
     return kDifBadArg;
   };
 
@@ -79,7 +78,7 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_sensor_ctrl_set_alert_en(const dif_sensor_ctrl_t *sensor_ctrl,
                                           dif_sensor_ctrl_event_idx_t event_idx,
                                           dif_toggle_t en) {
-  if (sensor_ctrl == NULL || is_ast_event_invalid(event_idx)) {
+  if (sensor_ctrl == NULL || !is_ast_event_valid(event_idx)) {
     return kDifBadArg;
   };
 
@@ -99,7 +98,7 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_sensor_ctrl_set_alert_fatal(
     const dif_sensor_ctrl_t *sensor_ctrl, dif_sensor_ctrl_event_idx_t event_idx,
     dif_toggle_t en_fatal) {
-  if (sensor_ctrl == NULL || is_ast_event_invalid(event_idx)) {
+  if (sensor_ctrl == NULL || !is_ast_event_valid(event_idx)) {
     return kDifBadArg;
   };
 
@@ -133,7 +132,7 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_sensor_ctrl_clear_recov_event(
     const dif_sensor_ctrl_t *sensor_ctrl,
     dif_sensor_ctrl_event_idx_t event_idx) {
-  if (sensor_ctrl == NULL || is_ast_event_invalid(event_idx)) {
+  if (sensor_ctrl == NULL || !is_ast_event_valid(event_idx)) {
     return kDifBadArg;
   };
 

--- a/sw/device/lib/dif/dif_sensor_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sensor_ctrl_unittest.cc
@@ -30,7 +30,7 @@ class SensorCtrlTest : public Test, public MmioTest {
 
 TEST_F(SensorCtrlTest, BadArgs) {
   uint32_t good_idx = 0;
-  uint32_t bad_idx = SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS + 1;
+  uint32_t bad_idx = SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS;
   dif_toggle_t toggle_arg{};
   dif_sensor_ctrl_events_t events_arg{};
   dif_sensor_ctrl_io_power_status_t power_arg{};


### PR DESCRIPTION
The `sensor_ctrl` DIF currently uses the following range check to determine if a supplied alert event is valid: https://github.com/lowRISC/opentitan/blob/51852781d790a158784169effa7b785ba689612f/sw/device/lib/dif/dif_sensor_ctrl.c#L22
However, the actual values of `event_idx` that are intended to be valid are those between `0` and `SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS - 1` inclusive.

This introduces a bug where an `event_idx` of `event_idx == SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS` can be given, resulting in a valid bitfield read (returns `kDifOk`) despite the fact that reading this bit is not defined.

This bug was not caught by the existing `dif_sensor_ctrl_unittest.cc` because it also makes this error, initialising an out-of-bounds index arg as follows: https://github.com/lowRISC/opentitan/blob/51852781d790a158784169effa7b785ba689612f/sw/device/lib/dif/dif_sensor_ctrl_unittest.cc#L33

This unit test itself defines `0` as a "good" event index, meaning that an `event_idx` of `SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS` should not be allowed per this test. Adding the following line to the `BadArgs`  test causes the test to fail as expected:
```c
EXPECT_DIF_BADARG(dif_sensor_ctrl_get_ast_event_trigger(
    &sensor_ctrl, SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS, &toggle_arg));
```

This PR instead replaces the function with an opposite `is_ast_event_valid` function, to improve the readability of the DIF code using the function (avoiding semantic double negation if we did any validity checks). As a result, it changes the comparison to be `<` instead of the `>=` that this fix requires.

This has been tested using:
```bash
./bazelisk.sh test -t- //sw/device/lib/dif:sensor_ctrl_unittest
```