### PR TITLE
[pwm,dv] Exclude impossible toggle coverage in u_reg.u_chk

### DIFF
--- a/hw/ip/pwm/dv/cov/cover.ccf
+++ b/hw/ip/pwm/dv/cov/cover.ccf
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Include the base version of cover.ccf
+include_ccf ${dv_root}/tools/xcelium/cover.ccf
+
+// Exclude some impossible toggle coverage
+set_toggle_excludefile -bitexclude ${proj_root}/hw/ip/pwm/dv/cov/toggle.exclude

--- a/hw/ip/pwm/dv/cov/toggle.exclude
+++ b/hw/ip/pwm/dv/cov/toggle.exclude
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// There is a prim_secded_inv_64_57_dec instance at pwm.u_reg.u_chk.u_chk which has a data_i port
+// whose input gets extended from a smaller width (a 42 bit "cmd" object gets extended to 57 bits).
+// The padding is constant: exclude bits 56:43 accordingly (with truly horrible syntax).
+-ere instance_signals tb\.dut\.u_reg\.u_chk\.u_chk data_i\[5[0-6]\]
+-ere instance_signals tb\.dut\.u_reg\.u_chk\.u_chk data_i\[4[3-9]\]

--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -40,6 +40,15 @@
   // Coverage exclusion
   xcelium_cov_refine_files: ["{proj_root}/hw/ip/pwm/dv/cov/pwm_unr_excl.vRefine"]
 
+  overrides: [
+    {
+      // Override the base ccf coverage configuration file for the "default" build mode (used for tests
+      // other than the CSR tests). This will include the default cover.ccf file as its first item.
+      name: default_xcelium_cov_cfg_file
+      value: "{proj_root}/hw/ip/pwm/dv/cov/cover.ccf"
+    }
+  ]
+
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 


### PR DESCRIPTION
Honestly, this isn't really a pwm-specific change so we'll probably want to move it eventually. Before this change, he reported toggle coverage misses bits 56:43 of data_i in tb.dut.u_reg.u_chk.u_chk. This instance is made with:

    prim_secded_inv_64_57_dec u_chk (
      .data_i({tl_i.a_user.cmd_intg, H2DCmdMaxWidth'(cmd)}),
      .data_o(),
      .syndrome_o(),
      .err_o(err)
    );

where cmd is 43 bits wide and H2DCmdMaxWidth is 57. As such, bits 56:43 are constant.