### PR TITLE
[manuf] Prepend a header to certificate before storing on flash

### DIFF
--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -40,7 +40,7 @@ typedef enum perso_tlv_obj_header_fields {
   kObjhSizeFieldWidth = 12,
   kObjhSizeFieldMask = (1 << kObjhSizeFieldWidth) - 1,
 
-  // Object type, one of perso_tlv_object_types_t.
+  // Object type, one of perso_tlv_object_type_t.
   kObjhTypeFieldShift = kObjhSizeFieldWidth,
   kObjhTypeFieldWidth =
       sizeof(perso_tlv_object_header_t) * 8 - kObjhSizeFieldWidth,
@@ -113,6 +113,7 @@ typedef enum perso_tlv_cert_header_fields {
  **/
 typedef struct perso_tlv_cert_block {
   size_t obj_size;
+  /* obj_size - obj_hdr_size - cert_hdr_size - cert_name_len */
   size_t wrapped_cert_size;
   const void *wrapped_cert_p;
   char name[kCrthNameSizeFieldMask + 1];


### PR DESCRIPTION
Currently, during ft_perso, the host write the RAW endorsed DICE certificate to flash_info pages.
When it needs to access them later on, the certificate length is calculated by parsing the ASN.1 header (1 or 2 bytes).
This design works for X.509 (which are ASN.1 encoded) but not CWT-CBOR since there's no such information in some CBOR types (map, array specifically).

Proposed format:
```
   *  d15                                         d0
   * +-------------+--------------------------------+
   * | 4 bit type  |   12 bits total object size    | <-- Object Header
   * +-------------+--------------------------------+
   * | name length |12 bits total cert payload size | <-- Cert Header
   * +-------------+--------------------------------+
   * |             cert name string                 |
   * +----------------------------------------------+
   * |                   cert                       |
   * +----------------------------------------------+
```

Fixes: #24942
Test: //sw/device/silicon_creator/manuf/base:ft_provision_cw340