### PR TITLE
[rv_dm,dv] Add a scanmode sequence

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -56,6 +56,7 @@ filesets:
       - seq_lib/rv_dm_hartsel_warl_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_buffered_enable_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_sparse_lc_gate_fsm_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_scanmode_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -187,9 +187,11 @@ class rv_dm_base_vseq extends cip_base_vseq #(
       end join
       if (!cfg.clk_rst_vif.rst_n) return;
 
-      // "Activate" the DM to facilitate ease of testing. This will exit early if there is a JTAG
-      // reset.
-      csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+      // "Activate" the DM to facilitate ease of testing, but only if not in scanmode (where the
+      // JTAG driver won't work properly). This will exit early if there is a JTAG reset.
+      if (!scanmode) begin
+        csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(1), .blocking(1), .predict(1));
+      end
     end
 
     // Start the SBA TL device seq.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -55,11 +55,6 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   //
   // A vseq that actually wants to exercise scanmode should override this constraint and turn it
   // back on.
-  //
-  // TODO(#23763): We don't currently run any tests with scanmode enabled. This is because doing so
-  //               changes the internal JTAG interface so that it is clocked from the main clock
-  //               instead of the jtag_if TCK. Muxing the tck signal in jtag_if isn't all that easy
-  //               because the jtag driver expects to be able to control it.
   constraint no_scanmode_c {
     scanmode == 1'b0;
   }

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_scanmode_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_scanmode_vseq.sv
@@ -1,0 +1,128 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A vseq that enables scanmode and sends a very simple JTAG transaction.
+//
+// This doesn't use the normal JTAG driver, because that driver expects to be able to *drive* TCK.
+// This doesn't really work in scanmode, where TCK is the main clk_i input.
+class rv_dm_scanmode_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_scanmode_vseq)
+  `uvm_object_new
+
+  // Override the base class constraint that would normally disable scanmode. We want to enable it.
+  constraint no_scanmode_c {
+    scanmode == 1'b1;
+  }
+
+  // Set tms/tdi as requested and then wait for the next negedge of clk (which gets to the
+  // corresponding negedge of TCK because we are in scanmode).
+  task tms_tdi(bit tms, bit tdi);
+    cfg.m_jtag_agent_cfg.vif.tms = tms;
+    cfg.m_jtag_agent_cfg.vif.tdi = tdi;
+    cfg.clk_rst_vif.wait_n_clks(1);
+  endtask
+
+  // Set tms as requested and drive a tdi of zero (which hopefully won't matter)
+  task send_tms(bit tms);
+    tms_tdi(tms, 0);
+  endtask
+
+  // Send value over IR or DR. td_o is collected and appears in the dout output argument.
+  //
+  // This task assumes we start in Select-*R-Scan, then completes back in Run-Test/Idle
+  task select_to_update(int unsigned value, int unsigned len, output logic [JTAG_DRW-1:0] dout);
+    `DV_CHECK_FATAL((value >> len) == 0)
+    `DV_CHECK_FATAL(len != 0)
+
+    send_tms(1'b0); // Capture-*R
+    send_tms(1'b0); // Shift-*R
+
+    dout = '0;
+
+    for (int i = 0; i < len; i++) begin
+      dout[i] = cfg.m_jtag_agent_cfg.vif.tdo;
+      tms_tdi(i == len - 1, value[i]);
+    end
+
+    send_tms(1'b1); // Update-*R
+    send_tms(1'b0); // Run-Test/Idle
+  endtask
+
+  // Send an IR or DR transaction with the given value.
+  //
+  // The task assumes that we start in Run-Test/Idle, then completes in the same state. Exits
+  // immediately on a system reset.
+  task send_xr(bit is_ir, int unsigned value, int unsigned len, output logic [JTAG_DRW-1:0] dout);
+    fork begin : isolation_fork
+      fork
+        begin
+          send_tms(1'b1);            // Select-DR-Scan
+          if (is_ir) send_tms(1'b1); // Select-IR-Scan
+          select_to_update(value, len, dout);
+        end
+        wait(!cfg.clk_rst_vif.rst_n);
+      join_any
+      disable fork;
+    end join
+  endtask
+
+  // Send an IR transaction with the given value.
+  //
+  // The task assumes that we start in Run-Test/Idle, then completes in the same state. Exits
+  // immediately on a system reset.
+  task send_ir(int unsigned value, int unsigned len);
+    logic [JTAG_DRW-1:0] dout;
+    send_xr(1'b1, value, len, dout);
+  endtask
+
+  // Send a DR transaction with the given value, sending td_o back in the dout argument.
+  //
+  // The task assumes that we start in Run-Test/Idle, then completes in the same state. Exits
+  // immediately on a system reset.
+  task send_dr(int unsigned value, int unsigned len, output logic [JTAG_DRW-1:0] dout);
+    send_xr(1'b0, value, len, dout);
+  endtask
+
+  task body();
+    logic [JTAG_DRW-1:0] data, dout;
+    int unsigned         len;
+
+    data = $urandom_range(0, 16'hffff);
+    len = 16;
+
+    // Wait for trst_n to go high, which should ensure that the JTAG connection has been made
+    // properly.
+    wait(cfg.m_jtag_agent_cfg.mon_vif.trst_n);
+
+    // Start by making sure the TAP fsm is in the Test-Logic/Reset state, then go to Run-Test/Idle.
+    // Exit early if there is a system reset.
+    fork begin : isolation_fork
+      fork
+        begin
+          repeat (5) tms_tdi(1'b1, 1'b0);
+          send_tms(0); // Go to Run-Test/Idle
+        end
+        wait(!cfg.clk_rst_vif.rst_n);
+      join_any
+      disable fork;
+    end join
+    if (!cfg.clk_rst_vif.rst_n) return;
+
+    // Select the BYPASS register (which has an IR of 0, different from the reset value, IDCODE).
+    // Exit immediately if we get to system reset.
+    `uvm_info(`gfn, "Selecting BYPASS register", UVM_LOW)
+    send_ir(8'h0, 8);
+    if (!cfg.clk_rst_vif.rst_n) return;
+
+    // Now write an arbitrary value and read it back out (shifted). Then exit if we get to system
+    // reset.
+    `uvm_info(`gfn, $sformatf("Writing arbitrary value (%0h) to BYPASS register", data), UVM_LOW)
+    send_dr(data, len, dout);
+    if (!cfg.clk_rst_vif.rst_n) return;
+
+    // The value that we read back out should equal the one we started with, with two zeros inserted
+    // at the bottom positions.
+    `DV_CHECK_EQ(dout, (data << 2) & 16'hffff)
+  endtask
+endclass

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -33,3 +33,4 @@
 `include "rv_dm_hartsel_warl_vseq.sv"
 `include "rv_dm_buffered_enable_vseq.sv"
 `include "rv_dm_sparse_lc_gate_fsm_vseq.sv"
+`include "rv_dm_scanmode_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -305,6 +305,11 @@
       reseed: 4
     }
     {
+      name: rv_dm_scanmode
+      uvm_test_seq: rv_dm_scanmode_vseq
+      reseed: 1
+    }
+    {
       name: rv_dm_stress_all
       uvm_test_seq: rv_dm_stress_all_vseq
     }


### PR DESCRIPTION
This is a (trivial) test to make sure that JTAG works as expected in scanmode.

Fixes #23763 (and should cover some conditions that we weren't seeing otherwise)