### PR TITLE
[ascon_core] add ctrl/status information

### DIFF
--- a/hw/ip/ascon/data/ascon.hjson
+++ b/hw/ip/ascon/data/ascon.hjson
@@ -436,18 +436,22 @@
             Once all registers of Share 0 have been written, Ascon starts to process the data depending on the !!CTRL_AUX_SHADOWED.manual_start_trigger.
           '''
         }
-        { bits: "8",
+        { bits: "11:8",
           name: "NO_MSG",
+          resval: "0x6",
           desc:  '''
-            There is no (1) message (plaintext/ciphertext) to be processed.
-            There is (0) a message.
+            This field is mubi4 encoded.
+            There is no (4'h6) message (plaintext/ciphertext) to be processed.
+            There is (4'h9) a message.
           '''
         }
-        { bits: "9",
+        { bits: "15:12",
           name: "NO_AD",
+          resval: "0x9",
           desc:  '''
-            There is no (1) associated data to be processed.
-            There is (0) associated data.
+            This field is mubi4 encoded.
+            There is no (4'h6) associated data to be processed.
+            There is (4'h9) associated data.
           '''
         }
       ]

--- a/hw/ip/ascon/data/ascon.hjson
+++ b/hw/ip/ascon/data/ascon.hjson
@@ -620,27 +620,11 @@
           name: "ALERT_RECOV_CTRL_UPDATE_ERR",
           resval: "0",
           desc:  '''
-            An update error has not occurred (0) or has occurred (1) in the shadowed Control Register.
-            Ascon operation needs to be restarted by re-writing the Control Register.
+            An update error has not occurred (0) or has occurred (1) in one of the shadowed Control
+            Registers. Ascon operation needs to be restarted by re-writing the Control Registers.
           '''
         }
         { bits: "5",
-          name: "ALERT_RECOV_CTRL_AUX_UPDATE_ERR",
-          resval: "0",
-          desc:  '''
-            An update error has not occurred (0) or has occurred (1) in the shadowed Auxiliary Control Register.
-            The register has to be rewritten.
-          '''
-        }
-        { bits: "6",
-          name: "ALERT_RECOV_BLOCK_CTRL_UPDATE_ERR",
-          resval: "0",
-          desc:  '''
-            An update error has not occurred (0) or has occurred (1) in the shadowed block Control Register.
-            The register has to be rewritten.
-          '''
-        }
-        { bits: "7",
           name: "ALERT_FATAL_FAULT",
           resval: "0",
           desc:  '''

--- a/hw/ip/ascon/data/ascon.hjson
+++ b/hw/ip/ascon/data/ascon.hjson
@@ -443,8 +443,8 @@
           resval: "0x6",
           desc:  '''
             This field is mubi4 encoded.
-            There is no (4'h6) message (plaintext/ciphertext) to be processed.
-            There is (4'h9) a message.
+            Mubi4True:  There is no message (plaintext/ciphertext) to be processed.
+            Mubi4False: There is a message.
           '''
         }
         { bits: "15:12",
@@ -452,8 +452,8 @@
           resval: "0x9",
           desc:  '''
             This field is mubi4 encoded.
-            There is no (4'h6) associated data to be processed.
-            There is (4'h9) associated data.
+            Mubi4True:  There are no associated data to be processed.
+            Mubi4False: There are associated data.
           '''
         }
       ]
@@ -646,21 +646,28 @@
     { name: "OUTPUT_VALID",
       desc: '''
         Output Valid Register
-        This register specifies which output register contains valid data and should be read next.
+        This register specifies which output register contains valid data.
         It also contains the status information whether the TAG comparison was valid or not.
       ''',
       swaccess: "ro",
       hwaccess: "hwo",
       fields: [
-        { bits: "2:0",
-          name: "DATA_TYPE",
+        { bits: "0",
+          name: "MSG_VALID",
           desc:  '''
-            Specifies which output type/register is valid.
-            There are:
-            PT_OUT, CT_OUT, TAG_OUT, NONE
+            Indicates if there is (1) or if there is not (0) valid data in the !!MSG_OUT register.
+            If !!OUTPUT_VALID.MSG_VALID and !!OUTPUT_VALID.TAG_VALID are both set, !!MSG_OUT should be read before !TAG_OUT.
           '''
         }
-        { bits: "4:3",
+        { bits: "1",
+          name: "TAG_VALID",
+          desc:  '''
+            Indicates if there is (1) or if there is not (0) valid data in the !!TAG_OUT register.
+            If !!OUTPUT_VALID.MSG_VALID and !!OUTPUT_VALID.TAG_VALID are both set,
+            !!MSG_OUT should be read before !TAG_OUT.
+          '''
+        }
+        { bits: "3:2",
           name: "TAG_COMPARISON_VALID",
           desc:  '''
             Indicates if the tag could be successfully compared 2'b01, or not 2'b10

--- a/hw/ip/ascon/data/ascon.hjson
+++ b/hw/ip/ascon/data/ascon.hjson
@@ -226,6 +226,7 @@
         For Ascon 128 the upper 64 bit can be set to any value
         For partial blocks the unused bytes can be set to any value.
         The order in which the registers are updated does not matter.
+        Writing to this register will invalidate previous values in the !!MSG_OUT register.
       '''
       count: "NumRegsData",
       cname: "MSG_IN_SHARE0",
@@ -254,6 +255,7 @@
         For Ascon 128 the upper 64 bit can be set to any value.
         For partial blocks the unused bytes can be set to any value.
         The order in which the registers are updated does not matter.
+        Writing to this register will invalidate previous values in the !!MSG_OUT register.
       '''
       count: "NumRegsData",
       cname: "MSG_IN_SHARE1",

--- a/hw/ip/ascon/doc/registers.md
+++ b/hw/ip/ascon/doc/registers.md
@@ -549,25 +549,23 @@ Writes to the Message and associated data Registers are not ignored but the data
 Status Register
 - Offset: `0xa8`
 - Reset default: `0x0`
-- Reset mask: `0xff`
+- Reset mask: `0x3f`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "IDLE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "STALL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "WAIT_EDN", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ASCON_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_RECOV_CTRL_UPDATE_ERR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_RECOV_CTRL_AUX_UPDATE_ERR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_RECOV_BLOCK_CTRL_UPDATE_ERR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_FATAL_FAULT", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 24}], "config": {"lanes": 1, "fontsize": 10, "vspace": 350}}
+{"reg": [{"name": "IDLE", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "STALL", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "WAIT_EDN", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ASCON_ERROR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_RECOV_CTRL_UPDATE_ERR", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "ALERT_FATAL_FAULT", "bits": 1, "attr": ["ro"], "rotate": -90}, {"bits": 26}], "config": {"lanes": 1, "fontsize": 10, "vspace": 290}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                                                                            |
-|:------:|:------:|:-------:|:--------------------------------------------------------------------------------|
-|  31:8  |        |         | Reserved                                                                        |
-|   7    |   ro   |   0x0   | [ALERT_FATAL_FAULT](#status--alert_fatal_fault)                                 |
-|   6    |   ro   |   0x0   | [ALERT_RECOV_BLOCK_CTRL_UPDATE_ERR](#status--alert_recov_block_ctrl_update_err) |
-|   5    |   ro   |   0x0   | [ALERT_RECOV_CTRL_AUX_UPDATE_ERR](#status--alert_recov_ctrl_aux_update_err)     |
-|   4    |   ro   |   0x0   | [ALERT_RECOV_CTRL_UPDATE_ERR](#status--alert_recov_ctrl_update_err)             |
-|   3    |   ro   |   0x0   | [ASCON_ERROR](#status--ascon_error)                                             |
-|   2    |   ro   |   0x0   | [WAIT_EDN](#status--wait_edn)                                                   |
-|   1    |   ro   |   0x0   | [STALL](#status--stall)                                                         |
-|   0    |   ro   |   0x0   | [IDLE](#status--idle)                                                           |
+|  Bits  |  Type  |  Reset  | Name                                                                |
+|:------:|:------:|:-------:|:--------------------------------------------------------------------|
+|  31:6  |        |         | Reserved                                                            |
+|   5    |   ro   |   0x0   | [ALERT_FATAL_FAULT](#status--alert_fatal_fault)                     |
+|   4    |   ro   |   0x0   | [ALERT_RECOV_CTRL_UPDATE_ERR](#status--alert_recov_ctrl_update_err) |
+|   3    |   ro   |   0x0   | [ASCON_ERROR](#status--ascon_error)                                 |
+|   2    |   ro   |   0x0   | [WAIT_EDN](#status--wait_edn)                                       |
+|   1    |   ro   |   0x0   | [STALL](#status--stall)                                             |
+|   0    |   ro   |   0x0   | [IDLE](#status--idle)                                               |
 
 ### STATUS . ALERT_FATAL_FAULT
 No fatal fault has occurred inside the Asconunit (0).
@@ -580,17 +578,9 @@ iv) errors in the internal round counter,
 v) escalations triggered by the life cycle controller, and
 vi) fatal integrity failures on the TL-UL bus.
 
-### STATUS . ALERT_RECOV_BLOCK_CTRL_UPDATE_ERR
-An update error has not occurred (0) or has occurred (1) in the shadowed block Control Register.
-The register has to be rewritten.
-
-### STATUS . ALERT_RECOV_CTRL_AUX_UPDATE_ERR
-An update error has not occurred (0) or has occurred (1) in the shadowed Auxiliary Control Register.
-The register has to be rewritten.
-
 ### STATUS . ALERT_RECOV_CTRL_UPDATE_ERR
-An update error has not occurred (0) or has occurred (1) in the shadowed Control Register.
-Ascon operation needs to be restarted by re-writing the Control Register.
+An update error has not occurred (0) or has occurred (1) in one of the shadowed Control
+Registers. Ascon operation needs to be restarted by re-writing the Control Registers.
 
 ### STATUS . ASCON_ERROR
 An error due to a misconfiguration has happened.

--- a/hw/ip/ascon/doc/registers.md
+++ b/hw/ip/ascon/doc/registers.md
@@ -376,20 +376,20 @@ Any write operation to this register will clear the status tracking required for
 A write to the Control Register is considered the start of a new message.
 Hence, software needs to provide a new Nonce and input data afterwards.
 - Offset: `0x94`
-- Reset default: `0x0`
-- Reset mask: `0x3ff`
+- Reset default: `0x9600`
+- Reset mask: `0xffff`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "OPERATION", "bits": 3, "attr": ["rw"], "rotate": -90}, {"name": "ASCON_VARIANT", "bits": 2, "attr": ["rw"], "rotate": -90}, {"name": "SIDELOAD_KEY", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "MASKED_AD_INPUT", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "MASKED_MSG_INPUT", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "NO_MSG", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "NO_AD", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 22}], "config": {"lanes": 1, "fontsize": 10, "vspace": 180}}
+{"reg": [{"name": "OPERATION", "bits": 3, "attr": ["rw"], "rotate": -90}, {"name": "ASCON_VARIANT", "bits": 2, "attr": ["rw"], "rotate": -90}, {"name": "SIDELOAD_KEY", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "MASKED_AD_INPUT", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "MASKED_MSG_INPUT", "bits": 1, "attr": ["rw"], "rotate": -90}, {"name": "NO_MSG", "bits": 4, "attr": ["rw"], "rotate": 0}, {"name": "NO_AD", "bits": 4, "attr": ["rw"], "rotate": 0}, {"bits": 16}], "config": {"lanes": 1, "fontsize": 10, "vspace": 180}}
 ```
 
 |  Bits  |  Type  |  Reset  | Name                                                 |
 |:------:|:------:|:-------:|:-----------------------------------------------------|
-| 31:10  |        |         | Reserved                                             |
-|   9    |   rw   |   0x0   | [NO_AD](#ctrl_shadowed--no_ad)                       |
-|   8    |   rw   |   0x0   | [NO_MSG](#ctrl_shadowed--no_msg)                     |
+| 31:16  |        |         | Reserved                                             |
+| 15:12  |   rw   |   0x9   | [NO_AD](#ctrl_shadowed--no_ad)                       |
+|  11:8  |   rw   |   0x6   | [NO_MSG](#ctrl_shadowed--no_msg)                     |
 |   7    |   rw   |   0x0   | [MASKED_MSG_INPUT](#ctrl_shadowed--masked_msg_input) |
 |   6    |   rw   |   0x0   | [MASKED_AD_INPUT](#ctrl_shadowed--masked_ad_input)   |
 |   5    |   rw   |   0x0   | [SIDELOAD_KEY](#ctrl_shadowed--sideload_key)         |
@@ -397,12 +397,14 @@ Hence, software needs to provide a new Nonce and input data afterwards.
 |  2:0   |   rw   |   0x0   | [OPERATION](#ctrl_shadowed--operation)               |
 
 ### CTRL_SHADOWED . NO_AD
-There is no (1) associated data to be processed.
-There is (0) associated data.
+This field is mubi4 encoded.
+There is no (4'h6) associated data to be processed.
+There is (4'h9) associated data.
 
 ### CTRL_SHADOWED . NO_MSG
-There is no (1) message (plaintext/ciphertext) to be processed.
-There is (0) a message.
+This field is mubi4 encoded.
+There is no (4'h6) message (plaintext/ciphertext) to be processed.
+There is (4'h9) a message.
 
 ### CTRL_SHADOWED . MASKED_MSG_INPUT
 Controls whether the message input is provided in shares (1) or not (0).

--- a/hw/ip/ascon/doc/registers.md
+++ b/hw/ip/ascon/doc/registers.md
@@ -400,13 +400,13 @@ Hence, software needs to provide a new Nonce and input data afterwards.
 
 ### CTRL_SHADOWED . NO_AD
 This field is mubi4 encoded.
-There is no (4'h6) associated data to be processed.
-There is (4'h9) associated data.
+Mubi4True:  There are no associated data to be processed.
+Mubi4False: There are associated data.
 
 ### CTRL_SHADOWED . NO_MSG
 This field is mubi4 encoded.
-There is no (4'h6) message (plaintext/ciphertext) to be processed.
-There is (4'h9) a message.
+Mubi4True:  There is no message (plaintext/ciphertext) to be processed.
+Mubi4False: There is a message.
 
 ### CTRL_SHADOWED . MASKED_MSG_INPUT
 Controls whether the message input is provided in shares (1) or not (0).
@@ -601,23 +601,24 @@ The Ascon unit is idle (0) or busy (1).
 
 ## OUTPUT_VALID
 Output Valid Register
-This register specifies which output register contains valid data and should be read next.
+This register specifies which output register contains valid data.
 It also contains the status information whether the TAG comparison was valid or not.
 - Offset: `0xac`
 - Reset default: `0x0`
-- Reset mask: `0x1f`
+- Reset mask: `0xf`
 
 ### Fields
 
 ```wavejson
-{"reg": [{"name": "DATA_TYPE", "bits": 3, "attr": ["ro"], "rotate": -90}, {"name": "TAG_COMPARISON_VALID", "bits": 2, "attr": ["ro"], "rotate": -90}, {"bits": 27}], "config": {"lanes": 1, "fontsize": 10, "vspace": 220}}
+{"reg": [{"name": "MSG_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TAG_VALID", "bits": 1, "attr": ["ro"], "rotate": -90}, {"name": "TAG_COMPARISON_VALID", "bits": 2, "attr": ["ro"], "rotate": -90}, {"bits": 28}], "config": {"lanes": 1, "fontsize": 10, "vspace": 220}}
 ```
 
-|  Bits  |  Type  |  Reset  | Name                 | Description                                                                                                                                        |
-|:------:|:------:|:-------:|:---------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------|
-|  31:5  |        |         |                      | Reserved                                                                                                                                           |
-|  4:3   |   ro   |   0x0   | TAG_COMPARISON_VALID | Indicates if the tag could be successfully compared 2'b01, or not 2'b10 2'b00 indicates that the tag hasn't been calculated, yet 2'b11 is invalid. |
-|  2:0   |   ro   |   0x0   | DATA_TYPE            | Specifies which output type/register is valid. There are: PT_OUT, CT_OUT, TAG_OUT, NONE                                                            |
+|  Bits  |  Type  |  Reset  | Name                 | Description                                                                                                                                                                                                                                                       |
+|:------:|:------:|:-------:|:---------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  31:4  |        |         |                      | Reserved                                                                                                                                                                                                                                                          |
+|  3:2   |   ro   |   0x0   | TAG_COMPARISON_VALID | Indicates if the tag could be successfully compared 2'b01, or not 2'b10 2'b00 indicates that the tag hasn't been calculated, yet 2'b11 is invalid.                                                                                                                |
+|   1    |   ro   |   0x0   | TAG_VALID            | Indicates if there is (1) or if there is not (0) valid data in the [`TAG_OUT`](#tag_out) register. If [`OUTPUT_VALID.MSG_VALID`](#output_valid) and [`OUTPUT_VALID.TAG_VALID`](#output_valid) are both set, [`MSG_OUT`](#msg_out) should be read before !TAG_OUT. |
+|   0    |   ro   |   0x0   | MSG_VALID            | Indicates if there is (1) or if there is not (0) valid data in the [`MSG_OUT`](#msg_out) register. If [`OUTPUT_VALID.MSG_VALID`](#output_valid) and [`OUTPUT_VALID.TAG_VALID`](#output_valid) are both set, [`MSG_OUT`](#msg_out) should be read before !TAG_OUT. |
 
 ## FSM_STATE
 Main FSM State register.

--- a/hw/ip/ascon/doc/registers.md
+++ b/hw/ip/ascon/doc/registers.md
@@ -214,6 +214,7 @@ Otherwise the engine stalls until all registers have been written.
 For Ascon 128 the upper 64 bit can be set to any value
 For partial blocks the unused bytes can be set to any value.
 The order in which the registers are updated does not matter.
+Writing to this register will invalidate previous values in the [`MSG_OUT`](#msg_out) register.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 
@@ -251,6 +252,7 @@ This basically disables input masking.
 For Ascon 128 the upper 64 bit can be set to any value.
 For partial blocks the unused bytes can be set to any value.
 The order in which the registers are updated does not matter.
+Writing to this register will invalidate previous values in the [`MSG_OUT`](#msg_out) register.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
 

--- a/hw/ip/ascon/pre_dv/ascon_tb/rtl/ascon_tl_ul_stim.sv
+++ b/hw/ip/ascon/pre_dv/ascon_tb/rtl/ascon_tl_ul_stim.sv
@@ -58,10 +58,12 @@ module ascon_tl_ul_stim
       put_full_data(32'h0, ASCON_KEY_SHARE1_2_OFFSET),
       put_full_data(32'h0, ASCON_KEY_SHARE1_3_OFFSET),
 
-      //Varaint+ Operation:
+      // Varaint+ Operation:
       // 5'b01_001 :  Ascon-128 Enc
-      put_full_data(32'h00000009, ASCON_CTRL_SHADOWED_OFFSET),
-      put_full_data(32'h00000009, ASCON_CTRL_SHADOWED_OFFSET),
+      // no_ad=false, no_msg = false
+      // 16'1001_1001_0000_0000
+      put_full_data(32'h00009909, ASCON_CTRL_SHADOWED_OFFSET),
+      put_full_data(32'h00009909, ASCON_CTRL_SHADOWED_OFFSET),
 
       // BLock Info
       // 3 bits reserved, 5 bits valid_bytes, 12 bits last, 12 bist start (ignored)

--- a/hw/ip/ascon/rtl/ascon.sv
+++ b/hw/ip/ascon/rtl/ascon.sv
@@ -78,6 +78,9 @@ module ascon
     .alert_recov_o(ascon_recov_alert),
     .alert_fatal_o(ascon_fatal_alert),
 
+    .error_recov_i(shadowed_update_err),
+    .error_fatal_i(alert[1]),
+
     .keymgr_key_i,
 
     .reg2hw(reg2hw),

--- a/hw/ip/ascon/rtl/ascon_core.sv
+++ b/hw/ip/ascon/rtl/ascon_core.sv
@@ -130,8 +130,19 @@ module ascon_core
   prim_mubi_pkg::mubi4_t tag_match;
   prim_mubi_pkg::mubi4_t tag_calculated;
 
-  // TODO
-  assign unused_keymgr_key_i     = keymgr_key_i;
+  // TODO Add sideload interface
+  logic  unused_sideload_key;
+  assign unused_sideload_key = sideload_key;
+  assign unused_keymgr_key_i = keymgr_key_i;
+
+  // TODO Add logic to provide inputs unmasked.
+  //      Atm both shares must be written.
+  logic  unused_masked_msg_input;
+  logic  unused_masked_ad_input;
+  assign unused_masked_ad_input  = masked_ad_input;
+  assign unused_masked_msg_input = masked_msg_input;
+
+  // TODO Add escalation Input
   assign unused_lc_escalate_en_i = lc_escalate_en_i;
 
   // DATA REGISTERS
@@ -291,8 +302,19 @@ module ascon_core
   assign hw2reg.trigger.start.d  = 1'b0;
   assign hw2reg.trigger.start.de = 1'b1;
 
+  // TODO Add wipe/reset
   assign hw2reg.trigger.wipe.d  = 1'b0;
   assign hw2reg.trigger.wipe.de = 1'b1;
+  logic  unused_wipe;
+  assign unused_wipe = wipe;
+
+  // TODO Add manual mode for SCA
+  logic unused_manual_start_trigger;
+  assign unused_manual_start_trigger = manual_start_trigger;
+
+  // TODO Add output overwrite
+  logic unused_force_data_overwrite;
+  assign unused_force_data_overwrite = force_data_overwrite;
 
   // STATUS
   assign hw2reg.status.idle.d  = prim_mubi_pkg::mubi4_test_true_strict(duplex_idle);
@@ -558,23 +580,6 @@ module ascon_core
   // This also invalidates the tag_calculated.
   // If the tag ist not read, the start of a new AEAD-Enc/Dec also clears the flag.
   assign tag_in_load = tag_out_read | start_ok;
-
-  // TODO: Build a very basic FSM here
-
-  // TODO: We don't use any control signals
-  logic        unused_force_data_overwrite;
-  logic        unused_manual_start_trigger;
-  logic        unused_wipe;
-  logic        unused_masked_msg_input;
-  logic        unused_masked_ad_input;
-  logic        unused_sideload_key;
-
-  assign unused_force_data_overwrite = force_data_overwrite;
-  assign unused_manual_start_trigger = manual_start_trigger;
-  assign unused_wipe                 = wipe;
-  assign unused_masked_ad_input      = masked_ad_input;
-  assign unused_masked_msg_input     = masked_msg_input;
-  assign unused_sideload_key         = sideload_key;
 
 
   // XOR shares for unprotected implementation

--- a/hw/ip/ascon/rtl/ascon_core.sv
+++ b/hw/ip/ascon/rtl/ascon_core.sv
@@ -7,7 +7,6 @@
 module ascon_core
   import ascon_reg_pkg::*;
   import ascon_pkg::*;
-  import prim_ascon_pkg::*;
 (
   input clk_i,
   input rst_ni,
@@ -88,8 +87,8 @@ module ascon_core
   data_type_e data_type_last;
   data_type_e data_type_start;
 
-  duplex_op_e      operation;
-  duplex_variant_e variant;
+  prim_ascon_pkg::duplex_op_e      operation;
+  prim_ascon_pkg::duplex_variant_e variant;
 
   logic [127:0]     msg_out;
   logic [3:0][31:0] msg_out_d;
@@ -293,15 +292,16 @@ module ascon_core
   assign hw2reg.output_valid.tag_comparison_valid.d  = 2'b00;
   assign hw2reg.output_valid.tag_comparison_valid.de = 1'b1;
 
-  // TODO FSM_STATE
-  assign hw2reg.fsm_state.d  = '0;
+  // FSM_STATE Debug Output
+  prim_ascon_pkg::duplex_fsm_state_e duplex_fsm_state;
+  assign hw2reg.fsm_state.d  = {{(32-prim_ascon_pkg::AsconDuplexFSMStateWidth){1'b0}},
+                                duplex_fsm_state};
+
   logic [31:0] unused_fsm_state_q;
   logic        unused_fsm_state_qe;
   assign unused_fsm_state_q  = reg2hw.fsm_state.q;
   assign unused_fsm_state_qe = reg2hw.fsm_state.qe;
 
-
-  // TODO FSM_STATE_REGEN
 
   // TODO ERROR
   assign hw2reg.error.no_key.d  = 1'b0;
@@ -518,6 +518,7 @@ module ascon_core
     .tag_out_o(tag_out),
     .tag_out_valid_o(tag_out_valid),
 
+    .fsm_state_o(duplex_fsm_state),
     .err_o(duplex_fatal_error)
   );
 

--- a/hw/ip/ascon/rtl/ascon_core.sv
+++ b/hw/ip/ascon/rtl/ascon_core.sv
@@ -18,6 +18,10 @@ module ascon_core
   output logic alert_recov_o,
   output logic alert_fatal_o,
 
+  // Input Errors for status register
+  input logic error_recov_i,
+  input logic error_fatal_i,
+
   // Key Manager
   input keymgr_pkg::hw_key_req_t keymgr_key_i,
 
@@ -295,15 +299,11 @@ module ascon_core
   assign hw2reg.status.idle.de = 1'b1;
   assign hw2reg.status.ascon_error.d  = ascon_error;
   assign hw2reg.status.ascon_error.de = 1'b1;
-  // TODO STATUS
-  assign hw2reg.status.alert_recov_ctrl_update_err.d  = 1'b0;
+  assign hw2reg.status.alert_recov_ctrl_update_err.d  = error_recov_i;
   assign hw2reg.status.alert_recov_ctrl_update_err.de = 1'b1;
-  assign hw2reg.status.alert_recov_ctrl_aux_update_err.d  = 1'b0;
-  assign hw2reg.status.alert_recov_ctrl_aux_update_err.de = 1'b1;
-  assign hw2reg.status.alert_recov_block_ctrl_update_err.d  = 1'b0;
-  assign hw2reg.status.alert_recov_block_ctrl_update_err.de = 1'b1;
-  assign hw2reg.status.alert_fatal_fault.d  = 1'b0;
+  assign hw2reg.status.alert_fatal_fault.d  = error_fatal_i;
   assign hw2reg.status.alert_fatal_fault.de = 1'b1;
+  // TODO STATUS
   assign hw2reg.status.stall.d  = 1'b0;
   assign hw2reg.status.stall.de = 1'b1;
   assign hw2reg.status.wait_edn.d  = 1'b0;

--- a/hw/ip/ascon/rtl/ascon_core.sv
+++ b/hw/ip/ascon/rtl/ascon_core.sv
@@ -344,33 +344,13 @@ module ascon_core
     end
   end
 
-  // According to the spec only one data type can be valid, however the implementation
-  // allows the tag to be valid while the last word of the message is also still valid
-  // This implementation now gives priority to the message, as the message should be read
-  // before the tag. It thus follows the spec "which output register [...] should be read next"
-  // TODO: Reconsider if the spec should be adjusted and only the value of
-  //       tag_out_reg_valid and msg_out_reg_valid should be exposed.
+  // TODO: directly assign hw2reg.output_valid.msg_valid and hw2reg.output_valid.tag_valid.d
+  //       in the track_output_status process above.
+  assign hw2reg.output_valid.msg_valid.d  = msg_out_reg_valid;
+  assign hw2reg.output_valid.msg_valid.de = 1'b1;
 
-  data_type_out_e msg_out_type;
-  assign msg_out_type = (operation == prim_ascon_pkg::ASCON_ENC) ? CT_OUT : PT_OUT;
-
-  always_comb begin : priority_mux_for_output_valid_data_type_reg
-    if (msg_out_reg_valid && !tag_out_reg_valid) begin
-      hw2reg.output_valid.data_type.d  = msg_out_type;
-    end else if (msg_out_reg_valid && tag_out_reg_valid) begin
-      if (msg_out_read) begin
-        hw2reg.output_valid.data_type.d  = TAG_OUT;
-      end else begin
-        hw2reg.output_valid.data_type.d  = msg_out_type;
-      end
-    end else if (tag_out_reg_valid) begin
-      hw2reg.output_valid.data_type.d  = TAG_OUT;
-    end else begin
-      hw2reg.output_valid.data_type.d  = NONE_OUT;
-    end
-  end
-  assign hw2reg.output_valid.data_type.de = 1'b1;
-
+  assign hw2reg.output_valid.tag_valid.d  = tag_out_reg_valid;
+  assign hw2reg.output_valid.tag_valid.de = 1'b1;
 
   // FSM_STATE Debug Output
   prim_ascon_pkg::duplex_fsm_state_e duplex_fsm_state;

--- a/hw/ip/ascon/rtl/ascon_pkg.sv
+++ b/hw/ip/ascon/rtl/ascon_pkg.sv
@@ -13,12 +13,6 @@ typedef enum logic [11:0] {
   NONE_IN = {prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False}
 } data_type_in_e;
 
-typedef enum logic [2:0] {
-  PT_OUT   = 3'b001,
-  CT_OUT   = 3'b010,
-  TAG_OUT  = 3'b100,
-  NONE_OUT = 3'b000
-} data_type_out_e;
 
 function automatic logic [127:0] swap_endianess_byte(logic [127:0] vector_in);
   logic [127:0] vector_out;

--- a/hw/ip/ascon/rtl/ascon_pkg.sv
+++ b/hw/ip/ascon/rtl/ascon_pkg.sv
@@ -7,11 +7,18 @@
 package ascon_pkg;
 
 typedef enum logic [11:0] {
-  MSG_IN = {prim_mubi_pkg::MuBi4True, prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False},
-  AD_IN =  {prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4True, prim_mubi_pkg::MuBi4False},
-  TAG_IN = {prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4True},
-  NONE =   {prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False}
-} data_type_e;
+  MSG_IN  = {prim_mubi_pkg::MuBi4True, prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False},
+  AD_IN   = {prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4True, prim_mubi_pkg::MuBi4False},
+  TAG_IN  = {prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4True},
+  NONE_IN = {prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False, prim_mubi_pkg::MuBi4False}
+} data_type_in_e;
+
+typedef enum logic [2:0] {
+  PT_OUT   = 3'b001,
+  CT_OUT   = 3'b010,
+  TAG_OUT  = 3'b100,
+  NONE_OUT = 3'b000
+} data_type_out_e;
 
 function automatic logic [127:0] swap_endianess_byte(logic [127:0] vector_in);
   logic [127:0] vector_out;

--- a/hw/ip/ascon/rtl/ascon_reg_pkg.sv
+++ b/hw/ip/ascon/rtl/ascon_reg_pkg.sv
@@ -207,9 +207,13 @@ package ascon_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [2:0]  d;
+      logic        d;
       logic        de;
-    } data_type;
+    } msg_valid;
+    struct packed {
+      logic        d;
+      logic        de;
+    } tag_valid;
     struct packed {
       logic [1:0]  d;
       logic        de;

--- a/hw/ip/ascon/rtl/ascon_reg_pkg.sv
+++ b/hw/ip/ascon/rtl/ascon_reg_pkg.sv
@@ -78,10 +78,10 @@ package ascon_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        q;
+      logic [3:0]  q;
     } no_ad;
     struct packed {
-      logic        q;
+      logic [3:0]  q;
     } no_msg;
     struct packed {
       logic        q;
@@ -249,17 +249,17 @@ package ascon_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    ascon_reg2hw_alert_test_reg_t alert_test; // [1267:1264]
-    ascon_reg2hw_key_share0_mreg_t [3:0] key_share0; // [1263:1132]
-    ascon_reg2hw_key_share1_mreg_t [3:0] key_share1; // [1131:1000]
-    ascon_reg2hw_nonce_share0_mreg_t [3:0] nonce_share0; // [999:868]
-    ascon_reg2hw_nonce_share1_mreg_t [3:0] nonce_share1; // [867:736]
-    ascon_reg2hw_data_in_share0_mreg_t [3:0] data_in_share0; // [735:604]
-    ascon_reg2hw_data_in_share1_mreg_t [3:0] data_in_share1; // [603:472]
-    ascon_reg2hw_tag_in_mreg_t [3:0] tag_in; // [471:340]
-    ascon_reg2hw_msg_out_mreg_t [3:0] msg_out; // [339:208]
-    ascon_reg2hw_tag_out_mreg_t [3:0] tag_out; // [207:76]
-    ascon_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [75:66]
+    ascon_reg2hw_alert_test_reg_t alert_test; // [1273:1270]
+    ascon_reg2hw_key_share0_mreg_t [3:0] key_share0; // [1269:1138]
+    ascon_reg2hw_key_share1_mreg_t [3:0] key_share1; // [1137:1006]
+    ascon_reg2hw_nonce_share0_mreg_t [3:0] nonce_share0; // [1005:874]
+    ascon_reg2hw_nonce_share1_mreg_t [3:0] nonce_share1; // [873:742]
+    ascon_reg2hw_data_in_share0_mreg_t [3:0] data_in_share0; // [741:610]
+    ascon_reg2hw_data_in_share1_mreg_t [3:0] data_in_share1; // [609:478]
+    ascon_reg2hw_tag_in_mreg_t [3:0] tag_in; // [477:346]
+    ascon_reg2hw_msg_out_mreg_t [3:0] msg_out; // [345:214]
+    ascon_reg2hw_tag_out_mreg_t [3:0] tag_out; // [213:82]
+    ascon_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [81:66]
     ascon_reg2hw_ctrl_aux_shadowed_reg_t ctrl_aux_shadowed; // [65:64]
     ascon_reg2hw_block_ctrl_shadowed_reg_t block_ctrl_shadowed; // [63:35]
     ascon_reg2hw_trigger_reg_t trigger; // [34:33]

--- a/hw/ip/ascon/rtl/ascon_reg_pkg.sv
+++ b/hw/ip/ascon/rtl/ascon_reg_pkg.sv
@@ -202,14 +202,6 @@ package ascon_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } alert_recov_ctrl_aux_update_err;
-    struct packed {
-      logic        d;
-      logic        de;
-    } alert_recov_block_ctrl_update_err;
-    struct packed {
-      logic        d;
-      logic        de;
     } alert_fatal_fault;
   } ascon_hw2reg_status_reg_t;
 
@@ -268,16 +260,16 @@ package ascon_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    ascon_hw2reg_key_share0_mreg_t [3:0] key_share0; // [1090:963]
-    ascon_hw2reg_key_share1_mreg_t [3:0] key_share1; // [962:835]
-    ascon_hw2reg_nonce_share0_mreg_t [3:0] nonce_share0; // [834:707]
-    ascon_hw2reg_nonce_share1_mreg_t [3:0] nonce_share1; // [706:579]
-    ascon_hw2reg_data_in_share0_mreg_t [3:0] data_in_share0; // [578:451]
-    ascon_hw2reg_data_in_share1_mreg_t [3:0] data_in_share1; // [450:323]
-    ascon_hw2reg_msg_out_mreg_t [3:0] msg_out; // [322:195]
-    ascon_hw2reg_tag_out_mreg_t [3:0] tag_out; // [194:67]
-    ascon_hw2reg_trigger_reg_t trigger; // [66:63]
-    ascon_hw2reg_status_reg_t status; // [62:47]
+    ascon_hw2reg_key_share0_mreg_t [3:0] key_share0; // [1086:959]
+    ascon_hw2reg_key_share1_mreg_t [3:0] key_share1; // [958:831]
+    ascon_hw2reg_nonce_share0_mreg_t [3:0] nonce_share0; // [830:703]
+    ascon_hw2reg_nonce_share1_mreg_t [3:0] nonce_share1; // [702:575]
+    ascon_hw2reg_data_in_share0_mreg_t [3:0] data_in_share0; // [574:447]
+    ascon_hw2reg_data_in_share1_mreg_t [3:0] data_in_share1; // [446:319]
+    ascon_hw2reg_msg_out_mreg_t [3:0] msg_out; // [318:191]
+    ascon_hw2reg_tag_out_mreg_t [3:0] tag_out; // [190:63]
+    ascon_hw2reg_trigger_reg_t trigger; // [62:59]
+    ascon_hw2reg_status_reg_t status; // [58:47]
     ascon_hw2reg_output_valid_reg_t output_valid; // [46:40]
     ascon_hw2reg_fsm_state_reg_t fsm_state; // [39:8]
     ascon_hw2reg_error_reg_t error; // [7:0]

--- a/hw/ip/ascon/rtl/ascon_reg_top.sv
+++ b/hw/ip/ascon/rtl/ascon_reg_top.sv
@@ -222,12 +222,12 @@ module ascon_reg_top (
   logic ctrl_shadowed_masked_msg_input_wd;
   logic ctrl_shadowed_masked_msg_input_storage_err;
   logic ctrl_shadowed_masked_msg_input_update_err;
-  logic ctrl_shadowed_no_msg_qs;
-  logic ctrl_shadowed_no_msg_wd;
+  logic [3:0] ctrl_shadowed_no_msg_qs;
+  logic [3:0] ctrl_shadowed_no_msg_wd;
   logic ctrl_shadowed_no_msg_storage_err;
   logic ctrl_shadowed_no_msg_update_err;
-  logic ctrl_shadowed_no_ad_qs;
-  logic ctrl_shadowed_no_ad_wd;
+  logic [3:0] ctrl_shadowed_no_ad_qs;
+  logic [3:0] ctrl_shadowed_no_ad_wd;
   logic ctrl_shadowed_no_ad_storage_err;
   logic ctrl_shadowed_no_ad_update_err;
   logic ctrl_aux_shadowed_re;
@@ -1305,11 +1305,11 @@ module ascon_reg_top (
     .err_storage (ctrl_shadowed_masked_msg_input_storage_err)
   );
 
-  //   F[no_msg]: 8:8
+  //   F[no_msg]: 11:8
   prim_subreg_shadow #(
-    .DW      (1),
+    .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
+    .RESVAL  (4'h6),
     .Mubi    (1'b0)
   ) u_ctrl_shadowed_no_msg (
     .clk_i   (clk_i),
@@ -1341,11 +1341,11 @@ module ascon_reg_top (
     .err_storage (ctrl_shadowed_no_msg_storage_err)
   );
 
-  //   F[no_ad]: 9:9
+  //   F[no_ad]: 15:12
   prim_subreg_shadow #(
-    .DW      (1),
+    .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0),
+    .RESVAL  (4'h9),
     .Mubi    (1'b0)
   ) u_ctrl_shadowed_no_ad (
     .clk_i   (clk_i),
@@ -2300,9 +2300,9 @@ module ascon_reg_top (
 
   assign ctrl_shadowed_masked_msg_input_wd = reg_wdata[7];
 
-  assign ctrl_shadowed_no_msg_wd = reg_wdata[8];
+  assign ctrl_shadowed_no_msg_wd = reg_wdata[11:8];
 
-  assign ctrl_shadowed_no_ad_wd = reg_wdata[9];
+  assign ctrl_shadowed_no_ad_wd = reg_wdata[15:12];
   assign ctrl_aux_shadowed_re = addr_hit[38] & reg_re & !reg_error;
   assign ctrl_aux_shadowed_we = addr_hit[38] & reg_we & !reg_error;
 
@@ -2541,8 +2541,8 @@ module ascon_reg_top (
         reg_rdata_next[5] = ctrl_shadowed_sideload_key_qs;
         reg_rdata_next[6] = ctrl_shadowed_masked_ad_input_qs;
         reg_rdata_next[7] = ctrl_shadowed_masked_msg_input_qs;
-        reg_rdata_next[8] = ctrl_shadowed_no_msg_qs;
-        reg_rdata_next[9] = ctrl_shadowed_no_ad_qs;
+        reg_rdata_next[11:8] = ctrl_shadowed_no_msg_qs;
+        reg_rdata_next[15:12] = ctrl_shadowed_no_ad_qs;
       end
 
       addr_hit[38]: begin

--- a/hw/ip/ascon/rtl/ascon_reg_top.sv
+++ b/hw/ip/ascon/rtl/ascon_reg_top.sv
@@ -268,7 +268,8 @@ module ascon_reg_top (
   logic status_ascon_error_qs;
   logic status_alert_recov_ctrl_update_err_qs;
   logic status_alert_fatal_fault_qs;
-  logic [2:0] output_valid_data_type_qs;
+  logic output_valid_msg_valid_qs;
+  logic output_valid_tag_valid_qs;
   logic [1:0] output_valid_tag_comparison_valid_qs;
   logic fsm_state_re;
   logic [31:0] fsm_state_qs;
@@ -1812,13 +1813,13 @@ module ascon_reg_top (
 
 
   // R[output_valid]: V(False)
-  //   F[data_type]: 2:0
+  //   F[msg_valid]: 0:0
   prim_subreg #(
-    .DW      (3),
+    .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h0),
+    .RESVAL  (1'h0),
     .Mubi    (1'b0)
-  ) u_output_valid_data_type (
+  ) u_output_valid_msg_valid (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -1827,8 +1828,8 @@ module ascon_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.output_valid.data_type.de),
-    .d      (hw2reg.output_valid.data_type.d),
+    .de     (hw2reg.output_valid.msg_valid.de),
+    .d      (hw2reg.output_valid.msg_valid.d),
 
     // to internal hardware
     .qe     (),
@@ -1836,10 +1837,37 @@ module ascon_reg_top (
     .ds     (),
 
     // to register interface (read)
-    .qs     (output_valid_data_type_qs)
+    .qs     (output_valid_msg_valid_qs)
   );
 
-  //   F[tag_comparison_valid]: 4:3
+  //   F[tag_valid]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0),
+    .Mubi    (1'b0)
+  ) u_output_valid_tag_valid (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.output_valid.tag_valid.de),
+    .d      (hw2reg.output_valid.tag_valid.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+    .ds     (),
+
+    // to register interface (read)
+    .qs     (output_valid_tag_valid_qs)
+  );
+
+  //   F[tag_comparison_valid]: 3:2
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2519,8 +2547,9 @@ module ascon_reg_top (
       end
 
       addr_hit[43]: begin
-        reg_rdata_next[2:0] = output_valid_data_type_qs;
-        reg_rdata_next[4:3] = output_valid_tag_comparison_valid_qs;
+        reg_rdata_next[0] = output_valid_msg_valid_qs;
+        reg_rdata_next[1] = output_valid_tag_valid_qs;
+        reg_rdata_next[3:2] = output_valid_tag_comparison_valid_qs;
       end
 
       addr_hit[44]: begin

--- a/hw/ip/ascon/rtl/ascon_reg_top.sv
+++ b/hw/ip/ascon/rtl/ascon_reg_top.sv
@@ -267,8 +267,6 @@ module ascon_reg_top (
   logic status_wait_edn_qs;
   logic status_ascon_error_qs;
   logic status_alert_recov_ctrl_update_err_qs;
-  logic status_alert_recov_ctrl_aux_update_err_qs;
-  logic status_alert_recov_block_ctrl_update_err_qs;
   logic status_alert_fatal_fault_qs;
   logic [2:0] output_valid_data_type_qs;
   logic [1:0] output_valid_tag_comparison_valid_qs;
@@ -1785,61 +1783,7 @@ module ascon_reg_top (
     .qs     (status_alert_recov_ctrl_update_err_qs)
   );
 
-  //   F[alert_recov_ctrl_aux_update_err]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_status_alert_recov_ctrl_aux_update_err (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.status.alert_recov_ctrl_aux_update_err.de),
-    .d      (hw2reg.status.alert_recov_ctrl_aux_update_err.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (status_alert_recov_ctrl_aux_update_err_qs)
-  );
-
-  //   F[alert_recov_block_ctrl_update_err]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0),
-    .Mubi    (1'b0)
-  ) u_status_alert_recov_block_ctrl_update_err (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.status.alert_recov_block_ctrl_update_err.de),
-    .d      (hw2reg.status.alert_recov_block_ctrl_update_err.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-    .ds     (),
-
-    // to register interface (read)
-    .qs     (status_alert_recov_block_ctrl_update_err_qs)
-  );
-
-  //   F[alert_fatal_fault]: 7:7
+  //   F[alert_fatal_fault]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2571,9 +2515,7 @@ module ascon_reg_top (
         reg_rdata_next[2] = status_wait_edn_qs;
         reg_rdata_next[3] = status_ascon_error_qs;
         reg_rdata_next[4] = status_alert_recov_ctrl_update_err_qs;
-        reg_rdata_next[5] = status_alert_recov_ctrl_aux_update_err_qs;
-        reg_rdata_next[6] = status_alert_recov_block_ctrl_update_err_qs;
-        reg_rdata_next[7] = status_alert_fatal_fault_qs;
+        reg_rdata_next[5] = status_alert_fatal_fault_qs;
       end
 
       addr_hit[43]: begin

--- a/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_duplex_tb/rtl/prim_ascon_duplex_tb.sv
+++ b/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_duplex_tb/rtl/prim_ascon_duplex_tb.sv
@@ -317,6 +317,7 @@ module prim_ascon_duplex_tb (
   .ascon_operation(OPERATION),
 
   .start_i(start),
+  .done_o(),
   .idle_o(idle),
 
   // It is assumed that no_ad, no_msg, key, and nonce are always

--- a/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_duplex_tb/rtl/prim_ascon_duplex_tb.sv
+++ b/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_duplex_tb/rtl/prim_ascon_duplex_tb.sv
@@ -289,14 +289,15 @@ module prim_ascon_duplex_tb (
   logic [127:0] dut_response_tag;
   logic         dut_response_tag_valid;
 
-  logic dut_no_msg;
-  logic dut_no_ad;
+  prim_mubi_pkg::mubi4_t dut_no_msg;
+  prim_mubi_pkg::mubi4_t dut_no_ad;
 
   assign dut_no_msg =
          ((OPERATION == ASCON_ENC && STIMULUS_MSG_LEN == 0)
         ||(OPERATION == ASCON_DEC && EXPECTED_MSG_LEN == 0))
-         ? 1'b1 : 1'b0;
-  assign dut_no_ad  = STIMULUS_AD_LEN  == 0 ? 1'b1 : 1'b0;
+         ? prim_mubi_pkg::MuBi4True : prim_mubi_pkg::MuBi4False;
+  assign dut_no_ad  = STIMULUS_AD_LEN  == 0 ? prim_mubi_pkg::MuBi4True :
+                                              prim_mubi_pkg::MuBi4False;
 
   mubi4_t dut_last_block_ad;
   mubi4_t dut_last_block_msg;
@@ -320,8 +321,8 @@ module prim_ascon_duplex_tb (
 
   // It is assumed that no_ad, no_msg, key, and nonce are always
   // valid and constant, when the cipher is triggered by the start command
-  .no_ad(dut_no_ad),
-  .no_msg(dut_no_msg),
+  .no_ad_i(dut_no_ad),
+  .no_msg_i(dut_no_msg),
 
   .key_i(key),
   .nonce_i(nonce),

--- a/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_duplex_tb/rtl/prim_ascon_duplex_tb.sv
+++ b/hw/ip/prim/pre_dv/prim_ascon/prim_ascon_duplex_tb/rtl/prim_ascon_duplex_tb.sv
@@ -343,6 +343,7 @@ module prim_ascon_duplex_tb (
   .tag_out_o(dut_response_tag),
   .tag_out_valid_o(dut_response_tag_valid),
 
+  .fsm_state_o(),
   .err_o()
   );
 

--- a/hw/ip/prim/rtl/prim_ascon_duplex.sv
+++ b/hw/ip/prim/rtl/prim_ascon_duplex.sv
@@ -49,6 +49,8 @@ module prim_ascon_duplex
   output logic [127:0] tag_out_o,
   output logic         tag_out_valid_o,
 
+  output duplex_fsm_state_e fsm_state_o,
+
   output logic err_o
 );
 
@@ -79,8 +81,10 @@ logic [319:0] state_from_round;
 logic [4:0][63:0] round_to_mux;
 assign round_to_mux = state_from_round;
 
-fsm_state_e fsm_state_d, fsm_state_q;
+duplex_fsm_state_e fsm_state_d, fsm_state_q;
 perm_offset_e perm_offset;
+
+assign fsm_state_o = fsm_state_q;
 
 logic  [63:0] iv;
 assign iv = (ascon_variant == ASCON_128) ? IV_128 : IV_128A;
@@ -592,7 +596,7 @@ always_comb begin : p_fsm
   endcase
 end
 
-`PRIM_FLOP_SPARSE_FSM(u_state_regs, fsm_state_d, fsm_state_q, fsm_state_e, Idle)
+`PRIM_FLOP_SPARSE_FSM(u_state_regs, fsm_state_d, fsm_state_q, duplex_fsm_state_e, Idle)
 
 assign err_o = round_count_error | sparse_fsm_error;
 

--- a/hw/ip/prim/rtl/prim_ascon_duplex.sv
+++ b/hw/ip/prim/rtl/prim_ascon_duplex.sv
@@ -22,7 +22,9 @@ module prim_ascon_duplex
   input duplex_variant_e ascon_variant,
   input duplex_op_e ascon_operation,
 
-  input  logic   start_i,
+  input  logic start_i,
+  output logic done_o,
+
   output prim_mubi_pkg::mubi4_t idle_o,
 
   // It is assumed that no_ad, no_msg, key, and nonce are always
@@ -328,6 +330,7 @@ always_comb begin : p_fsm
   set_round_counter = 1'b0;
   inc_round_counter = 1'b0;
   perm_offset = P12;
+  done_o = 1'b0;
   idle_o = prim_mubi_pkg::MuBi4False;
 
   // Default: Don't update state
@@ -584,6 +587,7 @@ always_comb begin : p_fsm
     SqueezeTagXorKey: begin
       tag_out_valid_o = 1'b1;
       fsm_state_d = Idle;
+      done_o = 1'b1;
     end
     Error: begin
       fsm_state_d = Error;

--- a/hw/ip/prim/rtl/prim_ascon_pkg.sv
+++ b/hw/ip/prim/rtl/prim_ascon_pkg.sv
@@ -116,8 +116,8 @@ typedef enum logic [PADDING_MUX_WIDTH-1:0] {
 // Minimum Hamming weight: 3
 // Maximum Hamming weight: 8
 //
-localparam int AsconFSMStateWidth = 10;
-typedef enum logic [AsconFSMStateWidth-1:0] {
+localparam int AsconDuplexFSMStateWidth = 10;
+typedef enum logic [AsconDuplexFSMStateWidth-1:0] {
   Idle             = 10'b1010101110,
   Init             = 10'b0110000110,
   PermInit         = 10'b1011110110,
@@ -136,7 +136,7 @@ typedef enum logic [AsconFSMStateWidth-1:0] {
   PermMSGEmpty     = 10'b1011111000,
   PermADEmpty      = 10'b0010111100,
   Error            = 10'b0100011110
-} fsm_state_e;
+} duplex_fsm_state_e;
 
 function automatic logic [127:0] bin2thermo(logic [4:0] valid_bytes);
   logic [127:0] valid_bytes_mask;


### PR DESCRIPTION
This PR implements the following tasks from https://github.com/lowRISC/opentitan/issues/22452
- [x] add mubi signals
- [x] hook up duplex FSM state register to debug register
- [x] create error codes and hook up error registers. This also slight changes the specification
- [x] add tag comparison
- [x] connect output valid register
