### PR TITLE
[pwm,rtl] Recode a write-enable in pwm_core.sv

### DIFF
--- a/hw/ip/pwm/rtl/pwm_core.sv
+++ b/hw/ip/pwm/rtl/pwm_core.sv
@@ -74,8 +74,8 @@ module pwm_core #(
   always_ff @(posedge clk_core_i or negedge rst_core_ni) begin
     if (!rst_core_ni) begin
       beat_ctr_q <= '0;
-    end else begin
-      beat_ctr_q <= beat_ctr_en ? beat_ctr_d : beat_ctr_q;
+    end else if (beat_ctr_en) begin
+      beat_ctr_q <= beat_ctr_d;
     end
   end
 


### PR DESCRIPTION
This is logically equivalent but avoids a coverage hole from an unreachable case. The coverage hole has `beat_ctr_en = 0` and `beat_ctr_q != 0`. If `beat_ctr_en` is zero, we know that both `clr_phase_cntr` and `cntr_en` are zero.

For `beat_ctr_q` to become nonzero, we need `beat_ctr_en` to be true (so that this write happens) and `cntr_en` to be true (so we're not clearing the phase counter). If `beat_ctr_en` now becomes false, it must follow that `cntr_en` has dropped. But this is `reg2hw.cfg.cntr_en.q`, so this must be because of a write to the `CNTR_EN` field of the `CFG` register. On the previous cycle, the `reg2hw.cfg.cntr_en.qe` signal was true, but this feeds into `clr_phase_cntr` and `beat_ctr_q` will have been zeroed.

(Note: this is equivalent to similar changes in #25062)