### PR TITLE
[util,topgen] Remove support for templated ips

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -84,7 +84,7 @@ endif
 
 .PHONY: $(ips_reg) $(tops_gen) $(tops_reg)
 
-all: $(ips_reg) $(tops_gen) $(tops_reg)
+all: $(ips_reg) $(tops_gen) $(tops_reg) cmdgen
 
 regs: $(ips_reg) $(tops_reg)
 

--- a/util/autogen_testutils.py
+++ b/util/autogen_testutils.py
@@ -42,14 +42,13 @@ def main():
     )
     args = parser.parse_args()
 
-    # Parse toplevel Hjson to get IPs that are templated / generated with IPgen.
+    # Parse toplevel Hjson to get IPs that are generated with IPgen.
     try:
         topcfg_text = args.topcfg_path.read_text()
     except FileNotFoundError:
         logging.error(f"hjson {args.topcfg_path} could not be found.")
         sys.exit(1)
     topcfg = hjson.loads(topcfg_text, use_decimal=True)
-    templated_modules = topgen_lib.get_templated_modules(topcfg)
     ipgen_modules = topgen_lib.get_ipgen_modules(topcfg)
 
     # Define autogen DIF directory.
@@ -67,8 +66,7 @@ def main():
         ip_name_snake = Path(autogen_dif_filename).stem[4:-8]
         # NOTE: ip.name_long_* not needed for auto-generated files which
         # are the only files (re-)generated in batch mode.
-        ips_with_difs.append(
-            Ip(ip_name_snake, "AUTOGEN", templated_modules, ipgen_modules))
+        ips_with_difs.append(Ip(ip_name_snake, "AUTOGEN", ipgen_modules))
 
     # Auto-generate testutils files.
     gen_testutils(ips_with_difs)

