### PR TITLE
[cherry-pick] manual cherry-pick of #24948, #25087, and #25106 to `earlgrey_1.0.0`

### DIFF
--- a/hw/ip/otp_ctrl/data/earlgrey_skus/emulation/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/emulation/BUILD
@@ -54,7 +54,7 @@ otp_json(
                 "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_FALSE),
                 "CREATOR_SW_CFG_JITTER_EN": otp_hex(CONST.MUBI4_FALSE),
                 "CREATOR_SW_CFG_RET_RAM_RESET_MASK": otp_hex(0x0),
-                "CREATOR_SW_CFG_MANUF_STATE": otp_hex(0x0),
+                "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.PERSONALIZED),
                 # ROM execution is enabled if this item is set to a non-zero
                 # value.
                 "CREATOR_SW_CFG_ROM_EXEC_EN": otp_hex(0xffffffff),

--- a/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
+++ b/hw/ip/otp_ctrl/data/earlgrey_skus/sival/BUILD
@@ -54,7 +54,7 @@ otp_json(
                 "CREATOR_SW_CFG_RNG_EN": otp_hex(CONST.HARDENED_FALSE),
                 "CREATOR_SW_CFG_JITTER_EN": otp_hex(CONST.MUBI4_FALSE),
                 "CREATOR_SW_CFG_RET_RAM_RESET_MASK": otp_hex(0x0),
-                "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
+                "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.PERSONALIZED),
                 # ROM execution is enabled if this item is set to a non-zero
                 # value.
                 "CREATOR_SW_CFG_ROM_EXEC_EN": otp_hex(0xffffffff),

--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -140,9 +140,12 @@ CONST = struct(
         ESC_PHASE_2 = 0x25,
         ESC_PHASE_3 = 0x76,
     ),
+    # The first three bytes of `MANUF_STATE` must be zeros, as
+    # they are reserved for storing the first three bytes of the
+    # `IMMUTABLE_ROM_EXT_SHA256_HASH`.
     MANUF_STATE = struct(
         PERSO_INITIAL = 0x00000000,
-        SIVAL = 0x30305653,  # ASCII `SV00`.
+        SIVAL = 0x00000053,  # ASCII `S`.
     ),
 )
 

--- a/rules/const.bzl
+++ b/rules/const.bzl
@@ -140,12 +140,9 @@ CONST = struct(
         ESC_PHASE_2 = 0x25,
         ESC_PHASE_3 = 0x76,
     ),
-    # The first three bytes of `MANUF_STATE` must be zeros, as
-    # they are reserved for storing the first three bytes of the
-    # `IMMUTABLE_ROM_EXT_SHA256_HASH`.
     MANUF_STATE = struct(
         PERSO_INITIAL = 0x00000000,
-        SIVAL = 0x00000053,  # ASCII `S`.
+        PERSONALIZED = 0x53524550,  # ASCII `PERS`.
     ),
 )
 

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -9,6 +9,7 @@ load(
     _OPENTITAN_PLATFORM = "OPENTITAN_PLATFORM",
     _opentitan_transition = "opentitan_transition",
 )
+load("@lowrisc_opentitan//rules:manifest.bzl", "update_manifest")
 load("@lowrisc_opentitan//rules:signing.bzl", "sign_binary")
 load("@lowrisc_opentitan//rules/opentitan:exec_env.bzl", "ExecEnvInfo")
 load(
@@ -196,6 +197,9 @@ def _build_binary(ctx, exec_env, name, deps, kind):
     ecdsa_key = get_fallback(ctx, "attr.ecdsa_key", exec_env)
     rsa_key = get_fallback(ctx, "attr.rsa_key", exec_env)
     spx_key = get_fallback(ctx, "attr.spx_key", exec_env)
+    if manifest and ctx.attr.immutable_rom_ext_enabled:
+        manifest = update_manifest(ctx, manifest, elf, exec_env._update_manifest_json)
+
     if (manifest or rsa_key) and kind != "ram":
         if not (manifest and (rsa_key or ecdsa_key)):
             fail("Signing requires a manifest and an rsa_key or ecdsa_key, and optionally an spx_key")
@@ -332,6 +336,10 @@ common_binary_attrs = {
         default = "//hw/ip/rom_ctrl/util:scramble_image",
         executable = True,
         cfg = "exec",
+    ),
+    "immutable_rom_ext_enabled": attr.bool(
+        doc = "Indicates whether the binary is intended for a chip with the immutable ROM_EXT feature enabled.",
+        default = False,
     ),
 }
 

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -82,6 +82,7 @@ def exec_env_as_dict(ctx):
     tc = ctx.toolchains[LOCALTOOLS_TOOLCHAIN]
     result = {
         "_opentitantool": tc.tools.opentitantool,
+        "_update_manifest_json": tc.tools.update_manifest_json,
     }
     for field, (path, required) in _FIELDS.items():
         val = getattr_path(ctx, path)

