### PR TITLE
[pentest] Add CSRNG Bias FI tests

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.h
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.h
@@ -80,6 +80,21 @@ status_t handle_rng_fi_edn_init(ujson_t *uj);
 status_t handle_rng_fi_csrng_bias(ujson_t *uj);
 
 /**
+ * rng_fi_entropy_src_bias_fw_override command handler.
+ *
+ * Write a fixed seed into the FW_OV_WR_DATA register in the FW override mode.
+ * This seed goes through the conditioner into the CSRNG. The software interface
+ * of the CSRNG is used to extract the random data.
+ *
+ * Faults are injected during the trigger_high & trigger_low.
+ *
+ * @param uj An initialized uJSON context.
+ * @param static_seed Use static seed or seed provided by user.
+ * @return OK or error.
+ */
+status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed);
+
+/**
  * Initializes the trigger and configures the device for the CSRNG FI test.
  *
  * @param uj An initialized uJSON context.

--- a/sw/device/tests/penetrationtests/json/rng_fi_commands.h
+++ b/sw/device/tests/penetrationtests/json/rng_fi_commands.h
@@ -14,6 +14,8 @@ extern "C" {
 #define RNGFI_SUBCOMMAND(_, value) \
     value(_, CsrngInit) \
     value(_, CsrngBias) \
+    value(_, CsrngBiasFWOverride) \
+    value(_, CsrngBiasFWOverrideStatic) \
     value(_, EdnInit) \
     value(_, EdnRespAck) \
     value(_, EdnBias) \
@@ -34,6 +36,13 @@ UJSON_SERDE_STRUCT(CryptoFiCsrngMode, crypto_fi_csrng_mode_t, CRYPTOFI_CSRNG_MOD
     field(alerts, uint32_t, 3) \
     field(err_status, uint32_t)
 UJSON_SERDE_STRUCT(RngFiCsrngOutput, rng_fi_csrng_output_t, RNGFI_CSRNG_OUTPUT);
+
+#define RNGFI_CSRNG_OV_OUTPUT(field, string) \
+    field(res, uint32_t) \
+    field(rand, uint32_t, 12) \
+    field(alerts, uint32_t, 3) \
+    field(err_status, uint32_t)
+UJSON_SERDE_STRUCT(RngFiCsrngOvOutput, rng_fi_csrng_ov_output_t, RNGFI_CSRNG_OV_OUTPUT);
 
 #define RNGFI_ENTRBIAS_OUTPUT(field, string) \
     field(rand, uint32_t, 32) \
@@ -57,6 +66,10 @@ UJSON_SERDE_STRUCT(RngFiEdn, rng_fi_edn_t, RNGFI_EDN);
 #define RNGFI_FWOVERWRITE_HEALTH(field, string) \
     field(disable_health_check, bool)
 UJSON_SERDE_STRUCT(RngFiFwOverwriteHealt, rng_fi_fw_overwrite_health_t, RNGFI_FWOVERWRITE_HEALTH);
+
+#define RNGFI_SEED(field, string) \
+    field(seed, uint32_t, 12)
+UJSON_SERDE_STRUCT(RngFiSeed, rng_fi_seed_t, RNGFI_SEED);
 
 // clang-format on
 


### PR DESCRIPTION
This commit adds the following two new FI tests:
- CsrngBiasFWOverride
- CsrngBiasFWOverrideStatic

These tests can be used to target the entropy source and they allow to monitor the data over the CSRNG
interface.