### PR TITLE
[prim,lint] Remove waiver for prim_sram_arbiter.sv

### DIFF
--- a/hw/ip/prim/lint/prim.waiver
+++ b/hw/ip/prim/lint/prim.waiver
@@ -12,10 +12,6 @@ waive -rules INTEGER           -location {prim_packer.sv} -msg {'i' of type int 
 waive -rules {ZERO_REP} -location {prim_packer_fifo.sv} -regexp {Replication count is zero in .*DepthW.*} \
       -comment "If InW equals OutW, DepthW is zero"
 
-# prim_sram_arbiter
-waive -rules CONST_OUTPUT -location {prim_sram_arbiter.sv} -regexp {rsp_error.* is driven by constant} \
-      -comment "SRAM protection is not yet implemented"
-
 # prim_fifo_async_simple
 waive -rules CONST_FF -location {prim_fifo_async_simple.sv} -msg {Flip-flop 'not_in_reset_q' is driven by constant one in module 'prim_fifo_async_simple'} \
       -comment "The flop input and reset values are constants."


### PR DESCRIPTION
This came from b4919e58, the initial commit to prim.waiver in 2020. As far as I can tell, it didn't even apply to the prim_sram_arbiter.sv in the initial commit in the repository (there was only one rsp_error* signal, but this was an output port which just matched the sram_rerror input port).