### PR TITLE
[ownership] Add a SelfVersion update_mode 

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/datatypes.h
+++ b/sw/device/silicon_creator/lib/ownership/datatypes.h
@@ -72,6 +72,12 @@ typedef enum ownership_update_mode {
    * if the config_version is newer)
    */
   kOwnershipUpdateModeNewVersion = 0x5657454e,
+  /**
+   * Update mode SelfVersion: `SELV`
+   * (unlock key only unlocks to UnlockedSelf; accept new owner configs from
+   * self-same owner if the config_version is newer)
+   */
+  kOwnershipUpdateModeSelfVersion = 0x564c4553,
 } ownership_update_mode_t;
 
 typedef enum lock_constraint {

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -23,6 +23,15 @@ enum {
   kFlashBankSize = FLASH_CTRL_PARAM_REG_PAGES_PER_BANK,
 };
 
+hardened_bool_t owner_block_newversion_mode(void) {
+  if (owner_page_valid[0] == kOwnerPageStatusSealed &&
+      (owner_page[0].update_mode == kOwnershipUpdateModeNewVersion ||
+       owner_page[0].update_mode == kOwnershipUpdateModeSelfVersion)) {
+    return kHardenedBoolTrue;
+  }
+  return kHardenedBoolFalse;
+}
+
 hardened_bool_t owner_block_page1_valid_for_transfer(boot_data_t *bootdata) {
   if (bootdata->ownership_state == kOwnershipStateLockedOwner &&
       owner_page_valid[1] == kOwnerPageStatusSealed) {

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -59,6 +59,13 @@ typedef struct owner_application_keyring {
 } owner_application_keyring_t;
 
 /**
+ * Determine if the ownership update mode is one of the "newversion" modes.
+ *
+ * @return kHardenedBoolTrue if it is a newversion mode.
+ */
+hardened_bool_t owner_block_newversion_mode(void);
+
+/**
  * Check if owner page 1 is valid for ownership transfer.
  *
  * @param bootdata The current bootdata.

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -69,7 +69,7 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
                                      owner_application_keyring_t *keyring) {
   if (owner_page_valid[0] == kOwnerPageStatusSealed &&
       owner_page_valid[1] == kOwnerPageStatusSigned &&
-      owner_page[0].update_mode == kOwnershipUpdateModeNewVersion &&
+      owner_block_newversion_mode() == kHardenedBoolTrue &&
       owner_page[1].config_version > owner_page[0].config_version &&
       hardened_memeq(owner_page[0].owner_key.raw, owner_page[1].owner_key.raw,
                      ARRAYSIZE(owner_page[0].owner_key.raw)) ==
@@ -309,9 +309,7 @@ void ownership_pages_lockdown(boot_data_t *bootdata, hardened_bool_t rescue) {
     return;
   }
   if (bootdata->ownership_state == kOwnershipStateLockedOwner) {
-    if (owner_page[0].update_mode == kOwnershipUpdateModeNewVersion) {
-      HARDENED_CHECK_EQ(owner_page[0].update_mode,
-                        kOwnershipUpdateModeNewVersion);
+    if (owner_block_newversion_mode() == kHardenedBoolTrue) {
       // Leave page 1 unlocked if we're in "NewVersion" update mode.
     } else {
       // Otherwise, make the page read-only.

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -277,6 +277,18 @@ rom_error_t ownership_flash_lockdown(boot_data_t *bootdata,
 }
 
 void ownership_pages_lockdown(boot_data_t *bootdata, hardened_bool_t rescue) {
+#ifdef ROM_EXT_KLOBBER_ALLOWED
+  if (rescue == kHardenedBoolTrue) {
+    // If ROM_EXT_KLOBBER_ALLOWED and we're in rescue mode, we skip
+    // lockdown because the rescue protcol is permitted, on DEV chips
+    // only, to erase the ownership pages.  This exists to simulate
+    // disaster scenarios and test the disaster recovery mechanisms.
+    //
+    // Under normal circumstances, the ROM_EXT is not built with this
+    // capability.
+    return;
+  }
+#endif
   flash_ctrl_perms_t perm = {
       .read = kMultiBitBool4True,
       .write = kMultiBitBool4False,

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock.c
@@ -67,6 +67,7 @@ static rom_error_t unlock(boot_svc_msg_t *msg, boot_data_t *bootdata) {
         // The NewVersion mode forbids all unlocks.
         return kErrorOwnershipUnlockDenied;
       case kOwnershipUpdateModeSelf:
+      case kOwnershipUpdateModeSelfVersion:
       default:
         // The `unlock` funciton services UnlockAny and UnlockEndorsed requests,
         // neither of which are valid for the `Self` mode.
@@ -107,6 +108,7 @@ static rom_error_t unlock_update(boot_svc_msg_t *msg, boot_data_t *bootdata) {
         // The NewVersion mode forbids all unlocks.
         return kErrorOwnershipUnlockDenied;
       case kOwnershipUpdateModeSelf:
+      case kOwnershipUpdateModeSelfVersion:
       case kOwnershipUpdateModeOpen:
       default:
           // The `unlock_update` funciton services UnlockUpdate update requests,

--- a/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/ownership_unlock_unittest.cc
@@ -394,6 +394,7 @@ TEST_P(OwnershipUnlockUpdateModesTest, UnlockAny) {
       expect = kErrorOwnershipUnlockDenied;
       break;
     case kOwnershipUpdateModeSelf:
+    case kOwnershipUpdateModeSelfVersion:
       expect = kErrorOwnershipInvalidMode;
       break;
   }
@@ -413,6 +414,7 @@ TEST_P(OwnershipUnlockUpdateModesTest, UnlockUpdate) {
   switch (mode) {
     case kOwnershipUpdateModeOpen:
     case kOwnershipUpdateModeSelf:
+    case kOwnershipUpdateModeSelfVersion:
       EXPECT_CALL(ownership_key_,
                   validate(0, static_cast<ownership_key_t>(kOwnershipKeyUnlock),
                            _, _, _))
@@ -435,6 +437,7 @@ TEST_P(OwnershipUnlockUpdateModesTest, UnlockUpdate) {
 INSTANTIATE_TEST_SUITE_P(AllCases, OwnershipUnlockUpdateModesTest,
                          testing::Values(kOwnershipUpdateModeOpen,
                                          kOwnershipUpdateModeSelf,
+                                         kOwnershipUpdateModeSelfVersion,
                                          kOwnershipUpdateModeNewVersion));
 
 }  // namespace

--- a/sw/device/silicon_creator/rom_ext/doc/rescue.md
+++ b/sw/device/silicon_creator/rom_ext/doc/rescue.md
@@ -217,3 +217,13 @@ The following errors and error responses can occur during Xmodem-CRC.
 - An invalid start-of-packet: the transfer is aborted.
 - An invalid block number: the transfer is cancelled.
 - An invalid CRC checksum: the frame is NAKed and the sender should retry the frame.
+
+## Security Considerations
+
+The ownership configuration can contain a `RescueConfig` structure that specifies which rescue commands are allowed.
+When the `RescueConfig` is absent from the ownership configuration, all commands are allowed.
+When the `RescueConfig` is present in the ownership configuration, all commands are subject to the `command_allow` list in the rescue configuration except for the following:
+
+- The reboot (`REBO`) command is always allowed.
+- The disable automatic reboot (`WAIT`) command is always allowed.
+- The change serial data rate (`BAUD`) command is always allowed.

--- a/sw/device/silicon_creator/rom_ext/rescue.c
+++ b/sw/device/silicon_creator/rom_ext/rescue.c
@@ -64,7 +64,7 @@ rom_error_t flash_owner_block(rescue_state_t *state, boot_data_t *bootdata) {
       bootdata->ownership_state == kOwnershipStateUnlockedSelf ||
       bootdata->ownership_state == kOwnershipStateUnlockedEndorsed ||
       (bootdata->ownership_state == kOwnershipStateLockedOwner &&
-       owner_page[0].update_mode == kOwnershipUpdateModeNewVersion)) {
+       owner_block_newversion_mode() == kHardenedBoolTrue)) {
     HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(
         &kFlashCtrlInfoPageOwnerSlot1, kFlashCtrlEraseTypePage));
     HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
@@ -177,7 +177,7 @@ static void validate_mode(uint32_t mode, rescue_state_t *state,
             bootdata->ownership_state == kOwnershipStateUnlockedSelf ||
             bootdata->ownership_state == kOwnershipStateUnlockedEndorsed ||
             (bootdata->ownership_state == kOwnershipStateLockedOwner &&
-             owner_page[0].update_mode == kOwnershipUpdateModeNewVersion)) {
+             owner_block_newversion_mode() == kHardenedBoolTrue)) {
           dbg_printf("ok: send owner_block via xmodem-crc\r\n");
         } else {
           dbg_printf("error: cannot accept owner_block in current state\r\n");

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -29,6 +29,7 @@ with_unknown! {
     pub enum OwnershipUpdateMode: u32 [default = Self::Open] {
         Open = u32::from_le_bytes(*b"OPEN"),
         UnlockSelf = u32::from_le_bytes(*b"SELF"),
+        SelfVersion = u32::from_le_bytes(*b"SELV"),
         NewVersion = u32::from_le_bytes(*b"NEWV"),
     }
 }


### PR DESCRIPTION
1. The `SelfVersion` update mode permits either an ownership unlock to `UnlockedSelf` or a new-version update from the current owner.
2. Adjust rescue security: Always allow the `REBO`, `WAIT` and `BAUD` commands.