### PR TITLE
[ownership] Initialize SRAM & rescue according to the owner configuration

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -195,3 +195,20 @@ rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
   }
   return kErrorOwnershipKeyNotFound;
 }
+
+hardened_bool_t owner_rescue_command_allowed(
+    const owner_rescue_config_t *rescue, uint32_t command) {
+  // If no rescue configuration is supplied in the owner config, then all rescue
+  // commands are allowed.
+  if ((hardened_bool_t)rescue == kHardenedBoolFalse)
+    return kHardenedBoolTrue;
+
+  hardened_bool_t allowed = kHardenedBoolFalse;
+  size_t length = (rescue->header.length - sizeof(*rescue)) / sizeof(uint32_t);
+  for (size_t i = 0; i < length; ++i) {
+    if (command == rescue->command_allow[i]) {
+      allowed = kHardenedBoolTrue;
+    }
+  }
+  return allowed;
+}

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNER_BLOCK_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNER_BLOCK_H_
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
@@ -85,6 +86,15 @@ rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
                                    uint32_t key_alg, uint32_t key_id,
                                    size_t *index);
 
+/**
+ * Determine whether a particular rescue command is allowed.
+ *
+ * @param rescue A pointer to the rescue configuration.
+ * @param command The rescue command to check.
+ * @return kHardenedBoolTrue if allowed.
+ */
+hardened_bool_t owner_rescue_command_allowed(
+    const owner_rescue_config_t *rescue, uint32_t command);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -92,7 +92,6 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
   HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotB,
                                                    bootdata->primary_bl0_slot));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
-  // TODO: apply SRAM exec config
   // TODO: apply rescue config
   return kErrorOk;
 }
@@ -165,7 +164,6 @@ static rom_error_t unlocked_init(boot_data_t *bootdata, owner_config_t *config,
   HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, secondary,
                                                    bootdata->primary_bl0_slot));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
-  // TODO: apply SRAM exec config
   // TODO: apply rescue config
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -92,7 +92,6 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
   HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotB,
                                                    bootdata->primary_bl0_slot));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
-  // TODO: apply rescue config
   return kErrorOk;
 }
 
@@ -164,7 +163,6 @@ static rom_error_t unlocked_init(boot_data_t *bootdata, owner_config_t *config,
   HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, secondary,
                                                    bootdata->primary_bl0_slot));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
-  // TODO: apply rescue config
   return kErrorOk;
 }
 
@@ -226,6 +224,7 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
   dbg_printf("ownership: %C\r\n", bootdata->ownership_state);
   owner_config_default(config);
   rom_error_t error = kErrorOwnershipNoOwner;
+  // TODO(#22386): Harden this switch/case statement.
   switch (bootdata->ownership_state) {
     case kOwnershipStateLockedOwner:
       error = locked_owner_init(bootdata, config, keyring);

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -30,7 +30,7 @@ rom_error_t test_owner_init(boot_data_t *bootdata, owner_config_t *config,
   owner_page[0].header.tag = kTlvTagOwner;
   owner_page[0].header.length = 2048;
   owner_page[0].version = 0;
-  owner_page[0].sram_exec_mode = kOwnerSramExecModeDisabled;
+  owner_page[0].sram_exec_mode = kOwnerSramExecModeDisabledLocked;
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
   owner_page[0].owner_key = (owner_key_t){OWNER_ECDSA_P256};
   owner_page[0].activate_key = (owner_key_t){ACTIVATE_ECDSA_P256};
@@ -108,9 +108,9 @@ rom_error_t test_owner_init(boot_data_t *bootdata, owner_config_t *config,
                                      sizeof(owner_page[0]) / sizeof(uint32_t),
                                      &owner_page[0]));
     OT_DISCARD(boot_data_write(bootdata));
-    dbg_printf("Test owner flash initialized\r\n");
+    dbg_printf("test_owner_init: flash\r\n");
   } else {
-    dbg_printf("Test owner ram initialized\r\n");
+    dbg_printf("test_owner_init: ram\r\n");
   }
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/xmodem.c
+++ b/sw/device/silicon_creator/lib/xmodem.c
@@ -166,6 +166,11 @@ static rom_error_t xmodem_send_start(void *iohandle, uint32_t retries) {
   return kErrorXModemTimeoutStart;
 }
 
