### PR TITLE
[earlgrey_1.0.0,top_earlgrey,spi_host] Fix `cio_sd_en_o` for SPI Host 1

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -73,6 +73,17 @@
       desc: "The size of the Cmd FIFO (one segment descriptor per entry)",
       type: "int",
       default: "4"
+    },
+    { name: "UpdateSdEnOnSck",
+      type: "bit",
+      desc: '''
+        Whether to update `cio_sd_en_o` on `cio_sck_o`.  If this parameter is `1'b1`, the logic
+        driving `cio_sd_en_o` (in non-passthrough mode) combinationally depends on `cio_sck_o`.
+        If this parameter is `1'b0`, `cio_sd_en_o` does not combinationally depend on `cio_sck_o`.
+      ''',
+      default: "1'b0",
+      local: "false",
+      expose: "true",
     }
   ],
   available_output_list: [

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -11,7 +11,8 @@
 module spi_host
   import spi_host_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  parameter bit UpdateSdEnOnSck = 1'b0
 ) (
   input              clk_i,
   input              rst_ni,
@@ -434,7 +435,8 @@ module spi_host
   assign en_sw  = reg2hw.control.spien.q;
 
   spi_host_core #(
-    .NumCS(NumCS)
+    .NumCS(NumCS),
+    .UpdateSdEnOnSck(UpdateSdEnOnSck)
   ) u_spi_core (
     .clk_i,
     .rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host_core.sv
+++ b/hw/ip/spi_host/rtl/spi_host_core.sv
@@ -6,7 +6,8 @@
 //
 
 module spi_host_core #(
-  parameter  int NumCS     = 1
+  parameter int NumCS = 1,
+  parameter bit UpdateSdEnOnSck = 1'b0
 ) (
   input                             clk_i,
   input                             rst_ni,
@@ -122,7 +123,8 @@ module spi_host_core #(
   );
 
   spi_host_fsm #(
-    .NumCS(NumCS)
+    .NumCS(NumCS),
+    .UpdateSdEnOnSck(UpdateSdEnOnSck)
   ) u_fsm (
     .clk_i,
     .rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -8,7 +8,8 @@
 module spi_host_fsm
   import spi_host_cmd_pkg::*;
 #(
-  parameter  int NumCS = 1
+  parameter int NumCS = 1,
+  parameter bit UpdateSdEnOnSck = 1'b0
 ) (
   input                              clk_i,
   input                              rst_ni,
@@ -608,15 +609,46 @@ module spi_host_fsm
   // ---------------------------------------------
   assign drive_posedge = (cpol != cpha);
 
-  always_comb begin
-    if (&csb_o) begin
-      sd_en_o[3:0] = 4'h0;
-    end else begin
-      // Only update the sd_en_o on the right clock transition. Since sck_o
-      // is generated from the sys clock we ensure we only drive the data on the
-      // right clock edge
-      if( (drive_posedge && sck_o) ||
-          (!drive_posedge && !sck_o) ) begin
+  if (UpdateSdEnOnSck) begin : gen_update_sd_en_on_sck
+    always_comb begin
+      if (&csb_o) begin
+        sd_en_o[3:0] = 4'h0;
+      end else begin
+        // Only update the sd_en_o on the right clock transition. Since sck_o
+        // is generated from the sys clock we ensure we only drive the data on the
+        // right clock edge
+        if( (drive_posedge && sck_o) ||
+            (!drive_posedge && !sck_o) ) begin
+          unique case (speed_o)
+            Standard: begin
+              sd_en_o[0]   = cmd_wr_en_q | cmd_wr_en_last_bit;
+              sd_en_o[1]   = 1'b0;
+              sd_en_o[3:2] = 2'b00;
+            end
+            Dual:     begin
+              sd_en_o[1:0] = {2{cmd_wr_en_q}};
+              sd_en_o[3:2] = 2'b00;
+            end
+            Quad:     begin
+              sd_en_o[3:0] = {4{cmd_wr_en_q}};
+            end
+            default: begin
+              // invalid speed
+              sd_en_o[3:0] = 4'h0;
+            end
+          endcase
+        end
+        else begin
+          sd_en_o  = sd_en_ff_q;
+        end
+      end // else: !if(&csb_o)
+    end
+
+  end else begin : gen_no_update_sd_en_on_sck
+    always_comb begin
+      if (&csb_o) begin
+        sd_en_o[3:0] = 4'h0;
+      end else begin
         unique case (speed_o)
           Standard: begin
             sd_en_o[0]   = cmd_wr_en_q | cmd_wr_en_last_bit;
@@ -635,11 +667,15 @@ module spi_host_fsm
             sd_en_o[3:0] = 4'h0;
           end
         endcase
-      end
-      else begin
-        sd_en_o  = sd_en_ff_q;
-      end
-    end // else: !if(&csb_o)
+      end // else: !if(&csb_o)
+    end
+
+    logic unused_sd_en_ff_q;
+    assign unused_sd_en_ff = ^{sd_en_ff_d, sd_en_ff_q};
+
+    logic unused_drive_posedge;
+    assign unused_drive_posedge = drive_posedge;
+
   end
 
   //

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2366,6 +2366,10 @@
           domain: "0"
         }
       }
