### PR TITLE
[rom_ctrl,dv] Fixed rom_ctrl_kmac_err_chk_fix failure

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -274,4 +274,20 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
     end
   endfunction
 
+  virtual function void phase_ready_to_end(uvm_phase phase);
+    if (phase.get_name() != "run") return;
+
+      // Raising an objection and waiting for the pwrmgr_complete to set. This will add an extra
+      // delay after the test finishes and rom_ctrl_fsm would be in a done state which will set
+      // pwrmgr_data_o.done.
+      phase.raise_objection(this, {`gfn, " objection raised"});
+      fork
+        begin
+          if (cfg.en_scb)
+            wait (pwrmgr_complete);
+          phase.drop_objection(this, {`gfn, " objection dropped"});
+        end
+      join_none
+  endfunction
+
 endclass


### PR DESCRIPTION
This PR fixes the `rom_ctrl_kmac_err_chk_fix` test failure.

rom_ctrl_scoreboard happens to fails the [pwrmgr_complete](https://github.com/lowRISC/opentitan/blob/ec74fd4b3fff1d9764cf1956c9f75057c00660e7/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv#L254C1-L254C74) check a cycle earlier when the rom_ctrl_fsm is not in a done state. rom_ctrl_fsm was still processing through its post-reset flow and state registers after virtual sequence ends.

The fix here ensures that the run_phase doesn't complete until the [pwrmgr_complete](https://github.com/lowRISC/opentitan/blob/ec74fd4b3fff1d9764cf1956c9f75057c00660e7/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv#L254C1-L254C74)  has happened.