### PR TITLE
[rom_ctrl, dv] Coverage Collection for tlul_adapter_sram

### DIFF
--- a/hw/ip/rom_ctrl/dv/cov/cover_reg_top.cfg
+++ b/hw/ip/rom_ctrl/dv/cov/cover_reg_top.cfg
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Collect coverage for tlul_adapter_sram to resolve coverage hole for intg_err.
++tree tb.dut.u_tl_adapter_rom
+
+begin line+cond+fsm+branch+assert
+  +moduletree tlul_adapter_sram
+end

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_base_sim_cfg.hjson
@@ -57,6 +57,10 @@
       name: rel_path
       value: "hw/ip/{name}_{variant}/dv"
     }
+    {
+      name: cover_reg_top_vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover_reg_top.cfg+{proj_root}/hw/ip/rom_ctrl/dv/cov/cover_reg_top.cfg"
+    }
   ]
 
   // Add ROM_CTRL specific exclusion files.


### PR DESCRIPTION
The coverage collection for tlul_adapter_sram for rom_ctrl_tl_intg_err test was disabled. The rom_ctrl_tl_intg_err test covers the intg_err signal in tlul_adapter_sram in rom_ctrl.
To let the nightly regression dashboard reporting intg_err as 1/0 being covered for the conditional statements present in rom_ctrl tlul_adapter_sram, this PR added a cover_reg_top.cfg file and overrides it in rom_ctrl_base_sim_cfg.hjson.