### PR TITLE
[prim,fpv] Tweak the prim_alert_rxtx_async tests

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_bind_fpv.sv
@@ -5,7 +5,7 @@
 
 module prim_alert_rxtx_async_bind_fpv;
 
-  bind prim_alert_rxtx_async_fpv
+  bind prim_alert_rxtx_async_tb
         prim_alert_rxtx_async_assert_fpv prim_alert_rxtx_async_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_bind_fpv.sv
@@ -5,7 +5,7 @@
 
 module prim_alert_rxtx_async_fatal_bind_fpv;
 
-  bind prim_alert_rxtx_async_fpv
+  bind prim_alert_rxtx_async_tb
         prim_alert_rxtx_async_assert_fpv prim_alert_rxtx_async_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
@@ -78,11 +78,11 @@ module prim_alert_rxtx_async_assert_fpv
   // be parameterized accordingly if different clock ratios are to be used here.
   // TODO: tighten bounds if possible
   sequence FullHandshake_S;
-    $rose(prim_alert_rxtx_async_tb.alert_pd)   ##[3:5]
+    $rose(prim_alert_rxtx_async_tb.alert_pd)   ##[3:6]
     $rose(prim_alert_rxtx_async_tb.ack_pd)     &&
-    $stable(prim_alert_rxtx_async_tb.alert_pd) ##[3:5]
+    $stable(prim_alert_rxtx_async_tb.alert_pd) ##[3:6]
     $fell(prim_alert_rxtx_async_tb.alert_pd)   &&
-    $stable(prim_alert_rxtx_async_tb.ack_pd)   ##[3:5]
+    $stable(prim_alert_rxtx_async_tb.ack_pd)   ##[3:6]
     $fell(prim_alert_rxtx_async_tb.ack_pd)     &&
     $stable(prim_alert_rxtx_async_tb.alert_pd);
   endsequence

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
@@ -125,7 +125,7 @@ module prim_alert_rxtx_async_assert_fpv
   `ASSERT(AlertCheck0_A,
       !ping_req_i [*10] ##1 ($rose(alert_req_i) || $rose(alert_test_i)) && sender_is_idle |->
       ##[3:5] alert_o,
-      clk_i, !rst_ni || ping_req_i || error_setreg_q || init_pending)
+      clk_i, !rst_ni || ping_req_i || error_setreg_q || init_pending || alert_skew_i || ack_skew_i)
   // eventual transmission of alerts in the general case which can include continous ping
   // collisions
   `ASSERT(AlertCheck1_A,

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
@@ -47,6 +47,12 @@ module prim_alert_rxtx_async_assert_fpv
                         prim_alert_rxtx_async_tb.i_prim_alert_receiver.InitReq,
                         prim_alert_rxtx_async_tb.i_prim_alert_receiver.InitAckWait};
 
+  logic sender_is_idle, receiver_is_idle, sender_is_pinging;
+  assign sender_is_idle = i_prim_alert_sender.state_q == i_prim_alert_sender.Idle;
+  assign receiver_is_idle = i_prim_alert_receiver.state_q == i_prim_alert_receiver.Idle;
+  assign sender_is_pinging = i_prim_alert_sender.state_q inside
+                             {i_prim_alert_sender.PingHsPhase1, i_prim_alert_sender.PingHsPhase2};
+
   // used to check that an error has never occured so far
   // this is used to check the handshake below. the handshake can lock up
   // the protocol FSMs causing the handshake to never complete.
