### PR TITLE
[perso] separate transport image into ROM_EXT and OWNER fw

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -30,6 +30,10 @@ load(
     "//sw/device/silicon_creator/rom_ext:defs.bzl",
     "ROM_EXT_VERSION",
 )
+load(
+    "//sw/device/silicon_creator/rom_ext/e2e:defs.bzl",
+    "OWNER_SLOTS",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -365,19 +369,21 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft:ft_{}"
         },
         fpga = fpga_params(
             timeout = "moderate",
-            assemble = "{ft_personalize}@{slot_a} {transport_image}@{slot_b}",
+            assemble = "{ft_personalize}@{rom_ext_slot_a} {rom_ext}@{rom_ext_slot_b} {owner_fw}@{owner_slot_b}",
             binaries =
                 {
                     ":sram_ft_individualize_{}".format(config["otp"]): "sram_ft_individualize",
                     ":ft_personalize_{}".format(sku): "ft_personalize",
-                    config["transport_image"]: "transport_image",
+                    config["rom_ext"]: "rom_ext",
+                    config["owner_fw"]: "owner_fw",
                 },
             changes_otp = True,
             data = FT_PERSONALIZE_ENDORSEMENT_KEYS,
             needs_jtag = True,
             otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_test_locked0_manuf_initialized",
-            slot_a = SLOTS["a"],
-            slot_b = SLOTS["b"],
+            owner_slot_b = OWNER_SLOTS["b"],
+            rom_ext_slot_a = SLOTS["a"],
+            rom_ext_slot_b = SLOTS["b"],
             tags = [
                 "lc_test_locked0",
                 "manuf",
@@ -386,19 +392,21 @@ _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft:ft_{}"
             test_harness = _FT_PROVISIONING_HARNESS.format(sku),
         ),
         silicon = silicon_params(
-            assemble = "{ft_personalize}@{slot_a} {transport_image}@{slot_b}",
+            assemble = "{ft_personalize}@{rom_ext_slot_a} {rom_ext}@{rom_ext_slot_b} {owner_fw}@{owner_slot_b}",
             binaries =
                 {
                     ":sram_ft_individualize_{}".format(config["otp"]): "sram_ft_individualize",
                     ":ft_personalize_{}".format(sku): "ft_personalize",
-                    config["transport_image"]: "transport_image",
+                    config["rom_ext"]: "rom_ext",
+                    config["owner_fw"]: "owner_fw",
                 },
             changes_otp = True,
             data = FT_PERSONALIZE_ENDORSEMENT_KEYS,
             interface = "teacup",
             needs_jtag = True,
-            slot_a = SLOTS["a"],
-            slot_b = SLOTS["b"],
+            owner_slot_b = OWNER_SLOTS["b"],
+            rom_ext_slot_a = SLOTS["a"],
+            rom_ext_slot_b = SLOTS["b"],
             test_cmd = _FT_PROVISIONING_CMD_ARGS,
             test_harness = _FT_PROVISIONING_HARNESS.format(sku),
         ),

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -25,7 +25,8 @@ EARLGREY_SKUS = {
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
-        "transport_image": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+        "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
     },
     # OTP Config: SIVAL; DICE Certs: CWT; Additional Certs: None
     # TODO(#24281): uncomment when DICE CWT cert flows are fully supported
@@ -34,7 +35,8 @@ EARLGREY_SKUS = {
     #     "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
     #     "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
     #     "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
-    #     "transport_image": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+    #     "rom_ext": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+    #     "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
     # },
     # OTP Config: SIVAL; DICE Certs: X.509; Additional Certs: TPM EK
     "sival_tpm": {
@@ -45,7 +47,8 @@ EARLGREY_SKUS = {
             "//sw/device/silicon_creator/lib/cert:tpm_ek_template_library",
             "//sw/device/silicon_creator/manuf/base:tpm_perso_fw_ext",
         ],
-        "transport_image": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_prod_signed_slot_b",
+        "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
     },
 } | EXT_EARLGREY_SKUS
 

--- a/sw/device/silicon_creator/rom_ext/e2e/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/defs.bzl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+OWNER_SLOTS = {
+    "a": "0x10000",
+    "b": "0x90000",
+}

--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -5,7 +5,7 @@
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:linker.bzl", "ld_library")
 load("//rules:manifest.bzl", "manifest")
-load("//rules/opentitan:defs.bzl", "cw310_params", "fpga_params", "opentitan_binary", "opentitan_test")
+load("//rules/opentitan:defs.bzl", "fpga_params", "opentitan_binary", "opentitan_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -84,6 +84,8 @@ opentitan_binary(
     srcs = ["bare_metal_start.S"],
     exec_env = [
         "//hw/top_earlgrey:fpga_cw310_rom_ext",
+        "//hw/top_earlgrey:fpga_cw340_rom_ext",
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
     ],
     linker_script = ":ld_slot_b",
     manifest = ":manifest",


### PR DESCRIPTION
This separations makes it easier to prepare transport images for devices being provisioned.

With this change, SKU owners can now place a bazel label in the [EARLGREY_SKUS configuration dict](https://cs.opensource.google/opentitan/opentitan/+/master:sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl;l=21?q=provisioning_inputs.bzl&ss=opentitan%2Fopentitan) for which ROM_EXT target they want to bootstrap into slot B to boot after perso runs, and similarly they can place a bazel label in the same configuration dict for which owner FW target they want to bootstrap in owner slot B to be booted by the ROM_EXT after perso runs.