### PR TITLE
Spi host timeout fixes and clkdiv testing

### DIFF
--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -68,8 +68,9 @@ class spi_host_base_vseq extends cip_base_vseq #(
   // Separate constraint to allow easy override in child sequences
   constraint spi_config_regs_clkdiv_c {
     spi_config_regs.clkdiv dist {
-      [cfg.seq_cfg.host_spi_min_clkdiv : cfg.seq_cfg.host_spi_lower_middle_clkdiv]      :/80,
-      [cfg.seq_cfg.host_spi_lower_middle_clkdiv+1 : cfg.seq_cfg.host_spi_middle_clkdiv] :/20
+      [cfg.seq_cfg.host_spi_min_clkdiv : cfg.seq_cfg.host_spi_lower_middle_clkdiv]      :/90,
+      [cfg.seq_cfg.host_spi_lower_middle_clkdiv+1 : cfg.seq_cfg.host_spi_middle_clkdiv] :/7,
+      [cfg.seq_cfg.host_spi_middle_clkdiv+1 : cfg.seq_cfg.host_spi_upper_middle_clkdiv] :/3
     };
   }
 
@@ -120,26 +121,132 @@ class spi_host_base_vseq extends cip_base_vseq #(
     super.pre_start();
   endtask : pre_start
 
