### PR TITLE
[dv, bazel] : run opentitantool with shared libs outside system lib path

### DIFF
--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -198,11 +198,20 @@ def _otp_alert_digest_impl(ctx):
     args.add_all(("--rcfile=", "otp", "alert-digest", ctx.file.otp_img))
     args.add("--output", file)
 
+    # By default, no environment variables are available to the action
+    # during bazel builds. This can not be changed with action_env.
+    # However, the opentitantool binary used in building the json target
+    # needs access to LD_LIBRARY_PATH to load shared libraries
+    # outside standard system paths.
+    # Setting use_default_shell_env to True allows passing LD_LIBRARY_PATH
+    # to the sandbox using --action_env switch
+
     ctx.actions.run(
         outputs = outputs,
         inputs = inputs,
         arguments = [args],
         executable = tc.tools.opentitantool,
+        use_default_shell_env = True,
     )
     return [DefaultInfo(files = depset([file]))]
 


### PR DESCRIPTION
This commit enables installing opentitantool to find and link to its library dependencies like libftdi, libusb, libudev that are installed in
 user's work area. This is particularly useful when the user's compute
enironment does not have these libraries preinstalled as part of the system and the user doesn't have root permissions to install these libraries using syatem package managers. While the custom paths to the headers and shared libs needed for building the opentitantool can be specified by setting the PKG_CONFIG_PATH environment variable through the bazel build action_env property in site specific .bazelrc-site file, these paths are not available in the bazel sandbox that runs the opentitantool to generate the otp json.
for example, bazel build //hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg. Attempts to pass in the user provided LD_LIBRARY_PATH using the bazel build action_env fail as this doesn't get propagated to the bazel subcommand that runs the opentitantool. Hence adding the LD_LIBRARY_PATH to the nonhermetic.bzl file to make this part of the ENV available to the
 opentitantool run sandbox.