### PR TITLE
bazel: fix //quality:rustfmt_fix

### DIFF
--- a/sw/host/opentitanlib/bindgen/lib.rs
+++ b/sw/host/opentitanlib/bindgen/lib.rs
@@ -10,8 +10,3 @@ pub use multibits;
 pub use sram_program;
 pub use status;
 pub use test_status;
-
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-pub mod rom_error;


### PR DESCRIPTION
There is no bindgen module rom_error any more (or maybe not yet?), in either case this patch is needed to make sure that 'basel run //quality:rustfmt_fix' can actually execute.