### PR TITLE
[hw,pwrmgr,rtl] Support more than 1 rom_ctrl input

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -72,14 +72,14 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
 
   // Override the default implementation in dv_base_env_cfg.
   //
-  // This is required for the SRAM environment for reuse at the chip level as 2 different
+  // This is required for the ROM environment for reuse at the chip level as 2 different
   // parameterizations of the design and testbench exist, as a result the custom RAL model for the
-  // SRAM memory primitive must also be explicitly parameterized.
+  // ROM memory primitive must also be explicitly parameterized.
   //
   // We cannot instantiate parameterized UVM objects/components using the standard factory
   // mechanisms, so a custom instantiation method is required here.
   //
-  // Note that the SRAM only has 2 RAL models, one is the "default" CSR model,
+  // Note that the ROM only has 2 RAL models, one is the "default" CSR model,
   // and the other is the custom model to represent the memory primitive.
   virtual function dv_base_reg_block create_ral_by_name(string name);
     if (name == RAL_T::type_name) begin

--- a/hw/ip_templates/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr.hjson.tpl
@@ -253,7 +253,9 @@
       type:    "uni",
       name:    "rom_ctrl",
       act:     "rcv",
+      width:   "${NumRomInputs}"
       package: "rom_ctrl_pkg",
+      default: "rom_ctrl_pkg::PWRMGR_DATA_DEFAULT"
     },
 
     { struct:  "lc_tx",
@@ -321,6 +323,13 @@
       desc: "Number of debug reset requets",
       type: "int",
       default: "${len(debug_reset_reqs)}",
+      local: "true"
+    },
+
+    { name: "NumRomInputs",
+      desc: "Number of inputs from ROM_CTRL",
+      type: "int",
+      default: "${NumRomInputs}",
       local: "true"
     },
 

--- a/hw/ip_templates/pwrmgr/data/pwrmgr.tpldesc.hjson
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr.tpldesc.hjson
@@ -58,5 +58,11 @@
       type: "bool"
       default: false
     }
+    {
+      name: "NumRomInputs"
+      desc: "Number of ROM inputs"
+      type: "int"
+      default: "1"
+    }
   ]
 }

--- a/hw/ip_templates/pwrmgr/dv/cov/pwrmgr_cov_bind.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/cov/pwrmgr_cov_bind.sv.tpl
@@ -15,16 +15,18 @@ module pwrmgr_cov_bind;
     .rst_ni (rst_ni),
     .val   (lc_hw_debug_en_i)
   );
+% for i in range(NumRomInputs):
 
-  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_rom_ctrl_good_mubi_cov_if (
+  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_rom_ctrl${i}_good_mubi_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (rom_ctrl_i.done)
+    .mubi   (rom_ctrl_i[${i}].done)
   );
 
-  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_rom_ctrl_done_mubi_cov_if (
+  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_rom_ctrl${i}_done_mubi_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (rom_ctrl_i.good)
+    .mubi   (rom_ctrl_i[${i}].good)
   );
