### PR TITLE
[top_englishbreakfast] Add second UART

### DIFF
--- a/hw/top_englishbreakfast/data/pins_cw305.xdc
+++ b/hw/top_englishbreakfast/data/pins_cw305.xdc
@@ -38,6 +38,10 @@ set_property -dict { PACKAGE_PIN C6 IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get
 set_property -dict { PACKAGE_PIN D6 IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get_ports { IOC8 }]; #USB_A18 (SAM3X)
 set_property -dict { PACKAGE_PIN C4 IOSTANDARD LVCMOS33 PULLTYPE PULLDOWN } [get_ports { IOC5 }]; #USB_A19 (SAM3X)
 
+# UART0
+set_property -dict { PACKAGE_PIN A12 IOSTANDARD LVCMOS33 } [get_ports { IOC3 }]; #JP3.A12 - IO5 - OpenTitan UART0 RX
+set_property -dict { PACKAGE_PIN B12 IOSTANDARD LVCMOS33 } [get_ports { IOC4 }]; #JP3.B12 - IO6 - OpenTitan UART0 TX
+
 ## OTHER IO
 set_property -dict { PACKAGE_PIN B16 IOSTANDARD LVCMOS33 } [get_ports { IOA4 }]; #JP3.B16
 set_property -dict { PACKAGE_PIN C13 IOSTANDARD LVCMOS33 } [get_ports { IOA5 }]; #JP3.C13
@@ -45,9 +49,7 @@ set_property -dict { PACKAGE_PIN D15 IOSTANDARD LVCMOS33 } [get_ports { IOA6 }];
 set_property -dict { PACKAGE_PIN E15 IOSTANDARD LVCMOS33 } [get_ports { IOA7 }]; #JP3.E15
 set_property -dict { PACKAGE_PIN E13 IOSTANDARD LVCMOS33 } [get_ports { IOB2 }]; #JP3.E13
 set_property -dict { PACKAGE_PIN F15 IOSTANDARD LVCMOS33 } [get_ports { IOB3 }]; #JP3.F15
-set_property -dict { PACKAGE_PIN E11 IOSTANDARD LVCMOS33 } [get_ports { IOB4 }]; #JP3.E11
-set_property -dict { PACKAGE_PIN F13 IOSTANDARD LVCMOS33 } [get_ports { IOB5 }]; #JP3.F13
-set_property -dict { PACKAGE_PIN A12 IOSTANDARD LVCMOS33 } [get_ports { IOB6 }]; #JP3.A12
+set_property -dict { PACKAGE_PIN F13 IOSTANDARD LVCMOS33 } [get_ports { IOB6 }]; #JP3.F13
 
 set_property -dict { PACKAGE_PIN C16 IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { USB_P }]; #JP3.C16
 set_property -dict { PACKAGE_PIN D13 IOSTANDARD LVCMOS33 DRIVE 8 SLEW FAST } [get_ports { USB_N }]; #JP3.D13
@@ -55,12 +57,12 @@ set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_D
 set_property -dict { PACKAGE_PIN D16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #JP3.D16
 set_property -dict { PACKAGE_PIN E16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #JP3.E16
 
-## Unused pins of JP3: B12, F12, G16
+## Unused pins of JP3: E11, F12, G16
 
 ## 20-Pin Connector (JP1)
 
-set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports { IOC4 }];      #JP1 PIN 12 TIO2    - OpenTitan UART0 TX
-set_property -dict { PACKAGE_PIN P16 IOSTANDARD LVCMOS33 } [get_ports { IOC3 }];      #JP1 PIN 10 TIO1    - OpenTitan UART0 RX
+set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports { IOB5 }];      #JP1 PIN 12 TIO2    - OpenTitan UART1 TX
+set_property -dict { PACKAGE_PIN P16 IOSTANDARD LVCMOS33 } [get_ports { IOB4 }];      #JP1 PIN 10 TIO1    - OpenTitan UART1 RX
 set_property -dict { PACKAGE_PIN T14 IOSTANDARD LVCMOS33 } [get_ports { IO_TRIGGER }]; #JP1 PIN 16 TIO4    - Capture Trigger
 set_property -dict { PACKAGE_PIN M16 IOSTANDARD LVCMOS33 } [get_ports { IO_CLKOUT }];  #JP1 PIN  4 TIO_HS1 - Target clock
 

--- a/hw/top_englishbreakfast/data/pins_cw305.xdc
+++ b/hw/top_englishbreakfast/data/pins_cw305.xdc
@@ -55,9 +55,7 @@ set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_D
 set_property -dict { PACKAGE_PIN D16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_SENSE0 }]; #JP3.D16
 set_property -dict { PACKAGE_PIN E16 IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DNPULLUP0 }]; #JP3.E16
 
