### PR TITLE
[sw,dv] Add support for basic `status_t` (%r) logging in DV tests

### DIFF
--- a/util/device_sw_utils/extract_sw_logs.py
+++ b/util/device_sw_utils/extract_sw_logs.py
@@ -65,13 +65,20 @@ def cleanup_format(_format):
     so they're converted to pointers instead.
     - Change %![N]?s        --> %[N]?s[%d].
     - Change %![N]?[xXyY]   --> %[N]?h.
-    - Change %![N]?b        --> %[N]?d.'''
+    - Change %![N]?b        --> %[N]?d.
+
+    Status values are printed as hexadecimal values which can be manually decoded
+    by users as necessary, to prevent errors occuring in tests due to lacking
+    support for this formatting specifier. JSON support for status printing is
+    likewise just replaced by displaying the hex.
+    - Change %!?[N]?r        --> %8h'''
     _format = re.sub(r"%(-?\d*)[iu]", r"%\1d", _format)
     _format = re.sub(r"%(-?\d*)[xp]", r"%\1h", _format)
     _format = re.sub(r"%(-?\d*)X", r"%\1H", _format)
     _format = re.sub(r"%!(-?\d*)s", r"%\1s[%d]", _format)
     _format = re.sub(r"%!(-?\d*)[xXyY]", r"%\1h[%d]", _format)
     _format = re.sub(r"%!(-?\d*)b", r"%\1d[%d]", _format)
+    _format = re.sub(r"%!?(-?\d*)r", r"%8h", _format)
     _format = re.sub(r"%([bcodhHs])", r"%0\1", _format)
     return cleanup_newlines(_format)
 


### PR DESCRIPTION
This PR addresses #20139.

As described there, there is currently no implementation of the custom formatting specifier `%r` in the C to System Verilog DV logging backdoor, which means that such logs end up producing irrelevant and useless error messages on DV test benches. 

I spent a while investigating the best way to fix this - custom System Verilog logic for performing the formatting could be introduced. However, while investigating this, it was found that `%r` was not the only broken formatting specifier, which is now tracked by a larger issue #24522.

As mentioned there, any relevant fix will likely require a large change to the way that the DV logging is performed, such as the introduction of a logging DPI to maintain consistency with non-DV logging. As such, it was opted to take a simple temporary fix to remove any errors and/or debugging frustration produced by `%r` currently, rather than a full SV implementation that will likely end up being replaced later on.

This PR simply adds a substitution rule to the current C->SV logging backdoor, which replaces the `%r` and `%!r` custom formatting specifiers (used to print a `status_t` normally, and in a JSON representation) with a hex dump of the 32-bit packed value. This prevents the errors, but still allows comparison with the `status_t` definition for debugging.