### PR TITLE
[ownership] Update owner entropy upon transfer

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -81,9 +81,11 @@ dual_cc_library(
     deps = dual_inputs(
         device = [
             ":ecdsa",
+            "//sw/device/lib/base:memory",
             "//sw/device/lib/base:hardened_memory",
             "//sw/device/silicon_creator/lib/drivers:keymgr",
             "//sw/device/silicon_creator/lib/drivers:kmac",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         ],
         host = [
             "//sw/device/lib/base:global_mock",
@@ -93,6 +95,7 @@ dual_cc_library(
         shared = [
             ":datatypes",
             "//sw/device/lib/base:hardened",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
             "//sw/device/silicon_creator/lib:error",
         ],
     ),

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.cc
@@ -26,5 +26,9 @@ rom_error_t ownership_seal_check(size_t page) {
   return MockOwnershipKey::Instance().seal_check(page);
 }
 
+rom_error_t ownership_secret_new() {
+  return MockOwnershipKey::Instance().secret_new();
+}
+
 }  // extern "C"
 }  // namespace rom_test

--- a/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/mock_ownership_key.h
@@ -23,6 +23,7 @@ class MockOwnershipKey : public global_mock::GlobalMock<MockOwnershipKey> {
   MOCK_METHOD(rom_error_t, seal_init, ());
   MOCK_METHOD(rom_error_t, seal_page, (size_t));
   MOCK_METHOD(rom_error_t, seal_check, (size_t));
+  MOCK_METHOD(rom_error_t, secret_new, ());
 };
 
 }  // namespace internal

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -185,6 +185,9 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageOwnerSlot0, cfg);
   flash_ctrl_info_perms_set(&kFlashCtrlInfoPageOwnerSlot1, perm);
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageOwnerSlot1, cfg);
+  // Set up the OwnerSecret page for ECC & Scrambling.  We won't
+  // turn on read/write/earse permissions until we need them.
+  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageOwnerSecret, cfg);
 
   ownership_seal_init();
   // We don't want to abort ownership setup if we fail to

--- a/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_activate_unittest.cc
@@ -262,6 +262,10 @@ TEST_P(OwnershipActivateValidStateTest, OwnerPageValid) {
                                      &owner_page[1]))
       .WillOnce(Return(kErrorOk));
 
+  if (state != kOwnershipStateUnlockedSelf) {
+    EXPECT_CALL(ownership_key_, secret_new()).WillOnce(Return(kErrorOk));
+  }
+
   // The nonce will be regenerated.
   EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(99));
   // The boot_svc response will be finalized.
@@ -326,6 +330,10 @@ TEST_P(OwnershipActivateValidStateTest, UpdateBootdataBl0) {
                                      sizeof(owner_page[1]) / sizeof(uint32_t),
                                      &owner_page[1]))
       .WillOnce(Return(kErrorOk));
+
+  if (state != kOwnershipStateUnlockedSelf) {
+    EXPECT_CALL(ownership_key_, secret_new()).WillOnce(Return(kErrorOk));
+  }
 
   // The nonce will be regenerated.
   EXPECT_CALL(rnd_, Uint32()).WillRepeatedly(Return(99));

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/kmac.h"
 #include "sw/device/silicon_creator/lib/ownership/ecdsa.h"
@@ -79,4 +80,95 @@ rom_error_t ownership_seal_check(size_t page) {
     return (rom_error_t)result;
   }
   return kErrorOwnershipInvalidInfoPage;
