### PR TITLE
[kmac, rtl/dv/sw] Remove unused error code

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env_cov.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cov.sv
@@ -301,8 +301,7 @@ class kmac_env_cov extends cip_base_env_cov #(.CFG_T(kmac_env_cfg));
     kmac_err_code: coverpoint kmac_err {
       ignore_bins ignore = {kmac_pkg::ErrNone};
       // Covered by direct sequence, if scb enabled for those seq, can remove it from this list.
-      illegal_bins il = {kmac_pkg::ErrShadowRegUpdate,
-                         kmac_pkg::ErrWaitTimerExpired,
+      illegal_bins il = {kmac_pkg::ErrWaitTimerExpired,
                          kmac_pkg::ErrIncorrectEntropyMode,
                          kmac_pkg::ErrSwHashingWithoutEntropyReady};
     }

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -456,9 +456,6 @@ package kmac_pkg;
     //  - Sw issues KMAC op without Entropy setting.
     ErrSwHashingWithoutEntropyReady = 8'h 09,
 
-    // Error Shadow register update
-    ErrShadowRegUpdate = 8'h C0,
-
     // Error due to lc_escalation_en_i or fatal fault
     ErrFatalError = 8'h C1,
 

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -402,8 +402,6 @@ typedef enum dif_kmac_error {
 
   kDifErrorSoftwareHashingWithoutEntropyReady = 9,
 
-  kDifErrorShadowRegisterUpdate = 0xC0,
-
   kDifErrorFatalError = 0xC1,
 
   kDifErrorPackerIntegrity = 0xC2,

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -792,7 +792,6 @@ class KmacGetErrorTest : public KmacTest {
       kDifErrorIncorrectFunctionName,
       kDifErrorSoftwareCommandSequence,
       kDifErrorSoftwareHashingWithoutEntropyReady,
-      kDifErrorShadowRegisterUpdate,
       kDifErrorFatalError,
       kDifErrorPackerIntegrity,
       kDifErrorMsgFifoIntegrity,


### PR DESCRIPTION
The `ErrShadowRegUpdate` code is never used in the RTL. Instead, according to the documentation, on a shadow register update error, a recoverable alert shall be triggered - this recoverable alert then is signaled in the STATUS register and not in the error code register.

Hence, this commit removes this error code as well as the corresponding SW code (`kDifErrorShadowRegisterUpdate`).