### PR TITLE
[opentitantool] improve user experience

### DIFF
--- a/sw/host/opentitanlib/src/image/manifest_def.rs
+++ b/sw/host/opentitanlib/src/image/manifest_def.rs
@@ -8,7 +8,7 @@ use crate::util::bigint::fixed_size_bigint;
 use crate::util::num_de::HexEncoded;
 use crate::util::parse_int::ParseInt;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -96,7 +96,9 @@ macro_rules! manifest_def {
 
 impl ManifestSpec {
     pub fn read_from_file(path: &Path) -> Result<ManifestSpec> {
-        Ok(deser_hjson::from_str(&std::fs::read_to_string(path)?)?)
+        Ok(deser_hjson::from_str(
+            &std::fs::read_to_string(path).with_context(|| format!("Failed to open {path:?}"))?,
+        )?)
     }
 
     pub fn overwrite_fields(&mut self, other: ManifestSpec) {

--- a/sw/host/opentitanlib/src/util/file.rs
+++ b/sw/host/opentitanlib/src/util/file.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context, Result};
 use pem_rfc7468::{Decoder, Encoder, LineEnding};
 use thiserror::Error;
 
@@ -72,7 +72,7 @@ pub trait FromReader: Sized {
 
     /// Reads an instance of `Self` from a binary file at `path`.
     fn read_from_file(path: &Path) -> Result<Self> {
-        let file = File::open(path)?;
+        let file = File::open(path).with_context(|| format!("Failed to open {path:?}"))?;
         Self::from_reader(file)
     }
 }
@@ -84,7 +84,7 @@ pub trait ToWriter: Sized {
 
     /// Writes `self` to a file at `path` in binary format.
     fn write_to_file(self, path: &Path) -> Result<()> {
-        let mut file = File::create(path)?;
+        let mut file = File::create(path).with_context(|| format!("Failed to create {path:?}"))?;
         self.to_writer(&mut file)
     }
 }

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context, Result};
 use clap::Args;
 use serde_annotate::Annotate;
 use std::any::Any;
@@ -51,7 +51,8 @@ impl BootstrapCommand {
             image.parse(&self.filename)?;
             image.assemble()
         } else {
-            Ok(std::fs::read(&self.filename[0])?)
+            Ok(std::fs::read(&self.filename[0])
+                .with_context(|| format!("Failed to read {}", self.filename[0]))?)
         }
     }
 }


### PR DESCRIPTION
When 'opentitiantool image manifest update ...' fails due to any input or output file name mistyped, or any of the input files does not exist, the error message is the same:

  Error: No such file or directory (os error 2)

Which does not help much the operator. This patch adds some code which will print the name of the file causing the error.

Tested by invoking 'image manifest update' with incorrectly specified various input files. In case of the wrong SPX key file name the file name is printed twice, since the code is trying to read the file first trying to retrieve a private key, and then if unsuccessful - one more time trying to retrieve the public key.

This double print could be eliminated by proper return error processing, but is left as is at this time.