### PR TITLE
[crypto] Read mode constants from OTBN binaries.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/ecdh_p256.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p256.c
@@ -13,7 +13,11 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '2', 'x')
 
-OTBN_DECLARE_APP_SYMBOLS(p256_ecdh);        // The OTBN ECDSH/P-256 app.
+// Declare the OTBN app.
+OTBN_DECLARE_APP_SYMBOLS(p256_ecdh);
+static const otbn_app_t kOtbnAppEcdh = OTBN_APP_T_INIT(p256_ecdh);
+
+// Declare offsets for input and output buffers.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, mode);  // ECDH application mode.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, x);     // The public key x-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, y);     // The public key y-coordinate.
@@ -23,7 +27,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh,
                          d1);             // The private key scalar d (share 1).
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, ok);  // Public key validity.
 
-static const otbn_app_t kOtbnAppEcdh = OTBN_APP_T_INIT(p256_ecdh);
 static const otbn_addr_t kOtbnVarEcdhMode = OTBN_ADDR_T_INIT(p256_ecdh, mode);
 static const otbn_addr_t kOtbnVarEcdhX = OTBN_ADDR_T_INIT(p256_ecdh, x);
 static const otbn_addr_t kOtbnVarEcdhY = OTBN_ADDR_T_INIT(p256_ecdh, y);
@@ -31,27 +34,25 @@ static const otbn_addr_t kOtbnVarEcdhD0 = OTBN_ADDR_T_INIT(p256_ecdh, d0);
 static const otbn_addr_t kOtbnVarEcdhD1 = OTBN_ADDR_T_INIT(p256_ecdh, d1);
 static const otbn_addr_t kOtbnVarEcdhOk = OTBN_ADDR_T_INIT(p256_ecdh, ok);
 
+// Declare mode constants.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, MODE_KEYPAIR_RANDOM);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, MODE_SHARED_KEY);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, MODE_KEYPAIR_FROM_SEED);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdh, MODE_SHARED_KEY_FROM_SEED);
+static const uint32_t kOtbnEcdhModeKeypairRandom =
+    OTBN_ADDR_T_INIT(p256_ecdh, MODE_KEYPAIR_RANDOM);
+static const uint32_t kOtbnEcdhModeSharedKey =
+    OTBN_ADDR_T_INIT(p256_ecdh, MODE_SHARED_KEY);
+static const uint32_t kOtbnEcdhModeKeypairFromSeed =
+    OTBN_ADDR_T_INIT(p256_ecdh, MODE_KEYPAIR_FROM_SEED);
+static const uint32_t kOtbnEcdhModeSharedKeyFromSeed =
+    OTBN_ADDR_T_INIT(p256_ecdh, MODE_SHARED_KEY_FROM_SEED);
+
 enum {
   /*
    * Mode is represented by a single word.
    */
   kOtbnEcdhModeWords = 1,
-  /*
-   * Mode to generate a new random keypair.
-   */
-  kOtbnEcdhModeKeypairRandom = 0x3f1,
-  /*
-   * Mode to generate a new shared key.
-   */
-  kOtbnEcdhModeSharedKey = 0x5ec,
-  /*
-   * Mode to generate a new sideloaded keypair.
-   */
-  kOtbnEcdhModeKeypairFromSeed = 0x29f,
-  /*
-   * Mode to generate a new sideloaded shared key.
-   */
-  kOtbnEcdhModeSharedKeyFromSeed = 0x74b,
 };
 
 status_t ecdh_p256_keypair_start(void) {

--- a/sw/device/lib/crypto/impl/ecc/ecdh_p384.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdh_p384.c
@@ -14,7 +14,11 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'x')
 
-OTBN_DECLARE_APP_SYMBOLS(p384_ecdh);        // The OTBN ECDSH/P-384 app.
+// Declare the OTBN app.
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdh);
+static const otbn_app_t kOtbnAppEcdh = OTBN_APP_T_INIT(p384_ecdh);
+
+// Declare offsets for input and output buffers.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, mode);  // ECDH application mode.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, x);     // The public key x-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, y);     // The public key y-coordinate.
@@ -23,34 +27,31 @@ OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh,
                          d1);  // The private key scalar d (share 1).
 
