### PR TITLE
[dv,jtag] Teach jtag_dmi_reg_frontdoor to handle resets

### DIFF
--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_frontdoor.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_reg_frontdoor.sv
@@ -22,9 +22,8 @@ class jtag_dmi_reg_frontdoor extends uvm_reg_frontdoor;
 
   virtual task body();
     csr_field_t         csr_or_fld;
-    uvm_reg_data_t      wdata = 0, rdata;
+    uvm_reg_data_t      wdata = 0;
     jtag_dtm_reg_block  jtag_dtm_ral = jtag_agent_cfg_h.jtag_dtm_ral;
-    jtag_dmi_op_rsp_e   op_rsp;
 
     // Configure the JTAG agent to have a positive run-to-clear length, ensuring that DMI operations
     // make it from dmi_jtag to dm_top and back again before TCK stops.
@@ -75,41 +74,102 @@ class jtag_dmi_reg_frontdoor extends uvm_reg_frontdoor;
     // Start the DMI request.
     csr_wr(.ptr(jtag_dtm_ral.dmi), .value(wdata), .blocking(1), .predict(1));
 
-    // Wait 10 tck cycles to allow the DMI req to complete. If we read the DTM DMI register too
-    // soon, it may end up setting the in progress sticky bit, causing more time wasted.
-    jtag_agent_cfg_h.vif.wait_tck(10);
+    if (jtag_agent_cfg_h.in_reset) begin
+      `uvm_info(`gfn, "DMI operation aborted: reset happened in middle of request", UVM_HIGH)
+      jtag_dtm_ral_sem_h.put();
+      return;
+    end
 
-    // Poll for completion. Reset DMI if the sticky bit 'InProgress' is set.
-    `DV_SPINWAIT_EXIT(
-      do begin
-        csr_rd(.ptr(jtag_dtm_ral.dmi), .value(rdata), .blocking(1));
-        op_rsp = jtag_dmi_op_rsp_e'(get_field_val(jtag_dtm_ral.dmi.op, rdata));
-        `uvm_info(`gfn, $sformatf("DMI CSR req status: %0s", op_rsp.name()), UVM_HIGH)
-        if (op_rsp == DmiOpInProgress) begin
-          csr_wr(.ptr(jtag_dtm_ral.dtmcs.dmireset), .value(1), .blocking(1), .predict(1));
-        end else begin
-          rw_info.status = op_rsp == DmiOpOk ? UVM_IS_OK : UVM_NOT_OK;
-          if (rw_info.kind == UVM_READ) begin
-            rdata = get_field_val(jtag_dtm_ral.dmi.data, rdata);
-            if (csr_or_fld.field != null) begin
-              rdata = get_field_val(csr_or_fld.field, rdata);
-            end
-            rw_info.value = new[1];
-            rw_info.value[0] = rdata;
-          end
+    // Wait 10 tck cycles to allow the DMI req to complete. If we read the DTM DMI register too
+    // soon, it may end up setting the in progress sticky bit, causing more time wasted. If there is
+    // a reset in the middle of the wait, stop immediately.
+    fork begin
+      fork
+        jtag_agent_cfg_h.vif.wait_tck(10);
+        wait(jtag_agent_cfg_h.in_reset);
+      join_any
+      disable fork;
+    end join
+    if (jtag_agent_cfg_h.in_reset) begin
+      `uvm_info(`gfn, "DMI operation aborted: reset happened in middle of request", UVM_HIGH)
+      jtag_dtm_ral_sem_h.put();
+      return;
+    end
+
+    // Do repeated reads of the DMI register to poll for completion, stopping early if we see a
+    // reset. Run this in parallel with a 10k TCK cycle wait so that we'll fail reasonably quickly
+    // if something gets completely stuck.
+    fork begin : isolation_fork
+      bit saw_completion = 1'b0;
+
+      fork
+        begin
+          poll_for_completion(jtag_dtm_ral, csr_or_fld.field);
+          saw_completion = 1'b1;
         end
-      end while (op_rsp == DmiOpInProgress);,
-      begin
-        fork
-          wait(jtag_agent_cfg_h.in_reset);
-          // TODO: Make timeout more configurable.
-          `DV_WAIT_TIMEOUT(jtag_agent_cfg_h.vif.tck_period_ps * 10_000_000 /*10 ms*/)
-        join_any
-      end
-    )
+        jtag_agent_cfg_h.vif.wait_tck(10_000);
+      join_any
+
+      // The DMI operation should have completed in the time we were waiting
+      `DV_CHECK(saw_completion)
+
+      disable fork;
+    end join
 
     `uvm_info(`gfn, $sformatf("DMI CSR req completed: %0s", rw_info.convert2string()), UVM_HIGH)
     jtag_dtm_ral_sem_h.put();
+  endtask
+
+  // Poll the DMI register over JTAG and wait until the operation is no longer in progress.
+  //
+  // When the operation completes, details are written to rw_info. If this is a read of a field
+  // (rather than an entire register), that should be passed as the field argument and this is used
+  // when constructing rdata.
+  //
+  // If there is a reset while we are waiting for completion, stop and set rw_info.status to
+  // UVM_NOT_OK.
+  task poll_for_completion(jtag_dtm_reg_block jtag_dtm_ral, uvm_reg_field field);
+    forever begin
+      uvm_reg_data_t    rdata;
+      jtag_dmi_op_rsp_e op_rsp;
+
+      // Try to read the DMI register over JTAG
+      csr_rd(.ptr(jtag_dtm_ral.dmi), .value(rdata), .blocking(1));
+
+      // If there was a JTAG reset in the meantime, set rw_info.status to UVM_NOT_OK and return.
+      if (jtag_agent_cfg_h.in_reset) begin
+        rw_info.status = UVM_NOT_OK;
+        return;
+      end
+
+      op_rsp = jtag_dmi_op_rsp_e'(get_field_val(jtag_dtm_ral.dmi.op, rdata));
+      `uvm_info(`gfn, $sformatf("DMI CSR req status: %0s", op_rsp.name()), UVM_HIGH)
+
+      // If op_rsp isn't DmiOpInProgress then the DMI operation has run to completion. Write the
+      // details of the response into rw_info and then return.
+      if (op_rsp != DmiOpInProgress) begin
+        rw_info.status = op_rsp == DmiOpOk ? UVM_IS_OK : UVM_NOT_OK;
+        if (rw_info.kind == UVM_READ) begin
+          rdata = get_field_val(jtag_dtm_ral.dmi.data, rdata);
+          if (field != null) begin
+            rdata = get_field_val(field, rdata);
+          end
+          rw_info.value = new[1];
+          rw_info.value[0] = rdata;
+        end
+        return;
+      end
+
+      // Otherwise, the operation was still in progress. Clear the (sticky) flag.
+      csr_wr(.ptr(jtag_dtm_ral.dtmcs.dmireset), .value(1), .blocking(1), .predict(1));
+
+      // Check there hasn't been a JTAG reset while we were clearing the "op in progress" flag. If
+      // not, we'll go around again (and read the DMI register again)
+      if (jtag_agent_cfg_h.in_reset) begin
+        rw_info.status = UVM_NOT_OK;
+        return;
+      end
+    end
   endtask
 
 endclass


### PR DESCRIPTION
This ensures that a DMI operation that is in flight will be aborted (rather than hanging) if a reset gets asserted.