### PR TITLE
[ci,check-generated] Handle empty text in CMDGEN

### DIFF
--- a/ci/scripts/check-generated.sh
+++ b/ci/scripts/check-generated.sh
@@ -41,7 +41,8 @@ gen_and_check_clean() {
 
 # A specialized version of gen_and_check_clean for targets of the Makefile in hw
 gen_hw_and_check_clean() {
-    gen_and_check_clean "$1" make -k -C hw "$2"
+    thing=$1; shift
+    gen_and_check_clean "$thing" make -k -C hw "$*"
 }
 
 # Check generated files are up to date
@@ -65,10 +66,14 @@ EOM
 fi
 destructive_cleanup
 
-gen_hw_and_check_clean "Register headers" regs         || bad=1
-gen_hw_and_check_clean "tops"             top          || bad=1
-gen_hw_and_check_clean "OTP memory map"   otp-mmap     || bad=1
-gen_hw_and_check_clean "LC state"         lc-state-enc || bad=1
+gen_hw_and_check_clean "Register headers" regs             || bad=1
+gen_hw_and_check_clean "OTP memory map"   otp-mmap         || bad=1
+gen_hw_and_check_clean "LC state"         lc-state-enc     || bad=1
+
+# This runs both top and cmdgen targets together since for ipgen
+# ips the top target will not run cmdgen on generated md files,
+# causing this check to fail.
+gen_hw_and_check_clean "top and cmdgen"   top_and_cmdgen   || bad=1
 
 gen_and_check_clean \
     "python-requirements.txt" \

--- a/doc/contributing/doc/README.md
+++ b/doc/contributing/doc/README.md
@@ -46,6 +46,7 @@ If run, the following snippet will have the register tables of the AES block (ou
 *Note, one should remove the `#` before the commands.
 This is there so that `CMDGEN` doesn't generate registers in this file.*
 
+The `CMDGEN` tool can also be invoked by the `./hw/Makefile` using the target `cmdgen`.
 
 [mdBook]: https://rust-lang.github.io/mdBook/
 [rustdoc]: https://doc.rust-lang.org/rustdoc/index.html

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -141,5 +141,10 @@ $(tops_reg): %_reg:
 	mkdir -p ${REG_OUTPUT_DV_DIR}/$*
 	${PRJ_DIR}/util/topgen.py -t $(top-hjson) -r -o ${REG_OUTPUT_DV_DIR}/$* ${toolflags}
 
+# This runs cmdgen on all md files of the repo.
+cmdgen:
+	${PRJ_DIR}/util/cmdgen.py -u '**/*.md'
+
+top_and_cmdgen: top cmdgen
 
 .PHONY: all


### PR DESCRIPTION
Change ci/scripts/check-generated.sh to run both top and cmdgen when checking for the topgen generated artifacts. This is to support template md files having no text between the BEGIN and END markers so they can handle multi-top.

Add a separate "cmdgen" target in the hw/Makefile and describe that in the README.md for contributing to documentation.

Fixes #24991