### PR TITLE
[pwm,dv] Exclude an unreachable item of block coverage

### DIFF
--- a/hw/ip/pwm/dv/cov/manual_excl.vRefine
+++ b/hw/ip/pwm/dv/cov/manual_excl.vRefine
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<refinement-file-root>
+  <rules>
+    <!--
+        Waive block coverage for a conditional which is true if the 'we' signal is true for the
+        REGWEN in register in prim_subreg_arb. If the signal is true, this denotes a write to the
+        register from hardware but the instantiation in pwm_reg_top wires it to zero.
+    -->
+    <rule ccType="inst"
+          entityName="pwm/u_reg/u_regwen/wr_en_data_arb/gen_w0c/gen_non_mubi/2"
+          entityType="block"
+          line="135"
+          name="exclude"></rule>
+  </rules>
+</refinement-file-root>

--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -38,7 +38,10 @@
   sim_tops: ["pwm_bind", "pwm_cov_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Coverage exclusion
-  xcelium_cov_refine_files: ["{proj_root}/hw/ip/pwm/dv/cov/pwm_unr_excl.vRefine"]
+  xcelium_cov_refine_files: [
+    "{proj_root}/hw/ip/pwm/dv/cov/pwm_unr_excl.vRefine"
+    "{proj_root}/hw/ip/pwm/dv/cov/manual_excl.vRefine"
+  ]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
This cannot happen because of a constant wiring value.

~~Note: This PR depends on #25088. Once that is merged, this PR will only contain the last commit.~~ (No longer true)