### PR TITLE
[bazel] Ensure output files of outquery are unique

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -103,7 +103,8 @@ function do_outquery() {
 
     "$file" "${pre_cmd_args[@]}" cquery "$@" \
         --output=starlark --starlark:expr="$qexpr" \
-        --ui_event_filters=-info --noshow_progress
+        --ui_event_filters=-info --noshow_progress \
+        | sort | uniq
 }
 
 function main() {


### PR DESCRIPTION
This PR resolves #23990.

After building a software target using `./bazelisk.sh build`, sometimes an `opentitan_test` would be built in multiple configurations, causing Bazel's `cquery` to return the same file multiple times in its output, as a result of us using `--output=starlark` for starlark postprocessing instead of the newer `--output=files`.

Some scripts, such as [`ci/scripts/target-location.sh`](https://github.com/lowRISC/opentitan/blob/39211701b5d2d8af1d52ab243b5b079bec36535f/ci/scripts/target-location.sh#L33C1-L37C36), rely on the fact that outquery will return a unique result. This ensures that these scripts will not break if a test target is built, by ensuring that output files are unique and non-duplicated.

To test, run the following commands:
```sh
./bazelisk.sh build //sw/device/tests:uart_smoketest_fpga_cw340_rom_ext
./bazelisk.sh outquery //sw/device/tests:uart_smoketest_fpga_cw340_rom_ext
```
Before this PR, you would get a duplicated output. With this PR, there should be a single unique output.