### PR TITLE
[rom_ext,dice] Fix incorrect dice page id

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -1,0 +1,32 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "fpga_params",
+    "opentitan_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+opentitan_test(
+    name = "no_refresh_test",
+    srcs = ["no_refresh_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
+        exit_success = "Rebooted\r\n",
+    ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/no_refresh_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/no_refresh_test.c
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  retention_sram_t *retram = retention_sram_get();
+
+  if (bitfield_bit32_read(retram->creator.reset_reasons,
+                          kRstmgrReasonPowerOn)) {
+    LOG_INFO("Rebooting");
+    rstmgr_reset();
+    return false;
+  }
+  LOG_INFO("Rebooted");
+  return true;
+}

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -136,6 +136,12 @@ typedef struct dice_chain {
   size_t tail_offset;
 
   /**
+   * Indicate the info page currently buffered in `data`.
+   * This is used to skip unnecessary read ops.
+   */
+  const flash_ctrl_info_page_t *info_page;
+
+  /**
    * Id pair which points to the endorsement and cert ids below.
    */
   cert_key_id_pair_t key_ids;
@@ -220,7 +226,7 @@ rom_error_t dice_chain_attestation_owner(
  * @return errors encountered during the operation.
  */
 OT_WARN_UNUSED_RESULT
-rom_error_t dice_chain_update_flash(void);
+rom_error_t dice_chain_flush_flash(void);
 
 OT_WARN_UNUSED_RESULT
 static rom_error_t rom_ext_irq_error(void) {
@@ -455,13 +461,6 @@ static void dice_chain_next_cert_obj(void) {
   dice_chain_reset_cert_obj();
 }
 
-// Skip the TLV entry if the name matches.
-static void dice_chain_skip_cert_obj(const char *name, size_t name_size) {
-  if (memcmp(dice_chain.cert_obj.name, name, name_size) == 0) {
-    dice_chain_next_cert_obj();
-  }
-}
-
 /**
  * Load the tlv cert obj from the tail buffer and check if it's valid.
  *
@@ -497,7 +496,7 @@ static rom_error_t dice_chain_load_cert_obj(const char *name,
 
   // Check if this cert is what we are looking for.
   HARDENED_CHECK_LE(name_size, sizeof(dice_chain.cert_obj.name));
-  if (memcmp(dice_chain.cert_obj.name, name, name_size) != 0) {
+  if (name == NULL || memcmp(dice_chain.cert_obj.name, name, name_size) != 0) {
     // Name unmatched, keep the cert_obj but mark it as invalid.
     dice_chain.cert_valid = kHardenedBoolFalse;
     return kErrorOk;
@@ -512,10 +511,29 @@ static rom_error_t dice_chain_load_cert_obj(const char *name,
   return kErrorOk;
 }
 
+// Skip the TLV entry if the name matches.
+static rom_error_t dice_chain_skip_cert_obj(const char *name,
+                                            size_t name_size) {
+  HARDENED_RETURN_IF_ERROR(dice_chain_load_cert_obj(NULL, 0));
+  if (memcmp(dice_chain.cert_obj.name, name, name_size) == 0) {
+    dice_chain_next_cert_obj();
+  }
+  return kErrorOk;
+}
+
 // Load the certificate data from flash to RAM buffer.
 OT_WARN_UNUSED_RESULT
 static rom_error_t dice_chain_load_flash(
     const flash_ctrl_info_page_t *info_page) {
+  // Skip reload if it's already buffered.
+  if (dice_chain.info_page == info_page) {
+    dice_chain.tail_offset = 0;
+    return kErrorOk;
+  }
+
+  // We are switching to a different page, flush changes (if dirty) first.
+  HARDENED_RETURN_IF_ERROR(dice_chain_flush_flash());
+
   // Read in a DICE certificate(s) page.
   static_assert(sizeof(dice_chain.data) == FLASH_CTRL_PARAM_BYTES_PER_PAGE,
                 "Invalid dice_chain buffer size");
@@ -527,6 +545,8 @@ static rom_error_t dice_chain_load_flash(
   // Resets the flash page status.
   dice_chain.data_dirty = kHardenedBoolFalse;
   dice_chain.tail_offset = 0;
+  dice_chain.info_page = info_page;
+  dice_chain_reset_cert_obj();
 
   return kErrorOk;
 }
@@ -580,8 +600,26 @@ rom_error_t dice_chain_attestation_silicon(void) {
   HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
       kDiceKeyUds, &dice_chain.subject_pubkey_id, &dice_chain.subject_pubkey));
 
-  // Move to the next object if the current one is UDS.
-  dice_chain_skip_cert_obj("UDS", 4);
+  // Switch page for the factory provisioned UDS cert.
+  HARDENED_RETURN_IF_ERROR(
+      dice_chain_load_flash(&kFlashCtrlInfoPageFactoryCerts));
+
+  // Check if the UDS cert is valid.
+  HARDENED_RETURN_IF_ERROR(dice_chain_load_cert_obj("UDS", /*name_size=*/4));
+  if (launder32(dice_chain.cert_valid) == kHardenedBoolFalse) {
+    // The UDS key ID (and cert itself) should never change unless:
+    // 1. there is a hardware issue / the page has been corrupted, or
+    // 2. the cert has not yet been provisioned.
+    //
+    // In both cases, we do nothing, and boot normally, later attestation
+    // attempts will fail in a detectable manner.
+    HARDENED_CHECK_EQ(dice_chain.cert_valid, kHardenedBoolFalse);
+    dbg_printf("Warning: UDS certificate not valid.\r\n");
+  } else {
+    // Cert is valid, move to the next one.
+    HARDENED_CHECK_EQ(dice_chain.cert_valid, kHardenedBoolTrue);
+    dice_chain_next_cert_obj();
+  }
 
   // Save UDS key for signing next stage cert.
   HARDENED_RETURN_IF_ERROR(otbn_boot_attestation_key_save(
@@ -607,8 +645,14 @@ rom_error_t dice_chain_attestation_creator(
   HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
       kDiceKeyCdi0, &dice_chain.subject_pubkey_id, &dice_chain.subject_pubkey));
 
+  // Switch page for the device generated CDI_0.
+  HARDENED_RETURN_IF_ERROR(dice_chain_load_flash(&kFlashCtrlInfoPageDiceCerts));
+
+  // Seek to skip previous objects.
+  HARDENED_RETURN_IF_ERROR(dice_chain_skip_cert_obj("UDS", /*name_size=*/4));
+
   // Check if the current CDI_0 cert is valid.
-  HARDENED_RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_0", 6));
+  HARDENED_RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_0", /*name_size=*/6));
   if (launder32(dice_chain.cert_valid) == kHardenedBoolFalse) {
     HARDENED_CHECK_EQ(dice_chain.cert_valid, kHardenedBoolFalse);
     dbg_printf("CDI_0 certificate not valid. Updating it ...\r\n");
@@ -651,8 +695,15 @@ rom_error_t dice_chain_attestation_owner(
   HARDENED_RETURN_IF_ERROR(otbn_boot_cert_ecc_p256_keygen(
       kDiceKeyCdi1, &dice_chain.subject_pubkey_id, &dice_chain.subject_pubkey));
 
+  // Switch page for the device generated CDI_1.
+  HARDENED_RETURN_IF_ERROR(dice_chain_load_flash(&kFlashCtrlInfoPageDiceCerts));
+
+  // Seek to skip previous objects.
+  HARDENED_RETURN_IF_ERROR(dice_chain_skip_cert_obj("UDS", /*name_size=*/4));
+  HARDENED_RETURN_IF_ERROR(dice_chain_skip_cert_obj("CDI_0", /*name_size=*/6));
+
   // Check if the current CDI_0 cert is valid.
-  HARDENED_RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_1", 6));
+  HARDENED_RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_1", /*name_size=*/6));
   if (launder32(dice_chain.cert_valid) == kHardenedBoolFalse) {
     HARDENED_CHECK_EQ(dice_chain.cert_valid, kHardenedBoolFalse);
     dbg_printf("CDI_1 certificate not valid. Updating it ...\r\n");
@@ -686,20 +737,22 @@ rom_error_t dice_chain_attestation_owner(
 }
 
 // Write the DICE certs to flash if they have been updated.
-rom_error_t dice_chain_update_flash(void) {
-  if (launder32(dice_chain.data_dirty) == kHardenedBoolTrue) {
+rom_error_t dice_chain_flush_flash(void) {
+  if (dice_chain.data_dirty == kHardenedBoolTrue &&
+      dice_chain.info_page != NULL) {
     HARDENED_CHECK_EQ(dice_chain.data_dirty, kHardenedBoolTrue);
-    HARDENED_RETURN_IF_ERROR(flash_ctrl_info_erase(&kFlashCtrlInfoPageDiceCerts,
-                                                   kFlashCtrlEraseTypePage));
+    HARDENED_RETURN_IF_ERROR(
+        flash_ctrl_info_erase(dice_chain.info_page, kFlashCtrlEraseTypePage));
     static_assert(sizeof(dice_chain.data) == FLASH_CTRL_PARAM_BYTES_PER_PAGE,
                   "Invalid dice_chain buffer size");
     HARDENED_RETURN_IF_ERROR(flash_ctrl_info_write(
-        &kFlashCtrlInfoPageDiceCerts,
+        dice_chain.info_page,
         /*offset=*/0,
         /*word_count=*/FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(uint32_t),
         dice_chain.data));
-  } else {
-    HARDENED_CHECK_EQ(dice_chain.data_dirty, kHardenedBoolFalse);
+    dbg_printf("Flushed dice cert page %d\r\n",
+               dice_chain.info_page->base_addr);
+    dice_chain.data_dirty = kHardenedBoolFalse;
   }
   return kErrorOk;
 }
@@ -711,7 +764,7 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
       dice_chain_attestation_owner(&boot_measurements.bl0, manifest));
 
   // Write the DICE certs to flash if they have been updated.
-  HARDENED_RETURN_IF_ERROR(dice_chain_update_flash());
+  HARDENED_RETURN_IF_ERROR(dice_chain_flush_flash());
 
   // Remove write and erase access to the certificate pages before handing over
   // execution to the owner firmware (owner firmware can still read).
@@ -1043,6 +1096,8 @@ rom_error_t dice_chain_init(void) {
   // Variable initialization.
   memset(&dice_chain, 0, sizeof(dice_chain));
   dice_chain.subject_pubkey = (ecdsa_p256_public_key_t){.x = {0}, .y = {0}};
+  dice_chain.data_dirty = kHardenedBoolFalse;
+  dice_chain.info_page = NULL;
   dice_chain.key_ids = (cert_key_id_pair_t){
       .endorsement = &dice_chain.endorsement_pubkey_id,
       .cert = &dice_chain.subject_pubkey_id,
@@ -1055,9 +1110,6 @@ rom_error_t dice_chain_init(void) {
   flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageFactoryCerts,
                           kCertificateInfoPageCfg);
   flash_ctrl_cert_info_page_owner_restrict(&kFlashCtrlInfoPageFactoryCerts);
-  HARDENED_RETURN_IF_ERROR(
-      dice_chain_load_flash(&kFlashCtrlInfoPageFactoryCerts));
-
   return kErrorOk;
 }
 


### PR DESCRIPTION
There's one rebase conflict resolved incorrectly in #24980. It tries to load the CDI certs from the Factory page which is only for UDS cert. So the CDI certificate is always not found, making the rom_ext refreshing the cert chain on every boot.

#### Changes
* Specify flash pages explicitly, so each certificate's handler is independent without relying on previous states.
* Add the UDS certificate error message back so we can do e2e test with perso.
* An new e2e test is added to ensure we skip unnecessary update correctly.