### PR TITLE
[manuf] Improve re-entrancy of the FT provisioning flow

### DIFF
--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -143,8 +143,11 @@ status_t otp_ctrl_testutils_dai_write32(const dif_otp_ctrl_t *otp,
   // Software partitions don't have scrambling or ECC enabled, so it is possible
   // to read the value and compare it against the expected value before
   // performing the write.
-  bool check_before_write = (partition == kDifOtpCtrlPartitionCreatorSwCfg ||
-                             partition == kDifOtpCtrlPartitionOwnerSwCfg);
+  bool check_before_write =
+      (partition == kDifOtpCtrlPartitionCreatorSwCfg ||
+       partition == kDifOtpCtrlPartitionOwnerSwCfg ||
+       partition == kDifOtpCtrlPartitionRotCreatorAuthCodesign ||
+       partition == kDifOtpCtrlPartitionRotCreatorAuthState);
   uint32_t stop_address = start_address + (len * sizeof(uint32_t));
   for (uint32_t addr = start_address, i = 0; addr < stop_address;
        addr += sizeof(uint32_t), ++i) {

--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -118,9 +118,11 @@ status_t otp_ctrl_testutils_dai_read64_array(const dif_otp_ctrl_t *otp,
  * Writes `len` number of 32bit words from buffer into otp `partition` starting
  * at `start_address` using the DAI interface.
  *
- * For software partitions (`kDifOtpCtrlPartitionCreatorSwCfg` or
- * `kDifOtpCtrlPartitionOwnerSwCfg`), the function will attempt to read the
- * target OTP offsets and skip the write if the existing value matches the
+ * For software partitions (`kDifOtpCtrlPartitionCreatorSwCfg`,
+ * `kDifOtpCtrlPartitionOwnerSwCfg`,
+ * `kDifOtpCtrlPartitionRotCreatorAuthCodesign`, or
+ * `kDifOtpCtrlPartitionRotCreatorAuthState`), the function will attempt to read
+ * the target OTP offsets and skip the write if the existing value matches the
  * expected one. This is possible due to the fact that software partitions are
  * not scrambled nor ECC protected.
  *

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -229,7 +229,9 @@ static status_t personalize_otp_and_flash_secrets(ujson_t *uj) {
   }
   if (!status_ok(
           manuf_individualize_device_flash_data_default_cfg_check(&otp_ctrl))) {
-    TRY(manuf_individualize_device_flash_data_default_cfg(&otp_ctrl));
+    TRY(manuf_individualize_device_field_cfg(
+        &otp_ctrl,
+        OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET));
     LOG_INFO("Bootstrap requested.");
     wait_for_interrupt();
   }
@@ -709,7 +711,8 @@ static status_t finalize_otp_partitions(void) {
 
   // Complete the provisioning of OTP OwnerSwCfg partition.
   if (!status_ok(manuf_individualize_device_owner_sw_cfg_check(&otp_ctrl))) {
-    TRY(manuf_individualize_device_rom_bootstrap_dis_cfg(&otp_ctrl));
+    TRY(manuf_individualize_device_field_cfg(
+        &otp_ctrl, OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET));
     TRY(check_otp_measurement_pre_lock(&otp_owner_sw_cfg_measurement,
                                        kOtpPartitionOwnerSwCfg));
     TRY(manuf_individualize_device_owner_sw_cfg_lock(&otp_ctrl));
@@ -720,8 +723,10 @@ static status_t finalize_otp_partitions(void) {
 
   // Complete the provisioning of OTP CreatorSwCfg partition.
   if (!status_ok(manuf_individualize_device_creator_sw_cfg_check(&otp_ctrl))) {
-    TRY(manuf_individualize_device_creator_manuf_state_cfg(&otp_ctrl));
-    TRY(manuf_individualize_device_immutable_rom_ext_en_cfg(&otp_ctrl));
+    TRY(manuf_individualize_device_field_cfg(
+        &otp_ctrl, OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET));
+    TRY(manuf_individualize_device_field_cfg(
+        &otp_ctrl, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET));
     TRY(check_otp_measurement_pre_lock(&otp_creator_sw_cfg_measurement,
                                        kOtpPartitionCreatorSwCfg));
     TRY(manuf_individualize_device_creator_sw_cfg_lock(&otp_ctrl));

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.c
@@ -248,15 +248,36 @@ status_t manuf_individualize_device_creator_sw_cfg(
   return OK_STATUS();
 }
 
-status_t manuf_individualize_device_flash_data_default_cfg(
-    const dif_otp_ctrl_t *otp_ctrl) {
-  uint32_t offset;
-  TRY(dif_otp_ctrl_relative_address(
-      kDifOtpCtrlPartitionCreatorSwCfg,
-      OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET, &offset));
-  TRY(otp_ctrl_testutils_dai_write32(
-      otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg, offset,
-      &kCreatorSwCfgFlashDataDefaultCfgValue, /*len=*/1));
+status_t manuf_individualize_device_field_cfg(const dif_otp_ctrl_t *otp_ctrl,
+                                              uint32_t field_offset) {
+  uint32_t relative_addr;
+  const uint32_t *field_value_addr;
+  dif_otp_ctrl_partition_t partition;
+  switch (field_offset) {
+    case OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET:
+      field_value_addr = &kOwnerSwCfgRomBootstrapDisValue;
+      partition = kDifOtpCtrlPartitionOwnerSwCfg;
+      break;
+    case OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET:
+      field_value_addr = &kCreatorSwCfgFlashDataDefaultCfgValue;
+      partition = kDifOtpCtrlPartitionCreatorSwCfg;
+      break;
+    case OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET:
+      field_value_addr = &kCreatorSwCfgImmutableRomExtEnValue;
+      partition = kDifOtpCtrlPartitionCreatorSwCfg;
+      break;
+    case OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET:
+      field_value_addr = &kCreatorSwCfgManufStateValue;
+      partition = kDifOtpCtrlPartitionCreatorSwCfg;
+      break;
+    default:
+      return INTERNAL();
+  }
+
+  TRY(dif_otp_ctrl_relative_address(partition, field_offset, &relative_addr));
+  TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, partition, relative_addr,
+                                     field_value_addr, /*len=*/1));
+
   return OK_STATUS();
 }
 
@@ -271,31 +292,6 @@ status_t manuf_individualize_device_flash_data_default_cfg_check(
                                     offset, &val));
   bool is_provisioned = (val == kCreatorSwCfgFlashDataDefaultCfgValue);
   return is_provisioned ? OK_STATUS() : INTERNAL();
-}
-
-status_t manuf_individualize_device_creator_manuf_state_cfg(
-    const dif_otp_ctrl_t *otp_ctrl) {
-  uint32_t offset;
-  TRY(dif_otp_ctrl_relative_address(
-      kDifOtpCtrlPartitionCreatorSwCfg,
-      OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET, &offset));
-  TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
-                                     offset, &kCreatorSwCfgManufStateValue,
-                                     /*len=*/1));
-  return OK_STATUS();
-}
-
-status_t manuf_individualize_device_immutable_rom_ext_en_cfg(
-    const dif_otp_ctrl_t *otp_ctrl) {
-  uint32_t offset;
-  TRY(dif_otp_ctrl_relative_address(
-      kDifOtpCtrlPartitionCreatorSwCfg,
-      OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET, &offset));
-  TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kDifOtpCtrlPartitionCreatorSwCfg,
-                                     offset,
-                                     &kCreatorSwCfgImmutableRomExtEnValue,
-                                     /*len=*/1));
-  return OK_STATUS();
 }
 
 status_t manuf_individualize_device_creator_sw_cfg_lock(
@@ -316,18 +312,6 @@ status_t manuf_individualize_device_owner_sw_cfg(
     const dif_otp_ctrl_t *otp_ctrl) {
   TRY(otp_img_write(otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg, kOtpKvOwnerSwCfg,
                     kOtpKvOwnerSwCfgSize));
-  return OK_STATUS();
-}
-
-status_t manuf_individualize_device_rom_bootstrap_dis_cfg(
-    const dif_otp_ctrl_t *otp_ctrl) {
-  uint32_t offset;
-  TRY(dif_otp_ctrl_relative_address(
-      kDifOtpCtrlPartitionOwnerSwCfg,
-      OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET, &offset));
-  TRY(otp_ctrl_testutils_dai_write32(otp_ctrl, kDifOtpCtrlPartitionOwnerSwCfg,
-                                     offset, &kOwnerSwCfgRomBootstrapDisValue,
-                                     /*len=*/1));
   return OK_STATUS();
 }
 

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h
@@ -69,49 +69,16 @@ status_t manuf_individualize_device_creator_sw_cfg(
     const dif_otp_ctrl_t *otp_ctrl, dif_flash_ctrl_state_t *flash_state);
 
 /**
- * Configures the FLASH_DATA_DEFAULT_CFG field in the CREATOR_SW_CFG OTP
- * partition.
+ * This must be called before both
+ * `manuf_individualize_device_creator_sw_cfg_lock()` and
+ * `manuf_individualize_device_owner_sw_cfg_lock()` are called. The operation
+ * will fail if there are any pre-programmed words not equal to the expected
+ * test values.
  *
- * This must be called before `manuf_individualize_device_creator_sw_cfg_lock()`
- * is called. The operation will fail if there are any pre-programmed words not
- * equal to the expected test values.
- *
- * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS if the FLASH_DATA_DEFAULT_CFG field was provisioned.
  */
 OT_WARN_UNUSED_RESULT
-status_t manuf_individualize_device_flash_data_default_cfg(
-    const dif_otp_ctrl_t *otp_ctrl);
-
-/**
- * Configures the MANUF_STATE field in the CREATOR_SW_CFG OTP
- * partition.
- *
- * This must be called before `manuf_individualize_device_creator_sw_cfg_lock()`
- * is called. The operation will fail if there are any pre-programmed words not
- * equal to the expected test values.
- *
- * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS if the MANUF_STATE field was provisioned.
- */
-OT_WARN_UNUSED_RESULT
-status_t manuf_individualize_device_creator_manuf_state_cfg(
-    const dif_otp_ctrl_t *otp_ctrl);
-
-/**
- * Configures the IMMUTABLE_ROM_EXT_EN field in the CREATOR_SW_CFG OTP
- * partition.
- *
- * This must be called before `manuf_individualize_device_creator_sw_cfg_lock()`
- * is called. The operation will fail if there are any pre-programmed words not
- * equal to the expected test values.
- *
- * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS if the IMMUTABLE_ROM_EXT_EN field was provisioned.
- */
-OT_WARN_UNUSED_RESULT
-status_t manuf_individualize_device_immutable_rom_ext_en_cfg(
-    const dif_otp_ctrl_t *otp_ctrl);
+status_t manuf_individualize_device_field_cfg(const dif_otp_ctrl_t *otp_ctrl,
+                                              uint32_t field_offset);
 
 /**
  * Checks the FLASH_DATA_DEFAULT_CFG field in the CREATOR_SW_CFG OTP
@@ -127,9 +94,8 @@ status_t manuf_individualize_device_flash_data_default_cfg_check(
 /**
  * Locks the CREATOR_SW_CFG OTP partition.
  *
- * This must be called after both `manuf_individualize_device_creator_sw_cfg()`
- * , `manuf_individualize_device_flash_data_default_cfg()` and
- * `manuf_individualize_device_creator_manuf_state_cfg()` have been called.
+ * This must be called after `manuf_individualize_device_field_cfg()`
+ * has been called.
  *
  * @param otp_ctrl OTP controller instance.
  * @return OK_STATUS if the CREATOR_SW_CFG partition was locked.
@@ -171,25 +137,10 @@ status_t manuf_individualize_device_owner_sw_cfg(
     const dif_otp_ctrl_t *otp_ctrl);
 
 /**
- * Configures the ROM_BOOTSTRAP_DIS field in the OWNER_SW_CFG OTP
- * partition.
- *
- * This must be called before `manuf_individualize_device_owner_sw_cfg_lock()`
- * is called. The operation will fail if there are any pre-programmed words not
- * equal to the expected test values.
- *
- * @param otp_ctrl OTP controller instance.
- * @return OK_STATUS if the ROM_BOOTSTRAP_DIS field was provisioned.
- */
-OT_WARN_UNUSED_RESULT
-status_t manuf_individualize_device_rom_bootstrap_dis_cfg(
-    const dif_otp_ctrl_t *otp_ctrl);
-
-/**
  * Locks the OWNER_SW_CFG OTP partition.
  *
- * This must be called after both `manuf_individualize_device_owner_sw_cfg()`
- * and `manuf_individualize_device_rom_bootstrap_dis_cfg()` have been called.
+ * This must be called after `manuf_individualize_device_field_cfg()`
+ * has been called.
  *
  * @param otp_ctrl OTP controller instance.
  * @return OK_STATUS if the OWNER_SW_CFG partition was locked.

--- a/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
+++ b/sw/device/silicon_creator/manuf/lib/individualize_sw_cfg_functest.c
@@ -128,12 +128,13 @@ bool test_main(void) {
     CHECK_STATUS_OK(init_flash_info_page0());
     CHECK_STATUS_OK(manuf_individualize_device_creator_sw_cfg(
         &otp_ctrl, &flash_ctrl_state));
-    CHECK_STATUS_OK(
-        manuf_individualize_device_flash_data_default_cfg(&otp_ctrl));
-    CHECK_STATUS_OK(
-        manuf_individualize_device_creator_manuf_state_cfg(&otp_ctrl));
-    CHECK_STATUS_OK(
-        manuf_individualize_device_immutable_rom_ext_en_cfg(&otp_ctrl));
+    CHECK_STATUS_OK(manuf_individualize_device_field_cfg(
+        &otp_ctrl,
+        OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET));
+    CHECK_STATUS_OK(manuf_individualize_device_field_cfg(
+        &otp_ctrl, OTP_CTRL_PARAM_CREATOR_SW_CFG_MANUF_STATE_OFFSET));
+    CHECK_STATUS_OK(manuf_individualize_device_field_cfg(
+        &otp_ctrl, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET));
     CHECK_STATUS_OK(manuf_individualize_device_creator_sw_cfg_lock(&otp_ctrl));
     CHECK_STATUS_OK(check_otp_ast_cfg());
     LOG_INFO("Provisioned and locked CREATOR_SW_CFG OTP partition.");
@@ -148,8 +149,8 @@ bool test_main(void) {
   // Provision OWNER_SW_CFG partition.
   if (!status_ok(manuf_individualize_device_owner_sw_cfg_check(&otp_ctrl))) {
     CHECK_STATUS_OK(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
-    CHECK_STATUS_OK(
-        manuf_individualize_device_rom_bootstrap_dis_cfg(&otp_ctrl));
+    CHECK_STATUS_OK(manuf_individualize_device_field_cfg(
+        &otp_ctrl, OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_BOOTSTRAP_DIS_OFFSET));
     CHECK_STATUS_OK(manuf_individualize_device_owner_sw_cfg_lock(&otp_ctrl));
     LOG_INFO("Provisioned and locked OWNER_SW_CFG OTP partition.");
     perform_reset |= true;


### PR DESCRIPTION
This PR has 3 commits that

1. Extend write-before-check  the following RoT partitions:
   - `kDifOtpCtrlPartitionRotCreatorAuthCodesign`
   - `kDifOtpCtrlPartitionRotCreatorAuthState`
2. Ensure the OTP measurements used during certificate generation match the final OTP values both before and after the OTP partitions are locked.
3. Refactor the OTP field configuration process by consolidating several individual functions into a single, unified function.
   - The following functions have been removed:
     - `manuf_individualize_device_flash_data_default_cfg()`
     - `manuf_individualize_device_creator_manuf_state_cfg()`
     - `manuf_individualize_device_immutable_rom_ext_en_cfg()`
     - `manuf_individualize_device_rom_bootstrap_dis_cfg()`
   - These functionalities are now handled by the `manuf_individualize_device_field_cfg()` function.

This PR addresses [#24610](https://github.com/lowRISC/opentitan/issues/24617).