### PR TITLE
Exclude mem init dynamic `if` from synthesis

### DIFF
--- a/hw/ip/prim/rtl/prim_util_memload.svh
+++ b/hw/ip/prim/rtl/prim_util_memload.svh
@@ -55,11 +55,13 @@
 `endif
 
 initial begin
+`ifndef SYNTHESIS
   logic show_mem_paths;
 
   // Print the hierarchical path to the memory to help make formal connectivity checks easy.
   void'($value$plusargs("show_mem_paths=%0b", show_mem_paths));
   if (show_mem_paths) $display("%m");
+`endif
 
   if (MemInitFile != "") begin : gen_meminit
       $display("Initializing memory %m from file '%s'.", MemInitFile);


### PR DESCRIPTION
Put memory path printing into a synthesis exclusion block to avoid synthesis tools complaining about it and ignoring it anyway.