### PR TITLE
Add missing include to rv_plic template file

### DIFF
--- a/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
+++ b/hw/ip_templates/rv_plic/rtl/rv_plic.sv.tpl
@@ -14,6 +14,8 @@
 // Verilog parameter
 //   MAX_PRIO: Maximum value of interrupt priority
 
+`include "prim_assert.sv"
+
 module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn  = {NumAlerts{1'b1}},
   // OpenTitan IP standardizes on level triggered interrupts,

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic.sv
@@ -14,6 +14,8 @@
 // Verilog parameter
 //   MAX_PRIO: Maximum value of interrupt priority
 
+`include "prim_assert.sv"
+
 module rv_plic import rv_plic_reg_pkg::*; #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn  = {NumAlerts{1'b1}},
   // OpenTitan IP standardizes on level triggered interrupts,


### PR DESCRIPTION
This provides `ASSERT definition that is otherwise missing