### PR TITLE
[ci] Update quick-lint & CI scripts after site move

### DIFF
--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -61,8 +61,5 @@ ci/scripts/rust-format.sh $tgt_branch
 echo -e "\n### Run shellcheck on all shell scripts"
 util/sh/scripts/run-shellcheck.sh
 
-echo -e "\n### Render landing site"
-ci/scripts/build-site.sh
-
 echo -e "\n### Check what kinds of changes the PR contains"
 ci/scripts/get-build-type.sh $tgt_branch PullRequest

--- a/ci/scripts/exec-check.sh
+++ b/ci/scripts/exec-check.sh
@@ -19,6 +19,7 @@ args=(
     -name .git -prune -o
     -name vendor -prune -o
     -name scratch -prune -o
+    -name build-site -prune -o
     # Filter to executable files.
     -type f
     -executable

--- a/util/sh/scripts/run-shellcheck.sh
+++ b/util/sh/scripts/run-shellcheck.sh
@@ -19,7 +19,7 @@ else
     SHELLCHECK="./bazelisk.sh run @shellcheck//:shellcheck --"
 fi
 
-EXCLUDED_DIRS="-name third_party -o -name vendor -o -name lowrisc_misc-linters"
+EXCLUDED_DIRS="-name third_party -o -name vendor -o -name build-site -o -name lowrisc_misc-linters"
 # Get an array of all shell scripts to check using input redirection and
 # process substitution. For details on this syntax, see ShellCheck SC2046.
 # shellcheck disable=SC2046


### PR DESCRIPTION
After the building of the site / landing page was moved to a separate repository, there is still an existing reference to the old `./ci/scripts/build-site.sh` script in `./ci/jobs/quick-lint.sh`, which causes the quick lint job to error near the end, This PR removes that reference from the job.

This commit also excludes the `build-site` directory from the CI executable file and shell check scripts, as current building of the docs via mdbook creates many executable files and shell scripts which do not pass linting standards (but are temporary, and local).

I've tested that this still works by simply running `./ci/jobs/quick_lint.sh`.