### PR TITLE
[sival] Fix bazel target spellings

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -131,7 +131,7 @@
       si_stage: SV1
       tests: ["chip_sw_lc_ctrl_otp_hw_cfg0"]
       lc_states: ["PROD"]
-      bazel: ["//sw/device/tests:lc_ctrl_otp_hw_cfg_test"]
+      bazel: ["//sw/device/tests:lc_ctrl_otp_hw_cfg0_test"]
     }
     {
       name: chip_sw_otp_ctrl_lc_signals

--- a/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_sram_ctrl_testplan.hjson
@@ -127,7 +127,7 @@
       lc_states: ["RMA"]
       tests: ["chip_sw_all_escalation_resets",
               "chip_sw_data_integrity_escalation"]
-      bazel: ["//sw/device/tests:sram_ctrl_lc_escalation"]
+      bazel: ["//sw/device/tests:sram_ctrl_lc_escalation_test"]
     }
 
     {

--- a/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_uart_testplan.hjson
@@ -93,7 +93,7 @@
       lc_states: ["PROD"]
       features: ["UART.PARITY"]
       tests: []
-      bazel: ["//sw/device/tests:uart_parity_test"]
+      bazel: ["//sw/device/tests:uart_parity_break_test"]
     }
     {
       name: chip_sw_uart_line_loopback


### PR DESCRIPTION
These targets have different names to what's in the testplans.