### PR TITLE
[manuf] Fix out-of-bounds memory access in ast_cfg_data

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -33,7 +33,7 @@ static dif_pinmux_t pinmux;
 
 static manuf_ft_individualize_data_t in_data;
 static uint32_t device_id[kHwCfgDeviceIdSizeIn32BitWords];
-static uint32_t ast_cfg_data[kHwCfgDeviceIdSizeIn32BitWords];
+static uint32_t ast_cfg_data[kFlashInfoAstCalibrationDataSizeIn32BitWords];
 
 /**
  * Initializes all DIF handles used in this SRAM program.


### PR DESCRIPTION
This PR has a commit that fixes out-of-bounds memory access in `ast_cfg_data`.

The device started hanging after I tried to make some modifications on `sram_ft_individualize` to switch the device console from Uart to SPI interface (#24420). Further investigation revealed that the root cause was an out-of-bounds memory access in the original code, which had not previously caused any issues though.