### PR TITLE
[rom_ext] Migrate ProdA users to ECDSA

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -443,7 +443,7 @@ silicon(
     base = ":silicon_owner_sival_rom_ext",
     # TODO(#24641): Simplify key selection after eliminating RSA keys.
     ecdsa_key = select({
-        "//signing:owner_key_ecdsa": {"//sw/device/silicon_creator/rom_ext/prodc/keys:keyset": "appkey_test_0"},
+        "//signing:owner_key_ecdsa": {"//sw/device/silicon_creator/rom_ext/proda/keys:keyset": "appkey_test_0"},
         "//signing:owner_key_rsa": CLEAR_KEY_SET,
         "//signing:test_keys_ecdsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_test_ecdsa": "test_key_0"},
         "//signing:test_keys_rsa": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_test_ecdsa": "test_key_0"},
@@ -455,7 +455,7 @@ silicon(
     }),
     rsa_key = select({
         "//signing:owner_key_ecdsa": CLEAR_KEY_SET,
-        "//signing:owner_key_rsa": {"//sw/device/silicon_creator/rom_ext/prodc/keys:keyset": "earlgrey_z0_sival_1"},
+        "//signing:owner_key_rsa": {"//sw/device/silicon_creator/rom_ext/proda/keys:keyset": "earlgrey_z0_sival_1"},
         "//signing:test_keys_ecdsa": CLEAR_KEY_SET,
         "//signing:test_keys_rsa": CLEAR_KEY_SET,
     }),


### PR DESCRIPTION
1. Correct a copy/paste error in the paths to proda key materials.

Addresses: #24641