--- a/util/dashboard/gen_dashboard_entry.py
+++ b/util/dashboard/gen_dashboard_entry.py
@@ -228,6 +228,7 @@ def gen_dashboard_row_html(config: Union[Path, Tuple[Path, Path]],
     Tuple -> (`hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson`,
               `hw/ip/clkmgr/`)
     """
+    # TODO: the tuple is obsolete since there are no more "templated" IPs.
 
     if isinstance(config, Tuple):
         hjson_path = config[0]

--- a/util/ipgen/lib.py
+++ b/util/ipgen/lib.py
@@ -72,6 +72,7 @@ def _parse_template_parameter(where: str, raw: object) -> TemplateParameter:
                          f'{", ".join(TemplateParameter.VALID_PARAM_TYPES)}.')
 
     r_default = rd.get('default')
+    param_type: Union[bool, int, str, Dict[str, Any]]
     if param_type == 'bool':
         default = check_bool(r_default, f'default field of {name}, (a boolean parameter)')
     elif param_type == 'int':
@@ -134,8 +135,8 @@ class IpTemplate:
         - The IP template name (TEMPLATE_NAME) is equal to the directory name.
         - It contains a file 'data/TEMPLATE_NAME.tpldesc.hjson' containing all
           configuration information related to the template.
-        - It contains zero or more files ending in '.tpl'. These files are
-          Mako templates and rendered into an file in the same location without
+        - It contains some files ending in '.tpl', which are Mako templates
+          and are rendered into a file in the same relative location without
           the '.tpl' file extension.
         """
 

--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -99,6 +99,23 @@ class IpTemplateRendererBase:
         return self._lookup
 
     def _tplfunc_instance_vlnv(self, template_vlnv_str: str) -> str:
+        """Makes a vlnv into an instance specific one.
+
+        A vlnv is a string of the form vendor:library:name[:version] where
+        the version is optional. This is transformed as follows:
+        - The vendor string becomes `lowrisc`.
+        - The library string becomes `opentitan`.
+        - The name is processed as follows:
+          - If the `module_instance_name` parameter exists, the name must start
+            with it as a prefix, and that is replaced by the `instance_name`
+            value.
+          - If the name starts with the template name, it is replaced by the
+            `instance_name` value.
+          - Otherwise the `instance_name` is prefixed to the name.
+        - The optional version is preserved.
+
+        Raises exceptions for malformed vlnvs.
+        """
         template_vlnv = template_vlnv_str.split(':')
         if len(template_vlnv) != 3 and len(template_vlnv) != 4:
             raise TemplateRenderError(
@@ -108,13 +125,12 @@ class IpTemplateRendererBase:
         template_core_version = (template_vlnv[3]
                                  if len(template_vlnv) == 4 else None)
 
-        # Remove the template name from the start of the core name.
-        # For example, a core name `rv_plic_component` will result in an
-        # instance name 'my_instance_component' (instead of
-        # 'my_instance_rv_plic_component').
         if "module_instance_name" in self.ip_config.param_values:
-            assert template_core_name.startswith(
-                self.ip_config.param_values["module_instance_name"])
+            if not template_core_name.startswith(
+                    self.ip_config.param_values["module_instance_name"]):
+                raise TemplateRenderError(
+                    f'The name field in {template_vlnv_str} must start with '
+                    f'{self.ip_config.param_values["module_instance_name"]}')
             idx = len(self.ip_config.param_values["module_instance_name"])
             template_core_name = template_core_name[idx:]
         elif template_core_name.startswith(self.ip_template.name):
@@ -124,7 +140,6 @@ class IpTemplateRendererBase:
         instance_core_name = self.ip_config.instance_name + template_core_name
         instance_vlnv = ['lowrisc', 'opentitan', instance_core_name]
 
-        # Keep the version component if it was present before.
         if template_core_version is not None:
             instance_vlnv.append(template_core_version)
 
@@ -138,8 +153,7 @@ class IpTemplateRendererBase:
             self.ip_template.template_path)
         template = lookup.get_template(str(template_filepath_rel))
 
-        helper_funcs = {}
-        helper_funcs['instance_vlnv'] = self._tplfunc_instance_vlnv
+        helper_funcs = {'instance_vlnv': self._tplfunc_instance_vlnv}
 
         # TODO: Introduce namespacing for the template parameters and other
         # parameters, and/or pass the IpConfig instance to the template after
@@ -190,29 +204,21 @@ class IpTemplateRendererBase:
 class IpDescriptionOnlyRenderer(IpTemplateRendererBase):
     """ Generate the IP description only.
 
-    The IP description is the content of what is typically stored
-    data/ip_name.hjson.
+    The IP description must be at data/ip_name.hjson.tpl.
     """
 
     def render(self) -> str:
-        template_path = self.ip_template.template_path
+        """Renders template file at data/ip_name.hjson.tpl as a string.
 
-        # Look for a data/ip_name.hjson.tpl template file and render it.
-        hjson_tpl_path = template_path / 'data' / (self.ip_template.name +
-                                                   '.hjson.tpl')
+        Raises an exception if the file is not found.
+        """
+        hjson_tpl_path = (self.ip_template.template_path / 'data' /
+                          f'{self.ip_template.name}.hjson.tpl')
         if hjson_tpl_path.is_file():
             return self._render_mako_template_to_str(hjson_tpl_path)
 
-        # Otherwise, if a data/ip_name.hjson file exists, use that.
-        hjson_path = template_path / 'data' / (self.ip_template.name +
-                                               '.hjson')
-        try:
-            with open(hjson_path, 'r') as f:
-                return f.read()
-        except FileNotFoundError:
-            raise TemplateRenderError(
-                f"Neither a IP description template at {hjson_tpl_path}, "
-                f"nor an IP description at {hjson_path} exist!")
+        raise TemplateRenderError(
+            f"No IP description template at {hjson_tpl_path}")
 
 
 class IpBlockRenderer(IpTemplateRendererBase):
@@ -226,10 +232,61 @@ class IpBlockRenderer(IpTemplateRendererBase):
     - Run reggen to generate the register interface.
     """
 
-    def render(self, output_dir: Path, overwrite_output_dir: bool) -> None:
-        """ Render the IP template into output_dir. """
+    def _refresh_directory(self, staging_dir: Path, output_dir: Path,
+                           overwrite_output_dir: bool) -> None:
+        """Safely overwrite the existing directory if necessary.
 
-        # Ensure that we operate on an absolute path for output_dir.
+        The staging directory contains the newly generated contents.
+        - First move the existing directory out of the way.
+        - Then move the staging directory in place.
+        - Finally remove the old directory.
+
+        If anything goes wrong in the meantime we are left with either
+        the old or the new directory, and potentially some backups of
+        outdated files.
+
+        Raises exceptions if any of the file operations fails.
+        """
+        do_overwrite = overwrite_output_dir and output_dir.exists()
+        output_dir_existing_bak = output_dir.with_suffix(
+            '.bak~' + str(int(time.time())))
+        if do_overwrite:
+            try:
+                os.rename(output_dir, output_dir_existing_bak)
+            except OSError as e:
+                msg = (f'Cannot move existing directory {output_dir} to '
+                       f'{output_dir_existing_bak}.')
+                raise TemplateRenderError(msg).with_traceback(
+                    e.__traceback__)
+
+        try:
+            os.rename(staging_dir, output_dir)
+        except OSError as e:
+            msg = (f'Cannot move staging directory {staging_dir} to '
+                   f'{output_dir}.')
+            raise TemplateRenderError(msg).with_traceback(e.__traceback__)
+
+        if do_overwrite:
+            try:
+                shutil.rmtree(output_dir_existing_bak)
+            except Exception as e:
+                msg = (
+                    'Unable to delete the backup directory '
+                    f'{output_dir_existing_bak} of the overwritten data. '
+                    'Please remove it manually.')
+                raise TemplateRenderError(msg).with_traceback(e.__traceback__)
+
+    def render(self, output_dir: Path, overwrite_output_dir: bool) -> None:
+        """ Render the IP template into output_dir.
+
+        Generates the IP directory in a staging area and atomically moves it
+        to the final destination if generation succeeds. Generation is done in
+        stages:
+        - Copy all non-template files.
+        - Render all *.tpl files to their corresponding location.
+        - Generate register file description with reggen.
+        """
+        # Ensure to operate on an absolute path for output_dir.
         output_dir = output_dir.resolve()
 
         if not overwrite_output_dir and output_dir.exists():
@@ -237,22 +294,24 @@ class IpBlockRenderer(IpTemplateRendererBase):
                 "Output directory '{}' exists and should not be overwritten.".
                 format(output_dir))
 
-        # Prepare the IP directory in a staging area to later atomically move it
-        # to the final destination.
-        output_dir_staging = output_dir.parent / f".~{output_dir.stem}.staging"
-        if output_dir_staging.is_dir():
+        staging_dir = output_dir.parents[0] / f".~{output_dir.stem}.staging"
+        if staging_dir.is_dir():
             raise TemplateRenderError(
-                f"Output staging directory '{output_dir_staging}' already "
-                "exists. Remove it and try again.")
+                f"Output staging directory '{staging_dir}' already exists: "
+                "remove it and try again.")
 
         template_path = self.ip_template.template_path
 
         try:
             # Copy everything but the templates and the template description.
             ignore = shutil.ignore_patterns('*.tpl', '*.tpldesc.hjson')
-            shutil.copytree(template_path, output_dir_staging, ignore=ignore)
+            shutil.copytree(template_path, staging_dir, ignore=ignore)
+        except shutil.Error as e:
+            log.error(f'Error copying non-template files: {e}')
+            raise TemplateRenderError("Error copying non-template files: {e}")
 
-            # Render templates.
+        # Render templates.
+        try:
             for template_filepath in template_path.glob('**/*.tpl'):
                 template_filepath_rel = template_filepath.relative_to(
                     template_path)
@@ -260,82 +319,53 @@ class IpBlockRenderer(IpTemplateRendererBase):
                 # Put the output file into the same relative directory as the
                 # template. The output file will also have the same name as the
                 # template, just without the '.tpl' suffix.
-                outdir_path = output_dir_staging / template_filepath_rel.parent
+                outdir_path = staging_dir / template_filepath_rel.parent
 
                 self._render_mako_template_to_file(template_filepath,
                                                    outdir_path)
-
-            # Generate register interface through reggen.
-            hjson_path = (output_dir_staging / 'data' /
-                          (self.ip_template.name + '.hjson'))
-            if "module_instance_name" in self.ip_config.param_values:
-                hjson_path = (
-                    output_dir_staging / 'data' /
-                    self.ip_config.param_values["module_instance_name"] +
-                    '.hjson')
-            if not hjson_path.exists():
-                raise TemplateRenderError(
-                    "Invalid template: The IP description file "
-                    f"{str(hjson_path)!r} does not exist.")
-            rtl_path = output_dir_staging / 'rtl'
-            rtl_path.mkdir(exist_ok=True)
-
-            obj = IpBlock.from_path(str(hjson_path), [])
-
-            # If this block has countermeasures, we grep for RTL annotations in
-            # all .sv implementation files and check whether they match up
-            # with what is defined inside the Hjson.
-            sv_files = rtl_path.glob('*.sv')
-            rtl_names = CounterMeasure.search_rtl_files(sv_files)
-            obj.check_cm_annotations(rtl_names, str(hjson_path))
-
-            # TODO: Pass on template parameters to reggen? Or enable the user
-            # to set a different set of parameters in the renderer?
-            reggen.gen_rtl.gen_rtl(obj, str(rtl_path))
-
-            # Write IP configuration (to reproduce the generation process).
-            # TODO: Should the ipconfig file be written to the instance name,
-            # or the template name?
-            self.ip_config.to_file(
-                output_dir_staging / 'data' /
-                f'{self.ip_config.instance_name}.ipconfig.hjson',
-                header=_HJSON_LICENSE_HEADER)
-
-            # Safely overwrite the existing directory if necessary:
-            #
-            # - First move the existing directory out of the way.
-            # - Then move the staging directory with the new content in place.
-            # - Finally remove the old directory.
-            #
-            # If anything goes wrong in the meantime we are left with either
-            # the old or the new directory, and potentially some backups of
-            # outdated files.
-            do_overwrite = overwrite_output_dir and output_dir.exists()
-            output_dir_existing_bak = output_dir.with_suffix(
-                '.bak~' + str(int(time.time())))
-            if do_overwrite:
-                os.rename(output_dir, output_dir_existing_bak)
-
-            # Move the staging directory to the final destination.
-            os.rename(output_dir_staging, output_dir)
-
-            # Remove the old/"overwritten" data.
-            if do_overwrite:
-                try:
-                    shutil.rmtree(output_dir_existing_bak)
-                except Exception as e:
-                    msg = (
-                        'Unable to delete the backup directory '
-                        f'{output_dir_existing_bak} of the overwritten data. '
-                        'Please remove it manually.')
-                    raise TemplateRenderError(msg).with_traceback(
-                        e.__traceback__)
-
-        except TemplateRenderError as e:
-            log.error(f'{e!s}')
+        except Exception:
+            shutil.rmtree(staging_dir, ignore_errors=True)
             raise
 
-        finally:
-            # Ensure that the staging directory is removed at the end. Ignore
-            # errors as the directory should not exist at this point actually.
-            shutil.rmtree(output_dir_staging, ignore_errors=True)
+        hjson_base_name = self.ip_config.param_values.get(
+            "module_instance_name", self.ip_template.name)
+
+        # Generate register interface through reggen.
+        hjson_path = staging_dir / 'data' / f'{hjson_base_name}.hjson'
+
+        if not hjson_path.exists():
+            raise TemplateRenderError(
+                "Invalid template: The IP description file "
+                f"{str(hjson_path)!r} does not exist. "
+                "Inspect the {staging_dir} directory.")
+
+        rtl_path = staging_dir / 'rtl'
+        rtl_path.mkdir(exist_ok=True)
+
+        obj = IpBlock.from_path(str(hjson_path), [])
+
+        # If this block has countermeasures, we grep for RTL annotations in
+        # all .sv implementation files and check whether they match up
+        # with what is defined inside the Hjson.
+        sv_files = rtl_path.glob('*.sv')
+        rtl_names = CounterMeasure.search_rtl_files(sv_files)
+        obj.check_cm_annotations(rtl_names, str(hjson_path))
+
+        # TODO: Pass on template parameters to reggen? Or enable the user
+        # to set a different set of parameters in the renderer?
+        reggen.gen_rtl.gen_rtl(obj, str(rtl_path))
+
+        # Write IP configuration (to reproduce the generation process).
+        # TODO: Should the ipconfig file be written to the instance name,
+        # or the template name?
+        self.ip_config.to_file(
+            staging_dir / 'data' /
+            f'{self.ip_config.instance_name}.ipconfig.hjson',
+            header=_HJSON_LICENSE_HEADER)
+
+        self._refresh_directory(staging_dir, output_dir,
+                                overwrite_output_dir)
+
+        # Ensure that the staging directory is removed at the end. Ignore
+        # errors as the directory should not exist at this point actually.
+        shutil.rmtree(staging_dir, ignore_errors=True)

--- a/util/make_new_dif.py
+++ b/util/make_new_dif.py
@@ -87,7 +87,8 @@ def main():
     # Parse CMD line args.
     ips = []
 
-    # Parse toplevel Hjson to get IPs that are templated / generated with IPgen.
+    # Parse toplevel Hjson to get IPs that are generated with IPgen and those
+    # that are under <top>/ip.
     if args.topcfg:
         topcfg_path = args.topcfg
     else:
@@ -98,7 +99,6 @@ def main():
     except FileNotFoundError:
         print(f"hjson {topcfg_path} could not be found")
         sys.exit(1)
-    templated_modules = lib.get_templated_modules(topcfg)
     ipgen_modules = lib.get_ipgen_modules(topcfg)
     reggen_top_modules = lib.get_top_reggen_modules(topcfg)
 
@@ -118,14 +118,13 @@ def main():
             # NOTE: ip.name_long_* not needed for auto-generated files which
             # are the only files (re-)generated in regen mode.
             ips.append(
-                Ip(ip_name_snake, "AUTOGEN", templated_modules, ipgen_modules,
-                   reggen_top_modules))
+                Ip(ip_name_snake, "AUTOGEN", ipgen_modules, reggen_top_modules))
     else:
         assert args.ip_name_snake and args.ip_name_long, \
             "ERROR: pass --ip-name-snake and --ip-name-long when --mode=new."
         ips.append(
-            Ip(args.ip_name_snake, args.ip_name_long, templated_modules,
-               ipgen_modules, reggen_top_modules))
+            Ip(args.ip_name_snake, args.ip_name_long, ipgen_modules,
+               reggen_top_modules))
 
     # Default to generating all parts.
     if len(args.only) == 0:

--- a/util/make_new_dif/ip.py
+++ b/util/make_new_dif/ip.py
@@ -89,14 +89,12 @@ class Ip:
     """
 
     def __init__(self, name_snake: str, name_long_lower: str,
-                 templated_modules: List[str], ipgen_modules: List[str],
-                 reggen_top_modules: List[str]) -> None:
+                 ipgen_modules: List[str], reggen_top_modules: List[str]) -> None:
         """Mines metadata to populate this Ip object.
 
         Args:
             name_snake: IP short name in lower snake case (e.g., pwrmgr).
             name_long_lower: IP full name in lower case (e.g., power manager).
-            templated_modules: Templated modules where hjson is under top_*
             ipgen_modules: Ipgen modules where hjson is under ip_autogen
             reggen_top_modules: Top Reggen modules where hjson is under top_*
         """
