### PR TITLE
[util/cmdgen.py] Ensure working directory is repo root

### DIFF
--- a/util/cmdgen.py
+++ b/util/cmdgen.py
@@ -89,7 +89,8 @@ def cmdgen_rewrite_md(filepath: Path, dry_run: bool, update: bool) -> bool:
             continue
 
         # Run the found-command in a subshell
-        res = subprocess.run(cmd, shell=True, capture_output=True)
+        res = subprocess.run(cmd, shell=True, capture_output=True,
+                             cwd=REPO_ROOT)
         if res.stderr:
             logger.info(
                 f"{rel_path}:L{match_start_linum}: `{cmd}` "


### PR DESCRIPTION
Commands may contain paths, which are relative to the root of the repository.  In order to make command invocation independent of the current working directory, we set `cwd` of `subprocess.run` to the root of the repository.

This supersedes PR #24986.