### PR TITLE
[prim,lint] Remove dead waivers for prim_fifo_*sync.sv

### DIFF
--- a/hw/ip/prim/lint/prim_fifo.waiver
+++ b/hw/ip/prim/lint/prim_fifo.waiver
@@ -10,19 +10,7 @@ waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_fifo_sync.sv} -msg {Memory 'gen
 waive -rules {INPUT_NOT_READ} -location {prim_fifo_sync.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from, instance.*Depth=0\)} \
       -comment "In passthrough mode, clk and reset are not read form within this module"
 
-
-waive -rules {ASSIGN_SIGN} -location {prim_fifo_async.sv} -msg {Signed target 'i' assigned unsigned value 'PTR_WIDTH - 3'} \
-      -comment "Parameter PTR_WIDTH is unsigned, but integer i is signed. This is fine. Changing the integer to unsigned might \
-                cause issues with the for loop never exiting, because an unsigned integer can never become < 0."
-
-waive -rules NOT_READ             -location {prim_fifo_async.sv} -regexp {Signal 'nc_decval_msb' is not read} \
-      -comment "Store temporary values. Not used intentionally"
-
-
 waive -rules VAR_INDEX_RANGE      -location {prim_fifo_*sync.sv} -regexp {maximum value .* may be too large for 'storage'} \
-      -comment "index is protected by control logic"
-
-waive -rules EXPLICIT_BITLEN      -location {prim_fifo_*sync.sv} -regexp {Bit length not specified for constant '1'} \
       -comment "index is protected by control logic"
 
 ## prim_fifo_async_sram_adapter

--- a/hw/ip/prim/rtl/prim_fifo_async.sv
+++ b/hw/ip/prim/rtl/prim_fifo_async.sv
@@ -249,8 +249,8 @@ module prim_fifo_async #(
       logic                 unused_decsub_msb;
 
       dec_tmp = '0;
-      for (int i = PTR_WIDTH-2; i >= 0; i--) begin
-        dec_tmp[i] = dec_tmp[i+1] ^ grayval[i];
+      for (int unsigned i = PTR_WIDTH-1; i > 0; i--) begin
+        dec_tmp[i-1] = dec_tmp[i] ^ grayval[i-1];
       end
       dec_tmp_sub = (PTR_WIDTH)'(Depth) - dec_tmp - 1'b1;
       if (grayval[PTR_WIDTH-1]) begin


### PR DESCRIPTION
The first can never match (because the subtraction was changed from -3 to -2 in 7cbebc2e690 in June 2021).

The second *has* never matched: I think the variable in question has been called unused_decval_msb since the initial commit in the repository.

I think the third matched some width arithmetic that was done on pointer values until commit 64272d832be replaced the inline logic with a prim_fifo_sync_cnt instance. (The waiver came from an initial bunch of waivers in 2020 and the comment doesn't make sense: it looks like it was accidentally copied from the previous waiver)