### PR TITLE
[rom_ext] Initialize boot_log after boot_svc

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_primary_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_primary_test.c
@@ -15,6 +15,7 @@ OTTF_DEFINE_TEST_CONFIG();
 
 static status_t initialize(retention_sram_t *retram, boot_svc_retram_t *state) {
   boot_svc_msg_t msg = {0};
+  TRY_CHECK(state->primary_side == 'A');
   boot_svc_next_boot_bl0_slot_req_init(
       /*primary_slot=*/kBootSlotB,
       /*next_slot=*/kBootSlotUnspecified, &msg.next_boot_bl0_slot_req);
@@ -32,6 +33,7 @@ static status_t check_side_b(retention_sram_t *retram,
   TRY_CHECK(msg.header.type == kBootSvcNextBl0SlotResType);
   TRY_CHECK(msg.next_boot_bl0_slot_res.status == kErrorOk);
   TRY_CHECK(state->current_side == 'B');
+  TRY_CHECK(state->primary_side == 'B');
   if (state->boots == 4) {
     // When we reach 4 boots, transition back to SlotA.
     boot_svc_next_boot_bl0_slot_req_init(
@@ -47,6 +49,7 @@ static status_t check_side_b(retention_sram_t *retram,
 static status_t check_return_side_a(retention_sram_t *retram,
                                     boot_svc_retram_t *state) {
   TRY_CHECK(state->current_side == 'A');
+  TRY_CHECK(state->primary_side == 'A');
   state->state = kBootSvcTestStateFinal;
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.c
@@ -32,6 +32,9 @@ status_t boot_svc_test_init(retention_sram_t *retram, boot_svc_test_t test) {
   state->current_side = (boot_log->bl0_slot == kBootSlotA)   ? 'A'
                         : (boot_log->bl0_slot == kBootSlotB) ? 'B'
                                                              : 'x';
+  state->primary_side = (boot_log->primary_bl0_slot == kBootSlotA)   ? 'A'
+                        : (boot_log->primary_bl0_slot == kBootSlotB) ? 'B'
+                                                                     : 'x';
   state->partition[state->boots] = state->current_side;
   state->boots += 1;
   return OK_STATUS();

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_test_lib.h
@@ -36,6 +36,8 @@ typedef struct boot_svc_retram {
   int boots;
   // The side we're currently booted to.
   char current_side;
+  // The primary side.
+  char primary_side;
   // The owner partition that was booted on each boot.
   char partition[10];
 } boot_svc_retram_t;

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -852,12 +852,6 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log->rom_ext_major = self->version_major;
   boot_log->rom_ext_minor = self->version_minor;
   boot_log->rom_ext_size = CHIP_ROM_EXT_SIZE_MAX;
-  boot_log->rom_ext_nonce = boot_data->nonce;
-  boot_log->ownership_state = boot_data->ownership_state;
-  boot_log->ownership_transfers = boot_data->ownership_transfers;
-  boot_log->rom_ext_min_sec_ver = boot_data->min_security_version_rom_ext;
-  boot_log->bl0_min_sec_ver = boot_data->min_security_version_bl0;
-  boot_log->primary_bl0_slot = boot_data->primary_bl0_slot;
 
   // On the ES chip, we need to check the reset reasons stored in retention RAM
   // and record whether or not the ROM initialized the retention RAM.
@@ -895,9 +889,13 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
     }
   }
 
-  // Re-sync the boot_log entries that could be changed by boot services.
+  // Synchronize the boot_log entries that could be changed by boot services.
   boot_log->rom_ext_nonce = boot_data->nonce;
   boot_log->ownership_state = boot_data->ownership_state;
+  boot_log->ownership_transfers = boot_data->ownership_transfers;
+  boot_log->rom_ext_min_sec_ver = boot_data->min_security_version_rom_ext;
+  boot_log->bl0_min_sec_ver = boot_data->min_security_version_bl0;
+  boot_log->primary_bl0_slot = boot_data->primary_bl0_slot;
   boot_log_digest_update(boot_log);
 
   if (uart_break_detect(kRescueDetectTime) == kHardenedBoolTrue) {


### PR DESCRIPTION
A number of `boot_log` fields are copies of fields in `boot_data`. Since boot services can update `boot_data`, we need to initialize those `boot_log` entries after boot services completes.

Fixes: 24768