### PR TITLE
[dice,cwt] Endorse and store all 4 DICE CWT/X509 certificates

### DIFF
--- a/sw/device/silicon_creator/lib/cert/cert.h
+++ b/sw/device/silicon_creator/lib/cert/cert.h
@@ -52,6 +52,15 @@ enum {
 };
 
 /**
+ * DICE certificate format. It supports 2 types currently.
+ * Each DICE implementation declares one of those specifically.
+ */
+typedef enum dice_cert_format {
+  kDiceCertFormatX509TcbInfo = 0,
+  kDiceCertFormatCWTAndroid = 1,
+} dice_cert_format_t;
+
+/**
  * Defines a grouping of certificates onto a single flash info page.
  */
 typedef struct cert_flash_info_layout {

--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -34,6 +34,8 @@ static cdi_1_sig_values_t cdi_1_cert_params = {
     .tbs_size = kCdi1MaxTbsSizeBytes,
 };
 
+const dice_cert_format_t kDiceCertFormat = kDiceCertFormatX509TcbInfo;
+
 static_assert(kDiceMeasurementSizeInBytes == 32,
               "The DICE attestation measurement size should equal the size of "
               "the keymgr binding registers.");

--- a/sw/device/silicon_creator/lib/cert/dice.h
+++ b/sw/device/silicon_creator/lib/cert/dice.h
@@ -23,6 +23,7 @@ enum {
   kDiceMeasurementSizeInBytes = kDiceMeasurementSizeInBits / 8,
 };
 
+extern const dice_cert_format_t kDiceCertFormat;
 /**
  * DICE ECC key descriptors.
  */

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -276,6 +276,7 @@ cc_library(
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/cert",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -476,7 +476,7 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   TRY(perso_tlv_push_cert_to_perso_blob(
       "UDS",
       /*needs_endorsement=*/kDiceCertFormat == kDiceCertFormatX509TcbInfo,
-      all_certs, curr_cert_size, &perso_blob_to_host));
+      kDiceCertFormat, all_certs, curr_cert_size, &perso_blob_to_host));
   LOG_INFO("Generated UDS certificate.");
 
   // Generate CDI_0 keys and cert.
@@ -495,8 +495,8 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // DO NOT CHANGE THE "CDI_0" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob("CDI_0", /*needs_endorsement=*/false,
-                                        all_certs, curr_cert_size,
-                                        &perso_blob_to_host));
+                                        kDiceCertFormat, all_certs,
+                                        curr_cert_size, &perso_blob_to_host));
   LOG_INFO("Generated CDI_0 certificate.");
 
   // Generate CDI_1 keys and cert.
@@ -516,8 +516,8 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   // DO NOT CHANGE THE "CDI_1" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
   TRY(perso_tlv_push_cert_to_perso_blob("CDI_1", /*needs_endorsement=*/false,
-                                        all_certs, curr_cert_size,
-                                        &perso_blob_to_host));
+                                        kDiceCertFormat, all_certs,
+                                        curr_cert_size, &perso_blob_to_host));
   LOG_INFO("Generated CDI_1 certificate.");
 
   return OK_STATUS();

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -29,6 +29,7 @@ typedef enum perso_tlv_object_type {
   kPersoObjectTypeX509Tbs = 0,
   kPersoObjectTypeX509Cert = 1,
   kPersoObjectTypeDevSeed = 2,
+  kPersoObjectTypeCwtCert = 3,
 } perso_tlv_object_type_t;
 
 typedef uint16_t perso_tlv_object_header_t;

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -11,6 +11,7 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
+#include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 /**
@@ -184,8 +185,7 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
  * +----------------------------------------------+
  *
  * @param name The name of the certificate.
- * @param needs_endorsement Defines the type of the LTV object the certificate
- *                          is wrapped into (TBS or fully formed).
+ * @param obj_type The object type that needs to encoded.
  * @param cert The binary certificate blob.
  * @param cert_size Size of the certificate blob in bytes.
  * @param[out] buf Output buffer to copy the data into.
