### PR TITLE
Cherry-pick from `master`: hsmtool fixes

### DIFF
--- a/sw/host/hsmtool/BUILD
+++ b/sw/host/hsmtool/BUILD
@@ -59,6 +59,7 @@ rust_library(
         "@crate_index//:clap",
         "@crate_index//:cryptoki",
         "@crate_index//:cryptoki-sys",
+        "@crate_index//:der",
         "@crate_index//:directories",
         "@crate_index//:ecdsa",
         "@crate_index//:hex",

--- a/sw/host/hsmtool/src/commands/ecdsa/verify.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/verify.rs
@@ -48,13 +48,19 @@ impl Dispatch for Verify {
 
         let mut data = helper::read_file(&self.input)?;
         if self.little_endian {
+            // OpenTitanTool writes digest files in little-endian byte order,
+            // (same as the hmac peripheral's default output mode).  The ECDSA
+            // implementation performs the signature calculation with the bytes in
+            // big-endian order.
             data.reverse();
         }
         let data = self.format.prepare(KeyType::Ec, &data)?;
         let mechanism = self.format.mechanism(KeyType::Ec)?;
         let mut signature = helper::read_file(&self.signature)?;
         if self.little_endian {
-            signature.reverse();
+            let half = signature.len() / 2;
+            signature[..half].reverse();
+            signature[half..].reverse();
         }
         session.verify(&mechanism, object, &data, &signature)?;
         Ok(Box::<BasicResult>::default())

--- a/sw/host/hsmtool/src/error.rs
+++ b/sw/host/hsmtool/src/error.rs
@@ -32,4 +32,6 @@ pub enum HsmError {
     TooManyObjects(usize, String),
     #[error("Expected only owner permissions, but found permissions {0:o}")]
     FilePermissionError(u32),
+    #[error("DER error: {0}")]
+    DerError(String),
 }

--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "crc",
  "cryptoki",
  "cryptoki-sys",
+ "der",
  "deser-hjson",
  "directories",
  "ecdsa",

--- a/third_party/rust/Cargo.toml
+++ b/third_party/rust/Cargo.toml
@@ -24,6 +24,7 @@ chrono = "0.4"
 const-oid = { version = "0.9.6", features=["std"] }
 clap = { version = "4.4", features = ["derive", "env", "deprecated"] }
 crc = "3.0"
+der = { version = "0.7.8", features = ["alloc"] }
 deser-hjson = "2.0.0"
 directories = "5.0.1"
 ecdsa = { version = "0.16.9", features = ["pkcs8", "pem", "signing", "verifying", "sha2", "std"] }

--- a/third_party/rust/crates/BUILD.bazel
+++ b/third_party/rust/crates/BUILD.bazel
@@ -122,6 +122,12 @@ alias(
 )
 
 alias(
+    name = "der",
+    actual = "@crate_index__der-0.7.8//:der",
+    tags = ["manual"],
+)
+
+alias(
     name = "deser-hjson",
     actual = "@crate_index__deser-hjson-2.1.0//:deser_hjson",
     tags = ["manual"],

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -310,6 +310,7 @@ _NORMAL_DEPENDENCIES = {
             "crc": "@crate_index__crc-3.0.1//:crc",
             "cryptoki": "@crate_index__cryptoki-0.5.0//:cryptoki",
             "cryptoki-sys": "@crate_index__cryptoki-sys-0.1.6//:cryptoki_sys",
+            "der": "@crate_index__der-0.7.8//:der",
             "deser-hjson": "@crate_index__deser-hjson-2.1.0//:deser_hjson",
             "directories": "@crate_index__directories-5.0.1//:directories",
             "ecdsa": "@crate_index__ecdsa-0.16.9//:ecdsa",
@@ -961,7 +962,7 @@ def crate_repositories():
         name = "crate_index__const-oid-0.9.6",
         sha256 = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8",
         type = "tar.gz",
-        urls = ["https://crates.io/api/v1/crates/const-oid/0.9.6/download"],
+        urls = ["https://static.crates.io/crates/const-oid/0.9.6/download"],
         strip_prefix = "const-oid-0.9.6",
         build_file = Label("@lowrisc_opentitan//third_party/rust/crates:BUILD.const-oid-0.9.6.bazel"),
     )


### PR DESCRIPTION
OpenTitan's ECDSA implementation expects the R and S components of an
ECDSA signature to be in little-endian order.

1. Reverse the R and S components individually rather than reversing the entire signature.
2. Following the PKCS#11 specifications, the CKA_EC_POINT should be the DER-encoding of ANSI X9.62 ECPoint value.

These cherry-picks are from #23962 and #23905.