-static const otbn_app_t kOtbnAppEcdh = OTBN_APP_T_INIT(p384_ecdh);
 static const otbn_addr_t kOtbnVarEcdhMode = OTBN_ADDR_T_INIT(p384_ecdh, mode);
 static const otbn_addr_t kOtbnVarEcdhX = OTBN_ADDR_T_INIT(p384_ecdh, x);
 static const otbn_addr_t kOtbnVarEcdhY = OTBN_ADDR_T_INIT(p384_ecdh, y);
 static const otbn_addr_t kOtbnVarEcdhD0 = OTBN_ADDR_T_INIT(p384_ecdh, d0);
 static const otbn_addr_t kOtbnVarEcdhD1 = OTBN_ADDR_T_INIT(p384_ecdh, d1);
 
+// Declare mode constants.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, MODE_KEYPAIR_RANDOM);
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, MODE_SHARED_KEY);
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, MODE_KEYPAIR_FROM_SEED);
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdh, MODE_SHARED_KEY_FROM_SEED);
+static const uint32_t kOtbnEcdhModeKeypairRandom =
+    OTBN_ADDR_T_INIT(p384_ecdh, MODE_KEYPAIR_RANDOM);
+static const uint32_t kOtbnEcdhModeSharedKey =
+    OTBN_ADDR_T_INIT(p384_ecdh, MODE_SHARED_KEY);
+static const uint32_t kOtbnEcdhModeKeypairFromSeed =
+    OTBN_ADDR_T_INIT(p384_ecdh, MODE_KEYPAIR_FROM_SEED);
+static const uint32_t kOtbnEcdhModeSharedKeyFromSeed =
+    OTBN_ADDR_T_INIT(p384_ecdh, MODE_SHARED_KEY_FROM_SEED);
+
 enum {
   /*
    * Mode is represented by a single word.
    */
   kOtbnEcdhModeWords = 1,
-  /*
-   * Mode to generate a new random keypair.
-   */
-  kOtbnEcdhModeKeypairRandom = 0x3f1,
-  /*
-   * Mode to generate a new shared key.
-   */
-  kOtbnEcdhModeSharedKey = 0x5ec,
-  /*
-   * Mode to generate a new sideloaded keypair.
-   */
-  kOtbnEcdhModeKeypairFromSeed = 0x29f,
-  /*
-   * Mode to generate a new sideloaded shared key.
-   */
-  kOtbnEcdhModeSharedKeyFromSeed = 0x74b,
 };
 
 status_t ecdh_p384_keypair_start(void) {

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p256.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p256.c
@@ -13,7 +13,11 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '2', 's')
 
-OTBN_DECLARE_APP_SYMBOLS(p256_ecdsa);        // The OTBN ECDSA/P-256 app.
+// Declare the OTBN app.
+OTBN_DECLARE_APP_SYMBOLS(p256_ecdsa);  // The OTBN ECDSA/P-256 app.
+static const otbn_app_t kOtbnAppEcdsa = OTBN_APP_T_INIT(p256_ecdsa);
+
+// Declare offsets for input and output buffers.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, mode);  // ECDSA mode (sign or verify).
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, msg);   // Message digest.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, r);     // The signature scalar R.
@@ -27,7 +31,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa,
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);  // Verification result.
 OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, ok);   // Status code.
 
-static const otbn_app_t kOtbnAppEcdsa = OTBN_APP_T_INIT(p256_ecdsa);
 static const otbn_addr_t kOtbnVarEcdsaMode = OTBN_ADDR_T_INIT(p256_ecdsa, mode);
 static const otbn_addr_t kOtbnVarEcdsaMsg = OTBN_ADDR_T_INIT(p256_ecdsa, msg);
 static const otbn_addr_t kOtbnVarEcdsaR = OTBN_ADDR_T_INIT(p256_ecdsa, r);