--- a/rules/opentitan/toolchain.bzl
+++ b/rules/opentitan/toolchain.bzl
@@ -12,6 +12,7 @@ LocalToolInfo = provider(fields = [
     "gen_otp_rot_auth_json",
     "gen_otp_immutable_rom_ext_json",
     "gen_otp_creator_manuf_state_json",
+    "update_manifest_json",
 ])
 
 def _localtools_toolchain(ctx):
@@ -20,6 +21,7 @@ def _localtools_toolchain(ctx):
         gen_mem_image = ctx.attr.gen_mem_image[0].files_to_run,
         gen_otp_rot_auth_json = ctx.attr.gen_otp_rot_auth_json[0].files_to_run,
         gen_otp_immutable_rom_ext_json = ctx.attr.gen_otp_immutable_rom_ext_json[0].files_to_run,
+        update_manifest_json = ctx.attr.update_manifest_json[0].files_to_run,
     )
     return platform_common.ToolchainInfo(
         name = ctx.label.name,
@@ -46,6 +48,11 @@ localtools_toolchain = rule(
         ),
         "gen_otp_immutable_rom_ext_json": attr.label(
             default = "//util/design:gen-otp-immutable-rom-ext-json",
+            executable = True,
+            cfg = host_tools_transition,
+        ),
+        "update_manifest_json": attr.label(
+            default = "//util/design:update-manifest-json",
             executable = True,
             cfg = host_tools_transition,
         ),

--- a/rules/opentitan/toolchain.bzl
+++ b/rules/opentitan/toolchain.bzl
@@ -11,6 +11,7 @@ LocalToolInfo = provider(fields = [
     "gen_mem_image",
     "gen_otp_rot_auth_json",
     "gen_otp_immutable_rom_ext_json",
+    "gen_otp_creator_manuf_state_json",
 ])
 
 def _localtools_toolchain(ctx):

--- a/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
@@ -5,8 +5,10 @@
 load(
     "//rules:const.bzl",
     "CONST",
+    "hex",
     "hex_digits",
 )
+load("//rules:manifest.bzl", "manifest")
 load(
     "//rules:otp.bzl",
     "STD_OTP_OVERLAYS",
@@ -27,6 +29,10 @@ load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
     "MSG_TEMPLATE_BFV",
     "SLOTS",
+)
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VERSION",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -59,7 +65,9 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "name": "exec_enabled_hash_valid",
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": True,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -68,7 +76,9 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": True,
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)),
         "exit_failure": DEFAULT_TEST_SUCCESS_MSG,
     },
@@ -76,7 +86,9 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "name": "exec_disabled_hash_valid",
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -85,13 +97,18 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     {
         "name": "exec_empty_hash_valid",
-        "otp_fields": {},
+        "otp_fields": {
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
+        },
+        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -99,7 +116,9 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "name": "exec_empty_hash_invalid",
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -108,7 +127,9 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET": otp_hex(0x4),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": True,
         # The hash check should fail, since the offset is included in the hash,
         # triggering a hardened check fail (which executes an unimp; triggering
         # an exception and shutdown).
@@ -120,7 +141,9 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET": otp_hex(0x4),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -129,7 +152,9 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_LENGTH": otp_hex(0x4),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": True,
         # The hash check should fail, since the length is included in the hash,
         # triggering a hardened check fail (which executes an unimp; triggering
         # an exception and shutdown).
@@ -141,7 +166,9 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_LENGTH": otp_hex(0x4),
+            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
+        "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
@@ -160,7 +187,10 @@ IMMUTABLE_PARTITION_TEST_CASES = [
                 items = t["otp_fields"],
             ),
         ],
-        rom_ext = ":immutable_rom_ext_section_test_{}".format(s["name"]),
+        rom_ext = ":immutable_rom_ext_section_test_{}_{}".format(
+            t["name"],
+            s["name"],
+        ),
         visibility = ["//visibility:private"],
     )
     for s in ROM_EXT_SLOTS
