### PR TITLE
[ci,SiVal] Backport github actions to earlgrey_1.0.0

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -52,8 +52,8 @@ runs:
         }
         sudo mkdir -p "${{ inputs.verilator-path }}"
         sudo chmod 777 "${{ inputs.verilator-path }}"
-        tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}" --strip-components=1
-        echo "${{ inputs.verilator-path }}/bin" >> "$GITHUB_PATH"
+        tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}"
+        echo "${{ inputs.verilator-path }}/v${{ inputs.verilator-version }}/bin" >> "$GITHUB_PATH"
       shell: bash
 
     - name: Install Verible

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -27,7 +27,9 @@ runs:
   using: composite
   steps:
     - name: Install system dependencies
-      run: grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      run: |
+        sudo apt update
+        grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
       shell: bash
 
     - uses: actions/setup-python@v5

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -32,15 +32,29 @@ runs:
         grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
       shell: bash
 
-    - uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v3
       with:
-        python-version: '3.8'
-        cache-dependency-path: python-requirements.txt
-        cache: pip
+        version: '0.4.20'
+        enable-cache: true
+        cache-dependency-glob: |
+          pyproject.toml
+          python-requirements.txt
+
+    - name: Install Python
+      shell: bash
+      run: |
+        uv python install 3.8
+        # Create a virtual environment for UV
+        uv venv ~/.local/share/venv
+        echo "$HOME/.local/share/venv/bin" >> "$GITHUB_PATH"
+        echo "VIRTUAL_ENV=$HOME/.local/share/venv" >> "$GITHUB_ENV"
 
     - name: Install Python dependencies
-      run: python3 -m pip install -r python-requirements.txt --require-hashes
       shell: bash
+      run: |
+        uv pip install -r python-requirements.txt --require-hashes
+        # We installed uv from setup-uv action, so uninstall from venv to prevent conflict
+        uv pip uninstall uv
 
     - name: Install Verilator
       run: |

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,67 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Install dependencies
+description: Install system dependencies needed for OpenTitan
+
+inputs:
+  verilator-version:
+    description: Verilator version to install
+    required: true
+    default: '4.210'
+  verilator-path:
+    description: Path at which to install Veriltator
+    required: true
+    default: /tools/verilator
+  verible-version:
+    description: Verible version to install
+    required: true
+    default: 'v0.0-3622-g07b310a3'
+  verible-path:
+    description: Path at which to install Verible
+    required: true
+    default: /tools/verible
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      run: grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      shell: bash
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.8'
+        cache-dependency-path: python-requirements.txt
+        cache: pip
+
+    - name: Install Python dependencies
+      run: python3 -m pip install -r python-requirements.txt --require-hashes
+      shell: bash
+
+    - name: Install Verilator
+      run: |
+        VERILATOR_TAR="verilator-v${{ inputs.verilator-version }}.tar.gz"
+        VERILATOR_URL="https://storage.googleapis.com/verilator-builds/${VERILATOR_TAR}"
+        curl -f -Ls -o "/tmp/${VERILATOR_TAR}" "$VERILATOR_URL" || {
+          echo "failed to download Verilator from ${VERILATOR_URL}" >&2
+          exit 1
+        }
+        sudo mkdir -p "${{ inputs.verilator-path }}"
+        sudo tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}" --strip-components=1
+        echo "${{ inputs.verilator-path }}/bin" >> "$GITHUB_PATH"
+      shell: bash
+
+    - name: Install Verible
+      run: |
+        VERIBLE_TAR="verible-${{ inputs.verible-version }}-linux-static-x86_64.tar.gz"
+        VERIBLE_URL="https://github.com/chipsalliance/verible/releases/download/${{ inputs.verible-version }}/${VERIBLE_TAR}"
+        curl -f -Ls -o "/tmp/${VERIBLE_TAR}" "$VERIBLE_URL" || {
+          echo "failed to download Verible from ${VERIBLE_URL}" >&2
+          exit 1
+        }
+        sudo mkdir -p "${{ inputs.verible-path }}"
+        sudo tar -C "${{ inputs.verible-path }}" -xvzf "/tmp/${VERIBLE_TAR}" --strip-components=1
+        echo "${{ inputs.verible-path }}/bin" >> "$GITHUB_PATH"
+      shell: bash

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -51,7 +51,8 @@ runs:
           exit 1
         }
         sudo mkdir -p "${{ inputs.verilator-path }}"
-        sudo tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}" --strip-components=1
+        sudo chmod 777 "${{ inputs.verilator-path }}"
+        tar -C "${{ inputs.verilator-path }}" -xvzf "/tmp/${VERILATOR_TAR}" --strip-components=1
         echo "${{ inputs.verilator-path }}/bin" >> "$GITHUB_PATH"
       shell: bash
 
@@ -64,6 +65,7 @@ runs:
           exit 1
         }
         sudo mkdir -p "${{ inputs.verible-path }}"
-        sudo tar -C "${{ inputs.verible-path }}" -xvzf "/tmp/${VERIBLE_TAR}" --strip-components=1
+        sudo chmod 777 "${{ inputs.verible-path }}"
+        tar -C "${{ inputs.verible-path }}" -xvzf "/tmp/${VERIBLE_TAR}" --strip-components=1
         echo "${{ inputs.verible-path }}/bin" >> "$GITHUB_PATH"
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Bitstream cache requires all commits.
-      - name: Install system dependencies
-        run: grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
       - name: Prepare airgapped environment
         run: ./util/prep-bazel-airgapped-build.sh
       - name: Build in the airgapped environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CI
+on:
+  pull_request:
+
+jobs:
+  airgapped_build:
+    name: Airgapped build
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Bitstream cache requires all commits.
+      - name: Install system dependencies
+        run: grep '^[^#]' apt-requirements.txt | xargs sudo apt install -y
+      - name: Prepare airgapped environment
+        run: ./util/prep-bazel-airgapped-build.sh
+      - name: Build in the airgapped environment
+        run: ./ci/scripts/test-airgapped-build.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,18 +121,6 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Confirm no .bazelrc-site files
 
-- job: airgapped_bazel_build
-  displayName: Test an airgapped Bazel build
-  timeoutInMinutes: 120
-  dependsOn: checkout
-  condition: eq(variables['Build.Reason'], 'PullRequest')
-  pool:
-    vmImage: ubuntu-20.04
-  steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - bash: ci/scripts/test-airgapped-build.sh
-
 - job: slow_lints
   displayName: Quality (in-depth lint)
   # Run code quality checks (in-depth lint)


### PR DESCRIPTION
This PR cherry-pick the minimum number de commits necessary for having the file `.github/actions/install-deps/action.yml` backported across into the `earlgrey_1.0.0` branch.
We need this change for the SiVal nightly job, which will run from master, but it will checkout the `earlgrey_1.0.0` branch.