+}
+
+static void reverse(void *buf, size_t len) {
+  char *x = (char *)buf;
+  char *y = x + len - 1;
+  for (; x < y; ++x, --y) {
+    char t = *x;
+    *x = *y;
+    *y = t;
+  }
+}
+
+static void secret_page_enable(multi_bit_bool_t read, multi_bit_bool_t write) {
+  flash_ctrl_perms_t perm = {
+      .read = read,
+      .write = write,
+      .erase = write,
+  };
+  flash_ctrl_info_perms_set(&kFlashCtrlInfoPageOwnerSecret, perm);
+}
+
+rom_error_t ownership_secret_new(void) {
+  owner_secret_page_t secret;
+
+  secret_page_enable(/*read=*/kMultiBitBool4True, /*write=*/kMultiBitBool4True);
+  rom_error_t error =
+      flash_ctrl_info_read(&kFlashCtrlInfoPageOwnerSecret, 0,
+                           sizeof(secret) / sizeof(uint32_t), &secret);
+  if (error != kErrorOk) {
+    HARDENED_CHECK_NE(error, kErrorOk);
+    // This should only happen on the FPGA during the first ownership transfer.
+    // TODO: What should we do if we ever encounter this error on silicon?
+    // A successful erase and reprogram will "heal" the chip, but any
+    // ownership history will be lost.
+    error = flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSecret,
+                                  kFlashCtrlEraseTypePage);
+    memset(&secret, 0xFF, sizeof(secret));
+  }
+  if (error != kErrorOk)
+    goto exitproc;
+
+  // Compute the ownership hash chain:
+  // owner_history = HASH(owner_history || new_owner_key)
+  hmac_sha256_init();
+  hmac_sha256_update(&secret.owner_history, sizeof(secret.owner_history));
+  size_t keysz = sizeof(owner_page[0].owner_key);
+  switch (owner_page[0].ownership_key_alg) {
+    case kOwnershipKeyAlgEcdsaP256:
+      keysz = sizeof(owner_page[0].owner_key.ecdsa);
+      break;
+    default:;
+  }
+  hmac_sha256_update(&owner_page[0].owner_key, keysz);
+  hmac_sha256_final(&secret.owner_history);
+  // TODO(cfrantz): when merging to master, use the big-endian form of
+  // the sha256 function to avoid the reversal operation at the end.
+  reverse(&secret.owner_history, sizeof(secret.owner_history));
+
+  // Generate a new owner secret seed.  This will completely disconnect
+  // the keymgr state from the previous owner's keymgr state.
+  // We hash the previous owner entropy with the new owner key.
+  // owner_secret = HASH(owner_secret || new_owner_key)
+  // TODO: is this sufficient, or should we generate new entropy?
+  hmac_sha256_init();
+  hmac_sha256_update(&secret.owner_secret, sizeof(secret.owner_secret));
+  hmac_sha256_update(&owner_page[0].owner_key, keysz);
+  hmac_sha256_final(&secret.owner_secret);
+
+  error = flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSecret,
+                                kFlashCtrlEraseTypePage);
+  if (error != kErrorOk)
+    goto exitproc;
+  error = flash_ctrl_info_write(&kFlashCtrlInfoPageOwnerSecret, 0,
+                                sizeof(secret) / sizeof(uint32_t), &secret);
+
+exitproc:
+  secret_page_enable(/*read=*/kMultiBitBool4False,
+                     /*write=*/kMultiBitBool4False);
+  return error;
+}
+
+rom_error_t ownership_history_get(hmac_digest_t *history) {
+  secret_page_enable(/*read=*/kMultiBitBool4True,
+                     /*write=*/kMultiBitBool4False);
+  rom_error_t error =
+      flash_ctrl_info_read(&kFlashCtrlInfoPageOwnerSecret,
+                           offsetof(owner_secret_page_t, owner_history),
+                           sizeof(*history) / sizeof(uint32_t), history);
+  secret_page_enable(/*read=*/kMultiBitBool4False,
+                     /*write=*/kMultiBitBool4False);
+  return error;
 }

--- a/sw/device/silicon_creator/lib/ownership/ownership_key.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership_key.h
@@ -6,6 +6,8 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNERSHIP_KEY_H_
 
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
@@ -29,6 +31,13 @@ typedef enum ownership_key {
   /** The silicon_creator no_owner_recovery key. */
   kOwnershipKeyRecovery = 0x8888,
 } ownership_key_t;
