### PR TITLE
[hsmtool] Refactor input endianness handling

### DIFF
--- a/sw/host/hsmtool/src/commands/ecdsa/sign.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/sign.rs
@@ -51,15 +51,10 @@ impl Dispatch for Sign {
         attrs.push(Attribute::Sign(true));
         let object = helper::find_one_object(session, &attrs)?;
 
-        let mut data = helper::read_file(&self.input)?;
-        if self.little_endian {
-            // OpenTitanTool writes digest files in little-endian byte order,
-            // (same as the hmac peripheral's default output mode).  The ECDSA
-            // implementation performs the signature calculation with the bytes in
-            // big-endian order.
-            data.reverse();
-        }
-        let data = self.format.prepare(KeyType::Ec, &data)?;
+        let data = helper::read_file(&self.input)?;
+        let data = self
+            .format
+            .prepare(KeyType::Ec, &data, self.little_endian)?;
         let mechanism = self.format.mechanism(KeyType::Ec)?;
         let mut result = session.sign(&mechanism, object, &data)?;
         if self.little_endian {

--- a/sw/host/hsmtool/src/commands/ecdsa/verify.rs
+++ b/sw/host/hsmtool/src/commands/ecdsa/verify.rs
@@ -51,15 +51,10 @@ impl Dispatch for Verify {
         attrs.push(Attribute::Verify(true));
         let object = helper::find_one_object(session, &attrs)?;
 
-        let mut data = helper::read_file(&self.input)?;
-        if self.little_endian {
-            // OpenTitanTool writes digest files in little-endian byte order,
-            // (same as the hmac peripheral's default output mode).  The ECDSA
-            // implementation performs the signature calculation with the bytes in
-            // big-endian order.
-            data.reverse();
-        }
-        let data = self.format.prepare(KeyType::Ec, &data)?;
+        let data = helper::read_file(&self.input)?;
+        let data = self
+            .format
+            .prepare(KeyType::Ec, &data, self.little_endian)?;
         let mechanism = self.format.mechanism(KeyType::Ec)?;
         let mut signature = if let Some(filename) = &self.signature {
             helper::read_file(filename)?

--- a/sw/host/hsmtool/src/commands/rsa/sign.rs
+++ b/sw/host/hsmtool/src/commands/rsa/sign.rs
@@ -51,11 +51,10 @@ impl Dispatch for Sign {
         attrs.push(Attribute::Sign(true));
         let object = helper::find_one_object(session, &attrs)?;
 
-        let mut data = helper::read_file(&self.input)?;
-        if self.little_endian {
-            data.reverse();
-        }
-        let data = self.format.prepare(KeyType::Rsa, &data)?;
+        let data = helper::read_file(&self.input)?;
+        let data = self
+            .format
+            .prepare(KeyType::Rsa, &data, self.little_endian)?;
         let mechanism = self.format.mechanism(KeyType::Rsa)?;
         let mut result = session.sign(&mechanism, object, &data)?;
         if self.little_endian {

--- a/sw/host/hsmtool/src/commands/rsa/verify.rs
+++ b/sw/host/hsmtool/src/commands/rsa/verify.rs
@@ -51,11 +51,10 @@ impl Dispatch for Verify {
         attrs.push(Attribute::Verify(true));
         let object = helper::find_one_object(session, &attrs)?;
 
-        let mut data = helper::read_file(&self.input)?;
-        if self.little_endian {
-            data.reverse();
-        }
-        let data = self.format.prepare(KeyType::Rsa, &data)?;
+        let data = helper::read_file(&self.input)?;
+        let data = self
+            .format
+            .prepare(KeyType::Rsa, &data, self.little_endian)?;
         let mechanism = self.format.mechanism(KeyType::Rsa)?;
         let mut signature = if let Some(filename) = &self.signature {
             helper::read_file(filename)?


### PR DESCRIPTION
When a sign or verify requests `little-endian`, the input should only be reversed if it is already a Sha256 hash.  We assume a pre-hashed input comes from opentitantool, which writes out its hash digests in little-endian order.