+% endfor
 
   bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_sw_rst_req_mubi_cov_if (
     .rst_ni (rst_ni),

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_if.sv
@@ -45,9 +45,9 @@ interface pwrmgr_if (
   logic                       [  pwrmgr_reg_pkg::NumWkups-1:0] wakeups_i;
   logic                       [pwrmgr_reg_pkg::NumRstReqs-1:0] rstreqs_i;
 
-  logic                                                        strap;
-  logic                                                        low_power;
-  rom_ctrl_pkg::pwrmgr_data_t                                  rom_ctrl;
+  logic                                                          strap;
+  logic                                                          low_power;
+  rom_ctrl_pkg::pwrmgr_data_t [pwrmgr_reg_pkg::NumRomInputs-1:0] rom_ctrl;
 
   prim_mubi_pkg::mubi4_t                                       sw_rst_req_i;
 

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -200,10 +200,13 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
   task rom_coverage_collector();
     forever
-      @(cfg.pwrmgr_vif.rom_ctrl or cfg.pwrmgr_vif.lc_hw_debug_en or cfg.pwrmgr_vif.lc_dft_en) begin
+      @(cfg.pwrmgr_vif.rom_ctrl[0] or
+        cfg.pwrmgr_vif.lc_hw_debug_en or
+        cfg.pwrmgr_vif.lc_dft_en) begin
         if (cfg.en_cov) begin
-          cov.rom_active_blockers_cg.sample(cfg.pwrmgr_vif.rom_ctrl.done,
-                                            cfg.pwrmgr_vif.rom_ctrl.good, cfg.pwrmgr_vif.lc_dft_en,
+          cov.rom_active_blockers_cg.sample(cfg.pwrmgr_vif.rom_ctrl[0].done,
+                                            cfg.pwrmgr_vif.rom_ctrl[0].good,
+                                            cfg.pwrmgr_vif.lc_dft_en,
                                             cfg.pwrmgr_vif.lc_hw_debug_en);
         end
       end

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -798,44 +798,44 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
                                          bad_bits[MUBI4W-1:0] != prim_mubi_pkg::MuBi4False;
                                          bad_bits[MUBI4W-1:0] != prim_mubi_pkg::MuBi4True;)
       `uvm_info(`gfn, $sformatf("add_rom_rsp_noise to 0x%x", bad_bits), UVM_HIGH)
-      cfg.pwrmgr_vif.rom_ctrl = bad_bits;
+      cfg.pwrmgr_vif.rom_ctrl[0] = bad_bits;
       #(delay * 10ns);
     end
   endtask : add_rom_rsp_noise
 
   // Drive rom_ctrl at post reset stage
   virtual task init_rom_response();
-    if (cfg.pwrmgr_vif.rom_ctrl.done != prim_mubi_pkg::MuBi4True) begin
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+    if (cfg.pwrmgr_vif.rom_ctrl[0].done != prim_mubi_pkg::MuBi4True) begin
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
       `DV_WAIT(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheckDone)
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
       cfg.slow_clk_rst_vif.wait_clks(10);
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
       cfg.slow_clk_rst_vif.wait_clks(5);
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
       cfg.slow_clk_rst_vif.wait_clks(5);
-      cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
-      cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+      cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
+      cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
     end
     `uvm_info(`gfn, "Set rom response to MuBi4True", UVM_MEDIUM)
   endtask

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
@@ -44,14 +44,14 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
           .t_weight(1), .f_weight(3), .other_weight(1)
       );
       cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(3), .other_weight(1));
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(1), .f_weight(3), .other_weight(1));
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(3), .other_weight(1));
 
       `uvm_info(`gfn, $sformatf(
-                "Set done 0x%x, good 0x%x", cfg.pwrmgr_vif.rom_ctrl.done,
-                cfg.pwrmgr_vif.rom_ctrl.good), UVM_MEDIUM)
+                "Set done 0x%x, good 0x%x", cfg.pwrmgr_vif.rom_ctrl[0].done,
+                cfg.pwrmgr_vif.rom_ctrl[0].good), UVM_MEDIUM)
 
       enabled_resets = resets_en & resets;
       `uvm_info(`gfn, $sformatf(
@@ -82,7 +82,7 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
       `uvm_info(`gfn, "Wait for Fast State NE FastPwrStateActive", UVM_MEDIUM)
       `DV_WAIT(cfg.pwrmgr_vif.fast_state != pwrmgr_pkg::FastPwrStateActive)
 
-      if (cfg.pwrmgr_vif.rom_ctrl.done != prim_mubi_pkg::MuBi4True) begin
+      if (cfg.pwrmgr_vif.rom_ctrl[0].done != prim_mubi_pkg::MuBi4True) begin
         // Check fast state is not FastPwrStateActive for a while
         repeat (20) begin
           @cfg.slow_clk_rst_vif.cb;
@@ -91,17 +91,17 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
 
         // Set done to True.
         `uvm_info(`gfn, "Set rom_ctrl.done input True", UVM_MEDIUM)
-        cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+        cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
         cfg.slow_clk_rst_vif.wait_clks(2);
       end
 
-      if (cfg.pwrmgr_vif.rom_ctrl.good != prim_mubi_pkg::MuBi4True) begin
+      if (cfg.pwrmgr_vif.rom_ctrl[0].good != prim_mubi_pkg::MuBi4True) begin
         bit blocked = 0;
         detect_block(blocked);
         if (blocked) begin
           if (release_by_good) begin
             // Set to good.
-            cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+            cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
           end else begin
             // Disable rom checks.
             `uvm_info(`gfn, "Set lc ctrl inputs On", UVM_MEDIUM)

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
@@ -19,15 +19,15 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
   // add invalid value to rom_ctrl
   virtual task twirl_rom_response();
     add_rom_rsp_noise();
-    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4False;
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4False;
     cfg.clk_rst_vif.wait_clks(5);
     add_rom_rsp_noise();
     wait(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheckDone);
     add_rom_rsp_noise();
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
     cfg.clk_rst_vif.wait_clks(5);
-    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
   endtask
 
   task body();

--- a/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv.tpl
@@ -29,17 +29,17 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
   // compliant with "ROM Integrity Checks" at
   // https://opentitan.org/book/hw/top_${topname}/ip_autogen/pwrmgr/doc/theory_of_operation.html#rom-integrity-checks
   virtual task twirl_rom_response();
-    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4False;
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4False;
     @(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateAckPwrUp);
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
     @(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheckDone);
     cfg.clk_rst_vif.wait_clks(10);
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4False;
     cfg.clk_rst_vif.wait_clks(5);
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
     cfg.clk_rst_vif.wait_clks(5);
-    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
   endtask
 
   task body();
@@ -136,9 +136,9 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
 
       if (mubi_mode == PwrmgrMubiRomCtrl) begin
         add_rom_rsp_noise();
-        cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+        cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
         cfg.clk_rst_vif.wait_clks(5);
-        cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+        cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
       end
 
       // This is the expected side-effect of the low power entry reset, since the source of the

--- a/hw/ip_templates/pwrmgr/dv/tb.sv.tpl
+++ b/hw/ip_templates/pwrmgr/dv/tb.sv.tpl
@@ -102,7 +102,7 @@ module tb;
     .fetch_en_o(pwrmgr_if.fetch_en),
     .wakeups_i (pwrmgr_if.wakeups_i),
 % if wait_for_external_reset:
-    // TOOD(#22710): properly cooperate with `pwrmgr_if.rstreqs_i[1]`
+    // TODO(#22710): properly cooperate with `pwrmgr_if.rstreqs_i[1]`
     .rstreqs_i ({int_reset_req, pwrmgr_if.rstreqs_i[0]}),
 % else:
     .rstreqs_i (pwrmgr_if.rstreqs_i),

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
@@ -77,7 +77,7 @@ module pwrmgr
 
   // rom_ctrl interface
   // SEC_CM: ROM_CTRL.INTERSIG.MUBI
-  input rom_ctrl_pkg::pwrmgr_data_t rom_ctrl_i,
+  input rom_ctrl_pkg::pwrmgr_data_t [NumRomInputs-1:0] rom_ctrl_i,
 
   // software issued reset request
   // SEC_CM: RSTMGR.INTERSIG.MUBI
@@ -272,8 +272,10 @@ module pwrmgr
   pwr_flash_t flash_rsp;
   pwr_otp_rsp_t otp_rsp;
 
-  prim_mubi_pkg::mubi4_t rom_ctrl_done;
-  prim_mubi_pkg::mubi4_t rom_ctrl_good;
+  prim_mubi_pkg::mubi4_t [NumRomInputs-1:0] rom_ctrl_done_async;
+  prim_mubi_pkg::mubi4_t [NumRomInputs-1:0] rom_ctrl_done;
+  prim_mubi_pkg::mubi4_t rom_ctrl_done_combined;
+  prim_mubi_pkg::mubi4_t rom_ctrl_good_combined;
 
   logic core_sleeping;
   logic low_power_entry;
@@ -402,6 +404,11 @@ module pwrmgr
   ///  cdc handling
   ////////////////////////////
 
+  // Assign to array for convenience in CDC block below.
+  for (genvar k = 0; k < NumRomInputs; k ++) begin : gen_done_assign
+    assign rom_ctrl_done_async[k] = rom_ctrl_i[k].done;
+  end
+
   pwrmgr_cdc u_cdc (
     .clk_i,
     .rst_ni,
@@ -466,7 +473,7 @@ module pwrmgr
     .otp_o(otp_rsp),
 
     // rom_ctrl signals
-    .rom_ctrl_done_i(rom_ctrl_i.done),
+    .rom_ctrl_done_i(rom_ctrl_done_async),
     .rom_ctrl_done_o(rom_ctrl_done),
 
     // core sleeping
@@ -474,9 +481,20 @@ module pwrmgr
     .core_sleeping_o(core_sleeping)
 
   );
-  // rom_ctrl_i.good is not synchronized as it acts as a "payload" signal
-  // to "done". Good is only observed if "done" is high.
-  assign rom_ctrl_good = rom_ctrl_i.good;
+
+  always_comb begin
+    rom_ctrl_done_combined = prim_mubi_pkg::MuBi4True;
+    rom_ctrl_good_combined = prim_mubi_pkg::MuBi4True;
+    for (int k = 0; k < NumRomInputs; k++) begin
+      rom_ctrl_done_combined =
+          prim_mubi_pkg::mubi4_and_hi(rom_ctrl_done_combined, rom_ctrl_done[k]);
+      // rom_ctrl_i.good is not synchronized as it acts as a "payload" signal
+      // to "done". Good is only observed if "done" is high.
+      rom_ctrl_good_combined =
+          prim_mubi_pkg::mubi4_and_hi(rom_ctrl_good_combined, rom_ctrl_i[k].good);
+    end
+  end
+
   assign hw2reg.cfg_cdc_sync.d = 1'b0;
 
   ////////////////////////////
@@ -659,8 +677,8 @@ module pwrmgr
     .flash_idle_i      (flash_rsp.flash_idle),
 
     // rom_ctrl
-    .rom_ctrl_done_i   (rom_ctrl_done),
-    .rom_ctrl_good_i   (rom_ctrl_good),
+    .rom_ctrl_done_i   (rom_ctrl_done_combined),
+    .rom_ctrl_good_i   (rom_ctrl_good_combined),
 
     // processing element
     .fetch_en_o,

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr_cdc.sv
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr_cdc.sv
@@ -71,8 +71,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   input pwr_ast_rsp_t ast_i,
 
   // rom_ctrl signals
-  input prim_mubi_pkg::mubi4_t rom_ctrl_done_i,
-  output prim_mubi_pkg::mubi4_t rom_ctrl_done_o,
+  input prim_mubi_pkg::mubi4_t [NumRomInputs-1:0] rom_ctrl_done_i,
+  output prim_mubi_pkg::mubi4_t [NumRomInputs-1:0] rom_ctrl_done_o,
 
   // core sleeping
   input core_sleeping_i,
@@ -306,16 +306,18 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .q_o(otp_o)
   );
 
-  prim_mubi4_sync #(
-    .NumCopies(1),
-    .AsyncOn(1),
-    .StabilityCheck(1)
-  ) u_sync_rom_ctrl (
-    .clk_i,
-    .rst_ni,
-    .mubi_i(rom_ctrl_done_i),
-    .mubi_o({rom_ctrl_done_o})
-  );
+  for (genvar k = 0; k < NumRomInputs; k++) begin : gen_rom_inputs
+    prim_mubi4_sync #(
+      .NumCopies(1),
+      .AsyncOn(1),
+      .StabilityCheck(1)
+    ) u_sync_rom_ctrl (
+      .clk_i,
+      .rst_ni,
+      .mubi_i(rom_ctrl_done_i[k]),
+      .mubi_o({rom_ctrl_done_o[k]})
+    );
+  end
 
   ////////////////////////////////
   // Handshake

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3360,8 +3360,8 @@
           type: uni
           act: rcv
           width: 1
