### PR TITLE
[pinmux,gen] Remove unused generator parameter

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -13,7 +13,6 @@
 ##  - n_dio_pads:          Number of dedicated IO pads
 ##  - n_wkup_detect:       Number of wakeup condition detectors
 ##  - wkup_cnt_width:      Width of wakeup counters
-##  - attr_dw:             Width of wakeup counters
 {
   name:               "pinmux",
   human_name:         "Pin Multiplexer",
@@ -347,12 +346,6 @@
       '''
       local:   "false",
       expose:  "true"
-    },
-    { name: "AttrDw",
-      desc: "Pad attribute data width",
-      type: "int",
-      default: "${attr_dw}",
-      local: "true"
     },
     { name: "NMioPeriphIn",
       desc: "Number of muxed peripheral inputs",

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -344,12 +344,6 @@
       local:   "false",
       expose:  "true"
     },
-    { name: "AttrDw",
-      desc: "Pad attribute data width",
-      type: "int",
-      default: "13",
-      local: "true"
-    },
     { name: "NMioPeriphIn",
       desc: "Number of muxed peripheral inputs",
       type: "int",

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -7,7 +7,6 @@
 package pinmux_reg_pkg;
 
   // Param list
-  parameter int AttrDw = 13;
   parameter int NMioPeriphIn = 57;
   parameter int NMioPeriphOut = 75;
   parameter int NMioPads = 47;

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -301,15 +301,11 @@ def generate_pinmux(top: Dict[str, object], out_path: Path) -> None:
                   pinmux["io_counts"]["dedicated"]["inputs"] +
                   pinmux["io_counts"]["dedicated"]["outputs"])
 
-    # TODO: derive this value
-    attr_dw = 13
-
     # Generation with zero MIO/DIO pads is currently not supported.
     assert (n_mio_pads > 0)
     assert (n_dio_pads > 0)
 
     log.info("Generating pinmux with following info from hjson:")
-    log.info("attr_dw:         %d" % attr_dw)
     log.info("num_wkup_detect: %d" % num_wkup_detect)
     log.info("wkup_cnt_width:  %d" % wkup_cnt_width)
     log.info("n_mio_periph_in:  %d" % n_mio_periph_in)
@@ -354,7 +350,6 @@ def generate_pinmux(top: Dict[str, object], out_path: Path) -> None:
                 n_dio_periph_in=n_dio_pads,
                 n_dio_periph_out=n_dio_pads,
                 n_dio_pads=n_dio_pads,
-                attr_dw=attr_dw,
                 n_wkup_detect=num_wkup_detect,
                 wkup_cnt_width=wkup_cnt_width)
         except:  # noqa: E722


### PR DESCRIPTION
The attr_dw topgen parameter for pinmux generation is unused, since it is used to initialize the unused SV parameter AttrDw. Also, the value used to initialize it was wrong anyway.