### PR TITLE
[pwm,dv] Use out-of-block declarations in the rest of the DV code

### DIFF
--- a/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
@@ -5,57 +5,67 @@
 // This sequence randomizes configurations at the output.
 class pwm_rand_output_vseq extends pwm_base_vseq;
   `uvm_object_utils(pwm_rand_output_vseq)
-  `uvm_object_new
 
-  // variables
+  // A parameter used for pwm_param for each channel
   rand param_reg_t rand_reg_param;
+
+  // Enable and invert bits for each channel
   rand bit [PWM_NUM_CHANNELS-1:0] rand_chan;
   rand bit [PWM_NUM_CHANNELS-1:0] rand_invert;
+
+  // If true, this stops the clock in "low power" mode
   rand bit low_power;
 
-  // constraints
-  constraint rand_reg_param_c {
-   rand_reg_param.HtbtEn == 1'b1 -> rand_reg_param.BlinkEn == 1'b1;
-   rand_reg_param.RsvParam == 0;
-   rand_reg_param.PhaseDelay inside {[0:MAX_16]};
-  }
+  // Make sure to enable blink if the heartbeat is enabled
+  extern constraint htbt_implies_blink_c;
 
-  constraint low_power_c {
-    // 1 in 10, in low power mode
-    low_power dist {1'b1:/1, 1'b0:/9};
-  }
+  // Model low power mode 10% of the time.
+  extern constraint low_power_c;
 
-  virtual task body();
+  extern function new (string name="");
+  extern virtual task body();
+endclass
 
