### PR TITLE
[tlul,rtl] Modify readback check error reporting logic

### DIFF
--- a/hw/ip/tlul/rtl/tlul_sram_byte.sv
+++ b/hw/ip/tlul/rtl/tlul_sram_byte.sv
@@ -262,8 +262,8 @@ module tlul_sram_byte import tlul_pkg::*; #(
             rdback_wait    = 1'b1;
             rdback_check_d = MuBi4False;
 
-            // Perform the readback check. Omit the check if the transaction contains an error.
-            if (!rdback_chk_ok && !error_i) begin
+            // Perform the readback check.
+            if (!rdback_chk_ok) begin
               alert_o = 1'b1;
             end
           end


### PR DESCRIPTION
Currently, only a readback error check is reported when the `error_i` signal is not raised. However, as this signal is also raised when there is no activity on the TL-UL bus, we might miss some readback failures.

This commit modifies the error reporting logic to also report the readback mismatch when the error signal is raised.

Closes #24698.