### PR TITLE
[hw,sram_ctrl,rtl] Sync sram_ctrl to master (integrated_dev to master)

### DIFF
--- a/hw/ip/sram_ctrl/dv/README.md
+++ b/hw/ip/sram_ctrl/dv/README.md
@@ -51,7 +51,7 @@ Two compile-time configurations are tested:
 * `sram_ctrl_ret` - this configuration uses a 10-bit-wide address space to emulate the retention SRAM used in the full design and turns off parameter `INSTR_EXEC` to disable TLUL instruction fetching altogether.
 
 
-A macro-define `SRAM_ADDR_WIDTH` is defined as a build option in `hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson`, which is used to set the correct compile-time settings for each configuration.
+A macro-define `SRAM_WORD_ADDR_WIDTH` is defined as a build option in `hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson`, which is used to set the correct compile-time settings for each configuration.
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends cip_base_vseq #(
+class sram_ctrl_base_vseq #(
+    parameter int AddrWidth = `SRAM_WORD_ADDR_WIDTH
+  ) extends cip_base_vseq #(
     .RAL_T               (sram_ctrl_regs_reg_block),
     .CFG_T               (sram_ctrl_env_cfg#(AddrWidth)),
     .COV_T               (sram_ctrl_env_cov#(AddrWidth)),

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
@@ -80,7 +80,7 @@ class sram_ctrl_lc_escalation_vseq extends sram_ctrl_multiple_keys_vseq;
             // a regular init for sram_ret (4kb) takes 1024 cycles
             // add some big delay before checking status, so that we know the status
             // always fails.
-            cfg.clk_rst_vif.wait_clks($urandom_range(0, 2 ** (`SRAM_ADDR_WIDTH + 1)));
+            cfg.clk_rst_vif.wait_clks($urandom_range(0, 2 ** (`SRAM_WORD_ADDR_WIDTH + 1)));
           end
           // read out STATUS csr, scoreboard will check that proper updates have been made
           csr_rd(.ptr(ral.status), .value(status));

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_exec_64kB_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_exec_64kB_sim_cfg.hjson
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+{
+  // Name of the sim cfg variant
+  variant: exec_64kB
+
+  // Import the base sram_ctrl sim_cfg file
+  import_cfgs: ["{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson"]
+
+  build_opts: ["+define+SRAM_WORD_ADDR_WIDTH=14",
+               "+define+INSTR_EXEC=1",
+               "+define+NUM_PRINCE_ROUNDS_HALF=3"]
+}

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson
@@ -11,7 +11,7 @@
   import_cfgs: ["{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson"]
 
   // These parameters are used for top_earlgrey main sram
-  build_opts: ["+define+SRAM_ADDR_WIDTH=15",
+  build_opts: ["+define+SRAM_WORD_ADDR_WIDTH=15",
                "+define+INSTR_EXEC=1",
                "+define+NUM_PRINCE_ROUNDS_HALF=2"]
 }

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson
@@ -11,7 +11,7 @@
   import_cfgs: ["{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson"]
 
   // These parameters are used for top_earlgrey retention sram
-  build_opts: ["+define+SRAM_ADDR_WIDTH=10",
+  build_opts: ["+define+SRAM_WORD_ADDR_WIDTH=10",
                "+define+INSTR_EXEC=0",
                "+define+NUM_PRINCE_ROUNDS_HALF=3"]
 }

--- a/hw/ip/sram_ctrl/dv/tb.sv
+++ b/hw/ip/sram_ctrl/dv/tb.sv
@@ -54,15 +54,15 @@ module tb;
 
   // DUT
 
-  // The exact number of address bits.
+  // The exact number of word address bits.
   // Will be set to 10 for retention SRAM and 14 for main SRAM.
-`ifndef SRAM_ADDR_WIDTH
-  `define SRAM_ADDR_WIDTH 32
+`ifndef SRAM_WORD_ADDR_WIDTH
+  `define SRAM_WORD_ADDR_WIDTH 32
 `endif
 
   sram_ctrl #(
     // memory size in bytes
-    .MemSizeRam(4 * 2 ** `SRAM_ADDR_WIDTH),
+    .MemSizeRam(4 * 2 ** `SRAM_WORD_ADDR_WIDTH),
     .InstrExec(`INSTR_EXEC),
     // number of PRINCE half rounds for the SRAM scrambling feature
     .NumPrinceRoundsHalf(`NUM_PRINCE_ROUNDS_HALF)

--- a/hw/ip/sram_ctrl/dv/tests/sram_ctrl_base_test.sv
+++ b/hw/ip/sram_ctrl/dv/tests/sram_ctrl_base_test.sv
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class sram_ctrl_base_test extends cip_base_test #(
-    .CFG_T(sram_ctrl_env_cfg#(`SRAM_ADDR_WIDTH)),
-    .ENV_T(sram_ctrl_env#(`SRAM_ADDR_WIDTH))
+    .CFG_T(sram_ctrl_env_cfg#(`SRAM_WORD_ADDR_WIDTH)),
+    .ENV_T(sram_ctrl_env#(`SRAM_WORD_ADDR_WIDTH))
   );
 
   `uvm_component_utils(sram_ctrl_base_test)


### PR DESCRIPTION
Only adds a clarification comment related to word addresses and SRAM configs used by Darjeeling.