### PR TITLE
[ci] Add checkout step to verify-fpga job

### DIFF
--- a/ci/verify-fpga-jobs.yml
+++ b/ci/verify-fpga-jobs.yml
@@ -24,6 +24,7 @@ jobs:
   # but we still want to verify the FPGA jobs.
   condition: succeededOrFailed()
   steps:
+  - template: checkout-template.yml
   - ${{ each job in parameters.fpga_jobs }}:
     - task: DownloadPipelineArtifact@2
       inputs:


### PR DESCRIPTION
Without this, Azure automatically checks out the repo at the time this job runs, not necessarily at the same commit as the previous FPGA jobs.

This can lead to a test not existing when the FPGA tests ran, but now existing when this verify job runs. The verify job then complains that you didn't run that test.