### PR TITLE
[ownership] Add node-locked owner configs 

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -106,6 +106,7 @@ cc_library(
         ":datatypes",
         ":ecdsa",
         ":owner_block",
+        ":ownership_activate",
         ":ownership_key",
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/silicon_creator/lib:boot_data",

--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -112,6 +112,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:dbg_print",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -74,6 +74,11 @@ typedef enum ownership_update_mode {
   kOwnershipUpdateModeNewVersion = 0x5657454e,
 } ownership_update_mode_t;
 
+typedef enum lock_constraint {
+  /** No locking constraint: `~~~~`. */
+  kLockConstraintNone = 0x7e7e7e7e,
+} lock_constraint_t;
+
 typedef enum tlv_tag {
   /** Owner struct: `OWNR`. */
   kTlvTagOwner = 0x524e574f,
@@ -130,8 +135,12 @@ typedef struct owner_block {
   uint32_t update_mode;
   /** Set the minimum security version to this value (UINT32_MAX: no change) */
   uint32_t min_security_version_bl0;
+  /** The device ID locking constraint */
+  uint32_t lock_constraint;
+  /** The device ID to which this config applies */
+  uint32_t device_id[8];
   /** Reserved space for future use. */
-  uint32_t reserved[25];
+  uint32_t reserved[16];
   /** Owner public key. */
   owner_key_t owner_key;
   /** Owner's Activate public key. */
@@ -152,7 +161,9 @@ OT_ASSERT_MEMBER_OFFSET(owner_block_t, sram_exec_mode, 12);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, ownership_key_alg, 16);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, update_mode, 20);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, min_security_version_bl0, 24);
-OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 28);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, lock_constraint, 28);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, device_id, 32);
+OT_ASSERT_MEMBER_OFFSET(owner_block_t, reserved, 64);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, owner_key, 128);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, activate_key, 224);
 OT_ASSERT_MEMBER_OFFSET(owner_block_t, unlock_key, 320);

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.c
@@ -14,7 +14,46 @@
 #include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
 
-static rom_error_t activate(boot_svc_msg_t *msg, boot_data_t *bootdata) {
+rom_error_t ownership_activate(boot_data_t *bootdata,
+                               hardened_bool_t write_both_pages) {
+  // Check if page1 parses correctly.
+  owner_config_t config;
+  owner_application_keyring_t keyring;
+  HARDENED_RETURN_IF_ERROR(
+      owner_block_parse(&owner_page[1], &config, &keyring));
+
+  // Seal page one to this chip.
+  ownership_seal_page(/*page=*/1);
+
+  // If requested, reset the mim security version of the application firmware.
+  if (owner_page[1].min_security_version_bl0 != UINT32_MAX) {
+    bootdata->min_security_version_bl0 = owner_page[1].min_security_version_bl0;
+  }
+
+  // TODO(cfrantz): Consider reading back the flash pages to check that the
+  // flash writes succeeded.
+  //
+  // Program the sealed page into slot 1.
+  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot1,
+                                                 kFlashCtrlEraseTypePage));
+  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
+      &kFlashCtrlInfoPageOwnerSlot1, 0,
+      sizeof(owner_page[1]) / sizeof(uint32_t), &owner_page[1]));
+
+  if (write_both_pages == kHardenedBoolTrue) {
+    // Program the same data into slot 0.
+    HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(
+        &kFlashCtrlInfoPageOwnerSlot0, kFlashCtrlEraseTypePage));
+    HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
+        &kFlashCtrlInfoPageOwnerSlot0, 0,
+        sizeof(owner_page[1]) / sizeof(uint32_t), &owner_page[1]));
+  }
+
+  return kErrorOk;
+}
+
+static rom_error_t activate_handler(boot_svc_msg_t *msg,
+                                    boot_data_t *bootdata) {
   // Check if page1 is in a valid state for a transfer (e.g. signature and owner
   // requirements are met). We do this first (rather than parse) because if the
   // signature requirements are not met, the RAM copy of the owner page will be
@@ -22,12 +61,6 @@ static rom_error_t activate(boot_svc_msg_t *msg, boot_data_t *bootdata) {
   if (owner_block_page1_valid_for_transfer(bootdata) != kHardenedBoolTrue) {
     return kErrorOwnershipInvalidInfoPage;
   }
-
-  // Check if page1 parses correctly.
-  owner_config_t config;
-  owner_application_keyring_t keyring;
-  HARDENED_RETURN_IF_ERROR(
-      owner_block_parse(&owner_page[1], &config, &keyring));
 
   // Check the activation key and the nonce.
   size_t len = (uintptr_t)&msg->ownership_activate_req.signature -
@@ -50,25 +83,8 @@ static rom_error_t activate(boot_svc_msg_t *msg, boot_data_t *bootdata) {
     return kErrorOwnershipInvalidDin;
   }
 
-  // Seal page one to this chip.
-  ownership_seal_page(/*page=*/1);
-
-  // TODO(cfrantz): Consider reading back the flash pages to check that the
-  // flash writes succeeded.
-  //
-  // Program the sealed page into slot 1.
-  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot1,
-                                                 kFlashCtrlEraseTypePage));
-  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
-      &kFlashCtrlInfoPageOwnerSlot1, 0,
-      sizeof(owner_page[1]) / sizeof(uint32_t), &owner_page[1]));
-
-  // Program the same data into slot 0.
-  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot0,
-                                                 kFlashCtrlEraseTypePage));
-  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
-      &kFlashCtrlInfoPageOwnerSlot0, 0,
-      sizeof(owner_page[1]) / sizeof(uint32_t), &owner_page[1]));
+  HARDENED_RETURN_IF_ERROR(
+      ownership_activate(bootdata, /*write_both_pages=*/kHardenedBoolTrue));
 
   // The requested primary_bl0_slot is user input.  Validate and clamp it to
   // legal values.
