### PR TITLE
[manuf] update RMA token input name

### DIFF
--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -73,12 +73,12 @@ FT_PERSONALIZE_ENDORSEMENT_KEYS = [
 # Note that uds-auth-key-id below is the actual hash of the public key of cert_endorsement_key.sk.der
 FT_PROVISIONING_INPUTS = _DEVICE_ID_AND_TEST_TOKENS + """
   --target-mission-mode-lc-state="prod"
+  --rma-unlock-token="0x01234567_89abcdef_01234567_89abcdef"
   --rom-ext-measurement="0x11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111"
   --owner-manifest-measurement="0x22222222_22222222_22222222_22222222_22222222_22222222_22222222_22222222"
   --owner-measurement="0x33333333_33333333_33333333_33333333_33333333_33333333_33333333_33333333"
   --rom-ext-security-version="0"
   --owner-security-version="0"
-  --rma-unlock-token-hash="0x01234567_89abcdef"
 """
 
 LOCAL_CERT_ENDORSEMENT_PARAMS = """

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -30,13 +30,17 @@ pub struct ManufFtProvisioningDataInput {
     #[arg(long)]
     pub device_id: String,
 
-    /// TestUnlock token.
+    /// TestUnlock token; a 128-bit hex string.
     #[arg(long)]
     pub test_unlock_token: String,
 
-    /// TestExit token.
+    /// TestExit token; a 128-bit hex string.
     #[arg(long)]
     pub test_exit_token: String,
+
+    /// RMA unlock token; a 128-bit hex string.
+    #[arg(long)]
+    pub rma_unlock_token: String,
 
     /// LC state to transition to from TEST_UNLOCKED*.
     #[arg(long, value_parser = DifLcCtrlState::parse_lc_state_str)]
@@ -77,10 +81,6 @@ pub struct ManufFtProvisioningDataInput {
     /// CA certificate to be used for verifying a cert chain.
     #[arg(long)]
     pub ca_certificate: PathBuf,
-
-    /// RMA unlock token hash to pass to the device, a string of 16 hex digits.
-    #[arg(long)]
-    pub rma_unlock_token_hash: String,
 }
 
 #[derive(Debug, Parser)]
@@ -124,8 +124,8 @@ fn main() -> Result<()> {
         hex_string_to_u32_arrayvec::<4>(opts.provisioning_data.test_unlock_token.as_str())?;
     let _test_exit_token =
         hex_string_to_u32_arrayvec::<4>(opts.provisioning_data.test_exit_token.as_str())?;
-    let rma_unlock_token_hash =
-        hex_string_to_u32_arrayvec::<4>(opts.provisioning_data.rma_unlock_token_hash.as_str())?;
+    let rma_unlock_token =
+        hex_string_to_u32_arrayvec::<4>(opts.provisioning_data.rma_unlock_token.as_str())?;
     // Format ujson data payload(s).
     // Individualization ujson payload.
     let _ft_individualize_data_in = ManufFtIndividualizeData {
@@ -237,7 +237,7 @@ fn main() -> Result<()> {
         &_perso_certgen_inputs,
         opts.timeout,
         opts.provisioning_data.ca_certificate,
-        &rma_unlock_token_hash,
+        &rma_unlock_token,
         &spi_console_device,
         opts.second_bootstrap,
     )?;

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -172,12 +172,12 @@ pub enum KeyWrapper {
 }
 
 fn send_rma_unlock_token_hash(
-    rma_unlock_token_hash: &ArrayVec<u32, 4>,
+    rma_unlock_token: &ArrayVec<u32, 4>,
     timeout: Duration,
     spi_console: &SpiConsoleDevice,
 ) -> Result<()> {
     let rma_token_hash = LcTokenHash {
-        hash: hash_lc_token(rma_unlock_token_hash.as_bytes())?,
+        hash: hash_lc_token(rma_unlock_token.as_bytes())?,
     };
 
     // Wait for test to start running.
@@ -465,7 +465,7 @@ pub fn run_ft_personalize(
     perso_certgen_inputs: &ManufCertgenInputs,
     timeout: Duration,
     ca_certificate: PathBuf,
-    rma_unlock_token_hash: &ArrayVec<u32, 4>,
+    rma_unlock_token: &ArrayVec<u32, 4>,
     spi_console: &SpiConsoleDevice,
     second_bootstrap: PathBuf,
 ) -> Result<()> {
@@ -475,7 +475,7 @@ pub fn run_ft_personalize(
     let _ = UartConsole::wait_for(spi_console, r"Bootstrap requested.", timeout)?;
     // This time loading personalization binary in flash slot A and ROM_EXT + Owner FW in flash slot B.
     init.bootstrap.load(transport, &second_bootstrap)?;
-    send_rma_unlock_token_hash(rma_unlock_token_hash, timeout, spi_console)?;
+    send_rma_unlock_token_hash(rma_unlock_token, timeout, spi_console)?;
     provision_certificates(
         cert_endorsement_key_wrapper,
         perso_certgen_inputs,


### PR DESCRIPTION
The raw RMA token is input into the FT provisioning test harness, where the harness itself computes the digest before sending the digest to the device. Additionally the token is 128-bits, not 64.