### PR TITLE
[rv_dm] Assert development stage V2S

### DIFF
--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -19,7 +19,7 @@
   version:            "1.1.0",
   life_stage:         "L1",
   design_stage:       "D2S",
-  verification_stage: "V1",
+  verification_stage: "V2S",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
     // Ideally, this is the processor clock and reset.


### PR DESCRIPTION
This follows the discussion in issue #22472, where we are now convinced that rv_dm is at the required stage.

Closes #22472.