### PR TITLE
[prim_pulse_sync] Add missing `include "prim_assert.sv"`

### DIFF
--- a/hw/ip/prim/rtl/prim_pulse_sync.sv
+++ b/hw/ip/prim/rtl/prim_pulse_sync.sv
@@ -11,6 +11,8 @@
 // Also note that a reset of either the source domain or the destination domain
 // in isolation may create a pulse at the destination.
 
+`include "prim_assert.sv"
+
 module prim_pulse_sync (
   // source clock domain
   input  logic clk_src_i,


### PR DESCRIPTION
This is needed to be able to analyze `prim_pulse_sync.sv` on its own (i.e., together with the modules it hierarchically instantiates but without assuming any non-dependencies have been analyzed before it).