### PR TITLE
[ci, SiVal] Publish bazel result to a gcp bucket

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -105,3 +105,25 @@ runs:
           echo "build --remote_upload_local_results=false" >> ~/.bazelrc
         fi
       shell: bash
+
+    - name: Install merge-junit
+      run: |
+        MERGE_JUNIT_PATH="/tools/merge-junit"
+        MERGE_JUNIT_TAR="merge-junit-v0.2.1-x86_64-unknown-linux-musl.tar.gz"
+        MERGE_JUNIT_URL="https://github.com/tobni/merge-junit/releases/download/v0.2.1/${MERGE_JUNIT_TAR}"
+        MERGE_JUNIT_SHA256="5c6a63063f3a155ea4da912d5cae2ec4a89022df31d7942f2aba463ee4790152"
+
+        curl -fLSs -o "/tmp/${MERGE_JUNIT_TAR}" "$MERGE_JUNIT_URL"
+        HASH=$(sha256sum "/tmp/$MERGE_JUNIT_TAR" | awk '{print $1}')
+        if [[ "$HASH" != "$MERGE_JUNIT_SHA256" ]]; then
+          echo "The hash of merge-junit does not match" >&2
+          echo "$HASH != $MERGE_JUNIT_SHA256" >&2
+          exit 1
+        fi
+
+        sudo mkdir -p $MERGE_JUNIT_PATH
+        sudo chmod 777 $MERGE_JUNIT_PATH
+        tar -C $MERGE_JUNIT_PATH -xvzf "/tmp/${MERGE_JUNIT_TAR}" --strip-components=1
+        echo $MERGE_JUNIT_PATH >> "$GITHUB_PATH"
+        rm "/tmp/${MERGE_JUNIT_TAR}"
+      shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,10 +14,19 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   FPGA-CW310-SiVal-Nightly:
     name: Fpga cw310 sival tests
     runs-on: [ubuntu-20.04-fpga, cw310]
+
+    env:
+      GS_PATH: gs://opentitan-test-results
+      BAZEL_TEST_RESULTS: test_results.xml
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,6 +35,8 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/prepare-env
+
+      - uses: google-github-actions/setup-gcloud@v2
 
       - name: Update hyperdebug
         # We run the update command twice to workaround an issue with udev on the container.
@@ -60,3 +71,12 @@ jobs:
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
           ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"
+
+      - name: Publish bazel test results
+        if: success() || failure()
+        run: |
+          # Bazel produce one xml for each test. So we merge them together.
+          find -L bazel-out -name "test.xml" | xargs merge-junit -o "$BAZEL_TEST_RESULTS"
+
+          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ github.ref_name }}/$(date +%Y-%m-%d-%H%M%S)_${BAZEL_TEST_RESULTS}
+          gcloud storage cp $BAZEL_TEST_RESULTS "$BUCKET_PATH"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,8 +19,8 @@ permissions:
   contents: read
 
 jobs:
-  FPGA-CW310-SiVal-Nightly:
-    name: Fpga cw310 sival tests
+  fpga_cw310_sival_nightly:
+    name: FPGA CW310 SiVal tests
     runs-on: [ubuntu-20.04-fpga, cw310]
 
     env:
@@ -51,23 +51,23 @@ jobs:
           || ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
 
       - name: Run tests after ROM boot stage
+        if: success() || failure()
         run: |
           module load xilinx/vivado
           bazel_tests="$(mktemp)"
-          ./bazelisk.sh query 'attr("tags", "[\[ ]cw310_sival[,\]]", tests(//...))' \
+          ./bazelisk.sh query 'attr("tags", "[\[ ]cw310_sival[,\]]", tests(//sw/device/...))' \
                                                     | grep -v examples \
-                                                    | grep -v third_party \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
           ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"
 
       - name: Run tests after ROM_EXT boot stage
+        if: success() || failure()
         run: |
           module load xilinx/vivado
           bazel_tests="$(mktemp)"
-          ./bazelisk.sh query 'attr("tags", "[\[ ]cw310_sival_rom_ext[,\]]", tests(//...))' \
+          ./bazelisk.sh query 'attr("tags", "[\[ ]cw310_sival_rom_ext[,\]]", tests(//sw/device/...))' \
                                                     | grep -v examples \
-                                                    | grep -v third_party \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
           ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"


### PR DESCRIPTION
This PR publishes the test results produced by bazel in a gcp bucket for the Nightly job for now.
The results will be consumed by scripts which will feed the Grafana database and the SiVal spreadsheet. 