### PR TITLE
[top_earlgrey] Reduce number of PRINCE half rounds for main SRAM scrambling

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -57,12 +57,17 @@ class mem_bkdr_util extends uvm_object;
   event readmemh_event;
   event writememh_event;
 
+  // Number of PRINCE half rounds for scrambling, can be [1..5].
+  protected int num_prince_rounds_half;
+
   // Initialize the class instance.
   // `extra_bits_per_subword` is the width any additional metadata that is not captured in secded
   // package.
   function new(string name = "", string path, int unsigned depth,
                longint unsigned n_bits, err_detection_e err_detection_scheme,
+               int num_prince_rounds_half = 3,
                int extra_bits_per_subword = 0, int unsigned system_base_addr = 0);
+
 
     bit res;
     super.new(name);
@@ -74,6 +79,7 @@ class mem_bkdr_util extends uvm_object;
     this.depth = depth;
     this.width = n_bits / depth;
     this.err_detection_scheme = err_detection_scheme;
+    this.num_prince_rounds_half = num_prince_rounds_half;
 
     if (`HAS_ECC) begin
       import prim_secded_pkg::prim_secded_e;
@@ -151,6 +157,10 @@ class mem_bkdr_util extends uvm_object;
 
   function err_detection_e get_err_detection_scheme();
     return err_detection_scheme;
+  endfunction
+
+  function int get_num_prince_rounds_half();
+    return num_prince_rounds_half;
   endfunction
 
   function uint32_t get_data_width();

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
@@ -67,7 +67,7 @@ function logic [38:0] get_sram_encrypt32_intg_data (
 
   wdata_arr = {<<{integ_data}};
   wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-      wdata_arr, 39, 39, addr_arr, full_addr_width, key_arr, nonce_arr
+      wdata_arr, 39, 39, addr_arr, full_addr_width, key_arr, nonce_arr, num_prince_rounds_half
   );
   scrambled_data = {<<{wdata_arr}};
   return scrambled_data;
@@ -110,7 +110,7 @@ local function logic [38:0] _sram_decrypt_read39(
   `uvm_info(`gfn, $sformatf("scr data: 0x%0x", rdata39), UVM_HIGH)
   rdata_arr = {<<{rdata39}};
   rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
-      rdata_arr, 39, 39, addr_arr, full_addr_width, key_arr, nonce_arr
+      rdata_arr, 39, 39, addr_arr, full_addr_width, key_arr, nonce_arr, num_prince_rounds_half
   );
   rdata39 = {<<{rdata_arr}};
   return rdata39;

--- a/hw/ip/prim/doc/prim_ram_1p_scr.md
+++ b/hw/ip/prim/doc/prim_ram_1p_scr.md
@@ -2,9 +2,10 @@
 
 # Overview
 
-The scrambling primitive `prim_ram_1p_scr` employs a reduced-round (7 instead of 11) PRINCE block cipher in CTR mode to scramble the data.
+The scrambling primitive `prim_ram_1p_scr` employs a reduced-round (5 or 7 instead of 11) PRINCE block cipher in CTR mode to scramble the data.
 The PRINCE lightweight block cipher has been selected due to its low latency and low area characteristics, see also [prim_prince](./prim_prince.md) for more information on PRINCE.
-The number of rounds is reduced to 7 in order to ease timing pressure and ensure single cycle operation (the number of rounds can always be increased if it turns out that there is enough timing slack).
+In the default configuration, the number of rounds is reduced to 7 in order to ease timing pressure and ensure single cycle operation (the number of rounds can always be increased via the `NumPrinceRoundsHalf` parameter if it turns out that there is enough timing slack).
+To ease timing closure at the top level, the number of rounds used for scrambling the main SRAM and the instruction cache of the Ibex processor core is 5 (`NumPrinceRoundsHalf` = 2).
 
 In [CTR mode](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_(CTR)), the block cipher is used to encrypt a 64bit IV with the scrambling key in order to create a 64bit keystream block that is bitwise XOR'ed with the data in order to transform plaintext into ciphertext and vice versa.
 The IV is assembled by concatenating a nonce with the word address.

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -86,6 +86,13 @@
       expose:    "true",
       default:   "1"
     },
+    { name:      "NumPrinceRoundsHalf",
+      desc:      "Number of PRINCE half rounds for the SRAM scrambling feature",
+      type:      "int",
+      local:     "false",
+      expose:    "true",
+      default:   "3"
+    },
   ]
 
   features: [

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
@@ -12,5 +12,6 @@
 
   // These parameters are used for top_earlgrey main sram
   build_opts: ["+define+SRAM_ADDR_WIDTH=15",
-               "+define+INSTR_EXEC=1"]
+               "+define+INSTR_EXEC=1",
+               "+define+NUM_PRINCE_ROUNDS_HALF=3"]
 }

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
@@ -13,5 +13,5 @@
   // These parameters are used for top_earlgrey main sram
   build_opts: ["+define+SRAM_ADDR_WIDTH=15",
                "+define+INSTR_EXEC=1",
-               "+define+NUM_PRINCE_ROUNDS_HALF=3"]
+               "+define+NUM_PRINCE_ROUNDS_HALF=2"]
 }

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson
@@ -12,5 +12,6 @@
 
   // These parameters are used for top_earlgrey retention sram
   build_opts: ["+define+SRAM_ADDR_WIDTH=10",
-               "+define+INSTR_EXEC=0"]
+               "+define+INSTR_EXEC=0",
+               "+define+NUM_PRINCE_ROUNDS_HALF=3"]
 }

--- a/hw/ip/sram_ctrl/dv/tb.sv
+++ b/hw/ip/sram_ctrl/dv/tb.sv
@@ -63,7 +63,9 @@ module tb;
   sram_ctrl #(
     // memory size in bytes
     .MemSizeRam(4 * 2 ** `SRAM_ADDR_WIDTH),
-    .InstrExec(`INSTR_EXEC)
+    .InstrExec(`INSTR_EXEC),
+    // number of PRINCE half rounds for the SRAM scrambling feature
+    .NumPrinceRoundsHalf(`NUM_PRINCE_ROUNDS_HALF)
   ) dut (
     // main clock
     .clk_i               (clk                       ),
@@ -112,7 +114,8 @@ module tb;
                           .n_bits($bits(`SRAM_CTRL_MEM_HIER)),
                           // Due to the end-to-end bus integrity scheme, the memory primitive itself
                           // does not encode and decode the redundancy information.
