### PR TITLE
[prim,fpv] Fix binding in prim_esc_rxtx_fpv

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_bind_fpv.sv
@@ -5,8 +5,8 @@
 
 module prim_esc_rxtx_bind_fpv;
 
-  bind prim_esc_rxtx_fpv
-    prim_esc_rxtx_assert_fpv #(TimeoutCntDw(TimeoutCntDw))
+  bind prim_esc_rxtx_tb
+    prim_esc_rxtx_assert_fpv #(.TimeoutCntDw(6))
     prim_esc_rxtx_assert_fpv (
       .clk_i       ,
       .rst_ni      ,


### PR DESCRIPTION
This bind statement had a typo which meant that it didn't actually bind in any assertions. Found by analysing formal coverage.