### PR TITLE
Enable entropy_src block level tests to run using vcs simulator tool …

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
@@ -4,6 +4,13 @@
 
 // This interface deals with the force paths in ENTROPY_SRC interrupt and error tests
 
+`define CORE \
+    tb.dut.u_entropy_src_core
+`define REPCNT \
+    u_entropy_src_repcnt_ht.u_prim_max_tree_rep_cntr_max
+`define BUCKET \
+    u_entropy_src_bucket_ht.u_prim_max_tree_bin_cntr_max
+
 interface entropy_src_path_if ();
   import uvm_pkg::*;
 
@@ -39,4 +46,70 @@ interface entropy_src_path_if ();
       end
     endcase // case (cntr_name)
   endfunction // cntr_err_path
+   // Disable assertions that we expect to trigger when injecting errors
+  task automatic assert_off_err();
+    $assertoff(0, tb.dut.AlertTxKnownO_A);
+    $assertoff(0, tb.dut.IntrEsFifoErrKnownO_A);
+    $assertoff(0, tb.dut.EsHwIfEsAckKnownO_A);
+    $assertoff(0, tb.dut.EsHwIfEsBitsKnownO_A);
+    $assertoff(0, tb.dut.EsHwIfEsFipsKnownO_A);
+    $assertoff(0, tb.dut.EsXhtEntropyBitKnownO_A);
+    $assertoff(0, tb.dut.IntrEsEntropyValidKnownO_A);
+    $assertoff(0, tb.dut.IntrEsHealthTestFailedKnownO_A);
+    $assertoff(0, tb.dut.tlul_assert_device.dKnown_A);
+    $assertoff(0, tb.dut.tlul_assert_device.gen_device.dDataKnown_A);
+    $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.AlertPKnownO_A);
+    $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.gen_async_assert.DiffEncoding_A);
+    $assertoff(0, `CORE.AtReset_ValidRngBitsPushedIntoEsrngFifo_A);
+    $assertoff(0, `CORE.Final_ValidRngBitsPushedIntoEsrngFifo_A);
+    $assertoff(0, `CORE.AtReset_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
+    $assertoff(0, `CORE.Final_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
+    $assertoff(0, `CORE.AtReset_EsbitFifoPushedIntoPosthtFifo_A);
+    $assertoff(0, `CORE.Final_EsbitFifoPushedIntoPosthtFifo_A);
+    $assertoff(0, `CORE.AtReset_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
+    $assertoff(0, `CORE.Final_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
+    $assertoff(0, `CORE.AtReset_PosthtFifoPushedIntoDistrFifo_A);
+    $assertoff(0, `CORE.Final_PosthtFifoPushedIntoDistrFifo_A);
+    $assertoff(0, `CORE.AtReset_DistrFifoPushedIntoPreconFifo_A);
+    $assertoff(0, `CORE.Final_DistrFifoPushedIntoPreconFifo_A);
+    $assertoff(0, `CORE.AtReset_EsfinalFifoPushed_A);
+    $assertoff(0, `CORE.Final_EsfinalFifoPushed_A);
+    $assertoff(0, `CORE.AtReset_EsfinalFifoPushedPostStartup_A);
+    $assertoff(0, `CORE.Final_EsfinalFifoPushedPostStartup_A);
+    $assertoff(0, `CORE.AtReset_PreconFifoPushedPostStartup_A);
+    $assertoff(0, `CORE.Final_PreconFifoPushedPostStartup_A);
+    $assertoff(0, `CORE.u_sha3.FsmKnown_A);
+    $assertoff(0, `CORE.u_sha3.MuxSelKnown_A);
+    $assertoff(0, `CORE.u_entropy_src_main_sm.u_state_regs_A);
+    $assertoff(0, `CORE.u_entropy_src_ack_sm.u_state_regs_A);
+    $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.DepthKnown_A);
+    $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.RvalidKnown_A);
+    $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.WreadyKnown_A);
+    $assertoff(0, `CORE.u_prim_fifo_sync_esrng.DataKnown_A);
+    $assertoff(0, `CORE.u_entropy_src_adaptp_ht.u_sum.SumComputation_A);
+    $assertoff(0, `CORE.u_entropy_src_markov_ht.u_sum.SumComputation_A);
+    $assertoff(0, `CORE.u_entropy_src_adaptp_ht.u_min.ValidInImpliesValidOut_A);
+    $assertoff(0, `CORE.u_entropy_src_adaptp_ht.u_max.ValidInImpliesValidOut_A);
+    $assertoff(0, `CORE.u_entropy_src_markov_ht.u_min.ValidInImpliesValidOut_A);
+    $assertoff(0, `CORE.u_entropy_src_markov_ht.u_max.ValidInImpliesValidOut_A);
+    $assertoff(0, `CORE.u_sha3.u_keccak.gen_unmask_st_chk.UnmaskValidStates_A);
+    $assertoff(0, `CORE.`REPCNT.ValidInImpliesValidOut_A);
+    $assertoff(0, `CORE.`BUCKET.ValidInImpliesValidOut_A);
+  endtask
+  function automatic void disable_entroy_drop_assertions();
+    // Disable assertions which expect that no entropy is dropped between the esrng,
+    // esbit and postht FIFOs.
+    $assertoff(0, `CORE.AtReset_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
+    $assertoff(0, `CORE.Final_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
+    $assertoff(0, `CORE.AtReset_EsbitFifoPushedIntoPosthtFifo_A);
+    $assertoff(0, `CORE.Final_EsbitFifoPushedIntoPosthtFifo_A);
+    $assertoff(0, `CORE.AtReset_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
+    $assertoff(0, `CORE.Final_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
+    // TODO(#24085): Remove this assertoff once the issue is solved.
+    $assertoff(0, `CORE.FifosEmptyWhenShaProcess_A);
+  endfunction
 endinterface // entropy_src_path_if
+
+`undef CORE
+`undef REPCNT
+`undef BUCKET

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_err_vseq.sv
@@ -218,53 +218,7 @@ class entropy_src_err_vseq extends entropy_src_base_vseq;
 
   // Disable assertions that we expect to trigger when injecting errors
   task assert_off_err();
-    $assertoff(0, tb.dut.AlertTxKnownO_A);
-    $assertoff(0, tb.dut.IntrEsFifoErrKnownO_A);
-    $assertoff(0, tb.dut.EsHwIfEsAckKnownO_A);
-    $assertoff(0, tb.dut.EsHwIfEsBitsKnownO_A);
-    $assertoff(0, tb.dut.EsHwIfEsFipsKnownO_A);
-    $assertoff(0, tb.dut.EsXhtEntropyBitKnownO_A);
-    $assertoff(0, tb.dut.IntrEsEntropyValidKnownO_A);
-    $assertoff(0, tb.dut.IntrEsHealthTestFailedKnownO_A);
-    $assertoff(0, tb.dut.tlul_assert_device.dKnown_A);
-    $assertoff(0, tb.dut.tlul_assert_device.gen_device.dDataKnown_A);
-    $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.AlertPKnownO_A);
-    $assertoff(0, tb.dut.gen_alert_tx[0].u_prim_alert_sender.gen_async_assert.DiffEncoding_A);
-    $assertoff(0, `CORE.AtReset_ValidRngBitsPushedIntoEsrngFifo_A);
-    $assertoff(0, `CORE.Final_ValidRngBitsPushedIntoEsrngFifo_A);
-    $assertoff(0, `CORE.AtReset_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
-    $assertoff(0, `CORE.Final_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
-    $assertoff(0, `CORE.AtReset_EsbitFifoPushedIntoPosthtFifo_A);
-    $assertoff(0, `CORE.Final_EsbitFifoPushedIntoPosthtFifo_A);
-    $assertoff(0, `CORE.AtReset_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
-    $assertoff(0, `CORE.Final_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
-    $assertoff(0, `CORE.AtReset_PosthtFifoPushedIntoDistrFifo_A);
-    $assertoff(0, `CORE.Final_PosthtFifoPushedIntoDistrFifo_A);
-    $assertoff(0, `CORE.AtReset_DistrFifoPushedIntoPreconFifo_A);
-    $assertoff(0, `CORE.Final_DistrFifoPushedIntoPreconFifo_A);
-    $assertoff(0, `CORE.AtReset_EsfinalFifoPushed_A);
-    $assertoff(0, `CORE.Final_EsfinalFifoPushed_A);
-    $assertoff(0, `CORE.AtReset_EsfinalFifoPushedPostStartup_A);
-    $assertoff(0, `CORE.Final_EsfinalFifoPushedPostStartup_A);
-    $assertoff(0, `CORE.AtReset_PreconFifoPushedPostStartup_A);
-    $assertoff(0, `CORE.Final_PreconFifoPushedPostStartup_A);
-    $assertoff(0, `CORE.u_sha3.FsmKnown_A);
-    $assertoff(0, `CORE.u_sha3.MuxSelKnown_A);
-    $assertoff(0, `CORE.u_entropy_src_main_sm.u_state_regs_A);
-    $assertoff(0, `CORE.u_entropy_src_ack_sm.u_state_regs_A);
-    $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.DepthKnown_A);
-    $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.RvalidKnown_A);
-    $assertoff(0, `CORE.u_prim_fifo_sync_esfinal.WreadyKnown_A);
-    $assertoff(0, `CORE.u_prim_fifo_sync_esrng.DataKnown_A);
-    $assertoff(0, `CORE.u_entropy_src_adaptp_ht.u_sum.SumComputation_A);
-    $assertoff(0, `CORE.u_entropy_src_markov_ht.u_sum.SumComputation_A);
-    $assertoff(0, `CORE.u_entropy_src_adaptp_ht.u_min.ValidInImpliesValidOut_A);
-    $assertoff(0, `CORE.u_entropy_src_adaptp_ht.u_max.ValidInImpliesValidOut_A);
-    $assertoff(0, `CORE.u_entropy_src_markov_ht.u_min.ValidInImpliesValidOut_A);
-    $assertoff(0, `CORE.u_entropy_src_markov_ht.u_max.ValidInImpliesValidOut_A);
-    $assertoff(0, `CORE.u_sha3.u_keccak.gen_unmask_st_chk.UnmaskValidStates_A);
-    $assertoff(0, `CORE.`REPCNT.ValidInImpliesValidOut_A);
-    $assertoff(0, `CORE.`BUCKET.ValidInImpliesValidOut_A);
+    cfg.entropy_src_path_vif.assert_off_err();
   endtask
 
 endclass : entropy_src_err_vseq

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -854,18 +854,9 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     // Don't enable here, let the main loop do that explicitly
   endtask
 
-  function void disable_assertions();
+  function void disable_entropy_drop_assertions();
     if (cfg.rng_max_delay) begin
-      // Disable assertions which expect that no entropy is dropped between the esrng,
-      // esbit and postht FIFOs.
-      $assertoff(0, tb.dut.u_entropy_src_core.AtReset_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
-      $assertoff(0, tb.dut.u_entropy_src_core.Final_EsrngFifoPushedIntoEsbitOrPosthtFifos_A);
-      $assertoff(0, tb.dut.u_entropy_src_core.AtReset_EsbitFifoPushedIntoPosthtFifo_A);
-      $assertoff(0, tb.dut.u_entropy_src_core.Final_EsbitFifoPushedIntoPosthtFifo_A);
-      $assertoff(0, tb.dut.u_entropy_src_core.AtReset_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
-      $assertoff(0, tb.dut.u_entropy_src_core.Final_PosthtFifoPushedFromEsbitOrEsrngFifos_A);
-      // TODO(#24085): Remove this assertoff once the issue is solved.
-      $assertoff(0, tb.dut.u_entropy_src_core.FifosEmptyWhenShaProcess_A);
+      cfg.entropy_src_path_vif.disable_entroy_drop_assertions();
     end
   endfunction
 
@@ -875,7 +866,7 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     continue_sim = 1;
     reset_needed = 0;
 
-    disable_assertions();
+    disable_entropy_drop_assertions();
     // Start sequences in the background
     start_indefinite_seqs();
 

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -480,6 +480,7 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   task entropy_inject_thread();
     bit do_inject, injection_mandatory;
     bit [TL_DW - 1:0] fw_ov_value;
+    bit [TL_DW - 1:0] unused;
 
     injection_mandatory = ((cfg.dut_cfg.fw_over_enable == MuBi4True) &&
                            (cfg.dut_cfg.fw_read_enable == MuBi4True));
@@ -504,7 +505,7 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
           `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_insert_entropy);
           cfg.clk_rst_vif.wait_clks(dly_to_insert_entropy);
           `uvm_info(`gfn, $sformatf("injecting entropy: %08x", fw_ov_value), UVM_FULL)
-          csr_rd(.ptr(ral.fw_ov_wr_fifo_full.fw_ov_wr_fifo_full));
+          csr_rd(.ptr(ral.fw_ov_wr_fifo_full.fw_ov_wr_fifo_full), .value(unused));
           ral.fw_ov_wr_data.set(fw_ov_value);
           csr_update(.csr(ral.fw_ov_wr_data));
         end


### PR DESCRIPTION
…by fixing a couple of issues

Issue 1: csr_rd function didn't specify all required arguments. In this case, it was the value argument.
------------------------------------------------------------------- Error-[TFAFTC] Too few arguments to function/task call
                ../src/lowrisc_dv_entropy_src_env_0.1/seq_lib/entropy_src_rng_vseq.sv, 507
                vcs_paramclassrepository, "csr_utils_pkg::csr_rd(ral.fw_ov_wr_fifo_full.fw_ov_wr_fifo_full);"
                  The above function/task call is not done with sufficient arguments.
-------------------------------------------------------------------- Solution: declare a variable (call it unused for clarity that the value will not be sampled elsewhere in code) pass this 'unused' variable as the value argument of the csr_rd call -------------------------------------------------------------------- -------------------------------------------------------------------- Issue 2: code to disable assertion from within sequences using XMR doesnt compile This is because VCS prohibits SV class inside a package to have XMRs to code in module outside -------------------------------------------------------------------- Error-[SV-LCM-HRP] Hierarchical reference in package
                ../src/lowrisc_dv_entropy_src_env_0.1/seq_lib/entropy_src_rng_vseq.sv, 861
                entropy_src_env_pkg, "tb.dut.u_entropy_src_core.AtReset_EsrngFifoPushedIntoEsbitOrPosthtFifos_A"
                  Hierarchical reference from package 'entropy_src_env_pkg' into module 'tb'
                  is not allowed.
-------------------------------------------------------------------- Solution: move the functions containing assert_off tasks to the entropy_src_path_if call these functions as appropriate from the sequences using handle to the virtual interface