### PR TITLE
[rom_ext] Move the rom_ext epmp lib to drivers

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -901,3 +901,16 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "epmp",
+    srcs = ["epmp.c"],
+    hdrs = ["epmp.h"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:epmp_state",
+    ],
+)

--- a/sw/device/silicon_creator/lib/drivers/epmp.h
+++ b/sw/device/silicon_creator/lib/drivers/epmp.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_EPMP_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_EPMP_H_
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_EPMP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_EPMP_H_
 
 #include <stdint.h>
 
@@ -14,7 +14,7 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * ROM_EXT ROM enhanced Physical Memory Protection (ePMP) library.
+ * Enhanced Physical Memory Protection (ePMP) library.
  *
  * The ePMP configuration is managed in two parts:
  *
@@ -33,8 +33,6 @@ extern "C" {
  * initialized) with the in-memory copy of the state used to double check the
  * configuration as required.
  */
-// TODO(lowrisc/opentitan#8800): Implement ePMP initialization for ROM_EXT
-// stage.
 
 /**
  * Clear an ePMP entry.
@@ -43,7 +41,7 @@ extern "C" {
  *
  * @param entry The ePMP entry to clear.
  */
-void rom_ext_epmp_clear(uint8_t entry);
+void epmp_clear(uint8_t entry);
 
 /**
  * Configures an ePMP entry for a NAPOT or NA4 region.
@@ -59,8 +57,7 @@ void rom_ext_epmp_clear(uint8_t entry);
  * @param region The address region to configure.
  * @param perm The ePMP permissions for the region.
  */
-void rom_ext_epmp_set_napot(uint8_t entry, epmp_region_t region,
-                            epmp_perm_t perm);
+void epmp_set_napot(uint8_t entry, epmp_region_t region, epmp_perm_t perm);
 
 /**
  * Configures an ePMP entry for a TOR region.
@@ -73,18 +70,17 @@ void rom_ext_epmp_set_napot(uint8_t entry, epmp_region_t region,
  * @param region The address region to configure.
  * @param perm The ePMP permissions for the region.
  */
-void rom_ext_epmp_set_tor(uint8_t entry, epmp_region_t region,
-                          epmp_perm_t perm);
+void epmp_set_tor(uint8_t entry, epmp_region_t region, epmp_perm_t perm);
 
 /**
  * Clear the rule-locking-bypass (RLB) bit.
  *
  * Clearing RLB causes the Lock bit in the ePMP to be enforced.
  */
-void rom_ext_epmp_clear_rlb(void);
+void epmp_clear_rlb(void);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_EPMP_H_
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_EPMP_H_

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -16,19 +16,6 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "rom_ext_epmp",
-    srcs = ["rom_ext_epmp.c"],
-    hdrs = ["rom_ext_epmp.h"],
-    deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:bitfield",
-        "//sw/device/lib/base:csr",
-        "//sw/device/lib/base:hardened",
-        "//sw/device/silicon_creator/lib:epmp_state",
-    ],
-)
-
-cc_library(
     name = "rescue",
     srcs = ["rescue.c"],
     hdrs = ["rescue.h"],
@@ -220,7 +207,6 @@ cc_library(
         ":rescue",
         ":rom_ext_boot_policy",
         ":rom_ext_boot_policy_ptrs",
-        ":rom_ext_epmp",
         ":sigverify_keys",
         "//hw/ip/sram_ctrl/data:sram_ctrl_c_regs",
         "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
@@ -248,6 +234,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
         "//sw/device/silicon_creator/lib/cert:dice",
         "//sw/device/silicon_creator/lib/drivers:ast",
+        "//sw/device/silicon_creator/lib/drivers:epmp",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:ibex",


### PR DESCRIPTION
Immutable rom_ext also needs the epmp lib for reconfiguration.
Since the library code is general and not specific to rom_ext, let's move it to driver lib.

This PR only rename symbols, there's no change to the functionalities.

This partially addresses #24368.