### PR TITLE
[bazel,otp,manuf] Support immutable ROM_EXT enabling during personalization 

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -22,6 +22,7 @@ load(
     "otp_image",
     "otp_image_consts",
     "otp_json",
+    "otp_json_immutable_rom_ext",
     "otp_partition",
     "otp_per_class_bytes",
     "otp_per_class_ints",
@@ -202,6 +203,20 @@ otp_json(
     ],
 )
 
+otp_json_immutable_rom_ext(
+    name = "otp_json_immutable_rom_ext",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
+            },
+        ),
+    ],
+    rom_ext = "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+    visibility = ["//visibility:private"],
+)
+
 # Create an overlay for the alert_handler digest.
 otp_alert_digest(
     name = "alert_digest_cfg",
@@ -294,6 +309,7 @@ MANUF_SW_INITIALIZED = [
     ":alert_digest_cfg",
     ":otp_json_creator_sw_cfg",
     ":otp_json_owner_sw_cfg",
+    ":otp_json_immutable_rom_ext",
 ]
 
 # The `MANUF_INDIVIDUALIZED` OTP profile configures the HW_CFG0/1, CREATOR_SW and

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -22,6 +22,7 @@ load(
     "otp_image",
     "otp_image_consts",
     "otp_json",
+    "otp_json_immutable_rom_ext",
     "otp_partition",
     "otp_per_class_bytes",
     "otp_per_class_ints",
@@ -201,6 +202,20 @@ otp_json(
     ],
 )
 
+otp_json_immutable_rom_ext(
+    name = "otp_json_immutable_rom_ext",
+    partitions = [
+        otp_partition(
+            name = "CREATOR_SW_CFG",
+            items = {
+                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
+            },
+        ),
+    ],
+    rom_ext = "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+    visibility = ["//visibility:private"],
+)
+
 # Create an overlay for the alert_handler digest.
 otp_alert_digest(
     name = "alert_digest_cfg",
@@ -307,6 +322,7 @@ MANUF_SW_INITIALIZED = [
     ":alert_digest_cfg",
     ":otp_json_creator_sw_cfg",
     ":otp_json_owner_sw_cfg",
+    ":otp_json_immutable_rom_ext",
 ]
 
 # The `MANUF_INDIVIDUALIZED` OTP profile configures the HW_CFG0/1, CREATOR_SW and

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img.c.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img.c.tpl
@@ -65,6 +65,7 @@ ${fileheader}
 
     base_declaration = f"const {type_str} {ToConstLabelValue(item['name'])}"
     if item['name'] not in [
+        'CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN',
         'CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG',
         'CREATOR_SW_CFG_MANUF_STATE',
         'OWNER_SW_CFG_ROM_BOOTSTRAP_DIS',

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -685,6 +685,7 @@ static status_t finalize_otp_partitions(void) {
   // Complete the provisioning of OTP CreatorSwCfg partition.
   if (!status_ok(manuf_individualize_device_creator_sw_cfg_check(&otp_ctrl))) {
     TRY(manuf_individualize_device_creator_manuf_state_cfg(&otp_ctrl));
+    TRY(manuf_individualize_device_immutable_rom_ext_en_cfg(&otp_ctrl));
     TRY(manuf_individualize_device_creator_sw_cfg_lock(&otp_ctrl));
   }
   TRY(check_otp_measurement(&otp_creator_sw_cfg_measurement,

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -63,6 +63,13 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
     // state, so once the manufacturing state is provisioned, the
     // personalization firmware can't be re-entrant.
     //
+    // We skip the provisioning of the immutable ROM_EXT enablement
+    // configuration as it must be provisioned only at the end of the
+    // personalization flow. The personalization firmware doesn't include an
+    // immutable ROM_EXT section. Enabling this feature with personalization
+    // firmware would result in ROM self-shutdown due to an invalid immutable
+    // ROM extension hash.
+    //
     // We also skip the provisioning of the ROM bootstrap disablement
     // configuration. This should only be disabled after all bootstrap
     // operations in the personalization flow have been completed.
@@ -73,6 +80,8 @@ static status_t otp_img_write(const dif_otp_ctrl_t *otp,
     if (kv[i].offset ==
             OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET ||
         kv[i].offset == OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET ||
+        kv[i].offset ==
+            OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET ||
         kv[i].offset == OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET ||
         (kv[i].offset >= kValidAstCfgOtpAddrLow &&
          kv[i].offset < kInvalidAstCfgOtpAddrHigh)) {
@@ -120,6 +129,10 @@ static status_t otp_img_expected_value_read(dif_otp_ctrl_partition_t partition,
       break;
     case OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET:
       memcpy(buffer + relative_addr, &kCreatorSwCfgManufStateValue,
+             sizeof(uint32_t));
+      break;
+    case OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET:
+      memcpy(buffer + relative_addr, &kCreatorSwCfgImmutableRomExtEnValue,
              sizeof(uint32_t));
       break;
     default:
@@ -272,6 +285,19 @@ status_t manuf_individualize_device_creator_manuf_state_cfg(
   return OK_STATUS();
 }
 
+status_t manuf_individualize_device_immutable_rom_ext_en_cfg(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  uint32_t offset;
+  TRY(dif_otp_ctrl_relative_address(
+      kDifOtpCtrlPartitionCreatorSwCfg,
+      OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET, &offset));
+  TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
+                                     offset,
+                                     &kCreatorSwCfgImmutableRomExtEnValue,
+                                     /*len=*/1));
+  return OK_STATUS();
+}
+
 status_t manuf_individualize_device_creator_sw_cfg_lock(
     const dif_otp_ctrl_t *otp_ctrl) {
   TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg));
@@ -316,6 +342,9 @@ status_t manuf_individualize_device_partition_expected_read(
     case kDifOtpCtrlPartitionCreatorSwCfg:
       TRY(otp_img_expected_value_read(
           partition, OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET, buffer));
+      TRY(otp_img_expected_value_read(
+          partition, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET,
+          buffer));
       break;
     default:
       return INTERNAL();

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
@@ -17,6 +17,7 @@ extern const size_t kOtpKvCreatorSwCfgSize;
 extern const otp_kv_t kOtpKvCreatorSwCfg[];
 extern const uint32_t kCreatorSwCfgFlashDataDefaultCfgValue;
 extern const uint32_t kCreatorSwCfgManufStateValue;
+extern const uint32_t kCreatorSwCfgImmutableRomExtEnValue;
 
 /**
  * OTP Owner Software Configuration Partition.
@@ -83,6 +84,21 @@ status_t manuf_individualize_device_flash_data_default_cfg(
  */
 OT_WARN_UNUSED_RESULT
 status_t manuf_individualize_device_creator_manuf_state_cfg(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Configures the IMMUTABLE_ROM_EXT_EN field in the CREATOR_SW_CFG OTP
+ * partition.
+ *
+ * This must be called before `manuf_individualize_device_creator_sw_cfg_lock()`
+ * is called. The operation will fail if there are any pre-programmed words not
+ * equal to the expected test values.
+ *
+ * @param otp_ctrl OTP controller instance.
+ * @return OK_STATUS if the IMMUTABLE_ROM_EXT_EN field was provisioned.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_individualize_device_immutable_rom_ext_en_cfg(
     const dif_otp_ctrl_t *otp_ctrl);
 
 /**

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
@@ -131,6 +131,8 @@ bool test_main(void) {
         manuf_individualize_device_flash_data_default_cfg(&otp_ctrl));
     CHECK_STATUS_OK(
         manuf_individualize_device_creator_manuf_state_cfg(&otp_ctrl));
+    CHECK_STATUS_OK(
+        manuf_individualize_device_immutable_rom_ext_en_cfg(&otp_ctrl));
     CHECK_STATUS_OK(manuf_individualize_device_creator_sw_cfg_lock(&otp_ctrl));
     CHECK_STATUS_OK(check_otp_ast_cfg());
     LOG_INFO("Provisioned and locked CREATOR_SW_CFG OTP partition.");


### PR DESCRIPTION
This PR has two commits that:

1. Update ROM_EXT immutable section OTP gen tooling
   - Consider `_rom_ext_start_address` when determining the manifest start address to support the common rom_ext binary
   - Updates the OTP  JSON file with data from an immutable ROM_EXT section only if the immutable ROM_EXT is enabled.
2. Delay IMMUTABLE_ROM_EXT_EN provisioning to end of personalization
   - Separate the provisioning of the IMMUTABLE_ROM_EXT_EN OTP field from the rest of the CREATOR_SW_CFG partition
   - Use the ROM_EXT immutable section OTP gen tool by default when building personalization binary

This PR addresses #24610 partially.

Note: this depends on #24783 and #24789. Only review the last 2 commits.