### PR TITLE
[top_earlgrey] Reduce number of PRINCE half rounds for main SRAM scrambling

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -86,6 +86,13 @@
       expose:    "true",
       default:   "1"
     },
+    { name:      "NumPrinceRoundsHalf",
+      desc:      "Number of PRINCE half rounds for the SRAM scrambling feature",
+      type:      "int",
+      local:     "false",
+      expose:    "true",
+      default:   "3"
+    },
   ]
 
   features: [

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -17,6 +17,11 @@ module sram_ctrl
   parameter logic [NumAlerts-1:0] AlertAsyncOn          = {NumAlerts{1'b1}},
   // Enables the execute from SRAM feature.
   parameter bit InstrExec                               = 1,
+  // Number of PRINCE half rounds for the SRAM scrambling feature, can be [1..5].
+  // Note that this needs to be low-latency, hence we have to keep the amount of cipher rounds low.
+  // PRINCE has 5 half rounds in its original form, which corresponds to 2*5 + 1 effective rounds.
+  // Setting this to 3 lowers this to approximately 7 effective rounds.
+  parameter int NumPrinceRoundsHalf                     = 3,
   // Random netlist constants
   parameter otp_ctrl_pkg::sram_key_t   RndCnstSramKey   = RndCnstSramKeyDefault,
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramNonce = RndCnstSramNonceDefault,
@@ -535,7 +540,8 @@ module sram_ctrl
     .Width(DataWidth),
     .Depth(Depth),
     .EnableParity(0),
-    .DataBitsPerMask(DataWidth)
+    .DataBitsPerMask(DataWidth),
+    .NumPrinceRoundsHalf(NumPrinceRoundsHalf)
   ) u_prim_ram_1p_scr (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4760,6 +4760,14 @@
           expose: "true"
           name_top: SramCtrlRetAonInstrExec
         }
+        {
+          name: NumPrinceRoundsHalf
+          desc: Number of PRINCE half rounds for the SRAM scrambling feature
+          type: int
+          default: "3"
+          expose: "true"
+          name_top: SramCtrlRetAonNumPrinceRoundsHalf
+        }
       ]
       inter_signal_list:
       [
@@ -7340,6 +7348,14 @@
           default: "1"
           expose: "true"
           name_top: SramCtrlMainInstrExec
+        }
+        {
+          name: NumPrinceRoundsHalf
+          desc: Number of PRINCE half rounds for the SRAM scrambling feature
+          type: int
+          default: "3"
+          expose: "true"
+          name_top: SramCtrlMainNumPrinceRoundsHalf
         }
       ]
       inter_signal_list:

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7265,6 +7265,7 @@
       param_decl:
       {
         InstrExec: "1"
+        NumPrinceRoundsHalf: "2"
       }
       base_addrs:
       {
@@ -7353,7 +7354,7 @@
           name: NumPrinceRoundsHalf
           desc: Number of PRINCE half rounds for the SRAM scrambling feature
           type: int
-          default: "3"
+          default: "2"
           expose: "true"
           name_top: SramCtrlMainNumPrinceRoundsHalf
         }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -727,6 +727,7 @@
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
       param_decl: {
         InstrExec: "1",
+        NumPrinceRoundsHalf: "2",
       },
       base_addrs: {regs: "0x411C0000", ram: "0x10000000"},
       // Memory regions must be associated with a dedicated

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -97,7 +97,7 @@ module top_earlgrey #(
   // parameters for edn1
   // parameters for sram_ctrl_main
   parameter bit SramCtrlMainInstrExec = 1,
-  parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
+  parameter int SramCtrlMainNumPrinceRoundsHalf = 2,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
   parameter bit SecRomCtrlDisableScrambling = 1'b0,

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -59,6 +59,7 @@ module top_earlgrey #(
   // parameters for sensor_ctrl_aon
   // parameters for sram_ctrl_ret_aon
   parameter bit SramCtrlRetAonInstrExec = 0,
+  parameter int SramCtrlRetAonNumPrinceRoundsHalf = 3,
   // parameters for flash_ctrl
   parameter bit SecFlashCtrlScrambleEn = 1,
   parameter int FlashCtrlProgFifoDepth = 4,
@@ -96,6 +97,7 @@ module top_earlgrey #(
   // parameters for edn1
   // parameters for sram_ctrl_main
   parameter bit SramCtrlMainInstrExec = 1,
+  parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
   parameter bit SecRomCtrlDisableScrambling = 1'b0,
@@ -2067,7 +2069,8 @@ module top_earlgrey #(
     .RndCnstLfsrSeed(RndCnstSramCtrlRetAonLfsrSeed),
     .RndCnstLfsrPerm(RndCnstSramCtrlRetAonLfsrPerm),
     .MemSizeRam(4096),
-    .InstrExec(SramCtrlRetAonInstrExec)
+    .InstrExec(SramCtrlRetAonInstrExec),
+    .NumPrinceRoundsHalf(SramCtrlRetAonNumPrinceRoundsHalf)
   ) u_sram_ctrl_ret_aon (
       // [34]: fatal_error
       .alert_tx_o  ( alert_tx[34:34] ),
@@ -2534,7 +2537,8 @@ module top_earlgrey #(
     .RndCnstLfsrSeed(RndCnstSramCtrlMainLfsrSeed),
     .RndCnstLfsrPerm(RndCnstSramCtrlMainLfsrPerm),
     .MemSizeRam(131072),
-    .InstrExec(SramCtrlMainInstrExec)
+    .InstrExec(SramCtrlMainInstrExec),
+    .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf)
   ) u_sram_ctrl_main (
       // [59]: fatal_error
       .alert_tx_o  ( alert_tx[59:59] ),


### PR DESCRIPTION
This PR contains multiple commits to reduce the number of PRINCE half rounds for the main SRAM scrambling from 3 back to 2 as used for Earlgrey ES. This is done to reduce timing pressure.

The scrambling parameters of the other scrambled memory primitives (retention SRAM, ROM, OTBN IMEM & DMEM) are not touched by this PR.

Note that this PR is currently WIP. It will most likely not pass CI yet as I need to also update the tooling to support backdoor loading of memories using different numbers of scrambling rounds. But this PR is sufficient to allow the PD team kicking off another synthesis run. The RTL changes are okay and I pushed this through lint which hasn't flagged any warnings / errors.

For reference, the PRs where we increased the number of scrambling rounds in the past are:
- https://github.com/lowRISC/opentitan/pull/22425
- https://github.com/lowRISC/opentitan/pull/22948