### PR TITLE
[ci] Move in-depth lint to GitHub Actions

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -51,7 +51,8 @@ runs:
           exit 1
         }
         sudo mkdir -p "${{ inputs.verilator-path }}"
-        sudo tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}" --strip-components=1
+        sudo chmod 777 "${{ inputs.verilator-path }}"
+        tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}" --strip-components=1
         echo "${{ inputs.verilator-path }}/bin" >> "$GITHUB_PATH"
       shell: bash
 
@@ -64,6 +65,7 @@ runs:
           exit 1
         }
         sudo mkdir -p "${{ inputs.verible-path }}"
-        sudo tar -C "${{ inputs.verible-path }}" -xvzf "/tmp/${VERIBLE_TAR}" --strip-components=1
+        sudo chmod 777 "${{ inputs.verible-path }}"
+        tar -C "${{ inputs.verible-path }}" -xvzf "/tmp/${VERIBLE_TAR}" --strip-components=1
         echo "${{ inputs.verible-path }}/bin" >> "$GITHUB_PATH"
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Countermeasures implemented (earlgrey)
         run: ./ci/scripts/check-countermeasures.sh earlgrey
         continue-on-error: true
+      - name: Countermeasures implemented (englishbreakfast)
+        run: ./ci/scripts/check-countermeasures.sh englishbreakfast
+        continue-on-error: true
       - name: Bazel test suite tags
         run: ./ci/scripts/check_bazel_test_suites.py
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,51 @@ jobs:
       - name: Generated documentation
         run: ./ci/scripts/check-cmdgen.sh
 
+  slow_lint:
+    name: Lint (slow)
+    runs-on: ubuntu-20.04
+    needs: quick_lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Bitstream cache requires all commits.
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+      - name: Countermeasures implemented (earlgrey)
+        run: ./ci/scripts/check-countermeasures.sh earlgrey
+        continue-on-error: true
+      - name: Bazel test suite tags
+        run: ./ci/scripts/check_bazel_test_suites.py
+        continue-on-error: true
+      # See #21973: disabled until Verilator tags are fixed.
+      # - name: Check Bazel tags
+      #   run: ./ci/scripts/check-bazel-tags.sh
+      #   continue-on-error: true
+      - name: Banned Bazel rules
+        run: ./ci/scripts/check-bazel-banned-rules.sh
+      - name: Bazel target names
+        run: ./ci/scripts/check_bazel_target_names.py
+        continue-on-error: true
+      - name: DV software images
+        run: ./ci/scripts/check_dv_sw_images.sh
+        continue-on-error: true
+      - name: Build documentation
+        run: ./ci/scripts/build-docs.sh
+      - name: Generated files
+        run: ./ci/scripts/check-generated.sh
+        env:
+          OT_DESTRUCTIVE: 1 # Required by the script to clean up.
+      - name: Buildifier
+        run: ./ci/bazelisk.sh test //quality:buildifier_check
+      - name: Vendored files
+        run: ./ci/scripts/check-vendoring.sh
+      - name: Verible RTL
+        run: ./ci/scripts/verible-lint.sh rtl
+      - name: Verible DV
+        run: ./ci/scripts/verible-lint.sh dv
+      - name: Verible FPV
+        run: ./ci/scripts/verible-lint.sh fpv
+
   airgapped_build:
     name: Airgapped build
     runs-on: ubuntu-20.04
@@ -76,7 +121,7 @@ jobs:
       - name: Build in the airgapped environment
         run: ./ci/scripts/test-airgapped-build.sh
 
-  verible-lint:
+  verible_lint:
     name: Verible lint
     runs-on: ubuntu-24.04
     needs: quick_lint

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,10 +243,6 @@ jobs:
       verilator --version
       verible-verilog-lint --version
     displayName: Display environment
-  # Check that all englishbreakfast countermeasures are implemented.
-  - bash: ci/scripts/check-countermeasures.sh englishbreakfast
-    displayName: Check countermeasures for top_englishbreakfast
-    continueOnError: True
   - bash: ci/scripts/build-chip-verilator.sh englishbreakfast
     displayName: Build simulation with Verilator
   - template: ci/upload-artifacts-template.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,57 +125,6 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Confirm no .bazelrc-site files
 
