### PR TITLE
[dv,usbdev] Ensure all endpoint types see PRE.

### DIFF
--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_low_speed_traffic_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_low_speed_traffic_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class usbdev_low_speed_traffic_vseq extends usbdev_max_non_iso_usb_traffic_vseq;
+class usbdev_low_speed_traffic_vseq extends usbdev_max_usb_traffic_vseq;
   `uvm_object_utils(usbdev_low_speed_traffic_vseq)
 
   `uvm_object_new

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_spray_packets_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_spray_packets_vseq.sv
@@ -140,7 +140,13 @@ class usbdev_spray_packets_vseq extends usbdev_base_vseq;
   task transaction_pre(bit acceptable, bit stall_expected, ref byte unsigned data[$],
                       output bit rx_expected);
     low_speed_traffic = 1'b1;
-    send_setup_packet(target_ep, data, target_addr);
+    // Send all three transaction types as if to a Low Speed device; downstream traffic to actual
+    // Low Speed device is propagated by hubs, but must be ignored by the DUT.
+    randcase
+      1: send_setup_packet(target_ep, data, target_addr);
+      1: send_token_packet(target_ep, PidTypeInToken, target_addr);
+      1: send_out_packet(target_ep, ($urandom & 1) ? PidTypeData1 : PidTypeData0, data);
+    endcase
     low_speed_traffic = 1'b0;
     // Low Speed traffic prefixed with a PRE token shall never be received!
     rx_expected = 0;

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -330,6 +330,10 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
     // PRE token used on the USB.
     if (handshake.low_speed) pid = PidTypePre;  // Coverage should show that PRE has been received.
     cov.pids_to_dut_cg.sample(pid);
+    // The endpoint to which the handshake is sent has been retained from the IN token packet.
+    if (bfm.tx_ep != usbdev_bfm::InvalidEP) begin
+      cov.data_tog_endp_cg.sample(handshake.m_pid_type, .dir_in(1'b1), .endp(bfm.tx_ep));
+    end
   endfunction
 
   // Collection of functional coverage for DUT responses.

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -294,6 +294,9 @@
     {
       name: usbdev_low_speed_traffic
       uvm_test_seq: usbdev_low_speed_traffic_vseq
+      // Model has no concept of elapsed time, and cannot change state in the
+      // absence of a missing USB host controller handshake (Isochronous IN traffic).
+      run_opts: ["+en_scb_rdchk_configin=0"]
     }
     {
       name: usbdev_max_inter_pkt_delay


### PR DESCRIPTION
The PRE special PID (used to shield Full Speed devices from Low Speed traffic) shall be seen by all endpoint types, and it shall produce no response/change in any.

Modify the existing sequences to ensure that all types of transactions may be sent as Low Speed traffic (with PREamble) to all types of endpoints, increasing testing and satisfying coverage points.

Low speed traffic sequence now derives directly from the max_usb_traffic sequence to ensure that Isochronous endpoints are also subjected to LS traffic.

There was also a failure to collect coverage for `data_tog_endp_cg` on handshake packets.