### PR TITLE
Cherry-pick to earlgrey_1.0.0: [rom_ext_e2e] Update CI to run ROM_EXT tests on hyper310

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -788,6 +788,33 @@ jobs:
     displayName: Execute tests
   - template: ci/publish-bazel-test-results.yml
 
+- job: execute_fpga_rom_ext_tests_cw310
+  displayName: CW310 ROM_EXT Tests
+  pool:
+    name: $(fpga_pool)
+    demands: BOARD -equals cw310
+  timeoutInMinutes: 60
+  dependsOn:
+    - chip_earlgrey_cw310_hyperdebug
+    - sw_build
+  condition: succeeded( 'chip_earlgrey_cw310_hyperdebug', 'sw_build' )
+  steps:
+  - template: ci/checkout-template.yml
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw310_hyperdebug
+        - sw_build
+  - template: ci/load-bazel-cache-write-creds.yml
+  - bash: |
+      set -e
+      . util/build_consts.sh
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+      ci/scripts/run-fpga-tests.sh hyper310 fpga_hyper310_rom_ext_tests || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
+    displayName: Execute tests
+  - template: ci/publish-bazel-test-results.yml
+
 - job: deploy_release_artifacts
   displayName: Package & deploy release
   pool:

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -121,6 +121,10 @@ then
     > "${pattern_file}"
     # We need to remove tests tagged as manual since we are not using a wildcard target.
     test_args="${test_args} --test_tag_filters=cw310_rom_with_fake_keys,cw310_rom_with_real_keys,-manuf,-broken,-skip_in_ci,-manual"
