### PR TITLE
[top_earlgrey,pinmux] Enable pull-down for TAP strap 0 at reset

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -439,6 +439,7 @@
                             Muxed pad attributes.
                             This register has WARL behavior since not each pad type may support
                             all attributes.
+                            The muxed pad that is used for TAP strap 0 has a different reset value, with `pull_en` set to 1.
                             ''',
                   count:        "NMioPads",
                   compact:      "false",
@@ -509,7 +510,8 @@
                   // read back the same value that was written to them.
                   // further, they have hardware side effects since they drive the
                   // pad attributes, and hence no random data should be written to them.
-                  tags: ["excl:CsrAllTests:CsrExclWrite"]
+                  // Additionally, their reset value is defined by the RTL implementation and may not equal `resval` for all instances (#24621).
+                  tags: ["excl:CsrAllTests:CsrExclAll"]
                 }
     },
 

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -556,6 +556,7 @@
                             Muxed pad attributes.
                             This register has WARL behavior since not each pad type may support
                             all attributes.
+                            The muxed pad that is used for TAP strap 0 has a different reset value, with `pull_en` set to 1.
                             ''',
                   count:        "NMioPads",
                   compact:      "false",
@@ -626,7 +627,8 @@
                   // read back the same value that was written to them.
                   // further, they have hardware side effects since they drive the
                   // pad attributes, and hence no random data should be written to them.
-                  tags: ["excl:CsrAllTests:CsrExclWrite"]
+                  // Additionally, their reset value is defined by the RTL implementation and may not equal `resval` for all instances (#24621).
+                  tags: ["excl:CsrAllTests:CsrExclAll"]
                 }
     },
 

--- a/hw/ip/pinmux/doc/registers.md
+++ b/hw/ip/pinmux/doc/registers.md
@@ -965,6 +965,7 @@ Register write enable for MIO PAD attributes.
 Muxed pad attributes.
 This register has WARL behavior since not each pad type may support
 all attributes.
+The muxed pad that is used for TAP strap 0 has a different reset value, with `pull_en` set to 1.
 - Reset default: `0x0`
 - Reset mask: `0xf300ff`
 

--- a/hw/ip/pinmux/lint/pinmux.waiver
+++ b/hw/ip/pinmux/lint/pinmux.waiver
@@ -37,3 +37,6 @@ waive -rules CLOCK_USE -location {pinmux.sv} -regexp {'(dio_wkup_mux\[12\]|dio_w
 
 waive -rules CLOCK_MUX -location {pinmux.sv} -regexp {Clock 'dio_in_i\[12\]' reaches a multiplexer here, used as a clock 'clk_i'} \
       -comment "This mux is required to filter designated scan clock inputs (e.g. 'DioSpiDeviceSck' at index 12) from wakeup detector inputs"
+
+waive -rules RESET_ONLY -location {pinmux.sv} -regexp {'mio_pad_attr_q\[0\]' is asynchronously reset but has no other assignments in this block} \
+      -comment "This error can safely be ignored: The signal is obviously driven further down in the very same block, changing the TargetCfg.tap_strap0_idx value to a non-zero value (which it actually is in the Earlgrey top level) makes the error go away."

--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -161,7 +161,17 @@ module pinmux
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin
       dio_pad_attr_q <= '0;
-      mio_pad_attr_q <= '0;
+      for (int kk = 0; kk < NMioPads; kk++) begin
+        if (kk == TargetCfg.tap_strap0_idx) begin
+          // TAP strap 0 is sampled after reset (and only once for life cycle states that are not
+          // TEST_UNLOCKED* or RMA).  To ensure it gets sampled as 0 unless driven to 1 from an
+          // external source (and specifically that it gets sampled as 0 when left floating / not
+          // connected), this enables the pull-down of the pad at reset.
+          mio_pad_attr_q[kk] <= '{pull_en: 1'b1, default: '0};
+        end else begin
+          mio_pad_attr_q[kk] <= '0;
+        end
+      end
     end else begin
       // dedicated pads
       for (int kk = 0; kk < NDioPads; kk++) begin

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -552,6 +552,7 @@
                             Muxed pad attributes.
                             This register has WARL behavior since not each pad type may support
                             all attributes.
+                            The muxed pad that is used for TAP strap 0 has a different reset value, with `pull_en` set to 1.
                             ''',
                   count:        "NMioPads",
                   compact:      "false",
@@ -622,7 +623,8 @@
                   // read back the same value that was written to them.
                   // further, they have hardware side effects since they drive the
                   // pad attributes, and hence no random data should be written to them.
-                  tags: ["excl:CsrAllTests:CsrExclWrite"]
+                  // Additionally, their reset value is defined by the RTL implementation and may not equal `resval` for all instances (#24621).
+                  tags: ["excl:CsrAllTests:CsrExclAll"]
                 }
     },
 


### PR DESCRIPTION
TAP strap 0 is sampled after reset (and only once for life cycle states
that are not TEST_UNLOCKED* or RMA).  To ensure it gets sampled as 0
unless driven to 1 from an external source (and specifically that it
gets sampled as 0 when left floating / not connected), this enables the
pull-down of the pad at reset.

This resolves issue #24576 on `master`.