### PR TITLE
[dice] Refactor some dice related constants and APIs

### DIFF
--- a/sw/device/silicon_creator/lib/base/util.c
+++ b/sw/device/silicon_creator/lib/base/util.c
@@ -35,3 +35,10 @@ void util_hexdump_byte(uint8_t byte, uint8_t *str) {
   str[0] = hexdump_halfbyte((byte & 0xF0) >> 4);
   str[1] = hexdump_halfbyte(byte & 0x0F);
 }
+
+void util_p256_signature_le_to_be_convert(
+    uint32_t r[kUtilEcdsaP256SignatureComponentWords],
+    uint32_t s[kUtilEcdsaP256SignatureComponentWords]) {
+  util_reverse_bytes(r, kUtilEcdsaP256SignatureComponentBytes);
+  util_reverse_bytes(s, kUtilEcdsaP256SignatureComponentBytes);
+}

--- a/sw/device/silicon_creator/lib/base/util.h
+++ b/sw/device/silicon_creator/lib/base/util.h
@@ -12,6 +12,23 @@
 extern "C" {
 #endif
 
+enum {
+  /**
+   * Size of an ECDSA P256 signature component in bits.
+   */
+  kUtilEcdsaP256SignatureComponentBits = 256,
+  /**
+   * Size of an ECDSA P256 signature component in bytes.
+   */
+  kUtilEcdsaP256SignatureComponentBytes =
+      kUtilEcdsaP256SignatureComponentBits / 8,
+  /**
+   * Size of an ECDSA P256 signature component in 32b words.
+   */
+  kUtilEcdsaP256SignatureComponentWords =
+      kUtilEcdsaP256SignatureComponentBytes / sizeof(uint32_t),
+};
+
 /**
  * Rounds up the passed value to get it aligned to the requested number of bits.
  *
@@ -45,6 +62,16 @@ void util_reverse_bytes(void *buf, size_t num_bytes);
  * byte in.
  */
 void util_hexdump_byte(uint8_t byte, uint8_t *str);
+
+/**
+ * Convert the calculated signature (r,s) from little endian to big endian
+ *
+ * @param r ECDSA signature r value
+ * @param s ECDSA signature s value
+ */
+void util_p256_signature_le_to_be_convert(
+    uint32_t r[kUtilEcdsaP256SignatureComponentWords],
+    uint32_t s[kUtilEcdsaP256SignatureComponentWords]);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -101,9 +101,9 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:util",
         "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
         "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
+        "//sw/device/silicon_creator/lib/cert:dice_keys",
         "//sw/device/silicon_creator/lib/cert:uds_template_library",
         "//sw/device/silicon_creator/lib/drivers:hmac",
-        "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
@@ -130,6 +130,15 @@ cc_library(
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
         "//sw/device/lib/base:status",
         "//sw/device/silicon_creator/lib:attestation",
+    ],
+)
+
+cc_library(
+    name = "dice_keys",
+    srcs = ["dice_keys.c"],
+    hdrs = ["dice_keys.h"],
+    deps = [
+        "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
     ],
 )

--- a/sw/device/silicon_creator/lib/cert/cbor.h
+++ b/sw/device/silicon_creator/lib/cert/cbor.h
@@ -9,97 +9,270 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
+#define CBOR_RETURN_IF_OVERFLOWED(p)    \
+  do {                                  \
+    if (CborOutOverflowed(p)) {         \
+      LOG_ERROR("CborOutOverflowed!!"); \
+      return kErrorCertInvalidSize;     \
+    }                                   \
+  } while (0)
+
 #define CBOR_CHECK_OVERFLOWED_AND_RETURN(p) \
   do {                                      \
-    if (CborOutOverflowed(p)) {             \
-      LOG_ERROR("CborOutOverflowed!!");     \
-      return kErrorCertInvalidSize;         \
-    }                                       \
+    CBOR_RETURN_IF_OVERFLOWED(p);           \
     return kErrorOk;                        \
   } while (0)
 
