### PR TITLE
[opentitantool] Add ISFB manifest extensions.

### DIFF
--- a/sw/host/opentitanlib/src/image/testdata/manifest_ext.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest_ext.hjson
@@ -11,6 +11,22 @@
       secver_write: true,
     },
     {
+      strike_mask: "0x0fedcba987654321fedcba9876543210"
+      product_expr: [
+        {
+          mask: "0xffffffff",
+          value: "0xa5a5a5a5",
+        },
+        {
+          mask: "0xf0f0f0f0",
+          value: "0xa0a0a0a0",
+        },
+      ]
+    },
+    {
+      erase_allowed: false,
+    },
+    {
       name: "0xbeef",
       identifier: "0xabcd",
       value: ["0x01", "0x23", "0x45", "0x67"],


### PR DESCRIPTION
Add opentitantool image manifest support for Integrator Specfic Firmware Binding (ISFB) extensions.

The following manifest extensions were added:

1. isfb: Integration specific firmware binding manifest extension. Contains anti-rollback strike mask as well as device expecific product expression.
2. isfb_erase_policy: This extension is used to authorize erasing of the ISFB region. Intended for testing purposes. The implementation will require node-locking for this policy to be effective.

This change does not integrate the extensions into the build system. This will be done in a separate commit.

This is part of: https://github.com/lowRISC/opentitan/issues/24666