### PR TITLE
[opentitantool] Add a debug flag to ownership serialization 

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/testdata/basic_owner.json5
+++ b/sw/device/silicon_creator/lib/ownership/testdata/basic_owner.json5
@@ -8,7 +8,6 @@
 // To convert this file to binary form, use opentitantool:
 // $ opentitantool ownership config --input file.json file.bin
 {
-  version: 0,
   sram_exec: "DisabledLocked",
   ownership_key_alg: "EcdsaP256",
   owner_key: {
@@ -198,5 +197,4 @@
       }
     }
   ],
-  seal: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 }

--- a/sw/host/opentitanlib/src/ownership/application_key.rs
+++ b/sw/host/opentitanlib/src/ownership/application_key.rs
@@ -10,6 +10,7 @@ use std::convert::TryFrom;
 use std::io::{Read, Write};
 
 use super::misc::{KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
+use super::GlobalFlags;
 use crate::with_unknown;
 
 with_unknown! {
@@ -25,7 +26,7 @@ with_unknown! {
 #[derive(Debug, Serialize, Deserialize, Annotate)]
 pub struct OwnerApplicationKey {
     /// Header identifying this struct.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "GlobalFlags::not_debug")]
     pub header: TlvHeader,
     /// The key algorithm for this key (ECDSA, SPX+, etc).
     pub key_alg: OwnershipKeyAlg,
@@ -106,10 +107,6 @@ mod test {
 00000060: c0 00 00 00 d0 00 00 00 e0 00 00 00 f0 00 00 00  ................\n\
 ";
     const OWNER_APPLICATION_KEY_JSON: &str = r#"{
-  header: {
-    identifier: "ApplicationKey",
-    length: 112
-  },
   key_alg: "EcdsaP256",
   key_domain: "Prod",
   key_diversifier: [

--- a/sw/host/opentitanlib/src/ownership/flash.rs
+++ b/sw/host/opentitanlib/src/ownership/flash.rs
@@ -9,6 +9,7 @@ use serde_annotate::Annotate;
 use std::io::{Read, Write};
 
 use super::misc::{TlvHeader, TlvTag};
+use super::GlobalFlags;
 use crate::chip::boolean::MultiBitBool4;
 
 /// Describes the proprerties of a flash region.
@@ -178,7 +179,7 @@ impl OwnerFlashRegion {
 #[derive(Debug, Serialize, Deserialize, Annotate)]
 pub struct OwnerFlashConfig {
     /// Header identifying this struct.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "GlobalFlags::not_debug")]
     pub header: TlvHeader,
     /// A list of flash region configurations.
     pub config: Vec<OwnerFlashRegion>,
@@ -244,10 +245,6 @@ r#"00000000: 46 4c 53 48 2c 00 00 00 00 00 00 00 96 09 00 99  FLSH,...........
 "#;
 
     const OWNER_FLASH_CONFIG_JSON: &str = r#"{
-  header: {
-    identifier: "FlashConfig",
-    length: 44
-  },
   config: [
     {
       start: 0,

--- a/sw/host/opentitanlib/src/ownership/flash_info.rs
+++ b/sw/host/opentitanlib/src/ownership/flash_info.rs
@@ -10,6 +10,7 @@ use std::io::{Read, Write};
 
 use super::flash::FlashFlags;
 use super::misc::{TlvHeader, TlvTag};
+use super::GlobalFlags;
 
 /// Describes an INFO page to which a set of flags apply.
 #[derive(Debug, Default, Deserialize, Serialize, Annotate)]
@@ -59,7 +60,7 @@ impl OwnerInfoPage {
 #[derive(Debug, Serialize, Deserialize, Annotate)]
 pub struct OwnerFlashInfoConfig {
     /// Header identifying this struct.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "GlobalFlags::not_debug")]
     pub header: TlvHeader,
     /// A list of info page configurations.
     pub config: Vec<OwnerInfoPage>,
@@ -125,10 +126,6 @@ r#"00000000: 49 4e 46 4f 2c 00 00 00 00 00 00 00 96 09 00 99  INFO,...........
 "#;
 
     const OWNER_FLASH_INFO_CONFIG_JSON: &str = r#"{
-  header: {
-    identifier: "FlashInfoConfig",
-    length: 44
-  },
   config: [
     {
       bank: 0,

--- a/sw/host/opentitanlib/src/ownership/misc.rs
+++ b/sw/host/opentitanlib/src/ownership/misc.rs
@@ -74,9 +74,13 @@ impl TlvHeader {
 #[derive(Debug, Serialize, Deserialize)]
 #[allow(clippy::len_without_is_empty)]
 pub enum KeyMaterial {
+    #[serde(alias = "unknown")]
     Unknown(Vec<u8>),
+    #[serde(alias = "ecdsa")]
     Ecdsa(#[serde(deserialize_with = "string_or_struct")] EcdsaRawPublicKey),
+    #[serde(alias = "rsa")]
     Rsa(#[serde(deserialize_with = "string_or_struct")] RsaRawPublicKey),
+    #[serde(alias = "spx")]
     Spx(#[serde(deserialize_with = "string_or_struct")] SpxRawPublicKey),
 }
 

--- a/sw/host/opentitanlib/src/ownership/mod.rs
+++ b/sw/host/opentitanlib/src/ownership/mod.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 mod application_key;
 mod flash;
 mod flash_info;
@@ -15,3 +17,20 @@ pub use flash_info::{OwnerFlashInfoConfig, OwnerInfoPage};
 pub use misc::{KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
 pub use owner::{OwnerBlock, OwnerConfigItem, SramExecMode};
 pub use rescue::{CommandTag, OwnerRescueConfig, RescueType};
+
+pub struct GlobalFlags;
+
+static DEBUG: AtomicBool = AtomicBool::new(false);
+
+impl GlobalFlags {
+    /// Set the value of the ownership debug flag.  This controls the serialization
+    /// of header and reserved fields in the ownership structs.
+    pub fn set_debug(v: bool) {
+        DEBUG.store(v, Ordering::Relaxed);
+    }
+
+    // Used by the serde serializer to query whether or not a field should be serialized.
+    pub fn not_debug<T>(_: &T) -> bool {
+        !DEBUG.load(Ordering::Relaxed)
+    }
+}

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -94,7 +94,7 @@ impl Default for OwnerBlock {
             unlock_key: KeyMaterial::default(),
             data: Vec::new(),
             signature: EcdsaRawSignature::default(),
-            seal: vec![0xffu8; 32],
+            seal: Vec::new(),
         }
     }
 }
@@ -140,7 +140,11 @@ impl OwnerBlock {
         data.resize(Self::DATA_SIZE, Self::NOT_PRESENT);
         dest.write_all(&data)?;
         self.signature.write(dest)?;
-        dest.write_all(&self.seal)?;
+        if self.seal.is_empty() {
+            dest.write_all(&[0u8; 32])?;
+        } else {
+            dest.write_all(&self.seal)?;
+        }
         Ok(())
     }
 

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -200,10 +200,15 @@ impl OwnerBlock {
 
 #[derive(Debug, Serialize, Deserialize, Annotate)]
 pub enum OwnerConfigItem {
+    #[serde(alias = "application_key")]
     ApplicationKey(OwnerApplicationKey),
+    #[serde(alias = "flash_info_config")]
     FlashInfoConfig(OwnerFlashInfoConfig),
+    #[serde(alias = "flash_config")]
     FlashConfig(OwnerFlashConfig),
+    #[serde(alias = "rescue_config")]
     RescueConfig(OwnerRescueConfig),
+    #[serde(alias = "raw")]
     Raw(
         #[serde(with = "serde_bytes")]
         #[annotate(format = hexdump)]

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -10,6 +10,7 @@ use std::convert::TryFrom;
 use std::io::{Read, Write};
 
 use super::misc::{KeyMaterial, OwnershipKeyAlg, TlvHeader, TlvTag};
+use super::GlobalFlags;
 use super::{OwnerApplicationKey, OwnerFlashConfig, OwnerFlashInfoConfig, OwnerRescueConfig};
 use crate::crypto::ecdsa::{EcdsaPrivateKey, EcdsaRawSignature};
 use crate::with_unknown;
@@ -36,7 +37,7 @@ with_unknown! {
 #[derive(Debug, Serialize, Deserialize, Annotate)]
 pub struct OwnerBlock {
     /// Header identifying this struct.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "GlobalFlags::not_debug")]
     pub header: TlvHeader,
     /// Version of this structure (ie: currently, zero).
     #[serde(default)]
@@ -55,7 +56,7 @@ pub struct OwnerBlock {
     /// Ownership update mode.
     #[serde(default)]
     pub update_mode: OwnershipUpdateMode,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "GlobalFlags::not_debug")]
     #[annotate(format=hex)]
     pub reserved: [u32; 24],
     /// The owner identity key.
@@ -388,42 +389,12 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
 "#;
 
     const OWNER_JSON: &str = r#"{
-  header: {
-    identifier: "Owner",
-    length: 2048
-  },
   struct_version: 0,
   sram_exec: "DisabledLocked",
   ownership_key_alg: "EcdsaP256",
   config_version: 0,
   min_security_version_bl0: "NoChange",
   update_mode: "Open",
-  reserved: [
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0,
-    0x0
-  ],
   owner_key: {
     Ecdsa: {
       x: "1111111111111111111111111111111111111111111111111111111111111111",
@@ -445,10 +416,6 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
   data: [
     {
       ApplicationKey: {
-        header: {
-          identifier: "ApplicationKey",
-          length: 112
-        },
         key_alg: "EcdsaP256",
         key_domain: "Prod",
         key_diversifier: [
@@ -471,10 +438,6 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
     },
     {
       FlashConfig: {
-        header: {
-          identifier: "FlashConfig",
-          length: 32
-        },
         config: [
           {
             start: 0,
@@ -505,10 +468,6 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
     },
     {
       FlashInfoConfig: {
-        header: {
-          identifier: "FlashInfoConfig",
-          length: 32
-        },
         config: [
           {
             bank: 0,
@@ -541,10 +500,6 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
     },
     {
       RescueConfig: {
-        header: {
-          identifier: "Rescue",
-          length: 80
-        },
         rescue_type: "Xmodem",
         start: 32,
         size: 224,

--- a/sw/host/opentitanlib/src/ownership/rescue.rs
+++ b/sw/host/opentitanlib/src/ownership/rescue.rs
@@ -10,6 +10,7 @@ use std::convert::TryFrom;
 use std::io::{Read, Write};
 
 use super::misc::{TlvHeader, TlvTag};
+use super::GlobalFlags;
 use crate::chip::boot_svc::BootSvcKind;
 use crate::with_unknown;
 
@@ -46,7 +47,7 @@ with_unknown! {
 #[derive(Debug, Serialize, Deserialize, Annotate)]
 pub struct OwnerRescueConfig {
     /// Header identifying this struct.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "GlobalFlags::not_debug")]
     pub header: TlvHeader,
     /// The type of rescue protocol to use (ie: Xmodem).
     pub rescue_type: RescueType,
@@ -147,10 +148,6 @@ mod test {
 00000040: 31 47 50 4f 44 49 54 4f 54 49 41 57              1GPODITOTIAW\n\
 ";
     const OWNER_RESCUE_CONFIG_JSON: &str = r#"{
-  header: {
-    identifier: "Rescue",
-    length: 76
-  },
   rescue_type: "Xmodem",
   start: 32,
   size: 100,

--- a/sw/host/opentitantool/src/command/ownership.rs
+++ b/sw/host/opentitantool/src/command/ownership.rs
@@ -13,7 +13,7 @@ use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams};
 use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaRawSignature};
-use opentitanlib::ownership::{OwnerBlock, TlvHeader};
+use opentitanlib::ownership::{GlobalFlags, OwnerBlock, TlvHeader};
 
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq)]
 enum Format {
@@ -24,6 +24,8 @@ enum Format {
 
 #[derive(Debug, Args)]
 pub struct OwnershipConfigCommand {
+    #[arg(long, help = "Show header and reserved fields")]
+    debug: bool,
     #[arg(long, help = "Use the basic ownership block", conflicts_with = "input")]
     basic: bool,
     #[arg(
@@ -50,6 +52,7 @@ impl CommandDispatch for OwnershipConfigCommand {
         _context: &dyn Any,
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Annotate>>> {
+        GlobalFlags::set_debug(self.debug);
         let mut config = if self.basic {
             OwnerBlock::basic()
         } else {


### PR DESCRIPTION
The ownership structs are TLV structs and the TLV headers and other
reserved fields are often irrelevant to the human-readable json
representation of the ownership config.

1. Add a flag to control serialization of headers and reserved fields.  By default, do not serialize them.
2. Handle a missing ownership seal in json.
3. Provide lower-case enum aliases for ownership configs.