### PR TITLE
[prim,rtl] Remove dead code in prim_fifo_async_sram_adapter

### DIFF
--- a/hw/ip/prim/rtl/prim_fifo_async_sram_adapter.sv
+++ b/hw/ip/prim/rtl/prim_fifo_async_sram_adapter.sv
@@ -267,8 +267,7 @@ module prim_fifo_async_sram_adapter #(
   //    - r_rptr_inc: Can request more
   //    - !r_rptr_inc: Can't request
   always_comb begin : r_sram_req
-    r_sram_req_o = 1'b 0;
-    // Karnough Map (!empty): sram_req
+    // Karnaugh Map (!empty): sram_req
     // {sram_rv, rfifo_ack} | 00 | 01          | 11 | 10
     // ----------------------------------------------------------
     // stored          | 0  |  1 |  impossible |  1 |  0


### PR DESCRIPTION
This write is always overridden by a write in the next if/else statement (and causes a hole in reported FPV statement coverage).