### PR TITLE
[darjeeling,sim] Replace DMI DPI to rv_dm with JTAG DPI to toplevel

### DIFF
--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -290,8 +290,6 @@ module rv_dm
   end
   assign debug_req_o = debug_req & debug_req_en;
 
-  // Bound-in DPI module replaces the TAP and TL-UL DMI
-`ifndef DMIDirectTAP
   tlul_pkg::tl_h2d_t dbg_tl_h2d_win;
   tlul_pkg::tl_d2h_t dbg_tl_d2h_win;
   rv_dm_dbg_reg_top u_rv_dm_dbg_reg_top (
@@ -332,11 +330,6 @@ module rv_dm
   // Since the JTAG DTM used in this system can always drain this FIFO,
   // no additional reset request should be needed in order to clear it.
   assign dmi_rst_n = rst_ni;
-`else
-  assign dbg_intg_error = 1'b0;
-  assign dmi_intg_error = 1'b0;
-  assign dbg_tl_d_o = tlul_pkg::TL_D2H_DEFAULT;
-`endif
 
   // SEC_CM: DM_EN.CTRL.LC_GATED
   // SEC_CM: MEM_TL_LC_GATE.FSM.SPARSE

--- a/hw/top_darjeeling/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_darjeeling/dv/verilator/chip_sim_tb.sv
@@ -16,6 +16,12 @@ module chip_sim_tb (
   logic cio_spi_device_sdi_p2d;
   logic cio_spi_device_sdo_d2p, cio_spi_device_sdo_en_d2p;
 
+  logic cio_jtag_tck;
+  logic cio_jtag_tms;
+  logic cio_jtag_trst_n;
+  logic cio_jtag_tdi;
+  logic cio_jtag_tdo;
+
   chip_darjeeling_verilator u_dut (
     .clk_i,
     .rst_ni,
@@ -36,7 +42,14 @@ module chip_sim_tb (
     .cio_spi_device_csb_p2d_i(cio_spi_device_csb_p2d),
     .cio_spi_device_sdi_p2d_i(cio_spi_device_sdi_p2d),
     .cio_spi_device_sdo_d2p_o(cio_spi_device_sdo_d2p),
-    .cio_spi_device_sdo_en_d2p_o(cio_spi_device_sdo_en_d2p)
+    .cio_spi_device_sdo_en_d2p_o(cio_spi_device_sdo_en_d2p),
+
+    // communication with JTAG
+    .cio_jtag_tck_i(cio_jtag_tck),
+    .cio_jtag_tms_i(cio_jtag_tms),
+    .cio_jtag_trst_ni(cio_jtag_trst_n),
+    .cio_jtag_tdi_i(cio_jtag_tdi),
+    .cio_jtag_tdo_o(cio_jtag_tdo)
   );
 
   // GPIO DPI
@@ -64,40 +77,18 @@ module chip_sim_tb (
     .rx_i   (cio_uart_tx_d2p)
   );
 
-`ifdef DMIDirectTAP
-  // OpenOCD direct DMI TAP
-  bind rv_dm dmidpi u_dmidpi (
+  // OpenOCD JTAG DPI (to rv_dm and lc_ctrl)
+  jtagdpi u_jtagdpi (
     .clk_i,
     .rst_ni,
-    .dmi_req_valid,
-    .dmi_req_ready,
-    .dmi_req_addr   (dmi_req.addr),
-    .dmi_req_op     (dmi_req.op),
-    .dmi_req_data   (dmi_req.data),
-    .dmi_rsp_valid,
-    .dmi_rsp_ready,
-    .dmi_rsp_data   (dmi_rsp.data),
-    .dmi_rsp_resp   (dmi_rsp.resp),
-    .dmi_rst_n      (dmi_rst_n)
-  );
-`else
-  // TODO: this is currently not supported.
-  // connect this to the correct pins once pinout is final and once the
-  // verilator testbench supports DFT/Debug strap sampling.
-  // See also #5221.
-  //
-  // jtagdpi u_jtagdpi (
-  //   .clk_i,
-  //   .rst_ni,
 
-  //   .jtag_tck    (cio_jtag_tck),
-  //   .jtag_tms    (cio_jtag_tms),
-  //   .jtag_tdi    (cio_jtag_tdi),
-  //   .jtag_tdo    (cio_jtag_tdo),
-  //   .jtag_trst_n (cio_jtag_trst_n),
-  //   .jtag_srst_n (cio_jtag_srst_n)
-  // );
-`endif
+    .jtag_tck    (cio_jtag_tck),
+    .jtag_tms    (cio_jtag_tms),
+    .jtag_tdi    (cio_jtag_tdi),
+    .jtag_tdo    (cio_jtag_tdo),
+    .jtag_trst_n (cio_jtag_trst_n),
+    .jtag_srst_n ()
+  );
 
   // SPI DPI
   spidpi u_spi (

--- a/util/openocd/interface/sim-jtagdpi.cfg
+++ b/util/openocd/interface/sim-jtagdpi.cfg
@@ -7,5 +7,5 @@
 # SystemVerilog DPI module.
 
 adapter driver remote_bitbang
-remote_bitbang_port 44853
-remote_bitbang_host localhost
+remote_bitbang port 44853
+remote_bitbang host localhost

--- a/util/openocd/target/lowrisc-darjeeling.cfg
+++ b/util/openocd/target/lowrisc-darjeeling.cfg
@@ -14,7 +14,7 @@ if { [info exists CPUTAPID ] } {
    set _CPUTAPID $CPUTAPID
 } else {
    # Defined in `hw/top_darjeeling/rtl/jtag_id_pkg.sv`.
-   set _CPUTAPID 0x10001cdf
+   set _CPUTAPID 0x10003cdf
 }
 
 jtag newtap $_CHIPNAME tap -irlen 5 -expected-id $_CPUTAPID


### PR DESCRIPTION
Commit 87d5764f brought rv_dm and lc_ctrl to the same debugging crossbar. However, the existing DMI DPI interface interacts only with rv_dm. Swap this out for the JTAG DPI interface so we can talk to both modules.

I really wanted to also support the old infrastructure, allowing folks to use dmidpi to talk directly (and exclusively) to rv_dm for better performance. But I couldn't find a clean way to do this: the old functionality was gated off by the [`DMIDirectTAP` Verilog define](https://github.com/lowRISC/opentitan/blob/2585f4a8cf61e3ccc4fe3565a7147e44ae9284ba/hw/top_darjeeling/dv/verilator/chip_sim.core#L55-L59), but as far as I can tell, FuseSoC will always define the Verilog macro, so using this Verilog \`ifdef won't work, as the \`else block will never be triggered (and Verilog lacks the `#if` that exists for the C preprocessor):

https://github.com/lowRISC/opentitan/blob/2585f4a8cf61e3ccc4fe3565a7147e44ae9284ba/hw/top_darjeeling/dv/verilator/chip_sim_tb.sv#L67-L100

Making it a Verilog _parameter_ might let it look like this:
```verilog
module chip_sim_tb # (
  parameter bit DMIDirectTAP = 0
)
   ...

  generate if (DMIDirectTAP)
    // instantiate the DMI DPI module
  else
    // instantiate the JTAG DPI module
  endgenerate
```
     
But this caused two problems: 1) I'd have to punch a signal from toplevel all the way to rv_dm, which feels clumsy, but the bigger problem was 2) Verilator seems to instantiate _both_ DPI modules, which caused OpenOCD to play poorly when trying to connect to the bitbang port.

This PR is a little more bold in that it eliminates the DMI DPI interface entirely. I'd sincerely appreciate comments on the best way to proceed from here.