### PR TITLE
[ownership] Require the device ID for ownership unlock/activate

### DIFF
--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_activate.h
@@ -38,13 +38,17 @@ typedef struct boot_svc_ownership_activate_req {
    */
   uint32_t primary_bl0_slot;
   /**
+   * The 64-bit DIN subfield of the full 256-bit device ID.
+   */
+  uint32_t din[2];
+  /**
    * Erase previous owner's flash (hardened_bool_t).
    */
   uint32_t erase_previous;
   /**
    * Reserved for future use.
    */
-  uint32_t reserved[33];
+  uint32_t reserved[31];
   /**
    * The current ownership nonce.
    */
@@ -59,10 +63,12 @@ typedef struct boot_svc_ownership_activate_req {
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, header, 0);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, primary_bl0_slot,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE);
-OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, erase_previous,
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, din,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE + 4);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, erase_previous,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 12);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, reserved,
-                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 8);
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 16);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, nonce,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE + 140);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_activate_req_t, signature,

--- a/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
+++ b/sw/device/silicon_creator/lib/boot_svc/boot_svc_ownership_unlock.h
@@ -47,9 +47,13 @@ typedef struct boot_svc_ownership_unlock_req {
    */
   uint32_t unlock_mode;
   /**
+   * The 64-bit ID subfield of the full 256-bit device ID.
+   */
+  uint32_t din[2];
+  /**
    * Reserved for future use.
    */
-  uint32_t reserved[10];
+  uint32_t reserved[8];
   /**
    * The current ownership nonce.
    */
@@ -68,8 +72,10 @@ typedef struct boot_svc_ownership_unlock_req {
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, header, 0);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, unlock_mode,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE);
-OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, reserved,
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, din,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE + 4);
+OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, reserved,
+                        CHIP_BOOT_SVC_MSG_HEADER_SIZE + 12);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, nonce,
                         CHIP_BOOT_SVC_MSG_HEADER_SIZE + 44);
 OT_ASSERT_MEMBER_OFFSET(boot_svc_ownership_unlock_req_t, next_owner_key,

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -100,3 +100,9 @@ void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {
           reg1, LC_CTRL_HW_REVISION1_REVISION_ID_FIELD),
   };
 }
+
+hardened_bool_t lifecycle_din_eq(lifecycle_device_id_t *id, uint32_t *din) {
+  if (id->device_id[1] == din[0] && id->device_id[2] == din[1])
+    return kHardenedBoolTrue;
+  return kHardenedBoolFalse;
+}

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 
 #ifdef __cplusplus
@@ -116,6 +117,14 @@ void lifecycle_device_id_get(lifecycle_device_id_t *device_id);
  * @param[out] hw_rev Hardware revision.
  */
 void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev);
+
+/**
+ * Determine if the device identification number subfield of the Device Id is
+ * equal to the supplied DIN.
+ *
+ * @returns kHardenedBoolTrue if equal, kHardenedBoolFalse if not equal.
+ */
+hardened_bool_t lifecycle_din_eq(lifecycle_device_id_t *id, uint32_t *din);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/mock_lifecycle.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_lifecycle.cc
@@ -21,5 +21,11 @@ void lifecycle_device_id_get(lifecycle_device_id_t *device_id) {
 void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {
   MockLifecycle::Instance().HwRev(hw_rev);
 }
+
+hardened_bool_t lifecycle_din_eq(lifecycle_device_id_t *id, uint32_t *din) {
+  if (id->device_id[1] == din[0] && id->device_id[2] == din[1])
+    return kHardenedBoolTrue;
+  return kHardenedBoolFalse;
+}
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -214,6 +214,7 @@ enum module_ {
   X(kErrorOwnershipNoOwner,           ERROR_(11, kModuleOwnership, kInternal)), \
   X(kErrorOwnershipKeyNotFound,       ERROR_(12, kModuleOwnership, kNotFound)), \
   X(kErrorOwnershipInvalidVersion,    ERROR_(13, kModuleOwnership, kInvalidArgument)), \
+  X(kErrorOwnershipInvalidDin,        ERROR_(14, kModuleOwnership, kInvalidArgument)), \
   \
   /* This comment prevent clang from trying to format the macro. */
 

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -158,6 +158,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],
 )
 
@@ -173,6 +174,7 @@ cc_test(
         "//sw/device/lib/base:hardened",
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_header",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/testing:rom_test",
         "@googletest//:gtest_main",
     ],
@@ -191,6 +193,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -9,6 +9,7 @@
 #include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
