### PR TITLE
[pwm,dv] Add stress_all_with_rand_reset support

### DIFF
--- a/hw/ip/pwm/dv/env/pwm_env_cfg.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_cfg.sv
@@ -6,8 +6,6 @@ class pwm_env_cfg extends cip_base_env_cfg #(.RAL_T(pwm_reg_block));
   `uvm_object_utils_begin(pwm_env_cfg)
   `uvm_object_utils_end
 
-  `uvm_object_new
-
   // configs
   pwm_monitor_cfg       m_pwm_monitor_cfg[PWM_NUM_CHANNELS];
 
@@ -20,12 +18,19 @@ class pwm_env_cfg extends cip_base_env_cfg #(.RAL_T(pwm_reg_block));
   rand int unsigned clk_scale;
   constraint clk_scale_c { clk_scale inside {[256:1024]}; }
 
+  extern function new (string name="");
+
   // Method from dv_base_env_cfg. Construct RAL models and fill in monitor configs.
   extern virtual function void initialize(bit [31:0] csr_base_addr = '1);
 
   // Return the scaled frequency in MHz for the core
   extern virtual function int get_clk_core_freq();
 endclass : pwm_env_cfg
+
+function pwm_env_cfg::new (string name="");
+  super.new(name);
+  can_reset_with_csr_accesses = 1'b1;
+endfunction
 
 function void pwm_env_cfg::initialize(bit [31:0] csr_base_addr = '1);
   list_of_alerts = pwm_env_pkg::LIST_OF_ALERTS;

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_common_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_common_vseq.sv
@@ -21,4 +21,10 @@ constraint pwm_common_vseq::num_trans_c {
 
 task pwm_common_vseq::body();
   run_common_vseq_wrapper(num_trans);
+
+  // Explicitly shut down the dut after running pwm_common_vseq. This shouldn't really matter except
+  // that the stress_all_with_rand_reset sequence won't "tidy up" after the last sequence if it
+  // happens to get killed and our monitor will not allow the test to end because the pwm is still
+  // active.
+  shutdown_dut();
 endtask

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
@@ -68,6 +68,8 @@ task pwm_perf_vseq::body();
   rand_pwm_cfg_reg();
 
   for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
+    if (!cfg.clk_rst_vif.rst_n) return;
+
     set_duty_cycle(i, .A(rand_dc), .B(rand_dc));
     set_blink(i, .A(rand_blink), .B(rand_blink));
 
@@ -76,11 +78,11 @@ task pwm_perf_vseq::body();
     set_param(i, pwm_param[i]);
   end
 
+  if (!cfg.clk_rst_vif.rst_n) return;
   set_ch_invert(rand_invert);
   set_ch_enables(rand_chan);
 
   low_power_mode(low_power, NUM_CYCLES);
 
   shutdown_dut();
-
 endtask : body

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_smoke_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_smoke_vseq.sv
@@ -31,6 +31,8 @@ task pwm_smoke_vseq::body();
   set_ch_enables(32'h1);
 
   // add some run time so we get some pulses
-  cfg.clk_rst_vif.wait_clks(50000);
+  cfg.clk_rst_vif.wait_clks_or_rst(50000);
+  if (!cfg.clk_rst_vif.rst_n) return;
+
   shutdown_dut();
 endtask

--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -30,7 +30,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
@@ -97,11 +97,6 @@
     {
       name: pwm_perf
       uvm_test_seq: pwm_perf_vseq
-    }
-    {
-      name: pwm_stress_all
-      uvm_test_seq: pwm_stress_all_vseq
-      run_opts:["+test_timeout_ns=10_000_000_000"]
     }
   ]
 


### PR DESCRIPTION
The first two commits get the vseqs working when a random reset is injected. The last turns on the tests.