### PR TITLE
[third_party] Add open-dice dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -149,6 +149,10 @@ sphincsplus_repos()
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")
 
+# CBOR reader & writer from open-dice
+load("//third_party/open-dice:repos.bzl", "open_dice_repos")
+open_dice_repos()
+
 # Setup for linking in externally managed test and provisioning customizations
 # for both secure/non-secure manufacturer domains.
 load("//rules:hooks_setup.bzl", "hooks_setup", "provisioning_exts_setup", "secure_hooks_setup")

--- a/third_party/open-dice/BUILD
+++ b/third_party/open-dice/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/open-dice/BUILD.open-dice.bazel
+++ b/third_party/open-dice/BUILD.open-dice.bazel
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "cbor_reader_writer",
+    srcs = [
+        "src/cbor_reader.c",
+        "src/cbor_writer.c",
+    ],
+    hdrs = [
+        "include/dice/cbor_reader.h",
+        "include/dice/cbor_writer.h",
+    ],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/open-dice/repos.bzl
+++ b/third_party/open-dice/repos.bzl
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:repo.bzl", "http_archive_or_local")
+
+def open_dice_repos(local = None):
+    http_archive_or_local(
+        name = "open-dice",
+        local = local,
+        build_file = Label("//third_party/open-dice:BUILD.open-dice.bazel"),
+        strip_prefix = "open-dice-cf3f4cc7a3506a33ee3a437544ef6f40056b3563",
+        urls = ["https://github.com/google/open-dice/archive/cf3f4cc7a3506a33ee3a437544ef6f40056b3563.zip"],
+        sha256 = "d7ce830111451afe2a255cac3b750f82e50efe2aaf6bac0b076881c964cfe78d",
+    )


### PR DESCRIPTION
We'll need the cbor_reader and cbor_writer implementations from the open-dice repository, for the CWT CBOR DICE implementation in the ROM_EXT.

Test: bazel build @@open-dice//:cbor_reader_writer