### PR TITLE
[pentest] Add LC_CTRL FI tests

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -13,6 +13,7 @@ package(default_visibility = ["//visibility:public"])
 
 FIRMWARE_DEPS_FPGA = [
     "//sw/device/tests/penetrationtests/firmware/fi:ibex_fi",
+    "//sw/device/tests/penetrationtests/firmware/fi:lc_ctrl_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:otbn_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:rng_fi",
     "//sw/device/tests/penetrationtests/firmware/sca:aes_sca",
@@ -36,6 +37,7 @@ FIRMWARE_DEPS_FPGA = [
 
 FIRMWARE_DEPS_FI = [
     "//sw/device/tests/penetrationtests/firmware/fi:ibex_fi",
+    "//sw/device/tests/penetrationtests/firmware/fi:lc_ctrl_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:otbn_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:rng_fi",
     "//sw/device/tests/penetrationtests/firmware/lib:extclk_sca_fi",

--- a/sw/device/tests/penetrationtests/firmware/fi/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/fi/BUILD
@@ -28,6 +28,25 @@ cc_library(
 )
 
 cc_library(
+    name = "lc_ctrl_fi",
+    srcs = ["lc_ctrl_fi.c"],
+    hdrs = ["lc_ctrl_fi.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:rv_core_ibex_testutils",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/sca/lib:sca",
+        "//sw/device/tests/penetrationtests/firmware/lib:sca_lib",
+        "//sw/device/tests/penetrationtests/json:lc_ctrl_fi_commands",
+    ],
+)
+
+cc_library(
     name = "otbn_fi",
     srcs = ["otbn_fi.c"],
     hdrs = ["otbn_fi.h"],

--- a/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.c
@@ -1,0 +1,126 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/rv_core_ibex_testutils.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/penetrationtests/firmware/lib/sca_lib.h"
+#include "sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// NOP macros.
+#define NOP1 "addi x0, x0, 0\n"
+#define NOP10 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1
+#define NOP100 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10 NOP10
+
+static dif_rv_core_ibex_t rv_core_ibex;
+static dif_lc_ctrl_t lc;
+
+status_t handle_lc_ctrl_fi_init(ujson_t *uj) {
+  sca_select_trigger_type(kScaTriggerTypeSw);
+  // As we are using the software defined trigger, the first argument of
+  // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
+  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4 | kScaPeripheralCsrng);
+
+  // Disable the instruction cache and dummy instructions for FI attacks.
+  sca_configure_cpu();
+
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // Configure LC Controller.
+  mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
+  TRY(dif_lc_ctrl_init(lc_reg, &lc));
+
+  // Configure the alert handler. Alerts triggered by IP blocks are captured
+  // and reported to the test.
+  sca_configure_alert_handler();
+
+  // Read device ID and return to host.
+  penetrationtest_device_id_t uj_output;
+  TRY(sca_read_device_id(uj_output.device_id));
+  RESP_OK(ujson_serialize_penetrationtest_device_id_t, uj, &uj_output);
+
+  return OK_STATUS();
+}
+
+status_t handle_lc_ctrl_fi_runtime_corruption(ujson_t *uj) {
+  // Clear registered alerts in alert handler.
+  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
+
+  // Read LC CTRL to get reference values.
+  dif_lc_ctrl_state_t lc_state_ref;
+  uint8_t lc_count_ref;
+  TRY(dif_lc_ctrl_get_state(&lc, &lc_state_ref));
+  TRY(dif_lc_ctrl_get_attempts(&lc, &lc_count_ref));
+
+  sca_set_trigger_high();
+  asm volatile(NOP100);
+  asm volatile(NOP100);
+  asm volatile(NOP100);
+  sca_set_trigger_low();
+
+  // Get registered alerts from alert handler.
+  reg_alerts = sca_get_triggered_alerts();
+
+  // Check if we have managed to manipulate the LC Controller.
+  dif_lc_ctrl_state_t lc_state_cmp;
+  uint8_t lc_count_cmp;
+  TRY(dif_lc_ctrl_get_state(&lc, &lc_state_cmp));
+  TRY(dif_lc_ctrl_get_attempts(&lc, &lc_count_cmp));
+
+  // Do the comparison. Return res = 0 if no mismatch was detected. 1 is
+  // returned if only the lc_state was manipulated. 2 if only the counter was
+  // manipulated. 3 if state and counter was manipulated.
+  lc_ctrl_fi_corruption_t uj_output;
+  uj_output.res = 0;
+  if (lc_state_cmp != lc_state_ref) {
+    uj_output.res = 1;
+  }
+
+  if (lc_count_cmp != lc_count_ref) {
+    if (uj_output.res) {
+      uj_output.res = 3;
+    } else {
+      uj_output.res = 2;
+    }
+  }
+
+  // Read ERR_STATUS register from Ibex.
+  dif_rv_core_ibex_error_status_t err_ibx;
+  TRY(dif_rv_core_ibex_get_error_status(&rv_core_ibex, &err_ibx));
+
+  // Send result & ERR_STATUS to host.
+  uj_output.state = lc_state_cmp;
+  uj_output.counter = lc_count_cmp;
+  uj_output.err_status = err_ibx;
+  memcpy(uj_output.alerts, reg_alerts.alerts, sizeof(reg_alerts.alerts));
+  RESP_OK(ujson_serialize_lc_ctrl_fi_corruption_t, uj, &uj_output);
+
+  return OK_STATUS();
+}
+
+status_t handle_lc_ctrl_fi(ujson_t *uj) {
+  lc_ctrl_fi_subcommand_t cmd;
+  TRY(ujson_deserialize_lc_ctrl_fi_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kLcCtrlFiSubcommandInit:
+      return handle_lc_ctrl_fi_init(uj);
+    case kLcCtrlFiSubcommandRuntimeCorruption:
+      return handle_lc_ctrl_fi_runtime_corruption(uj);
+    default:
+      LOG_ERROR("Unrecognized LC CTRL FI subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/fi/lc_ctrl_fi.h
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_FI_LC_CTRL_FI_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_FI_LC_CTRL_FI_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+/**
+ * Initializes the trigger and configures the device for the LC CTRL FI test.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_lc_ctrl_fi_init(ujson_t *uj);
+
+/**
+ * lc_ctrl.runtime_corruption command handler.
+ *
+ * Try to manipulate the LC state and counter using FI.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_lc_ctrl_fi_runtime_corruption(ujson_t *uj);
+
+/**
+ * LC CTRL FI command handler.
+ *
+ * Command handler for the LC CTRL FI command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_lc_ctrl_fi(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_FI_LC_CTRL_FI_H_

--- a/sw/device/tests/penetrationtests/firmware/firmware.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware.c
@@ -17,6 +17,7 @@
 #include "sw/device/tests/penetrationtests/json/ibex_fi_commands.h"
 #include "sw/device/tests/penetrationtests/json/ibex_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/kmac_sca_commands.h"
+#include "sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h"
 #include "sw/device/tests/penetrationtests/json/otbn_fi_commands.h"
 #include "sw/device/tests/penetrationtests/json/prng_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/rng_fi_commands.h"
@@ -25,6 +26,7 @@
 
 // Include handlers
 #include "fi/ibex_fi.h"
+#include "fi/lc_ctrl_fi.h"
 #include "fi/otbn_fi.h"
 #include "fi/rng_fi.h"
 #include "lib/extclk_sca_fi.h"
@@ -56,6 +58,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kPenetrationtestCommandKmacSca:
         RESP_ERR(uj, handle_kmac_sca(uj));
+        break;
+      case kPenetrationtestCommandLCCtrlFi:
+        RESP_ERR(uj, handle_lc_ctrl_fi(uj));
         break;
       case kPenetrationtestCommandOtbnFi:
         RESP_ERR(uj, handle_otbn_fi(uj));

--- a/sw/device/tests/penetrationtests/firmware/firmware_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_fi.c
@@ -13,11 +13,13 @@
 // Include commands
 #include "sw/device/tests/penetrationtests/json/commands.h"
 #include "sw/device/tests/penetrationtests/json/ibex_fi_commands.h"
+#include "sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h"
 #include "sw/device/tests/penetrationtests/json/otbn_fi_commands.h"
 #include "sw/device/tests/penetrationtests/json/rng_fi_commands.h"
 
 // Include handlers
 #include "fi/ibex_fi.h"
+#include "fi/lc_ctrl_fi.h"
 #include "fi/otbn_fi.h"
 #include "fi/rng_fi.h"
 #include "lib/extclk_sca_fi.h"
@@ -34,6 +36,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kPenetrationtestCommandIbexFi:
         RESP_ERR(uj, handle_ibex_fi(uj));
+        break;
+      case kPenetrationtestCommandLCCtrlFi:
+        RESP_ERR(uj, handle_lc_ctrl_fi(uj));
         break;
       case kPenetrationtestCommandOtbnFi:
         RESP_ERR(uj, handle_otbn_fi(uj));

--- a/sw/device/tests/penetrationtests/json/BUILD
+++ b/sw/device/tests/penetrationtests/json/BUILD
@@ -13,6 +13,7 @@ cc_library(
         ":extclk_sca_fi_commands",
         ":ibex_fi_commands",
         ":kmac_sca_commands",
+        ":lc_ctrl_fi_commands",
         ":otbn_fi_commands",
         ":prng_sca_commands",
         ":sha3_sca_commands",
@@ -53,6 +54,13 @@ cc_library(
     name = "kmac_sca_commands",
     srcs = ["kmac_sca_commands.c"],
     hdrs = ["kmac_sca_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "lc_ctrl_fi_commands",
+    srcs = ["lc_ctrl_fi_commands.c"],
+    hdrs = ["lc_ctrl_fi_commands.h"],
     deps = ["//sw/device/lib/ujson"],
 )
 

--- a/sw/device/tests/penetrationtests/json/commands.h
+++ b/sw/device/tests/penetrationtests/json/commands.h
@@ -17,6 +17,7 @@ extern "C" {
     value(_, IbexFi) \
     value(_, IbexSca) \
     value(_, KmacSca) \
+    value(_, LCCtrlFi) \
     value(_, OtbnFi) \
     value(_, PrngSca) \
     value(_, RngFi) \

--- a/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.c
+++ b/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "lc_ctrl_fi_commands.h"

--- a/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/lc_ctrl_fi_commands.h
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_LC_CTRL_FI_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_LC_CTRL_FI_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define LCCTRLFI_SUBCOMMAND(_, value) \
+    value(_, Init) \
+    value(_, RuntimeCorruption)
+UJSON_SERDE_ENUM(LcCtrlFiSubcommand, lc_ctrl_fi_subcommand_t, LCCTRLFI_SUBCOMMAND);
+
+#define LCCTRLFI_CORRUPTION(field, string) \
+    field(res, uint32_t) \
+    field(state, uint32_t) \
+    field(counter, uint32_t) \
+    field(alerts, uint32_t, 3) \
+    field(err_status, uint32_t)
+UJSON_SERDE_STRUCT(LcCtrlFiCorruption, lc_ctrl_fi_corruption_t, LCCTRLFI_CORRUPTION);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_LC_CTRL_FI_COMMANDS_H_


### PR DESCRIPTION
This commit pulls over the lc_ctrl.runtime_corruption FI test from the pentest branch of nasahlpa/opentitan that has been used for the penetration testing.