-  // csr_spinwait wrapper to allow finer control of task fields
-  // Any VSEQ extending from these spi_host VSEQs which call csr_spinwait will have a custom timeout
-  virtual task automatic csr_spinwait(input  uvm_object        ptr,
-                                      input  uvm_reg_data_t    exp_data,
-                                      input  uvm_check_e       check = default_csr_check,
-                                      input  uvm_path_e        path = UVM_DEFAULT_PATH,
-                                      input  uvm_reg_map       map = null,
-                                      input  uvm_reg_frontdoor user_ftdr =
-                                                                 default_user_frontdoor,
-                                      input  uint              spinwait_delay_ns = 0,
-                                      input  uint              timeout_ns =
-                                                                 cfg.csr_spinwait_timeout_ns,
-                                      input  compare_op_e      compare_op = CompareOpEq,
-                                      input  bit               backdoor = 0,
-                                      input  uvm_verbosity     verbosity = UVM_HIGH);
-    csr_utils_pkg::csr_spinwait( .ptr(ptr), .exp_data(exp_data), .check(check), .path(path),
-                                 .map(map), .user_ftdr(user_ftdr),
-                                 .spinwait_delay_ns(spinwait_delay_ns),
-                                 .timeout_ns(timeout_ns), .compare_op(compare_op),
-                                 .backdoor(backdoor), .verbosity(verbosity));
+  // Like csr_spinwait, only the timeout can be stop by using an event.
+  // In addition, one needs to pass the clock cycle period.
+  // This can be used instead of csr_spinwait for moments in which the timeout needs to be
+  // controlled due to RTL conditions such as SW_rest or the module being disabled.
+  task automatic csr_spinwait_stoppable(
+    input   uvm_object ptr,
+    input   uvm_reg_data_t exp_data,
+    input   uvm_check_e check = default_csr_check,
+    input   uvm_path_e path = UVM_DEFAULT_PATH,
+    input   uvm_reg_map map = null,
+    input   uvm_reg_frontdoor user_ftdr = default_user_frontdoor,
+    input   uint spinwait_delay_ns = 0,
+    input   uint timeout_ns = default_spinwait_timeout_ns,
+    input   compare_op_e compare_op = CompareOpEq,
+    input   bit backdoor = 0,
+    input   uvm_verbosity verbosity = UVM_HIGH,
+    input   uint clk_cycle_period_ns,
+    input   string start_stop_ev_name = "start_stop_spinwait_ev"
+    );
+    static int     count;
+    count++;
+    `uvm_info($sformatf("%m()"),
+              $sformatf("- (call_count=%0d, backdoor=%0d, exp_data=%0d, ptr=%s)",
+                        count,backdoor,exp_data, ptr.get_name()), verbosity)
+    fork
+      begin : isolation_fork
+        fork
+          begin
+            csr_utils_pkg::csr_spinwait(.ptr(ptr),
+                                        .exp_data(exp_data),
+                                        .check(check),
+                                        .path(path),
+                                        .map(map),
+                                        .user_ftdr(user_ftdr),
+                                        .spinwait_delay_ns(spinwait_delay_ns),
+                                        // Timeout is 1000 longer than actual timeout so
+                                        // the stoppable timeout part of the fork below can
+                                        // block the count
+                                        .timeout_ns(timeout_ns*10000),
+                                        .compare_op(compare_op),
+                                        .backdoor(backdoor),
+                                        .verbosity(verbosity)
+                                        );
+          end
+          begin: timeout_block
+            stoppable_timeout(clk_cycle_period_ns, timeout_ns, start_stop_ev_name, exp_data,
+                              compare_op, ptr, count);
+          end : timeout_block
+        join_any
+        disable fork;
+      end : isolation_fork
+    join
+  endtask
+
+  // This task applies a timeout that can be stopped. It's used in situations where spi_host is
+  // disabled or when there is a SW reset
+  task stoppable_timeout(input uint clk_cycle_period_ns,
+                         input        uint timeout_ns,
+                         input string start_stop_ev_name,
+                         input        uvm_reg_data_t exp_data,
+                         input        compare_op_e compare_op,
+                         input        uvm_object ptr,
+                         input int    call_count
+                         );
+    int unsigned clk_cycles = 0;
+    csr_spinwait_ctrl_object obj;
+    uvm_event start_stop_spinwait_ev = uvm_event_pool::get_global(start_stop_ev_name);
+    csr_field_t csr_or_fld;
+
+    while ( (clk_cycles * clk_cycle_period_ns) <= timeout_ns) begin
+      clk_cycles++;
+      #(clk_cycle_period_ns * 1ns);
+      if (start_stop_spinwait_ev.is_on()) begin
+        uvm_object ev_obj;
+        // Event triggerred
+        ev_obj = start_stop_spinwait_ev.get_trigger_data();
+        if (!$cast(obj, ev_obj))
+          `uvm_fatal($sformatf("%m()"), "CAST FAILED")
+
+        if (obj.stop) begin
+          start_stop_spinwait_ev.wait_ptrigger_data(ev_obj);
+          `uvm_info($sformatf("%m"), "Event triggered to halt the timeout", UVM_DEBUG)
+          if (!$cast(obj, ev_obj))
+            `uvm_fatal($sformatf("%m()"), "CAST FAILED")
+          if(obj.stop)
+            `uvm_fatal($sformatf("%m"), "Event has already been triggered with stop=1")
+        end
+      end
+    end
+
+    csr_or_fld = decode_csr_or_field(ptr);
+    `uvm_fatal($sformatf("%m()"),
+               $sformatf({"timeout = %0dns %0s (addr=0x%0h,",
+                          " Comparison=%s, exp_data=0x%0h, call_count=%0d"} ,timeout_ns,
+                         ptr.get_full_name(), csr_or_fld.csr.get_address(),
+                         compare_op.name, exp_data, call_count))
+  endtask
+
+  // wrapping csr_spinwait over csr_spinwait_stoppable so we can stop the timeout
+  // count in circumstances like the RTL being disable due to spien or sw_rst.
+  virtual task automatic csr_spinwait( input  uvm_object        ptr,
+                                       input  uvm_reg_data_t    exp_data,
+                                       input  uvm_check_e       check = default_csr_check,
+                                       input  uvm_path_e        path = UVM_DEFAULT_PATH,
+                                       input  uvm_reg_map       map = null,
+                                       input  uvm_reg_frontdoor user_ftdr =
+                                                                default_user_frontdoor,
+                                       input  uint              spinwait_delay_ns = 0,
+                                       input  uint              timeout_ns =
+                                                                  cfg.csr_spinwait_timeout_ns,
+                                       input  compare_op_e      compare_op = CompareOpEq,
+                                       input  bit               backdoor = 0,
+                                       input  uvm_verbosity     verbosity = UVM_HIGH,
+                                       input  uint              clk_cycle_period_ns =
+                                                                  (cfg.clk_rst_vif.clk_period_ps
+                                                                  / 1000),
+                                       input  string start_stop_ev_name = "start_stop_spinwait_ev"
+                                      );
+    csr_spinwait_stoppable( .ptr(ptr), .exp_data(exp_data), .check(check),
+                            .path(path), .map(map), .user_ftdr(user_ftdr),
+                            .spinwait_delay_ns(spinwait_delay_ns),
+                            .timeout_ns(timeout_ns), .compare_op(compare_op),
+                            .backdoor(backdoor), .verbosity(verbosity),
+                            .clk_cycle_period_ns(clk_cycle_period_ns),
+                            .start_stop_ev_name("start_stop_spinwait_ev")
+                            );
   endtask
 
   // Start sequences on the spi_agent (configured as a Device) that will respond to host bus activity.

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_smoke_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_smoke_vseq.sv
@@ -21,6 +21,7 @@ class spi_host_smoke_vseq extends spi_host_tx_rx_vseq;
 
 
   virtual task body();
