### PR TITLE
[sival] Include cryptolib tests in earlgrey sival testplan

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -18,6 +18,9 @@
     // Manufacturing test cases are part of the Silicon Validation (SiVal) test plan.
     "sw/device/silicon_creator/manuf/data/manuf_testplan.hjson"
 
+    // Cryptolib tests are also part of silicon validation.
+    "sw/device/lib/crypto/data/crypto_testplan.hjson"
+
     // IP block specific top level test plans.
     "hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_aes_testplan.hjson",

--- a/sw/device/lib/crypto/data/crypto_testplan.hjson
+++ b/sw/device/lib/crypto/data/crypto_testplan.hjson
@@ -11,7 +11,7 @@
             Run the hash algorithms Sha256, Sha384 and Sha512 and compare the digist against
             the NIST test vector.
       '''
-      stage: NA
+      stage: N.A.
       si_stage: SV3
       tests: []
       bazel: [
@@ -34,7 +34,7 @@
              - ECDH signature.
              - ECDH signature verification.
       '''
-      stage: NA
+      stage: N.A.
       si_stage: SV3
       tests: []
       bazel: [
@@ -56,7 +56,7 @@
              - Sign a message with the private key.
              - Verify the signarue with public key.
       '''
-      stage: NA
+      stage: N.A.
       si_stage: SV3
       tests: []
       bazel: [
@@ -75,7 +75,7 @@
              - RSA signature verification.
             With the keys sizes 2048, 3072 and 4096 bits.
       '''
-      stage: NA
+      stage: N.A.
       si_stage: SV3
       tests: []
       bazel: [
@@ -101,7 +101,7 @@
              - AES-GCM encryption.
              - AES-GCM decryption.
       '''
-      stage: NA
+      stage: N.A.
       si_stage: SV3
       tests: []
       bazel: [
@@ -119,7 +119,7 @@
             Generate symmetric keys using entropy from the CSRNG and check it quality using
             a statistical test.
       '''
-      stage: NA
+      stage: N.A.
       si_stage: SV3
       tests: []
       bazel: ["//sw/device/tests/crypto:symmetric_keygen_functest"]
@@ -131,7 +131,7 @@
 
             Initialize the PRNG with a known seed and compare the entropy generated against a test vector.
       '''
-      stage: NA
+      stage: N.A.
       si_stage: SV3
       tests: []
       bazel: ["//sw/device/tests/crypto/cryptotest:drbg_kat"]


### PR DESCRIPTION
These tests must pass for silicon validation, so we should include them in the testplan for Earl Grey.