@@ -39,41 +42,28 @@ static const otbn_addr_t kOtbnVarEcdsaD1 = OTBN_ADDR_T_INIT(p256_ecdsa, d1);
 static const otbn_addr_t kOtbnVarEcdsaXr = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
 static const otbn_addr_t kOtbnVarEcdsaOk = OTBN_ADDR_T_INIT(p256_ecdsa, ok);
 
+// Declare mode constants.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, MODE_KEYGEN);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, MODE_SIGN);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, MODE_VERIFY);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, MODE_SIDELOAD_KEYGEN);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, MODE_SIDELOAD_SIGN);
+static const uint32_t kOtbnEcdsaModeKeygen =
+    OTBN_ADDR_T_INIT(p256_ecdsa, MODE_KEYGEN);
+static const uint32_t kOtbnEcdsaModeSign =
+    OTBN_ADDR_T_INIT(p256_ecdsa, MODE_SIGN);
+static const uint32_t kOtbnEcdsaModeVerify =
+    OTBN_ADDR_T_INIT(p256_ecdsa, MODE_VERIFY);
+static const uint32_t kOtbnEcdsaModeSideloadKeygen =
+    OTBN_ADDR_T_INIT(p256_ecdsa, MODE_SIDELOAD_KEYGEN);
+static const uint32_t kOtbnEcdsaModeSideloadSign =
+    OTBN_ADDR_T_INIT(p256_ecdsa, MODE_SIDELOAD_SIGN);
+
 enum {
   /*
    * Mode is represented by a single word.
    */
   kOtbnEcdsaModeWords = 1,
-  /*
-   * Mode to generate a new random keypair.
-   *
-   * Value taken from `p256_ecdsa.s`.
-   */
-  kOtbnEcdsaModeKeygen = 0x3d4,
-  /*
-   * Mode to generate a signature.
-   *
-   * Value taken from `p256_ecdsa.s`.
-   */
-  kOtbnEcdsaModeSign = 0x15b,
-  /*
-   * Mode to verify a signature.
-   *
-   * Value taken from `p256_ecdsa.s`.
-   */
-  kOtbnEcdsaModeVerify = 0x727,
-  /*
-   * Mode to generate a sideloaded key.
-   *
-   * Value taken from `p256_ecdsa.s`.
-   */
-  kOtbnEcdsaModeSideloadKeygen = 0x5e8,
-  /*
-   * Mode to sign with a sideloaded key.
-   *
-   * Value taken from `p256_ecdsa.s`.
-   */
-  kOtbnEcdsaModeSideloadSign = 0x49e,
 };
 
 status_t ecdsa_p256_keygen_start(void) {

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_keygen.c
@@ -13,7 +13,12 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 'k')
 
-OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_keygen);  // The OTBN ECDSA/P-384 app.
+// Declare the OTBN app.
+OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_keygen);
+static const otbn_app_t kOtbnAppEcdsaKeygen =
+    OTBN_APP_T_INIT(p384_ecdsa_keygen);
+
+// Declare offsets for input and output buffers.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen,
                          mode);  // ECDSA keygen application mode.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, d0);  // Private key first share.
@@ -21,8 +26,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, d1);  // Private key second share.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, x);   // x-coordinate.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, y);   // y-coordinate.
 
-static const otbn_app_t kOtbnAppEcdsaKeygen =
-    OTBN_APP_T_INIT(p384_ecdsa_keygen);
 static const otbn_addr_t kOtbnVarEcdsaMode =
     OTBN_ADDR_T_INIT(p384_ecdsa_keygen, mode);
 static const otbn_addr_t kOtbnVarEcdsaX =
@@ -34,23 +37,19 @@ static const otbn_addr_t kOtbnVarEcdsaD0 =
 static const otbn_addr_t kOtbnVarEcdsaD1 =
     OTBN_ADDR_T_INIT(p384_ecdsa_keygen, d1);
 