-// Wrappers for each CBOR type and CBOR handle initialization
-static inline rom_error_t cbor_write_out_init(struct CborOut *p, void *buf,
-                                              const size_t buf_size) {
+/**
+ * Initialize a CborOut structure.
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param buf The buffer that can be used for CBOR encoding
+ * @param buf_size The buffer size
+ * @return kErrorOk, or kErrorCertInvalidSize if the buf_size exceeds the
+ *         buffer size that is recorded in p.
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_out_init(
+    struct CborOut *p, void *buf, const size_t buf_size) {
   CborOutInit(buf, buf_size, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_map_init(struct CborOut *p,
-                                        const size_t num_pairs) {
+/**
+ * Add a "map" header along with the elements count to a CborOut structure.
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param num_pairs The elements count in the map
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_map_init(
+    struct CborOut *p, const size_t num_pairs) {
   CborWriteMap(num_pairs, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_array_init(struct CborOut *p,
-                                          const size_t num_elements) {
+/**
+ * Add a "array" header along with the elements count to a CborOut structure.
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param num_elements The elements count in the map
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_array_init(
+    struct CborOut *p, const size_t num_elements) {
   CborWriteArray(num_elements, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_write_string(struct CborOut *p,
-                                            const char *str) {
+/**
+ * Add a "tstr" to a CborOut structure
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param str The string pointer
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_string(
+    struct CborOut *p, const char *str) {
   CborWriteTstr(str, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_write_bytes(struct CborOut *p,
-                                           const uint8_t *data,
-                                           const size_t data_size) {
+/**
+ * Add a "bstr" to a CborOut structure
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param data The pointer to the data that needs to be packed
+ * @packed data_size Size of the data
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_bytes(
+    struct CborOut *p, const uint8_t *data, const size_t data_size) {
   CborWriteBstr(data_size, data, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
 
-// Wrappers to encode a pair of data for cbor-map
-static inline rom_error_t cbor_write_pair_uint_uint(struct CborOut *p,
-                                                    uint64_t key,
-                                                    uint64_t value) {
+/***********************************************
+ * Wrappers to encode a pair of data for cbor-map
+ ***********************************************/
+/**
+ * Add 2 elements, "uint" and "uint", to a CborOut structure
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param key The first "uint" element
+ * @param value The second "uint" element
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_uint(
+    struct CborOut *p, uint64_t key, uint64_t value) {
   CborWriteUint(key, p);
   CborWriteUint(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_write_pair_int_uint(struct CborOut *p,
-                                                   int64_t key,
-                                                   uint64_t value) {
+/**
+ * Add 2 elements, "int" and "uint", to a CborOut structure
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param key The first "int" element
+ * @param value The second "uint" element
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_int_uint(
+    struct CborOut *p, int64_t key, uint64_t value) {
   CborWriteInt(key, p);
   CborWriteUint(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_write_pair_uint_int(struct CborOut *p,
-                                                   uint64_t key,
-                                                   int64_t value) {
+/**
+ * Add 2 elements, "uint" and "int", to a CborOut structure
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param key The first "uint" element
+ * @param value The second "int" element
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_int(
+    struct CborOut *p, uint64_t key, int64_t value) {
   CborWriteUint(key, p);
   CborWriteInt(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_write_pair_int_bytes(struct CborOut *p,
-                                                    int64_t key,
-                                                    const uint8_t *value,
-                                                    const size_t value_size) {
+/**
+ * Add 2 elements, "int" and "bstr", to a CborOut structure
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param key The first "int" element
+ * @param value The pointer of the second "bstr" element
+ * @param value_size Size of the value
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_int_bytes(
+    struct CborOut *p, int64_t key, const uint8_t *value,
+    const size_t value_size) {
   CborWriteInt(key, p);
   CborWriteBstr(value_size, value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_write_pair_uint_tstr(struct CborOut *p,
-                                                    uint64_t key,
-                                                    const char *value) {
+/**
+ * Add 2 elements, "uint" and "tstr", to a CborOut structure
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param key The first "uint" element
+ * @param value The pointer of the second "tstr" element
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_tstr(
+    struct CborOut *p, uint64_t key, const char *value) {
   CborWriteUint(key, p);
   CborWriteTstr(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
-
-static inline rom_error_t cbor_write_pair_int_tstr(struct CborOut *p,
-                                                   int64_t key,
-                                                   const char *value) {
+/**
+ * Add 2 elements, "int" and "tstr", to a CborOut structure
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param key The first "int" element
+ * @param value The pointer of the second "tstr" element
+ * @return kErrorOk, or kErrorCertInvalidSize if the updated CborOut is
+ *         overflowed
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_int_tstr(
+    struct CborOut *p, int64_t key, const char *value) {
   CborWriteInt(key, p);
   CborWriteTstr(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
 
-#undef CBOR_CHECK_OVERFLOWED_AND_RETURN
+/***********************************************
+ * Helpers for the auto-gen template
+ ***********************************************/
+/**
+ * Calculate how much space is needed in the header for an "unsigned interger"
+ * type of CBOR argument.
+ *
+ * @param value An unsigned integer argument.
+ * @return Size required in the header
+ */
+static inline size_t cbor_calc_arg_size(uint64_t value) {
+  if (value <= 23) {
+    return 0;
+  } else if (value <= 0xff) {
+    return 1;
+  } else if (value <= 0xffff) {
+    return 2;
+  } else if (value <= 0xffffffff) {
+    return 4;
+  } else {
+    return 8;
+  };
+}
+/**
+ * Calculate how much space is needed in the header for a "signed interger" type
+ * of CBOR argument.
+ *
+ * @param value An signed integer argument.
+ * @return Size required in the header
+ */
+static inline size_t cbor_calc_int_size(int64_t value) {
+  if (value < 0)
+    return cbor_calc_arg_size((uint64_t)(-(value + 1)));
 
+  return cbor_calc_arg_size((uint64_t)value);
+}
+
+// Add a bstr/tstr header with size, and rewind the cursor
+/**
+ * Add a "bstr" header along with the payload size, and rewind the cursor of
+ * CborOut structure.
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param bstr_size The size of the payload
+ * @return kErrorOk, or kErrorCertInvalidSize if the bstr_size exceeds the
+ *         buffer size that is recorded in p.
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_bstr_header(
+    struct CborOut *p, const size_t bstr_size) {
+  if (NULL == CborAllocBstr(bstr_size, p))
+    return kErrorCertInvalidSize;
+  p->cursor -= bstr_size;
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+/**
+ * Add a "tstr" header along with the payload size, and rewind the cursor of
+ * CborOut structure.
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param tstr_size The size of the payload
+ * @return kErrorOk, or kErrorCertInvalidSize if the tstr_size exceeds the
+ *         buffer size that is recorded in p.
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_tstr_header(
+    struct CborOut *p, const size_t tstr_size) {
+  if (NULL == CborAllocTstr(tstr_size, p))
+    return kErrorCertInvalidSize;
+  p->cursor -= tstr_size;
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
+
+/**
+ * Fill in raw data to a given CborOut structure.
+ *
+ * @param[in,out] p The pointer to a CborOut structure
+ * @param raw The pointer to the raw bytes
+ * @param raw_size The size of the raw byptes
+ * @return kErrorOk, or kErrorCertInvalidSize if the raw_size exceeds the
+ *         buffer size that is recorded in p.
+ */
+OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_raw_bytes(
+    struct CborOut *p, const uint8_t *raw, const size_t raw_size) {
+  if (p->cursor + raw_size > p->buffer_size)
+    return kErrorCertInvalidSize;
+  memcpy(&p->buffer[p->cursor], raw, raw_size);
+  p->cursor += raw_size;
+  CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
+}
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_

--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -12,9 +12,9 @@
 #include "sw/device/silicon_creator/lib/cert/cdi_0.h"  // Generated.
 #include "sw/device/silicon_creator/lib/cert/cdi_1.h"  // Generated.
 #include "sw/device/silicon_creator/lib/cert/cert.h"
+#include "sw/device/silicon_creator/lib/cert/dice_keys.h"
 #include "sw/device/silicon_creator/lib/cert/uds.h"  // Generated.
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
-#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
@@ -47,73 +47,6 @@ static bool is_debug_exposed(void) {
   }
   return true;
 }
