### PR TITLE
[bazel] Move consts from legacy rule files

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -455,7 +455,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
           // A flash image could be signed, and if it is, Bazel will attach a
           // suffix to the image name.
           if ("signed" inside {sw_image_flags[i]}) begin
-            // Options match DEFAULT_SIGNING_KEYS in `rules/opentitan.bzl`.
+            // Options match DEFAULT_SIGNING_KEYS in `rules/opentitan/keyutils.bzl`.
             if ("fake_ecdsa_dev_key_0" inside {sw_image_flags[i]}) begin
               sw_images[i] = $sformatf("%0s.fake_ecdsa_dev_key_0.signed", sw_images[i]);
             end else if ("fake_ecdsa_prod_key_0" inside {sw_image_flags[i]}) begin

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_PLATFORM")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_PLATFORM")
 load("//rules:stamp.bzl", "stamp_flag")
 
 package(default_visibility = ["//visibility:public"])

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -17,6 +17,11 @@ load("@crt//rules:transition.bzl", "platform_target")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_skylib//lib:structs.bzl", "structs")
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
+load(
+    "//rules/opentitan:keyutils.bzl",
+    "ECDSA_ONLY_KEY_STRUCTS",
+    "RSA_ONLY_ROM_EXT_KEY_STRUCTS",
+)
 
 """Rules to build OpenTitan for the RISC-V target"""
 
@@ -42,138 +47,8 @@ PER_DEVICE_DEPS = {
     "fpga_cw340": ["@//sw/device/lib/arch:fpga_cw340"],
 }
 
-def create_key_(name, label, hw_lc_states):
-    return struct(
-        name = name,
-        label = label,
-        hw_lc_states = hw_lc_states,
-    )
-
-def create_test_key(name, label):
-    return create_key_(name, label, [
-        CONST.LCV.TEST_UNLOCKED0,
-        CONST.LCV.TEST_UNLOCKED1,
-        CONST.LCV.TEST_UNLOCKED2,
-        CONST.LCV.TEST_UNLOCKED3,
-        CONST.LCV.TEST_UNLOCKED4,
-        CONST.LCV.TEST_UNLOCKED5,
-        CONST.LCV.TEST_UNLOCKED6,
-        CONST.LCV.TEST_UNLOCKED7,
-        CONST.LCV.RMA,
-    ])
-
-def create_dev_key(name, label):
-    return create_key_(name, label, [
-        CONST.LCV.DEV,
-    ])
-
-def create_prod_key(name, label):
-    return create_key_(name, label, [
-        CONST.LCV.TEST_UNLOCKED0,
-        CONST.LCV.TEST_UNLOCKED1,
-        CONST.LCV.TEST_UNLOCKED2,
-        CONST.LCV.TEST_UNLOCKED3,
-        CONST.LCV.TEST_UNLOCKED4,
-        CONST.LCV.TEST_UNLOCKED5,
-        CONST.LCV.TEST_UNLOCKED6,
-        CONST.LCV.TEST_UNLOCKED7,
-        CONST.LCV.DEV,
-        CONST.LCV.PROD,
-        CONST.LCV.PROD_END,
-        CONST.LCV.RMA,
-    ])
-
-def create_key_struct(ecdsa_key, rsa_key, spx_key):
-    return struct(
-        ecdsa = ecdsa_key,
-        rsa = rsa_key,
-        spx = spx_key,
-    )
-
-# Keys available in the repo
-SILICON_CREATOR_KEYS = struct(
-    FAKE = struct(
-        ECDSA = struct(
-            TEST = [
-                create_test_key("fake_ecdsa_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256"),
-            ],
-            DEV = [
-                create_dev_key("fake_ecdsa_dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:dev_key_0_ecdsa_p256"),
-            ],
-            PROD = [
-                create_prod_key("fake_ecdsa_prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256"),
-            ],
-        ),
-        SPX = struct(
-            TEST = [
-                create_test_key("fake_spx_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:test_key_0_spx"),
-            ],
-            DEV = [
-                create_dev_key("fake_spx_dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:dev_key_0_spx"),
-            ],
-            PROD = [
-                create_prod_key("fake_spx_prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx"),
-            ],
-        ),
-    ),
-    # We can't expose real private keys publicly.
-    REAL = None,
-    UNAUTHORIZED = struct(
-        SPX = [
-            create_key_("spx_unauthorized_0", "@//sw/device/silicon_creator/rom/keys/unauthorized/spx:unauthorized_0_spx", []),
-        ],
-    ),
-)
-
-SILICON_OWNER_KEYS = struct(
-    FAKE = struct(
-        RSA = struct(
-            TEST = [
-                create_test_key("fake_rsa_rom_ext_test_key_0", "@//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0"),
-            ],
-            DEV = [
-                create_dev_key("fake_rsa_rom_ext_dev_key_0", "@//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_dev_private_key_0"),
-            ],
-            PROD = None,
-        ),
-        # We can't expose real private keys publicly.
-        REAL = None,
-        UNAUTHORIZED = None,
-    ),
-)
-
 def flatten(l):
     return [item for ll in l for item in ll]
