### PR TITLE
[hmac,sw] Workaround to avoid hang - Stop CMD is not triggered

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -183,6 +183,7 @@ cc_library(
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
         "//sw/device/lib/crypto/impl:status",
+        "//sw/device/lib/runtime:ibex",
     ],
 )
 


### PR DESCRIPTION
- Implement a workaround in C cryptolib as HW is hanged
 after a stop in certain conditions.
- Refer to issue https://github.com/lowRISC/opentitan/issues/24767