### PR TITLE
[ci] increase GitHub bitstream job timeout

### DIFF
--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -18,7 +18,7 @@ jobs:
   bitstream:
     name: Build bitstream
     runs-on: ubuntu-22.04-bitstream
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The job itself doesn't take much time, but it needs time to wait for license to become available.