+    `uvm_info(`gfn, "Starting 'spi_host_smoke_vseq'", UVM_DEBUG)
     fork
       begin : isolation_fork
         fork
@@ -38,7 +39,11 @@ class spi_host_smoke_vseq extends spi_host_tx_rx_vseq;
         disable fork;
       end
       begin
-        read_rx_fifo();
+        wait (num_rd > 0 || spi_host_txn_sent);
+        // Only calling rd_rx_fifo if there are reads on the bus
+        // otherwise `rd_rx_fifo` will lock up
+        if (num_rd > 0)
+          read_rx_fifo();
       end
     join
   endtask : body

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_spien_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_spien_vseq.sv
@@ -20,14 +20,16 @@ class spi_host_spien_vseq extends spi_host_tx_rx_vseq;
 
   virtual task body();
     spi_host_status_t status;
-
+    csr_utils_pkg::csr_spinwait_ctrl_object spinwait_ctrl_obj;
+    bit rd_rx_fifo_finished;
+    spinwait_ctrl_obj = csr_spinwait_ctrl_object::type_id::create("spien_ctrl_obj");
     fork start_agent_reactive_seqs(); join_none
     wait_ready_for_command();
 
     fork
       begin
-        read_rx_fifo();
         // Read RXFIFO until STATUS.ACTIVE == 0
+        read_rx_fifo();
       end
       begin
         start_spi_host_trans(.num_transactions(3), .wait_ready(1));
