### PR TITLE
[bazel] add full bazel label to dep

### DIFF
--- a/rules/certificates.bzl
+++ b/rules/certificates.bzl
@@ -116,7 +116,7 @@ def certificate_template(name, template):
         srcs = [":{}_srcs".format(name)],
         hdrs = [":{}_hdrs".format(name)],
         deps = [
-            ":asn1",
+            "@//sw/device/silicon_creator/lib/cert:asn1",
         ],
     )
 


### PR DESCRIPTION
This adds the full bazel label to the `asn1` device lib dep when generating certificates to enable provisioning extension repos to make use of the upstream Bazel targets.