### PR TITLE
[ot_certs] Add support for custom key usage

### DIFF
--- a/sw/device/silicon_creator/lib/cert/cdi_0.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_0.hjson
@@ -79,6 +79,7 @@
         // https://pigweed.googlesource.com/open-dice/+/refs/heads/main/docs/specification.md#certificate-details
         // The standard extensions are fixed by the specification.
         basic_constraints: { ca: true },
+        key_usage: { cert_sign: true },
         private_extensions: [
             {
                 type: "dice_tcb_info",

--- a/sw/device/silicon_creator/lib/cert/cdi_1.hjson
+++ b/sw/device/silicon_creator/lib/cert/cdi_1.hjson
@@ -84,6 +84,7 @@
         // https://pigweed.googlesource.com/open-dice/+/refs/heads/main/docs/specification.md#certificate-details
         // The standard extensions are fixed by the specification.
         basic_constraints: { ca: true },
+        key_usage: { cert_sign: true },
         private_extensions: [
             {
                 type: "dice_tcb_info",

--- a/sw/device/silicon_creator/lib/cert/tpm_ek.hjson
+++ b/sw/device/silicon_creator/lib/cert/tpm_ek.hjson
@@ -82,6 +82,7 @@
         authority_key_identifier: { var: "auth_key_key_id" },
         subject_key_identifier: { var: "tpm_ek_pub_key_id" },
         basic_constraints: { ca: false },
+        key_usage: { cert_sign: true },
         subject_alt_name: [
             { tpm_vendor: { var: "tpm_vendor" } },
             { tpm_model: { var: "tpm_model" } },

--- a/sw/device/silicon_creator/lib/cert/uds.hjson
+++ b/sw/device/silicon_creator/lib/cert/uds.hjson
@@ -98,6 +98,7 @@
         // https://pigweed.googlesource.com/open-dice/+/refs/heads/main/docs/specification.md#certificate-details
         // The standard extensions are fixed by the specification.
         basic_constraints: { ca: true },
+        key_usage: { cert_sign: true },
         private_extensions: [
             {
                 type: "dice_tcb_info",

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -75,6 +75,7 @@ pub struct Certificate {
     pub subject_key_identifier: Value<Vec<u8>>,
     // X509 basic constraints extension, optional.
     pub basic_constraints: Option<BasicConstraints>,
+    pub key_usage: Option<KeyUsage>,
     /// X509 Subject Alternative Name extension, optional.
     #[serde(default)]
     pub subject_alt_name: Name,
@@ -97,6 +98,13 @@ pub type Name = Vec<IndexMap<AttributeType, Value<String>>>;
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct BasicConstraints {
     pub ca: Value<bool>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct KeyUsage {
+    pub digital_signature: Option<Value<bool>>,
+    pub key_agreement: Option<Value<bool>>,
+    pub cert_sign: Option<Value<bool>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -466,6 +474,7 @@ mod tests {
                 },
                 authority_key_identifier: { var: "signing_pub_key_id" },
                 subject_key_identifier: { var: "owner_pub_key_id" },
+                key_usage: { key_agreement: true },
                 private_extensions: [
                     {
                         type: "dice_tcb_info",
@@ -562,6 +571,11 @@ mod tests {
             authority_key_identifier: Value::variable("signing_pub_key_id"),
             subject_key_identifier: Value::variable("owner_pub_key_id"),
             basic_constraints: None,
+            key_usage: Some(KeyUsage {
+                digital_signature: None,
+                key_agreement: Some(Value::literal(true)),
+                cert_sign: None,
+            }),
             subject_alt_name: vec![],
             private_extensions: vec![CertificateExtension::DiceTcbInfo(DiceTcbInfoExtension {
                 vendor: Some(Value::literal("OpenTitan")),

--- a/sw/host/ot_certs/src/template/subst.rs
+++ b/sw/host/ot_certs/src/template/subst.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::template::{
     BasicConstraints, Certificate, CertificateExtension, Conversion, DiceTcbInfoExtension,
-    DiceTcbInfoFlags, EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, Signature,
-    SubjectPublicKeyInfo, Template, Value, Variable, VariableType,
+    DiceTcbInfoFlags, EcPublicKey, EcPublicKeyInfo, EcdsaSignature, FirmwareId, KeyUsage,
+    Signature, SubjectPublicKeyInfo, Template, Value, Variable, VariableType,
 };
 
 /// Substitution value: this is the raw value loaded from a hjson/json file
@@ -362,6 +362,10 @@ impl Subst for Certificate {
                 .basic_constraints
                 .subst(data)
                 .context("cannot substitute basic constraints")?,
+            key_usage: self
+                .key_usage
+                .subst(data)
+                .context("cannot substitute key usage")?,
             private_extensions: self
                 .private_extensions
                 .iter()
@@ -460,6 +464,25 @@ impl Subst for DiceTcbInfoFlags {
                 .debug
                 .subst(data)
                 .context("cannot substitute not_configured flag")?,
+        })
+    }
+}
+
+impl Subst for KeyUsage {
+    fn subst(&self, data: &SubstData) -> Result<KeyUsage> {
+        Ok(KeyUsage {
+            digital_signature: self
+                .digital_signature
+                .subst(data)
+                .context("cannot substitute digital signature key usage")?,
+            key_agreement: self
+                .key_agreement
+                .subst(data)
+                .context("cannot substitute key agreement")?,
+            cert_sign: self
+                .cert_sign
+                .subst(data)
+                .context("cannot substitute cert sign")?,
         })
     }
 }

--- a/sw/host/ot_certs/tests/example.hjson
+++ b/sw/host/ot_certs/tests/example.hjson
@@ -40,6 +40,11 @@
             { tpm_model: "TPM Model" },
             { tpm_version: "TPM Version" },
         ],
+        key_usage: {
+            digital_signature: true,
+            key_agreement: false,
+            cert_sign: true,
+        }
         private_extensions: [
             {
                 type: "dice_tcb_info",

--- a/sw/host/ot_certs/tests/example_data.json
+++ b/sw/host/ot_certs/tests/example_data.json
@@ -24,5 +24,8 @@
     "basic_constraints_ca": true,
     "tpm_vendor": "TPM Vendor",
     "tpm_model": "TPM Model",
-    "tpm_version": "TPM Version"
+    "tpm_version": "TPM Version",
+    "key_usage_digital_signature": true,
+    "key_usage_key_agreement": false,
+    "key_usage_cert_sign": true
 }

--- a/sw/host/ot_certs/tests/generic.hjson
+++ b/sw/host/ot_certs/tests/generic.hjson
@@ -104,6 +104,15 @@
             type: "string",
             size: 100,
         }
+        key_usage_cert_sign: {
+            type: "boolean"
+        }
+        key_usage_key_agreement: {
+            type: "boolean"
+        }
+        key_usage_digital_signature: {
+            type: "boolean"
+        }
     },
 
     certificate: {
@@ -135,6 +144,11 @@
             { tpm_model: { var: "tpm_model" } },
             { tpm_version: { var: "tpm_version" } },
         ],
+        key_usage: {
+            digital_signature: {var: "key_usage_digital_signature" },
+            key_agreement: {var: "key_usage_key_agreement" },
+            cert_sign: {var: "key_usage_cert_sign" },
+        }
         private_extensions: [
             {
                 type: "dice_tcb_info",


### PR DESCRIPTION
This allows certificate templates to specify whether they want a key usage extension at all, and if they do what the key usages are. I only added support for the 3 usages that seem the most 