### PR TITLE
[cherry-pick] manual cherry-pick of #25130 to `earlgrey_1.0.0`

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load(
     "@lowrisc_opentitan//rules:rv.bzl",
     "rv_rule",
@@ -12,12 +11,15 @@ load(
 )
 load("@lowrisc_opentitan//rules:signing.bzl", "sign_binary")
 load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
-load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_override")
 load(
     "@lowrisc_opentitan//rules/opentitan:transform.bzl",
     "obj_disassemble",
     "obj_transform",
 )
+load("@lowrisc_opentitan//rules/opentitan:util.bzl", "get_fallback", "get_override")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
+load("//rules/opentitan:util.bzl", "assemble_for_test")
 
 # Re-exports of names from transition.bzl; many files in the repo use opentitan.bzl
 # to get to them.
@@ -238,7 +240,7 @@ def _opentitan_binary(ctx):
         deps = ctx.attr.deps + exec_env.libs
         kind = ctx.attr.kind
         provides, signed = _build_binary(ctx, exec_env, name, deps, kind)
-        providers.append(exec_env.provider(**provides))
+        providers.append(exec_env.provider(kind = kind, **provides))
         default_info.append(provides["default"])
         default_info.append(provides["elf"])
 
@@ -451,4 +453,39 @@ opentitan_test = rv_rule(
     fragments = ["cpp"],
     toolchains = ["@rules_cc//cc:toolchain_type"],
     test = True,
+)
+
+def _opentitan_binary_assemble_impl(ctx):
+    assembled_bins = []
+    tc = ctx.toolchains[LOCALTOOLS_TOOLCHAIN]
+    for env in ctx.attr.exec_env:
+        exec_env_name = env[ExecEnvInfo].exec_env
+        exec_env_provider = env[ExecEnvInfo].provider
+        name = "{}_{}".format(ctx.attr.name, exec_env_name)
+        spec = []
+        input_bins = []
+        for binary, offset in ctx.attr.bins.items():
+            if binary[exec_env_provider].kind != "flash":
+                fail("Only flash binaries can be assembled.")
+            input_bins.append(binary[exec_env_provider].default)
+            spec.append("{}@{}".format(binary[exec_env_provider].default.path, offset))
+        assembled_bins.append(
+            assemble_for_test(ctx, name, spec, input_bins, tc.tools.opentitantool),
+        )
+    return [DefaultInfo(files = depset(assembled_bins))]
+
+opentitan_binary_assemble = rule(
+    implementation = _opentitan_binary_assemble_impl,
+    attrs = {
+        "bins": attr.label_keyed_string_dict(
+            allow_files = True,
+            mandatory = True,
+            doc = "Dictionary of binaries and the offsets they should be placed.",
+        ),
+        "exec_env": attr.label_list(
+            providers = [ExecEnvInfo],
+            doc = "List of execution environments for this target.",
+        ),
+    },
+    toolchains = [LOCALTOOLS_TOOLCHAIN],
 )

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -4,7 +4,10 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//rules:const.bzl", "CONST", "hex")
+
+#load("//rules:files.bzl", "output_groups")
 load("//rules:manifest.bzl", "manifest")
+load("//rules/opentitan:cc.bzl", "opentitan_binary_assemble")
 load(
     "//rules/opentitan:defs.bzl",
     "fpga_params",
@@ -356,6 +359,24 @@ _FT_PROVISIONING_CMD_ARGS = """
 })
 
 _FT_PROVISIONING_HARNESS = "//sw/host/provisioning/ft:ft_{}"
+
+[
+    opentitan_binary_assemble(
+        name = "ft_fw_bundle_{}".format(sku),
+        testonly = True,
+        bins = {
+            ":ft_personalize_{}".format(sku): SLOTS["a"],
+            config["rom_ext"]: SLOTS["b"],
+            config["owner_fw"]: OWNER_SLOTS["b"],
+        },
+        exec_env = [
+            "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys",
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
+            "//hw/top_earlgrey:silicon_creator",
+        ],
+    )
+    for sku, config in EARLGREY_SKUS.items()
+]
 
 [
     opentitan_test(


### PR DESCRIPTION
This adds a rule (`opentitan_binary_assemble`) to assemble a flash image from several opentitan_binary images. This is useful when building firmware images during provisioning.