-- job: slow_lints
-  displayName: Quality (in-depth lint)
-  # Run code quality checks (in-depth lint)
-  dependsOn: lint
-  pool:
-    vmImage: ubuntu-20.04
-  steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  # Check that all earlgrey countermeasures are implemented.
-  - bash: ci/scripts/check-countermeasures.sh earlgrey
-    displayName: Check countermeasures for top_earlgrey
-    continueOnError: True
-  # Bazel test suites are a common cause of problematic tags. Check test suites
-  # before checking for other tag issues.
-  - bash:  ci/scripts/check_bazel_test_suites.py
-    displayName: Check Bazel test suites (Experimental)
-    continueOnError: True
-  # #21973: Disabled until Verilator tags are fixed in our build tree.
-  #- bash: ci/scripts/check-bazel-tags.sh
-  #  displayName: Check Bazel Tags (Experimental)
-  #  continueOnError: True
-  - bash: ci/scripts/check-bazel-banned-rules.sh
-    displayName: Check for banned rules
-  - bash:  ci/scripts/check_bazel_target_names.py
-    displayName: Check Bazel target names (Experimental)
-    continueOnError: True
-  - bash: ci/scripts/check_dv_sw_images.sh
-    displayName: Check DV software images (Experimental)
-    continueOnError: True
-  - bash: ci/scripts/build-docs.sh
-    displayName: Render documentation
-  # Define OT_DESTRUCTIVE=1 to enable ci/scripts/check-generated.sh to delete
-  # uncommitted changes.
-  - bash: OT_DESTRUCTIVE=1 ci/scripts/check-generated.sh
-    displayName: Check Generated
-    # Ensure all generated files are clean and up-to-date
-  - bash: ci/bazelisk.sh test //quality:buildifier_check --test_output=streamed
-    displayName: Buildifier (Bazel lint)
-  - bash: ci/scripts/check-vendoring.sh
-    displayName: Vendored directories
-  - bash: ci/scripts/verible-lint.sh rtl
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Verible RTL (Verilog lint)
-  - bash: ci/scripts/verible-lint.sh dv
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Verible DV (Verilog lint)
-  - bash: ci/scripts/verible-lint.sh fpv
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Verible FPV (Verilog lint)
-
 - job: sw_build
   displayName: Earl Grey SW Build
   # Build software tests for the Earl Grey toplevel design

--- a/ci/.bazelrc
+++ b/ci/.bazelrc
@@ -22,3 +22,6 @@ build --keep_going
 # Use the remote Bazel cache for CI.
 build --remote_cache=https://storage.googleapis.com/opentitan-bazel-cache
 build --remote_timeout=5
+
+# Print the full stdout and stderr of tests, not just the summary
+test --test_output=all

--- a/ci/scripts/build-docs.sh
+++ b/ci/scripts/build-docs.sh
@@ -7,16 +7,6 @@
 
 set -e
 util/site/build-docs.sh build-local || {
-  echo -n "##vso[task.logissue type=error]"
-  echo "Documentation build failed."
+  echo "::error::Documentation build failed."
   exit 1
 }
-
-# Upload Doxygen Warnings if Present
-if [ -f "build-site/gen/doxygen_warnings.log" ]; then
-  echo -n "##vso[task.uploadfile]"
-  echo "${PWD}/build-site/gen/doxygen_warnings.log"
-  # Doxygen currently generates lots of warnings.
-  # echo -n "##vso[task.issue type=warning]"
-  # echo "Doxygen generated warnings. Use 'util/site/build-docs.sh' to generate warning logfile."
-fi

--- a/ci/scripts/check-countermeasures.sh
+++ b/ci/scripts/check-countermeasures.sh
@@ -19,7 +19,6 @@ if [ ! -f ${hjson_file} ]; then
 fi
 
 ./util/topgen.py -t ${hjson_file} --check-cm || {
-    echo -n "##vso[task.logissue type=error]"
-    echo "Countermeasure check failed."
+    echo "::error::Countermeasure check failed."
     exit 1
 }