-
-def key_allowed_in_lc_state(key, hw_lc_state_val):
-    all_hw_lc_state_vals = structs.to_dict(CONST.LCV).values()
-    if not hw_lc_state_val in all_hw_lc_state_vals:
-        fail("Wrong life cycle state value: '{}', must be one of {}. Did you pass a string instead of the integer value?".format(hw_lc_state_val, all_hw_lc_state_vals))
-    return hw_lc_state_val in key.hw_lc_states
-
-def filter_key_structs_for_lc_state(key_structs, hw_lc_state):
-    return [k for k in key_structs if (
-        (not k.rsa or key_allowed_in_lc_state(k.rsa, hw_lc_state)) and
-        (not k.ecdsa or key_allowed_in_lc_state(k.ecdsa, hw_lc_state)) and
-        (not k.spx or key_allowed_in_lc_state(k.spx, hw_lc_state))
-    )]
-
-ECDSA_ONLY_KEY_STRUCTS = [
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.TEST[0], None, None),
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.DEV[0], None, None),
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.PROD[0], None, None),
-]
-
-ECDSA_SPX_KEY_STRUCTS = [
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.TEST[0], None, SILICON_CREATOR_KEYS.FAKE.SPX.TEST[0]),
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.DEV[0], None, SILICON_CREATOR_KEYS.FAKE.SPX.DEV[0]),
-    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.PROD[0], None, SILICON_CREATOR_KEYS.FAKE.SPX.PROD[0]),
-]
-
-RSA_ONLY_ROM_EXT_KEY_STRUCTS = [
-    create_key_struct(None, SILICON_OWNER_KEYS.FAKE.RSA.TEST[0], None),
-    create_key_struct(None, SILICON_OWNER_KEYS.FAKE.RSA.DEV[0], None),
-]
 
 def _obj_transform_impl(ctx):
     cc_toolchain = find_cc_toolchain(ctx)

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -3,13 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
-load(
-    "@lowrisc_opentitan//rules:rv.bzl",
-    "rv_rule",
-    _OPENTITAN_CPU = "OPENTITAN_CPU",
-    _OPENTITAN_PLATFORM = "OPENTITAN_PLATFORM",
-    _opentitan_transition = "opentitan_transition",
-)
+load("@lowrisc_opentitan//rules:rv.bzl", "rv_rule")
 load("@lowrisc_opentitan//rules:signing.bzl", "sign_binary")
 load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
 load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_override")
@@ -18,12 +12,6 @@ load(
     "obj_disassemble",
     "obj_transform",
 )
