### PR TITLE
[ci] Port software build job from Azure to GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,8 +242,8 @@ jobs:
         with:
           context: site/redirector/landing
 
-  sw_build:
-    name: Build all software
+  sw_build_test:
+    name: Build and test software
     runs-on: ubuntu-22.04-vivado
     timeout-minutes: 120
     needs: quick_lint
@@ -293,3 +293,20 @@ jobs:
             --define DISABLE_VERILATOR_BUILD=true            \
             --test_tag_filters=-broken,-cw310,-verilator,-dv \
             --target_pattern_file="$target_pattern_file"
+      - name: Run software unit tests
+        run: |
+          ./bazelisk.sh test                                          \
+            --build_tests_only=false                                  \
+            --test_output=errors                                      \
+            --define DISABLE_VERILATOR_BUILD=true                     \
+            --test_tag_filters=-broken,-cw310,-verilator,-dv,-silicon \
+            --target_pattern_file="$target_pattern_file"
+      - name: Publish test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_results
+          path: "**/test.xml"
+          overwrite: true
+      - name: Check for unrunnable tests
+        run: ./ci/scripts/check-unrunnable-tests.sh
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,3 +241,55 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: site/redirector/landing
+
+  sw_build:
+    name: Build all software
+    runs-on: ubuntu-22.04-vivado
+    timeout-minutes: 120
+    needs: quick_lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for bitstream cache to work.
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-env
+      - name: Check Bazel build graph
+        run: |
+          # Test the graph with both an empty and filled bitstream cache.
+          ./ci/scripts/test-empty-bitstream-cache.sh
+          ./bazelisk.sh build --nobuild //...
+      - name: Select software targets
+        run: |
+          target_pattern_file="$(mktemp)"
+          echo "target_pattern_file=${target_pattern_file}" >> "$GITHUB_ENV"
+
+          # Start with building the whole graph.
+          echo '//...' > "$target_pattern_file"
+          # Exclude some targets:
+          #
+          # 1. `//hw/...` is out of scope.
+          # 2. `//quality/...` is tested by the lint jobs.
+          # 3. `//sw/otbn/crypto/...` is tested by the OTBN job.
+          # 4. `//third_party/...` which is not our code.
+          printf "%s\n"             \
+            "-//hw/..."             \
+            "-//quality/..."        \
+            "-//sw/otbn/crypto/..." \
+            "-//third_party/..."    \
+            >> "$target_pattern_file"
+          # Exclude anything that requires a bitstream splice.
+          ./bazelisk.sh cquery                               \
+            --noinclude_aspects                              \
+            --output=starlark                                \
+            --starlark:expr='"-{}".format(target.label)'     \
+            --define DISABLE_VERILATOR_BUILD=true            \
+            -- "rdeps(//..., kind(bitstream_splice, //...))" \
+            >> "$target_pattern_file"
+      - name: Build software targets
+        run: |
+          # Build everything we selected, excluding some tags.
+          ./bazelisk.sh build                                \
+            --build_tests_only=false                         \
+            --define DISABLE_VERILATOR_BUILD=true            \
+            --test_tag_filters=-broken,-cw310,-verilator,-dv \
+            --target_pattern_file="$target_pattern_file"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,35 +198,6 @@ jobs:
       includePatterns:
         - "/sw/***"
 
-- job: sw_test
-  displayName: Earl Grey SW Test
-  timeoutInMinutes: 120
-  dependsOn: sw_build
-  pool: ci-public
-  steps:
-  - template: ci/checkout-template.yml
-  - template: ci/install-package-dependencies.yml
-  - template: ci/load-bazel-cache-write-creds.yml
-  - download: current
-    artifact: target_pattern_file
-  - bash: |
-      TARGET_PATTERN_FILE="$(Pipeline.Workspace)/target_pattern_file/target_pattern.txt"
-      ci/bazelisk.sh test \
-        --build_tests_only=false \
-        --test_output=errors \
-        --define DISABLE_VERILATOR_BUILD=true \
-        --test_tag_filters=-broken,-cw310,-verilator,-dv,-silicon \
-        --target_pattern_file="${TARGET_PATTERN_FILE}"
-    displayName: Build & test SW
-  - template: ci/publish-bazel-test-results.yml
-  # We run this lint in the sw_test job instead of lints because it requires an expensive
-  # cquery. By running it after we have run the tests, we can save most of the preparation
-  # time of the query.
-  - bash: ci/scripts/check-unrunnable-tests.sh
-    displayName: Check for unrunnable tests
-    condition: succeededOrFailed()
-    continueOnError: True
-
 - job: execute_verilated_tests
   displayName: Fast Verilated Earl Grey tests
   # Build and run fast tests on sim_verilator


### PR DESCRIPTION
Moves both the `sw_build` and `sw_test` jobs from Azure into one `sw_build_test` job in GitHub Actions.

There's a small improvement in execution time here for a cold build. I'll check the time when the results are cached once this merges.