### PR TITLE
[prim,fpv] Strengthen CntErrReported_A assertion in prim_count.sv

### DIFF
--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -292,10 +292,14 @@ module prim_count
           $past(clr_i || set_i || (commit_i && (incr_en_i || decr_en_i))),
           clk_i, err_d || fpv_err_present || !rst_ni)
 
-  // Check that count errors are reported properly in err_d
-  `ASSERT(CntErrReported_A, ((cnt_q[1] + cnt_q[0]) != {Width{1'b1}}) == err_d)
+  // Check that count errors are reported properly in err_o
+  //
+  // This is essentially a "|=> implication", but is structured in a way to avoid generating a cover
+  // property for the left hand side if PrimCountFpv is not defined (because we won't have a way to
+  // inject an error if not)
+  `ASSERT(CntErrReported_A, ##1 $past((cnt_q[1] + cnt_q[0]) != {Width{1'b1}}) == err_o)
  `ifdef PrimCountFpv
-  `COVER(CntErr_C, err_d)
+  `COVER(CntErr_C, err_o)
  `endif
 
   // This logic that will be assign to one, when user adds macro


### PR DESCRIPTION
The err_d signal is flopped into err_q, which appears as err_o. The existing assertion (that err_d went high) was correct, but didn't check the err_q/err_o part. This eventually translated into a coverage hole where no property had a CoI that included the "err_q <= err_d" line.

Change things so that we use err_o instead. This feels a little "less internal" anyway, which is nice, and also includes the register stage.