### PR TITLE
[sram_ctrl,dv] Adapt throughput tests for readback feature

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_testplan.hjson
@@ -140,9 +140,11 @@
             Without partial write, if driver doesn't introduce any delay, it takes N+1 cycles to
             finish N SRAM read/write accesses.
             With partial write, it needs 2 extra cycles per partial write.
+            With readback enabled, each read needs 2 cycles and each write 3 cycles.
             '''
       stage: V2
-      tests: ["{name}_max_throughput", "{name}_throughput_w_partial_write"]
+      tests: ["{name}_max_throughput", "{name}_throughput_w_partial_write",
+              "{name}_throughput_w_readback"]
     }
     {
       name: regwen

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_throughput_vseq.sv
@@ -12,11 +12,22 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
 
   int num_partial_write;
 
+  // Track the number of writes and reads and whether the most recent transaction
+  // was a write. This is updated in get_rand_mask.
+  int num_writes;
+  int num_reads;
+  int last_was_write;
+
   task body();
     // In order to have max throughput, don't drop a_valid
     cfg.m_tl_agent_cfgs[cfg.sram_ral_name].allow_a_valid_drop_wo_a_ready = 0;
 
     req_mem_init();
+    if (init_w_readback) begin
+      // Init the sequence with the SRAM readback feature enabled.
+      csr_wr(.ptr(ral.readback), .value(MuBi4True));
+    end
+
     // And wait for side_effects of ram_init to be done, since detection of the end is not very
     // accurate and memory transactions wll be blocked until init is completely done. The number
     // 20 below is not special, it is just a sensible guess.
@@ -26,6 +37,10 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
       int num_cycles = 0;
 
       num_partial_write = 0;
+
+      num_writes = 0;
+      num_reads = 0;
+      last_was_write = 0;
 
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)
       `uvm_info(`gfn, $sformatf("iteration: %0d, issuing %0d ops", i, num_ops), UVM_LOW)
@@ -42,16 +57,32 @@ class sram_ctrl_throughput_vseq extends sram_ctrl_smoke_vseq;
 
       `uvm_info(`gfn, $sformatf("num_cycles: %0d, num_ops: %0d, num_partial_write: %0d",
                                 num_cycles, num_ops, num_partial_write), UVM_MEDIUM)
-
-      `DV_CHECK_EQ(num_cycles, num_ops + 1 + num_partial_write * 2);
+      if (init_w_readback) begin
+        // In throughput_w_readback test, if the last operation was a write, subtract
+        // one as the write already gets acknowledged over TLUL while the readback error
+        // is still doing the readback of the written value.
+        `DV_CHECK_EQ(num_cycles, num_writes * 3 + num_reads * 2 - last_was_write);
+      end else begin
+        `DV_CHECK_EQ(num_cycles, num_ops + 1 + num_partial_write * 2);
+      end
     end
   endtask : body
 
-  // override the function to count how many partial writes are sent
+  // override the function to count how many reads, writes, and partial writes are sent
   virtual function bit[bus_params_pkg::BUS_DBW-1:0] get_rand_mask(bit write);
     bit [bus_params_pkg::BUS_DBW-1:0] mask = super.get_rand_mask(write);
 
     if (write && mask != '1) num_partial_write++;
+
+    // Keep track of number of writes and reads for readback test.
+    if (write) begin
+      num_writes++;
+      last_was_write = 1;
+    end else begin
+      num_reads++;
+      last_was_write = 0;
+    end
+
     return mask;
   endfunction
 

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -109,6 +109,11 @@
       run_opts: ["+zero_delays=1 +partial_access_pct=20"]
     }
     {
+      name: "{name}_throughput_w_readback"
+      uvm_test_seq: sram_ctrl_throughput_vseq
+      run_opts: ["+zero_delays=1 +partial_access_pct=0 +init_w_readback=1"]
+    }
+    {
       name: "{name}_lc_escalation"
       uvm_test_seq: sram_ctrl_lc_escalation_vseq
     }


### PR DESCRIPTION
When the readback feature is enabled, reads and writes take longer. This commit adapts the cycle prediction to account for that delay.

Closes lowRISC/opentitan#23321