-set_property -dict { PACKAGE_PIN G16 IOSTANDARD LVCMOS33 } [get_ports { IO_UTX_DEBUG }]; #JP3.G16 (UART) for debugging
-
-## Unused pins of JP3: B12, F12
+## Unused pins of JP3: B12, F12, G16
 
 ## 20-Pin Connector (JP1)
 

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -186,12 +186,27 @@
       // the ip.hjson will declare the clock port names
       // If none are defined at ip.hjson, clk_i is used by default
       clock_srcs: {clk_i: "io_div4"},
-
+      clock_group: "peri",
       // reset connections defines the port to top level reset connection
       // the ip.hjson will declare the reset port names
       // If none are defined at ip.hjson, rst_ni is used by default
-      reset_connections: {rst_ni: "sys_io_div4"},
+      reset_connections: {rst_ni: "lc_io_div4"},
       base_addr: "0x40000000",
+    },
+    { name: "uart1",    // instance name
+      type: "uart",     // Must be matched to the ip name in `ip.hson` (_reg, _cfg permitted)
+                        // and `hw/ip/{type}`
+
+      // clock connections defines the port to top level clock connection
+      // the ip.hjson will declare the clock port names
+      // If none are defined at ip.hjson, clk_i is used by default
+      clock_srcs: {clk_i: "io_div4"},
+      clock_group: "peri",
+      // reset connections defines the port to top level reset connection
+      // the ip.hjson will declare the reset port names
+      // If none are defined at ip.hjson, rst_ni is used by default
+      reset_connections: {rst_ni: "lc_io_div4"},
+      base_addr: "0x40010000",
     },
     { name: "gpio",
       type: "gpio",
@@ -681,6 +696,7 @@
   // Modules whose interrupts are connected to RV_PLIC.
   interrupt_module: [
     "uart0",
+    "uart1",
     "gpio",
     "spi_device",
     "spi_host0",
@@ -852,6 +868,7 @@
       // MIOs
       { instance: "gpio",            port: '',      connection: 'muxed' , pad: ''             , desc: ''},
       { instance: "uart0",           port: '',      connection: 'muxed' , pad: ''             , desc: ''},
+      { instance: "uart1",           port: '',      connection: 'muxed' , pad: ''             , desc: ''},
       { instance: "flash_ctrl",      port: '',      connection: 'muxed' , pad: ''             , desc: ''},
       { instance: 'usbdev',          port: 'sense', connection: 'muxed' , pad: ''             , desc: ''},
     ],

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -900,7 +900,6 @@
           // ChipWhisperer IO
           { name: 'IO_CLKOUT',        type: 'BidirStd', bank: 'VCC', connection: 'manual', desc: 'Manual clock output for SCA setup'}
           { name: 'IO_TRIGGER',       type: 'BidirStd', bank: 'VCC', connection: 'manual', desc: 'Manual trigger output for SCA setup'}
-          { name: 'IO_UTX_DEBUG',     type: 'BidirStd', bank: 'VCC', connection: 'manual', desc: 'Manual UART TX debug output'}
         ],
       }
 

--- a/hw/top_englishbreakfast/data/xbar_peri.hjson
+++ b/hw/top_englishbreakfast/data/xbar_peri.hjson
@@ -23,6 +23,12 @@
       reset:     "rst_peri_ni",
       pipeline:  false
     },
