### PR TITLE
[flash_ctrl,dv] Correct syntax in flash_ctrl_phy_arb_redun_vseq

### DIFF
--- a/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/ip_templates/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -45,7 +45,7 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
 
 `define HIER_PATH(prefix, copy, suffix) `"prefix.copy.suffix`"
 
-  arb_t arbs[NumArbiters] = {
+  arb_t arbs[NumArbiters] = '{
     '{
       name: "host_arb[0]",
       copy_0_req: `HIER_PATH(`HOST_ARB_0_PREFIX, `COPY_0, `REQ_SUFFIX),

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_redun_vseq.sv
@@ -45,7 +45,7 @@ class flash_ctrl_phy_arb_redun_vseq extends flash_ctrl_err_base_vseq;
 
 `define HIER_PATH(prefix, copy, suffix) `"prefix.copy.suffix`"
 
-  arb_t arbs[NumArbiters] = {
+  arb_t arbs[NumArbiters] = '{
     '{
       name: "host_arb[0]",
       copy_0_req: `HIER_PATH(`HOST_ARB_0_PREFIX, `COPY_0, `REQ_SUFFIX),


### PR DESCRIPTION
It seems that VCS accepts the code that was there but it isn't quite in accordance with the allowed syntax for structure literals (see IEEE 1800, section 5.10). Fortunately, the fix is pretty trivial!