@@ -39,6 +40,14 @@ static rom_error_t activate(boot_svc_msg_t *msg, boot_data_t *bootdata) {
   }
   if (!nonce_equal(&msg->ownership_activate_req.nonce, &bootdata->nonce)) {
     return kErrorOwnershipInvalidNonce;
+  }
+
+  // Verify the device identification number is correct.
+  lifecycle_device_id_t device_id;
+  lifecycle_device_id_get(&device_id);
+  if (lifecycle_din_eq(&device_id, msg->ownership_activate_req.din) !=
+      kHardenedBoolTrue) {
+    return kErrorOwnershipInvalidDin;
   }
 
   // Seal page one to this chip.

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
@@ -9,6 +9,7 @@
 #include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
 
@@ -27,6 +28,15 @@ static rom_error_t do_unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
   if (!nonce_equal(&msg->ownership_unlock_req.nonce, &bootdata->nonce)) {
     return kErrorOwnershipInvalidNonce;
   }
+
+  // Verify the device identification number is correct.
+  lifecycle_device_id_t device_id;
+  lifecycle_device_id_get(&device_id);
+  if (lifecycle_din_eq(&device_id, msg->ownership_unlock_req.din) !=
+      kHardenedBoolTrue) {
+    return kErrorOwnershipInvalidDin;
+  }
+
   if (msg->ownership_unlock_req.unlock_mode == kBootSvcUnlockEndorsed) {
     hmac_digest_t digest;
     hmac_sha256(&msg->ownership_unlock_req.next_owner_key,
@@ -105,6 +115,14 @@ static rom_error_t unlock_abort(boot_svc_msg_t *msg, boot_data_t *bootdata) {
     }
     if (!nonce_equal(&msg->ownership_unlock_req.nonce, &bootdata->nonce)) {
       return kErrorOwnershipInvalidNonce;
+    }
+
+    // Verify the device identification number is correct.
+    lifecycle_device_id_t device_id;
+    lifecycle_device_id_get(&device_id);
+    if (lifecycle_din_eq(&device_id, msg->ownership_unlock_req.din) !=
+        kHardenedBoolTrue) {
+      return kErrorOwnershipInvalidDin;
     }
     // Go back to locked owner.
     bootdata->ownership_state = kOwnershipStateLockedOwner;

--- a/sw/device/silicon_creator/lib/xmodem.c
+++ b/sw/device/silicon_creator/lib/xmodem.c
@@ -85,8 +85,7 @@ void xmodem_ack(void *iohandle, bool ack) {
 rom_error_t xmodem_recv_frame(void *iohandle, uint32_t frame, uint8_t *data,
                               size_t *rxlen, uint8_t *unknown_rx) {
   uint8_t ch;
-  size_t n = xmodem_read(iohandle, &ch, sizeof(ch),
-                         frame == 1 ? kXModemLongTimeout : kXModemShortTimeout);
+  size_t n = xmodem_read(iohandle, &ch, sizeof(ch), kXModemLongTimeout);
   if (n == 0) {
     return kErrorXModemTimeoutStart;
   } else if (ch == kXModemStx || ch == kXModemSoh) {
@@ -117,6 +116,7 @@ rom_error_t xmodem_recv_frame(void *iohandle, uint32_t frame, uint8_t *data,
       return kErrorXModemTimeoutCrc;
     }
     if (cancel) {
+      xmodem_cancel(iohandle);
       return kErrorXModemCancel;
     }
 

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -1,6 +1,7 @@
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
 load("//rules:const.bzl", "CONST", "hex")
 load(
     "//rules/opentitan:defs.bzl",
@@ -27,6 +28,12 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
     ],
 )
+
+# Note: the boot_svc commands for ownership_{activate,unlock} are tested by
+# the ownership transfer tests.  These two commands are unlike the rest of
+# the ownership commands in that they require a nonce, the device
+# identification number and a signature, and thus require far more test
+# infrastructure than the common boot_svc commands.
 
 opentitan_test(
     name = "boot_svc_empty_test",
@@ -164,44 +171,6 @@ opentitan_test(
         "//sw/device/silicon_creator/lib/boot_svc:boot_svc_next_boot_bl0_slot",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
-    ],
-)
-
-opentitan_test(
-    name = "boot_svc_ownership_unlock_test",
-    srcs = [
-        "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
-    ],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
-    },
-    fpga = fpga_params(
-        data = [
-            "//sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key",
-        ],
-        exit_failure = "(PASS|FAIL|FAULT).*\n",
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='ownership_state = OWND\r\n' --exit-failure='{exit_failure}'"
-            --exec="rescue boot-svc ownership-unlock \
-                    --mode Any \
-                    --nonce 0 \
-                    --sign $(location //sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key)"
-            --exec="console --non-interactive --exit-success='ownership_state = UANY\r\n' --exit-failure='{exit_failure}'"
-
-            # Since we've altered the ownership state, clear the bitstream to not affect later tests.
-            --exec="fpga clear-bitstream"
-            no-op
-        """,
-    ),
-    deps = [
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib:boot_log",
-        "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
 )
 

--- a/sw/host/opentitanlib/src/chip/device_id.rs
+++ b/sw/host/opentitanlib/src/chip/device_id.rs
@@ -11,29 +11,29 @@ use std::io::{Read, Write};
 #[derive(Debug, Default, Serialize, Annotate)]
 pub struct DeviceId {
     #[annotate(format=hex)]
-    creator: u16,
+    pub creator: u16,
     #[annotate(format=hex)]
-    product: u16,
+    pub product: u16,
     #[annotate(format=hex)]
-    id: u64,
+    pub din: u64,
     #[annotate(format=hex)]
-    crc32: u32,
+    pub crc32: u32,
     #[annotate(format=hex)]
-    sku_specific: [u32; 4],
+    pub sku_specific: [u32; 4],
 }
 
 impl DeviceId {
     pub fn read(src: &mut impl Read) -> Result<Self> {
         let creator = src.read_u16::<LittleEndian>()?;
         let product = src.read_u16::<LittleEndian>()?;
-        let id = src.read_u64::<LittleEndian>()?;
+        let din = src.read_u64::<LittleEndian>()?;
         let crc32 = src.read_u32::<LittleEndian>()?;
         let mut sku_specific = [0u32; 4];
         src.read_u32_into::<LittleEndian>(&mut sku_specific)?;
         Ok(Self {
             creator,
             product,
-            id,
+            din,
             crc32,
             sku_specific,
         })
@@ -42,7 +42,7 @@ impl DeviceId {
     pub fn write(&self, dest: &mut impl Write) -> Result<()> {
         dest.write_u16::<LittleEndian>(self.creator)?;
         dest.write_u16::<LittleEndian>(self.product)?;
-        dest.write_u64::<LittleEndian>(self.id)?;
+        dest.write_u64::<LittleEndian>(self.din)?;
         dest.write_u32::<LittleEndian>(self.crc32)?;
         for sku_specific in &self.sku_specific {
             dest.write_u32::<LittleEndian>(*sku_specific)?;

--- a/sw/host/opentitanlib/src/chip/helper.rs
+++ b/sw/host/opentitanlib/src/chip/helper.rs
@@ -17,6 +17,8 @@ pub struct OwnershipUnlockParams {
     pub mode: Option<UnlockMode>,
     #[arg(long, value_parser = u64::from_str, help="Current ROM_EXT nonce")]
     pub nonce: Option<u64>,
+    #[arg(long, value_parser = u64::from_str, help="Device Identification Number of the chip")]
+    pub din: Option<u64>,
     #[arg(long, help = "A path to the next owner key (for endorsed mode)")]
     pub next_owner: Option<PathBuf>,
     #[arg(long, help = "A path to a detached signature for the unlock request")]
@@ -33,6 +35,9 @@ impl OwnershipUnlockParams {
         }
         if let Some(nonce) = &self.nonce {
             unlock.nonce = *nonce;
+        }
+        if let Some(din) = &self.din {
+            unlock.din = *din;
         }
         if let Some(next_owner) = &self.next_owner {
             let key = EcdsaPublicKey::load(next_owner)?;
@@ -67,6 +72,8 @@ impl OwnershipUnlockParams {
 pub struct OwnershipActivateParams {
     #[arg(long, value_parser = u64::from_str, help="Current ROM_EXT nonce")]
     pub nonce: Option<u64>,
+    #[arg(long, value_parser = u64::from_str, help="Device Identification Number of the chip")]
+    pub din: Option<u64>,
     #[arg(long, help = "A path to a detached signature for the activate request")]
     pub signature: Option<PathBuf>,
     #[arg(long, help = "A path to a private key to sign the request")]
@@ -78,6 +85,9 @@ impl OwnershipActivateParams {
     pub fn apply(&self, activate: &mut OwnershipActivateRequest) -> Result<()> {
         if let Some(nonce) = &self.nonce {
             activate.nonce = *nonce;
+        }
+        if let Some(din) = &self.din {
+            activate.din = *din;
         }
         if let Some(signature) = &self.signature {
             let mut f = File::open(signature)?;

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -281,11 +281,11 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
 00000220: 66 06 00 00 00 01 00 02 77 17 11 88 77 17 11 11  f.......w...w...
 00000230: 49 4e 46 4f 20 00 00 00 00 01 00 00 66 06 00 99  INFO .......f...
 00000240: 66 06 00 00 01 05 00 00 77 17 11 88 77 17 11 11  f.......w...w...
-00000250: 52 45 53 51 38 00 00 00 58 4d 44 4d 20 00 e0 00  RESQ8...XMDM ...
+00000250: 52 45 53 51 50 00 00 00 58 4d 44 4d 20 00 e0 00  RESQP...XMDM ...
 00000260: 45 4d 50 54 4d 53 45 43 4e 45 58 54 55 4e 4c 4b  EMPTMSECNEXTUNLK
-00000270: 41 43 54 56 51 53 45 52 47 4f 4c 42 51 45 52 42  ACTVQSERGOLBQERB
-00000280: 50 53 52 42 52 4e 57 4f 5a 5a 5a 5a 5a 5a 5a 5a  PSRBRNWOZZZZZZZZ
-00000290: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
+00000270: 41 43 54 56 51 53 45 52 42 53 45 52 4f 42 45 52  ACTVQSERBSEROBER
+00000280: 47 4f 4c 42 51 45 52 42 50 53 52 42 52 4e 57 4f  GOLBQERBPSRBRNWO
+00000290: 30 47 50 4f 31 47 50 4f 44 49 54 4f 54 49 41 57  0GPO1GPODITOTIAW
 000002a0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
 000002b0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
 000002c0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
@@ -530,7 +530,7 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
       RescueConfig: {
         header: {
           identifier: "Rescue",
-          length: 56
+          length: 80
         },
         rescue_type: "Xmodem",
         start: 32,
@@ -542,10 +542,16 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
           "OwnershipUnlockRequest",
           "OwnershipActivateRequest",
           "Rescue",
+          "RescueB",
+          "Reboot",
           "GetBootLog",
           "BootSvcReq",
           "BootSvcRsp",
-          "OwnerBlock"
+          "OwnerBlock",
+          "GetOwnerPage0",
+          "GetOwnerPage1",
+          "GetDeviceId",
+          "Wait"
         ]
       }
     }

--- a/sw/host/opentitanlib/src/ownership/rescue.rs
+++ b/sw/host/opentitanlib/src/ownership/rescue.rs
@@ -118,10 +118,16 @@ impl OwnerRescueConfig {
                 CommandTag::OwnershipUnlockRequest,
                 CommandTag::OwnershipActivateRequest,
                 CommandTag::Rescue,
+                CommandTag::RescueB,
+                CommandTag::Reboot,
                 CommandTag::GetBootLog,
                 CommandTag::BootSvcReq,
                 CommandTag::BootSvcRsp,
                 CommandTag::OwnerBlock,
+                CommandTag::GetOwnerPage0,
+                CommandTag::GetOwnerPage1,
+                CommandTag::GetDeviceId,
+                CommandTag::Wait,
             ],
             ..Default::default()
         }

--- a/sw/host/opentitanlib/src/rescue/serial.rs
+++ b/sw/host/opentitanlib/src/rescue/serial.rs
@@ -96,7 +96,13 @@ impl RescueSerial {
         self.uart.write(&mode)?;
         let enter = b'\r';
         self.uart.write(std::slice::from_ref(&enter))?;
-        let result = UartConsole::wait_for(&*self.uart, r"(ok|error):.*\r\n", Self::ONE_SECOND)?;
+        let mode = std::str::from_utf8(&mode)?;
+        let result = UartConsole::wait_for(
+            &*self.uart,
+            &format!("mode: {mode}\r\n(ok|error):.*\r\n"),
+            Self::ONE_SECOND,
+        )?;
+
         if result[1] == "error" {
             return Err(RescueError::BadMode(result[0].clone()).into());
         }

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -108,13 +108,14 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
     let rescue = RescueSerial::new(Rc::clone(&uart));
 
     log::info!("###### Get Boot Log (1/2) ######");
-    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;
     log::info!("###### Ownership Unlock ######");
     transfer_lib::ownership_unlock(
         transport,
         &rescue,
         opts.unlock_mode,
         data.rom_ext_nonce,
+        devid.din,
         &opts.unlock_key,
         if opts.unlock_mode == UnlockMode::Endorsed {
             opts.next_owner_key_pub.as_deref()
@@ -194,13 +195,14 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
     }
 
     log::info!("###### Get Boot Log (2/2) ######");
-    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    let (data, _) = transfer_lib::get_device_info(transport, &rescue)?;
 
     log::info!("###### Ownership Activate Block ######");
     transfer_lib::ownership_activate(
         transport,
         &rescue,
         data.rom_ext_nonce,
+        devid.din,
         opts.activate_key
             .as_deref()
             .unwrap_or(&opts.next_activate_key),

--- a/sw/host/tests/ownership/rescue_limit_test.rs
+++ b/sw/host/tests/ownership/rescue_limit_test.rs
@@ -65,13 +65,14 @@ fn flash_limit_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let rescue = RescueSerial::new(Rc::clone(&uart));
 
     log::info!("###### Get Boot Log (1/2) ######");
-    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;
     log::info!("###### Ownership Unlock ######");
     transfer_lib::ownership_unlock(
         transport,
         &rescue,
         opts.unlock_mode,
         data.rom_ext_nonce,
+        devid.din,
         &opts.unlock_key,
         if opts.unlock_mode == UnlockMode::Endorsed {
             opts.next_owner_key_pub.as_deref()
@@ -93,13 +94,14 @@ fn flash_limit_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     )?;
 
     log::info!("###### Get Boot Log (2/2) ######");
-    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    let (data, _) = transfer_lib::get_device_info(transport, &rescue)?;
 
     log::info!("###### Ownership Activate Block ######");
     transfer_lib::ownership_activate(
         transport,
         &rescue,
         data.rom_ext_nonce,
+        devid.din,
         opts.activate_key
             .as_deref()
             .unwrap_or(&opts.next_activate_key),

--- a/sw/host/tests/ownership/rescue_permission_test.rs
+++ b/sw/host/tests/ownership/rescue_permission_test.rs
@@ -57,13 +57,14 @@ fn rescue_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<(
     let rescue = RescueSerial::new(Rc::clone(&uart));
 
     log::info!("###### Get Boot Log (1/2) ######");
-    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;
     log::info!("###### Ownership Unlock ######");
     transfer_lib::ownership_unlock(
         transport,
         &rescue,
         opts.unlock_mode,
         data.rom_ext_nonce,
+        devid.din,
         &opts.unlock_key,
         if opts.unlock_mode == UnlockMode::Endorsed {
             opts.next_owner_key_pub.as_deref()
@@ -85,13 +86,14 @@ fn rescue_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<(
     )?;
 
     log::info!("###### Get Boot Log (2/2) ######");
-    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    let (data, _) = transfer_lib::get_device_info(transport, &rescue)?;
 
     log::info!("###### Ownership Activate Block ######");
     transfer_lib::ownership_activate(
         transport,
         &rescue,
         data.rom_ext_nonce,
+        devid.din,
         opts.activate_key
             .as_deref()
             .unwrap_or(&opts.next_activate_key),

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -74,13 +74,14 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let rescue = RescueSerial::new(Rc::clone(&uart));
 
     log::info!("###### Get Boot Log (1/2) ######");
-    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    let (data, devid) = transfer_lib::get_device_info(transport, &rescue)?;
     log::info!("###### Ownership Unlock ######");
     transfer_lib::ownership_unlock(
         transport,
         &rescue,
         opts.unlock_mode,
         data.rom_ext_nonce,
+        devid.din,
         &opts.unlock_key,
         if opts.unlock_mode == UnlockMode::Endorsed {
             opts.next_owner_key_pub.as_deref()
@@ -128,13 +129,14 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     }
 
     log::info!("###### Get Boot Log (2/2) ######");
-    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    let (data, _) = transfer_lib::get_device_info(transport, &rescue)?;
 
     log::info!("###### Ownership Activate Block ######");
     transfer_lib::ownership_activate(
         transport,
         &rescue,
         data.rom_ext_nonce,
+        devid.din,
         opts.activate_key
             .as_deref()
             .unwrap_or(&opts.next_activate_key),


### PR DESCRIPTION
1. Include the Device Identification Number (DIN) subfield of the full 256-bit device ID into the ownership unlock and activate commands.
2. Update the Rust versions of the unlock/activate requests to include the DIN.
3. Update unittests.
4. Update the rescue mode-change function to wait for the requested `mode` event to confirm entry into the requested mode.
5. Update ownership transfer tests.