@@ -194,7 +194,8 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
  * @return status of the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t perso_tlv_cert_obj_build(const char *name, bool needs_endorsement,
+rom_error_t perso_tlv_cert_obj_build(const char *name,
+                                     const perso_tlv_object_type_t obj_type,
                                      const uint8_t *cert, size_t cert_size,
                                      uint8_t *buf, size_t *buf_size);
 
@@ -206,6 +207,7 @@ rom_error_t perso_tlv_cert_obj_build(const char *name, bool needs_endorsement,
  * @param name The name of the certificate.
  * @param needs_endorsement Defines the type of the LTV object the certificate
  *                          is wrapped into (TBS or fully formed).
+ * @param cert_format The format of the certificate.
  * @param cert The binary certificate blob.
  * @param cert_size Size of the certificate blob in bytes.
  * @param perso_blob Pointer to the `perso_blob_t` to copy the object to.
@@ -214,6 +216,7 @@ rom_error_t perso_tlv_cert_obj_build(const char *name, bool needs_endorsement,
 OT_WARN_UNUSED_RESULT
 status_t perso_tlv_push_cert_to_perso_blob(const char *name,
                                            bool needs_endorsement,
+                                           const dice_cert_format_t cert_format,
                                            const uint8_t *cert,
                                            size_t cert_size, perso_blob_t *pb);
 

--- a/sw/device/silicon_creator/manuf/base/personalize_ext.h
+++ b/sw/device/silicon_creator/manuf/base/personalize_ext.h
@@ -48,11 +48,26 @@ typedef struct personalize_extension_pre_endorse {
    * knows where to place endorsed objects received from the host.
    */
   cert_flash_info_layout_t *cert_flash_layout;
-
   /**
    * Pointer to the flash controller handle necessary for proper flash access.
    */
   dif_flash_ctrl_state_t *flash_ctrl_handle;
+  /**
+   * Pointer to the UDS public key. Personalization extensions may require
+   * accessing it to generate different certificate chains that fit a specific
+   * SKU's requirements.
+   */
+  ecdsa_p256_public_key_t *uds_pubkey;
+  hmac_digest_t *uds_pubkey_id;
+  /**
+   * Pointer to the OTP measurements used to generate the UDS public key.
+   * Personalization extensions may require accessing these to generate
+   * different certificate chains that fit a specific SKU's requirements.
+   */
+  hmac_digest_t *otp_creator_sw_cfg_measurement;
+  hmac_digest_t *otp_owner_sw_cfg_measurement;
+  hmac_digest_t *otp_rot_creator_auth_codesign_measurement;
+  hmac_digest_t *otp_rot_creator_auth_state_measurement;
 } personalize_extension_pre_endorse_t;
 
 /**

--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -80,9 +80,9 @@ static status_t personalize_gen_tpm_ek_certificate(
   curr_cert_size = sizeof(cert_buffer);
   TRY(tpm_ek_tbs_cert_build(&tpm_key_ids, &curr_pubkey, cert_buffer,
                             &curr_cert_size));
-  return perso_tlv_push_cert_to_perso_blob("TPM EK", /*needs_endorsement=*/true,
-                                           cert_buffer, curr_cert_size,
-                                           perso_blob);
+  return perso_tlv_push_cert_to_perso_blob(
+      "TPM EK", /*needs_endorsement=*/true, kDiceCertFormatX509TcbInfo,
+      cert_buffer, curr_cert_size, perso_blob);
 }
 
 status_t personalize_extension_pre_cert_endorse(

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -543,9 +543,9 @@ static rom_error_t dice_chain_push_cert(const char *name, const uint8_t *cert,
 
   // Encode the certificate to the tail buffer.
   size_t cert_page_left = dice_chain_get_tail_size();
-  HARDENED_RETURN_IF_ERROR(perso_tlv_cert_obj_build(
-      name, /*needs_endorsement=*/false, cert, cert_size,
-      dice_chain_get_tail_buffer(), &cert_page_left));
+  HARDENED_RETURN_IF_ERROR(
+      perso_tlv_cert_obj_build(name, kPersoObjectTypeX509Cert, cert, cert_size,
+                               dice_chain_get_tail_buffer(), &cert_page_left));
 
   // Move the offset to the new tail.
   HARDENED_RETURN_IF_ERROR(perso_tlv_get_cert_obj(dice_chain_get_tail_buffer(),

--- a/sw/host/provisioning/perso_tlv_lib/src/lib.rs
+++ b/sw/host/provisioning/perso_tlv_lib/src/lib.rs
@@ -11,6 +11,7 @@ pub enum ObjType {
     UnendorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Tbs as isize,
     EndorsedX509Cert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeX509Cert as isize,
     DevSeed = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeDevSeed as isize,
+    EndorsedCwtCert = perso_tlv_objects::perso_tlv_object_type_kPersoObjectTypeCwtCert as isize,
 }
 
 impl ObjType {
@@ -19,6 +20,7 @@ impl ObjType {
             0 => Ok(ObjType::UnendorsedX509Cert),
             1 => Ok(ObjType::EndorsedX509Cert),
             2 => Ok(ObjType::DevSeed),
+            3 => Ok(ObjType::EndorsedCwtCert),
             _ => bail!("incorrect input value of {value} for ObjType"),
         }
     }


### PR DESCRIPTION
In this implementation,
- Add one more object type "kPersoObjectTypeCwtCert" to reflects the CWT implementation
- Update "struct personalize_extension_pre_endorse{}" to pass more OTP measurments to the perso_ext for uds_build_tbs()
- Update the personalize_endorse_certificates() logic, to parse the payload based on DICE chain type

Bug: 356532759
Bug: #24943 
Test: //sw/device/silicon_creator/manuf/base:ft_provision_cw340