### PR TITLE
[rom_ext] Fix reporting of `primary_bl0_slot`

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_next_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_next_test.c
@@ -31,6 +31,8 @@ static status_t check_side_b(retention_sram_t *retram,
   TRY_CHECK(msg.header.type == kBootSvcNextBl0SlotResType);
   TRY_CHECK(msg.next_boot_bl0_slot_res.status == kErrorOk);
   TRY_CHECK(state->current_side == 'B');
+  TRY_CHECK(state->primary_side == 'A');
+  TRY_CHECK(msg.next_boot_bl0_slot_res.primary_bl0_slot == kBootSlotA);
   state->state = kBootSvcTestStateReturnSideA;
   rstmgr_reset();
   return INTERNAL();
@@ -39,6 +41,7 @@ static status_t check_side_b(retention_sram_t *retram,
 static status_t check_return_side_a(retention_sram_t *retram,
                                     boot_svc_retram_t *state) {
   TRY_CHECK(state->current_side == 'A');
+  TRY_CHECK(state->primary_side == 'A');
   state->state = kBootSvcTestStateFinal;
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_primary_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/boot_svc_primary_test.c
@@ -32,6 +32,7 @@ static status_t check_side_b(retention_sram_t *retram,
   TRY(boot_svc_header_check(&msg.header));
   TRY_CHECK(msg.header.type == kBootSvcNextBl0SlotResType);
   TRY_CHECK(msg.next_boot_bl0_slot_res.status == kErrorOk);
+  TRY_CHECK(msg.next_boot_bl0_slot_res.primary_bl0_slot == kBootSlotB);
   TRY_CHECK(state->current_side == 'B');
   TRY_CHECK(state->primary_side == 'B');
   if (state->boots == 4) {
@@ -48,8 +49,12 @@ static status_t check_side_b(retention_sram_t *retram,
 
 static status_t check_return_side_a(retention_sram_t *retram,
                                     boot_svc_retram_t *state) {
+  boot_svc_msg_t msg = retram->creator.boot_svc_msg;
+  TRY(boot_svc_header_check(&msg.header));
+  TRY_CHECK(msg.header.type == kBootSvcNextBl0SlotResType);
   TRY_CHECK(state->current_side == 'A');
   TRY_CHECK(state->primary_side == 'A');
+  TRY_CHECK(msg.next_boot_bl0_slot_res.primary_bl0_slot == kBootSlotA);
   state->state = kBootSvcTestStateFinal;
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -634,7 +634,8 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
 
 OT_WARN_UNUSED_RESULT
 static rom_error_t boot_svc_next_boot_bl0_slot_handler(
-    boot_svc_msg_t *boot_svc_msg, boot_data_t *boot_data) {
+    boot_svc_msg_t *boot_svc_msg, boot_data_t *boot_data,
+    boot_log_t *boot_log) {
   uint32_t active_slot = boot_data->primary_bl0_slot;
   uint32_t primary_slot = boot_svc_msg->next_boot_bl0_slot_req.primary_bl0_slot;
   rom_error_t error = kErrorOk;
@@ -651,6 +652,8 @@ static rom_error_t boot_svc_next_boot_bl0_slot_handler(
         // Read the boot data back to ensure the correct slot is booted this
         // time.
         HARDENED_RETURN_IF_ERROR(boot_data_read(lc_state, boot_data));
+        // Update the boot log.
+        boot_log->primary_bl0_slot = boot_data->primary_bl0_slot;
         break;
       case kBootSlotUnspecified:
         // Do nothing.
@@ -737,7 +740,8 @@ static rom_error_t boot_svc_min_sec_ver_handler(boot_svc_msg_t *boot_svc_msg,
 }
 
 OT_WARN_UNUSED_RESULT
-static rom_error_t handle_boot_svc(boot_data_t *boot_data) {
+static rom_error_t handle_boot_svc(boot_data_t *boot_data,
+                                   boot_log_t *boot_log) {
   boot_svc_msg_t *boot_svc_msg = &retention_sram_get()->creator.boot_svc_msg;
   // TODO(lowRISC#22387): Examine the boot_svc code paths for boot loops.
   if (boot_svc_msg->header.identifier == kBootSvcIdentifier) {
@@ -750,7 +754,8 @@ static rom_error_t handle_boot_svc(boot_data_t *boot_data) {
         break;
       case kBootSvcNextBl0SlotReqType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcNextBl0SlotReqType);
-        return boot_svc_next_boot_bl0_slot_handler(boot_svc_msg, boot_data);
+        return boot_svc_next_boot_bl0_slot_handler(boot_svc_msg, boot_data,
+                                                   boot_log);
       case kBootSvcMinBl0SecVerReqType:
         HARDENED_CHECK_EQ(msg_type, kBootSvcMinBl0SecVerReqType);
         return boot_svc_min_sec_ver_handler(boot_svc_msg, boot_data);
@@ -853,6 +858,10 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log->rom_ext_major = self->version_major;
   boot_log->rom_ext_minor = self->version_minor;
   boot_log->rom_ext_size = CHIP_ROM_EXT_SIZE_MAX;
+  // Even though `primary_bl0_slot` can be changed by boot svc, we initialize
+  // it here so the "SetNextBl0" can do a one-time override of the RAM copy
+  // of `boot_data`.
+  boot_log->primary_bl0_slot = boot_data->primary_bl0_slot;
 
   // On the ES chip, we need to check the reset reasons stored in retention RAM
   // and record whether or not the ROM initialized the retention RAM.
@@ -886,7 +895,7 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   // Handle any pending boot_svc commands.
   uint32_t skip_boot_svc = reset_reasons & (1 << kRstmgrReasonLowPowerExit);
   if (skip_boot_svc == 0) {
-    error = handle_boot_svc(boot_data);
+    error = handle_boot_svc(boot_data, boot_log);
     if (error == kErrorWriteBootdataThenReboot) {
       // Boot services reports errors by writing a status code into the reply
       // messages.  Regardless of whether a boot service request produced an
@@ -902,7 +911,6 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   boot_log->ownership_transfers = boot_data->ownership_transfers;
   boot_log->rom_ext_min_sec_ver = boot_data->min_security_version_rom_ext;
   boot_log->bl0_min_sec_ver = boot_data->min_security_version_bl0;
-  boot_log->primary_bl0_slot = boot_data->primary_bl0_slot;
   boot_log_digest_update(boot_log);
 
   if (uart_break_detect(kRescueDetectTime) == kHardenedBoolTrue) {


### PR DESCRIPTION
The `primary_bl0_slot` can be reported incorrectly when a `SetNextBl0` command is issued.

1. Initialize `boot_log->primary_bl0_slot` before boot services so that a temporary override doesn't get reported as the new primary.
2. Update the "set next bl0" test to verify that the primary_bl0_slot didn't change.