@@ -76,11 +92,6 @@ static rom_error_t activate(boot_svc_msg_t *msg, boot_data_t *bootdata) {
     bootdata->primary_bl0_slot = kBootSlotB;
   } else {
     bootdata->primary_bl0_slot = kBootSlotA;
-  }
-
-  // If requested, reset the mim security version of the application firmware.
-  if (owner_page[1].min_security_version_bl0 != UINT32_MAX) {
-    bootdata->min_security_version_bl0 = owner_page[1].min_security_version_bl0;
   }
 
   // Set the ownership state to LockedOwner.
@@ -98,7 +109,7 @@ rom_error_t ownership_activate_handler(boot_svc_msg_t *msg,
     case kOwnershipStateUnlockedSelf:
     case kOwnershipStateUnlockedAny:
     case kOwnershipStateUnlockedEndorsed:
-      error = activate(msg, bootdata);
+      error = activate_handler(msg, bootdata);
       break;
     default:
         /* nothing */;

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.h
@@ -14,12 +14,24 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * Activate the owner configuration on owner page 1.
+ *
+ * @param bootdata A pointer to the current boot_data in RAM.
+ * @param write_both_pages Whether to write the activated page to both owner
+ *                         pages.
+ * @return rom_error_t
+ */
+rom_error_t ownership_activate(boot_data_t *bootdata,
+                               hardened_bool_t write_both_pages);
+
+/**
  * Process a boot_svc OwnershipActivate message.
  *
  * @param msg The boot_svc OwnershipActivate message to process.
  * @param bootdata A pointer to the current boot_data in RAM.
  * @return rom_error_t
  */
+
 rom_error_t ownership_activate_handler(boot_svc_msg_t *msg,
                                        boot_data_t *bootdata);
 

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate.h
@@ -7,6 +7,7 @@
 
 #include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/boot_svc/boot_svc_msg.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -38,6 +38,8 @@ class OwnershipActivateTest : public rom_test::RomTest {
     owner_page[1].header.version = (struct_version_t){0, 0};
     owner_page[1].config_version = 0;
     owner_page[1].min_security_version_bl0 = UINT32_MAX;
+    owner_page[1].lock_constraint = 0;
+    memset(owner_page[1].device_id, 0x7e, sizeof(owner_page[1].device_id));
     memset(owner_page[1].data, 0x5a, sizeof(owner_page[1].data));
   }
 
@@ -123,7 +125,7 @@ INSTANTIATE_TEST_SUITE_P(AllCases, OwnershipActivateInvalidStateTest,
                          testing::Values(kOwnershipStateLockedOwner,
                                          kOwnershipStateRecovery));
 
