### PR TITLE
[top_darjeeling,lint,sim] Add lint and sim cfg for Darjeeling

### DIFF
--- a/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
+++ b/hw/top_darjeeling/dv/top_darjeeling_sim_cfgs.hjson
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // This is a cfg hjson group for DV simulations. It includes ALL individual DV simulation
+  // cfgs of the IPs and the full chip used in top_darjeeling. This enables the common
+  // regression sets to be run in one shot.
+  name: top_darjeeling_batch_sim
+
+  import_cfgs: [// Project wide common cfg file
+                "{proj_root}/hw/data/common_project_cfg.hjson"]
+
+  flow: sim
+
+  rel_path: "hw/top_darjeeling/dv/summary"
+
+  // Maintain alphabetical order below.
+  use_cfgs: [
+             // Unit tests for UVCs.
+             "{proj_root}/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson",
+             // IPs.
+             "{proj_root}/hw/ip/aes/dv/aes_unmasked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/aes/dv/aes_masked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
+             "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
+             "{proj_root}/hw/ip/dma/dv/dma_sim_cfg.hjson",
+             "{proj_root}/hw/ip/edn/dv/edn_sim_cfg.hjson",
+             "{proj_root}/hw/ip/gpio/dv/gpio_sim_cfg.hjson",
+             "{proj_root}/hw/ip/hmac/dv/hmac_sim_cfg.hjson",
+             "{proj_root}/hw/ip/i2c/dv/i2c_sim_cfg.hjson",
+             "{proj_root}/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson",
+            //  "{proj_root}/hw/ip/keymgr_dpe/dv/keymgr_dpe_sim_cfg.hjson",
+             "{proj_root}/hw/ip/kmac/dv/kmac_masked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/kmac/dv/kmac_unmasked_sim_cfg.hjson",
+             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_disabled_sim_cfg.hjson",
+             "{proj_root}/hw/ip/lc_ctrl/dv/lc_ctrl_volatile_unlock_enabled_sim_cfg.hjson",
+            //  "{proj_root}/hw/ip/mbx/dv/mbx_sim_cfg.hjson",
+             "{proj_root}/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson",
+             "{proj_root}/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",
+             "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_32kB_sim_cfg.hjson",
+             "{proj_root}/hw/ip/rom_ctrl/dv/rom_ctrl_64kB_sim_cfg.hjson",
+             "{proj_root}/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson",
+             "{proj_root}/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson",
+             "{proj_root}/hw/ip/spi_host/dv/spi_host_sim_cfg.hjson",
+             "{proj_root}/hw/ip/spi_device/dv/spi_device_1r1w_sim_cfg.hjson",
+             "{proj_root}/hw/ip/spi_device/dv/spi_device_2p_sim_cfg.hjson",
+             "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson",
+             "{proj_root}/hw/ip/sram_ctrl/dv/sram_ctrl_ret_sim_cfg.hjson",
+             "{proj_root}/hw/ip/uart/dv/uart_sim_cfg.hjson",
+             // Top level IPs.
+            //  "{proj_root}/hw/top_darjeeling/ip_autogen/alert_handler/dv/alert_handler_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip_autogen/clkmgr/dv/clkmgr_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip_autogen/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip_autogen/pwrmgr/dv/pwrmgr_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_cnsty_chk/rstmgr_cnsty_chk_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip_autogen/rstmgr/dv/rstmgr_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip/xbar_main/dv/autogen/xbar_main_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip/xbar_peri/dv/autogen/xbar_peri_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip/xbar_dbg/dv/autogen/xbar_dbg_sim_cfg.hjson",
+            //  "{proj_root}/hw/top_darjeeling/ip/xbar_mbx/dv/autogen/xbar_mbx_sim_cfg.hjson",
+            //  // Top level.
+            //  "{proj_root}/hw/top_darjeeling/dv/chip_sim_cfg.hjson"
+             ]
+}

