### PR TITLE
[ownership] Rename `LockedUpdate` to `UnlockedSelf`

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -40,8 +40,8 @@ typedef union owner_signature {
 typedef enum ownership_state {
   /* Locked Owner: `OWND`. */
   kOwnershipStateLockedOwner = 0x444e574f,
-  /* Locked Update: `LUPD`. */
-  kOwnershipStateLockedUpdate = 0x4450554c,
+  /* Locked Update: `USLF`. */
+  kOwnershipStateUnlockedSelf = 0x464c5355,
   /* Unlocked Any: `UANY`. */
   kOwnershipStateUnlockedAny = 0x594e4155,
   /* Unlocked Endorsed: `UEND`. */

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -34,8 +34,8 @@ hardened_bool_t owner_block_page1_valid_for_transfer(boot_data_t *bootdata) {
       case kOwnershipStateUnlockedAny:
         // In UnlockedAny, any valid (signed) Owner Page 1 is acceptable.
         return kHardenedBoolTrue;
-      case kOwnershipStateLockedUpdate:
-        // In LockedUpdate, the owner key must be the same.  If not,
+      case kOwnershipStateUnlockedSelf:
+        // In UnlockedSelf, the owner key must be the same.  If not,
         // skip parsing of Owner Page 1.
         if (hardened_memeq(
                 owner_page[0].owner_key.raw, owner_page[1].owner_key.raw,

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -97,9 +97,9 @@ static rom_error_t unlocked_init(boot_data_t *bootdata, owner_config_t *config,
                                  owner_application_keyring_t *keyring) {
   uint32_t secondary =
       bootdata->primary_bl0_slot == kBootSlotA ? kBootSlotB : kBootSlotA;
-  if (bootdata->ownership_state == kOwnershipStateLockedUpdate &&
+  if (bootdata->ownership_state == kOwnershipStateUnlockedSelf &&
       owner_page_valid[0] != kOwnerPageStatusSealed) {
-    // Owner Page 0 must be sealed in the "LockedUpdate" state.  If not,
+    // Owner Page 0 must be sealed in the "UnlockedSelf" state.  If not,
     // go to the Recovery state.
     bootdata->ownership_state = kOwnershipStateRecovery;
     nonce_new(&bootdata->nonce);
@@ -168,7 +168,7 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
   //     - Make sure page0 and page1 are identical and fix if not.
   //     - Set up flash config.
   //     - Enumerate application keys.
-  // - kOwnershipStateLockedUpdate:
+  // - kOwnershipStateUnlockedSelf:
   //     - Allow the pages to be different if the owner keys are the same.
   //     - Set up flash config: primary from page0, secondary from page 1.
   //     - Enumerate application keys from both pages.
@@ -192,7 +192,7 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
     case kOwnershipStateLockedOwner:
       error = locked_owner_init(bootdata, config, keyring);
       break;
-    case kOwnershipStateLockedUpdate:
+    case kOwnershipStateUnlockedSelf:
       OT_FALLTHROUGH_INTENDED;
     case kOwnershipStateUnlockedAny:
       OT_FALLTHROUGH_INTENDED;

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -72,7 +72,7 @@ rom_error_t ownership_activate_handler(boot_svc_msg_t *msg,
                                        boot_data_t *bootdata) {
   rom_error_t error = kErrorOwnershipInvalidState;
   switch (bootdata->ownership_state) {
-    case kOwnershipStateLockedUpdate:
+    case kOwnershipStateUnlockedSelf:
     case kOwnershipStateUnlockedAny:
     case kOwnershipStateUnlockedEndorsed:
       error = activate(msg, bootdata);

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -51,7 +51,7 @@ class OwnershipActivateTest : public rom_test::RomTest {
                 bootdata_.next_owner[6],
                 bootdata_.next_owner[7],
             }}));
-      case kOwnershipStateLockedUpdate:
+      case kOwnershipStateUnlockedSelf:
         owner_page[1].owner_key = owner_page[0].owner_key;
         owner_page[1].owner_key.raw[0] += modifier;
         break;
@@ -155,7 +155,7 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageInvalid) {
   MakePage1Valid(false);
 
   switch (state) {
-    case kOwnershipStateLockedUpdate:
+    case kOwnershipStateUnlockedSelf:
     case kOwnershipStateUnlockedEndorsed:
       // Test should fail with "Invalid Info Page".
       expected_result = kErrorOwnershipInvalidInfoPage;
@@ -185,7 +185,7 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageValid) {
       .WillOnce(Return(kHardenedBoolTrue));
 
   switch (state) {
-    case kOwnershipStateLockedUpdate:
+    case kOwnershipStateUnlockedSelf:
     case kOwnershipStateUnlockedAny:
     case kOwnershipStateUnlockedEndorsed:
       // Test should pass.
@@ -229,7 +229,7 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageValid) {
 }
 
 INSTANTIATE_TEST_SUITE_P(AllCases, OwnershipActivateValidStateTest,
-                         testing::Values(kOwnershipStateLockedUpdate,
+                         testing::Values(kOwnershipStateUnlockedSelf,
                                          kOwnershipStateUnlockedAny,
                                          kOwnershipStateUnlockedEndorsed));
 

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
@@ -14,7 +14,7 @@
 
 static hardened_bool_t is_locked_none(uint32_t ownership_state) {
   if (ownership_state == kOwnershipStateLockedOwner ||
-      ownership_state == kOwnershipStateLockedUpdate ||
+      ownership_state == kOwnershipStateUnlockedSelf ||
       ownership_state == kOwnershipStateUnlockedAny ||
       ownership_state == kOwnershipStateUnlockedEndorsed) {
     return kHardenedBoolFalse;
@@ -36,7 +36,7 @@ static rom_error_t do_unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
   } else if (msg->ownership_unlock_req.unlock_mode == kBootSvcUnlockAny) {
     bootdata->ownership_state = kOwnershipStateUnlockedAny;
   } else if (msg->ownership_unlock_req.unlock_mode == kBootSvcUnlockUpdate) {
-    bootdata->ownership_state = kOwnershipStateLockedUpdate;
+    bootdata->ownership_state = kOwnershipStateUnlockedSelf;
   } else {
     return kErrorOwnershipInvalidMode;
   }
@@ -95,7 +95,7 @@ static rom_error_t unlock_abort(boot_svc_msg_t *msg, boot_data_t *bootdata) {
                (uintptr_t)&msg->ownership_unlock_req.unlock_mode;
   if (bootdata->ownership_state == kOwnershipStateUnlockedEndorsed ||
       bootdata->ownership_state == kOwnershipStateUnlockedAny ||
-      bootdata->ownership_state == kOwnershipStateLockedUpdate) {
+      bootdata->ownership_state == kOwnershipStateUnlockedSelf) {
     // Check the signature against the unlock key.
     if (ownership_key_validate(/*page=*/0, kOwnershipKeyUnlock,
                                &msg->ownership_unlock_req.signature,

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
@@ -145,7 +145,7 @@ TEST_P(OwnershipUnlockAnyStateTest, InvalidState) {
 }
 
 INSTANTIATE_TEST_SUITE_P(AllCases, OwnershipUnlockAnyStateTest,
-                         testing::Values(kOwnershipStateLockedUpdate,
+                         testing::Values(kOwnershipStateUnlockedSelf,
                                          kOwnershipStateUnlockedAny,
                                          kOwnershipStateUnlockedEndorsed));
 
@@ -223,11 +223,11 @@ TEST_P(OwnershipUnlockEndorsedStateTest, InvalidState) {
 }
 
 INSTANTIATE_TEST_SUITE_P(AllCases, OwnershipUnlockEndorsedStateTest,
-                         testing::Values(kOwnershipStateLockedUpdate,
+                         testing::Values(kOwnershipStateUnlockedSelf,
                                          kOwnershipStateUnlockedAny,
                                          kOwnershipStateUnlockedEndorsed));
 
-// Test that requesting LockedOwner->LockedUpdate works.
+// Test that requesting LockedOwner->UnlockedSelf works.
 TEST_F(OwnershipUnlockTest, UnlockUpdate) {
   message_.ownership_unlock_req.unlock_mode = kBootSvcUnlockUpdate;
   EXPECT_CALL(
@@ -241,10 +241,10 @@ TEST_F(OwnershipUnlockTest, UnlockUpdate) {
   EXPECT_EQ(error, kErrorWriteBootdataThenReboot);
   EXPECT_EQ(bootdata_.nonce.value[0], 5);
   EXPECT_EQ(bootdata_.nonce.value[1], 5);
-  EXPECT_EQ(bootdata_.ownership_state, kOwnershipStateLockedUpdate);
+  EXPECT_EQ(bootdata_.ownership_state, kOwnershipStateUnlockedSelf);
 }
 
-// Test that requesting LockedOwner->LockedUpdate fails when the signature is
+// Test that requesting LockedOwner->UnlockedSelf fails when the signature is
 // bad.
 TEST_F(OwnershipUnlockTest, UnlockedUpdateBadSignature) {
   message_.ownership_unlock_req.unlock_mode = kBootSvcUnlockUpdate;
@@ -259,7 +259,7 @@ TEST_F(OwnershipUnlockTest, UnlockedUpdateBadSignature) {
   EXPECT_EQ(bootdata_.ownership_state, kOwnershipStateLockedOwner);
 }
 
-// Test that requesting LockedOwner->LockedUpdate fails when the nonce doesn't
+// Test that requesting LockedOwner->UnlockedSelf fails when the nonce doesn't
 // match.
 TEST_F(OwnershipUnlockTest, UnlockedUpdateBadNonce) {
   message_.ownership_unlock_req.unlock_mode = kBootSvcUnlockUpdate;
@@ -287,7 +287,7 @@ TEST_P(OwnershipUnlockedUpdateStateTest, InvalidState) {
 }
 
 INSTANTIATE_TEST_SUITE_P(AllCases, OwnershipUnlockedUpdateStateTest,
-                         testing::Values(kOwnershipStateLockedUpdate,
+                         testing::Values(kOwnershipStateUnlockedSelf,
                                          kOwnershipStateUnlockedEndorsed,
                                          kOwnershipStateRecovery));
 
@@ -310,7 +310,7 @@ TEST_P(OwnershipUnlockAbortValidStateTest, UnlockAbort) {
 }
 
 INSTANTIATE_TEST_SUITE_P(AllCases, OwnershipUnlockAbortValidStateTest,
-                         testing::Values(kOwnershipStateLockedUpdate,
+                         testing::Values(kOwnershipStateUnlockedSelf,
                                          kOwnershipStateUnlockedEndorsed,
                                          kOwnershipStateUnlockedAny));
 

--- a/sw/device/silicon_creator/rom_ext/data/rom_ext_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom_ext/data/rom_ext_e2e_testplan.hjson
@@ -389,7 +389,7 @@
         Verify that ROM_EXT accepts an owner configuration update.
 
         - Start in an locked & owned state with the `fake` owner as owner.
-        - Unlock the chip into the LockedUpdate state using the `fake` owner unlock key.
+        - Unlock the chip into the UnlockedSelf state using the `fake` owner unlock key.
         - Upload an new owner block using the `fake` owner key (ie: embed the `dummy` app key in the `fake` owner block).
         - Activate ownership with the `fake` activate key.
         - Confirm code execution with the `dummy` owner application key.
@@ -413,7 +413,7 @@
         Verify that ROM_EXT rejects an owner configuration update.
 
         - Start in an locked & owned state with the `fake` owner as owner.
-        - Unlock the chip into the LockedUpdate state using the `fake` owner unlock key.
+        - Unlock the chip into the UnlockedSelf state using the `fake` owner unlock key.
         - Upload an new owner block using the wrong owner key (ie: use the `dummy` owner and app key).
         - Activate ownership with the `fake` activate key.
         - Confirm the activate is rejected with an `OwnershipInvalidInfoPage` error.

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -236,7 +236,7 @@ ownership_transfer_test(
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_locked_update_test
-# Part 1: Ensure a LockedUpdate with a new owner key is rejected.
+# Part 1: Ensure in UnlockedSelf that a new owner key is rejected.
 ownership_transfer_test(
     name = "bad_locked_update_test",
     fpga = fpga_params(
@@ -262,7 +262,7 @@ ownership_transfer_test(
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_locked_update_test
-# Part 2: Ensure a LockedUpdate denies execution to anything signed with new app keys.
+# Part 2: Ensure the UnlockedSelf state denies execution to anything signed with new app keys.
 ownership_transfer_test(
     name = "bad_locked_update_no_exec_test",
     fpga = fpga_params(

--- a/sw/device/silicon_creator/rom_ext/rescue.c
+++ b/sw/device/silicon_creator/rom_ext/rescue.c
@@ -60,7 +60,7 @@ rom_error_t flash_firmware_block(rescue_state_t *state) {
 
 rom_error_t flash_owner_block(rescue_state_t *state, boot_data_t *bootdata) {
   if (bootdata->ownership_state == kOwnershipStateUnlockedAny ||
-      bootdata->ownership_state == kOwnershipStateLockedUpdate ||
+      bootdata->ownership_state == kOwnershipStateUnlockedSelf ||
       bootdata->ownership_state == kOwnershipStateUnlockedEndorsed) {
     HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(
         &kFlashCtrlInfoPageOwnerSlot1, kFlashCtrlEraseTypePage));
@@ -129,7 +129,7 @@ static void validate_mode(uint32_t mode, rescue_state_t *state,
         break;
       case kRescueModeOwnerBlock:
         if (bootdata->ownership_state == kOwnershipStateUnlockedAny ||
-            bootdata->ownership_state == kOwnershipStateLockedUpdate ||
+            bootdata->ownership_state == kOwnershipStateUnlockedSelf ||
             bootdata->ownership_state == kOwnershipStateUnlockedEndorsed) {
           dbg_printf("ok: send owner_block via xmodem-crc\r\n");
         } else {

--- a/sw/host/opentitanlib/src/chip/boot_log.rs
+++ b/sw/host/opentitanlib/src/chip/boot_log.rs
@@ -17,7 +17,7 @@ with_unknown! {
     pub enum OwnershipState: u32 [default = Self::Recovery] {
         Recovery = 0,
         LockedOwner = 0x444e574f,
-        LockedUpdate = 0x4450554c,
+        UnlockedSelf = 0x464c5355,
         UnlockedAny = 0x594e4155,
         UnlockedEndorsed = 0x444e4555,
     }

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -111,7 +111,7 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         match opts.unlock_mode {
             UnlockMode::Any => assert_eq!(capture[1], "UANY"),
             UnlockMode::Endorsed => assert_eq!(capture[1], "UEND"),
-            UnlockMode::Update => assert_eq!(capture[1], "LUPD"),
+            UnlockMode::Update => assert_eq!(capture[1], "USLF"),
             _ => return Err(anyhow!("Unexpected ownership state: {}", capture[1])),
         }
         transfers0 = capture[2].parse::<u32>()?;


### PR DESCRIPTION
The name `LockedUpdate` is confusing because it is an unlocked chip state.  This state is to allow the chip to accept an owner configuration update that must be from the self-same owner.