### PR TITLE
[rv_core_ibex, top_earlgrey] Enable SecureIbex for CW340

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -1079,9 +1079,9 @@ module chip_earlgrey_cw310 #(
     .KeymgrKmacEnMasking(0),
     .SecKmacCmdDelay(0),
     .SecKmacIdleAcceptSwMsg(1'b0),
+    .RvCoreIbexSecureIbex(0),
     .RomCtrlBootRomInitFile(BootRomInitFile),
     .RvCoreIbexRegFile(ibex_pkg::RegFileFPGA),
-    .RvCoreIbexSecureIbex(0),
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -1063,9 +1063,9 @@ module chip_earlgrey_cw340 #(
     .KmacEnMasking(1),
     .KmacSwKeyMasked(1),
     .KeymgrKmacEnMasking(1),
+    .RvCoreIbexSecureIbex(1),
     .RomCtrlBootRomInitFile(BootRomInitFile),
     .RvCoreIbexRegFile(ibex_pkg::RegFileFPGA),
-    .RvCoreIbexSecureIbex(0),
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (

--- a/hw/top_earlgrey/templates/chiplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/chiplevel.sv.tpl
@@ -1148,6 +1148,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),
     .UsbdevStub(1'b1),
+    .RvCoreIbexSecureIbex(0),
 % else:
     .SecAesMasking(1'b0),
     .SecAesSBoxImpl(aes_pkg::SBoxImplLut),
@@ -1168,16 +1169,17 @@ module chip_${top["name"]}_${target["name"]} #(
     .KmacEnMasking(1),
     .KmacSwKeyMasked(1),
     .KeymgrKmacEnMasking(1),
+    .RvCoreIbexSecureIbex(1),
 % elif target["name"] == "cw310":
     .KmacEnMasking(0),
     .KmacSwKeyMasked(1),
     .KeymgrKmacEnMasking(0),
     .SecKmacCmdDelay(0),
     .SecKmacIdleAcceptSwMsg(1'b0),
+    .RvCoreIbexSecureIbex(0),
 % endif
     .RomCtrlBootRomInitFile(BootRomInitFile),
     .RvCoreIbexRegFile(ibex_pkg::RegFileFPGA),
-    .RvCoreIbexSecureIbex(0),
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_${top["name"]} (


### PR DESCRIPTION
As the `SecureIbex` configuration is the one we use for the Earl Grey ASIC, we also should enable it for the FPGA boards.

Due to resource constraints, this is only possible for the CW340 but not the CW310.

**Report for CW340 with SecureIbex enabled:**
Resource utilization stays still well below 70%:
![image](https://github.com/user-attachments/assets/8357f8c9-49f8-420e-8882-1b6a4dd3505a)

And timing is met:
![image](https://github.com/user-attachments/assets/40fb3a7f-db06-47ab-ac52-cb5794ce1e3e)

**Report for CW340 with SecureIbex disabled:**
![image](https://github.com/user-attachments/assets/8852a77f-c7dc-4871-beea-0bdba6998f9e)
![image](https://github.com/user-attachments/assets/ea243e42-82a1-4bf0-be1e-691a11a89355)


Closes lowRISC/opentitan#25137