### PR TITLE
[bazel] Fix shellcheck lints and path to binary

### DIFF
--- a/quality/BUILD.bazel
+++ b/quality/BUILD.bazel
@@ -213,4 +213,7 @@ sh_test(
         "//:WORKSPACE",
         "@shellcheck",
     ],
+    env = {
+        "SHELLCHECK": "$(location @shellcheck//:shellcheck)",
+    },
 )

--- a/util/sh/scripts/run-shellcheck.sh
+++ b/util/sh/scripts/run-shellcheck.sh
@@ -19,11 +19,15 @@ else
     SHELLCHECK="./bazelisk.sh run @shellcheck//:shellcheck --"
 fi
 
-EXCLUDED_DIRS="-name third_party -o -name vendor -o -name build-site -o -name lowrisc_misc-linters"
+EXCLUDED_DIRS=(
+    "-name" "third_party" "-o"
+    "-name" "vendor" "-o"
+    "-name" "build-site" "-o"
+    "-name" "lowrisc_misc-linters"
+)
 # Get an array of all shell scripts to check using input redirection and
 # process substitution. For details on this syntax, see ShellCheck SC2046.
-# shellcheck disable=SC2046
 readarray -t shell_scripts < \
-    <(find . \( $EXCLUDED_DIRS \) -prune -o -name '*.sh' -print)
+    <(find . \( "${EXCLUDED_DIRS[@]}" \) -prune -o -name '*.sh' -print)
 
-$SHELLCHECK --severity=warning "${shell_scripts[@]}"
+"$SHELLCHECK" --severity=warning "${shell_scripts[@]}"

--- a/util/sh/scripts/run-shellcheck.sh
+++ b/util/sh/scripts/run-shellcheck.sh
@@ -10,7 +10,7 @@ set -e
 # This assumption enables us to infer that we're running in the sandbox when we
 # see a symlink named "WORKSPACE".
 if [[ -L WORKSPACE ]]; then
-    SHELLCHECK="$(realpath external/shellcheck/shellcheck)"
+    SHELLCHECK="$(realpath "${SHELLCHECK}")"
     REPO_TOP="$(dirname "$(realpath WORKSPACE)")"
     cd "${REPO_TOP}"
 else


### PR DESCRIPTION
This PR:

* Fixes shellcheck errors in the `run-shellcheck.sh` script.
* Fixes the path to the `shellcheck` binary when run under Bazel.
  * The current method uses a hard-coded path in `external/` which is fragile.
  * This path is incorrect under bzlmod.
  * Use the more robust `$(location ...)` method via an env var instead.