### PR TITLE
[SPI,dv] Set strong drive strength and fast slew rate for SPI device

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3422,6 +3422,7 @@ opentitan_test(
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:spi_device_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/device/lib/testing/test_framework:status",
     ],

--- a/sw/device/tests/spi_device_tpm_tx_rx_test.c
+++ b/sw/device/tests/spi_device_tpm_tx_rx_test.c
@@ -11,6 +11,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/irq.h"
 #include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/spi_device_testutils.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 #include "sw/device/lib/testing/test_framework/ottf_main.h"
 #include "sw/device/lib/testing/test_framework/status.h"
@@ -154,6 +155,9 @@ bool test_main(void) {
                                             kDifPinmuxPadKindMio, in_attr,
                                             &out_attr));
   }
+
+  // Configure fast slew rate and strong drive strength for SPI device pads.
+  CHECK_STATUS_OK(spi_device_testutils_configure_pad_attrs(&pinmux));
 
   CHECK_DIF_OK(
       dif_spi_device_tpm_configure(&spi_device, kDifToggleEnabled, kTpmConfig));


### PR DESCRIPTION
SPI device pads should use strong drive strength and fast slew rate.