### PR TITLE
[provisioning] remove crc32 from device ID and testonly flags from CP/FT harnesses

### DIFF
--- a/sw/host/provisioning/cp/BUILD
+++ b/sw/host/provisioning/cp/BUILD
@@ -8,7 +8,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_binary(
     name = "cp",
-    testonly = True,
     srcs = ["src/main.rs"],
     deps = [
         "//sw/host/opentitanlib",

--- a/sw/host/provisioning/ft/BUILD
+++ b/sw/host/provisioning/ft/BUILD
@@ -13,7 +13,6 @@ package(default_visibility = ["//visibility:public"])
 [
     rust_binary(
         name = "ft_{}".format(sku),
-        testonly = True,
         srcs = ["src/main.rs"],
         deps = [
             "//sw/host/opentitanlib",
@@ -31,7 +30,6 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "ft_all",
-    testonly = True,
     srcs = [
         ":ft_{}".format(sku)
         for sku in EARLGREY_SKUS.keys()

--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Module for computing OpenTitan device IDs."""
 
-import binascii
 import struct
 from dataclasses import dataclass
 
@@ -74,7 +73,6 @@ class DeviceId():
         si_creator_id: A 16-bit number assigned by the OpenTitan project.
         product_id: A 16-bit number assigned by the OpenTitan project.
         din: A 64-bit unique identifier.
-        crc32: A CRC32 over the above 96-bits.
         package_id: A 16-bit number indicating which package the chip is in.
         sku_id: A 32-bit string indicating the SKU the chip was provisioned for.
     """
@@ -103,14 +101,9 @@ class DeviceId():
         # - Wafer Y coord.
         self.din = din
 
-        # Build CRC32 over HW origin + DIN.
-        self.crc32 = binascii.crc32(
-            struct.pack("<IQ", self._hw_origin, self.din.to_int()))
-
         # Build base unique ID.
         self._base_uid = bytes_to_int(
-            struct.pack("<IQI", self._hw_origin, self.din.to_int(),
-                        self.crc32))
+            struct.pack("<IQI", self._hw_origin, self.din.to_int(), 0))
 
         # Build SKU specific field.
         self.package_id = sku_config.package_id
@@ -147,12 +140,12 @@ class DeviceId():
         print("DIN Wafer:         {}".format(self.din.wafer))
         print("DIN Wafer X Coord: {}".format(self.din.wafer_x_coord))
         print("DIN Wafer Y Coord: {}".format(self.din.wafer_y_coord))
+        print("Reserved:          {}".format(hex(0)))
         print("SKU ID:            {} ({})".format(
             format_hex(self.sku_id),
             self.sku_id.to_bytes(length=4, byteorder="big").decode("utf-8")))
         print("Package ID:        {} ({})".format(self.package_id,
                                                   self._package))
-        print("CRC32:             {}".format(hex(self.crc32)))
 
     def __str__(self):
         return self.to_hexstr()

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -139,7 +139,7 @@ class OtDut():
             fw_bundle_bin = fw_bundle_bin.format(self.sku_config.name,
                                                  "silicon_creator")
 
-        # Assemble bazel command.
+        # Assemble FT command.
         # TODO: support multiple CAs
         # TODO: support cloud KMS CAs
         # TODO: autocompute measurements of expected ROM_EXT + Owner FW payloads

--- a/sw/host/provisioning/orchestrator/tests/device_id_test.py
+++ b/sw/host/provisioning/orchestrator/tests/device_id_test.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unittests for device_id.py module."""
 
-import binascii
 import unittest
 
 import hjson
@@ -105,10 +104,8 @@ class TestDeviceId(unittest.TestCase):
                 format_hex(actual_field, width=2),
                 format_hex(expected_field, width=2)))
 
-    def test_crc32_field(self):
-        expected_field = binascii.crc32(
-            ((self.din.to_int() << 32) | 0x00024001).to_bytes(
-                length=12, byteorder="little"))
+    def test_uid_reserved_field(self):
+        expected_field = 0
         actual_field = (self.device_id.to_int() >> 96) & 0xffffffff
         self.assertEqual(
             actual_field, expected_field, "actual: {}, expected: {}.".format(


### PR DESCRIPTION
This contains two commits that address review feedback in #25151 and #25152. Specifically, this:

1. removes the CRC32 field from the device ID and marks it as reserved, and
2. removes `testonly` flag from CP/FT host bins.