+elif [ "${fpga_tags}" == "fpga_hyper310_rom_ext_tests" ]
+then
+    test_args="${test_args} --test_tag_filters=hyper310_rom_ext,-broken,-skip_in_ci"
+    echo "//sw/device/silicon_creator/rom_ext/e2e/..." > "${pattern_file}"
 else
     test_args="${test_args} --test_tag_filters=${fpga_tags},-broken,-skip_in_ci"
     echo "//..." > "${pattern_file}"

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -31,7 +31,7 @@ opentitan_test(
     name = "boot_svc_empty_test",
     srcs = ["boot_svc_empty_test.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@0 {firmware}@0x10000 {firmware}@0x90000",
@@ -56,7 +56,7 @@ opentitan_test(
     name = "boot_svc_wakeup_test",
     srcs = ["boot_svc_wakeup_test.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@0 {firmware}@0x10000",
@@ -84,7 +84,7 @@ opentitan_test(
     name = "boot_svc_next_test",
     srcs = ["boot_svc_next_test.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@0 {firmware}@0x10000 {firmware}@0x90000",
@@ -110,7 +110,7 @@ opentitan_test(
     name = "boot_svc_primary_test",
     srcs = ["boot_svc_primary_test.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@0 {firmware}@0x10000 {firmware}@0x90000",
@@ -144,7 +144,7 @@ opentitan_test(
     name = "boot_svc_bad_next_test",
     srcs = ["boot_svc_bad_next_test.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@0 {firmware}@0x10000 {firmware}@0x90000",
@@ -172,26 +172,27 @@ opentitan_test(
         "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
     ],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         data = [
             "//sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key",
         ],
         exit_failure = "(PASS|FAIL|FAULT).*\n",
-        # This test requires serial break support which is not available in CI yet.
-        tags = ["broken"],
         test_cmd = """
             --exec="transport init"
             --exec="fpga clear-bitstream"
             --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='ownership_state: \\x00\\x00\\x00\\x00\r\n' --exit-failure='{exit_failure}'"
+            --exec="console --non-interactive --exit-success='ownership_state = OWND\r\n' --exit-failure='{exit_failure}'"
             --exec="rescue boot-svc ownership-unlock \
                     --mode Any \
                     --nonce 0 \
                     --sign $(location //sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key)"
             --exec="console --non-interactive --exit-success='ownership_state = UANY\r\n' --exit-failure='{exit_failure}'"
+
+            # Since we've altered the ownership state, clear the bitstream to not affect later tests.
+            --exec="fpga clear-bitstream"
             no-op
         """,
     ),
@@ -215,7 +216,7 @@ opentitan_binary(
     testonly = True,
     srcs = ["boot_svc_min_sec_ver_test.c"],
     exec_env = [
-        "//hw/top_earlgrey:fpga_cw310_rom_ext",
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     manifest = ":manifest_version_4",
@@ -237,7 +238,7 @@ opentitan_test(
     name = "boot_svc_min_sec_ver_test",
     srcs = ["boot_svc_min_sec_ver_test.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@0 {firmware}@0x10000 {min_sec_ver_4:signed_bin}@0x90000",

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -59,7 +59,7 @@ _FAULT_TEST_CASES = {
         ],
         defines = test_data["defines"],
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         },
         fpga = fpga_params(
             exit_success = test_data["exit_success"],

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
@@ -14,7 +14,7 @@ opentitan_test(
     name = "otp_creator_lockdown",
     srcs = ["otp_creator_lockdown.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         exit_failure = "PASS|FAIL|BFV:.*\r\n",
@@ -36,7 +36,7 @@ opentitan_test(
     name = "otp_dai_lockdown",
     srcs = ["otp_dai_lockdown.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         exit_failure = "PASS|FAIL|BFV:.*\r\n",
@@ -60,7 +60,7 @@ opentitan_test(
     name = "sram_lockdown",
     srcs = ["sram_lockdown.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     deps = [
         "//hw/ip/sram_ctrl/data:sram_ctrl_c_regs",
@@ -74,7 +74,7 @@ opentitan_test(
     name = "epmp_rlb_lockdown",
     srcs = ["epmp_rlb_lockdown.c"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/lockdown/BUILD
@@ -23,6 +23,7 @@ opentitan_test(
         # corresponds to the OTP controller at
         # OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + OTP_CTRL_PARAM_CREATOR_SW_CFG_OFFSET.
         exit_success = "FAULT: Load Access Fault.*MTVAL=40131040\r\n",
+        tags = ["broken"],
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -47,6 +48,7 @@ opentitan_test(
         # The address below # corresponds to the OTP controller at
         # OTP_CTRL_CHECK_REGWEN_REG_OFFSET.
         exit_success = "FAULT: Load Access Fault.*MTVAL=4013003c\r\n",
+        tags = ["broken"],
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -76,6 +78,9 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
+    fpga = fpga_params(
+        tags = ["broken"],
+    ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -35,7 +35,7 @@ _POSITIONS = {
             "//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test",
         ],
         exec_env = [
-            "//hw/top_earlgrey:fpga_cw310_rom_ext",
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext",
         ],
         linker_script = position["linker_script"],
         deps = [
@@ -52,7 +52,7 @@ _POSITIONS = {
     opentitan_test(
         name = "rescue_firmware_{}".format(name),
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         },
         fpga = fpga_params(
             assemble = "",
@@ -80,7 +80,7 @@ _POSITIONS = {
 opentitan_test(
     name = "next_slot",
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@0 {slot_a:signed_bin}@0x10000 {slot_b:signed_bin}@0x90000",
@@ -108,7 +108,7 @@ opentitan_test(
 opentitan_test(
     name = "primary_slot",
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         assemble = "{rom_ext}@0 {slot_a:signed_bin}@0x10000 {slot_b:signed_bin}@0x90000",

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -84,7 +84,7 @@ _POSITIONS = {
         name = "position_{}".format(name),
         srcs = [":boot_test"],
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         },
         fpga = fpga_params(
             assemble = "{romext}@{romext_offset} {firmware}@{owner_offset}",
@@ -124,7 +124,7 @@ opentitan_test(
     name = "bad_manifest_test",
     srcs = [":boot_test"],
     exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
     },
     fpga = fpga_params(
         exit_failure = "PASS|FAIL|FAULT|BFV:.{8}",
@@ -169,7 +169,7 @@ _KEYS = {
         name = "key_{}".format(name),
         srcs = [":boot_test"],
         exec_env = {
-            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         },
         fpga = fpga_params(
             exit_failure = keyinfo["exit_failure"],


### PR DESCRIPTION
This is a manual cherry-pick of #24430,

Use the fpga_hyper310_rom_ext environment for ROM_EXT end-to-end tests.
The hyperdebug serial ports support serial break out of the box, whereas
the CW310 serial ports require special SAM3x firmware to support serial
break.