+// Declare mode constants.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, MODE_KEYGEN_RANDOM);
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_keygen, MODE_KEYGEN_FROM_SEED);
+static const uint32_t kOtbnEcdsaModeKeygen =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, MODE_KEYGEN_RANDOM);
+static const uint32_t kOtbnEcdsaModeSideloadKeygen =
+    OTBN_ADDR_T_INIT(p384_ecdsa_keygen, MODE_KEYGEN_FROM_SEED);
+
 enum {
   /*
    * Mode is represented by a single word.
    */
   kOtbnEcdsaModeWords = 1,
-  /*
-   * Mode to generate a new random keypair.
-   *
-   * Value taken from `p384_ecdsa_keygen.s`.
-   */
-  kOtbnEcdsaModeKeygen = 0x3d4,
-  /*
-   * Mode to generate a sideloaded key.
-   *
-   * Value taken from `p384_ecdsa_keygen.s`.
-   */
-  kOtbnEcdsaModeSideloadKeygen = 0x5e8,
 };
 
 status_t ecdsa_p384_keygen_start(void) {

--- a/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.c
+++ b/sw/device/lib/crypto/impl/ecc/ecdsa_p384_sign.c
@@ -13,7 +13,11 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('p', '3', 's')
 
+// Declare the OTBN app.
 OTBN_DECLARE_APP_SYMBOLS(p384_ecdsa_sign);  // The OTBN ECDSA/P-384 app.
+static const otbn_app_t kOtbnAppEcdsaSign = OTBN_APP_T_INIT(p384_ecdsa_sign);
+
+// Declare offsets for input and output buffers.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign,
                          mode);                  // ECDSA sign application mode.
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, d0);   // private key first share
@@ -22,7 +26,6 @@ OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, msg);  // hash message to sign/verify
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, r);    // r part of signature
 OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, s);    // s part of signature
 
-static const otbn_app_t kOtbnAppEcdsaSign = OTBN_APP_T_INIT(p384_ecdsa_sign);
 static const otbn_addr_t kOtbnVarEcdsaMode =
     OTBN_ADDR_T_INIT(p384_ecdsa_sign, mode);
 static const otbn_addr_t kOtbnVarEcdsaD0 =
@@ -34,23 +37,19 @@ static const otbn_addr_t kOtbnVarEcdsaMsg =
 static const otbn_addr_t kOtbnVarEcdsaR = OTBN_ADDR_T_INIT(p384_ecdsa_sign, r);
 static const otbn_addr_t kOtbnVarEcdsaS = OTBN_ADDR_T_INIT(p384_ecdsa_sign, s);
 
+// Declare mode constants.
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, MODE_SIGN);
+OTBN_DECLARE_SYMBOL_ADDR(p384_ecdsa_sign, MODE_SIDELOAD_SIGN);
+static const uint32_t kOtbnEcdsaModeSign =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, MODE_SIGN);
+static const uint32_t kOtbnEcdsaModeSideloadSign =
+    OTBN_ADDR_T_INIT(p384_ecdsa_sign, MODE_SIDELOAD_SIGN);
+
 enum {
   /*
    * Mode is represented by a single word.
    */
   kOtbnEcdsaModeWords = 1,
-  /*
-   * Mode to generate a signature.
-   *
-   * Value taken from `p384_ecdsa.s`.
-   */
-  kOtbnEcdsaModeSign = 0x15b,
-  /*
-   * Mode to sign with a sideloaded key.
-   *
-   * Value taken from `p384_ecdsa.s`.
-   */
-  kOtbnEcdsaModeSideloadSign = 0x49e,
 };
 
 status_t ecdsa_p384_sign_start(const uint32_t digest[kP384ScalarWords],

--- a/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
@@ -11,13 +11,16 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('r', 'k', 'g')
 
-OTBN_DECLARE_APP_SYMBOLS(run_rsa_keygen);         // The OTBN RSA keygen binary.
-OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, mode);   // Application mode.
-OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_n);  // Public exponent n.
-OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_d);  // Private exponent d.
+// Declare the OTBN app.
+OTBN_DECLARE_APP_SYMBOLS(run_rsa_keygen);
+static const otbn_app_t kOtbnAppRsaKeygen = OTBN_APP_T_INIT(run_rsa_keygen);
+
+// Declare offsets for input and output buffers.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, mode);          // Application mode.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_n);         // Public exponent n.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_d);         // Private exponent d.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_cofactor);  // Cofactor p or q.
 
