### PR TITLE
[ownership] Add config version and secver reset fields

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -106,8 +106,12 @@ typedef struct owner_block {
   uint32_t sram_exec_mode;
   /** Ownership key algorithm (currently, only ECDSA is supported). */
   uint32_t ownership_key_alg;
+  /** Configuraion version (monotonically increasing per owner) */
+  uint32_t config_version;
+  /** Set the minimum security version to this value (UINT32_MAX: no change) */
+  uint32_t min_security_version_bl0;
   /** Reserved space for future use. */
-  uint32_t reserved[27];
+  uint32_t reserved[25];
   /** Owner public key. */
   owner_key_t owner_key;
   /** Owner's Activate public key. */
@@ -126,7 +130,9 @@ OT_ASSERT_MEMBER_OFFSET(owner_block_t, header, 0);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, struct_version, 8);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, sram_exec_mode, 12);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, ownership_key_alg, 16);
-OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 20);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, config_version, 20);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, min_security_version_bl0, 24);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 28);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, owner_key, 128);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, activate_key, 224);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, unlock_key, 320);

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -69,6 +69,11 @@ static rom_error_t activate(boot_svc_msg_t *msg, boot_data_t *bootdata) {
     bootdata->primary_bl0_slot = kBootSlotA;
   }
 
+  // If requested, reset the mim security version of the application firmware.
+  if (owner_page[1].min_security_version_bl0 != UINT32_MAX) {
+    bootdata->min_security_version_bl0 = owner_page[1].min_security_version_bl0;
+  }
+
   // Set the ownership state to LockedOwner.
   nonce_new(&bootdata->nonce);
   bootdata->ownership_state = kOwnershipStateLockedOwner;

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
@@ -20,25 +21,50 @@
 #include "sw/device/silicon_creator/lib/ownership/ownership.h"
 
 /*
- * This module overrides the weak `test_owner_init` symbol in ownership.c, thus
- * allowing FPGA builds to boot in the `LockedOwner` state with a valid set of
- * keys.
+ * This module overrides the weak `sku_creator_owner_init` symbol in
+ * ownership.c, thus allowing FPGA builds to boot in the `LockedOwner` state
+ * with a valid set of keys.
  */
 
