### PR TITLE
[rom_ext_e2e] Ownership rescue configuration tests

### DIFF
--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -183,6 +183,8 @@ RUST_TARGETS = [
     "//sw/host/tests/chip/gpio:gpio",
     "//sw/host/tests/chip/power_virus:power_virus",
     "//sw/host/tests/chip/spi_device:spi_passthru",
+    "//sw/host/tests/ownership:rescue_limit_test",
+    "//sw/host/tests/ownership:rescue_permission_test",
     "//sw/host/tests/ownership:transfer_lib",
     "//sw/host/tests/ownership:transfer_test",
     "//sw/host/tests/rom/e2e_bootstrap_disabled:e2e_bootstrap_disabled",

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -5,6 +5,7 @@
 load(
     "//rules/opentitan:defs.bzl",
     "fpga_params",
+    "opentitan_binary",
     "opentitan_test",
 )
 load(
@@ -18,6 +19,24 @@ package(default_visibility = ["//visibility:public"])
 # but they don't change OTP.  They modify the ownership INFO pages,
 # so we need to clear the bitstream after the test, which is what the
 # `changes_otp` parameter actually does.
+
+opentitan_binary(
+    name = "boot_test",
+    testonly = True,
+    srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    rsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod": "app_prod",
+    },
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_transfer_any_test
 ownership_transfer_test(
@@ -104,7 +123,7 @@ ownership_transfer_test(
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
-            --corrupt-owner-block-signature=true
+            --config-kind=corrupt
             --dual-owner-boot-check=false
             --expected-error=OwnershipInvalidInfoPage
         """,
@@ -246,5 +265,56 @@ ownership_transfer_test(
             --expected-error=OwnershipKeyNotFound
         """,
         test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_rescue_limit_test
+ownership_transfer_test(
+    name = "rescue_limit_test",
+    srcs = ["flash_contents.c"],
+    fpga = fpga_params(
+        timeout = "long",
+        # We boot on Side B since rescue will rewrite side A.
+        assemble = "{rom_ext}@0 {firmware}@0x90000",
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Any
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+        """,
+        test_harness = "//sw/host/tests/ownership:rescue_limit_test",
+    ),
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
+    deps = [
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+    ],
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_rescue_permission_test
+ownership_transfer_test(
+    name = "rescue_permission_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Any
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+        """,
+        test_harness = "//sw/host/tests/ownership:rescue_permission_test",
     ),
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/flash_contents.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/flash_contents.c
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/boot_log.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+#include "flash_ctrl_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+status_t flash_contents_print(boot_log_t *boot_log) {
+  TRY(boot_log_check(boot_log));
+  uint32_t *data = (uint32_t *)(TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR +
+                                boot_log->rom_ext_size);
+  uint32_t *end = (uint32_t *)(TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR +
+                               FLASH_CTRL_PARAM_BYTES_PER_BANK);
+  uint32_t incr = FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(uint32_t);
+
+  for (; data < end; data += incr) {
+    LOG_INFO("flash %p = %x", data, *data);
+  }
+  return OK_STATUS();
+}
+
+bool test_main(void) {
+  status_t sts = flash_contents_print(&retention_sram_get()->creator.boot_log);
+  if (status_err(sts)) {
+    LOG_ERROR("flash_contents_print: %r", sts);
+  }
+  return status_ok(sts);
+}

--- a/sw/host/opentitanlib/src/ownership/mod.rs
+++ b/sw/host/opentitanlib/src/ownership/mod.rs
@@ -14,4 +14,4 @@ pub use flash::{FlashFlags, OwnerFlashConfig, OwnerFlashRegion};
 pub use flash_info::{OwnerFlashInfoConfig, OwnerInfoPage};
 pub use misc::{KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
 pub use owner::{OwnerBlock, OwnerConfigItem, SramExecMode};
-pub use rescue::{OwnerRescueConfig, RescueType};
+pub use rescue::{CommandTag, OwnerRescueConfig, RescueType};

--- a/sw/host/tests/ownership/BUILD
+++ b/sw/host/tests/ownership/BUILD
@@ -13,15 +13,42 @@ rust_library(
     deps = [
         "//sw/host/opentitanlib",
         "@crate_index//:anyhow",
+        "@crate_index//:clap",
         "@crate_index//:log",
     ],
 )
 
 rust_binary(
     name = "transfer_test",
-    srcs = [
-        "transfer_test.rs",
+    srcs = ["transfer_test.rs"],
+    deps = [
+        ":transfer_lib",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
     ],
+)
+
+rust_binary(
+    name = "rescue_limit_test",
+    srcs = ["rescue_limit_test.rs"],
+    deps = [
+        ":transfer_lib",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+    ],
+)
+
+rust_binary(
+    name = "rescue_permission_test",
+    srcs = ["rescue_permission_test.rs"],
     deps = [
         ":transfer_lib",
         "//sw/host/opentitanlib",

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::bool_assert_comparison)]
 use anyhow::{anyhow, Result};
+use clap::ValueEnum;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::boot_log::BootLog;
 use opentitanlib::chip::boot_svc::{Message, UnlockMode};
@@ -11,8 +12,8 @@ use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams}
 use opentitanlib::crypto::ecdsa::EcdsaPrivateKey;
 use opentitanlib::crypto::rsa::RsaPublicKey;
 use opentitanlib::ownership::{
-    ApplicationKeyDomain, KeyMaterial, OwnerApplicationKey, OwnerBlock, OwnerConfigItem,
-    OwnershipKeyAlg,
+    ApplicationKeyDomain, CommandTag, FlashFlags, KeyMaterial, OwnerApplicationKey, OwnerBlock,
+    OwnerConfigItem, OwnerFlashConfig, OwnerFlashRegion, OwnerRescueConfig, OwnershipKeyAlg,
 };
 use opentitanlib::rescue::serial::RescueSerial;
 
@@ -86,6 +87,31 @@ pub fn ownership_activate(
     }
 }
 
+// These flags request certain features of the ownership configuration.
+// The names like "FLASH1" or "RESCUE1" don't have any special significance
+// other than to give them a distinct name.
+
+// Request to corrupt the owner config block.
+const CFG_CORRUPT: u32 = 0x0000_0001;
+// Request a config with a flash configuration.
+const CFG_FLASH1: u32 = 0x0000_0002;
+// Request a config with a rescue configuration.
+const CFG_RESCUE1: u32 = 0x0000_0004;
+// Request a rescue configuration that restricts the set of allowed commands
+// (e.g. this one removes "SetNextBl0Slot" from the set of allowed commands).
+const CFG_RESCUE_RESTRICT: u32 = 0x0000_0008;
+
+#[repr(u32)]
+#[derive(Debug, Default, Copy, Clone, ValueEnum)]
+pub enum OwnerConfigKind {
+    #[default]
+    Basic = 0,
+    Corrupt = CFG_CORRUPT,
+    WithFlash = CFG_FLASH1 | CFG_RESCUE1,
+    WithRescue = CFG_RESCUE1,
+    WithRescueRestricted = CFG_FLASH1 | CFG_RESCUE1 | CFG_RESCUE_RESTRICT,
+}
+
 /// Prepares an OwnerBlock and sends it to the chip.
 pub fn create_owner(
     transport: &TransportWrapper,
@@ -94,8 +120,9 @@ pub fn create_owner(
     activate_key: &Path,
     unlock_key: &Path,
     app_key: &Path,
-    corrupt_signature: bool,
+    config: OwnerConfigKind,
 ) -> Result<()> {
+    let config = config as u32;
     let owner_key = EcdsaPrivateKey::load(owner_key)?;
     let activate_key = EcdsaPrivateKey::load(activate_key)?;
     let unlock_key = EcdsaPrivateKey::load(unlock_key)?;
@@ -112,8 +139,37 @@ pub fn create_owner(
         })],
         ..Default::default()
     };
+    if config & CFG_FLASH1 != 0 {
+        owner
+            .data
+            .push(OwnerConfigItem::FlashConfig(OwnerFlashConfig {
+                config: vec![
+                    // Side A: 0-64K romext, 64-448K firmware, 448-512K filesystem.
+                    OwnerFlashRegion::new(0, 32, FlashFlags::rom_ext()),
+                    OwnerFlashRegion::new(32, 192, FlashFlags::firmware()),
+                    OwnerFlashRegion::new(224, 32, FlashFlags::filesystem()),
+                    // Side B: 0-64K romext, 64-448K firmware, 448-512K filesystem.
+                    OwnerFlashRegion::new(256, 32, FlashFlags::rom_ext()),
+                    OwnerFlashRegion::new(256 + 32, 192, FlashFlags::firmware()),
+                    OwnerFlashRegion::new(256 + 224, 32, FlashFlags::filesystem()),
+                ],
+                ..Default::default()
+            }));
+    }
+    if config & CFG_RESCUE1 != 0 {
+        let mut rescue = OwnerRescueConfig::all();
+        rescue.start = 32;
+        rescue.size = 192;
+        if config & CFG_RESCUE_RESTRICT != 0 {
+            // Restrict one of the boot_svc commands in "restrict" mode.
+            rescue
+                .command_allow
+                .retain(|t| *t != CommandTag::NextBl0SlotRequest);
+        }
+        owner.data.push(OwnerConfigItem::RescueConfig(rescue));
+    }
     owner.sign(&owner_key)?;
-    if corrupt_signature {
+    if config & CFG_CORRUPT != 0 {
         owner.signature.r[0] += 1;
     }
     let mut owner_config = Vec::new();


### PR DESCRIPTION
Test the configuration options of the rescue protocol.

The `transfer_lib` is enhanced to allow for pre-set variations of the ownership config through the `OwnerConfigKind` enum.  The rust-based test harnesses are near-clones of the `transfer_test` harness, however, they allow for certain expected errors during the transfer process (such as a `Cancel` during the rescue upload) and test for specific conditions after owner activation.

`rescue_limit_test`: Fixes #24474.
`rescue_permission_test`: Fixes #24475.