-static const otbn_app_t kOtbnAppRsaKeygen = OTBN_APP_T_INIT(run_rsa_keygen);
 static const otbn_addr_t kOtbnVarRsaMode =
     OTBN_ADDR_T_INIT(run_rsa_keygen, mode);
 static const otbn_addr_t kOtbnVarRsaN = OTBN_ADDR_T_INIT(run_rsa_keygen, rsa_n);
@@ -25,25 +28,26 @@ static const otbn_addr_t kOtbnVarRsaD = OTBN_ADDR_T_INIT(run_rsa_keygen, rsa_d);
 static const otbn_addr_t kOtbnVarRsaCofactor =
     OTBN_ADDR_T_INIT(run_rsa_keygen, rsa_cofactor);
 
+// Declare mode constants.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, MODE_GEN_RSA_2048);
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, MODE_COFACTOR_RSA_2048);
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, MODE_GEN_RSA_3072);
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_keygen, MODE_GEN_RSA_4096);
+static const uint32_t kOtbnRsaModeGen2048 =
+    OTBN_ADDR_T_INIT(run_rsa_keygen, MODE_GEN_RSA_2048);
+static const uint32_t kOtbnRsaModeCofactor2048 =
+    OTBN_ADDR_T_INIT(run_rsa_keygen, MODE_COFACTOR_RSA_2048);
+static const uint32_t kOtbnRsaModeGen3072 =
+    OTBN_ADDR_T_INIT(run_rsa_keygen, MODE_GEN_RSA_3072);
+static const uint32_t kOtbnRsaModeGen4096 =
+    OTBN_ADDR_T_INIT(run_rsa_keygen, MODE_GEN_RSA_4096);
+
 enum {
   /* Fixed public exponent for generated keys. This exponent is 2^16 + 1, also
      known as "F4" because it's the fourth Fermat number. */
   kFixedPublicExponent = 65537,
   /* Number of words used to represent the application mode. */
   kOtbnRsaModeWords = 1,
-};
-
-// Available application modes. Must match the values from `run_rsa_keygen.s`.
-// TODO: I think it's possible to pull these values directly from symbols in
-// the binary. See:
-//   hw/ip/otbn/util/otbn_objdump.py -t run_rsa_keygen.rv32embed.o
-enum {
-  kOtbnRsaModeGen2048 = 0x137,
-  kOtbnRsaModeGen3072 = 0x4e5,
-  kOtbnRsaModeGen4096 = 0x63a,
-  kOtbnRsaModeCofactor2048 = 0x34e,
-  kOtbnRsaModeCofactor3072 = 0x0db,
-  kOtbnRsaModeCofactor4096 = 0x794,
 };
 
 /**

--- a/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
@@ -9,13 +9,16 @@
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('r', 'm', 'e')
 
-OTBN_DECLARE_APP_SYMBOLS(run_rsa_modexp);         // The OTBN RSA modexp binary.
+// Declare the OTBN app.
+OTBN_DECLARE_APP_SYMBOLS(run_rsa_modexp);
+static const otbn_app_t kOtbnAppRsaModexp = OTBN_APP_T_INIT(run_rsa_modexp);
+
+// Declare offsets for input and output buffers.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, mode);   // Application mode.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, n);      // Public modulus n.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, d);      // Private exponent d.
 OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, inout);  // Input/output buffer.
 
-static const otbn_app_t kOtbnAppRsaModexp = OTBN_APP_T_INIT(run_rsa_modexp);
 static const otbn_addr_t kOtbnVarRsaMode =
     OTBN_ADDR_T_INIT(run_rsa_modexp, mode);
 static const otbn_addr_t kOtbnVarRsaN = OTBN_ADDR_T_INIT(run_rsa_modexp, n);
@@ -23,17 +26,27 @@ static const otbn_addr_t kOtbnVarRsaD = OTBN_ADDR_T_INIT(run_rsa_modexp, d);
 static const otbn_addr_t kOtbnVarRsaInOut =
     OTBN_ADDR_T_INIT(run_rsa_modexp, inout);
 
+// Declare mode constants.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, MODE_RSA_2048_MODEXP);
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, MODE_RSA_2048_MODEXP_F4);
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, MODE_RSA_3072_MODEXP);
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, MODE_RSA_3072_MODEXP_F4);
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, MODE_RSA_4096_MODEXP);
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_modexp, MODE_RSA_4096_MODEXP_F4);
+static const uint32_t kMode2048Modexp =
+    OTBN_ADDR_T_INIT(run_rsa_modexp, MODE_RSA_2048_MODEXP);
+static const uint32_t kMode2048ModexpF4 =
+    OTBN_ADDR_T_INIT(run_rsa_modexp, MODE_RSA_2048_MODEXP_F4);
+static const uint32_t kMode3072Modexp =
+    OTBN_ADDR_T_INIT(run_rsa_modexp, MODE_RSA_3072_MODEXP);
+static const uint32_t kMode3072ModexpF4 =
+    OTBN_ADDR_T_INIT(run_rsa_modexp, MODE_RSA_3072_MODEXP_F4);
+static const uint32_t kMode4096Modexp =
+    OTBN_ADDR_T_INIT(run_rsa_modexp, MODE_RSA_4096_MODEXP);
+static const uint32_t kMode4096ModexpF4 =
+    OTBN_ADDR_T_INIT(run_rsa_modexp, MODE_RSA_4096_MODEXP_F4);
+
 enum {
-  /**
-   * Available modes for the OTBN application. Must match the values from
-   * `run_rsa_modexp.s`.
-   */
-  kMode2048Modexp = 0x76b,
-  kMode2048ModexpF4 = 0x565,
-  kMode3072Modexp = 0x378,
-  kMode3072ModexpF4 = 0x6d1,
-  kMode4096Modexp = 0x70b,
-  kMode4096ModexpF4 = 0x0ee,
   /**
    * Common RSA exponent with a specialized implementation.
    *
@@ -52,25 +65,15 @@ status_t rsa_modexp_wait(size_t *num_words) {
   HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &mode));
 
   *num_words = 0;
-  switch (mode) {
-    case kMode2048Modexp:
-      OT_FALLTHROUGH_INTENDED;
-    case kMode2048ModexpF4:
-      *num_words = kRsa2048NumWords;
-      break;
-    case kMode3072Modexp:
-      OT_FALLTHROUGH_INTENDED;
-    case kMode3072ModexpF4:
-      *num_words = kRsa3072NumWords;
-      break;
-    case kMode4096Modexp:
-      OT_FALLTHROUGH_INTENDED;
-    case kMode4096ModexpF4:
-      *num_words = kRsa4096NumWords;
-      break;
-    default:
-      // Unrecognized mode.
-      return OTCRYPTO_FATAL_ERR;
+  if (mode == kMode2048Modexp || mode == kMode2048ModexpF4) {
+    *num_words = kRsa2048NumWords;
+  } else if (mode == kMode3072Modexp || mode == kMode3072ModexpF4) {
+    *num_words = kRsa3072NumWords;
+  } else if (mode == kMode4096Modexp || mode == kMode4096ModexpF4) {
+    *num_words = kRsa4096NumWords;
+  } else {
+    // Unrecognized mode.
+    return OTCRYPTO_FATAL_ERR;
   }
 
   return OTCRYPTO_OK;

--- a/sw/otbn/crypto/p256_ecdh.s
+++ b/sw/otbn/crypto/p256_ecdh.s
@@ -31,6 +31,14 @@
 .equ MODE_SHARED_KEY_FROM_SEED, 0x74b
 
 /**
+ * Make the mode constants visible to Ibex.
+ */
+.globl MODE_KEYPAIR_RANDOM
+.globl MODE_SHARED_KEY
+.globl MODE_KEYPAIR_FROM_SEED
+.globl MODE_SHARED_KEY_FROM_SEED
+
+/**
  * Hardened boolean values.
  *
  * Should match the values in `hardened_asm.h`.

--- a/sw/otbn/crypto/p256_ecdsa.s
+++ b/sw/otbn/crypto/p256_ecdsa.s
@@ -32,6 +32,15 @@
 .equ MODE_SIDELOAD_KEYGEN, 0x5e8
 .equ MODE_SIDELOAD_SIGN, 0x49e
 
+/**
+ * Make the mode constants visible to Ibex.
+ */
+.globl MODE_KEYGEN
+.globl MODE_SIGN
+.globl MODE_VERIFY
+.globl MODE_SIDELOAD_KEYGEN
+.globl MODE_SIDELOAD_SIGN
+
 .section .text.start
 .globl start
 start:

