### PR TITLE
[pentest] Add EDN SCA tests

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/BUILD
@@ -20,6 +20,7 @@ FIRMWARE_DEPS_FPGA = [
     "//sw/device/tests/penetrationtests/firmware/fi:rng_fi",
     "//sw/device/tests/penetrationtests/firmware/fi:rom_fi",
     "//sw/device/tests/penetrationtests/firmware/sca:aes_sca",
+    "//sw/device/tests/penetrationtests/firmware/sca:edn_sca",
     "//sw/device/tests/penetrationtests/firmware/sca:hmac_sca",
     "//sw/device/tests/penetrationtests/firmware/sca:ibex_sca",
     "//sw/device/tests/penetrationtests/firmware/sca:kmac_sca",
@@ -63,6 +64,7 @@ FIRMWARE_DEPS_FI = [
 
 FIRMWARE_DEPS_SCA = [
     "//sw/device/tests/penetrationtests/firmware/sca:aes_sca",
+    "//sw/device/tests/penetrationtests/firmware/sca:edn_sca",
     "//sw/device/tests/penetrationtests/firmware/sca:hmac_sca",
     "//sw/device/tests/penetrationtests/firmware/sca:ibex_sca",
     "//sw/device/tests/penetrationtests/firmware/sca:kmac_sca",

--- a/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/rng_fi.c
@@ -505,7 +505,7 @@ status_t handle_rng_fi_csrng_bias(ujson_t *uj) {
 
 status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
   // Clear registered alerts in alert handler.
-  sca_registered_alerts_t reg_alerts = sca_get_triggered_alerts();
+  sca_registered_alerts_t reg_alerts = pentest_get_triggered_alerts();
 
   uint32_t received_data[kCsrngBiasFWFifoBufferSize];
   const dif_csrng_seed_material_t kEmptySeedMaterial = {0};
@@ -561,7 +561,7 @@ status_t handle_rng_fi_csrng_bias_fw_override(ujson_t *uj, bool static_seed) {
   sca_set_trigger_low();
 
   // Get registered alerts from alert handler.
-  reg_alerts = sca_get_triggered_alerts();
+  reg_alerts = pentest_get_triggered_alerts();
 
   // Read ERR_STATUS register from Ibex.
   dif_rv_core_ibex_error_status_t err_ibx;

--- a/sw/device/tests/penetrationtests/firmware/firmware.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware.c
@@ -14,6 +14,7 @@
 #include "sw/device/tests/penetrationtests/json/aes_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/commands.h"
 #include "sw/device/tests/penetrationtests/json/crypto_fi_commands.h"
+#include "sw/device/tests/penetrationtests/json/edn_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/extclk_sca_fi_commands.h"
 #include "sw/device/tests/penetrationtests/json/hmac_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/ibex_fi_commands.h"
@@ -39,6 +40,7 @@
 #include "fi/rom_fi.h"
 #include "lib/extclk_sca_fi.h"
 #include "sca/aes_sca.h"
+#include "sca/edn_sca.h"
 #include "sca/hmac_sca.h"
 #include "sca/ibex_sca.h"
 #include "sca/kmac_sca.h"
@@ -59,6 +61,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kPenetrationtestCommandCryptoFi:
         RESP_ERR(uj, handle_crypto_fi(uj));
+        break;
+      case kPenetrationtestCommandEdnSca:
+        RESP_ERR(uj, handle_edn_sca(uj));
         break;
       case kPenetrationtestCommandExtClkScaFi:
         RESP_ERR(uj, handle_extclk_sca_fi(uj));

--- a/sw/device/tests/penetrationtests/firmware/firmware_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/firmware_sca.c
@@ -13,6 +13,7 @@
 // Include commands
 #include "sw/device/tests/penetrationtests/json/aes_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/commands.h"
+#include "sw/device/tests/penetrationtests/json/edn_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/hmac_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/ibex_sca_commands.h"
 #include "sw/device/tests/penetrationtests/json/kmac_sca_commands.h"
@@ -24,6 +25,7 @@
 // Include handlers
 #include "lib/extclk_sca_fi.h"
 #include "sca/aes_sca.h"
+#include "sca/edn_sca.h"
 #include "sca/hmac_sca.h"
 #include "sca/ibex_sca.h"
 #include "sca/kmac_sca.h"
@@ -41,6 +43,9 @@ status_t process_cmd(ujson_t *uj) {
     switch (cmd) {
       case kPenetrationtestCommandAesSca:
         RESP_ERR(uj, handle_aes_sca(uj));
+        break;
+      case kPenetrationtestCommandEdnSca:
+        RESP_ERR(uj, handle_edn_sca(uj));
         break;
       case kPenetrationtestCommandExtClkScaFi:
         RESP_ERR(uj, handle_extclk_sca_fi(uj));

--- a/sw/device/tests/penetrationtests/firmware/sca/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/sca/BUILD
@@ -47,6 +47,30 @@ cc_library(
 )
 
 cc_library(
+    name = "edn_sca",
+    srcs = ["edn_sca.c"],
+    hdrs = ["edn_sca.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:csrng_shared",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:rv_core_ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:rv_core_ibex_testutils",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/sca/lib:prng",
+        "//sw/device/sca/lib:sca",
+        "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
+        "//sw/device/tests/penetrationtests/json:edn_sca_commands",
+    ],
+)
+
+cc_library(
     name = "extclk_sca_fi",
     srcs = ["extclk_sca_fi.c"],
     hdrs = ["extclk_sca_fi.h"],

--- a/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/edn_sca.c
@@ -1,0 +1,239 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/dif_csrng_shared.h"
+#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/rv_core_ibex_testutils.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/sca/lib/prng.h"
+#include "sw/device/sca/lib/sca.h"
+#include "sw/device/tests/penetrationtests/firmware/lib/pentest_lib.h"
+#include "sw/device/tests/penetrationtests/json/edn_sca_commands.h"
+
+#include "edn_regs.h"  // Generated
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// NOP macros.
+#define NOP1 "addi x0, x0, 0\n"
+#define NOP10 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1 NOP1
+#define NOP30 NOP10 NOP10 NOP10
+
+enum {
+  kEdnKatTimeout = (10 * 1000 * 1000),
+  kEdnKatMaxClen = 12,
+  kEdnKatOutputLen = 16,
+  kEdnKatWordsPerBlock = 4,
+  /**
+   * Max number of traces per batch.
+   */
+  kNumBatchOpsMax = 128,
+};
+
+static dif_rv_core_ibex_t rv_core_ibex;
+static dif_entropy_src_t entropy_src;
+static dif_csrng_t csrng;
+static dif_edn_t edn0;
+
+// Generate random values used by the test by calling the SCA PRNG.
+static void generate_random(size_t num_values, uint32_t values[]) {
+  for (size_t i = 0; i < num_values; i++) {
+    values[i] = prng_rand_uint32();
+  }
+}
+
+// Configure the EDN with the provided seed material, set the SCA trigger,
+// generate and receive random data, and unset the trigger.
+static status_t config_run_edn(uint32_t init_seed[12], uint32_t reseed[12]) {
+  // Setup seed material.
+  // Seed material for the EDN instantiate command.
+  dif_edn_seed_material_t kEdnKatSeedMaterialInstantiate = {
+      .len = kEdnKatMaxClen,
+      .data = {init_seed[0], init_seed[1], init_seed[2], init_seed[3],
+               init_seed[4], init_seed[5], init_seed[6], init_seed[7],
+               init_seed[8], init_seed[9], init_seed[10], init_seed[11]}};
+  // Seed material for the EDN reseed command.
+  dif_edn_seed_material_t kEdnKatSeedMaterialReseed = {
+      .len = kEdnKatMaxClen,
+      .data = {reseed[0], reseed[1], reseed[2], reseed[3], reseed[4], reseed[5],
+               reseed[6], reseed[7], reseed[8], reseed[9], reseed[10],
+               reseed[11]}};
+  // Seed material for the EDN generate command.
+  const dif_edn_seed_material_t kEdnKatSeedMaterialGenerate = {
+      .len = 0,
+  };
+
+  dif_edn_auto_params_t edn_params;
+  edn_params.instantiate_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdInstantiate, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialInstantiate.len, /*generate_len=*/0);
+  edn_params.instantiate_cmd.seed_material = kEdnKatSeedMaterialInstantiate;
+  edn_params.reseed_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdReseed, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialReseed.len,
+      /*generate_len=*/0);
+  edn_params.reseed_cmd.seed_material = kEdnKatSeedMaterialReseed;
+  edn_params.generate_cmd.cmd = csrng_cmd_header_build(
+      kCsrngAppCmdGenerate, kDifCsrngEntropySrcToggleDisable,
+      kEdnKatSeedMaterialGenerate.len,
+      /*generate_len=*/
+      kEdnKatOutputLen / kEdnKatWordsPerBlock);
+
+  edn_params.generate_cmd.seed_material = kEdnKatSeedMaterialGenerate;
+  edn_params.reseed_interval = 32;
+
+  // Disable the entropy complex.
+  TRY(entropy_testutils_stop_all());
+  // Enable ENTROPY_SRC in FIPS mode.
+  TRY(dif_entropy_src_configure(
+      &entropy_src, entropy_testutils_config_default(), kDifToggleEnabled));
+  // Enable CSRNG.
+  TRY(dif_csrng_configure(&csrng));
+  // Enable EDN0 in auto request mode.
+  TRY(dif_edn_set_auto_mode(&edn0, edn_params));
+
+  uint32_t ibex_rnd_data;
+
+  // Capture trace during generation and transportation of random data.
+  sca_set_trigger_high();
+  asm volatile(NOP30);
+  TRY(rv_core_ibex_testutils_get_rnd_data(&rv_core_ibex, kEdnKatTimeout,
+                                          &ibex_rnd_data));
+  sca_set_trigger_low();
+  asm volatile(NOP30);
+
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca_bus_data(ujson_t *uj) {
+  // Get seed material.
+  edn_sca_seed_t uj_data;
+  TRY(ujson_deserialize_edn_sca_seed_t(uj, &uj_data));
+
+  // Configure EDN with provided seed material, set trigger and start generating
+  // and fetching data.
+  config_run_edn(uj_data.init_seed, uj_data.reseed);
+
+  // Acknowledge test.
+  edn_sca_result_t uj_output;
+  uj_output.result = 0;
+  RESP_OK(ujson_serialize_edn_sca_result_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca_bus_data_batch_fvsr(ujson_t *uj) {
+  // Get seed material.
+  edn_sca_seed_batch_t uj_data;
+  TRY(ujson_deserialize_edn_sca_seed_batch_t(uj, &uj_data));
+
+  bool sample_fixed = true;
+  uint32_t last_value = 0;
+
+  uint32_t init_seed[kNumBatchOpsMax][12];
+  uint32_t reseed[kNumBatchOpsMax][12];
+
+  for (size_t it = 0; it < uj_data.num_iterations; it++) {
+    if (sample_fixed) {
+      memcpy(init_seed[it], uj_data.init_seed, 12 * sizeof(uint32_t));
+      memcpy(reseed[it], uj_data.reseed, 12 * sizeof(uint32_t));
+    } else {
+      // Generate random seeds for the EDN configuration.
+      generate_random(12, init_seed[it]);
+      generate_random(12, reseed[it]);
+    }
+    sample_fixed = prng_rand_uint32() & 0x1;
+  }
+
+  for (size_t it = 0; it < uj_data.num_iterations; it++) {
+    // Configure EDN with random seed material, set trigger and start generating
+    // and fetching data.
+    TRY(config_run_edn(init_seed[it], reseed[it]));
+    last_value = reseed[it][11];
+  }
+
+  // Acknowledge test, send last reseed value back to host
+  // for verification.
+  edn_sca_result_t uj_output;
+  uj_output.result = last_value;
+  RESP_OK(ujson_serialize_edn_sca_result_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca_bus_data_batch_random(ujson_t *uj) {
+  // Get number of iterations.
+  edn_sca_batch_t uj_data;
+  TRY(ujson_deserialize_edn_sca_batch_t(uj, &uj_data));
+
+  uint32_t init_seed[kNumBatchOpsMax][12];
+  uint32_t reseed[kNumBatchOpsMax][12];
+  for (size_t it = 0; it < uj_data.num_iterations; it++) {
+    // Generate random seeds for the EDN configuration.
+    generate_random(12, init_seed[it]);
+    generate_random(12, reseed[it]);
+  }
+
+  for (size_t it = 0; it < uj_data.num_iterations; it++) {
+    // Configure EDN with random seed material, set trigger and start generating
+    // and fetching data.
+    TRY(config_run_edn(init_seed[it], reseed[it]));
+  }
+
+  // Acknowledge test, send last random reseed value back to host
+  // for verification.
+  edn_sca_result_t uj_output;
+  uj_output.result = reseed[uj_data.num_iterations - 1][11];
+  RESP_OK(ujson_serialize_edn_sca_result_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca_init(ujson_t *uj) {
+  sca_select_trigger_type(kScaTriggerTypeSw);
+  // As we are using the software defined trigger, the first argument of
+  // sca_init is not needed. kScaTriggerSourceAes is selected as a placeholder.
+  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4 | kScaPeripheralEntropy |
+                                     kScaPeripheralCsrng | kScaPeripheralEdn);
+
+  // Disable the instruction cache and dummy instructions for SCA attacks.
+  pentest_configure_cpu();
+
+  // Configure Ibex to allow reading ERR_STATUS register.
+  TRY(dif_rv_core_ibex_init(
+      mmio_region_from_addr(TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR),
+      &rv_core_ibex));
+
+  // Initialize peripherals used in this SCA test.
+  TRY(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
+  TRY(dif_csrng_init(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+                     &csrng));
+  TRY(dif_edn_init(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR), &edn0));
+
+  return OK_STATUS();
+}
+
+status_t handle_edn_sca(ujson_t *uj) {
+  edn_sca_subcommand_t cmd;
+  TRY(ujson_deserialize_edn_sca_subcommand_t(uj, &cmd));
+  switch (cmd) {
+    case kEdnScaSubcommandBusData:
+      return handle_edn_sca_bus_data(uj);
+    case kEdnScaSubcommandBusDataBatchFvsr:
+      return handle_edn_sca_bus_data_batch_fvsr(uj);
+    case kEdnScaSubcommandBusDataBatchRandom:
+      return handle_edn_sca_bus_data_batch_random(uj);
+    case kEdnScaSubcommandInit:
+      return handle_edn_sca_init(uj);
+    default:
+      LOG_ERROR("Unrecognized EDN SCA subcommand: %d", cmd);
+      return INVALID_ARGUMENT();
+  }
+  return OK_STATUS();
+}

--- a/sw/device/tests/penetrationtests/firmware/sca/edn_sca.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/edn_sca.h
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_SCA_EDN_SCA_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_SCA_EDN_SCA_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+/**
+ * edn.sca.bus_data command handler.
+ *
+ * The goal of this penetration test is to capture traces when
+ * the EDN generated random data and transfers it to Ibex.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca_bus_data(ujson_t *uj);
+
+/**
+ * edn.sca.bus_data_batch_fvsr command handler.
+ *
+ * Batch version of edn.sca.bus_data with FvsR data.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca_bus_data_batch_fvsr(ujson_t *uj);
+
+/**
+ * edn.sca.bus_data_batch_random command handler.
+ *
+ * Batch version of edn.sca.bus_data with random data.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca_bus_data_batch_random(ujson_t *uj);
+
+/**
+ * Initializes the trigger and configures the device for the EDN SCA test.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca_init(ujson_t *uj);
+
+/**
+ * EDN SCA command handler.
+ *
+ * Command handler for the EDN SCA command.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_edn_sca(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_FIRMWARE_SCA_EDN_SCA_H_

--- a/sw/device/tests/penetrationtests/json/BUILD
+++ b/sw/device/tests/penetrationtests/json/BUILD
@@ -11,6 +11,7 @@ cc_library(
     deps = [
         ":aes_sca_commands",
         ":crypto_fi_commands",
+        ":edn_sca_commands",
         ":extclk_sca_fi_commands",
         ":hmac_sca_commands",
         ":ibex_fi_commands",
@@ -38,6 +39,13 @@ cc_library(
     name = "crypto_fi_commands",
     srcs = ["crypto_fi_commands.c"],
     hdrs = ["crypto_fi_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
+)
+
+cc_library(
+    name = "edn_sca_commands",
+    srcs = ["edn_sca_commands.c"],
+    hdrs = ["edn_sca_commands.h"],
     deps = ["//sw/device/lib/ujson"],
 )
 

--- a/sw/device/tests/penetrationtests/json/commands.h
+++ b/sw/device/tests/penetrationtests/json/commands.h
@@ -14,6 +14,7 @@ extern "C" {
 #define COMMAND(_, value) \
     value(_, AesSca) \
     value(_, CryptoFi) \
+    value(_, EdnSca) \
     value(_, ExtClkScaFi) \
     value(_, HmacSca) \
     value(_, IbexFi) \

--- a/sw/device/tests/penetrationtests/json/edn_sca_commands.c
+++ b/sw/device/tests/penetrationtests/json/edn_sca_commands.c
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "edn_sca_commands.h"

--- a/sw/device/tests/penetrationtests/json/edn_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/edn_sca_commands.h
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_EDN_SCA_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_EDN_SCA_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// clang-format off
+
+#define EDNSCA_SUBCOMMAND(_, value) \
+    value(_, BusData) \
+    value(_, BusDataBatchFvsr) \
+    value(_, BusDataBatchRandom) \
+    value(_, Init)
+UJSON_SERDE_ENUM(EdnScaSubcommand, edn_sca_subcommand_t, EDNSCA_SUBCOMMAND);
+
+#define EDNSCA_RESULT(field, string) \
+    field(result, uint32_t)
+UJSON_SERDE_STRUCT(EdnScaResult, edn_sca_result_t, EDNSCA_RESULT);
+
+#define EDNSCA_SEED(field, string) \
+    field(init_seed, uint32_t, 12) \
+    field(reseed, uint32_t, 12)
+UJSON_SERDE_STRUCT(EdnScaSeed, edn_sca_seed_t, EDNSCA_SEED);
+
+#define EDNSCA_SEED_BATCH(field, string) \
+    field(init_seed, uint32_t, 12) \
+    field(reseed, uint32_t, 12) \
+    field(num_iterations, uint32_t)
+UJSON_SERDE_STRUCT(EdnScaSeedBatch, edn_sca_seed_batch_t, EDNSCA_SEED_BATCH);
+
+#define EDNSCA_BATCH(field, string) \
+    field(num_iterations, uint32_t)
+UJSON_SERDE_STRUCT(EdnScaBatch, edn_sca_batch_t, EDNSCA_BATCH);
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_PENETRATIONTESTS_JSON_EDN_SCA_COMMANDS_H_


### PR DESCRIPTION
This commit pulls over the EDN SCA tests from nasahlpa/opentitan that have been used in the pentesting:
- edn.sca.bus_data
- edn.sca.bus_data_batch_fvsr
- edn.sca.bus_data_batch_random

These tests can be used to analyze the SCA security of the EDN.