### PR TITLE
[prim,fpv] Fix the bind statement in prim_alert_rxtx_fatal_bind_fpv

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_bind_fpv.sv
@@ -6,7 +6,7 @@
 module prim_alert_rxtx_fatal_bind_fpv;
 
   // this reuses the synchronous VIP.
-  bind prim_alert_rxtx_fpv
+  bind prim_alert_rxtx_tb
         prim_alert_rxtx_assert_fpv prim_alert_rxtx_assert_fpv (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
The statement that was previously there didn't actually bind the assertions into anything. This was only noticed because of low formal coverage numbers.