### PR TITLE
[earlgrey_1.0.0,spi_host/rtl] Fix `sd_en_o` of `spi_host_fsm`

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -591,7 +591,6 @@ module spi_host_fsm
     if (!rst_ni) begin
       sd_en_ff_q <= 0;
     end
-    //TODO: do we need an enable signal?
     else begin
       sd_en_ff_q <= sd_en_ff_d;
     end
@@ -612,35 +611,32 @@ module spi_host_fsm
     if (&csb_o) begin
       sd_en_o[3:0] = 4'h0;
     end else begin
-      // Only update the sd_en_o on the right clock transition. Since sck_o
-      // is generated from the sys clock we ensure we only drive the data on the
-      // right clock edge
-      if( (drive_posedge && sck_o) ||
-          (!drive_posedge && !sck_o) ) begin
-        unique case (speed_o)
-          Standard: begin
-            sd_en_o[0]   = cmd_wr_en_q | cmd_wr_en_last_bit;
-            sd_en_o[1]   = 1'b0;
-            sd_en_o[3:2] = 2'b00;
-          end
-          Dual:     begin
-            sd_en_o[1:0] = {2{cmd_wr_en_q}};
-            sd_en_o[3:2] = 2'b00;
-          end
-          Quad:     begin
-            sd_en_o[3:0] = {4{cmd_wr_en_q}};
-          end
-          default: begin
-            // invalid speed
-            sd_en_o[3:0] = 4'h0;
-          end
-        endcase
-      end
-      else begin
-        sd_en_o  = sd_en_ff_q;
-      end
+      unique case (speed_o)
+        Standard: begin
+          sd_en_o[0]   = cmd_wr_en_q | cmd_wr_en_last_bit;
+          sd_en_o[1]   = 1'b0;
+          sd_en_o[3:2] = 2'b00;
+        end
+        Dual:     begin
+          sd_en_o[1:0] = {2{cmd_wr_en_q}};
+          sd_en_o[3:2] = 2'b00;
+        end
+        Quad:     begin
+          sd_en_o[3:0] = {4{cmd_wr_en_q}};
+        end
+        default: begin
+          // invalid speed
+          sd_en_o[3:0] = 4'h0;
+        end
+      endcase
     end // else: !if(&csb_o)
   end
+
+  // The following signals are unused since their usages got removed in an ECO.  In order to
+  // minimize the netlist diff, the signals are kept in this code.
+  logic unused_sd_en_ff, unused_drive_posedge;
+  assign unused_sd_en_ff = ^{sd_en_ff_d, sd_en_ff_q};
+  assign unused_drive_posedge = drive_posedge;
 
   //
   // Assertions confirming valid user input.


### PR DESCRIPTION
This partially reverts commit 7eb53da738a770a4cc00153eb7179a2c2d9bdda9, which introduced a glitch on the `sd_en_o` output of `spi_host_fsm`. The reversal is partial in order to minimize the netlist diff.  The `drive_posedge` signal as well as the four `sd_en_ff_q` flops are now unused.

