### PR TITLE
[perso] fix bug in SHA256 measurement computation

### DIFF
--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -311,6 +311,8 @@ static void compute_keymgr_owner_binding(manuf_certgen_inputs_t *inputs) {
                      kDiceMeasurementSizeInBytes);
   hmac_sha256_update((unsigned char *)inputs->owner_manifest_measurement,
                      kDiceMeasurementSizeInBytes);
+  hmac_sha256_process();
+  hmac_sha256_final(&combined_measurements);
   memcpy(attestation_binding_value.data, combined_measurements.digest,
          kDiceMeasurementSizeInBytes);
   memset(sealing_binding_value.data, 0, kDiceMeasurementSizeInBytes);


### PR DESCRIPTION
A SHA256 measurement of the owner FW and owner configuration block had not been completed before using the measurement.