### PR TITLE
[ci] Enable GitHub Actions CI on pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@
 name: CI
 on:
   pull_request:
+  push:
+    branches-ignore:
+      - "backport-*"
+    tags:
+      - "*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,14 @@ jobs:
       - name: Validate testplans with schema
         run: ./ci/scripts/validate_testplans.sh
       - name: C/C++ formatting
-        run: ./ci/scripts/clang-format.sh "$GITHUB_BASE_REF"
+        run: ./ci/bazelisk.sh test //quality:clang_format_check
       - name: Rust formatting
-        run: ./ci/scripts/rust-format.sh "$GITHUB_BASE_REF"
+        run: ./ci/bazelisk.sh test //quality:rustfmt_check
       - name: Shellcheck
         run: ./ci/bazelisk.sh test //quality:shellcheck_check
       - name: Header guards
         run: ./ci/scripts/include-guard.sh "$GITHUB_BASE_REF"
+        if: ${{ github.event_name == 'pull_request' }}
       - name: Trailing whitespace
         run: ./ci/scripts/whitespace.sh "$GITHUB_BASE_REF"
       - name: Broken links

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,17 @@ jobs:
         run: ./ci/scripts/show-env.sh
       - name: Commit metadata
         run: ./ci/scripts/lint-commits.sh "$GITHUB_BASE_REF"
+        if: ${{ github.event_name == 'pull_request' }}
       - name: License headers
         run: ./ci/scripts/check-licence-headers.sh "$GITHUB_BASE_REF"
+        if: ${{ github.event_name == 'pull_request' }}
       - name: Executable bits
         run: ./ci/scripts/exec-check.sh
       - name: Non-ASCII characters
         run: ./ci/scripts/check-ascii.sh
       - name: Python (flake8)
         run: ./ci/scripts/python-lint.sh "$GITHUB_BASE_REF"
+        if: ${{ github.event_name == 'pull_request' }}
       - name: Python (mypy)
         run: ./ci/scripts/mypy.sh
       - name: Validate testplans with schema
@@ -47,6 +50,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
       - name: Trailing whitespace
         run: ./ci/scripts/whitespace.sh "$GITHUB_BASE_REF"
+        if: ${{ github.event_name == 'pull_request' }}
       - name: Broken links
         run: ./ci/scripts/check-links.sh
       - name: Generated documentation
@@ -71,6 +75,7 @@ jobs:
     name: Verible lint
     runs-on: ubuntu-24.04
     needs: quick_lint
+    if: ${{ github.event_name == 'pull_request' }}
     env:
       verible_config: hw/lint/tools/veriblelint/lowrisc-styleguide.rules.verible_lint
       verible_version: v0.0-3430-g060bde0f


### PR DESCRIPTION
Before this PR, the CI only ran for pull requests and not, `master`, `earlgrey_es_sival`, etc.

This PR enables the CI workflow for all non-backport branches. Certain steps are skipped since they only lint diffs and not the whole repo (which isn't lint clean unfortunately). This should be fixed in the future but I don't have the patience right now.