### PR TITLE
[manuf,rom_ext] write certs to flash in perso LTV object format

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -54,6 +54,7 @@ enum module_ {
   kModuleRescue =          MODULE_CODE('R', 'S'),
   kModuleCert =            MODULE_CODE('C', 'E'),
   kModuleOwnership =       MODULE_CODE('O', 'W'),
+  kModulePersoTlv =        MODULE_CODE('P', 'T'),
   // clang-format on
 };
 
@@ -215,6 +216,9 @@ enum module_ {
   X(kErrorOwnershipBadInfoPage,       ERROR_(10, kModuleOwnership, kInternal)), \
   X(kErrorOwnershipNoOwner,           ERROR_(11, kModuleOwnership, kInternal)), \
   X(kErrorOwnershipKeyNotFound,       ERROR_(12, kModuleOwnership, kNotFound)), \
+  \
+  X(kErrorPersoTlvInternal,           ERROR_(0, kModulePersoTlv, kInternal)), \
+  X(kErrorPersoTlvCertObjNotFound,    ERROR_(1, kModulePersoTlv, kNotFound)), \
   \
   /* This comment prevent clang from trying to format the macro. */
 

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -219,6 +219,8 @@ enum module_ {
   \
   X(kErrorPersoTlvInternal,           ERROR_(0, kModulePersoTlv, kInternal)), \
   X(kErrorPersoTlvCertObjNotFound,    ERROR_(1, kModulePersoTlv, kNotFound)), \
+  X(kErrorPersoTlvCertNameTooLong,    ERROR_(2, kModulePersoTlv, kOutOfRange)), \
+  X(kErrorPersoTlvOutputBufTooSmall,  ERROR_(3, kModulePersoTlv, kOutOfRange)), \
   \
   /* This comment prevent clang from trying to format the macro. */
 

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -254,7 +254,9 @@ cc_library(
     srcs = ["perso_tlv_data.c"],
     deps = [
         ":perso_tlv_headers",
+        "//sw/device/lib/base:status",
         "//sw/device/lib/runtime:log",
+        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/cert",
     ],
 )

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -23,12 +23,12 @@ load(
     "LOCAL_CERT_ENDORSEMENT_PARAMS",
 )
 load(
-    "//sw/device/silicon_creator/rom_ext:defs.bzl",
-    "ROM_EXT_VERSION",
-)
-load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "SLOTS",
+)
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VERSION",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -269,6 +269,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/json:provisioning_data",
+        "//sw/device/silicon_creator/lib:error",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -439,8 +439,10 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
       all_certs, &curr_cert_size));
   // DO NOT CHANGE THE "UDS" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
-  TRY(perso_tlv_prepare_cert_for_shipping("UDS", true, all_certs,
-                                          curr_cert_size, &perso_blob_to_host));
+  TRY(perso_tlv_push_cert_to_perso_blob("UDS", /*needs_endorsement=*/true,
+                                        all_certs, curr_cert_size,
+                                        &perso_blob_to_host));
+  LOG_INFO("Generated UDS certificate.");
 
   // Generate CDI_0 keys and cert.
   curr_cert_size = kCdi0MaxCertSizeBytes;
@@ -457,8 +459,10 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   cdi_0_offset = perso_blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_0" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
-  TRY(perso_tlv_prepare_cert_for_shipping("CDI_0", false, all_certs,
-                                          curr_cert_size, &perso_blob_to_host));
+  TRY(perso_tlv_push_cert_to_perso_blob("CDI_0", /*needs_endorsement=*/false,
+                                        all_certs, curr_cert_size,
+                                        &perso_blob_to_host));
+  LOG_INFO("Generated CDI_0 certificate.");
 
   // Generate CDI_1 keys and cert.
   curr_cert_size = kCdi1MaxCertSizeBytes;
