### PR TITLE
[rom] fix ROM_EXT immutable section to work with address translation

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/uart.c
+++ b/sw/device/silicon_creator/lib/drivers/uart.c
@@ -72,8 +72,7 @@ static bool uart_rx_empty(void) {
   return bitfield_bit32_read(reg, UART_STATUS_RXEMPTY_BIT);
 }
 
-OT_WARN_UNUSED_RESULT
-static bool uart_tx_idle(void) {
+bool uart_tx_idle(void) {
   uint32_t reg =
       abs_mmio_read32(TOP_EARLGREY_UART0_BASE_ADDR + UART_STATUS_REG_OFFSET);
   return bitfield_bit32_read(reg, UART_STATUS_TXIDLE_BIT);

--- a/sw/device/silicon_creator/lib/drivers/uart.h
+++ b/sw/device/silicon_creator/lib/drivers/uart.h
@@ -93,6 +93,14 @@ OT_WARN_UNUSED_RESULT
 size_t uart_read(uint8_t *data, size_t len, uint32_t timeout_ms);
 
 /**
+ * Returns true if UART TX is idle, otherwise returns false.
+ *
+ * @return Boolean indicating UART TX activity status.
+ */
+OT_WARN_UNUSED_RESULT
+bool uart_tx_idle(void);
+
+/**
  * Detect if a UART break is asserted for a given period of time.
  *
  * UART break must already be asserted upon entry to this function and must

--- a/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
@@ -3,20 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
     "//rules:const.bzl",
     "CONST",
-    "hex",
     "hex_digits",
 )
-load(
-    "//sw/device/silicon_creator/rom_ext:defs.bzl",
-    "ROM_EXT_VERSION",
-)
-load("//rules:manifest.bzl", "manifest")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -36,13 +26,32 @@ load(
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_TEMPLATE_BFV",
+    "SLOTS",
 )
 
 package(default_visibility = ["//visibility:public"])
 
-ROM_EXT_LINKER_SCRIPTS = [
-    "a",
-    "virtual",
+ROM_EXT_SLOTS = [
+    {
+        "name": "a",
+        "slot": "a",
+        "offset": SLOTS["a"],
+    },
+    {
+        "name": "virtual_a",
+        "slot": "a",
+        "offset": SLOTS["a"],
+    },
+    {
+        "name": "b",
+        "slot": "b",
+        "offset": SLOTS["b"],
+    },
+    {
+        "name": "virtual_b",
+        "slot": "b",
+        "offset": SLOTS["b"],
+    },
 ]
 
 IMMUTABLE_PARTITION_TEST_CASES = [
@@ -142,7 +151,7 @@ IMMUTABLE_PARTITION_TEST_CASES = [
     otp_json_immutable_rom_ext(
         name = "otp_json_immutable_rom_ext_{}_{}".format(
             t["name"],
-            ld_script,
+            s["name"],
         ),
         testonly = True,
         partitions = [
@@ -151,10 +160,10 @@ IMMUTABLE_PARTITION_TEST_CASES = [
                 items = t["otp_fields"],
             ),
         ],
-        rom_ext = ":immutable_rom_ext_section_test_{}".format(ld_script),
+        rom_ext = ":immutable_rom_ext_section_test_{}".format(s["name"]),
         visibility = ["//visibility:private"],
     )
-    for ld_script in ROM_EXT_LINKER_SCRIPTS
+    for s in ROM_EXT_SLOTS
     for t in IMMUTABLE_PARTITION_TEST_CASES
 ]
 
@@ -162,55 +171,31 @@ IMMUTABLE_PARTITION_TEST_CASES = [
     otp_image(
         name = "otp_img_immutable_rom_ext_{}_{}".format(
             t["name"],
-            ld_script,
+            s["name"],
         ),
         testonly = True,
         src = "//hw/ip/otp_ctrl/data:otp_json_prod",
         overlays = STD_OTP_OVERLAYS + [
             ":otp_json_immutable_rom_ext_{}_{}".format(
                 t["name"],
-                ld_script,
+                s["name"],
             ),
         ],
         visibility = ["//visibility:private"],
     )
-    for ld_script in ROM_EXT_LINKER_SCRIPTS
+    for s in ROM_EXT_SLOTS
     for t in IMMUTABLE_PARTITION_TEST_CASES
 ]
 
-_MANIFEST_CONFIG = {
-    "identifier": hex(CONST.ROM_EXT),
-    "version_major": ROM_EXT_VERSION.MAJOR,
-    "version_minor": ROM_EXT_VERSION.MINOR,
-    "security_version": ROM_EXT_VERSION.SECURITY,
-}
-
-manifest(d = dicts.add(
-    _MANIFEST_CONFIG,
-    {
-        "name": "manifest_addr_trans_on",
-        "address_translation": hex(CONST.HARDENED_TRUE),
-    },
-))
-
-manifest(d = dicts.add(
-    _MANIFEST_CONFIG,
-    {
-        "name": "manifest_addr_trans_off",
-        "address_translation": hex(CONST.HARDENED_FALSE),
-    },
-))
-
 [
     opentitan_binary(
-        name = "immutable_rom_ext_section_test_{}".format(ld_script),
+        name = "immutable_rom_ext_section_test_{}".format(s["name"]),
         testonly = True,
         srcs = ["immutable_rom_ext_section_test.c"],
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310_sival",
         ],
-        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(ld_script),
-        manifest = ":manifest_addr_trans_on" if ld_script == "virtual" else ":manifest_addr_trans_off",
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(s["slot"]),
         deps = [
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -222,31 +207,33 @@ manifest(d = dicts.add(
             "//sw/device/silicon_creator/lib/drivers:uart",
         ],
     )
-    for ld_script in ROM_EXT_LINKER_SCRIPTS
+    for s in ROM_EXT_SLOTS
 ]
 
 [
     opentitan_test(
         name = "immutable_section_{}_{}".format(
             t["name"],
-            ld_script,
+            s["name"],
         ),
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
         },
         fpga = fpga_params(
+            assemble = "{firmware}@{offset}",
             binaries = {
-                ":immutable_rom_ext_section_test_{}".format(ld_script): "firmware",
+                ":immutable_rom_ext_section_test_{}".format(s["name"]): "firmware",
             },
             exit_failure = t["exit_failure"],
             exit_success = t["exit_success"],
+            offset = s["offset"],
             otp = ":otp_img_immutable_rom_ext_{}_{}".format(
                 t["name"],
-                ld_script,
+                s["name"],
             ),
         ),
     )
-    for ld_script in ROM_EXT_LINKER_SCRIPTS
+    for s in ROM_EXT_SLOTS
     for t in IMMUTABLE_PARTITION_TEST_CASES
 ]
 
@@ -256,9 +243,9 @@ test_suite(
     tests = [
         "immutable_section_{}_{}".format(
             t["name"],
-            ld_script,
+            s["name"],
         )
-        for ld_script in ROM_EXT_LINKER_SCRIPTS
+        for s in ROM_EXT_SLOTS
         for t in IMMUTABLE_PARTITION_TEST_CASES
     ],
 )

--- a/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/immutable_rom_ext_section_test.c
+++ b/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/immutable_rom_ext_section_test.c
@@ -36,6 +36,10 @@ void rom_ext_non_mutable(void) {
   uart_write_imm(kStr2);
   uart_write_imm(kNewline);
 
+  // Wait until the UART is done transmitting.
+  while (!uart_tx_idle()) {
+  }
+
   // Set a magic value ("PASS") in retention SRAM.
   retention_sram_get()->owner.reserved[0] = kSramValuePass;
 
@@ -63,6 +67,15 @@ bool test_main(void) {
       immutable_rom_ext_hash[5], immutable_rom_ext_hash[4],
       immutable_rom_ext_hash[3], immutable_rom_ext_hash[2],
       immutable_rom_ext_hash[1], immutable_rom_ext_hash[0]);
+
+  // Check the same immutable section offset is used by every test to ensure it
+  // is portable across various ROM_EXT slot configurations.
+  if (immutable_rom_ext_section_enabled == kHardenedBoolTrue) {
+    CHECK(
+        otp_read32(
+            OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET_OFFSET) ==
+        0x400);
+  }
 
   // Check the immutabled section executed by reading out the retention SRAM.
   if (immutable_rom_ext_section_enabled == kHardenedBoolTrue) {

--- a/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
+++ b/sw/device/silicon_creator/rom/e2e/release/rom_e2e_self_hash_test.c
@@ -40,16 +40,16 @@ enum {
 
 const size_t kGoldenRomSizeBytes = 32652 - sizeof(chip_info_t);
 const uint32_t kSimDvGoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0x953cca70, 0x018fb4c7, 0xcd2ebc02, 0x95680df3,
-    0x220ca956, 0xe890a35d, 0xe8b62c21, 0x15bfa5e0,
+    0xc16e04d6, 0x2e94b881, 0x0759b405, 0xd0a28cde,
+    0xa8c900f3, 0x57b8c7f6, 0xacc910b0, 0x43000c0a,
 };
 const uint32_t kFpgaCw310GoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0x876747cf, 0xec01137f, 0x159bdc7f, 0x8177d11c,
-    0xcad1fb4e, 0xc0d3ccd0, 0xc7cb8699, 0x99c8a56b,
+    0xf3508c51, 0xef65a542, 0xc20e55d9, 0xada4c934,
+    0x8015bbca, 0xa863db5a, 0xd1ead827, 0x968d94cb,
 };
 const uint32_t kSiliconGoldenRomHash[kSha256HashSizeIn32BitWords] = {
-    0x5d02eeae, 0x76d7386c, 0x063a84ea, 0x279865f6,
-    0xf05b04e8, 0x06a569e0, 0xa8f2053b, 0x66c2cb77,
+    0x43b60e89, 0xbfa80347, 0xeeceb60a, 0x356bc7f1,
+    0xbd023b8a, 0xe5a4ddfc, 0xf66b45b5, 0x5b2ba0ba,
 };
 
 extern const char _chip_info_start[];

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -679,6 +679,14 @@ static rom_error_t rom_boot(const manifest_t *manifest, uint32_t flash_exec) {
         OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_LENGTH_OFFSET);
     uintptr_t immutable_rom_ext_entry_point =
         (uintptr_t)manifest + immutable_rom_ext_start_offset;
+    // If address translation is enabled, adjust the entry_point.
+    if (launder32(manifest->address_translation) == kHardenedBoolTrue) {
+      HARDENED_CHECK_EQ(manifest->address_translation, kHardenedBoolTrue);
+      immutable_rom_ext_entry_point =
+          rom_ext_vma_get(manifest, immutable_rom_ext_entry_point);
+    } else {
+      HARDENED_CHECK_NE(manifest->address_translation, kHardenedBoolTrue);
+    }
 
     // Compute a hash of the code section.
     // Include the start offset and the length of the section in the hash.


### PR DESCRIPTION
The original ROM_EXT immutable section configuration did not account for the address translation adjustments to the immutable section entry point. This meant that if address translation was enabled, the immutable section entry point would never get moved to the virtual address space, which gets marked RX. The physical address space of the current slot would only be marked R, and when jumping to the entry point an exception would occur. This slipped through b/c our tooling always calculated the correct offset to the immutable section base on symbols in the ELF, but meant that the same offset could not be used across different ROM_EXT slot locations (which is important since the immutable section offset is stored in fuses). This fixes that error and enhances the tests to ensure the same ROM_EXT mutable section offset can be used across tests that load a ROM_EXT in different slots (A, B, or Virtual slots).