--- a/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_dv_lint_cfgs.hjson
@@ -1,0 +1,220 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+
+  // This is the primary cfg hjson for DV linting. It imports ALL individual lint
+  // cfgs of the IPs DV environments and the full chip DV environment for top_darjeeling.
+  // This enables to run them all as a regression in one shot.
+  name: top_darjeeling_dv_batch
+
+  import_cfgs:      [// common server configuration for results upload
+                     "{proj_root}/hw/data/common_project_cfg.hjson"
+                     // tool-specific configuration
+                     "{proj_root}/hw/lint/tools/dvsim/{tool}.hjson"]
+
+  flow: "lint"
+
+  // Different dashboard output path for each tool
+  rel_path: "hw/top_darjeeling/dv/lint/{tool}/summary"
+
+  use_cfgs: [{    name: dma
+                  fusesoc_core: lowrisc:ip:dma_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/dma/lint/{tool}"
+             },
+             {    name: mbx
+                  fusesoc_core: lowrisc:ip:mbx_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/mbx/lint/{tool}"
+             },
+             {    name: aes
+                  fusesoc_core: lowrisc:dv:aes_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/aes/dv/lint/{tool}"
+             },
+          //    {    name: alert_handler
+          //         fusesoc_core: lowrisc:opentitan:top_darjeeling_alert_handler_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip_autogen/alert_handler/dv/lint/{tool}"
+          //    },
+          //    {    name: aon_timer
+          //         fusesoc_core: lowrisc:dv:aon_timer_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip/aon_timer/dv/lint/{tool}"
+          //    },
+          //    {    name: clkmgr
+          //         fusesoc_core: lowrisc:dv:clkmgr_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip_autogen/clkmgr/dv/lint/{tool}"
+          //    },
+             {    name: csrng
+                  fusesoc_core: lowrisc:dv:csrng_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/csrng/dv/lint/{tool}"
+             },
+             {    name: adc_ctrl
+                  fusesoc_core: lowrisc:dv:adc_ctrl_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/adc_ctrl/dv/lint/{tool}"
+             },
+             {    name: entropy_src
+                  fusesoc_core: lowrisc:dv:entropy_src_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/entropy_src/dv/lint/{tool}"
+             },
+             {    name: edn
+                  fusesoc_core: lowrisc:dv:edn_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/edn/dv/lint/{tool}"
+             },
+          //    {    name: flash_ctrl
+          //         fusesoc_core: lowrisc:dv:flash_ctrl_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip_autogen/flash_ctrl/dv/lint/{tool}"
+          //    },
+             {    name: gpio
+                  fusesoc_core: lowrisc:dv:gpio_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/gpio/dv/lint/{tool}"
+             },
+             {    name: hmac
+                  fusesoc_core: lowrisc:dv:hmac_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/hmac/dv/lint/{tool}"
+             },
+             {    name: i2c
+                  fusesoc_core: lowrisc:dv:i2c_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/i2c/dv/lint/{tool}"
+             },
+             {    name: keymgr
+                  fusesoc_core: lowrisc:dv:keymgr_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/keymgr/dv/lint/{tool}"
+             },
+             {    name: keymgr_dpe
+                  fusesoc_core: lowrisc:dv:keymgr_dpe_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/keymgr_dpe/dv/lint/{tool}"
+             },
+             {
+                  name: kmac
+                  fusesoc_core: lowrisc:dv:kmac_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/kmac/dv/lint/{tool}"
+             },
+             {
+                  name: lc_ctrl
+                  fusesoc_core: lowrisc:dv:lc_ctrl_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/lc_ctrl/dv/lint/{tool}"
+             },
+             {    name: otp_ctrl
+                  fusesoc_core: lowrisc:dv:otp_ctrl_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/otp_ctrl/dv/lint/{tool}"
+             },
+             {    name: pattgen
+                  fusesoc_core: lowrisc:,dv:pattgen_sim,
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
+                  rel_path: "hw/ip/pattgen/dv/lint/{tool}"
+             },
+             {    name: prim_alert
+                  fusesoc_core: lowrisc:dv:prim_alert_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/prim/dv/prim_alert/lint/{tool}"
+             },
+             {    name: prim_esc
+                  fusesoc_core: lowrisc:dv:prim_esc_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/prim/dv/prim_esc/lint/{tool}"
+             },
+             {    name: prim_lfsr
+                  fusesoc_core: lowrisc:dv:prim_lfsr_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/prim/dv/prim_lfsr/lint/{tool}"
+             },
+             {    name: prim_present
+                  fusesoc_core: lowrisc:dv:prim_present_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/prim/dv/prim_present/lint/{tool}"
+             },
+             {    name: prim_prince
+                  fusesoc_core: lowrisc:dv:prim_prince_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/prim/dv/prim_prince/lint/{tool}"
+             },
+          //    {    name: pwrmgr
+          //         fusesoc_core: lowrisc:dv:pwrmgr_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip_autogen/pwrmgr/dv/lint/{tool}"
+          //    },
+             {    name: rom_ctrl
+                  fusesoc_core: lowrisc:dv:rom_ctrl_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/rom_ctrl/dv/lint/{tool}"
+             },
+          //    {    name: rstmgr
+          //         fusesoc_core: lowrisc:dv:rstmgr_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip_autogen/rstmgr/dv/lint/{tool}"
+          //    },
+             {    name: rv_dm
+                  fusesoc_core: lowrisc:dv:rv_dm_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/rv_dm/dv/lint/{tool}"
+             },
+             {    name: rv_timer
+                  fusesoc_core: lowrisc:dv:rv_timer_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/rv_timer/dv/lint/{tool}"
+             },
+             {    name: spi_device
+                  fusesoc_core: lowrisc:dv:spi_device_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/spi_device/dv/lint/{tool}"
+             },
+             {    name: spi_host
+                  fusesoc_core: lowrisc:dv:spi_host_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/spi_host/dv/lint/{tool}"
+             },
+             {    name: sram_ctrl
+                  fusesoc_core: lowrisc:dv:sram_ctrl_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/sram_ctrl/dv/lint/{tool}"
+             },
+             {    name: uart
+                  fusesoc_core: lowrisc:dv:uart_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/uart/dv/lint/{tool}"
+             },
+          //    {    name: xbar_main
+          //         fusesoc_core: lowrisc:dv:top_darjeeling_xbar_main_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip/xbar_main/dv/lint/{tool}"
+          //    },
+          //    {    name: xbar_peri
+          //         fusesoc_core: lowrisc:dv:top_darjeeling_xbar_peri_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip/xbar_peri/dv/lint/{tool}"
+          //    },
+          //    {    name: xbar_mbx
+          //         fusesoc_core: lowrisc:dv:top_darjeeling_xbar_mbx_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/ip/xbar_mbx/dv/lint/{tool}"
+          //    },
+          //    {    name: chip
+          //         fusesoc_core: lowrisc:dv:chip_sim
+          //         import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+          //         rel_path: "hw/top_darjeeling/dv/lint/{tool}"
+          //         overrides: [
+          //           {
+          //             name: design_level
+          //             value: "top"
+          //           }
+          //         ]
+          //    },
+            ]
+}

