### PR TITLE
[dvsim] Create symlink to source folder for xcelium DPI builds

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -242,7 +242,7 @@ class Deploy():
         the final resolved 'cmd' & the exports. The 'name' field will be unique
         to 'item' and 'self', so we take that out of the comparison.
         """
-        if type(self) != type(item):
+        if not isinstance(self, type(item)):
             return False
 
         # Check if the cmd field is identical.
@@ -320,6 +320,8 @@ class Deploy():
         """
         # Retain the handle to self for lookup & callbacks.
         self.launcher = get_launcher(self)
+        # Pass the used tool to the launcher for some tool dependent configuration
+        self.launcher.tool = self.sim_cfg.tool
 
 
 class CompileSim(Deploy):

--- a/util/dvsim/Launcher.py
+++ b/util/dvsim/Launcher.py
@@ -175,6 +175,15 @@ class Launcher:
             clean_odirs(odir=self.deploy.odir, max_odirs=self.max_odirs)
         os.makedirs(self.deploy.odir, exist_ok=True)
 
+        if self.tool == 'xcelium':
+            # Create symlink for src folder within the scratch directory path errors for DPI builds
+            try:
+                os.symlink(os.path.join(self.deploy.odir, "sim-vcs", "src"),
+                           os.path.join(self.deploy.odir, "src"),
+                           target_is_directory=True)
+            except FileExistsError:
+                pass
+
     def _link_odir(self, status):
         """Soft-links the job's directory based on job's status.
 


### PR DESCRIPTION
Within the build directory, dvsim creates a folder `sim-vcs/src`, which contains the source fusesoc packages, e.g., `lowrisc_constants_top_pkg_0`.
Xcelium, however, expects a slightly different layout when it comes to building DPI models of IPs. It expects the folder containing the fusesoc packages to be available at `src`.

To overcome this different folder layout, this PR adds a symlink in the scratch directory between those folders when using Xcelium.

There might be a different solution to this problem, but this at least works.
