### PR TITLE
[ci] Add `quick_lint` job to GitHub Actions CI workflow

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,67 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Install dependencies
+description: Install system dependencies needed for OpenTitan
+
+inputs:
+  verilator-version:
+    description: Verilator version to install
+    required: true
+    default: '4.210'
+  verilator-path:
+    description: Path at which to install Veriltator
+    required: true
+    default: /tools/verilator
+  verible-version:
+    description: Verible version to install
+    required: true
+    default: 'v0.0-3622-g07b310a3'
+  verible-path:
+    description: Path at which to install Verible
+    required: true
+    default: /tools/verible
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      run: grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      shell: bash
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.8'
+        cache-dependency-path: python-requirements.txt
+        cache: pip
+
+    - name: Install Python dependencies
+      run: python3 -m pip install -r python-requirements.txt --require-hashes
+      shell: bash
+
+    - name: Install Verilator
+      run: |
+        VERILATOR_TAR="verilator-v${{ inputs.verilator-version }}.tar.gz"
+        VERILATOR_URL="https://storage.googleapis.com/verilator-builds/${VERILATOR_TAR}"
+        curl -f -Ls -o "/tmp/${VERILATOR_TAR}" "$VERILATOR_URL" || {
+          echo "failed to download Verilator from ${VERILATOR_URL}" >&2
+          exit 1
+        }
+        sudo mkdir -p "${{ inputs.verilator-path }}"
+        sudo tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}" --strip-components=1
+        echo "${{ inputs.verilator-path }}/bin" >> "$GITHUB_PATH"
+      shell: bash
+
+    - name: Install Verible
+      run: |
+        VERIBLE_TAR="verible-${{ inputs.verible-version }}-linux-static-x86_64.tar.gz"
+        VERIBLE_URL="https://github.com/chipsalliance/verible/releases/download/${{ inputs.verible-version }}/${VERIBLE_TAR}"
+        curl -f -Ls -o "/tmp/${VERIBLE_TAR}" "$VERIBLE_URL" || {
+          echo "failed to download Verible from ${VERIBLE_URL}" >&2
+          exit 1
+        }
+        sudo mkdir -p "${{ inputs.verible-path }}"
+        sudo tar -C "${{ inputs.verible-path }}" -xvzf "/tmp/${VERIBLE_TAR}" --strip-components=1
+        echo "${{ inputs.verible-path }}/bin" >> "$GITHUB_PATH"
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
-      - name: Install system dependencies
-        run: grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
       - name: Prepare airgapped environment
         run: ./util/prep-bazel-airgapped-build.sh
       - name: Build in the airgapped environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,48 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  quick_lint:
+    name: Lint (quick)
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required so we can lint commit messages.
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+      - name: Environment
+        run: ./ci/scripts/show-env.sh
+      - name: Commit metadata
+        run: ./ci/scripts/lint-commits.sh "$GITHUB_BASE_REF"
+      - name: License headers
+        run: ./ci/scripts/check-licence-headers.sh "$GITHUB_BASE_REF"
+      - name: Executable bits
+        run: ./ci/scripts/exec-check.sh
+      - name: Non-ASCII characters
+        run: ./ci/scripts/check-ascii.sh
+      - name: Python (flake8)
+        run: ./ci/scripts/python-lint.sh "$GITHUB_BASE_REF"
+      - name: Python (mypy)
+        run: ./ci/scripts/mypy.sh
+      - name: C/C++ formatting
+        run: ./ci/scripts/clang-format.sh "$GITHUB_BASE_REF"
+      - name: Rust formatting
+        run: ./ci/scripts/rust-format.sh "$GITHUB_BASE_REF"
+      - name: Shellcheck
+        run: ./ci/bazelisk.sh test //quality:shellcheck_check
+      - name: Header guards
+        run: ./ci/scripts/include-guard.sh "$GITHUB_BASE_REF"
+      - name: Trailing whitespace
+        run: ./ci/scripts/whitespace.sh "$GITHUB_BASE_REF"
+      - name: Broken links
+        run: ./ci/scripts/check-links.sh
+      - name: Generated documentation
+        run: ./ci/scripts/check-cmdgen.sh
+
   airgapped_build:
     name: Airgapped build
     runs-on: ubuntu-20.04
+    needs: quick_lint
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ name: CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   airgapped_build:
     name: Airgapped build


### PR DESCRIPTION
In Azure, we use these quick lints as a filter before we run the rest of the pipeline. We need this job running in parallel in GitHub Actions to start porting things over.

* I've dropped the "Determine build type" step as we don't need this right now and it's not a lint anyway.
* I also dropped the "Confirm no `.bazelrc-site`" step since it's already in `.gitignore` and this check seems superfluous.
* Otherwise, no changes.

This PR also ports the `ci/install-dependencies.{sh,yml}` files from Azure to GitHub (with some duplication). I'd still like to extract the Verilator and Verible versions to some external file. Same for the Python version ideally.