### PR TITLE
[ci] Fix verilator installation path

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -52,8 +52,8 @@ runs:
         }
         sudo mkdir -p "${{ inputs.verilator-path }}"
         sudo chmod 777 "${{ inputs.verilator-path }}"
-        tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}" --strip-components=1
-        echo "${{ inputs.verilator-path }}/bin" >> "$GITHUB_PATH"
+        tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}"
+        echo "${{ inputs.verilator-path }}/v${{ inputs.verilator-version }}/bin" >> "$GITHUB_PATH"
       shell: bash
 
     - name: Install Verible


### PR DESCRIPTION
The binaries were compiled with the `v4.210` component of the path, so we have to leave this in.