### PR TITLE
[personalization_ext] Improve personalization extensions API

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -212,9 +212,16 @@ filegroup(
 )
 
 cc_library(
+    name = "personalize_ext",
+    hdrs = ["personalize_ext.h"],
+)
+
+cc_library(
     name = "ft_personalize_base",
     srcs = ["ft_personalize.c"],
     deps = [
+        ":perso_tlv_data",
+        ":personalize_ext",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:lc_ctrl",
@@ -241,7 +248,6 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:kmac",
-        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
         "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_sku_sival",
         "//sw/device/silicon_creator/manuf/lib:personalize",
@@ -252,6 +258,7 @@ cc_library(
     name = "tpm_perso_fw_ext",
     srcs = ["tpm_personalize_ext.c"],
     deps = [
+        ":personalize_ext",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:status",

--- a/sw/device/silicon_creator/manuf/base/personalize_ext.h
+++ b/sw/device/silicon_creator/manuf/base/personalize_ext.h
@@ -1,0 +1,87 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_BASE_PERSONALIZE_EXT_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_BASE_PERSONALIZE_EXT_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
+#include "sw/device/silicon_creator/lib/cert/cert.h"
+
+/**
+ * Parameters passed to personalization extension function invoked before data
+ * is sent to the host for endorsement. Not all parameters are necessarily used
+ * by all extension implementations.
+ */
+typedef struct personalize_extension_pre_endorse {
+  /**
+   *  Serialization interface, marshals/unmarshals structures' fields and
+   *  communicates with the host.
+   */
+  ujson_t *uj;
+  /**
+   *  Pointer to information used for generating certificates.
+   */
+  manuf_certgen_inputs_t *certgen_inputs;
+  /**
+   *  Pointer to the TLV data blob sent to the host for endorsement.
+   */
+  perso_blob_t *perso_blob_to_host;
+  /**
+   * Pointer to the flash layout table, the extension could enable disabled
+   * entries in the table and configure its INFO space use so that the caller
+   * knows where to place endorsed objects received from the host.
+   */
+  cert_flash_info_layout_t *cert_flash_layout;
+
+  /**
+   * Pointer to the flash controller handle necessary for proper flash access.
+   */
+  dif_flash_ctrl_state_t *flash_ctrl_handle;
+} personalize_extension_pre_endorse_t;
+
+/**
+ * Parameters passed to personalization extension function invoked after the
+ * host finished endorsement processing and sent endorsed data to the device.
+ */
+typedef struct personalize_extension_post_endorse {
+  /**
+   *  Serialization interface, marshals/unmarshals structures' fields and
+   *  communicates with the host.
+   */
+  ujson_t *uj;
+  /**
+   *  Pointer to the TLV data blob received from the host.
+   */
+  perso_blob_t *perso_blob_from_host;
+  /**
+   * Pointer to the flash layout table used previously when saving pre
+   * endorsement data..
+   */
+  cert_flash_info_layout_t *cert_flash_layout;
+} personalize_extension_post_endorse_t;
+
+/**
+ * A custom extension to the personalization flow.
+ *
+ * This extension runs *BEFORE* TBS certificates are sent to the host to be
+ * endorsed. Implementing this extension enables SKU owners to add more TBS
+ * certificates to the list of certificates to be endorsed by the host.
+ */
+status_t personalize_extension_pre_cert_endorse(
+    personalize_extension_pre_endorse_t *pre_params);
+
+/**
+ * A custom extension to the personalization flow.
+ *
+ * This extension runs *AFTER* (endorsed) certificates are sent back to the
+ * device from the host. Implementing this extension enables SKU owners to
+ * provision additional data into flash, in addition to the endorsed
+ * certificates in the `perso_blob_from_host` struct.
+ */
+status_t personalize_extension_post_cert_endorse(
+    personalize_extension_post_endorse_t *post_params);
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_BASE_PERSONALIZE_EXT_H_

--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -13,6 +13,7 @@
 #include "sw/device/silicon_creator/lib/cert/tpm_ek.h"  // Generated.
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/manuf/base/personalize_ext.h"
 #include "sw/device/silicon_creator/manuf/lib/personalize.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -91,20 +92,18 @@ static status_t personalize_gen_tpm_ek_certificate(
 }
 
 status_t personalize_extension_pre_cert_endorse(
-    ujson_t *uj, manuf_certgen_inputs_t *certgen_inputs,
-    perso_blob_t *perso_blob, cert_flash_info_layout_t *cert_flash_layout,
-    dif_flash_ctrl_state_t *flash_ctrl_handle) {
+    personalize_extension_pre_endorse_t *pre_params) {
   LOG_INFO("Running TPM perso extension ...");
   TRY(peripheral_handles_init());
   TRY(config_and_erase_tpm_certificate_flash_pages());
-  TRY(personalize_gen_tpm_ek_certificate(certgen_inputs, perso_blob,
-                                         cert_flash_layout));
+  TRY(personalize_gen_tpm_ek_certificate(pre_params->certgen_inputs,
+                                         pre_params->perso_blob_to_host,
+                                         pre_params->cert_flash_layout));
   return OK_STATUS();
 }
 
 status_t personalize_extension_post_cert_endorse(
-    ujson_t *uj, perso_blob_t *perso_blob_from_host,
-    cert_flash_info_layout_t *cert_flash_layout) {
+    personalize_extension_post_endorse_t *post_params) {
   /* Empty because it is unused but we still need to link to something. */
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/extensions/BUILD.bazel
+++ b/sw/device/silicon_creator/manuf/extensions/BUILD.bazel
@@ -29,6 +29,7 @@ cc_library(
         "@//sw/device/lib/testing/test_framework:status",
         "@//sw/device/lib/testing/test_framework:ujson_ottf",
         "@//sw/device/silicon_creator/lib/cert",
+        "@//sw/device/silicon_creator/manuf/base:personalize_ext",
     ],
 )
 
@@ -41,6 +42,7 @@ cc_library(
         "@//sw/device/lib/testing/test_framework:status",
         "@//sw/device/lib/testing/test_framework:ujson_ottf",
         "@//sw/device/silicon_creator/lib/cert",
+        "@//sw/device/silicon_creator/manuf/base:personalize_ext",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/extensions/default_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/extensions/default_personalize_ext.c
@@ -7,16 +7,14 @@
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
+#include "sw/device/silicon_creator/manuf/base/personalize_ext.h"
 
 status_t personalize_extension_pre_cert_endorse(
-    ujson_t *uj, manuf_certgen_inputs_t *certgen_inputs,
-    perso_blob_t *tbs_certs, cert_flash_info_layout_t *cert_flash_layout,
-    dif_flash_ctrl_state_t *flash_ctrl_handle) {
+    personalize_extension_pre_endorse_t *pre_params) {
   return OK_STATUS();
 }
 
 status_t personalize_extension_post_cert_endorse(
-    ujson_t *uj, perso_blob_t *perso_blob_from_host,
-    cert_flash_info_layout_t *cert_flash_layout) {
+    personalize_extension_post_endorse_t *post_params) {
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/extensions/example_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/extensions/example_personalize_ext.c
@@ -8,18 +8,16 @@
 #include "sw/device/lib/testing/test_framework/status.h"
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
+#include "sw/device/silicon_creator/manuf/base/personalize_ext.h"
 
 status_t personalize_extension_pre_cert_endorse(
-    ujson_t *uj, manuf_certgen_inputs_t *certgen_inputs,
-    perso_blob_t *tbs_certs, cert_flash_info_layout_t *cert_flash_layout,
-    dif_flash_ctrl_state_t *flash_ctrl_handle) {
+    personalize_extension_pre_endorse_t *pre_params) {
   LOG_INFO("Running example pre-cert-endorsement perso extension ...");
   return OK_STATUS();
 }
 
 status_t personalize_extension_post_cert_endorse(
-    ujson_t *uj, perso_blob_t *perso_blob_from_host,
-    cert_flash_info_layout_t *cert_flash_layout) {
+    personalize_extension_post_endorse_t *post_params) {
   LOG_INFO("Running example post-cert-endorsement perso extension ...");
   return OK_STATUS();
 }


### PR DESCRIPTION
Declare interface functions in a .h file so that they can be validated at compile time and move all passed in parameters into the respective structures. Not all extesnions use all interface parameters, keeping paramters in structures will allow to add new interface parameters without modifying extensions which do not use the new parameters.

Tested by running various personalization end to end tests both local and with extensions.