### PR TITLE
[ownership] Fix protect_when_active behavior 

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -272,14 +272,13 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
 }
 
 rom_error_t ownership_flash_lockdown(boot_data_t *bootdata,
+                                     uint32_t active_slot,
                                      const owner_config_t *config) {
   if (bootdata->ownership_state == kOwnershipStateLockedOwner) {
-    HARDENED_RETURN_IF_ERROR(
-        owner_block_flash_apply(config->flash, kBootSlotA,
-                                /*lockdown=*/bootdata->primary_bl0_slot));
-    HARDENED_RETURN_IF_ERROR(
-        owner_block_flash_apply(config->flash, kBootSlotB,
-                                /*lockdown=*/bootdata->primary_bl0_slot));
+    HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotA,
+                                                     /*lockdown=*/active_slot));
+    HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotB,
+                                                     /*lockdown=*/active_slot));
   } else {
     HARDENED_CHECK_NE(bootdata->ownership_state, kOwnershipStateLockedOwner);
   }

--- a/sw/device/silicon_creator/lib/ownership/ownership.h
+++ b/sw/device/silicon_creator/lib/ownership/ownership.h
@@ -21,10 +21,12 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
  * Lockdown the flash configuration.
  *
  * @param bootdata The current bootdata.
+ * @param active_slot The active slot.
  * @param config The current owner configuration.
  * @return error state.
  */
 rom_error_t ownership_flash_lockdown(boot_data_t *bootdata,
+                                     uint32_t active_slot,
                                      const owner_config_t *config);
 
 /**

--- a/sw/device/silicon_creator/lib/ownership/testdata/basic_owner.json5
+++ b/sw/device/silicon_creator/lib/ownership/testdata/basic_owner.json5
@@ -63,7 +63,7 @@
             scramble: false,
             ecc: false,
             high_endurance: false,
-            protect_when_primary: true
+            protect_when_active: true
           },
           {
             start: 32,
@@ -74,7 +74,7 @@
             scramble: true,
             ecc: true,
             high_endurance: false,
-            protect_when_primary: true
+            protect_when_active: true
           },
           {
             start: 224,
@@ -85,7 +85,7 @@
             scramble: false,
             ecc: false,
             high_endurance: true,
-            protect_when_primary: false
+            protect_when_active: false
           },
           {
             start: 256,
@@ -96,7 +96,7 @@
             scramble: false,
             ecc: false,
             high_endurance: false,
-            protect_when_primary: true
+            protect_when_active: true
           },
           {
             start: 288,
@@ -107,7 +107,7 @@
             scramble: true,
             ecc: true,
             high_endurance: false,
-            protect_when_primary: true
+            protect_when_active: true
           },
           {
             start: 480,
@@ -118,7 +118,7 @@
             scramble: false,
             ecc: false,
             high_endurance: true,
-            protect_when_primary: false
+            protect_when_active: false
           }
         ]
       }
@@ -136,7 +136,7 @@
             scramble: true,
             ecc: true,
             high_endurance: false,
-            protect_when_primary: false
+            protect_when_active: false
           },
           {
             bank: 0,
@@ -148,7 +148,7 @@
             scramble: true,
             ecc: true,
             high_endurance: false,
-            protect_when_primary: false
+            protect_when_active: false
           },
           {
             bank: 0,
@@ -160,7 +160,7 @@
             scramble: true,
             ecc: true,
             high_endurance: false,
-            protect_when_primary: false
+            protect_when_active: false
           },
           {
             bank: 0,
@@ -172,7 +172,7 @@
             scramble: true,
             ecc: true,
             high_endurance: false,
-            protect_when_primary: false
+            protect_when_active: false
           }
         ]
       }

--- a/sw/device/silicon_creator/rom_ext/data/rom_ext_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/rom_ext/data/rom_ext_e2e_testplan.hjson
@@ -493,10 +493,10 @@
           The new flash configuration should have a different scrambling or ECC configuration than the current configuration.
         - Boot owner firmware and examine the flash controller's region configuration registers.
         - Confirm that in the intermediate "dual-owner" state, the primary half of the flash is configured for the previous owner and the secondary half is configured for the next owner.
-          Confirm that the `protect_when_primary` condition does not apply during the dual-owner state.
+          Confirm that the `protect_when_active` condition does not apply during the dual-owner state.
         - Activate ownership with the `dummy` activate key.
         - Use the rescue protocol to upload owner firmware into the newly-configured flash regions.
-        - Confirm that in the owned state, the entire flash is configured for the new owner and that the `protect_when_primary` condition removes erase/program permissions appropriately.
+        - Confirm that in the owned state, the entire flash is configured for the new owner and that the `protect_when_active` condition removes erase/program permissions appropriately.
         '''
       tags:
       [

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -53,6 +53,7 @@ opentitan_binary(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
     },
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",
@@ -397,34 +398,40 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_flash_permission_test
 # Note: rescue-after-activate tests that rescue correctly accesses regions with
 # different scrambling/ECC properties than the default flash configuration.
-ownership_transfer_test(
-    name = "flash_permission_test",
-    srcs = ["flash_regions.c"],
-    fpga = fpga_params(
-        binaries = {
-            ":flash_regions": "flash_regions",
-        },
-        test_cmd = """
-            --clear-bitstream
-            --bootstrap={firmware}
-            --unlock-mode=Any
-            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
-            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
-            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
-            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
-            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
-            --config-kind=with-flash-locked
-            --rescue-after-activate={flash_regions}
-        """,
-        test_harness = "//sw/host/tests/ownership:flash_permission_test",
-    ),
-    deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/dif:flash_ctrl",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-    ],
-)
+[
+    ownership_transfer_test(
+        name = "flash_permission_test_slot_{}".format(slot),
+        srcs = ["flash_regions.c"],
+        fpga = fpga_params(
+            binaries = {
+                ":flash_regions": "flash_regions",
+            },
+            slot = "Slot{}".format(slot.upper()),
+            test_cmd = """
+                --clear-bitstream
+                --bootstrap={firmware}
+                --unlock-mode=Any
+                --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+                --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+                --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+                --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+                --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
+                --config-kind=with-flash-locked
+                --rescue-after-activate={flash_regions}
+                --rescue-slot={slot}
+            """,
+            test_harness = "//sw/host/tests/ownership:flash_permission_test",
+        ),
+        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+        deps = [
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/dif:flash_ctrl",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+        ],
+    )
+    for slot in ("a", "b")
+]
 
 # Tests that a owner config with an improper flash configuration cannot be activated.
 ownership_transfer_test(

--- a/sw/device/silicon_creator/rom_ext/prodc/prodc_owner.json5
+++ b/sw/device/silicon_creator/rom_ext/prodc/prodc_owner.json5
@@ -65,7 +65,7 @@
             // Slot A ROM_EXT region: 0 to 64 KiB.
             "start": 0,
             "size": 32,
-            // Permissions: read, erase and program. But override by protect_when_primary
+            // Permissions: read, erase and program. But override by protect_when_active
             "read": true,
             "program": true,
             "erase": true,
@@ -74,14 +74,14 @@
             "scramble": true,
             "ecc": true,
             "high_endurance": false,
-            "protect_when_primary": true,
+            "protect_when_active": true,
             "lock": true
           },
           {
             // Slot B ROM_EXT region
             "start": 256,
             "size": 32,
-            // Permissions: read, erase and program. But override by protect_when_primary
+            // Permissions: read, erase and program. But override by protect_when_active
             "read": true,
             "program": true,
             "erase": true,
@@ -90,7 +90,7 @@
             "scramble": true,
             "ecc": true,
             "high_endurance": false,
-            "protect_when_primary": true,
+            "protect_when_active": true,
             "lock": true
           },
           {
@@ -105,7 +105,7 @@
             "scramble": true,
             "ecc": true,
             "high_endurance": false,
-            "protect_when_primary": true,
+            "protect_when_active": true,
             "lock": true
           },
           {
@@ -120,7 +120,7 @@
             "scramble": true,
             "ecc": true,
             "high_endurance": false,
-            "protect_when_primary": true,
+            "protect_when_active": true,
             "lock": true
           },
           {
@@ -136,7 +136,7 @@
             "scramble": false,
             "ecc": true,
             "high_endurance": true,
-            "protect_when_primary": false,
+            "protect_when_active": false,
             "lock": false
           },
           {
@@ -152,7 +152,7 @@
             "scramble": false,
             "ecc": true,
             "high_endurance": true,
-            "protect_when_primary": false,
+            "protect_when_active": false,
             "lock": false
           },
           {
@@ -167,7 +167,7 @@
             "scramble": true,
             "ecc": true,
             "high_endurance": false,
-            "protect_when_primary": false,
+            "protect_when_active": false,
             "lock": true
           }
         ]
@@ -177,7 +177,7 @@
       // The Flash INFO Config defines how the INFO pages reserved for the
       // owner will be configured.  The configuration properties are the
       // same as the flash region config properties, however the
-      // `protect_when_primary` flag is meaningless.
+      // `protect_when_active` flag is meaningless.
       //
       // On the Earlgrey_ES chip, INFO pages 6 to 9 (inclusive) in bank 0
       // are reserved for owner use.

--- a/sw/host/opentitanlib/src/chip/boot_svc.rs
+++ b/sw/host/opentitanlib/src/chip/boot_svc.rs
@@ -52,6 +52,16 @@ with_unknown! {
     }
 }
 
+impl BootSlot {
+    pub fn opposite(self) -> Result<Self> {
+        match self {
+            BootSlot::SlotA => Ok(BootSlot::SlotB),
+            BootSlot::SlotB => Ok(BootSlot::SlotA),
+            _ => Err(ChipDataError::BadSlot(self).into()),
+        }
+    }
+}
+
 /// The Boot Services header common to all boot services commands and responses.
 #[derive(Debug, Default, Serialize, Annotate)]
 pub struct Header {

--- a/sw/host/opentitanlib/src/chip/mod.rs
+++ b/sw/host/opentitanlib/src/chip/mod.rs
@@ -21,6 +21,8 @@ pub enum ChipDataError {
     Anyhow(#[from] anyhow::Error),
     #[error("bad size: expected {0} bytes, but found {1}")]
     BadSize(usize, usize),
+    #[error("bad slot: {0:x}")]
+    BadSlot(boot_svc::BootSlot),
     #[error("invalid digest")]
     InvalidDigest,
 }

--- a/sw/host/opentitanlib/src/ownership/flash.rs
+++ b/sw/host/opentitanlib/src/ownership/flash.rs
@@ -33,9 +33,9 @@ pub struct FlashFlags {
     /// The high endurance feature is enabled in this region.
     #[serde(default)]
     pub high_endurance: bool,
-    /// Forbid program and erase operations when in the primary flash side.
+    /// Forbid program and erase operations when in the active flash side.
     #[serde(default)]
-    pub protect_when_primary: bool,
+    pub protect_when_active: bool,
     /// Lock the configuration of this region.
     #[serde(default)]
     pub lock: bool,
@@ -64,7 +64,7 @@ impl FlashFlags {
             read: true,
             program: true,
             erase: true,
-            protect_when_primary: true,
+            protect_when_active: true,
             ..Default::default()
         }
     }
@@ -77,7 +77,7 @@ impl FlashFlags {
             erase: true,
             scramble: true,
             ecc: true,
-            protect_when_primary: true,
+            protect_when_active: true,
             ..Default::default()
         }
     }
@@ -114,7 +114,7 @@ impl From<u64> for FlashFlags {
             read:                 flags & 0xF == Self::TRUE,
             program:              (flags >> 4) & 0xF == Self::TRUE,
             erase:                (flags >> 8) & 0xF == Self::TRUE,
-            protect_when_primary: (flags >> 24) & 0xF == Self::TRUE,
+            protect_when_active:  (flags >> 24) & 0xF == Self::TRUE,
             lock:                 (flags >> 28) & 0xF == Self::TRUE,
 
             // Second 32-bit word: flash properties.
@@ -134,7 +134,7 @@ impl From<FlashFlags> for u64 {
             if flags.read                 { FlashFlags::TRUE } else { FlashFlags::FALSE } |
             if flags.program              { FlashFlags::TRUE } else { FlashFlags::FALSE } << 4 |
             if flags.erase                { FlashFlags::TRUE } else { FlashFlags::FALSE } << 8 |
-            if flags.protect_when_primary { FlashFlags::TRUE } else { FlashFlags::FALSE } << 24 |
+            if flags.protect_when_active  { FlashFlags::TRUE } else { FlashFlags::FALSE } << 24 |
             if flags.lock                 { FlashFlags::TRUE } else { FlashFlags::FALSE } << 28 |
 
             // Second 32-bit word: flash properties.
@@ -263,7 +263,7 @@ r#"00000000: 46 4c 53 48 2c 00 00 00 00 00 00 00 96 09 00 99  FLSH,...........
       scramble: false,
       ecc: true,
       high_endurance: false,
-      protect_when_primary: false,
+      protect_when_active: false,
       lock: false
     },
     {
@@ -275,7 +275,7 @@ r#"00000000: 46 4c 53 48 2c 00 00 00 00 00 00 00 96 09 00 99  FLSH,...........
       scramble: false,
       ecc: false,
       high_endurance: false,
-      protect_when_primary: false,
+      protect_when_active: false,
       lock: false
     },
     {
@@ -287,7 +287,7 @@ r#"00000000: 46 4c 53 48 2c 00 00 00 00 00 00 00 96 09 00 99  FLSH,...........
       scramble: true,
       ecc: true,
       high_endurance: true,
-      protect_when_primary: false,
+      protect_when_active: false,
       lock: false
     }
   ]

--- a/sw/host/opentitanlib/src/ownership/flash_info.rs
+++ b/sw/host/opentitanlib/src/ownership/flash_info.rs
@@ -145,7 +145,7 @@ r#"00000000: 49 4e 46 4f 2c 00 00 00 00 00 00 00 96 09 00 99  INFO,...........
       scramble: false,
       ecc: true,
       high_endurance: false,
-      protect_when_primary: false,
+      protect_when_active: false,
       lock: false
     },
     {
@@ -158,7 +158,7 @@ r#"00000000: 49 4e 46 4f 2c 00 00 00 00 00 00 00 96 09 00 99  INFO,...........
       scramble: false,
       ecc: false,
       high_endurance: false,
-      protect_when_primary: false,
+      protect_when_active: false,
       lock: false
     },
     {
@@ -171,7 +171,7 @@ r#"00000000: 49 4e 46 4f 2c 00 00 00 00 00 00 00 96 09 00 99  INFO,...........
       scramble: true,
       ecc: true,
       high_endurance: true,
-      protect_when_primary: false,
+      protect_when_active: false,
       lock: false
     }
   ]

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -493,7 +493,7 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
             scramble: true,
             ecc: true,
             high_endurance: true,
-            protect_when_primary: false,
+            protect_when_active: false,
             lock: false
           },
           {
@@ -505,7 +505,7 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
             scramble: true,
             ecc: true,
             high_endurance: true,
-            protect_when_primary: false,
+            protect_when_active: false,
             lock: false
           }
         ]
@@ -524,7 +524,7 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
             scramble: true,
             ecc: true,
             high_endurance: true,
-            protect_when_primary: false,
+            protect_when_active: false,
             lock: false
           },
           {
@@ -537,7 +537,7 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
             scramble: true,
             ecc: true,
             high_endurance: true,
-            protect_when_primary: false,
+            protect_when_active: false,
             lock: false
           }
         ]

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -160,7 +160,7 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         // Earlgrey-specific.
         //
         // Note: when in an unlocked state, flash lockdown doesn't apply, so neither
-        // the `protect_when_primary` nor `lock` bits for individual regions will
+        // the `protect_when_active` nor `lock` bits for individual regions will
         // affect the region config.
         assert_eq!(
             region[0],
@@ -241,10 +241,10 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         return RomError(u32::from_str_radix(&capture[3], 16)?).into();
     }
     let region = FlashRegion::find_all(&capture[1])?;
-    // Flash SideA is the primary side and has protect_when_primary = true.
+    // Flash SideA is the primary side and has protect_when_active = true.
     //
     // Since we are in a locked ownership state, we expect the region configuration
-    // to reflect both the `protect_when_primary` and `lock` properties of the
+    // to reflect both the `protect_when_active` and `lock` properties of the
     // owner's flash configuration.
     let locked = if opts.config_kind.is_flash_locked() {
         "LK"
@@ -263,7 +263,7 @@ fn flash_permission_test(opts: &Opts, transport: &TransportWrapper) -> Result<()
         region[2],
         FlashRegion("data", 2, 224, 32, "RD-WR-ER-xx-xx-HE", locked)
     );
-    // Flash SideB is the secondary side, so protect_when_primary doesn't apply.
+    // Flash SideB is the secondary side, so protect_when_active doesn't apply.
     assert_eq!(
         region[3],
         FlashRegion("data", 3, 256, 32, "RD-WR-ER-xx-xx-xx", locked)

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -153,7 +153,7 @@ impl OwnerConfigKind {
             scramble: self as u32 & CFG_FLASH_ERROR != 0,
             ecc: self as u32 & CFG_FLASH_ERROR != 0,
             high_endurance: false,
-            protect_when_primary: true,
+            protect_when_active: true,
             lock: self.is_flash_locked(),
         }
     }
@@ -166,7 +166,7 @@ impl OwnerConfigKind {
             scramble: true,
             ecc: true,
             high_endurance: false,
-            protect_when_primary: true,
+            protect_when_active: true,
             lock: self.is_flash_locked(),
         }
     }
@@ -179,7 +179,7 @@ impl OwnerConfigKind {
             scramble: false,
             ecc: false,
             high_endurance: true,
-            protect_when_primary: false,
+            protect_when_active: false,
             lock: self.is_flash_locked(),
         }
     }


### PR DESCRIPTION
1. Rename `protect_when_primary` to `protect_when_active`, as this feature
   is supposed to protect flash pages in whichever side is the active side
   regardless of which side is the primary side.
2. When this feature was named `protect_when_primary`, I did the
   seemingly correct thing and protected the slot that was the primary
   boot slot.  This is, in fact, not what this feature should actually
   do; it _should_ protect the active slot.
3. Update the test to verify the behavior of the feature in both slots.
