### PR TITLE
[i2c,dif] Test i2c dif SCL high and low time cycle bounds on clock stretching

### DIFF
--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -235,14 +235,12 @@ dif_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
   }
 
   // For clock stretching detection to work, the SCL high and low time must be
-  // at leats 4 cycles.
-  // TODO The i2c IP has a parameter (InputDelayCycles) for that, use this when
-  // topgen supports exposing it in the headers (Issue#23786).
-  if (config->scl_time_high_cycles < 4) {
-    config->scl_time_high_cycles = 4;
+  // at least 4 cycles.
+  if (config->scl_time_high_cycles < kDifI2cInputDelayCycles) {
+    config->scl_time_high_cycles = kDifI2cInputDelayCycles;
   }
-  if (config->scl_time_low_cycles < 4) {
-    config->scl_time_low_cycles = 4;
+  if (config->scl_time_low_cycles < kDifI2cInputDelayCycles) {
+    config->scl_time_low_cycles = kDifI2cInputDelayCycles;
   }
 
   return kDifOk;

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -43,6 +43,16 @@ typedef enum dif_i2c_speed {
   kDifI2cSpeedFastPlus,
 } dif_i2c_speed_t;
 
+// TODO(#23786) The i2c IP has a parameter (InputDelayCycles), use this when
+// topgen supports exposing it in the headers.
+enum {
+  /**
+   * Input Delay Cycles; for clock stretching detection to work, the SCL high
+   * and low time must be at least 4 cycles.
+   */
+  kDifI2cInputDelayCycles = 4,
+};
+
 /**
  * Timing configuration parameters for I2C.
  *

--- a/sw/device/lib/dif/dif_i2c_unittest.cc
+++ b/sw/device/lib/dif/dif_i2c_unittest.cc
@@ -162,6 +162,32 @@ TEST(ComputeTimingTest, StandardSpeed) {
   };
   EXPECT_DIF_OK(dif_i2c_compute_timing(config, &params));
   EXPECT_EQ(params, expected);
+
+  // Test that the SCL high and low times are bounded at a minimum
+  // of 4 cycles. for these branches to execute we need to have
+  // scl_time_high_cycles < 4 and scl_time_low_cycles < 4
+  // and lengthened_high_cycles (calculated in the DIF) < 4.
+  // Based on our config and the DIFs calculations we choose the
+  // smallest valid multiple of 100, which is 1600.
+  static_assert(kDifI2cInputDelayCycles == 4,
+                "I2C DIF unit tests are hardcoded for 4 input delay cycles.");
+  config = kBaseConfigSlow;
+  config.lowest_target_device_speed = kDifI2cSpeedStandard;
+  config.clock_period_nanos = 1600;
+  expected = {
+      .scl_time_high_cycles = 4,
+      .scl_time_low_cycles = 4,
+      .rise_cycles = 1,
+      .fall_cycles = 1,
+      .start_signal_setup_cycles = 3,
+      .start_signal_hold_cycles = 3,
+      .data_signal_setup_cycles = 1,
+      .data_signal_hold_cycles = 1,
+      .stop_signal_setup_cycles = 3,
+      .stop_signal_hold_cycles = 3,
+  };
+  EXPECT_DIF_OK(dif_i2c_compute_timing(config, &params));
+  EXPECT_EQ(params, expected);
 }
 
 TEST(ComputeTimingTest, FastSpeed) {
@@ -219,6 +245,32 @@ TEST(ComputeTimingTest, FastSpeed) {
   };
   EXPECT_DIF_OK(dif_i2c_compute_timing(config, &params));
   EXPECT_EQ(params, expected);
+
+  // Test that the SCL high and low times are bounded at a minimum
+  // of 4 cycles. for these branches to execute we need to have
+  // scl_time_high_cycles < 4 and scl_time_low_cycles < 4
+  // and lengthened_high_cycles (calculated in the DIF) < 4.
+  // Based on our config and the DIFs calculations we choose the
+  // smallest valid multiple of 100, which is 500.
+  static_assert(kDifI2cInputDelayCycles == 4,
+                "I2C DIF unit tests are hardcoded for 4 input delay cycles.");
+  config = kBaseConfigSlow;
+  config.lowest_target_device_speed = kDifI2cSpeedFast;
+  config.clock_period_nanos = 500;
+  expected = {
+      .scl_time_high_cycles = 4,
+      .scl_time_low_cycles = 4,
+      .rise_cycles = 1,
+      .fall_cycles = 1,
+      .start_signal_setup_cycles = 2,
+      .start_signal_hold_cycles = 2,
+      .data_signal_setup_cycles = 1,
+      .data_signal_hold_cycles = 1,
+      .stop_signal_setup_cycles = 2,
+      .stop_signal_hold_cycles = 3,
+  };
+  EXPECT_DIF_OK(dif_i2c_compute_timing(config, &params));
+  EXPECT_EQ(params, expected);
 }
 
 TEST(ComputeTimingTest, FastPlusSpeed) {
@@ -256,6 +308,32 @@ TEST(ComputeTimingTest, FastPlusSpeed) {
       .data_signal_hold_cycles = 1,
       .stop_signal_setup_cycles = 13,
       .stop_signal_hold_cycles = 25,
+  };
+  EXPECT_DIF_OK(dif_i2c_compute_timing(config, &params));
+  EXPECT_EQ(params, expected);
+
+  // Test that the SCL high and low times are bounded at a minimum
+  // of 4 cycles. for these branches to execute we need to have
+  // scl_time_high_cycles < 4 and scl_time_low_cycles < 4
+  // and lengthened_high_cycles (calculated in the DIF) < 4.
+  // Based on our config and the DIFs calculations we choose the
+  // smallest valid multiple of 100, which is 200.
+  static_assert(kDifI2cInputDelayCycles == 4,
+                "I2C DIF unit tests are hardcoded for 4 input delay cycles.");
+  config = kBaseConfigFast;
+  config.lowest_target_device_speed = kDifI2cSpeedFastPlus;
+  config.clock_period_nanos = 200;
+  expected = {
+      .scl_time_high_cycles = 4,
+      .scl_time_low_cycles = 4,
+      .rise_cycles = 1,
+      .fall_cycles = 1,
+      .start_signal_setup_cycles = 2,
+      .start_signal_hold_cycles = 2,
+      .data_signal_setup_cycles = 1,
+      .data_signal_hold_cycles = 1,
+      .stop_signal_setup_cycles = 2,
+      .stop_signal_hold_cycles = 3,
   };
   EXPECT_DIF_OK(dif_i2c_compute_timing(config, &params));
   EXPECT_EQ(params, expected);


### PR DESCRIPTION
The i2c block requires a minimum value (for the current setup, at least 4 cycles) for the SCL high and low time in order for clock stretching to function. This functionality was previously added to the DIF (see #23772), and so this PR updates the relevant unit tests to also check for these conditional cases. Modified input clock periods are used that have been calculated to execute minimum boundary branch cases, and a static assertion before the test ensures that these calculated values will not fall out of sync if the minimum high/low time does change.

This has been tested by running the following command:
```sh
./bazelisk.sh test -t- --test_output=streamed //sw/device/lib/dif:i2c_unittest
```
which still passes after the changes as expected.