### PR TITLE
[manuf] erase AST config data from flash after use

### DIFF
--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -177,6 +177,7 @@ cc_library(
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:macros",
+        "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/dif:flash_ctrl",

--- a/sw/device/silicon_creator/manuf/lib/ast_program_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/ast_program_functest.c
@@ -63,8 +63,6 @@ static status_t program_page(void) {
   for (size_t i = 0; i < ARRAYSIZE(ast_cfg_data); ++i) {
     ast_cfg_data[i] = i;
   }
-
-  // The AST blob is 1 count word plus 2 additional words for every <count>.
   return flash_ctrl_testutils_write(
       &flash_state, byte_address, kFlashInfoFieldAstCalibrationData.partition,
       ast_cfg_data, kDifFlashCtrlPartitionTypeInfo,


### PR DESCRIPTION
This updates the individualization firmware to erase the AST configuration data from flash info after committing it to OTP.

This fixes #24526.