### PR TITLE
[rom_ext] Call immutable section first at startup

### DIFF
--- a/sw/device/silicon_creator/imm_rom_ext/BUILD
+++ b/sw/device/silicon_creator/imm_rom_ext/BUILD
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "main_lib",
+    srcs = ["imm_rom_ext.c"],
+    hdrs = ["imm_rom_ext.h"],
+)

--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.h"
+
+void imm_rom_ext_main(void) {
+  // TODO(opentitan#24368): Implement this.
+  return;
+}

--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.h
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.h
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void imm_rom_ext_main(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_H_

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -230,6 +230,7 @@ cc_library(
         "//sw/device/lib/base:stdasm",
         "//sw/device/lib/crypto/drivers:entropy",
         "//sw/device/lib/runtime:hart",
+        "//sw/device/silicon_creator/imm_rom_ext:main_lib",
         "//sw/device/silicon_creator/lib:attestation",
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:boot_log",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/runtime/hart.h"
+#include "sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
 #include "sw/device/silicon_creator/lib/base/chip.h"
@@ -929,6 +930,11 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
 }
 
 void rom_ext_main(void) {
+  // TODO(opentitan#24368): Call immutable main in .rom_ext_immutable.
+  // The immutable rom_ext startup code is not ready yet, so we call it here
+  // to avoid breaking tests.
+  imm_rom_ext_main();
+
   rom_ext_check_rom_expectations();
   boot_data_t boot_data;
   boot_log_t *boot_log = &retention_sram_get()->creator.boot_log;
@@ -951,3 +957,9 @@ void rom_ext_exception_handler(void);
 
 OT_ALIAS("rom_ext_interrupt_handler")
 void rom_ext_nmi_handler(void);
+
+// A no-op immutable rom_ext fallback to avoid breaking tests before the
+// proper bazel target is ready.
+// TODO(opentitan#24368): Remove this nop fallback.
+OT_SECTION(".rom_ext_immutable.fallback")
+void imm_rom_ext_placeholder(void) {}

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -77,6 +77,10 @@ SECTIONS {
     _text_start = .;
     _rom_ext_immutable_start = .;
     KEEP(*(.rom_ext_immutable))
+
+    /* TODO: Remove this fallback when rom_ext_immutable section is ready. */
+    KEEP(*(.rom_ext_immutable.fallback))
+
     /* Ensure section end is word-aligned. */
     . = ALIGN(256);
     _rom_ext_immutable_end = .;

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "sw/device/lib/base/hardened_asm.h"
+#include "otp_ctrl_regs.h"
 
 /**
  * ROM_EXT Interrupt Vector
@@ -78,15 +80,32 @@ _rom_ext_interrupt_vector:
   .type _rom_ext_start_boot, @function
 _rom_ext_start_boot:
   /**
-   * Set up the global pointer `gp`.
-   *
    * Linker relaxations are disabled until the global pointer is setup below,
    * because otherwise some sequences may be turned into `gp`-relative
    * sequences, which is incorrect when `gp` is not initialized.
    */
   .option push
   .option norelax
+
+  /**
+   * Call the .rom_ext_immutable first if it's not called by ROM.
+   */
+  li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
+            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET)
+  lw   t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN_OFFSET(a0)
+  li   t1, HARDENED_BOOL_TRUE
+  beq  t0, t1, .L_mutable_start_boot
+  call _rom_ext_immutable_start
+
+  /**
+   * Continue booting the mutable rom_ext.
+   */
+.L_mutable_start_boot:
+  /**
+   * Set up the global pointer `gp`.
+   */
   la gp, __global_pointer$
+
   .option pop
 
   /**


### PR DESCRIPTION
To minimize the divergence between SKUs that with and without immutable rom_ext feature enabled in ROM, we propose always linking the section to rom_ext, and call it first if it isn’t called by ROM.

With this change, the boot flows will be always (almost) the same, while the OTP flag `IMMUTABLE_ROM_EXT_EN` basically only controls whether the immutability is enforced by ROM.

SKUs without the immutability enforced enable should still link with the trunk/master imm_rom_ext section, but without the EN bit set in their OTP configuration.

This partially addresses #24368.

A placeholder is added to avoid breaking current tests, and should be replaced by a proper target after #25043 is merged.