### PR TITLE
[tl,dv] Remove d_error check from bus2reg in reg adapter

### DIFF
--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -89,10 +89,6 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
     rw.data    = (rw.kind == UVM_WRITE) ? bus_rsp.a_data : bus_rsp.d_data;
     rw.byte_en = bus_rsp.a_mask;
     `DV_CHECK_EQ(bus_rsp.d_source, bus_rsp.a_source)
-    // expect d_error = 0 as we won't drive any error case through RAL
-    if (cfg.check_tl_errs) begin
-      `DV_CHECK_EQ(bus_rsp.d_error, 0)
-    end
     // indicate if the item is completed successfully for upper level to update predict value
     rw.status  = !bus_rsp.req_completed ? UVM_NOT_OK : UVM_IS_OK;
     `uvm_info(this.get_name(), {"tl_reg_adapter::bus2reg: ", bus_rsp.convert2string()}, UVM_HIGH)

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_debug_disabled_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_debug_disabled_vseq.sv
@@ -48,11 +48,6 @@ class rv_dm_debug_disabled_vseq extends rv_dm_base_vseq;
 
 
   task body();
-    // Disable TL error checks in tl_reg_adapter. It doesn't expect to see TL errors (since it's not
-    // doing anything untoward), but we've configured rv_dm to respond with an error to *every*
-    // request.
-    cfg.m_tl_agent_cfgs["rv_dm_mem_reg_block"].check_tl_errs = 0;
-
     repeat (4) begin
       // Pick an arbitrary value for lc_hw_debug_en_i other than On and then wait a short time to
       // make sure it has had an effect.


### PR DESCRIPTION
This was sitting in rather the wrong place: bus2reg shouldn't really be doing scoreboard checks. It was also failing for some rv_dm vseqs, which sent TL transactions when debug is disabled, which means they all get error responses.

This commit also removes the line that turns off this check in rv_dm_debug_disabled_vseq (because the check isn't there any more to be turned off)