### PR TITLE
[rom_ext] Facilitate builds of DEV artifacts

### DIFF
--- a/sw/device/silicon_creator/rom_ext/proda/BUILD
+++ b/sw/device/silicon_creator/rom_ext/proda/BUILD
@@ -50,7 +50,10 @@ manifest(d = {
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
         linkopts = LINK_ORDER,
         manifest = ":manifest_proda",
-        rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+        rsa_key = select({
+            "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+            "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_dev_0"},
+        }),
         deps = [
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",

--- a/sw/device/silicon_creator/rom_ext/prodc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/prodc/BUILD
@@ -50,7 +50,10 @@ manifest(d = {
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
         linkopts = LINK_ORDER,
         manifest = ":manifest_prodc",
-        rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_2": "prod_key_2"},
+        rsa_key = select({
+            "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_2"},
+            "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_dev_0"},
+        }),
         deps = [
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -50,7 +50,10 @@ manifest(d = {
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
         linkopts = LINK_ORDER,
         manifest = ":manifest_sival",
-        rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+        rsa_key = select({
+            "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+            "//conditions:default": {"//sw/device/silicon_creator/rom/keys/real/rsa:keyset": "earlgrey_a0_dev_0"},
+        }),
         deps = [
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",


### PR DESCRIPTION
Add key selection to the "fake signed" ROM_EXT targets for each of the current customer configurations.  This allows a developer in possession of a lifecycle-state-`DEV` chip to more easily produce a ROM_EXT binary for such chips.

Example:
```
$ bazel build \
    --//signing:token=//signing/tokens:nitrokey \
    //sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_a
```