### PR TITLE
[gpiodpi] fix activation and the effective clock generation

### DIFF
--- a/hw/dv/dpi/gpiodpi/gpiodpi.sv
+++ b/hw/dv/dpi/gpiodpi/gpiodpi.sv
@@ -53,7 +53,8 @@ module gpiodpi
      gpiodpi_close(ctx);
    end
 
-   logic eff_clk = clk_i && active;
+   logic eff_clk;
+   assign eff_clk = clk_i && active;
 
    logic [N_GPIO-1:0] gpio_d2p_r;
    always_ff @(posedge eff_clk) begin


### PR DESCRIPTION
Assignments on variables (reg/logic) are just initialization. Assignments wires are continuous assignment (assign).