@@ -187,15 +217,30 @@ IMMUTABLE_PARTITION_TEST_CASES = [
     for t in IMMUTABLE_PARTITION_TEST_CASES
 ]
 
+manifest(d = {
+    "name": "manifest",
+    "identifier": hex(CONST.ROM_EXT),
+    "manuf_state_creator": hex(CONST.MANUF_STATE.SIVAL),
+    "visibility": ["//visibility:private"],
+    "version_major": ROM_EXT_VERSION.MAJOR,
+    "version_minor": ROM_EXT_VERSION.MINOR,
+    "security_version": ROM_EXT_VERSION.SECURITY,
+})
+
 [
     opentitan_binary(
-        name = "immutable_rom_ext_section_test_{}".format(s["name"]),
+        name = "immutable_rom_ext_section_test_{}_{}".format(
+            t["name"],
+            s["name"],
+        ),
         testonly = True,
         srcs = ["immutable_rom_ext_section_test.c"],
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310_sival",
         ],
+        immutable_rom_ext_enabled = t["immutable_rom_ext_enabled"],
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_{}".format(s["slot"]),
+        manifest = ":manifest",
         deps = [
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -208,6 +253,7 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         ],
     )
     for s in ROM_EXT_SLOTS
+    for t in IMMUTABLE_PARTITION_TEST_CASES
 ]
 
 [
@@ -222,7 +268,10 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         fpga = fpga_params(
             assemble = "{firmware}@{offset}",
             binaries = {
-                ":immutable_rom_ext_section_test_{}".format(s["name"]): "firmware",
+                ":immutable_rom_ext_section_test_{}_{}".format(
+                    t["name"],
+                    s["name"],
+                ): "firmware",
             },
             exit_failure = t["exit_failure"],
             exit_success = t["exit_success"],

--- a/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/immutable_rom_ext_section/BUILD
@@ -65,7 +65,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "name": "exec_enabled_hash_valid",
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": True,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
@@ -76,7 +75,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": True,
         "exit_success": MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)),
