### PR TITLE
[rv_dm,dv] Handle reset at surprising time in resuming vseq

### DIFF
--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_resuming_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_mem_tl_access_resuming_vseq.sv
@@ -59,6 +59,7 @@ class rv_dm_mem_tl_access_resuming_vseq extends rv_dm_base_vseq;
     // Clear the halt request
     jtag_dmi_ral.dmcontrol.haltreq.set(1'b0);
     jtag_dmi_ral.dmcontrol.update(.status(dmi_status));
+    if (!cfg.clk_rst_vif.rst_n) return;
     `DV_CHECK_EQ(dmi_status, UVM_IS_OK)
 
     // Now tell the hart to resume, and acknowledge the request as the hart.


### PR DESCRIPTION
This vseq is mostly careful to follow the form:

  Do a TL transaction
  Stop if we are in reset (since the transaction was aborted)
  Check the result

But I missed an instance! Put it in.