### PR TITLE
[util] update python version check in check_tool_requirements.py

### DIFF
--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -16,6 +16,7 @@
 #                 entry gives the required version.
 #
 __TOOL_REQUIREMENTS__ = {
+    'python': '3.8',
     'edalize': '0.2.0',
     'ninja': {
         'min_version': '1.8.2',


### PR DESCRIPTION
distutils is deprecated and will generate warnings when used. Replace it with packaging.version instead.

pip3 command line invocation is replaced with importlib.metadata, which removes dependency on pip3 being present.

This is the OT port of https://github.com/lowRISC/ibex/pull/2119