### PR TITLE
[dv,usbdev] Changes to improve coverage

### DIFF
--- a/hw/ip/usbdev/dv/cov/usbdev_manual_excl.el
+++ b/hw/ip/usbdev/dv/cov/usbdev_manual_excl.el
@@ -22,6 +22,10 @@ ANNOTATION: "Signal `ev_reset` is delayed relative to the signal `ev_bus_active`
 Branch 1 "2905358650" "((!see_pwr_sense) || (!usb_pullup_en_i))" (7) "((!see_pwr_sense) || (!usb_pullup_en_i)) 0,LinkPoweredSuspended ,-,-,-,-,1,-,-,-,-,-,-,-,-"
 ANNOTATION: "Signal `ev_reset` is delayed relative to the signal `ev_bus_active` which also triggers."
 Branch 1 "2905358650" "((!see_pwr_sense) || (!usb_pullup_en_i))" (18) "((!see_pwr_sense) || (!usb_pullup_en_i)) 0,LinkSuspended ,-,-,-,-,-,-,-,-,-,-,-,1,-"
+ANNOTATION: "rtl/usbdev_linkstate.sv, LineNumber: 169"
+Block 23 "99569725" "link_state_d = LinkActiveNoSOF;"
+ANNOTATION: "rtl/usbdev_linkstate.sv, LineNumber: 213"
+Block 41 "3734498758" "link_resume_o = 1;"
 
 // The detection of Reset Signaling during device transmission is prevented in `usbdev_linkstate`
 // in case the PHY does not echo the transmission on the receiver inputs (see `line_se0_raw`).
@@ -33,3 +37,22 @@ Transition OsWaitByte->OsIdle "1->0"
 Fsm state_q "1416230131"
 ANNOTATION: "Link reset will not be detected whilst the DUT is transmitting."
 Transition Sync->Idle "1->0"
+
+// DUT does not write into a RX FIFO when it is full.
+CHECKSUM: "1206032831 1104852947"
+ANNOTATION: "ModuleName: usbdev_usbif"
+INSTANCE: tb.dut.usbdev_impl
+ANNOTATION: "DUT shall not write into full FIFO"
+Condition 16 "3133442943" "(av_rvalid & (std_write_q | (((~out_max_used_q[PktW])) & (out_max_used_q[1:0] != 2'b11) & out_ep_acked))) 1 -1" (1 "01")
+
+// DUT does not read from AVOut/AVSetup FIFO when it is empty.
+CHECKSUM: "7115036 3660765074"
+ANNOTATION: "ModuleName: prim_fifo_sync ( parameter Width=5,Pass=0,Depth=4,OutputZeroIfEmpty=0,Secure=0,DepthW=3,gen_normal_fifo.PtrW=2 + Width=5,Pass=0,Depth=8,OutputZeroIfEmpty=0,Secure=0,DepthW=4,gen_normal_fifo.PtrW=3 ) "
+INSTANCE: tb.dut.usbdev_avsetupfifo
+ANNOTATION: "DUT shall not read from empty FIFO"
+Condition 4 "1324655787" "(rvalid_o & rready_i & ((~gen_normal_fifo.under_rst))) 1 -1" (1 "011")
+CHECKSUM: "7115036 3660765074"
+ANNOTATION: "ModuleName: prim_fifo_sync ( parameter Width=5,Pass=0,Depth=4,OutputZeroIfEmpty=0,Secure=0,DepthW=3,gen_normal_fifo.PtrW=2 + Width=5,Pass=0,Depth=8,OutputZeroIfEmpty=0,Secure=0,DepthW=4,gen_normal_fifo.PtrW=3 ) "
+INSTANCE: tb.dut.usbdev_avoutfifo
+ANNOTATION: "DUT shall not read from empty FIFO"
+Condition 4 "1324655787" "(rvalid_o & rready_i & ((~gen_normal_fifo.under_rst))) 1 -1" (1 "011")

--- a/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_scoreboard.sv
@@ -355,14 +355,20 @@ class usbdev_scoreboard extends cip_base_scoreboard #(
       end
       // Handshake packets sent by the DUT.
       PidTypeAck, PidTypeNak: begin
-        // The endpoint number for the OUT DATA transfer is sent in the preceding token packet,
+        // The endpoint number for the IN DATA transfer is sent in the preceding token packet,
         // if there was one and it was valid.
-        if (bfm.rx_token != null) begin
-          cov.data_tog_endp_cg.sample(item.m_pid_type, .dir_in(1'b0), .endp(bfm.rx_token.endpoint));
+        if (bfm.tx_ep != usbdev_bfm::InvalidEP) begin
+          cov.data_tog_endp_cg.sample(item.m_pid_type, .dir_in(1'b1), .endp(bfm.tx_ep));
+        end
+        // The endpoint number for the OUT DATA transfer is sent in the preceding token packet;
+        // if there was one and it was valid the BFM will have retained the endpoint number since
+        // it is not present in the DUT response.
+        if (bfm.rx_ep != usbdev_bfm::InvalidEP) begin
+          cov.data_tog_endp_cg.sample(item.m_pid_type, .dir_in(1'b0), .endp(bfm.rx_ep));
         end
       end
       default: begin
-        // Nothing to do for other packet types.
+        // Nothing more to do for other packet types.
       end
     endcase
   endfunction

--- a/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
+++ b/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson
@@ -542,7 +542,7 @@
                  "+wt_bitstuff_errs=1",
                  "+en_scb_rdchk_linkstate=0"]
       // Very long simulation times
-      reseed: 5
+      reseed: 10
     }
     {
       name: usbdev_stream_len_max


### PR DESCRIPTION
This PR makes a couple of small changes to improve the coverage results:
- handshake packets were not being collected appropriately for contributing to the functional coverage results.
- manual exclusions are introduce for the line coverage to match the FSM transitions that had already been manually excluded as unreachable. Condition coverage exclusions are added for invalid FIFO operations that we _do not expect to see_.

The third commit simply increases the number of seeds used for one of the stress sequences because otherwise the pass rate will fluctuate between 80% and 100% if a single seed fails.