### PR TITLE
[base,ottf,test] Refactor ujson ottf console to support spi_device console

### DIFF
--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -241,6 +241,8 @@ static size_t base_dev_spi_device(void *data, const char *buf, size_t len) {
   return write_data_len;
 }
 
+sink_func_ptr get_spi_device_sink(void) { return &base_dev_spi_device; }
+
 static size_t base_dev_uart(void *data, const char *buf, size_t len) {
   const dif_uart_t *uart = (const dif_uart_t *)data;
   for (size_t i = 0; i < len; ++i) {
@@ -250,6 +252,8 @@ static size_t base_dev_uart(void *data, const char *buf, size_t len) {
   }
   return len;
 }
+
+sink_func_ptr get_uart_sink(void) { return &base_dev_uart; }
 
 void base_spi_device_stdout(const dif_spi_device_handle_t *spi_device) {
   // Reset the frame counter.

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -29,6 +29,12 @@
  */
 
 /**
+ * Function pointer type for data sink.
+ * The function should return the number of bytes actually written.
+ */
+typedef size_t (*sink_func_ptr)(void *data, const char *buf, size_t len);
+
+/**
  * A buffer_sink_t represents a place to write bytes to, implemented as a
  * C-style "closure".
  *
@@ -36,12 +42,21 @@
  * information, and a sink function, which takes the data pointer, a buffer, and
  * that buffer's length.
  *
- * The sink function should return the number of bytes actually written.
  */
 typedef struct buffer_sink {
   void *data;
-  size_t (*sink)(void *data, const char *buf, size_t len);
+  sink_func_ptr sink;
 } buffer_sink_t;
+
+/**
+ * Returns a function pointer to the spi device sink function.
+ */
+sink_func_ptr get_spi_device_sink(void);
+
+/**
+ * Returns a function pointer to the uart sink function.
+ */
+sink_func_ptr get_uart_sink(void);
 
 /**
  * Prints out a message to stdout, formatted according to the format string

--- a/sw/device/lib/testing/test_framework/ottf_console.h
+++ b/sw/device/lib/testing/test_framework/ottf_console.h
@@ -109,4 +109,21 @@ uint32_t ottf_console_get_flow_control_irqs(void);
  */
 size_t ottf_console_spi_device_read(size_t buf_size, uint8_t *const buf);
 
+/**
+ * Write a buffer to the OTTF console.
+ *
+ * @param context An IO context
+ * @param buf The buffer to write to the OTTF console.
+ * @param len The length of the buffer.
+ * @return OK or an error.
+ */
+status_t ottf_console_putbuf(void *io, const char *buf, size_t len);
+
+/**
+ * Get a single character from the OTTF console.
+ *
+ * @return The next character or an error.
+ */
+status_t ottf_console_getc(void *io);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_CONSOLE_H_

--- a/sw/device/lib/testing/test_framework/ujson_ottf.c
+++ b/sw/device/lib/testing/test_framework/ujson_ottf.c
@@ -6,26 +6,9 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/dif/dif_uart.h"
-#include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/test_framework/ottf_console.h"
 #include "sw/device/lib/ujson/ujson.h"
 
-static status_t ottf_putbuf(void *io, const char *buf, size_t len) {
-  const dif_uart_t *uart = (const dif_uart_t *)io;
-  for (size_t i = 0; i < len; ++i) {
-    TRY(dif_uart_byte_send_polled(uart, buf[i]));
-  }
-  return OK_STATUS((int32_t)len);
-}
-
-static status_t ottf_getc(void *io) {
-  const dif_uart_t *uart = (const dif_uart_t *)io;
-  uint8_t byte;
-  TRY(dif_uart_byte_receive_polled(uart, &byte));
-  TRY(ottf_console_flow_control(uart, kOttfConsoleFlowControlAuto));
-  return OK_STATUS(byte);
-}
-
 ujson_t ujson_ottf_console(void) {
-  return ujson_init(ottf_console_get(), ottf_getc, ottf_putbuf);
+  return ujson_init(ottf_console_get(), ottf_console_getc, ottf_console_putbuf);
 }

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3276,6 +3276,36 @@ opentitan_test(
 )
 
 opentitan_test(
+    name = "spi_device_ujson_console_test",
+    srcs = ["spi_device_ujson_console_test.c"],
+    exec_env = dicts.add(
+        EARLGREY_CW340_TEST_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
+        },
+    ),
+    fpga = fpga_params(
+        test_cmd = """
+            --bootstrap="{firmware}"
+            "{firmware:elf}"
+        """,
+        test_harness = "//sw/host/tests/chip/spi_device_ujson_console_test",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:spi_flash_testutils",
+        "//sw/device/lib/testing/json:command",
+        "//sw/device/lib/testing/json:provisioning_data",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/lib/testing/test_framework:ujson_ottf_commands",
+    ],
+)
+
+opentitan_test(
     name = "spi_device_sleep_test",
     srcs = ["spi_device_sleep_test.c"],
     exec_env = dicts.add(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1387,7 +1387,10 @@ opentitan_test(
 opentitan_test(
     name = "example_mem_ujcmd_test",
     srcs = ["example_mem_ujcmd.c"],
-    exec_env = EARLGREY_TEST_ENVS,
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_CW340_TEST_ENVS,
+    ),
     fpga = fpga_params(
         test_cmd = " ".join([
             "--bootstrap=\"{firmware}\"",

--- a/sw/device/tests/spi_device_ottf_console_test.c
+++ b/sw/device/tests/spi_device_ottf_console_test.c
@@ -143,5 +143,18 @@ bool test_main(void) {
       ottf_console_spi_device_read(sizeof(input_buf), input_buf);
   CHECK(received_data_len == sizeof(kTest4KbDataStr));
   CHECK_ARRAYS_EQ(input_buf, kTest4KbDataStr, ARRAYSIZE(kTest4KbDataStr));
+
+  // Verify that reading data byte-by-byte using `ottf_console_getc` matches the
+  // expected output. This function is crucial in the UJSON OTTF console data
+  // pipeline.
+  memset(&input_buf, 0, sizeof(input_buf));
+  LOG_INFO("SYNC: Waiting for console data");
+  for (int i = 0; i < sizeof(kTest4KbDataStr); i++) {
+    status_t s = ottf_console_getc(ottf_console_get());
+    CHECK_STATUS_OK(s);
+    input_buf[i] = (uint8_t)s.value;
+  }
+  CHECK_ARRAYS_EQ(input_buf, kTest4KbDataStr, ARRAYSIZE(kTest4KbDataStr));
+
   return true;
 }

--- a/sw/device/tests/spi_device_ujson_console_test.c
+++ b/sw/device/tests/spi_device_ujson_console_test.c
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/json/command.h"
+#include "sw/device/lib/testing/json/mem.h"
+#include "sw/device/lib/testing/json/provisioning_data.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf_commands.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/**
+ * Tests SPI device integration with the ujson OTTF console.
+ *
+ * This test verifies the ability to send and receive personalized
+ * blob ujson structs and mem commands/payloads between the host
+ * and the SPI device using the OTTF console.
+ */
+
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false, );
+
+volatile uint8_t kTestBytes[256];
+volatile uint32_t kTestWord;
+volatile uint32_t kEndTest;
+static perso_blob_t perso_blob_to_host;
+static perso_blob_t perso_blob_from_host;
+
+status_t command_processor(ujson_t *uj) {
+  while (!kEndTest) {
+    test_command_t command;
+    TRY(UJSON_WITH_CRC(ujson_deserialize_test_command_t, uj, &command));
+    status_t status = ujson_ottf_dispatch(uj, command);
+    if (status_err(status) == kUnimplemented) {
+      RESP_ERR(uj, status);
+    } else if (status_err(status) != kOk) {
+      return status;
+    }
+  }
+  return OK_STATUS();
+}
+
+status_t perso_blob_transaction_test(ujson_t *uj) {
+  LOG_INFO("SYNC: Sending perso blob");
+  TRY(RESP_OK(ujson_serialize_perso_blob_t, uj, &perso_blob_to_host));
+  memset(&perso_blob_from_host, 0xa5, sizeof(perso_blob_from_host));
+  LOG_INFO("SYNC: Waiting for perso blob");
+  TRY(ujson_deserialize_perso_blob_t(uj, &perso_blob_from_host));
+  CHECK_ARRAYS_EQ((uint8_t *)&perso_blob_to_host,
+                  (uint8_t *)&perso_blob_from_host,
+                  sizeof(perso_blob_from_host));
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  kEndTest = 0;
+  kTestWord = 0xface1234u;
+  for (size_t i = 0; i < 256; ++i) {
+    kTestBytes[i] = (uint8_t)i;
+  }
+  ujson_t uj = ujson_ottf_console();
+
+  status_t result = OK_STATUS();
+  EXECUTE_TEST(result, perso_blob_transaction_test, &uj);
+  EXECUTE_TEST(result, command_processor, &uj);
+
+  return status_ok(result);
+}

--- a/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ottf_console/src/main.rs
@@ -88,9 +88,12 @@ fn spi_device_console_test(opts: &Opts, transport: &TransportWrapper) -> Result<
     data = test_utils::object::symbol_data(&object, "kTest4KbDataStr")?;
     data_str = std::str::from_utf8(&data)?.trim_matches(char::from(0));
     _ = UartConsole::wait_for(&spi_console_device, data_str, opts.timeout)?;
-    log::info!("Sending 4KB data to Device...");
-    _ = UartConsole::wait_for(&spi_console_device, SYNC_MSG, opts.timeout)?;
-    spi_console_device.console_write(&data)?;
+    // 4KB data will be sent twice.
+    for _round in 0..2 {
+        log::info!("Sending 4KB data to Device...");
+        _ = UartConsole::wait_for(&spi_console_device, SYNC_MSG, opts.timeout)?;
+        spi_console_device.console_write(&data)?;
+    }
 
     let result = console.interact(&spi_console_device, None, Some(&mut stdout))?;
     match result {

--- a/sw/host/tests/chip/spi_device_ujson_console_test/BUILD
+++ b/sw/host/tests/chip/spi_device_ujson_console_test/BUILD
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "spi_device_ujson_console_test",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+        "//sw/host/provisioning/ujson_lib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:object",
+        "@crate_index//:once_cell",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
@@ -1,0 +1,130 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::bool_assert_comparison)]
+use anyhow::Result;
+use clap::Parser;
+use object::{Object, ObjectSymbol};
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::mem::{MemRead32Req, MemReadReq, MemWrite32Req, MemWriteReq};
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+use ujson_lib::provisioning_data::PersoBlob;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "30s")]
+    timeout: Duration,
+
+    /// Name of the SPI interface to connect to the OTTF console.
+    #[arg(long, default_value = "BOOTSTRAP")]
+    console_spi: String,
+
+    /// Path to the firmware's ELF file, for querying symbol addresses.
+    #[arg(value_name = "FIRMWARE_ELF")]
+    firmware_elf: PathBuf,
+}
+
+const SYNC_MSG: &str = r"SYNC:.*\r\n";
+
+fn test_perso_blob_strcut(opts: &Opts, spi_console: &SpiConsoleDevice) -> Result<()> {
+    UartConsole::wait_for(spi_console, SYNC_MSG, opts.timeout)?;
+    let perso_blob = PersoBlob::recv(spi_console, opts.timeout, true)?;
+    UartConsole::wait_for(spi_console, SYNC_MSG, opts.timeout)?;
+    perso_blob.send(spi_console)?;
+    Ok(())
+}
+
+fn test_mem_word_commands(
+    _opts: &Opts,
+    test_word_address: u32,
+    spi_console: &SpiConsoleDevice,
+) -> Result<()> {
+    let read_value = MemRead32Req::execute(spi_console, test_word_address)?;
+    assert!(read_value == 0xface1234_u32);
+
+    let expected_value = 0x12345678_u32;
+    MemWrite32Req::execute(spi_console, test_word_address, expected_value)?;
+    let read_value = MemRead32Req::execute(spi_console, test_word_address)?;
+    assert!(read_value == expected_value);
+    Ok(())
+}
+
+fn test_mem_array_commands(
+    _opts: &Opts,
+    test_bytes_address: u32,
+    spi_console: &SpiConsoleDevice,
+) -> Result<()> {
+    let mut data: [u8; 256] = [0; 256];
+    MemReadReq::execute(spi_console, test_bytes_address, data.as_mut_slice())?;
+    let mut expected_value = Vec::<u8>::from_iter(0..=255);
+    assert!(data.as_slice() == expected_value.as_slice());
+
+    data.reverse();
+    expected_value.reverse();
+    MemWriteReq::execute(spi_console, test_bytes_address, expected_value.as_slice())?;
+    MemReadReq::execute(spi_console, test_bytes_address, data.as_mut_slice())?;
+    assert!(data.as_slice() == expected_value.as_slice());
+    Ok(())
+}
+
+fn test_end(opts: &Opts, end_test_address: u32, spi_console: &SpiConsoleDevice) -> Result<()> {
+    let end_test_value = MemRead32Req::execute(spi_console, end_test_address)?;
+    assert!(end_test_value == 0);
+    MemWrite32Req::execute(spi_console, end_test_address, /*value=*/ 1)?;
+    let _ = UartConsole::wait_for(spi_console, r"PASS![^\r\n]*", opts.timeout)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let elf_binary = fs::read(&opts.firmware_elf)?;
+    let elf_file = object::File::parse(&*elf_binary)?;
+    let mut symbols = HashMap::<String, u32>::new();
+    for sym in elf_file.symbols() {
+        symbols.insert(sym.name()?.to_owned(), sym.address() as u32);
+    }
+    let end_test_address = symbols
+        .get("kEndTest")
+        .expect("Provided ELF missing 'kEndTest' symbol");
+    let test_word_address = symbols
+        .get("kTestWord")
+        .expect("Provided ELF missing 'kTestWord' symbol");
+    let test_bytes_address = symbols
+        .get("kTestBytes")
+        .expect("Provided ELF missing 'kTestBytes' symbol");
+
+    let transport = opts.init.init_target()?;
+    let spi = transport.spi(&opts.console_spi)?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
+
+    execute_test!(test_perso_blob_strcut, &opts, &spi_console_device);
+    execute_test!(
+        test_mem_word_commands,
+        &opts,
+        *test_word_address,
+        &spi_console_device
+    );
+    execute_test!(
+        test_mem_array_commands,
+        &opts,
+        *test_bytes_address,
+        &spi_console_device
+    );
+    execute_test!(test_end, &opts, *end_test_address, &spi_console_device);
+    Ok(())
+}


### PR DESCRIPTION
This PR has four commits that:
1. Refactor ujson ottf console and implement `getc` for SPI device.
2. Test the new `getc` implementation.
3. Refactor mem module to support the new SPI device console
4. Add an example test for spi_device ujson ottf console.

This fixes #21726.