### PR TITLE
[util] Remove expand_seed routine.

### DIFF
--- a/util/design/lib/LcStEnc.py
+++ b/util/design/lib/LcStEnc.py
@@ -8,9 +8,8 @@ import logging as log
 from collections import OrderedDict
 
 from Crypto.Hash import cSHAKE128
-from lib.common import (check_int, ecc_encode, expand_seed, get_hd,
-                        hd_histogram, is_valid_codeword, random_or_hexvalue,
-                        scatter_bits)
+from lib.common import (check_int, ecc_encode, get_hd, hd_histogram,
+                        is_valid_codeword, random_or_hexvalue, scatter_bits)
 from topgen import secure_prng as sp
 
 # Seed diversification constant for LcStEnc (this enables to use
@@ -288,7 +287,7 @@ class LcStEnc():
         log.info('Seed: {0:x}'.format(config['seed']))
         log.info('')
 
-        sp.reseed(expand_seed(LC_SEED_DIVERSIFIER + int(config['seed'])))
+        sp.reseed(LC_SEED_DIVERSIFIER + int(config['seed']))
 
         log.info('Checking SECDED.')
         _validate_secded(config)

--- a/util/design/lib/OtpMemImg.py
+++ b/util/design/lib/OtpMemImg.py
@@ -224,7 +224,7 @@ class OtpMemImg(OtpMemMap):
         log.info('')
 
         # Re-initialize with seed to make results reproducible.
-        sp.reseed(common.expand_seed(OTP_IMG_SEED_DIVERSIFIER + int(img_config['seed'])))
+        sp.reseed(OTP_IMG_SEED_DIVERSIFIER + int(img_config['seed']))
 
         if 'partitions' not in img_config:
             raise RuntimeError('Missing partitions key in configuration.')

--- a/util/design/lib/OtpMemMap.py
+++ b/util/design/lib/OtpMemMap.py
@@ -8,7 +8,7 @@ documentation, and to create OTP memory images for preloading.
 import logging as log
 from math import ceil, log2
 
-from lib.common import check_bool, check_int, expand_seed, random_or_hexvalue
+from lib.common import check_bool, check_int, random_or_hexvalue
 from mubi.prim_mubi import is_width_valid, mubi_value_as_int
 from tabulate import tabulate
 from topgen import secure_prng as sp
@@ -405,7 +405,7 @@ class OtpMemMap():
         config["seed"] = check_int(config["seed"])
 
         # Initialize RNG.
-        sp.reseed(expand_seed(OTP_SEED_DIVERSIFIER + int(config['seed'])))
+        sp.reseed(OTP_SEED_DIVERSIFIER + int(config['seed']))
         log.info('Seed: {0:x}'.format(config['seed']))
         log.info('')
 

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -7,7 +7,7 @@ import random
 import re
 import sys
 import textwrap
-from math import ceil, log, log2
+from math import ceil, log2
 from pathlib import Path
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
@@ -114,19 +114,6 @@ def blockify(s, size, limit):
         numbits = limit * 4
 
     return (",\n  ".join(s_list))
-
-
-def expand_seed(seed):
-    '''Checks if the input seed is shorter than 256 bits and expands it if
-    it's not.
-    '''
-    new_seed = seed
-    seed_bytes = ceil(log(seed + 1, 256))
-    while new_seed < (1 << 256):
-        new_seed <<= seed_bytes * 8
-        new_seed += seed
-    new_seed %= (1 << 256)
-    return new_seed
 
 
 def get_random_perm_hex_literal(numel):

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -19,7 +19,6 @@ from typing import Dict, List, Optional, Tuple
 import hjson
 import tlgen
 import version_file
-from design.lib.common import expand_seed
 from ipgen import (IpBlockRenderer, IpConfig, IpDescriptionOnlyRenderer,
                    IpTemplate, TemplateRenderError)
 from mako import exceptions
@@ -1081,7 +1080,8 @@ def main():
     elif "rnd_cnst_seed" not in topcfg:
         log.error('Seed "rnd_cnst_seed" not found in configuration HJSON.')
         exit(1)
-    secure_prng.reseed(expand_seed(topcfg["rnd_cnst_seed"]))
+
+    secure_prng.reseed(topcfg["rnd_cnst_seed"])
 
     # TODO, long term, the levels of dependency should be automatically
     # determined instead of hardcoded.  The following are a few examples:


### PR DESCRIPTION
This routine wasn't currently affecting the logic, but would have weakened certain seeds that happened to have low values. Ideally this should all be refactored to use byte strings so it's clearer what range the value is sampled from, but for now just removing the harmful logic should suffice.