### PR TITLE
[otp_img] cleanup OTP images used across SKUs

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -12,14 +12,12 @@ load(
     "CONST",
     "EARLGREY_ALERTS",
     "EARLGREY_LOC_ALERTS",
-    "get_lc_items",
 )
 load(
     "//rules:otp.bzl",
     "otp_alert_classification",
     "otp_alert_digest",
     "otp_hex",
-    "otp_image",
     "otp_image_consts",
     "otp_json",
     "otp_json_immutable_rom_ext",
@@ -223,43 +221,11 @@ otp_alert_digest(
     otp_img = ":otp_json_owner_sw_cfg",
 )
 
-# The `LC_MISSION_STATES` object contains the set of mission mode life cycle
-# states. A device is considered to be mission mode configured if it has a
-# matching `MANUF_PERSONALIZED` OTP configuration.
-LC_MISSION_STATES = get_lc_items(
-    CONST.LCV.DEV,
-    CONST.LCV.PROD,
-    CONST.LCV.PROD_END,
-)
-
-# The `MANUF_INITIALIZED` OTP profile configures the SECRET0 partition to
-# enable the device to transition between test_unlock and test_locked states,
-# as well as to transition out of test_unlock into any of the
-# `LC_MISSION_STATES`.
-MANUF_INITIALIZED = [
-    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret0",
-    "//sw/device/silicon_creator/rom/keys/fake/otp:json_rot_keys",
-]
-
 MANUF_SW_INITIALIZED = [
     ":alert_digest_cfg",
     ":otp_json_creator_sw_cfg",
     ":otp_json_owner_sw_cfg",
     ":otp_json_immutable_rom_ext",
-]
-
-# The `MANUF_INDIVIDUALIZED` OTP profile configures the HW_CFG0/1, CREATOR_SW and
-# OWNER_SW OTP partitions. It also includes the `MANUF_INITIALIZED`.
-MANUF_INDIVIDUALIZED = MANUF_INITIALIZED + MANUF_SW_INITIALIZED + [
-    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg0",
-    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg1",
-]
-
-# The `MANUF_PERSONALIZED` OTP profile configures the SECRET1 and SECRET2 OTP
-# partitions. It also includes the `MANUF_INDIVIDUALIZED` profile.
-MANUF_PERSONALIZED = MANUF_INDIVIDUALIZED + [
-    "//hw/ip/otp_ctrl/data:otp_json_secret1",
-    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
 ]
 
 # OTP SW Configuration. Used to generate a configuration program used during
@@ -280,89 +246,5 @@ cc_library(
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/silicon_creator/manuf/lib:otp_img_types",
-    ],
-)
-
-# Initial test_unlocked state. Only applicable for test_unlocked0. All other
-# test states require the SECRET0 partition to be configured.
-# In this configuration, ROM execution is disabled by default. JTAG should be
-# used to bootstrap code into SRAM or FLASH.
-# See sw/device/tests/doc/sival/devguide.md for more details.
-otp_image(
-    name = "otp_img_test_unlocked0_manuf_empty",
-    src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked0",
-)
-
-# `MANUF_INITIALIZED` configuration. This configuration will be generally used
-# to lock the chips before shipping to the Final-Test test house.
-# See sw/device/tests/doc/sival/devguide.md for more details.
-otp_image(
-    name = "otp_img_test_locked0_manuf_initialized",
-    src = "//hw/ip/otp_ctrl/data:otp_json_test_locked0",
-    overlays = MANUF_INITIALIZED,
-)
-
-# `MANUF_INITIALIZED` OTP configuration. Available on TEST_UNLOCK states 1-7.
-# See sw/device/tests/doc/sival/devguide.md for more details.
-[
-    otp_image(
-        name = "otp_img_test_unlocked{}_manuf_initialized".format(i),
-        src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked{}".format(i),
-        overlays = MANUF_INITIALIZED,
-    )
-    for i in range(1, 8)
-]
-
-# `MANUF_INDIVIDUALIZED` configuration. Available on TEST_UNLOCK states 1-7, as
-# well as dev, prod, prod_end and rma. This configuration has flash scrambling
-# disabled. See the personalized OTP configuration for targets requiring flash
-# scrambling enabled.
-# See sw/device/tests/doc/sival/devguide.md for more details.
-[
-    otp_image(
-        name = "otp_img_{}_manuf_individualized".format(lc_state),
-        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
-        overlays = MANUF_INDIVIDUALIZED,
-    )
-    for lc_state, _ in get_lc_items(
-        CONST.LCV.TEST_UNLOCKED1,
-        CONST.LCV.TEST_UNLOCKED2,
-        CONST.LCV.TEST_UNLOCKED3,
-        CONST.LCV.TEST_UNLOCKED4,
-        CONST.LCV.TEST_UNLOCKED5,
-        CONST.LCV.TEST_UNLOCKED6,
-        CONST.LCV.TEST_UNLOCKED7,
-        CONST.LCV.DEV,
-        CONST.LCV.PROD,
-        CONST.LCV.PROD_END,
-    )
-]
-
-# `MANUF_PERSONALIZED` configuration. Available on `LC_MISSION_STATES` life
-# cycle states.
-# See sw/device/tests/doc/sival/devguide.md for more details.
-[
-    otp_image(
-        name = "otp_img_{}_manuf_personalized".format(lc_state),
-        src = "//hw/ip/otp_ctrl/data:otp_json_{}".format(lc_state),
-        overlays = MANUF_PERSONALIZED,
-    )
-    for lc_state, _ in LC_MISSION_STATES
-]
-
-# `MANUF_PERSONALIZED` configuration for RMA. Only available in secure environments.
-otp_image(
-    name = "otp_img_rma_manuf_personalized",
-    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
-    overlays = MANUF_PERSONALIZED,
-)
-
-# `MANUF_PERSONALIZED` configuration for RMA with SPHINCS+ signature verification
-# enabled for secure boot. Only available in secure environments.
-otp_image(
-    name = "otp_img_rma_manuf_personalized_spx_enabled",
-    src = "//hw/ip/otp_ctrl/data:otp_json_rma",
-    overlays = MANUF_PERSONALIZED + [
-        "//sw/device/silicon_creator/rom/e2e/sigverify_spx:otp_json_sigverify_spx_enabled_true",
     ],
 )

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -20,7 +20,6 @@ load(
     "otp_hex",
     "otp_image_consts",
     "otp_json",
-    "otp_json_immutable_rom_ext",
     "otp_partition",
     "otp_per_class_bytes",
     "otp_per_class_ints",
@@ -101,6 +100,9 @@ otp_json(
                 # Any value different than `CONST.HARDENED_FALSE` will force
                 # main SRAM scramble key rotation.
                 "CREATOR_SW_CFG_SRAM_KEY_RENEW_EN": otp_hex(0x0),
+
+                # Disable the use of the ROM_EXT immutable section.
+                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             },
         ),
     ],
