### PR TITLE
[bazel,otlib] enable otlib to be built as external dep

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -689,8 +689,9 @@ class SignConverter {
 };
 }  // namespace
 }
-#define OT_SIGNED(value) (SignConverter<typeof(value)>::as_signed((value)))
-#define OT_UNSIGNED(value) (SignConverter<typeof(value)>::as_unsigned((value)))
+#define OT_SIGNED(value) (SignConverter<__typeof__(value)>::as_signed((value)))
+#define OT_UNSIGNED(value) \
+  (SignConverter<__typeof__(value)>::as_unsigned((value)))
 #endif  // __cplusplus
 #endif  // !defined(__ASSEMBLER__) && !defined(NOSTDINC) &&
         // !defined(RUST_PREPROCESSOR_EMIT)

--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -9,5 +9,5 @@ def hyperdebug_repos():
         name = "hyperdebug_firmware",
         urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240621_01/hyperdebug-firmware.tar.gz"],
         sha256 = "649a8cd6d183bc3fb286ea5895c752cfec3aa29b9990f44bb9e7621c0414c7de",
-        build_file = "@//third_party/hyperdebug:BUILD",
+        build_file = "@lowrisc_opentitan//third_party/hyperdebug:BUILD",
     )

--- a/third_party/openocd/repos.bzl
+++ b/third_party/openocd/repos.bzl
@@ -16,12 +16,12 @@ def openocd_repos(local = None):
             "https://sourceforge.net/projects/openocd/files/openocd/{version}/openocd-{version}.tar.gz".format(version = OPENOCD_VERSION),
         ],
         strip_prefix = "openocd-" + OPENOCD_VERSION,
-        build_file = "//third_party/openocd:BUILD.openocd.bazel",
+        build_file = "@lowrisc_opentitan//third_party/openocd:BUILD.openocd.bazel",
         sha256 = "af254788be98861f2bd9103fe6e60a774ec96a8c374744eef9197f6043075afa",
         # See Issue(#18087)
         patches = [
-            Label("//third_party/openocd:reset_on_dmi_op_error.patch"),
-            Label("//third_party/openocd:string_truncate_build_error.patch"),
+            Label("@lowrisc_opentitan//third_party/openocd:reset_on_dmi_op_error.patch"),
+            Label("@lowrisc_opentitan//third_party/openocd:string_truncate_build_error.patch"),
         ],
         patch_args = ["-p1"],
     )

--- a/third_party/python/pip.bzl
+++ b/third_party/python/pip.bzl
@@ -9,5 +9,5 @@ def pip_deps():
     pip_parse(
         name = "ot_python_deps",
         python_interpreter_target = interpreter,
-        requirements_lock = "//:python-requirements.txt",
+        requirements_lock = "@lowrisc_opentitan//:python-requirements.txt",
     )

--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -41,17 +41,17 @@ crates_vendor(
     annotations = {
         "libudev-sys": [crate.annotation(
             patch_args = ["-p1"],
-            patches = ["@//third_party/rust/patches:libudev-sys-0.1.4.patch"],
+            patches = ["@lowrisc_opentitan//third_party/rust/patches:libudev-sys-0.1.4.patch"],
         )],
         "mdbook": [crate.annotation(
             gen_binaries = True,
             patch_args = ["-p1"],
-            patches = ["@//third_party/rust/patches:mdbook-landing-page-links.patch"],
+            patches = ["@lowrisc_opentitan//third_party/rust/patches:mdbook-landing-page-links.patch"],
         )],
         "cryptoki": [crate.annotation(
             patch_args = ["-p2"],
             patches = [
-                "@//third_party/rust/patches:cryptoki-vendor-defined-mechanism-type.patch",
+                "@lowrisc_opentitan//third_party/rust/patches:cryptoki-vendor-defined-mechanism-type.patch",
             ],
         )],
         "cryptoki-sys": [crate.annotation(
@@ -73,11 +73,11 @@ crates_vendor(
                 "PKG_CONFIG_PATH": "$(OPENSSL_PKG_CONFIG_PATH)",
                 "OPENSSL_STATIC": "1",
             },
-            build_script_toolchains = ["@//third_party/rust:openssl_pkg_config_path"],
+            build_script_toolchains = ["@lowrisc_opentitan//third_party/rust:openssl_pkg_config_path"],
         )],
     },
-    cargo_lockfile = "//third_party/rust:Cargo.lock",
-    manifests = ["//third_party/rust:Cargo.toml"],
+    cargo_lockfile = "@lowrisc_opentitan//third_party/rust:Cargo.lock",
+    manifests = ["@lowrisc_opentitan//third_party/rust:Cargo.toml"],
     mode = "remote",
     tags = ["manual"],
     vendor_path = "crates",

--- a/third_party/rust/crates/BUILD.openssl-sys-0.9.102.bazel
+++ b/third_party/rust/crates/BUILD.openssl-sys-0.9.102.bazel
@@ -122,7 +122,7 @@ cargo_build_script(
         "noclippy",
         "norustfmt",
     ],
-    toolchains = ["@//third_party/rust:openssl_pkg_config_path"],
+    toolchains = ["@lowrisc_opentitan//third_party/rust:openssl_pkg_config_path"],
     version = "0.9.102",
     visibility = ["//visibility:private"],
     deps = [

--- a/third_party/rust/crates/defs.bzl
+++ b/third_party/rust/crates/defs.bzl
@@ -1059,7 +1059,7 @@ def crate_repositories():
             "-p2",
         ],
         patches = [
-            "@//third_party/rust/patches:cryptoki-vendor-defined-mechanism-type.patch",
+            "@lowrisc_opentitan//third_party/rust/patches:cryptoki-vendor-defined-mechanism-type.patch",
         ],
         sha256 = "95d9fb68c88020896fa3741a10e41f206b2ace927724170a753a3f2ba5f77c2b",
         type = "tar.gz",
@@ -1775,7 +1775,7 @@ def crate_repositories():
             "-p1",
         ],
         patches = [
-            "@//third_party/rust/patches:libudev-sys-0.1.4.patch",
+            "@lowrisc_opentitan//third_party/rust/patches:libudev-sys-0.1.4.patch",
         ],
         sha256 = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324",
         type = "tar.gz",
