### PR TITLE
[prim,fpv] Remove initialisation before a test

### DIFF
--- a/hw/ip/prim/rtl/prim_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_lfsr.sv
@@ -419,7 +419,6 @@ module prim_lfsr #(
       // Check that the permutation is indeed a permutation.
       logic [LfsrDw-1:0] sbox_perm_test;
       always_comb begin : p_perm_check
-        sbox_perm_test = '0;
         for (int k = 0; k < LfsrDw; k++) begin
           sbox_perm_test[sbox_in_indices[k]] = 1'b1;
         end


### PR DESCRIPTION
This initialisation isn't really needed because the array will come up as 'x and the SboxPermutationCheck_A assertion below would fail if the end result wasn't '1.

The existing code also causes a reported coverage hole in the FPV flow, which notes that assigning sbox_perm_test to zero has no effect.

Obviously, this is a little silly: it's inside ifndef SYNTHESIS so coverage doesn't really matter! But waiving this sort of coverage hole more generally might be tricky and this particular case can just be "fixed".