### PR TITLE
[pwm,dv] Use out-of-block declarations in some of the DV code

### DIFF
--- a/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
@@ -9,118 +9,156 @@ class pwm_base_vseq extends cip_base_vseq #(
   .VIRTUAL_SEQUENCER_T(pwm_virtual_sequencer)
 );
   `uvm_object_utils(pwm_base_vseq)
-  `uvm_object_new
+  extern function new (string name="");
 
-  virtual task set_cfg_reg(bit [26:0] ClkDiv, bit [3:0] DcResn, bit CntrEn);
-    ral.cfg.clk_div.set(ClkDiv);
-    ral.cfg.dc_resn.set(DcResn);
-    ral.cfg.cntr_en.set(CntrEn);
-    csr_update(ral.cfg);
-    foreach(cfg.m_pwm_monitor_cfg[i]) begin
-      cfg.m_pwm_monitor_cfg[i].resolution = DcResn;
-    end
-  endtask
+  // Tasks overridden from dv_base_vseq
+  extern task apply_reset(string kind = "HARD");
+  extern task apply_resets_concurrently(int reset_duration_ps = 0);
 
-  virtual task automatic rand_pwm_cfg_reg();
-    bit [26:0] ClkDiv = $urandom_range(0, int'(MAX_CLK_DIV));
-    bit [3:0]  DcResn = $urandom_range(0, 14);
-    bit        CntrEn = 1'b1;
-    set_cfg_reg(ClkDiv, DcResn, CntrEn);
-  endtask
+  // Set the CFG register with the given ClkDiv, DcResn, CntrEn with a CSR write
+  extern task set_cfg_reg(bit [26:0] ClkDiv, bit [3:0] DcResn, bit CntrEn);
 
-  virtual task set_ch_invert(bit [PWM_NUM_CHANNELS-1:0] enables);
-    csr_wr(.ptr(ral.invert[0]), .value(enables));
-    foreach (enables[ii]) begin
-      cfg.m_pwm_monitor_cfg[ii].invert = enables[ii];
-    end
-  endtask
+  // Pick a random value for the CFG register with cntr_en=1.
+  extern task rand_pwm_cfg_reg();
 
-  virtual task set_ch_enables(bit [PWM_NUM_CHANNELS-1:0] enables);
-    csr_wr(.ptr(ral.pwm_en[0]), .value(enables));
-    foreach (enables[ii]) begin
-      cfg.m_pwm_monitor_cfg[ii].active = enables[ii];
-    end
-  endtask
+  // Use a CSR write to set the INVERT bits as requested.
+  extern task set_ch_invert(bit [PWM_NUM_CHANNELS-1:0] enables);
 
-  virtual task set_duty_cycle(int unsigned channel, bit [15:0] A, bit [15:0] B);
-    `DV_CHECK_FATAL(channel < NOutputs)
+  // Use a CSR write to set the PWM_EN bits as requested.
+  extern task set_ch_enables(bit [PWM_NUM_CHANNELS-1:0] enables);
 
-    ral.duty_cycle[channel].set({B, A});
-    csr_update(ral.duty_cycle[channel]);
-  endtask
+  // Use a CSR write to set the duty cycle for the given channel.
+  extern task set_duty_cycle(int unsigned channel, bit [15:0] A, bit [15:0] B);
+
+  // Use a CSR write to set BLINK_PARAM for the given channel
+  extern task set_blink(int unsigned channel, bit [15:0] A, bit [15:0] B);
+
+  // Use a CSR write to set PWM_PARAM for the given channel.
+  extern task set_param(int unsigned channel, param_reg_t value);
 
   // Return a randomized duty cycle where both fields are nonzero.
-  function dc_blink_t rand_pwm_duty_cycle();
-    dc_blink_t value;
-    value.A = $urandom_range(1, int'(MAX_16));
-    value.B = $urandom_range(1, int'(MAX_16));
-    return value;
-  endfunction
-
-  virtual task set_blink(int unsigned channel, bit [15:0] A, bit [15:0] B);
-    `DV_CHECK_FATAL(channel < NOutputs)
-
-    ral.blink_param[channel].set({B, A});
-    csr_update(ral.blink_param[channel]);
-  endtask
+  extern function dc_blink_t rand_pwm_duty_cycle();
 
   // Return a randomized blink duty cycle where both fields are nonzero.
   //
   // Also ensure that the sum of A and B for the blink duty cycle fits in 16 bits. Similarly, ensure
   // that BLINK.B + DUTY_CYCLE.A fits in 16 bits (taking the channel's duty cycle as an argument).
   // This is to prevent counter overflow in both cases.
-  function dc_blink_t rand_pwm_blink(dc_blink_t duty_cycle);
-    dc_blink_t blink;
-    blink.B = $urandom_range(1, int'(MAX_16) - duty_cycle.A);
-    blink.A = $urandom_range(1, int'(MAX_16) - blink.B);
-    return blink;
-  endfunction
+  extern function dc_blink_t rand_pwm_blink(dc_blink_t duty_cycle);
 
-  virtual task set_param(int unsigned channel, param_reg_t value);
-    `DV_CHECK_FATAL(channel < NOutputs)
+  // Inject cycles of delay, disabling the main clock for a time in the middle if enable is true.
+  extern task low_power_mode(bit enable, uint cycles);
 
-    ral.pwm_param[channel].set(value);
-    csr_update(ral.pwm_param[channel]);
-  endtask // set_param
-
-  // override apply_reset to handle reset for bus and core domain
-  virtual task apply_reset(string kind = "HARD");
-    fork
-      if (kind == "HARD" || kind == "TL_IF") begin
-        super.apply_reset("HARD");
-      end
-      if (kind == "HARD" || kind == "CORE_IF") begin
-        cfg.clk_rst_core_vif.apply_reset();
-      end
-    join
-  endtask : apply_reset
-
-   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
-    cfg.clk_rst_core_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently(cfg.clk_rst_core_vif.clk_period_ps);
-    cfg.clk_rst_core_vif.drive_rst_pin(1);
-  endtask
-
-  virtual task low_power_mode(bit enable, uint cycles);
-    if (enable) begin
-      `uvm_info(`gfn, "Running in low power mode...", UVM_HIGH)
-      cfg.clk_rst_vif.wait_clks(cycles/2);
-      // in the middle of test turn off tl_ul clk to observe that
-      // the output does not change
-      cfg.clk_rst_vif.stop_clk();
-      // use core clk to determine when to turn tl_ul clk back on
-      cfg.clk_rst_core_vif.wait_clks(1);
-      cfg.clk_rst_vif.start_clk();
-      cfg.clk_rst_vif.wait_clks(cycles/2);
-    end else begin
-      cfg.clk_rst_vif.wait_clks(cycles);
-    end
-  endtask
-
-  virtual task shutdown_dut();
-    // shutdown dut to make last item finish gracefully
-    `uvm_info(`gfn, $sformatf("disabling channel"), UVM_HIGH)
-    set_ch_enables(32'h0);
-    dut_shutdown();
-  endtask
+  // Shutdown the dut in a way that helps the last item to finish gracefully.
+  extern task shutdown_dut();
 endclass : pwm_base_vseq
+
+function pwm_base_vseq::new (string name = "");
+  super.new(name);
+endfunction
+
+task pwm_base_vseq::apply_reset(string kind = "HARD");
+  fork
+    if (kind == "HARD" || kind == "TL_IF") begin
+      super.apply_reset("HARD");
+    end
+    if (kind == "HARD" || kind == "CORE_IF") begin
+      cfg.clk_rst_core_vif.apply_reset();
+    end
+  join
+endtask
+
+task pwm_base_vseq::apply_resets_concurrently(int reset_duration_ps = 0);
+  cfg.clk_rst_core_vif.drive_rst_pin(0);
+  super.apply_resets_concurrently(cfg.clk_rst_core_vif.clk_period_ps);
+  cfg.clk_rst_core_vif.drive_rst_pin(1);
+endtask
+
+task pwm_base_vseq::set_cfg_reg(bit [26:0] ClkDiv, bit [3:0] DcResn, bit CntrEn);
+  ral.cfg.clk_div.set(ClkDiv);
+  ral.cfg.dc_resn.set(DcResn);
+  ral.cfg.cntr_en.set(CntrEn);
+  csr_update(ral.cfg);
+  foreach(cfg.m_pwm_monitor_cfg[i]) begin
+    cfg.m_pwm_monitor_cfg[i].resolution = DcResn;
+  end
+endtask
+
+task pwm_base_vseq::rand_pwm_cfg_reg();
+  bit [26:0] ClkDiv = $urandom_range(0, int'(MAX_CLK_DIV));
+  bit [3:0]  DcResn = $urandom_range(0, 14);
+  bit        CntrEn = 1'b1;
+  set_cfg_reg(ClkDiv, DcResn, CntrEn);
+endtask
+
+task pwm_base_vseq::set_ch_invert(bit [PWM_NUM_CHANNELS-1:0] enables);
+  csr_wr(.ptr(ral.invert[0]), .value(enables));
+  foreach (enables[ii]) begin
+    cfg.m_pwm_monitor_cfg[ii].invert = enables[ii];
+  end
+endtask
+
+task pwm_base_vseq::set_ch_enables(bit [PWM_NUM_CHANNELS-1:0] enables);
+  csr_wr(.ptr(ral.pwm_en[0]), .value(enables));
+  foreach (enables[ii]) begin
+    cfg.m_pwm_monitor_cfg[ii].active = enables[ii];
+  end
+endtask
+
+task pwm_base_vseq::set_duty_cycle(int unsigned channel, bit [15:0] A, bit [15:0] B);
+  `DV_CHECK_FATAL(channel < NOutputs)
+
+  ral.duty_cycle[channel].set({B, A});
+  csr_update(ral.duty_cycle[channel]);
+endtask
+
+task pwm_base_vseq::set_blink(int unsigned channel, bit [15:0] A, bit [15:0] B);
+  `DV_CHECK_FATAL(channel < NOutputs)
+
+  ral.blink_param[channel].set({B, A});
+  csr_update(ral.blink_param[channel]);
+endtask
+
+task pwm_base_vseq::set_param(int unsigned channel, param_reg_t value);
+  `DV_CHECK_FATAL(channel < NOutputs)
+
+  ral.pwm_param[channel].set(value);
+  csr_update(ral.pwm_param[channel]);
+endtask // set_param
+
+function dc_blink_t pwm_base_vseq::rand_pwm_duty_cycle();
+  dc_blink_t value;
+  value.A = $urandom_range(1, int'(MAX_16));
+  value.B = $urandom_range(1, int'(MAX_16));
+  return value;
+endfunction
+
+function dc_blink_t pwm_base_vseq::rand_pwm_blink(dc_blink_t duty_cycle);
+  dc_blink_t blink;
+  blink.B = $urandom_range(1, int'(MAX_16) - duty_cycle.A);
+  blink.A = $urandom_range(1, int'(MAX_16) - blink.B);
+  return blink;
+endfunction
+
+task pwm_base_vseq::low_power_mode(bit enable, uint cycles);
+  if (enable) begin
+    `uvm_info(`gfn, "Running in low power mode...", UVM_HIGH)
+    cfg.clk_rst_vif.wait_clks(cycles/2);
+    // in the middle of test turn off tl_ul clk to observe that
+    // the output does not change
+    cfg.clk_rst_vif.stop_clk();
+    // use core clk to determine when to turn tl_ul clk back on
+    cfg.clk_rst_core_vif.wait_clks(1);
+    cfg.clk_rst_vif.start_clk();
+    cfg.clk_rst_vif.wait_clks(cycles/2);
+  end else begin
+    cfg.clk_rst_vif.wait_clks(cycles);
+  end
+endtask
+
+task pwm_base_vseq::shutdown_dut();
+  // shutdown dut to make last item finish gracefully
+  `uvm_info(`gfn, $sformatf("disabling channel"), UVM_HIGH)
+  set_ch_enables(32'h0);
+  dut_shutdown();
+endtask

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
@@ -64,19 +64,17 @@ class pwm_base_vseq extends cip_base_vseq #(
     csr_update(ral.blink_param[channel]);
   endtask
 
-  // Summation of PARAM.X and PARAM.Y shouldn't go beyond MAX_16
-  // Summation of PARAM.y and DUTY_CYLE.A shouldn't go beyond MAX_16
-  // This is to prevent counter overflow
-  virtual task automatic rand_pwm_blink(int unsigned channel);
-    dc_blink_t duty_cycle, blink;
-
-    `DV_CHECK_FATAL(channel < NOutputs)
-    duty_cycle = `gmv(ral.duty_cycle[channel]);
-
+  // Return a randomized blink duty cycle where both fields are nonzero.
+  //
+  // Also ensure that the sum of A and B for the blink duty cycle fits in 16 bits. Similarly, ensure
+  // that BLINK.B + DUTY_CYCLE.A fits in 16 bits (taking the channel's duty cycle as an argument).
+  // This is to prevent counter overflow in both cases.
+  function dc_blink_t rand_pwm_blink(dc_blink_t duty_cycle);
+    dc_blink_t blink;
     blink.B = $urandom_range(1, int'(MAX_16) - duty_cycle.A);
     blink.A = $urandom_range(1, int'(MAX_16) - blink.B);
-    set_blink(channel, .A(blink.A), .B(blink.B));
-  endtask
+    return blink;
+  endfunction
 
   virtual task set_param(int unsigned channel, param_reg_t value);
     `DV_CHECK_FATAL(channel < NOutputs)

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_common_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_common_vseq.sv
@@ -4,17 +4,21 @@
 
 class pwm_common_vseq extends pwm_base_vseq;
   `uvm_object_utils(pwm_common_vseq)
-  `uvm_object_new
+  extern function new (string name="");
 
-  constraint num_trans_c { num_trans inside {[1:2]}; }
+  extern constraint num_trans_c;
 
-  // for this vseq, $value$plusargs "+en_scb=0" is defined in pwm_sim_cfg.hjson
-  // disable pwm_monitor and pwm_scoreboard since they can not handle this test
-
-  virtual task body();
-    `uvm_info(`gfn, "\n--> start of pwm_common_vseq", UVM_DEBUG)
-    run_common_vseq_wrapper(num_trans);
-    `uvm_info(`gfn, "\n--> end of pwm_common_vseq", UVM_DEBUG)
-  endtask : body
-
+  extern task body();
 endclass : pwm_common_vseq
+
+function pwm_common_vseq::new (string name = "");
+  super.new(name);
+endfunction
+
+constraint pwm_common_vseq::num_trans_c {
+  num_trans inside {[1:2]};
+}
+
+task pwm_common_vseq::body();
+  run_common_vseq_wrapper(num_trans);
+endtask

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
@@ -5,61 +5,85 @@
 // sequence to check operation at min/max bandwidth
 class pwm_perf_vseq extends pwm_rand_output_vseq;
   `uvm_object_utils(pwm_perf_vseq)
-  `uvm_object_new
 
-  // variables
+  // The duty cycle used for all channels
   rand bit [15:0]  rand_dc;
+
+  // The blink threshold used for all channels
   rand bit [15:0]  rand_blink;
+
+  // A param_reg_t value to configure each channel
   rand param_reg_t pwm_param[PWM_NUM_CHANNELS];
 
-  // constraints
-  constraint rand_chan_c {
-    rand_chan dist {MAX_32:/1, 0:/1};
-  }
+  // Either enable all channels or none of them. Similarly for inverting channels.
+  extern constraint rand_chan_c;
+  extern constraint rand_invert_c;
 
-  constraint rand_invert_c {
-    rand_invert dist {MAX_32:/1, 0:/1};
-  }
+  // Enable "low power mode" half of the time (overriding the constraint with the same name in
+  // pwm_rand_output_vseq that uses low power mode less often)
+  extern constraint low_power_c;
 
-  constraint rand_reg_param_c {
-    rand_reg_param.HtbtEn == 1'b1 -> rand_reg_param.BlinkEn == 1'b1;
-    rand_reg_param.RsvParam == 0;
-    rand_reg_param.PhaseDelay dist {MAX_16:/1, 0:/1};
-  }
+  // Pick minimum or maximum phase delay and ensure heartbeat implies blink (overriding the
+  // constraint with the same name in pwm_rand_output_vseq that is more general about phase delay).
+  extern constraint rand_reg_param_c;
 
-  constraint low_power_c {
-    low_power dist {1'b1:/1, 1'b0:/1};
-  }
+  // The duty cycle and the threshold for the heartbeat blink counter should be minimal or maximal,
+  // correspoding to both counters being minimal or both counters being maximal.
+  extern constraint rand_dc_c;
+  extern constraint rand_blink_c;
 
-  constraint rand_dc_c {
-    rand_dc dist {MAX_16:/1, 16'h1:/1, 16'h0:/1};
-  }
+  extern function new (string name="");
+  extern virtual task body();
+endclass
 
-  constraint rand_blink_c {
-    rand_blink dist {MAX_16:/1, 16'h1:/1, 16'h0:/1};
-  }
+constraint pwm_perf_vseq::rand_chan_c {
+  rand_chan dist {MAX_32 :/ 1, 0 :/ 1};
+}
 
-  virtual task body();
+constraint pwm_perf_vseq::rand_invert_c {
+  rand_invert dist {MAX_32 :/ 1, 0 :/ 1};
+}
 
-    set_ch_enables(32'h0);
-    rand_pwm_cfg_reg();
+constraint pwm_perf_vseq::low_power_c {
+  low_power dist {1'b1 :/ 1, 1'b0 :/ 1};
+}
 
-    for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
-      set_duty_cycle(i, .A(rand_dc), .B(rand_dc));
-      set_blink(i, .A(rand_blink), .B(rand_blink));
+constraint pwm_perf_vseq::rand_reg_param_c {
+  rand_reg_param.HtbtEn == 1'b1 -> rand_reg_param.BlinkEn == 1'b1;
+  rand_reg_param.RsvParam == 0;
+  rand_reg_param.PhaseDelay dist {MAX_16 :/ 1, 0 :/ 1};
+}
 
-      pwm_param[i].HtbtEn = rand_reg_param.HtbtEn;
-      pwm_param[i].BlinkEn = rand_reg_param.BlinkEn;
-      set_param(i, pwm_param[i]);
-    end
+constraint pwm_perf_vseq::rand_dc_c {
+  rand_dc dist {MAX_16 :/ 1, 16'h0 :/ 1};
+}
 
-    set_ch_invert(rand_invert);
-    set_ch_enables(rand_chan);
+constraint pwm_perf_vseq::rand_blink_c {
+  rand_blink dist {MAX_16 :/ 1, 16'h0 :/ 1};
+}
 
-    low_power_mode(low_power, NUM_CYCLES);
+function pwm_perf_vseq::new (string name = "");
+  super.new(name);
+endfunction
 
-    shutdown_dut();
+task pwm_perf_vseq::body();
+  set_ch_enables(32'h0);
+  rand_pwm_cfg_reg();
 
-  endtask : body
+  for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
+    set_duty_cycle(i, .A(rand_dc), .B(rand_dc));
+    set_blink(i, .A(rand_blink), .B(rand_blink));
 
-endclass : pwm_perf_vseq
+    pwm_param[i].HtbtEn = rand_reg_param.HtbtEn;
+    pwm_param[i].BlinkEn = rand_reg_param.BlinkEn;
+    set_param(i, pwm_param[i]);
+  end
+
+  set_ch_invert(rand_invert);
+  set_ch_enables(rand_chan);
+
+  low_power_mode(low_power, NUM_CYCLES);
+
+  shutdown_dut();
+
+endtask : body

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
@@ -45,8 +45,8 @@ class pwm_perf_vseq extends pwm_rand_output_vseq;
     rand_pwm_cfg_reg();
 
     for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
-      set_duty_cycle(i, .A(rand_dc[i]), .B(rand_dc[i]));
-      set_blink(i, .A(rand_blink[i]), .B(rand_blink[i]));
+      set_duty_cycle(i, .A(rand_dc), .B(rand_dc));
+      set_blink(i, .A(rand_blink), .B(rand_blink));
 
       pwm_param[i].HtbtEn = rand_reg_param.HtbtEn;
       pwm_param[i].BlinkEn = rand_reg_param.BlinkEn;

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
@@ -33,17 +33,19 @@ class pwm_rand_output_vseq extends pwm_base_vseq;
 
     // set random dc and params for all channels
     for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
-      dc_blink_t duty_cycle = rand_pwm_duty_cycle();
       param_reg_t pwm_param;
+      dc_blink_t blink, duty_cycle;
 
+      duty_cycle = rand_pwm_duty_cycle();
+      blink = rand_pwm_blink(duty_cycle);
+
+      // phase delay of the PWM rising edge, in units of 2^(-16) PWM cycles
       pwm_param.PhaseDelay = (rand_reg_param.PhaseDelay * (2**(-16)));
       pwm_param.HtbtEn = rand_reg_param.HtbtEn;
       pwm_param.BlinkEn = rand_reg_param.BlinkEn;
 
       set_duty_cycle(i, .A(duty_cycle.A), .B(duty_cycle.B));
-      rand_pwm_blink(i);
-
-      // phase delay of the PWM rising edge, in units of 2^(-16) PWM cycles
+      set_blink(i, .A(blink.A), .B(blink.B));
       set_param(i, pwm_param);
     end
 


### PR DESCRIPTION
This is not the entire DV code (because the list of commits was getting rather long!), but changes a reasonable tranche. There are five commits:

- [pwm,dv] Change rand_pwm_blink to return the randomised value
- [pwm,dv] Use out-of-block declarations in pwm_base_vseq
- [pwm,dv] Use out-of-block declarations in pwm_common_vseq
- [pwm,dv] Correctly set duty_cycle / blink in pwm_perf_vseq
- [pwm,dv] Use out-of-block declarations in pwm_perf_vseq
