### PR TITLE
[rom_ctrl, dv] Uncovered conditional coverage for tlul_adapter_sram

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
@@ -10,6 +10,7 @@
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
                      "rom_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -41,7 +41,8 @@
 
   // Add additional tops for simulation.
   sim_tops: ["rom_ctrl_bind", "rom_ctrl_cov_bind",
-             "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind"]
+             "sec_cm_prim_sparse_fsm_flop_bind", "sec_cm_prim_onehot_check_bind",
+             "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
The nightly regression coverage dashboard thrown an uncovered conditional coverage hole on L138 and L131 in tlul_adapter_sram. To resolve the issue rom_ctrl_sec_cm test has been used. 

This PR fixes two kind of vulnerabilities.
1) The test rom_ctrl_sec_sm wasn't collecting the coverage for the wires that were uncovered by the report. Fixing this was straight forward to add the proxy binds in rom_ctrl_base_sim_cfg.hjson that were injecting faults to different blocks inside rom_ctrl and add the sec_cm_count test_plan in rom_ctrl_testplan.hjson. 
2) As the test inject faults to different blocks of rom_ctrl(FSM, SRAM, ...), the testbench should know what to do next if something bad has happened. For this particular coverage hole, the proxy_if was prim_count that pokes cnt_q in prim_count.sv and that generates an error. If the fifo was empty, that will lead alot of signals become 'X and the fifo
error being stuck at 'X. To avoid this, we splat the backing sram. Then there were something assertions in prim_fifo_sync and rom_ctrl that fails and needs to switched off during fault injection. Last to compare the respective fatal_alert_cause registers.