### PR TITLE
[manuf] decrease FT provisioning flow test timeout

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -361,7 +361,7 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft:ft_{}"
             "//hw/top_earlgrey:silicon_creator": None,
         },
         fpga = fpga_params(
-            timeout = "long",
+            timeout = "moderate",
             assemble = "{ft_personalize}@{slot_a} {transport_image}@{slot_b}",
             binaries =
                 {


### PR DESCRIPTION
This decreases the test timeout for the FT provisioning flow from "long" to "moderate" so that it is always run in CI. Currently CI only runs "short" and "moderate" tests due to resource constraints.