### PR TITLE
[dv,vcs] Tidy up the comments where we disable coverage in a prim

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -18,8 +18,8 @@
 -moduletree prim_lfsr
 -moduletree prim_onehot_check
 -moduletree prim_prince
--moduletree prim_secded_inv_64_57_dec // use in reg_top
--moduletree prim_secded_inv_39_32_dec // use in reg_top
+-moduletree prim_secded_inv_64_57_dec
+-moduletree prim_secded_inv_39_32_dec
 
 // csr_assert_fpv is an auto-generated csr read assertion module. So only assertion coverage is
 // meaningful to collect.

--- a/hw/dv/tools/vcs/cover_reg_top.cfg
+++ b/hw/dv/tools/vcs/cover_reg_top.cfg
@@ -4,13 +4,16 @@
 
 // Limits coverage collection only to the *_reg_top module and the TL interface
 // of the DUT.
-
 +moduletree *_reg_top
 +node tb.dut tl_*
+
+// Disable collection is some modules that are instantiated inside the reg_top module but verified
+// by a different mechanism (prims that are verified by FPV) or are just DV constructs where
+// coverage doesn't matter.
 -module prim_cdc_rand_delay  // DV construct.
--module prim_onehot_check    // FPV verified
--moduletree prim_secded_inv_64_57_dec // use in reg_top
--moduletree prim_secded_inv_39_32_dec // use in reg_top
+-module prim_onehot_check              // FPV verified
+-moduletree prim_secded_inv_64_57_dec  // FPV verified
+-moduletree prim_secded_inv_39_32_dec  // FPV verified
 
 begin assert
   +moduletree *csr_assert_fpv


### PR DESCRIPTION
No functional change but this took me a while to understand! I think the "use in reg_top" comment in cover.cfg was copied from cover_reg_top.cfg (where it made slightly more sense).