### PR TITLE
[manuf] Finalize {Creator,Owner}SwCfg at end of perso flow 

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -93,7 +93,6 @@ cc_library(
     hdrs = ["dice.h"],
     deps = [
         ":cert",
-        "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:check",
@@ -106,7 +105,6 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
-        "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
     ],

--- a/sw/device/silicon_creator/lib/cert/dice.h
+++ b/sw/device/silicon_creator/lib/cert/dice.h
@@ -32,6 +32,13 @@ extern const sc_keymgr_ecc_key_t kDiceKeyCdi1;
 /**
  * Generates the UDS attestation keypair and (unendorsed) X.509 TBS certificate.
  *
+ * @param otp_creator_sw_cfg_measurement Pointer to the CreatorSwCfg
+ * measurement.
+ * @param otp_owner_sw_cfg_measurement Pointer to the OwnerSwCfg measurement.
+ * @param otp_rot_creator_auth_codesign_measurement Pointer to the
+ * RotCreatorAuthCodesign measurement.
+ * @param otp_rot_creator_auth_state_measurement Pointer to the
+ * RotCreatorAuthState measurement.
  * @param key_ids Pointer to the (current and endorsement) public key IDs.
  * @param uds_pubkey Pointer to the (current stage) public key in big endian.
  * @param[out] cert Buffer to hold the generated UDS certificate.
@@ -41,9 +48,13 @@ extern const sc_keymgr_ecc_key_t kDiceKeyCdi1;
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t dice_uds_tbs_cert_build(cert_key_id_pair_t *key_ids,
-                                    ecdsa_p256_public_key_t *uds_pubkey,
-                                    uint8_t *tbs_cert, size_t *tbs_cert_size);
+rom_error_t dice_uds_tbs_cert_build(
+    hmac_digest_t *otp_creator_sw_cfg_measurement,
+    hmac_digest_t *otp_owner_sw_cfg_measurement,
+    hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
+    hmac_digest_t *otp_rot_creator_auth_state_measurement,
+    cert_key_id_pair_t *key_ids, ecdsa_p256_public_key_t *uds_pubkey,
+    uint8_t *tbs_cert, size_t *tbs_cert_size);
 
 /**
  * Generates the CDI_0 attestation keypair and X.509 certificate.

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -103,9 +103,13 @@ const sc_keymgr_ecc_key_t kDiceKeyCdi1 = {
 //     -2 : bstr,                   ; X coordinate, big-endian
 //     -3 : bstr                    ; Y coordinate, big-endian
 // }
-rom_error_t dice_uds_tbs_cert_build(cert_key_id_pair_t *key_ids,
-                                    ecdsa_p256_public_key_t *uds_pubkey,
-                                    uint8_t *tbs_cert, size_t *tbs_cert_size) {
+rom_error_t dice_uds_tbs_cert_build(
+    hmac_digest_t *otp_creator_sw_cfg_measurement,
+    hmac_digest_t *otp_owner_sw_cfg_measurement,
+    hmac_digest_t *otp_rot_creator_auth_codesign_measurement,
+    hmac_digest_t *otp_rot_creator_auth_state_measurement,
+    cert_key_id_pair_t *key_ids, ecdsa_p256_public_key_t *uds_pubkey,
+    uint8_t *tbs_cert, size_t *tbs_cert_size) {
   struct CborOut kCborOutHandle;
 
   struct CborOut *pCborOut = &kCborOutHandle;

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -41,7 +41,7 @@ static uint32_t
  * @param kv OTP Array of OTP key values. See `otp_kv_t` documentation for more
  * details.
  * @param len Length of the `kv` array.
- * @return OT_WARN_UNUSED_RESULT
+ * @return OK_STATUS if the OTP values were written into the target partition.
  */
 OT_WARN_UNUSED_RESULT
 static status_t otp_img_write(const dif_otp_ctrl_t *otp,
@@ -92,6 +92,32 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
 }
 
 /**
+ * Overwrites the target field with its expected final value in a buffer
+ * representing the provided partition.
+ *
+ * @param partition Target OTP partition.
+ * @param field_offset An offest of the target OTP field.
+ * @param buffer A buffer containing the entire target OTP partition.
+ * @return OK_STATUS if the expected OTP values are successfully written to the
+ * `buffer`.
+ */
+static status_t otp_img_expected_value_read(dif_otp_ctrl_partition_t partition,
+                                            uint32_t field_offset,
+                                            uint8_t *buffer) {
+  uint32_t relative_addr;
+  TRY(dif_otp_ctrl_relative_address(partition, field_offset, &relative_addr));
+  switch (field_offset) {
+    case OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET:
+      memcpy(buffer + relative_addr, &kOwnerSwCfgRomBootstrapDisValue,
+             sizeof(uint32_t));
+      break;
+    default:
+      return INTERNAL();
+  }
+  return OK_STATUS();
+}
+
+/**
  * Computes a SHA256 digest of an OTP partition and uses the least significant
  * 64-bits of the digest to additionally lock the partition.
  *
@@ -100,7 +126,7 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
  *
  * @param otp OTP Controller instance.
  * @param partition Target OTP partition.
- * @return OT_WARN_UNUSED_RESULT
+ * @return OK_STATUS if the target partition was locked.
  */
 OT_WARN_UNUSED_RESULT
 static status_t lock_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
@@ -210,6 +236,19 @@ status_t manuf_individualize_device_flash_data_default_cfg(
   return OK_STATUS();
 }
 
+status_t manuf_individualize_device_flash_data_default_cfg_check(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  uint32_t offset;
+  TRY(dif_otp_ctrl_relative_address(
+      kDifOtpCtrlPartitionCreatorSwCfg,
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET, &offset));
+  uint32_t val = 0;
+  TRY(otp_ctrl_testutils_dai_read32(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
+                                    offset, &val));
+  bool is_provisioned = (val == kCreatorSwCfgFlashDataDefaultCfgValue);
+  return is_provisioned ? OK_STATUS() : INTERNAL();
+}
+
 status_t manuf_individualize_device_creator_sw_cfg_lock(
     const dif_otp_ctrl_t *otp_ctrl) {
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg));
@@ -240,6 +279,23 @@ status_t manuf_individualize_device_rom_bootstrap_dis_cfg(
   TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg,
                                      offset, &kOwnerSwCfgRomBootstrapDisValue,
                                      /*len=*/1));
