### PR TITLE
[dv] add vseq to check ROM hash in GLS

### DIFF
--- a/hw/top_earlgrey/dv/chip_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_rom_tests.hjson
@@ -803,7 +803,7 @@
     // macro into the netlist.
     // {
     //   name: rom_e2e_self_hash_no_bkdr_rom_load
-    //   uvm_test_seq: chip_sw_base_vseq
+    //   uvm_test_seq: chip_sw_rom_e2e_self_hash_gls_vseq
     //   sw_images: [
     //     "//sw/device/silicon_creator/rom/e2e/release:rom_e2e_self_hash_test:1:new_rules:silicon_creator",
     //     "//sw/device/silicon_creator/rom/e2e/release:otp_img_sigverify_spx_prod:4",
@@ -815,6 +815,7 @@
     //   en_run_modes: ["sw_test_mode_common"]
     //   run_opts: [
     //     "+skip_rom_bkdr_load=1",
+    //     "+uart_baud_rate=115200",
     //     "+sw_test_timeout_ns=200_000_000",
     //     "+use_otp_image=OtpTypeCustom",
     //   ]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -146,6 +146,7 @@ filesets:
       - seq_lib/chip_sw_rom_e2e_asm_init_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_jtag_debug_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_e2e_jtag_inject_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rom_e2e_self_hash_gls_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_power_idle_load_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_power_sleep_load_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_power_virus_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_base_vseq.sv
@@ -30,7 +30,9 @@ class chip_sw_rom_e2e_base_vseq extends chip_sw_base_vseq;
     // Wait until we receive the expected boot fault message length of bytes over UART0.
     `DV_WAIT(uart_tx_data_q.size() == exp_msg.len(),
       "Timeout waiting for UART FIFO to fill.", 200_000_000)
-    `uvm_info(`gfn, "Checking the UART TX data matches expected boot fault msg ...", UVM_LOW)
+    `uvm_info(`gfn,
+      $sformatf("Checking UART TX data matches '%s'...", exp_msg),
+      UVM_LOW);
     actual_msg = {>>{uart_tx_data_q}};
     `DV_CHECK_STREQ(actual_msg, exp_msg)
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_self_hash_gls_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_self_hash_gls_vseq.sv
@@ -21,7 +21,6 @@ class chip_sw_rom_e2e_self_hash_gls_vseq extends
                         cfg.sw_test_timeout_ns),
              cfg.sw_test_timeout_ns)
     connect_rom_uart_agent();
-    check_uart_output_msg("Starting test hash_rom...\x0d\n");
     check_uart_output_msg($sformatf("ROM Hash: 0x%s\x0d\n", ROM_HASH));
 
     // DV test status window is not written to for silicon SW images, so we

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_self_hash_gls_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_self_hash_gls_vseq.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rom_e2e_self_hash_gls_vseq extends
+  chip_sw_rom_e2e_base_vseq;
+  `uvm_object_utils(chip_sw_rom_e2e_self_hash_gls_vseq)
+  `uvm_object_new
+
+  // Must match the `kSiliconGoldenRomHash` value in
+  // `sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c`.
+  localparam string ROM_HASH = "66c2cb77a8f2053b06a569e0f05b04e8279865f6063a84ea76d7386c5d02eeae";
+
+  virtual task body();
+    super.body();
+    // Wait until we start executing from flash.
+    `DV_WAIT(cfg.chip_vif.probed_cpu_pc.pc_wb >= 32'h2000_0000,
+             $sformatf({"Timeout occurred when waiting for flash execution; ",
+                        "Current pc_wb = 32x%0x, Timeout value = %0dns"},
+                        cfg.chip_vif.probed_cpu_pc.pc_wb,
+                        cfg.sw_test_timeout_ns),
+             cfg.sw_test_timeout_ns)
+    connect_rom_uart_agent();
+    check_uart_output_msg("Starting test hash_rom...\x0d\n");
+    check_uart_output_msg($sformatf("ROM Hash: 0x%s\x0d\n", ROM_HASH));
+
+    // DV test status window is not written to for silicon SW images, so we
+    // must force the test pass flag to end the simulation.
+    apply_reset();
+    override_test_status_and_finish(.passed(1'b1));
+    disconnect_rom_uart_agent();
+  endtask
+
+endclass : chip_sw_rom_e2e_self_hash_gls_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -103,6 +103,7 @@
 `include "chip_sw_rom_e2e_asm_init_vseq.sv"
 `include "chip_sw_rom_e2e_jtag_debug_vseq.sv"
 `include "chip_sw_rom_e2e_jtag_inject_vseq.sv"
+`include "chip_sw_rom_e2e_self_hash_gls_vseq.sv"
 `include "chip_sw_power_idle_load_vseq.sv"
 `include "chip_sw_power_sleep_load_vseq.sv"
 `include "chip_sw_ast_clk_rst_inputs_vseq.sv"

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -107,7 +107,9 @@ static void report_test_status(bool result) {
     if (kOttfTestConfig.console.test_may_clobber) {
       ottf_console_init();
     }
-    LOG_INFO("Finished %s", kOttfTestConfig.file);
+    if (!kOttfTestConfig.silence_console_prints) {
+      LOG_INFO("Finished %s", kOttfTestConfig.file);
+    }
   }
   // Print the reported status in case of error. Beware that
   // status_report_list_cnt might be greater than kStatusReportListSize which
@@ -160,7 +162,9 @@ void _ottf_main(void) {
   // Initialize the console to enable logging for non-DV simulation platforms.
   if (kDeviceType != kDeviceSimDV) {
     ottf_console_init();
-    LOG_INFO("Running %s", kOttfTestConfig.file);
+    if (!kOttfTestConfig.silence_console_prints) {
+      LOG_INFO("Running %s", kOttfTestConfig.file);
+    }
   }
 
   // Initialize a global random number generator testutil context to provide

--- a/sw/device/lib/testing/test_framework/ottf_test_config.h
+++ b/sw/device/lib/testing/test_framework/ottf_test_config.h
@@ -81,6 +81,10 @@ typedef struct ottf_test_config {
   bool clear_reset_reason;
 
   /**
+   */
+  bool silence_console_prints;
+
+  /**
    * Name of the file in which `kOttfTestConfig` is defined. Most of the time,
    * this will be the file that defines `test_main()`.
    */

--- a/sw/device/silicon_creator/rom/e2e/release/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/release/BUILD
@@ -46,6 +46,7 @@ opentitan_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
         "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:chip_info",


### PR DESCRIPTION
The final ROM image is built for the "silicon" device, and as such does not write to the DV_SIM_WINDOW to signal a test pass. This adds a DV vseq that will signal test pass once the UART prints the expected ROM hash.