### PR TITLE
[sw/tests] Add OTP descrambling test

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -873,6 +873,18 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_otp_ctrl_descrambling
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: [
+        "//sw/device/tests:otp_ctrl_descrambling_test:1:new_rules",
+        "//sw/device/tests:otp_ctrl_descrambling_otp_image:4",
+      ]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: [
+        "+use_otp_image=OtpTypeCustom",
+      ]
+    }
+    {
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
       name: chip_sw_lc_ctrl_transition
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1983,6 +1983,71 @@ opentitan_test(
     ],
 )
 
+otp_json(
+    name = "otp_ctrl_descrambling_otp_json",
+    partitions = [
+        otp_partition(
+            name = "SECRET0",
+            items = {
+                "TEST_UNLOCK_TOKEN": "117dbd7aca3f7de6749f1cb4a7daf4f5",
+                "TEST_EXIT_TOKEN": "1dc4b32c25ef2c31d6313735da1740e4",
+            },
+            lock = False,
+        ),
+        otp_partition(
+            name = "SECRET1",
+            items = {
+                "FLASH_ADDR_KEY_SEED": "434677540fdc9956038c1b4e7bd7394c8251c8921ed1a7fc8ed040844dde2dca",
+                "FLASH_DATA_KEY_SEED": "7cdb1a9d39c20016dcc70e44beeff5f4871b3d2726a673365cc32c34646c9a9f",
+                "SRAM_DATA_KEY_SEED": "57f20b5b2e200c010e83fabc03c68203",
+            },
+            lock = False,
+        ),
+        otp_partition(
+            name = "SECRET2",
+            items = {
+                "RMA_TOKEN": "6ef5b95acb3ded39bed4fd235f6b24d4",
+                "CREATOR_ROOT_KEY_SHARE0": "f915734729d70391ea9f54f370a2fdf8196906bfe0051fa8a9398fab0bba1e23",
+                "CREATOR_ROOT_KEY_SHARE1": "e889c1ccf0f57d6ddda3ceb51b6cbc3bbaa7bc074a97c885d3bd2ecfc0fc7581",
+            },
+            lock = False,
+        ),
+    ],
+)
+
+otp_image(
+    name = "otp_ctrl_descrambling_otp_image",
+    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
+    overlays = STD_OTP_OVERLAYS + [":otp_ctrl_descrambling_otp_json"],
+    visibility = ["//visibility:private"],
+)
+
+opentitan_test(
+    name = "otp_ctrl_descrambling_test",
+    srcs = ["otp_ctrl_descrambling_test.c"],
+    dv = dv_params(
+        otp = ":otp_ctrl_descrambling_otp_image",
+    ),
+    exec_env = dicts.add(
+        {
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+            "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            # This test is not expected to run on silicon, as it would require a very specific OTP configuration that is only useful for this test.
+        },
+    ),
+    fpga = fpga_params(
+        otp = ":otp_ctrl_descrambling_otp_image",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 opentitan_test(
     name = "keymgr_sideload_aes_test",
     srcs = ["keymgr_sideload_aes_test.c"],

--- a/sw/device/tests/otp_ctrl_descrambling_test.c
+++ b/sw/device/tests/otp_ctrl_descrambling_test.c
@@ -1,0 +1,127 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+typedef struct partition_data {
+  dif_otp_ctrl_partition_t partition;
+  size_t size;
+} partition_data_t;
+
+static const partition_data_t kPartitions[] = {
+    {
+        .partition = kDifOtpCtrlPartitionSecret0,
+        .size =
+            (OTP_CTRL_PARAM_SECRET0_SIZE - OTP_CTRL_PARAM_SECRET0_DIGEST_SIZE) /
+            sizeof(uint64_t),
+    },
+    {
+        .partition = kDifOtpCtrlPartitionSecret1,
+        .size =
+            (OTP_CTRL_PARAM_SECRET1_SIZE - OTP_CTRL_PARAM_SECRET1_DIGEST_SIZE) /
+            sizeof(uint64_t),
+    },
+    {
+        .partition = kDifOtpCtrlPartitionSecret2,
+        .size =
+            (OTP_CTRL_PARAM_SECRET2_SIZE - OTP_CTRL_PARAM_SECRET2_DIGEST_SIZE) /
+            sizeof(uint64_t),
+    },
+};
+
+static inline uint32_t lower(uint64_t dword) { return (uint32_t)dword; }
+
+static inline uint32_t upper(uint64_t dword) { return (uint32_t)(dword >> 32); }
+
+size_t compare_dword(const uint64_t *actual_arr, uint32_t part_idx,
+                     uint32_t dword_idx, uint64_t expected) {
+  const uint64_t actual = actual_arr[dword_idx];
+  if (actual == expected) {
+    return 0;
+  } else {
+    LOG_WARNING("SECRET%0d, dword %0d: 0x%08x%08x != 0x%08x%08x", part_idx,
+                dword_idx, upper(actual), lower(actual), upper(expected),
+                lower(expected));
+    return 1;
+  }
+}
+
+bool test_main(void) {
+  dif_otp_ctrl_t otp_ctrl;
+
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+
+  // Number of 64-bit words that differ from the expected value; used to
+  // determine overall test pass or failure.
+  size_t dwords_diff = 0;
+
+  // Iterate over the partitions that are scrambled and read them out via the
+  // DAI.  This SW-based access is only possible because the partitions have not
+  // been locked in/before this test.
+  for (uint32_t i = 0; i < ARRAYSIZE(kPartitions); ++i) {
+    const partition_data_t *partition = &kPartitions[i];
+    uint64_t readout[partition->size];
+
+    LOG_INFO("Checking partition SECRET%0d.", i);
+    CHECK_STATUS_OK(otp_ctrl_testutils_dai_read64_array(
+        &otp_ctrl, partition->partition, 0, readout, ARRAYSIZE(readout)));
+
+    // Compare values read from OTP to expected values stored in the OTP image.
+    switch (i) {
+      case 0:
+        dwords_diff += compare_dword(readout, 0, 0, 0x749f1cb4a7daf4f5);
+        dwords_diff += compare_dword(readout, 0, 1, 0x117dbd7aca3f7de6);
+        dwords_diff += compare_dword(readout, 0, 2, 0xd6313735da1740e4);
+        dwords_diff += compare_dword(readout, 0, 3, 0x1dc4b32c25ef2c31);
+        CHECK(partition->size == 4, "Unexpected size of SECRET0 partition!");
+        break;
+
+      case 1:
+        dwords_diff += compare_dword(readout, 1, 0, 0x8ed040844dde2dca);
+        dwords_diff += compare_dword(readout, 1, 1, 0x8251c8921ed1a7fc);
+        dwords_diff += compare_dword(readout, 1, 2, 0x038c1b4e7bd7394c);
+        dwords_diff += compare_dword(readout, 1, 3, 0x434677540fdc9956);
+        dwords_diff += compare_dword(readout, 1, 4, 0x5cc32c34646c9a9f);
+        dwords_diff += compare_dword(readout, 1, 5, 0x871b3d2726a67336);
+        dwords_diff += compare_dword(readout, 1, 6, 0xdcc70e44beeff5f4);
+        dwords_diff += compare_dword(readout, 1, 7, 0x7cdb1a9d39c20016);
+        dwords_diff += compare_dword(readout, 1, 8, 0x0e83fabc03c68203);
+        dwords_diff += compare_dword(readout, 1, 9, 0x57f20b5b2e200c01);
+        CHECK(partition->size == 10, "Unexpected size of SECRET1 partition!");
+        break;
+
+      case 2:
+        dwords_diff += compare_dword(readout, 2, 0, 0xbed4fd235f6b24d4);
+        dwords_diff += compare_dword(readout, 2, 1, 0x6ef5b95acb3ded39);
+        dwords_diff += compare_dword(readout, 2, 2, 0xa9398fab0bba1e23);
+        dwords_diff += compare_dword(readout, 2, 3, 0x196906bfe0051fa8);
+        dwords_diff += compare_dword(readout, 2, 4, 0xea9f54f370a2fdf8);
+        dwords_diff += compare_dword(readout, 2, 5, 0xf915734729d70391);
+        dwords_diff += compare_dword(readout, 2, 6, 0xd3bd2ecfc0fc7581);
+        dwords_diff += compare_dword(readout, 2, 7, 0xbaa7bc074a97c885);
+        dwords_diff += compare_dword(readout, 2, 8, 0xdda3ceb51b6cbc3b);
+        dwords_diff += compare_dword(readout, 2, 9, 0xe889c1ccf0f57d6d);
+        CHECK(partition->size == 10, "Unexpected size of SECRET2 partition!");
+        break;
+
+      default:
+        OT_UNREACHABLE();
+        break;
+    }
+  }
+
+  // Test succeeds if no value read from OTP differed from the expected value.
+  return dwords_diff == 0;
+}


### PR DESCRIPTION
This adds a top-level test for the descrambling functionality/datapath of `otp_ctrl`.  All checks are done in SW; there's no need for any checks on the DV side.  The test works by reading out all three SECRET OTP partitions from SW (which is possible before they get locked) and confirm that the descrambled value that SW reads from OTP equals the expected value that is stored in the OTP image (the OTP image itself is scrambled).