### PR TITLE
[docs,bazel] Update FPGA bootstrapping docs to match current build flow

### DIFF
--- a/ci/scripts/target-location.sh
+++ b/ci/scripts/target-location.sh
@@ -30,8 +30,8 @@ then
   REDIR='/dev/null'
 fi
 
-REL_PATH=$(${REPO_TOP}/bazelisk.sh outquery "$@" 2>$REDIR)
+REL_PATH=$(${REPO_TOP}/bazelisk.sh cquery --output=files "$@" 2>$REDIR)
 readonly REL_PATH
 REPO_EXECROOT=$(${REPO_TOP}/bazelisk.sh info --show_make_env execution_root)
 readonly REPO_EXECROOT
-echo "${REPO_EXECROOT}/${REL_PATH}"
+echo "${REL_PATH}" | awk -v root="$REPO_EXECROOT" '{print root "/" $0}'

--- a/doc/contributing/fpga/ref_manual_fpga.md
+++ b/doc/contributing/fpga/ref_manual_fpga.md
@@ -64,8 +64,8 @@ The example below builds the `hello_world` image and loads it onto the FPGA.
 ```console
 $ cd ${REPO_TOP}
 $ bazel run //sw/host/opentitantool fpga set-pll # This needs to be done only once.
-$ bazel build //sw/device/examples/hello_world:hello_world_fpga_cw310_bin
-$ bazel run //sw/host/opentitantool bootstrap $(ci/scripts/target-location.sh //sw/device/examples/hello_world:hello_world_fpga_cw310_bin)
+$ bazel build //sw/device/examples/hello_world
+$ bazel run //sw/host/opentitantool -- bootstrap $(ci/scripts/target-location.sh //sw/device/examples/hello_world | grep fpga_${BOARD}.bin)
 ```
 
 Uart output:

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -18,6 +18,7 @@ opentitan_binary(
     ],
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv",
         "//hw/top_earlgrey:sim_verilator",
         # For some reason, this target makes englishbreakfast builds fail.


### PR DESCRIPTION
This PR addresses issue #22912.

The documentation has fallen out of date with regards to the FPGA bootstrapping process - the CW340 target is not defined for the `hello_world` demo like is suggested, and the bootstrapping commands have changed since the documentation was written. This PR adds the extra build target, updates the commands to those that can be used to build the `hello_world` binary and execute it on a given board, and corrects a few semantic errors and adds some additional information in different parts of the documentation.

As part of this PR, the `target-location.sh` script has also been modified so that it can handle multiple output files, as the current build flow for `opentitan_binary` targets now produces multiple outputs and as such, these must all be translated to absolute paths. I have run a `rgrep -uuu target-location.sh` to confirm that the places that this script was being used in are unaffected by this change. These are:
- In the `azure-pipelines.yml` to find the Test ROM for the cw305
- In `get-bitstream-strategy.sh` to get the location of the bitstream manifest file)

To test this PR, you can follow the commands described in the updated documentation to run the `hello_world` demo as described on either the CW310 or CW340. 