### PR TITLE
[rom_ext, attestation] Fix DICE measurements

### DIFF
--- a/sw/host/tests/attestation/BUILD
+++ b/sw/host/tests/attestation/BUILD
@@ -15,6 +15,7 @@ rust_binary(
         "@crate_index//:anyhow",
         "@crate_index//:base64ct",
         "@crate_index//:clap",
+        "@crate_index//:hex",
         "@crate_index//:humantime",
         "@crate_index//:log",
         "@crate_index//:num-bigint-dig",


### PR DESCRIPTION
1. Report the DICE measurements in big-endian order.
2. Check the key IDs reported by the DICE certs.