### PR TITLE
[tl_agent,dv] Disable covg_disable_cg for xcelium

### DIFF
--- a/hw/dv/sv/tl_agent/dv/tb/tb.sv
+++ b/hw/dv/sv/tl_agent/dv/tb/tb.sv
@@ -8,6 +8,7 @@ module tb;
   import dv_utils_pkg::*;
   import tl_agent_pkg::*;
   import tl_agent_env_pkg::*;
+  import tl_agent_test_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
+++ b/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
@@ -31,12 +31,28 @@
   // Enable cdc instrumentation.
   run_opts: ["+cdc_instrumentation_enabled=1"]
 
+  run_modes: [
+    {
+      name: vcs_disable_cg_mode
+      run_opts: ["-covg_disable_cg"]
+    }
+    // Xcelium does not support the -covg_disable_cg flag
+    {
+      name: xcelium_disable_cg_mode
+      run_opts: []
+    }
+    {
+      name: disable_cg_mode
+      en_run_modes: ["{tool}_disable_cg_mode"]
+    }
+  ]
+
   // List of test specifications.
   tests: [
     {
       name: tl_agent_smoke
       uvm_test_seq: tl_agent_base_vseq
-      run_opts: ["-covg_disable_cg"]
+      en_run_modes: ["{tool}_disable_cg_mode"]
     }
   ]
 


### PR DESCRIPTION
The code successfully removes the `covg_disable_cg` flag for xcelium. 

However, the test still fails for xcelium with:

```
UVM_WARNING @ 0 ps: reporter [BDTYP] Cannot create a component of type 'tl_agent_base_test' because it is not registered with the factory.
                UVM_FATAL @ 0 ps: reporter [INVTST] Requested test from command line +UVM_TESTNAME=tl_agent_base_test not found.
                UVM_INFO /tools/eda/cadence/xcelium/23.09-s004/tools/methodology/UVM/CDNS-1.2/sv/src/base/uvm_report_catcher.svh(705) @ 0 ps: reporter [UVM/REPORT/CATCHER]
                --- UVM Report catcher Summary ---
````

@rswarbrick As an UVM expert, could you help me on that one?