@@ -114,9 +112,6 @@ class Ip:
         # Load HJSON data.
         if self.name_snake in ipgen_modules:
             data_dir = REPO_TOP / "hw/top_earlgrey/ip_autogen/{0}/data".format(
-                self.name_snake)
-        elif self.name_snake in templated_modules:
-            data_dir = REPO_TOP / "hw/top_earlgrey/ip/{0}/data/autogen".format(
                 self.name_snake)
         elif self.name_snake in reggen_top_modules:
             data_dir = REPO_TOP / "hw/top_earlgrey/ip/{0}/data/".format(

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -501,9 +501,9 @@ def generate_top_ral(top: Dict[str, object], name_to_block: Dict[str, IpBlock],
 
     # Generate a map from instance name to the block that it instantiates,
     # together with a map of interface addresses.
-    inst_to_block = {}  # type: Dict[str, str]
-    if_addrs = {}  # type: Dict[Tuple[str, Optional[str]], int]
-    attrs = {}  # type: Dict[str, str]
+    inst_to_block: Dict[str, str] = {}
+    if_addrs: Dict[Tuple[str, Optional[str]], int] = {}
+    attrs: Dict[str, str] = {}
 
     for module in top["module"]:
         inst_name = module["name"]

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -11,9 +11,8 @@ import sys
 import tempfile
 from collections import OrderedDict
 from copy import deepcopy
-from itertools import chain
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 import hjson
 import tlgen
@@ -57,6 +56,8 @@ GENCMD = ("// util/topgen.py -t hw/{top_name}/data/{top_name}.hjson\n"
 SRCTREE_TOP = Path(__file__).parents[1].resolve()
 
 TOPGEN_TEMPLATE_PATH = SRCTREE_TOP / "util" / "topgen" / "templates"
+IP_RAW_PATH = SRCTREE_TOP / "hw" / "ip"
+IP_TEMPLATES_PATH = SRCTREE_TOP / "hw" / "ip_templates"
 
 
 def ipgen_render(template_name: str, topname: str, params: Dict[str, object],
@@ -232,13 +233,8 @@ def generate_plic(top: Dict[str, object], out_path: Path) -> None:
     ipgen_render("rv_plic", topname, params, out_path)
 
 
-# TODO(lowrisc/opentitan#8440): For templated IPs we have to search
-# both the source and destination RTL directories, since not all files
-# are copied over. This is a workaround which can be removed once all
-# generated IPs have transitioned to IPgen.
 def generate_regfile_from_path(hjson_path: Path,
-                               generated_rtl_path: Path,
-                               original_rtl_path: Path = None) -> None:
+                               generated_rtl_path: Path) -> None:
     """Generate RTL register file from path and check countermeasure labels"""
     obj = IpBlock.from_path(str(hjson_path), [])
 
@@ -246,8 +242,6 @@ def generate_regfile_from_path(hjson_path: Path,
     # all .sv implementation files and check whether they match up
     # with what is defined inside the Hjson.
     sv_files = generated_rtl_path.glob("*.sv")
-    if original_rtl_path is not None:
-        sv_files = chain(sv_files, original_rtl_path.glob("*.sv"))
     rtl_names = CounterMeasure.search_rtl_files(sv_files)
     obj.check_cm_annotations(rtl_names, str(hjson_path))
     gen_rtl.gen_rtl(obj, str(generated_rtl_path))
@@ -475,20 +469,15 @@ def generate_top_only(top_only_dict: Dict[str, bool], out_path: Path,
     log.info("Generating top only modules")
 
     for ip, reggen_only in top_only_dict.items():
-
-        if reggen_only and alt_hjson_path is not None:
-            hjson_dir = Path(alt_hjson_path)
+        ip_out_path = out_path / "ip" / ip
+        if reggen_only and alt_hjson_path:
+            hjson_path = Path(alt_hjson_path)
         else:
-            hjson_dir = (SRCTREE_TOP / "hw" / top_name / "ip" / ip / "data")
-
-        hjson_path = hjson_dir / f"{ip}.hjson"
-
-        genrtl_dir = out_path / "ip" / ip / "rtl"
+            hjson_path = ip_out_path / "data" / f"{ip}.hjson"
+        genrtl_dir = ip_out_path / "rtl"
         genrtl_dir.mkdir(parents=True, exist_ok=True)
-        log.info("Generating top modules {}, hjson: {}, output: {}".format(
-            ip, hjson_path, genrtl_dir))
-
-        # Generate reg files
+        log.info(f"Generating registers for top module {ip}, hjson: "
+                 f"{hjson_path}, output: {genrtl_dir}")
         generate_regfile_from_path(hjson_path, genrtl_dir)
 
 
@@ -510,12 +499,6 @@ def generate_top_ral(top: Dict[str, object], name_to_block: Dict[str, IpBlock],
         block_name = module["type"]
         block = name_to_block[block_name]
         if "attr" in module:
-            if module["attr"] not in [
-                    "templated", "ipgen", "reggen_top", "reggen_only"
-            ]:
-                raise ValueError(
-                    "Unsupported value for attr field of {}: {!r}".format(
-                        inst_name, module["attr"]))
             attrs[inst_name] = module["attr"]
 
         inst_to_block[inst_name] = block_name
@@ -529,7 +512,7 @@ def generate_top_ral(top: Dict[str, object], name_to_block: Dict[str, IpBlock],
         mems.append(create_mem(item, addrsep, regwidth))
 
     # Top-level may override the mem setting. Store the new type to name_to_block
-    # If no other instance uses the orignal type, delete it
+    # If no other instance uses the original type, delete it
     original_types = set()
     for module in top["module"]:
         if "memory" in module.keys() and len(module["memory"]) > 0:
@@ -633,15 +616,17 @@ def _process_top(
         topcfg: Dict[str, object], args: argparse.Namespace, cfg_path: Path,
         out_path: Path, pass_idx: int
 ) -> (Dict[str, object], Dict[str, IpBlock], Dict[str, Path]):
-    # Create generated list
-    # These modules are generated through topgen
-    templated_list = lib.get_templated_modules(topcfg)
-    log.info("Templated list is {}".format(templated_list))
+    # Check that all modules have valid attributes
+    invalid_attr_mods = [ip for ip in topcfg["module"]
+                         if not lib.is_module_attr_valid(ip)]
+    if invalid_attr_mods:
+        log.error("The following ips have incorrect attr fields: "
+                  ", ".join([ip['type'] for ip in invalid_attr_mods]))
+        raise SystemExit(sys.exc_info()[1])
 
+    # Create list of modules generated with ipgen
     ipgen_list = lib.get_ipgen_modules(topcfg)
     log.info("Ip gen list is {}".format(ipgen_list))
-
-    generated_list = templated_list + ipgen_list
 
     # These modules are NOT generated but belong to a specific top
     # and therefore not part of "hw/ip"
@@ -653,12 +638,11 @@ def _process_top(
 
     top_name = f"top_{topcfg['name']}"
 
-    # Sweep the IP directory and gather the config files
-    ip_dir = Path(__file__).parents[1] / "hw/ip"
-    ips = search_ips(ip_dir)
+    # Sweep the hw/ip directory and gather the config files
+    ips = search_ips(IP_RAW_PATH)
 
     # exclude filtered IPs (to use ${top_name} one) and
-    exclude_list = generated_list + list(top_only_dict.keys())
+    exclude_list = ipgen_list + list(top_only_dict.keys())
     ips = [x for x in ips if not x.parents[1].name in exclude_list]
 
     # Hack alert
@@ -671,45 +655,29 @@ def _process_top(
     generate_clkmgr(topcfg, out_path)
 
     # It may require two passes to check if the module is needed.
-    # TODO: first run of topgen will fail due to the absent of rv_plic.
+    # TODO: first run of topgen will fail due to the absence of rv_plic.
     # It needs to run up to amend_interrupt in merge_top function
     # then creates rv_plic.hjson then run xbar generation.
     hjson_dir = Path(args.topcfg).parent
 
-    for ip in generated_list:
+    for ip in ipgen_list:
         # For modules that are generated prior to gathering, we need to take it from
         # the output path.  For modules not generated before, it may exist in a
         # pre-defined area already.
         log.info("Appending {}".format(ip))
-        if ip in ipgen_list:
-            ip_relpath = "ip_autogen"
-            desc_file_relpath = "data"
-        else:
-            ip_relpath = "ip"
-            desc_file_relpath = "data/autogen"
-
-        if ip == "clkmgr" or (pass_idx > 0):
-            ip_hjson = (Path(out_path) / ip_relpath / ip / desc_file_relpath /
-                        f"{ip}.hjson")
-        else:
-            ip_hjson = (hjson_dir.parent / ip_relpath / ip /
-                        desc_file_relpath / f"{ip}.hjson")
+        ip_hjson = out_path / "ip_autogen" / ip / "data" / f"{ip}.hjson"
         ips.append(ip_hjson)
 
     for ip, reggen_only in top_only_dict.items():
         log.info("Appending {}".format(ip))
-
-        if reggen_only and args.hjson_path:
-            ip_hjson = Path(args.hjson_path) / f"{ip}.hjson"
-        else:
-            ip_hjson = hjson_dir.parent / f"ip/{ip}/data/{ip}.hjson"
-
+        ip_hjson = cfg_path / "ip" / ip / "data" / f"{ip}.hjson"
         ips.append(ip_hjson)
 
+    name_to_hjson: Dict[str, Path] = {}
+    ip_objs: List[IpBlock] = []
+
     # load Hjson and pass validate from reggen
-    name_to_hjson = {}  # type Dict[str, Path]
     try:
-        ip_objs = []
         for ip_desc_file in ips:
             ip_name = ip_desc_file.stem
             # Skip if it is not in the module list
@@ -724,48 +692,37 @@ def _process_top(
             # TODO: All of this is a rather ugly hack that we need to get rid
             # of as soon as we don't arbitrarily template IP description Hjson
             # files any more.
-            if ip_name in generated_list and not ip_desc_file.is_file():
-                if ip_name in ipgen_list:
-                    log.info(
-                        "To-be-auto-generated Hjson %s does not yet exist. "
-                        "Falling back to the default configuration of template "
-                        "%s for initial validation." % (ip_desc_file, ip_name))
+            if ip_name in ipgen_list and not ip_desc_file.is_file():
+                log.info(
+                    f"To-be-generated Hjson {ip_desc_file} does not yet exist. "
+                    "Falling back to the default configuration of template "
+                    f"{ip_name} for initial validation.")
 
-                    tpl_path = SRCTREE_TOP / "hw/ip_templates" / ip_name
-                    ip_template = IpTemplate.from_template_path(tpl_path)
-                    ip_config = IpConfig(ip_template.params,
-                                         f"{top_name}_{ip_name}")
+                tpl_path = IP_TEMPLATES_PATH / ip_name
+                ip_template = IpTemplate.from_template_path(tpl_path)
+                ip_config = IpConfig(ip_template.params,
+                                     f"{top_name}_{ip_name}")
 
-                    try:
-                        ip_desc = IpDescriptionOnlyRenderer(
-                            ip_template, ip_config).render()
-                    except TemplateRenderError as e:
-                        log.error(e.verbose_str())
-                        sys.exit(1)
-                    name_to_hjson[ip_name.lower()] = tpl_path
-                    s = "default description of IP template {}".format(ip_name)
-                    ip_objs.append(IpBlock.from_text(ip_desc, [], s))
-                else:
-                    # TODO: Remove this block as soon as all IP templates use
-                    # ipgen.
-                    template_hjson_file = ip_dir / "{}/data/{}.hjson".format(
-                        ip_name, ip_name)
-                    log.info(
-                        "To-be-auto-generated Hjson %s does not yet exist. "
-                        "Falling back to Hjson description file %s shipped "
-                        "with the IP template for initial validation." %
-                        (ip_desc_file, template_hjson_file))
-                    name_to_hjson[ip_name] = template_hjson_file
-                    ip_objs.append(
-                        IpBlock.from_path(str(template_hjson_file), []))
-            else:
+                try:
+                    ip_desc = IpDescriptionOnlyRenderer(
+                        ip_template, ip_config).render()
+                except TemplateRenderError as e:
+                    log.error(e.verbose_str())
+                    sys.exit(1)
+                name_to_hjson[ip_name.lower()] = tpl_path
+                s = "default description of IP template {}".format(ip_name)
+                ip_objs.append(IpBlock.from_text(ip_desc, [], s))
+            elif ip_desc_file.is_file():
                 name_to_hjson[ip_name] = ip_desc_file
                 ip_objs.append(IpBlock.from_path(str(ip_desc_file), []))
+            else:
+                log.error(f"Descrition file not found: {ip_desc_file}")
+                raise SystemExit(sys.exc_info()[1])
 
     except ValueError:
         raise SystemExit(sys.exc_info()[1])
 
-    name_to_block = {}  # type: Dict[str, IpBlock]
+    name_to_block: Dict[str, IpBlock] = {}
     for block in ip_objs:
         lblock = block.name.lower()
         assert lblock not in name_to_block
@@ -792,8 +749,8 @@ def _process_top(
     # Read the crossbars under the top directory
     xbar_objs = get_hjsonobj_xbars(hjson_dir)
 
-    log.info("Detected crossbars: %s" %
-             (", ".join([x["name"] for x in xbar_objs])))
+    log.info("Detected crossbars: " +
+             ", ".join([x["name"] for x in xbar_objs]))
 
     topcfg, error = validate_top(topcfg, ip_objs, xbar_objs)
     if error != 0:
@@ -832,8 +789,8 @@ def _process_top(
     generate_rstmgr(completecfg, out_path)
 
     # Generate top only modules
-    # These modules are not templated, but are not in hw/ip
-    generate_top_only(top_only_dict, out_path, top_name, args.hjson_path)
+    # These modules are not ipgen, but are not in hw/ip
+    generate_top_only(top_only_dict, cfg_path, top_name, args.hjson_path)
 
     return completecfg, name_to_block, name_to_hjson
 
@@ -844,25 +801,7 @@ def _check_countermeasures(completecfg: Dict[str, object],
     success = True
     for name, hjson_path in name_to_hjson.items():
         log.debug("name %s, hjson %s", name, hjson_path)
-        ip_index = [m['type'] for m in completecfg['module']].index(name)
-        # TODO(lowrisc/opentitan#8440): For templated IPs we have to search
-        # both the source and destination RTL directories, since not all files
-        # are copied over. This is a workaround which can be removed once all
-        # generated IPs have transitioned to IPgen.
-        if ('attr' in completecfg['module'][ip_index] and
-                completecfg['module'][ip_index]['attr'] == 'templated'):
-            ip_proper_rtl_path = hjson_path.parents[5] / 'ip' / name / 'rtl'
-            sv_files = (hjson_path.parents[2] / 'rtl' / 'autogen').glob('*.sv')
-            sv_files = set(sv_files)
-            sv_names = set([f.name for f in sv_files])
-            proper_rtl_files = {
-                f
-                for f in ip_proper_rtl_path.glob('*.sv')
-                if f.name not in sv_names
-            }
-            sv_files = sv_files | proper_rtl_files
-        else:
-            sv_files = (hjson_path.parents[1] / 'rtl').glob('*.sv')
+        sv_files = (hjson_path.parents[1] / 'rtl').glob('*.sv')
         rtl_names = CounterMeasure.search_rtl_files(sv_files)
         log.debug("Checking countermeasures for %s.", name)
         success &= name_to_block[name].check_cm_annotations(
@@ -1009,7 +948,7 @@ def main():
 
     if not args.outdir:
         outdir = Path(args.topcfg).parents[1]
-        log.info("TOP directory not given. Use %s", (outdir))
+        log.info("TOP directory not given. Using %s", (outdir))
     elif not Path(args.outdir).is_dir():
         log.error("'--outdir' should point to writable directory")
         raise SystemExit(sys.exc_info()[1])

--- a/util/topgen/c_test.py
+++ b/util/topgen/c_test.py
@@ -28,21 +28,19 @@ class TestPeripheral:
     headers, rather than hard-coded constants. This is done to ensure that a
     single source of truth is referenced in all of the tests.
     """
-    def __init__(self, name: str, inst_name: str, base_addr_name: str,
-                 is_templated: bool):
+    def __init__(self, name: str, inst_name: str, base_addr_name: str):
         self.name = name
         self.inst_name = inst_name
         self.base_addr_name = base_addr_name
-        self.is_templated = is_templated
 
 
 class IrqTestPeripheral(TestPeripheral):
     """Captures a peripheral instance's attributes for use in IRQ test."""
     def __init__(self, name: str, inst_name: str, base_addr_name: str,
-                 is_templated: bool, plic_name: str, start_irq: str,
-                 end_irq: str, plic_start_irq: str, status_type_mask: int,
+                 plic_name: str, start_irq: str, end_irq: str,
+                 plic_start_irq: str, status_type_mask: int,
                  status_default_mask: int):
-        super().__init__(name, inst_name, base_addr_name, is_templated)
+        super().__init__(name, inst_name, base_addr_name)
         self.plic_name = plic_name
         self.start_irq = start_irq
         self.end_irq = end_irq
@@ -54,9 +52,8 @@ class IrqTestPeripheral(TestPeripheral):
 class AlertTestPeripheral(TestPeripheral):
     """Captures a peripheral instance's attributes for use in IRQ test."""
     def __init__(self, name: str, inst_name: str, base_addr_name: str,
-                 is_templated: bool, top_alert_name: str,
-                 dif_alert_name: str, num_alerts: int):
-        super().__init__(name, inst_name, base_addr_name, is_templated)
+                 top_alert_name: str, dif_alert_name: str, num_alerts: int):
+        super().__init__(name, inst_name, base_addr_name)
         self.top_alert_name = top_alert_name
         self.dif_alert_name = dif_alert_name
         self.num_alerts = num_alerts
@@ -95,7 +92,6 @@ class TopGenCTest(TopGenC):
                 sys.exit(1)
 
             base_addr_name = region.base_addr_name().as_c_define()
-            is_templated = 'attr' in entry and entry['attr'] == 'templated'
 
             plic_name = (self._top_name + Name(["plic", "peripheral"]) +
                          Name.from_snake_case(inst_name))
@@ -129,8 +125,7 @@ class TopGenCTest(TopGenC):
                     n += irq["width"]
 
             irq_peripheral = IrqTestPeripheral(name, inst_name, base_addr_name,
-                                               is_templated, plic_name,
-                                               start_irq, end_irq,
+                                               plic_name, start_irq, end_irq,
                                                plic_start_irq, status_type_mask,
                                                status_default_mask)
             irq_peripherals.append(irq_peripheral)
@@ -166,7 +161,6 @@ class TopGenCTest(TopGenC):
                     base_addr_name = region.base_addr_name().as_c_define()
                     break
 
-            is_templated = 'attr' in entry and entry['attr'] == 'templated'
             dif_alert_name = self.device_alerts[inst_name][0]
             num_alerts = len(self.device_alerts[inst_name])
 
@@ -179,7 +173,7 @@ class TopGenCTest(TopGenC):
             dif_alert_name = dif_alert_name.replace(inst_name, f"dif_{name}_alert", 1)
             dif_alert_name = Name.from_snake_case(dif_alert_name).as_c_enum()
 
-            alert_peripheral = AlertTestPeripheral(name, inst_name, base_addr_name, is_templated,
+            alert_peripheral = AlertTestPeripheral(name, inst_name, base_addr_name,
                                                    top_alert_name, dif_alert_name, num_alerts)
             alert_peripherals.append(alert_peripheral)
 

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -607,12 +607,6 @@ def get_unused_resets(top):
     return top['resets'].get_unused_resets(top['power']['domains'])
 
 
-def get_templated_modules(top):
-    """Returns list of all templated modules.
-    """
-    return [m['type'] for m in top['module'] if is_templated(m)]
-
-
 def get_ipgen_modules(top):
     """Returns list of all ipgen modules.
     """
@@ -625,10 +619,9 @@ def get_top_reggen_modules(top):
     return [m['type'] for m in top['module'] if is_top_reggen(m)]
 
 
-def is_templated(module):
-    """Returns an indication where a particular module is templated
-    """
-    return module.get('attr') in ["templated"]
+def is_module_attr_valid(module):
+    return ('attr' not in module or
+            module.get('attr') in ["ipgen", "reggen_top", "reggen_only"])
 
 
 def is_ipgen(module):
@@ -638,14 +631,14 @@ def is_ipgen(module):
 
 
 def is_top_reggen(module):
-    """Returns an indication where a particular module is NOT templated
+    """Returns an indication where a particular module is NOT generated
        and requires top level specific reggen
     """
     return module.get('attr') in ["reggen_top", "reggen_only"]
 
 
 def is_reggen_only(module):
-    """Returns an indication where a particular module is NOT templated,
+    """Returns an indication where a particular module is NOT generated,
        requires top level specific reggen and is NOT instantiated in the
        top
     """
@@ -661,7 +654,7 @@ def is_inst(module):
 
     if "attr" not in module:
         top_level_module = True
-    elif module["attr"] in ["normal", "templated", "ipgen", "reggen_top"]:
+    elif module["attr"] in ["normal", "ipgen", "reggen_top"]:
         top_level_module = True
     elif module["attr"] in ["reggen_only"]:
         top_level_module = False

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -592,12 +592,12 @@ def extract_clocks(top: OrderedDict):
     '''Add clock exports to top and connections to endpoints
 
     This function sets up all the clock-related machinery that is needed to
-    generate the (templated) clkmgr code. This runs before we load up IP blocks
-    with reggen, so can only see top-level configuration.
+    generate the clkmgr code. This runs before we load up IP blocks with
+    reggen, so can only see top-level configuration.
 
-    By default each end point (peripheral, memory etc) is in the same clock group.
-    However, it is possible to define the group attribute per clock if required.
-
+    By default each end point (peripheral, memory etc) is in the same clock
+    group. However, it is possible to define the group attribute per clock
+    if required.
     '''
     clocks = top['clocks']
     assert isinstance(clocks, Clocks)

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -194,7 +194,7 @@ module_optional = {
     'clock_reset_export': ['l', 'optional list with prefixes for exported '
                                 'clocks and resets at the chip level'],
     'attr': ['s', 'optional attribute indicating whether the IP is '
-                  '"templated" or "reggen_only"'],
+                  '"ipgen", "reggen_top", or "reggen_only"'],
     'base_addr': ['g', 'dict of address space mapped to the corresponding '
                        'hex start address of the peripheral '
                        '(if the IP has only a single TL-UL interface)'],


### PR DESCRIPTION
This has 4 commits with no breakages in between:
- Add cmdgen to "all" target in hw/Makefile
- Move type hints from comments to variable declarations in util/topgen.py
- Remove support for templated ips in topgen
- Improve ipgen docs, exception handling, and make minor implifications

Some are part of #8440