### PR TITLE
[ci] add GitHub actions private CI

### DIFF
--- a/.github/workflows/private-ci.yml
+++ b/.github/workflows/private-ci.yml
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Private CI
+
+on:
+  push:
+    branches-ignore:
+      - "backport-*"
+    tags:
+      - "*"
+  pull_request_target:
+    branches:
+      - "*"
+
+permissions:
+  contents: write # For repository dispatch
+
+jobs:
+  trigger:
+    name: Trigger Private CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Private CI
+        run: |
+          PAYLOAD='"target":"${{ github.repository_owner }}/opentitan-private-ci/master/private-ci.yml","sha":"${{ github.event.pull_request.head.sha || github.sha }}"'
+          if ${{ github.event_name == 'pull_request_target' }}; then
+            PAYLOAD+=',"pull_request":${{ github.event.pull_request.number }}'
+          fi
+          curl -fL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d '{"event_type":"cross-repo-ci","client_payload":{'"$PAYLOAD"'}}'
+
+      - name: Trigger AscentLint CI
+        run: |
+          PAYLOAD='"target":"${{ github.repository_owner }}/opentitan-realintent-ci/main/ascentlint-ci.yml","sha":"${{ github.event.pull_request.head.sha || github.sha }}"'
+          if ${{ github.event_name == 'pull_request_target' }}; then
+            PAYLOAD+=',"pull_request":${{ github.event.pull_request.number }}'
+          fi
+          curl -fL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d '{"event_type":"cross-repo-ci","client_payload":{'"$PAYLOAD"'}}'


### PR DESCRIPTION
This adds GitHub action based private CI for:
* AscentLint (replacing kokoro)
* Xcelium/VCS (replacing Azure pipeline-based private CI)

Both AZP and GitHub CI would still be side-by-side for a while before we decide to turn one off.

See https://github.com/lowRISC/ibex/blob/master/.github/workflows/private-ci.yml for a working example.