### PR TITLE
[aes/dv] Randomly drive invalid AES operation values

### DIFF
--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -60,7 +60,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   int                key_256b_weight            = 10;
 
   // reseed weigth
-  int                per8_weight                = 60;
+  int                per1_weight                = 60;
   int                per64_weight               = 30;
   int                per8k_weight               = 10;
 

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -76,7 +76,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   bit                fixed_data_en              = 0;
   // fixed operation
   bit                fixed_operation_en         = 0;
-  bit                fixed_operation            = 1'b0;
+  bit [1:0]          fixed_operation            = AES_ENC;
   // fixed iv (will set all to bits 0)
   bit                fixed_iv_en                = 0;
 
@@ -90,10 +90,14 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   //   [3]: inject Lc_escalate
   error_types_t      error_types                = 4'b1111;
 
-  //   [2]: reseed error
-  //   [1]: mode error
-  //   [0]: key_len
-  cfg_error_type_t   config_error_type          = 3'b111;
+  //   [0]: op_error
+  //   [1]: reseed error
+  //   [2]: mode error
+  //   [3]: key_len
+  cfg_error_type_t   config_error_type_en       = '{key_len:  1'b1,
+                                                    mode:     1'b1,
+                                                    rsd_rate: 1'b1,
+                                                    op:       1'b1};
   int                config_error_pct           = 30;
 
   // min and max wait (clk) before an error injection

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -58,6 +58,7 @@ package aes_env_pkg;
     bit          key_len;
     bit          mode;
     bit          rsd_rate;
+    bit          op;
   } cfg_error_type_t;
 
   // used in FI verification seq and if

--- a/hw/ip/aes/dv/env/aes_message_item.sv
+++ b/hw/ip/aes/dv/env/aes_message_item.sv
@@ -68,7 +68,7 @@ class aes_message_item extends uvm_sequence_item;
   int    key_256b_weight      = 10;
 
   // reseed weight
-  int    per8_weight          = 60;
+  int    per1_weight          = 60;
   int    per64_weight         = 30;
   int    per8k_weight         = 10;
 
