### PR TITLE
[test] adjust the timeout of ujson_console test

### DIFF
--- a/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
+++ b/sw/host/tests/chip/spi_device_ujson_console_test/src/main.rs
@@ -24,7 +24,7 @@ struct Opts {
     init: InitializeTest,
 
     /// Console receive timeout.
-    #[arg(long, value_parser = humantime::parse_duration, default_value = "30s")]
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "60s")]
     timeout: Duration,
 
     /// Name of the SPI interface to connect to the OTTF console.


### PR DESCRIPTION
It was spotted that `spi_device_ujson_console_test` may take longer than 30s to finish on cw310 in the CI pipeline. This PR modifies the timeout of  the test to 60s to avoid the test being timeout.