-
-# Re-exports of names from transition.bzl; many files in the repo use opentitan.bzl
-# to get to them.
-OPENTITAN_CPU = _OPENTITAN_CPU
-OPENTITAN_PLATFORM = _OPENTITAN_PLATFORM
-opentitan_transition = _opentitan_transition
 
 def _expand(ctx, name, items):
     """Perform location and make_variable expansion on a list of items.

--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -57,8 +57,7 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 # and opentitan_binary rules.
 CLEAR_KEY_SET = {"//signing:none_key": "none_key"}
 
-# Re-exports of names from transition.bzl; many files in the repo use opentitan.bzl
-# to get to them.
+# Re-exports of names from transition.bzl
 OPENTITAN_CPU = _OPENTITAN_CPU
 OPENTITAN_PLATFORM = _OPENTITAN_PLATFORM
 opentitan_transition = _opentitan_transition

--- a/rules/opentitan/keyutils.bzl
+++ b/rules/opentitan/keyutils.bzl
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "key_allowed_in_lc_state")
 load("//rules:signing.bzl", "KeyInfo")
+load("//rules:const.bzl", "CONST")
+load("@bazel_skylib//lib:structs.bzl", "structs")
 
 def _build_key_info_handler(id):
     """Return a handler that creates a KeyInfo provider.
@@ -161,3 +162,133 @@ def spx_key_by_name(key_structs, nickname):
     return {
         keys[0].spx.label: keys[0].spx.name,
     }
+
+def key_allowed_in_lc_state(key, hw_lc_state_val):
+    all_hw_lc_state_vals = structs.to_dict(CONST.LCV).values()
+    if not hw_lc_state_val in all_hw_lc_state_vals:
+        fail("Wrong life cycle state value: '{}', must be one of {}. Did you pass a string instead of the integer value?".format(hw_lc_state_val, all_hw_lc_state_vals))
+    return hw_lc_state_val in key.hw_lc_states
+
+def filter_key_structs_for_lc_state(key_structs, hw_lc_state):
+    return [k for k in key_structs if (
+        (not k.rsa or key_allowed_in_lc_state(k.rsa, hw_lc_state)) and
+        (not k.ecdsa or key_allowed_in_lc_state(k.ecdsa, hw_lc_state)) and
+        (not k.spx or key_allowed_in_lc_state(k.spx, hw_lc_state))
+    )]
+
+def create_key_(name, label, hw_lc_states):
+    return struct(
+        name = name,
+        label = label,
+        hw_lc_states = hw_lc_states,
+    )
+
+def create_test_key(name, label):
+    return create_key_(name, label, [
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.TEST_UNLOCKED1,
+        CONST.LCV.TEST_UNLOCKED2,
+        CONST.LCV.TEST_UNLOCKED3,
+        CONST.LCV.TEST_UNLOCKED4,
+        CONST.LCV.TEST_UNLOCKED5,
+        CONST.LCV.TEST_UNLOCKED6,
+        CONST.LCV.TEST_UNLOCKED7,
+        CONST.LCV.RMA,
+    ])
+
+def create_dev_key(name, label):
+    return create_key_(name, label, [
+        CONST.LCV.DEV,
+    ])
+
+def create_prod_key(name, label):
+    return create_key_(name, label, [
+        CONST.LCV.TEST_UNLOCKED0,
+        CONST.LCV.TEST_UNLOCKED1,
+        CONST.LCV.TEST_UNLOCKED2,
+        CONST.LCV.TEST_UNLOCKED3,
+        CONST.LCV.TEST_UNLOCKED4,
+        CONST.LCV.TEST_UNLOCKED5,
+        CONST.LCV.TEST_UNLOCKED6,
+        CONST.LCV.TEST_UNLOCKED7,
+        CONST.LCV.DEV,
+        CONST.LCV.PROD,
+        CONST.LCV.PROD_END,
+        CONST.LCV.RMA,
+    ])
+
+def create_key_struct(ecdsa_key, rsa_key, spx_key):
+    return struct(
+        ecdsa = ecdsa_key,
+        rsa = rsa_key,
+        spx = spx_key,
+    )
+
+# Keys available in the repo
+SILICON_CREATOR_KEYS = struct(
+    FAKE = struct(
+        ECDSA = struct(
+            TEST = [
+                create_test_key("fake_ecdsa_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256"),
+            ],
+            DEV = [
+                create_dev_key("fake_ecdsa_dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:dev_key_0_ecdsa_p256"),
+            ],
+            PROD = [
+                create_prod_key("fake_ecdsa_prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256"),
+            ],
+        ),
+        SPX = struct(
+            TEST = [
+                create_test_key("fake_spx_test_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:test_key_0_spx"),
+            ],
+            DEV = [
+                create_dev_key("fake_spx_dev_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:dev_key_0_spx"),
+            ],
+            PROD = [
+                create_prod_key("fake_spx_prod_key_0", "@//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx"),
+            ],
+        ),
+    ),
+    # We can't expose real private keys publicly.
+    REAL = None,
+    UNAUTHORIZED = struct(
+        SPX = [
+            create_key_("spx_unauthorized_0", "@//sw/device/silicon_creator/rom/keys/unauthorized/spx:unauthorized_0_spx", []),
+        ],
+    ),
+)
+
+SILICON_OWNER_KEYS = struct(
+    FAKE = struct(
+        RSA = struct(
+            TEST = [
+                create_test_key("fake_rsa_rom_ext_test_key_0", "@//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_test_private_key_0"),
+            ],
+            DEV = [
+                create_dev_key("fake_rsa_rom_ext_dev_key_0", "@//sw/device/silicon_creator/rom_ext/keys/fake:rom_ext_dev_private_key_0"),
+            ],
+            PROD = None,
+        ),
+        # We can't expose real private keys publicly.
+        REAL = None,
+        UNAUTHORIZED = None,
+    ),
+)
+
+ECDSA_ONLY_KEY_STRUCTS = [
+    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.TEST[0], None, None),
+    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.DEV[0], None, None),
+    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.PROD[0], None, None),
+]
+
+ECDSA_SPX_KEY_STRUCTS = [
+    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.TEST[0], None, SILICON_CREATOR_KEYS.FAKE.SPX.TEST[0]),
+    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.DEV[0], None, SILICON_CREATOR_KEYS.FAKE.SPX.DEV[0]),
+    create_key_struct(SILICON_CREATOR_KEYS.FAKE.ECDSA.PROD[0], None, SILICON_CREATOR_KEYS.FAKE.SPX.PROD[0]),
+]
+
+RSA_ONLY_ROM_EXT_KEY_STRUCTS = [
+    create_key_struct(None, SILICON_OWNER_KEYS.FAKE.RSA.TEST[0], None),
+    create_key_struct(None, SILICON_OWNER_KEYS.FAKE.RSA.DEV[0], None),
+]

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -4,10 +4,10 @@
 
 load(
     "@//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
     "opentitan_flash_binary",
     "opentitan_rom_binary",
 )
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("@bazel_skylib//lib:collections.bzl", "collections")
 