+          default: rom_ctrl_pkg::PWRMGR_DATA_DEFAULT
           inst_name: pwrmgr_aon
-          default: ""
           top_signame: rom_ctrl_pwrmgr_data
           index: -1
         }
@@ -18543,8 +18543,8 @@
         type: uni
         act: rcv
         width: 1
+        default: rom_ctrl_pkg::PWRMGR_DATA_DEFAULT
         inst_name: pwrmgr_aon
-        default: ""
         top_signame: rom_ctrl_pwrmgr_data
         index: -1
       }

--- a/hw/top_earlgrey/dv/env/chip_if.sv
+++ b/hw/top_earlgrey/dv/env/chip_if.sv
@@ -686,8 +686,8 @@ interface chip_if;
 
   wire flash_core1_host_req = 0;
 `else
-  wire rom_ctrl_done = `PWRMGR_HIER.rom_ctrl_i.done == prim_mubi_pkg::MuBi4True;
-  wire rom_ctrl_good = `PWRMGR_HIER.rom_ctrl_i.good == prim_mubi_pkg::MuBi4True;
+  wire rom_ctrl_done = `PWRMGR_HIER.rom_ctrl_i[0].done == prim_mubi_pkg::MuBi4True;
+  wire rom_ctrl_good = `PWRMGR_HIER.rom_ctrl_i[0].good == prim_mubi_pkg::MuBi4True;
 
   wire rv_core_ibex_icache_otp_key_req = `RV_CORE_IBEX_HIER.icache_otp_key_o.req;
   wire rv_core_ibex_icache_otp_key_ack = `RV_CORE_IBEX_HIER.icache_otp_key_i.ack;

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr.hjson
@@ -264,7 +264,9 @@
       type:    "uni",
       name:    "rom_ctrl",
       act:     "rcv",
+      width:   "1"
       package: "rom_ctrl_pkg",
+      default: "rom_ctrl_pkg::PWRMGR_DATA_DEFAULT"
     },
 
     { struct:  "lc_tx",
@@ -363,6 +365,13 @@
 
     { name: "NumDebugRstReqs",
       desc: "Number of debug reset requets",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+
+    { name: "NumRomInputs",
+      desc: "Number of inputs from ROM_CTRL",
       type: "int",
       default: "1",
       local: "true"

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/top_earlgrey_pwrmgr.ipconfig.hjson
@@ -80,6 +80,7 @@
     }
     NumRstReqs: 2
     wait_for_external_reset: false
+    NumRomInputs: 1
     topname: earlgrey
   }
 }

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/cov/pwrmgr_cov_bind.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/cov/pwrmgr_cov_bind.sv
@@ -16,14 +16,14 @@ module pwrmgr_cov_bind;
     .val   (lc_hw_debug_en_i)
   );
 
-  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_rom_ctrl_good_mubi_cov_if (
+  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_rom_ctrl0_good_mubi_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (rom_ctrl_i.done)
+    .mubi   (rom_ctrl_i[0].done)
   );
 
-  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_rom_ctrl_done_mubi_cov_if (
+  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_rom_ctrl0_done_mubi_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (rom_ctrl_i.good)
+    .mubi   (rom_ctrl_i[0].good)
   );
 
   bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_sw_rst_req_mubi_cov_if (

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
@@ -45,9 +45,9 @@ interface pwrmgr_if (
   logic                       [  pwrmgr_reg_pkg::NumWkups-1:0] wakeups_i;
   logic                       [pwrmgr_reg_pkg::NumRstReqs-1:0] rstreqs_i;
 
-  logic                                                        strap;
-  logic                                                        low_power;
-  rom_ctrl_pkg::pwrmgr_data_t                                  rom_ctrl;
+  logic                                                          strap;
+  logic                                                          low_power;
+  rom_ctrl_pkg::pwrmgr_data_t [pwrmgr_reg_pkg::NumRomInputs-1:0] rom_ctrl;
 
   prim_mubi_pkg::mubi4_t                                       sw_rst_req_i;
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -200,10 +200,13 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
   task rom_coverage_collector();
     forever
-      @(cfg.pwrmgr_vif.rom_ctrl or cfg.pwrmgr_vif.lc_hw_debug_en or cfg.pwrmgr_vif.lc_dft_en) begin
+      @(cfg.pwrmgr_vif.rom_ctrl[0] or
+        cfg.pwrmgr_vif.lc_hw_debug_en or
+        cfg.pwrmgr_vif.lc_dft_en) begin
         if (cfg.en_cov) begin
-          cov.rom_active_blockers_cg.sample(cfg.pwrmgr_vif.rom_ctrl.done,
-                                            cfg.pwrmgr_vif.rom_ctrl.good, cfg.pwrmgr_vif.lc_dft_en,
+          cov.rom_active_blockers_cg.sample(cfg.pwrmgr_vif.rom_ctrl[0].done,
+                                            cfg.pwrmgr_vif.rom_ctrl[0].good,
+                                            cfg.pwrmgr_vif.lc_dft_en,
                                             cfg.pwrmgr_vif.lc_hw_debug_en);
         end
       end

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -798,44 +798,44 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
                                          bad_bits[MUBI4W-1:0] != prim_mubi_pkg::MuBi4False;
                                          bad_bits[MUBI4W-1:0] != prim_mubi_pkg::MuBi4True;)
       `uvm_info(`gfn, $sformatf("add_rom_rsp_noise to 0x%x", bad_bits), UVM_HIGH)
-      cfg.pwrmgr_vif.rom_ctrl = bad_bits;
+      cfg.pwrmgr_vif.rom_ctrl[0] = bad_bits;
       #(delay * 10ns);
     end
   endtask : add_rom_rsp_noise
 
   // Drive rom_ctrl at post reset stage
   virtual task init_rom_response();
-    if (cfg.pwrmgr_vif.rom_ctrl.done != prim_mubi_pkg::MuBi4True) begin
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+    if (cfg.pwrmgr_vif.rom_ctrl[0].done != prim_mubi_pkg::MuBi4True) begin
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
       `DV_WAIT(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheckDone)
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
       cfg.slow_clk_rst_vif.wait_clks(10);
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
       cfg.slow_clk_rst_vif.wait_clks(5);
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(1), .other_weight(1)
       );
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(0), .f_weight(1), .other_weight(1)
       );
       cfg.slow_clk_rst_vif.wait_clks(5);
