### PR TITLE
[otbn,dv] Correct the timing for when we zero insn_cnt in model

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -138,7 +138,12 @@ class OTBNState:
         # cancelled).
         self.injected_err_bits = 0
         self.lock_immediately = False
-        self.zero_insn_cnt_next = False
+
+        # OTBN might zero its insn_cnt register during a secure wipe. The
+        # precise cycle that this happens depends slightly on how we decide to
+        # do so. If this is not None, it is a counter of the number of cycles
+        # before the zeroing should happen.
+        self.time_to_insn_cnt_zero = None  # type: Optional[int]
 
         # If this is set, all software errors should result in the model status
         # being locked.


### PR DESCRIPTION
There are two paths by which this can happen in the RTL (the insn_cnt_clear_int_o signal from otbn_start_stop_control and the way that otbn_controller can go into a locked state). These have slightly different timings!

Make sure to model them correctly.

This fixes failures in `otbn_escalate`. Last night had 5 failures in 60 runs, four of which were caused by this sort of mismatch. I've just run some seeds locally and I see this mismatch cause failures in 2 runs of 100, so the "pass rate" for this check goes from 93% to 98%, which should hopefully be worth it.