### PR TITLE
[hw,dma] Add a chunk_done interrupt

### DIFF
--- a/hw/ip/dma/data/dma.hjson
+++ b/hw/ip/dma/data/dma.hjson
@@ -102,6 +102,10 @@
       desc: "DMA operation has been completed."
       type: "status"
     }
+    { name: "dma_chunk_done"
+      desc: "Indicates the transfer of a single chunk has been completed."
+      type: "status"
+    }
     { name: "dma_error"
       desc: "DMA error has occurred. DMA_STATUS.error_code register shows the details."
       type: "status"

--- a/hw/ip/dma/doc/registers.md
+++ b/hw/ip/dma/doc/registers.md
@@ -71,55 +71,58 @@
 Interrupt State Register
 - Offset: `0x0`
 - Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset mask: `0x7`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "dma_done", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "dma_error", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
+{"reg": [{"name": "dma_done", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "dma_chunk_done", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "dma_error", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 29}], "config": {"lanes": 1, "fontsize": 10, "vspace": 160}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name      | Description                                                               |
-|:------:|:------:|:-------:|:----------|:--------------------------------------------------------------------------|
-|  31:2  |        |         |           | Reserved                                                                  |
-|   1    |   ro   |   0x0   | dma_error | DMA error has occurred. DMA_STATUS.error_code register shows the details. |
-|   0    |   ro   |   0x0   | dma_done  | DMA operation has been completed.                                         |
+|  Bits  |  Type  |  Reset  | Name           | Description                                                               |
+|:------:|:------:|:-------:|:---------------|:--------------------------------------------------------------------------|
+|  31:3  |        |         |                | Reserved                                                                  |
+|   2    |   ro   |   0x0   | dma_error      | DMA error has occurred. DMA_STATUS.error_code register shows the details. |
+|   1    |   ro   |   0x0   | dma_chunk_done | Indicates the transfer of a single chunk has been completed.              |
+|   0    |   ro   |   0x0   | dma_done       | DMA operation has been completed.                                         |
 
 ## INTR_ENABLE
 Interrupt Enable Register
 - Offset: `0x4`
 - Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset mask: `0x7`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "dma_done", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "dma_error", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
+{"reg": [{"name": "dma_done", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "dma_chunk_done", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "dma_error", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 29}], "config": {"lanes": 1, "fontsize": 10, "vspace": 160}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name      | Description                                                         |
-|:------:|:------:|:-------:|:----------|:--------------------------------------------------------------------|
-|  31:2  |        |         |           | Reserved                                                            |
-|   1    |   rw   |   0x0   | dma_error | Enable interrupt when [`INTR_STATE.dma_error`](#intr_state) is set. |
-|   0    |   rw   |   0x0   | dma_done  | Enable interrupt when [`INTR_STATE.dma_done`](#intr_state) is set.  |
+|  Bits  |  Type  |  Reset  | Name           | Description                                                              |
+|:------:|:------:|:-------:|:---------------|:-------------------------------------------------------------------------|
+|  31:3  |        |         |                | Reserved                                                                 |
+|   2    |   rw   |   0x0   | dma_error      | Enable interrupt when [`INTR_STATE.dma_error`](#intr_state) is set.      |
+|   1    |   rw   |   0x0   | dma_chunk_done | Enable interrupt when [`INTR_STATE.dma_chunk_done`](#intr_state) is set. |
+|   0    |   rw   |   0x0   | dma_done       | Enable interrupt when [`INTR_STATE.dma_done`](#intr_state) is set.       |
 
 ## INTR_TEST
 Interrupt Test Register
 - Offset: `0x8`
 - Reset default: `0x0`
-- Reset mask: `0x3`
+- Reset mask: `0x7`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "dma_done", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "dma_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 30}], "config": {"lanes": 1, "fontsize": 10, "vspace": 110}}
+{"reg": [{"name": "dma_done", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "dma_chunk_done", "bits": 1, "attr": ["wo"], "rotate": -90}, {"name": "dma_error", "bits": 1, "attr": ["wo"], "rotate": -90}, {"bits": 29}], "config": {"lanes": 1, "fontsize": 10, "vspace": 160}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name      | Description                                                  |
-|:------:|:------:|:-------:|:----------|:-------------------------------------------------------------|
-|  31:2  |        |         |           | Reserved                                                     |
-|   1    |   wo   |   0x0   | dma_error | Write 1 to force [`INTR_STATE.dma_error`](#intr_state) to 1. |
-|   0    |   wo   |   0x0   | dma_done  | Write 1 to force [`INTR_STATE.dma_done`](#intr_state) to 1.  |
+|  Bits  |  Type  |  Reset  | Name           | Description                                                       |
+|:------:|:------:|:-------:|:---------------|:------------------------------------------------------------------|
+|  31:3  |        |         |                | Reserved                                                          |
+|   2    |   wo   |   0x0   | dma_error      | Write 1 to force [`INTR_STATE.dma_error`](#intr_state) to 1.      |
+|   1    |   wo   |   0x0   | dma_chunk_done | Write 1 to force [`INTR_STATE.dma_chunk_done`](#intr_state) to 1. |
+|   0    |   wo   |   0x0   | dma_done       | Write 1 to force [`INTR_STATE.dma_done`](#intr_state) to 1.       |
 
 ## ALERT_TEST
 Alert Test Register

--- a/hw/ip/dma/dv/env/dma_env_pkg.sv
+++ b/hw/ip/dma/dv/env/dma_env_pkg.sv
@@ -32,20 +32,21 @@ package dma_env_pkg;
   parameter uint HOST_DATA_WIDTH = 32;
   parameter uint SYS_ADDR_WIDTH = 64;
 
-  // Index of interrupt in intf_vif
-  // TODO: rename `DMA_x` to indicate that they are interrupt numbers.
-  parameter uint DMA_DONE = 0;
-  parameter uint DMA_CHUNK_DONE = 1;
-  parameter uint DMA_ERROR = 2;
-  parameter uint NumDmaInterrupts = 3;
+  // Index of interrupt in intf_vif and bits within `intr_` registers.
+  typedef enum {
+    IntrDmaDone = 0,
+    IntrDmaChunkDone,
+    IntrDmaError,
+    // Count of the number of used interrupts.
+    NumDmaInterrupts
+  } dma_intr_e;
 
   // Completion status bits (DV-internal)
   typedef enum {
     StatusDone,
     StatusChunkDone,
     StatusError,
-    StatusAborted,
-    StatusTimeout
+    StatusAborted
   } status_e;
   // Bitmask of completion reason(s)
   typedef uint status_t;

--- a/hw/ip/dma/dv/env/dma_env_pkg.sv
+++ b/hw/ip/dma/dv/env/dma_env_pkg.sv
@@ -35,12 +35,14 @@ package dma_env_pkg;
   // Index of interrupt in intf_vif
   // TODO: rename `DMA_x` to indicate that they are interrupt numbers.
   parameter uint DMA_DONE = 0;
-  parameter uint DMA_ERROR = 1;
-  parameter uint NumDmaInterrupts = 2;
+  parameter uint DMA_CHUNK_DONE = 1;
+  parameter uint DMA_ERROR = 2;
+  parameter uint NumDmaInterrupts = 3;
 
   // Completion status bits (DV-internal)
   typedef enum {
     StatusDone,
+    StatusChunkDone,
     StatusError,
     StatusAborted,
     StatusTimeout

--- a/hw/ip/dma/dv/env/dma_scoreboard.sv
+++ b/hw/ip/dma/dv/env/dma_scoreboard.sv
@@ -612,9 +612,10 @@ class dma_scoreboard extends cip_base_scoreboard #(
           if (curr_intr[i] !== exp_intr[i]) begin
             // Collect a list of the mismatched interrupts
             unique case (i)
-              DMA_DONE:      rsn = {rsn, "Done "};
-              DMA_ERROR:     rsn = {rsn, "Error "};
-              default:       rsn = {rsn, "Unknown intr"};
+              DMA_DONE:       rsn = {rsn, "Done "};
+              DMA_CHUNK_DONE: rsn = {rsn, "Chunk Done "};
+              DMA_ERROR:      rsn = {rsn, "Error "};
+              default:        rsn = {rsn, "Unknown intr"};
             endcase
           end
         end

--- a/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
+++ b/hw/ip/dma/dv/env/seq_lib/dma_generic_vseq.sv
@@ -276,6 +276,12 @@ class dma_generic_vseq extends dma_base_vseq;
           clear_done();
           status[StatusDone] = 1'b0;
         end
+        if (status[StatusChunkDone]) begin
+          // Clear STATUS.chunk_done bit and then clear the interrupt, if enabled.
+          clear_chunk_done();
+          clear_interrupts(1 << DMA_CHUNK_DONE);
+          status[StatusChunkDone] = 1'b0;
+        end
         if (status[StatusError]) begin
           // Clear STATUS.error condition and associcated interrupt.
           clear_errors(dma_config);

--- a/hw/ip/dma/dv/tb/tb.sv
+++ b/hw/ip/dma/dv/tb/tb.sv
@@ -50,9 +50,9 @@ module tb;
     .rst_ni (rst_n),
     .scanmode_i (prim_mubi_pkg::MuBi4False),
     .lsio_trigger_i (handshake_i),
-    .intr_dma_done_o (interrupts[DMA_DONE]),
-    .intr_dma_chunk_done_o (interrupts[DMA_CHUNK_DONE]),
-    .intr_dma_error_o (interrupts[DMA_ERROR]),
+    .intr_dma_done_o (interrupts[IntrDmaDone]),
+    .intr_dma_chunk_done_o (interrupts[IntrDmaChunkDone]),
+    .intr_dma_error_o (interrupts[IntrDmaError]),
     .alert_rx_i (alert_rx),
     .alert_tx_o (alert_tx),
     // TL Interface to OT Internal address space

--- a/hw/ip/dma/dv/tb/tb.sv
+++ b/hw/ip/dma/dv/tb/tb.sv
@@ -51,6 +51,7 @@ module tb;
     .scanmode_i (prim_mubi_pkg::MuBi4False),
     .lsio_trigger_i (handshake_i),
     .intr_dma_done_o (interrupts[DMA_DONE]),
+    .intr_dma_chunk_done_o (interrupts[DMA_CHUNK_DONE]),
     .intr_dma_error_o (interrupts[DMA_ERROR]),
     .alert_rx_i (alert_rx),
     .alert_tx_o (alert_tx),

--- a/hw/ip/dma/rtl/dma.sv
+++ b/hw/ip/dma/rtl/dma.sv
@@ -21,6 +21,7 @@ module dma
   input prim_mubi_pkg::mubi4_t                      scanmode_i,
   // DMA interrupts and incoming LSIO triggers
   output  logic                                     intr_dma_done_o,
+  output  logic                                     intr_dma_chunk_done_o,
   output  logic                                     intr_dma_error_o,
   input   lsio_trigger_t                            lsio_trigger_i,
   // Alerts
@@ -1004,6 +1005,7 @@ module dma
               // In non-hardware handshake mode, finishing one chunk should raise the done IRQ
               // and done bit, and release the go bit for the next FW-controlled chunk.
               clear_go     = !control_q.cfg_handshake_en;
+              chunk_done   = !control_q.cfg_handshake_en;
               ctrl_state_d = DmaIdle;
             end else begin
               ctrl_state_d = DmaAddrSetup;
@@ -1098,6 +1100,21 @@ module dma
     .hw2reg_intr_state_de_o ( hw2reg.intr_state.dma_done.de ),
     .hw2reg_intr_state_d_o  ( hw2reg.intr_state.dma_done.d  ),
     .intr_o                 ( intr_dma_done_o               )
+  );
+
+  prim_intr_hw #(
+    .IntrT ( "Status" )
+  ) u_intr_chunk_dma_done (
+    .clk_i                  ( clk_i                               ),
+    .rst_ni                 ( rst_ni                              ),
+    .event_intr_i           ( reg2hw.status.chunk_done.q          ),
+    .reg2hw_intr_enable_q_i ( reg2hw.intr_enable.dma_chunk_done.q ),
+    .reg2hw_intr_test_q_i   ( reg2hw.intr_test.dma_chunk_done.q   ),
+    .reg2hw_intr_test_qe_i  ( reg2hw.intr_test.dma_chunk_done.qe  ),
+    .reg2hw_intr_state_q_i  ( reg2hw.intr_state.dma_chunk_done.q  ),
+    .hw2reg_intr_state_de_o ( hw2reg.intr_state.dma_chunk_done.de ),
+    .hw2reg_intr_state_d_o  ( hw2reg.intr_state.dma_chunk_done.d  ),
+    .intr_o                 ( intr_dma_chunk_done_o               )
   );
 
   prim_intr_hw #(

--- a/hw/ip/dma/rtl/dma_reg_pkg.sv
+++ b/hw/ip/dma/rtl/dma_reg_pkg.sv
@@ -23,6 +23,9 @@ package dma_reg_pkg;
     } dma_error;
     struct packed {
       logic        q;
+    } dma_chunk_done;
+    struct packed {
+      logic        q;
     } dma_done;
   } dma_reg2hw_intr_state_reg_t;
 
@@ -30,6 +33,9 @@ package dma_reg_pkg;
     struct packed {
       logic        q;
     } dma_error;
+    struct packed {
+      logic        q;
+    } dma_chunk_done;
     struct packed {
       logic        q;
     } dma_done;
@@ -40,6 +46,10 @@ package dma_reg_pkg;
       logic        q;
       logic        qe;
     } dma_error;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } dma_chunk_done;
     struct packed {
       logic        q;
       logic        qe;
@@ -182,6 +192,10 @@ package dma_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } dma_chunk_done;
+    struct packed {
+      logic        d;
+      logic        de;
     } dma_error;
   } dma_hw2reg_intr_state_reg_t;
 
@@ -293,9 +307,9 @@ package dma_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    dma_reg2hw_intr_state_reg_t intr_state; // [1038:1037]
-    dma_reg2hw_intr_enable_reg_t intr_enable; // [1036:1035]
-    dma_reg2hw_intr_test_reg_t intr_test; // [1034:1031]
+    dma_reg2hw_intr_state_reg_t intr_state; // [1042:1040]
+    dma_reg2hw_intr_enable_reg_t intr_enable; // [1039:1037]
+    dma_reg2hw_intr_test_reg_t intr_test; // [1036:1031]
     dma_reg2hw_alert_test_reg_t alert_test; // [1030:1029]
     dma_reg2hw_src_addr_lo_reg_t src_addr_lo; // [1028:997]
     dma_reg2hw_src_addr_hi_reg_t src_addr_hi; // [996:965]
@@ -320,7 +334,7 @@ package dma_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    dma_hw2reg_intr_state_reg_t intr_state; // [701:698]
+    dma_hw2reg_intr_state_reg_t intr_state; // [703:698]
     dma_hw2reg_src_addr_lo_reg_t src_addr_lo; // [697:665]
     dma_hw2reg_src_addr_hi_reg_t src_addr_hi; // [664:632]
     dma_hw2reg_dst_addr_lo_reg_t dst_addr_lo; // [631:599]
@@ -396,8 +410,9 @@ package dma_reg_pkg;
   parameter logic [BlockAw-1:0] DMA_INTR_SRC_WR_VAL_10_OFFSET = 9'h 144;
 
   // Reset values for hwext registers and their fields
-  parameter logic [1:0] DMA_INTR_TEST_RESVAL = 2'h 0;
+  parameter logic [2:0] DMA_INTR_TEST_RESVAL = 3'h 0;
   parameter logic [0:0] DMA_INTR_TEST_DMA_DONE_RESVAL = 1'h 0;
+  parameter logic [0:0] DMA_INTR_TEST_DMA_CHUNK_DONE_RESVAL = 1'h 0;
   parameter logic [0:0] DMA_INTR_TEST_DMA_ERROR_RESVAL = 1'h 0;
   parameter logic [0:0] DMA_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] DMA_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;

--- a/sw/device/lib/dif/autogen/dif_dma_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_dma_autogen.c
@@ -54,6 +54,9 @@ static bool dma_get_irq_bit_index(dif_dma_irq_t irq,
     case kDifDmaIrqDmaDone:
       *index_out = DMA_INTR_COMMON_DMA_DONE_BIT;
       break;
+    case kDifDmaIrqDmaChunkDone:
+      *index_out = DMA_INTR_COMMON_DMA_CHUNK_DONE_BIT;
+      break;
     case kDifDmaIrqDmaError:
       *index_out = DMA_INTR_COMMON_DMA_ERROR_BIT;
       break;
@@ -65,6 +68,7 @@ static bool dma_get_irq_bit_index(dif_dma_irq_t irq,
 }
 
 static dif_irq_type_t irq_types[] = {
+    kDifIrqTypeStatus,
     kDifIrqTypeStatus,
     kDifIrqTypeStatus,
 };

--- a/sw/device/lib/dif/autogen/dif_dma_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_dma_autogen.h
@@ -79,9 +79,13 @@ typedef enum dif_dma_irq {
    */
   kDifDmaIrqDmaDone = 0,
   /**
+   * Indicates the transfer of a single chunk has been completed.
+   */
+  kDifDmaIrqDmaChunkDone = 1,
+  /**
    * DMA error has occurred. DMA_STATUS.error_code register shows the details.
    */
-  kDifDmaIrqDmaError = 1,
+  kDifDmaIrqDmaError = 2,
 } dif_dma_irq_t;
 
 /**

--- a/sw/device/lib/dif/autogen/dif_dma_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_dma_autogen_unittest.cc
@@ -156,7 +156,7 @@ TEST_F(AcknowledgeStateTest, NullArgs) {
 }
 
 TEST_F(AcknowledgeStateTest, AckSnapshot) {
-  constexpr uint32_t num_irqs = 2;
+  constexpr uint32_t num_irqs = 3;
   constexpr uint32_t irq_mask = (uint64_t{1} << num_irqs) - 1;
   dif_dma_irq_state_snapshot_t irq_snapshot = 1;
 


### PR DESCRIPTION
This PR adds a new chunk_done interrupt. This interrupt is raised for chunked mem2mem transfers when a single chunk is transferred and the SW needs to start the transfer of a new chunk. When transferring the last chunk, only the `done` interrupt is raised.

This PR is based upon https://github.com/lowRISC/opentitan/pull/24108