### PR TITLE
[tl,dv] Avoid silly hole in tl_a_chan_cov_cg

### DIFF
--- a/hw/dv/sv/tl_agent/tl_agent_cov.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cov.sv
@@ -34,7 +34,7 @@ covergroup tl_a_chan_cov_cg(string name, int valid_source_width, string path) wi
     bins values[] = {Get, PutFullData, PutPartialData};
   }
   cp_mask: coverpoint item.a_mask {
-    bins all_enables  = {'1};
+    bins all_enables  = {{MaskWidth{1'b1}}};
     bins others       = default;
   }
   cp_size: coverpoint item.a_size {


### PR DESCRIPTION
The cp_mask field expects to see a value of '1 (i.e. all byte lanes are enabled). Bizarrely, a full-width read doesn't match the coverpoint bin for some reason, yielding a hole in the cross at the bottom of the covergroup.

Calculate the "replicated ones" explicitly, which seems to solve the problem.