### PR TITLE
[hw,spi_host,rtl] Implement LSIO trigger (integrated_dev to master)

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -41,6 +41,15 @@
       act:     "rsp",
       width:   "1"
     }
+    { struct: "logic",
+      type:   "uni",
+      name:   "lsio_trigger",
+      desc: '''
+            Self-clearing status trigger for the DMA.
+            Set when RX or TX FIFOs are past their configured watermarks matching watermark interrupt behaviour.
+            '''
+      act:    "req",
+    }
   ]
   regwidth: "32",
   param_list: [

--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -20,7 +20,7 @@
   sw_checklist:       "/sw/device/lib/dif/dif_spi_host",
   revisions: [
     {
-      version:            "2.0.0",
+      version:            "2.1.0",
       life_stage:         "L1",
       design_stage:       "D2S",
       verification_stage: "V2S",

--- a/hw/ip/spi_host/doc/interfaces.md
+++ b/hw/ip/spi_host/doc/interfaces.md
@@ -17,10 +17,11 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name   | Package::Struct             | Type    | Act   |   Width | Description   |
-|:------------|:----------------------------|:--------|:------|--------:|:--------------|
-| passthrough | spi_device_pkg::passthrough | req_rsp | rsp   |       1 |               |
-| tl          | tlul_pkg::tl                | req_rsp | rsp   |       1 |               |
+| Port Name    | Package::Struct             | Type    | Act   |   Width | Description                                                                                                                                    |
+|:-------------|:----------------------------|:--------|:------|--------:|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| passthrough  | spi_device_pkg::passthrough | req_rsp | rsp   |       1 |                                                                                                                                                |
+| lsio_trigger | logic                       | uni     | req   |       1 | Self-clearing status trigger for the DMA. Set when RX or TX FIFOs are past their configured watermarks matching watermark interrupt behaviour. |
+| tl           | tlul_pkg::tl                | req_rsp | rsp   |       1 |                                                                                                                                                |
 
 ## Interrupts
 

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -37,6 +37,8 @@ module spi_host
   input  spi_device_pkg::passthrough_req_t passthrough_i,
   output spi_device_pkg::passthrough_rsp_t passthrough_o,
 
+  output logic             lsio_trigger_o,
+
   output logic             intr_error_o,
   output logic             intr_spi_event_o
 );
@@ -562,6 +564,8 @@ module spi_host
 
   // Qualify interrupt sources individually with dedicated mask register CSR.EVENT_ENABLE
   assign status_spi_event = |(event_vector & event_mask);
+
+  assign lsio_trigger_o = tx_wm | rx_wm;
 
   prim_intr_hw #(
     .Width(1),

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -565,7 +565,14 @@ module spi_host
   // Qualify interrupt sources individually with dedicated mask register CSR.EVENT_ENABLE
   assign status_spi_event = |(event_vector & event_mask);
 
-  assign lsio_trigger_o = tx_wm | rx_wm;
+  // Flop trigger signal to avoid glitches on the output
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      lsio_trigger_o <= 1'b0;
+    end else begin
+      lsio_trigger_o <= tx_wm | rx_wm;
+    end
+  end
 
   prim_intr_hw #(
     .Width(1),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2391,6 +2391,20 @@
           index: -1
         }
         {
+          name: lsio_trigger
+          desc:
+            '''
+            Self-clearing status trigger for the DMA.
+            Set when RX or TX FIFOs are past their configured watermarks matching watermark interrupt behaviour.
+            '''
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          inst_name: spi_host0
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -2443,6 +2457,20 @@
           package: spi_device_pkg
           type: req_rsp
           act: rsp
+          width: 1
+          inst_name: spi_host1
+          index: -1
+        }
+        {
+          name: lsio_trigger
+          desc:
+            '''
+            Self-clearing status trigger for the DMA.
+            Set when RX or TX FIFOs are past their configured watermarks matching watermark interrupt behaviour.
+            '''
+          struct: logic
+          type: uni
+          act: req
           width: 1
           inst_name: spi_host1
           index: -1
@@ -17063,6 +17091,20 @@
         index: -1
       }
       {
+        name: lsio_trigger
+        desc:
+          '''
+          Self-clearing status trigger for the DMA.
+          Set when RX or TX FIFOs are past their configured watermarks matching watermark interrupt behaviour.
+          '''
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        inst_name: spi_host0
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -17081,6 +17123,20 @@
         package: spi_device_pkg
         type: req_rsp
         act: rsp
+        width: 1
+        inst_name: spi_host1
+        index: -1
+      }
+      {
+        name: lsio_trigger
+        desc:
+          '''
+          Self-clearing status trigger for the DMA.
+          Set when RX or TX FIFOs are past their configured watermarks matching watermark interrupt behaviour.
+          '''
+        struct: logic
+        type: uni
+        act: req
         width: 1
         inst_name: spi_host1
         index: -1

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1601,6 +1601,7 @@ module top_earlgrey #(
       // Inter-module signals
       .passthrough_i(spi_device_passthrough_req),
       .passthrough_o(spi_device_passthrough_rsp),
+      .lsio_trigger_o(),
       .tl_i(spi_host0_tl_req),
       .tl_o(spi_host0_tl_rsp),
 
@@ -1633,6 +1634,7 @@ module top_earlgrey #(
       // Inter-module signals
       .passthrough_i(spi_device_pkg::PASSTHROUGH_REQ_DEFAULT),
       .passthrough_o(),
+      .lsio_trigger_o(),
       .tl_i(spi_host1_tl_req),
       .tl_o(spi_host1_tl_rsp),
 


### PR DESCRIPTION
In this minimal implementation, SPI Host asserts `lsio_trigger_o` iff the TX FIFO fill level is smaller than the configured watermark or the RX FIFO fill level is greater than or equal to the configured watermark, independent of IRQ enablement.