+    { name:      "uart1",
+      type:      "device",
+      clock:     "clk_peri_i",
+      reset:     "rst_peri_ni",
+      pipeline:  false
+    },
     { name:      "gpio",
       type:      "device",
       clock:     "clk_peri_i",
@@ -86,7 +92,7 @@
   ],
   connections: {
     main:  [
-      "uart0",
+      "uart0", "uart1",
       "gpio", "spi_device", "spi_host0", "rv_timer", "usbdev",
       "pwrmgr_aon", "rstmgr_aon", "clkmgr_aon", "pinmux_aon",
       "ast"

--- a/sw/device/lib/testing/pinmux_testutils.c
+++ b/sw/device/lib/testing/pinmux_testutils.c
@@ -37,7 +37,6 @@ void pinmux_testutils_init(dif_pinmux_t *pinmux) {
   CHECK_DIF_OK(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIoc4,
                                         kTopEarlgreyPinmuxOutselUart0Tx));
 
-#if !OT_IS_ENGLISH_BREAKFAST
   // Enable pull-ups on UART0 RX
   // Pull-ups are available only on certain platforms.
   if (kDeviceType == kDeviceSimDV) {
@@ -63,6 +62,7 @@ void pinmux_testutils_init(dif_pinmux_t *pinmux) {
   CHECK_DIF_OK(dif_pinmux_output_select(pinmux, kTopEarlgreyPinmuxMioOutIob5,
                                         kTopEarlgreyPinmuxOutselUart1Tx));
 
+#if !OT_IS_ENGLISH_BREAKFAST
   // Configure a higher drive strength for the USB_P and USB_N pads because we
   // must the pad drivers must be capable of overpowering the 'pull' signal
   // strength of the internal pull ups in the differential receiver.

--- a/sw/device/lib/testing/test_framework/ottf_console.c
+++ b/sw/device/lib/testing/test_framework/ottf_console.c
@@ -258,13 +258,13 @@ void ottf_console_configure_spi_device(uintptr_t base_addr) {
 static uint32_t get_flow_control_watermark_plic_id(void) {
   switch (kOttfTestConfig.console.base_addr) {
 #if !OT_IS_ENGLISH_BREAKFAST
-    case TOP_EARLGREY_UART1_BASE_ADDR:
-      return kTopEarlgreyPlicIrqIdUart1RxWatermark;
     case TOP_EARLGREY_UART2_BASE_ADDR:
       return kTopEarlgreyPlicIrqIdUart2RxWatermark;
     case TOP_EARLGREY_UART3_BASE_ADDR:
       return kTopEarlgreyPlicIrqIdUart3RxWatermark;
 #endif
+    case TOP_EARLGREY_UART1_BASE_ADDR:
+      return kTopEarlgreyPlicIrqIdUart1RxWatermark;
     case TOP_EARLGREY_UART0_BASE_ADDR:
     default:
       return kTopEarlgreyPlicIrqIdUart0RxWatermark;

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -67,12 +67,12 @@ enum {
 static unsigned int trigger_bit_index = kTriggerHwGateBitIndex;
 
 static dif_uart_t uart0;
+static dif_uart_t uart1;
 static dif_gpio_t gpio;
 static dif_pinmux_t pinmux;
 static dif_rv_timer_t timer;
 
 #if !OT_IS_ENGLISH_BREAKFAST
-static dif_uart_t uart1;
 static dif_csrng_t csrng;
 static dif_edn_t edn0;
 static dif_edn_t edn1;
@@ -101,11 +101,9 @@ static void sca_init_uart(void) {
   OT_DISCARD(dif_uart_configure(&uart0, uart_config));
   base_uart_stdout(&uart0);
 
-#if !OT_IS_ENGLISH_BREAKFAST
   OT_DISCARD(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR),
                            &uart1));
   OT_DISCARD(dif_uart_configure(&uart1, uart_config));
-#endif
 }
 
 /**
@@ -285,13 +283,7 @@ void sca_init(sca_trigger_source_t trigger, sca_peripherals_t enable) {
   sca_disable_peripherals(~enable);
 }
 
-const dif_uart_t *sca_get_uart(void) {
-#if !OT_IS_ENGLISH_BREAKFAST
-  return &uart1;
-#else
-  return &uart0;
-#endif
-}
+const dif_uart_t *sca_get_uart(void) { return &uart1; }
 
 void sca_select_trigger_type(sca_trigger_type_t trigger_type) {
   if (trigger_type == kScaTriggerTypeHwGated) {

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1291,11 +1291,7 @@ module chip_${top["name"]}_${target["name"]} #(
   // 20-pin connector. This is used for SCA/FI experiments only.
 
   logic unused_inputs;
-  % if target["name"] == "cw305":
-  assign unused_inputs = manual_in_io_clkout ^ manual_in_io_trigger ^ manual_in_io_utx_debug;
-  % else:
   assign unused_inputs = manual_in_io_clkout ^ manual_in_io_trigger;
-  % endif
 
   // Synchronous clock output to capture board.
   assign manual_out_io_clkout = manual_in_io_clk;
@@ -1371,13 +1367,6 @@ module chip_${top["name"]}_${target["name"]} #(
   assign manual_out_io_trigger =
       manual_in_io_clk_trigger_sw_en | (manual_in_io_clk_trigger_hw_en &
           prim_mubi_pkg::mubi4_test_false_strict(manual_in_io_clk_idle));
-% endif
-## This separate UART debugging output is needed for the CW305 only.
-% if target["name"] == "cw305":
-
-  // UART Tx for debugging. The UART itself is connected to the capture board.
-  assign manual_out_io_utx_debug = top_${top["name"]}.cio_uart0_tx_d2p;
-  assign manual_oe_io_utx_debug = 1'b1;
 % endif
 
 endmodule : chip_${top["name"]}_${target["name"]}


### PR DESCRIPTION
For penetration testing, we've been using a second UART on the CW310 and the silicon platform such that the host can directly communicate with the target using the uJSON protocol instead of looping this communication through the simpleserial channel with the scope (available on Husky only anyways).

This commit now adds a second UART to the English Breakfast top level such that we can re-align the capture setups again. Ultimately, this will allow removing the simpleserial-based communication which will quite notably simplify code maintenance in the future.

For reference, see also https://github.com/lowRISC/ot-sca/issues/235.