### PR TITLE
Revert "[dv] Add a quick exit in csr_rd_sub when in reset"

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -348,16 +348,6 @@ package csr_utils_pkg;
       status = UVM_IS_OK;
       return;
     end
-
-    // If we are under reset then we want to respond instantly with a bad return value and
-    // UVM_NOT_OK, rather than blocking indefinitely on the bus.
-    if (under_reset) begin
-      `uvm_info(msg_id, "Early-exit from csr_rd_sub because we are in reset", UVM_LOW)
-      value = '1;
-      status = UVM_NOT_OK;
-      return;
-    end
-
     fork
       begin : isolation_fork
         csr_field_t   csr_or_fld;


### PR DESCRIPTION
This reverts commit b400b907d0891418ad4e12e05e6213e68a01391c.

The change there sort of made sense: if there's a reset when we're doing a CSR operation, it's probably more defensible to return with a silly answer than to block indefinitely. Unfortunately, this doesn't quite work with the pwrmgr DV code, which seems to set the under_reset flag well before it causes a reset (and the code doesn't seem to clear it again either).

Thinking harder about the problem, I think the correct behaviour should probably be that the driver/monitor are in charge of responding quickly when they see a reset on the interface in question. Revert the (badly thought out) initial change from me in the meantime.

Fixes #24214.