+  return OK_STATUS();
+}
+
+status_t manuf_individualize_device_partition_expected_read(
+    dif_otp_ctrl_partition_t partition, uint8_t *buffer) {
+  switch (partition) {
+    case kDifOtpCtrlPartitionOwnerSwCfg:
+      TRY(otp_img_expected_value_read(
+          partition, OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET,
+          buffer));
+      break;
+    case kDifOtpCtrlPartitionCreatorSwCfg:
+      break;
+    default:
+      return INTERNAL();
+  }
+
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
@@ -69,6 +69,17 @@ status_t manuf_individualize_device_flash_data_default_cfg(
     const dif_otp_ctrl_t *otp_ctrl);
 
 /**
+ * Checks the FLASH_DATA_DEFAULT_CFG field in the CREATOR_SW_CFG OTP
+ * partition.
+ *
+ * @param otp_ctrl OTP controller instance.
+ * @return OK_STATUS if the FLASH_DATA_DEFAULT_CFG field is provisioned.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_individualize_device_flash_data_default_cfg_check(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
  * Locks the CREATOR_SW_CFG OTP partition.
  *
  * This must be called after both `manuf_individualize_device_creator_sw_cfg()`
@@ -146,5 +157,17 @@ status_t manuf_individualize_device_owner_sw_cfg_lock(
  */
 status_t manuf_individualize_device_owner_sw_cfg_check(
     const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Overwrites unprovisioned fields with their expected final values in a buffer
+ * representing the provided partition.
+ *
+ * @param partition Target OTP partition.
+ * @param[out] buffer A buffer containing the entire target OTP partition.
+ * @return OK_STATUS if the expected partition values are successfully written
+ * to the `buffer`.
+ */
+status_t manuf_individualize_device_partition_expected_read(
+    dif_otp_ctrl_partition_t partition, uint8_t *buffer);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_INDIVIDUALIZE_SW_CFG_H_


### PR DESCRIPTION
This PR has two commits that:

1. Move the calculation of OTP measurement from `dice_uds_tbs_cert_build` to `ft_personalize`
2. Modify the perso flow to complete the provisioning of the `CreatorSwCfg` and `OwnerSwCfg` OTP partitions at the end of the process.

   - Sets the expected values for fields in the OTP that are not provisioned until the final stages of personalization.
   - Compare the OTP measurement used during certificate generation with the value stored in the OTP.

This PR addresses #24610 partially.