### PR TITLE
[rom_ext,ownership] Diversify keymgr on owner measurements 

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -125,6 +125,7 @@ cc_library(
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -166,14 +166,19 @@ typedef struct owner_application_key {
   tlv_header_t header;
   /** Key algorithm.  One of ECDSA, SPX+ or SPXq20. */
   uint32_t key_alg;
-  /** Key domain.  Recognized values: PROD, DEV, TEST */
-  uint32_t key_domain;
-  /** Key diversifier.
-   *
-   * This value is concatenated to key_domain to create an 8 word
-   * diversification constant to be programmed into the keymgr.
-   */
-  uint32_t key_diversifier[7];
+  union {
+    struct {
+      /** Key domain.  Recognized values: PROD, DEV, TEST */
+      uint32_t key_domain;
+      /** Key diversifier.
+       *
+       * This value is concatenated to key_domain to create an 8 word
+       * diversification constant to be programmed into the keymgr.
+       */
+      uint32_t key_diversifier[7];
+    };
+    uint32_t raw_diversifier[8];
+  };
   /** Usage constraint must match manifest header's constraint */
   uint32_t usage_constraint;
   /** Key material.  Varies by algorithm type. */

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -115,6 +115,13 @@ rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
                                    size_t *index);
 
 /**
+ * Determine whether the given key is on owner page 0 or page 1.
+ *
+ * @return page number.
+ */
+size_t owner_block_key_page(const owner_application_key_t *key);
+
+/**
  * Determine whether a particular rescue command is allowed.
  *
  * @param rescue A pointer to the rescue configuration.
@@ -123,6 +130,14 @@ rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
  */
 hardened_bool_t owner_rescue_command_allowed(
     const owner_rescue_config_t *rescue, uint32_t command);
+
+/**
+ * Measure the content of the owner page.
+ *
+ * @param page The owner page to measure.
+ * @param measurement The measurement value.
+ */
+void owner_block_measurement(size_t page, hmac_digest_t *mesaurment);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
1. Measure the owner configuration and combine that measurement with the
   BL0 measurement to diversify the attestation ladder.
2. Apply the diversifier from the app verification key to the sealing
   ladder iff the ownership state is LockedOwner.

Addresses: lowRISC#21583 (adds owner firmware measurement to CDI_1 cert)
Addresses: lowRISC#19596 (add owner configuration block measurement to CDI_1 cert)