### PR TITLE
[pwm,dv] Cap number of sequences in pwm_stress_all_vseq

### DIFF
--- a/hw/ip/pwm/dv/env/seq_lib/pwm_stress_all_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_stress_all_vseq.sv
@@ -7,10 +7,9 @@ class pwm_stress_all_vseq extends pwm_base_vseq;
   `uvm_object_utils(pwm_stress_all_vseq)
   `uvm_object_new
 
-  // constraints
-  constraint num_trans_c {
-    num_trans inside {[5:8]};
-  }
+  // Constrain things so we run five sequences each time. This should be enough to "run some
+  // back-to-back", but avoids needing to run lots sequentially (so avoids a large runtime)
+  constraint num_trans_c { num_trans == 5; }
 
   constraint duration_cycles_c {
     duration_cycles dist {


### PR DESCRIPTION
Fixing the number of sequences that is run to 5 (instead of uniformly choosing from [5, 8]) will slightly reduce the average number of iterations (from 6.5 to 5). The plus side is that it will avoid very long runs (which occasionally time out because they take more than 10s). We'll still get a reasonable number of "back-to-back" sequences (since 5 is much more than 1!).

The total amount run will drop slightly. To avoid that, we could up the reseed count for this test to 6.5/5*50 = 65, but I'm reasonably convinced that the number for this vseq come from a default, so I don't believe there's any need to worry about it.