### PR TITLE
[prim,lint] Remove waiver for prim_subreg.sv

### DIFF
--- a/hw/ip/prim/lint/prim_subreg.waiver
+++ b/hw/ip/prim/lint/prim_subreg.waiver
@@ -2,8 +2,5 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-waive -rules INPUT_NOT_READ       -location {prim_subreg.sv} -regexp {Input port 'wd' is not read from} \
-      -comment "for RO wd is not used"
-
 waive -rules {PARAM_NOT_USED} -location {prim_subreg_shadow.sv} -regexp {Mubi} \
       -comment "Mubi is not yet supported in prim_subreg_shadow."


### PR DESCRIPTION
The linter would warn about an input port that wasn't used, but this input port is now passed along to prim_subreg_arb (which has been the case since 7b2a5c3690c), so the lint warning will no longer come up.