@@ -43,8 +45,15 @@ class spi_host_spien_vseq extends spi_host_tx_rx_vseq;
 
         // Deassert CONTROL.SPIEN for a random length of time
         csr_wr(.ptr(ral.control.spien), .value(1'b0));
+        spinwait_ctrl_obj.stop = 1;
+        start_stop_spinwait_ev.trigger(spinwait_ctrl_obj);
+        `uvm_info(`gfn, "Triggered 'start_stop_spinwait_ev' due to Control.spien=0", UVM_DEBUG)
+
         cfg.clk_rst_vif.wait_clks($urandom_range(0, 20000));
         csr_wr(.ptr(ral.control.spien), .value(1'b1));
+        spinwait_ctrl_obj.stop = 0;
+        start_stop_spinwait_ev.trigger(spinwait_ctrl_obj);
+        `uvm_info(`gfn, "Triggered 'start_stop_spinwait_ev' due to Control.spien=1", UVM_DEBUG)
 
         // Break when STATUS.ACTIVE == 0
         csr_rd(.ptr(ral.status), .value(status), .backdoor(1));

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_spien_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_spien_vseq.sv
@@ -20,9 +20,9 @@ class spi_host_spien_vseq extends spi_host_tx_rx_vseq;
 
   virtual task body();
     spi_host_status_t status;
-    csr_utils_pkg::csr_spinwait_ctrl_object spinwait_ctrl_obj;
+    csr_spinwait_ctrl_object spinwait_ctrl_obj;
     bit rd_rx_fifo_finished;
-    spinwait_ctrl_obj = csr_spinwait_ctrl_object::type_id::create("spien_ctrl_obj");
+    spinwait_ctrl_obj = csr_spinwait_ctrl_object::type_id::create("spinwait_ctrl_obj");
     fork start_agent_reactive_seqs(); join_none
     wait_ready_for_command();
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_status_stall_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_status_stall_vseq.sv
@@ -35,13 +35,26 @@ class spi_host_status_stall_vseq extends spi_host_tx_rx_vseq;
       begin
         program_spi_host_regs();
         while (rxqd < SPI_HOST_RX_DEPTH) begin
-          wait_ready_for_command();
           generate_stall_transaction();
           rd_trans(transaction);
           if (rxqd == SPI_HOST_RX_DEPTH) break;
           else begin
+            int unsigned  current_rxqd;
             // If we have not yet filled the RXFIFO, confirm that the DUT does
             // not indicate rxfull or rxstall.
+
+            // if we're mid-spi transaction and the QUEUE is FULL minus 1 then we need to
+            // check if it fils up
+            csr_rd(.ptr(ral.status.rxqd), .value(current_rxqd), .backdoor(1));
+            if ((rxqd + 1) == SPI_HOST_RX_DEPTH &&
+                cfg.m_spi_agent_cfg.vif.csb[0] === 0 // active spi txn
+                ) begin
+              cfg.m_spi_agent_cfg.vif.wait_for_clks(1);
+              csr_rd(.ptr(ral.status.rxqd), .value(current_rxqd), .backdoor(1));
+              if (rxqd == SPI_HOST_RX_DEPTH)
+                break; // break because Q is full!
+            end
+
             check_event(ral.status.rxfull, 0, 0);
             csr_rd_check(.ptr(ral.status.rxstall), .compare_value(1'b0));
           end
@@ -89,7 +102,8 @@ class spi_host_status_stall_vseq extends spi_host_tx_rx_vseq;
     begin : clear_rxfifo
       spi_host_status_t status;
       csr_rd(.ptr(ral.status), .value(status));
-      if (status.rx_qd != 0) read_rx_fifo();
+      if (status.rx_qd != 0)
+        read_rx_fifo();
     end
     cfg.clk_rst_vif.wait_clks(1000);
 
@@ -99,9 +113,61 @@ class spi_host_status_stall_vseq extends spi_host_tx_rx_vseq;
   // segments, or the RXQD indicates we are full.
   virtual task rd_trans(spi_transaction_item trans, bit wait_ready = 1'b1);
     spi_segment_item segment;
-    while ((trans.segments.size() > 0)  && (!(rxqd == SPI_HOST_RX_DEPTH))) begin
-      if (wait_ready) wait_ready_for_command();
 
+    while ((trans.segments.size() > 0)  && (!(rxqd == SPI_HOST_RX_DEPTH))) begin
+      if (wait_ready) begin
+        bit rxfifo_full;
+        bit ready;
+        spi_host_status_t status;
+        csr_rd(.ptr(ral.status), .value(status), .backdoor(1));
+
+        fork
+          begin: iso_fork
+            fork
+              begin
+                while (!ready) begin
+                  csr_rd(.ptr(ral.status), .value(status), .backdoor(0));
+                  if (status.rxfull || status.rxstall)
+                    read_rx_fifo();
+
+                  if (status.ready)
+                    ready = 1;
+                end
+              end
+              begin
+                spi_host_status_t status;
+                string fail_printout = {"Waiting for READY to be high",
+                                        $sformatf(" (ready=0x%0x), and RXFIFO not stalled", ready)};
+
+                fork
+                  begin : timeout_blk
+                    # (cfg.csr_spinwait_timeout_ns);
+                      `uvm_fatal(`gfn, {$sformatf("%m - timeout = %0d",
+                                                  cfg.csr_spinwait_timeout_ns),
+                                        fail_printout})
+                  end
+                  begin
+                    while(status.ready==0) begin
+                      // We don't want to fail test if ready becomes available prior to the timeout
+                      cfg.clk_rst_vif.wait_clks(1);
+                      // Can't use csr_spinwait since it uses iso_fork which prevents that part
+                      // of the thread from being killed
+                      csr_rd(.ptr(ral.status), .value(status), .backdoor(1));
+                    end
+                  end
+                join_any
+                disable timeout_blk;
+                // Blocking for 'ready' to be set (handled in other parallel thread)
+                // since otherwise we may kill the above thread when it's running
+                wait(ready);
+
+              end
+            join_any
+            disable fork;
+          end // block: iso_fork
+        join
+
+      end
       // Lock fifo to this task, write any data to TXFIFO if required, write COMMAND csr starts txn.
       spi_host_atomic.get(1); begin : locked_fifo_access
         segment = trans.segments.pop_back();

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_upper_range_clkdiv_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_upper_range_clkdiv_vseq.sv
@@ -62,7 +62,7 @@ class spi_host_upper_range_clkdiv_vseq extends spi_host_speed_vseq;
     // Redefining the ranges to ensure 'num_cmd_bytes' gets randomised to a
     // lower value to ensure simulations finish sooner
     cfg.seq_cfg.host_spi_min_len = 1;
-    cfg.seq_cfg.host_spi_max_len = 3;
+    cfg.seq_cfg.host_spi_max_len = 2;
   endfunction
 
 endclass : spi_host_upper_range_clkdiv_vseq

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_upper_range_clkdiv_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_upper_range_clkdiv_vseq.sv
@@ -19,13 +19,43 @@ class spi_host_upper_range_clkdiv_vseq extends spi_host_speed_vseq;
     max_range_value -> (spi_config_regs.clkdiv == cfg.seq_cfg.host_spi_max_clkdiv);
     !max_range_value -> (spi_config_regs.clkdiv inside {[cfg.seq_cfg.host_spi_middle_clkdiv :
                                                          cfg.seq_cfg.host_spi_max_clkdiv]});
+
+    // In order to minimise sim-time the idle/lead/trail delays are all set to 0.
+    foreach (spi_config_regs.csnlead[i]) {
+      spi_config_regs.csnlead[i] == 0;
+    }
+    foreach (spi_config_regs.csntrail[i]) {
+      spi_config_regs.csntrail[i] == 0;
+    }
+    foreach (spi_config_regs.csnidle[i]) {
+      spi_config_regs.csnidle[i] == 0 ;
+    }
+  }
+
+
+  constraint spi_config_regs_faster_clkdiv_c {
+    // Only multiples of 16 to quicken up the clock - this constraint should be part of the clkdiv
+    spi_config_regs.clkdiv[3:0] == 0;
   }
 
   constraint num_trans_c {
     // Really low number of TXN generated to avoid lenghty simulation time
     // since we already have a very slow SPI clock
-    num_trans inside {[1 : 3]};
+    num_trans inside {[1 : 2]};
   }
+
+  // This VSEQ is the only one which allows large clock divider values and due to that the
+  // VSEQ allow the internal FSM counter to be decremented by 16-units.
+  // The VIF flag is enabled only whilst this VSEQ is run
+  virtual task pre_start();
+    super.pre_start();
+    cfg.force_spi_fsm_vif.fast_mode = 1;
+  endtask
+
+  virtual task post_start();
+    super.post_start();
+    cfg.force_spi_fsm_vif.fast_mode = 0;
+  endtask
 
   function void pre_randomize();
     super.pre_randomize();

--- a/hw/ip/spi_host/dv/env/spi_host_env.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env.sv
@@ -26,7 +26,11 @@ class spi_host_env extends cip_base_env #(
        "spi_passthrough_vif", cfg.spi_passthrough_vif)) begin
       `uvm_fatal(get_full_name(), "failed to get spi_passthrough_if from uvm_config_db")
     end
-  endfunction : build_phase
+
+    if (!uvm_config_db#(virtual spi_host_fsm_if)::get(this, "", "fast_prescaler_bound_if",
+                                                      cfg.force_spi_fsm_vif))
+      `uvm_fatal(`gfn, "failed to get fast_prescaler_bound_if from uvm_config_db")
+ endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);

--- a/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
@@ -73,8 +73,14 @@ class spi_host_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_host_reg_block));
     // create the seq_cfg
     seq_cfg = spi_host_seq_cfg::type_id::create("seq_cfg");
 
+    set_default_csr_timeout();
+
     // set num_interrupts & num_alerts
     num_interrupts = ral.intr_state.get_n_used_bits();
+  endfunction
+
+  function void set_default_csr_timeout();
+    csr_spinwait_timeout_ns = csr_utils_pkg::default_spinwait_timeout_ns;
   endfunction
 
   // clk_core_freq_mhz is set by

--- a/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
@@ -31,6 +31,10 @@ class spi_host_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_host_reg_block));
   // higher values
   uint csr_spinwait_timeout_ns = csr_utils_pkg::default_spinwait_timeout_ns;
 
+  // Used to provide a faster decrement via forcing internal RTL signals, so simulations
+  // finish more quickly.
+  virtual interface spi_host_fsm_if force_spi_fsm_vif;
+
   constraint dummy_c {
     num_dummy inside { [min_dummy_cycles:max_dummy_cycles]};
   }

--- a/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
@@ -160,6 +160,19 @@ package spi_host_env_pkg;
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
 
+  // Object shared through UVM events using the UVM pool for finer timeout control.
+  // It's used so an UVM event is triggered and depending whether the object has the
+  // field `stop` set the timeout continues or stall.
+  // This is used in SPI host in situations where there `spien` or `sw_rst` are set, so the timeout
+  // shouldn't be counting until the module is re-enabled
+  class csr_spinwait_ctrl_object extends uvm_object;
+    `uvm_object_utils(csr_spinwait_ctrl_object)
+    bit            stop;
+    function new(string name = "");
+      super.new(name);
+    endfunction
+  endclass
+
   // functions
 
   // Convenience function to detect mask validity for TXFIFO. Actual allowed masks are taken

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -572,8 +572,13 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
 
     end else `uvm_fatal(`gfn, $sformatf("\n  scb: access unexpected addr 0x%0h", csr_addr))
 
+    `uvm_info(`gfn, $sformatf("%m - csr_name = %s, write = %0d, channel = %s",
+                              csr_name, write, channel.name), UVM_DEBUG)
+
+
     if (cmd_phase_write) begin
