### PR TITLE
[rom_ext] Advance version to ROM_EXT 0.7

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -14,8 +14,8 @@ def secver_write_selection():
 # because of how the bazel rule accepts attributes.
 ROM_EXT_VERSION = struct(
     MAJOR = "0",
-    MINOR = "6",
-    SECURITY = "6",
+    MINOR = "7",
+    SECURITY = "7",
 )
 
 SLOTS = [


### PR DESCRIPTION
Features:
- Ownership Transfer.
- Valid DICE chain from CA->UDS->CDI_0->CDI_1.

Bug fixes:
- `protect_when_primary` is renamed to `protect_when_active` and protects whichever slot is the active slot.
- Report the `primary_bl0_slot` correctly after a `SetNextBl0` command.