-rom_error_t test_owner_init(boot_data_t *bootdata, owner_config_t *config,
-                            owner_application_keyring_t *keyring) {
-  bool flash_invalid = owner_page[0].header.tag == 0xFFFFFFFF &&
-                       owner_page[1].header.tag == 0xFFFFFFFF;
+// NOTE: if you update this version number, you must also update the version
+// number in the test library `sw/host/tests/ownership/transfer_lib.rs`.
+#define TEST_OWNER_CONFIG_VERSION 1
+
+rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
+                                   owner_config_t *config,
+                                   owner_application_keyring_t *keyring) {
+  owner_key_t owner = (owner_key_t){
+      // Although this is an ECDSA key, we initialize the `raw` member of the
+      // union to zero-initialize the unused space.
+      .raw = OWNER_ECDSA_P256};
+  ownership_state_t state = bootdata->ownership_state;
+
+  if (state == kOwnershipStateUnlockedSelf ||
+      state == kOwnershipStateUnlockedAny ||
+      state == kOwnershipStateUnlockedEndorsed) {
+    // Nothing to do when in an unlocked state.
+    return kErrorOk;
+  } else if (state == kOwnershipStateLockedOwner) {
+    if (hardened_memeq(owner.raw, owner_page[0].owner_key.raw,
+                       ARRAYSIZE(owner.raw)) != kHardenedBoolTrue ||
+        TEST_OWNER_CONFIG_VERSION <= owner_page[0].config_version) {
+      // Different owner or already newest config version; nothing to do.
+      return kErrorOk;
+    }
+  } else {
+    // State is an unknown value, which is the same as kOwnershipStateRecovery.
+    // We'll not return, thus allowing the owner config below to be programmed
+    // into flash.
+  }
 
   owner_page[0].header.tag = kTlvTagOwner;
   owner_page[0].header.length = 2048;
   owner_page[0].struct_version = 0;
   owner_page[0].sram_exec_mode = kOwnerSramExecModeDisabledLocked;
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
-  owner_page[0].owner_key = (owner_key_t){
-      // Although this is an ECDSA key, we initialize the `raw` member of the
-      // union to zero-initialize the unused space.
-      .raw = OWNER_ECDSA_P256};
+  owner_page[0].config_version = TEST_OWNER_CONFIG_VERSION;
+  owner_page[0].min_security_version_bl0 = UINT32_MAX;
+  owner_page[0].owner_key = owner;
   owner_page[0].activate_key = (owner_key_t){
       // Although this is an ECDSA key, we initialize the `raw` member of the
       // union to zero-initialize the unused space.
@@ -141,6 +167,7 @@ rom_error_t test_owner_init(boot_data_t *bootdata, owner_config_t *config,
   memset(app, 0x5a, len);
 
   owner_block_page_seal(/*page=*/0);
+  memcpy(&owner_page[1], &owner_page[0], sizeof(owner_page[0]));
 
   RETURN_IF_ERROR(owner_block_parse(&owner_page[0], config, keyring));
   RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotA,
@@ -152,16 +179,23 @@ rom_error_t test_owner_init(boot_data_t *bootdata, owner_config_t *config,
   // Since this module should only get linked in to FPGA builds, we can simply
   // thunk the ownership state to LockedOwner.
   bootdata->ownership_state = kOwnershipStateLockedOwner;
-  if (flash_invalid) {
-    OT_DISCARD(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot0,
-                                     kFlashCtrlEraseTypePage));
-    OT_DISCARD(flash_ctrl_info_write(&kFlashCtrlInfoPageOwnerSlot0, 0,
-                                     sizeof(owner_page[0]) / sizeof(uint32_t),
-                                     &owner_page[0]));
-    OT_DISCARD(boot_data_write(bootdata));
-    dbg_printf("test_owner_init: flash\r\n");
-  } else {
-    dbg_printf("test_owner_init: ram\r\n");
-  }
+
+  // Write the configuration to both owner pages.
+  OT_DISCARD(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot0,
+                                   kFlashCtrlEraseTypePage));
+  OT_DISCARD(flash_ctrl_info_write(&kFlashCtrlInfoPageOwnerSlot0, 0,
+                                   sizeof(owner_page[0]) / sizeof(uint32_t),
+                                   &owner_page[0]));
+  owner_page_valid[0] = kOwnerPageStatusSealed;
+
+  OT_DISCARD(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot1,
+                                   kFlashCtrlEraseTypePage));
+  OT_DISCARD(flash_ctrl_info_write(&kFlashCtrlInfoPageOwnerSlot1, 0,
+                                   sizeof(owner_page[0]) / sizeof(uint32_t),
+                                   &owner_page[0]));
+  owner_page_valid[1] = kOwnerPageStatusSealed;
+
+  OT_DISCARD(boot_data_write(bootdata));
+  dbg_printf("sku_creator_owner_init: saved to flash\r\n");
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -368,3 +368,30 @@ ownership_transfer_test(
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
+
+# Test that the `sku_creator_owner_init` function responsible for installing the test owner on
+# FPGA builds will automatically update from an older owner block.
+ownership_transfer_test(
+    name = "fpga_owner_upgrade_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Update
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            # `sku_creator_owner_init` has a newer version number than this and should self-update.
+            --config-version=0
+            # NOTE: Should sku_creator_owner_init fail to upgrade to its built-in owner block, then the
+            # dummy key will prevent the test program from executing and we'll get a failure from the test.
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+    rsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod": "app_prod",
+    },
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
@@ -11,7 +11,7 @@ def ownership_transfer_test(
         name,
         srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         },
         rsa_key = {
             "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod": "app_prod",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -848,7 +848,7 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   }
   // TODO(cfrantz): evaluate permissible ownership init failure conditions
   // and change this to HARDENED_RETURN_IF_ERROR.
-  if (error == kErrorOk) {
+  if (error != kErrorOk) {
     dbg_printf("ownership_init: %x\r\n", error);
   }
 

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -132,6 +132,7 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         &opts.next_unlock_key,
         &opts.next_application_key,
         opts.config_kind,
+        /*customize=*/ |_| {},
     )?;
 
     if opts.dual_owner_boot_check {

--- a/sw/host/tests/ownership/rescue_limit_test.rs
+++ b/sw/host/tests/ownership/rescue_limit_test.rs
@@ -89,6 +89,7 @@ fn flash_limit_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         &opts.next_unlock_key,
         &opts.next_application_key,
         opts.config_kind,
+        /*customize=*/ |_| {},
     )?;
 
     log::info!("###### Get Boot Log (2/2) ######");

--- a/sw/host/tests/ownership/rescue_permission_test.rs
+++ b/sw/host/tests/ownership/rescue_permission_test.rs
@@ -81,6 +81,7 @@ fn rescue_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<(
         &opts.next_unlock_key,
         &opts.next_application_key,
         opts.config_kind,
+        /*customize=*/ |_| {},
     )?;
 
     log::info!("###### Get Boot Log (2/2) ######");

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -39,6 +39,12 @@ struct Opts {
     next_unlock_key: PathBuf,
     #[arg(long, help = "Next Owner's application public key (RSA3K)")]
     next_application_key: PathBuf,
+    #[arg(
+        long,
+        default_value_t = transfer_lib::TEST_OWNER_CONFIG_VERSION,
+        help = "Configuration version to put in the owner config"
+    )]
+    config_version: u32,
 
     #[arg(
         long,
@@ -92,6 +98,10 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         &opts.next_unlock_key,
         &opts.next_application_key,
         opts.config_kind,
+        /*customize=*/
+        |owner| {
+            owner.config_version = opts.config_version;
+        },
     )?;
 
     let mut transfers0 = 0;


### PR DESCRIPTION
1. Add a `config_version` field to permit monotonically increasing updates of the ownership configuration.
2. Add a `min_security_version_bl0` field to allow the owner to reset the minimum security version with a new ownership configuration.
3. Refactor the `test_owner_init` function into `sku_creator_owner_init` to allow versioned updates of built-in ownership configs.
4. Add tests for `min_security_version_bl0` and the built-in self update behavior.