-
-// UDS (Creator) attestation key diverisfier constants.
-// Note: versions are always set to 0 so these keys are always valid from the
-// perspective of the keymgr hardware.
-const sc_keymgr_diversification_t kUdsKeymgrDiversifier = {
-    .salt =
-        {
-            0xabffa6a9,
-            0xc781f1ad,
-            0x4c1107ad,
-            0xf9210d85,
-            0x0931f555,
-            0x6c5aef5d,
-            0xb9ba4df0,
-            0x77b248d2,
-        },
-    .version = 0,
-};
-// CDI_0 (OwnerIntermediate) attestation key diverisfier constants.
-const sc_keymgr_diversification_t kCdi0KeymgrDiversifier = {
-    .salt =
-        {
-            0x3e5913c7,
-            0x41156f1d,
-            0x998ddb9f,
-            0xfa334191,
-            0x8a85380e,
-            0xba76ca1a,
-            0xdb17c4a7,
-            0xfb8852dc,
-        },
-    .version = 0,
-};
-// CDI_1 (Owner) attestation key diverisfier constants.
-const sc_keymgr_diversification_t kCdi1KeymgrDiversifier = {
-    .salt =
-        {
-            0x2d12c2e3,
-            0x6acc6876,
-            0x4bfb07ee,
-            0xc45fc414,
-            0x5d4fa9de,
-            0xf295b128,
-            0x50f49882,
-            0xbbdefa29,
-        },
-    .version = 0,
-};
-
-const sc_keymgr_ecc_key_t kDiceKeyUds = {
-    .type = kScKeymgrKeyTypeAttestation,
-    .keygen_seed_idx = kFlashInfoFieldUdsKeySeedIdx,
-    .keymgr_diversifier = &kUdsKeymgrDiversifier,
-    .required_keymgr_state = kScKeymgrStateCreatorRootKey,
-};
-const sc_keymgr_ecc_key_t kDiceKeyCdi0 = {
-    .type = kScKeymgrKeyTypeAttestation,
-    .keygen_seed_idx = kFlashInfoFieldCdi0KeySeedIdx,
-    .keymgr_diversifier = &kCdi0KeymgrDiversifier,
-    .required_keymgr_state = kScKeymgrStateOwnerIntermediateKey,
-};
-const sc_keymgr_ecc_key_t kDiceKeyCdi1 = {
-    .type = kScKeymgrKeyTypeAttestation,
-    .keygen_seed_idx = kFlashInfoFieldCdi1KeySeedIdx,
-    .keymgr_diversifier = &kCdi1KeymgrDiversifier,
-    .required_keymgr_state = kScKeymgrStateOwnerKey,
-};
 
 rom_error_t dice_uds_tbs_cert_build(
     hmac_digest_t *otp_creator_sw_cfg_measurement,

--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -115,15 +115,6 @@ const sc_keymgr_ecc_key_t kDiceKeyCdi1 = {
     .required_keymgr_state = kScKeymgrStateOwnerKey,
 };
 
-/**
- * Helper function to convert an attestation certificate signature from little
- * to big endian.
- */
-static void curr_tbs_signature_le_to_be_convert(ecdsa_p256_signature_t *sig) {
-  util_reverse_bytes(sig->r, kEcdsaP256SignatureComponentBytes);
-  util_reverse_bytes(sig->s, kEcdsaP256SignatureComponentBytes);
-}
-
 rom_error_t dice_uds_tbs_cert_build(
     hmac_digest_t *otp_creator_sw_cfg_measurement,
     hmac_digest_t *otp_owner_sw_cfg_measurement,
@@ -189,7 +180,9 @@ rom_error_t dice_cdi_0_cert_build(hmac_digest_t *rom_ext_measurement,
   hmac_sha256(cdi_0_cert_params.tbs, cdi_0_cert_params.tbs_size, &tbs_digest);
   HARDENED_RETURN_IF_ERROR(
       otbn_boot_attestation_endorse(&tbs_digest, &curr_tbs_signature));
-  curr_tbs_signature_le_to_be_convert(&curr_tbs_signature);
+  util_p256_signature_le_to_be_convert(curr_tbs_signature.r,
+                                       curr_tbs_signature.s);
+
   cdi_0_cert_params.cert_signature_r = (unsigned char *)curr_tbs_signature.r;
   cdi_0_cert_params.cert_signature_r_size = kAttestationSignatureBytes / 2;
   cdi_0_cert_params.cert_signature_s = (unsigned char *)curr_tbs_signature.s;
@@ -238,7 +231,8 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
   hmac_sha256(cdi_1_cert_params.tbs, cdi_1_cert_params.tbs_size, &tbs_digest);
   HARDENED_RETURN_IF_ERROR(
       otbn_boot_attestation_endorse(&tbs_digest, &curr_tbs_signature));
-  curr_tbs_signature_le_to_be_convert(&curr_tbs_signature);
+  util_p256_signature_le_to_be_convert(curr_tbs_signature.r,
+                                       curr_tbs_signature.s);
   cdi_1_cert_params.cert_signature_r = (unsigned char *)curr_tbs_signature.r;
   cdi_1_cert_params.cert_signature_r_size = kAttestationSignatureBytes / 2;
   cdi_1_cert_params.cert_signature_s = (unsigned char *)curr_tbs_signature.s;

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -8,8 +8,8 @@
 #include "sw/device/silicon_creator/lib/cert/cbor.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/cert/dice.h"
+#include "sw/device/silicon_creator/lib/cert/dice_keys.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
-#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
@@ -28,73 +28,6 @@ const int64_t kCoseEc2YLabel = -3;
 const int64_t kCoseKeyAlgEcdsa256 = -7;
 const int64_t kCoseEc2CrvP256 = 1;
 const int64_t kCoseKeyKtyEc2 = 2;
-
-// UDS (Creator) attestation key diverisfier constants.
-// Note: versions are always set to 0 so these keys are always valid from the
-// perspective of the keymgr hardware.
-const sc_keymgr_diversification_t kUdsKeymgrDiversifier = {
-    .salt =
-        {
-            0xabffa6a9,
-            0xc781f1ad,
-            0x4c1107ad,
-            0xf9210d85,
-            0x0931f555,
-            0x6c5aef5d,
-            0xb9ba4df0,
-            0x77b248d2,
-        },
-    .version = 0,
-};
-// CDI_0 (OwnerIntermediate) attestation key diverisfier constants.
-const sc_keymgr_diversification_t kCdi0KeymgrDiversifier = {
-    .salt =
-        {
-            0x3e5913c7,
-            0x41156f1d,
-            0x998ddb9f,
-            0xfa334191,
-            0x8a85380e,
-            0xba76ca1a,
-            0xdb17c4a7,
-            0xfb8852dc,
-        },
-    .version = 0,
-};
-// CDI_1 (Owner) attestation key diverisfier constants.
-const sc_keymgr_diversification_t kCdi1KeymgrDiversifier = {
-    .salt =
-        {
-            0x2d12c2e3,
-            0x6acc6876,
-            0x4bfb07ee,
-            0xc45fc414,
-            0x5d4fa9de,
-            0xf295b128,
-            0x50f49882,
-            0xbbdefa29,
-        },
-    .version = 0,
-};
-
-const sc_keymgr_ecc_key_t kDiceKeyUds = {
-    .type = kScKeymgrKeyTypeAttestation,
-    .keygen_seed_idx = kFlashInfoFieldUdsKeySeedIdx,
-    .keymgr_diversifier = &kUdsKeymgrDiversifier,
-    .required_keymgr_state = kScKeymgrStateCreatorRootKey,
-};
-const sc_keymgr_ecc_key_t kDiceKeyCdi0 = {
-    .type = kScKeymgrKeyTypeAttestation,
-    .keygen_seed_idx = kFlashInfoFieldCdi0KeySeedIdx,
-    .keymgr_diversifier = &kCdi0KeymgrDiversifier,
-    .required_keymgr_state = kScKeymgrStateOwnerIntermediateKey,
-};
-const sc_keymgr_ecc_key_t kDiceKeyCdi1 = {
-    .type = kScKeymgrKeyTypeAttestation,
-    .keygen_seed_idx = kFlashInfoFieldCdi1KeySeedIdx,
-    .keymgr_diversifier = &kCdi1KeymgrDiversifier,
-    .required_keymgr_state = kScKeymgrStateOwnerKey,
-};
 
 // PubKeyECDSA256 = {               ; COSE_Key [RFC9052 s7]
 //     1 : 2,                       ; Key type : EC2

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -8,12 +8,10 @@
 #include "sw/device/silicon_creator/lib/cert/cbor.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/cert/dice.h"
-#include "sw/device/silicon_creator/lib/cert/dice_keys.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
-#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 
 #include "otp_ctrl_regs.h"  // Generated.
 

--- a/sw/device/silicon_creator/lib/cert/dice_keys.c
+++ b/sw/device/silicon_creator/lib/cert/dice_keys.c
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+#include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
+
+// UDS (Creator) attestation key diverisfier constants.
+// Note: versions are always set to 0 so these keys are always valid from the
+// perspective of the keymgr hardware.
+const sc_keymgr_diversification_t kUdsKeymgrDiversifier = {
+    .salt =
+        {
+            0xabffa6a9,
+            0xc781f1ad,
+            0x4c1107ad,
+            0xf9210d85,
+            0x0931f555,
+            0x6c5aef5d,
+            0xb9ba4df0,
+            0x77b248d2,
+        },
+    .version = 0,
+};
+// CDI_0 (OwnerIntermediate) attestation key diverisfier constants.
+const sc_keymgr_diversification_t kCdi0KeymgrDiversifier = {
+    .salt =
+        {
+            0x3e5913c7,
+            0x41156f1d,
+            0x998ddb9f,
+            0xfa334191,
+            0x8a85380e,
+            0xba76ca1a,
+            0xdb17c4a7,
+            0xfb8852dc,
+        },
+    .version = 0,
+};
+// CDI_1 (Owner) attestation key diverisfier constants.
+const sc_keymgr_diversification_t kCdi1KeymgrDiversifier = {
+    .salt =
+        {
+            0x2d12c2e3,
+            0x6acc6876,
+            0x4bfb07ee,
+            0xc45fc414,
+            0x5d4fa9de,
+            0xf295b128,
+            0x50f49882,
+            0xbbdefa29,
+        },
+    .version = 0,
+};
+
+const sc_keymgr_ecc_key_t kDiceKeyUds = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldUdsKeySeedIdx,
+    .keymgr_diversifier = &kUdsKeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateCreatorRootKey,
+};
+
+const sc_keymgr_ecc_key_t kDiceKeyCdi0 = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldCdi0KeySeedIdx,
+    .keymgr_diversifier = &kCdi0KeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateOwnerIntermediateKey,
+};
+
+const sc_keymgr_ecc_key_t kDiceKeyCdi1 = {
+    .type = kScKeymgrKeyTypeAttestation,
+    .keygen_seed_idx = kFlashInfoFieldCdi1KeySeedIdx,
+    .keymgr_diversifier = &kCdi1KeymgrDiversifier,
+    .required_keymgr_state = kScKeymgrStateOwnerKey,
+};

--- a/sw/device/silicon_creator/lib/cert/dice_keys.h
+++ b/sw/device/silicon_creator/lib/cert/dice_keys.h
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_KEYS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_KEYS_H_
+
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+
+extern const sc_keymgr_ecc_key_t kDiceKeyUds;
+extern const sc_keymgr_ecc_key_t kDiceKeyCdi0;
+extern const sc_keymgr_ecc_key_t kDiceKeyCdi1;
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_KEYS_H_


### PR DESCRIPTION
Some DICE key creation constants and utilities are invoked by several modules.
Refactor them for a better code reuse. 