### PR TITLE
 [manuf] add more personalization extension hooks

### DIFF
--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -133,14 +133,20 @@ static status_t personalize_gen_tpm_certificates(
   return OK_STATUS();
 }
 
-status_t personalize_extension(ujson_t *uj,
-                               manuf_certgen_inputs_t *certgen_inputs,
-                               manuf_certs_t *tbs_certs,
-                               cert_flash_info_layout_t *cert_flash_layout) {
+status_t personalize_extension_pre_cert_endorse(
+    ujson_t *uj, manuf_certgen_inputs_t *certgen_inputs,
+    manuf_certs_t *tbs_certs, cert_flash_info_layout_t *cert_flash_layout) {
   LOG_INFO("Running TPM perso extension ...");
   TRY(peripheral_handles_init());
   TRY(config_and_erase_tpm_certificate_flash_pages());
   TRY(personalize_gen_tpm_certificates(uj, certgen_inputs, tbs_certs,
                                        cert_flash_layout));
+  return OK_STATUS();
+}
+
+status_t personalize_extension_post_cert_endorse(
+    ujson_t *uj, manuf_certs_t *endorsed_certs,
+    cert_flash_info_layout_t *cert_flash_layout) {
+  /* Empty because it is unused but we still need to link to something. */
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/extensions/BUILD.bazel
+++ b/sw/device/silicon_creator/manuf/extensions/BUILD.bazel
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -41,12 +42,33 @@ cc_library(
     ],
 )
 
-_PERSO_EXTS = select({
+_DEVICE_PERSO_EXTS = select({
     "example_perso_ext_cfg": [":example_perso_fw_ext"],
     "//conditions:default": [":default_perso_fw_ext"],
 })
 
 cc_library(
     name = "perso_fw_ext",
-    deps = _PERSO_EXTS,
+    deps = _DEVICE_PERSO_EXTS,
+)
+
+rust_library(
+    name = "default_ft_ext_lib",
+    srcs = ["default_ft_ext_lib.rs"],
+    crate_name = "ft_ext_lib",
+    deps = [
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+    ],
+)
+
+rust_library(
+    name = "example_ft_ext_lib",
+    srcs = ["example_ft_ext_lib.rs"],
+    crate_name = "ft_ext_lib",
+    deps = [
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:log",
+    ],
 )

--- a/sw/device/silicon_creator/manuf/extensions/cfg.bzl
+++ b/sw/device/silicon_creator/manuf/extensions/cfg.bzl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+HOST_FT_EXTS = select({
+    "@provisioning_exts//:example_perso_ext_cfg": ["@provisioning_exts//:example_ft_ext_lib"],
+    "//conditions:default": ["@provisioning_exts//:default_ft_ext_lib"],
+})

--- a/sw/device/silicon_creator/manuf/extensions/default_ft_ext_lib.rs
+++ b/sw/device/silicon_creator/manuf/extensions/default_ft_ext_lib.rs
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+
+pub fn ft_ext(endorsed_cert_concat: ArrayVec<u8, 4096>) -> Result<ArrayVec<u8, 4096>> {
+    Ok(endorsed_cert_concat)
+}

--- a/sw/device/silicon_creator/manuf/extensions/default_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/extensions/default_personalize_ext.c
@@ -7,9 +7,14 @@
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 
-status_t personalize_extension(ujson_t *uj,
-                               manuf_certgen_inputs_t *certgen_inputs,
-                               manuf_certs_t *tbs_certs,
-                               cert_flash_info_layout_t *cert_flash_layout) {
+status_t personalize_extension_pre_cert_endorse(
+    ujson_t *uj, manuf_certgen_inputs_t *certgen_inputs,
+    manuf_certs_t *tbs_certs, cert_flash_info_layout_t *cert_flash_layout) {
+  return OK_STATUS();
+}
+
+status_t personalize_extension_post_cert_endorse(
+    ujson_t *uj, manuf_certs_t *endorsed_certs,
+    cert_flash_info_layout_t *cert_flash_layout) {
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/extensions/example_ft_ext_lib.rs
+++ b/sw/device/silicon_creator/manuf/extensions/example_ft_ext_lib.rs
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+
+pub fn ft_ext(endorsed_cert_concat: ArrayVec<u8, 4096>) -> Result<ArrayVec<u8, 4096>> {
+    log::info!("Running example host FT extension ...");
+    Ok(endorsed_cert_concat)
+}

--- a/sw/device/silicon_creator/manuf/extensions/example_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/extensions/example_personalize_ext.c
@@ -8,10 +8,16 @@
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 
-status_t personalize_extension(ujson_t *uj,
-                               manuf_certgen_inputs_t *certgen_inputs,
-                               manuf_certs_t *tbs_certs,
-                               cert_flash_info_layout_t *cert_flash_layout) {
-  LOG_INFO("Running example perso extension ...");
+status_t personalize_extension_pre_cert_endorse(
+    ujson_t *uj, manuf_certgen_inputs_t *certgen_inputs,
+    manuf_certs_t *tbs_certs, cert_flash_info_layout_t *cert_flash_layout) {
+  LOG_INFO("Running example pre-cert-endorsement perso extension ...");
+  return OK_STATUS();
+}
+
+status_t personalize_extension_post_cert_endorse(
+    ujson_t *uj, manuf_certs_t *endorsed_certs,
+    cert_flash_info_layout_t *cert_flash_layout) {
+  LOG_INFO("Running example post-cert-endorsement perso extension ...");
   return OK_STATUS();
 }

--- a/sw/host/provisioning/ft_lib/BUILD
+++ b/sw/host/provisioning/ft_lib/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@provisioning_exts//:cfg.bzl", "HOST_FT_EXTS")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -26,5 +27,5 @@ rust_library(
         "@crate_index//:serde_json",
         "@crate_index//:sha2",
         "@crate_index//:zerocopy",
-    ],
+    ] + HOST_FT_EXTS,
 )

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -16,6 +16,7 @@ use zerocopy::AsBytes;
 use cert_lib::{
     get_cert_size, parse_and_endorse_x509_cert, validate_certs_chain, CertEndorsementKey,
 };
+use ft_ext_lib::ft_ext;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg};
 use opentitanlib::io::jtag::{JtagParams, JtagTap};
@@ -254,6 +255,12 @@ fn provision_certificates(
         // info pages match those verified on the host.
         cert_hasher.update(cert_bytes);
     }
+
+    // Execute extension hook.
+    endorsed_cert_concat = ft_ext(endorsed_cert_concat)?;
+
+    // Complete hash of all certs that will be sent back to the device and written to flash. This
+    // is used as integrity check on what will be written to flash.
     let host_computed_certs_hash = cert_hasher.finalize();
 
     // Send endorsed certificates back to the device.


### PR DESCRIPTION
This adds both:
1. a post-cert-endorsment perso extension hook to the perso firmware, and
2. a provisioning extension hook to the host side FT provisioning test harness,
that enables SKU owners to inject additional assets into the device that originate on the host side. This expands on the existing FT provisioning test harness that only enabled endorsing certificates the device had originally sent the host.

CC: @tommychiu-github 