### PR TITLE
Owner page seal

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -60,13 +60,6 @@ hardened_bool_t owner_block_page1_valid_for_transfer(boot_data_t *bootdata) {
   return kHardenedBoolFalse;
 }
 
-void owner_block_page_seal(size_t page) {
-  size_t seal_len = (uintptr_t)&owner_page[0].seal - (uintptr_t)&owner_page[0];
-  hmac_digest_t digest;
-  hmac_sha256(&owner_page[page], seal_len, &digest);
-  memcpy(&owner_page[page].seal, digest.digest, sizeof(digest.digest));
-}
-
 void owner_config_default(owner_config_t *config) {
   // Use a bogus pointer value to avoid the all-zeros pattern of NULL.
   config->flash = (const owner_flash_config_t *)kHardenedBoolFalse;

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -67,15 +67,6 @@ typedef struct owner_application_keyring {
 hardened_bool_t owner_block_page1_valid_for_transfer(boot_data_t *bootdata);
 
 /**
- * Seal an owner page.
- *
- * Calculates and applies the seal to an owner page in RAM.
- *
- * @param page Which owner page to seal.
- */
-void owner_block_page_seal(size_t page);
-
-/**
  * Initialize the owner config with default values.
  *
  * The sram_exec mode is set to DisabledLocked and the three configuration

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -42,7 +42,7 @@ static rom_error_t activate(boot_svc_msg_t *msg, boot_data_t *bootdata) {
   }
 
   // Seal page one to this chip.
-  owner_block_page_seal(/*page=*/1);
+  ownership_seal_page(/*page=*/1);
 
   // TODO(cfrantz): Consider reading back the flash pages to check that the
   // flash writes succeeded.

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -217,8 +217,7 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageValid) {
       FAIL() << "Invalid state for this test: " << state;
   }
   // Once the new owner page is determined to be valid, the page will be sealed.
-  EXPECT_CALL(hmac_, sha256(_, _, _))
-      .WillOnce(SetArgPointee<2>((hmac_digest_t){{0x5a5a5a5a}}));
+  EXPECT_CALL(ownership_key_, seal_page(1));
 
   // The sealed page will be written into flash owner slot 1 first.
   EXPECT_CALL(flash_ctrl_,
@@ -246,7 +245,6 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageValid) {
   EXPECT_EQ(error, kErrorWriteBootdataThenReboot);
   // After succeeding, the page should be sealed, the nonce changed and the
   // ownership state set to LockedOwner.
-  EXPECT_EQ(owner_page[1].seal[0], 0x5a5a5a5a);
   EXPECT_FALSE(nonce_equal(&bootdata_.nonce, &kDefaultNonce));
   EXPECT_EQ(bootdata_.ownership_state, kOwnershipStateLockedOwner);
   // The default value of `owner_page.min_security_version_bl0` should perform
@@ -282,8 +280,7 @@ TEST_P(OwnershipActivateValidStateTest, UpdateBootdataBl0) {
       FAIL() << "Invalid state for this test: " << state;
   }
   // Once the new owner page is determined to be valid, the page will be sealed.
-  EXPECT_CALL(hmac_, sha256(_, _, _))
-      .WillOnce(SetArgPointee<2>((hmac_digest_t){{0x5a5a5a5a}}));
+  EXPECT_CALL(ownership_key_, seal_page(1));
 
   // The sealed page will be written into flash owner slot 1 first.
   EXPECT_CALL(flash_ctrl_,
@@ -311,7 +308,6 @@ TEST_P(OwnershipActivateValidStateTest, UpdateBootdataBl0) {
   EXPECT_EQ(error, kErrorWriteBootdataThenReboot);
   // After succeeding, the page should be sealed, the nonce changed and the
   // ownership state set to LockedOwner.
-  EXPECT_EQ(owner_page[1].seal[0], 0x5a5a5a5a);
   EXPECT_FALSE(nonce_equal(&bootdata_.nonce, &kDefaultNonce));
   EXPECT_EQ(bootdata_.ownership_state, kOwnershipStateLockedOwner);
   // Bootdata should receive the owner_block's minimum version upon activation.

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -19,6 +19,7 @@
 #include "sw/device/silicon_creator/lib/ownership/keys/fake/unlock_ecdsa_p256.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership.h"
+#include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
 
 /*
  * This module overrides the weak `sku_creator_owner_init` symbol in
@@ -166,7 +167,7 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
                (uintptr_t)app;
   memset(app, 0x5a, len);
 
-  owner_block_page_seal(/*page=*/0);
+  ownership_seal_page(/*page=*/0);
   memcpy(&owner_page[1], &owner_page[0], sizeof(owner_page[0]));
 
   RETURN_IF_ERROR(owner_block_parse(&owner_page[0], config, keyring));


### PR DESCRIPTION
[ownership] Use KMAC to seal the owner block to the chip 

1. Use KMAC to generate a chip-unique seal for an owner block.

Note: this PR depends on #23209.  You need only review the last commit.
