### PR TITLE
[pwm,dv] Improvements in rand_output_vseq

### DIFF
--- a/hw/ip/pwm/dv/env/pwm_env_pkg.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_pkg.sv
@@ -47,7 +47,6 @@ package pwm_env_pkg;
   typedef struct packed {
     bit          BlinkEn;
     bit          HtbtEn;
-    bit [13:0]   RsvParam;
     bit [15:0]   PhaseDelay;
   } param_reg_t;
 

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
@@ -122,7 +122,9 @@ endtask
 task pwm_base_vseq::set_param(int unsigned channel, param_reg_t value);
   `DV_CHECK_FATAL(channel < NOutputs)
 
-  ral.pwm_param[channel].set(value);
+  ral.pwm_param[channel].blink_en.set(value.BlinkEn);
+  ral.pwm_param[channel].htbt_en.set(value.HtbtEn);
+  ral.pwm_param[channel].phase_delay.set(value.PhaseDelay);
   csr_update(ral.pwm_param[channel]);
 endtask // set_param
 

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
@@ -23,9 +23,8 @@ class pwm_perf_vseq extends pwm_rand_output_vseq;
   // pwm_rand_output_vseq that uses low power mode less often)
   extern constraint low_power_c;
 
-  // Pick minimum or maximum phase delay and ensure heartbeat implies blink (overriding the
-  // constraint with the same name in pwm_rand_output_vseq that is more general about phase delay).
-  extern constraint rand_reg_param_c;
+  // Constrain phase delay to be minimal or maximal
+  extern constraint phase_delay_c;
 
   // The duty cycle and the threshold for the heartbeat blink counter should be minimal or maximal,
   // correspoding to both counters being minimal or both counters being maximal.
@@ -48,9 +47,7 @@ constraint pwm_perf_vseq::low_power_c {
   low_power dist {1'b1 :/ 1, 1'b0 :/ 1};
 }
 
-constraint pwm_perf_vseq::rand_reg_param_c {
-  rand_reg_param.HtbtEn == 1'b1 -> rand_reg_param.BlinkEn == 1'b1;
-  rand_reg_param.RsvParam == 0;
+constraint pwm_perf_vseq::phase_delay_c {
   rand_reg_param.PhaseDelay dist {MAX_16 :/ 1, 0 :/ 1};
 }
 

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
@@ -44,20 +44,14 @@ task pwm_rand_output_vseq::body();
 
   // Set random dc and params for all channels
   for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
-    param_reg_t pwm_param;
     dc_blink_t blink, duty_cycle;
 
     duty_cycle = rand_pwm_duty_cycle();
     blink = rand_pwm_blink(duty_cycle);
 
-    // phase delay of the PWM rising edge, in units of 2^(-16) PWM cycles
-    pwm_param.PhaseDelay = (rand_reg_param.PhaseDelay * (2**(-16)));
-    pwm_param.HtbtEn = rand_reg_param.HtbtEn;
-    pwm_param.BlinkEn = rand_reg_param.BlinkEn;
-
     set_duty_cycle(i, .A(duty_cycle.A), .B(duty_cycle.B));
     set_blink(i, .A(blink.A), .B(blink.B));
-    set_param(i, pwm_param);
+    set_param(i, rand_reg_param);
   end
 
   set_ch_invert(rand_invert);

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
@@ -28,7 +28,6 @@ endclass
 
 constraint pwm_rand_output_vseq::htbt_implies_blink_c {
   rand_reg_param.HtbtEn == 1'b1 -> rand_reg_param.BlinkEn == 1'b1;
-  rand_reg_param.RsvParam == 0;
 }
 
 constraint pwm_rand_output_vseq::low_power_c {

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
@@ -29,7 +29,6 @@ endclass
 constraint pwm_rand_output_vseq::htbt_implies_blink_c {
   rand_reg_param.HtbtEn == 1'b1 -> rand_reg_param.BlinkEn == 1'b1;
   rand_reg_param.RsvParam == 0;
-  rand_reg_param.PhaseDelay inside {[0:MAX_16]};
 }
 
 constraint pwm_rand_output_vseq::low_power_c {


### PR DESCRIPTION
This builds on top of #25057 (converting things to use out-of-block declarations), which should be merged first. Once that has been merged, there are the following commits:
- 2df2c0dca9 [pwm,dv] Simplify how we override reg_param in pwm_perf_vseq
- 17c8223356 [pwm,dv] Remove empty constraint in pwm_rand_output_vseq
- 4514d379c3 [pwm,dv] Drop RsvParam from param_reg_t
- 99dcd29a64 [pwm,dv] Fix units in pwm_rand_output_vseq