--- a/sw/device/examples/hello_usbdev/BUILD
+++ b/sw/device/examples/hello_usbdev/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules/opentitan:defs.bzl", "opentitan_binary")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 opentitan_binary(
     name = "hello_usbdev",

--- a/sw/device/examples/teacup_demos/data/BUILD
+++ b/sw/device/examples/teacup_demos/data/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/lib/crt/BUILD
+++ b/sw/device/lib/crt/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 cc_library(
     name = "crt",

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 config_setting(
     name = "crypto_status_debug",

--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 cc_library(
     name = "ecdh_p256",

--- a/sw/device/lib/crypto/impl/rsa/BUILD
+++ b/sw/device/lib/crypto/impl/rsa/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 cc_library(
     name = "rsa_datatypes",

--- a/sw/device/lib/crypto/impl/sha2/BUILD
+++ b/sw/device/lib/crypto/impl/sha2/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 cc_library(
     name = "sha256",

--- a/sw/device/lib/runtime/BUILD
+++ b/sw/device/lib/runtime/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
 
 package(default_visibility = ["//visibility:public"])

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:cross_platform.bzl", "dual_cc_library", "dual_inputs")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -8,7 +8,7 @@ load(
 )
 load("//rules:autogen.bzl", "autogen_chip_info")
 load("//rules:cross_platform.bzl", "dual_cc_device_library_of", "dual_cc_library", "dual_inputs")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load(
     "//rules/opentitan:defs.bzl",
     "EARLGREY_TEST_ENVS",

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -4,10 +4,7 @@
 
 load("//rules:const.bzl", "CONST", "get_lc_items")
 load("//rules:lc.bzl", "lc_raw_unlock_token")
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_SPX_KEY_STRUCTS",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_SPX_KEY_STRUCTS")
 load(
     "//rules:otp.bzl",
     "OTP_SIGVERIFY_FAKE_KEYS",

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -2,21 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
-    "//rules:const.bzl",
-    "CONST",
-    "hex_digits",
-)
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("//rules:const.bzl", "CONST", "hex_digits")
 load(
     "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
     "bin_to_vmem",
     "scramble_flash_vmem",
 )
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load(
     "//rules:otp.bzl",
     "OTP_SIGVERIFY_FAKE_KEYS",
@@ -24,14 +17,8 @@ load(
     "otp_json",
     "otp_partition",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
-load(
-    "//rules:splice.bzl",
-    "bitstream_splice",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
+load("//rules:splice.bzl", "bitstream_splice")
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_PASS",

--- a/sw/device/silicon_creator/rom/e2e/boot_data_recovery/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_data_recovery/BUILD
@@ -10,20 +10,14 @@ load(
     "fpga_params",
     "opentitan_test",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load(
     "//rules:const.bzl",
     "CONST",
     "hex",
     "hex_digits",
 )
-load(
-    "//rules:manifest.bzl",
-    "manifest",
-)
+load("//rules:manifest.bzl", "manifest")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -32,10 +26,7 @@ load(
     "otp_json",
     "otp_partition",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_PASS",

--- a/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/boot_policy_bad_manifest/BUILD
@@ -14,11 +14,6 @@ load(
     "manifest",
 )
 load(
-    "//rules:opentitan_test.bzl",
-    "OTTF_SUCCESS_MSG",
-    "ROM_BOOT_FAILURE_MSG",
-)
-load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
     "otp_image",
@@ -31,6 +26,8 @@ load(
 )
 load(
     "//rules/opentitan:defs.bzl",
+    "OTTF_SUCCESS_MSG",
+    "ROM_BOOT_FAILURE_MSG",
     "cw310_params",
     "fpga_params",
     "opentitan_test",

--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -9,14 +9,8 @@ load(
     "fpga_params",
     "opentitan_test",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
-load(
-    "//rules:const.bzl",
-    "CONST",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
+load("//rules:const.bzl", "CONST")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
@@ -9,18 +9,9 @@ load(
     "fpga_params",
     "opentitan_test",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
-load(
-    "//rules:const.bzl",
-    "get_lc_items",
-)
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
+load("//rules:const.bzl", "get_lc_items")
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/silicon_creator/rom/e2e/defs.bzl
+++ b/sw/device/silicon_creator/rom/e2e/defs.bzl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:const.bzl", "CONST", "hex_digits")
-load("//rules:opentitan.bzl", "SILICON_CREATOR_KEYS")
+load("//rules/opentitan:keyutils.bzl", "SILICON_CREATOR_KEYS")
 
 MSG_TEMPLATE_BFV = "{}{}\r\n(?s:.*){}{}\r\n".format(
     CONST.SHUTDOWN.PREFIX.BFV,

--- a/sw/device/silicon_creator/rom/e2e/epmp_init/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/epmp_init/BUILD
@@ -15,14 +15,8 @@ load(
     "CONST",
     "get_lc_items",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -9,20 +9,14 @@ load(
     "fpga_params",
     "opentitan_test",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load(
     "//rules:const.bzl",
     "CONST",
     "get_lc_items",
     "hex",
 )
-load(
-    "//rules:manifest.bzl",
-    "manifest",
-)
+load("//rules:manifest.bzl", "manifest")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -31,10 +25,7 @@ load(
     "otp_json",
     "otp_partition",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/silicon_creator/rom/e2e/shutdown_alert/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_alert/BUILD
@@ -2,10 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load(
     "//rules:const.bzl",
     "CONST",
@@ -33,10 +30,7 @@ load(
     "otp_per_class_ints",
     "otp_per_class_lists",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/silicon_creator/rom/e2e/shutdown_output/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_output/BUILD
@@ -10,10 +10,7 @@ load(
     "fpga_params",
     "opentitan_test",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load(
     "//rules:const.bzl",
     "CONST",

--- a/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/shutdown_watchdog/BUILD
@@ -14,10 +14,7 @@ load(
     "CONST",
     "get_lc_items",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -26,10 +23,7 @@ load(
     "otp_json",
     "otp_partition",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_always/BUILD
@@ -15,7 +15,7 @@ load(
     "hex_digits",
 )
 load(
-    "//rules:opentitan.bzl",
+    "//rules/opentitan:keyutils.bzl",
     "ECDSA_ONLY_KEY_STRUCTS",
     "filter_key_structs_for_lc_state",
 )

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_type/BUILD
@@ -2,15 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load(
-    "//rules:const.bzl",
-    "CONST",
-    "get_lc_items",
-)
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_SPX_KEY_STRUCTS",
-)
+load("//rules:const.bzl", "CONST", "get_lc_items")
+load("//rules/opentitan:keyutils.bzl", "ECDSA_SPX_KEY_STRUCTS")
 load(
     "//rules/opentitan:defs.bzl",
     "cw310_params",
@@ -25,14 +18,8 @@ load(
     "otp_json",
     "otp_partition",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     ":key_type.bzl",
     "ecdsa_exit_failure",

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_type/key_type.bzl
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_type/key_type.bzl
@@ -4,24 +4,14 @@
 
 """Helper functions for generating expected test signatures for sigverify_key_type tests."""
 
-load(
-    "//rules/opentitan:defs.bzl",
-    "DEFAULT_TEST_FAILURE_MSG",
-)
-load(
-    "//rules:const.bzl",
-    "CONST",
-    "hex_digits",
-)
+load("//rules/opentitan:defs.bzl", "DEFAULT_TEST_FAILURE_MSG")
+load("//rules:const.bzl", "CONST", "hex_digits")
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_PASS",
     "MSG_TEMPLATE_BFV_LCV",
 )
-load(
-    "//rules:opentitan.bzl",
-    "key_allowed_in_lc_state",
-)
+load("//rules/opentitan:keyutils.bzl", "key_allowed_in_lc_state")
 
 # SPHINCS+ is disabled uncoditionally in these lifecycle states.
 SPX_DISABLED_LC_STATES = [

--- a/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_key_validity/BUILD
@@ -16,7 +16,7 @@ load(
     "hex_digits",
 )
 load(
-    "//rules:opentitan.bzl",
+    "//rules/opentitan:keyutils.bzl",
     "ECDSA_SPX_KEY_STRUCTS",
     "filter_key_structs_for_lc_state",
 )

--- a/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_spx/BUILD
@@ -11,15 +11,8 @@ load(
     "opentitan_test",
     "spx_key_for_lc_state",
 )
-load(
-    "//rules:const.bzl",
-    "CONST",
-    "get_lc_items",
-)
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_SPX_KEY_STRUCTS",
-)
+load("//rules:const.bzl", "CONST", "get_lc_items")
+load("//rules/opentitan:keyutils.bzl", "ECDSA_SPX_KEY_STRUCTS")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -28,18 +21,9 @@ load(
     "otp_json",
     "otp_partition",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
-load(
-    "//rules:splice.bzl",
-    "bitstream_splice",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
+load("//rules:splice.bzl", "bitstream_splice")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/silicon_creator/rom/e2e/sigverify_usage_constraints/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/sigverify_usage_constraints/BUILD
@@ -18,14 +18,8 @@ load(
     "hex_digits",
     "lcv_hw_to_sw",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
-load(
-    "//rules:manifest.bzl",
-    "manifest",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
+load("//rules:manifest.bzl", "manifest")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -33,14 +27,8 @@ load(
     "otp_json",
     "otp_partition",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
-load(
-    "@bazel_skylib//lib:structs.bzl",
-    "structs",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
+load("@bazel_skylib//lib:structs.bzl", "structs")
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_TEMPLATE_BFV",

--- a/sw/device/silicon_creator/rom/e2e/watchdog/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/watchdog/BUILD
@@ -11,14 +11,8 @@ load(
     "opentitan_test",
     "verilator_params",
 )
-load(
-    "@//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
-load(
-    "//rules:const.bzl",
-    "get_lc_items",
-)
+load("@//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
+load("//rules:const.bzl", "get_lc_items")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -26,10 +20,7 @@ load(
     "otp_json",
     "otp_partition",
 )
-load(
-    "//rules:rom_e2e.bzl",
-    "maybe_skip_in_ci",
-)
+load("//rules:rom_e2e.bzl", "maybe_skip_in_ci")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/silicon_owner/tock/apps/hello/BUILD
+++ b/sw/device/silicon_owner/tock/apps/hello/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load("//rules:tock.bzl", "tock_elf2tab", "tock_image")
 
 package(default_visibility = ["//visibility:public"])

--- a/sw/device/silicon_owner/tock/kernel/BUILD
+++ b/sw/device/silicon_owner/tock/kernel/BUILD
@@ -4,7 +4,8 @@
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//rules:linker.bzl", "ld_library")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU", "elf_to_disassembly", "obj_transform")
+load("//rules:opentitan.bzl", "elf_to_disassembly", "obj_transform")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/silicon_owner/tock/upstream_kernel/BUILD
+++ b/sw/device/silicon_owner/tock/upstream_kernel/BUILD
@@ -4,7 +4,8 @@
 
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//rules:linker.bzl", "ld_library")
-load("//rules:opentitan.bzl", "OPENTITAN_CPU", "elf_to_disassembly", "obj_transform")
+load("//rules:opentitan.bzl", "elf_to_disassembly", "obj_transform")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -14,7 +14,6 @@ load(
 load(
     "//rules:opentitan.bzl",
     "ECDSA_ONLY_KEY_STRUCTS",
-    "OPENTITAN_CPU",
 )
 load(
     "//rules:otp.bzl",
@@ -28,6 +27,7 @@ load(
     "EARLGREY_CW340_TEST_ENVS",
     "EARLGREY_SILICON_OWNER_ROM_EXT_ENVS",
     "EARLGREY_TEST_ENVS",
+    "OPENTITAN_CPU",
     "dv_params",
     "ecdsa_key_for_lc_state",
     "fpga_params",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2,19 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "//rules:const.bzl",
     "CONST",
     "get_lc_items",
 )
-load(
-    "//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
+load("//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",

--- a/sw/device/tests/closed_source/BUILD.bazel
+++ b/sw/device/tests/closed_source/BUILD.bazel
@@ -3,10 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@//rules:const.bzl", "CONST")
-load(
-    "@//rules:opentitan.bzl",
-    "ECDSA_ONLY_KEY_STRUCTS",
-)
+load("@//rules/opentitan:keyutils.bzl", "ECDSA_ONLY_KEY_STRUCTS")
 load(
     "@//rules/opentitan:defs.bzl",
     "dv_params",

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 load("//rules/opentitan:defs.bzl", "opentitan_test")
 
 opentitan_test(

--- a/third_party/freertos/BUILD
+++ b/third_party/freertos/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/third_party/llvm_compiler_rt/BUILD
+++ b/third_party/llvm_compiler_rt/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
This PR moves the remaining consts from the legacy `opentitan.bzl` and `opentitan_test.bzl` files to the `//rules/opentitan` package.

I've moved the key utils associated with these consts as well for simplicity.