### PR TITLE
Bump CRT to v0.4.13

### DIFF
--- a/third_party/crt/repos.bzl
+++ b/third_party/crt/repos.bzl
@@ -15,7 +15,7 @@ def crt_repos(local = None):
         maybe(
             http_archive,
             name = "crt",
-            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.10.tar.gz",
-            strip_prefix = "crt-0.4.10",
-            sha256 = "655a7cd56d22485a96e9ffca8dd2b4b8b3134099407899300354367ce708ed32",
+            url = "https://github.com/lowRISC/crt/archive/refs/tags/v0.4.13.tar.gz",
+            strip_prefix = "crt-0.4.13",
+            sha256 = "9813c8a3aeb72c3951d305e19a69dbbd17a3a6313bef938c20b1e214eb51e6e6",
         )


### PR DESCRIPTION
Bumps the CRT to the latest version. Here are the relevant CRT release items:

* Bump toolchain to release 20240923-1 by @luismarques in https://github.com/lowRISC/crt/pull/38
* Add `lto` feature to the `feature_set` `common` by @luismarques in https://github.com/lowRISC/crt/pull/36
* [features] Add LTO feature by @luismarques in https://github.com/lowRISC/crt/pull/25
* Add -Wtype-limits feature by @jwnrt in https://github.com/lowRISC/crt/pull/34
