### PR TITLE
[fpv,prim] Fix PrimCountFpv define in prim_count tests

### DIFF
--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_prim_cfgs.hjson
@@ -95,7 +95,8 @@
                dut: prim_count_tb
                fusesoc_core: lowrisc:fpv:prim_count_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-               build_opts: ["-define ResetValue -1 -define PrimCountFpv 1"]
+               build_opts: ["-define ResetValue -1"]
+               defines: "PrimCountFpv"
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: true
              }
@@ -104,7 +105,8 @@
                dut: prim_count_tb
                fusesoc_core: lowrisc:fpv:prim_count_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-               build_opts: ["-define ResetValue 0 -define PrimCountFpv 1"]
+               build_opts: ["-define ResetValue 0"]
+               defines: "PrimCountFpv"
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: true
              }


### PR DESCRIPTION
The existing code was wrong, and it was my fault: I had thought that the Jasper "-define" argument would turn into a pre-processor define. But it doesn't! It actually defines a TCL variable that (in our case) is visible in fpv.tcl.

Fortunately, the hjson/tcl machinery has a "defines" key, which common_formal_cfg.hjson translates into an FPV_DEFINES environment variable, which then gets picked up by fpv.tcl and passed in to the JasperGold "analyze" command.

This commit switches to using that.