### PR TITLE
[dv,spi] Set strong drive strength and fast slew rate for SPI pads

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -458,7 +458,9 @@ cc_library(
     hdrs = ["spi_device_testutils.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:pinmux",
         "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/testing/json:spi_passthru",
         "//sw/device/lib/testing/test_framework:check",

--- a/sw/device/lib/testing/spi_device_testutils.c
+++ b/sw/device/lib/testing/spi_device_testutils.c
@@ -326,6 +326,37 @@ status_t spi_device_testutils_configure_read_pipeline(
   return OK_STATUS();
 }
 
+status_t spi_device_testutils_configure_pad_attrs(dif_pinmux_t *pinmux) {
+  dif_pinmux_pad_attr_t out_attr;
+  dif_pinmux_pad_attr_t in_attr = {.slew_rate = 1, .drive_strength = 3};
+  dif_result_t res;
+  for (uint32_t i = 0; i <= ARRAYSIZE(spi_device_direct_pads); ++i) {
+    res = dif_pinmux_pad_write_attrs(pinmux, spi_device_direct_pads[i],
+                                     kDifPinmuxPadKindDio, in_attr, &out_attr);
+    if (res == kDifError) {
+      // Some target platforms may not support the specified value for slew rate
+      // and drive strength. If that's the case, use the values actually
+      // supported.
+      if (out_attr.slew_rate != in_attr.slew_rate) {
+        LOG_INFO(
+            "Specified slew rate not supported, trying supported slew rate");
+        in_attr.slew_rate = out_attr.slew_rate;
+      }
+      if (out_attr.drive_strength != in_attr.drive_strength) {
+        LOG_INFO(
+            "Specified drive strength not supported, trying supported drive "
+            "strength");
+        in_attr.drive_strength = out_attr.drive_strength;
+      }
+      TRY(dif_pinmux_pad_write_attrs(pinmux, spi_device_direct_pads[i],
+                                     kDifPinmuxPadKindDio, in_attr, &out_attr));
+      // Note: fallthrough with the modified `in_attr` so that the same
+      // attributes are used for all pads.
+    }
+  }
+  return OK_STATUS();
+}
+
 status_t spi_device_testutils_wait_for_upload(dif_spi_device_handle_t *spid,
                                               upload_info_t *info) {
   // Wait for a SPI transaction cause an upload.

--- a/sw/device/lib/testing/spi_device_testutils.h
+++ b/sw/device/lib/testing/spi_device_testutils.h
@@ -9,8 +9,11 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/status.h"
+#include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/testing/json/spi_passthru.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 /**
  * A set of typical opcodes for named flash commands.
@@ -53,6 +56,17 @@ typedef enum spi_device_flash_opcode {
 enum spi_device_command_slot {
   kSpiDeviceReadCommandSlotBase = 0,
   kSpiDeviceWriteCommandSlotBase = 11,
+};
+
+/*
+ * The SPI device pads for which `spi_device_testutils_configure_pad_attrs()`
+ * configures the pad attributes.
+ */
+static const top_earlgrey_direct_pads_t spi_device_direct_pads[4] = {
+    kTopEarlgreyDirectPadsSpiDeviceSd3,  // sio[3]
+    kTopEarlgreyDirectPadsSpiDeviceSd2,  // sio[2]
+    kTopEarlgreyDirectPadsSpiDeviceSd1,  // sio[1]
+    kTopEarlgreyDirectPadsSpiDeviceSd0   // sio[0]
 };
 
 /**
@@ -111,6 +125,15 @@ status_t spi_device_testutils_configure_read_pipeline(
     dif_spi_device_handle_t *spi_device,
     dif_spi_device_read_pipeline_mode_t dual_mode,
     dif_spi_device_read_pipeline_mode_t quad_mode);
+
+/**
+ * Configure the SPI device pad attributes.
+ *
+ * @return A status_t indicating success or failure configuring the pad
+ * attributes.
+ */
+OT_WARN_UNUSED_RESULT
+status_t spi_device_testutils_configure_pad_attrs(dif_pinmux_t *pinmux);
 
 /**
  * Wait for a spi command upload.

--- a/sw/device/lib/testing/spi_host_testutils.h
+++ b/sw/device/lib/testing/spi_host_testutils.h
@@ -12,12 +12,36 @@
 #include "sw/device/lib/dif/dif_pinmux.h"
 #include "sw/device/lib/dif/dif_spi_host.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
 typedef enum spi_pinmux_platform_id {
   kSpiPinmuxPlatformIdCw310 = 0,
   kSpiPinmuxPlatformIdCw340,
   kSpiPinmuxPlatformIdTeacup,
   kSpiPinmuxPlatformIdCount,
 } spi_pinmux_platform_id_t;
+
+/*
+ * The SPI host pads for which `spi_host_testutils_configure_host0_pad_attrs()`
+ * configures the pad attributes.
+ */
+static const top_earlgrey_direct_pads_t spi_host0_direct_pads[6] = {
+    kTopEarlgreyDirectPadsSpiHost0Sck,  // sck
+    kTopEarlgreyDirectPadsSpiHost0Csb,  // csb
+    kTopEarlgreyDirectPadsSpiHost0Sd3,  // sio[3]
+    kTopEarlgreyDirectPadsSpiHost0Sd2,  // sio[2]
+    kTopEarlgreyDirectPadsSpiHost0Sd1,  // sio[1]
+    kTopEarlgreyDirectPadsSpiHost0Sd0   // sio[0]
+};
+
+/**
+ * Configure the pad attributes of SPI Host 0.
+ *
+ * @return A status_t indicating success or failure configuring the pad
+ * attributes.
+ */
+OT_WARN_UNUSED_RESULT
+status_t spi_host_testutils_configure_host0_pad_attrs(dif_pinmux_t *pinmux);
 
 /**
  * Return True if spi host is active.

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4459,6 +4459,7 @@ opentitan_test(
         "//sw/device/lib/testing:otbn_testutils_rsa",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing:spi_device_testutils",
+        "//sw/device/lib/testing:spi_host_testutils",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -32,6 +32,7 @@
 #include "sw/device/lib/testing/otbn_testutils_rsa.h"
 #include "sw/device/lib/testing/pinmux_testutils.h"
 #include "sw/device/lib/testing/spi_device_testutils.h"
+#include "sw/device/lib/testing/spi_host_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_macros.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
@@ -286,14 +287,6 @@ static const uint8_t kI2cMessage[] = {
     0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
     0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
     0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
-};
-
-static const top_earlgrey_direct_pads_t spi_host0_direct_pads[5] = {
-    kTopEarlgreyDirectPadsSpiHost0Sck,  // sck
-    kTopEarlgreyDirectPadsSpiHost0Sd3,  // sio[3]
-    kTopEarlgreyDirectPadsSpiHost0Sd2,  // sio[2]
-    kTopEarlgreyDirectPadsSpiHost0Sd1,  // sio[1]
-    kTopEarlgreyDirectPadsSpiHost0Sd0   // sio[0]
 };
 
 static void log_entropy_src_alert_failures(void) {
@@ -693,40 +686,9 @@ static void configure_pinmux_sim(void) {
   CHECK_DIF_OK(dif_pinmux_output_select(&pinmux, kTopEarlgreyPinmuxMioOutIor11,
                                         kTopEarlgreyPinmuxOutselPwmAonPwm0));
 
-  // Set fast slew rate and strong drive strengh for SPI host0 pads.
-  dif_pinmux_pad_attr_t out_attr;
-  dif_pinmux_pad_attr_t in_attr = {
-      .slew_rate = 1,
-      .drive_strength = 3,
-      // Set weak pull-ups for all the pads.
-      .flags = kDifPinmuxPadAttrPullResistorEnable |
-               kDifPinmuxPadAttrPullResistorUp};
-  dif_result_t res;
-  for (uint32_t i = 0; i <= ARRAYSIZE(spi_host0_direct_pads); ++i) {
-    res = dif_pinmux_pad_write_attrs(&pinmux, spi_host0_direct_pads[i],
-                                     kDifPinmuxPadKindDio, in_attr, &out_attr);
-    if (res == kDifError) {
-      // Some target platforms may not support the specified value for slew rate
-      // and drive strength. If that's the case, use the values actually
-      // supported.
-      if (out_attr.slew_rate != in_attr.slew_rate) {
-        LOG_INFO(
-            "Specified slew rate not supported, trying supported slew rate");
-        in_attr.slew_rate = out_attr.slew_rate;
-      }
-      if (out_attr.drive_strength != in_attr.drive_strength) {
-        LOG_INFO(
-            "Specified drive strength not supported, trying supported drive "
-            "strength");
-        in_attr.drive_strength = out_attr.drive_strength;
-      }
-      CHECK_DIF_OK(dif_pinmux_pad_write_attrs(&pinmux, spi_host0_direct_pads[i],
-                                              kDifPinmuxPadKindDio, in_attr,
-                                              &out_attr));
-      // Note: fallthrough with the modified `in_attr` so that the same
-      // attributes are used for all pads.
-    }
-  }
+  // Configure fast slew rate, strong drive strength, and weak pull-ups for SPI
+  // Host 0 pads.
+  CHECK_STATUS_OK(spi_host_testutils_configure_host0_pad_attrs(&pinmux));
 
   // Configure fast slew rate and strong drive strength for SPI device pads.
   CHECK_STATUS_OK(spi_device_testutils_configure_pad_attrs(&pinmux));

--- a/sw/device/tests/power_virus_systemtest.c
+++ b/sw/device/tests/power_virus_systemtest.c
@@ -296,13 +296,6 @@ static const top_earlgrey_direct_pads_t spi_host0_direct_pads[5] = {
     kTopEarlgreyDirectPadsSpiHost0Sd0   // sio[0]
 };
 
-static const top_earlgrey_direct_pads_t spi_device_direct_pads[4] = {
-    kTopEarlgreyDirectPadsSpiDeviceSd3,  // sio[3]
-    kTopEarlgreyDirectPadsSpiDeviceSd2,  // sio[2]
-    kTopEarlgreyDirectPadsSpiDeviceSd1,  // sio[1]
-    kTopEarlgreyDirectPadsSpiDeviceSd0   // sio[0]
-};
-
 static void log_entropy_src_alert_failures(void) {
   dif_entropy_src_alert_fail_counts_t counts;
   CHECK_DIF_OK(dif_entropy_src_get_alert_fail_counts(&entropy_src, &counts));
@@ -735,36 +728,8 @@ static void configure_pinmux_sim(void) {
     }
   }
 
-  // Set fast slew rate and strong drive strengh for SPI device pads.
-  in_attr.slew_rate = 1;
-  in_attr.drive_strength = 3;
-  // Don't enable pull-ups for SPI device pads.
-  in_attr.flags = 0;
-  for (uint32_t i = 0; i <= ARRAYSIZE(spi_device_direct_pads); ++i) {
-    res = dif_pinmux_pad_write_attrs(&pinmux, spi_device_direct_pads[i],
-                                     kDifPinmuxPadKindDio, in_attr, &out_attr);
-    if (res == kDifError) {
-      // Some target platforms may not support the specified value for slew rate
-      // and drive strength. If that's the case, use the values actually
-      // supported.
-      if (out_attr.slew_rate != in_attr.slew_rate) {
-        LOG_INFO(
-            "Specified slew rate not supported, trying supported slew rate");
-        in_attr.slew_rate = out_attr.slew_rate;
-      }
-      if (out_attr.drive_strength != in_attr.drive_strength) {
-        LOG_INFO(
-            "Specified drive strength not supported, trying supported drive "
-            "strength");
-        in_attr.drive_strength = out_attr.drive_strength;
-      }
-      CHECK_DIF_OK(
-          dif_pinmux_pad_write_attrs(&pinmux, spi_device_direct_pads[i],
-                                     kDifPinmuxPadKindDio, in_attr, &out_attr));
-      // Note: fallthrough with the modified `in_attr` so that the same
-      // attributes are used for all pads.
-    }
-  }
+  // Configure fast slew rate and strong drive strength for SPI device pads.
+  CHECK_STATUS_OK(spi_device_testutils_configure_pad_attrs(&pinmux));
 }
 
 /**

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -524,6 +524,7 @@ opentitan_test(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing:spi_host_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
@@ -547,6 +548,7 @@ opentitan_test(
         "//sw/device/lib/testing:pinmux_testutils",
         "//sw/device/lib/testing:spi_device_testutils",
         "//sw/device/lib/testing:spi_flash_testutils",
+        "//sw/device/lib/testing:spi_host_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )

--- a/sw/device/tests/sim_dv/spi_host_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_host_tx_rx_test.c
@@ -147,17 +147,38 @@ void init_spi_host(dif_spi_host_t *spi_host,
  * This peripheral is 'direct' connected to the pads.
  */
 void setup_pads_spi_host0(void) {
-  // set weak pull-ups for all the pads
+  // set weak pull-ups, fast slew rate and strong drive strengh for all the pads
   dif_pinmux_pad_attr_t out_attr;
   dif_pinmux_pad_attr_t in_attr = {
-      .slew_rate = 0,
-      .drive_strength = 0,
+      .slew_rate = 1,
+      .drive_strength = 3,
       .flags = kDifPinmuxPadAttrPullResistorEnable |
                kDifPinmuxPadAttrPullResistorUp};
+  dif_result_t res;
   for (uint32_t i = 0; i <= ARRAYSIZE(spi_host0_direct_pads); ++i) {
-    CHECK_DIF_OK(dif_pinmux_pad_write_attrs(&pinmux, spi_host0_direct_pads[i],
-                                            kDifPinmuxPadKindDio, in_attr,
-                                            &out_attr));
+    res = dif_pinmux_pad_write_attrs(&pinmux, spi_host0_direct_pads[i],
+                                     kDifPinmuxPadKindDio, in_attr, &out_attr);
+    if (res == kDifError) {
+      // Some target platforms may not support the specified value for slew rate
+      // and drive strength. If that's the case, use the values actually
+      // supported.
+      if (out_attr.slew_rate != in_attr.slew_rate) {
+        LOG_INFO(
+            "Specified slew rate not supported, trying supported slew rate");
+        in_attr.slew_rate = out_attr.slew_rate;
+      }
+      if (out_attr.drive_strength != in_attr.drive_strength) {
+        LOG_INFO(
+            "Specified drive strength not supported, trying supported drive "
+            "strength");
+        in_attr.drive_strength = out_attr.drive_strength;
+      }
+      CHECK_DIF_OK(dif_pinmux_pad_write_attrs(&pinmux, spi_host0_direct_pads[i],
+                                              kDifPinmuxPadKindDio, in_attr,
+                                              &out_attr));
+      // Note: fallthrough with the modified `in_attr` so that the same
+      // attributes are used for all pads.
+    }
   }
 }
 
@@ -167,18 +188,39 @@ void setup_pads_spi_host0(void) {
  * This peripheral is 'muxed', so configure the pinmux as well as pads.
  */
 void setup_pinmux_pads_spi_host1(void) {
-  // Set weak pull-ups for the pads
+  // Set weak pull-ups, fast slew rate and strong drive strengh for the pads
   dif_pinmux_pad_attr_t out_attr;
   dif_pinmux_pad_attr_t in_attr = {
-      .slew_rate = 0,
-      .drive_strength = 0,
+      .slew_rate = 1,
+      .drive_strength = 3,
       // set weak pull-ups for all the pads
       .flags = kDifPinmuxPadAttrPullResistorEnable |
                kDifPinmuxPadAttrPullResistorUp};
+  dif_result_t res;
   for (uint32_t i = 0; i <= ARRAYSIZE(spi_host1_muxed_pads); ++i) {
-    CHECK_DIF_OK(dif_pinmux_pad_write_attrs(&pinmux, spi_host1_muxed_pads[i],
-                                            kDifPinmuxPadKindMio, in_attr,
-                                            &out_attr));
+    res = dif_pinmux_pad_write_attrs(&pinmux, spi_host1_muxed_pads[i],
+                                     kDifPinmuxPadKindMio, in_attr, &out_attr);
+    if (res == kDifError) {
+      // Some target platforms may not support the specified value for slew rate
+      // and drive strength. If that's the case, use the values actually
+      // supported.
+      if (out_attr.slew_rate != in_attr.slew_rate) {
+        LOG_INFO(
+            "Specified slew rate not supported, trying supported slew rate");
+        in_attr.slew_rate = out_attr.slew_rate;
+      }
+      if (out_attr.drive_strength != in_attr.drive_strength) {
+        LOG_INFO(
+            "Specified drive strength not supported, trying supported drive "
+            "strength");
+        in_attr.drive_strength = out_attr.drive_strength;
+      }
+      CHECK_DIF_OK(dif_pinmux_pad_write_attrs(&pinmux, spi_host1_muxed_pads[i],
+                                              kDifPinmuxPadKindMio, in_attr,
+                                              &out_attr));
+      // Note: fallthrough with the modified `in_attr` so that the same
+      // attributes are used for all pads.
+    }
   }
 
   // Setup Inputs

--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -144,13 +144,6 @@ static const top_earlgrey_direct_pads_t spi_host0_direct_pads[5] = {
     kTopEarlgreyDirectPadsSpiHost0Sd0   // sio[0]
 };
 
-static const top_earlgrey_direct_pads_t spi_device_direct_pads[4] = {
-    kTopEarlgreyDirectPadsSpiDeviceSd3,  // sio[3]
-    kTopEarlgreyDirectPadsSpiDeviceSd2,  // sio[2]
-    kTopEarlgreyDirectPadsSpiDeviceSd1,  // sio[1]
-    kTopEarlgreyDirectPadsSpiDeviceSd0   // sio[0]
-};
-
 /**
  * Initialize the provided SPI host. For the most part, the values provided are
  * filler, as spi_host0 will be in passthrough mode and spi_host1 will remain
@@ -427,36 +420,8 @@ bool test_main(void) {
     }
   }
 
-  // Set fast slew rate and strong drive strengh for SPI device pads.
-  in_attr.slew_rate = 1;
-  in_attr.drive_strength = 3;
-  // Don't enable pull-ups for SPI device pads.
-  in_attr.flags = 0;
-  for (uint32_t i = 0; i <= ARRAYSIZE(spi_device_direct_pads); ++i) {
-    res = dif_pinmux_pad_write_attrs(&pinmux, spi_device_direct_pads[i],
-                                     kDifPinmuxPadKindDio, in_attr, &out_attr);
-    if (res == kDifError) {
-      // Some target platforms may not support the specified value for slew rate
-      // and drive strength. If that's the case, use the values actually
-      // supported.
-      if (out_attr.slew_rate != in_attr.slew_rate) {
-        LOG_INFO(
-            "Specified slew rate not supported, trying supported slew rate");
-        in_attr.slew_rate = out_attr.slew_rate;
-      }
-      if (out_attr.drive_strength != in_attr.drive_strength) {
-        LOG_INFO(
-            "Specified drive strength not supported, trying supported drive "
-            "strength");
-        in_attr.drive_strength = out_attr.drive_strength;
-      }
-      CHECK_DIF_OK(
-          dif_pinmux_pad_write_attrs(&pinmux, spi_device_direct_pads[i],
-                                     kDifPinmuxPadKindDio, in_attr, &out_attr));
-      // Note: fallthrough with the modified `in_attr` so that the same
-      // attributes are used for all pads.
-    }
-  }
+  // Configure fast slew rate and strong drive strength for SPI device pads.
+  CHECK_STATUS_OK(spi_device_testutils_configure_pad_attrs(&pinmux));
 
   // Initialize the PLIC.
   CHECK_DIF_OK(dif_rv_plic_init(

--- a/sw/device/tests/sim_dv/spi_passthrough_test.c
+++ b/sw/device/tests/sim_dv/spi_passthrough_test.c
@@ -136,6 +136,21 @@ static const pinmux_select_t pinmux_in_config[] = {
     //     },
 };
 
+static const top_earlgrey_direct_pads_t spi_host0_direct_pads[5] = {
+    kTopEarlgreyDirectPadsSpiHost0Sck,  // sck
+    kTopEarlgreyDirectPadsSpiHost0Sd3,  // sio[3]
+    kTopEarlgreyDirectPadsSpiHost0Sd2,  // sio[2]
+    kTopEarlgreyDirectPadsSpiHost0Sd1,  // sio[1]
+    kTopEarlgreyDirectPadsSpiHost0Sd0   // sio[0]
+};
+
+static const top_earlgrey_direct_pads_t spi_device_direct_pads[4] = {
+    kTopEarlgreyDirectPadsSpiDeviceSd3,  // sio[3]
+    kTopEarlgreyDirectPadsSpiDeviceSd2,  // sio[2]
+    kTopEarlgreyDirectPadsSpiDeviceSd1,  // sio[1]
+    kTopEarlgreyDirectPadsSpiDeviceSd0   // sio[0]
+};
+
 /**
  * Initialize the provided SPI host. For the most part, the values provided are
  * filler, as spi_host0 will be in passthrough mode and spi_host1 will remain
@@ -375,6 +390,72 @@ bool test_main(void) {
     pinmux_select_t setting = pinmux_out_config[i];
     CHECK_DIF_OK(
         dif_pinmux_output_select(&pinmux, setting.pad, setting.peripheral));
+  }
+
+  // Set fast slew rate and strong drive strengh for SPI host0 pads.
+  dif_pinmux_pad_attr_t out_attr;
+  dif_pinmux_pad_attr_t in_attr = {
+      .slew_rate = 1,
+      .drive_strength = 3,
+      // Set weak pull-ups for all the pads.
+      .flags = kDifPinmuxPadAttrPullResistorEnable |
+               kDifPinmuxPadAttrPullResistorUp};
+  dif_result_t res;
+  for (uint32_t i = 0; i <= ARRAYSIZE(spi_host0_direct_pads); ++i) {
+    res = dif_pinmux_pad_write_attrs(&pinmux, spi_host0_direct_pads[i],
+                                     kDifPinmuxPadKindDio, in_attr, &out_attr);
+    if (res == kDifError) {
+      // Some target platforms may not support the specified value for slew rate
+      // and drive strength. If that's the case, use the values actually
+      // supported.
+      if (out_attr.slew_rate != in_attr.slew_rate) {
+        LOG_INFO(
+            "Specified slew rate not supported, trying supported slew rate");
+        in_attr.slew_rate = out_attr.slew_rate;
+      }
+      if (out_attr.drive_strength != in_attr.drive_strength) {
+        LOG_INFO(
+            "Specified drive strength not supported, trying supported drive "
+            "strength");
+        in_attr.drive_strength = out_attr.drive_strength;
+      }
+      CHECK_DIF_OK(dif_pinmux_pad_write_attrs(&pinmux, spi_host0_direct_pads[i],
+                                              kDifPinmuxPadKindDio, in_attr,
+                                              &out_attr));
+      // Note: fallthrough with the modified `in_attr` so that the same
+      // attributes are used for all pads.
+    }
+  }
+
+  // Set fast slew rate and strong drive strengh for SPI device pads.
+  in_attr.slew_rate = 1;
+  in_attr.drive_strength = 3;
+  // Don't enable pull-ups for SPI device pads.
+  in_attr.flags = 0;
+  for (uint32_t i = 0; i <= ARRAYSIZE(spi_device_direct_pads); ++i) {
+    res = dif_pinmux_pad_write_attrs(&pinmux, spi_device_direct_pads[i],
+                                     kDifPinmuxPadKindDio, in_attr, &out_attr);
+    if (res == kDifError) {
+      // Some target platforms may not support the specified value for slew rate
+      // and drive strength. If that's the case, use the values actually
+      // supported.
+      if (out_attr.slew_rate != in_attr.slew_rate) {
+        LOG_INFO(
+            "Specified slew rate not supported, trying supported slew rate");
+        in_attr.slew_rate = out_attr.slew_rate;
+      }
+      if (out_attr.drive_strength != in_attr.drive_strength) {
+        LOG_INFO(
+            "Specified drive strength not supported, trying supported drive "
+            "strength");
+        in_attr.drive_strength = out_attr.drive_strength;
+      }
+      CHECK_DIF_OK(
+          dif_pinmux_pad_write_attrs(&pinmux, spi_device_direct_pads[i],
+                                     kDifPinmuxPadKindDio, in_attr, &out_attr));
+      // Note: fallthrough with the modified `in_attr` so that the same
+      // attributes are used for all pads.
+    }
   }
 
   // Initialize the PLIC.


### PR DESCRIPTION
SPI pads should use strong drive strength and fast slew rate.