-      cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
-      cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+      cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
+      cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
     end
     `uvm_info(`gfn, "Set rom response to MuBi4True", UVM_MEDIUM)
   endtask

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_disable_rom_integrity_check_vseq.sv
@@ -44,14 +44,14 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
           .t_weight(1), .f_weight(3), .other_weight(1)
       );
       cfg.pwrmgr_vif.lc_dft_en = get_rand_lc_tx_val(.t_weight(1), .f_weight(3), .other_weight(1));
-      cfg.pwrmgr_vif.rom_ctrl.done = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].done = get_rand_mubi4_val(
           .t_weight(1), .f_weight(3), .other_weight(1));
-      cfg.pwrmgr_vif.rom_ctrl.good = get_rand_mubi4_val(
+      cfg.pwrmgr_vif.rom_ctrl[0].good = get_rand_mubi4_val(
           .t_weight(1), .f_weight(3), .other_weight(1));
 
       `uvm_info(`gfn, $sformatf(
-                "Set done 0x%x, good 0x%x", cfg.pwrmgr_vif.rom_ctrl.done,
-                cfg.pwrmgr_vif.rom_ctrl.good), UVM_MEDIUM)
+                "Set done 0x%x, good 0x%x", cfg.pwrmgr_vif.rom_ctrl[0].done,
+                cfg.pwrmgr_vif.rom_ctrl[0].good), UVM_MEDIUM)
 
       enabled_resets = resets_en & resets;
       `uvm_info(`gfn, $sformatf(
@@ -82,7 +82,7 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
       `uvm_info(`gfn, "Wait for Fast State NE FastPwrStateActive", UVM_MEDIUM)
       `DV_WAIT(cfg.pwrmgr_vif.fast_state != pwrmgr_pkg::FastPwrStateActive)
 
-      if (cfg.pwrmgr_vif.rom_ctrl.done != prim_mubi_pkg::MuBi4True) begin
+      if (cfg.pwrmgr_vif.rom_ctrl[0].done != prim_mubi_pkg::MuBi4True) begin
         // Check fast state is not FastPwrStateActive for a while
         repeat (20) begin
           @cfg.slow_clk_rst_vif.cb;
@@ -91,17 +91,17 @@ class pwrmgr_disable_rom_integrity_check_vseq extends pwrmgr_base_vseq;
 
         // Set done to True.
         `uvm_info(`gfn, "Set rom_ctrl.done input True", UVM_MEDIUM)
-        cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+        cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
         cfg.slow_clk_rst_vif.wait_clks(2);
       end
 
-      if (cfg.pwrmgr_vif.rom_ctrl.good != prim_mubi_pkg::MuBi4True) begin
+      if (cfg.pwrmgr_vif.rom_ctrl[0].good != prim_mubi_pkg::MuBi4True) begin
         bit blocked = 0;
         detect_block(blocked);
         if (blocked) begin
           if (release_by_good) begin
             // Set to good.
-            cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+            cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
           end else begin
             // Disable rom checks.
             `uvm_info(`gfn, "Set lc ctrl inputs On", UVM_MEDIUM)

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
@@ -19,15 +19,15 @@ class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_wakeup_reset_vseq;
   // add invalid value to rom_ctrl
   virtual task twirl_rom_response();
     add_rom_rsp_noise();
-    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4False;
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4False;
     cfg.clk_rst_vif.wait_clks(5);
     add_rom_rsp_noise();
     wait(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheckDone);
     add_rom_rsp_noise();
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
     cfg.clk_rst_vif.wait_clks(5);
-    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
   endtask
 
   task body();

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
@@ -29,17 +29,17 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
   // compliant with "ROM Integrity Checks" at
   // https://opentitan.org/book/hw/top_earlgrey/ip_autogen/pwrmgr/doc/theory_of_operation.html#rom-integrity-checks
   virtual task twirl_rom_response();
-    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4False;
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4False;
     @(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateAckPwrUp);
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
     @(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheckDone);
     cfg.clk_rst_vif.wait_clks(10);
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4False;
     cfg.clk_rst_vif.wait_clks(5);
-    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
     cfg.clk_rst_vif.wait_clks(5);
-    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+    cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
   endtask
 
   task body();
@@ -136,9 +136,9 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
 
       if (mubi_mode == PwrmgrMubiRomCtrl) begin
         add_rom_rsp_noise();
-        cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+        cfg.pwrmgr_vif.rom_ctrl[0].good = prim_mubi_pkg::MuBi4True;
         cfg.clk_rst_vif.wait_clks(5);
-        cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+        cfg.pwrmgr_vif.rom_ctrl[0].done = prim_mubi_pkg::MuBi4True;
       end
 
       // This is the expected side-effect of the low power entry reset, since the source of the

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -74,7 +74,7 @@ module pwrmgr
 
   // rom_ctrl interface
   // SEC_CM: ROM_CTRL.INTERSIG.MUBI
-  input rom_ctrl_pkg::pwrmgr_data_t rom_ctrl_i,
+  input rom_ctrl_pkg::pwrmgr_data_t [NumRomInputs-1:0] rom_ctrl_i,
 
   // software issued reset request
   // SEC_CM: RSTMGR.INTERSIG.MUBI
@@ -269,8 +269,10 @@ module pwrmgr
   pwr_flash_t flash_rsp;
   pwr_otp_rsp_t otp_rsp;
 
-  prim_mubi_pkg::mubi4_t rom_ctrl_done;
-  prim_mubi_pkg::mubi4_t rom_ctrl_good;
+  prim_mubi_pkg::mubi4_t [NumRomInputs-1:0] rom_ctrl_done_async;
+  prim_mubi_pkg::mubi4_t [NumRomInputs-1:0] rom_ctrl_done;
+  prim_mubi_pkg::mubi4_t rom_ctrl_done_combined;
+  prim_mubi_pkg::mubi4_t rom_ctrl_good_combined;
 
   logic core_sleeping;
   logic low_power_entry;
@@ -399,6 +401,11 @@ module pwrmgr
   ///  cdc handling
   ////////////////////////////
 
+  // Assign to array for convenience in CDC block below.
+  for (genvar k = 0; k < NumRomInputs; k ++) begin : gen_done_assign
+    assign rom_ctrl_done_async[k] = rom_ctrl_i[k].done;
+  end
+
   pwrmgr_cdc u_cdc (
     .clk_i,
     .rst_ni,
@@ -463,7 +470,7 @@ module pwrmgr
     .otp_o(otp_rsp),
 
     // rom_ctrl signals
-    .rom_ctrl_done_i(rom_ctrl_i.done),
+    .rom_ctrl_done_i(rom_ctrl_done_async),
     .rom_ctrl_done_o(rom_ctrl_done),
 
     // core sleeping
@@ -471,9 +478,20 @@ module pwrmgr
     .core_sleeping_o(core_sleeping)
 
   );
-  // rom_ctrl_i.good is not synchronized as it acts as a "payload" signal
-  // to "done". Good is only observed if "done" is high.
-  assign rom_ctrl_good = rom_ctrl_i.good;
+
+  always_comb begin
+    rom_ctrl_done_combined = prim_mubi_pkg::MuBi4True;
+    rom_ctrl_good_combined = prim_mubi_pkg::MuBi4True;
+    for (int k = 0; k < NumRomInputs; k++) begin
+      rom_ctrl_done_combined =
+          prim_mubi_pkg::mubi4_and_hi(rom_ctrl_done_combined, rom_ctrl_done[k]);
+      // rom_ctrl_i.good is not synchronized as it acts as a "payload" signal
+      // to "done". Good is only observed if "done" is high.
+      rom_ctrl_good_combined =
+          prim_mubi_pkg::mubi4_and_hi(rom_ctrl_good_combined, rom_ctrl_i[k].good);
+    end
+  end
+
   assign hw2reg.cfg_cdc_sync.d = 1'b0;
 
   ////////////////////////////
@@ -632,8 +650,8 @@ module pwrmgr
     .flash_idle_i      (flash_rsp.flash_idle),
 
     // rom_ctrl
-    .rom_ctrl_done_i   (rom_ctrl_done),
-    .rom_ctrl_good_i   (rom_ctrl_good),
+    .rom_ctrl_done_i   (rom_ctrl_done_combined),
+    .rom_ctrl_good_i   (rom_ctrl_good_combined),
 
     // processing element
     .fetch_en_o,

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_cdc.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_cdc.sv
@@ -71,8 +71,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   input pwr_ast_rsp_t ast_i,
 
   // rom_ctrl signals
-  input prim_mubi_pkg::mubi4_t rom_ctrl_done_i,
-  output prim_mubi_pkg::mubi4_t rom_ctrl_done_o,
+  input prim_mubi_pkg::mubi4_t [NumRomInputs-1:0] rom_ctrl_done_i,
+  output prim_mubi_pkg::mubi4_t [NumRomInputs-1:0] rom_ctrl_done_o,
 
   // core sleeping
   input core_sleeping_i,
@@ -306,16 +306,18 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .q_o(otp_o)
   );
 
-  prim_mubi4_sync #(
-    .NumCopies(1),
-    .AsyncOn(1),
-    .StabilityCheck(1)
-  ) u_sync_rom_ctrl (
-    .clk_i,
-    .rst_ni,
-    .mubi_i(rom_ctrl_done_i),
-    .mubi_o({rom_ctrl_done_o})
-  );
+  for (genvar k = 0; k < NumRomInputs; k++) begin : gen_rom_inputs
+    prim_mubi4_sync #(
+      .NumCopies(1),
+      .AsyncOn(1),
+      .StabilityCheck(1)
+    ) u_sync_rom_ctrl (
+      .clk_i,
+      .rst_ni,
+      .mubi_i(rom_ctrl_done_i[k]),
+      .mubi_o({rom_ctrl_done_o[k]})
+    );
+  end
 
   ////////////////////////////////
   // Handshake

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_reg_pkg.sv
@@ -17,6 +17,7 @@ package pwrmgr_reg_pkg;
   parameter int NumRstReqs = 2;
   parameter int NumIntRstReqs = 2;
   parameter int NumDebugRstReqs = 1;
+  parameter int NumRomInputs = 1;
   parameter int ResetMainPwrIdx = 2;
   parameter int ResetEscIdx = 3;
   parameter int ResetNdmIdx = 4;

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -375,6 +375,9 @@ def generate_pwrmgr(top: Dict[str, object], out_path: Path) -> None:
     n_rstreqs = len(top["reset_requests"]["peripheral"])
     log.info("Found {} reset request signals".format(n_rstreqs))
 
+    n_rom_ctrl = lib.num_rom_ctrl(top['module'])
+    assert n_rom_ctrl > 0
+
     if n_wkups < 1:
         n_wkups = 1
         log.warning(
@@ -390,7 +393,8 @@ def generate_pwrmgr(top: Dict[str, object], out_path: Path) -> None:
         "Wkups": top["wakeups"],
         "rst_reqs": top["reset_requests"],
         "NumRstReqs": n_rstreqs,
-        "wait_for_external_reset": top['power']['wait_for_external_reset']
+        "wait_for_external_reset": top['power']['wait_for_external_reset'],
+        "NumRomInputs": n_rom_ctrl
     }
 
     ipgen_render("pwrmgr", topname, params, out_path)


### PR DESCRIPTION
Darjeeling has 2 rom_ctrls. Template the rom_ctrl input to support more than 1 rom_ctrl input.

This pulls over work from the integrated_dev branch.