--- a/ci/scripts/check-generated.sh
+++ b/ci/scripts/check-generated.sh
@@ -25,16 +25,14 @@ gen_and_check_clean() {
     thing="$1"
     shift
     "$@" || {
-        echo -n "##vso[task.logissue type=error]"
-        echo "Failed to auto-generate $thing. (command: '$*')"
+        echo "::error::Failed to auto-generate ${thing}. (command: '$*')"
         echo
         destructive_cleanup
         return 1
     }
 
     is_clean || {
-        echo -n "##vso[task.logissue type=error]"
-        echo "Auto-generated $thing not up-to-date. Regenerate with '$*'."
+        echo "::error::Auto-generated ${thing} not up-to-date. Regenerate with '$*'."
         echo
         destructive_cleanup
         return 1

--- a/ci/scripts/check-vendoring.sh
+++ b/ci/scripts/check-vendoring.sh
@@ -21,7 +21,6 @@ find . \
 }
 
 git diff --exit-code || {
-    echo >&2 -n "##vso[task.logissue type=error]"
-    echo >&2 "Vendored repositories not up-to-date. Run util/vendor.py to fix."
+    echo >&2 "::error::Vendored repositories not up-to-date. Run util/vendor.py to fix."
     exit 1
 }

--- a/ci/scripts/check_bazel_target_names.py
+++ b/ci/scripts/check_bazel_target_names.py
@@ -10,15 +10,13 @@ import sys
 
 from lib.bazel_query import BazelQueryRunner
 
-AZURE_PIPELINES_ERROR = "##vso[task.logissue type=warning]"
 
 if __name__ == '__main__':
     bazel = BazelQueryRunner()
 
     results = list(bazel.find_targets_with_banned_chars())
     if results:
-        print(AZURE_PIPELINES_ERROR +
-              "Some target names have banned characters.")
+        print("::error::Some target names have banned characters.")
     for target, bad_chars in results:
         print("Target name contains banned characters {}: {}".format(
             bad_chars, target))

--- a/ci/scripts/check_bazel_test_suites.py
+++ b/ci/scripts/check_bazel_test_suites.py
@@ -26,9 +26,6 @@ EMPTY_TEST_SUITE_DESCRIPTION = """
 Test suites below contain zero tests. This is probably an accident.
 """
 
-AZURE_PIPELINES_WARNING = "##vso[task.logissue type=warning]"
-AZURE_PIPELINES_ERROR = "##vso[task.logissue type=error]"
-
 if __name__ == '__main__':
     bazel = BazelQueryRunner()
     non_manual_test_suites = list(bazel.find_non_manual_test_suites())
@@ -36,13 +33,13 @@ if __name__ == '__main__':
 
     if non_manual_test_suites:
         print("-" * 80)
-        print(AZURE_PIPELINES_WARNING + NON_MANUAL_TEST_SUITE_DESCRIPTION)
+        print("::warning::" + NON_MANUAL_TEST_SUITE_DESCRIPTION)
         for target in non_manual_test_suites:
             print("  - " + target)
 
     if empty_test_suites:
         print("-" * 80)
-        print(AZURE_PIPELINES_ERROR + EMPTY_TEST_SUITE_DESCRIPTION)
+        print("::error::" + EMPTY_TEST_SUITE_DESCRIPTION)
         for target in empty_test_suites:
             print("  - " + target)
 

--- a/ci/scripts/verible-lint.sh
+++ b/ci/scripts/verible-lint.sh
@@ -47,7 +47,8 @@ fi
 
 env DVSIM_MAX_PARALLEL="$mp" \
   util/dvsim/dvsim.py --tool=veriblelint "$dvsim_cfg" || {
-    echo -n "##vso[task.logissue type=error]"
-    echo "Verilog style lint of $human_desc sources with Verible failed. Run 'util/dvsim/dvsim.py -t veriblelint $dvsim_cfg' and fix all errors."
+    echo "::error::"\
+        "Verilog style lint of ${human_desc} sources with Verible failed." \
+        "Run 'util/dvsim/dvsim.py -t veriblelint ${dvsim_cfg}' and fix all errors."
     exit 1
 }


### PR DESCRIPTION
This PR also includes a fix to the `install-deps` action for Verilator and Verible permissions.

It moves the "countermeasure implementation" check for `englishbreakfast` into the in-depth lint job for consistency.