### PR TITLE
[dv, aes] : Relax strict wall timeout for aes fi tests

### DIFF
--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -179,20 +179,20 @@
       uvm_test: aes_fi_test
       uvm_test_seq: aes_control_fi_vseq
       reseed: 300 // Test must cover 150 bins. Overseed by 2x to get reasonable coverage.
-      run_timeout_mins: 1 // Short test; if not done within 1 min, something's wrong.
+      run_timeout_mins: 5 // Short test; if not done within 5 min, something's wrong.
     }
     {
       name: aes_cipher_fi
       uvm_test: aes_fi_test
       uvm_test_seq: aes_cipher_fi_vseq
       reseed: 350 // Test must cover 175 bins. Overseed by 2x to get reasonable coverage.
-      run_timeout_mins: 1 // Short test; if not done within 1 min, something's wrong.
+      run_timeout_mins: 5 // Short test; if not done within 5 min, something's wrong.
     }
     {
       name: aes_ctr_fi
       uvm_test: aes_fi_test
       uvm_test_seq: aes_ctr_fi_vseq
-      run_timeout_mins: 1 // Short test; if not done within 1 min, something's wrong.
+      run_timeout_mins: 5 // Short test; if not done within 5 min, something's wrong.
     }
     {
       name: aes_core_fi


### PR DESCRIPTION
Increasing timeout from 1 min to 5 mins for fi tests as 1 min run times are not practical when running on compute farm with heavy workloads from multiple projects operating simultaneously. The wall time includes the time spent in a queue waiting to land on a node in the farm and possibly the time to acquire a simulator license. Then depending on workloads on the servers and the NFS disk, the job may sometimes run slower (clock cycles per sec) than usual. Increasing the timeout value to avoid false failures.