### PR TITLE
[manifest tools] Add extension params to manifest json file.

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -9,6 +9,57 @@ _SEL_MANUF_STATE_CREATOR = (1 << 8)
 _SEL_MANUF_STATE_OWNER = (1 << 9)
 _SEL_LIFE_CYCLE_STATE = (1 << 10)
 
+def product_expr(name, mask, value):
+    """Create a Product Expression JSON object.
+
+    Args:
+        name: The name of the product expression (unused).
+        mask: The mask for the product expression.
+        value: The value for the product expression.
+    Returns:
+        A dictionary representing the product expression.
+    """
+    return {
+        "mask": mask,
+        "value": value,
+    }
+
+def integrator_specific_firmware_binding(name, strike_mask, product_exprs):
+    """Create an Integrator Specific Firmware Block (ISFB) JSON object.
+
+    Args:
+        name: The name of the ISFB (unused).
+        strike_mask: The strike mask for the ISFB.
+        product_exprs: A list of product expressions for the ISFB.
+
+    Returns:
+        A JSON string representing the ISFB.
+    """
+    isfb = {}
+
+    if strike_mask:
+        isfb["strike_mask"] = strike_mask
+
+    if product_exprs:
+        if len(product_exprs) > 16:
+            fail("Too many product expressions ({}), maximum is 16.".format(len(product_exprs)))
+
+        isfb["product_expr"] = product_exprs
+
+    return json.encode(isfb)
+
+def isfb_erase_allowed_policy(name, erase_allowed):
+    """Create an ISFB Erase Allowed Policy JSON object.
+
+    Args:
+        name: The name of the policy (unused).
+        erase_allowed: A boolean indicating if erasing is allowed.
+
+    Returns:
+        A JSON string representing the policy.
+    """
+    return json.encode({"erase_allowed": erase_allowed})
+
 def _manifest_impl(ctx):
     mf = {}
     mf_version = {}
@@ -113,8 +164,8 @@ def _manifest_impl(ctx):
             "spx_key",
             "spx_signature",
             "secver_write",
-            None,
-            None,
+            "isfb",
+            "isfb_erase",
             None,
             None,
             None,
@@ -126,6 +177,21 @@ def _manifest_impl(ctx):
             None,
             None,
         ]
+
+    mf["extension_params"] = []
+    if ctx.attr.integrator_specific_firmware_binding:
+        mf["extension_params"].append(
+            {
+                "integrator_specific_firmware_binding": json.decode(ctx.attr.integrator_specific_firmware_binding),
+            },
+        )
+
+    if ctx.attr.isfb_erase_allowed_policy:
+        mf["extension_params"].append(
+            {
+                "isfb_erase_policy": json.decode(ctx.attr.isfb_erase_allowed_policy),
+            },
+        )
 
     file = ctx.actions.declare_file("{}.json".format(ctx.attr.name))
     ctx.actions.write(file, json.encode_indent(mf))
@@ -161,6 +227,8 @@ _manifest = rule(
         "code_end": attr.string(doc = "End offset of the executable region in the image as a 0x-prefixed hex-encoded string"),
         "entry_point": attr.string(doc = "Offset of the first instruction in the image as a 0x-prefixed hex-encoded string"),
         "extensions": attr.string_list(doc = "Names of the manifest extensions as an array of strings"),
+        "integrator_specific_firmware_binding": attr.string(doc = "Create an Integrator Specific Firmware Block (ISFB) JSON object"),
+        "isfb_erase_allowed_policy": attr.string(doc = "Create an ISFB Erase Allowed Policy JSON object"),
     },
 )
 

--- a/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
@@ -1,0 +1,71 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:const.bzl", "CONST", "hex")
+load(
+    "//rules/opentitan:defs.bzl",
+    "opentitan_binary",
+)
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VERSION",
+)
+load(
+    "//rules:manifest.bzl",
+    "integrator_specific_firmware_binding",
+    "isfb_erase_allowed_policy",
+    "manifest",
+    "product_expr",
+)
+
+manifest(d = {
+    "name": "manifest",
+    "identifier": hex(CONST.ROM_EXT),
+    "visibility": ["//visibility:public"],
+    "version_major": ROM_EXT_VERSION.MAJOR,
+    "version_minor": ROM_EXT_VERSION.MINOR,
+    "security_version": ROM_EXT_VERSION.SECURITY,
+    "integrator_specific_firmware_binding": integrator_specific_firmware_binding(
+        name = "isfb",
+        product_exprs = [
+            product_expr(
+                name = "constraint1",
+                mask = "0xffffffff",
+                value = "0xa5a5a5a5",
+            ),
+            product_expr(
+                name = "constraint2",
+                mask = "0xf0f0f0f0",
+                value = "0xa0a0a0a0",
+            ),
+        ],
+        strike_mask = "0x00000000000000000000000000000001",
+    ),
+    "isfb_erase_allowed_policy": isfb_erase_allowed_policy(
+        name = "isfb_erase_allowed",
+        erase_allowed = True,
+    ),
+})
+
+opentitan_binary(
+    name = "boot_test",
+    testonly = True,
+    srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+    defines = ["WITH_OWNERSHIP_INFO=1"],
+    ecdsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa": "app_prod",
+    },
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+    },
+    manifest = ":manifest",
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib:boot_log",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/ownership:datatypes",
+    ],
+)

