### PR TITLE
[flash_crtl] Re-arrange the INFO page layout

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -79,20 +79,20 @@ typedef enum flash_ctrl_partition {
   X(kFlashCtrlInfoPageOwnerReserved1,      0, 6) \
   X(kFlashCtrlInfoPageOwnerReserved2,      0, 7) \
   X(kFlashCtrlInfoPageOwnerReserved3,      0, 8) \
-  X(kFlashCtrlInfoPageOwnerReserved4,      0, 9) \
+  X(kFlashCtrlInfoPageCreatorReserved0,    0, 9) \
   /**
    * Bank 1 information partition type 0 pages.
    */ \
-  X(kFlashCtrlInfoPageBootData0,       1, 0) \
-  X(kFlashCtrlInfoPageBootData1,       1, 1) \
-  X(kFlashCtrlInfoPageOwnerSlot0,      1, 2) \
-  X(kFlashCtrlInfoPageOwnerSlot1,      1, 3) \
-  X(kFlashCtrlInfoPageOwnerReserved5,  1, 4) \
-  X(kFlashCtrlInfoPageOwnerReserved6,  1, 5) \
-  X(kFlashCtrlInfoPageOwnerReserved7,  1, 6) \
-  X(kFlashCtrlInfoPageBootServices,    1, 7) \
-  X(kFlashCtrlInfoPageOwnerReserved8,  1, 8) \
-  X(kFlashCtrlInfoPageDiceCerts,       1, 9) \
+  X(kFlashCtrlInfoPageBootData0,           1, 0) \
+  X(kFlashCtrlInfoPageBootData1,           1, 1) \
+  X(kFlashCtrlInfoPageOwnerSlot0,          1, 2) \
+  X(kFlashCtrlInfoPageOwnerSlot1,          1, 3) \
+  X(kFlashCtrlInfoPageCreatorReserved1,    1, 4) \
+  X(kFlashCtrlInfoPageOwnerReserved4,      1, 5) \
+  X(kFlashCtrlInfoPageOwnerReserved5,      1, 6) \
+  X(kFlashCtrlInfoPageOwnerReserved6,      1, 7) \
+  X(kFlashCtrlInfoPageOwnerReserved7,      1, 8) \
+  X(kFlashCtrlInfoPageDiceCerts,           1, 9) \
 // clang-format on
 
 /**

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -101,13 +101,13 @@ static cert_flash_info_layout_t cert_flash_layout[] = {
     {
         .used = false,
         .group_name = "Ext0",
-        .info_page = &kFlashCtrlInfoPageOwnerReserved7,
+        .info_page = &kFlashCtrlInfoPageOwnerReserved6,
         .num_certs = 0,
     },
     {
         .used = false,
         .group_name = "Ext1",
-        .info_page = &kFlashCtrlInfoPageOwnerReserved8,
+        .info_page = &kFlashCtrlInfoPageOwnerReserved7,
         .num_certs = 0,
     },
 };

--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -55,8 +55,8 @@ enum {
  * Configures flash info pages to store device certificates.
  */
 static status_t config_and_erase_tpm_certificate_flash_pages(void) {
-  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageOwnerReserved7);
-  TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerReserved7,
+  flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageOwnerReserved6);
+  TRY(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerReserved6,
                             kFlashCtrlEraseTypePage));
   return OK_STATUS();
 }


### PR DESCRIPTION
1. Claim 2 pages as CreatorReserved.  These pages are to be used in the future for creator features or some other as-yet unanticipated need.
2. Arrange for the OwnerReserved pages to be arranged equally between the banks.
3. Update OwnerReserved page indicies in perso.