### PR TITLE
[entropy_src/dv] fix entropy drop assertions

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -863,16 +863,6 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
       $assertoff(0, tb.dut.u_entropy_src_core.Final_EsbitFifoPushedIntoPosthtFifo_A);
       $assertoff(0, tb.dut.u_entropy_src_core.AtReset_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
       $assertoff(0, tb.dut.u_entropy_src_core.Final_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
-      // TODO(#24103): Change rng_valid_bit_cnt_d to use the current value of enable
-      // instead of es_delayed_enable_q.
-      // If done, we can remove the two related assertoffs below.
-      $assertoff(0, tb.dut.u_entropy_src_core.AtReset_ValidRngBitsPushedIntoEsrngFifo_A);
-      $assertoff(0, tb.dut.u_entropy_src_core.Final_ValidRngBitsPushedIntoEsrngFifo_A);
-      // TODO(#24103): Replace esfinal_exp_drop by ~sfifo_esfinal_not_full, since the assumptions in
-      // the comments for esfinal_exp_drop are not true anymore.
-      // If done, we can remove the two related assertoffs below.
-      $assertoff(0, tb.dut.u_entropy_src_core.AtReset_EsfinalFifoPushedPostStartup_A);
-      $assertoff(0, tb.dut.u_entropy_src_core.Final_EsfinalFifoPushedPostStartup_A);
       // TODO(#24085): Remove this assertoff once the issue is solved.
       $assertoff(0, tb.dut.u_entropy_src_core.FifosEmptyWhenShaProcess_A);
     end


### PR DESCRIPTION
This commit changes a couple of assertions to not falsely trigger during max rate tests.

Closes [#24103](https://github.com/lowRISC/opentitan/issues/24103)