### PR TITLE
[otp] Embed the first three bytes of imt_ex hash into MANUF_STATE

### DIFF
--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -140,9 +140,12 @@ CONST = struct(
         ESC_PHASE_2 = 0x25,
         ESC_PHASE_3 = 0x76,
     ),
+    # The first three bytes of `MANUF_STATE` must be zeros, as
+    # they are reserved for storing the first three bytes of the
+    # `IMMUTABLE_ROM_EXT_SHA256_HASH`.
     MANUF_STATE = struct(
         PERSO_INITIAL = 0x00000000,
-        SIVAL = 0x30305653,  # ASCII `SV00`.
+        SIVAL = 0x00000053,  # ASCII `S`.
     ),
 )
 

--- a/rules/opentitan/toolchain.bzl
+++ b/rules/opentitan/toolchain.bzl
@@ -11,6 +11,7 @@ LocalToolInfo = provider(fields = [
     "gen_mem_image",
     "gen_otp_rot_auth_json",
     "gen_otp_immutable_rom_ext_json",
+    "gen_otp_creator_manuf_state_json",
 ])
 
 def _localtools_toolchain(ctx):


### PR DESCRIPTION
This enhances the ROM_EXT immutable section OTP tooling to embed the first three bytes of immutable ROM_EXT hash into the `MANUF_STATE` field in the `CREATOR_SW_CFG` OTP partition.

This partially addresses #24610

### Background
During boot, if the immutable ROM extension feature is enabled, ROM verifies the IM_EXT hash against the OTP value. Any mismatch results in an immediate ROM shutdown, safeguarding the device's integrity. However, this check occurs after ROM_EXT signature verification, and there's no fallback to another slot if the hash is invalid.

To mitigate this limitation, we use the first three bytes of `CREATOR_SW_CFG_MANUF_STATE` to represent the first three bytes of IM_EXT's hash. If the IM_EXT feature is disabled, "000000" is used instead. This allows us to invalidate the ROM_EXT's signature if the unexpected IM_EXT section is included in the ROM_EXT. Avoid bricking the device with an invalid immutable ROM_EXT hash. The last byte in the `CREATOR_SW_CFG_MANUF_STATE` is specifically reserved for the original manufacturing state's intended purpose. Examples of such manufacturing states include SIVAL and PRODC.


