### PR TITLE
[dv/flash] Increase fatal_err delay in flash_ctrl_phy_ack_consistency

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
@@ -21,7 +21,7 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
     cfg.scb_h.skip_alert_chk["recov_err"] = 1;
 
     cfg.scb_h.expected_alert["fatal_err"].expected = 1;
-    cfg.scb_h.expected_alert["fatal_err"].max_delay = 20000;
+    cfg.scb_h.expected_alert["fatal_err"].max_delay = 2_000_000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
     $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_host_rsp_fifo.gen_normal_fifo.u_fifo_cnt");
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_ack_consistency_vseq.sv
@@ -21,7 +21,7 @@ class flash_ctrl_phy_ack_consistency_vseq extends flash_ctrl_phy_host_grant_err_
     cfg.scb_h.skip_alert_chk["recov_err"] = 1;
 
     cfg.scb_h.expected_alert["fatal_err"].expected = 1;
-    cfg.scb_h.expected_alert["fatal_err"].max_delay = 20000;
+    cfg.scb_h.expected_alert["fatal_err"].max_delay = 2_000_000;
     cfg.scb_h.exp_alert_contd["fatal_err"] = 10000;
     $assertoff(0, "tb.dut.u_eflash.gen_flash_cores[0].u_host_rsp_fifo.gen_normal_fifo.u_fifo_cnt");
 


### PR DESCRIPTION
Hi,
This small PR is increasing the delay for the fatal_err timeout in the flash_ctrl_phy_ack_consistency test because it seems to be insufficient in some seeds for the extending environment.
