### PR TITLE
[ownership] Rename `version` to `struct_version`

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -212,6 +212,7 @@ enum module_ {
   X(kErrorOwnershipBadInfoPage,       ERROR_(10, kModuleOwnership, kInternal)), \
   X(kErrorOwnershipNoOwner,           ERROR_(11, kModuleOwnership, kInternal)), \
   X(kErrorOwnershipKeyNotFound,       ERROR_(12, kModuleOwnership, kNotFound)), \
+  X(kErrorOwnershipInvalidVersion,    ERROR_(13, kModuleOwnership, kInvalidArgument)), \
   \
   /* This comment prevent clang from trying to format the macro. */
 

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -101,7 +101,7 @@ typedef struct owner_block {
    */
   tlv_header_t header;
   /** Version of the owner struct.  Currently `0`. */
-  uint32_t version;
+  uint32_t struct_version;
   /** SRAM execution configuration (DisabledLocked, Disabled, Enabled). */
   uint32_t sram_exec_mode;
   /** Ownership key algorithm (currently, only ECDSA is supported). */
@@ -123,7 +123,7 @@ typedef struct owner_block {
 } owner_block_t;
 
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, header, 0);
-OT_ASSERT_MEMBER_OFFSET(owner_block_t, version, 8);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, struct_version, 8);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, sram_exec_mode, 12);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, ownership_key_alg, 16);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 20);

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -78,12 +78,14 @@ void owner_config_default(owner_config_t *config) {
 rom_error_t owner_block_parse(const owner_block_t *block,
                               owner_config_t *config,
                               owner_application_keyring_t *keyring) {
+  owner_config_default(config);
   if (block->header.tag != kTlvTagOwner)
     return kErrorOwnershipInvalidTag;
   if (block->header.length != sizeof(owner_block_t))
     return kErrorOwnershipInvalidTagLength;
+  if (block->struct_version != 0)
+    return kErrorOwnershipInvalidVersion;
 
-  owner_config_default(config);
   config->sram_exec = block->sram_exec_mode;
 
   uint32_t remain = sizeof(block->data);

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -32,7 +32,7 @@ rom_error_t test_owner_init(boot_data_t *bootdata, owner_config_t *config,
 
   owner_page[0].header.tag = kTlvTagOwner;
   owner_page[0].header.length = 2048;
-  owner_page[0].version = 0;
+  owner_page[0].struct_version = 0;
   owner_page[0].sram_exec_mode = kOwnerSramExecModeDisabledLocked;
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
   owner_page[0].owner_key = (owner_key_t){


### PR DESCRIPTION
1. Rename `version` to `struct_version`.
2. Verify the struct_version when parsing the owner block.
3. A correct parse is a pre-condition for activation.