### PR TITLE
[rv_dm,dv] Fix condition for check in scoreboard

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -195,7 +195,7 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
 
       // If the debugger is not enabled and cfg.sba_tl_tx_requires_debug=1 then we should not have
       // seen the SBA item translate into a TL access.
-      if (cfg.sba_tl_tx_requires_debug) begin
+      if (cfg.sba_tl_tx_requires_debug && cfg.rv_dm_vif.lc_hw_debug_en != lc_ctrl_pkg::On) begin
         `DV_CHECK(sba_tl_access_q.size() == 0)
       end
 


### PR DESCRIPTION
Commit 9d5ec8c was supposed to weaken a check so that we don't require debug access for an SBA to come out if there's a magic flag set. (This is to handle fault injection tests).

But I got it wrong! And it is now checking that SBA transactions don't happen at all. Fix the mistake.