### PR TITLE
[dv,vcs,pwrmgr] Fix compilation warnings

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -281,7 +281,7 @@
       name: vcs_waves_off
       is_sim_mode: 1
       build_opts: [// disable dumping assertion failures to improve runtime performance
-                   "-assert novpi+dbgopt"]
+                   "-assert dbgopt"]
     }
     {
       name: vcs_cov
@@ -296,7 +296,7 @@
                    // Dump toggle coverage on mdas, array of structs and on ports only
                    "-cm_tgl mda+structarr+portsonly",
                    // Report condition coverage within tasks, functions and for loops.
-                   "-cm_cond for+tf",
+                   "-cm_cond for",
                    // Ignore initial blocks for coverage
                    "-cm_report noinitial",
                    // Filter unreachable/statically constant blocks. seqnoconst does a more

--- a/hw/ip_templates/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg
+++ b/hw/ip_templates/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg
@@ -6,4 +6,4 @@
 // This file contains outputs of pwrmgr tied to constants.
 //======================================================================
 
--module_node clkmgr pwr_ast_o.slow_clk_en
+-module_node pwrmgr pwr_ast_o.slow_clk_en

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/cov/pwrmgr_tgl_excl.cfg
@@ -6,4 +6,4 @@
 // This file contains outputs of pwrmgr tied to constants.
 //======================================================================
 
--module_node clkmgr pwr_ast_o.slow_clk_en
+-module_node pwrmgr pwr_ast_o.slow_clk_en


### PR DESCRIPTION
This fixes two sources of warnings:
- Change global VCS flags: remove an unnecessary flag and one that is unused and causes a warning due to a conflict with coverage features
- Fix silly typo causing compilation warning
