### PR TITLE
[rom_ctrl,util] Rework memory collision check

### DIFF
--- a/util/design/secded_gen.py
+++ b/util/design/secded_gen.py
@@ -409,7 +409,7 @@ def ecc_encode(config: Dict[str, Any], codetype: str, k: int, dataword: int) -> 
 def ecc_encode_some(config: Dict[str, Any],
                     codetype: str,
                     k: int,
-                    datawords: int) -> Tuple[List[int], int]:
+                    datawords: List[int]) -> Tuple[List[int], int]:
     m, bitmasks, invert = _ecc_pick_code(config, codetype, k)
     codewords = [int(_ecc_encode(k, m, bitmasks, invert, w), 2)
                  for w in datawords]


### PR DESCRIPTION
As ROMs get bigger, scrambled memory collision checker in `mem.py` becomes slower.

On my local machine using this revised implementation, scrambling the second rom only takes 1.75 seconds vs. 7.68 seconds with the previous implementation (> 4x speed up).

I've tested collisions detections forcing several of them and checking the collision report remains the same:

```diff
diff --git a/hw/ip/rom_ctrl/util/scramble_image.py b/hw/ip/rom_ctrl/util/scramble_image.py
index c3e1cd0d63..6d70c2144e 100755
--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -493,6 +493,8 @@ def main() -> int:
         scr_mem.add_ecc32()
         assert scr_mem.width == 39

+    scr_mem.chunks[0].words[4] = scr_mem.chunks[0].words[78] = scr_mem.chunks[0].words[453]
+    scr_mem.chunks[0].words[12] = scr_mem.chunks[0].words[1000]
     # Check for collisions
     collisions = scr_mem.collisions()
     if collisions:
```
