### PR TITLE
[ottf,opentitanlib,test] Impl spi device ottf tx console

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -94,4 +94,19 @@ bool ottf_console_flow_control_isr(uint32_t *exc_info);
  */
 uint32_t ottf_console_get_flow_control_irqs(void);
 
+/**
+ * Read data from the host via the OTTF SPI device console into a provided
+ * buffer.
+ *
+ * The function waits for spi upload commands, then transfers data in chunks
+ * until a transmission complete signal is received. If the size of data sent
+ * from the host is greater than the provided buffer, then the excess data will
+ * be discarded.
+ *
+ * @param buf_size The size, in bytes, of the `buf`.
+ * @param[out] buf A pointer to the location where the data should be stored.
+ * @return The number of bytes actually received from the host.
+ */
+size_t ottf_console_spi_device_read(size_t buf_size, uint8_t *const buf);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_H_

--- a/sw/device/tests/spi_device_ottf_console_test.c
+++ b/sw/device/tests/spi_device_ottf_console_test.c
@@ -4,7 +4,9 @@
 
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -93,22 +95,53 @@ static const char kTest4KbDataStr[] =
     "B30518D571FDD6D38E0477F6CB83C7729A45494F5D7805CCC1432C816B7D8CB089CEA56216"
     "9489E4F80E70FA685F39E1CD0AD7AD703C2E9601D442004F3D4CE043F0E84007FB7438FE82"
     "DF4D9304C90B48BB25762DD29D";
+
+static uint8_t input_buf[5120];
+
 bool test_main(void) {
-  LOG_INFO("Sending empty string...");
+  LOG_INFO("Sending empty string to Host...");
   LOG_INFO("");
-  LOG_INFO("Sending test string...");
+  LOG_INFO("Sending test string to Host...");
   LOG_INFO("%s", kTestStr);
-  LOG_INFO("Sending 64B data...");
+  LOG_INFO("SYNC: Waiting for console data");
+  size_t received_data_len =
+      ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+  CHECK(received_data_len == sizeof(kTestStr));
+  CHECK_ARRAYS_EQ(input_buf, kTestStr, ARRAYSIZE(kTestStr));
+
+  LOG_INFO("Sending 64B data to Host...");
   LOG_INFO("%s", kTest64bDataStr);
-  LOG_INFO("Sending 256B data...");
+  LOG_INFO("SYNC: Waiting for console data");
+  received_data_len =
+      ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+  CHECK(received_data_len == sizeof(kTest64bDataStr));
+  CHECK_ARRAYS_EQ(input_buf, kTest64bDataStr, ARRAYSIZE(kTest64bDataStr));
+
+  LOG_INFO("Sending 256B data to Host...");
   LOG_INFO("%s", kTest256bDataStr);
-  LOG_INFO("Sending 1KB data...");
+  LOG_INFO("SYNC: Waiting for console data");
+  received_data_len =
+      ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+  CHECK(received_data_len == sizeof(kTest256bDataStr));
+  CHECK_ARRAYS_EQ(input_buf, kTest256bDataStr, ARRAYSIZE(kTest256bDataStr));
+
+  LOG_INFO("Sending 1KB data to Host...");
   for (int i = 1; i <= 2; i++) {
     LOG_INFO("Round: %d", i);
     LOG_INFO("%s", kTest1KbDataStr);
+    LOG_INFO("SYNC: Waiting for console data");
+    received_data_len =
+        ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+    CHECK(received_data_len == sizeof(kTest1KbDataStr));
+    CHECK_ARRAYS_EQ(input_buf, kTest1KbDataStr, ARRAYSIZE(kTest1KbDataStr));
   }
-  LOG_INFO("Sending 4KB data...");
-  LOG_INFO("%s", kTest4KbDataStr);
 
+  LOG_INFO("Sending 4KB data to Host...");
+  LOG_INFO("%s", kTest4KbDataStr);
+  LOG_INFO("SYNC: Waiting for console data");
+  received_data_len =
+      ottf_console_spi_device_read(sizeof(input_buf), input_buf);
+  CHECK(received_data_len == sizeof(kTest4KbDataStr));
+  CHECK_ARRAYS_EQ(input_buf, kTest4KbDataStr, ARRAYSIZE(kTest4KbDataStr));
   return true;
 }


### PR DESCRIPTION
This PR has three commits that:

1. Update the opentitanlib SPI console module to support TX direction
2. Add support for reading data from the Host via the OTTF SPI device console
3. Test the OTTF spi_device console in TX direction.

Workflow:
1. Device Ready Signal: Device initiates communication by sending a sync message to Host, signaling its readiness to receive data and its active wait state for an upload command.
2. Host Initiates Upload: Host responds by issuing an upload command. Following this, Host actively polls the status register, waiting for the BUSY bit to be cleared.
3. Device Data Processing: Upon receiving the upload command, Device reads data from the payload buffer. After processing, it clears the BUSY bit and enters a busy wait state, anticipating the next upload command.
4. Host Continues Upload: Host proceeds to send the subsequent upload command, repeating the process from step 2.

Transmission Completion:
- The write address of the last data chunk will be set to a special address, informing Device that the transmission is completed and Device can stop its busy wait state for further upload commands.

This PR addresses #21726 partially. The support for ujson_ottf will be added in another PR.