### PR TITLE
[opentitantool] do not create duplicate extension entries

### DIFF
--- a/sw/host/opentitanlib/src/image/manifest_def.rs
+++ b/sw/host/opentitanlib/src/image/manifest_def.rs
@@ -177,8 +177,23 @@ impl ManifestPacked<[ManifestExtTableEntry; CHIP_MANIFEST_EXT_TABLE_COUNT]>
 
     fn overwrite(&mut self, o: Self) {
         for i in 0..self.len() {
-            if !matches!(o[i].0, ManifestExtEntryVar::None) {
-                self[i].0 = o[i].0.clone();
+            match o[i].0 {
+                ManifestExtEntryVar::Name(other_id) => match self[i].0 {
+                    ManifestExtEntryVar::IdOffset {
+                        identifier: self_id,
+                        offset: _,
+                    } => {
+                        if self_id == other_id {
+                            // Do not overwrite existing entries with matching IDs.
+                            continue;
+                        } else {
+                            self[i].0 = o[i].0.clone()
+                        }
+                    }
+                    _ => self[i].0 = o[i].0.clone(),
+                },
+                ManifestExtEntryVar::None => (),
+                _ => self[i].0 = o[i].0.clone(),
             }
         }
     }


### PR DESCRIPTION
It was observed that repetitive invoking 'opentitiantool image manifest update ...' passing an --spx_key and same manifest input file which included SPX key and signature extensions repetitively is causing addition of the SPX key and SPX signature space every time opentitantool is invoked.

This patch fixes the problem.

All opentitantool and opentitanlib tests pass, and running the same invocation does not cause additions of the SPX key and signature spaces any more.