### PR TITLE
[docs] Disable documentation rendering (`earlgrey_es_sival`)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,8 +159,9 @@ jobs:
   - bash: ci/scripts/check_dv_sw_images.sh
     displayName: Check DV software images (Experimental)
     continueOnError: True
-  - bash: ci/scripts/build-docs.sh
-    displayName: Render documentation
+  # #24772 - Disabled documentation rendering.
+  #- bash: ci/scripts/build-docs.sh
+  #  displayName: Render documentation
   # Define OT_DESTRUCTIVE=1 to enable ci/scripts/check-generated.sh to delete
   # uncommitted changes.
   - bash: OT_DESTRUCTIVE=1 ci/scripts/check-generated.sh


### PR DESCRIPTION
The documentation build is currently broken on the `earlgrey_es_sival` branch.  The aparent cause is a missing DV report from the reports bucket.

Addresses: #24772