### PR TITLE
[dv,alerts] Fix alert_sva_active to have correct reset polarity

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -181,7 +181,7 @@ interface alert_esc_if(input clk, input rst_n);
   endtask : wait_esc_ping
 
   logic alert_sva_active;
-  always_comb alert_sva_active = is_alert && !rst_n;
+  always_comb alert_sva_active = is_alert && rst_n;
 
   // Check the differential alert signals have no unknown values.
   `ASSERT_KNOWN(PingKnown_A, alert_rx.ping_p ^ alert_rx.ping_n, clk, !alert_sva_active)


### PR DESCRIPTION
This PR fix the reset polarization of the alert_sva_active flag in the alert_esc_if which was inverted.
The alerts SVA should be active only when the reset is deasserted, which means when rst_n = 1.
This means alert_sva_active should be with the same polarization as rst_n, hence the fix.