### PR TITLE
[topgen] Fail more understandably if we start in an unexpected place

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -742,6 +742,16 @@ def _process_top(
         else:
             ip_hjson = hjson_dir.parent / f"ip/{ip}/data/{ip}.hjson"
 
+            # In this situation, we are computing the path to the IP's hjson
+            # file by walking a relative path from hjson_dir. That hjson file
+            # should exist at this point, but things get confused if we started
+            # from a top file in an unexpected place. Check now to make sure
+            # this hasn't happened.
+            if not ip_hjson.is_file():
+                log.error(f'Cannot find a file at {ip_hjson}, which was '
+                          f'computed as a relative path from {args.topcfg}')
+                sys.exit(1)
+
         ips.append(ip_hjson)
 
     # load Hjson and pass validate from reggen


### PR DESCRIPTION
This should fix issue #24595. The problem that caused the issue is that we compute paths to the various IP blocks that should be included by following relative paths from the `-t` argument. This doesn't work very well if the top_earlgrey.hjson file moves around!

A sensible design would probably point more explicitly at where to find IPs, but this should hopefully be a little easier to debug.