--- a/sw/otbn/crypto/p384_ecdh.s
+++ b/sw/otbn/crypto/p384_ecdh.s
@@ -37,6 +37,14 @@
 .equ MODE_KEYPAIR_FROM_SEED, 0x29f
 .equ MODE_SHARED_KEY_FROM_SEED, 0x74b
 
+/**
+ * Make the mode constants visible to Ibex.
+ */
+.globl MODE_SHARED_KEY
+.globl MODE_KEYPAIR_RANDOM
+.globl MODE_KEYPAIR_FROM_SEED
+.globl MODE_SHARED_KEY_FROM_SEED
+
 .section .text.start
 start:
   /* Init all-zero register. */

--- a/sw/otbn/crypto/p384_ecdsa_keygen.s
+++ b/sw/otbn/crypto/p384_ecdsa_keygen.s
@@ -15,6 +15,12 @@
 .equ MODE_KEYGEN_RANDOM, 0x3d4
 .equ MODE_KEYGEN_FROM_SEED, 0x5e8
 
+/**
+ * Make the mode constants visible to Ibex.
+ */
+.globl MODE_KEYGEN_RANDOM
+.globl MODE_KEYGEN_FROM_SEED
+
 .section .text.start
 .globl start
 start:

--- a/sw/otbn/crypto/p384_ecdsa_sign.s
+++ b/sw/otbn/crypto/p384_ecdsa_sign.s
@@ -28,6 +28,12 @@
 .equ MODE_SIGN, 0x15b
 .equ MODE_SIDELOAD_SIGN, 0x49e
 
