### PR TITLE
[kmac/dv] Adjust some test timeouts

### DIFF
--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -95,7 +95,7 @@
       name: "{name}_long_msg_and_output"
       uvm_test_seq: kmac_long_msg_and_output_vseq
       run_opts: ["+test_timeout_ns=10_000_000_000"]
-      run_timeout_mins: 90
+      run_timeout_mins: 120
     }
     {
       name: "{name}_sideload"
@@ -147,7 +147,7 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_shake_variant=128"]
-      run_timeout_mins: 180
+      run_timeout_mins: 90
       reseed: 5
     }
     {
@@ -156,7 +156,7 @@
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0",
                  "+test_timeout_ns=5_000_000_000",
                  "+test_vectors_shake_variant=256"]
-      run_timeout_mins: 180
+      run_timeout_mins: 90
       reseed: 5
     }
     {


### PR DESCRIPTION
In the nightly regression we've been observing some test timeouts for kmac_long_msg_and_output which is most likely related to lowRISC/OpenTitan#24225.

After recuding the test time spent on testing NIST test vectors in lowRISC/OpenTitan#24279, the timeouts for
kmac_test_vectors_shake_128/256 can safely be reduced again.