### PR TITLE
[dv,usbdev] Delayed response to IN token packets in model

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_iso_retraction_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_iso_retraction_vseq.sv
@@ -180,5 +180,10 @@ class usbdev_iso_retraction_vseq extends usbdev_base_vseq;
       end
     end
     if (pkts_rcvd != pkts_sent) `uvm_fatal(`gfn, "Device- and host-side do not agree")
+
+    // Deactivate the DUT.
+    usbdev_disconnect();
+    csr_wr(.ptr(ral.in_iso[0].iso[ep_default]), .value(1'b0));
+    csr_wr(.ptr(ral.ep_in_enable[0].enable[ep_default]), .value(1'b0));
   endtask
 endclass : usbdev_iso_retraction_vseq


### PR DESCRIPTION
This PR slightly delays the response to IN token packets within the device model, since the DUT does not respond immediately and there is a risk of CSR traffic introducing a discrepancy between the model and the DUT.

The timed-delay model is very simple at present but may later be extended to support other timed events such as detecting the absence of the host or violations of inter-packet delays.

The lack of temporal modeling was causing failures within the sequences `usbdev_iso_retraction` which heavily exercises CSR traffic and USB collection of Isochronous IN packets.

The PR also addresses the failure of that sequence to tidy up upon termination, which occasionally caused a failure in the interrupt clearing in `cip_base_vseq`. With this PR the sequence `usbdev_iso_retraction` has now been seen to pass successfully for 100 random seeds.