### PR TITLE
Cherry pick into integrated_dev: [tools] Use bazel-provided Python for fusesoc subprocesses

### DIFF
--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -102,7 +102,7 @@ fusesoc_build = rule(
         "verilator_options": attr.label(),
         "make_options": attr.label(),
         "_fusesoc": attr.label(
-            default = entry_point("fusesoc"),
+            default = "//util:fusesoc_build",
             executable = True,
             cfg = "exec",
         ),

--- a/util/BUILD
+++ b/util/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_python//python:defs.bzl", "py_binary")
-load("@ot_python_deps//:requirements.bzl", "requirement")
+load("@ot_python_deps//:requirements.bzl", "all_requirements", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -103,4 +103,10 @@ filegroup(
         "topgen.core",
         "topgen-reg-only.core",
     ],
+)
+
+py_binary(
+    name = "fusesoc_build",
+    srcs = ["fusesoc_build.py"],
+    deps = all_requirements,
 )

--- a/util/fusesoc_build.py
+++ b/util/fusesoc_build.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""Command-line tool to add the calling interpreter to fusesoc's PATH, so it
+is used for generators.
+"""
+
+
+import os
+import sys
+from fusesoc.main import main
+
+if __name__ == "__main__":
+    # First, ensure the calling interpreter is on the PATH first, so any
+    # generators asking /usr/bin/env for python3 will use the same version.
+    path_env = os.environ["PATH"]
+    if path_env is not None:
+        path_env = ":" + path_env
+    path_env = os.path.dirname(sys.executable) + path_env
+    os.environ["PATH"] = path_env
+
+    # Start fusesoc
+    rc = main()
+    sys.exit(rc)


### PR DESCRIPTION
I've been noticing that builds involving FuseSoC were being done twice: in Verilator simulations, I found my RTL verilated twice, and in Vivado bitstream builds, I found that Vivado was going through the entire process twice.

Doing some digging, I found https://github.com/bazelbuild/rules_python/issues/675, which calls the entry point of anything in `py_binary` _twice_. This was version 0.9 of rules_python, which incidentally is the version pinned by lowRISC/rules_python: https://github.com/lowRISC/rules_python/blob/07c3f8547abbd5b97839a48af226a0fbcfaa5e7c/python/pip_install/extract_wheels/lib/bazel.py#L38-L49

I initially tried bumping the version of rules_python, but found this interacted badly with other deps. I found #19162 which sidesteps rules_python's `py_binary` entirely with its own explicit FuseSoC wrapper script. Incidentally, after this PR got merged in the master branch, CW310 Earl Grey bitstream build times dropped from 123 minutes before this PR got merged (https://github.com/lowRISC/opentitan/commit/76713f7281a476bd2ca6d86221892e247db120bf) to 61 mintues afterwards (https://github.com/lowRISC/opentitan/commit/91befd8f69bda56a464ab905d11b6237c4e99959).

This PR simply cherry picks e38937c8e50573ae8d462750707873765bcdc07f to integrated_dev with a trivial merge conflict fixup.