### PR TITLE
[cherry-pick] manually cherry-pick of #24980 and #25136 onto `earlgrey_1.0.0` branch

### DIFF
--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -130,6 +130,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/sigverify:ecdsa_p256_key",
+        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
         "//sw/device/silicon_creator/manuf/lib:flash_info_fields",
     ],
 )
@@ -171,6 +172,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/base:util",
         "//sw/device/silicon_creator/lib/cert:dice_keys",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/cert/dice.c
+++ b/sw/device/silicon_creator/lib/cert/dice.c
@@ -19,6 +19,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 #include "sw/device/silicon_creator/manuf/lib/flash_info_fields.h"
 
 static ecdsa_p256_signature_t curr_tbs_signature = {.r = {0}, .s = {0}};
@@ -188,4 +189,18 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
       *kDiceKeyCdi1.keymgr_diversifier));
 
   return kErrorOk;
+}
+
+rom_error_t dice_cert_check_valid(const perso_tlv_cert_obj_t *cert_obj,
+                                  const hmac_digest_t *pubkey_id,
+                                  const ecdsa_p256_public_key_t *pubkey,
+                                  hardened_bool_t *cert_valid_output) {
+  // The function prototype is shared across X.509 and CWT cert formats.
+  // For X.509, we only check the serial_number but not public key contents.
+  OT_DISCARD(pubkey);
+
+  size_t cert_size = cert_obj->cert_body_size;
+  return cert_x509_asn1_check_serial_number(cert_obj->cert_body_p, 0,
+                                            (uint8_t *)pubkey_id->digest,
+                                            cert_valid_output, &cert_size);
 }

--- a/sw/device/silicon_creator/lib/cert/dice.h
+++ b/sw/device/silicon_creator/lib/cert/dice.h
@@ -13,6 +13,7 @@
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 
 enum {
   /**
@@ -98,5 +99,22 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
                                   cert_key_id_pair_t *key_ids,
                                   ecdsa_p256_public_key_t *cdi_1_pubkey,
                                   uint8_t *cert, size_t *cert_size);
+
+/**
+ * Check if a subject pubkey ID (serial number) or subject pubkey match the
+ * contents of the provided certificate.
+ *
+ * @param cert_obj Pointer to the TLV cert object from the flash.
+ * @param pubkey_id Pointer to the subject pubkey ID (serial number).
+ * @param pubkey Pointer to the subject pubkey contents.
+ * @param[out] cert_valid_output If unmatched, set `cert_valid_output` to
+ * kHardenedBoolFalse for triggering cert regeneration.
+ * @return errors encountered during the check.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t dice_cert_check_valid(const perso_tlv_cert_obj_t *cert_obj,
+                                  const hmac_digest_t *pubkey_id,
+                                  const ecdsa_p256_public_key_t *pubkey,
+                                  hardened_bool_t *cert_valid_output);
 
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_DICE_H_

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -20,6 +20,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/otbn_boot_services.h"
 #include "sw/device/silicon_creator/lib/sigverify/ecdsa_p256_key.h"
+#include "sw/device/silicon_creator/manuf/base/perso_tlv_data.h"
 
 #include "otp_ctrl_regs.h"  // Generated.
 
@@ -306,5 +307,13 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
       kDiceKeyCdi1.keygen_seed_idx, kDiceKeyCdi1.type,
       *kDiceKeyCdi1.keymgr_diversifier));
 
+  return kErrorOk;
+}
+
+rom_error_t dice_cert_check_valid(const perso_tlv_cert_obj_t *cert_obj,
+                                  const hmac_digest_t *pubkey_id,
+                                  const ecdsa_p256_public_key_t *pubkey,
+                                  hardened_bool_t *cert_valid_output) {
+  // TODO(lowRISC/opentitan:#24281): implement body
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
+++ b/sw/device/silicon_creator/manuf/base/perso_tlv_data.c
@@ -26,10 +26,10 @@ rom_error_t perso_tlv_get_cert_obj(uint8_t *buf, size_t ltv_buf_size,
   // Extract LTV object type.
   PERSO_TLV_GET_FIELD(Objh, Type, objh, &obj_type);
   obj->obj_type = obj_type;
-  if (obj_type != kPersoObjectTypeX509Cert &&
-      obj_type != kPersoObjectTypeCwtCert) {
-    return kErrorPersoTlvCertObjNotFound;
-  }
+  /*if (obj_type != kPersoObjectTypeX509Cert &&*/
+  /*obj_type != kPersoObjectTypeCwtCert) {*/
+  /*return kErrorPersoTlvCertObjNotFound;*/
+  /*}*/
   buf += sizeof(perso_tlv_object_header_t);
   ltv_buf_size -= sizeof(perso_tlv_object_header_t);
 

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -181,6 +181,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:boot_log",
         "//sw/device/silicon_creator/lib:dbg_print",
+        "//sw/device/silicon_creator/lib:keymgr_binding",
         "//sw/device/silicon_creator/lib:manifest",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/lib:otbn_boot_services",

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -1,0 +1,32 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "fpga_params",
+    "opentitan_test",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+opentitan_test(
+    name = "no_refresh_test",
+    srcs = ["no_refresh_test.c"],
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
+        exit_success = "Rebooted\r\n",
+    ),
+    deps = [
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+    ],
+)

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/no_refresh_test.c
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/no_refresh_test.c
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  retention_sram_t *retram = retention_sram_get();
+
+  if (bitfield_bit32_read(retram->creator.reset_reasons,
+                          kRstmgrReasonPowerOn)) {
+    LOG_INFO("Rebooting");
+    rstmgr_reset();
+    return false;
+  }
+  LOG_INFO("Rebooted");
+  return true;
+}


### PR DESCRIPTION
This cherry pick includes a bug fix to the ROM_EXT that ensures the DICE CDI_1 private is left in OTBN DMEM when the owner firmware is booted. Additionally, this adds a ROM_EXT E2E test to ensure the DICE certs are valid after an update.