+
+typedef struct owner_secret_page {
+  /** Owner entropy. */
+  hmac_digest_t owner_secret;
+  /** Hash chain of previous owners. */
+  hmac_digest_t owner_history;
+} owner_secret_page_t;
 
 /**
  * Validate that a message was signed with a given owner key.
@@ -71,5 +80,20 @@ rom_error_t ownership_seal_page(size_t page);
  * @return Success or error code.
  */
 rom_error_t ownership_seal_check(size_t page);
+
+/**
+ * Replace the owner secret with new entropy and update the ownership history.
+ *
+ * @return Success or error code.
+ */
+rom_error_t ownership_secret_new(void);
+
+/**
+ * Retrieve the owner history digest from the OwnerSecret page.
+ *
+ * @param history Digest of all previous owner keys.
+ * @return Success or error code.
+ */
+rom_error_t ownership_history_get(hmac_digest_t *history);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNERSHIP_KEY_H_

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -286,6 +286,7 @@ ownership_transfer_test(
             # NOTE: We rotate the `fake` test owner's application key to the dummy key to test that
             #       we can execute code with the new key.
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
+            --non-transfer-update=true
         """,
         test_harness = "//sw/host/tests/ownership:transfer_test",
     ),
@@ -447,6 +448,7 @@ ownership_transfer_test(
             # NOTE: Should sku_creator_owner_init fail to upgrade to its built-in owner block, then the
             # dummy key will prevent the test program from executing and we'll get a failure from the test.
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
+            --non-transfer-update=true
         """,
         test_harness = "//sw/host/tests/ownership:transfer_test",
     ),
@@ -548,4 +550,73 @@ ownership_transfer_test(
         """,
         test_harness = "//sw/host/tests/ownership:newversion_test",
     ),
+)
+
+opentitan_binary(
+    name = "keymgr_test",
+    testonly = True,
+    srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+    defines = [
+        "WITH_OWNERSHIP_INFO=1",
+        "WITH_KEYMGR=1",
+    ],
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod",
+    },
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/ownership:datatypes",
+    ],
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_transfer_any_test
+ownership_transfer_test(
+    name = "transfer_keymgr_test",
+    srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+    defines = [
+        "WITH_OWNERSHIP_INFO=1",
+        "WITH_KEYMGR=1",
+    ],
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "app_prod",
+    },
+    fpga = fpga_params(
+        binaries = {
+            ":keymgr_test": "keymgr_test",
+        },
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --pre-transfer-boot-check=true
+            --unlock-mode=Any
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
+            --rescue-after-activate={keymgr_test}
+            --keygen-check=true
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/ownership:datatypes",
+    ],
 )

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -44,6 +44,7 @@
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_activate.h"
+#include "sw/device/silicon_creator/lib/ownership/ownership_key.h"
 #include "sw/device/silicon_creator/lib/ownership/ownership_unlock.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
@@ -826,7 +827,6 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
 
   // Establish our identity.
   HARDENED_RETURN_IF_ERROR(rom_ext_attestation_silicon());
-  HARDENED_RETURN_IF_ERROR(rom_ext_attestation_creator(self));
 
   const manifest_ext_secver_write_t *secver;
   rom_error_t error;
@@ -871,6 +871,12 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   if (error != kErrorOk) {
     dbg_printf("ownership_init: %x\r\n", error);
   }
+
+  // NOTE: In the ES silicon, the OwnerSecret page perturbs the keymgr at the
+  // OwnerIntermediateKey stage.  As such, we perform ownership init before
+  // reaching that stage so that an ownership transfer wont break the derivation
+  // of the ownership sealing key (derived in `ownership_init`).
+  HARDENED_RETURN_IF_ERROR(rom_ext_attestation_creator(self));
 
   // Configure SRAM execution as the owner requested.
   rom_ext_sram_exec(owner_config.sram_exec);


### PR DESCRIPTION
1. Rewrite the OwnerSecret page when performing an ownership transfer.
2. Test that the sealing derivation changes in each state along the transfer (e.g. CurrentOwner -> Unlocked -> NextOwner).

Addresses: #24667