### PR TITLE
[rom_ext] Release ROM_EXT 0.4

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,8 +14,8 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "3",
-    SECURITY = "3",
+    MINOR = "4",
+    SECURITY = "4",
 )
 
 SLOTS = [


### PR DESCRIPTION
1. Set `boot_log.rom_ext_slot` on every boot.
2. Do not process `boot_svc` commands during low power wakeups.
3. Combine the `primary_bl0_slot` command into the `next_bl0_slot` command.