### PR TITLE
[prim,fpv] Get rid of ASSERT_KNOWN in an FPV context

### DIFF
--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -127,8 +127,10 @@
 // Assert that signal has a known value (each bit is either '0' or '1') after reset if enable is
 // set.  It can be called as a module (or interface) body item.
 `define ASSERT_KNOWN_IF(__name, __sig, __enable, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+`ifndef FPV_ON                                                                                             \
   `ASSERT_KNOWN(__name``KnownEnable, __enable, __clk, __rst)                                               \
-  `ASSERT_IF(__name, !$isunknown(__sig), __enable, __clk, __rst)
+  `ASSERT_IF(__name, !$isunknown(__sig), __enable, __clk, __rst)                                           \
+`endif
 
 //////////////////////////////////
 // For formal verification only //

--- a/hw/ip/prim/rtl/prim_assert_standard_macros.svh
+++ b/hw/ip/prim/rtl/prim_assert_standard_macros.svh
@@ -87,7 +87,9 @@
     end
 
 `define ASSERT_KNOWN(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-  `ASSERT(__name, !$isunknown(__sig), __clk, __rst)
+`ifndef FPV_ON                                                                                \
+  `ASSERT(__name, !$isunknown(__sig), __clk, __rst)                                           \
+`endif
 
 `define COVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
   __name: cover property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop));


### PR DESCRIPTION
Unknown signals aren't really supported by Jasper, which drops the assertion accordingly. Unfortunately, this shows up as a coverage hole (for a rather silly reason). Get rid of the assertion entirely if we are in this context (the signal is not X because the tool doesn't allow that to happen...)