### PR TITLE
[opentitanlib] Activate LED driver on HyperTeacup 1.5

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -404,6 +404,16 @@
       "name": "VBUS_SENSE",
       "mode": "Input",
       "alias_of": "CN10_18"
+    },
+    {
+        // Connected to active-low shutdown pin on the LED driver. This is
+        // pulled low by the rev 1.5 Teacup board, so it must be driven high to
+        // activate the driver. This configuration makes a high output the
+        // default.
+        "name": "LED_SD_L",
+        "mode": "PushPull",
+        "level": true,
+        "alias_of": "CN10_15"
     }
   ],
   "spi": [


### PR DESCRIPTION
I noticed that running `//sw/device/examples/teacup_demos:teacup_leds_demo` on a HyperTeacup rev 1.5.0 board doesn't work as-is (the board's LEDs don't light up at all). This PR fixes the issue, although I'm not sure whether this is the best solution and would appreciate feedback from folks more familiar with the board design and this part of the codebase. 

Explanation:

The latest rev of the HyperTeacup board (v1.5.0) connects the active-low shutdown pin of the LED driver to HyperDebug pin CN10.15. The board pulls this pin low with a resistor, so the HyperDebug needs to actively drive it high to enable the LED driver. (See signal `LED_DRV_SD_L` on pages 5 and 7 of the [schematic](https://github.com/lowRISC/opentitan-hyperdebug-shield/blob/main/drawings/hyp_ot_evt_v150_042624.pdf)). 

This commit updates opentitanlib's HyperTeacup configuration to drive this pin high by default, ensuring that the driver is always active.

CN10.15 is not connected on HyperTeacup rev 1.3.0, so this change should be backwards compatible with this rev of board. I'm not sure what other revs might be in the wild though, and whether this backwards compatibility holds for all of these revs. 