### PR TITLE
[pwrmgr,pinmux] Cleanup comments from previous PRs

### DIFF
--- a/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
+++ b/hw/ip_templates/pinmux/data/pinmux.tpldesc.hjson
@@ -60,13 +60,13 @@
     {
       name: "enable_usb_wakeup"
       desc: "Enable USB wakeup"
-      type: "int"
+      type: "bool"
       default: "1"
     }
     {
       name: "enable_strap_sampling"
       desc: "Set to true to instantiate the HW strap sampling and TAP selection submodule wake submodule"
-      type: "int"
+      type: "bool"
       default: "1"
     }
   ]

--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -60,8 +60,9 @@ class IpTemplateRendererBase:
 
             assert template_param.param_type in TemplateParameter.VALID_PARAM_TYPES
             try:
+                val_typed: Union[bool, int, str, object] = None
                 if template_param.param_type == 'string':
-                    val_typed = str(val)  # type: Union[bool, int, str, object]
+                    val_typed = str(val)
                 elif template_param.param_type == 'int':
                     if not isinstance(val, int):
                         val_typed = int(val, 0)


### PR DESCRIPTION
This PR fixes 2 comments from previous PRs:
* On the pwrmgr, it defines a typed variable
* On the pinmux, a boolean parameter is used in the template description