### PR TITLE
[ownership] Add an `update_mode` to the configuration

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -715,8 +715,6 @@ static const flash_ctrl_info_page_t *kInfoPagesNoOwnerAccess[] = {
     // Bank 1
     &kFlashCtrlInfoPageBootData0,
     &kFlashCtrlInfoPageBootData1,
-    &kFlashCtrlInfoPageOwnerSlot0,
-    &kFlashCtrlInfoPageOwnerSlot1,
 };
 
 enum {

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -165,7 +165,7 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  * ```
  */
 enum {
-  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 16,
+  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 12,
   kFlashCtrlSecMmioCertInfoPagesCreatorCfg = 10,
   kFlashCtrlSecMmioCertInfoPagesOwnerRestrict = 5,
   kFlashCtrlSecMmioDataDefaultCfgSet = 1,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -682,11 +682,10 @@ INSTANTIATE_TEST_SUITE_P(AllCases, FlashCtrlCfgSetTest,
                              }));
 
 TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
-  std::array<const flash_ctrl_info_page_t *, 8> no_owner_access = {
+  std::array<const flash_ctrl_info_page_t *, 6> no_owner_access = {
       &kFlashCtrlInfoPageFactoryId,   &kFlashCtrlInfoPageCreatorSecret,
       &kFlashCtrlInfoPageOwnerSecret, &kFlashCtrlInfoPageWaferAuthSecret,
       &kFlashCtrlInfoPageBootData0,   &kFlashCtrlInfoPageBootData1,
-      &kFlashCtrlInfoPageOwnerSlot0,  &kFlashCtrlInfoPageOwnerSlot1,
   };
   for (auto page : no_owner_access) {
     auto info_page = InfoPages().at(page);

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -215,6 +215,7 @@ enum module_ {
   X(kErrorOwnershipKeyNotFound,       ERROR_(12, kModuleOwnership, kNotFound)), \
   X(kErrorOwnershipInvalidVersion,    ERROR_(13, kModuleOwnership, kInvalidArgument)), \
   X(kErrorOwnershipInvalidDin,        ERROR_(14, kModuleOwnership, kInvalidArgument)), \
+  X(kErrorOwnershipUnlockDenied,      ERROR_(15, kModuleOwnership, kPermissionDenied)), \
   \
   /* This comment prevent clang from trying to format the macro. */
 

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -151,6 +151,7 @@ cc_library(
     hdrs = ["ownership_unlock.h"],
     deps = [
         ":datatypes",
+        ":owner_block",
         ":ownership_key",
         "//sw/device/lib/base:memory",
         "//sw/device/silicon_creator/lib:boot_data",
@@ -218,6 +219,24 @@ cc_library(
     name = "test_owner",
     testonly = True,
     srcs = ["test_owner.c"],
+    deps = [
+        ":datatypes",
+        ":owner_block",
+        ":ownership",
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:includes",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "test_owner_update_mode_newversion",
+    testonly = True,
+    srcs = ["test_owner.c"],
+    defines = [
+        "TEST_OWNER_UPDATE_MODE=kOwnershipUpdateModeNewVersion",
+    ],
     deps = [
         ":datatypes",
         ":owner_block",

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -61,6 +61,19 @@ typedef enum ownership_key_alg {
   kOwnershipKeyAlgSpxq20 = 0x30327153,
 } ownership_key_alg_t;
 
+typedef enum ownership_update_mode {
+  /** Update mode open: `OPEN` (unlock key has full power) */
+  kOwnershipUpdateModeOpen = 0x4e45504f,
+  /** Update mode self: `SELF` (unlock key only unlocks to UnlockedSelf) */
+  kOwnershipUpdateModeSelf = 0x464c4553,
+  /**
+   * Update mode NewVersion: `NEWV`
+   * (unlock key can't unlock; accept new owner configs from self-same owner
+   * if the config_version is newer)
+   */
+  kOwnershipUpdateModeNewVersion = 0x5657454e,
+} ownership_update_mode_t;
+
 typedef enum tlv_tag {
   /** Owner struct: `OWNR`. */
   kTlvTagOwner = 0x524e574f,
@@ -110,8 +123,10 @@ typedef struct owner_block {
   uint32_t config_version;
   /** Set the minimum security version to this value (UINT32_MAX: no change) */
   uint32_t min_security_version_bl0;
+  /** Ownership update mode (one of OPEN, SELF, NEWV) */
+  uint32_t update_mode;
   /** Reserved space for future use. */
-  uint32_t reserved[25];
+  uint32_t reserved[24];
   /** Owner public key. */
   owner_key_t owner_key;
   /** Owner's Activate public key. */
@@ -132,7 +147,8 @@ OT_ASSERT_MEMBER_OFFSET(owner_block_t, sram_exec_mode, 12);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, ownership_key_alg, 16);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, config_version, 20);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, min_security_version_bl0, 24);
-OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 28);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, update_mode, 28);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 32);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, owner_key, 128);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, activate_key, 224);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, unlock_key, 320);

--- a/sw/device/silicon_creator/lib/ownership/ownership.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership.h
@@ -20,12 +20,19 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
 /**
  * Lockdown the flash configuration.
  *
- *
  * @param bootdata The current bootdata.
  * @param config The current owner configuration.
  * @return error state.
  */
 rom_error_t ownership_flash_lockdown(boot_data_t *bootdata,
                                      const owner_config_t *config);
+
+/**
+ * Lockdown the ownership info pages.
+ *
+ * @param bootdata The current bootdata.
+ * @param rescue Whether the ROM_EXT is in rescue mode.
+ */
+void ownership_pages_lockdown(boot_data_t *bootdata, hardened_bool_t rescue);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNERSHIP_H_

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -31,6 +31,10 @@
 // number in the test library `sw/host/tests/ownership/transfer_lib.rs`.
 #define TEST_OWNER_CONFIG_VERSION 1
 
+#ifndef TEST_OWNER_UPDATE_MODE
+#define TEST_OWNER_UPDATE_MODE kOwnershipUpdateModeOpen
+#endif
+
 rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
                                    owner_config_t *config,
                                    owner_application_keyring_t *keyring) {
@@ -65,6 +69,7 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
   owner_page[0].config_version = TEST_OWNER_CONFIG_VERSION;
   owner_page[0].min_security_version_bl0 = UINT32_MAX;
+  owner_page[0].update_mode = TEST_OWNER_UPDATE_MODE;
   owner_page[0].owner_key = owner;
   owner_page[0].activate_key = (owner_key_t){
       // Although this is an ECDSA key, we initialize the `raw` member of the

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -318,6 +318,28 @@ opentitan_binary(
     ],
 )
 
+# This binary is a test-only ROM_EXT that has ownership initialized in
+# the "NewVersion" update mode.  Initializing in this mode makes the
+# test flows for the "NewVersion" style of ownership updates easier.
+opentitan_binary(
+    name = "rom_ext_owner_update_newversion",
+    testonly = True,
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+    ],
+    linker_script = ":ld_slot_a",
+    manifest = ":manifest",
+    rsa_key = {"//sw/device/silicon_creator/rom/keys/fake/rsa:prod_private_key_0": "prod_key_0"},
+    secver_write = secver_write_selection(),
+    deps = [
+        ":rom_ext",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+        "//sw/device/silicon_creator/lib/ownership:test_owner_update_mode_newversion",
+        "//sw/device/silicon_creator/lib/ownership/keys/fake",
+    ],
+)
+
 manifest(d = {
     "name": "manifest_bad_address_translation",
     "address_translation": "0",

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -24,6 +24,7 @@ opentitan_binary(
     name = "boot_test",
     testonly = True,
     srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+    defines = ["WITH_OWNERSHIP_INFO=1"],
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod",
     },
@@ -34,7 +35,9 @@ opentitan_binary(
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/ownership:datatypes",
     ],
 )
 
@@ -390,5 +393,53 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
         """,
         test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+ownership_transfer_test(
+    name = "newversion_update_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa_pub)
+            --config-version=2
+            # We expect to see the version updated and the owner key the same.
+            --expect "config_version = 2"
+            --expect "owner_key = 8e3dcb50"
+        """,
+        test_harness = "//sw/host/tests/ownership:newversion_test",
+    ),
+)
+
+ownership_transfer_test(
+    name = "newversion_noupdate_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa_pub)
+            --config-version=0
+            # We expect to see the version unchanged.
+            --expect "config_version = 1"
+            --expect "owner_key = 8e3dcb50"
+        """,
+        test_harness = "//sw/host/tests/ownership:newversion_test",
     ),
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
@@ -28,11 +28,14 @@ def ownership_transfer_test(
             "//sw/device/silicon_creator/lib/ownership/keys/fake:owner_key_pub",
             "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa_pub",
         ],
+        defines = ["WITH_OWNERSHIP_INFO=1"],
         deps = [
             "//sw/device/lib/base:status",
             "//sw/device/lib/testing/test_framework:ottf_main",
             "//sw/device/silicon_creator/lib:boot_log",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
             "//sw/device/silicon_creator/lib/drivers:retention_sram",
+            "//sw/device/silicon_creator/lib/ownership:datatypes",
         ],
         **kwargs):
     opentitan_test(
@@ -41,6 +44,7 @@ def ownership_transfer_test(
         exec_env = exec_env,
         ecdsa_key = ecdsa_key,
         data = data,
+        defines = defines,
         deps = deps,
         **kwargs
     )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/flash_regions.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/flash_regions.c
@@ -56,17 +56,19 @@ status_t flash_regions_print(dif_flash_ctrl_state_t *f) {
     TRY(dif_flash_ctrl_data_region_is_locked(f, i, &locked));
     flash_data_region_print(i, &p, locked);
   }
-  for (uint32_t i = 0; i < 4; ++i) {
-    dif_flash_ctrl_info_region_t region = {
-        .bank = 0,
-        .partition_id = 0,
-        .page = 6 + i,
-    };
-    bool locked;
-    dif_flash_ctrl_region_properties_t p;
-    TRY(dif_flash_ctrl_get_info_region_properties(f, region, &p));
-    TRY(dif_flash_ctrl_info_region_is_locked(f, region, &locked));
-    flash_info_region_print(region, &p, locked);
+  for (uint32_t bank = 0; bank < 2; ++bank) {
+    for (uint32_t page = 0; page < 10; ++page) {
+      dif_flash_ctrl_info_region_t region = {
+          .bank = bank,
+          .partition_id = 0,
+          .page = page,
+      };
+      bool locked;
+      dif_flash_ctrl_region_properties_t p;
+      TRY(dif_flash_ctrl_get_info_region_properties(f, region, &p));
+      TRY(dif_flash_ctrl_info_region_is_locked(f, region, &locked));
+      flash_info_region_print(region, &p, locked);
+    }
   }
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/boot_test.c
@@ -8,6 +8,28 @@
 #include "sw/device/silicon_creator/lib/boot_log.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 
+#ifdef WITH_OWNERSHIP_INFO
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/ownership/datatypes.h"
+
+status_t ownership_print(void) {
+  owner_block_t config;
+  TRY(flash_ctrl_info_read(&kFlashCtrlInfoPageOwnerSlot0, 0,
+                           sizeof(config) / sizeof(uint32_t), &config));
+
+  LOG_INFO("owner_page0 tag = %C", config.header.tag);
+  LOG_INFO("owner_page0 ownership_key_alg = %C", config.ownership_key_alg);
+  LOG_INFO("owner_page0 config_version = %d", config.config_version);
+  LOG_INFO("owner_page0 min_security_version_bl0 = %08x",
+           config.min_security_version_bl0);
+  LOG_INFO("owner_page0 update_mode = %C", config.update_mode);
+  LOG_INFO("owner_page0 owner_key = %08x", config.owner_key.raw[0]);
+  return OK_STATUS();
+}
+#else
+status_t ownership_print(void) { return OK_STATUS(); }
+#endif
+
 OTTF_DEFINE_TEST_CONFIG();
 
 status_t boot_log_print(boot_log_t *boot_log) {
@@ -29,7 +51,7 @@ status_t boot_log_print(boot_log_t *boot_log) {
   LOG_INFO("boot_log rom_ext_min_sec_ver = %u", boot_log->rom_ext_min_sec_ver);
   LOG_INFO("boot_log bl0_min_sec_ver = %u", boot_log->bl0_min_sec_ver);
   LOG_INFO("boot_log primary_bl0_slot = %C", boot_log->primary_bl0_slot);
-  return OK_STATUS();
+  return ownership_print();
 }
 
 bool test_main(void) {

--- a/sw/device/silicon_creator/rom_ext/rescue.c
+++ b/sw/device/silicon_creator/rom_ext/rescue.c
@@ -62,7 +62,9 @@ rom_error_t flash_firmware_block(rescue_state_t *state) {
 rom_error_t flash_owner_block(rescue_state_t *state, boot_data_t *bootdata) {
   if (bootdata->ownership_state == kOwnershipStateUnlockedAny ||
       bootdata->ownership_state == kOwnershipStateUnlockedSelf ||
-      bootdata->ownership_state == kOwnershipStateUnlockedEndorsed) {
+      bootdata->ownership_state == kOwnershipStateUnlockedEndorsed ||
+      (bootdata->ownership_state == kOwnershipStateLockedOwner &&
+       owner_page[0].update_mode == kOwnershipUpdateModeNewVersion)) {
     HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(
         &kFlashCtrlInfoPageOwnerSlot1, kFlashCtrlEraseTypePage));
     HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
@@ -158,7 +160,9 @@ static void validate_mode(uint32_t mode, rescue_state_t *state,
       case kRescueModeOwnerBlock:
         if (bootdata->ownership_state == kOwnershipStateUnlockedAny ||
             bootdata->ownership_state == kOwnershipStateUnlockedSelf ||
-            bootdata->ownership_state == kOwnershipStateUnlockedEndorsed) {
+            bootdata->ownership_state == kOwnershipStateUnlockedEndorsed ||
+            (bootdata->ownership_state == kOwnershipStateLockedOwner &&
+             owner_page[0].update_mode == kOwnershipUpdateModeNewVersion)) {
           dbg_printf("ok: send owner_block via xmodem-crc\r\n");
         } else {
           dbg_printf("error: cannot accept owner_block in current state\r\n");

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -889,10 +889,12 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   if (uart_break_detect(kRescueDetectTime) == kHardenedBoolTrue) {
     dbg_printf("rescue: remember to clear break\r\n");
     uart_enable_receiver();
+    ownership_pages_lockdown(boot_data, /*rescue=*/kHardenedBoolTrue);
     // TODO: update rescue protocol to accept boot data and rescue
     // config from the owner_config.
     error = rescue_protocol(boot_data, owner_config.rescue);
   } else {
+    ownership_pages_lockdown(boot_data, /*rescue=*/kHardenedBoolFalse);
     error = rom_ext_try_next_stage(boot_data, boot_log);
   }
   return error;

--- a/sw/host/tests/ownership/BUILD
+++ b/sw/host/tests/ownership/BUILD
@@ -73,3 +73,17 @@ rust_binary(
         "@crate_index//:regex",
     ],
 )
+
+rust_binary(
+    name = "newversion_test",
+    srcs = ["newversion_test.rs"],
+    deps = [
+        ":transfer_lib",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:regex",
+    ],
+)

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -156,6 +156,9 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         // Flash SideA is the previous owner configuration.  The `fake` test owner
         // has no flash configuration at all.
         //
+        // Note: The number of regions and indices of the regions is currently
+        // Earlgrey-specific.
+        //
         // Note: when in an unlocked state, flash lockdown doesn't apply, so neither
         // the `protect_when_primary` nor `lock` bits for individual regions will
         // affect the region config.
@@ -191,6 +194,18 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         assert_eq!(
             region[7],
             FlashRegion("data", 7, 0, 0, "xx-xx-xx-xx-xx-xx", "UN")
+        );
+
+        // Bank 1, pages 2-3 are the ownership pages.  In an ownership unlocked
+        // state, OwnerPage0 (bank 1 page 2) should be read-only and OwnerPage1
+        // (bank1 page 3) should be read/write.
+        assert_eq!(
+            region[20],
+            FlashRegion("info", 1, 0, 2, "RD-xx-xx-SC-EC-xx", "LK")
+        );
+        assert_eq!(
+            region[21],
+            FlashRegion("info", 1, 0, 3, "RD-WR-ER-SC-EC-xx", "LK")
         );
     }
 
@@ -270,6 +285,17 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
     assert_eq!(
         region[7],
         FlashRegion("data", 7, 0, 0, "xx-xx-xx-xx-xx-xx", "UN")
+    );
+
+    // Bank 1, pages 2-3 are the ownership pages.  In an ownership locked
+    // state, both pages should be read-only.
+    assert_eq!(
+        region[20],
+        FlashRegion("info", 1, 0, 2, "RD-xx-xx-SC-EC-xx", "LK")
+    );
+    assert_eq!(
+        region[21],
+        FlashRegion("info", 1, 0, 3, "RD-xx-xx-SC-EC-xx", "LK")
     );
 
     Ok(())

--- a/sw/host/tests/ownership/newversion_test.rs
+++ b/sw/host/tests/ownership/newversion_test.rs
@@ -1,0 +1,119 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::bool_assert_comparison)]
+use anyhow::{anyhow, ensure, Result};
+use clap::Parser;
+use regex::Regex;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::Duration;
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::chip::rom_error::RomError;
+use opentitanlib::rescue::serial::RescueSerial;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    /// Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+    #[arg(long, help = "Next Owner private key (ECDSA P256)")]
+    next_owner_key: PathBuf,
+    #[arg(long, help = "Next Owner public key (ECDSA P256)")]
+    next_owner_key_pub: Option<PathBuf>,
+    #[arg(long, help = "Next Owner activate private key (ECDSA P256)")]
+    next_activate_key: PathBuf,
+    #[arg(long, help = "Next Owner unlock private key (ECDSA P256)")]
+    next_unlock_key: PathBuf,
+    #[arg(long, help = "Next Owner's application public key (ECDSA P256)")]
+    next_application_key: PathBuf,
+    #[arg(
+        long,
+        default_value_t = transfer_lib::TEST_OWNER_CONFIG_VERSION,
+        help = "Configuration version to put in the owner config"
+    )]
+    config_version: u32,
+
+    #[arg(
+        long,
+        value_enum,
+        default_value = "basic",
+        help = "Style of Owner Config for this test"
+    )]
+    config_kind: transfer_lib::OwnerConfigKind,
+
+    #[arg(long, help = "Expected success conditions")]
+    expect: Vec<String>,
+
+    #[arg(long, help = "Expected error condition")]
+    expected_error: Option<String>,
+}
+
+fn newversion_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let uart = transport.uart("console")?;
+    let rescue = RescueSerial::new(Rc::clone(&uart));
+
+    log::info!("###### Upload Owner Block ######");
+    transfer_lib::create_owner(
+        transport,
+        &rescue,
+        &opts.next_owner_key,
+        &opts.next_activate_key,
+        &opts.next_unlock_key,
+        &opts.next_application_key,
+        opts.config_kind,
+        /*customize=*/
+        |owner| {
+            owner.config_version = opts.config_version;
+        },
+    )?;
+
+    log::info!("###### Boot After Update Complete ######");
+    transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
+    let capture = UartConsole::wait_for(
+        &*uart,
+        r"(?msR)Running.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
+        opts.timeout,
+    )?;
+    if capture[0].starts_with("BFV") {
+        return RomError(u32::from_str_radix(&capture[1], 16)?).into();
+    }
+
+    for exp in opts.expect.iter() {
+        let erx = Regex::new(exp)?;
+        ensure!(erx.is_match(&capture[0]), "Did not find expected output {exp:?}");
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let result = newversion_test(&opts, &transport);
+    if let Some(error) = &opts.expected_error {
+        match result {
+            Ok(_) => Err(anyhow!("Ok when expecting {error:?}")),
+            Err(e) => {
+                let re = Regex::new(error).expect("regex");
+                if re.is_match(&e.to_string()) {
+                    log::info!("Got expected error code: {e}");
+                    Ok(())
+                } else {
+                    Err(anyhow!("Expected {error:?} but got {e}"))
+                }
+            }
+        }
+    } else {
+        result
+    }
+}

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -199,6 +199,7 @@ where
     let unlock_key = EcdsaPrivateKey::load(unlock_key)?;
     let app_key = EcdsaPublicKey::load(app_key)?;
     let mut owner = OwnerBlock {
+        ownership_key_alg: OwnershipKeyAlg::EcdsaP256,
         owner_key: KeyMaterial::Ecdsa(owner_key.public_key().try_into()?),
         activate_key: KeyMaterial::Ecdsa(activate_key.public_key().try_into()?),
         unlock_key: KeyMaterial::Ecdsa(unlock_key.public_key().try_into()?),


### PR DESCRIPTION
The ownership `update_mode` allows the owner to attenuate the power of the unlock key:
- UpdateMode::Open - The unlock key has full unlock power.
- UpdateMode::Self - The unlock key can only unlock the device for updates to the self-same owner.
- UpdateMode::NewVersion - The device cannot unlock, but can accept a signed update from the self-same owner.

1. Add an `unlock_mode` field to the owner config and the associated UpdateMode constants.
2. Based on the UpdateMode, allow or deny the unlock command.
3. When in the NewVersion mode, check for updates during locked owner initialization.
4. Implement owner page lockdown based on the ownership state and update mode.
5. Test that updates are accepted in NewVersion mode.  Test that the permissions are set appropriately on the owner pages.

Addresses: lowRISC#24657