### PR TITLE
[rv_dm,dv] Make lots of changes to vseqs to allow reset during a run

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_monitor.sv
+++ b/hw/dv/sv/jtag_agent/jtag_monitor.sv
@@ -179,7 +179,11 @@ class jtag_monitor extends dv_base_monitor #(
   virtual protected task monitor_reset();
     forever begin
       @(cfg.vif.trst_n);
+
       cfg.in_reset = !cfg.vif.trst_n;
+      if (cfg.in_reset) begin
+        cfg.jtag_dtm_ral.reset("HARD");
+      end
     end
   endtask
 

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -400,6 +400,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
     tl_sba_a_chan_fifo.flush();
     tl_sba_d_chan_fifo.flush();
     selected_dtm_csr = cfg.m_jtag_agent_cfg.jtag_dtm_ral.idcode;
+    cfg.jtag_dmi_ral.reset(kind);
   endfunction
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -201,8 +201,6 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     cfg.m_jtag_agent_cfg.vif.set_tck_period_ps(tck_period_ps);
     fork
       if (kind inside {"HARD", "TRST"}) begin
-        jtag_dtm_ral.reset("HARD");
-        jtag_dmi_ral.reset("HARD");
         cfg.m_jtag_agent_cfg.vif.do_trst_n();
       end
       if (kind inside {"HARD", "SCAN"}) apply_scan_reset();

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -260,9 +260,14 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   endtask
 
   // Stop running the m_tl_sba_device_seq seq.
+  //
+  // This is a no-op if the sequence is actually null (because we never completed dut_init, which
+  // would have constructed the object),
   virtual task sba_tl_device_seq_stop();
-    m_tl_sba_device_seq.seq_stop();
-    `uvm_info(`gfn, "Stopped running m_tl_sba_device_seq", UVM_MEDIUM)
+    if (m_tl_sba_device_seq != null) begin
+      m_tl_sba_device_seq.seq_stop();
+      `uvm_info(`gfn, "Stopped running m_tl_sba_device_seq", UVM_MEDIUM)
+    end
   endtask
 
   // Task forked off to disable TLUL host SBA assertions when injecting intg errors on the response

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -383,11 +383,12 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     `DV_CHECK_EQ(expected_dmistat, get_field_val(jtag_dtm_ral.dtmcs.dmistat, rdata))
   endtask
 
-  // Check that the cmderr field in abstractcs is as expected
+  // Check that the cmderr field in abstractcs is as expected, skipping the check if the system is
+  // in reset.
   task check_cmderr(cmderr_e cmderr_exp);
     abstractcs_t abstractcs;
     read_abstractcs(abstractcs);
-    `DV_CHECK_EQ(abstractcs.cmderr, cmderr_exp);
+    if (cfg.clk_rst_vif.rst_n) `DV_CHECK_EQ(abstractcs.cmderr, cmderr_exp);
   endtask
 
   // Clear the cmderr field of abstractcs.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -237,7 +237,8 @@ class rv_dm_base_vseq extends cip_base_vseq #(
     sba_tl_device_seq_stop();
     // Check for pending rv_dm operations and wait for them to complete.
     // TODO: Improve this later.
-    cfg.clk_rst_vif.wait_clks(200);
+    `DV_SPINWAIT_EXIT(cfg.clk_rst_vif.wait_clks(200);,
+                      wait (!cfg.clk_rst_vif.rst_n);)
   endtask
 
   // Spawns off a thread to auto-respond to incoming TL accesses on the SBA host interface.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_hard_reset_vseq.sv
@@ -17,18 +17,20 @@ class rv_dm_jtag_dtm_hard_reset_vseq extends rv_dm_base_vseq;
     csr_wr(.ptr(jtag_dmi_ral.progbuf[0]), .value(value));
   endtask
 
-  // Read abstractdata[0] over DMI and check it has the expected value
+  // Read abstractdata[0] over DMI and check it has the expected value (unless the system is in
+  // reset)
   task check_abstractdata0(bit [31:0] expected);
     uvm_reg_data_t rdata;
     csr_rd(.ptr(jtag_dmi_ral.abstractdata[0]), .value(rdata));
-    `DV_CHECK_EQ(rdata, expected)
+    if (cfg.clk_rst_vif.rst_n) `DV_CHECK_EQ(rdata, expected)
   endtask
 
-  // Read progbuf[0] over DMI and check it has the expected value
+  // Read progbuf[0] over DMI and check it has the expected value (unless the system is in
+  // reset)
   task check_progbuf0(bit [31:0] expected);
     uvm_reg_data_t rdata;
     csr_rd(.ptr(jtag_dmi_ral.progbuf[0]), .value(rdata));
-    `DV_CHECK_EQ(rdata, expected)
+    if (cfg.clk_rst_vif.rst_n) `DV_CHECK_EQ(rdata, expected)
   endtask
 
   task body();
