### PR TITLE
[personalisation] dev seed hash generation and transfer

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -270,6 +270,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
+        "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
         "//sw/device/silicon_creator/manuf/lib:personalize",
     ],
 )

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -553,7 +553,6 @@ static status_t personalize_endorse_certificates(ujson_t *uj) {
       // We just prepared the set of wrapped certificates, let's trust that the
       // data is correct and does not need more validation.
       memcpy(&crth, certs, sizeof(crth));
-      crth = __builtin_bswap16(crth);
       certs += sizeof(crth);
       PERSO_TLV_GET_FIELD(Crth, NameSize, crth, &name_len);
       memcpy(name, certs, name_len);

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -30,7 +30,6 @@ status_t perso_tlv_set_cert_block(const uint8_t *buf, size_t max_room,
   perso_tlv_object_header_t obj_type;
 
   memcpy(&objh, buf, sizeof(objh));
-  objh = __builtin_bswap16(objh);
   PERSO_TLV_GET_FIELD(Objh, Size, objh, &obj_size);
 
   if (obj_size > max_room)
@@ -53,7 +52,6 @@ status_t perso_tlv_set_cert_block(const uint8_t *buf, size_t max_room,
   // Let's retrieve cert wrapper header.
   block->wrapped_cert_p = buf;
   memcpy(&crth, buf, sizeof(crth));
-  crth = __builtin_bswap16(crth);
   max_room -= sizeof(crth);
   buf += sizeof(crth);
   PERSO_TLV_GET_FIELD(Crth, Size, crth, &wrapped_cert_size);
@@ -148,10 +146,8 @@ status_t perso_tlv_prepare_cert_for_shipping(const char *name,
   PERSO_TLV_SET_FIELD(Crth, Size, cert_header, wrapped_len);
   PERSO_TLV_SET_FIELD(Crth, NameSize, cert_header, name_len);
 
-  uint16_t swapped = __builtin_bswap16(obj_header);
-  TRY(perso_tlv_push_to_blob(&swapped, sizeof(obj_header), pb));
-  swapped = __builtin_bswap16(cert_header);
-  TRY(perso_tlv_push_to_blob(&swapped, sizeof(cert_header), pb));
+  TRY(perso_tlv_push_to_blob(&obj_header, sizeof(obj_header), pb));
+  TRY(perso_tlv_push_to_blob(&cert_header, sizeof(cert_header), pb));
   TRY(perso_tlv_push_to_blob(name, name_len, pb));
   TRY(perso_tlv_push_to_blob(cert_body, cert_size, pb));
   pb->num_objs++;

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -73,23 +73,25 @@ typedef enum perso_tlv_cert_header_fields {
   kCrthNameSizeFieldMask = (1 << kCrthNameSizeFieldWidth) - 1,
 } perso_tlv_cert_header_fields_t;
 
-// Helper macros allowing set or get various header fields.
-#define PERSO_TLV_SET_FIELD(type_name, field_name, full_value, field_value)   \
-  {                                                                           \
-    uint16_t mask = k##type_name##field_name##FieldMask;                      \
-    uint16_t shift = k##type_name##field_name##FieldShift;                    \
-    uint16_t fieldv = (uint16_t)field_value;                                  \
-    uint16_t fullv = (uint16_t)full_value;                                    \
-    fieldv = field_value & mask;                                              \
-    mask = (uint16_t)(mask << shift);                                         \
-    full_value = (uint16_t)((fullv & ~mask) | (((uint16_t)fieldv) << shift)); \
+// Helper macros allowing set or get various object and certificate header
+// fields. Operate on objects in big endian representation, as they are
+// transferred over wire.
+#define PERSO_TLV_SET_FIELD(type_name, field_name, full_value, field_value) \
+  {                                                                         \
+    uint16_t mask = k##type_name##field_name##FieldMask;                    \
+    uint16_t shift = k##type_name##field_name##FieldShift;                  \
+    uint16_t fieldv = (uint16_t)(field_value)&mask;                         \
+    uint16_t fullv = __builtin_bswap16((uint16_t)(full_value));             \
+    mask = (uint16_t)(mask << shift);                                       \
+    (full_value) = __builtin_bswap16(                                       \
+        (uint16_t)((fullv & ~mask) | (((uint16_t)fieldv) << shift)));       \
   }
 
 #define PERSO_TLV_GET_FIELD(type_name, field_name, full_value, field_value) \
   {                                                                         \
     uint16_t mask = k##type_name##field_name##FieldMask;                    \
     uint16_t shift = k##type_name##field_name##FieldShift;                  \
-    *field_value = (full_value >> shift) & mask;                            \
+    *(field_value) = (__builtin_bswap16(full_value) >> shift) & mask;       \
   }
 
 /**

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -47,6 +47,19 @@ typedef enum perso_tlv_obj_header_fields {
   kObjhTypeFieldMask = (1 << kObjhTypeFieldWidth) - 1,
 } perso_tlv_obj_header_fields_t;
 
+typedef struct perso_tlv_dev_seed_element {
+  uint32_t el[8];
+} perso_tlv_dev_seed_element_t;
+
+typedef struct perso_tlv_dev_seed {
+  perso_tlv_dev_seed_element_t key;
+  perso_tlv_dev_seed_element_t context;
+} perso_tlv_dev_seed_t;
+
+typedef struct perso_tlv_dev_seed_set {
+  perso_tlv_dev_seed_t seeds[2];
+} perso_tlv_dev_seed_set_t;
+
 /**
  * The x509 certificate is prepended by a 16 bits header followed by the ASCII
  * characters of the certificate name, followed by the certificate body.

--- a/sw/device/silicon_creator/manuf/extensions/BUILD.bazel
+++ b/sw/device/silicon_creator/manuf/extensions/BUILD.bazel
@@ -30,6 +30,7 @@ cc_library(
         "@//sw/device/lib/testing/test_framework:ujson_ottf",
         "@//sw/device/silicon_creator/lib/cert",
         "@//sw/device/silicon_creator/manuf/base:personalize_ext",
+        "@//sw/device/silicon_creator/manuf/lib:flash_info_fields",
     ],
 )
 
@@ -43,6 +44,7 @@ cc_library(
         "@//sw/device/lib/testing/test_framework:ujson_ottf",
         "@//sw/device/silicon_creator/lib/cert",
         "@//sw/device/silicon_creator/manuf/base:personalize_ext",
+        "@//sw/device/silicon_creator/manuf/lib:flash_info_fields",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.c
@@ -99,20 +99,6 @@ const flash_info_field_t kFlashInfoFieldTpmEkAttestationKeySeed = {
     .byte_offset = kFlashInfoFieldTpmEkKeySeedIdx * kAttestationSeedBytes,
 };
 
-const flash_info_field_t kFlashInfoFieldTpmCekAttestationKeySeed = {
-    .partition = 0,
-    .bank = 0,
-    .page = 4,
-    .byte_offset = kFlashInfoFieldTpmCekKeySeedIdx * kAttestationSeedBytes,
-};
-
-const flash_info_field_t kFlashInfoFieldTpmCikAttestationKeySeed = {
-    .partition = 0,
-    .bank = 0,
-    .page = 4,
-    .byte_offset = kFlashInfoFieldTpmCikKeySeedIdx * kAttestationSeedBytes,
-};
-
 const flash_info_field_t kFlashInfoFieldAttestationKeyGenVersion = {
     .partition = 0,
     .bank = 0,

--- a/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
+++ b/sw/device/silicon_creator/manuf/lib/flash_info_fields.h
@@ -41,8 +41,6 @@ enum {
   kFlashInfoFieldCdi0KeySeedIdx = 1,
   kFlashInfoFieldCdi1KeySeedIdx = 2,
   kFlashInfoFieldTpmEkKeySeedIdx = 3,
-  kFlashInfoFieldTpmCekKeySeedIdx = 4,
-  kFlashInfoFieldTpmCikKeySeedIdx = 5,
 };
 
 extern const flash_info_field_t kFlashInfoFieldDeviceId;
@@ -58,6 +56,7 @@ extern const flash_info_field_t kFlashInfoFieldCdi1AttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldTpmEkAttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldTpmCekAttestationKeySeed;
 extern const flash_info_field_t kFlashInfoFieldTpmCikAttestationKeySeed;
+extern const flash_info_field_t kFlashInfoFieldDevSeedSeed;
 extern const flash_info_field_t kFlashInfoFieldAttestationKeyGenVersion;
 
 /**

--- a/sw/host/provisioning/perso_tlv_lib/src/lib.rs
+++ b/sw/host/provisioning/perso_tlv_lib/src/lib.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Result};
 
 // Types of objects which can come from the device in the perso blob.
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ObjType {
     UnendorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Tbs as isize,
     EndorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Cert as isize,
@@ -18,7 +18,7 @@ impl ObjType {
         match value {
             0 => Ok(ObjType::UnendorsedX509Cert),
             1 => Ok(ObjType::EndorsedX509Cert),
-            3 => Ok(ObjType::DevSeed),
+            2 => Ok(ObjType::DevSeed),
             _ => bail!("incorrect input value of {value} for ObjType"),
         }
     }


### PR DESCRIPTION
This patch adds the dev seed hash to the set of objects generated by the device and transferred to the host during personalization.

In fact dev seed hash is a SKU specific object, its processing should be used to SKU specific code on both device and host, along with TPM certificates produced by the cros SKU, this is left as a future enhancement.