### PR TITLE
[opentitanlib] Refactor RPC module to enable supporting future console interfaces (e.g., SPI)

### DIFF
--- a/sw/host/opentitanlib/src/test_utils/gpio.rs
+++ b/sw/host/opentitanlib/src/test_utils/gpio.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::io::uart::Uart;
 use crate::test_utils::e2e_command::TestCommand;
-use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use crate::test_utils::status::Status;
 
 // Bring in the auto-generated sources.

--- a/sw/host/opentitanlib/src/test_utils/i2c_target.rs
+++ b/sw/host/opentitanlib/src/test_utils/i2c_target.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::io::uart::Uart;
 use crate::test_utils::e2e_command::TestCommand;
-use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use crate::test_utils::status::Status;
 
 // Bring in the auto-generated sources.

--- a/sw/host/opentitanlib/src/test_utils/mem.rs
+++ b/sw/host/opentitanlib/src/test_utils/mem.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use crate::io::uart::Uart;
 use crate::test_utils::e2e_command::TestCommand;
-use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use crate::test_utils::status::Status;
 
 // Bring in the auto-generated sources.

--- a/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
+++ b/sw/host/opentitanlib/src/test_utils/pinmux_config.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use crate::chip::autogen::earlgrey::{PinmuxInsel, PinmuxMioOut, PinmuxOutsel, PinmuxPeripheralIn};
 use crate::io::uart::Uart;
 use crate::test_utils::e2e_command::TestCommand;
-use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use crate::test_utils::status::Status;
 
 // Bring in the auto-generated sources.

--- a/sw/host/opentitanlib/src/test_utils/rpc.rs
+++ b/sw/host/opentitanlib/src/test_utils/rpc.rs
@@ -16,7 +16,7 @@ use crate::uart::console::{ExitStatus, UartConsole};
 // Bring in the auto-generated sources.
 include!(env!("ottf"));
 
-pub trait UartSend<T>
+pub trait ConsoleSend<T>
 where
     T: ConsoleDevice + ?Sized,
 {
@@ -24,7 +24,7 @@ where
     fn send_with_crc(&self, device: &T) -> Result<()>;
 }
 
-impl<T, U> UartSend<T> for U
+impl<T, U> ConsoleSend<T> for U
 where
     T: ConsoleDevice + ?Sized,
     U: Serialize,
@@ -47,7 +47,7 @@ where
     }
 }
 
-pub trait UartRecv<T>
+pub trait ConsoleRecv<T>
 where
     T: ConsoleDevice + ?Sized,
 {
@@ -56,7 +56,7 @@ where
         Self: Sized;
 }
 
-impl<T, U> UartRecv<T> for U
+impl<T, U> ConsoleRecv<T> for U
 where
     T: ConsoleDevice + ?Sized,
     U: DeserializeOwned,

--- a/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
+++ b/sw/host/opentitanlib/src/test_utils/spi_passthru.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use crate::io::uart::Uart;
 use crate::test_utils::e2e_command::TestCommand;
-use crate::test_utils::rpc::{UartRecv, UartSend};
+use crate::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use crate::test_utils::status::Status;
 
 // Bring in the auto-generated sources.

--- a/sw/host/provisioning/cp_lib/src/lib.rs
+++ b/sw/host/provisioning/cp_lib/src/lib.rs
@@ -14,7 +14,7 @@ use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
 use opentitanlib::test_utils::load_sram_program::{
     ExecutionMode, ExecutionResult, SramProgramParams,
 };
