### PR TITLE
[hw,rstmgr,dv] Use Xcelium compatible syntax

### DIFF
--- a/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
+++ b/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
@@ -49,7 +49,7 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   endfunction
 
   task wait_and_check(string path);
-    prim_mubi_pkg::mubi4_t rst_en;
+    logic [3:0] rst_en;
     logic leaf_rst;
     string epath = {path, ".rst_en_o"};
     string opath = {path, ".leaf_rst_o"};
@@ -62,7 +62,8 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
     `DV_CHECK(uvm_hdl_read(epath, rst_en), $sformatf("Path %0s has problem", epath))
     `DV_CHECK(uvm_hdl_read(opath, leaf_rst), $sformatf("Path %0s has problem", opath))
 
-    `DV_CHECK_EQ(rst_en, prim_mubi_pkg::MuBi4False, $sformatf("%s value mismatch", epath))
+    `DV_CHECK_EQ(prim_mubi_pkg::mubi4_t'(rst_en), prim_mubi_pkg::MuBi4False,
+                 $sformatf("%s value mismatch", epath))
     `DV_CHECK_EQ(leaf_rst, 1, $sformatf("%s value mismatch", opath))
   endtask : wait_and_check
 

--- a/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
+++ b/hw/ip_templates/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
@@ -35,10 +35,11 @@ class rstmgr_sec_cm_scan_intersig_mubi_vseq extends rstmgr_smoke_vseq;
       delay = $urandom_range(5, 30);
       fork
         // This waits for a certain number of cycles or for a change in scan_rst_ni,
-        //  whichever is sooner, or it could end up skipping a full scan reset.
+        // whichever is sooner, or it could end up skipping a full scan reset.
         begin : isolation_fork
           fork
-            @(edge cfg.rstmgr_vif.scan_rst_ni);
+            // @(edge) is not supported by xcelium, workaround with posedge+negedge
+            @(posedge cfg.rstmgr_vif.scan_rst_ni or negedge cfg.rstmgr_vif.scan_rst_ni);
             cfg.clk_rst_vif.wait_clks(delay);
           join_any
           disable fork;

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_leaf_rst_shadow_attack_vseq.sv
@@ -49,7 +49,7 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
   endfunction
 
   task wait_and_check(string path);
-    prim_mubi_pkg::mubi4_t rst_en;
+    logic [3:0] rst_en;
     logic leaf_rst;
     string epath = {path, ".rst_en_o"};
     string opath = {path, ".leaf_rst_o"};
@@ -62,7 +62,8 @@ class rstmgr_leaf_rst_shadow_attack_vseq extends rstmgr_base_vseq;
     `DV_CHECK(uvm_hdl_read(epath, rst_en), $sformatf("Path %0s has problem", epath))
     `DV_CHECK(uvm_hdl_read(opath, leaf_rst), $sformatf("Path %0s has problem", opath))
 
-    `DV_CHECK_EQ(rst_en, prim_mubi_pkg::MuBi4False, $sformatf("%s value mismatch", epath))
+    `DV_CHECK_EQ(prim_mubi_pkg::mubi4_t'(rst_en), prim_mubi_pkg::MuBi4False,
+                 $sformatf("%s value mismatch", epath))
     `DV_CHECK_EQ(leaf_rst, 1, $sformatf("%s value mismatch", opath))
   endtask : wait_and_check
 

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/seq_lib/rstmgr_sec_cm_scan_intersig_mubi_vseq.sv
@@ -35,10 +35,11 @@ class rstmgr_sec_cm_scan_intersig_mubi_vseq extends rstmgr_smoke_vseq;
       delay = $urandom_range(5, 30);
       fork
         // This waits for a certain number of cycles or for a change in scan_rst_ni,
-        //  whichever is sooner, or it could end up skipping a full scan reset.
+        // whichever is sooner, or it could end up skipping a full scan reset.
         begin : isolation_fork
           fork
-            @(edge cfg.rstmgr_vif.scan_rst_ni);
+            // @(edge) is not supported by xcelium, workaround with posedge+negedge
+            @(posedge cfg.rstmgr_vif.scan_rst_ni or negedge cfg.rstmgr_vif.scan_rst_ni);
             cfg.clk_rst_vif.wait_clks(delay);
           join_any
           disable fork;


### PR DESCRIPTION
This PR adds two changes to make the rstmgr simulation compatible with xcelium:

1. It removes the `@edge` and replaces it with a combination of `@posedge` and `@negedge`
2. Because of strong typing rules it's possible to directly read via `uvm_hdl_read` into a `prim_mubi_pkg::mubi4_t`. Read into a `logic` and cast the result to `prim_mubi_pkg::mubi4_t`