This is *not* a cherry pick of a commit on `master`, where the glitch is planned to be fixed with a full reversal of the commit mentioned above (in PR #24500).

## Test results

Relevant block- and top-level tests are currently running; I'll post the results here once they're done.

### Block-level tests

Full block-level regression doesn't show any new failures:
```
### Test Results                                                                                                                                                                                  
|  Stage  |                   Name                    | Tests                               |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |                          
|:-------:|:-----------------------------------------:|:------------------------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|                          
|   V1    |                   smoke                   | spi_host_smoke                      |      7.700m       |     15.034ms     |    50     |   50    |  100.00 %   |                          
|   V1    |               csr_hw_reset                | spi_host_csr_hw_reset               |      8.000s       |     17.400us     |     5     |    5    |  100.00 %   |                          
|   V1    |                  csr_rw                   | spi_host_csr_rw                     |      8.000s       |     15.750us     |    20     |   20    |  100.00 %   |                          
|   V1    |               csr_bit_bash                | spi_host_csr_bit_bash               |      9.000s       |    336.302us     |     5     |    5    |  100.00 %   |                          
|   V1    |               csr_aliasing                | spi_host_csr_aliasing               |      8.000s       |     21.887us     |     5     |    5    |  100.00 %   |                          
|   V1    |        csr_mem_rw_with_rand_reset         | spi_host_csr_mem_rw_with_rand_reset |      8.000s       |     70.262us     |    20     |   20    |  100.00 %   |                          
|   V1    | regwen_csr_and_corresponding_lockable_csr | spi_host_csr_rw                     |      8.000s       |     15.750us     |    20     |   20    |  100.00 %   |                          
|         |                                           | spi_host_csr_aliasing               |      8.000s       |     21.887us     |     5     |    5    |  100.00 %   |                          
|   V1    |                 mem_walk                  | spi_host_mem_walk                   |      8.000s       |     29.592us     |     5     |    5    |  100.00 %   |                          
|   V1    |            mem_partial_access             | spi_host_mem_partial_access         |      8.000s       |     54.530us     |     5     |    5    |  100.00 %   |                          
|   V1    |                                           | **TOTAL**                           |                   |                  |    115    |   115   |  100.00 %   |                          
|   V2    |                performance                | spi_host_performance                |      8.000s       |     97.249us     |    50     |   50    |  100.00 %   |                          
|   V2    |             error_event_intr              | spi_host_overflow_underflow         |      2.650m       |     7.058ms      |    50     |   50    |  100.00 %   |                          
|         |                                           | spi_host_error_cmd                  |      8.000s       |     77.955us     |    50     |   50    |  100.00 %   |                          
|         |                                           | spi_host_event                      |      14.967m      |     97.246ms     |    50     |   50    |  100.00 %   |                          
|   V2    |                clock_rate                 | spi_host_speed                      |      28.000s      |     2.078ms      |    50     |   50    |  100.00 %   |                          
|   V2    |                   speed                   | spi_host_speed                      |      28.000s      |     2.078ms      |    50     |   50    |  100.00 %   |                          
|   V2    |            chip_select_timing             | spi_host_speed                      |      28.000s      |     2.078ms      |    50     |   50    |  100.00 %   |                          
|   V2    |                 sw_reset                  | spi_host_sw_reset                   |      3.350m       |     4.474ms      |    50     |   50    |  100.00 %   |                          
|   V2    |             passthrough_mode              | spi_host_passthrough_mode           |      8.000s       |    421.906us     |    50     |   50    |  100.00 %   |                          
|   V2    |                 cpol_cpha                 | spi_host_speed                      |      28.000s      |     2.078ms      |    50     |   50    |  100.00 %   |                          
|   V2    |                full_cycle                 | spi_host_speed                      |      28.000s      |     2.078ms      |    50     |   50    |  100.00 %   |                          
|   V2    |                  duplex                   | spi_host_smoke                      |      7.700m       |     15.034ms     |    50     |   50    |  100.00 %   |                          
|   V2    |                tx_rx_only                 | spi_host_smoke                      |      7.700m       |     15.034ms     |    50     |   50    |  100.00 %   |                          
|   V2    |                stress_all                 | spi_host_stress_all                 |      8.700m       |     15.013ms     |    48     |   50    |   96.00 %   |                          
|   V2    |                   spien                   | spi_host_spien                      |      5.550m       |     91.488ms     |    50     |   50    |  100.00 %   |                          
|   V2    |                   stall                   | spi_host_status_stall               |      8.333m       |     15.188ms     |    46     |   50    |   92.00 %   |                          
|   V2    |               Idlecsbactive               | spi_host_idlecsbactive              |      27.000s      |     1.103ms      |    50     |   50    |  100.00 %   |                          
|   V2    |             data_fifo_status              | spi_host_overflow_underflow         |      2.650m       |     7.058ms      |    50     |   50    |  100.00 %   |                          
|   V2    |                alert_test                 | spi_host_alert_test                 |      8.000s       |     47.025us     |    50     |   50    |  100.00 %   |                          
|   V2    |                 intr_test                 | spi_host_intr_test                  |      8.000s       |     23.535us     |    50     |   50    |  100.00 %   |                          
|   V2    |           tl_d_oob_addr_access            | spi_host_tl_errors                  |      10.000s      |     1.303ms      |    20     |   20    |  100.00 %   |                          
|   V2    |            tl_d_illegal_access            | spi_host_tl_errors                  |      10.000s      |     1.303ms      |    20     |   20    |  100.00 %   |                          
|   V2    |          tl_d_outstanding_access          | spi_host_csr_hw_reset               |      8.000s       |     17.400us     |     5     |    5    |  100.00 %   |                          
|         |                                           | spi_host_csr_rw                     |      8.000s       |     15.750us     |    20     |   20    |  100.00 %   |                          
|         |                                           | spi_host_csr_aliasing               |      8.000s       |     21.887us     |     5     |    5    |  100.00 %   |                          
|         |                                           | spi_host_same_csr_outstanding       |      8.000s       |     17.298us     |    20     |   20    |  100.00 %   |                          
|   V2    |            tl_d_partial_access            | spi_host_csr_hw_reset               |      8.000s       |     17.400us     |     5     |    5    |  100.00 %   |                          
|         |                                           | spi_host_csr_rw                     |      8.000s       |     15.750us     |    20     |   20    |  100.00 %   |                          
|         |                                           | spi_host_csr_aliasing               |      8.000s       |     21.887us     |     5     |    5    |  100.00 %   |                          
|         |                                           | spi_host_same_csr_outstanding       |      8.000s       |     17.298us     |    20     |   20    |  100.00 %   |                          
|   V2    |                                           | **TOTAL**                           |                   |                  |    684    |   690   |   99.13 %   |                          
|   V2S   |                tl_intg_err                | spi_host_tl_intg_err                |      8.000s       |    183.359us     |    20     |   20    |  100.00 %   |                          
|         |                                           | spi_host_sec_cm                     |      8.000s       |    164.330us     |     5     |    5    |  100.00 %   |                          
|   V2S   |           sec_cm_bus_integrity            | spi_host_tl_intg_err                |      8.000s       |    183.359us     |    20     |   20    |  100.00 %   |                          
|   V2S   |                                           | **TOTAL**                           |                   |                  |    25     |   25    |  100.00 %   |                          
|         |              Unmapped tests               | spi_host_upper_range_clkdiv         |      49.833m      |    100.002ms     |     2     |   10    |   20.00 %   |                          
|         |                                           | **TOTAL**                           |                   |                  |    826    |   840   |   98.33 %   |                          
## Failure Buckets                                                                                                                                                                                
                                                                                                                                                                                                  
* `UVM_FATAL (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.rxempty (addr=*, Comparison=CompareOpEq, exp_data=*, call_count=2)` has 4 failures:               
    * Test spi_host_upper_range_clkdiv has 4 failures.                                                                                                                                            
        * 1.spi_host_upper_range_clkdiv.72156752524221300659599687245568311176582643778670077808732328448094984466721\                                                                            
          Line 115, in log /home/dev/src/scratch/spi_host_fsm-fix-earlgrey_1.0.0/spi_host-sim-xcelium/1.spi_host_upper_range_clkdiv/latest/run.log                                                
                                                                                                                                                                                                  
                UVM_FATAL @ 100004025228 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.rxempty (addr=0x19208194, Comparison=CompareOpEq, exp_data=0x0, ca
ll_count=2)                                                                                                                                                                                       
                UVM_INFO @ 100004025228 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]                                                                                                     
                --- UVM Report catcher Summary ---                                                                                                                                                
                                                                                                                                                                                                  
                                                                                                                                                                                                  
                                                                                                                                                                                                  
        * 5.spi_host_upper_range_clkdiv.5737203958546986429594201155418617551367697306309699199397349908724971537214\                                                                             
          Line 139, in log /home/dev/src/scratch/spi_host_fsm-fix-earlgrey_1.0.0/spi_host-sim-xcelium/5.spi_host_upper_range_clkdiv/latest/run.log                                                
                                                                                                                                                                                                  
                UVM_FATAL @ 100002201889 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.rxempty (addr=0xe9cf454, Comparison=CompareOpEq, exp_data=0x0, cal
l_count=2)                                                                                                                                                                                        
                UVM_INFO @ 100002201889 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]                                                                                                     
                --- UVM Report catcher Summary ---                                                                                                                                                
                                                                                                                                                                                                  
                                                                                                                                                                                                  
                                                                                                                                                                                                  
        * ... and 2 more failures.                                                                                                                                                                
* `UVM_FATAL (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.active (addr=*, Comparison=CompareOpEq, exp_data=*, call_count=12)` has 2 failures:               
    * Test spi_host_upper_range_clkdiv has 2 failures.                                                                                                                                            
        * 2.spi_host_upper_range_clkdiv.39218226151255517111729713801782320840177786226626139663711522995276209772970\                                                                            
          Line 141, in log /home/dev/src/scratch/spi_host_fsm-fix-earlgrey_1.0.0/spi_host-sim-xcelium/2.spi_host_upper_range_clkdiv/latest/run.log                                                
                                                                                                                                                                                                  
                UVM_FATAL @ 100003286369 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.active (addr=0x3b352ed4, Comparison=CompareOpEq, exp_data=0x0, cal
l_count=12)                                                                                                                                                                                       
                UVM_INFO @ 100003286369 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]                                                                                                     
                --- UVM Report catcher Summary ---                                                                                                                                                
                                                                                                                                                                                                  
                                                                                                                                                                                                  
                                                                                                                                                                                                  
        * 4.spi_host_upper_range_clkdiv.115346368214317624209778851708975967263254834535973433780776842207152449966571\                                                                           
          Line 149, in log /home/dev/src/scratch/spi_host_fsm-fix-earlgrey_1.0.0/spi_host-sim-xcelium/4.spi_host_upper_range_clkdiv/latest/run.log                                                
                                                                                                                                                                                                  
                UVM_FATAL @ 100013316476 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.active (addr=0xfb27d794, Comparison=CompareOpEq, exp_data=0x0, cal
l_count=12)                                                                                                                                                                                       
                UVM_INFO @ 100013316476 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]                                                                                                     
                --- UVM Report catcher Summary ---                                                                                                                                                
                                                                                                                                                                                                  
                                                                                                                                                                                                  
                                                                                                                                                                                                  
* `UVM_FATAL (uvm_phase.svh:1521) [PH_TIMEOUT] Explicit timeout of * ps hit, indicating a probable testbench issue` has 1 failures:                                                               
    * Test spi_host_upper_range_clkdiv has 1 failures.                                                                                                                                            
        * 0.spi_host_upper_range_clkdiv.63083292467868165920894123838142417305137740727774484733916475613513480824763\                                                                            
          Line 189, in log /home/dev/src/scratch/spi_host_fsm-fix-earlgrey_1.0.0/spi_host-sim-xcelium/0.spi_host_upper_range_clkdiv/latest/run.log                                                
                                                                                                                                                                                                  
                UVM_FATAL @ 200000000000 ps: (uvm_phase.svh:1521) [PH_TIMEOUT] Explicit timeout of 200000000000 ps hit, indicating a probable testbench issue                                     
                UVM_INFO @ 200000000000 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]                                                                                                     
                --- UVM Report catcher Summary ---                                                                                                                                                
                                                                                                                                                                                                  
                                                                                                                                                                                                  
                                                                                                                                                                                                  
* `UVM_FATAL (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.ready (addr=*, Comparison=CompareOpEq, exp_data=*, call_count=75)` has 1 failures:                
    * Test spi_host_status_stall has 1 failures.                                                                                                                                                  
        * 4.spi_host_status_stall.20262247579714294508448451600854606523280908808966030256012262483671622127194\                                                                                  
          Line 659, in log /home/dev/src/scratch/spi_host_fsm-fix-earlgrey_1.0.0/spi_host-sim-xcelium/4.spi_host_status_stall/latest/run.log                                                      
                                                                                                                                                                                                  
                UVM_FATAL @ 11208265705 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.ready (addr=0x2e005e14, Comparison=CompareOpEq, exp_data=0x1, call_
count=75)                                                                                                                                                                                         
                UVM_INFO @ 11208265705 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]                                                                                                      
                --- UVM Report catcher Summary ---                                                                                                                                                
                                                                                                                                                                                                  
                                                                                                                                                                                                  
                                                                                                                                                                                                  



```

### Top-level tests

Relevant TLT with `-rx 10` passes 100%:
```
### Test Results
|  Stage  |          Name          | Tests                  |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:----------------------:|:-----------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V2    | chip_sw_spi_host_tx_rx | chip_sw_spi_host_tx_rx |      4.763m       |     2.495ms      |    30     |   30    |  100.00 %   |
|   V2    |                        | **TOTAL**              |                   |                  |    30     |   30    |  100.00 %   |
|         |                        | **TOTAL**              |                   |                  |    30     |   30    |  100.00 %   |
```