### PR TITLE
[rom_ctrl,dv] Make it possible to inject resets more easily

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -39,6 +39,8 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   function new (string name="");
     super.new(name);
 
+    can_reset_with_csr_accesses = 1'b1;
+
     list_of_alerts = rom_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal";
     ral_model_names.push_back("rom_ctrl_prim_reg_block");

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -84,14 +84,18 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
 
   // Read the digest[i] registers (computed by kmac) and the exp_digest[i] registers (which rom_ctrl
   // read from the top of the ROM). Check these registers all have their expected values.
+  //
+  // Exits early on a system reset.
   virtual task read_digest_regs();
     uvm_status_e status;
     for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
       ral.digest[i].mirror(.status(status), .check(UVM_CHECK));
+      if (!cfg.clk_rst_vif.rst_n) return;
       `DV_CHECK_EQ(status, UVM_IS_OK)
     end
     for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
       ral.exp_digest[i].mirror(.status(status), .check(UVM_CHECK));
+      if (!cfg.clk_rst_vif.rst_n) return;
       `DV_CHECK_EQ(status, UVM_IS_OK)
     end
   endtask


### PR DESCRIPTION
The important change is the second one (which should fix a bunch of failures in the stress_all_with_rand_reset sequence), but it needs the (reasonably trivial) first commit as well.