-    set_ch_enables(32'h0);
+constraint pwm_rand_output_vseq::htbt_implies_blink_c {
+  rand_reg_param.HtbtEn == 1'b1 -> rand_reg_param.BlinkEn == 1'b1;
+  rand_reg_param.RsvParam == 0;
+  rand_reg_param.PhaseDelay inside {[0:MAX_16]};
+}
 
-    rand_pwm_cfg_reg();
+constraint pwm_rand_output_vseq::low_power_c {
+  low_power dist {1'b1:/1, 1'b0:/9};
+}
 
-    // set random dc and params for all channels
-    for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
-      param_reg_t pwm_param;
-      dc_blink_t blink, duty_cycle;
+function pwm_rand_output_vseq::new (string name = "");
+  super.new(name);
+endfunction
 
-      duty_cycle = rand_pwm_duty_cycle();
-      blink = rand_pwm_blink(duty_cycle);
+task pwm_rand_output_vseq::body();
+  set_ch_enables(32'h0);
+  rand_pwm_cfg_reg();
 
-      // phase delay of the PWM rising edge, in units of 2^(-16) PWM cycles
-      pwm_param.PhaseDelay = (rand_reg_param.PhaseDelay * (2**(-16)));
-      pwm_param.HtbtEn = rand_reg_param.HtbtEn;
-      pwm_param.BlinkEn = rand_reg_param.BlinkEn;
+  // Set random dc and params for all channels
+  for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
+    param_reg_t pwm_param;
+    dc_blink_t blink, duty_cycle;
 
-      set_duty_cycle(i, .A(duty_cycle.A), .B(duty_cycle.B));
-      set_blink(i, .A(blink.A), .B(blink.B));
-      set_param(i, pwm_param);
-    end
+    duty_cycle = rand_pwm_duty_cycle();
+    blink = rand_pwm_blink(duty_cycle);
 
-    set_ch_invert(rand_invert);
-    set_ch_enables(rand_chan);
+    // phase delay of the PWM rising edge, in units of 2^(-16) PWM cycles
+    pwm_param.PhaseDelay = (rand_reg_param.PhaseDelay * (2**(-16)));
+    pwm_param.HtbtEn = rand_reg_param.HtbtEn;
+    pwm_param.BlinkEn = rand_reg_param.BlinkEn;
 
-    low_power_mode(low_power, NUM_CYCLES);
+    set_duty_cycle(i, .A(duty_cycle.A), .B(duty_cycle.B));
+    set_blink(i, .A(blink.A), .B(blink.B));
+    set_param(i, pwm_param);
+  end
 
-    shutdown_dut();
+  set_ch_invert(rand_invert);
+  set_ch_enables(rand_chan);
 
-  endtask : body
+  low_power_mode(low_power, NUM_CYCLES);
 
-endclass : pwm_rand_output_vseq
+  shutdown_dut();
+endtask

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_smoke_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_smoke_vseq.sv
@@ -2,38 +2,35 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// smoke test vseq: accessing a major datapath within the pwm
+// Smoke test vseq: accessing a major datapath within the pwm
 class pwm_smoke_vseq extends pwm_base_vseq;
   `uvm_object_utils(pwm_smoke_vseq)
-  `uvm_object_new
 
-
-    // variables
-
-    virtual task pre_start();
-      super.pre_start();
-    endtask // pre_start
-
-
-  virtual task body();
-    param_reg_t pwm_param;
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(pwm_param, pwm_param.BlinkEn == 1;)
-
-    // disable channel 0
-    set_ch_enables(32'h0);
-    //setup general config
-    set_cfg_reg(10, 1, 1);
-
-    set_duty_cycle(.channel(0), .A(13000), .B(6500));
-    set_blink(.channel(0), .A(0), .B(0));
-    set_param(0, pwm_param);
-
-    // enable channel 0
-    set_ch_enables(32'h1);
-
-    // add some run time so we get some pulses
-    cfg.clk_rst_vif.wait_clks(50000);
-    shutdown_dut();
-  endtask
-
+  extern function new (string name="");
+  extern virtual task body();
 endclass : pwm_smoke_vseq
+
+function pwm_smoke_vseq::new (string name = "");
+  super.new(name);
+endfunction
+
+task pwm_smoke_vseq::body();
+  param_reg_t pwm_param;
+  `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(pwm_param, pwm_param.BlinkEn == 1;)
+
+  // disable channel 0
+  set_ch_enables(32'h0);
+  // set up general config
+  set_cfg_reg(10, 1, 1);
+
+  set_duty_cycle(.channel(0), .A(13000), .B(6500));
+  set_blink(.channel(0), .A(0), .B(0));
+  set_param(0, pwm_param);
+
+  // enable channel 0
+  set_ch_enables(32'h1);
+
+  // add some run time so we get some pulses
+  cfg.clk_rst_vif.wait_clks(50000);
+  shutdown_dut();
+endtask

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_stress_all_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_stress_all_vseq.sv
@@ -2,39 +2,46 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// sequence to stress test with reset and extended runtime
+// Sequence that performs a stress test by running other sequences back-to-back
 class pwm_stress_all_vseq extends pwm_base_vseq;
   `uvm_object_utils(pwm_stress_all_vseq)
-  `uvm_object_new
 
   // Constrain things so we run five sequences each time. This should be enough to "run some
   // back-to-back", but avoids needing to run lots sequentially (so avoids a large runtime)
-  constraint num_trans_c { num_trans == 5; }
+  extern constraint num_trans_c;
 
-  virtual task body();
-    string seq_names[] = {"pwm_smoke_vseq",
-                          "pwm_common_vseq",
-                          "pwm_perf_vseq",
-                          "pwm_rand_output_vseq"};
+  extern function new (string name="");
+  extern virtual task body();
+endclass
 
-    for (int i = 1; i <= num_trans; i++) begin
-      uvm_sequence   seq;
-      pwm_base_vseq  pwm_vseq;
-      uint           seq_idx = $urandom_range(0, seq_names.size - 1);
-      seq = create_seq_by_name(seq_names[seq_idx]);
-      `downcast(pwm_vseq, seq)
+constraint pwm_stress_all_vseq::num_trans_c { num_trans == 5; }
 
-      pwm_vseq.do_apply_reset = 0;
-      pwm_vseq.set_sequencer(p_sequencer);
-      `uvm_info(`gfn, $sformatf("Running %s sequence", seq_names[seq_idx]), UVM_LOW)
-      `DV_CHECK_RANDOMIZE_FATAL(pwm_vseq)
-      if (seq_names[seq_idx] == "pwm_common_vseq") begin
-        pwm_common_vseq common_vseq;
-        `downcast(common_vseq, pwm_vseq);
-        common_vseq.common_seq_type = "intr_test";
-      end
-      pwm_vseq.start(p_sequencer);
+function pwm_stress_all_vseq::new (string name = "");
+  super.new(name);
+endfunction
+
+task pwm_stress_all_vseq::body();
+  string seq_names[] = {"pwm_smoke_vseq",
+                        "pwm_common_vseq",
+                        "pwm_perf_vseq",
+                        "pwm_rand_output_vseq"};
+
+  for (int i = 1; i <= num_trans; i++) begin
+    uvm_sequence   seq;
+    pwm_base_vseq  pwm_vseq;
+    uint           seq_idx = $urandom_range(0, seq_names.size - 1);
+    seq = create_seq_by_name(seq_names[seq_idx]);
+    `downcast(pwm_vseq, seq)
+
+    pwm_vseq.do_apply_reset = 0;
+    pwm_vseq.set_sequencer(p_sequencer);
+    `uvm_info(`gfn, $sformatf("Running %s sequence", seq_names[seq_idx]), UVM_LOW)
+    `DV_CHECK_RANDOMIZE_FATAL(pwm_vseq)
+    if (seq_names[seq_idx] == "pwm_common_vseq") begin
+      pwm_common_vseq common_vseq;
+      `downcast(common_vseq, pwm_vseq);
+      common_vseq.common_seq_type = "intr_test";
     end
-  endtask : body
-
-endclass : pwm_stress_all_vseq
+    pwm_vseq.start(p_sequencer);
+  end
+endtask : body


### PR DESCRIPTION
This builds on top of #25056 (which should be merged first). Once that has been merged, there are only the following three commits:

- b1d4a6e906 [pwm,dv] Use out-of-block declarations in pwm_rand_output_vseq
- cad204d17c [pwm,dv] Use out-of-block declarations in pwm_smoke_vseq
- 40e83cf8c5 [pwm,dv] Use out-of-block definitions in pwm_stress_all_vseq

and this converts all of the PWM DV code to use out-of-block declarations.