### PR TITLE
[sival,kmac] Add chip_sw_kmac_entropy test

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -96,7 +96,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_kmac_entropy"]
-      bazel: []
+      bazel: ["//sw/device/tests:kmac_entropy_test"]
     }
     {
       name: chip_sw_kmac_idle

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2279,15 +2279,22 @@ opentitan_test(
 opentitan_test(
     name = "kmac_entropy_test",
     srcs = ["kmac_entropy_test.c"],
-    exec_env = EARLGREY_TEST_ENVS,
-    # TODO(#15530): EDN doesn't timeout on FPGA
-    fpga = fpga_params(tags = ["broken"]),
+    exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+        },
+    ),
+    verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:kmac",
         "//sw/device/lib/runtime:irq",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )


### PR DESCRIPTION
Map `kmac_entropy_test` to `chip_sw_kmac_entropy` and include more execution targets.