### PR TITLE
Remove some support for Python <= 3.7

### DIFF
--- a/python-requirements.in
+++ b/python-requirements.in
@@ -51,8 +51,6 @@ mypy==0.971
 yapf==0.32.0
 
 # Type stubs for mypy checking.
-# types-dataclasses is only needed for Python <= 3.6.
-types-dataclasses==0.6.6
 types-pkg_resources==0.1.3
 types-pyyaml==6.0.11
 types-tabulate==0.8.11

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -627,9 +627,6 @@ tomli==2.0.1 \
 typer==0.6.1 \
     --hash=sha256:2d5720a5e63f73eaf31edaa15f6ab87f35f0690f8ca233017d7d23d743a91d73 \
     --hash=sha256:54b19e5df18654070a82f8c2aa1da456a4ac16a2a83e6dcd9f170e291c56338e
-types-dataclasses==0.6.6 \
-    --hash=sha256:4b5a2fcf8e568d5a1974cd69010e320e1af8251177ec968de7b9bb49aa49f7b9 \
-    --hash=sha256:a0a1ab5324ba30363a15c9daa0f053ae4fff914812a1ebd8ad84a08e5349574d
 types-pkg-resources==0.1.3 \
     --hash=sha256:0cb9972cee992249f93fff1a491bf2dc3ce674e5a1926e27d4f0866f7d9b6d9c \
     --hash=sha256:834a9b8d3dbea343562fd99d5d3359a726f6bf9d3733bccd2b4f3096fbab9dae

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -16,6 +16,7 @@
 #                 entry gives the required version.
 #
 __TOOL_REQUIREMENTS__ = {
+    'python': '3.8',
     'edalize': '0.2.0',
     'ninja': {
         'min_version': '1.8.2',

--- a/util/lintpy.py
+++ b/util/lintpy.py
@@ -10,13 +10,7 @@ import subprocess
 import sys
 
 from typing import List
-
-# TODO: Once we depend on Python 3.8, we can switch to unconditionally using
-# importlib.metadata and drop the get_version function.
-try:
-    import importlib.metadata
-except ModuleNotFoundError:
-    import pkg_resources
+import importlib.metadata
 
 # A map from tool name to the tuple (check, fix). These are two commands which
 # should be run to check for and fix errors, respectively. If the tool doesn't
@@ -26,13 +20,6 @@ _KNOWN_TOOLS = {
     'isort': (['isort', '-c', '-w79'], ['isort', '-w79']),
     'flake8': (['flake8'], None)
 }
-
-
-def get_version(pkg_name: str) -> str:
-    try:
-        return importlib.metadata.version(pkg_name)
-    except NameError:
-        return pkg_resources.require(pkg_name)[0].version
 
 
 # include here because in hook case don't want to import reggen
@@ -46,7 +33,7 @@ def show_and_exit(clitool: str, packages: List[str]) -> None:
         ver = 'not found (not in Git repository?)'
     sys.stderr.write(clitool + " Git version " + ver + '\n')
     for p in packages:
-        sys.stderr.write(p + ' ' + get_version(p) + '\n')
+        sys.stderr.write(p + ' ' + importlib.metadata.version(p) + '\n')
     sys.exit(0)
 
 

--- a/util/reggen/params.py
+++ b/util/reggen/params.py
@@ -267,10 +267,9 @@ def _parse_parameter(where: str, raw: object) -> BaseParam:
 
 
 # Note: With a modern enough Python, we'd like this to derive from
-#       "MutableMapping[str, BaseParam]". Unfortunately, this doesn't work with
-#       Python 3.6 (where collections.abc.MutableMapping isn't subscriptable).
-#       So we derive from just "MutableMapping" and tell mypy not to worry
-#       about it.
+#       "MutableMapping[str, BaseParam]". Unfortunately, the MutableMapping
+#       class only become subscriptable in Python 3.9. So we derive from just
+#       "MutableMapping" and tell mypy not to worry about it.
 class Params(MutableMapping):  # type: ignore
     def __init__(self) -> None:
         self.by_name = {}  # type: Dict[str, BaseParam]


### PR DESCRIPTION
This builds on #24512 (the first commit in the PR) and removes some compatibility code that I put into the tooling to support older Python versions. Detailed notes in commit messages.