### PR TITLE
[kmac/dv] Reduce test time spent on testing NIST test vectors

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_test_vectors_base_vseq.sv
@@ -18,6 +18,11 @@ class kmac_test_vectors_base_vseq extends kmac_smoke_vseq;
   task body();
     test_vectors_pkg::test_vectors_t vectors[];
 
+    // Randomly pick a single test vector set to limit test run time.
+    int test_idx = $urandom_range(0, test_list.size - 1);
+    test_list = {test_list[test_idx]};
+    `uvm_info(`gfn, $sformatf("test_idx = %0d", test_idx), UVM_MEDIUM)
+
     foreach (test_list[i]) begin
       // parse each test vector file
       test_vectors_pkg::get_hash_test_vectors(test_list[i], vectors);

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -114,6 +114,7 @@
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_sha3_variant=224"]
       run_timeout_mins: 90
+      reseed: 5
     }
     {
       name: "{name}_test_vectors_sha3_256"
@@ -122,6 +123,7 @@
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_sha3_variant=256"]
       run_timeout_mins: 90
+      reseed: 5
     }
     {
       name: "{name}_test_vectors_sha3_384"
@@ -129,6 +131,7 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_sha3_variant=384"]
+      reseed: 5
     }
     {
       name: "{name}_test_vectors_sha3_512"
@@ -136,6 +139,7 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_sha3_variant=512"]
+      reseed: 5
     }
     {
       name: "{name}_test_vectors_shake_128"
@@ -144,6 +148,7 @@
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_shake_variant=128"]
       run_timeout_mins: 180
+      reseed: 5
     }
     {
       name: "{name}_test_vectors_shake_256"
@@ -152,16 +157,19 @@
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_shake_variant=256"]
       run_timeout_mins: 180
+      reseed: 5
     }
     {
       name: "{name}_test_vectors_kmac"
       uvm_test_seq: kmac_test_vectors_kmac_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
+      reseed: 5
     }
     {
       name: "{name}_test_vectors_kmac_xof"
       uvm_test_seq: kmac_test_vectors_kmac_xof_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]
+      reseed: 5
     }
     {
       name: "{name}_app"


### PR DESCRIPTION
Previously, these tests were testing up to three complete test vector sets per test run, which could take several hours per run. And for each of these tests, we were running 50 seeds in the nightlies per default.

As these tests don't contribute much to the test coverage, this commit reduces the number of seeds per test. In addition, only one test vector set is tested per test run to reduce the time spent per run.

This is a follow-up of lowRISC/OpenTitan#24233. This resolves lowRISC/OpenTitan#24225.