### PR TITLE
[ci] add apt-get update

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -27,7 +27,9 @@ runs:
   using: composite
   steps:
     - name: Install system dependencies
-      run: grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      run: |
+        sudo apt update
+        grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
       shell: bash
 
     - uses: actions/setup-python@v5


### PR DESCRIPTION
Add apt-get update to the `install-deps` CI step to ensure the dependency resolution is based on the latest remote apt package index rather than the cached one baked into the ubuntu container running the job.