### PR TITLE
[pinmux/dif] Allow WARL behavior for pad attribute registers

### DIFF
--- a/sw/device/lib/dif/dif_pinmux.c
+++ b/sw/device/lib/dif/dif_pinmux.c
@@ -304,6 +304,12 @@ dif_result_t dif_pinmux_pad_write_attrs(const dif_pinmux_t *pinmux,
   uint32_t read_value = mmio_region_read32(pinmux->base_addr, reg_offset);
   *attrs_out = dif_pinmux_reg_to_pad_attr(read_value);
 
+  // Not all pads implement all attributes and not all target platforms support
+  // all attribute values. The underlying hardware registers implement Write-Any
+  // Read-Legal (WARL) semantics. If the specified attribute values are not
+  // supported by the hardware, return `kDifError`. The caller then needs to
+  // decide on how to resolve the situation. Unsupported attribute values can be
+  // identified by comparing `attrs_in` to `attrs_out`.
   if (reg_value != read_value) {
     return kDifError;
   }

--- a/sw/device/lib/dif/dif_pinmux.h
+++ b/sw/device/lib/dif/dif_pinmux.h
@@ -345,8 +345,13 @@ dif_result_t dif_pinmux_output_select(const dif_pinmux_t *pinmux,
  * Not all pads implement all attributes and some combinations cannot be
  * enabled together. This function returns a `kDifBadArg` error in case of
  * invalid `attrs_in`.
- * Conflicting attributes will be discarded by the hardware, and can be
- * identified by comparing `attrs_in` to `attrs_out`.
+ * Not all target platforms support all attribute values and the underlying
+ * hardware registers implement Write-Any Read-Legal (WARL) semantics. For
+ * example, the maximum supported slew rate and drive strength may vary between
+ * platforms. If the specified attribute values are valid but not supported by
+ * the hardware, this function returns `kDifError` and the caller needs to
+ * decide on how to resolve the situation. Unsupported or conflicting attribute
+ * values can be identified by comparing `attrs_in` to `attrs_out`.
  *
  * IMPORTANT:
  * See `dif_pinmux_pad_attr` for information on which attributes are compulsory


### PR DESCRIPTION
The MIO|DIO_PAD_ATTR registers are specified as WARL meaning certain bits written by software may get discarded by the hardware. For example the supported number of drive strength bits can depend on the hardware platform (simulation, FPGA, silicon).

Without this commit, the DIF treated these registers as RW: After writing pad attributes, it would perform a read back and error out in case of mismatches.

This is related to lowRISC/OpenTitan#24577.

---

The pinmux spec is probably a bit ambiguous with respect to the WARL/RW behavior of these registers:
![Screenshot from 2024-09-27 23-25-12](https://github.com/user-attachments/assets/18b4f7b6-d88f-4554-9a40-b163f2cae54b)

![Screenshot from 2024-09-27 23-25-35](https://github.com/user-attachments/assets/33d6b7d6-4208-4e9f-89a0-8aaf8ce2b547)

I think the main issue is that the regtool does not support WARL inherently. But the registers are really WARL, depending on the hardware/simulation platform and pad implementation, a different number of drive strength bits can be accepted while unsupported bits are tied to zero.