### PR TITLE
[opentitantool] Support gpio analog-write via proxy

### DIFF
--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -96,6 +96,14 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_pull_mode(*pull)?;
                         Ok(Response::Gpio(GpioResponse::SetPullMode))
                     }
+                    GpioRequest::AnalogRead => {
+                        let value = instance.analog_read()?;
+                        Ok(Response::Gpio(GpioResponse::AnalogRead { value }))
+                    }
+                    GpioRequest::AnalogWrite { value } => {
+                        instance.analog_write(*value)?;
+                        Ok(Response::Gpio(GpioResponse::AnalogWrite))
+                    }
                     GpioRequest::MultiSet {
                         mode,
                         value,

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -75,6 +75,10 @@ pub enum GpioRequest {
     SetPullMode {
         pull: PullMode,
     },
+    AnalogWrite {
+        value: f32,
+    },
+    AnalogRead,
     MultiSet {
         mode: Option<PinMode>,
         value: Option<bool>,
@@ -89,6 +93,8 @@ pub enum GpioResponse {
     Read { value: bool },
     SetMode,
     SetPullMode,
+    AnalogWrite,
+    AnalogRead { value: f32 },
     MultiSet,
 }
 

--- a/sw/host/opentitanlib/src/transport/proxy/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/gpio.rs
@@ -76,6 +76,20 @@ impl GpioPin for ProxyGpioPin {
         }
     }
 
+    fn analog_read(&self) -> Result<f32> {
+        match self.execute_command(GpioRequest::AnalogRead)? {
+            GpioResponse::AnalogRead { value } => Ok(value),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
+    fn analog_write(&self, volts: f32) -> Result<()> {
+        match self.execute_command(GpioRequest::AnalogWrite { value: volts })? {
+            GpioResponse::AnalogWrite => Ok(()),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     fn set(
         &self,
         mode: Option<PinMode>,


### PR DESCRIPTION
Add a few method needed to propagate calls to `Gpio::analog_write()` and `Gpio::analog_read()` via the proxy protocol.  This appears to have been an oversight at the time when the analog functionality was added, which has gone undetected the feature was needed by Google now.
