### PR TITLE
[ci] use service accounts instead of workload identity federation

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -6,6 +6,9 @@ name: Prepare environment
 description: Install dependencies and prepare environment needed for OpenTitan
 
 inputs:
+  service_account_json:
+    description: Service account JSON for Google Cloud access
+    default: ''
   verilator-version:
     description: Verilator version to install
     required: true
@@ -80,13 +83,13 @@ runs:
         echo "${{ inputs.verible-path }}/bin" >> "$GITHUB_PATH"
       shell: bash
 
-    # Log into Google Cloud using Workload Identity Federation
-    # This needs `id-token: write` permission and doesn't work for pull request.
+    # Log into Google Cloud using service account JSON.
+    # This can't be Workload Identity Federation because Bazel performance using WIF is terrible.
+    # This needs access to secrets and thus doesn't work for pull request.
     - uses: google-github-actions/auth@v2
       if: github.event_name != 'pull_request'
       with:
-        project_id: active-premise-257318
-        workload_identity_provider: projects/281751345158/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+        credentials_json: '${{ inputs.service_account_json }}'
 
     - name: Configure ~/.bazelrc
       if: inputs.configure-bazel == 'true'

--- a/.github/workflows/bitstream.yml
+++ b/.github/workflows/bitstream.yml
@@ -25,6 +25,8 @@ jobs:
           fetch-depth: 0 # Required by get-bitstream-strategy.sh
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
 
       - name: Configure bitstream strategy
         id: strategy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
           fetch-depth: 0 # Required so we can lint commit messages.
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Show environment
         run: ./ci/scripts/show-env.sh
       - name: Commit metadata
@@ -79,6 +81,8 @@ jobs:
           fetch-depth: 0 # Bitstream cache requires all commits.
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Countermeasures implemented (earlgrey)
         run: ./ci/scripts/check-countermeasures.sh earlgrey
         continue-on-error: true
@@ -128,6 +132,7 @@ jobs:
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
         with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
           configure-bazel: false
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -182,6 +187,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Build simulator with Verilator
         run: ./ci/scripts/build-chip-verilator.sh englishbreakfast
       - name: Upload binary
@@ -202,6 +209,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Build bitstream
         run: |
           # Build CW305 test rom required by `build-bitstream-vivado.sh`
@@ -229,6 +238,7 @@ jobs:
     name: Earl Grey for CW310
     needs: quick_lint
     uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
     with:
       top_name: earlgrey
       design_suffix: cw310
@@ -238,6 +248,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     needs: quick_lint
     uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
     with:
       top_name: earlgrey
       design_suffix: cw310_hyperdebug
@@ -247,6 +258,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     needs: quick_lint
     uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
     with:
       top_name: earlgrey
       design_suffix: cw340
@@ -263,6 +275,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Download partial build-bin
         uses: ./.github/actions/download-partial-build-bin
         with:
@@ -319,6 +333,8 @@ jobs:
           fetch-depth: 0 # Required for bitstream cache to work.
       - name: Prepare environment
         uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
       - name: Check Bazel build graph
         run: |
           # Test the graph with both an empty and filled bitstream cache.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
 
       - uses: google-github-actions/setup-gcloud@v2
 


### PR DESCRIPTION
It appears that Bazel cache performance suffers when using WIF. This is likely a bug in Bazel (or google-auth-library java) since both the ID token and the exchanged access token can be cached. I suppose when WIF is in use there're excessive amount of access token exchange happening which slows down all Google bucket accessese.

As a workaround, go back to use service account JSON instead of WIF.