-use opentitanlib::test_utils::rpc::UartSend;
+use opentitanlib::test_utils::rpc::ConsoleSend;
 use opentitanlib::uart::console::UartConsole;
 use ujson_lib::provisioning_data::ManufCpProvisioningData;
 

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -25,7 +25,7 @@ use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
 use opentitanlib::test_utils::load_sram_program::{
     ExecutionMode, ExecutionResult, SramProgramParams,
 };
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 use ot_certs::x509::parse_certificate;
 use ujson_lib::provisioning_data::{

--- a/sw/host/tests/chip/i2c_target/src/main.rs
+++ b/sw/host/tests/chip/i2c_target/src/main.rs
@@ -16,7 +16,7 @@ use opentitanlib::test_utils;
 use opentitanlib::test_utils::e2e_command::TestCommand;
 use opentitanlib::test_utils::i2c_target::{I2cTargetAddress, I2cTestConfig, I2cTransferStart};
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::test_utils::status::Status;
 use opentitanlib::uart::console::UartConsole;
 use std::borrow::Borrow;

--- a/sw/host/tests/crypto/aes_nist_kat/src/main.rs
+++ b/sw/host/tests/crypto/aes_nist_kat/src/main.rs
@@ -19,7 +19,7 @@ use cryptotest_commands::commands::CryptotestCommand;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 
 #[derive(Debug, Parser)]

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -16,7 +16,7 @@ use cryptotest_commands::drbg_commands::{CryptotestDrbgInput, CryptotestDrbgOutp
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 
 #[derive(Debug, Parser)]

--- a/sw/host/tests/crypto/ecdh_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdh_kat/src/main.rs
@@ -19,7 +19,7 @@ use cryptotest_commands::ecdh_commands::{
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 use p256::elliptic_curve::scalar::ScalarPrimitive as ScalarPrimitiveP256;
 use p256::U256;

--- a/sw/host/tests/crypto/ecdsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdsa_kat/src/main.rs
@@ -31,7 +31,7 @@ use cryptotest_commands::ecdsa_commands::{
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 
 #[derive(Debug, Parser)]

--- a/sw/host/tests/crypto/hash_kat/src/main.rs
+++ b/sw/host/tests/crypto/hash_kat/src/main.rs
@@ -19,7 +19,7 @@ use cryptotest_commands::hash_commands::{
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 
 #[derive(Debug, Parser)]

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -18,7 +18,7 @@ use cryptotest_commands::hmac_commands::{
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 
 #[derive(Debug, Parser)]

--- a/sw/host/tests/crypto/kmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/kmac_kat/src/main.rs
@@ -19,7 +19,7 @@ use cryptotest_commands::kmac_commands::{
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 
 #[derive(Debug, Parser)]

--- a/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
+++ b/sw/host/tests/crypto/sphincsplus_kat/src/main.rs
@@ -20,7 +20,7 @@ use cryptotest_commands::sphincsplus_commands::{
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 
 #[derive(Debug, Parser)]

--- a/sw/host/tests/manuf/cp_provision_functest/src/main.rs
+++ b/sw/host/tests/manuf/cp_provision_functest/src/main.rs
@@ -20,7 +20,7 @@ use opentitanlib::test_utils::lc_transition;
 use opentitanlib::test_utils::load_sram_program::{
     ExecutionMode, ExecutionResult, SramProgramParams,
 };
-use opentitanlib::test_utils::rpc::UartSend;
+use opentitanlib::test_utils::rpc::ConsoleSend;
 use opentitanlib::uart::console::UartConsole;
 use ujson_lib::provisioning_data::ManufCpProvisioningData;
 use util_lib::hash_lc_token;

--- a/sw/host/tests/manuf/personalize_functest/src/main.rs
+++ b/sw/host/tests/manuf/personalize_functest/src/main.rs
@@ -16,7 +16,7 @@ use opentitanlib::io::jtag::JtagTap;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc::read_lc_state;
 use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
-use opentitanlib::test_utils::rpc::UartSend;
+use opentitanlib::test_utils::rpc::ConsoleSend;
 use opentitanlib::uart::console::UartConsole;
 use util_lib::hash_lc_token;
 

--- a/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
+++ b/sw/host/tests/rom/e2e_chip_specific_startup/src/main.rs
@@ -13,7 +13,7 @@ use opentitanlib::test_utils::e2e_command::TestCommand;
 use opentitanlib::test_utils::epmp::constants::*;
 use opentitanlib::test_utils::epmp::{Epmp, EpmpAddressRange, EpmpEntry, EpmpRegionKind};
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
 use std::time::Duration;
 

--- a/sw/host/tests/rom/sw_strap_value/src/main.rs
+++ b/sw/host/tests/rom/sw_strap_value/src/main.rs
@@ -10,7 +10,7 @@ use opentitanlib::execute_test;
 use opentitanlib::io::gpio::{PinMode, PullMode};
 use opentitanlib::test_utils::e2e_command::TestCommand;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::rpc::{UartRecv, UartSend};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::test_utils::status::Status;
 use opentitanlib::uart::console::UartConsole;
 use std::time::Duration;


### PR DESCRIPTION
This PR has a commit that refactors the RPC module to support additional console devices, e.g. the SPI device console.

This PR aims to support a future OTTF SPI  device console (#21726)