-      `uvm_info(`gfn, $sformatf("Accessing CSR: %s",csr_name), UVM_DEBUG)
+      `uvm_info(`gfn, $sformatf("Accessing CSR: %s - data = 0x%0x / mask = 0x%0x",
+                                csr_name, item.a_data, item.a_mask), UVM_DEBUG)
       case (csr_name)
         default:; // Do nothing
         "control": begin

--- a/hw/ip/spi_host/dv/env/spi_host_seq_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_seq_cfg.sv
@@ -7,20 +7,23 @@ class spi_host_seq_cfg extends uvm_object;
   `uvm_object_utils(spi_host_seq_cfg)
 
   // knobs for number of requests sent to dut
-  uint host_spi_min_trans             = 10;
-  uint host_spi_max_trans             = 20;
+  uint host_spi_min_trans             = 2;
+  uint host_spi_max_trans             = 5;
 
   // knobs for number of retry after reset
   // for stress_all, error_intr, stress_all_with_rand_reset
-  uint host_spi_min_runs              = 5;
-  uint host_spi_max_runs              = 10;
+  uint host_spi_min_runs              = 2;
+  uint host_spi_max_runs              = 3;
 
   // knobs for dut's config registers
   uint host_spi_min_csn_latency       = 0;
   uint host_spi_max_csn_latency       = 15;
+  // Several ranges of clock ratio to allow constraints to use a closer
+  // to spi-host_core clock ratio in most tests
   uint host_spi_min_clkdiv            = 0;
   uint host_spi_lower_middle_clkdiv   = 16'hF;
-  uint host_spi_middle_clkdiv         = 16'hFF;
+  uint host_spi_middle_clkdiv         = 16'hF0;
+  uint host_spi_upper_middle_clkdiv   = 16'hFF;
   uint host_spi_max_clkdiv            = 16'hFFFF;
   uint host_spi_min_len               = 3;
   uint host_spi_max_len               = 6;

--- a/hw/ip/spi_host/dv/spi_host_fsm_if.sv
+++ b/hw/ip/spi_host/dv/spi_host_fsm_if.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Interface used to have the SPI host FSM decrement the counter by more than 1 unit by
+// forcing a decrement in the FSM counter
+// This is used currently on tests running VSEQ `spi_host_upper_range_clkdiv_vseq`
+// with the purpose of making simulations take less time for longer tests
+interface spi_host_fsm_if ();
+
+  // Knowb to be enabled in UVM VSEQs whenever we want the decrement signal to be
+  // greater than 1 (currently hardcoded at 16 when in fast_mode)
+  bit fast_mode;
+
+  always @(posedge u_fsm.clk_i) begin
+    if (u_fsm.rst_ni && fast_mode) begin
+      if (!(u_fsm.sw_rst_i || !u_fsm.clk_cntr_en ||
+            u_fsm.new_command || u_fsm.is_idle || !u_fsm.clk_cntr_q)) begin
+        // This check matches the one defining clk_cntr_d in spi_host_fsm.sv. It expects to
+        // decrement by 1. If we are in "fast mode", we should decrement by 16 instead.
+        force u_fsm.clk_cntr_d = u_fsm.clk_cntr_q - 16;
+        @(posedge u_fsm.clk_i or negedge u_fsm.rst_ni);
+        release u_fsm.clk_cntr_d;
+      end
+    end
+  end
+endinterface

--- a/hw/ip/spi_host/dv/spi_host_sim.core
+++ b/hw/ip/spi_host/dv/spi_host_sim.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:dv:spi_host_sva
     files:
       - tb.sv
+      - spi_host_fsm_if.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/spi_host/dv/tb.sv
+++ b/hw/ip/spi_host/dv/tb.sv
@@ -112,6 +112,9 @@ module tb;
   assign interrupts[SpiHostError] = intr_error;
   assign interrupts[SpiHostEvent] = intr_event;
 
+  // Bind
+  bind dut.u_spi_core spi_host_fsm_if fast_prescaler_bound_if();
+
   initial begin
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
@@ -121,6 +124,9 @@ module tb;
                                                  spi_passthrough_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
+
+    uvm_config_db#(virtual spi_host_fsm_if)::set(null, "*.env", "fast_prescaler_bound_if",
+                                                 dut.u_spi_core.fast_prescaler_bound_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
Split the clk-divider high values to be tested in a different config which sets  a `define and decrements the pres-scaler in 16-units to quicken up simulation.

Tweaked TB knobs to reduce test duration in general.

Extra checks in VSEQs to avoid timeouts in corner case situations