### PR TITLE
[sw,lib] Add unit test for debug printing four character codes

### DIFF
--- a/sw/device/lib/runtime/print_unittest.cc
+++ b/sw/device/lib/runtime/print_unittest.cc
@@ -308,6 +308,21 @@ TEST_F(PrintfTest, StatusErrorWithArg) {
   EXPECT_EQ(buf_, absl::StrFormat("Hello, InvalidArgument:[\"PRI\",%d]\n", 2));
 }
 
+TEST_F(PrintfTest, FourCharacterCode) {
+  EXPECT_EQ(base_printf("Hello, %C\n", 0x5CA245D3), 18);
+  EXPECT_EQ(buf_, "Hello, \\xd3E\\xa2\\\n");
+}
+
+TEST_F(PrintfTest, FourCharacterCodePrintable) {
+  EXPECT_EQ(base_printf("Hello, %C\n", 0x65766144), 12);
+  EXPECT_EQ(buf_, "Hello, Dave\n");
+}
+
+TEST_F(PrintfTest, FourCharacterCodeNonPrintable) {
+  EXPECT_EQ(base_printf("Hello, %C\n", 0xAABBCCDD), 24);
+  EXPECT_EQ(buf_, "Hello, \\xdd\\xcc\\xbb\\xaa\n");
+}
+
 TEST_F(PrintfTest, IncompleteSpec) {
   base_printf("Hello, %");
   EXPECT_THAT(buf_, StartsWith("Hello, "));


### PR DESCRIPTION
The `printf` unit testing was missing tests for the custom debug formatting specifier `kFourCC`, which is used for formatting Four Character Codes. This specifier prints a `uint32_t` as four ASCII characters encoded in little endian order. Existing print unit tests did not check this specifier, and so this commit introduces three additional small unit tests to check that the implementation is working as intended.

This has been tested by running the following command:
```sh
./bazelisk.sh test -t- --test_output=streamed //sw/device/lib/runtime:print_unittest
```
which still passes after the changes as expected.