### PR TITLE
[prim,dv] Fix a failure mode for ASSERT_FPV_LINEAR_FSM

### DIFF
--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -179,7 +179,7 @@
      property __name``_p;                                                                                        \
        __type initial_state;                                                                                     \
        (!$stable(__state) & __name``_cond, initial_state = $past(__state)) |->                                   \
-           (__state != initial_state) until (__rst == 1'b1);                                                     \
+           (__state != initial_state) until !(__name``_cond);                                                    \
      endproperty                                                                                                 \
    `ASSERT(__name, __name``_p, __clk, 0)                                                                         \
   `endif


### PR DESCRIPTION
I tweaked this assertion in commit b5b4087 (to allow a formal tool to see the assertion run to completion) but there is a chip-level test (`chip_sw_pwrmgr_sleep_power_glitch_reset`) which fails this assertion (with or without my change).

The test resets the block (which causes the FSM state to go back to its initial value) but the `until` operator doesn't complete, because:

 - The property gets sampled on every posedge of `__clk` (this is because of the definition of `` `ASSERT``)

 - In the failing test, we go into reset (putting the FSM back to its initial state) and then come out of reset.

 - We then sample the property again. But it was never sampled when we were in reset so the `until` doesn't complete.

This commit tweaks the `until` so that it waits until the ```__name``_cond``` signal goes low. This happens on reset (without waiting for the next clock edge), which means that we see the zero value on the first clock after the reset, completing the property.

The ```__name``_cond``` signal goes high at that point, so the property will now be checked for this iteration. There is still a tiny window: if the initial FSM state changed on the first clock-edge, we'd snapshot the second state. But fixing that would be rather complicated and it seems extremely unlikely to cause a problem.