@@ -40,6 +42,7 @@ class rv_dm_jtag_dtm_hard_reset_vseq extends rv_dm_base_vseq;
     set_progbuf0(progbuf_val);
     check_abstractdata0(abstractdata_val);
     check_progbuf0(progbuf_val);
+    if (!cfg.clk_rst_vif.rst_n) return;
 
     // Perform the hard reset
     csr_wr(.ptr(jtag_dtm_ral.dtmcs.dmihardreset), .value(1));

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_halted_vseq.sv
@@ -18,11 +18,16 @@ class rv_dm_mem_tl_access_halted_vseq extends rv_dm_base_vseq;
     // the flush state.
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(0));
 
-    // Verify that writing to HALTED causes anyhalted and allhalted to be set.
+    // Write to HALTED, which should cause anyhalted and allhalted to be set.
     request_halt();
     csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(r_data));
-    `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.dmstatus.anyhalted, r_data))
-    `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.dmstatus.allhalted, r_data))
+
+    // Assuming that we haven't entered reset (in which case r_data could be anything), check that
+    // anyhalted and allhalted are indeed set.
+    if (cfg.clk_rst_vif.rst_n) begin
+      `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.dmstatus.anyhalted, r_data))
+      `DV_CHECK_EQ(1, get_field_val(jtag_dmi_ral.dmstatus.allhalted, r_data))
+    end
   endtask : body
 
 endclass : rv_dm_mem_tl_access_halted_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -17,7 +17,7 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     `DV_CHECK_STD_RANDOMIZE_FATAL(data)
     csr_wr(.ptr(jtag_dtm_ral.idcode), .value(data));
     csr_rd(.ptr(jtag_dtm_ral.idcode), .value(data));
-    `DV_CHECK_EQ(data, RV_DM_JTAG_IDCODE)
+    if (cfg.clk_rst_vif.rst_n) `DV_CHECK_EQ(data, RV_DM_JTAG_IDCODE)
   endtask
 
   // Check that writing to haltreq controls the debug_req_o output.
@@ -33,7 +33,7 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     // need to wait because the write goes through a jtag_dmi_agent, which follows the write
     // operation with a read operation (polling) to check that it was applied.
 
-    `DV_CHECK_EQ(cfg.rv_dm_vif.cb.debug_req, data)
+    if (cfg.clk_rst_vif.rst_n) `DV_CHECK_EQ(cfg.rv_dm_vif.cb.debug_req, data)
   endtask
 
   // Check that the ndmreset field controls the ndmreset_req_o output
@@ -43,7 +43,7 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
   task check_ndmreset();
     uvm_reg_data_t data = $urandom_range(0, 1);
     csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(data));
-    `DV_CHECK_EQ(cfg.rv_dm_vif.cb.ndmreset_req, data)
+    if (cfg.clk_rst_vif.rst_n) `DV_CHECK_EQ(cfg.rv_dm_vif.cb.ndmreset_req, data)
   endtask
 
   // Verify that the dmstatus[*unavail] field tracks the unavailable_i input.
@@ -51,10 +51,12 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
     uvm_reg_data_t data = $urandom_range(0, 1);
     cfg.rv_dm_vif.cb.unavailable <= data;
     csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(data));
-    `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
-                 get_field_val(jtag_dmi_ral.dmstatus.anyunavail, data))
-    `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
-                 get_field_val(jtag_dmi_ral.dmstatus.allunavail, data))
+    if (cfg.clk_rst_vif.rst_n) begin
+      `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
+                   get_field_val(jtag_dmi_ral.dmstatus.anyunavail, data))
+      `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
+                   get_field_val(jtag_dmi_ral.dmstatus.allunavail, data))
+    end
   endtask
 
   // Verify that writing to dmactive causes dmactive output to be set.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_stress_all_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_stress_all_vseq.sv
@@ -49,6 +49,12 @@ class rv_dm_stress_all_vseq extends rv_dm_base_vseq;
       rv_dm_vseq.set_sequencer(p_sequencer);
       `DV_CHECK_RANDOMIZE_FATAL(rv_dm_vseq)
       rv_dm_vseq.start(p_sequencer);
+
+      // The subsequence might have applied a reset in dut_init (if do_apply_reset=1), but will
+      // normally have come out of reset by the end. If we are in reset now, that must mean that it
+      // has been applied from outside (probably in the stress_all_with_rand_reset vseq). Stop our
+      // vseq accordingly.
+      if (!cfg.clk_rst_vif.rst_n) return;
      end
    endtask
 


### PR DESCRIPTION
This is tied in with changes I'm making locally to allow a reset to happen more easily in the middle of a run (for the stress_all_with_rand_reset testpoint). When the base vseq is configured to allow these resets to occur, the changes in this PR are needed to avoid things falling apart.

This PR has quite a few commits (sorry!). All of them are new except for the first one, which is from #24138 (which I hadn't been chasing reviews for: oops).