--- a/hw/top_darjeeling/lint/top_darjeeling_fpga_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_fpga_lint_cfgs.hjson
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+
+  // This is the fpga cfg hjson for RTL linting.
+  name: top_darjeeling_fpga_batch
+
+  flow: lint
+
+  import_cfgs:      [// common server configuration for results upload
+                     "{proj_root}/hw/data/common_project_cfg.hjson"
+                     // tool-specific configuration
+                     "{proj_root}/hw/lint/tools/dvsim/{tool}.hjson"]
+
+  // Different dashboard output path for each tool
+  rel_path: "hw/top_darjeeling/lint/{tool}"
+
+  // Severities to be printed in the summary report
+  report_severities: ["warning", "error"]
+
+  use_cfgs: [
+            //  {    name: chip_darjeeling_cw310
+            //       fusesoc_core: lowrisc:systems:chip_darjeeling_cw310
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/chip_darjeeling_asic/lint/{tool}"
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+            ]
+
+}

--- a/hw/top_darjeeling/lint/top_darjeeling_fpv_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_fpv_lint_cfgs.hjson
@@ -1,0 +1,156 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  flow: lint
+
+  // This is the primary cfg hjson for FPV linting. It imports ALL individual lint
+  // cfgs of the IPs FPV environments.
+  // This enables to run them all as a regression in one shot.
+  name: top_darjeeling_fpv_batch
+
+  import_cfgs:      [// common server configuration for results upload
+                     "{proj_root}/hw/data/common_project_cfg.hjson"
+                     // tool-specific configuration
+                     "{proj_root}/hw/lint/tools/dvsim/{tool}.hjson"
+                     // Import shared FPV lint config
+                     "{proj_root}/hw/lint/shared_fpv_lint_cfgs.hjson"]
+
+  // Different dashboard output path for each tool
+  rel_path: "hw/top_darjeeling/fpv/lint/{tool}/summary"
+
+  use_cfgs: [
+            // {
+            //   name: alert_handler_esc_timer_fpv
+            //   fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_esc_timer_fpv
+            //   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //   rel_path: "hw/ip/alert_handler/alert_handler_esc_timer_fpv/lint/{tool}"
+            //  }
+            //  {
+            //   name: alert_handler_ping_timer_fpv
+            //   fusesoc_core: lowrisc:opentitan:top_earlgrey_alert_handler_ping_timer_fpv
+            //   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //   rel_path: "hw/ip/alert_handler/alert_handler_ping_timer_fpv/lint/{tool}"
+            // }
+            {
+               name: prim_arbiter_ppc_fpv
+               fusesoc_core: lowrisc:fpv:prim_arbiter_ppc_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_arbiter_ppc_fpv/lint/{tool}"
+             }
+             {
+               name: prim_arbiter_tree_fpv
+               fusesoc_core: lowrisc:fpv:prim_arbiter_tree_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_arbiter_tree_fpv/lint/{tool}"
+             }
+             {
+               name: prim_arbiter_fixed_fpv
+               fusesoc_core: lowrisc:fpv:prim_arbiter_fixed_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_arbiter_fixed_fpv/lint/{tool}"
+             }
+             {
+               name: prim_lfsr_fpv
+               fusesoc_core: lowrisc:fpv:prim_lfsr_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_lfsr_fpv/lint/{tool}"
+             }
+             {
+               name: prim_fifo_sync_fpv
+               fusesoc_core: lowrisc:fpv:prim_fifo_sync_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_fifo_sync_fpv/lint/{tool}"
+             }
+             {
+               name: prim_alert_rxtx_fpv
+               fusesoc_core: lowrisc:fpv:prim_alert_rxtx_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_alert_rxtx_fpv/lint/{tool}"
+             }
+             {
+               name: prim_alert_rxtx_async_fpv
+               fusesoc_core: lowrisc:fpv:prim_alert_rxtx_async_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_alert_rxtx_async_fpv/lint/{tool}"
+             }
+             {
+               name: prim_esc_rxtx_fpv
+               fusesoc_core: lowrisc:fpv:prim_esc_rxtx_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_esc_rxtx_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_22_16_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_22_16_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_22_16_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_28_22_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_28_22_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_28_22_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_39_32_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_39_32_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_39_32_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_64_57_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_64_57_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_64_57_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_72_64_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_72_64_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_72_64_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_hamming_22_16_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_hamming_22_16_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_hamming_22_16_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_hamming_39_32_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_hamming_39_32_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_hamming_39_32_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_hamming_72_64_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_hamming_72_64_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_hamming_72_64_fpv/lint/{tool}"
+             }
+             {
+               name: prim_packer_fpv
+               fusesoc_core: lowrisc:fpv:prim_packer_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_packer_fpv/lint/{tool}"
+             }
+             {
+               name: pinmux_fpv
+               fusesoc_core: lowrisc:fpv:pinmux_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/pinmux/fpv/lint/{tool}"
+             }
+             {
+               name: sha3pad_fpv
+               fusesoc_core: lowrisc:fpv:sha3pad_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/kmac/fpv/lint/{tool}"
+             }
+            //  {
+            //     name: top_darjeeling_rv_plic_fpv
+            //     fusesoc_core: lowrisc:opentitan:top_darjeeling_rv_plic_fpv
+            //     import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //     rel_path: "hw/top_darjeeling/ip_autogen/rv_plic/fpv/lint/{tool}"
+            //  }
+            ]
+}

