### PR TITLE
[ci] configure Bazel cache for GitHub actions

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Install dependencies
-description: Install system dependencies needed for OpenTitan
+name: Prepare environment
+description: Install dependencies and prepare environment needed for OpenTitan
 
 inputs:
   verilator-version:
@@ -22,6 +22,10 @@ inputs:
     description: Path at which to install Verible
     required: true
     default: /tools/verible
+  configure-bazel:
+    description: Configure Bazel to use remote cache
+    required: true
+    default: true
 
 runs:
   using: composite
@@ -82,4 +86,30 @@ runs:
         sudo chmod 777 "${{ inputs.verible-path }}"
         tar -C "${{ inputs.verible-path }}" -xvzf "/tmp/${VERIBLE_TAR}" --strip-components=1
         echo "${{ inputs.verible-path }}/bin" >> "$GITHUB_PATH"
+      shell: bash
+
+    # Log into Google Cloud using Workload Identity Federation
+    # This needs `id-token: write` permission and doesn't work for pull request.
+    - uses: google-github-actions/auth@v2
+      if: github.event_name != 'pull_request'
+      with:
+        project_id: active-premise-257318
+        workload_identity_provider: projects/281751345158/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+    - name: Configure ~/.bazelrc
+      if: inputs.configure-bazel == 'true'
+      run: |
+        cp ci/.bazelrc ~/.bazelrc
+        # Inject the OS version into a parameter used in the action key computation to
+        # avoid collisions between different operating systems in the caches.
+        # See #14695 for more information.
+        echo "build --remote_default_exec_properties=OSVersion=\"$(lsb_release -ds)\"" >> ~/.bazelrc
+
+        if ${{ github.event_name != 'pull_request' }}; then
+          echo "Will upload to the cache." >&2
+          echo "build --google_default_credentials" >> ~/.bazelrc
+        else
+          echo "Download from cache only." >&2
+          echo "build --remote_upload_local_results=false" >> ~/.bazelrc
+        fi
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: read
+  # Needed for workload identity federation
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -26,9 +31,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required so we can lint commit messages.
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-      - name: Environment
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+      - name: Show environment
         run: ./ci/scripts/show-env.sh
       - name: Commit metadata
         run: ./ci/scripts/lint-commits.sh "$GITHUB_BASE_REF"
@@ -48,11 +53,11 @@ jobs:
       - name: Validate testplans with schema
         run: ./ci/scripts/validate_testplans.sh
       - name: C/C++ formatting
-        run: ./ci/bazelisk.sh test //quality:clang_format_check
+        run: ./bazelisk.sh test //quality:clang_format_check
       - name: Rust formatting
-        run: ./ci/bazelisk.sh test //quality:rustfmt_check
+        run: ./bazelisk.sh test //quality:rustfmt_check
       - name: Shellcheck
-        run: ./ci/bazelisk.sh test //quality:shellcheck_check
+        run: ./bazelisk.sh test //quality:shellcheck_check
       - name: Header guards
         run: ./ci/scripts/include-guard.sh "$GITHUB_BASE_REF"
         if: ${{ github.event_name == 'pull_request' }}
@@ -72,8 +77,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
       - name: Countermeasures implemented (earlgrey)
         run: ./ci/scripts/check-countermeasures.sh earlgrey
         continue-on-error: true
@@ -102,7 +107,7 @@ jobs:
         env:
           OT_DESTRUCTIVE: 1 # Required by the script to clean up.
       - name: Buildifier
-        run: ./ci/bazelisk.sh test //quality:buildifier_check
+        run: ./bazelisk.sh test //quality:buildifier_check
       - name: Vendored files
         run: ./ci/scripts/check-vendoring.sh
       - name: Verible RTL
@@ -120,8 +125,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+        with:
+          configure-bazel: false
       - name: Prepare airgapped environment
         run: ./util/prep-bazel-airgapped-build.sh
       - name: Build in the airgapped environment
@@ -165,8 +172,8 @@ jobs:
     needs: quick_lint
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
       - name: Build simulator with Verilator
         run: ./ci/scripts/build-chip-verilator.sh englishbreakfast
       - name: Upload binary
@@ -185,16 +192,16 @@ jobs:
     needs: quick_lint
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
       - name: Build bitstream
         run: |
           # Build CW305 test rom required by `build-bitstream-vivado.sh`
           rom_path="sw/device/lib/testing/test_rom"
-          ci/bazelisk.sh build "//${rom_path}:test_rom_fpga_cw305" \
+          ./bazelisk.sh build "//${rom_path}:test_rom_fpga_cw305" \
             --features=-rv32_bitmanip \
             --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_
-          vmem="$(ci/bazelisk.sh cquery --output=files "//${rom_path}:test_rom_fpga_cw305" \
+          vmem="$(./bazelisk.sh cquery --output=files "//${rom_path}:test_rom_fpga_cw305" \
             --features=-rv32_bitmanip \
             --copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_
           )"

--- a/ci/bazelisk.sh
+++ b/ci/bazelisk.sh
@@ -3,6 +3,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# In GitHub actions, we configure Bazel using ~/.bazelisk using .github/actions/prepare-env
+# So execute bazelisk.sh directly.
+if [[ -n "$GITHUB_ACTIONS" ]]; then
+    exec "$(dirname $0)"/../bazelisk.sh "$@"
+fi
+
 # This is the CI version of `bazelisk.sh`, which calls into the "usual" wrapper,
 # but adds various flags to produce CI-friendly output. It does so by prociding a
 # command-line specified .bazelrc (that is applied alongside //.bazelrc).


### PR DESCRIPTION
This should not be merged yet until we have configured bucket permission so that workload identity federation can write to the cache properly.