### PR TITLE
[prim,fpv] Tweak DataKnown_A assertion in prim_fifo_sync.sv

### DIFF
--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -148,7 +148,7 @@ module prim_fifo_sync #(
   // Known Assertions //
   //////////////////////
 
-  `ASSERT(DataKnown_A, rvalid_o |-> !$isunknown(rdata_o))
+  `ASSERT_KNOWN_IF(DataKnown_A, rdata_o, rvalid_o)
   `ASSERT_KNOWN(DepthKnown_A, depth_o)
   `ASSERT_KNOWN(RvalidKnown_A, rvalid_o)
   `ASSERT_KNOWN(WreadyKnown_A, wready_o)


### PR DESCRIPTION
This doesn't change the meaning, but it means that we now use ASSERT_KNOWN_IF instead of explicitly talking about $isunknown. Doing so will allow FPV runs (that don't support $isunknown) to avoid needing to report unprocessed code.

Note that this won't make any difference without #24454.