### PR TITLE
[keymgr_dpe,mbx,rstmgr]  Remove references to obsolete devmode interface

### DIFF
--- a/hw/ip/keymgr_dpe/dv/README.md
+++ b/hw/ip/keymgr_dpe/dv/README.md
@@ -29,7 +29,6 @@ In addition, it instantiates the following interfaces, connects them to the DUT 
 * KEYMGR_DPE IOs (`keymgr_dpe_if`)
 * Interrupts ([`pins_if`](../../../dv/sv/common_ifs/README.md))
 * Alerts ([`alert_esc_if`](../../../dv/sv/alert_esc_agent/README.md))
-* Devmode ([`pins_if`](../../../dv/sv/common_ifs/README.md))
 
 ### Common DV utility components
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:

--- a/hw/ip/keymgr_dpe/dv/tb.sv
+++ b/hw/ip/keymgr_dpe/dv/tb.sv
@@ -14,7 +14,6 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n, rst_shadowed_n;
-  wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   assign interrupts[NUM_MAX_INTERRUPTS-1:1] = '0;
@@ -23,7 +22,6 @@ module tb;
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   rst_shadowed_if rst_shadowed_if(.rst_n(rst_n), .rst_shadowed_n(rst_shadowed_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
-  pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   keymgr_dpe_if keymgr_dpe_if(.clk(clk), .rst_n(rst_n));
   kmac_app_intf keymgr_dpe_kmac_intf(.clk(clk), .rst_n(rst_n));
@@ -84,7 +82,6 @@ module tb;
     uvm_config_db#(virtual rst_shadowed_if)::set(null, "*.env", "rst_shadowed_vif",
                                                  rst_shadowed_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual keymgr_dpe_if)::set(null, "*.env", "keymgr_dpe_vif", keymgr_dpe_if);
     uvm_config_db#(virtual kmac_app_intf)::set(null,

--- a/hw/ip/mbx/dv/env/mbx_env_cfg.sv
+++ b/hw/ip/mbx/dv/env/mbx_env_cfg.sv
@@ -14,7 +14,6 @@ class mbx_env_cfg extends cip_base_env_cfg #(
 
   function new(string name = "");
     super.new(name);
-    has_devmode = 0;
   endfunction: new
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);

--- a/hw/ip/mbx/rtl/mbx_hostif.sv
+++ b/hw/ip/mbx/rtl/mbx_hostif.sv
@@ -104,8 +104,7 @@ module mbx_hostif
     .tl_o       ( tl_host_o     ),
     .reg2hw     ( reg2hw        ),
     .hw2reg     ( hw2reg        ),
-    .intg_err_o ( tlul_intg_err ),
-    .devmode_i  ( 1'b1          )
+    .intg_err_o ( tlul_intg_err )
   );
 
   logic intr_ready_de, intr_abort_de, intr_error_de;

--- a/hw/ip/mbx/rtl/mbx_sysif.sv
+++ b/hw/ip/mbx/rtl/mbx_sysif.sv
@@ -73,8 +73,7 @@ module mbx_sysif
     .tl_win_i   ( tl_win_d2h ),
     .reg2hw     ( reg2hw     ),
     .hw2reg     ( hw2reg     ),
-    .intg_err_o ( intg_err_o ),
-    .devmode_i  ( 1'b1       )
+    .intg_err_o ( intg_err_o )
   );
 
   // Straps for the external capability header registers

--- a/hw/ip_templates/rstmgr/dv/README.md.tpl
+++ b/hw/ip_templates/rstmgr/dv/README.md.tpl
@@ -29,7 +29,6 @@ In addition, it instantiates the following interfaces, connects them to the DUT 
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
 * RSTMGR interface [`hw/top_${topname}/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_${topname}/ip_autogen/rstmgr/dv/env/rstmgr_if.sv)
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
-* Devmode ([`pins_if`](../../../../dv/sv/common_ifs/README.md))
 
 ### Common DV utility components
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:

--- a/hw/top_earlgrey/ip_autogen/rstmgr/dv/README.md
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/dv/README.md
@@ -23,7 +23,6 @@ In addition, it instantiates the following interfaces, connects them to the DUT 
 * [TileLink host interface](../../../../dv/sv/tl_agent/README.md)
 * RSTMGR interface [`hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_if.sv`](https://github.com/lowRISC/opentitan/blob/master/hw/top_earlgrey/ip_autogen/rstmgr/dv/env/rstmgr_if.sv)
 * Alerts ([`alert_esc_if`](../../../../dv/sv/alert_esc_agent/README.md))
-* Devmode ([`pins_if`](../../../../dv/sv/common_ifs/README.md))
 
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
 * [dv_utils_pkg](../../../../dv/sv/dv_utils/README.md)


### PR DESCRIPTION
The `devmode` interface on the reg_tops was removed on master. This PR removes all references to that from the `keymgr_dpe`, `mbx`, and `rstmgr` IPs.