### PR TITLE
[dv/chip/rom] Update the timeout of DV_WAIT

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_base_vseq.sv
@@ -54,7 +54,12 @@ class chip_sw_rom_e2e_base_vseq extends chip_sw_base_vseq;
     // prevent X's propagating as a result of multiple drivers on pins IOC3 and IOC4 (due to DFT
     // strap sampling in TestUnlocked* and RMA lifecycle states). Once the retention SRAM is
     // initialized, we have made it to `rom_main()`.
-    `DV_WAIT(cfg.chip_vif.sram_ret_init_done == 1)
+    `DV_WAIT(cfg.chip_vif.sram_ret_init_done == 1,
+             $sformatf({"Timeout occurred when waiting for SRAM initialization; ",
+                        "Current sram_ret_init_done = 1'%0b, Timeout value = %0dns"},
+                        cfg.chip_vif.sram_ret_init_done,
+                        cfg.sw_test_timeout_ns),
+             cfg.sw_test_timeout_ns)
   endtask
 
 endclass : chip_sw_rom_e2e_base_vseq


### PR DESCRIPTION
Hi,
This change is required for the GL in which the DV_WAIT default timeout is not long enough.
Done here as we done in the chip_sw_rom_e2e_self_hash_gls_vseq in the previous PR #24339:
https://github.com/lowRISC/opentitan/blob/cf32d0f1190b72144c52ffe1b226b4fe37eb3988/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_e2e_self_hash_gls_vseq.sv#L17-L22