@@ -90,79 +96,58 @@ module prim_alert_rxtx_async_assert_fpv
   // note: injected errors may lockup the FSMs, and hence the full HS can
   // only take place if both FSMs are in a good state
   `ASSERT(PingHs_A, ##1 $changed(prim_alert_rxtx_async_tb.ping_pd) &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
+      sender_is_idle && receiver_is_idle |-> ##[0:5] FullHandshake_S,
       clk_i, !rst_ni || error_setreg_q || init_pending)
   `ASSERT(AlertHs_A, alert_req_i &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
+      sender_is_idle && receiver_is_idle |-> ##[0:5] FullHandshake_S,
       clk_i, !rst_ni || error_setreg_q || init_pending)
   `ASSERT(AlertTestHs_A, alert_test_i &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
+      sender_is_idle && receiver_is_idle |-> ##[0:5] FullHandshake_S,
       clk_i, !rst_ni || error_setreg_q || init_pending)
   // Make sure we eventually get an ACK
   `ASSERT(AlertReqAck_A, alert_req_i &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |-> strong(##[1:$] alert_ack_o),
+      sender_is_idle && receiver_is_idle |-> strong(##[1:$] alert_ack_o),
       clk_i, !rst_ni || error_setreg_q || init_pending)
 
   // transmission of pings
   // this bound is relatively large as in the worst case, we need to resolve
   // staggered differential signal patterns on all three differential channels
   // note: the complete transmission of pings only happen when no ping handshake is in progress
-  `ASSERT(AlertPingOk_A, !(prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q inside {
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.PingHsPhase1,
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
-      ##[1:23] ping_ok_o,
-      clk_i, !rst_ni || error_setreg_q || init_pending)
-  `ASSERT(AlertPingIgnored_A, (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q inside {
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.PingHsPhase1,
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
-      ping_ok_o == 0 throughout ping_req_i[->1],
-      clk_i, !rst_ni || error_setreg_q)
+  `ASSERT(AlertPingOk_A,
+          !sender_is_pinging && $rose(ping_req_i) |-> ##[1:23] ping_ok_o,
+          clk_i, !rst_ni || error_setreg_q || init_pending)
+
+  `ASSERT(AlertPingIgnored_A,
+          sender_is_pinging && $rose(ping_req_i) |-> ping_ok_o == 0 throughout ping_req_i[->1],
+          clk_i, !rst_ni || error_setreg_q)
+
   // transmission of first alert assertion (no ping collision)
-  `ASSERT(AlertCheck0_A, !ping_req_i [*10] ##1 ($rose(alert_req_i) || $rose(alert_test_i)) &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) |->
+  `ASSERT(AlertCheck0_A,
+      !ping_req_i [*10] ##1 ($rose(alert_req_i) || $rose(alert_test_i)) && sender_is_idle |->
       ##[3:5] alert_o,
       clk_i, !rst_ni || ping_req_i || error_setreg_q || init_pending)
   // eventual transmission of alerts in the general case which can include continous ping
   // collisions
-  `ASSERT(AlertCheck1_A, alert_req_i || alert_test_i |->
-      strong(##[1:$] (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle && !ping_req_i) ##[3:5] alert_o),
+  `ASSERT(AlertCheck1_A,
+      alert_req_i || alert_test_i |-> strong(##[1:$] sender_is_idle ##[3:5] alert_o),
       clk_i, !rst_ni || error_setreg_q ||
       prim_alert_rxtx_async_tb.i_prim_alert_sender.alert_clr || init_pending)
 
   // basic liveness of FSMs in case no errors are present
-  `ASSERT(FsmLivenessSender_A, !error_present [*2] ##1 !error_present &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q !=
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) |->
-      strong(##[1:$] (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle)),
+  `ASSERT(FsmLivenessSender_A,
+      !error_present [*2] ##1 !error_present && !sender_is_idle |->
+      strong(##[1:$] sender_is_idle),
       clk_i, !rst_ni || error_present || init_pending)
-  `ASSERT(FsmLivenessReceiver_A, !error_present [*2] ##1 !error_present &&
-      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q !=
-      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |->
-      strong(##[1:$] (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle)),
+  `ASSERT(FsmLivenessReceiver_A,
+      !error_present [*2] ##1 !error_present && receiver_is_idle |->
+      strong(##[1:$] receiver_is_idle),
       clk_i, !rst_ni || error_present || init_pending)
 
   // check that the in-band reset moves sender FSM into Idle state.
   `ASSERT(InBandInitFromReceiverToSender_A,
       mubi4_test_true_strict(init_trig_i)
       |->
-      ##[1:30] (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle),
+      ##[1:30] sender_is_idle,
       clk_i, !rst_ni || error_present)
 
 endmodule : prim_alert_rxtx_async_assert_fpv

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
@@ -43,9 +43,9 @@ module prim_alert_rxtx_async_assert_fpv
 
   logic init_pending;
   assign init_pending = mubi4_test_true_strict(init_trig_i) ||
-                        prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q inside {
-                        prim_alert_rxtx_async_fpv.i_prim_alert_receiver.InitReq,
-                        prim_alert_rxtx_async_fpv.i_prim_alert_receiver.InitAckWait};
+                        prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q inside {
+                        prim_alert_rxtx_async_tb.i_prim_alert_receiver.InitReq,
+                        prim_alert_rxtx_async_tb.i_prim_alert_receiver.InitAckWait};
 
   // used to check that an error has never occured so far
   // this is used to check the handshake below. the handshake can lock up
@@ -78,91 +78,91 @@ module prim_alert_rxtx_async_assert_fpv
   // be parameterized accordingly if different clock ratios are to be used here.
   // TODO: tighten bounds if possible
   sequence FullHandshake_S;
-    $rose(prim_alert_rxtx_async_fpv.alert_pd)   ##[3:5]
-    $rose(prim_alert_rxtx_async_fpv.ack_pd)     &&
-    $stable(prim_alert_rxtx_async_fpv.alert_pd) ##[3:5]
-    $fell(prim_alert_rxtx_async_fpv.alert_pd)   &&
-    $stable(prim_alert_rxtx_async_fpv.ack_pd)   ##[3:5]
-    $fell(prim_alert_rxtx_async_fpv.ack_pd)     &&
-    $stable(prim_alert_rxtx_async_fpv.alert_pd);
+    $rose(prim_alert_rxtx_async_tb.alert_pd)   ##[3:5]
+    $rose(prim_alert_rxtx_async_tb.ack_pd)     &&
+    $stable(prim_alert_rxtx_async_tb.alert_pd) ##[3:5]
+    $fell(prim_alert_rxtx_async_tb.alert_pd)   &&
+    $stable(prim_alert_rxtx_async_tb.ack_pd)   ##[3:5]
+    $fell(prim_alert_rxtx_async_tb.ack_pd)     &&
+    $stable(prim_alert_rxtx_async_tb.alert_pd);
   endsequence
 
   // note: injected errors may lockup the FSMs, and hence the full HS can
   // only take place if both FSMs are in a good state
-  `ASSERT(PingHs_A, ##1 $changed(prim_alert_rxtx_async_fpv.ping_pd) &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
+  `ASSERT(PingHs_A, ##1 $changed(prim_alert_rxtx_async_tb.ping_pd) &&
+      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) &&
+      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
       clk_i, !rst_ni || error_setreg_q || init_pending)
   `ASSERT(AlertHs_A, alert_req_i &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
+      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) &&
+      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
       clk_i, !rst_ni || error_setreg_q || init_pending)
   `ASSERT(AlertTestHs_A, alert_test_i &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
+      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) &&
+      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
       clk_i, !rst_ni || error_setreg_q || init_pending)
   // Make sure we eventually get an ACK
   `ASSERT(AlertReqAck_A, alert_req_i &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |-> strong(##[1:$] alert_ack_o),
+      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) &&
+      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |-> strong(##[1:$] alert_ack_o),
       clk_i, !rst_ni || error_setreg_q || init_pending)
 
   // transmission of pings
   // this bound is relatively large as in the worst case, we need to resolve
   // staggered differential signal patterns on all three differential channels
   // note: the complete transmission of pings only happen when no ping handshake is in progress
-  `ASSERT(AlertPingOk_A, !(prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q inside {
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.PingHsPhase1,
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
+  `ASSERT(AlertPingOk_A, !(prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q inside {
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.PingHsPhase1,
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
       ##[1:23] ping_ok_o,
       clk_i, !rst_ni || error_setreg_q || init_pending)
-  `ASSERT(AlertPingIgnored_A, (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q inside {
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.PingHsPhase1,
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
+  `ASSERT(AlertPingIgnored_A, (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q inside {
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.PingHsPhase1,
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
       ping_ok_o == 0 throughout ping_req_i[->1],
       clk_i, !rst_ni || error_setreg_q)
   // transmission of first alert assertion (no ping collision)
   `ASSERT(AlertCheck0_A, !ping_req_i [*10] ##1 ($rose(alert_req_i) || $rose(alert_test_i)) &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) |->
+      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) |->
       ##[3:5] alert_o,
       clk_i, !rst_ni || ping_req_i || error_setreg_q || init_pending)
   // eventual transmission of alerts in the general case which can include continous ping
   // collisions
   `ASSERT(AlertCheck1_A, alert_req_i || alert_test_i |->
-      strong(##[1:$] (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle && !ping_req_i) ##[3:5] alert_o),
+      strong(##[1:$] (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle && !ping_req_i) ##[3:5] alert_o),
       clk_i, !rst_ni || error_setreg_q ||
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.alert_clr || init_pending)
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.alert_clr || init_pending)
 
   // basic liveness of FSMs in case no errors are present
   `ASSERT(FsmLivenessSender_A, !error_present [*2] ##1 !error_present &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q !=
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) |->
-      strong(##[1:$] (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle)),
+      (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q !=
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle) |->
+      strong(##[1:$] (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle)),
       clk_i, !rst_ni || error_present || init_pending)
   `ASSERT(FsmLivenessReceiver_A, !error_present [*2] ##1 !error_present &&
-      (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q !=
-      prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |->
-      strong(##[1:$] (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle)),
+      (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q !=
+      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle) |->
+      strong(##[1:$] (prim_alert_rxtx_async_tb.i_prim_alert_receiver.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_receiver.Idle)),
       clk_i, !rst_ni || error_present || init_pending)
 
   // check that the in-band reset moves sender FSM into Idle state.
   `ASSERT(InBandInitFromReceiverToSender_A,
       mubi4_test_true_strict(init_trig_i)
       |->
-      ##[1:30] (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle),
+      ##[1:30] (prim_alert_rxtx_async_tb.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_tb.i_prim_alert_sender.Idle),
       clk_i, !rst_ni || error_present)
 
 endmodule : prim_alert_rxtx_async_assert_fpv


### PR DESCRIPTION
These tests weren't actually doing anything because we were binding them into a nonexistent module (found by looking at formal coverage).

Fix that and fix most of the broken properties. Annoyingly, `AlertCheck0_A` still doesn't quite work. This property is supposed to be putting an upper bound on the time between someone asking the alert sender to do something and the alert receiver registering that it has happened. I suspect this just needs a small tweak (since the non-async version is working fine!). But it seems a bit fiddly and I'm hoping someone who understands this primitive better than me can help...

I think this change is worth taking either way because it enables a load of testing that we weren't previously running. And most of it passes!