### PR TITLE
[sival,i2c] Fix and re-enable I2C target test by adding config ujson CRC

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5529,11 +5529,10 @@ opentitan_test(
     srcs = [
         "i2c_target_test.c",
     ],
-    broken = fpga_params(tags = ["broken"]),
     exec_env = dicts.add(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
-            "//hw/top_earlgrey:fpga_cw310_sival": "broken",
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
         },
     ),
     fpga = fpga_params(

--- a/sw/device/tests/i2c_target_test.c
+++ b/sw/device/tests/i2c_target_test.c
@@ -329,7 +329,7 @@ static status_t command_processor(ujson_t *uj) {
         break;
       case kTestCommandI2cTestConfig: {
         i2c_test_config_t config;
-        TRY(ujson_deserialize_i2c_test_config_t(uj, &config));
+        TRY(UJSON_WITH_CRC(ujson_deserialize_i2c_test_config_t, uj, &config));
         i2c_clock_stretching_delay_micros =
             config.clock_stretching_delay_millis * 1000;
         RESP_ERR(uj, RESP_OK_STATUS(uj));

--- a/sw/host/opentitanlib/src/test_utils/i2c_target.rs
+++ b/sw/host/opentitanlib/src/test_utils/i2c_target.rs
@@ -77,8 +77,8 @@ impl I2cTransferStart {
 
 impl I2cTestConfig {
     pub fn write(&self, uart: &dyn Uart) -> Result<()> {
-        TestCommand::I2cTestConfig.send(uart)?;
-        self.send(uart)?;
+        TestCommand::I2cTestConfig.send_with_crc(uart)?;
+        self.send_with_crc(uart)?;
         Status::recv(uart, Duration::from_secs(300), false)?;
         Ok(())
     }


### PR DESCRIPTION
The I2C target test was failing because the ujson `I2cTestConfig` command added for clock stretching (#22816) when backported from `earlgrey_es_sival` did not have a CRC added to it (#22277), causing the de-serialization to fail. This was not noticed as the test was marked broken at the time due to an unrelated issue (#22729). This commit adds this CRC, adds an additional CRC to the configuration payload itself, and marks the test as no longer being broken. 

This has been tested locally to pass on a CW310 using: `./bazelisk.sh test -t- --test_output=streamed --runs_per_test 10 //sw/device/tests:i2c_target_test_fpga_cw310_sival`.