### PR TITLE
Cherry-pick to earlgrey_1.0.0: [ownership] Initialize SRAM & rescue according to the owner configuration

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -195,3 +195,20 @@ rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
   }
   return kErrorOwnershipKeyNotFound;
 }
+
+hardened_bool_t owner_rescue_command_allowed(
+    const owner_rescue_config_t *rescue, uint32_t command) {
+  // If no rescue configuration is supplied in the owner config, then all rescue
+  // commands are allowed.
+  if ((hardened_bool_t)rescue == kHardenedBoolFalse)
+    return kHardenedBoolTrue;
+
+  hardened_bool_t allowed = kHardenedBoolFalse;
+  size_t length = (rescue->header.length - sizeof(*rescue)) / sizeof(uint32_t);
+  for (size_t i = 0; i < length; ++i) {
+    if (command == rescue->command_allow[i]) {
+      allowed = kHardenedBoolTrue;
+    }
+  }
+  return allowed;
+}

--- a/sw/device/silicon_creator/lib/ownership/owner_block.h
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNER_BLOCK_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OWNERSHIP_OWNER_BLOCK_H_
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
@@ -85,6 +86,15 @@ rom_error_t owner_keyring_find_key(const owner_application_keyring_t *keyring,
                                    uint32_t key_alg, uint32_t key_id,
                                    size_t *index);
 
+/**
+ * Determine whether a particular rescue command is allowed.
+ *
+ * @param rescue A pointer to the rescue configuration.
+ * @param command The rescue command to check.
+ * @return kHardenedBoolTrue if allowed.
+ */
+hardened_bool_t owner_rescue_command_allowed(
+    const owner_rescue_config_t *rescue, uint32_t command);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -92,7 +92,6 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
   HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotB,
                                                    bootdata->primary_bl0_slot));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
-  // TODO: apply SRAM exec config
   // TODO: apply rescue config
   return kErrorOk;
 }
@@ -165,7 +164,6 @@ static rom_error_t unlocked_init(boot_data_t *bootdata, owner_config_t *config,
   HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, secondary,
                                                    bootdata->primary_bl0_slot));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
-  // TODO: apply SRAM exec config
   // TODO: apply rescue config
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/ownership/ownership.c
+++ b/sw/device/silicon_creator/lib/ownership/ownership.c
@@ -92,7 +92,6 @@ static rom_error_t locked_owner_init(boot_data_t *bootdata,
   HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, kBootSlotB,
                                                    bootdata->primary_bl0_slot));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
-  // TODO: apply rescue config
   return kErrorOk;
 }
 
@@ -164,7 +163,6 @@ static rom_error_t unlocked_init(boot_data_t *bootdata, owner_config_t *config,
   HARDENED_RETURN_IF_ERROR(owner_block_flash_apply(config->flash, secondary,
                                                    bootdata->primary_bl0_slot));
   HARDENED_RETURN_IF_ERROR(owner_block_info_apply(config->info));
-  // TODO: apply rescue config
   return kErrorOk;
 }
 