+/**
+ * Make the mode constants visible to Ibex.
+ */
+.globl MODE_SIGN
+.globl MODE_SIDELOAD_SIGN
+
 .section .text.start
 .globl start
 start:

--- a/sw/otbn/crypto/run_rsa_keygen.s
+++ b/sw/otbn/crypto/run_rsa_keygen.s
@@ -32,6 +32,16 @@
 .equ MODE_COFACTOR_RSA_3072, 0x0db
 .equ MODE_COFACTOR_RSA_4096, 0x794
 
+/**
+ * Make the mode constants visible to Ibex.
+ */
+.globl MODE_GEN_RSA_2048
+.globl MODE_COFACTOR_RSA_2048
+.globl MODE_GEN_RSA_3072
+.globl MODE_COFACTOR_RSA_3072
+.globl MODE_GEN_RSA_4096
+.globl MODE_COFACTOR_RSA_4096
+
 .section .text.start
 start:
   /* Init all-zero register. */

--- a/sw/otbn/crypto/run_rsa_modexp.s
+++ b/sw/otbn/crypto/run_rsa_modexp.s
@@ -40,6 +40,16 @@
 .equ MODE_RSA_4096_MODEXP, 0x70b
 .equ MODE_RSA_4096_MODEXP_F4, 0x0ee
 
+/**
+ * Make the mode constants visible to Ibex.
+ */
+.globl MODE_RSA_2048_MODEXP
+.globl MODE_RSA_2048_MODEXP_F4
+.globl MODE_RSA_3072_MODEXP
+.globl MODE_RSA_3072_MODEXP_F4
+.globl MODE_RSA_4096_MODEXP
+.globl MODE_RSA_4096_MODEXP_F4
+
 .section .text.start
 start:
   /* Init all-zero register. */


### PR DESCRIPTION
Small adjustment to the cryptolib OTBN routines that allows them to read mode constants directly from the OTBN binary, so that these do not have to be manually adjusted when they change. This is a minor cleanup I'd been planning on for a while, and had the impetus to fix because of a discussion in https://github.com/lowRISC/opentitan/issues/24277