+      param_decl:
+      {
+        UpdateSdEnOnSck: 1'b1
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_peri
@@ -2374,8 +2378,23 @@
       [
         "0"
       ]
-      param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: UpdateSdEnOnSck
+          desc:
+            '''
+            Whether to update `cio_sd_en_o` on `cio_sck_o`.  If this parameter is `1'b1`, the logic
+            driving `cio_sd_en_o` (in non-passthrough mode) combinationally depends on `cio_sck_o`.
+            If this parameter is `1'b0`, `cio_sd_en_o` does not combinationally depend on `cio_sck_o`.
+            '''
+          type: bit
+          default: 1'b1
+          expose: "true"
+          name_top: SpiHost0UpdateSdEnOnSck
+        }
+      ]
       inter_signal_list:
       [
         {
@@ -2425,6 +2444,10 @@
           domain: "0"
         }
       }
+      param_decl:
+      {
+        UpdateSdEnOnSck: 1'b0
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div2_peri
@@ -2433,8 +2456,23 @@
       [
         "0"
       ]
-      param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: UpdateSdEnOnSck
+          desc:
+            '''
+            Whether to update `cio_sd_en_o` on `cio_sck_o`.  If this parameter is `1'b1`, the logic
+            driving `cio_sd_en_o` (in non-passthrough mode) combinationally depends on `cio_sck_o`.
+            If this parameter is `1'b0`, `cio_sd_en_o` does not combinationally depend on `cio_sck_o`.
+            '''
+          type: bit
+          default: 1'b0
+          expose: "true"
+          name_top: SpiHost1UpdateSdEnOnSck
+        }
+      ]
       inter_signal_list:
       [
         {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -330,6 +330,9 @@
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_host0"},
       base_addr: "0x40300000",
+      param_decl: {
+        UpdateSdEnOnSck: "1'b1",
+      },
     },
     { name: "spi_host1",
       type: "spi_host",
@@ -337,6 +340,9 @@
       clock_group: "peri",
       reset_connections: {rst_ni: "spi_host1"},
       base_addr: "0x40310000",
+      param_decl: {
+        UpdateSdEnOnSck: "1'b0",
+      },
     },
     { name: "usbdev",
       type: "usbdev",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -40,7 +40,9 @@ module top_earlgrey #(
   parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::LC_CTRL_JTAG_IDCODE,
   // parameters for alert_handler
   // parameters for spi_host0
+  parameter bit SpiHost0UpdateSdEnOnSck = 1'b1,
   // parameters for spi_host1
+  parameter bit SpiHost1UpdateSdEnOnSck = 1'b0,
   // parameters for usbdev
   parameter bit UsbdevStub = 0,
   parameter int UsbdevRcvrWakeTimeUs = 100,
@@ -1577,7 +1579,8 @@ module top_earlgrey #(
       .rst_edn_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   spi_host #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19]),
+    .UpdateSdEnOnSck(SpiHost0UpdateSdEnOnSck)
   ) u_spi_host0 (
 
       // Input
@@ -1609,7 +1612,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel])
   );
   spi_host #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[20:20])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[20:20]),
