### PR TITLE
[manuf] move transport image selection to SKU config

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -362,12 +362,12 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft:ft_{}"
         },
         fpga = fpga_params(
             timeout = "long",
-            assemble = "{ft_personalize}@{slot_a} {rom_ext}@{slot_b}",
+            assemble = "{ft_personalize}@{slot_a} {transport_image}@{slot_b}",
             binaries =
                 {
                     ":sram_ft_individualize_{}".format(config["otp"]): "sram_ft_individualize",
                     ":ft_personalize_{}".format(sku): "ft_personalize",
-                    "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b": "rom_ext",
+                    config["transport_image"]: "transport_image",
                 },
             changes_otp = True,
             data = FT_PERSONALIZE_ENDORSEMENT_KEYS,
@@ -383,12 +383,12 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft:ft_{}"
             test_harness = _FT_PROVISIONING_HARNESS.format(sku),
         ),
         silicon = silicon_params(
-            assemble = "{ft_personalize}@{slot_a} {rom_ext}@{slot_b}",
+            assemble = "{ft_personalize}@{slot_a} {transport_image}@{slot_b}",
             binaries =
                 {
                     ":sram_ft_individualize_{}".format(config["otp"]): "sram_ft_individualize",
                     ":ft_personalize_{}".format(sku): "ft_personalize",
-                    "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b": "rom_ext",
+                    config["transport_image"]: "transport_image",
                 },
             changes_otp = True,
             data = FT_PERSONALIZE_ENDORSEMENT_KEYS,

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -26,6 +26,7 @@ EARLGREY_SKUS = {
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
+        "transport_image": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
     },
     # OTP Config: SIVAL; DICE Certs: CWT; Additional Certs: None
     # TODO(#24281): uncomment when DICE CWT cert flows are fully supported
@@ -34,6 +35,7 @@ EARLGREY_SKUS = {
     #     "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
     #     "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
     #     "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
+    #     "transport_image": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
     # },
     # OTP Config: SIVAL; DICE Certs: X.509; Additional Certs: TPM EK
     "sival_tpm": {
@@ -44,6 +46,7 @@ EARLGREY_SKUS = {
             "//sw/device/silicon_creator/lib/cert:tpm_ek_template_library",
             "//sw/device/silicon_creator/manuf/base:tpm_perso_fw_ext",
         ],
+        "transport_image": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
     },
     # OTP Config: PRODC; DICE Certs: X.509; Additional Certs: None
     "prodc": {
@@ -51,6 +54,7 @@ EARLGREY_SKUS = {
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
+        "transport_image": "//sw/device/silicon_creator/rom_ext/prodc:rom_ext_fake_prod_signed_slot_b",
     },
 } | EXT_EARLGREY_SKUS
 

--- a/sw/device/silicon_creator/rom_ext/prodc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/prodc/BUILD
@@ -42,12 +42,14 @@ opentitan_binary(
     exec_env = [
         "//hw/top_earlgrey:silicon_creator",
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
     ],
     linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_a",
     linkopts = LINK_ORDER,
     manifest = ":manifest_prodc",
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
@@ -62,12 +64,14 @@ opentitan_binary(
     exec_env = [
         "//hw/top_earlgrey:silicon_creator",
         "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
     ],
     linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_b",
     linkopts = LINK_ORDER,
     manifest = ":manifest_prodc",
+    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
     deps = [
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -242,11 +242,8 @@ fn main() -> Result<()> {
         opts.second_bootstrap,
     )?;
 
-    log::info!("Provisioning Done");
-
     check_rom_ext_boot_up(&transport, &opts.init, opts.timeout)?;
-
-    log::info!("Successfully boot into ROM_EXT");
+    log::info!("Provisioning Done");
 
     Ok(())
 }


### PR DESCRIPTION
This updates the SKU configuration to enable selection of the transport image that is loaded in flash slot B during personalization.

This fixes #17394.