### PR TITLE
[manuf,rom_ext] move UDS cert to separate info page

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -356,6 +356,22 @@ rom_error_t flash_ctrl_info_read(const flash_ctrl_info_page_t *info_page,
   return wait_for_done(kErrorFlashCtrlInfoRead);
 }
 
+rom_error_t flash_ctrl_info_read_zeros_on_read_error(
+    const flash_ctrl_info_page_t *info_page, uint32_t offset,
+    uint32_t word_count, void *data) {
+  rom_error_t err = flash_ctrl_info_read(info_page, offset, word_count, data);
+  if (err != kErrorOk) {
+    flash_ctrl_error_code_t flash_ctrl_err_code;
+    flash_ctrl_error_code_get(&flash_ctrl_err_code);
+    if (flash_ctrl_err_code.rd_err) {
+      // If we encountered a read error, return all 0s.
+      memset(data, 0, word_count * sizeof(uint32_t));
+      return kErrorOk;
+    }
+  }
+  return err;
+}
+
 rom_error_t flash_ctrl_data_write(uint32_t addr, uint32_t word_count,
                                   const void *data) {
   return write(addr, kFlashCtrlPartitionData, word_count, data,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -79,7 +79,7 @@ typedef enum flash_ctrl_partition {
   X(kFlashCtrlInfoPageOwnerReserved1,      0, 6) \
   X(kFlashCtrlInfoPageOwnerReserved2,      0, 7) \
   X(kFlashCtrlInfoPageOwnerReserved3,      0, 8) \
-  X(kFlashCtrlInfoPageCreatorReserved0,    0, 9) \
+  X(kFlashCtrlInfoPageFactoryCerts,        0, 9) \
   /**
    * Bank 1 information partition type 0 pages.
    */ \
@@ -87,7 +87,7 @@ typedef enum flash_ctrl_partition {
   X(kFlashCtrlInfoPageBootData1,           1, 1) \
   X(kFlashCtrlInfoPageOwnerSlot0,          1, 2) \
   X(kFlashCtrlInfoPageOwnerSlot1,          1, 3) \
-  X(kFlashCtrlInfoPageCreatorReserved1,    1, 4) \
+  X(kFlashCtrlInfoPageCreatorReserved0,    1, 4) \
   X(kFlashCtrlInfoPageOwnerReserved4,      1, 5) \
   X(kFlashCtrlInfoPageOwnerReserved5,      1, 6) \
   X(kFlashCtrlInfoPageOwnerReserved6,      1, 7) \
@@ -317,6 +317,25 @@ OT_WARN_UNUSED_RESULT
 rom_error_t flash_ctrl_info_read(const flash_ctrl_info_page_t *info_page,
                                  uint32_t offset, uint32_t word_count,
                                  void *data);
+
+/**
+ * Reads data from an information page, returning all zeros if a read error code
+ * is encountered.
+ *
+ * The flash controller will truncate to the closest, lower word aligned
+ * address. For example, if 0x13 is supplied, the controller will start reading
+ * at address 0x10.
+ *
+ * @param info_page Information page to read from.
+ * @param offset Offset from the start of the page.
+ * @param word_count Number of bus words to read.
+ * @param[out] data Buffer to store the read data. Must be word aligned.
+ * @return Result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t flash_ctrl_info_read_zeros_on_read_error(
+    const flash_ctrl_info_page_t *info_page, uint32_t offset,
+    uint32_t word_count, void *data);
 
 /**
  * Writes data to the data partition.

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -27,6 +27,7 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   obj->obj_size = obj_size;
   // Extract LTV object type.
   PERSO_TLV_GET_FIELD(Objh, Type, objh, &obj_type);
+  obj->obj_type = obj_type;
   if (obj_type != kPersoObjectTypeX509Cert) {
     LOG_INFO("Skipping object of type %d", obj_type);
     return kErrorPersoTlvCertObjNotFound;

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -122,6 +122,10 @@ typedef struct perso_tlv_cert_obj {
    */
   size_t obj_size;
   /**
+   * LTV object type.
+   */
+  uint32_t obj_type;
+  /**
    * Pointer to the start of the certificate body (i.e., ASN.1 object for X.509
    * certificates, or CBOR object for CWT certificates).
    */

--- a/sw/device/silicon_creator/manuf/base/personalize_ext.h
+++ b/sw/device/silicon_creator/manuf/base/personalize_ext.h
@@ -10,6 +10,19 @@
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 
+enum {
+  /**
+   * Index of the first available page in the `cert_flash_layout` array that
+   * personalization extensions may use.
+   */
+  kCertFlashLayoutExt0Idx = 2,
+  /**
+   * Index of the second available page in the `cert_flash_layout` array that
+   * personalization extensions may use.
+   */
+  kCertFlashLayoutExt1Idx = 3,
+};
+
 /**
  * Parameters passed to personalization extension function invoked before data
  * is sent to the host for endorsement. Not all parameters are necessarily used

--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -43,14 +43,6 @@ static status_t peripheral_handles_init(void) {
   return OK_STATUS();
 }
 
-enum {
-  /**
-   * Index of the `cert_flash_layout` array in the `ft_personalize.c` base
-   * firmware to use to hold the TPM EK certificate.
-   */
-  kTpmCertFlashLayoutIdx = 1,
-};
-
 /**
  * Configures flash info pages to store device certificates.
  */
@@ -73,9 +65,9 @@ static status_t personalize_gen_tpm_ek_certificate(
          kCertKeyIdSizeInBytes);
 
   // Set the flash info page layout.
-  cert_flash_layout[kTpmCertFlashLayoutIdx].used = true;
-  cert_flash_layout[kTpmCertFlashLayoutIdx].group_name = "TPM";
-  cert_flash_layout[kTpmCertFlashLayoutIdx].num_certs = 1;
+  cert_flash_layout[kCertFlashLayoutExt0Idx].used = true;
+  cert_flash_layout[kCertFlashLayoutExt0Idx].group_name = "TPM";
+  cert_flash_layout[kCertFlashLayoutExt0Idx].num_certs = 1;
 
   // Provision TPM keygen seeds to flash info.
   TRY(manuf_personalize_flash_asymm_key_seed(

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -349,30 +349,19 @@ static rom_error_t rom_ext_attestation_increment_cert_offset(void) {
 }
 
 OT_WARN_UNUSED_RESULT
-static rom_error_t rom_ext_buffer_dice_certs_into_ram(void) {
-  rom_error_t err = flash_ctrl_info_read(
-      &kFlashCtrlInfoPageDiceCerts, /*offset=*/0,
+static rom_error_t rom_ext_buffer_dice_certs_into_ram(
+    const flash_ctrl_info_page_t *info_page) {
+  // Read in a DICE certificate(s) page.
+  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_read_zeros_on_read_error(
+      info_page, /*offset=*/0,
       /*word_count=*/FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(uint32_t),
-      dice_certs_page);
-  if (err != kErrorOk) {
-    flash_ctrl_error_code_t flash_ctrl_err_code;
-    flash_ctrl_error_code_get(&flash_ctrl_err_code);
-    if (flash_ctrl_err_code.rd_err) {
-      // If we encountered a read error, this could mean the certificate page
-      // has been corrupted or is not provisioned yet. In this case, we mark the
-      // page as "dirty" and set the buffer to all 0s.
-      memset(dice_certs_page, 0, FLASH_CTRL_PARAM_BYTES_PER_PAGE);
-      dice_certs_page_dirty = true;
-      return kErrorOk;
-    }
-    return err;
-  }
-
-  // Certificates are stored on flash info pages in perso LTV object form, see
-  // `sw/device/silicon_creator/manuf/base/perso_tlv_data.h` for more details.
-  // We must extract the offsets of the first DICE certificate (i.e., UDS).
-  err = perso_tlv_get_cert_obj(dice_certs_page, FLASH_CTRL_PARAM_BYTES_PER_PAGE,
-                               &dice_cert_obj);
+      dice_certs_page));
+  // Certificates are stored on flash info pages in perso LTV object form,
+  // see `sw/device/silicon_creator/manuf/base/perso_tlv_data.h` for more
+  // details. We must extract the offsets of the first DICE certificate
+  // (i.e., UDS).
+  rom_error_t err = perso_tlv_get_cert_obj(
+      dice_certs_page, FLASH_CTRL_PARAM_BYTES_PER_PAGE, &dice_cert_obj);
   if (err == kErrorPersoTlvCertObjNotFound) {
     // If the UDS cert is not found it is because we are running on a sim or
     // FPGA platform, or the device has not yet been provisioned.
@@ -415,33 +404,16 @@ static rom_error_t rom_ext_attestation_silicon(void) {
       &cert_valid, /*out_cert_size=*/NULL));
   if (launder32(cert_valid) == kHardenedBoolFalse) {
     // The UDS key ID (and cert itself) should never change unless:
-    // 1. there is a hardware issue, or
+    // 1. there is a hardware issue / the page has been corrupted, or
     // 2. the cert has not yet been provisioned.
     //
-    // In either case, we do not need to (re)generate the certificate since an
-    // out of band attestation attempt will detect both conditions.
+    // In both cases, we do nothing, and boot normally, later attestation
+    // attempts will fail in a detectable manner.
     HARDENED_CHECK_EQ(cert_valid, kHardenedBoolFalse);
     dbg_printf("Warning: UDS certificate not valid.\r\n");
-
-    // On sim and FPGA platforms, or silicon that has not been provisioned
-    // fully, we expect the cert to be missing. In this case, we write a
-    // 0-length (invalid) ASN.1 certificate header blob to avoid breaking tests
-    // that run on these platforms.
-    if (dice_cert_obj.cert_body_size == 0) {
-      dbg_printf("Writing empty UDS certificate ASN.1 blob.\r\n");
-      uint8_t uds_cert[4] = {0x30, 0x82, 0x00, 0x00};
-      size_t cert_page_left = dice_certs_buffer_space_remaining();
-      HARDENED_RETURN_IF_ERROR(perso_tlv_cert_obj_build(
-          "UDS", /*needs_endorsement=*/false, uds_cert, sizeof(uds_cert),
-          dice_cert_obj.obj_p, &cert_page_left));
-      dice_certs_page_dirty = kHardenedBoolTrue;
-      // Reload the cert perso LTV object.
-      HARDENED_RETURN_IF_ERROR(perso_tlv_get_cert_obj(
-          dice_cert_obj.obj_p, dice_certs_buffer_space_remaining(),
-          &dice_cert_obj));
-    }
   }
-  HARDENED_RETURN_IF_ERROR(rom_ext_attestation_increment_cert_offset());
+  HARDENED_RETURN_IF_ERROR(
+      rom_ext_buffer_dice_certs_into_ram(&kFlashCtrlInfoPageDiceCerts));
   return kErrorOk;
 }
 
@@ -895,7 +867,9 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   // Configure DICE certificate flash info page and buffer it into RAM.
   flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageAttestationKeySeeds);
   flash_ctrl_cert_info_page_creator_cfg(&kFlashCtrlInfoPageDiceCerts);
-  HARDENED_RETURN_IF_ERROR(rom_ext_buffer_dice_certs_into_ram());
+  flash_ctrl_cert_info_page_owner_restrict(&kFlashCtrlInfoPageFactoryCerts);
+  HARDENED_RETURN_IF_ERROR(
+      rom_ext_buffer_dice_certs_into_ram(&kFlashCtrlInfoPageFactoryCerts));
 
   // Establish our identity.
   HARDENED_RETURN_IF_ERROR(rom_ext_attestation_silicon());


### PR DESCRIPTION
The DICE UDS certificate is endorsed offline at manufacturing time, and injected into a flash info page on the chip. It must remain stable for the lifetime of a chip.

Previously, the CDI_0 and CDI_1 DICE certificates were also written to the same flash info page. However, the ROM_EXT can update these certificates in the event that the ROM_EXT or Owner FW is ever updated (as this triggers a CDI0/1 key pair change). To update these certificates, the ROM_EXT buffered all certificates in RAM, erased the flash info page, and re-wrote it with the udpated certificates.

If there is a power outage during the certificate update, after the flash page was erased but before the certificates had been written back, there could be a moment when the UDS certificate was lost.

To prevent this from happening, the UDS certificate was moved to its own flash info page, that is never erased for the lifetime of the chip. Additionally, this updatest the ROM_EXT to never write a dummy UDS cert to flash in the event a chip is not provisioned, or we are running on a sim/FPGA platform, and instead, just write a warning message to the console.