### PR TITLE
[ci] Cut down `apt-requirements`

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -9,26 +9,19 @@
 # and are maintained in yum-requirements.txt.
 #
 # Keep it sorted.
-autoconf
-bison
 brotli
 build-essential
 clang-format
-cmake
 curl
 doxygen
-flex
 g++
 git
-golang
-lcov
 libelf1
 libelf-dev
 libftdi1-2
 libftdi1-dev
 # A requirement of the prebuilt clang toolchain.
 libncursesw5
-libpcsclite-dev
 libssl-dev
 libudev-dev
 libusb-1.0-0
@@ -36,17 +29,13 @@ lld
 lrzsz
 lsb-release
 make
-ninja-build
 openssl
-perl
-pkgconf
 python3
 python3-pip
 python3-setuptools
 python3-urllib3
 python3-wheel
 srecord
-tree
 xsltproc
 zlib1g-dev
 xz-utils

--- a/doc/getting_started/unofficial/fedora.md
+++ b/doc/getting_started/unofficial/fedora.md
@@ -9,12 +9,10 @@ Fedora uses a different package manager than the officially supported Ubuntu dev
 You can install equivalent packages to the `apt-requirements.txt` file with the following command:
 
 ```shell
-sudo dnf install autoconf bison make automake gcc gcc-c++ kernel-devel \
-         clang-tools-extra clang cmake curl \
-         doxygen flex g++ git golang lcov elfutils-libelf \
-         libftdi libftdi-devel ncurses-compat-libs openssl-devel \
-         systemd-devel libusb redhat-lsb-core \
-         make ninja-build perl pkgconf python3 python3-pip python3-setuptools \
-         python3-urllib3 python3-wheel srecord tree xsltproc zlib-devel xz clang-tools-extra \
-         clang11-libs clang-devel elfutils-libelf-devel
+sudo dnf install make gcc gcc-c++ kernel-devel clang-tools-extra clang         \
+         curl doxygen g++ git elfutils-libelf libftdi libftdi-devel            \
+         ncurses-compat-libs openssl-devel systemd-devel libusb                \
+         redhat-lsb-core make python3 python3-pip python3-setuptools           \
+         python3-urllib3 python3-wheel srecord xsltproc zlib-devel xz          \
+         clang-tools-extra clang11-libs clang-devel elfutils-libelf-devel      \
 ```

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -6,17 +6,12 @@
 #
 # Keep it sorted.
 "Development Tools"
-autoconf
-bison
 brotli
-cmake
 curl
 doxygen
 epel-release
-flex
 gcc-c++
 git
-golang
 elfutils-libelf
 elfutils-libelf-devel
 libftdi
@@ -29,17 +24,13 @@ openssl-devel
 redhat-lsb-core
 # A requirement of the prebuilt clang toolchain.
 ncurses
-ninja-build
 openssl11-libs
 openssl11-devel
-perl
-pkgconfig
 python3
 python3-pip
 python3-setuptools
 python3-wheel
 srecord
-tree
 libxslt
 zlib-devel
 xz-libs


### PR DESCRIPTION
These system dependencies don't seem to be required any more.