+    .UpdateSdEnOnSck(SpiHost1UpdateSdEnOnSck)
   ) u_spi_host1 (
 
       // Input


### PR DESCRIPTION
This partially reverts commit 7eb53da738a770a4cc00153eb7179a2c2d9bdda9, which introduced a glitch on the `sd_en_o` output of `spi_host_fsm`, for `u_spi_host1` of `top_earlgrey`.  Details are as follows:

- This commit adds a parameter, `UpdateSdEnOnSck`, to the `spi_host` module and its sub-modules down to `spi_host_fsm`.
  - If set to `1`, the RTL is the currently implemented one, where the logic driving `cio_sd_en_o` (in non-passthrough mode) combinationally depends on `cio_sck_o`.
  - If set to `0`, the RTL is the one before the commit mentioned above, where `cio_sd_en_o` does not combinationally depend on `cio_sck_o`.

- In `top_earlgrey`, the `UpdateSdEnOnSck` parameter is set to:
  - `1` for `u_spi_host0`, meaning that SPI Host 0 keeps the current RTL where glitches need to be prevented with timing fixes;
  - `0` for `u_spi_host1`, meaning that SPI Host 1 gets the previous RTL that should be glitch-free.

- The reason for the introduced difference between SPI Host 0 and SPI Host 1 is that a logic ECO is possible for SPI Host 1 while SPI Host 0 has to be fixed with a timing ECO.

- The default value of `UpdateSdEnOnSck` is `0`, meaning that `spi_host` block-level DV runs with the partially reverted RTL. Together with many regression runs over the past weeks that were run on the un-reverted RTL, this should result in broad coverage of both code paths.  The main `spi_host` top-level test, `chip_sw_spi_host_tx_rx`, randomly selects between SPI Host 0 and 1, so both are covered at the top level.

- The reversal inside `spi_host_fsm` is partial in order to minimize the netlist diff.  The `drive_posedge` signal as well as the four `sd_en_ff_q` flops are unused for `UpdateSdEnOnSck = 0`.

A full block-level regression didn't show any new test failures:
```
### Test Results                                                                                                                                                                                                                            
|  Stage  |                   Name                    | Tests                               |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |                                                                    
|:-------:|:-----------------------------------------:|:------------------------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|                                                                    
|   V1    |                   smoke                   | spi_host_smoke                      |      5.867m       |     33.707ms     |    50     |   50    |  100.00 %   |                                                                    
|   V1    |               csr_hw_reset                | spi_host_csr_hw_reset               |      7.000s       |     43.721us     |     5     |    5    |  100.00 %   |                                                                    
|   V1    |                  csr_rw                   | spi_host_csr_rw                     |      7.000s       |     35.177us     |    20     |   20    |  100.00 %   |                                                                    
|   V1    |               csr_bit_bash                | spi_host_csr_bit_bash               |      8.000s       |    224.582us     |     5     |    5    |  100.00 %   |                                                                    
|   V1    |               csr_aliasing                | spi_host_csr_aliasing               |      7.000s       |     43.962us     |     5     |    5    |  100.00 %   |                                                                    
|   V1    |        csr_mem_rw_with_rand_reset         | spi_host_csr_mem_rw_with_rand_reset |      8.000s       |     29.279us     |    20     |   20    |  100.00 %   |                                                                    
|   V1    | regwen_csr_and_corresponding_lockable_csr | spi_host_csr_rw                     |      7.000s       |     35.177us     |    20     |   20    |  100.00 %   |
|         |                                           | spi_host_csr_aliasing               |      7.000s       |     43.962us     |     5     |    5    |  100.00 %   |                                                                    
|   V1    |                 mem_walk                  | spi_host_mem_walk                   |      7.000s       |     41.333us     |     5     |    5    |  100.00 %   |                                                                    
|   V1    |            mem_partial_access             | spi_host_mem_partial_access         |      8.000s       |     18.713us     |     5     |    5    |  100.00 %   |                                                                    
|   V1    |                                           | **TOTAL**                           |                   |                  |    115    |   115   |  100.00 %   |                                                                    
|   V2    |                performance                | spi_host_performance                |      8.000s       |     33.109us     |    50     |   50    |  100.00 %   |                                                                    
|   V2    |             error_event_intr              | spi_host_overflow_underflow         |      2.050m       |     17.140ms     |    50     |   50    |  100.00 %   |                                                                    
|         |                                           | spi_host_error_cmd                  |      7.000s       |     43.946us     |    50     |   50    |  100.00 %   |                                                                    
|         |                                           | spi_host_event                      |      10.317m      |     20.018ms     |    50     |   50    |  100.00 %   |                                                                    
|   V2    |                clock_rate                 | spi_host_speed                      |      34.000s      |     2.600ms      |    50     |   50    |  100.00 %   |                                                                    
|   V2    |                   speed                   | spi_host_speed                      |      34.000s      |     2.600ms      |    50     |   50    |  100.00 %   |                                                                    
|   V2    |            chip_select_timing             | spi_host_speed                      |      34.000s      |     2.600ms      |    50     |   50    |  100.00 %   |                                                                    
|   V2    |                 sw_reset                  | spi_host_sw_reset                   |      2.483m       |     4.992ms      |    50     |   50    |  100.00 %   |                                                                    
|   V2    |             passthrough_mode              | spi_host_passthrough_mode           |      7.000s       |    368.437us     |    50     |   50    |  100.00 %   |
|   V2    |                 cpol_cpha                 | spi_host_speed                      |      34.000s      |     2.600ms      |    50     |   50    |  100.00 %   |                                                                    
|   V2    |                full_cycle                 | spi_host_speed                      |      34.000s      |     2.600ms      |    50     |   50    |  100.00 %   |                                                                    
|   V2    |                  duplex                   | spi_host_smoke                      |      5.867m       |     33.707ms     |    50     |   50    |  100.00 %   |                                                                    
|   V2    |                tx_rx_only                 | spi_host_smoke                      |      5.867m       |     33.707ms     |    50     |   50    |  100.00 %   |                                                                    
|   V2    |                stress_all                 | spi_host_stress_all                 |      2.617m       |     3.456ms      |    50     |   50    |  100.00 %   |                                                                    
|   V2    |                   spien                   | spi_host_spien                      |      2.783m       |     83.781ms     |    50     |   50    |  100.00 %   |
|   V2    |                   stall                   | spi_host_status_stall               |      6.017m       |     15.686ms     |    48     |   50    |   96.00 %   |
|   V2    |               Idlecsbactive               | spi_host_idlecsbactive              |      48.000s      |     2.078ms      |    50     |   50    |  100.00 %   |
|   V2    |             data_fifo_status              | spi_host_overflow_underflow         |      2.050m       |     17.140ms     |    50     |   50    |  100.00 %   |                                     
|   V2    |                alert_test                 | spi_host_alert_test                 |      7.000s       |     38.949us     |    50     |   50    |  100.00 %   |
|   V2    |                 intr_test                 | spi_host_intr_test                  |      7.000s       |     17.008us     |    50     |   50    |  100.00 %   |                                                                    
|   V2    |           tl_d_oob_addr_access            | spi_host_tl_errors                  |      8.000s       |    118.135us     |    20     |   20    |  100.00 %   |                                                                    
|   V2    |            tl_d_illegal_access            | spi_host_tl_errors                  |      8.000s       |    118.135us     |    20     |   20    |  100.00 %   |                                                                    
|   V2    |          tl_d_outstanding_access          | spi_host_csr_hw_reset               |      7.000s       |     43.721us     |     5     |    5    |  100.00 %   |                                                                    
|         |                                           | spi_host_csr_rw                     |      7.000s       |     35.177us     |    20     |   20    |  100.00 %   |                                                                    
|         |                                           | spi_host_csr_aliasing               |      7.000s       |     43.962us     |     5     |    5    |  100.00 %   |                                                                    
|         |                                           | spi_host_same_csr_outstanding       |      7.000s       |     93.448us     |    20     |   20    |  100.00 %   |                                                                    
|   V2    |            tl_d_partial_access            | spi_host_csr_hw_reset               |      7.000s       |     43.721us     |     5     |    5    |  100.00 %   |
|         |                                           | spi_host_csr_rw                     |      7.000s       |     35.177us     |    20     |   20    |  100.00 %   |                                                                    
|         |                                           | spi_host_csr_aliasing               |      7.000s       |     43.962us     |     5     |    5    |  100.00 %   |                                                                    
|         |                                           | spi_host_same_csr_outstanding       |      7.000s       |     93.448us     |    20     |   20    |  100.00 %   |                                                                    
|   V2    |                                           | **TOTAL**                           |                   |                  |    688    |   690   |   99.71 %   |
|   V2S   |                tl_intg_err                | spi_host_tl_intg_err                |      8.000s       |     68.178us     |    20     |   20    |  100.00 %   |
|         |                                           | spi_host_sec_cm                     |      8.000s       |    134.979us     |     5     |    5    |  100.00 %   |
|   V2S   |           sec_cm_bus_integrity            | spi_host_tl_intg_err                |      8.000s       |     68.178us     |    20     |   20    |  100.00 %   |
|   V2S   |                                           | **TOTAL**                           |                   |                  |    25     |   25    |  100.00 %   |
|         |              Unmapped tests               | spi_host_upper_range_clkdiv         |      34.767m      |    100.005ms     |     5     |   10    |   50.00 %   |
|         |                                           | **TOTAL**                           |                   |                  |    833    |   840   |   99.17 %   |
```

```
## Failure Buckets                                                                                                                                                                                                                          
                                                                                                                                                                                                                                            
* `UVM_FATAL (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.rxempty (addr=*, Comparison=CompareOpEq, exp_data=*, call_count=2)` has 2 failures:                                                         
    * Test spi_host_upper_range_clkdiv has 2 failures.
        * 2.spi_host_upper_range_clkdiv.63377196913979367402618923361295192532734255698408695985212014579393666184349\ 
          Line 167, in log /home/dev/src/scratch/spi_host1-fix/spi_host-sim-xcelium/2.spi_host_upper_range_clkdiv/latest/run.log

                UVM_FATAL @ 100004421746 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.rxempty (addr=0x6dbf2814, Comparison=CompareOpEq, exp_data=0x0, call_count=2)
                UVM_INFO @ 100004421746 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
                 
                 

        * 3.spi_host_upper_range_clkdiv.18123123611689678923451580059856850032405755728708233827692342383944855598562\ 
          Line 171, in log /home/dev/src/scratch/spi_host1-fix/spi_host-sim-xcelium/3.spi_host_upper_range_clkdiv/latest/run.log

                UVM_FATAL @ 100003652144 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.rxempty (addr=0xdccb7654, Comparison=CompareOpEq, exp_data=0x0, call_count=2)
                UVM_INFO @ 100003652144 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
                 
                 

* `Job timed out after * minutes` has 2 failures:
    * Test spi_host_upper_range_clkdiv has 2 failures.
        * 4.spi_host_upper_range_clkdiv.46044846589130626064640037605214099261916511704004833024812316411665519702264\ 
         Log /home/dev/src/scratch/spi_host1-fix/spi_host-sim-xcelium/4.spi_host_upper_range_clkdiv/latest/run.log

                Job timed out after 60 minutes

        * 9.spi_host_upper_range_clkdiv.100548126602877298633529472099766309874292419873152380587453585843132911744285\
         Log /home/dev/src/scratch/spi_host1-fix/spi_host-sim-xcelium/9.spi_host_upper_range_clkdiv/latest/run.log

                Job timed out after 60 minutes

* `UVM_FATAL (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.active (addr=*, Comparison=CompareOpEq, exp_data=*, call_count=11)` has 1 failures:
    * Test spi_host_upper_range_clkdiv has 1 failures.
        * 5.spi_host_upper_range_clkdiv.82543484564348415575484440949325261758955162740481378054155010750204292480971\ 
          Line 153, in log /home/dev/src/scratch/spi_host1-fix/spi_host-sim-xcelium/5.spi_host_upper_range_clkdiv/latest/run.log

                UVM_FATAL @ 100005322915 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.active (addr=0x530d1c54, Comparison=CompareOpEq, exp_data=0x0, call_count=11)
                UVM_INFO @ 100005322915 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
                 
                 

* `UVM_FATAL (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.rxempty (addr=*, Comparison=CompareOpEq, exp_data=*, call_count=168)` has 1 failures:
    * Test spi_host_status_stall has 1 failures.
        * 39.spi_host_status_stall.5839262245463838692330774518959798382536067218122088904330370124333586196005\
          Line 788, in log /home/dev/src/scratch/spi_host1-fix/spi_host-sim-xcelium/39.spi_host_status_stall/latest/run.log

                UVM_FATAL @ 15685519877 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.rxempty (addr=0xaa8a1fd4, Comparison=CompareOpEq, exp_data=0x0, call_count=168)
                UVM_INFO @ 15685519877 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
                 
                 

* `UVM_FATAL (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.ready (addr=*, Comparison=CompareOpEq, exp_data=*, call_count=76)` has 1 failures:
    * Test spi_host_status_stall has 1 failures.
        * 45.spi_host_status_stall.8943642049174832962295679510414478064321030622924547928608586031891426114022\
          Line 683, in log /home/dev/src/scratch/spi_host1-fix/spi_host-sim-xcelium/45.spi_host_status_stall/latest/run.log

                UVM_FATAL @ 10038143410 ps: (csr_utils_pkg.sv:587) [csr_utils::csr_spinwait] timeout spi_host_reg_block.status.ready (addr=0xae5edc14, Comparison=CompareOpEq, exp_data=0x1, call_count=76)
                UVM_INFO @ 10038143410 ps: (uvm_report_catcher.svh:705) [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
```

Also an extended (`-rx 10`) run of the `chip_sw_spi_host_tx_rx` TLT didn't show any problems:
```
### Test Results
|  Stage  |          Name          | Tests                  |  Max Job Runtime  |  Simulated Time  |  Passing  |  Total  |  Pass Rate  |
|:-------:|:----------------------:|:-----------------------|:-----------------:|:----------------:|:---------:|:-------:|:-----------:|
|   V2    | chip_sw_spi_host_tx_rx | chip_sw_spi_host_tx_rx |      5.305m       |     3.130ms      |    30     |   30    |  100.00 %   |
|   V2    |                        | **TOTAL**              |                   |                  |    30     |   30    |  100.00 %   |
|         |                        | **TOTAL**              |                   |                  |    30     |   30    |  100.00 %   |
```
