### PR TITLE
[cdc,top_earlgrey] Add user configuration file

### DIFF
--- a/hw/cdc/tools/dvsim/meridiancdc.hjson
+++ b/hw/cdc/tools/dvsim/meridiancdc.hjson
@@ -8,6 +8,7 @@
     { FOUNDRY_CONSTRAINT:  "{foundry_sdc_file}" }
     { CDC_WAIVER_FILE:     "{cdc_waiver_file}" }
     { ENV_FILE:            "{cdc_env_file}" }
+    { USER_CONFIG_FILE:    "{cdc_config_file}" }
   ]
 
   // Tool invocation

--- a/hw/cdc/tools/meridiancdc/run-cdc.tcl
+++ b/hw/cdc/tools/meridiancdc/run-cdc.tcl
@@ -24,6 +24,7 @@ set PARAMS              [get_env_var "PARAMS"]
 set CDC_WAIVER_FILE     [get_env_var "CDC_WAIVER_FILE"]
 set CDC_WAIVER_DIR      [file dirname $CDC_WAIVER_FILE]
 set ENV_FILE            [get_env_var "ENV_FILE"]
+set USER_CONFIG_FILE    [get_env_var "USER_CONFIG_FILE"]
 
 # Used to disable some SDC constructs that are not needed by CDC.
 set IS_CDC_RUN 1
@@ -86,6 +87,9 @@ read_env $ENV_FILE
 
 # Analyze the intents of the design.
 analyze_intent
+
+# Run design-specific configuration commands.
+source $USER_CONFIG_FILE
 
 # Create directory for reports (if it doesn't exist already).
 set REPORT_DIR reports

--- a/hw/top_earlgrey/cdc/chip_earlgrey_asic_cdc_cfg.hjson
+++ b/hw/top_earlgrey/cdc/chip_earlgrey_asic_cdc_cfg.hjson
@@ -33,6 +33,9 @@
   // CDC customized env file
   cdc_env_file: "{proj_root}/hw/top_earlgrey/cdc/user_intent.env"
 
+  // CDC customized configuration file (to be sourced after customized env)
+  cdc_config_file: "{proj_root}/hw/top_earlgrey/cdc/user_configuration.tcl"
+
   // Technology path for this module (empty for open-source runs)
   foundry_root: ""
 

--- a/hw/top_earlgrey/cdc/user_configuration.tcl
+++ b/hw/top_earlgrey/cdc/user_configuration.tcl
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# MeridianCDC user configuration file for Earlgrey


### PR DESCRIPTION
This file allows to configure the CDC tool after constraints have been evaluated and additional user intents specified.  The file is currently empty; it will be populated in later PRs.