@@ -1881,7 +1881,7 @@ def crate_repositories():
             "-p1",
         ],
         patches = [
-            "@//third_party/rust/patches:mdbook-landing-page-links.patch",
+            "@lowrisc_opentitan//third_party/rust/patches:mdbook-landing-page-links.patch",
         ],
         sha256 = "c55eb7c4dad20cc5bc15181c2aaf43d5689d5c3e0b80b50cc4cf0b7fe72a26d9",
         type = "tar.gz",

--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_rust//bindgen:repositories.bzl", "rust_bindgen_dependencies")
-load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains", "rust_repository_set")
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
 load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
 
 def rust_deps():
@@ -29,7 +29,7 @@ def rust_deps():
 
     rust_bindgen_dependencies()
     native.register_toolchains(
-        "//third_party/rust:bindgen_toolchain",
+        "@lowrisc_opentitan//third_party/rust:bindgen_toolchain",
     )
 
     rust_analyzer_dependencies()

--- a/third_party/sphincsplus/repos.bzl
+++ b/third_party/sphincsplus/repos.bzl
@@ -8,7 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def sphincsplus_repos(local = None):
     http_archive(
         name = "sphincsplus_shake256_kat",
-        build_file = Label("//third_party/sphincsplus:BUILD.sphincsplus_common.bazel"),
+        build_file = Label("@lowrisc_opentitan//third_party/sphincsplus:BUILD.sphincsplus_common.bazel"),
         sha256 = "95f5c79995ad8a3bc752c760f93ec409763cf2b23d1a7a7404219f26d665f7ab",
         urls = [
             # Self-hosted GCP ZIP that contains the 128s/SHAKE256 test
@@ -19,7 +19,7 @@ def sphincsplus_repos(local = None):
     )
     http_archive(
         name = "sphincsplus_sha256_kat",
-        build_file = Label("//third_party/sphincsplus:BUILD.sphincsplus_common.bazel"),
+        build_file = Label("@lowrisc_opentitan//third_party/sphincsplus:BUILD.sphincsplus_common.bazel"),
         sha256 = "1656a6aa06d731905ef72fcfbdf65f365d4c0fe89cbf3b24d1dbb64669a25e35",
         urls = [
             # Self-hosted GCP ZIP that contains the 128s/SHAKE256 test
@@ -33,10 +33,10 @@ def sphincsplus_repos(local = None):
         local = local,
         url = "https://github.com/sphincs/sphincsplus/archive/129b72c80e122a22a61f71b5d2b042770890ccee.tar.gz",
         strip_prefix = "sphincsplus-129b72c80e122a22a61f71b5d2b042770890ccee/ref",
-        build_file = "//third_party/sphincsplus:BUILD.sphincsplus.bazel",
+        build_file = "@lowrisc_opentitan//third_party/sphincsplus:BUILD.sphincsplus.bazel",
         sha256 = "b301faa7a42ef538323a732929d49341b1cbd8375f643f7d98ca32cd6efacc32",
         patches = [
-            Label("//third_party/sphincsplus:sphincsplus-namespace.patch"),
+            Label("@lowrisc_opentitan//third_party/sphincsplus:sphincsplus-namespace.patch"),
         ],
         patch_args = ["-p2"],
     )


### PR DESCRIPTION
This change enables this repo (`lowrisc_opentitan`) to be brought in as an external Bazel dependency in another Bazel project for the purpose of building opentitanlib as an external dependency in another Bazel project. This will be used by the `opentitan_provisioning` repo to build a provisioning testbed based on FPGA provisioning flows.