### PR TITLE
[rom_ext] Eliminate unwanted dependencies

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -258,8 +258,6 @@ cc_library(
     srcs = ["perso_tlv_data.c"],
     deps = [
         ":perso_tlv_headers",
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/runtime:log",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/cert",
     ],
@@ -273,7 +271,6 @@ cc_library(
     name = "perso_tlv_headers",
     hdrs = ["perso_tlv_data.h"],
     deps = [
-        "//sw/device/lib/base:status",
         "//sw/device/lib/testing/json:provisioning_data",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/cert",

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.h
@@ -9,7 +9,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/status.h"
 #include "sw/device/lib/testing/json/provisioning_data.h"
 #include "sw/device/silicon_creator/lib/cert/cert.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -214,11 +213,10 @@ rom_error_t perso_tlv_cert_obj_build(const char *name,
  * @return status of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t perso_tlv_push_cert_to_perso_blob(const char *name,
-                                           bool needs_endorsement,
-                                           const dice_cert_format_t cert_format,
-                                           const uint8_t *cert,
-                                           size_t cert_size, perso_blob_t *pb);
+rom_error_t perso_tlv_push_cert_to_perso_blob(
+    const char *name, bool needs_endorsement,
+    const dice_cert_format_t cert_format, const uint8_t *cert, size_t cert_size,
+    perso_blob_t *pb);
 
 /**
  * Pushes arbitrary data to the perso blob that is sent between host and device.
@@ -229,7 +227,7 @@ status_t perso_tlv_push_cert_to_perso_blob(const char *name,
  * @return status of the operation.
  */
 OT_WARN_UNUSED_RESULT
-status_t perso_tlv_push_to_perso_blob(const void *data, size_t size,
-                                      perso_blob_t *perso_blob);
+rom_error_t perso_tlv_push_to_perso_blob(const void *data, size_t size,
+                                         perso_blob_t *perso_blob);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MANUF_BASE_PERSO_TLV_DATA_H_

--- a/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
+++ b/sw/device/silicon_creator/manuf/base/tpm_personalize_ext.c
@@ -80,9 +80,10 @@ static status_t personalize_gen_tpm_ek_certificate(
   curr_cert_size = sizeof(cert_buffer);
   TRY(tpm_ek_tbs_cert_build(&tpm_key_ids, &curr_pubkey, cert_buffer,
                             &curr_cert_size));
-  return perso_tlv_push_cert_to_perso_blob(
-      "TPM EK", /*needs_endorsement=*/true, kDiceCertFormatX509TcbInfo,
-      cert_buffer, curr_cert_size, perso_blob);
+  TRY(perso_tlv_push_cert_to_perso_blob("TPM EK", /*needs_endorsement=*/true,
+                                        kDiceCertFormatX509TcbInfo, cert_buffer,
+                                        curr_cert_size, perso_blob));
+  return OK_STATUS();
 }
 
 status_t personalize_extension_pre_cert_endorse(


### PR DESCRIPTION
Eliminate a dependency in `//sw/device/lib/runtime:log` and `//sw/device/lib/base:status`, as these two deps are not wanted in rom or rom_ext code.