-                          .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone));
+                          .err_detection_scheme(mem_bkdr_util_pkg::ErrDetectionNone),
+                          .num_prince_rounds_half(`NUM_PRINCE_ROUNDS_HALF));
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -17,6 +17,11 @@ module sram_ctrl
   parameter logic [NumAlerts-1:0] AlertAsyncOn          = {NumAlerts{1'b1}},
   // Enables the execute from SRAM feature.
   parameter bit InstrExec                               = 1,
+  // Number of PRINCE half rounds for the SRAM scrambling feature, can be [1..5].
+  // Note that this needs to be low-latency, hence we have to keep the amount of cipher rounds low.
+  // PRINCE has 5 half rounds in its original form, which corresponds to 2*5 + 1 effective rounds.
+  // Setting this to 3 lowers this to approximately 7 effective rounds.
+  parameter int NumPrinceRoundsHalf                     = 3,
   // Random netlist constants
   parameter otp_ctrl_pkg::sram_key_t   RndCnstSramKey   = RndCnstSramKeyDefault,
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramNonce = RndCnstSramNonceDefault,
@@ -535,7 +540,8 @@ module sram_ctrl
     .Width(DataWidth),
     .Depth(Depth),
     .EnableParity(0),
-    .DataBitsPerMask(DataWidth)
+    .DataBitsPerMask(DataWidth),
+    .NumPrinceRoundsHalf(NumPrinceRoundsHalf)
   ) u_prim_ram_1p_scr (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4760,6 +4760,14 @@
           expose: "true"
           name_top: SramCtrlRetAonInstrExec
         }
+        {
+          name: NumPrinceRoundsHalf
+          desc: Number of PRINCE half rounds for the SRAM scrambling feature
+          type: int
+          default: "3"
+          expose: "true"
+          name_top: SramCtrlRetAonNumPrinceRoundsHalf
+        }
       ]
       inter_signal_list:
       [
@@ -7340,6 +7348,14 @@
           default: "1"
           expose: "true"
           name_top: SramCtrlMainInstrExec
+        }
+        {
+          name: NumPrinceRoundsHalf
+          desc: Number of PRINCE half rounds for the SRAM scrambling feature
+          type: int
+          default: "3"
+          expose: "true"
+          name_top: SramCtrlMainNumPrinceRoundsHalf
         }
       ]
       inter_signal_list:

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7265,6 +7265,7 @@
       param_decl:
       {
         InstrExec: "1"
+        NumPrinceRoundsHalf: "2"
       }
       base_addrs:
       {
@@ -7353,7 +7354,7 @@
           name: NumPrinceRoundsHalf
           desc: Number of PRINCE half rounds for the SRAM scrambling feature
           type: int
-          default: "3"
+          default: "2"
           expose: "true"
           name_top: SramCtrlMainNumPrinceRoundsHalf
         }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -727,6 +727,7 @@
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
       param_decl: {
         InstrExec: "1",
+        NumPrinceRoundsHalf: "2",
       },
       base_addrs: {regs: "0x411C0000", ram: "0x10000000"},
       // Memory regions must be associated with a dedicated

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -555,6 +555,7 @@ module tb;
           .depth ($size(`RAM_MAIN_MEM_HIER)),
           .n_bits($bits(`RAM_MAIN_MEM_HIER)),
           .err_detection_scheme(mem_bkdr_util_pkg::EccInv_39_32),
+          .num_prince_rounds_half(2),
           .system_base_addr    (top_earlgrey_pkg::TOP_EARLGREY_RAM_MAIN_BASE_ADDR));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain0], `RAM_MAIN_MEM_HIER)
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -97,7 +97,7 @@ module top_earlgrey #(
   // parameters for edn1
   // parameters for sram_ctrl_main
   parameter bit SramCtrlMainInstrExec = 1,
-  parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
+  parameter int SramCtrlMainNumPrinceRoundsHalf = 2,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
   parameter bit SecRomCtrlDisableScrambling = 1'b0,

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -59,6 +59,7 @@ module top_earlgrey #(
   // parameters for sensor_ctrl_aon
   // parameters for sram_ctrl_ret_aon
   parameter bit SramCtrlRetAonInstrExec = 0,
+  parameter int SramCtrlRetAonNumPrinceRoundsHalf = 3,
   // parameters for flash_ctrl
   parameter bit SecFlashCtrlScrambleEn = 1,
   parameter int FlashCtrlProgFifoDepth = 4,
@@ -96,6 +97,7 @@ module top_earlgrey #(
   // parameters for edn1
   // parameters for sram_ctrl_main
   parameter bit SramCtrlMainInstrExec = 1,
+  parameter int SramCtrlMainNumPrinceRoundsHalf = 3,
   // parameters for rom_ctrl
   parameter RomCtrlBootRomInitFile = "",
   parameter bit SecRomCtrlDisableScrambling = 1'b0,
@@ -2067,7 +2069,8 @@ module top_earlgrey #(
     .RndCnstLfsrSeed(RndCnstSramCtrlRetAonLfsrSeed),
     .RndCnstLfsrPerm(RndCnstSramCtrlRetAonLfsrPerm),
     .MemSizeRam(4096),
-    .InstrExec(SramCtrlRetAonInstrExec)
+    .InstrExec(SramCtrlRetAonInstrExec),
+    .NumPrinceRoundsHalf(SramCtrlRetAonNumPrinceRoundsHalf)
   ) u_sram_ctrl_ret_aon (
       // [34]: fatal_error
       .alert_tx_o  ( alert_tx[34:34] ),
@@ -2534,7 +2537,8 @@ module top_earlgrey #(
     .RndCnstLfsrSeed(RndCnstSramCtrlMainLfsrSeed),
     .RndCnstLfsrPerm(RndCnstSramCtrlMainLfsrPerm),
     .MemSizeRam(131072),
-    .InstrExec(SramCtrlMainInstrExec)
+    .InstrExec(SramCtrlMainInstrExec),
+    .NumPrinceRoundsHalf(SramCtrlMainNumPrinceRoundsHalf)
   ) u_sram_ctrl_main (
       // [59]: fatal_error
       .alert_tx_o  ( alert_tx[59:59] ),


### PR DESCRIPTION
This PR contains multiple commits to reduce the number of PRINCE half rounds for the main SRAM scrambling from 3 back to 2 as used for Earlgrey ES. This is done to reduce timing pressure.

The scrambling parameters of the other scrambled memory primitives (retention SRAM, ROM, OTBN IMEM & DMEM) are not touched by this PR.

This PR supersedes #24376 as it also includes the required tooling changes. #24376 is intentionally left untouched to allow comparing the RTL changes as #24376 has already been absorbed by the PD team last week, i.e., we must not change the RTL beyond #24376.

For reference, the PRs where we increased the number of scrambling rounds in the past are:
- https://github.com/lowRISC/opentitan/pull/22425
- https://github.com/lowRISC/opentitan/pull/22948