### PR TITLE
[dv,usbdev] Fixes for usbdev_stress_usb_traffic

### DIFF
--- a/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
+++ b/hw/dv/sv/usb20_agent/usb20_agent_cfg.sv
@@ -41,6 +41,10 @@ class usb20_agent_cfg extends dv_base_agent_cfg;
   // RTL has limited ability to recover from an invalid SYNC signal at the start of the packet.
   bit rtl_limited_sync_recovery = 1'b1;
 
+  // RTL has limited ability to detect bit stuffing violations; specifically it does not detect a
+  // bit stuffing violation that occurs right at the end of the packet.
+  bit rtl_limited_bitstuff_detection = 1'b1;
+
   // RTL has limited ability to recover from bit stuffing violations; subsequent bits within the
   // packet may be misinterpreted as another SYNC signal.
   bit rtl_limited_bitstuff_recovery = 1'b1;

--- a/hw/dv/sv/usb20_agent/usb20_monitor.sv
+++ b/hw/dv/sv/usb20_agent/usb20_monitor.sv
@@ -667,7 +667,9 @@ class usb20_monitor extends dv_base_monitor #(
         else consecutive_ones_count = 0;
       end
     end
-    if (consecutive_ones_count >= 6) begin
+    // See explanation in `usb20_agent_cfg.sv` => the DUT presently does not detect bit stuffing
+    // violations that occur right at the end of the packet.
+    if (!cfg.rtl_limited_bitstuff_detection && consecutive_ones_count >= 6) begin
       `uvm_info(`gfn, $sformatf("Bit stuffing violation detected in %p at bit %d", packet, i),
                 UVM_LOW)
       valid_stuffing = 0;

--- a/hw/ip/usbdev/dv/env/usbdev_bfm.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_bfm.sv
@@ -590,7 +590,14 @@ class usbdev_bfm extends uvm_component;
         // Process the most recent SETUP/OUT packet and DATA packet together.
         return out_packet(rx_token, data, rsp);
       end
-    end else cancel_out();
+    end else begin
+      // A SETUP packet that would not be received does not result in a LinkOutErr if the DATA
+      // packet is invalid because the OUT Packet Engine does not start accepting it.
+      if (rx_token != null && rx_token.m_pid_type == PidTypeSetupToken &&
+          !rxenable_setup[rx_token.endpoint]) begin
+        rx_token = null;
+      end else cancel_out();
+    end
     return 0;
   endfunction
 


### PR DESCRIPTION
Fix a couple of seed-dependent failures in the stress_usb_traffic sequence; in one case the BFM incorrectly predicted a LinkOutErr and in the other the inability of the DUT to detect and report a bit stuffing error exactly at the end of the received packet was being triggered by randomly-chosen address and endpoint, and the monitor did report a bit stuffing violation when the intention was to introduce a deliberate violation only in the subsequent data packet.