--- a/sw/host/opentitanlib/src/image/image.rs
+++ b/sw/host/opentitanlib/src/image/image.rs
@@ -22,7 +22,7 @@ use crate::image::manifest::{
     CHIP_MANIFEST_VERSION_MINOR1,
 };
 use crate::image::manifest_def::{ManifestSigverifyBuffer, ManifestSpec};
-use crate::image::manifest_ext::{ManifestExtEntry, ManifestExtSpec};
+use crate::image::manifest_ext::{ManifestExtEntry, ManifestExtEntrySpec};
 use crate::util::file::{FromReader, ToWriter};
 use crate::util::parse_int::ParseInt;
 
@@ -193,31 +193,30 @@ impl Image {
 
     /// Adds an extension to the signed region of this `Image`.
     ///
-    /// This will take all the extensions in `spec.signed_region` and append them to the image.
+    /// This will take all the signed extensions in `spec` and append them to the image.
     /// This should be called before adding any unsigned extensions to ensure all extensions that
     /// are a part of the signature exist within the contiguous signed region of the image.
-    pub fn add_signed_manifest_extensions(&mut self, spec: &ManifestExtSpec) -> Result<()> {
-        for entry_spec in &spec.signed_region {
-            self.add_manifest_extension(ManifestExtEntry::from_spec(
-                entry_spec,
-                spec.source_path(),
-            )?)?;
-        }
-        Ok(())
+    pub fn add_signed_manifest_extensions(&mut self, spec: &[ManifestExtEntrySpec]) -> Result<()> {
+        spec.iter()
+            .filter(|entry_spec| entry_spec.is_signed())
+            .try_for_each(|entry_spec| {
+                self.add_manifest_extension(ManifestExtEntry::from_spec(entry_spec)?)
+            })
     }
 
     /// Adds an extension to the unsigned region of this `Image`.
     ///
-    /// This will take all the extensions in `spec.unsigned_region` and append them to the image.
+    /// This will take all the unsigned extensions in `spec` and append them to the image.
     /// This should only be called once all signed extensions have been added.
-    pub fn add_unsigned_manifest_extensions(&mut self, spec: &ManifestExtSpec) -> Result<()> {
-        for entry_spec in &spec.unsigned_region {
-            self.add_manifest_extension(ManifestExtEntry::from_spec(
-                entry_spec,
-                spec.source_path(),
-            )?)?;
-        }
-        Ok(())
+    pub fn add_unsigned_manifest_extensions(
+        &mut self,
+        spec: &[ManifestExtEntrySpec],
+    ) -> Result<()> {
+        spec.iter()
+            .filter(|entry_spec| !entry_spec.is_signed())
+            .try_for_each(|entry_spec| {
+                self.add_manifest_extension(ManifestExtEntry::from_spec(entry_spec)?)
+            })
     }
 
     /// Adds an extension to the end of this `Image`.

--- a/sw/host/opentitanlib/src/image/manifest_def.rs
+++ b/sw/host/opentitanlib/src/image/manifest_def.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::image::manifest::*;
-use crate::image::manifest_ext::ManifestExtId;
+use crate::image::manifest_ext::{ManifestExtEntrySpec, ManifestExtId};
 use crate::util::bigint::fixed_size_bigint;
 use crate::util::num_de::HexEncoded;
 use crate::util::parse_int::ParseInt;
@@ -220,27 +220,152 @@ impl<T: ParseInt + fmt::LowerHex, const N: usize> ManifestPacked<[T; N]>
     }
 }
 
-manifest_def! {
-    pub struct ManifestSpec {
-        signature: ManifestSigverifyBigInt,
-        usage_constraints: ManifestUsageConstraintsDef,
-        pub_key: ManifestSigverifyBigInt,
-        address_translation: ManifestSmallInt<u32>,
-        identifier: ManifestSmallInt<u32>,
-        manifest_version: ManifestVersionDef,
-        signed_region_end: ManifestSmallInt<u32>,
-        length: ManifestSmallInt<u32>,
-        version_major: ManifestSmallInt<u32>,
-        version_minor: ManifestSmallInt<u32>,
-        security_version: ManifestSmallInt<u32>,
-        timestamp: [ManifestSmallInt<u32>; 2],
-        binding_value: [ManifestSmallInt<u32>; 8],
-        max_key_version: ManifestSmallInt<u32>,
-        code_start: ManifestSmallInt<u32>,
-        code_end: ManifestSmallInt<u32>,
-        entry_point: ManifestSmallInt<u32>,
-        extensions: [ManifestExtTableEntryDef; CHIP_MANIFEST_EXT_TABLE_COUNT],
-    }, Manifest
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub struct ManifestSpec {
+    #[serde(default)]
+    signature: ManifestSigverifyBigInt,
+
+    #[serde(default)]
+    usage_constraints: ManifestUsageConstraintsDef,
+
+    #[serde(default)]
+    pub_key: ManifestSigverifyBigInt,
+
+    #[serde(default)]
+    address_translation: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    identifier: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    manifest_version: ManifestVersionDef,
+
+    #[serde(default)]
+    signed_region_end: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    length: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    version_major: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    version_minor: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    security_version: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    timestamp: [ManifestSmallInt<u32>; 2],
+
+    #[serde(default)]
+    binding_value: [ManifestSmallInt<u32>; 8],
+
+    #[serde(default)]
+    max_key_version: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    code_start: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    code_end: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    entry_point: ManifestSmallInt<u32>,
+
+    #[serde(default)]
+    extensions: [ManifestExtTableEntryDef; CHIP_MANIFEST_EXT_TABLE_COUNT],
+
+    #[serde(default)]
+    pub extension_params: Vec<ManifestExtEntrySpec>,
+}
+
+impl ManifestPacked<Manifest> for ManifestSpec {
+    fn unpack(self, _name: &'static str) -> Result<Manifest> {
+        Ok(Manifest {
+            // Call `unpack()` on each field with the field's name included for use in
+            // error messages.
+            signature: self.signature.unpack("signature")?.try_into()?,
+            usage_constraints: self.usage_constraints.unpack("usage_constraints")?,
+            pub_key: self.pub_key.unpack("pub_key")?.try_into()?,
+            address_translation: self.address_translation.unpack("address_translation")?,
+            identifier: self.identifier.unpack("identifier")?,
+            manifest_version: self.manifest_version.unpack("manifest_version")?,
+            signed_region_end: self.signed_region_end.unpack("signed_region_end")?,
+            length: self.length.unpack("length")?,
+            version_major: self.version_major.unpack("version_major")?,
+            version_minor: self.version_minor.unpack("version_minor")?,
+            security_version: self.security_version.unpack("security_version")?,
+            timestamp: self.timestamp.unpack("timestamp")?.try_into()?,
+            binding_value: self.binding_value.unpack("binding_value")?.try_into()?,
+            max_key_version: self.max_key_version.unpack("max_key_version")?,
+            code_start: self.code_start.unpack("code_start")?,
+            code_end: self.code_end.unpack("code_end")?,
+            entry_point: self.entry_point.unpack("entry_point")?,
+            extensions: self.extensions.unpack("extensions")?.into(),
+        })
+    }
+
+    fn overwrite(&mut self, o: ManifestSpec) {
+        self.signature.overwrite(o.signature);
+        self.usage_constraints.overwrite(o.usage_constraints);
+        self.pub_key.overwrite(o.pub_key);
+        self.address_translation.overwrite(o.address_translation);
+        self.identifier.overwrite(o.identifier);
+        self.manifest_version.overwrite(o.manifest_version);
+        self.signed_region_end.overwrite(o.signed_region_end);
+        self.length.overwrite(o.length);
+        self.version_major.overwrite(o.version_major);
+        self.version_minor.overwrite(o.version_minor);
+        self.security_version.overwrite(o.security_version);
+        self.timestamp.overwrite(o.timestamp);
+        self.binding_value.overwrite(o.binding_value);
+        self.max_key_version.overwrite(o.max_key_version);
+        self.code_start.overwrite(o.code_start);
+        self.code_end.overwrite(o.code_end);
+        self.entry_point.overwrite(o.entry_point);
+        self.extensions.overwrite(o.extensions);
+        // TODO(moidx): Implement extension_params overwrite.
+        // Extension params are not overwritten.
+    }
+}
+
+impl TryInto<Manifest> for ManifestSpec {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<Manifest> {
+        self.unpack("")
+    }
+}
+
+impl TryFrom<&Manifest> for ManifestSpec {
+    type Error = anyhow::Error;
+
+    fn try_from(o: &Manifest) -> Result<Self> {
+        Ok(ManifestSpec {
+            signature: (&o.signature).try_into()?,
+            usage_constraints: (&o.usage_constraints).try_into()?,
+            pub_key: (&o.pub_key).try_into()?,
+            address_translation: (&o.address_translation).into(),
+            identifier: (&o.identifier).into(),
+            manifest_version: (&o.manifest_version).try_into()?,
+            signed_region_end: (&o.signed_region_end).into(),
+            length: (&o.length).into(),
+            version_major: (&o.version_major).into(),
+            version_minor: (&o.version_minor).into(),
+            security_version: (&o.security_version).into(),
+            timestamp: (&o.timestamp).into(),
+            binding_value: (&o.binding_value).into(),
+            max_key_version: (&o.max_key_version).into(),
+            code_start: (&o.code_start).into(),
+            code_end: (&o.code_end).into(),
+            entry_point: (&o.entry_point).into(),
+            extensions: (&o.extensions).into(),
+
+            // TODO(moidx): Implement extension_params extraction from Manifest.
+            extension_params: Vec::new(),
+        })
+    }
 }
 
 manifest_def! {

--- a/sw/host/opentitanlib/src/image/testdata/manifest.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest.hjson
@@ -193,5 +193,27 @@
     null,
     null,
     null,
+  ],
+  extension_params: [
+    {
+      integrator_specific_firmware_binding: {
+        strike_mask: "0x0fedcba987654321fedcba9876543210",
+        product_expr: [
+          {
+            mask: "0xffffffff",
+            value: "0xa5a5a5a5"
+          },
+          {
+            mask: "0xf0f0f0f0",
+            value: "0xa0a0a0a0"
+          }
+        ]
+      }
+    },
+    {
+      isfb_erase_policy: {
+        erase_allowed: false
+      }
+    },
   ]
 }

--- a/sw/host/opentitanlib/src/image/testdata/manifest_ext.hjson
+++ b/sw/host/opentitanlib/src/image/testdata/manifest_ext.hjson
@@ -3,38 +3,49 @@
 // SPDX-License-Identifier: Apache-2.0
 
 {
-  signed_region: [
+  extension_params: [
     {
-      spx_key: "test_spx.pem",
+      spx_key: {
+        spx_key: "test_spx.pem"
+      }
     },
     {
-      secver_write: true,
+      secver_write: {
+        secver_write: true
+      }
     },
     {
-      strike_mask: "0x0fedcba987654321fedcba9876543210"
-      product_expr: [
-        {
-          mask: "0xffffffff",
-          value: "0xa5a5a5a5",
-        },
-        {
-          mask: "0xf0f0f0f0",
-          value: "0xa0a0a0a0",
-        },
-      ]
+      integrator_specific_firmware_binding: {
+        strike_mask: "0x0fedcba987654321fedcba9876543210"
+        product_expr: [
+          {
+            mask: "0xffffffff",
+            value: "0xa5a5a5a5"
+          },
+          {
+            mask: "0xf0f0f0f0",
+            value: "0xa0a0a0a0"
+          }
+        ]
+      }
     },
     {
-      erase_allowed: false,
+      isfb_erase_policy: {
+        erase_allowed: false
+      }
     },
     {
-      name: "0xbeef",
-      identifier: "0xabcd",
-      value: ["0x01", "0x23", "0x45", "0x67"],
+      raw: {
+        name: "0xbeef",
+        identifier: "0xabcd",
+        signed: true,
+        value: ["0x01", "0x23", "0x45", "0x67"]
+      }
+    },
+    {
+      spx_signature: {
+        spx_signature: "test_signature.bin"
+      }
     }
-  ],
-  unsigned_region: [
-    {
-      spx_signature: "test_signature.bin",
-    },
   ],
 }


### PR DESCRIPTION
Update `opentitanlib` and `opentitantool` to support manifest extension configuration parameters in the main manifest JSON file.

1. Discontinue support for the `--manifest_ext` flag in the image manifest update command. Most extensions are manipulated directly by the command, and other extension parameters are now included in the main manifest JSON configuration file.
2. Update `ManifestExtEntrySpec` to add an attribute to determine if a given manifest extension should be signed. The OpenTitan specifications defines whether a extension should be signed or not. Capturing this information in `opentitanlib` makes the implementation less prone to user configuration errors.
3. Make `ManifestExtEntrySpec` serialization use named attributes to make the configuration easier to read.
4. Remove support for relative paths from various `manifest_ext` methods and structs. `opentitantool` loads files directly before calling any `manifest_ext` methods, and it does no rely on the spx extension params provided by `ManifestExtEntrySpec:Spx` and `ManifestExtEntrySpec::SpxSignature`. These are the only extensions that were previously supporting relative paths.
5. Add support for `integrator_specific_firmware_binding` and `isfb_erase_policy` manifest extensions to the Bazel manifest.bzl infrastructure.

This is part of: https://github.com/lowRISC/opentitan/issues/24666