+void xmodem_cancel(void *iohandle) {
+  xmodem_putchar(iohandle, kXModemCancel);
+  xmodem_putchar(iohandle, kXModemCancel);
+}
+
 static rom_error_t xmodem_send_finish(void *iohandle) {
   xmodem_putchar(iohandle, kXModemEof);
   uint8_t ch;

--- a/sw/device/silicon_creator/lib/xmodem.h
+++ b/sw/device/silicon_creator/lib/xmodem.h
@@ -25,6 +25,11 @@ void xmodem_recv_start(void *iohandle);
 void xmodem_ack(void *iohandle, bool ack);
 
 /**
+ * Send an Xmodem cancel sequence.
+ */
+void xmodem_cancel(void *iohandle);
+
+/**
  * Receive a frame using Xmodem-CRC
  *
  * @param iohandle An opaque user point associated with the io device.

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -63,6 +63,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/ownership:owner_block",
     ],
 )
 

--- a/sw/device/silicon_creator/rom_ext/rescue.h
+++ b/sw/device/silicon_creator/rom_ext/rescue.h
@@ -8,7 +8,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
 enum {
   // Rescue is signalled by asserting serial break to the UART for at least
@@ -66,10 +68,13 @@ typedef struct RescueState {
   // Range to erase and write for firmware rescue (inclusive).
   uint32_t flash_start;
   uint32_t flash_limit;
+  // Rescue configuration.
+  const owner_rescue_config_t *config;
   // Data buffer to hold xmodem upload data.
   uint8_t data[2048];
 } rescue_state_t;
 
-rom_error_t rescue_protocol(void);
+rom_error_t rescue_protocol(boot_data_t *bootdata,
+                            const owner_rescue_config_t *rescue);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_RESCUE_H_

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -220,20 +220,28 @@ static rom_error_t rom_ext_init(boot_data_t *boot_data) {
   return kErrorOk;
 }
 
-void rom_ext_sram_exec(hardened_bool_t enable) {
-  switch (enable) {
-    case kHardenedBoolTrue:
-      // In the case where we enable SRAM exec, we do not lock the register as
-      // some later code may want to disable it.
-      HARDENED_CHECK_EQ(enable, kHardenedBoolTrue);
+void rom_ext_sram_exec(owner_sram_exec_mode_t mode) {
+  switch (mode) {
+    case kOwnerSramExecModeEnabled:
+      // In enabled mode, we do not lock the register so owner code can disable
+      // SRAM exec at some later time.
+      HARDENED_CHECK_EQ(mode, kOwnerSramExecModeEnabled);
       sec_mmio_write32(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR +
                            SRAM_CTRL_EXEC_REG_OFFSET,
                        kMultiBitBool4True);
       break;
-    case kHardenedBoolFalse:
-      // In the case where we disable SRAM exec, we lock the register so that it
-      // cannot be re-enabled later.
-      HARDENED_CHECK_EQ(enable, kHardenedBoolFalse);
+    case kOwnerSramExecModeDisabled:
+      // In disabled mode, we do not lock the register so owner code can enable
+      // SRAM exec at some later time.
+      HARDENED_CHECK_EQ(mode, kOwnerSramExecModeDisabled);
+      sec_mmio_write32(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR +
+                           SRAM_CTRL_EXEC_REG_OFFSET,
+                       kMultiBitBool4False);
+      break;
+    case kOwnerSramExecModeDisabledLocked:
+    default:
+      // In disabled locked mode, we lock the register so the mode cannot be
+      // changed.
       sec_mmio_write32(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR +
                            SRAM_CTRL_EXEC_REG_OFFSET,
                        kMultiBitBool4False);
@@ -241,8 +249,6 @@ void rom_ext_sram_exec(hardened_bool_t enable) {
                            SRAM_CTRL_EXEC_REGWEN_REG_OFFSET,
                        0);
       break;
-    default:
-      HARDENED_TRAP();
   }
 }
 
@@ -255,12 +261,14 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
       &keyring, kOwnershipKeyAlgRsa,
       sigverify_rsa_key_id_get(&manifest->rsa_modulus), &kindex));
 
-  dbg_printf("application key %u: alg=%C domain=%C\r\n", kindex,
+  dbg_printf("app_verify: key=%u alg=%C domain=%C\r\n", kindex,
              keyring.key[kindex]->key_alg, keyring.key[kindex]->key_domain);
 
   hmac_sha256_init();
   // Hash usage constraints.
   manifest_usage_constraints_t usage_constraints_from_hw;
+  // TODO(cfrantz): Combine key's usage constraints with manifest's
+  // usage_constraints.
   sigverify_usage_constraints_get(manifest->usage_constraints.selector_bits,
                                   &usage_constraints_from_hw);
   hmac_sha256_update(&usage_constraints_from_hw,
@@ -560,9 +568,6 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
   rom_ext_epmp_clear_rlb();
   HARDENED_RETURN_IF_ERROR(epmp_state_check());
 
-  // Forbid code execution from SRAM.
-  rom_ext_sram_exec(kHardenedBoolFalse);
-
   // Lock the address translation windows.
   ibex_addr_remap_lockdown(0);
   ibex_addr_remap_lockdown(1);
@@ -821,6 +826,8 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   if (error == kErrorWriteBootdataThenReboot) {
     return error;
   }
+  // Configure SRAM execution as the owner requested.
+  rom_ext_sram_exec(owner_config.sram_exec);
 
   // Handle any pending boot_svc commands.
   uint32_t skip_boot_svc = reset_reasons & (1 << kRstmgrReasonLowPowerExit);

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -852,7 +852,7 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
     uart_enable_receiver();
     // TODO: update rescue protocol to accept boot data and rescue
     // config from the owner_config.
-    error = rescue_protocol();
+    error = rescue_protocol(boot_data, owner_config.rescue);
   } else {
     error = rom_ext_try_next_stage(boot_data, boot_log);
   }

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -253,8 +253,8 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
 00000180: 66 06 00 00 01 05 00 00 77 17 11 88 77 17 11 11  f.......w...w...
 00000190: 52 45 53 51 38 00 00 00 58 4d 44 4d 20 00 e0 00  RESQ8...XMDM ...
 000001a0: 45 4d 50 54 4d 53 45 43 4e 45 58 54 55 4e 4c 4b  EMPTMSECNEXTUNLK
-000001b0: 41 43 54 56 52 45 53 51 42 4c 4f 47 42 52 45 51  ACTVRESQBLOGBREQ
-000001c0: 42 52 53 50 4f 57 4e 52 5a 5a 5a 5a 5a 5a 5a 5a  BRSPOWNRZZZZZZZZ
+000001b0: 41 43 54 56 51 53 45 52 47 4f 4c 42 51 45 52 42  ACTVQSERGOLBQERB
+000001c0: 50 53 52 42 52 4e 57 4f 5a 5a 5a 5a 5a 5a 5a 5a  PSRBRNWOZZZZZZZZ
 000001d0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
 000001e0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
 000001f0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
@@ -497,8 +497,8 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
           "Empty",
           "MinBl0SecVerRequest",
           "NextBl0SlotRequest",
-          "UnlockOwnershipRequest",
-          "ActivateOwnerRequest",
+          "OwnershipUnlockRequest",
+          "OwnershipActivateRequest",
           "Rescue",
           "GetBootLog",
           "BootSvcReq",

--- a/sw/host/opentitanlib/src/ownership/rescue.rs
+++ b/sw/host/opentitanlib/src/ownership/rescue.rs
@@ -24,13 +24,16 @@ with_unknown! {
         Empty = BootSvcKind::EmptyRequest.0,
         MinBl0SecVerRequest = BootSvcKind::MinBl0SecVerRequest.0,
         NextBl0SlotRequest = BootSvcKind::NextBl0SlotRequest.0,
-        UnlockOwnershipRequest = BootSvcKind::OwnershipUnlockRequest.0,
-        ActivateOwnerRequest = BootSvcKind::OwnershipActivateRequest.0,
-        Rescue = u32::from_le_bytes(*b"RESQ"),
-        GetBootLog = u32::from_le_bytes(*b"BLOG"),
-        BootSvcReq = u32::from_le_bytes(*b"BREQ"),
-        BootSvcRsp = u32::from_le_bytes(*b"BRSP"),
-        OwnerBlock = u32::from_le_bytes(*b"OWNR"),
+        OwnershipUnlockRequest = BootSvcKind::OwnershipUnlockRequest.0,
+        OwnershipActivateRequest =   BootSvcKind::OwnershipActivateRequest.0,
+
+        // The rescue protocol-level commands are represented in big-endian order.
+        Rescue = u32::from_be_bytes(*b"RESQ"),
+        Reboot = u32::from_be_bytes(*b"REBO"),
+        GetBootLog = u32::from_be_bytes(*b"BLOG"),
+        BootSvcReq = u32::from_be_bytes(*b"BREQ"),
+        BootSvcRsp = u32::from_be_bytes(*b"BRSP"),
+        OwnerBlock = u32::from_be_bytes(*b"OWNR"),
     }
 }
 
@@ -107,8 +110,8 @@ impl OwnerRescueConfig {
                 CommandTag::Empty,
                 CommandTag::MinBl0SecVerRequest,
                 CommandTag::NextBl0SlotRequest,
-                CommandTag::UnlockOwnershipRequest,
-                CommandTag::ActivateOwnerRequest,
+                CommandTag::OwnershipUnlockRequest,
+                CommandTag::OwnershipActivateRequest,
                 CommandTag::Rescue,
                 CommandTag::GetBootLog,
                 CommandTag::BootSvcReq,
@@ -128,8 +131,8 @@ mod test {
     const OWNER_RESCUE_CONFIG_BIN: &str = "\
 00000000: 52 45 53 51 38 00 00 00 58 4d 44 4d 20 00 64 00  RESQ8...XMDM .d.\n\
 00000010: 45 4d 50 54 4d 53 45 43 4e 45 58 54 55 4e 4c 4b  EMPTMSECNEXTUNLK\n\
-00000020: 41 43 54 56 52 45 53 51 42 4c 4f 47 42 52 45 51  ACTVRESQBLOGBREQ\n\
-00000030: 42 52 53 50 4f 57 4e 52                          BRSPOWNR\n\
+00000020: 41 43 54 56 51 53 45 52 47 4f 4c 42 51 45 52 42  ACTVQSERGOLBQERB\n\
+00000030: 50 53 52 42 52 4e 57 4f                          PSRBRNWO\n\
 ";
     const OWNER_RESCUE_CONFIG_JSON: &str = r#"{
   header: {
@@ -143,8 +146,8 @@ mod test {
     "Empty",
     "MinBl0SecVerRequest",
     "NextBl0SlotRequest",
-    "UnlockOwnershipRequest",
-    "ActivateOwnerRequest",
+    "OwnershipUnlockRequest",
+    "OwnershipActivateRequest",
     "Rescue",
     "GetBootLog",
     "BootSvcReq",
@@ -164,8 +167,8 @@ mod test {
                 CommandTag::Empty,
                 CommandTag::MinBl0SecVerRequest,
                 CommandTag::NextBl0SlotRequest,
-                CommandTag::UnlockOwnershipRequest,
-                CommandTag::ActivateOwnerRequest,
+                CommandTag::OwnershipUnlockRequest,
+                CommandTag::OwnershipActivateRequest,
                 CommandTag::Rescue,
                 CommandTag::GetBootLog,
                 CommandTag::BootSvcReq,


### PR DESCRIPTION
1. Configure SRAM execution as specified in the owner configuration.
2. Configure rescue according to the owner configuration.
2a. Set bounds on the firmware rescue region in flash.
2b. Disallow rescue modes not allowed by the configuration.
2c. Disallow boot_svc commands not allowed by the configuration.
3. Correct an endian issue with the rescue-mode FourCC codes.  Rescue-modes are expressed in big-endian order, whereas all other FourCC codes are expressed in little-endian order (the reason is that rescue-modes should be thought of more as 4-byte strings than identifier words).