### PR TITLE
[manuf,otp] provision secure boot keys during individualization

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -615,3 +615,9 @@ pkg_files(
     srcs = [":otp_imgs"],
     prefix = "earlgrey/otp",
 )
+
+# Partition used to set a fixed seed value in `otp_image_consts` targets.
+otp_json(
+    name = "otp_json_baseline",
+    seed = "85452983286950371191603618368782861611109037138182535346147818831008789508651",
+)

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/prodc/BUILD
@@ -15,6 +15,7 @@ load(
 )
 load(
     "//rules:otp.bzl",
+    "OTP_SIGVERIFY_FAKE_KEYS",
     "otp_alert_classification",
     "otp_alert_digest",
     "otp_hex",
@@ -27,12 +28,6 @@ load(
 )
 
 package(default_visibility = ["//visibility:public"])
-
-# Partition used to set a fixed seed value in `otp_image_consts` targets.
-otp_json(
-    name = "otp_json_baseline",
-    seed = "85452983286950371191603618368782861611109037138182535346147818831008789508651",
-)
 
 otp_json(
     name = "otp_json_creator_sw_cfg",
@@ -209,20 +204,23 @@ otp_alert_digest(
     otp_img = ":otp_json_owner_sw_cfg",
 )
 
-# OTP *_SW_CFG constants used to generate an FT individualization binary.
+# OTP *_SW_CFG and ROT_CREATOR_AUTH_* constants used to generate an FT
+# individualization binary.
 otp_image_consts(
-    name = "otp_sw_cfg_c_file",
-    src = ":otp_json_baseline",
+    name = "otp_consts_c_file",
+    src = "//hw/ip/otp_ctrl/data:otp_json_baseline",
     overlays = [
         ":alert_digest_cfg",
         ":otp_json_creator_sw_cfg",
         ":otp_json_owner_sw_cfg",
-    ],
+    ] + OTP_SIGVERIFY_FAKE_KEYS,
 )
 
+# Library containing {CREATOR,OWNER}_SW_CFG and
+# ROT_CREATOR_AUTH_{CODESIGN,STATE} partition constants.
 cc_library(
-    name = "otp_sw_cfg",
-    srcs = [":otp_sw_cfg_c_file"],
+    name = "otp_consts",
+    srcs = [":otp_consts_c_file"],
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/silicon_creator/manuf/lib:otp_img_types",

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -16,6 +16,7 @@ load(
 )
 load(
     "//rules:otp.bzl",
+    "OTP_SIGVERIFY_FAKE_KEYS",
     "otp_alert_classification",
     "otp_alert_digest",
     "otp_hex",
@@ -29,12 +30,6 @@ load(
 )
 
 package(default_visibility = ["//visibility:public"])
-
-# Partition used to set a fixed seed value in `otp_image_consts` targets.
-otp_json(
-    name = "otp_json_baseline",
-    seed = "85452983286950371191603618368782861611109037138182535346147818831008789508651",
-)
 
 otp_json(
     name = "otp_json_creator_sw_cfg",
@@ -236,48 +231,59 @@ LC_MISSION_STATES = get_lc_items(
 
 # The `MANUF_INITIALIZED` OTP profile configures the SECRET0 partition to
 # enable the device to transition between test_unlock and test_locked states,
-# as well as to transition out of test_unlock into any of the
-# `LC_MISSION_STATES`.
+# as well as to transition out of test_unlock into any mission mode state.
+# This profile represents the OTP state of a device that has completed CP
+# provisioning.
 MANUF_INITIALIZED = [
     "//hw/ip/otp_ctrl/data:otp_json_fixed_secret0",
-    "//sw/device/silicon_creator/rom/keys/fake/otp:json_rot_keys",
 ]
 
+# The `MANUF_SW_INITIALIZED` OTP profile configures the following partitions:
+# - CREATOR_SW_CFG, and
+# - OWNER_SW_CFG.
+# This profile is used to construct the `MANUF_INDIVIDUALIZED` profile below.
 MANUF_SW_INITIALIZED = [
     ":alert_digest_cfg",
     ":otp_json_creator_sw_cfg",
     ":otp_json_owner_sw_cfg",
 ]
 
-# The `MANUF_INDIVIDUALIZED` OTP profile configures the HW_CFG0/1, CREATOR_SW and
-# OWNER_SW OTP partitions. It also includes the `MANUF_INITIALIZED`.
-MANUF_INDIVIDUALIZED = MANUF_INITIALIZED + MANUF_SW_INITIALIZED + [
+# The `MANUF_INDIVIDUALIZED` OTP profile configures the following partitions:
+# - CREATOR_SW_CFG,
+# - OWNER_SW_CFG,
+# - ROT_CREATOR_AUTH_CODESIGN,
+# - ROT_CREATOR_AUTH_STATE, and
+# - HW_CFG0/1.
+# It also includes the `MANUF_INITIALIZED` profile defined above. It represents
+# the OTP state of a device that has completed FT individualize provisioning.
+MANUF_INDIVIDUALIZED = MANUF_INITIALIZED + MANUF_SW_INITIALIZED + OTP_SIGVERIFY_FAKE_KEYS + [
     "//hw/ip/otp_ctrl/data:otp_json_hw_cfg0",
     "//hw/ip/otp_ctrl/data:otp_json_hw_cfg1",
 ]
 
 # The `MANUF_PERSONALIZED` OTP profile configures the SECRET1 and SECRET2 OTP
-# partitions. It also includes the `MANUF_INDIVIDUALIZED` profile.
+# partitions. It also includes the `MANUF_INDIVIDUALIZED` profile. It represents
+# the OTP state of a device that has completed all provisioning steps.
 MANUF_PERSONALIZED = MANUF_INDIVIDUALIZED + [
     "//hw/ip/otp_ctrl/data:otp_json_secret1",
     "//hw/ip/otp_ctrl/data:otp_json_fixed_secret2",
 ]
 
-# OTP *_SW_CFG constants used to generate an FT individualization binary.
-# The `MANUF_SW_INITIALIZED` OTP profile is also used to derive OTP profiles
-# representing the state of the device after running the FT individualization
-# binary that consumes this dependency.
+# OTP *_SW_CFG and ROT_CREATOR_AUTH_* constants used to generate an FT
+# individualization binary.
 otp_image_consts(
-    name = "otp_sw_cfg_c_file",
-    src = ":otp_json_baseline",
+    name = "otp_consts_c_file",
+    src = "//hw/ip/otp_ctrl/data:otp_json_baseline",
     # Do not add additional overlays here. Update the `MANUF_SW_INITIALIZED`
     # OTP profile instead.
-    overlays = MANUF_SW_INITIALIZED,
+    overlays = MANUF_SW_INITIALIZED + OTP_SIGVERIFY_FAKE_KEYS,
 )
 
+# Library containing {CREATOR,OWNER}_SW_CFG and
+# ROT_CREATOR_AUTH_{CODESIGN,STATE} partition constants.
 cc_library(
-    name = "otp_sw_cfg",
-    srcs = [":otp_sw_cfg_c_file"],
+    name = "otp_consts",
+    srcs = [":otp_consts_c_file"],
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/silicon_creator/manuf/lib:otp_img_types",
@@ -315,7 +321,7 @@ otp_image(
 ]
 
 # `MANUF_INDIVIDUALIZED` configuration. Available on TEST_UNLOCK states 1-7, as
-# well as dev, prod, prod_end and rma. This configuration has flash scrambling
+# well as DEV, PROD, PROD_END and RMA. This configuration has flash scrambling
 # disabled. See the personalized OTP configuration for targets requiring flash
 # scrambling enabled.
 # See sw/device/tests/doc/sival/devguide.md for more details.

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img.c.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img.c.tpl
@@ -105,8 +105,7 @@ ${fileheader}
 // OTP values
 % for partition_name in data:
 <%
-  if len(data[partition_name]["items"]) == 0:
-    continue
+  assert(len(data[partition_name]["items"]))
   alignment = data[partition_name]["alignment"]
 %>
 // Partition ${partition_name} values
@@ -119,8 +118,7 @@ ${ConstTypeDefinition(item, data[partition_name]["alignment"])}
 
 % for partition_name in data:
 <%
-  if len(data[partition_name]["items"]) == 0:
-    continue
+  assert(len(data[partition_name]["items"]))
   alignment = data[partition_name]["alignment"]
 %>
 // Partition ${partition_name}
@@ -129,7 +127,7 @@ const otp_kv_t ${"kOtpKv" + ToPascalCase(partition_name)}[] = {
   % for item in data[partition_name]["items"]:
   {
     .type = ${ToOtpValType(alignment)},
-    .offset = ${"OTP_CTRL_PARAM_" + item["name"] + "_OFFSET"},
+    .offset = ${"OTP_CTRL_PARAM_" + item["offset_name"]},
     .num_values = ${int(item["num_items"])},
     ${RefValue(item, alignment)},
   },

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -16,6 +16,7 @@ load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
     "CLOUD_KMS_CERT_ENDORSEMENT_PARAMS",
     "CP_PROVISIONING_INPUTS",
+    "EARLGREY_OTP_CFGS",
     "EARLGREY_SKUS",
     "FT_PERSONALIZE_ENDORSEMENT_KEYS",
     "FT_PROVISIONING_INPUTS",
@@ -170,7 +171,7 @@ opentitan_test(
 
 [
     opentitan_binary(
-        name = "sram_ft_individualize_{}".format(sku),
+        name = "sram_ft_individualize_{}".format(cfg),
         testonly = True,
         srcs = ["sram_ft_individualize.c"],
         exec_env = {
@@ -202,18 +203,18 @@ opentitan_test(
             "//sw/device/silicon_creator/manuf/lib:individualize",
             "//sw/device/silicon_creator/manuf/lib:otp_fields",
             "//sw/device/silicon_creator/manuf/lib:sram_start",
-            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_{}".format(sku),
+            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_{}".format(cfg),
         ],
     )
-    for sku in EARLGREY_SKUS
+    for cfg in EARLGREY_OTP_CFGS
 ]
 
 filegroup(
     name = "sram_ft_individualize_all",
     testonly = True,
     srcs = [
-        ":sram_ft_individualize_{}".format(sku)
-        for sku in EARLGREY_SKUS
+        ":sram_ft_individualize_{}".format(cfg)
+        for cfg in EARLGREY_OTP_CFGS
     ],
 )
 
@@ -221,61 +222,6 @@ cc_library(
     name = "personalize_ext",
     hdrs = ["personalize_ext.h"],
 )
-
-_DICE_EXTS = [
-    {
-        "suffix": "",
-        "ext_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
-    },
-    {
-        "suffix": "_dice_cwt",
-        "ext_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
-    },
-]
-
-[
-    cc_library(
-        name = "ft_personalize_{}_base{}".format(
-            sku,
-            dice["suffix"],
-        ),
-        srcs = ["ft_personalize.c"],
-        deps = [
-            ":perso_tlv_data",
-            ":personalize_ext",
-            "//sw/device/lib/crypto/drivers:entropy",
-            "//sw/device/lib/dif:flash_ctrl",
-            "//sw/device/lib/dif:lc_ctrl",
-            "//sw/device/lib/dif:otp_ctrl",
-            "//sw/device/lib/dif:rstmgr",
-            "//sw/device/lib/runtime:log",
-            "//sw/device/lib/testing:lc_ctrl_testutils",
-            "//sw/device/lib/testing:rstmgr_testutils",
-            "//sw/device/lib/testing/json:provisioning_data",
-            "//sw/device/lib/testing/test_framework:check",
-            "//sw/device/lib/testing/test_framework:ottf_main",
-            "//sw/device/lib/testing/test_framework:status",
-            "//sw/device/lib/testing/test_framework:ujson_ottf",
-            "//sw/device/silicon_creator/lib:attestation",
-            "//sw/device/silicon_creator/lib:otbn_boot_services",
-            "//sw/device/silicon_creator/lib/base:util",
-            "//sw/device/silicon_creator/lib/cert",
-            "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
-            "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
-            "//sw/device/silicon_creator/lib/cert:tpm_ek_template_library",
-            "//sw/device/silicon_creator/lib/cert:uds_template_library",
-            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-            "//sw/device/silicon_creator/lib/drivers:hmac",
-            "//sw/device/silicon_creator/lib/drivers:keymgr",
-            "//sw/device/silicon_creator/lib/drivers:kmac",
-            "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
-            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_{}".format(sku),
-            "//sw/device/silicon_creator/manuf/lib:personalize",
-        ] + dice["ext_libs"],
-    )
-    for sku in EARLGREY_SKUS
-    for dice in _DICE_EXTS
-]
 
 cc_library(
     name = "tpm_perso_fw_ext",
@@ -322,17 +268,6 @@ cc_library(
     ],
 )
 
-_FT_PERSO_EXTS = [
-    {
-        "suffix": "",
-        "ext_libs": ["@provisioning_exts//:perso_fw_ext"],
-    },
-    {
-        "suffix": "_tpm_ext",
-        "ext_libs": [":tpm_perso_fw_ext"],
-    },
-]
-
 manifest(d = {
     "name": "manifest_perso",
     "identifier": hex(CONST.ROM_EXT),
@@ -345,10 +280,7 @@ manifest(d = {
 
 [
     opentitan_binary(
-        name = "ft_personalize_{}{}".format(
-            sku,
-            ext["suffix"] + dice["suffix"],
-        ),
+        name = "ft_personalize_{}".format(sku),
         testonly = True,
         srcs = ["ft_personalize.c"],
         ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
@@ -360,27 +292,47 @@ manifest(d = {
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
         manifest = ":manifest_perso",
         spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
-        deps = [":ft_personalize_{}_base{}".format(
-            sku,
-            dice["suffix"],
-        )] + ext["ext_libs"],
+        deps = [
+            ":perso_tlv_data",
+            ":personalize_ext",
+            "//sw/device/lib/crypto/drivers:entropy",
+            "//sw/device/lib/dif:flash_ctrl",
+            "//sw/device/lib/dif:lc_ctrl",
+            "//sw/device/lib/dif:otp_ctrl",
+            "//sw/device/lib/dif:rstmgr",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:lc_ctrl_testutils",
+            "//sw/device/lib/testing:rstmgr_testutils",
+            "//sw/device/lib/testing/json:provisioning_data",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/lib/testing/test_framework:status",
+            "//sw/device/lib/testing/test_framework:ujson_ottf",
+            "//sw/device/silicon_creator/lib:attestation",
+            "//sw/device/silicon_creator/lib:otbn_boot_services",
+            "//sw/device/silicon_creator/lib/base:util",
+            "//sw/device/silicon_creator/lib/cert",
+            "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
+            "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
+            "//sw/device/silicon_creator/lib/cert:uds_template_library",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
+            "//sw/device/silicon_creator/lib/drivers:keymgr",
+            "//sw/device/silicon_creator/lib/drivers:kmac",
+            "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
+            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_{}".format(config["otp"]),
+            "//sw/device/silicon_creator/manuf/lib:personalize",
+        ] + config["dice_libs"] + config["ext_libs"],
     )
-    for sku in EARLGREY_SKUS
-    for ext in _FT_PERSO_EXTS
-    for dice in _DICE_EXTS
+    for sku, config in EARLGREY_SKUS.items()
 ]
 
 filegroup(
     name = "ft_personalize_all",
     testonly = True,
     srcs = [
-        ":ft_personalize_{}{}".format(
-            sku,
-            ext["suffix"] + dice["suffix"],
-        )
-        for sku in EARLGREY_SKUS
-        for ext in _FT_PERSO_EXTS
-        for dice in _DICE_EXTS
+        ":ft_personalize_{}".format(sku)
+        for sku in EARLGREY_SKUS.keys()
     ],
 )
 
@@ -406,10 +358,7 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
 
 [
     opentitan_test(
-        name = "ft_provision_{}{}".format(
-            sku,
-            ext["suffix"] + dice["suffix"],
-        ),
+        name = "ft_provision_{}".format(sku),
         exec_env = {
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
@@ -419,11 +368,8 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
             timeout = "long",
             binaries =
                 {
-                    ":sram_ft_individualize_{}".format(sku): "sram_ft_individualize",
-                    ":ft_personalize_{}{}".format(
-                        sku,
-                        ext["suffix"] + dice["suffix"],
-                    ): "ft_personalize",
+                    ":sram_ft_individualize_{}".format(config["otp"]): "sram_ft_individualize",
+                    ":ft_personalize_{}".format(sku): "ft_personalize",
                 },
             changes_otp = True,
             data = FT_PERSONALIZE_ENDORSEMENT_KEYS,
@@ -439,11 +385,8 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
         silicon = silicon_params(
             binaries =
                 {
-                    ":sram_ft_individualize_{}".format(sku): "sram_ft_individualize",
-                    ":ft_personalize_{}{}".format(
-                        sku,
-                        ext["suffix"] + dice["suffix"],
-                    ): "ft_personalize",
+                    ":sram_ft_individualize_{}".format(config["otp"]): "sram_ft_individualize",
+                    ":ft_personalize_{}".format(sku): "ft_personalize",
                 },
             changes_otp = True,
             data = FT_PERSONALIZE_ENDORSEMENT_KEYS,
@@ -453,7 +396,23 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
             test_harness = _FT_PROVISIONING_HARNESS,
         ),
     )
-    for sku in EARLGREY_SKUS
-    for ext in _FT_PERSO_EXTS
-    for dice in _DICE_EXTS
+    for sku, config in EARLGREY_SKUS.items()
 ]
+
+test_suite(
+    name = "ft_provision_cw310",
+    tags = ["manual"],
+    tests = [
+        ":ft_provision_{}_fpga_hyper310_rom_with_fake_keys".format(sku)
+        for sku in EARLGREY_SKUS.keys()
+    ],
+)
+
+test_suite(
+    name = "ft_provision_cw340",
+    tags = ["manual"],
+    tests = [
+        ":ft_provision_{}_fpga_cw340_rom_with_fake_keys".format(sku)
+        for sku in EARLGREY_SKUS.keys()
+    ],
+)

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -16,8 +16,8 @@ load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
     "CLOUD_KMS_CERT_ENDORSEMENT_PARAMS",
     "CP_PROVISIONING_INPUTS",
-    "EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS",
-    "FT_PERSONALIZE_KEYS",
+    "EARLGREY_SKUS",
+    "FT_PERSONALIZE_ENDORSEMENT_KEYS",
     "FT_PROVISIONING_INPUTS",
     "LOCAL_CERT_ENDORSEMENT_PARAMS",
 )
@@ -170,7 +170,7 @@ opentitan_test(
 
 [
     opentitan_binary(
-        name = "sram_ft_individualize_{}".format(otp_sw_cfgs),
+        name = "sram_ft_individualize_{}".format(sku),
         testonly = True,
         srcs = ["sram_ft_individualize.c"],
         exec_env = {
@@ -202,18 +202,18 @@ opentitan_test(
             "//sw/device/silicon_creator/manuf/lib:individualize",
             "//sw/device/silicon_creator/manuf/lib:otp_fields",
             "//sw/device/silicon_creator/manuf/lib:sram_start",
-            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_sku_{}".format(otp_sw_cfgs),
+            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_{}".format(sku),
         ],
     )
-    for otp_sw_cfgs in EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS
+    for sku in EARLGREY_SKUS
 ]
 
 filegroup(
     name = "sram_ft_individualize_all",
     testonly = True,
     srcs = [
-        ":sram_ft_individualize_prodc",
-        ":sram_ft_individualize_sival",
+        ":sram_ft_individualize_{}".format(sku)
+        for sku in EARLGREY_SKUS
     ],
 )
 
@@ -235,7 +235,10 @@ _DICE_EXTS = [
 
 [
     cc_library(
-        name = "ft_personalize_base{}".format(dice["suffix"]),
+        name = "ft_personalize_{}_base{}".format(
+            sku,
+            dice["suffix"],
+        ),
         srcs = ["ft_personalize.c"],
         deps = [
             ":perso_tlv_data",
@@ -266,10 +269,11 @@ _DICE_EXTS = [
             "//sw/device/silicon_creator/lib/drivers:keymgr",
             "//sw/device/silicon_creator/lib/drivers:kmac",
             "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
-            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_sku_sival",
+            "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_{}".format(sku),
             "//sw/device/silicon_creator/manuf/lib:personalize",
         ] + dice["ext_libs"],
     )
+    for sku in EARLGREY_SKUS
     for dice in _DICE_EXTS
 ]
 
@@ -341,7 +345,10 @@ manifest(d = {
 
 [
     opentitan_binary(
-        name = "ft_personalize{}".format(ext["suffix"] + dice["suffix"]),
+        name = "ft_personalize_{}{}".format(
+            sku,
+            ext["suffix"] + dice["suffix"],
+        ),
         testonly = True,
         srcs = ["ft_personalize.c"],
         ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
@@ -353,11 +360,29 @@ manifest(d = {
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
         manifest = ":manifest_perso",
         spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
-        deps = [":ft_personalize_base{}".format(dice["suffix"])] + ext["ext_libs"],
+        deps = [":ft_personalize_{}_base{}".format(
+            sku,
+            dice["suffix"],
+        )] + ext["ext_libs"],
     )
+    for sku in EARLGREY_SKUS
     for ext in _FT_PERSO_EXTS
     for dice in _DICE_EXTS
 ]
+
+filegroup(
+    name = "ft_personalize_all",
+    testonly = True,
+    srcs = [
+        ":ft_personalize_{}{}".format(
+            sku,
+            ext["suffix"] + dice["suffix"],
+        )
+        for sku in EARLGREY_SKUS
+        for ext in _FT_PERSO_EXTS
+        for dice in _DICE_EXTS
+    ],
+)
 
 config_setting(
     name = "ckms_cert_endorsement_params",
@@ -381,7 +406,10 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
 
 [
     opentitan_test(
-        name = "ft_provision{}".format(ext["suffix"] + dice["suffix"]),
+        name = "ft_provision_{}{}".format(
+            sku,
+            ext["suffix"] + dice["suffix"],
+        ),
         exec_env = {
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
@@ -389,12 +417,16 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
         },
         fpga = fpga_params(
             timeout = "long",
-            binaries = {
-                ":sram_ft_individualize_sival": "sram_ft_individualize",
-                ":ft_personalize{}".format(ext["suffix"] + dice["suffix"]): "ft_personalize",
-            },
+            binaries =
+                {
+                    ":sram_ft_individualize_{}".format(sku): "sram_ft_individualize",
+                    ":ft_personalize_{}{}".format(
+                        sku,
+                        ext["suffix"] + dice["suffix"],
+                    ): "ft_personalize",
+                },
             changes_otp = True,
-            data = FT_PERSONALIZE_KEYS,
+            data = FT_PERSONALIZE_ENDORSEMENT_KEYS,
             needs_jtag = True,
             otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_test_locked0_manuf_initialized",
             tags = [
@@ -405,18 +437,23 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft"
             test_harness = _FT_PROVISIONING_HARNESS,
         ),
         silicon = silicon_params(
-            binaries = {
-                ":sram_ft_individualize_sival": "sram_ft_individualize",
-                ":ft_personalize{}".format(ext["suffix"] + dice["suffix"]): "ft_personalize",
-            },
+            binaries =
+                {
+                    ":sram_ft_individualize_{}".format(sku): "sram_ft_individualize",
+                    ":ft_personalize_{}{}".format(
+                        sku,
+                        ext["suffix"] + dice["suffix"],
+                    ): "ft_personalize",
+                },
             changes_otp = True,
-            data = FT_PERSONALIZE_KEYS,
+            data = FT_PERSONALIZE_ENDORSEMENT_KEYS,
             interface = "teacup",
             needs_jtag = True,
             test_cmd = _FT_PROVISIONING_CMD_ARGS,
             test_harness = _FT_PROVISIONING_HARNESS,
         ),
     )
+    for sku in EARLGREY_SKUS
     for ext in _FT_PERSO_EXTS
     for dice in _DICE_EXTS
 ]

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -2,10 +2,41 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-EARLGREY_SKUS = [
+EARLGREY_OTP_CFGS = [
     "sival",
     "prodc",
 ]
+
+EARLGREY_SKUS = {
+    # OTP Config: SIVAL; DICE Certs: X.509; Additional Certs: None
+    "sival": {
+        "otp": "sival",
+        "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
+        "ext_libs": ["@provisioning_exts//:perso_fw_ext"],
+    },
+    # OTP Config: SIVAL; DICE Certs: CWT; Additional Certs: None
+    # TODO(#24281): uncomment when DICE CWT cert flows are fully supported
+    # "sival_dice_cwt": {
+    #     "otp": "sival",
+    #     "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
+    #     "ext_libs": ["@provisioning_exts//:perso_fw_ext"],
+    # },
+    # OTP Config: SIVAL; DICE Certs: X.509; Additional Certs: TPM EK
+    "sival_tpm": {
+        "otp": "sival",
+        "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
+        "ext_libs": [
+            "//sw/device/silicon_creator/lib/cert:tpm_ek_template_library",
+            "//sw/device/silicon_creator/manuf/base:tpm_perso_fw_ext",
+        ],
+    },
+    # OTP Config: PRODC; DICE Certs: X.509; Additional Certs: None
+    "prodc": {
+        "otp": "prodc",
+        "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
+        "ext_libs": ["@provisioning_exts//:perso_fw_ext"],
+    },
+}
 
 _DEVICE_ID_AND_TEST_TOKENS = """
   --device-id="0x11111111_22222222_33333333_44444444_55555555_66666666_77777777_88888888"

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS = [
+EARLGREY_SKUS = [
     "sival",
     "prodc",
 ]
@@ -18,7 +18,7 @@ CP_PROVISIONING_INPUTS = _DEVICE_ID_AND_TEST_TOKENS + """
   --wafer-auth-secret="0x00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000"
 """
 
-FT_PERSONALIZE_KEYS = [
+FT_PERSONALIZE_ENDORSEMENT_KEYS = [
     "//sw/device/silicon_creator/manuf/keys/fake:cert_endorsement_key.sk.der",
     "//sw/device/silicon_creator/manuf/keys/fake:fake_ca.pem",
     "//sw/device/silicon_creator/manuf/keys/fake:ckms_ca.pem",

--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -81,13 +81,11 @@ static status_t print_flash_info_0_data_to_console(void) {
 }
 
 /**
- * Provision OTP {CreatorSw,OwnerSw,Hw}Cfg partitions.
+ * Provision OTP {CreatorSw,OwnerSw,Hw}Cfg and RotCreatorAuth{Codesign,State}
+ * partitions.
  *
- * Note: CreatorSwCfg partition is not locked yet, as the flash scrambling OTP
- * field is not provisioned until after the Secret1 partition is provisioned
- * during personalization. OwnerSwCfg partition is also not locked yet, as the
- * bootstrap disablement OTP field is not provisioned until the last bootstrap
- * operation is done in the personalization flow.
+ * Note: CreatorSwCfg and OwnerSwCfg partitions are not locked yet, as not
+ * all fields can be programmed until the personalization stage.
  */
 static status_t provision(ujson_t *uj) {
   LOG_INFO("Waiting for FT SRAM provisioning data ...");
@@ -97,6 +95,8 @@ static status_t provision(ujson_t *uj) {
                                         in_data.device_id));
   TRY(manuf_individualize_device_creator_sw_cfg(&otp_ctrl, &flash_ctrl_state));
   TRY(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
+  TRY(manuf_individualize_device_rot_creator_auth_codesign(&otp_ctrl));
+  TRY(manuf_individualize_device_rot_creator_auth_state(&otp_ctrl));
   LOG_INFO("FT SRAM provisioning done.");
   return OK_STATUS();
 }

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -11,7 +11,7 @@ load(
 )
 load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
-    "EARLGREY_SKUS",
+    "EARLGREY_OTP_CFGS",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -188,16 +188,16 @@ cc_library(
 )
 
 # As more SKUs are created with different OTP configurations, libraries can be
-# added by updating EARLGREY_SKUS accordingly.
+# added by updating EARLGREY_OTP_CFGS accordingly.
 [
     cc_library(
-        name = "individualize_sw_cfg_{}".format(sku),
+        name = "individualize_sw_cfg_{}".format(cfg),
         deps = [
             ":individualize_sw_cfg",
-            "//hw/ip/otp_ctrl/data/earlgrey_skus/{}:otp_consts".format(sku),
+            "//hw/ip/otp_ctrl/data/earlgrey_skus/{}:otp_consts".format(cfg),
         ],
     )
-    for sku in EARLGREY_SKUS
+    for cfg in EARLGREY_OTP_CFGS
 ]
 
 opentitan_test(

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -11,7 +11,7 @@ load(
 )
 load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
-    "EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS",
+    "EARLGREY_SKUS",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -187,17 +187,17 @@ cc_library(
     ],
 )
 
-# As more SKUs are created with different OTP software configuration partitions,
-# libraries can be added to INDIVIDUALIZE_OTP_SW_CFGS accordingly.
+# As more SKUs are created with different OTP configurations, libraries can be
+# added by updating EARLGREY_SKUS accordingly.
 [
     cc_library(
-        name = "individualize_sw_cfg_earlgrey_sku_{}".format(otp_sw_cfg),
+        name = "individualize_sw_cfg_{}".format(sku),
         deps = [
             ":individualize_sw_cfg",
-            "//hw/ip/otp_ctrl/data/earlgrey_skus/{}:otp_sw_cfg".format(otp_sw_cfg),
+            "//hw/ip/otp_ctrl/data/earlgrey_skus/{}:otp_consts".format(sku),
         ],
     )
-    for otp_sw_cfg in EARLGREY_INDIVIDUALIZE_OTP_SW_CFGS
+    for sku in EARLGREY_SKUS
 ]
 
 opentitan_test(
@@ -218,7 +218,8 @@ opentitan_test(
     ),
     deps = [
         ":flash_info_fields",
-        ":individualize_sw_cfg_earlgrey_sku_sival",
+        # Testing sival SKU only should be sufficient.
+        ":individualize_sw_cfg_sival",
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -366,3 +366,36 @@ status_t manuf_individualize_device_owner_sw_cfg_check(
                                       &is_locked));
   return is_locked ? OK_STATUS() : INTERNAL();
 }
+
+status_t manuf_individualize_device_rot_creator_auth_codesign(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign,
+                    kOtpKvRotCreatorAuthCodesign,
+                    kOtpKvRotCreatorAuthCodesignSize));
+  TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign));
+  return OK_STATUS();
+}
+
+status_t manuf_individualize_device_rot_creator_auth_state(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState,
+                    kOtpKvRotCreatorAuthState, kOtpKvRotCreatorAuthStateSize));
+  TRY(lock_otp_partition(otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState));
+  return OK_STATUS();
+}
+
+status_t manuf_individualize_device_rot_creator_auth_codesign_check(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  bool is_locked;
+  TRY(dif_otp_ctrl_is_digest_computed(
+      otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign, &is_locked));
+  return is_locked ? OK_STATUS() : INTERNAL();
+}
+
+status_t manuf_individualize_device_rot_creator_auth_state_check(
+    const dif_otp_ctrl_t *otp_ctrl) {
+  bool is_locked;
+  TRY(dif_otp_ctrl_is_digest_computed(
+      otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState, &is_locked));
+  return is_locked ? OK_STATUS() : INTERNAL();
+}

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
@@ -27,6 +27,18 @@ extern const otp_kv_t kOtpKvOwnerSwCfg[];
 extern const uint32_t kOwnerSwCfgRomBootstrapDisValue;
 
 /**
+ * OTP RoT Creator Auth Codesign Partition.
+ */
+extern const size_t kOtpKvRotCreatorAuthCodesignSize;
+extern const otp_kv_t kOtpKvRotCreatorAuthCodesign[];
+
+/**
+ * OTP RoT Creator Auth State Partition.
+ */
+extern const size_t kOtpKvRotCreatorAuthStateSize;
+extern const otp_kv_t kOtpKvRotCreatorAuthState[];
+
+/**
  * Configures the CREATOR_SW_CFG OTP partition.
  *
  * The CREATOR_SW_CFG partition contains various settings for the ROM, e.g.,:
@@ -152,7 +164,7 @@ status_t manuf_individualize_device_creator_sw_cfg_check(
  *   partition is locked, and the final transport image is loaded.
  *
  * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS if the HW_CFG0 partition is locked.
+ * @return OK_STATUS if the OWNER_SW_CFG partition is locked.
  */
 OT_WARN_UNUSED_RESULT
 status_t manuf_individualize_device_owner_sw_cfg(
@@ -206,5 +218,49 @@ status_t manuf_individualize_device_owner_sw_cfg_check(
  */
 status_t manuf_individualize_device_partition_expected_read(
     dif_otp_ctrl_partition_t partition, uint8_t *buffer);
+
+/**
+ * Configures and locks the ROT_CREATOR_AUTH_CODESIGN OTP partition.
+ *
+ * The ROT_CREATOR_AUTH_CODESIGN partition contains the first stage
+ * (ROM->ROM_EXT) secure boot public keys.
+ *
+ * @param otp_ctrl OTP controller instance.
+ * @return OK_STATUS if the ROT_CREATOR_AUTH_CODESIGN partition has been locked.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_individualize_device_rot_creator_auth_codesign(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Checks the ROT_CREATOR_AUTH_CODESIGN OTP partition end state.
+ *
+ * @param otp_ctrl OTP controller interface.
+ * @return OK_STATUS if the ROT_CREATOR_AUTH_CODESIGN partition is locked.
+ */
+status_t manuf_individualize_device_rot_creator_auth_codesign_check(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Configures and locks the ROT_CREATOR_AUTH_STATE OTP partition.
+ *
+ * The ROT_CREATOR_AUTH_STATE partition contains the first stage
+ * (ROM->ROM_EXT) secure boot public key validity states.
+ *
+ * @param otp_ctrl OTP controller instance.
+ * @return OK_STATUS if the ROT_CREATOR_AUTH_STATE partition has been locked.
+ */
+OT_WARN_UNUSED_RESULT
+status_t manuf_individualize_device_rot_creator_auth_state(
+    const dif_otp_ctrl_t *otp_ctrl);
+
+/**
+ * Checks the ROT_CREATOR_AUTH_STATE OTP partition end state.
+ *
+ * @param otp_ctrl OTP controller interface.
+ * @return OK_STATUS if the ROT_CREATOR_AUTH_STATE partition is locked.
+ */
+status_t manuf_individualize_device_rot_creator_auth_state_check(
+    const dif_otp_ctrl_t *otp_ctrl);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_LIB_INDIVIDUALIZE_SW_CFG_H_

--- a/sw/device/silicon_creator/manuf/lib/util.c
+++ b/sw/device/silicon_creator/manuf/lib/util.c
@@ -77,7 +77,6 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
           vendor_test_32bit_array[(OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
                                    OTP_CTRL_PARAM_VENDOR_TEST_DIGEST_SIZE) /
                                   sizeof(uint32_t)];
-
       TRY(otp_ctrl_testutils_dai_read32_array(
           otp_ctrl, kDifOtpCtrlPartitionVendorTest, 0, vendor_test_32bit_array,
           (OTP_CTRL_PARAM_VENDOR_TEST_SIZE -
@@ -107,6 +106,42 @@ status_t manuf_util_hash_otp_partition(const dif_otp_ctrl_t *otp_ctrl,
                                     OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET),
           .len = OTP_CTRL_PARAM_OWNER_SW_CFG_SIZE -
                  OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_SIZE,
+      };
+      TRY(otcrypto_hash(input, digest));
+    } break;
+    case kDifOtpCtrlPartitionRotCreatorAuthCodesign: {
+      uint32_t rot_creator_auth_codesign_32bit_array
+          [(OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
+            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE) /
+           sizeof(uint32_t)];
+      TRY(otp_ctrl_testutils_dai_read32_array(
+          otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthCodesign, 0,
+          rot_creator_auth_codesign_32bit_array,
+          (OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
+           OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE) /
+              sizeof(uint32_t)));
+      otcrypto_const_byte_buf_t input = {
+          .data = (unsigned char *)rot_creator_auth_codesign_32bit_array,
+          .len = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_SIZE -
+                 OTP_CTRL_PARAM_ROT_CREATOR_AUTH_CODESIGN_DIGEST_SIZE,
+      };
+      TRY(otcrypto_hash(input, digest));
+    } break;
+    case kDifOtpCtrlPartitionRotCreatorAuthState: {
+      uint32_t rot_creator_auth_state_32bit_array
+          [(OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
+            OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE) /
+           sizeof(uint32_t)];
+      TRY(otp_ctrl_testutils_dai_read32_array(
+          otp_ctrl, kDifOtpCtrlPartitionRotCreatorAuthState, 0,
+          rot_creator_auth_state_32bit_array,
+          (OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
+           OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE) /
+              sizeof(uint32_t)));
+      otcrypto_const_byte_buf_t input = {
+          .data = (unsigned char *)rot_creator_auth_state_32bit_array,
+          .len = OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_SIZE -
+                 OTP_CTRL_PARAM_ROT_CREATOR_AUTH_STATE_DIGEST_SIZE,
       };
       TRY(otcrypto_hash(input, digest));
     } break;

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -293,7 +293,7 @@ opentitan_binary(
         "//sw/device/lib/testing/test_framework:ottf_test_config",
         "//sw/device/lib/testing/test_framework:status",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
-        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_earlgrey_sku_sival",
+        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_sival",
         "//sw/device/silicon_creator/manuf/lib:sram_start",
     ],
 )

--- a/sw/host/provisioning/ft/BUILD
+++ b/sw/host/provisioning/ft/BUILD
@@ -5,7 +5,7 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load(
     "//sw/device/silicon_creator/manuf/base:provisioning_inputs.bzl",
-    "FT_PERSONALIZE_KEYS",
+    "FT_PERSONALIZE_ENDORSEMENT_KEYS",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -17,12 +17,12 @@ rust_binary(
     testonly = True,
     srcs = ["src/main.rs"],
     data = [
-        "//sw/device/silicon_creator/manuf/base:ft_personalize",
+        "//sw/device/silicon_creator/manuf/base:ft_personalize_all",
         "//sw/device/silicon_creator/manuf/base:sram_ft_individualize_all",
         "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
         "//third_party/openocd:jtag_olimex_cfg",
         "//third_party/openocd:openocd_bin",
-    ] + FT_PERSONALIZE_KEYS,
+    ] + FT_PERSONALIZE_ENDORSEMENT_KEYS,
     deps = [
         "//sw/host/opentitanlib",
         "//sw/host/provisioning/ft_lib",

--- a/sw/host/tests/manuf/individualize_sw_cfg_functest/src/main.rs
+++ b/sw/host/tests/manuf/individualize_sw_cfg_functest/src/main.rs
@@ -37,9 +37,20 @@ fn individualize_sw_cfg(opts: &Opts, transport: &TransportWrapper) -> Result<()>
     uart.clear_rx_buffer()?;
     opts.init.bootstrap.init(transport)?;
 
+    // Wait for each partition to be provisioned.
     let _ = UartConsole::wait_for(
         &*uart,
         r"Provisioned and locked OWNER_SW_CFG OTP partition.",
+        opts.timeout,
+    )?;
+    let _ = UartConsole::wait_for(
+        &*uart,
+        r"Provisioned and locked ROT_CREATOR_AUTH_CODESIGN OTP partition.",
+        opts.timeout,
+    )?;
+    let _ = UartConsole::wait_for(
+        &*uart,
+        r"Provisioned and locked ROT_CREATOR_AUTH_STATE OTP partition.",
         opts.timeout,
     )?;
 


### PR DESCRIPTION
This updates the FT individualization provisioning stage to provision the first stage secure boot keys into the ROT_CREATOR_AUTH* partitions.

Doing so required updating the OTP C file constants generation to allow generating a C file that contains the secure boot key constants that are to be provisioned into OTP during individualization.

Additionally, this fixes a bug in the generation of the perso firmware that was always using the sival SKU OTP SW_CFG constants for the fields that cannot be provisioned during individualization. Now, a separate personalization binary is generated for each SKU.

Lastly, this simplifies how FT binary generation is done. Specifically, FT individualization and personalization binaries are generated based on a SKU. A SKU can be defined as a combination of the following:
- OTP constants
- DICE certificate format used
- personalization extension
This wraps these configuration settings in a dict that consolidates all SKU configuration data in one place, and generates one perso binary per SKU. Before, perso binaries that may not have been used by a SKU were being generated.

This fixes #21554.