### PR TITLE
[rom_ctrl, dv] Fixed rom_ctrl checker fsm conditional coverage

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -51,6 +51,10 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
     m_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
     m_kmac_agent_cfg.start_default_device_seq = 1'b1;
     m_kmac_agent_cfg.constant_share_means_error = 1'b0;
+    // The checker reads the upper 8 words of ROM which takes 9 cycles. The rsp_delay_max has been
+    // rounded off by 9*2=18 cycles along with adding 2 just to give an extra precision.
+    m_kmac_agent_cfg.rsp_delay_min = 'd0;
+    m_kmac_agent_cfg.rsp_delay_max = 'd20;
 
     sec_cm_alert_name = "fatal";
   endfunction


### PR DESCRIPTION
The conditional coverage was uncovered on [L157](https://github.com/KinzaQamar/opentitan/blob/6e5b27f59be08e442daf27791f085f77c9695896/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv#L157) for kmax_err_i being 1. This is due to the scenario an unaligned transitions b/w fsm state (ReadingHigh), kmac_done_i, counter_done and kmac_err_i. All should be synced and raised on the exact clock edge. kmac_err_i was unsynced and raised to 1 when the state was RomAhead.

The fix tweaks the rsp_delay in rom_ctrl_env_cfg.sv just to get the precision in the delay and that kmac_err_i should be raised for the particular scenario when state is ReadingHigh and both kmac_done_i and counter_done are set.