### PR TITLE
[pentest] Add RSA512 decryption SCA test

### DIFF
--- a/sw/device/tests/penetrationtests/firmware/sca/BUILD
+++ b/sw/device/tests/penetrationtests/firmware/sca/BUILD
@@ -160,6 +160,7 @@ cc_library(
         "//sw/device/tests/penetrationtests/firmware/lib:pentest_lib",
         "//sw/device/tests/penetrationtests/firmware/sca/otbn:otbn_key_sideload_sca",
         "//sw/device/tests/penetrationtests/json:otbn_sca_commands",
+        "//sw/otbn/crypto:rsa",
     ],
 )
 

--- a/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.h
+++ b/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.h
@@ -91,6 +91,17 @@ status_t handle_otbn_pentest_init_keymgr(ujson_t *uj);
 status_t handle_otbn_sca_key_sideload_fvsr(ujson_t *uj);
 
 /**
+ * Command handler for the otbn.sca.rsa512_decrypt test.
+ *
+ * RSA512 decryption side-channel test. Get mod, exp, and msg from uJSON.
+ * Perform RSA512 decryption and send back the message.
+ *
+ * @param uj An initialized uJSON context.
+ * @return OK or error.
+ */
+status_t handle_otbn_sca_rsa512_decrypt(ujson_t *uj);
+
+/**
  * OTBN SCA command handler.
  *
  * Command handler for the OTBN SCA command.

--- a/sw/device/tests/penetrationtests/json/otbn_sca_commands.h
+++ b/sw/device/tests/penetrationtests/json/otbn_sca_commands.h
@@ -24,7 +24,8 @@ extern "C" {
     value(_, Ecc256SetSeed) \
     value(_, Init) \
     value(_, InitKeyMgr) \
-    value(_, KeySideloadFvsr)
+    value(_, KeySideloadFvsr) \
+    value(_, Rsa512Decrypt)
 UJSON_SERDE_ENUM(OtbnScaSubcommand, otbn_sca_subcommand_t, OTBNSCA_SUBCOMMAND);
 
 #define OTBN_SCA_EN_MASKS(field, string) \
@@ -55,6 +56,16 @@ UJSON_SERDE_STRUCT(PenetrationtestOtbnScaKey, penetrationtest_otbn_sca_key_t, OT
 #define OTBN_SCA_FIXED_SEED(field, string) \
     field(fixed_seed, uint32_t)
 UJSON_SERDE_STRUCT(PenetrationtestOtbnScaFixedKey, penetrationtest_otbn_sca_fixed_seed_t, OTBN_SCA_FIXED_SEED);
+
+#define OTBN_SCA_RSA512_DEC(field, string) \
+    field(mod, uint8_t, 64) \
+    field(exp, uint8_t, 64) \
+    field(msg, uint8_t, 64)
+UJSON_SERDE_STRUCT(PenetrationtestOtbnScaRsa512Dec, penetrationtest_otbn_sca_rsa512_dec_t, OTBN_SCA_RSA512_DEC);
+
+#define OTBN_SCA_RSA512_DEC_OUT(field, string) \
+    field(out, uint8_t, 64)
+UJSON_SERDE_STRUCT(PenetrationtestOtbnScaRsa512DecOut, penetrationtest_otbn_sca_rsa512_dec_out_t, OTBN_SCA_RSA512_DEC_OUT);
 
 // clang-format on
 


### PR DESCRIPTION
This commit adds the otbn.sca.rsa512_decrypt penetration test. The user needs to provide the mod, exp, and message which then gets decrypted using the rsa OTBN app. The result is transmitted back to the host. SCA measurements can be conducted during the trigger window.