@@ -143,7 +143,7 @@ class aes_message_item extends uvm_sequence_item;
     solve cfg_error_type before reseed_rate;
     if (!(has_config_error && cfg_error_type.rsd_rate) ) {
       reseed_rate inside { 3'b001, 3'b010, 3'b100 };
-      reseed_rate dist   { 3'b001 :/ per8_weight,
+      reseed_rate dist   { 3'b001 :/ per1_weight,
                            3'b010 :/ per64_weight,
                            3'b100 :/ per8k_weight };
     } else {

--- a/hw/ip/aes/dv/env/aes_message_item.sv
+++ b/hw/ip/aes/dv/env/aes_message_item.sv
@@ -298,53 +298,66 @@ class aes_message_item extends uvm_sequence_item;
   virtual function string convert2string();
     string str;
     str = super.convert2string();
-    str = {str,  $sformatf("\n\t ----| \t\t AES MESSAGE ITEM   \t      |----\t ")
-           };
+    str = {str,  $sformatf("\n\t ----| AES MESSAGE ITEM")};
     str = {str, "\n\t ----| "};
-    str = {str,  $sformatf("\n\t ----| Mode: \t  \t \t %s                         \t ",
-                           aes_mode.name())};
+    str = {str,  $sformatf("\n\t ----| Message Length:       %0d", message_length)};
     str = {str,  $sformatf("\n\t ----| Operation:            %s",
                            aes_operation == AES_ENC ? "AES_ENC" :
                            aes_operation == AES_DEC ? "AES_DEC" : "INVALID")};
-    str = {str,  $sformatf("\n\t ----| has Configuration error:  %s  \t  \t        \t ",
-                           (has_config_error==1) ? "TRUE" : "FALSE")};
-    str = {str,  $sformatf("\n\t ----| Mode error en:  \t %d \n\t ----| Key_len error en: \t %d  \t         \t ",
-                           cfg_error_type.mode, cfg_error_type.key_len)};
-    str = {str,  $sformatf("\n\t ----| Message Length:  \t  \t %d             \t ",
-                           message_length)};
-
-    str = {str,  $sformatf("\n\t ----| Key Length:   \t \t %03b                             \t ",
-                           aes_keylen)};
-    str = {str,  $sformatf("\n\t ----| Key Share 0: \t \t ")};
+    str = {str,  $sformatf("\n\t ----| Mode:                 %s", aes_mode.name())};
+    str = {str,  $sformatf("\n\t ----| Key Length:           %03b", aes_keylen)};
+    str = {str,  $sformatf("\n\t ----| Key Share 0:          ")};
     for (int i=0; i <8; i++) begin
-      str = {str, $sformatf("%h ",aes_key[0][i])};
+      str = {str, $sformatf("%h ", aes_key[0][i])};
     end
-    str = {str,  $sformatf("\n\t ----| Key Share 1: \t \t ")};
+    str = {str,  $sformatf("\n\t ----| Key Share 1:          ")};
     for (int i=0; i <8; i++) begin
-      str = {str, $sformatf("%h ",aes_key[1][i])};
+      str = {str, $sformatf("%h ", aes_key[1][i])};
     end
-    str = {str,  $sformatf("\n\t ----| Key Mask:  \t  \t %0b                             |----\t ",
-                           keymask)};
-     str = {str,  $sformatf("\n\t ----| Initializaion vector:     \t    \t ")};
+    str = {str,  $sformatf("\n\t ----| Key Mask:             %0b", keymask)};
+    str = {str,  $sformatf("\n\t ----| Initializaion vector: ")};
     for (int i=0; i <4; i++) begin
-      str = {str, $sformatf("%h ",aes_iv[i])};
+      str = {str, $sformatf("%h ", aes_iv[i])};
     end
-    str = {str,  $sformatf("\n\t ----| Manual Mode : %b      \t   \t ", manual_operation)};
-    str = {str,  $sformatf("\n\t ----| SideLoad En : %b      \t   \t ", sideload_en)};
-    str = {str,  $sformatf("\n\t ----| errors types enabled: %b      \t   \t ", error_types)};
-    str = {str,  $sformatf("\n\t ----| CFB Weight: %d       \t \t ", cfb_weight)};
-    str = {str,  $sformatf("\n\t ----| OFB Weight: %d       \t \t ", ofb_weight)};
-    str = {str,  $sformatf("\n\t ----| ECB Weight: %d       \t \t ", ecb_weight)};
-    str = {str,  $sformatf("\n\t ----| CBC Weight: %d       \t \t ", cbc_weight)};
-    str = {str,  $sformatf("\n\t ----| CTR Weight: %d       \t \t ", ctr_weight)};
-    str = {str,  $sformatf("\n\t ----| Key Len Distribution: \t \t " ) };
-    str = {str,  $sformatf("\n\t ----| 128 Weight: %d       \t \t ", key_128b_weight)};
-    str = {str,  $sformatf("\n\t ----| 192 Weight: %d       \t \t ", key_192b_weight)};
-    str = {str,  $sformatf("\n\t ----| 256 Weight: %d       \t \t ", key_256b_weight)};
+    str = {str,  $sformatf("\n\t ----| Sideload:             %0b", sideload_en)};
+    str = {str,  $sformatf("\n\t ----| Manual Operation:     %0b", manual_operation)};
     str = {str,  $sformatf("\n\t")};
-
     return str;
   endfunction // conver2string
+
+  function string cfg_error_string();
+    string str;
+    str = {      $sformatf("\n\t ----| error_types:             %03b", error_types)};
+    str = {str,  $sformatf("\n\t ----| has_config_error:        %01b", has_config_error)};
+    str = {str,  $sformatf("\n\t ----| cfg_error_type.op:       %01b", cfg_error_type.op)};
+    str = {str,  $sformatf("\n\t ----| cfg_error_type.rsd_rate: %01b", cfg_error_type.rsd_rate)};
+    str = {str,  $sformatf("\n\t ----| cfg_error_type.mode:     %01b", cfg_error_type.mode)};
+    str = {str,  $sformatf("\n\t ----| cfg_error_type.key_len:  %01b", cfg_error_type.key_len)};
+    str = {str,  $sformatf("\n\t ----| aes_operation:           %02b", aes_operation)};
+    str = {str,  $sformatf("\n\t ----| reseed_rate:             %03b", reseed_rate)};
+    str = {str,  $sformatf("\n\t ----| aes_mode:                %06b", aes_mode)};
+    str = {str,  $sformatf("\n\t ----| aes_keylen:              %03b", aes_keylen)};
+    return str;
+  endfunction
+
+  function string field_distribution_string();
+    string str;
+    str = {      $sformatf("\n\t ----| Mode Distribution:")};
+    str = {str,  $sformatf("\n\t ----| CFB Weight: %0d", cfb_weight)};
+    str = {str,  $sformatf("\n\t ----| OFB Weight: %0d", ofb_weight)};
+    str = {str,  $sformatf("\n\t ----| ECB Weight: %0d", ecb_weight)};
+    str = {str,  $sformatf("\n\t ----| CBC Weight: %0d", cbc_weight)};
+    str = {str,  $sformatf("\n\t ----| CTR Weight: %0d", ctr_weight)};
+    str = {str,  $sformatf("\n\t ----| Key Length Distribution:")};
+    str = {str,  $sformatf("\n\t ----| AES-128 Weight: %0d", key_128b_weight)};
+    str = {str,  $sformatf("\n\t ----| AES-192 Weight: %0d", key_192b_weight)};
+    str = {str,  $sformatf("\n\t ----| AES-256 Weight: %0d", key_256b_weight)};
+    str = {str,  $sformatf("\n\t ----| Reseed Rate Distribution:")};
+    str = {str,  $sformatf("\n\t ----| Per-1  Weight: %0d", per1_weight)};
+    str = {str,  $sformatf("\n\t ----| Per-64 Weight: %0d", per64_weight)};
+    str = {str,  $sformatf("\n\t ----| Per-8K Weight: %0d", per8k_weight)};
+    return str;
+  endfunction
 
    virtual function string print_data();
      string txt="";

--- a/hw/ip/aes/dv/env/aes_message_item.sv
+++ b/hw/ip/aes/dv/env/aes_message_item.sv
@@ -247,14 +247,26 @@ class aes_message_item extends uvm_sequence_item;
     this.aes_operation = item.operation;
     this.aes_key       = item.key;
     this.aes_iv        = item.iv;
+    this.reseed_rate   = item.reseed_rate;
 
-    // check for valid keylen
-    if (item.key_len inside { 3'b001, 3'b010, 3'b100 }) begin
-      this.aes_keylen  = item.key_len;
+    // Check for invalid configuration values and resolve them if necessary. Illegal mode values
+    // don't need to be handled here as they don't result in the DUT actually producing output
+    // data.
+    if (item.key_len inside {AES_128, AES_192, AES_256}) begin
+      this.aes_keylen = item.key_len;
     end else begin
-      this.aes_keylen = 3'b100; // force to 256b
-      `uvm_info(`gfn, $sformatf("\n\t ---| Illegal key len detected reverting to default 256"),
-                UVM_MEDIUM)
+      this.aes_keylen = AES_256;
+      `uvm_info(`gfn,
+          $sformatf("\n\t ---| Illegal key length value detected. Resolving to default AES_256"),
+          UVM_MEDIUM)
+    end
+    if (item.reseed_rate inside {PER_1, PER_64, PER_8K}) begin
+      this.reseed_rate = item.reseed_rate;
+    end else begin
+      this.reseed_rate = PER_1;
+      `uvm_info(`gfn,
+          $sformatf("\n\t ---| Illegal reseed rate value detected. Resolving to default PER_1"),
+          UVM_MEDIUM)
     end
     add_data_item(item);
   endfunction // add_start_msg_item

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -7,7 +7,7 @@ class aes_seq_item extends uvm_sequence_item;
   `uvm_object_utils(aes_seq_item)
 
   aes_item_type_e  item_type;
-  aes_op_e operation;
+  bit [1:0] operation;
 
   ///////////////////////////////////////
   //  Control Knobs                    //
@@ -335,7 +335,8 @@ class aes_seq_item extends uvm_sequence_item;
     str = {str,  $psprintf("\n\t ----| AES Mode:    \t %s                          |----\t ",
                           mode.name()) };
     str = {str,  $psprintf("\n\t ----| Operation:    \t %s                          |----\t ",
-                           operation.name() ) };
+                           operation == AES_ENC ? "AES_ENC" :
+                           operation == AES_DEC ? "AES_DEC" : "INVALID")};
     str = {str,  $psprintf("\n\t ----| Key len:    \t %s  \t(%3b)                           |----\t ",
                           (key_len==3'b001) ? "128b" : (key_len == 3'b010) ? "192b" : "256b", key_len)};
     str = {str,  $psprintf("\n\t ----| Key Share 0: \t ")};

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -1041,8 +1041,12 @@ class aes_base_vseq extends cip_base_vseq #(
       end
       `downcast(cloned_message, aes_message.clone());
       message_queue.push_front(cloned_message);
-      `uvm_info(`gfn, $sformatf("\n\t ----| MESSAGE # %d \n %s",i, cloned_message.convert2string())
-               , UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("\n\t ----| MESSAGE #%0d\n %s",
+          i, cloned_message.convert2string()), UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("\n\t ----| \n %s",
+          cloned_message.cfg_error_string()), UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("\n\t ----| \n %s",
+          cloned_message.field_distribution_string()), UVM_MEDIUM)
     end
   endfunction // generate_message_queue
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -1022,7 +1022,7 @@ class aes_base_vseq extends cip_base_vseq #(
     aes_message.fixed_keylen         = cfg.fixed_keylen;
     aes_message.fixed_iv_en          = cfg.fixed_iv_en;
     aes_message.sideload_pct         = cfg.sideload_pct;
-    aes_message.per8_weight          = cfg.per8_weight;
+    aes_message.per1_weight          = cfg.per1_weight;
     aes_message.per64_weight         = cfg.per64_weight;
     aes_message.per8k_weight         = cfg.per8k_weight;
   endfunction

--- a/hw/ip/aes/dv/tests/aes_alert_reset_test.sv
+++ b/hw/ip/aes/dv/tests/aes_alert_reset_test.sv
@@ -35,7 +35,7 @@ class aes_alert_reset_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b001;

--- a/hw/ip/aes/dv/tests/aes_b2b_test.sv
+++ b/hw/ip/aes/dv/tests/aes_b2b_test.sv
@@ -34,7 +34,7 @@ class aes_b2b_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b010;

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -70,7 +70,7 @@ class aes_base_test extends cip_base_test #(
     cfg.fixed_data_en               = 0;
   // fixed operation (enc or dec)
     cfg.fixed_operation_en          = 0;
-    cfg.fixed_operation             = 1'b0;
+    cfg.fixed_operation             = aes_pkg::AES_ENC;
   // fixed iv (will set all to 0)
     cfg.fixed_iv_en                 = 0;
     cfg.fixed_keylen_en             = 0;

--- a/hw/ip/aes/dv/tests/aes_clear_test.sv
+++ b/hw/ip/aes/dv/tests/aes_clear_test.sv
@@ -35,7 +35,7 @@ class aes_clear_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b001;

--- a/hw/ip/aes/dv/tests/aes_config_error_test.sv
+++ b/hw/ip/aes/dv/tests/aes_config_error_test.sv
@@ -18,7 +18,10 @@ class aes_config_error_test extends aes_base_test;
 
     cfg.error_types              = 4'b0001;
     cfg.config_error_pct         = 75;
-    cfg.config_error_type        = 3'b111;
+    cfg.config_error_type_en     = '{key_len:  1'b1,
+                                     mode:     1'b1,
+                                     rsd_rate: 1'b1,
+                                     op:       1'b1};
     cfg.num_messages_min         = 3;
     cfg.num_messages_max         = 10;
     // message related knobs
@@ -37,7 +40,7 @@ class aes_config_error_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b001;

--- a/hw/ip/aes/dv/tests/aes_fi_test.sv
+++ b/hw/ip/aes/dv/tests/aes_fi_test.sv
@@ -36,7 +36,7 @@ class aes_fi_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b001;

--- a/hw/ip/aes/dv/tests/aes_manual_config_err_test.sv
+++ b/hw/ip/aes/dv/tests/aes_manual_config_err_test.sv
@@ -21,8 +21,10 @@ class aes_manual_config_err_test extends aes_base_test;
     // all should have error
     cfg.config_error_pct         = 100;
     // only allow mode errors
-    cfg.config_error_type        = 3'b010;
-
+    cfg.config_error_type_en     = '{key_len:  1'b0,
+                                     mode:     1'b1,
+                                     rsd_rate: 1'b0,
+                                     op:       1'b0};
     cfg.num_messages_min         = 1;
     cfg.num_messages_max         = 1;
     // message related knobs

--- a/hw/ip/aes/dv/tests/aes_reseed_test.sv
+++ b/hw/ip/aes/dv/tests/aes_reseed_test.sv
@@ -33,7 +33,7 @@ class aes_reseed_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b010;

--- a/hw/ip/aes/dv/tests/aes_sideload_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sideload_test.sv
@@ -34,7 +34,7 @@ class aes_sideload_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b001;

--- a/hw/ip/aes/dv/tests/aes_smoke_test.sv
+++ b/hw/ip/aes/dv/tests/aes_smoke_test.sv
@@ -34,7 +34,7 @@ class aes_smoke_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b001;

--- a/hw/ip/aes/dv/tests/aes_stress_test.sv
+++ b/hw/ip/aes/dv/tests/aes_stress_test.sv
@@ -37,7 +37,7 @@ class aes_stress_test extends aes_base_test;
     cfg.fixed_key_en             = 0;
 
     cfg.fixed_operation_en       = 0;
-    cfg.fixed_operation          = 0;
+    cfg.fixed_operation          = aes_pkg::AES_ENC;
 
     cfg.fixed_keylen_en          = 0;
     cfg.fixed_keylen             = 3'b010;


### PR DESCRIPTION
This PR contains a couple of commits to enable closing a small coverage hole.

The main commit is the last one. It properly randomizes the operation values. Previously, the operation field of the main control register was only written with valid one-hot encoded values but not with invalid values leading to a small DV coverage hole.

This resolves https://github.com/lowRISC/opentitan/issues/20941.