### PR TITLE
[ot_certs] Various fixes

### DIFF
--- a/sw/host/ot_certs/src/asn1/x509.rs
+++ b/sw/host/ot_certs/src/asn1/x509.rs
@@ -153,8 +153,12 @@ impl X509 {
                         if let Some(key_usage) = &cert.key_usage {
                             Self::push_key_usage_ext(builder, key_usage)?;
                         }
-                        Self::push_auth_key_id_ext(builder, &cert.authority_key_identifier)?;
-                        Self::push_subject_key_id_ext(builder, &cert.subject_key_identifier)?;
+                        if let Some(auth_key_id) = &cert.authority_key_identifier {
+                            Self::push_auth_key_id_ext(builder, auth_key_id)?;
+                        }
+                        if let Some(subj_key_id) = &cert.subject_key_identifier {
+                            Self::push_subject_key_id_ext(builder, subj_key_id)?;
+                        }
                         for ext in &cert.private_extensions {
                             Self::push_cert_extension(builder, ext)?
                         }

--- a/sw/host/ot_certs/src/template/mod.rs
+++ b/sw/host/ot_certs/src/template/mod.rs
@@ -70,9 +70,9 @@ pub struct Certificate {
     /// X509 certificate's public key.
     pub subject_public_key_info: SubjectPublicKeyInfo,
     /// X509 certificate's authority key identifier.
-    pub authority_key_identifier: Value<Vec<u8>>,
+    pub authority_key_identifier: Option<Value<Vec<u8>>>,
     /// X509 certificate's public key identifier.
-    pub subject_key_identifier: Value<Vec<u8>>,
+    pub subject_key_identifier: Option<Value<Vec<u8>>>,
     // X509 basic constraints extension, optional.
     pub basic_constraints: Option<BasicConstraints>,
     pub key_usage: Option<KeyUsage>,
@@ -568,8 +568,8 @@ mod tests {
                     y: Value::variable("owner_pub_key_ec_y"),
                 },
             }),
-            authority_key_identifier: Value::variable("signing_pub_key_id"),
-            subject_key_identifier: Value::variable("owner_pub_key_id"),
+            authority_key_identifier: Some(Value::variable("signing_pub_key_id")),
+            subject_key_identifier: Some(Value::variable("owner_pub_key_id")),
             basic_constraints: None,
             key_usage: Some(KeyUsage {
                 digital_signature: None,

--- a/sw/host/ot_certs/tests/parse_test.rs
+++ b/sw/host/ot_certs/tests/parse_test.rs
@@ -18,6 +18,8 @@ fn main() -> Result<()> {
         Template::from_hjson_str(GENERIC_CERT).expect("failed to parse generic template");
     // Generate some random test data.
     let test_data = generic_tmpl.random_test()?;
+    // Print test data so we can reproduce the test on failure.
+    println!("test data: {test_data:?}");
     // Substitute data into the template.
     let cert = generic_tmpl.subst(&test_data)?;
     // Use DER to generate a binary certificate.


### PR DESCRIPTION
The primary goal of this PR is to fix some flakiness in the `ot_certs` parse test. See the commit for an explanation.

The short summary is that OpenSSL has an undocumented quirk: if the basic key usage is empty (and possibly in other circumstances?), it silently pretend that the certificate has no authority or subject key identifier. It is not clear whether this is intentional or a side-effect of a bug but the result is the same: a seemingly valid (but stupid) certificate will generate an error when parse with ot_certs. When we generate random certificates for parsing test, we can sometimes create some with no key usage set which triggers this behaviour.

To solve this, I have switch to manually parsing of the auth key id and subj key id. This is very easy and we already parse most extensions manually anyway.