### PR TITLE
[hw,keymgr_dpe,rtl] Remove flash seed input as not used currently

### DIFF
--- a/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
+++ b/hw/ip/keymgr_dpe/data/keymgr_dpe.hjson
@@ -89,12 +89,6 @@
       act:     "rcv",
       package: "otp_ctrl_pkg",
     },
-    { struct:  "keymgr_flash",
-      type:    "uni",
-      name:    "flash",
-      act:     "rcv",
-      package: "flash_ctrl_pkg",
-    },
     { struct:  "lc_tx",
       type:    "uni",
       name:    "lc_keymgr_en",
@@ -124,18 +118,6 @@
   ],
 
   param_list: [
-    { name:      "UseOtpSeedsInsteadOfFlash",
-      desc:      '''
-                 Flag indicating whether to use the creator / owner seeds provided
-                 via otp_key_i instead of the the ones provided in flash_i. This option
-                 can be used in integrations where that do not have an embedded flash
-                 controller (in which case flash_i should just be tied off).
-                 ''',
-      type:      "bit",
-      default:   "0",
-      local:     "false",
-      expose:    "true",
-    }
     { name:      "KmacEnMasking",
       desc:      "Flag indicating with kmac masking is enabled",
       type:      "bit",

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cfg.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_cfg.sv
@@ -7,7 +7,7 @@ class keymgr_dpe_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_dpe_reg_block)
   rand kmac_app_agent_cfg m_keymgr_dpe_kmac_agent_cfg;
 
   keymgr_dpe_scoreboard scb;
-  // interface for input data from LC, OTP and flash
+  // interface for input data from LC or OTP
   keymgr_dpe_vif keymgr_dpe_vif;
 
   `uvm_object_utils_begin(keymgr_dpe_env_cfg)

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_pkg.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_env_pkg.sv
@@ -45,9 +45,7 @@ package keymgr_dpe_env_pkg;
     LcStateInvalid,
     OtpDevIdInvalid,
     RomDigestInvalid,
-    RomDigestValidLow,
-    FlashCreatorSeedInvalid,
-    FlashOwnerSeedInvalid
+    RomDigestValidLow
   } keymgr_dpe_invalid_hw_input_type_e;
 
   typedef enum bit[1:0] {

--- a/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
+++ b/hw/ip/keymgr_dpe/dv/env/keymgr_dpe_scoreboard.sv
@@ -1261,10 +1261,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
 
     if (exp_match) `DV_CHECK_EQ(byte_data_q.size, keymgr_pkg::AdvDataWidth / 8)
     act = {<<8{byte_data_q}};
-
-    exp.DiversificationKey = (cfg.keymgr_dpe_vif.UseOtpSeedsInsteadOfFlash) ?
-      cfg.keymgr_dpe_vif.otp_key.creator_seed :
-      cfg.keymgr_dpe_vif.flash.seeds[flash_ctrl_pkg::CreatorSeedIdx];
+    exp.DiversificationKey = cfg.keymgr_dpe_vif.otp_key.creator_seed;
 
     for (int i = 0; i < keymgr_dpe_reg_pkg::NumRomDigestInputs; ++i) begin
       exp.RomDigests[i] = cfg.keymgr_dpe_vif.rom_digests[i].data;
@@ -1300,9 +1297,7 @@ class keymgr_dpe_scoreboard extends cip_base_scoreboard #(
     string str = $sformatf("src_slot: %0d\n", current_key_slot.src_slot);
 
     act = {<<8{byte_data_q}};
-    exp.OwnerRootSecret = (cfg.keymgr_dpe_vif.UseOtpSeedsInsteadOfFlash) ?
-      cfg.keymgr_dpe_vif.otp_key.owner_seed :
-      cfg.keymgr_dpe_vif.flash.seeds[flash_ctrl_pkg::OwnerSeedIdx];
+    exp.OwnerRootSecret = cfg.keymgr_dpe_vif.otp_key.owner_seed;
     get_sw_binding_mirrored_value(exp.SoftwareBinding);
 
     `CREATE_CMP_STR(unused)

--- a/hw/ip/keymgr_dpe/dv/tb.sv
+++ b/hw/ip/keymgr_dpe/dv/tb.sv
@@ -42,11 +42,9 @@ module tb;
   assign keymgr_dpe_if.lfsr_en   = dut.lfsr_en;
 
   // dut
-  keymgr_dpe #(
-    // TODO(opentitan-integrated/issues/332):
-    // need to model the OTP seed input
-    .UseOtpSeedsInsteadOfFlash(keymgr_dpe_if.UseOtpSeedsInsteadOfFlash)
-  ) dut (
+  // TODO(opentitan-integrated/issues/332):
+  // need to model the OTP seed input
+  keymgr_dpe dut (
     .clk_i                (clk           ),
     .rst_ni               (rst_n         ),
     .rst_shadowed_ni      (rst_shadowed_n),
@@ -65,7 +63,6 @@ module tb;
     .rom_digest_i         (keymgr_dpe_if.rom_digests),
     .edn_o                (edn_if[0].req),
     .edn_i                ({edn_if[0].ack, edn_if[0].d_data}),
-    .flash_i              (keymgr_dpe_if.flash),
     .intr_op_done_o       (interrupts[0]),
     .alert_rx_i           (alert_rx   ),
     .alert_tx_o           (alert_tx   ),

--- a/hw/ip/keymgr_dpe/keymgr_dpe.core
+++ b/hw/ip/keymgr_dpe/keymgr_dpe.core
@@ -18,7 +18,6 @@ filesets:
       - lowrisc:prim:sec_anchor
       - lowrisc:prim:secded
       - lowrisc:prim:sparse_fsm
-      - lowrisc:ip:flash_ctrl_pkg
       - lowrisc:ip:keymgr_dpe_pkg
       - lowrisc:ip:kmac_pkg
       - lowrisc:ip:otp_ctrl_pkg


### PR DESCRIPTION
The flash seed input pulls in the flash_ctrl_pkg, which is ip-gened. Darjeeling, who is the only user of keymgr_dpe by now, does not have a flash_ctrl and so it does not use the flash seed input. To remove the dependency of flash_ctrl, remove the flash seed input from keymgr_dpe