### PR TITLE
[sival] Replace nonexistent bazel targets in HMAC and KMAC testplans

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_hmac_testplan.hjson
@@ -128,7 +128,9 @@
       lc_states: ["PROD"]
       tests: []
       bazel: [
-        "//sw/device/tests/crypto/cryptotest:hmac_kat",
+        "//sw/device/tests/crypto/cryptotest:hmac_sha256_kat",
+        "//sw/device/tests/crypto/cryptotest:hmac_sha384_kat",
+        "//sw/device/tests/crypto/cryptotest:hmac_sha512_kat",
         "//sw/device/tests/crypto:kmac_functest_hardcoded",
         "//sw/device/tests/crypto:hmac_sha512_functest",
         "//sw/device/tests/crypto:hmac_sha384_functest"

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -133,7 +133,9 @@
       lc_states: ["PROD"]
       tests: []
       bazel: [
-        "//sw/device/tests/crypto/cryptotest:hash_kat",
+        "//sw/device/tests/crypto/cryptotest:sha3_256_kat",
+        "//sw/device/tests/crypto/cryptotest:sha3_384_kat",
+        "//sw/device/tests/crypto/cryptotest:sha3_512_kat",
       ]
     }
     {
@@ -155,7 +157,8 @@
       lc_states: ["PROD"]
       tests: []
       bazel: [
-        "//sw/device/tests/crypto/cryptotest:hash_kat",
+        "//sw/device/tests/crypto/cryptotest:shake128_kat",
+        "//sw/device/tests/crypto/cryptotest:shake256_kat",
       ]
     }
     {
@@ -177,7 +180,6 @@
       lc_states: ["PROD"]
       tests: []
       bazel: [
-        "//sw/device/tests/crypto/cryptotest:hash_kat",
         "//sw/device/tests:kmac_mode_cshake_test",
       ]
     }


### PR DESCRIPTION
The old `hmac_kat` and `hash_kat` cryptotest targets had been split up. This PR updates these targets in the HMAC and KMAC testplans.

One thing to note is that looking at cSHAKE, it only has four test cases that are defined in `sw/device/tests/kmac_mode_cshake_test.c`. We don't have any large set of NIST KAT test vectors since I don't think they ever released any. We do have two examples that NIST has provided that we manually extracted from a PDF. They are currently in `sw/device/tests/crypto/testvectors/cshake_hardcoded.hjson` but are not used anywhere. Do we want to include these two hardcoded tests?

More broadly, do we want to include the hardcoded tests under `sw/device/tests/crypto/testvectors` for other algorithms as well as part of the sival tests? As best as I can tell, several of the hardcoded tests currently aren't being used.