### PR TITLE
[manuf] Update CP and FT provisioning tests to utilize SPI device console

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -41,7 +41,9 @@
 #include "flash_ctrl_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false, );
 
 /**
  * Peripheral handles.
@@ -184,7 +186,6 @@ static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
     // Wait for host the host generated RMA unlock token hash to arrive over the
     // console.
     LOG_INFO("Waiting For RMA Unlock Token Hash ...");
-
     CHECK_STATUS_OK(
         UJSON_WITH_CRC(ujson_deserialize_lc_token_hash_t, uj, &token_hash));
 

--- a/sw/device/silicon_creator/manuf/base/sram_cp_provision.c
+++ b/sw/device/silicon_creator/manuf/base/sram_cp_provision.c
@@ -29,7 +29,9 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otp_ctrl_regs.h"  // Generated.
 
-OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false, );
 
 static dif_otp_ctrl_t otp_ctrl;
 static dif_pinmux_t pinmux;

--- a/sw/device/silicon_creator/manuf/base/sram_cp_provision_functest.c
+++ b/sw/device/silicon_creator/manuf/base/sram_cp_provision_functest.c
@@ -27,7 +27,9 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otp_ctrl_regs.h"  // Generated.
 
-OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false, );
 
 static dif_otp_ctrl_t otp_ctrl;
 static dif_pinmux_t pinmux;

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -25,7 +25,9 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false, );
 
 static dif_flash_ctrl_state_t flash_ctrl_state;
 static dif_otp_ctrl_t otp_ctrl;


### PR DESCRIPTION
This PR  has two commits that:

1. Add host-device resync mechnisam for SPI device RX console to enhance robustness against device resets during provisioning
2. Switch provisioning flow to use spi console 

This fixes #24420.
Note: this depends on #24530. Only review the last 2 commits.