### PR TITLE
[dv] Allow assertions from ASSERT_FPV_LINEAR_FSM to complete

### DIFF
--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -179,7 +179,7 @@
        (!$stable(__state) & __name``_cond, initial_state = $past(__state)) |->                                   \
            (__state != initial_state) until (__rst == 1'b1);                                                     \
      endproperty                                                                                                 \
-   `ASSERT(__name, __name``_p, __clk, __rst)                                                                     \
+   `ASSERT(__name, __name``_p, __clk, 0)                                                                         \
   `endif
 
 `include "prim_assert_sec_cm.svh"


### PR DESCRIPTION
The assertion is supposed to start and say that we don't come back to a state until reset. Unfortunately, the implementation was disabling the property when reset happened, which meant that the assertion never finished, so it got marked as incomplete in the coverage.

Change the call to `ASSERT() so that it doesn't kill the property any more, relying on the fact that the property will terminate on its own once we go into reset.

This is associated with #24322, but I'm not marking the PR as fixing that issue because the "rom_ctrl assertions terminating" is addressed by a different PR.