### PR TITLE
[ci] Add GitHub Actions version of airgapped build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CI
+on:
+  pull_request:
+
+jobs:
+  airgapped_build:
+    name: Airgapped build
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Bitstream cache requires all commits.
+      - name: Install system dependencies
+        run: grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      - name: Prepare airgapped environment
+        run: ./util/prep-bazel-airgapped-build.sh
+      - name: Build in the airgapped environment
+        run: ./ci/scripts/test-airgapped-build.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,6 +131,7 @@ jobs:
   steps:
   - template: ci/checkout-template.yml
   - template: ci/install-package-dependencies.yml
+  - bash: util/prep-bazel-airgapped-build.sh
   - bash: ci/scripts/test-airgapped-build.sh
 
 - job: slow_lints

--- a/ci/scripts/test-airgapped-build.sh
+++ b/ci/scripts/test-airgapped-build.sh
@@ -5,8 +5,11 @@
 
 set -ex
 
-# Prefetch bazel airgapped dependencies.
-util/prep-bazel-airgapped-build.sh -f
+# Prefetch bazel airgapped dependencies if not already done.
+if [ ! -d bazel-airgapped ]; then
+  echo "Airgapped environment not found, preparing..." >&2
+  util/prep-bazel-airgapped-build.sh -f
+fi
 
 # Remove the airgapped network namespace.
 remove_airgapped_netns() {


### PR DESCRIPTION
This PR adds a GitHub Actions equivalent to the airgapped build job. It does not remove the Azure job (yet).

## Motivation

### Disk space limits

The airgapped build is now using 95% of the disk space for public Azure runners (10GiB):

* Azure won't give us more. We would have to move it to a self-hosted Azure runner.
* GitHub Actions free runners provide 14GiB which should be enough for now.
* We can pay for more if needed without having to self-host.

### Enabling signing

This should unblock the ability to test signing binaries (with fake keys) in the airgapped build test. We know how to grant permission for GitHub Actions CI jobs to access Google Cloud signing services. We haven't done it before in Azure.

### Starting the move to GitHub Actions

We would like to move CI over to GitHub Actions eventually. The airgapped build is independent of all other jobs, making it a good candidate for the first job to move.

### Speed-up

As a bonus, it takes ~6 minutes here versus ~15 minutes in Azure.