### PR TITLE
[SiVal] Fix branch name when publishing the  nightlies resport

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,5 +78,5 @@ jobs:
           # Bazel produce one xml for each test. So we merge them together.
           find -L bazel-out -name "test.xml" | xargs merge-junit -o "$BAZEL_TEST_RESULTS"
 
-          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ github.ref_name }}/$(date +%Y-%m-%d-%H%M%S)_${BAZEL_TEST_RESULTS}
+          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ inputs.branch || 'earlgrey_1.0.0'}}/$(date +%Y-%m-%d-%H%M%S)_${BAZEL_TEST_RESULTS}
           gcloud storage cp $BAZEL_TEST_RESULTS "$BUCKET_PATH"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
                                                     | grep -v examples \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
-          ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test --build_tests_only --test_tag_filters=-broken --target_pattern_file="$bazel_tests"
 
       - name: Run tests after ROM_EXT boot stage
         if: success() || failure()
@@ -70,7 +70,7 @@ jobs:
                                                     | grep -v examples \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
-          ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test --build_tests_only --test_tag_filters=-broken --target_pattern_file="$bazel_tests"
 
       - name: Publish bazel test results
         if: success() || failure()


### PR DESCRIPTION
 -  The branch name should be the one where the tests run.