### PR TITLE
[ci] move GitHub runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   quick_lint:
     name: Lint (quick)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,7 +71,7 @@ jobs:
 
   slow_lint:
     name: Lint (slow)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: quick_lint
     steps:
       - uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
 
   airgapped_build:
     name: Airgapped build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: quick_lint
     steps:
       - uses: actions/checkout@v4
@@ -176,7 +176,7 @@ jobs:
 
   verilator_englishbreakfast:
     name: Verilated English Breakfast
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: quick_lint
     steps:
       - uses: actions/checkout@v4
@@ -227,7 +227,7 @@ jobs:
 
   build_docker_containers:
     name: Build Docker Containers
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: quick_lint
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   fpga_cw310_sival_nightly:
     name: FPGA CW310 SiVal tests
-    runs-on: [ubuntu-20.04-fpga, cw310]
+    runs-on: [ubuntu-22.04-fpga, cw310]
 
     env:
       GS_PATH: gs://opentitan-test-results


### PR DESCRIPTION
GitHub action is moving latest to 24.04 and 20.04 may be deprecated soon. The Ubuntu 20.04 OS itself will also reach EOL early next year.