### PR TITLE
[dv,vcs] Tidy up how coverage is collected in assertion modules

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -21,10 +21,20 @@
 -moduletree prim_secded_inv_64_57_dec // use in reg_top
 -moduletree prim_secded_inv_39_32_dec // use in reg_top
 
-// csr_assert_fpv is an auto-generated csr read assertion module. So only assertion coverage is
-// meaningful to collect.
+// The DV environment binds in some modules to add CSR and TileLink
+// assertions. Disable all coverage for these modules here. We'll
+// enable assertion coverage for the modules below.
 -moduletree *csr_assert_fpv
+-moduletree tlul_assert
+
 -module prim_cdc_rand_delay  // DV construct.
+
+begin assert
+  // Enable assertion coverage for bound-in assertion modules (we
+  // disabled all coverage earlier in the file)
+  +moduletree *csr_assert_fpv
+  +moduletree tlul_assert
+end
 
 begin tgl
   -tree tb
@@ -39,8 +49,4 @@ begin tgl
   +module prim_prince
   +module prim_secded_inv_64_57_dec
   +module prim_secded_inv_39_32_dec
-end
-
-begin assert
-  +moduletree *csr_assert_fpv
 end

--- a/hw/dv/tools/vcs/cover_reg_top.cfg
+++ b/hw/dv/tools/vcs/cover_reg_top.cfg
@@ -12,7 +12,15 @@
 -moduletree prim_secded_inv_64_57_dec // use in reg_top
 -moduletree prim_secded_inv_39_32_dec // use in reg_top
 
+// The DV environment binds in some modules to add CSR and Tilelink assertions. Make sure that we
+// collect assertion coverage for these modules (since that's the whole point!) but don't collect
+// any other sort of coverage.
+-moduletree *csr_assert_fpv
+-moduletree tlul_assert
+
 begin assert
+  // Enable assertion coverage for bound-in assertion modules (we
+  // disabled all coverage earlier in the file)
   +moduletree *csr_assert_fpv
   +moduletree tlul_assert
 end

--- a/hw/ip/rv_dm/dv/cov/cover.cfg
+++ b/hw/ip/rv_dm/dv/cov/cover.cfg
@@ -1,9 +1,0 @@
-// Copyright lowRISC contributors (OpenTitan project).
-// Licensed under the Apache License, Version 2.0, see LICENSE for details.
-// SPDX-License-Identifier: Apache-2.0
-
-// Non-RTL assertion only blocks.
--moduletree rv_dm_regs_csr_assert_fpv
-begin assert
-  +moduletree rv_dm_regs_csr_assert_fpv
-end

--- a/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg
+++ b/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg
@@ -5,13 +5,6 @@
 +node tb.dut *_tl_*
 +node tb.dut jtag_*
 
-// Non-RTL assertion only blocks.
--moduletree rv_dm_regs_csr_assert_fpv
-
-begin assert
-  +moduletree rv_dm_regs_csr_assert_fpv
-end
-
 // The JTAG DTM is functionally verified, even in CSR tests.
 begin line+cond+fsm+branch+assert
   +moduletree dmi_jtag

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -61,7 +61,7 @@
     }
     {
       name: default_vcs_cov_cfg_file
-      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/ip/rv_dm/dv/cov/cover.cfg"
+      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg"
     }
     {
       name: cover_reg_top_vcs_cov_cfg_file


### PR DESCRIPTION
- Stop collecting non-assertion coverage from the tlul_assert block (since that seems a bit pointless).

- Mirror this change in cover_reg_top.cfg

- Refactor stuff in the rv_dm specialisations of the two files because they are supposed to *extend* the base versions rather than reimplementing them.

- The resulting rv_dm version of cover.cfg ends up empty (which causes VCS to segfault!). Remove it.