@@ -226,6 +224,7 @@ rom_error_t ownership_init(boot_data_t *bootdata, owner_config_t *config,
   dbg_printf("ownership: %C\r\n", bootdata->ownership_state);
   owner_config_default(config);
   rom_error_t error = kErrorOwnershipNoOwner;
+  // TODO(#22386): Harden this switch/case statement.
   switch (bootdata->ownership_state) {
     case kOwnershipStateLockedOwner:
       error = locked_owner_init(bootdata, config, keyring);

--- a/sw/device/silicon_creator/lib/ownership/test_owner.c
+++ b/sw/device/silicon_creator/lib/ownership/test_owner.c
@@ -30,7 +30,7 @@ rom_error_t test_owner_init(boot_data_t *bootdata, owner_config_t *config,
   owner_page[0].header.tag = kTlvTagOwner;
   owner_page[0].header.length = 2048;
   owner_page[0].version = 0;
-  owner_page[0].sram_exec_mode = kOwnerSramExecModeDisabled;
+  owner_page[0].sram_exec_mode = kOwnerSramExecModeDisabledLocked;
   owner_page[0].ownership_key_alg = kOwnershipKeyAlgEcdsaP256;
   owner_page[0].owner_key = (owner_key_t){OWNER_ECDSA_P256};
   owner_page[0].activate_key = (owner_key_t){ACTIVATE_ECDSA_P256};
@@ -108,9 +108,9 @@ rom_error_t test_owner_init(boot_data_t *bootdata, owner_config_t *config,
                                      sizeof(owner_page[0]) / sizeof(uint32_t),
                                      &owner_page[0]));
     OT_DISCARD(boot_data_write(bootdata));
-    dbg_printf("Test owner flash initialized\r\n");
+    dbg_printf("test_owner_init: flash\r\n");
   } else {
-    dbg_printf("Test owner ram initialized\r\n");
+    dbg_printf("test_owner_init: ram\r\n");
   }
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/xmodem.c
+++ b/sw/device/silicon_creator/lib/xmodem.c
@@ -166,6 +166,11 @@ static rom_error_t xmodem_send_start(void *iohandle, uint32_t retries) {
   return kErrorXModemTimeoutStart;
 }
 
+void xmodem_cancel(void *iohandle) {
+  xmodem_putchar(iohandle, kXModemCancel);
+  xmodem_putchar(iohandle, kXModemCancel);
+}
+
 static rom_error_t xmodem_send_finish(void *iohandle) {
   xmodem_putchar(iohandle, kXModemEof);
   uint8_t ch;

--- a/sw/device/silicon_creator/lib/xmodem.h
+++ b/sw/device/silicon_creator/lib/xmodem.h
@@ -25,6 +25,11 @@ void xmodem_recv_start(void *iohandle);
 void xmodem_ack(void *iohandle, bool ack);
 
 /**
+ * Send an Xmodem cancel sequence.
+ */
+void xmodem_cancel(void *iohandle);
+
+/**
  * Receive a frame using Xmodem-CRC
  *
  * @param iohandle An opaque user point associated with the io device.

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -42,6 +42,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/ownership:owner_block",
     ],
 )
 

--- a/sw/device/silicon_creator/rom_ext/rescue.c
+++ b/sw/device/silicon_creator/rom_ext/rescue.c
@@ -6,11 +6,14 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/dbg_print.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
+#include "sw/device/silicon_creator/lib/ownership/datatypes.h"
+#include "sw/device/silicon_creator/lib/ownership/owner_block.h"
 #include "sw/device/silicon_creator/lib/xmodem.h"
 
 #include "flash_ctrl_regs.h"
@@ -32,32 +35,37 @@ rom_error_t flash_firmware_block(rescue_state_t *state) {
         .write = kMultiBitBool4True,
         .erase = kMultiBitBool4True,
     });
-    for (uint32_t addr = state->flash_start; addr <= state->flash_limit;
+    for (uint32_t addr = state->flash_start; addr < state->flash_limit;
          addr += kFlashPageSize) {
       HARDENED_RETURN_IF_ERROR(
           flash_ctrl_data_erase(addr, kFlashCtrlEraseTypePage));
     }
     state->flash_offset = state->flash_start;
   }
-  if (state->flash_offset <= state->flash_limit) {
+  if (state->flash_offset < state->flash_limit) {
     HARDENED_RETURN_IF_ERROR(flash_ctrl_data_write(
         state->flash_offset, sizeof(state->data) / sizeof(uint32_t),
         state->data));
     state->flash_offset += sizeof(state->data);
   } else {
+    xmodem_cancel(iohandle);
     return kErrorRescueImageTooBig;
   }
   return kErrorOk;
 }
 
-rom_error_t flash_owner_block(rescue_state_t *state) {
-  // FIXME: validate that we're in a state capable of accepting an owner
-  // block and validate the block before flashing it.
-  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageOwnerSlot1,
-                                                 kFlashCtrlEraseTypePage));
-  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
-      &kFlashCtrlInfoPageOwnerSlot1, 0, sizeof(state->data) / sizeof(uint32_t),
-      state->data));
+rom_error_t flash_owner_block(rescue_state_t *state, boot_data_t *bootdata) {
+  if (bootdata->ownership_state == kOwnershipStateUnlockedAny ||
+      bootdata->ownership_state == kOwnershipStateLockedUpdate ||
+      bootdata->ownership_state == kOwnershipStateUnlockedEndorsed) {
+    HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(
+        &kFlashCtrlInfoPageOwnerSlot1, kFlashCtrlEraseTypePage));
+    HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
+        &kFlashCtrlInfoPageOwnerSlot1, 0,
+        sizeof(state->data) / sizeof(uint32_t), state->data));
+  } else {
+    dbg_printf("error: cannot accept owner_block in current state\r\n");
+  }
   return kErrorOk;
 }
 
@@ -97,55 +105,62 @@ static void change_speed(void) {
   }
 }
 
-static void validate_mode(uint32_t mode, rescue_state_t *state) {
+static void validate_mode(uint32_t mode, rescue_state_t *state,
+                          boot_data_t *bootdata) {
   dbg_printf("\r\nmode: %C\r\n", bitfield_byteswap32(mode));
-  switch (mode) {
-    case kRescueModeBaud:
-      change_speed();
-      return;
-    case kRescueModeBootLog:
-      dbg_printf("ok: receive boot_log via xmodem-crc\r\n");
-      break;
-    case kRescueModeBootSvcRsp:
-      dbg_printf("ok: receive boot_svc response via xmodem-crc\r\n");
-      break;
-    case kRescueModeBootSvcReq:
-      dbg_printf("ok: send boot_svc request via xmodem-crc\r\n");
-      break;
-    case kRescueModeOwnerBlock:
-      dbg_printf("ok: send owner_block via xmodem-crc\r\n");
-      break;
-    case kRescueModeFirmware:
-      dbg_printf("ok: send firmware via xmodem-crc\r\n");
-      // Ensure the start/limit are in SlotA.
-      state->flash_start &= ~kFlashBankSize;
-      state->flash_limit &= ~kFlashBankSize;
-      break;
-    case kRescueModeFirmwareSlotB:
-      dbg_printf("ok: send slot-b firmware via xmodem-crc\r\n");
-      // Ensure the start/limit are in SlotB.
-      state->flash_start |= kFlashBankSize;
-      state->flash_limit |= kFlashBankSize;
-      break;
-    case kRescueModeReboot:
-      dbg_printf("ok: reboot\r\n");
-      break;
-    case kRescueModeWait:
-      state->reboot = false;
-      dbg_printf("ok: wait after upload\r\n");
-      return;
-    default:
-      // User input error.  Do not change modes.
-      dbg_printf("error: unrecognized mode\r\n");
-      return;
+  hardened_bool_t allow = owner_rescue_command_allowed(state->config, mode);
+  if (allow == kHardenedBoolTrue) {
+    switch (mode) {
+      case kRescueModeBaud:
+        change_speed();
+        return;
+      case kRescueModeBootLog:
+        dbg_printf("ok: receive boot_log via xmodem-crc\r\n");
+        break;
+      case kRescueModeBootSvcRsp:
+        dbg_printf("ok: receive boot_svc response via xmodem-crc\r\n");
+        break;
+      case kRescueModeBootSvcReq:
+        dbg_printf("ok: send boot_svc request via xmodem-crc\r\n");
+        break;
+      case kRescueModeOwnerBlock:
+        if (bootdata->ownership_state == kOwnershipStateUnlockedAny ||
+            bootdata->ownership_state == kOwnershipStateLockedUpdate ||
+            bootdata->ownership_state == kOwnershipStateUnlockedEndorsed) {
+          dbg_printf("ok: send owner_block via xmodem-crc\r\n");
+        } else {
+          dbg_printf("error: cannot accept owner_block in current state\r\n");
+          return;
+        }
+        break;
+      case kRescueModeFirmware:
+        dbg_printf("ok: send firmware via xmodem-crc\r\n");
+        break;
+      case kRescueModeReboot:
+        dbg_printf("ok: reboot\r\n");
+        break;
+      default:
+        // User input error.  Do not change modes.
+        dbg_printf("error: unrecognized mode\r\n");
+        return;
+    }
+    state->mode = (rescue_mode_t)mode;
+  } else {
+    dbg_printf("error: mode not allowed\r\n");
   }
-  state->mode = (rescue_mode_t)mode;
   state->frame = 1;
   state->offset = 0;
   state->flash_offset = 0;
 }
 
-static rom_error_t handle_send_modes(rescue_state_t *state) {
+static rom_error_t handle_send_modes(rescue_state_t *state,
+                                     boot_data_t *bootdata) {
+  hardened_bool_t allow =
+      owner_rescue_command_allowed(state->config, state->mode);
+  if (allow != kHardenedBoolTrue) {
+    return kErrorRescueBadMode;
+  }
+
   const retention_sram_t *rr = retention_sram_get();
   switch (state->mode) {
     case kRescueModeBootLog:
@@ -170,11 +185,19 @@ static rom_error_t handle_send_modes(rescue_state_t *state) {
       // This state should be impossible.
       return kErrorRescueBadMode;
   }
-  validate_mode(kRescueModeFirmware, state);
+  validate_mode(kRescueModeFirmware, state, bootdata);
   return kErrorOk;
 }
 
-static rom_error_t handle_recv_modes(rescue_state_t *state) {
+static rom_error_t handle_recv_modes(rescue_state_t *state,
+                                     boot_data_t *bootdata) {
+  hardened_bool_t allow =
+      owner_rescue_command_allowed(state->config, state->mode);
+  if (allow != kHardenedBoolTrue) {
+    xmodem_cancel(iohandle);
+    return kErrorRescueBadMode;
+  }
+
   retention_sram_t *rr = retention_sram_get();
   switch (state->mode) {
     case kRescueModeBootLog:
@@ -183,6 +206,12 @@ static rom_error_t handle_recv_modes(rescue_state_t *state) {
       break;
     case kRescueModeBootSvcReq:
       if (state->offset >= sizeof(rr->creator.boot_svc_msg)) {
+        const boot_svc_msg_t *msg = (const boot_svc_msg_t *)state->data;
+        allow = owner_rescue_command_allowed(state->config, msg->header.type);
+        if (allow != kHardenedBoolTrue) {
+          xmodem_cancel(iohandle);
+          return kErrorRescueBadMode;
+        }
         memcpy(&rr->creator.boot_svc_msg, state->data,
                sizeof(rr->creator.boot_svc_msg));
         state->offset = 0;
@@ -190,7 +219,7 @@ static rom_error_t handle_recv_modes(rescue_state_t *state) {
       break;
     case kRescueModeOwnerBlock:
       if (state->offset == sizeof(state->data)) {
-        HARDENED_RETURN_IF_ERROR(flash_owner_block(state));
+        HARDENED_RETURN_IF_ERROR(flash_owner_block(state, bootdata));
         state->offset = 0;
       }
       break;
@@ -209,24 +238,18 @@ static rom_error_t handle_recv_modes(rescue_state_t *state) {
   return kErrorOk;
 }
 
-static rom_error_t protocol(rescue_state_t *state) {
+static rom_error_t protocol(rescue_state_t *state, boot_data_t *bootdata) {
   rom_error_t result;
   size_t rxlen;
   uint8_t command;
   uint32_t next_mode = 0;
 
   state->reboot = true;
-  validate_mode(kRescueModeFirmware, &rescue_state);
-
-  // The rescue region starts immediately after the ROM_EXT and ends
-  // at the end of the flash bank.
-  // TODO(cfrantz): This needs to be owner-configurable.
-  state->flash_start = 0x10000;
-  state->flash_limit = 0x7FFFF;
+  validate_mode(kRescueModeFirmware, &rescue_state, bootdata);
 
   xmodem_recv_start(iohandle);
   while (true) {
-    HARDENED_RETURN_IF_ERROR(handle_send_modes(&rescue_state));
+    HARDENED_RETURN_IF_ERROR(handle_send_modes(&rescue_state, bootdata));
     result = xmodem_recv_frame(iohandle, state->frame,
                                state->data + state->offset, &rxlen, &command);
     if (state->frame == 1 && result == kErrorXModemTimeoutStart) {
@@ -237,7 +260,7 @@ static rom_error_t protocol(rescue_state_t *state) {
       case kErrorOk:
         // Packet ok.
         state->offset += rxlen;
-        HARDENED_RETURN_IF_ERROR(handle_recv_modes(&rescue_state));
+        HARDENED_RETURN_IF_ERROR(handle_recv_modes(&rescue_state, bootdata));
         xmodem_ack(iohandle, true);
         break;
       case kErrorXModemEndOfFile:
@@ -247,7 +270,7 @@ static rom_error_t protocol(rescue_state_t *state) {
           while (state->offset % 2048 != 0) {
             state->data[state->offset++] = 0xFF;
           }
-          HARDENED_RETURN_IF_ERROR(handle_recv_modes(&rescue_state));
+          HARDENED_RETURN_IF_ERROR(handle_recv_modes(&rescue_state, bootdata));
         }
         xmodem_ack(iohandle, true);
         if (!state->reboot) {
@@ -265,7 +288,7 @@ static rom_error_t protocol(rescue_state_t *state) {
       case kErrorXModemUnknown:
         if (state->frame == 1) {
           if (command == '\r') {
-            validate_mode(next_mode, &rescue_state);
+            validate_mode(next_mode, &rescue_state, bootdata);
             next_mode = 0;
           } else {
             next_mode = (next_mode << 8) | command;
@@ -280,8 +303,21 @@ static rom_error_t protocol(rescue_state_t *state) {
   }
 }
 
-rom_error_t rescue_protocol(void) {
-  rom_error_t result = protocol(&rescue_state);
+rom_error_t rescue_protocol(boot_data_t *bootdata,
+                            const owner_rescue_config_t *config) {
+  rescue_state.config = config;
+  if ((hardened_bool_t)config == kHardenedBoolFalse) {
+    HARDENED_CHECK_EQ((hardened_bool_t)config, kHardenedBoolFalse);
+    // If there is no rescue config, then the rescue region starts immediately
+    // after the ROM_EXT and ends at the end of the flash bank.
+    rescue_state.flash_start = CHIP_ROM_EXT_SIZE_MAX;
+    rescue_state.flash_limit = kFlashBankSize;
+  } else {
+    rescue_state.flash_start = (uint32_t)config->start * kFlashPageSize;
+    rescue_state.flash_limit =
+        (uint32_t)(config->start + config->size) * kFlashPageSize;
+  }
+  rom_error_t result = protocol(&rescue_state, bootdata);
   if (result == kErrorRescueReboot) {
     rstmgr_reset();
   }

--- a/sw/device/silicon_creator/rom_ext/rescue.h
+++ b/sw/device/silicon_creator/rom_ext/rescue.h
@@ -8,7 +8,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/ownership/datatypes.h"
 
 enum {
   // Rescue is signalled by asserting serial break to the UART for at least
@@ -66,10 +68,13 @@ typedef struct RescueState {
   // Range to erase and write for firmware rescue (inclusive).
   uint32_t flash_start;
   uint32_t flash_limit;
+  // Rescue configuration.
+  const owner_rescue_config_t *config;
   // Data buffer to hold xmodem upload data.
   uint8_t data[2048];
 } rescue_state_t;
 
-rom_error_t rescue_protocol(void);
+rom_error_t rescue_protocol(boot_data_t *bootdata,
+                            const owner_rescue_config_t *rescue);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_RESCUE_H_

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -898,7 +898,7 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
     uart_enable_receiver();
     // TODO: update rescue protocol to accept boot data and rescue
     // config from the owner_config.
-    error = rescue_protocol();
+    error = rescue_protocol(boot_data, owner_config.rescue);
   } else {
     error = rom_ext_try_next_stage(boot_data, boot_log);
   }

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -213,20 +213,28 @@ static rom_error_t rom_ext_init(boot_data_t *boot_data) {
   return kErrorOk;
 }
 
-void rom_ext_sram_exec(hardened_bool_t enable) {
-  switch (enable) {
-    case kHardenedBoolTrue:
-      // In the case where we enable SRAM exec, we do not lock the register as
-      // some later code may want to disable it.
-      HARDENED_CHECK_EQ(enable, kHardenedBoolTrue);
+void rom_ext_sram_exec(owner_sram_exec_mode_t mode) {
+  switch (mode) {
+    case kOwnerSramExecModeEnabled:
+      // In enabled mode, we do not lock the register so owner code can disable
+      // SRAM exec at some later time.
+      HARDENED_CHECK_EQ(mode, kOwnerSramExecModeEnabled);
       sec_mmio_write32(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR +
                            SRAM_CTRL_EXEC_REG_OFFSET,
                        kMultiBitBool4True);
       break;
-    case kHardenedBoolFalse:
-      // In the case where we disable SRAM exec, we lock the register so that it
-      // cannot be re-enabled later.
-      HARDENED_CHECK_EQ(enable, kHardenedBoolFalse);
+    case kOwnerSramExecModeDisabled:
+      // In disabled mode, we do not lock the register so owner code can enable
+      // SRAM exec at some later time.
+      HARDENED_CHECK_EQ(mode, kOwnerSramExecModeDisabled);
+      sec_mmio_write32(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR +
+                           SRAM_CTRL_EXEC_REG_OFFSET,
+                       kMultiBitBool4False);
+      break;
+    case kOwnerSramExecModeDisabledLocked:
+    default:
+      // In disabled locked mode, we lock the register so the mode cannot be
+      // changed.
       sec_mmio_write32(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR +
                            SRAM_CTRL_EXEC_REG_OFFSET,
                        kMultiBitBool4False);
@@ -234,8 +242,6 @@ void rom_ext_sram_exec(hardened_bool_t enable) {
                            SRAM_CTRL_EXEC_REGWEN_REG_OFFSET,
                        0);
       break;
-    default:
-      HARDENED_TRAP();
   }
 }
 
@@ -248,7 +254,7 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
       &keyring, kOwnershipKeyAlgRsa,
       sigverify_rsa_key_id_get(&manifest->rsa_modulus), &kindex));
 
-  dbg_printf("application key %u: alg=%C domain=%C\r\n", kindex,
+  dbg_printf("app_verify: key=%u alg=%C domain=%C\r\n", kindex,
              keyring.key[kindex]->key_alg, keyring.key[kindex]->key_domain);
 
   memset(boot_measurements.bl0.data, (int)rnd_uint32(),
@@ -257,6 +263,8 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
   hmac_sha256_init();
   // Hash usage constraints.
   manifest_usage_constraints_t usage_constraints_from_hw;
+  // TODO(cfrantz): Combine key's usage constraints with manifest's
+  // usage_constraints.
   sigverify_usage_constraints_get(manifest->usage_constraints.selector_bits,
                                   &usage_constraints_from_hw);
   hmac_sha256_update(&usage_constraints_from_hw,
@@ -625,9 +633,6 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
   rom_ext_epmp_clear_rlb();
   HARDENED_RETURN_IF_ERROR(epmp_state_check());
 
-  // Forbid code execution from SRAM.
-  rom_ext_sram_exec(kHardenedBoolFalse);
-
   // Lock the address translation windows.
   ibex_addr_remap_lockdown(0);
   ibex_addr_remap_lockdown(1);
@@ -866,6 +871,8 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   if (error == kErrorWriteBootdataThenReboot) {
     return error;
   }
+  // Configure SRAM execution as the owner requested.
+  rom_ext_sram_exec(owner_config.sram_exec);
 
   // Handle any pending boot_svc commands.
   uint32_t reset_reasons = retention_sram_get()->creator.reset_reasons;

--- a/sw/host/opentitanlib/src/ownership/owner.rs
+++ b/sw/host/opentitanlib/src/ownership/owner.rs
@@ -253,8 +253,8 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
 00000180: 66 06 00 00 01 05 00 00 77 17 11 88 77 17 11 11  f.......w...w...
 00000190: 52 45 53 51 38 00 00 00 58 4d 44 4d 20 00 e0 00  RESQ8...XMDM ...
 000001a0: 45 4d 50 54 4d 53 45 43 4e 45 58 54 55 4e 4c 4b  EMPTMSECNEXTUNLK
-000001b0: 41 43 54 56 52 45 53 51 42 4c 4f 47 42 52 45 51  ACTVRESQBLOGBREQ
-000001c0: 42 52 53 50 4f 57 4e 52 5a 5a 5a 5a 5a 5a 5a 5a  BRSPOWNRZZZZZZZZ
+000001b0: 41 43 54 56 51 53 45 52 47 4f 4c 42 51 45 52 42  ACTVQSERGOLBQERB
+000001c0: 50 53 52 42 52 4e 57 4f 5a 5a 5a 5a 5a 5a 5a 5a  PSRBRNWOZZZZZZZZ
 000001d0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
 000001e0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
 000001f0: 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a 5a  ZZZZZZZZZZZZZZZZ
@@ -497,8 +497,8 @@ r#"00000000: 4f 57 4e 52 00 08 00 00 00 00 00 00 4c 4e 45 58  OWNR........LNEX
           "Empty",
           "MinBl0SecVerRequest",
           "NextBl0SlotRequest",
-          "UnlockOwnershipRequest",
-          "ActivateOwnerRequest",
+          "OwnershipUnlockRequest",
+          "OwnershipActivateRequest",
           "Rescue",
           "GetBootLog",
           "BootSvcReq",

--- a/sw/host/opentitanlib/src/ownership/rescue.rs
+++ b/sw/host/opentitanlib/src/ownership/rescue.rs
@@ -24,13 +24,16 @@ with_unknown! {
         Empty = BootSvcKind::EmptyRequest.0,
         MinBl0SecVerRequest = BootSvcKind::MinBl0SecVerRequest.0,
         NextBl0SlotRequest = BootSvcKind::NextBl0SlotRequest.0,
-        UnlockOwnershipRequest = BootSvcKind::OwnershipUnlockRequest.0,
-        ActivateOwnerRequest = BootSvcKind::OwnershipActivateRequest.0,
-        Rescue = u32::from_le_bytes(*b"RESQ"),
-        GetBootLog = u32::from_le_bytes(*b"BLOG"),
-        BootSvcReq = u32::from_le_bytes(*b"BREQ"),
-        BootSvcRsp = u32::from_le_bytes(*b"BRSP"),
-        OwnerBlock = u32::from_le_bytes(*b"OWNR"),
+        OwnershipUnlockRequest = BootSvcKind::OwnershipUnlockRequest.0,
+        OwnershipActivateRequest =   BootSvcKind::OwnershipActivateRequest.0,
+
+        // The rescue protocol-level commands are represented in big-endian order.
+        Rescue = u32::from_be_bytes(*b"RESQ"),
+        Reboot = u32::from_be_bytes(*b"REBO"),
+        GetBootLog = u32::from_be_bytes(*b"BLOG"),
+        BootSvcReq = u32::from_be_bytes(*b"BREQ"),
+        BootSvcRsp = u32::from_be_bytes(*b"BRSP"),
+        OwnerBlock = u32::from_be_bytes(*b"OWNR"),
     }
 }
 
@@ -107,8 +110,8 @@ impl OwnerRescueConfig {
                 CommandTag::Empty,
                 CommandTag::MinBl0SecVerRequest,
                 CommandTag::NextBl0SlotRequest,
-                CommandTag::UnlockOwnershipRequest,
-                CommandTag::ActivateOwnerRequest,
+                CommandTag::OwnershipUnlockRequest,
+                CommandTag::OwnershipActivateRequest,
                 CommandTag::Rescue,
                 CommandTag::GetBootLog,
                 CommandTag::BootSvcReq,
@@ -128,8 +131,8 @@ mod test {
     const OWNER_RESCUE_CONFIG_BIN: &str = "\
 00000000: 52 45 53 51 38 00 00 00 58 4d 44 4d 20 00 64 00  RESQ8...XMDM .d.\n\
 00000010: 45 4d 50 54 4d 53 45 43 4e 45 58 54 55 4e 4c 4b  EMPTMSECNEXTUNLK\n\
-00000020: 41 43 54 56 52 45 53 51 42 4c 4f 47 42 52 45 51  ACTVRESQBLOGBREQ\n\
-00000030: 42 52 53 50 4f 57 4e 52                          BRSPOWNR\n\
+00000020: 41 43 54 56 51 53 45 52 47 4f 4c 42 51 45 52 42  ACTVQSERGOLBQERB\n\
+00000030: 50 53 52 42 52 4e 57 4f                          PSRBRNWO\n\
 ";
     const OWNER_RESCUE_CONFIG_JSON: &str = r#"{
   header: {
@@ -143,8 +146,8 @@ mod test {
     "Empty",
     "MinBl0SecVerRequest",
     "NextBl0SlotRequest",
-    "UnlockOwnershipRequest",
-    "ActivateOwnerRequest",
+    "OwnershipUnlockRequest",
+    "OwnershipActivateRequest",
     "Rescue",
     "GetBootLog",
     "BootSvcReq",
@@ -164,8 +167,8 @@ mod test {
                 CommandTag::Empty,
                 CommandTag::MinBl0SecVerRequest,
                 CommandTag::NextBl0SlotRequest,
-                CommandTag::UnlockOwnershipRequest,
-                CommandTag::ActivateOwnerRequest,
+                CommandTag::OwnershipUnlockRequest,
+                CommandTag::OwnershipActivateRequest,
                 CommandTag::Rescue,
                 CommandTag::GetBootLog,
                 CommandTag::BootSvcReq,


### PR DESCRIPTION
This is a manual cherry-pick of  #24387.

1. Configure SRAM execution as specified in the owner configuration.
2. Configure rescue according to the owner configuration.
2a. Set bounds on the firmware rescue region in flash.
2b. Disallow rescue modes not allowed by the configuration.
2c. Disallow boot_svc commands not allowed by the configuration.
3. Correct an endian issue with the rescue-mode FourCC codes.  Rescue-modes are expressed in big-endian order, whereas all other FourCC codes are expressed in little-endian order (the reason is that rescue-modes should be thought of more as 4-byte strings than identifier words).