### PR TITLE
[bazel] Enable --build_tests_only globally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -148,3 +148,8 @@ build --flag_alias=ckms_cert_endorsement=//sw/device/silicon_creator/manuf/skus/
 
 # cquery output option.
 cquery --output=files
+
+# When test suites are specified in `bazel test`, only build the ones matching the tag filters.
+# This prevents having to build Verilator or an FPGA bitstream when not needed.
+# https://bazel.build/docs/user-manual#build-tests-only
+test --build_tests_only


### PR DESCRIPTION
When test suites are specified in `bazel test` (e.g. `//sw/device/tests/uart_smoketest` or `//sw/device/tests/...`), Bazel will build all the targets in that suite even if some are filtered out (e.g. with `--test_tag_filters=verilator`).

This flag causes Bazel to only build the tests that will be run.

This prevents having to build Verilator sims or FPGA bitstreams when they aren't needed.

https://bazel.build/docs/user-manual#build-tests-only
