### PR TITLE
[sival] Add a few crypto/boot services test refs to testplan.

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -98,7 +98,10 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_keymgr_sideload_kmac"]
-      bazel: ["//sw/device/tests:keymgr_sideload_kmac_test"]
+      bazel: [
+        "//sw/device/tests:keymgr_sideload_kmac_test",
+        "//sw/device/tests/crypto:kmac_sideload_functest",
+      ]
     }
     {
       name: chip_sw_keymgr_sideload_aes
@@ -134,6 +137,8 @@
       bazel: [
         "//sw/device/tests/crypto:ecdh_p256_sideload_functest",
         "//sw/device/tests/crypto:ecdsa_p256_sideload_functest",
+        "//sw/device/tests/crypto:ecdh_p384_sideload_functest",
+        "//sw/device/tests/crypto:ecdsa_p384_sideload_functest",
       ]
     }
     {
@@ -142,7 +147,6 @@
 
             - For each keymgr operational state: `CreatorRootKey`, `OwnerIntKey` and `OwnerKey`:
               - Generate identity SW output for the Attestation CDI.
-              - Generate SW output for the Attestation CDI.
               - Generate OTBN sideload output for the Attestation CDI.
             - Ensure that the key output changes after calculating the previous steps after a
               keymgr advance operation.
@@ -170,7 +174,10 @@
             si_stage: SV2
             lc_states: ["PROD"]
             tests: []
-            bazel: []
+            bazel: [
+              // Covers all points in the test except for the software binding registers.
+              "//sw/device/silicon_creator/lib:otbn_boot_services_functest",
+            ]
     }
     {
       name: chip_sw_keymgr_derive_sealing

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -275,7 +275,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: ["//sw/device/tests/crypto:kmac_functest_hardcoded"]
+      bazel: []
     }
     {
       name: chip_sw_kmac_error_conditions


### PR DESCRIPTION
Also:
- remove one reference to a KMAC crypto test that doesn't actually cover the test point
- make a small adjustment to the boot services test so that it covers all key manager stages
- adjust the attestation test point to not generate SW output (we would never need to do this for the attestation CDI, so I'm not sure it makes sense to include it -- if there's a reason I'm happy to add it back)

I went through the test plan (at the suggestion of @matutem) to see if any crypto tests I know of might cover the test points. I found one that's mostly covered by some attestation tests, but mostly the points covered by crypto tests were already noted. I adjusted the attestation tests to more thoroughly cover the test point, as well (by going through the same steps in one additional key manager stage).

I also found one test that I know _doesn't_ cover the test point it's linked to (because it only tests KMAC in one entropy mode and the test point is primarily about testing multiple settings).