@@ -86,7 +84,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "name": "exec_disabled_hash_valid",
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
@@ -97,7 +94,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
@@ -105,9 +101,7 @@ IMMUTABLE_PARTITION_TEST_CASES = [
     },
     {
         "name": "exec_empty_hash_valid",
-        "otp_fields": {
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
-        },
+        "otp_fields": {},
         "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
@@ -116,7 +110,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "name": "exec_empty_hash_invalid",
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_SHA256_HASH": otp_hex(0x1234),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
@@ -127,7 +120,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET": otp_hex(0x4),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": True,
         # The hash check should fail, since the offset is included in the hash,
@@ -141,7 +133,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET": otp_hex(0x4),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
@@ -152,7 +143,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_TRUE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_LENGTH": otp_hex(0x4),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": True,
         # The hash check should fail, since the length is included in the hash,
@@ -166,7 +156,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
         "otp_fields": {
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN": otp_hex(CONST.HARDENED_FALSE),
             "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_LENGTH": otp_hex(0x4),
-            "CREATOR_SW_CFG_MANUF_STATE": otp_hex(CONST.MANUF_STATE.SIVAL),
         },
         "immutable_rom_ext_enabled": False,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
@@ -220,7 +209,6 @@ IMMUTABLE_PARTITION_TEST_CASES = [
 manifest(d = {
     "name": "manifest",
     "identifier": hex(CONST.ROM_EXT),
-    "manuf_state_creator": hex(CONST.MANUF_STATE.SIVAL),
     "visibility": ["//visibility:private"],
     "version_major": ROM_EXT_VERSION.MAJOR,
     "version_minor": ROM_EXT_VERSION.MINOR,

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -25,7 +25,7 @@ LINK_ORDER = [
 manifest(d = {
     "name": "manifest_sival",
     "identifier": hex(CONST.ROM_EXT),
-    "manuf_state_creator": hex(CONST.MANUF_STATE.SIVAL),
+    "manuf_state_creator": hex(CONST.MANUF_STATE.PERSONALIZED),
     "version_major": ROM_EXT_VERSION.MAJOR,
     "version_minor": ROM_EXT_VERSION.MINOR,
     "security_version": ROM_EXT_VERSION.SECURITY,
@@ -33,7 +33,7 @@ manifest(d = {
 })
 
 # To test that the fake-signed SiVAL ROM_EXT can boot, you need a bitstream
-# with the OTP word CREATOR_SW_CCFG_MANUF_STATE set to `SIVAL` (as above
+# with the OTP word CREATOR_SW_CCFG_MANUF_STATE set to `PERSONALIZED` (as above
 # in the manifest definition).  You can manually create such a bitstream with:
 #
 # bazel build //hw/bitstream/universal:splice --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_cw310_sival

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -77,6 +77,16 @@ py_binary(
 )
 
 py_binary(
+    name = "update-manifest-json",
+    srcs = ["update-manifest-json.py"],
+    imports = ["."],
+    deps = [
+        "//util/design/lib:immutable_section_processor",
+        requirement("hjson"),
+    ],
+)
+
+py_binary(
     name = "sparse-fsm-encode",
     srcs = ["sparse-fsm-encode.py"],
     imports = ["."],

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -71,9 +71,8 @@ py_binary(
     srcs = ["gen-otp-immutable-rom-ext-json.py"],
     imports = ["."],
     deps = [
+        "//util/design/lib:immutable_section_processor",
         requirement("hjson"),
-        requirement("pycryptodome"),
-        requirement("pyelftools"),
     ],
 )
 

--- a/util/design/gen-otp-immutable-rom-ext-json.py
+++ b/util/design/gen-otp-immutable-rom-ext-json.py
@@ -6,19 +6,12 @@ r"""Generate immutable ROM_EXT section data from ELF file and JSON overlay."""
 
 import argparse
 import json
-import logging
-import sys
 
 import hjson
-from Crypto.Hash import SHA256
-from elftools.elf import elffile
+from lib.ImmutableSectionProcessor import ImmutableSectionProcessor
 from typing import Optional
 
 _OTP_PARTITION_NAME = "CREATOR_SW_CFG"
-
-_OTTF_START_OFFSET_SYMBOL_NAME = "_ottf_start_address"
-_ROM_EXT_SATRT_OFFSET_SYMBOL_NAME = "_rom_ext_start_address"
-_ROM_EXT_IMMUTABLE_SECTION_NAME = ".rom_ext_immutable"
 
 _ENABLE_FIELD_NAME = "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_EN"
 _START_OFFSET_FIELD_NAME = "CREATOR_SW_CFG_IMMUTABLE_ROM_EXT_START_OFFSET"
@@ -29,54 +22,11 @@ _CREATOR_MANUF_STATE_FIELD_NAME = "CREATOR_SW_CFG_MANUF_STATE"
 # This must match the definitions in hardened.h.
 _HARDENED_TRUE = 0x739
 
-_PREFIX_FOR_HEX = "0x"
 
-
-class RomExtImmutableSectionOtpFields:
+class RomExtImmutableSectionOtpFields(ImmutableSectionProcessor):
 
     def __init__(self, rom_ext_elf, json_data):
-        self.rom_ext_elf = rom_ext_elf
-        self.json_data = json_data
-        self.immutable_section_idx = None
-        self.manifest_offset = None
-        self.start_offset = None
-        self.size_in_bytes = None
-        self.hash = None
-
-        with open(self.rom_ext_elf, 'rb') as f:
-            elf = elffile.ELFFile(f)
-            # Find the offset of the current slot we are in.
-            for symbol in elf.get_section_by_name(".symtab").iter_symbols():
-                if symbol.name in [
-                    _OTTF_START_OFFSET_SYMBOL_NAME,
-                    _ROM_EXT_SATRT_OFFSET_SYMBOL_NAME,
-                ]:
-                    if self.manifest_offset is not None:
-                        raise ValueError(
-                            f"More than one manifest start address exists. "
-                            f"Current offset: {self.manifest_offset}, "
-                            f"new offset: {symbol.entry['st_value']}"
-                        )
-                    self.manifest_offset = symbol.entry["st_value"]
-            assert self.manifest_offset, "Manifest start address not found."
-
-            # Find the immutable section and compute the OTP values.
-            for section_idx in range(elf.num_sections()):
-                section = elf.get_section(section_idx)
-                if section.name == _ROM_EXT_IMMUTABLE_SECTION_NAME:
-                    self.immutable_section_idx = section_idx
-                    self.start_offset = (int(section.header['sh_addr']) -
-                                         self.manifest_offset)
-                    self.size_in_bytes = int(section.header['sh_size'])
-                    assert self.size_in_bytes == len(section.data())
-                    # Prepend the start offset and length to section data
-                    data_to_hash = bytearray()
-                    data_to_hash += self.start_offset.to_bytes(
-                        4, byteorder='little')
-                    data_to_hash += self.size_in_bytes.to_bytes(
-                        4, byteorder='little')
-                    data_to_hash += section.data()
-                    self.hash = bytearray(SHA256.new(data_to_hash).digest())
+        super().__init__(rom_ext_elf, json_data)
 
     def insert_key_value(self, item_name: str, value: str) -> None:
         """Insert the value of the item if it does not exist.
@@ -142,43 +92,19 @@ class RomExtImmutableSectionOtpFields:
         Returns:
             None
         """
-        creator_manuf_state = self.get_key_value(_CREATOR_MANUF_STATE_FIELD_NAME)
+        creator_manuf_state = self.get_key_value(
+            _CREATOR_MANUF_STATE_FIELD_NAME
+        )
 
         if creator_manuf_state is None:
             return
 
-        # Check if the state value starts with the hexadecimal prefix.
-        if creator_manuf_state[:2] == _PREFIX_FOR_HEX:
-            # Remove the hexadecimal prefix.
-            creator_manuf_state = creator_manuf_state[2:]
-        # Pad with leading zeros to ensure 4 bytes long.
-        creator_manuf_state = creator_manuf_state.zfill(8)
-
-        if creator_manuf_state[:6] != "0" * 6:
-            raise ValueError(
-                f"The first three bytes of CREATOR_MANUF_STATE must be zeros. "
-                f"Current value: 0x{creator_manuf_state}"
-            )
-
-        if not self.immutable_rom_ext_enable():
-            return
-
-        im_ext_hash = self.get_key_value(_HASH_FIELD_NAME)
-        assert isinstance(im_ext_hash, str)
-
-        # Check if the state value starts with the hexadecimal prefix.
-        if im_ext_hash[:2] == _PREFIX_FOR_HEX:
-            # Remove the hexadecimal prefix.
-            im_ext_hash = im_ext_hash[2:]
-        # Pad with leading zeros to ensure 4 bytes long.
-        im_ext_hash = im_ext_hash.zfill(8)
-
-        # Embed the first three bytes of `IMMUTABLE_ROM_EXT_SHA256_HASH` into
-        # `CREATOR_MANUF_STATE`
-        creator_manuf_state = (
-            _PREFIX_FOR_HEX + im_ext_hash[:6] + creator_manuf_state[6:]
+        new_creator_manuf_state = self.update_creator_manuf_state_data(
+            creator_manuf_state, f"0x{self.hash.hex()}"
         )
-        self.update_key_value(_CREATOR_MANUF_STATE_FIELD_NAME, creator_manuf_state)
+        self.update_key_value(
+            _CREATOR_MANUF_STATE_FIELD_NAME, new_creator_manuf_state
+        )
 
     def immutable_rom_ext_enable(self) -> bool:
         """Checks if immutable ROM extension is enabled.
@@ -226,10 +152,6 @@ def main() -> None:
     # Extract the immutable ROM_EXT section data, compute hash, and update OTP
     # CREATOR_SW_CFG partition fields.
     imm_section_otp = RomExtImmutableSectionOtpFields(args.elf, json_in)
-    if not imm_section_otp.immutable_section_idx:
-        logging.error("Cannot find {} section in ROM_EXT ELF {}.".format(
-            _ROM_EXT_IMMUTABLE_SECTION_NAME, args.elf))
-        sys.exit(1)
 
     if imm_section_otp.immutable_rom_ext_enable():
         imm_section_otp.update_json_with_immutable_rom_ext_section_data()

--- a/util/design/gen-otp-immutable-rom-ext-json.py
+++ b/util/design/gen-otp-immutable-rom-ext-json.py
@@ -97,7 +97,7 @@ class RomExtImmutableSectionOtpFields(ImmutableSectionProcessor):
         )
 
         if creator_manuf_state is None:
-            return
+            raise ValueError("CREATOR_SW_CFG_MANUF_STATE field doesn't exist")
 
         new_creator_manuf_state = self.update_creator_manuf_state_data(
             creator_manuf_state, f"0x{self.hash.hex()}"
@@ -155,8 +155,7 @@ def main() -> None:
 
     if imm_section_otp.immutable_rom_ext_enable():
         imm_section_otp.update_json_with_immutable_rom_ext_section_data()
-
-    imm_section_otp.update_json_with_creator_manuf_state_data()
+        imm_section_otp.update_json_with_creator_manuf_state_data()
 
     # Write out the OTP fields to a JSON file.
     with open(args.output, 'w') as f:

--- a/util/design/gen-otp-immutable-rom-ext-json.py
+++ b/util/design/gen-otp-immutable-rom-ext-json.py
@@ -43,22 +43,6 @@ class RomExtImmutableSectionOtpFields(ImmutableSectionProcessor):
                         return
                 partition["items"].append({"name": item_name, "value": value})
 
-    def update_key_value(self, item_name: str, value: str) -> None:
-        """Update the value of the item if it exists.
-        Args:
-            item_name: The name of the item to update.
-            value: The value to update the item with.
-        Returns:
-            None
-        """
-        for partition in self.json_data["partitions"]:
-            if partition["name"] == _OTP_PARTITION_NAME:
-                for item in partition["items"]:
-                    if item["name"] == item_name:
-                        item["value"] = value
-                        return
-        raise ValueError(f"{item_name} item doesn't exist")
-
     def get_key_value(self, item_name: str) -> Optional[str]:
         """Get the value of the item if it exists.
         Args:
@@ -92,17 +76,11 @@ class RomExtImmutableSectionOtpFields(ImmutableSectionProcessor):
         Returns:
             None
         """
-        creator_manuf_state = self.get_key_value(
-            _CREATOR_MANUF_STATE_FIELD_NAME
-        )
-
-        if creator_manuf_state is None:
-            raise ValueError("CREATOR_SW_CFG_MANUF_STATE field doesn't exist")
 
         new_creator_manuf_state = self.update_creator_manuf_state_data(
-            creator_manuf_state, f"0x{self.hash.hex()}"
+            f"0x{self.hash.hex()}"
         )
-        self.update_key_value(
+        self.insert_key_value(
             _CREATOR_MANUF_STATE_FIELD_NAME, new_creator_manuf_state
         )
 

--- a/util/design/lib/BUILD
+++ b/util/design/lib/BUILD
@@ -22,6 +22,16 @@ py_test(
 )
 
 py_library(
+    name = "immutable_section_processor",
+    srcs = ["ImmutableSectionProcessor.py"],
+    imports = ["../../"],
+    deps = [
+        requirement("pycryptodome"),
+        requirement("pyelftools"),
+    ],
+)
+
+py_library(
     name = "lc_st_enc",
     srcs = ["LcStEnc.py"],
     imports = ["../../"],

--- a/util/design/lib/ImmutableSectionProcessor.py
+++ b/util/design/lib/ImmutableSectionProcessor.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""Extract the immutable ROM_EXT section data from ELF file."""
+
+import logging
+import sys
+
+from Crypto.Hash import SHA256
+from elftools.elf import elffile
+
+_OTTF_START_OFFSET_SYMBOL_NAME = "_ottf_start_address"
+_ROM_EXT_SATRT_OFFSET_SYMBOL_NAME = "_rom_ext_start_address"
+_ROM_EXT_IMMUTABLE_SECTION_NAME = ".rom_ext_immutable"
+
+_PREFIX_FOR_HEX = "0x"
+
+
+class ImmutableSectionProcessor:
+
+    def __init__(self, rom_ext_elf, json_data):
+        self.rom_ext_elf = rom_ext_elf
+        self.json_data = json_data
+        self.immutable_section_idx = None
+        self.manifest_offset = None
+        self.start_offset = None
+        self.size_in_bytes = None
+        self.hash = None
+
+        with open(self.rom_ext_elf, 'rb') as f:
+            elf = elffile.ELFFile(f)
+            # Find the offset of the current slot we are in.
+            for symbol in elf.get_section_by_name(".symtab").iter_symbols():
+                if symbol.name in [
+                    _OTTF_START_OFFSET_SYMBOL_NAME,
+                    _ROM_EXT_SATRT_OFFSET_SYMBOL_NAME,
+                ]:
+                    if self.manifest_offset is not None:
+                        raise ValueError(
+                            f"More than one manifest start address exists. "
+                            f"Current offset: {self.manifest_offset}, "
+                            f"new offset: {symbol.entry['st_value']}"
+                        )
+                    self.manifest_offset = symbol.entry["st_value"]
+            assert self.manifest_offset, "Manifest start address not found."
+
+            # Find the immutable section and compute the OTP values.
+            for section_idx in range(elf.num_sections()):
+                section = elf.get_section(section_idx)
+                if section.name == _ROM_EXT_IMMUTABLE_SECTION_NAME:
+                    self.immutable_section_idx = section_idx
+                    self.start_offset = (int(section.header['sh_addr']) -
+                                         self.manifest_offset)
+                    self.size_in_bytes = int(section.header['sh_size'])
+                    assert self.size_in_bytes == len(section.data())
+                    # Prepend the start offset and length to section data
+                    data_to_hash = bytearray()
+                    data_to_hash += self.start_offset.to_bytes(
+                        4, byteorder='little')
+                    data_to_hash += self.size_in_bytes.to_bytes(
+                        4, byteorder='little')
+                    data_to_hash += section.data()
+                    self.hash = bytearray(SHA256.new(data_to_hash).digest())
+
+        if not self.immutable_section_idx:
+            logging.error("Cannot find {} section in ROM_EXT ELF {}.".format(
+                _ROM_EXT_IMMUTABLE_SECTION_NAME, self.rom_ext_elf))
+            sys.exit(1)
+
+    def update_creator_manuf_state_data(self, creator_manuf_state, im_ext_hash) -> None:
+        """Update the creator's manufacturing state with the immutable ROM_EXT hash.
+        Args:
+            creator_manuf_state: The creator's manufacturing state as a hexadecimal string.
+            im_ext_hash: The immutable ROM_EXT hash as a hexadecimal string.
+        Returns:
+            The updated manufacturing state as a hexadecimal string.
+        Raises:
+            ValueError: If the creator's manufacturing state does not have zeros
+                        in the first three bytes.
+        """
+
+        # Check if the state value starts with the hexadecimal prefix.
+        if creator_manuf_state[:2] == _PREFIX_FOR_HEX:
+            # Remove the hexadecimal prefix.
+            creator_manuf_state = creator_manuf_state[2:]
+        # Pad with leading zeros to ensure 4 bytes long.
+        creator_manuf_state = creator_manuf_state.zfill(8)
+
+        if creator_manuf_state[:6] != "0" * 6:
+            raise ValueError(
+                f"The first three bytes of CREATOR_MANUF_STATE must be zeros. "
+                f"Current value: 0x{creator_manuf_state}"
+            )
+
+        # Check if the state value starts with the hexadecimal prefix.
+        if im_ext_hash[:2] == _PREFIX_FOR_HEX:
+            # Remove the hexadecimal prefix.
+            im_ext_hash = im_ext_hash[2:]
+        # Pad with leading zeros to ensure 4 bytes long.
+        im_ext_hash = im_ext_hash.zfill(8)
+
+        # Embed the first three bytes of `IMMUTABLE_ROM_EXT_SHA256_HASH` into
+        # `CREATOR_MANUF_STATE`
+        creator_manuf_state = (
+            _PREFIX_FOR_HEX + im_ext_hash[:6] + creator_manuf_state[6:]
+        )
+
+        return creator_manuf_state

--- a/util/design/lib/ImmutableSectionProcessor.py
+++ b/util/design/lib/ImmutableSectionProcessor.py
@@ -68,42 +68,33 @@ class ImmutableSectionProcessor:
                 _ROM_EXT_IMMUTABLE_SECTION_NAME, self.rom_ext_elf))
             sys.exit(1)
 
-    def update_creator_manuf_state_data(self, creator_manuf_state, im_ext_hash) -> None:
+    def update_creator_manuf_state_data(self, im_ext_hash) -> None:
         """Update the creator's manufacturing state with the immutable ROM_EXT hash.
         Args:
-            creator_manuf_state: The creator's manufacturing state as a hexadecimal string.
             im_ext_hash: The immutable ROM_EXT hash as a hexadecimal string.
         Returns:
             The updated manufacturing state as a hexadecimal string.
         Raises:
-            ValueError: If the creator's manufacturing state does not have zeros
-                        in the first three bytes.
+            ValueError: If the immutable ROM_EXT hash are all zeros in the
+                        first four bytes.
         """
 
-        # Check if the state value starts with the hexadecimal prefix.
-        if creator_manuf_state[:2] == _PREFIX_FOR_HEX:
-            # Remove the hexadecimal prefix.
-            creator_manuf_state = creator_manuf_state[2:]
-        # Pad with leading zeros to ensure 4 bytes long.
-        creator_manuf_state = creator_manuf_state.zfill(8)
-
-        if creator_manuf_state[:6] != "0" * 6:
-            raise ValueError(
-                f"The first three bytes of CREATOR_MANUF_STATE must be zeros. "
-                f"Current value: 0x{creator_manuf_state}"
-            )
-
-        # Check if the state value starts with the hexadecimal prefix.
+        # Check if the hash value starts with the hexadecimal prefix.
         if im_ext_hash[:2] == _PREFIX_FOR_HEX:
             # Remove the hexadecimal prefix.
             im_ext_hash = im_ext_hash[2:]
         # Pad with leading zeros to ensure 4 bytes long.
         im_ext_hash = im_ext_hash.zfill(8)
 
-        # Embed the first three bytes of `IMMUTABLE_ROM_EXT_SHA256_HASH` into
+        # Ensure the hash is different from the `PERSO_INITIAL` defined in
+        # rules/const.bzl.
+        if im_ext_hash[:8] == "0" * 8:
+            raise ValueError("The hash value are all zeros.")
+
+        # Embed the first four bytes of `IMMUTABLE_ROM_EXT_SHA256_HASH` into
         # `CREATOR_MANUF_STATE`
         creator_manuf_state = (
-            _PREFIX_FOR_HEX + im_ext_hash[:6] + creator_manuf_state[6:]
+            _PREFIX_FOR_HEX + im_ext_hash[:8]
         )
 
         return creator_manuf_state

--- a/util/design/update-manifest-json.py
+++ b/util/design/update-manifest-json.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""Update the creator_manuf_state in a ROM_EXT manifest."""
+
+import argparse
+import json
+
+import hjson
+from lib.ImmutableSectionProcessor import ImmutableSectionProcessor
+
+_USAGE_CONSTRAINTS_NAME = "usage_constraints"
+_MANUF_STATE_CREATOR_NAME = "manuf_state_creator"
+_IDENTIFIER_NAME = "identifier"
+
+# This must match the definitions in chip.h.
+_CHIP_ROM_EXT_IDENTIFIER = 0x4552544f
+
+
+class RomExtImmutableSection(ImmutableSectionProcessor):
+
+    def __init__(self, rom_ext_elf, json_data):
+        super().__init__(rom_ext_elf, json_data)
+
+    def update_manifest_with_creator_manuf_state_data(self) -> None:
+        """Update the manifest with the manuf_state_creator data.
+        Args:
+            None
+        Returns:
+            None
+        """
+        creator_manuf_state = self.json_data[_USAGE_CONSTRAINTS_NAME][
+            _MANUF_STATE_CREATOR_NAME
+        ]
+        new_creator_manuf_state = self.update_creator_manuf_state_data(
+            creator_manuf_state, f"0x{self.hash.hex()}"
+        )
+
+        self.json_data[_USAGE_CONSTRAINTS_NAME][
+            _MANUF_STATE_CREATOR_NAME
+        ] = new_creator_manuf_state
+
+    def is_rom_ext_manifest(self) -> bool:
+        """Check if the loaded manifest is for a ROM_EXT image.
+
+        This function determines if the loaded JSON manifest data corresponds to
+        a ROM_EXT image by checking the identifier field in the manifest.
+
+        Returns:
+            True if the manifest is for a ROM_EXT image, False otherwise.
+        """
+        identifier = self.json_data[_IDENTIFIER_NAME]
+        identifier_value = int(identifier, 0)
+        return identifier_value == _CHIP_ROM_EXT_IDENTIFIER
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="update-manifest-json",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('-i',
+                        '--input',
+                        type=str,
+                        metavar='<path>',
+                        help='Input JSON file path.')
+    parser.add_argument('-e',
+                        '--elf',
+                        type=str,
+                        metavar='<path>',
+                        help='Input ELF file path.')
+    parser.add_argument('-o',
+                        '--output',
+                        type=str,
+                        metavar='<path>',
+                        help='Output JSON file path.')
+    args = parser.parse_args()
+
+    # Read in the manifest fields (encoded in JSON) we will be updating.
+    json_in = None
+    with open(args.input, 'r') as f:
+        json_in = hjson.load(f)
+
+    # Extract the immutable ROM_EXT section data, compute hash, and update
+    # manifest `manuf_state_creator` binding field
+    rom_ext_immutable_section = RomExtImmutableSection(args.elf, json_in)
+
+    if rom_ext_immutable_section.is_rom_ext_manifest():
+        rom_ext_immutable_section.update_manifest_with_creator_manuf_state_data()
+
+    # Write out the new `manuf_state_creator` field to a JSON file.
+    with open(args.output, 'w') as f:
+        f.write(json.dumps(rom_ext_immutable_section.json_data, indent=4))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This cherry-picks several commits to `earlgrey_1.0.0` that prevent the personalization firmware from executing again once a device has been successfully personalized.