### PR TITLE
[i2c,dv] Add csr write excl to OVERRIDE csr

### DIFF
--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -571,6 +571,9 @@
           desc: "Value for SDA Override. Set to 0 to drive TX Low, and set to 1 for high-Z"
         }
       ]
+      tags: [// Overriding can cause sda/scl_interference interrupts to trigger continously.
+             // These then become unclearable interrupts at the end of csr_tests (clear_all_interrupts() fails).
+             "excl:CsrRwTest:CsrExclWriteCheck"]
     }
     { name: "VAL"
       desc: "Oversampled RX values"


### PR DESCRIPTION
Writes can affect hardware in a way that causes interrupts (sda/scl_interference) to re-assert continuously, preventing the end-of-test clear_interrupts routine from completing.