### PR TITLE
[rv_dm,dv] Slightly broaden dependency in rv_dm_env.core

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -7,15 +7,13 @@ description: "RV_DM DV UVM environment"
 filesets:
   files_dv:
     depend:
+      - lowrisc:ip:rv_dm
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:dv:dv_base_reg
       - lowrisc:dv:jtag_agent
       - lowrisc:dv:jtag_dmi_agent
       - lowrisc:opentitan:bus_params_pkg
-      # Note: This core pulls in an rv_dm implementation. We actually
-      # just need the package (dm_pkg.sv) for DV here.
-      - pulp-platform:riscv-dbg:0.1
     files:
       - rv_dm_env_pkg.sv
       - rv_dm_if.sv


### PR DESCRIPTION
When the core file originally got a dependency on the IP itself (in 1f3a0e5f53b), the tests were only actually depending on the debug module package. But that's not true any more! In particular, rv_dm_env_pkg now depends on rv_dm_reg_pkg (since commit 840a2455268).

Depend on hw:ip:rv_dm to make this explicit (rather than depending on the ordering fusesoc happens to choose, which doesn't necessarily get what we need).