### PR TITLE
Enable running the spi_host block level tests using vcs simulator by …

### DIFF
--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -114,7 +114,8 @@ class spi_host_base_vseq extends cip_base_vseq #(
       end
       [cfg.seq_cfg.host_spi_middle_clkdiv+1 : 16'hFFF] : cfg.csr_spinwait_timeout_ns *= 5;
       [16'hFFF+1 : cfg.seq_cfg.host_spi_max_clkdiv] : cfg.csr_spinwait_timeout_ns *= 10;
-      default : `uvm_fatal(`gfn, $sformatf("spi_config_regs.clkdiv[0]=0x%0x is out range"))
+      default : `uvm_fatal(`gfn, $sformatf("spi_config_regs.clkdiv[0]=0x%0x is out range",
+                                           spi_config_regs.clkdiv[0]))
     endcase
   endfunction
 


### PR DESCRIPTION
…fixing a compile issue

Issue: No argument for format specification
Error-[MEAFFS] No argument for format specification
               ../src/lowrisc_dv_spi_host_env_0.1/seq_lib/spi_host_base_vseq.sv, 117
                 Missing or empty argument for format specification
                 Source info: $sformatf("spi_config_regs.clkdiv[0]=0x%0x is out range")