### PR TITLE
[dv,jtag] Change JTAG clock frequency to 24MHz for GLS

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -5,10 +5,10 @@
 // TODO(#24580): A JTAG UVM agent should configure the JTAG frequency (and not this interface)
 `ifdef GATE_LEVEL
   // jtag interface with default 24MHz tck for GLS
-  interface jtag_if #(parameter int unsigned JtagDefaultTckPeriodPs = 20_000) ();
+  interface jtag_if #(parameter int unsigned JtagDefaultTckPeriodPs = 41_664) ();
 `else
   // jtag interface with default 50MHz tck for faster DV simulations
-  interface jtag_if #(parameter int unsigned JtagDefaultTckPeriodPs = 41_664) ();
+  interface jtag_if #(parameter int unsigned JtagDefaultTckPeriodPs = 20_000) ();
 `endif
 
   // interface pins


### PR DESCRIPTION
Fix the code to match to the comments (24MHz for GLS, 50MHz for RTL).

Reverting the frequencies in [#24580](https://github.com/lowRISC/opentitan/pull/24580) so it will be correct.