### PR TITLE
Cherry-pick to master: [rom_ext] Do not process boot_svc request for wakeups

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.c
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.c
@@ -4,15 +4,22 @@
 
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
 
-void boot_svc_empty_init(boot_svc_empty_t *msg) {
-  size_t i = 0, j = kBootSvcEmptyPayloadWordCount - 1;
+void boot_svc_empty_req_init(boot_svc_empty_t *msg) {
+  // We use `uint32_t` instead of `size_t` so that end-of-loop check passes both
+  // on- and off-target tests.
+  uint32_t i = 0, j = kBootSvcEmptyPayloadWordCount - 1;
   for (; launder32(i) < kBootSvcEmptyPayloadWordCount &&
          launder32(j) < kBootSvcEmptyPayloadWordCount;
        ++i, --j) {
     msg->payload[i] = 0;
   }
   HARDENED_CHECK_EQ(i, kBootSvcEmptyPayloadWordCount);
-  HARDENED_CHECK_EQ(j, SIZE_MAX);
-  boot_svc_header_finalize(kBootSvcEmptyType, sizeof(boot_svc_empty_t),
+  HARDENED_CHECK_EQ(j, UINT32_MAX);
+  boot_svc_header_finalize(kBootSvcEmptyReqType, sizeof(boot_svc_empty_t),
+                           &msg->header);
+}
+
+void boot_svc_empty_res_init(boot_svc_empty_t *msg) {
+  boot_svc_header_finalize(kBootSvcEmptyResType, sizeof(boot_svc_empty_t),
                            &msg->header);
 }

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h
@@ -16,7 +16,9 @@ extern "C" {
 
 enum {
   /** Empty boot services request: `EMPT`. */
-  kBootSvcEmptyType = 0x54504d45,
+  kBootSvcEmptyReqType = 0x54504d45,
+  /** Empty boot services response: `TPME`. */
+  kBootSvcEmptyResType = 0x454d5054,
   kBootSvcEmptyPayloadWordCount =
       CHIP_BOOT_SVC_MSG_PAYLOAD_SIZE_MAX / sizeof(uint32_t),
 };
@@ -48,11 +50,18 @@ OT_ASSERT_MEMBER_OFFSET(boot_svc_empty_t, payload,
 OT_ASSERT_SIZE(boot_svc_empty_t, CHIP_BOOT_SVC_MSG_SIZE_MAX);
 
 /**
- * Initialize an empty boot services message.
+ * Initialize an empty boot services request.
  *
  * @param[out] msg Output buffer for the message.
  */
-void boot_svc_empty_init(boot_svc_empty_t *msg);
+void boot_svc_empty_req_init(boot_svc_empty_t *msg);
+
+/**
+ * Initialize an empty boot services response.
+ *
+ * @param[inout] msg Buffer for the message.
+ */
+void boot_svc_empty_res_init(boot_svc_empty_t *msg);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty_unittest.cc
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_empty_unittest.cc
@@ -31,9 +31,9 @@ TEST_F(BootSvcEmptyTest, Init) {
 
   boot_svc_empty_t msg{};
   EXPECT_CALL(boot_svc_header_,
-              Finalize(kBootSvcEmptyType, sizeof(msg), &msg.header));
+              Finalize(kBootSvcEmptyReqType, sizeof(msg), &msg.header));
 
-  boot_svc_empty_init(&msg);
+  boot_svc_empty_req_init(&msg);
 
   EXPECT_THAT(msg.payload, ElementsAreArray(payload));
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -53,6 +53,34 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "boot_svc_wakeup_test",
+    srcs = ["boot_svc_wakeup_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{rom_ext}@0 {firmware}@0x10000",
+        #exit_failure = "BFV|PASS|FAIL",
+        #exit_success = "FinalBootLog: 2:AA\r\n",
+    ),
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+    deps = [
+        ":boot_svc_test_lib",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_empty",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)
+
+opentitan_test(
     name = "boot_svc_next_test",
     srcs = ["boot_svc_next_test.c"],
     exec_env = {

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -124,12 +124,12 @@ opentitan_test(
             --exec="fpga clear-bitstream"
             --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='ownership_state = LockedNone\r\n' --exit-failure='{exit_failure}'"
+            --exec="console --non-interactive --exit-success='ownership_state = .x00.x00.x00.x00\r\n' --exit-failure='{exit_failure}'"
             --exec="rescue boot-svc ownership-unlock \
                     --mode Any \
                     --nonce 0 \
                     --sign $(location //sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key)"
-            --exec="console --non-interactive --exit-success='ownership_state = UnlockedAny\r\n' --exit-failure='{exit_failure}'"
+            --exec="console --non-interactive --exit-success='ownership_state = UANY\r\n' --exit-failure='{exit_failure}'"
             no-op
         """,
     ),

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_empty_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_empty_test.c
@@ -16,7 +16,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 static status_t initialize(retention_sram_t *retram, boot_svc_retram_t *state) {
   boot_svc_msg_t msg = {0};
-  boot_svc_empty_init(&msg.empty);
+  boot_svc_empty_req_init(&msg.empty);
   retram->creator.boot_svc_msg = msg;
   state->state = kBootSvcTestStateCheckEmpty;
   rstmgr_reset();
@@ -27,7 +27,7 @@ static status_t check_empty(retention_sram_t *retram,
                             boot_svc_retram_t *state) {
   boot_svc_msg_t msg = retram->creator.boot_svc_msg;
   TRY(boot_svc_header_check(&msg.header));
-  TRY_CHECK(msg.header.type == kBootSvcEmptyType);
+  TRY_CHECK(msg.header.type == kBootSvcEmptyResType);
   state->state = kBootSvcTestStateFinal;
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_min_sec_ver_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_min_sec_ver_test.c
@@ -17,7 +17,6 @@ OTTF_DEFINE_TEST_CONFIG();
 
 static status_t initialize(retention_sram_t *retram, boot_svc_retram_t *state) {
   boot_svc_msg_t msg = {0};
-  boot_svc_empty_init(&msg.empty);
   boot_svc_min_bl0_sec_ver_req_init(2, &msg.min_bl0_sec_ver_req);
   retram->creator.boot_svc_msg = msg;
   state->state = kBootSvcTestStateMinSecAdvance;

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h
@@ -12,6 +12,7 @@ typedef enum boot_svc_test {
   kBootSvcTestNextBl0 = 2,
   kBootSvcTestBadNextBl0 = 3,
   kBootSvcTestBl0MinSecVer = 4,
+  kBootSvcTestWakeup = 5,
 } boot_svc_test_t;
 
 typedef enum boot_svc_test_state {

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_wakeup_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_wakeup_test.c
@@ -1,0 +1,106 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/boot_svc/boot_svc_empty.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+static dif_pwrmgr_t pwrmgr;
+static dif_aon_timer_t aon_timer;
+
+static status_t test_init(void) {
+  // Initialize aon timer to use the wdog.
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+  TRY(dif_pwrmgr_init(mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR),
+                      &pwrmgr));
+  return OK_STATUS();
+}
+
+static status_t deep_sleep_enter(uint32_t wakeup_ticks) {
+  dif_pwrmgr_domain_config_t pwrmgr_domain_cfg = 0;
+  // WakeupSourceFive is the AonTimer source.
+  // See hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_env_pkg.sv%wakeup_e.
+  TRY(pwrmgr_testutils_enable_low_power(
+      &pwrmgr, kDifPwrmgrWakeupRequestSourceFive, pwrmgr_domain_cfg));
+  TRY(dif_aon_timer_wakeup_start(&aon_timer, wakeup_ticks, 0));
+  LOG_INFO("Going to sleep.");
+  wait_for_interrupt();
+  LOG_INFO("Unexpected wakeup from deep sleep.");
+  return UNKNOWN();
+}
+
+static status_t deep_sleep_check(void) {
+  bool wkup = TRY(pwrmgr_testutils_is_wakeup_reason(
+      &pwrmgr, kDifPwrmgrWakeupRequestSourceFive));
+  return OK_STATUS(wkup);
+}
+
+static status_t initialize(retention_sram_t *retram, boot_svc_retram_t *state) {
+  boot_svc_msg_t msg = {0};
+  boot_svc_empty_req_init(&msg.empty);
+  retram->creator.boot_svc_msg = msg;
+  state->state = kBootSvcTestStateCheckEmpty;
+  TRY(deep_sleep_enter((uint32_t)kClockFreqAonHz));
+  return INTERNAL();
+}
+
+static status_t check_empty(retention_sram_t *retram,
+                            boot_svc_retram_t *state) {
+  if (!TRY(deep_sleep_check())) {
+    LOG_ERROR("Expected wakup from deep sleep");
+    return INTERNAL();
+  }
+  boot_svc_msg_t msg = retram->creator.boot_svc_msg;
+  TRY(boot_svc_header_check(&msg.header));
+  // We expect the `EmptyReqType` here because the ROM_EXT should not process
+  // boot_svc requests when waking from deep sleep.
+  TRY_CHECK(msg.header.type == kBootSvcEmptyReqType);
+  state->state = kBootSvcTestStateFinal;
+  return OK_STATUS();
+}
+
+static status_t empty_message_test(void) {
+  TRY(test_init());
+  retention_sram_t *retram = retention_sram_get();
+  TRY(boot_svc_test_init(retram, kBootSvcTestWakeup));
+  boot_svc_retram_t *state = (boot_svc_retram_t *)&retram->owner;
+
+  for (;;) {
+    LOG_INFO("Test state = %d", state->state);
+    switch (state->state) {
+      case kBootSvcTestStateInit:
+        TRY(initialize(retram, state));
+        break;
+      case kBootSvcTestStateCheckEmpty:
+        TRY(check_empty(retram, state));
+        break;
+      case kBootSvcTestStateFinal:
+        return OK_STATUS();
+      default:
+        return UNKNOWN();
+    }
+  }
+}
+
+bool test_main(void) {
+  status_t sts = empty_message_test();
+  if (status_err(sts)) {
+    LOG_ERROR("boot_svc_wakeup_test: %r", sts);
+  }
+  return status_ok(sts);
+}

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -36,6 +36,7 @@
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/epmp_state.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
@@ -863,13 +864,17 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
 
   // Handle any pending boot_svc commands.
   rom_error_t error;
-  error = handle_boot_svc(boot_data);
-  if (error == kErrorWriteBootdataThenReboot) {
-    // Boot services reports errors by writing a status code into the reply
-    // messages.  Regardless of whether a boot service request produced an
-    // error, we want to continue booting unless the error specifically asks
-    // for a reboot.
-    return error;
+  uint32_t reset_reasons = retention_sram_get()->creator.reset_reasons;
+  uint32_t skip_boot_svc = reset_reasons & (1 << kRstmgrReasonLowPowerExit);
+  if (skip_boot_svc == 0) {
+    error = handle_boot_svc(boot_data);
+    if (error == kErrorWriteBootdataThenReboot) {
+      // Boot services reports errors by writing a status code into the reply
+      // messages.  Regardless of whether a boot service request produced an
+      // error, we want to continue booting unless the error specifically asks
+      // for a reboot.
+      return error;
+    }
   }
 
   // Re-sync the boot_log entries that could be changed by boot services.

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -757,8 +757,9 @@ static rom_error_t handle_boot_svc(boot_data_t *boot_data) {
     HARDENED_RETURN_IF_ERROR(boot_svc_header_check(&boot_svc_msg->header));
     uint32_t msg_type = boot_svc_msg->header.type;
     switch (launder32(msg_type)) {
-      case kBootSvcEmptyType:
-        HARDENED_CHECK_EQ(msg_type, kBootSvcEmptyType);
+      case kBootSvcEmptyReqType:
+        HARDENED_CHECK_EQ(msg_type, kBootSvcEmptyReqType);
+        boot_svc_empty_res_init(&boot_svc_msg->empty);
         break;
       case kBootSvcNextBl0SlotReqType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcNextBl0SlotReqType);
@@ -772,6 +773,7 @@ static rom_error_t handle_boot_svc(boot_data_t *boot_data) {
       case kBootSvcOwnershipUnlockReqType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcOwnershipUnlockReqType);
         return ownership_unlock_handler(boot_svc_msg, boot_data);
+      case kBootSvcEmptyResType:
       case kBootSvcNextBl0SlotResType:
       case kBootSvcPrimaryBl0SlotResType:
       case kBootSvcMinBl0SecVerResType:


### PR DESCRIPTION
The ROM_EXT should not process boot_svc requests for low-power exit
cases as resuming from sleep is not expected to change the state of the
chip.

This is a manual cherry-pick of #24247.
This PR depends on #23311.