### PR TITLE
[rv_dm,dv] Drop a wait from dut_shutdown

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -233,10 +233,6 @@ class rv_dm_base_vseq extends cip_base_vseq #(
 
   virtual task dut_shutdown();
     sba_tl_device_seq_stop();
-    // Check for pending rv_dm operations and wait for them to complete.
-    // TODO: Improve this later.
-    `DV_SPINWAIT_EXIT(cfg.clk_rst_vif.wait_clks(200);,
-                      wait (!cfg.clk_rst_vif.rst_n);)
   endtask
 
   // Spawns off a thread to auto-respond to incoming TL accesses on the SBA host interface.


### PR DESCRIPTION
The first commit is from #24265, which should be merged first. The second commit's message is below.

I'm splitting the commits like this because I *think* the combination is correct (and needed), but the first commit is *definitely* safe. Splitting like this means that things are a bit easier to debug if something goes wrong.

**[rv_dm,dv] Drop a wait from dut_shutdown**

I think the logic behind this was that a vseq might have started some operations and we want to wait for them to run to completion. I don't believe that there *are* any such operations in rv_dm's sequences and this just made the code more complicated. Drop it.