### PR TITLE
[dice,cwt] Add more utilities for CWT implementation

### DIFF
--- a/sw/device/silicon_creator/lib/base/util.c
+++ b/sw/device/silicon_creator/lib/base/util.c
@@ -22,3 +22,16 @@ void util_reverse_bytes(void *buf, size_t num_bytes) {
     byte_buf[num_bytes - i - 1] = temp;
   }
 }
+
+// Returns hexdump character for the half-byte.
+static inline uint8_t hexdump_halfbyte(uint8_t half_byte) {
+  if (half_byte < 10)
+    return '0' + half_byte;
+  else
+    return 'a' + half_byte - 10;
+}
+
+void util_hexdump_byte(uint8_t byte, uint8_t *str) {
+  str[0] = hexdump_halfbyte((byte & 0xF0) >> 4);
+  str[1] = hexdump_halfbyte(byte & 0x0F);
+}

--- a/sw/device/silicon_creator/lib/base/util.h
+++ b/sw/device/silicon_creator/lib/base/util.h
@@ -37,6 +37,15 @@ uint32_t util_size_to_words(uint32_t bytes);
  */
 void util_reverse_bytes(void *buf, size_t num_bytes);
 
+/**
+ * Fills hexdump of the byte (lowercase).
+ *
+ * @param byte Byte to convert to a hex string.
+ * @param[out] str String buffer (always 2 bytes) to place hex string encoded
+ * byte in.
+ */
+void util_hexdump_byte(uint8_t byte, uint8_t *str);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/cert/cbor.h
+++ b/sw/device/silicon_creator/lib/cert/cbor.h
@@ -31,6 +31,25 @@ static inline rom_error_t cbor_map_init(struct CborOut *p,
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
 
+static inline rom_error_t cbor_array_init(struct CborOut *p,
+                                          const size_t num_elements) {
+  CborWriteArray(num_elements, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+static inline rom_error_t cbor_write_string(struct CborOut *p,
+                                            const char *str) {
+  CborWriteTstr(str, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+static inline rom_error_t cbor_write_bytes(struct CborOut *p,
+                                           const uint8_t *data,
+                                           const size_t data_size) {
+  CborWriteBstr(data_size, data, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
 // Wrappers to encode a pair of data for cbor-map
 static inline rom_error_t cbor_write_pair_uint_uint(struct CborOut *p,
                                                     uint64_t key,
@@ -57,10 +76,27 @@ static inline rom_error_t cbor_write_pair_uint_int(struct CborOut *p,
 }
 
 static inline rom_error_t cbor_write_pair_int_bytes(struct CborOut *p,
-                                                    int64_t key, uint8_t *value,
-                                                    size_t value_size) {
+                                                    int64_t key,
+                                                    const uint8_t *value,
+                                                    const size_t value_size) {
   CborWriteInt(key, p);
   CborWriteBstr(value_size, value, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+static inline rom_error_t cbor_write_pair_uint_tstr(struct CborOut *p,
+                                                    uint64_t key,
+                                                    const char *value) {
+  CborWriteUint(key, p);
+  CborWriteTstr(value, p);
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+static inline rom_error_t cbor_write_pair_int_tstr(struct CborOut *p,
+                                                   int64_t key,
+                                                   const char *value) {
+  CborWriteInt(key, p);
+  CborWriteTstr(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
 

--- a/third_party/open-dice/Add-a-local-strlen-implementation.patch
+++ b/third_party/open-dice/Add-a-local-strlen-implementation.patch
@@ -1,0 +1,39 @@
+From 1a2ead40e2e15ca058882ad86f4ac32e5c5b6177 Mon Sep 17 00:00:00 2001
+From: Tommy Chiu <tommychiu@google.com>
+Date: Thu, 17 Oct 2024 13:23:43 +0800
+Subject: [PATCH] Add a local strlen implementation
+
+Not all developing environments have access to strlen.
+---
+ src/cbor_writer.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/cbor_writer.c b/src/cbor_writer.c
+index 6c70129..c473543 100644
+--- a/src/cbor_writer.c
++++ b/src/cbor_writer.c
+@@ -30,6 +30,12 @@ enum CborType {
+   CBOR_TYPE_SIMPLE = 7,
+ };
+ 
++static unsigned long _strlen(const char* in) {
++  unsigned long ret;
++  for (ret = 0; *in++; ret++);
++  return ret;
++}
++
+ static bool CborWriteWouldOverflowCursor(size_t size, struct CborOut* out) {
+   return size > SIZE_MAX - out->cursor;
+ }
+@@ -127,7 +133,7 @@ uint8_t* CborAllocBstr(size_t data_size, struct CborOut* out) {
+ }
+ 
+ void CborWriteTstr(const char* str, struct CborOut* out) {
+-  CborWriteStr(CBOR_TYPE_TSTR, strlen(str), str, out);
++  CborWriteStr(CBOR_TYPE_TSTR, _strlen(str), str, out);
+ }
+ 
+ char* CborAllocTstr(size_t size, struct CborOut* out) {
+-- 
+2.47.0.rc1.288.g06298d1525-goog
+

--- a/third_party/open-dice/repos.bzl
+++ b/third_party/open-dice/repos.bzl
@@ -12,4 +12,8 @@ def open_dice_repos(local = None):
         strip_prefix = "open-dice-cf3f4cc7a3506a33ee3a437544ef6f40056b3563",
         urls = ["https://github.com/google/open-dice/archive/cf3f4cc7a3506a33ee3a437544ef6f40056b3563.zip"],
         sha256 = "d7ce830111451afe2a255cac3b750f82e50efe2aaf6bac0b076881c964cfe78d",
+        patches = [
+            Label("//third_party/open-dice:Add-a-local-strlen-implementation.patch"),
+        ],
+        patch_args = ["-p1"],
     )


### PR DESCRIPTION
It requires some more cbor wrappers to generate different type of data. Add
1. A patch to open-dice library for strlen()
2. A binary to hex-string convertor
3. Wrappers of cbor_writer to perform API status check