@@ -201,43 +203,21 @@ otp_json(
     ],
 )
 
-otp_json_immutable_rom_ext(
-    name = "otp_json_immutable_rom_ext",
-    partitions = [
-        otp_partition(
-            name = "CREATOR_SW_CFG",
-            items = {
-                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
-            },
-        ),
-    ],
-    rom_ext = "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
-    visibility = ["//visibility:private"],
-)
-
 # Create an overlay for the alert_handler digest.
 otp_alert_digest(
     name = "alert_digest_cfg",
     otp_img = ":otp_json_owner_sw_cfg",
 )
 
-MANUF_SW_INITIALIZED = [
-    ":alert_digest_cfg",
-    ":otp_json_creator_sw_cfg",
-    ":otp_json_owner_sw_cfg",
-    ":otp_json_immutable_rom_ext",
-]
-
-# OTP SW Configuration. Used to generate a configuration program used during
-# manufacturing. The `MANUF_SW_INITIALIZED` OTP profile is also used to derive
-# OTP profiles representing the state of the device after running manufacturing
-# steps consuming this dependency.
+# OTP *_SW_CFG constants used to generate an FT individualization binary.
 otp_image_consts(
     name = "otp_sw_cfg_c_file",
     src = ":otp_json_baseline",
-    # Do not add additional overlays here. Update the `MANUF_SW_INITIALIZED`
-    # OTP profile instead.
-    overlays = MANUF_SW_INITIALIZED,
+    overlays = [
+        ":alert_digest_cfg",
+        ":otp_json_creator_sw_cfg",
+        ":otp_json_owner_sw_cfg",
+    ],
 )
 
 cc_library(

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -223,70 +223,6 @@ otp_alert_digest(
     otp_img = ":otp_json_owner_sw_cfg",
 )
 
-otp_json(
-    name = "otp_json_hw_cfg0",
-    partitions = [
-        otp_partition(
-            name = "HW_CFG0",
-            items = {
-                "DEVICE_ID": "<random>",
-            },
-            lock = True,
-        ),
-    ],
-)
-
-otp_json(
-    name = "otp_json_hw_cfg1",
-    partitions = [
-        otp_partition(
-            name = "HW_CFG1",
-            items = {
-                # Enable code execution from SRAM in PROD state.
-                "EN_SRAM_IFETCH": True,
-                # Cryptolib and chip-level tests require access to the CSRNG
-                # software interfaces.
-                "EN_CSRNG_SW_APP_READ": True,
-                # Use legacy behavior and disable late debug enable.
-                "DIS_RV_DM_LATE_DEBUG": True,
-            },
-            lock = True,
-        ),
-    ],
-)
-
-otp_json(
-    name = "otp_json_secret1",
-    partitions = [
-        otp_partition(
-            name = "SECRET1",
-            items = {
-                "FLASH_ADDR_KEY_SEED": "<random>",
-                "FLASH_DATA_KEY_SEED": "<random>",
-                "SRAM_DATA_KEY_SEED": "<random>",
-            },
-            lock = True,
-        ),
-    ],
-)
-
-otp_json(
-    name = "otp_json_fixed_secret2",
-    partitions = [
-        otp_partition(
-            name = "SECRET2",
-            items = {
-                # We aren't testing keymgr for ROM_EXT tests and we want
-                # reproducible bitstreams for all tests.
-                "RMA_TOKEN": "0x1faf9056acde66561685549803a28bec",
-                "CREATOR_ROOT_KEY_SHARE0": "1111111111111111111111111111111111111111111111111111111111111111",
-                "CREATOR_ROOT_KEY_SHARE1": "2222222222222222222222222222222222222222222222222222222222222222",
-            },
-            lock = True,
-        ),
-    ],
-)
-
 # The `LC_MISSION_STATES` object contains the set of mission mode life cycle
 # states. A device is considered to be mission mode configured if it has a
 # matching `MANUF_PERSONALIZED` OTP configuration.
@@ -315,15 +251,15 @@ MANUF_SW_INITIALIZED = [
 # The `MANUF_INDIVIDUALIZED` OTP profile configures the HW_CFG0/1, CREATOR_SW and
 # OWNER_SW OTP partitions. It also includes the `MANUF_INITIALIZED`.
 MANUF_INDIVIDUALIZED = MANUF_INITIALIZED + MANUF_SW_INITIALIZED + [
-    ":otp_json_hw_cfg0",
-    ":otp_json_hw_cfg1",
+    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg0",
+    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg1",
 ]
 
 # The `MANUF_PERSONALIZED` OTP profile configures the SECRET1 and SECRET2 OTP
 # partitions. It also includes the `MANUF_INDIVIDUALIZED` profile.
 MANUF_PERSONALIZED = MANUF_INDIVIDUALIZED + [
-    ":otp_json_secret1",
-    ":otp_json_fixed_secret2",
+    "//hw/ip/otp_ctrl/data:otp_json_secret1",
+    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
 ]
 
 # OTP SW Configuration. Used to generate a configuration program used during

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -222,38 +222,7 @@ otp_alert_digest(
     otp_img = ":otp_json_owner_sw_cfg",
 )
 
-otp_json(
-    name = "otp_json_hw_cfg0",
-    partitions = [
-        otp_partition(
-            name = "HW_CFG0",
-            items = {
-                "DEVICE_ID": "<random>",
-            },
-            lock = True,
-        ),
-    ],
-)
-
-otp_json(
-    name = "otp_json_hw_cfg1",
-    partitions = [
-        otp_partition(
-            name = "HW_CFG1",
-            items = {
-                # Enable code execution from SRAM in PROD state.
-                "EN_SRAM_IFETCH": True,
-                # Cryptolib and chip-level tests require access to the CSRNG
-                # software interfaces.
-                "EN_CSRNG_SW_APP_READ": True,
-                # Use legacy behavior and disable late debug enable.
-                "DIS_RV_DM_LATE_DEBUG": True,
-            },
-            lock = True,
-        ),
-    ],
-)
-
+# Create an overlay that enalbes the rv_dm late debug feature.
 otp_json(
     name = "otp_json_hw_cfg1_enable_rv_dm_late_debug",
     partitions = [
@@ -262,38 +231,6 @@ otp_json(
             items = {
                 # Use legacy behavior and disable late debug enable.
                 "DIS_RV_DM_LATE_DEBUG": False,
-            },
-            lock = True,
-        ),
-    ],
-)
-
-otp_json(
-    name = "otp_json_secret1",
-    partitions = [
-        otp_partition(
-            name = "SECRET1",
-            items = {
-                "FLASH_ADDR_KEY_SEED": "<random>",
-                "FLASH_DATA_KEY_SEED": "<random>",
-                "SRAM_DATA_KEY_SEED": "<random>",
-            },
-            lock = True,
-        ),
-    ],
-)
-
-otp_json(
-    name = "otp_json_fixed_secret2",
-    partitions = [
-        otp_partition(
-            name = "SECRET2",
-            items = {
-                # We aren't testing keymgr for ROM_EXT tests and we want
-                # reproducible bitstreams for all tests.
-                "RMA_TOKEN": "0x1faf9056acde66561685549803a28bec",
-                "CREATOR_ROOT_KEY_SHARE0": "1111111111111111111111111111111111111111111111111111111111111111",
-                "CREATOR_ROOT_KEY_SHARE1": "2222222222222222222222222222222222222222222222222222222222222222",
             },
             lock = True,
         ),
@@ -328,15 +265,15 @@ MANUF_SW_INITIALIZED = [
 # The `MANUF_INDIVIDUALIZED` OTP profile configures the HW_CFG0/1, CREATOR_SW and
 # OWNER_SW OTP partitions. It also includes the `MANUF_INITIALIZED`.
 MANUF_INDIVIDUALIZED = MANUF_INITIALIZED + MANUF_SW_INITIALIZED + [
-    ":otp_json_hw_cfg0",
-    ":otp_json_hw_cfg1",
+    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg0",
+    "//hw/ip/otp_ctrl/data:otp_json_hw_cfg1",
 ]
 
 # The `MANUF_PERSONALIZED` OTP profile configures the SECRET1 and SECRET2 OTP
 # partitions. It also includes the `MANUF_INDIVIDUALIZED` profile.
 MANUF_PERSONALIZED = MANUF_INDIVIDUALIZED + [
-    ":otp_json_secret1",
-    ":otp_json_fixed_secret2",
+    "//hw/ip/otp_ctrl/data:otp_json_secret1",
+    "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
 ]
 
 # OTP SW Configuration. Used to generate a configuration program used during

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -22,7 +22,6 @@ load(
     "otp_image",
     "otp_image_consts",
     "otp_json",
-    "otp_json_immutable_rom_ext",
     "otp_partition",
     "otp_per_class_bytes",
     "otp_per_class_ints",
@@ -104,6 +103,9 @@ otp_json(
                 # Any value different than `CONST.HARDENED_FALSE` will force
                 # main SRAM scramble key rotation.
                 "CREATOR_SW_CFG_SRAM_KEY_RENEW_EN": otp_hex(0x0),
+
+                # Disable the use of the ROM_EXT immutable section.
+                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             },
         ),
     ],
@@ -202,20 +204,6 @@ otp_json(
     ],
 )
 
-otp_json_immutable_rom_ext(
-    name = "otp_json_immutable_rom_ext",
-    partitions = [
-        otp_partition(
-            name = "CREATOR_SW_CFG",
-            items = {
-                "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
-            },
-        ),
-    ],
-    rom_ext = "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
-    visibility = ["//visibility:private"],
-)
-
 # Create an overlay for the alert_handler digest.
 otp_alert_digest(
     name = "alert_digest_cfg",
@@ -259,7 +247,6 @@ MANUF_SW_INITIALIZED = [
     ":alert_digest_cfg",
     ":otp_json_creator_sw_cfg",
     ":otp_json_owner_sw_cfg",
-    ":otp_json_immutable_rom_ext",
 ]
 
 # The `MANUF_INDIVIDUALIZED` OTP profile configures the HW_CFG0/1, CREATOR_SW and
@@ -276,10 +263,10 @@ MANUF_PERSONALIZED = MANUF_INDIVIDUALIZED + [
     "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
 ]
 
-# OTP SW Configuration. Used to generate a configuration program used during
-# manufacturing. The `MANUF_SW_INITIALIZED` OTP profile is also used to derive
-# OTP profiles representing the state of the device after running manufacturing
-# steps consuming this dependency.
+# OTP *_SW_CFG constants used to generate an FT individualization binary.
+# The `MANUF_SW_INITIALIZED` OTP profile is also used to derive OTP profiles
+# representing the state of the device after running the FT individualization
+# binary that consumes this dependency.
 otp_image_consts(
     name = "otp_sw_cfg_c_file",
     src = ":otp_json_baseline",

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -16,7 +16,7 @@ load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
     "CLOUD_KMS_CERT_ENDORSEMENT_PARAMS",
     "CP_PROVISIONING_INPUTS",
-    "EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS",
+    "EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS",
     "FT_PERSONALIZE_KEYS",
     "FT_PROVISIONING_INPUTS",
     "LOCAL_CERT_ENDORSEMENT_PARAMS",
@@ -205,7 +205,7 @@ opentitan_test(
             "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_sku_{}".format(otp_sw_cfgs),
         ],
     )
-    for otp_sw_cfgs in EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS
+    for otp_sw_cfgs in EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS
 ]
 
 filegroup(

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS = [
+EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS = [
     "sival",
     "prodc",
 ]

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -11,7 +11,7 @@ load(
 )
 load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
-    "EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS",
+    "EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -197,7 +197,7 @@ cc_library(
             "//hw/ip/otp_ctrl/data/earlgrey_skus/{}:otp_sw_cfg".format(otp_sw_cfg),
         ],
     )
-    for otp_sw_cfg in EARLGREY_A0_INDIVIDUALIZE_OTP_SW_CFGS
+    for otp_sw_cfg in EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS
 ]
 
 opentitan_test(


### PR DESCRIPTION
This removes several duplicate and unused OTP image and overlay definitions across the prodc and sival SKUs. Note, most image definitions removed were those from the prodc SKU as they are not used during sival. Only the prodc *_SW_CFG definitions should exist as those could *potentially* be different and are used to generate a different individualization binary for provisioning.