### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@38c07093

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 96a1c02ba03400a8b0d69f08b97004adc436dfb7
+    rev: 38c070939183cc10940b66c8e9e04eeca6b65470
   }
 }

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
@@ -352,7 +352,7 @@ module ibex_controller #(
 
     // As integrity error is the only internal interrupt implement, set irq_nm_* signals directly
     // within this generate block.
-    assign irq_nm_int       = mem_resp_intg_err_irq_set | mem_resp_intg_err_irq_pending_q;
+    assign irq_nm_int       = mem_resp_intg_err_irq_pending_q;
     assign irq_nm_int_cause = NMI_INT_CAUSE_ECC;
     assign irq_nm_int_mtval = mem_resp_intg_err_addr_q;
   end else begin : g_no_intg_irq_int


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
38c070939183cc10940b66c8e9e04eeca6b65470

* [rtl] Remove ECC related data_rdata_i -> instr_X_o feedthroughs (Greg Chadwick)

This is related to #24404.