### PR TITLE
[sram_ctrl,dv] Wait with reset after mem_init

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_all_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_all_vseq.sv
@@ -39,6 +39,13 @@ class sram_ctrl_stress_all_vseq extends sram_ctrl_base_vseq;
       seq = create_seq_by_name(cur_vseq_name);
       `downcast(sram_vseq, seq)
 
+      // Wait a few cycles until the memory init request is finished. Without
+      // this wait, we could land up resetting the SRAM controller when the last
+      // write of the memory init is in the write pipeline. This could result in
+      // having an uninitialized memory.
+      if (i == 0) begin
+        cfg.clk_rst_vif.wait_clks(2);
+      end
       sram_vseq.do_apply_reset = (do_apply_reset) ? $urandom_range(0, 1) : 0;
 
       sram_vseq.set_sequencer(p_sequencer);


### PR DESCRIPTION
Currently, some of the sram_ctrl_stress_all fail with a DataKnown_A assertion.

The reason for this failure is that the sram_ctrl_stress_all test, depending on the seed, immediately triggers a reset before the first test is started. However, this reset before the first test interferes with the hardware-based memory initialization feature.
![image](https://github.com/user-attachments/assets/d642c454-d1fb-472a-9008-1c885d7e7864)
More specifically, this reset currently happens when the last write of the mem init is issued, i.e., the write gets not finished. Hence, the memory at the last address is uninitialized, triggering the DataKnown_A assertions.

To circumvent this issue, this commit adds a wait_clks(2) before the reset.