@@ -476,8 +480,12 @@ static status_t personalize_gen_dice_certificates(ujson_t *uj) {
   cdi_1_offset = perso_blob_to_host.next_free;
   // DO NOT CHANGE THE "CDI_1" STRING BELOW with modifying the `dice_cert_names`
   // collection in sw/host/provisioning/ft_lib/src/lib.rs.
-  return perso_tlv_prepare_cert_for_shipping(
-      "CDI_1", false, all_certs, curr_cert_size, &perso_blob_to_host);
+  TRY(perso_tlv_push_cert_to_perso_blob("CDI_1", /*needs_endorsement=*/false,
+                                        all_certs, curr_cert_size,
+                                        &perso_blob_to_host));
+  LOG_INFO("Generated CDI_1 certificate.");
+
+  return OK_STATUS();
 }
 
 // Returns how much data is left in the perso blob receive buffer (i.e., `body`

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -510,23 +510,22 @@ static status_t extract_next_cert(uint8_t **dest, size_t *free_room) {
   // Scan the received buffer until the next endorsed cert is found.
   while (perso_blob_from_host.num_objs != 0) {
     perso_tlv_cert_obj_t block;
-    status_t status;
 
     // Extract the next perso LTV object, aborting if it is not a certificate.
-    status = perso_tlv_get_cert_obj(
+    rom_error_t err = perso_tlv_get_cert_obj(
         perso_blob_from_host.body + perso_blob_from_host.next_free,
         max_available(), &block);
-    switch (status_err(status)) {
-      case kOk:
+    switch (err) {
+      case kErrorOk:
         break;
-      case kNotFound: {
+      case kErrorPersoTlvCertObjNotFound: {
         // The object found is not a certificate. Skip to next perso LTV object.
         perso_blob_from_host.next_free += block.obj_size;
         perso_blob_from_host.num_objs--;
         continue;
       }
       default:
-        return status;
+        return INTERNAL();
     }
 
     // Check there is enough room in the destination buffer to copy the

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -20,8 +20,10 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   memcpy(&objh, buf, sizeof(perso_tlv_object_header_t));
   // Extract LTV object size.
   PERSO_TLV_GET_FIELD(Objh, Size, objh, &obj_size);
+  if (obj_size == 0)
+    return kErrorPersoTlvCertObjNotFound;  // Object is empty.
   if (obj_size > ltv_buf_size)
-    return kErrorPersoTlvInternal;  // Something is really screwed up.
+    return kErrorPersoTlvInternal;  // Object exceeds the size of host buffer.
   obj->obj_size = obj_size;
   // Extract LTV object type.
   PERSO_TLV_GET_FIELD(Objh, Type, objh, &obj_type);

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -7,10 +7,6 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 
-/**
- * A helper function adding arbitrary amount of data to the body of the perso
- * blob, returns error if the passed in data would not fit.
- */
 status_t perso_tlv_push_to_blob(const void *data, size_t size,
                                 perso_blob_t *perso_blob) {
   size_t room = sizeof(perso_blob->body) - perso_blob->next_free;
@@ -23,68 +19,68 @@ status_t perso_tlv_push_to_blob(const void *data, size_t size,
   return OK_STATUS();
 }
 
-status_t perso_tlv_set_cert_block(const uint8_t *buf, size_t max_room,
-                                  perso_tlv_cert_block_t *block) {
+status_t perso_tlv_get_cert_obj(const uint8_t *buf, size_t ltv_buf_size,
+                                perso_tlv_cert_obj_t *obj) {
   perso_tlv_object_header_t objh;
+  perso_tlv_object_type_t obj_type;
   uint16_t obj_size;
-  perso_tlv_object_header_t obj_type;
 
-  memcpy(&objh, buf, sizeof(objh));
+  // Extract LTV object header, including: size and type.
+  obj->obj_p = buf;
+  memcpy(&objh, buf, sizeof(perso_tlv_object_header_t));
+  // Extract LTV object size.
   PERSO_TLV_GET_FIELD(Objh, Size, objh, &obj_size);
-
-  if (obj_size > max_room)
+  if (obj_size > ltv_buf_size)
     return INTERNAL();  // Something is really screwed up.
-
-  buf += sizeof(objh);
-  max_room -= sizeof(objh);
-  block->obj_size = obj_size;
+  obj->obj_size = obj_size;
+  // Extract LTV object type.
   PERSO_TLV_GET_FIELD(Objh, Type, objh, &obj_type);
-
   if (obj_type != kPersoObjectTypeX509Cert) {
     LOG_INFO("Skipping object of type %d", obj_type);
     return NOT_FOUND();
   }
+  buf += sizeof(perso_tlv_object_header_t);
+  ltv_buf_size -= sizeof(perso_tlv_object_header_t);
+
+  // If we made it this far, we found a certificate LTV object, so we will parse
+  // the object's header and metadata next.
 
   perso_tlv_cert_header_t crth;
   uint16_t wrapped_cert_size;
   uint16_t name_len;
 
-  // Let's retrieve cert wrapper header.
-  block->wrapped_cert_p = buf;
-  memcpy(&crth, buf, sizeof(crth));
-  max_room -= sizeof(crth);
-  buf += sizeof(crth);
-  PERSO_TLV_GET_FIELD(Crth, Size, crth, &wrapped_cert_size);
+  // Extract the certificate object header, including: certificate object and
+  // nameksizes, certificate name string, and pointer to the certificate body.
+  memcpy(&crth, buf, sizeof(perso_tlv_cert_header_t));
+  // Extract certificate name size.
   PERSO_TLV_GET_FIELD(Crth, NameSize, crth, &name_len);
-
-  const size_t min_header_size = sizeof(objh) + sizeof(crth);
-
-  // At least 8 bytes in the certificate body to get its size.
-  if ((wrapped_cert_size < (name_len + min_header_size + 8)) ||
-      (wrapped_cert_size > max_room))
+  // Extract wrapped certificate object size.
+  PERSO_TLV_GET_FIELD(Crth, Size, crth, &wrapped_cert_size);
+  // There are at least 4 bytes in an X.509 ASN.1 DER certificate: two bytes of
+  // header and two bytes of size data.
+  if ((wrapped_cert_size < (sizeof(perso_tlv_cert_header_t) + name_len + 4)) ||
+      (wrapped_cert_size > ltv_buf_size))
     return INTERNAL();  // Something is really screwed up.
-
-  memcpy(block->name, buf, name_len);
+  buf += sizeof(perso_tlv_cert_header_t);
+  ltv_buf_size -= sizeof(perso_tlv_cert_header_t);
+  // Extract certificate name string.
+  memcpy(obj->name, buf, name_len);
+  obj->name[name_len] = '\0';
   buf += name_len;
-  max_room -= name_len;
-  block->name[name_len] = '\0';
-
-  size_t cert_size;
-
-  cert_size = cert_x509_asn1_decode_size_header(buf);
-  if (cert_size > max_room)
-    return INTERNAL();
-
-  uint16_t wire_cert_size =
+  ltv_buf_size -= name_len;
+  // Set pointer to certificate body.
+  obj->cert_body_size =
       wrapped_cert_size - sizeof(perso_tlv_cert_header_t) - name_len;
+  obj->cert_body_p = buf;
 
-  if (cert_size != wire_cert_size) {
-    LOG_ERROR("Unexpected cert size %d instead of %d for cert %s", cert_size,
-              wire_cert_size, block->name);
+  // Sanity check on the certificate body size.
+  size_t decoded_cert_size =
+      cert_x509_asn1_decode_size_header(obj->cert_body_p);
+  if (decoded_cert_size != obj->cert_body_size) {
+    LOG_ERROR("Unexpected cert size %d instead of %d for cert %s",
+              decoded_cert_size, obj->cert_body_size, obj->name);
     return INTERNAL();
   }
-
-  block->wrapped_cert_size = wrapped_cert_size;
 
   return OK_STATUS();
 }
@@ -94,58 +90,41 @@ status_t perso_tlv_prepare_cert_for_shipping(const char *name,
                                              const void *cert_body,
                                              size_t cert_size,
                                              perso_blob_t *pb) {
-  /**
-   * * The certificate is laid out in the perso blob buffer as follows:
-   * - 16 bit object header
-   * - 16 bits cert wrapper header
-   * - Certificate name string
-   * - Cerificate data itself
-   *
-   * Note that both certificate and object headers'
-   * are 16 bit integers in big endian format.
-   *
-   *  d15                                         d0
-   * +-------------+--------------------------------+
-   * | 4 bit type  |   12 bits total object size    | <-- Object Header
-   * +-------------+--------------------------------+
-   * | name length |12 bits total cert payload size | <-- Cert Header
-   * +-------------+--------------------------------+
-   * |             cert name string                 |
-   * +----------------------------------------------+
-   * |                   cert                       |
-   * +----------------------------------------------+
-   */
   perso_tlv_object_header_t obj_header = 0;
   perso_tlv_cert_header_t cert_header = 0;
   size_t name_len;
   size_t obj_len;
   size_t wrapped_len;
 
-  // strlen() is not available.
+  // Compute the name length (strlen() is not available).
   name_len = 0;
   while (name[name_len])
     name_len++;
-
   if (name_len > kCrthNameSizeFieldMask)
     return OUT_OF_RANGE();
 
+  // Compute the wrapped certificate object (cert header + cert data) and perso
+  // LTV object sizes.
   wrapped_len = sizeof(perso_tlv_cert_header_t) + name_len + cert_size;
   obj_len = wrapped_len + sizeof(perso_tlv_object_header_t);
 
+  // Check there is enough room in the buffer to store the perso LTV object.
   if (obj_len > (sizeof(pb->body) - pb->next_free))
     return OUT_OF_RANGE();
 
+  // Setup the perso LTV object header.
   if (needs_endorsement) {
     PERSO_TLV_SET_FIELD(Objh, Type, obj_header, kPersoObjectTypeX509Tbs);
   } else {
     PERSO_TLV_SET_FIELD(Objh, Type, obj_header, kPersoObjectTypeX509Cert);
   }
-
   PERSO_TLV_SET_FIELD(Objh, Size, obj_header, obj_len);
 
+  // Setup the cert object header.
   PERSO_TLV_SET_FIELD(Crth, Size, cert_header, wrapped_len);
   PERSO_TLV_SET_FIELD(Crth, NameSize, cert_header, name_len);
 
+  // Push the entire cert perso LTV object to the buffer.
   TRY(perso_tlv_push_to_blob(&obj_header, sizeof(obj_header), pb));
   TRY(perso_tlv_push_to_blob(&cert_header, sizeof(cert_header), pb));
   TRY(perso_tlv_push_to_blob(name, name_len, pb));

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -11,6 +11,7 @@
 
 #include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
+#include "sw/device/silicon_creator/lib/error.h"
 
 /**
  * Personalization data is sent between the device and the host during the
@@ -149,8 +150,9 @@ typedef struct perso_tlv_cert_obj {
  * @return OK_STATUS on success, NOT_FOUND if the object is not an endorsed
  *                   certificate, or the error condition encountered.
  */
-status_t perso_tlv_get_cert_obj(const uint8_t *buf, size_t ltv_buf_size,
-                                perso_tlv_cert_obj_t *obj);
+OT_WARN_UNUSED_RESULT
+rom_error_t perso_tlv_get_cert_obj(const uint8_t *buf, size_t ltv_buf_size,
+                                   perso_tlv_cert_obj_t *obj);
 
 /**
  * Wrap the passed in certificate in a perso LTV object and copy it into the
@@ -186,6 +188,7 @@ status_t perso_tlv_get_cert_obj(const uint8_t *buf, size_t ltv_buf_size,
  *
  * @return status of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t perso_tlv_prepare_cert_for_shipping(const char *name,
                                              bool needs_endorsement,
                                              const void *cert_body,
@@ -202,6 +205,7 @@ status_t perso_tlv_prepare_cert_for_shipping(const char *name,
  *
  * @return status of the operation.
  */
+OT_WARN_UNUSED_RESULT
 status_t perso_tlv_push_to_blob(const void *data, size_t size,
                                 perso_blob_t *perso_blob);
 

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -94,7 +94,7 @@ typedef enum perso_tlv_cert_header_fields {
   {                                                                         \
     uint16_t mask = k##type_name##field_name##FieldMask;                    \
     uint16_t shift = k##type_name##field_name##FieldShift;                  \
-    uint16_t fieldv = (uint16_t)(field_value) & mask;                       \
+    uint16_t fieldv = (uint16_t)(field_value)&mask;                         \
     uint16_t fullv = __builtin_bswap16((uint16_t)(full_value));             \
     mask = (uint16_t)(mask << shift);                                       \
     (full_value) = __builtin_bswap16(                                       \
@@ -116,7 +116,7 @@ typedef struct perso_tlv_cert_obj {
   /**
    * Pointer to the start of the perso LTV object.
    */
-  const void *obj_p;
+  uint8_t *obj_p;
   /**
    * LTV object size (in bytes).
    */
@@ -125,7 +125,7 @@ typedef struct perso_tlv_cert_obj {
    * Pointer to the start of the certificate body (i.e., ASN.1 object for X.509
    * certificates, or CBOR object for CWT certificates).
    */
-  const void *cert_body_p;
+  uint8_t *cert_body_p;
   /**
    * Certificate (ASN.1 or CBOR) body size (in bytes).
    *
@@ -151,18 +151,18 @@ typedef struct perso_tlv_cert_obj {
  *                   certificate, or the error condition encountered.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t perso_tlv_get_cert_obj(const uint8_t *buf, size_t ltv_buf_size,
+rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
                                    perso_tlv_cert_obj_t *obj);
 
 /**
- * Wrap the passed in certificate in a perso LTV object and copy it into the
- * body of the perso_blob.
+ * Wraps the passed certificate in a perso LTV object and copies it to an output
+ * buffer.
  *
  * The certificate perso LTV object is laid out as follows:
  * - 16 bit LTV object header
- * - 16 bits cert wrapper header
+ * - 16 bit cert header
  * - Certificate name string
- * - Cerificate data itself
+ * - Cerificate data
  *
  * Note that both certificate and object headers' are 16 bit integers in big
  * endian format.
@@ -178,35 +178,50 @@ rom_error_t perso_tlv_get_cert_obj(const uint8_t *buf, size_t ltv_buf_size,
  * |                   cert                       |
  * +----------------------------------------------+
  *
- *
- * @param name the name of the certificate
- * @param needs_endorsement defines the type of the LTV object the certificate
- *                          is wrapped into
- * @param cert_body the actual certificate
- * @param cert_size size of the certificate in bytes
- * @param[out] perso_blob container for sending data to host.
- *
+ * @param name The name of the certificate.
+ * @param needs_endorsement Defines the type of the LTV object the certificate
+ *                          is wrapped into (TBS or fully formed).
+ * @param cert The binary certificate blob.
+ * @param cert_size Size of the certificate blob in bytes.
+ * @param[out] buf Output buffer to copy the data into.
+ * @param[inout] buf_size Input is size of the output buffer in bytes; output is
+ *                        space of buffer that was consumed by the LTV object.
  * @return status of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t perso_tlv_prepare_cert_for_shipping(const char *name,
-                                             bool needs_endorsement,
-                                             const void *cert_body,
-                                             size_t cert_size,
-                                             perso_blob_t *perso_blob);
+rom_error_t perso_tlv_cert_obj_build(const char *name, bool needs_endorsement,
+                                     const uint8_t *cert, size_t cert_size,
+                                     uint8_t *buf, size_t *buf_size);
 
 /**
- * A helper function adding arbitrary amount of data to the body of a perso
- * blob.
+ * Constructs an certificate perso LTV object (shown above) by invoking
+ * `perso_tlv_cert_obj_build()` and pushes it to a `perso_blob_t` object used
+ * for shuffling data between the host and device during personalization.
  *
- * @param data ponter to the data to add to the blob
- * @param size number of bytes of data
- * @param perso_blob pointer to the blob to add data to
- *
+ * @param name The name of the certificate.
+ * @param needs_endorsement Defines the type of the LTV object the certificate
+ *                          is wrapped into (TBS or fully formed).
+ * @param cert The binary certificate blob.
+ * @param cert_size Size of the certificate blob in bytes.
+ * @param perso_blob Pointer to the `perso_blob_t` to copy the object to.
  * @return status of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t perso_tlv_push_to_blob(const void *data, size_t size,
-                                perso_blob_t *perso_blob);
+status_t perso_tlv_push_cert_to_perso_blob(const char *name,
+                                           bool needs_endorsement,
+                                           const uint8_t *cert,
+                                           size_t cert_size, perso_blob_t *pb);
+
+/**
+ * Pushes arbitrary data to the perso blob that is sent between host and device.
+ *
+ * @param data Pointer to the data to add to the blob.
+ * @param size Size of the data to add in bytes.
+ * @param perso_blob Pointer to the perso blob to add the data to.
+ * @return status of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+status_t perso_tlv_push_to_perso_blob(const void *data, size_t size,
+                                      perso_blob_t *perso_blob);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_BASE_PERSO_TLV_DATA_H_

--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -88,8 +88,9 @@ static status_t personalize_gen_tpm_ek_certificate(
   curr_cert_size = sizeof(cert_buffer);
   TRY(tpm_ek_tbs_cert_build(&tpm_key_ids, &curr_pubkey, cert_buffer,
                             &curr_cert_size));
-  return perso_tlv_prepare_cert_for_shipping("TPM EK", true, cert_buffer,
-                                             curr_cert_size, perso_blob);
+  return perso_tlv_push_cert_to_perso_blob("TPM EK", /*needs_endorsement=*/true,
+                                           cert_buffer, curr_cert_size,
+                                           perso_blob);
 }
 
 status_t personalize_extension_pre_cert_endorse(

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -262,6 +262,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/ownership:ownership_activate",
         "//sw/device/silicon_creator/lib/ownership:ownership_unlock",
         "//sw/device/silicon_creator/lib/sigverify",
+        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
         "//sw/otbn/crypto:boot",
     ],
 )

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -49,6 +49,7 @@
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
 #include "sw/device/silicon_creator/lib/sigverify/rsa_verify.h"
 #include "sw/device/silicon_creator/lib/sigverify/sigverify.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 #include "sw/device/silicon_creator/rom_ext/rescue.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h"
@@ -101,6 +102,13 @@ const epmp_region_t kFlashRegion = {
 // Certificate data.
 static uint8_t dice_certs_page[FLASH_CTRL_PARAM_BYTES_PER_PAGE];
 static hardened_bool_t dice_certs_page_dirty = kHardenedBoolFalse;
+static perso_tlv_cert_obj_t dice_cert_obj = {
+    .obj_p = dice_certs_page,        // Pointer to a perso TLV cert obj.
+    .obj_size = 0,                   // Perso TLV object size in bytes.
+    .cert_body_p = dice_certs_page,  // Pointer to the cert data in the TLV obj.
+    .cert_body_size = 0,             // Size of the cert data in bytes.
+    .name = {0},                     // Name of the cert.
+};
 static size_t dice_certs_page_offset = 0;
 static hmac_digest_t uds_pubkey_id;
 static hmac_digest_t cdi_0_pubkey_id;
@@ -309,14 +317,35 @@ static uintptr_t owner_vma_get(const manifest_t *manifest, uintptr_t lma_addr) {
           (uintptr_t)_owner_virtual_start_address + CHIP_ROM_EXT_SIZE_MAX);
 }
 
+static size_t dice_certs_buffer_space_remaining(void) {
+  return FLASH_CTRL_PARAM_BYTES_PER_PAGE -
+         (size_t)(dice_cert_obj.obj_p - dice_certs_page);
+}
+
 /**
  * Increments the DICE cert page offset (ensuring to round up to the 64-bit
  * flash word offset to prevent potential ECC issues).
  */
-static void rom_ext_attestation_increment_cert_offset(size_t cert_size) {
-  HARDENED_CHECK_GE(cert_size, 4);
-  dice_certs_page_offset += util_size_to_words(cert_size) * sizeof(uint32_t);
+static rom_error_t rom_ext_attestation_increment_cert_offset(void) {
+  // Round up to next flash word for next perso TLV object offset.
+  HARDENED_CHECK_GE(dice_cert_obj.cert_body_size, 4);
+  dice_certs_page_offset +=
+      util_size_to_words(dice_cert_obj.obj_size) * sizeof(uint32_t);
   dice_certs_page_offset = util_round_up_to(dice_certs_page_offset, 3);
+
+  // Attempt to retrieve a perso TLV cert object.
+  rom_error_t err = perso_tlv_get_cert_obj(
+      dice_certs_page + dice_certs_page_offset,
+      FLASH_CTRL_PARAM_BYTES_PER_PAGE - dice_certs_page_offset, &dice_cert_obj);
+  if (err == kErrorPersoTlvCertObjNotFound) {
+    // If the cert is not found it is because we are running on a sim or FPGA
+    // platform, or the device has not yet been provisioned. Continue, and let
+    // the ROM_EXT generate an identity certificate for the current DICE stage.
+    return kErrorOk;
+  }
+  HARDENED_RETURN_IF_ERROR(err);
+
+  return kErrorOk;
 }
 
 OT_WARN_UNUSED_RESULT
@@ -331,12 +360,23 @@ static rom_error_t rom_ext_buffer_dice_certs_into_ram(void) {
     if (flash_ctrl_err_code.rd_err) {
       // If we encountered a read error, this could mean the certificate page
       // has been corrupted or is not provisioned yet. In this case, we mark the
-      // page as "dirty" and set the buffer to all 1s, which are the values read
-      // from a freshly erased flash page.
-      memset(dice_certs_page, UINT8_MAX, FLASH_CTRL_PARAM_BYTES_PER_PAGE);
+      // page as "dirty" and set the buffer to all 0s.
+      memset(dice_certs_page, 0, FLASH_CTRL_PARAM_BYTES_PER_PAGE);
       dice_certs_page_dirty = true;
       return kErrorOk;
     }
+    return err;
+  }
+
+  // Certificates are stored on flash info pages in perso LTV object form, see
+  // `sw/device/silicon_creator/manuf/base/perso_tlv_data.h` for more details.
+  // We must extract the offsets of the first DICE certificate (i.e., UDS).
+  err = perso_tlv_get_cert_obj(dice_certs_page, FLASH_CTRL_PARAM_BYTES_PER_PAGE,
+                               &dice_cert_obj);
+  if (err == kErrorPersoTlvCertObjNotFound) {
+    // If the UDS cert is not found it is because we are running on a sim or
+    // FPGA platform, or the device has not yet been provisioned.
+    return kErrorOk;
   }
   return err;
 }
@@ -370,10 +410,9 @@ static rom_error_t rom_ext_attestation_silicon(void) {
       kDiceKeyUds.keygen_seed_idx, kDiceKeyUds.type,
       *kDiceKeyUds.keymgr_diversifier));
   hardened_bool_t cert_valid = kHardenedBoolFalse;
-  uint32_t cert_size = 0;
   HARDENED_RETURN_IF_ERROR(cert_x509_asn1_check_serial_number(
-      dice_certs_page, dice_certs_page_offset, (uint8_t *)uds_pubkey_id.digest,
-      &cert_valid, &cert_size));
+      dice_cert_obj.cert_body_p, 0, (uint8_t *)uds_pubkey_id.digest,
+      &cert_valid, /*out_cert_size=*/NULL));
   if (launder32(cert_valid) == kHardenedBoolFalse) {
     // The UDS key ID (and cert itself) should never change unless:
     // 1. there is a hardware issue, or
@@ -388,19 +427,21 @@ static rom_error_t rom_ext_attestation_silicon(void) {
     // fully, we expect the cert to be missing. In this case, we write a
     // 0-length (invalid) ASN.1 certificate header blob to avoid breaking tests
     // that run on these platforms.
-    if (cert_size == 0) {
+    if (dice_cert_obj.cert_body_size == 0) {
       dbg_printf("Writing empty UDS certificate ASN.1 blob.\r\n");
-      dice_certs_page[0] = 0x30;
-      dice_certs_page[1] = 0x82;
-      dice_certs_page[2] = 0x00;
-      dice_certs_page[3] = 0x00;
-      cert_size = 4;
+      uint8_t uds_cert[4] = {0x30, 0x82, 0x00, 0x00};
+      size_t cert_page_left = dice_certs_buffer_space_remaining();
+      HARDENED_RETURN_IF_ERROR(perso_tlv_cert_obj_build(
+          "UDS", /*needs_endorsement=*/false, uds_cert, sizeof(uds_cert),
+          dice_cert_obj.obj_p, &cert_page_left));
       dice_certs_page_dirty = kHardenedBoolTrue;
+      // Reload the cert perso LTV object.
+      HARDENED_RETURN_IF_ERROR(perso_tlv_get_cert_obj(
+          dice_cert_obj.obj_p, dice_certs_buffer_space_remaining(),
+          &dice_cert_obj));
     }
   }
-
-  rom_ext_attestation_increment_cert_offset(cert_size);
-
+  HARDENED_RETURN_IF_ERROR(rom_ext_attestation_increment_cert_offset());
   return kErrorOk;
 }
 
@@ -419,10 +460,9 @@ static rom_error_t rom_ext_attestation_creator(
   HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
       kDiceKeyCdi0, &cdi_0_pubkey_id, &curr_attestation_pubkey));
   hardened_bool_t cert_valid = kHardenedBoolFalse;
-  uint32_t cert_size = 0;
   HARDENED_RETURN_IF_ERROR(cert_x509_asn1_check_serial_number(
-      dice_certs_page, dice_certs_page_offset,
-      (uint8_t *)cdi_0_pubkey_id.digest, &cert_valid, &cert_size));
+      dice_cert_obj.cert_body_p, /*offset=*/0,
+      (uint8_t *)cdi_0_pubkey_id.digest, &cert_valid, /*out_cert_size=*/NULL));
   if (launder32(cert_valid) == kHardenedBoolFalse) {
     HARDENED_CHECK_EQ(cert_valid, kHardenedBoolFalse);
     dbg_printf("CDI_0 certificate not valid. Updating it ...\r\n");
@@ -432,16 +472,21 @@ static rom_error_t rom_ext_attestation_creator(
         rom_ext_manifest->security_version, &cdi_0_key_ids,
         &curr_attestation_pubkey, cdi_0_cert, &updated_cert_size));
     // Update the cert page buffer.
-    memcpy(&dice_certs_page[dice_certs_page_offset], cdi_0_cert,
-           updated_cert_size);
+    size_t cert_page_left = dice_certs_buffer_space_remaining();
+    HARDENED_RETURN_IF_ERROR(perso_tlv_cert_obj_build(
+        "CDI_0", /*needs_endorsement=*/false, cdi_0_cert, updated_cert_size,
+        dice_cert_obj.obj_p, &cert_page_left));
     dice_certs_page_dirty = kHardenedBoolTrue;
-    rom_ext_attestation_increment_cert_offset(updated_cert_size);
+    // Reload the cert perso LTV object.
+    HARDENED_RETURN_IF_ERROR(perso_tlv_get_cert_obj(
+        dice_cert_obj.obj_p, dice_certs_buffer_space_remaining(),
+        &dice_cert_obj));
+    HARDENED_RETURN_IF_ERROR(rom_ext_attestation_increment_cert_offset());
     // If the CDI_0 cert is updated, it could overrun the CDI_1 cert, so we make
     // sure to update that as well by erasing the existing cert from the buffer.
-    memset(&dice_certs_page[dice_certs_page_offset], UINT8_MAX,
-           FLASH_CTRL_PARAM_BYTES_PER_PAGE - dice_certs_page_offset);
+    memset(dice_cert_obj.obj_p, 0, dice_certs_buffer_space_remaining());
   } else {
-    rom_ext_attestation_increment_cert_offset(cert_size);
+    HARDENED_RETURN_IF_ERROR(rom_ext_attestation_increment_cert_offset());
   }
   return kErrorOk;
 }
@@ -461,10 +506,9 @@ static rom_error_t rom_ext_attestation_owner(const manifest_t *owner_manifest) {
   HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
       kDiceKeyCdi1, &cdi_1_pubkey_id, &curr_attestation_pubkey));
   hardened_bool_t cert_valid = kHardenedBoolFalse;
-  uint32_t cert_size = 0;
   HARDENED_RETURN_IF_ERROR(cert_x509_asn1_check_serial_number(
-      dice_certs_page, dice_certs_page_offset,
-      (uint8_t *)cdi_1_pubkey_id.digest, &cert_valid, &cert_size));
+      dice_cert_obj.cert_body_p, /*offset=*/0,
+      (uint8_t *)cdi_1_pubkey_id.digest, &cert_valid, /*out_cert_size=*/NULL));
   if (launder32(cert_valid) == kHardenedBoolFalse) {
     HARDENED_CHECK_EQ(cert_valid, kHardenedBoolFalse);
     dbg_printf("CDI_1 certificate not valid. Updating it ...\r\n");
@@ -476,16 +520,21 @@ static rom_error_t rom_ext_attestation_owner(const manifest_t *owner_manifest) {
         owner_manifest->security_version, &cdi_1_key_ids,
         &curr_attestation_pubkey, cdi_1_cert, &updated_cert_size));
     // Update the cert page buffer.
-    memcpy(&dice_certs_page[dice_certs_page_offset], cdi_1_cert,
-           updated_cert_size);
+    size_t cert_page_left = dice_certs_buffer_space_remaining();
+    HARDENED_RETURN_IF_ERROR(perso_tlv_cert_obj_build(
+        "CDI_1", /*needs_endorsement=*/false, cdi_1_cert, updated_cert_size,
+        dice_cert_obj.obj_p, &cert_page_left));
     dice_certs_page_dirty = kHardenedBoolTrue;
-    rom_ext_attestation_increment_cert_offset(updated_cert_size);
+    // Reload the cert perso LTV object.
+    HARDENED_RETURN_IF_ERROR(perso_tlv_get_cert_obj(
+        dice_cert_obj.obj_p, dice_certs_buffer_space_remaining(),
+        &dice_cert_obj));
+    HARDENED_RETURN_IF_ERROR(rom_ext_attestation_increment_cert_offset());
     // If the CDI_1 cert is updated, it could be smaller than the previous CDI_1
     // cert, so we make sure to clear out the rest of the buffer.
-    memset(&dice_certs_page[dice_certs_page_offset], UINT8_MAX,
-           FLASH_CTRL_PARAM_BYTES_PER_PAGE - dice_certs_page_offset);
+    memset(dice_cert_obj.obj_p, 0, dice_certs_buffer_space_remaining());
   } else {
-    rom_ext_attestation_increment_cert_offset(cert_size);
+    HARDENED_RETURN_IF_ERROR(rom_ext_attestation_increment_cert_offset());
   }
 
   // TODO: elimiate this call when we've fully programmed keymgr and lock it.


### PR DESCRIPTION
Currently, during ft_perso, the host writes the raw endorsed X.509 certificates (in ASN.1 DER format) to flash_info pages. When it needs to access them later on, the certificate length is calculated by parsing the ASN.1 header (1 or 2 bytes). This design works for X509 but not CWT-CBOR since there's no such information in some CBOR types (map, array specifically). This updates the perso flow to write the certificates to the info page wrapped in the perso LTV object header. Additionally, this refactors the `perso_tlv_data` code to use `rom_error_t` where applicable so it can be shared with the ROM_EXT, which also must parse and potentially update CDI_0/1 DICE certificates.

Fixes #24942.
Test: //sw/device/silicon_creator/manuf/base:ft_provision_cw340

This is a refactor of #24951 that improves code-reuse and documentation.