### PR TITLE
[manuf] add flash info field for writing characterization data

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -41,6 +41,15 @@ const flash_info_field_t kFlashInfoFieldAstCalibrationData = {
         OTP_CTRL_PARAM_DEVICE_ID_SIZE + OTP_CTRL_PARAM_MANUF_STATE_SIZE,
 };
 
+const flash_info_field_t kFlashInfoFieldCharacterizationData = {
+    .partition = 0,
+    .bank = 0,
+    .page = 0,
+    .byte_offset = OTP_CTRL_PARAM_DEVICE_ID_SIZE +
+                   OTP_CTRL_PARAM_MANUF_STATE_SIZE +
+                   kFlashInfoAstCalibrationDataSizeIn32BitWords,
+};
+
 const flash_info_field_t kFlashInfoFieldCreatorSeed = {
     .partition = 0,
     .bank = 0,

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -25,8 +25,10 @@ enum {
    *
    * Number of AST calibration words that will be stored in flash / OTP.
    */
+  kFlashInfoAstCalibrationDataSizeInBytes =
+      AST_REGAL_REG_OFFSET + sizeof(uint32_t),
   kFlashInfoAstCalibrationDataSizeIn32BitWords =
-      (AST_REGAL_REG_OFFSET + sizeof(uint32_t)) / sizeof(uint32_t),
+      kFlashInfoAstCalibrationDataSizeInBytes / sizeof(uint32_t),
 
   // Creator/Owner Seeds - Bank 0, Pages 1 and 2
   kFlashInfoKeySeedSizeIn32BitWords = 32 / sizeof(uint32_t),
@@ -46,6 +48,7 @@ enum {
 extern const flash_info_field_t kFlashInfoFieldDeviceId;
 extern const flash_info_field_t kFlashInfoFieldManufState;
 extern const flash_info_field_t kFlashInfoFieldAstCalibrationData;
+extern const flash_info_field_t kFlashInfoFieldCharacterizationData;
 extern const flash_info_field_t kFlashInfoFieldCreatorSeed;
 extern const flash_info_field_t kFlashInfoFieldOwnerSeed;
 extern const flash_info_field_t kFlashInfoFieldWaferAuthSecret;


### PR DESCRIPTION
Some SKU owners may desire to obtain characterization data during manufacturing. This allocates a field in flash info page 0 for this to be written to.