### PR TITLE
[dvsim] Avoid some type comparisons in dvsim code

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -242,7 +242,7 @@ class Deploy():
         the final resolved 'cmd' & the exports. The 'name' field will be unique
         to 'item' and 'self', so we take that out of the comparison.
         """
-        if type(self) != type(item):
+        if not isinstance(item, Deploy):
             return False
 
         # Check if the cmd field is identical.

--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -301,17 +301,17 @@ class FlowCfg():
                               "Found this instead:\n%s", str(item))
                     sys.exit(1)
 
-    def _do_override(self, ov_name, ov_value):
+    def _do_override(self, ov_name: str, ov_value: object) -> None:
         # Go through self attributes and replace with overrides
         if hasattr(self, ov_name):
             orig_value = getattr(self, ov_name)
-            if type(orig_value) == type(ov_value):
+            if isinstance(ov_value, type(orig_value)):
                 log.debug("Overriding \"%s\" value \"%s\" with \"%s\"",
                           ov_name, orig_value, ov_value)
                 setattr(self, ov_name, ov_value)
             else:
                 log.error("The type of override value \"%s\" for \"%s\" "
-                          "mismatches the type of original value \"%s\"",
+                          "doesn't match the type of original value \"%s\"",
                           ov_value, ov_name, orig_value)
                 sys.exit(1)
         else:

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -449,10 +449,11 @@ class SimCfg(FlowCfg):
             # existing one.
             is_unique = True
             for build in self.builds:
-                if build.is_equivalent_job(new_build):
-                    # Discard `new_build` since it is equivalent to build. If
-                    # `new_build` is the same as `primary_build_mode`, update
-                    # `primary_build_mode` to match `build`.
+                if new_build.is_equivalent_job(build):
+                    # Discard `new_build` since build implements the same
+                    # thing. If `new_build` is the same as
+                    # `primary_build_mode`, update `primary_build_mode` to
+                    # match `build`.
                     if new_build.name == self.primary_build_mode:
                         self.primary_build_mode = build.name
                     new_build = build


### PR DESCRIPTION
These comparisons trigger flake8 warnings if you have a PR that touches any of these files. Get rid of them.