### PR TITLE
[entropy_src,verilator] Reduce entropy tests requirements on Verilator to fix failing test targets

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6327,8 +6327,8 @@ opentitan_test(
             "//hw/top_earlgrey:silicon_creator": None,
         },
     ),
-    # This test can take > 40 minutes, so mark it manual as it shouldn't run
-    # in CI/nightlies.
+    # This takes around 2 hours to run on Verilator, and so should only be
+    # run manually for debugging purposes.
     verilator = verilator_params(tags = ["manual"]),
     deps = [
         ":otbn_randomness_impl",

--- a/sw/device/tests/entropy_src_fw_observe_many_contiguous.c
+++ b/sw/device/tests/entropy_src_fw_observe_many_contiguous.c
@@ -27,6 +27,11 @@ enum {
    * The number of contiguous samples we want to capture.
    */
   kContiguousSamplesCount = 1024,
+  /**
+   * The number of contiguous samples we want to capture when running on
+   * Verilator.
+   */
+  kVerilatorContiguousSamplesCount = 8,
   /*
    * Timeout to read kContiguousSamplesCount.
    */
@@ -203,10 +208,19 @@ bool test_main(void) {
       kDifEntropySrcSingleBitMode1,        kDifEntropySrcSingleBitMode2,
       kDifEntropySrcSingleBitMode3,
   };
+  uint32_t contiguous_sample_count = kContiguousSamplesCount;
+  if (kDeviceType == kDeviceSimVerilator) {
+    // If running on Verilator, then entropy is observed much more slowly,
+    // in addition to the standard simulator overhead. Observing 1024 words
+    // would take around 30+ seconds each, which would take dozens of hours
+    // to simulate. We only care that entropy observation works on Verilator
+    // and not that it works at a given rate, so we just observe 8 samples.
+    contiguous_sample_count = kVerilatorContiguousSamplesCount;
+  }
   status_t test_result = OK_STATUS();
   for (size_t i = 0; i < ARRAYSIZE(kModes); i++) {
     EXECUTE_TEST(test_result, firmware_override_observe,
-                 kContiguousSamplesCount, kModes[i], kTimeoutUsec,
+                 contiguous_sample_count, kModes[i], kTimeoutUsec,
                  kRepeatCount);
   }
 


### PR DESCRIPTION
This PR partially addresses #24184 (specifically, it addresses the two tests found to fail if given long enough to run in Verilator).

Entropy is generated much more slowly in Verilator, and as a result, two tests were timing-out (and if given long enough, failing) when run in Verilator. These are `sw/device/tests:entropy_src_fw_observe_many_contiguous_test_sim_verilator`, and `sw/device/tests:entropy_src_fw_override_test_sim_verilator`. This PR conditionally lowers the test requirements for the Verilator simulation environment to allow these tests to pass on Verilator.

For `fw_observe_many_contiguous_test`, the number of entropy samples to be observed is reduced from 1024 to just 8, as the full 1024 would take around 13-15 hours. For `fw_override_test`, the entropy consumers have been limited to just random number generation, and the test is terminated after this on Verilator. The timeout given to observe this Entropy is also increased 30x on Verilator.

Note that these code changes do not modify the operation of any execution environments other than Verilator; only Verilator has had conditional changes. If this is deemed not appropriate due to requirements of these tests, then instead the Verilator environment should be removed from these two tests.

This has been tested by running the following command:
```sh
./bazelisk.sh test -t- --test_output=streamed --test_timeout=3600,3600,3600,3600 \
    //sw/device/tests:entropy_src_fw_observe_many_contiguous_test_sim_verilator 
    //sw/device/tests:entropy_src_fw_override_test_sim_verilator
```
which now passes as expected:
```sh
//sw/device/tests:entropy_src_fw_observe_many_contiguous_test_sim_verilator PASSED in 2807.4s
//sw/device/tests:entropy_src_fw_override_test_sim_verilator             PASSED in 3358.1s
```