### PR TITLE
Backport 24794 to earlgrey_es_sival

### DIFF
--- a/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_teacup.json
@@ -321,6 +321,16 @@
       "name": "VBUS_SENSE",
       "mode": "Input",
       "alias_of": "CN10_18"
+    },
+    {
+        // Connected to active-low shutdown pin on the LED driver. This is
+        // pulled low by the rev 1.5 Teacup board, so it must be driven high to
+        // activate the driver. This configuration makes a high output the
+        // default.
+        "name": "LED_SD_L",
+        "mode": "PushPull",
+        "level": true,
+        "alias_of": "CN10_15"
     }
   ],
   "spi": [


### PR DESCRIPTION
The latest rev of the HyperTeacup board (v1.5.0) connects the active-low shutdown pin of the LED driver to HyperDebug pin CN10.15. The board pulls this pin low by default, so the HyperDebug needs to actively drive it high to enable the LED driver.

This commit updates opentitanlib's HyperTeacup configuration to drive this pin high by default, ensuring that the driver is always active.

CN10.15 is not connected on HyperTeacup rev 1.3.0, so this change should be backwards compatible with older boards.

Signed-off-by: Noah Moroze <noah@opentitan.org>
(cherry picked from commit cb5bf502a94ef3a7969aa6b43dfbfee92d377854)