-// Tests that an owner block with an invalid signature fails.
+// Tests that an owner block with an invalid version fails.
 TEST_P(OwnershipActivateValidStateTest, InvalidVersion) {
   bootdata_.ownership_state = static_cast<uint32_t>(GetParam());
   MakePage1Valid(true);
@@ -153,7 +155,7 @@ TEST_P(OwnershipActivateValidStateTest, InvalidSignature) {
   EXPECT_EQ(error, kErrorOwnershipInvalidSignature);
 }
 
-// Tests that an owner block with an invalid nonce fails.
+// Tests that an ownership activate with an invalid nonce fails.
 TEST_P(OwnershipActivateValidStateTest, InvalidNonce) {
   bootdata_.ownership_state = static_cast<uint32_t>(GetParam());
   bootdata_.nonce = {3, 4};
@@ -168,8 +170,8 @@ TEST_P(OwnershipActivateValidStateTest, InvalidNonce) {
   EXPECT_EQ(error, kErrorOwnershipInvalidNonce);
 }
 
-// Tests that an owner block with an invalid DIN fails.
-TEST_P(OwnershipActivateValidStateTest, InvalidDin) {
+// Tests that an ownership activate with an invalid DIN fails.
+TEST_P(OwnershipActivateValidStateTest, InvalidActivateDin) {
   bootdata_.ownership_state = static_cast<uint32_t>(GetParam());
   // We want to pass the page 1 validity test to check the nonce of the
   // message.

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -129,6 +129,10 @@ TEST_P(OwnershipActivateValidStateTest, InvalidVersion) {
   MakePage1Valid(true);
   owner_page[1].header.version.major = 5;
 
+  EXPECT_CALL(ownership_key_, validate(1, kOwnershipKeyActivate, _, _, _))
+      .WillOnce(Return(kHardenedBoolTrue));
+  EXPECT_CALL(lifecycle_, DeviceId(_))
+      .WillOnce(SetArgPointee<0>((lifecycle_device_id_t){0}));
   EXPECT_CALL(hdr_, Finalize(_, _, _));
 
   rom_error_t error = ownership_activate_handler(&message_, &bootdata_);

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -67,6 +67,9 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
   owner_page[0].update_mode = TEST_OWNER_UPDATE_MODE;
   owner_page[0].min_security_version_bl0 = UINT32_MAX;
+  owner_page[0].lock_constraint = 0;
+  memset(owner_page[0].device_id, kLockConstraintNone,
+         sizeof(owner_page[0].device_id));
   owner_page[0].owner_key = owner;
   owner_page[0].activate_key = (owner_key_t){
       // Although this is an ECDSA key, we initialize the `raw` member of the

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -499,3 +499,53 @@ ownership_transfer_test(
         test_harness = "//sw/host/tests/ownership:newversion_test",
     ),
 )
+
+ownership_transfer_test(
+    name = "newversion_nodelock_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa_pub)
+            --config-version=2
+            # A DIN of zero will cause the test program to use the DUT's current DIN.
+            --locked-to-din=0
+            --expect "config_version = 2"
+            --expect "owner_key = 8e3dcb50"
+        """,
+        test_harness = "//sw/host/tests/ownership:newversion_test",
+    ),
+)
+
+ownership_transfer_test(
+    name = "newversion_badlock_test",
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+    },
+    fpga = fpga_params(
+        changes_otp = True,
+        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa_pub)
+            --config-version=2
+            --locked-to-din=12345
+            # We expect to see the version unchanged.
+            --expect "config_version = 1"
+            --expect "owner_key = 8e3dcb50"
+        """,
+        test_harness = "//sw/host/tests/ownership:newversion_test",
+    ),
+)

--- a/sw/device/silicon_creator/rom_ext/proda/proda_owner.c
+++ b/sw/device/silicon_creator/rom_ext/proda/proda_owner.c
@@ -63,6 +63,9 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
   owner_page[0].update_mode = kOwnershipUpdateModeOpen;
   owner_page[0].min_security_version_bl0 = UINT32_MAX;
+  owner_page[0].lock_constraint = 0;
+  memset(owner_page[0].device_id, kLockConstraintNone,
+         sizeof(owner_page[0].device_id));
   owner_page[0].owner_key = owner;
   owner_page[0].activate_key = (owner_key_t){
       // Although this is an ECDSA key, we initialize the `raw` member of the

--- a/sw/device/silicon_creator/rom_ext/prodc/prodc_owner.c
+++ b/sw/device/silicon_creator/rom_ext/prodc/prodc_owner.c
@@ -63,6 +63,9 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
   owner_page[0].update_mode = kOwnershipUpdateModeOpen;
   owner_page[0].min_security_version_bl0 = UINT32_MAX;
+  owner_page[0].lock_constraint = 0;
+  memset(owner_page[0].device_id, kLockConstraintNone,
+         sizeof(owner_page[0].device_id));
   owner_page[0].owner_key = owner;
   owner_page[0].activate_key = (owner_key_t){
       // Although this is an ECDSA key, we initialize the `raw` member of the

--- a/sw/device/silicon_creator/rom_ext/sival/sival_owner.c
+++ b/sw/device/silicon_creator/rom_ext/sival/sival_owner.c
@@ -63,6 +63,9 @@ rom_error_t sku_creator_owner_init(boot_data_t *bootdata,
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
   owner_page[0].update_mode = kOwnershipUpdateModeOpen;
   owner_page[0].min_security_version_bl0 = UINT32_MAX;
+  owner_page[0].lock_constraint = 0;
+  memset(owner_page[0].device_id, kLockConstraintNone,
+         sizeof(owner_page[0].device_id));
   owner_page[0].owner_key = owner;
   owner_page[0].activate_key = (owner_key_t){
       // Although this is an ECDSA key, we initialize the `raw` member of the


### PR DESCRIPTION
Allow the owenrship block to specify that it is locked to a specific device ID.

1. Add `lock_constraints` and `device_id` fields to the owner config.
2. Use the device_id from the lifecycle controller in the cryptographic verification of the owner config.
3. Add tests to verify node locking.

Addresses: #24657 