--- a/hw/top_darjeeling/lint/top_darjeeling_lint_cfgs.hjson
+++ b/hw/top_darjeeling/lint/top_darjeeling_lint_cfgs.hjson
@@ -1,0 +1,298 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+
+  // This is the primary cfg hjson for RTL linting. It imports ALL individual lint
+  // cfgs of the IPs and the full chip used in top_darjeeling. This enables to run
+  // them all as a regression in one shot.
+  name: top_darjeeling_batch
+
+  flow: lint
+
+  import_cfgs:      [// common server configuration for results upload
+                     "{proj_root}/hw/data/common_project_cfg.hjson"
+                     // tool-specific configuration
+                     "{proj_root}/hw/lint/tools/dvsim/{tool}.hjson"]
+
+  // Different dashboard output path for each tool
+  rel_path: "hw/top_darjeeling/lint/{tool}/summary"
+
+  // Severities to be printed in the summary report
+  report_severities: ["warning", "error"]
+
+  use_cfgs: [{    name: mbx
+                  fusesoc_core: lowrisc:ip:mbx
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/mbx/lint/{tool}"
+            },
+            {    name: dma
+                 fusesoc_core: lowrisc:ip:dma
+                 import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                 rel_path: "hw/ip/dma/lint/{tool}"
+            },
+            {     name: aes
+                  fusesoc_core: lowrisc:ip:aes
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/aes/lint/{tool}"
+             },
+            //  {    name: alert_handler
+            //       fusesoc_core: lowrisc:opentitan:top_darjeeling_alert_handler
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/top_darjeeling/ip_autogen/alert_handler/lint/{tool}"
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+             {    name: aon_timer
+                  fusesoc_core: lowrisc:ip:aon_timer
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/aon_timer/lint/{tool}"
+             },
+            //  {    name: ast
+            //       fusesoc_core: lowrisc:systems:ast
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/top_darjeeling/ip/ast/lint/{tool}"
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+            //  {    name: clkmgr
+            //       fusesoc_core: lowrisc:opentitan:top_darjeeling_clkmgr
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
+            //       rel_path: "hw/top_darjeeling/ip_autogen/clkmgr/lint/{tool}",
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+             {    name: csrng
+                  fusesoc_core: lowrisc:ip:csrng
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/csrng/lint/{tool}"
+             },
+             {    name: edn
+                  fusesoc_core: lowrisc:ip:edn
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/edn/lint/{tool}"
+             },
+            //  {    name: flash_ctrl
+            //       fusesoc_core: lowrisc:opentitan:top_darjeeling_flash_ctrl
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/top_darjeeling/ip_autogen/flash_ctrl/lint/{tool}"
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+             {    name: gpio
+                  fusesoc_core: lowrisc:ip:gpio
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/gpio/lint/{tool}"
+             },
+             {    name: hmac
+                  fusesoc_core: lowrisc:ip:hmac
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/hmac/lint/{tool}"
+             },
+             {    name: kmac
+                  fusesoc_core: lowrisc:ip:kmac
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/kmac/lint/{tool}"
+             },
+             {    name: i2c
+                  fusesoc_core: lowrisc:ip:i2c
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/i2c/lint/{tool}"
+             },
+            //  {    name: lc_ctrl
+            //       fusesoc_core: lowrisc:ip:lc_ctrl
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/ip/lc_ctrl/lint/{tool}"
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+             {    name: keymgr
+                  fusesoc_core: lowrisc:ip:keymgr
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/keymgr/lint/{tool}"
+             },
+             {    name: keymgr_dpe
+                  fusesoc_core: lowrisc:ip:keymgr_dpe
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/keymgr_dpe/lint/{tool}"
+             },
+             {    name: otbn
+                  fusesoc_core: lowrisc:ip:otbn
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/otbn/lint/{tool}"
+             },
+            //  {    name: otp_ctrl
+            //       fusesoc_core: lowrisc:ip:otp_ctrl
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/ip/otp_ctrl/lint/{tool}"
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+            //  {    name: pinmux
+            //       fusesoc_core: lowrisc:ip:pinmux
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/ip/pinmux/lint/{tool}"
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+             {    name: pwm
+                  fusesoc_core: lowrisc:ip:pwm
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/pwm/lint/{tool}"
+                  overrides: [
+                    {
+                      name: design_level
+                      value: "top"
+                    }
+                  ]
+             },
+            //  {    name: pwrmgr
+            //       fusesoc_core: lowrisc:opentitan:top_darjeeling_pwrmgr
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
+            //       rel_path: "hw/top_darjeeling/ip_autogen/pwrmgr/lint/{tool}",
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+             {    name: rom_ctrl
+                  fusesoc_core: lowrisc:ip:rom_ctrl
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/rom_ctrl/lint/{tool}"
+             },
+            //  {    name: rstmgr
+            //       fusesoc_core: lowrisc:opentitan:top_darjeeling_rstmgr
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"],
+            //       rel_path: "hw/top_darjeeling/ip_autogen/rstmgr/lint/{tool}",
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+             {    name: rv_core_ibex
+                  fusesoc_core: lowrisc:ip:rv_core_ibex
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/rv_core_ibex/lint/{tool}"
+             },
+             {    name: rv_dm
+                  fusesoc_core: lowrisc:ip:rv_dm
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/rv_dm/lint/{tool}"
+             },
+            //  {    name: top_darjeeling_rv_plic
+            //       fusesoc_core: lowrisc:opentitan:top_darjeeling_rv_plic
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/top_darjeeling/ip_autogen/rv_plic/lint/{tool}"
+            //  },
+             {    name: rv_timer
+                  fusesoc_core: lowrisc:ip:rv_timer
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/rv_timer/lint/{tool}"
+             },
+             {    name: soc_proxy
+                  fusesoc_core: lowrisc:systems:soc_proxy
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/top_darjeeling/ip/soc_proxy/lint/{tool}"
+             },
+             {    name: spi_device
+                  fusesoc_core: lowrisc:ip:spi_device
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/spi_device/lint/{tool}"
+             },
+             {    name: spi_host
+                  fusesoc_core: lowrisc:ip:spi_host
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/spi_host/lint/{tool}"
+             },
+             {    name: sram_ctrl
+                  fusesoc_core: lowrisc:ip:sram_ctrl
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/sram_ctrl/lint/{tool}"
+                  overrides: [
+                    {
+                      name: design_level
+                      value: "top"
+                    }
+                  ]
+             },
+             {    name: uart
+                  fusesoc_core: lowrisc:ip:uart
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/uart/lint/{tool}"
+             },
+             {    name: socket_1n
+                  fusesoc_core: lowrisc:tlul:socket_1n
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/tlul/socket_1n/lint/{tool}"
+             },
+             {    name: socket_m1
+                  fusesoc_core: lowrisc:tlul:socket_m1
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/tlul/socket_m1/lint/{tool}"
+             },
+             {    name: adapter_reg
+                  fusesoc_core: lowrisc:tlul:adapter_reg
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/tlul/adapter_reg/lint/{tool}"
+             },
+             {    name: adapter_sram
+                  fusesoc_core: lowrisc:tlul:adapter_sram
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/tlul/adapter_sram/lint/{tool}"
+             },
+            //  {    name: sensor_ctrl
+            //       fusesoc_core: lowrisc:systems:sensor_ctrl
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/top_darjeeling/ip/sensor_ctrl/lint/{tool}"
+            //  },
+             {    name: sram2tlul
+                  fusesoc_core: lowrisc:tlul:sram2tlul
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/tlul/sram2tlul/lint/{tool}"
+             },
+            //  {    name: chip_darjeeling_asic
+            //       fusesoc_core: lowrisc:systems:chip_darjeeling_asic
+            //       import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+            //       rel_path: "hw/top_darjeeling/lint/{tool}"
+            //       overrides: [
+            //         {
+            //           name: design_level
+            //           value: "top"
+            //         }
+            //       ]
+            //  },
+            ]
+
+}


### PR DESCRIPTION
This PR adds the block level lint and sim configuration for the Darjeeling top. It only adds the IPs that are used in Darjeeling, ignoring other IPs that are used in Earlgrey.

The PR enables the DMA, MBX, KeymgrDPE, soc_proxy IP.