### PR TITLE
[pwm,dv] Add a pwm_heartbeat_wrap test to see heartbeat wrapping

### DIFF
--- a/hw/ip/pwm/data/pwm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_testplan.hjson
@@ -109,6 +109,17 @@
         tests: ["pwm_rand_output"]
     }
     {
+      name: heartbeat_wrap
+      desc: '''
+            Observe wrapping behaviour when doing heartbeat operation.
+
+            This will exercise saturation of the duty cycle value
+            (dc_htbt_q), which is clamped to [0, ffff].
+      '''
+      stage: V3
+      tests: ["pwm_heartbeat_wrap"]
+    }
+    {
       name: perf
       desc: '''
             Checking ip operation at min/max bandwidth

--- a/hw/ip/pwm/dv/env/pwm_env.core
+++ b/hw/ip/pwm/dv/env/pwm_env.core
@@ -24,6 +24,7 @@ filesets:
       - seq_lib/pwm_common_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_rand_output_vseq.sv: {is_include_file: true}
+      - seq_lib/pwm_heartbeat_wrap_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_perf_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
@@ -37,14 +37,14 @@ class pwm_base_vseq extends cip_base_vseq #(
   extern task set_param(int unsigned channel, param_reg_t value);
 
   // Return a randomized duty cycle where both fields are nonzero.
-  extern function dc_blink_t rand_pwm_duty_cycle();
+  extern virtual function dc_blink_t rand_pwm_duty_cycle();
 
   // Return a randomized blink duty cycle where both fields are nonzero.
   //
   // Also ensure that the sum of A and B for the blink duty cycle fits in 16 bits. Similarly, ensure
   // that BLINK.B + DUTY_CYCLE.A fits in 16 bits (taking the channel's duty cycle as an argument).
   // This is to prevent counter overflow in both cases.
-  extern function dc_blink_t rand_pwm_blink(dc_blink_t duty_cycle);
+  extern virtual function dc_blink_t rand_pwm_blink(dc_blink_t duty_cycle);
 
   // Inject cycles of delay, disabling the main clock for a time in the middle if enable is true.
   extern task low_power_mode(bit enable, uint cycles);

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_heartbeat_wrap_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_heartbeat_wrap_vseq.sv
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A version of pwm_rand_output_vseq that is constrained to ensure that it does heartbeats and wraps
+// (to 16 bits) reasonably quickly.
+class pwm_heartbeat_wrap_vseq extends pwm_rand_output_vseq;
+  `uvm_object_utils(pwm_heartbeat_wrap_vseq)
+
+  // Enable heartbeat (since we're trying to make it wrap, so it definitely needs to be enabled)
+  extern constraint with_heartbeat_c;
+
+  extern function new (string name="");
+
+  // This overrides a function from pwm_base_vseq. We want to choose a "maximal" duty cycle, where A
+  // and B are near the endpoints of the 16 bit data type (to make it likely that the increment will
+  // wrap).
+  extern function dc_blink_t rand_pwm_duty_cycle();
+
+  // This overrides a function from pwm_base_vseq. We want to choose a large value for blink.B. This
+  // is used as the increment for the duty cycle in heartbeat mode and we want to get through the 16
+  // bit range quickly.
+  extern function dc_blink_t rand_pwm_blink(dc_blink_t duty_cycle);
+endclass
+
+constraint pwm_heartbeat_wrap_vseq::with_heartbeat_c {
+  rand_reg_param.HtbtEn == 1'b1;
+}
+
+function pwm_heartbeat_wrap_vseq::new (string name);
+  super.new(name);
+endfunction
+
+function dc_blink_t pwm_heartbeat_wrap_vseq::rand_pwm_duty_cycle();
+  dc_blink_t ret;
+  int low_delta = $urandom_range(1, 100), high_delta = $urandom_range(1, 100);
+  bit a_lt_b = $urandom_range(0, 1);
+
+  ret.A = a_lt_b ? low_delta : MAX_16 - high_delta;
+  ret.B = a_lt_b ? MAX_16 - high_delta : low_delta;
+  return ret;
+endfunction
+
+function dc_blink_t pwm_heartbeat_wrap_vseq::rand_pwm_blink(dc_blink_t duty_cycle);
+  dc_blink_t ret = super.rand_pwm_blink(duty_cycle);
+
+  // Make sure that ret.B is large
+  ret.B |= 16'hf000;
+  return ret;
+endfunction

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_vseq_list.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_vseq_list.sv
@@ -7,4 +7,5 @@
 `include "pwm_common_vseq.sv"
 `include "pwm_rand_output_vseq.sv"
 `include "pwm_perf_vseq.sv"
+`include "pwm_heartbeat_wrap_vseq.sv"
 `include "pwm_stress_all_vseq.sv"

--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -73,6 +73,13 @@
       uvm_test_seq: pwm_rand_output_vseq
     }
     {
+      name: pwm_heartbeat_wrap
+      uvm_test_seq: pwm_heartbeat_wrap_vseq
+      // We don't need many seeds of this test: it will exercise
+      // identical code across the different channels anyway.
+      reseed: 10
+    }
+    {
       name: pwm_perf
       uvm_test_seq: pwm_perf_vseq
     }


### PR DESCRIPTION
This covers a code coverage hole, where we didn't see the second ternary on this line being true:

    assign duty_cycle_htbt = !dc_wrap_q ? dc_htbt_q : pos_htbt ? 16'hffff : '0;

The code is trying to saturate the updated `dc_htbt_q` value to `[0, ffff]`. Underflowing zero isn't too hard, but we never saw the behaviour when we overflowed `ffff`.

(This PR builds on #25056, which should be merged first. Once that has been merged, this PR only contains the last commit, whose commit message appears above)