### PR TITLE
[pwm,dv] Avoid running as UVM_HIGH by default

### DIFF
--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -54,9 +54,7 @@
     }
   ]
 
-    run_opts: ["+uvm_set_verbosity={component_a},{id_a},{verbosity_a},{phase_a}",
-               "+cdc_instrumentation_enabled=1"]
-
+  run_opts: ["+cdc_instrumentation_enabled=1"]
 
   // Default UVM test and seq class name.
   uvm_test: pwm_base_test


### PR DESCRIPTION
I think the initial commit of this code included a run mode as default (presumably when getting it working in the first place), which wasn't stripped out. Strip it out.