### PR TITLE
[dice] Refactor the `dice` library to support multiple implementations

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -113,10 +113,21 @@ cc_library(
 )
 
 cc_library(
+    name = "cbor",
+    hdrs = ["cbor.h"],
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
+        "@open-dice//:cbor_reader_writer",
+    ],
+)
+
+cc_library(
     name = "dice_cwt",
     srcs = ["dice_cwt.c"],
     hdrs = ["dice.h"],
     deps = [
+        ":cbor",
         ":cert",
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -113,6 +113,19 @@ cc_library(
 )
 
 cc_library(
+    name = "dice_cwt",
+    srcs = ["dice_cwt.c"],
+    hdrs = ["dice.h"],
+    deps = [
+        ":cert",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
+        "//sw/device/lib/base:status",
+        "//sw/device/silicon_creator/lib:attestation",
+        "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
+    ],
+)
+
+cc_library(
     name = "tpm",
     srcs = ["tpm.c"],
     hdrs = ["tpm.h"],

--- a/sw/device/silicon_creator/lib/cert/cbor.h
+++ b/sw/device/silicon_creator/lib/cert/cbor.h
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_
+
+#include "include/dice/cbor_writer.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#define CBOR_CHECK_OVERFLOWED_AND_RETURN(p) \
+  do {                                      \
+    if (CborOutOverflowed(p)) {             \
+      LOG_ERROR("CborOutOverflowed!!");     \
+      return kErrorCertInvalidSize;         \
+    }                                       \
+    return kErrorOk;                        \
+  } while (0)
+
+// Wrappers for each CBOR type and CBOR handle initialization
+static inline rom_error_t cbor_write_out_init(struct CborOut *p, void *buf,
+                                              const size_t buf_size) {
+  CborOutInit(buf, buf_size, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+static inline rom_error_t cbor_map_init(struct CborOut *p,
+                                        const size_t num_pairs) {
+  CborWriteMap(num_pairs, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+// Wrappers to encode a pair of data for cbor-map
+static inline rom_error_t cbor_write_pair_uint_uint(struct CborOut *p,
+                                                    uint64_t key,
+                                                    uint64_t value) {
+  CborWriteUint(key, p);
+  CborWriteUint(value, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+static inline rom_error_t cbor_write_pair_int_uint(struct CborOut *p,
+                                                   int64_t key,
+                                                   uint64_t value) {
+  CborWriteInt(key, p);
+  CborWriteUint(value, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+static inline rom_error_t cbor_write_pair_uint_int(struct CborOut *p,
+                                                   uint64_t key,
+                                                   int64_t value) {
+  CborWriteUint(key, p);
+  CborWriteInt(value, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+static inline rom_error_t cbor_write_pair_int_bytes(struct CborOut *p,
+                                                    int64_t key, uint8_t *value,
+                                                    size_t value_size) {
+  CborWriteInt(key, p);
+  CborWriteBstr(value_size, value, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+#undef CBOR_CHECK_OVERFLOWED_AND_RETURN
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -1,0 +1,112 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/cert/dice.h"
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/cert/cert.h"
+#include "sw/device/silicon_creator/lib/cert/dice.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
+
+#include "otp_ctrl_regs.h"  // Generated.
+
+// UDS (Creator) attestation key diverisfier constants.
+// Note: versions are always set to 0 so these keys are always valid from the
+// perspective of the keymgr hardware.
+const sc_keymgr_diversification_t kUdsKeymgrDiversifier = {
+    .salt =
+        {
+            0xabffa6a9,
+            0xc781f1ad,
+            0x4c1107ad,
+            0xf9210d85,
+            0x0931f555,
+            0x6c5aef5d,
+            0xb9ba4df0,
+            0x77b248d2,
+        },
+    .version = 0,
+};
+// CDI_0 (OwnerIntermediate) attestation key diverisfier constants.
+const sc_keymgr_diversification_t kCdi0KeymgrDiversifier = {
+    .salt =
+        {
+            0x3e5913c7,
+            0x41156f1d,
+            0x998ddb9f,
+            0xfa334191,
+            0x8a85380e,
+            0xba76ca1a,
+            0xdb17c4a7,
+            0xfb8852dc,
+        },
+    .version = 0,
+};
+// CDI_1 (Owner) attestation key diverisfier constants.
+const sc_keymgr_diversification_t kCdi1KeymgrDiversifier = {
+    .salt =
+        {
+            0x2d12c2e3,
+            0x6acc6876,
+            0x4bfb07ee,
+            0xc45fc414,
+            0x5d4fa9de,
+            0xf295b128,
+            0x50f49882,
+            0xbbdefa29,
+        },
+    .version = 0,
+};
+
+const sc_keymgr_ecc_key_t kDiceKeyUds = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldUdsKeySeedIdx,
+    .keymgr_diversifier = &kUdsKeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateCreatorRootKey,
+};
+const sc_keymgr_ecc_key_t kDiceKeyCdi0 = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldCdi0KeySeedIdx,
+    .keymgr_diversifier = &kCdi0KeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateOwnerIntermediateKey,
+};
+const sc_keymgr_ecc_key_t kDiceKeyCdi1 = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldCdi1KeySeedIdx,
+    .keymgr_diversifier = &kCdi1KeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateOwnerKey,
+};
+
+
+rom_error_t dice_uds_tbs_cert_build(cert_key_id_pair_t *key_ids,
+                                    ecdsa_p256_public_key_t *uds_pubkey,
+                                    uint8_t *tbs_cert, size_t *tbs_cert_size) {
+  return kErrorOk;
+}
+
+rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
+                                  uint32_t rom_ext_security_version,
+                                  cert_key_id_pair_t *key_ids,
+                                  ecdsa_p256_public_key_t *cdi_0_pubkey,
+                                  uint8_t *cert, size_t *cert_size) {
+  // TODO(lowRISC/opentitan:#24281): implement body
+  return kErrorOk;
+}
+
+rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
+                                  hmac_digest_t *owner_manifest_measurement,
+                                  uint32_t owner_security_version,
+                                  cert_key_id_pair_t *key_ids,
+                                  ecdsa_p256_public_key_t *cdi_1_pubkey,
+                                  uint8_t *cert, size_t *cert_size) {
+  // TODO(lowRISC/opentitan:#24281): implement body
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -2,11 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/silicon_creator/lib/cert/dice.h"
-
 #include <stdint.h>
 
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/cert/cbor.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/cert/dice.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
@@ -17,6 +16,18 @@
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 
 #include "otp_ctrl_regs.h"  // Generated.
+
+// Keys
+const int64_t kCoseKeyKtyLabel = 1;
+const int64_t kCoseKeyAlgLabel = 3;
+const int64_t kCoseEc2CrvLabel = -1;
+const int64_t kCoseEc2XLabel = -2;
+const int64_t kCoseEc2YLabel = -3;
+
+// Values
+const int64_t kCoseKeyAlgEcdsa256 = -7;
+const int64_t kCoseEc2CrvP256 = 1;
+const int64_t kCoseKeyKtyEc2 = 2;
 
 // UDS (Creator) attestation key diverisfier constants.
 // Note: versions are always set to 0 so these keys are always valid from the
@@ -85,10 +96,37 @@ const sc_keymgr_ecc_key_t kDiceKeyCdi1 = {
     .required_keymgr_state = kScKeymgrStateOwnerKey,
 };
 
-
+// PubKeyECDSA256 = {               ; COSE_Key [RFC9052 s7]
+//     1 : 2,                       ; Key type : EC2
+//     3 : AlgorithmES256,          ; Algorithm : ECDSA w/ SHA-256
+//     -1 : 1,                      ; Curve: P256
+//     -2 : bstr,                   ; X coordinate, big-endian
+//     -3 : bstr                    ; Y coordinate, big-endian
+// }
 rom_error_t dice_uds_tbs_cert_build(cert_key_id_pair_t *key_ids,
                                     ecdsa_p256_public_key_t *uds_pubkey,
                                     uint8_t *tbs_cert, size_t *tbs_cert_size) {
+  struct CborOut kCborOutHandle;
+
+  struct CborOut *pCborOut = &kCborOutHandle;
+
+  HARDENED_RETURN_IF_ERROR(
+      cbor_write_out_init(pCborOut, tbs_cert, *tbs_cert_size));
+  HARDENED_RETURN_IF_ERROR(cbor_map_init(pCborOut, 5));
+  HARDENED_RETURN_IF_ERROR(
+      cbor_write_pair_uint_uint(pCborOut, kCoseKeyKtyLabel, kCoseKeyKtyEc2));
+  HARDENED_RETURN_IF_ERROR(cbor_write_pair_uint_int(pCborOut, kCoseKeyAlgLabel,
+                                                    kCoseKeyAlgEcdsa256));
+  HARDENED_RETURN_IF_ERROR(
+      cbor_write_pair_int_uint(pCborOut, kCoseEc2CrvLabel, kCoseEc2CrvP256));
+  HARDENED_RETURN_IF_ERROR(cbor_write_pair_int_bytes(pCborOut, kCoseEc2XLabel,
+                                                     (uint8_t *)uds_pubkey->x,
+                                                     sizeof(uds_pubkey->x)));
+  HARDENED_RETURN_IF_ERROR(cbor_write_pair_int_bytes(pCborOut, kCoseEc2YLabel,
+                                                     (uint8_t *)uds_pubkey->y,
+                                                     sizeof(uds_pubkey->y)));
+  *tbs_cert_size = CborOutSize(pCborOut);
+
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -216,43 +216,56 @@ cc_library(
     hdrs = ["personalize_ext.h"],
 )
 
-cc_library(
-    name = "ft_personalize_base",
-    srcs = ["ft_personalize.c"],
-    deps = [
-        ":perso_tlv_data",
-        ":personalize_ext",
-        "//sw/device/lib/crypto/drivers:entropy",
-        "//sw/device/lib/dif:flash_ctrl",
-        "//sw/device/lib/dif:lc_ctrl",
-        "//sw/device/lib/dif:otp_ctrl",
-        "//sw/device/lib/dif:rstmgr",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing:lc_ctrl_testutils",
-        "//sw/device/lib/testing:rstmgr_testutils",
-        "//sw/device/lib/testing/json:provisioning_data",
-        "//sw/device/lib/testing/test_framework:check",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/lib/testing/test_framework:status",
-        "//sw/device/lib/testing/test_framework:ujson_ottf",
-        "//sw/device/silicon_creator/lib:attestation",
-        "//sw/device/silicon_creator/lib:otbn_boot_services",
-        "//sw/device/silicon_creator/lib/base:util",
-        "//sw/device/silicon_creator/lib/cert",
-        "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
-        "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
-        "//sw/device/silicon_creator/lib/cert:dice",
-        "//sw/device/silicon_creator/lib/cert:tpm_ek_template_library",
-        "//sw/device/silicon_creator/lib/cert:uds_template_library",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/lib/drivers:hmac",
-        "//sw/device/silicon_creator/lib/drivers:keymgr",
-        "//sw/device/silicon_creator/lib/drivers:kmac",
-        "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
-        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_sku_sival",
-        "//sw/device/silicon_creator/manuf/lib:personalize",
-    ],
-)
+_DICE_EXTS = [
+    {
+        "suffix": "",
+        "ext_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
+    },
+    {
+        "suffix": "_dice_cwt",
+        "ext_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
+    },
+]
+
+[
+    cc_library(
+        name = "ft_personalize_base{}".format(dice["suffix"]),
+        srcs = ["ft_personalize.c"],
+        deps = [
+            ":perso_tlv_data",
+            ":personalize_ext",
+            "//sw/device/lib/crypto/drivers:entropy",
+            "//sw/device/lib/dif:flash_ctrl",
+            "//sw/device/lib/dif:lc_ctrl",
+            "//sw/device/lib/dif:otp_ctrl",
+            "//sw/device/lib/dif:rstmgr",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:lc_ctrl_testutils",
+            "//sw/device/lib/testing:rstmgr_testutils",
+            "//sw/device/lib/testing/json:provisioning_data",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/lib/testing/test_framework:status",
+            "//sw/device/lib/testing/test_framework:ujson_ottf",
+            "//sw/device/silicon_creator/lib:attestation",
+            "//sw/device/silicon_creator/lib:otbn_boot_services",
+            "//sw/device/silicon_creator/lib/base:util",
+            "//sw/device/silicon_creator/lib/cert",
+            "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
+            "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
+            "//sw/device/silicon_creator/lib/cert:tpm_ek_template_library",
+            "//sw/device/silicon_creator/lib/cert:uds_template_library",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
+            "//sw/device/silicon_creator/lib/drivers:keymgr",
+            "//sw/device/silicon_creator/lib/drivers:kmac",
+            "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
+            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_sku_sival",
+            "//sw/device/silicon_creator/manuf/lib:personalize",
+        ] + dice["ext_libs"],
+    )
+    for dice in _DICE_EXTS
+]
 
 cc_library(
     name = "tpm_perso_fw_ext",
@@ -312,7 +325,7 @@ _FT_PERSO_EXTS = [
 
 [
     opentitan_binary(
-        name = "ft_personalize{}".format(ext["suffix"]),
+        name = "ft_personalize{}".format(ext["suffix"] + dice["suffix"]),
         testonly = True,
         srcs = ["ft_personalize.c"],
         ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
@@ -323,9 +336,10 @@ _FT_PERSO_EXTS = [
         },
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
         spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
-        deps = [":ft_personalize_base"] + ext["ext_libs"],
+        deps = [":ft_personalize_base{}".format(dice["suffix"])] + ext["ext_libs"],
     )
     for ext in _FT_PERSO_EXTS
+    for dice in _DICE_EXTS
 ]
 
 config_setting(
@@ -350,7 +364,7 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
 
 [
     opentitan_test(
-        name = "ft_provision{}".format(ext["suffix"]),
+        name = "ft_provision{}".format(ext["suffix"] + dice["suffix"]),
         exec_env = {
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
@@ -360,7 +374,7 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
             timeout = "long",
             binaries = {
                 ":sram_ft_individualize_sival": "sram_ft_individualize",
-                ":ft_personalize{}".format(ext["suffix"]): "ft_personalize",
+                ":ft_personalize{}".format(ext["suffix"] + dice["suffix"]): "ft_personalize",
             },
             changes_otp = True,
             data = FT_PERSONALIZE_KEYS,
@@ -376,7 +390,7 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
         silicon = silicon_params(
             binaries = {
                 ":sram_ft_individualize_sival": "sram_ft_individualize",
-                ":ft_personalize{}".format(ext["suffix"]): "ft_personalize",
+                ":ft_personalize{}".format(ext["suffix"] + dice["suffix"]): "ft_personalize",
             },
             changes_otp = True,
             data = FT_PERSONALIZE_KEYS,
@@ -387,4 +401,5 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
         ),
     )
     for ext in _FT_PERSO_EXTS
+    for dice in _DICE_EXTS
 ]


### PR DESCRIPTION
To support mutliple DICE implementation (X.509 with ASN.1, and CWT with CBOR), it'll require to refactor current dice lib implementation.
1. Add a `dice_cwt` lib (implementation details to be added later)
2. Levaraging the third_party `open_dice` library to generate UDS_Pub structure