### PR TITLE
[opentitantool] Advanced TPM primitives in transport

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -180,6 +180,7 @@ pub struct SpiConfiguration {
     pub host_out_device_in: Option<String>,
     pub host_in_device_out: Option<String>,
     pub chip_select: Option<String>,
+    pub gsc_ready: Option<String>,
     pub bits_per_word: Option<u32>,
     pub bits_per_sec: Option<u32>,
 }

--- a/sw/host/opentitanlib/src/app/spi.rs
+++ b/sw/host/opentitanlib/src/app/spi.rs
@@ -60,6 +60,7 @@ struct Inner {
     host_out_device_in: Option<Rc<dyn GpioPin>>,
     host_in_device_out: Option<Rc<dyn GpioPin>>,
     chip_select: Option<Rc<dyn GpioPin>>,
+    gsc_ready: Option<Rc<dyn GpioPin>>,
 }
 
 impl LogicalSpiWrapper {
@@ -81,6 +82,7 @@ impl LogicalSpiWrapper {
                 host_out_device_in: Self::lookup_pin(transport, &conf.host_out_device_in)?,
                 host_in_device_out: Self::lookup_pin(transport, &conf.host_in_device_out)?,
                 chip_select: Self::lookup_pin(transport, &conf.chip_select)?,
+                gsc_ready: Self::lookup_pin(transport, &conf.gsc_ready)?,
             }),
         })
     }
@@ -123,12 +125,13 @@ impl LogicalSpiWrapper {
             inner.host_out_device_in.as_ref(),
             inner.host_in_device_out.as_ref(),
             inner.chip_select.as_ref(),
+            inner.gsc_ready.as_ref(),
         ) {
-            (None, None, None, None) => (),
-            (clock, hodi, hido, cs) => self
+            (None, None, None, None, None) => (),
+            (clock, hodi, hido, cs, rdy) => self
                 .physical_wrapper
                 .underlying_target
-                .set_pins(clock, hodi, hido, cs)?,
+                .set_pins(clock, hodi, hido, cs, rdy)?,
         }
         self.physical_wrapper.last_used_by_uid.set(Some(self.uid));
         Ok(())
@@ -166,12 +169,17 @@ impl Target for LogicalSpiWrapper {
             .supports_bidirectional_transfer()
     }
 
+    fn supports_tpm_poll(&self) -> Result<bool> {
+        self.physical_wrapper.underlying_target.supports_tpm_poll()
+    }
+
     fn set_pins(
         &self,
         serial_clock: Option<&Rc<dyn GpioPin>>,
         host_out_device_in: Option<&Rc<dyn GpioPin>>,
         host_in_device_out: Option<&Rc<dyn GpioPin>>,
         chip_select: Option<&Rc<dyn GpioPin>>,
+        gsc_ready: Option<&Rc<dyn GpioPin>>,
     ) -> Result<()> {
         let mut inner = self.inner.borrow_mut();
         if serial_clock.is_some() {
@@ -185,6 +193,9 @@ impl Target for LogicalSpiWrapper {
         }
         if chip_select.is_some() {
             inner.chip_select = chip_select.map(Rc::clone);
+        }
+        if gsc_ready.is_some() {
+            inner.gsc_ready = gsc_ready.map(Rc::clone);
         }
         Ok(())
     }

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -334,17 +334,23 @@ impl<'a> TransportCommandHandler<'a> {
                             has_support,
                         }))
                     }
+                    SpiRequest::SupportsTpmPoll => {
+                        let has_support = instance.supports_tpm_poll()?;
+                        Ok(Response::Spi(SpiResponse::SupportsTpmPoll { has_support }))
+                    }
                     SpiRequest::SetPins {
                         serial_clock,
                         host_out_device_in,
                         host_in_device_out,
                         chip_select,
+                        gsc_ready,
                     } => {
                         instance.set_pins(
                             self.optional_pin(serial_clock)?.as_ref(),
                             self.optional_pin(host_out_device_in)?.as_ref(),
                             self.optional_pin(host_in_device_out)?.as_ref(),
                             self.optional_pin(chip_select)?.as_ref(),
+                            self.optional_pin(gsc_ready)?.as_ref(),
                         )?;
                         Ok(Response::Spi(SpiResponse::SetPins))
                     }
@@ -378,6 +384,8 @@ impl<'a> TransportCommandHandler<'a> {
                                 SpiTransferRequest::Both { data } => SpiTransferResponse::Both {
                                     data: vec![0; data.len()],
                                 },
+                                SpiTransferRequest::TpmPoll => SpiTransferResponse::TpmPoll,
+                                SpiTransferRequest::GscReady => SpiTransferResponse::GscReady,
                             })
                             .collect();
                         // Now carefully craft a proper parameter to the
@@ -400,6 +408,12 @@ impl<'a> TransportCommandHandler<'a> {
                                     SpiTransferRequest::Both { data: wdata },
                                     SpiTransferResponse::Both { data },
                                 ) => spi::Transfer::Both(wdata, data),
+                                (SpiTransferRequest::TpmPoll, SpiTransferResponse::TpmPoll) => {
+                                    spi::Transfer::TpmPoll
+                                }
+                                (SpiTransferRequest::GscReady, SpiTransferResponse::GscReady) => {
+                                    spi::Transfer::GscReady
+                                }
                                 _ => {
                                     // This can only happen if the logic in this method is
                                     // flawed.  (Never due to network input.)
@@ -452,6 +466,18 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_max_speed(*value)?;
                         Ok(Response::I2c(I2cResponse::SetMaxSpeed))
                     }
+                    I2cRequest::SetPins {
+                        serial_clock,
+                        serial_data,
+                        gsc_ready,
+                    } => {
+                        instance.set_pins(
+                            self.optional_pin(serial_clock)?.as_ref(),
+                            self.optional_pin(serial_data)?.as_ref(),
+                            self.optional_pin(gsc_ready)?.as_ref(),
+                        )?;
+                        Ok(Response::I2c(I2cResponse::SetPins))
+                    }
                     I2cRequest::RunTransaction {
                         address,
                         transaction: reqs,
@@ -464,6 +490,7 @@ impl<'a> TransportCommandHandler<'a> {
                                     data: vec![0; *len as usize],
                                 },
                                 I2cTransferRequest::Write { .. } => I2cTransferResponse::Write,
+                                I2cTransferRequest::GscReady => I2cTransferResponse::GscReady,
                             })
                             .collect();
                         // Now carefully craft a proper parameter to the
@@ -482,6 +509,9 @@ impl<'a> TransportCommandHandler<'a> {
                                     I2cTransferRequest::Write { data },
                                     I2cTransferResponse::Write,
                                 ) => i2c::Transfer::Write(data),
+                                (I2cTransferRequest::GscReady, I2cTransferResponse::GscReady) => {
+                                    i2c::Transfer::GscReady
+                                }
                                 _ => {
                                     // This can only happen if the logic in this method is
                                     // flawed.  (Never due to network input.)

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -210,6 +210,8 @@ pub enum SpiTransferRequest {
     Read { len: u32 },
     Write { data: Vec<u8> },
     Both { data: Vec<u8> },
+    TpmPoll,
+    GscReady,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -217,6 +219,8 @@ pub enum SpiTransferResponse {
     Read { data: Vec<u8> },
     Write,
     Both { data: Vec<u8> },
+    TpmPoll,
+    GscReady,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -234,11 +238,13 @@ pub enum SpiRequest {
         value: u32,
     },
     SupportsBidirectionalTransfer,
+    SupportsTpmPoll,
     SetPins {
         serial_clock: Option<String>,
         host_out_device_in: Option<String>,
         host_in_device_out: Option<String>,
         chip_select: Option<String>,
+        gsc_ready: Option<String>,
     },
     GetMaxTransferCount,
     GetMaxTransferSizes,
@@ -270,6 +276,9 @@ pub enum SpiResponse {
     SupportsBidirectionalTransfer {
         has_support: bool,
     },
+    SupportsTpmPoll {
+        has_support: bool,
+    },
     SetPins,
     GetMaxTransferCount {
         number: usize,
@@ -292,12 +301,14 @@ pub enum SpiResponse {
 pub enum I2cTransferRequest {
     Read { len: u32 },
     Write { data: Vec<u8> },
+    GscReady,
 }
 
 #[derive(Serialize, Deserialize)]
 pub enum I2cTransferResponse {
     Read { data: Vec<u8> },
     Write,
+    GscReady,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -309,6 +320,11 @@ pub enum I2cRequest {
     GetMaxSpeed,
     SetMaxSpeed {
         value: u32,
+    },
+    SetPins {
+        serial_clock: Option<String>,
+        serial_data: Option<String>,
+        gsc_ready: Option<String>,
     },
     RunTransaction {
         address: Option<u8>,
@@ -331,6 +347,7 @@ pub enum I2cResponse {
         speed: u32,
     },
     SetMaxSpeed,
+    SetPins,
     RunTransaction {
         transaction: Vec<I2cTransferResponse>,
     },

--- a/sw/host/opentitanlib/src/transport/dediprog/spi.rs
+++ b/sw/host/opentitanlib/src/transport/dediprog/spi.rs
@@ -349,6 +349,10 @@ impl Target for DediprogSpi {
         Ok(false)
     }
 
+    fn supports_tpm_poll(&self) -> Result<bool> {
+        Ok(false)
+    }
+
     fn get_max_transfer_count(&self) -> Result<usize> {
         // Arbitrary value: number of `Transfers` that can be in a single transaction.
         Ok(42)

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -380,6 +380,7 @@ impl Bus for HyperdebugI2cBus {
                     transaction = &mut transaction[1..];
                 }
                 [] => (),
+                _ => bail!(TransportError::UnsupportedOperation),
             }
         }
         Ok(())

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -443,6 +443,7 @@ pub struct CachedIo {
 
 pub struct Conn {
     console_port: RefCell<TTYPort>,
+    first_use: Cell<bool>,
 }
 
 // The way that the HyperDebug allows callers to request optimization for a sequence of operations
@@ -468,6 +469,7 @@ impl Inner {
         flock_serial(&port, port_name)?;
         let conn = Rc::new(Conn {
             console_port: RefCell::new(port),
+            first_use: Cell::new(true),
         });
         // Return a (strong) reference to the newly opened connection, while keeping a weak
         // reference to the same in this `Inner` object.  The result is that if the caller keeps
@@ -561,10 +563,16 @@ impl Conn {
     fn execute_command(&self, cmd: &str, mut callback: impl FnMut(&str)) -> Result<()> {
         let port: &mut TTYPort = &mut self.console_port.borrow_mut();
 
-        // Send Ctrl-C, followed by the command, then newline.  This will discard any previous
-        // partial input, before executing our command.
-        port.write(format!("\x03{}\n", cmd).as_bytes())
-            .context("writing to HyperDebug console")?;
+        if self.first_use.get() {
+            // Send Ctrl-C, followed by the command, then newline.  This will discard any previous
+            // partial input, before executing our command.
+            port.write(format!("\x03{}\n", cmd).as_bytes())
+                .context("writing to HyperDebug console")?;
+            self.first_use.set(false);
+        } else {
+            port.write(format!("{}\n", cmd).as_bytes())
+                .context("writing to HyperDebug console")?;
+        }
 
         // Now process response from HyperDebug.  First we expect to see the echo of the command
         // we just "typed". Then zero, one or more lines of useful output, which we want to pass

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -138,6 +138,7 @@ impl<T: Flavor> Hyperdebug<T> {
     const GOOGLE_CAP_GPIO_MONITORING: u16 = 0x0004;
     const GOOGLE_CAP_GPIO_BITBANGING: u16 = 0x0008;
     const GOOGLE_CAP_UART_QUEUE_CLEAR: u16 = 0x0010;
+    const GOOGLE_CAP_TPM_POLL: u16 = 0x0020;
 
     /// Establish connection with a particular HyperDebug.
     pub fn open(
@@ -656,6 +657,7 @@ impl<T: Flavor> Transport for Hyperdebug<T> {
             &self.spi_interface,
             enable_cmd,
             idx,
+            self.get_cmsis_google_capabilities()? & Self::GOOGLE_CAP_TPM_POLL != 0,
         )?);
         self.cached_io_interfaces
             .spis

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -684,14 +684,23 @@ impl Target for HyperdebugSpiTarget {
         Ok((self.feature_bitmap & FEATURE_BIT_FULL_DUPLEX) != 0)
     }
 
+    fn supports_tpm_poll(&self) -> Result<bool> {
+        Ok(false)
+    }
+
     fn set_pins(
         &self,
         serial_clock: Option<&Rc<dyn GpioPin>>,
         host_out_device_in: Option<&Rc<dyn GpioPin>>,
         host_in_device_out: Option<&Rc<dyn GpioPin>>,
         chip_select: Option<&Rc<dyn GpioPin>>,
+        gsc_ready: Option<&Rc<dyn GpioPin>>,
     ) -> Result<()> {
-        if serial_clock.is_some() || host_out_device_in.is_some() || host_in_device_out.is_some() {
+        if serial_clock.is_some()
+            || host_out_device_in.is_some()
+            || host_in_device_out.is_some()
+            || gsc_ready.is_some()
+        {
             bail!(SpiError::InvalidPin);
         }
         if let Some(pin) = chip_select {
@@ -824,6 +833,8 @@ impl Target for HyperdebugSpiTarget {
                     self.transmit(wbuf, FULL_DUPLEX)?;
                     self.receive(rbuf)?;
                 }
+                [Transfer::TpmPoll, ..] => bail!(TransportError::UnsupportedOperation),
+                [Transfer::GscReady, ..] => bail!(TransportError::UnsupportedOperation),
                 [] => (),
             }
             idx += 1;

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -24,6 +24,7 @@ pub struct HyperdebugSpiTarget {
     target_enable_cmd: u8,
     target_idx: u8,
     feature_bitmap: u16,
+    supports_tpm_poll: bool,
     max_sizes: MaxSizes,
     cs_asserted_count: Cell<u32>,
 }
@@ -73,6 +74,8 @@ const EEPROM_FLAGS_WIDTH_4WIRE: u32 = 0x00000100;
 const EEPROM_FLAGS_WIDTH_8WIRE: u32 = 0x00000180;
 const EEPROM_FLAGS_DTR: u32 = 0x00000200;
 const EEPROM_FLAGS_DUMMY_CYCLES_POS: u8 = 10;
+const EEPROM_FLAGS_GSC_READY: u32 = 0x04000000;
+const EEPROM_FLAGS_TPM: u32 = 0x08000000;
 const EEPROM_FLAGS_WRITE_ENABLE: u32 = 0x10000000;
 const EEPROM_FLAGS_POLL_BUSY: u32 = 0x20000000;
 const EEPROM_FLAGS_DOUBLE_BUFFER: u32 = 0x40000000;
@@ -251,6 +254,7 @@ impl HyperdebugSpiTarget {
         spi_interface: &BulkInterface,
         enable_cmd: u8,
         idx: u8,
+        supports_tpm_poll: bool,
     ) -> Result<Self> {
         let mut usb_handle = inner.usb_device.borrow_mut();
 
@@ -293,6 +297,7 @@ impl HyperdebugSpiTarget {
             target_enable_cmd: enable_cmd,
             target_idx: idx,
             feature_bitmap: resp.feature_bitmap,
+            supports_tpm_poll,
             max_sizes: MaxSizes {
                 read: resp.max_read_chunk as usize,
                 write: resp.max_write_chunk as usize,
@@ -324,6 +329,52 @@ impl HyperdebugSpiTarget {
         let databytes = std::cmp::min(USB_MAX_SIZE - 6, wbuf.len());
         req.data[0..databytes].clone_from_slice(&wbuf[0..databytes]);
         self.usb_write_bulk(&req.as_bytes()[0..6 + databytes])?;
+        let mut index = databytes;
+
+        while index < wbuf.len() {
+            let mut req = CmdTransferContinue::new();
+            req.data_index = index as u16;
+            let databytes = std::cmp::min(USB_MAX_SIZE - 4, wbuf.len() - index);
+            req.data[0..databytes].clone_from_slice(&wbuf[index..index + databytes]);
+            self.usb_write_bulk(&req.as_bytes()[0..4 + databytes])?;
+            index += databytes;
+        }
+        Ok(())
+    }
+
+    /// Preform TPM transactions, that is, send four bytes of header/address, then repeatedly poll
+    /// for ready statys from the device, before sending/receiving the data bytes.  Optionally
+    /// wait for falling edge on "GSC ready" pin, at appropriate time during tracsation.
+    fn tpm_transmit(&self, wbuf: &[u8], rbuf_len: usize, await_gsc_ready: bool) -> Result<()> {
+        const TPM_HEADER_SIZE: usize = 4;
+        let mut req = CmdEepromTransferStart::new();
+        if rbuf_len == 0 {
+            req.flags |= EEPROM_FLAGS_WRITE;
+            req.count = (wbuf.len() - TPM_HEADER_SIZE) as u16;
+            ensure!(
+                wbuf.len() > TPM_HEADER_SIZE,
+                SpiError::InvalidDataLength(wbuf.len())
+            );
+        } else {
+            req.count = rbuf_len as u16;
+            ensure!(
+                wbuf.len() == TPM_HEADER_SIZE,
+                SpiError::InvalidDataLength(wbuf.len())
+            );
+        }
+
+        req.flags |= (TPM_HEADER_SIZE as u32) << EEPROM_FLAGS_ADDR_LEN_POS;
+        req.flags |= EEPROM_FLAGS_TPM;
+        if await_gsc_ready {
+            req.flags |= EEPROM_FLAGS_GSC_READY;
+        }
+
+        let data_start_offset = 0;
+        // Optional write data bytes
+        let databytes = std::cmp::min(USB_MAX_SIZE - 8 - data_start_offset, wbuf.len());
+        req.data[data_start_offset..data_start_offset + databytes]
+            .clone_from_slice(&wbuf[0..databytes]);
+        self.usb_write_bulk(&req.as_bytes()[0..8 + data_start_offset + databytes])?;
         let mut index = databytes;
 
         while index < wbuf.len() {
@@ -685,7 +736,7 @@ impl Target for HyperdebugSpiTarget {
     }
 
     fn supports_tpm_poll(&self) -> Result<bool> {
-        Ok(false)
+        Ok(self.supports_tpm_poll)
     }
 
     fn set_pins(
@@ -696,16 +747,19 @@ impl Target for HyperdebugSpiTarget {
         chip_select: Option<&Rc<dyn GpioPin>>,
         gsc_ready: Option<&Rc<dyn GpioPin>>,
     ) -> Result<()> {
-        if serial_clock.is_some()
-            || host_out_device_in.is_some()
-            || host_in_device_out.is_some()
-            || gsc_ready.is_some()
-        {
+        if serial_clock.is_some() || host_out_device_in.is_some() || host_in_device_out.is_some() {
             bail!(SpiError::InvalidPin);
         }
         if let Some(pin) = chip_select {
             self.inner.cmd_no_output(&format!(
                 "spi set cs {} {}",
+                &self.target_idx,
+                pin.get_internal_pin_name().ok_or(SpiError::InvalidPin)?
+            ))?;
+        }
+        if let Some(pin) = gsc_ready {
+            self.inner.cmd_no_output(&format!(
+                "spi set ready {} {}",
                 &self.target_idx,
                 pin.get_internal_pin_name().ok_or(SpiError::InvalidPin)?
             ))?;
@@ -747,6 +801,36 @@ impl Target for HyperdebugSpiTarget {
                 self.receive(rbuf)?;
                 return Ok(());
             }
+            [Transfer::Write(wbuf), Transfer::GscReady, Transfer::TpmPoll, Transfer::Read(rbuf)] => {
+                // Hyperdebug can do SPI TPM transaction as a single USB
+                // request/reply.
+                ensure!(
+                    wbuf.len() <= self.max_sizes.write,
+                    SpiError::InvalidDataLength(wbuf.len())
+                );
+                ensure!(
+                    rbuf.len() <= self.max_sizes.read,
+                    SpiError::InvalidDataLength(rbuf.len())
+                );
+                self.tpm_transmit(wbuf, rbuf.len(), true)?;
+                self.receive(rbuf)?;
+                return Ok(());
+            }
+            [Transfer::Write(wbuf), Transfer::TpmPoll, Transfer::Read(rbuf)] => {
+                // Hyperdebug can do SPI TPM transaction as a single USB
+                // request/reply.
+                ensure!(
+                    wbuf.len() <= self.max_sizes.write,
+                    SpiError::InvalidDataLength(wbuf.len())
+                );
+                ensure!(
+                    rbuf.len() <= self.max_sizes.read,
+                    SpiError::InvalidDataLength(rbuf.len())
+                );
+                self.tpm_transmit(wbuf, rbuf.len(), false)?;
+                self.receive(rbuf)?;
+                return Ok(());
+            }
             [Transfer::Write(wbuf)] => {
                 ensure!(
                     wbuf.len() <= self.max_sizes.write,
@@ -765,6 +849,35 @@ impl Target for HyperdebugSpiTarget {
                     self.receive(&mut [])?;
                     return Ok(());
                 }
+            }
+            [Transfer::Write(wbuf1), Transfer::TpmPoll, Transfer::Write(wbuf2), Transfer::GscReady] =>
+            {
+                // Hyperdebug can do SPI TPM transaction as a single USB
+                // request/reply.
+                ensure!(
+                    wbuf1.len() + wbuf2.len() <= self.max_sizes.write,
+                    SpiError::InvalidDataLength(wbuf1.len() + wbuf2.len())
+                );
+                let mut combined_buf = vec![0u8; wbuf1.len() + wbuf2.len()];
+                combined_buf[..wbuf1.len()].clone_from_slice(wbuf1);
+                combined_buf[wbuf1.len()..].clone_from_slice(wbuf2);
+                self.tpm_transmit(&combined_buf, 0, true)?;
+                self.receive(&mut [])?;
+                return Ok(());
+            }
+            [Transfer::Write(wbuf1), Transfer::TpmPoll, Transfer::Write(wbuf2)] => {
+                // Hyperdebug can do SPI TPM transaction as a single USB
+                // request/reply.
+                ensure!(
+                    wbuf1.len() + wbuf2.len() <= self.max_sizes.write,
+                    SpiError::InvalidDataLength(wbuf1.len() + wbuf2.len())
+                );
+                let mut combined_buf = vec![0u8; wbuf1.len() + wbuf2.len()];
+                combined_buf[..wbuf1.len()].clone_from_slice(wbuf1);
+                combined_buf[wbuf1.len()..].clone_from_slice(wbuf2);
+                self.tpm_transmit(&combined_buf, 0, false)?;
+                self.receive(&mut [])?;
+                return Ok(());
             }
             [Transfer::Read(rbuf)] => {
                 ensure!(

--- a/sw/host/opentitanlib/src/transport/proxy/spi.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/spi.rs
@@ -101,18 +101,27 @@ impl Target for ProxySpi {
         }
     }
 
+    fn supports_tpm_poll(&self) -> Result<bool> {
+        match self.execute_command(SpiRequest::SupportsTpmPoll)? {
+            SpiResponse::SupportsTpmPoll { has_support } => Ok(has_support),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     fn set_pins(
         &self,
         serial_clock: Option<&Rc<dyn gpio::GpioPin>>,
         host_out_device_in: Option<&Rc<dyn gpio::GpioPin>>,
         host_in_device_out: Option<&Rc<dyn gpio::GpioPin>>,
         chip_select: Option<&Rc<dyn gpio::GpioPin>>,
+        gsc_ready: Option<&Rc<dyn gpio::GpioPin>>,
     ) -> Result<()> {
         match self.execute_command(SpiRequest::SetPins {
             serial_clock: spi_pin_name(serial_clock)?,
             host_out_device_in: spi_pin_name(host_out_device_in)?,
             host_in_device_out: spi_pin_name(host_in_device_out)?,
             chip_select: spi_pin_name(chip_select)?,
+            gsc_ready: spi_pin_name(gsc_ready)?,
         })? {
             SpiResponse::SetPins => Ok(()),
             _ => bail!(ProxyError::UnexpectedReply()),
@@ -166,6 +175,8 @@ impl Target for ProxySpi {
                         data: wbuf.to_vec(),
                     })
                 }
+                Transfer::TpmPoll => req.push(SpiTransferRequest::TpmPoll),
+                Transfer::GscReady => req.push(SpiTransferRequest::GscReady),
             }
         }
         match self.execute_command(SpiRequest::RunTransaction { transaction: req })? {
@@ -181,6 +192,8 @@ impl Target for ProxySpi {
                             rbuf.clone_from_slice(data);
                         }
                         (SpiTransferResponse::Write, Transfer::Write(_)) => (),
+                        (SpiTransferResponse::TpmPoll, Transfer::TpmPoll) => (),
+                        (SpiTransferResponse::GscReady, Transfer::GscReady) => (),
                         _ => bail!(ProxyError::UnexpectedReply()),
                     }
                 }

--- a/sw/host/opentitanlib/src/transport/ti50emulator/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/i2c.rs
@@ -261,6 +261,7 @@ impl Bus for Ti50I2cBus {
                 Transfer::Read(rd) => {
                     self.read(addr, rd)?;
                 }
+                _ => bail!(TransportError::UnsupportedOperation),
             }
         }
         Ok(())

--- a/sw/host/opentitanlib/src/transport/ti50emulator/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ti50emulator/spi.rs
@@ -47,6 +47,11 @@ impl Target for Ti50Spi {
         Err(TransportError::UnsupportedOperation.into())
     }
 
+    /// Indicates whether `Transfer::TpmPoll` is supported.
+    fn supports_tpm_poll(&self) -> Result<bool> {
+        Err(TransportError::UnsupportedOperation.into())
+    }
+
     /// Returns the maximum number of transfers allowed in a single transaction.
     fn get_max_transfer_count(&self) -> Result<usize> {
         Err(TransportError::UnsupportedOperation.into())

--- a/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -12,6 +12,7 @@ use crate::io::spi::{
 };
 use crate::transport::ultradebug::mpsse;
 use crate::transport::ultradebug::Ultradebug;
+use crate::transport::TransportError;
 
 struct Inner {
     mode: TransferMode,
@@ -101,6 +102,10 @@ impl Target for UltradebugSpi {
         Ok(true)
     }
 
+    fn supports_tpm_poll(&self) -> Result<bool> {
+        Ok(false)
+    }
+
     fn get_max_transfer_count(&self) -> Result<usize> {
         // Arbitrary value: number of `Transfers` that can be in a single transaction.
         Ok(42)
@@ -164,6 +169,7 @@ impl Target for UltradebugSpi {
                     },
                     rbuf,
                 ),
+                _ => bail!(TransportError::UnsupportedOperation),
             });
         }
         if cs_not_already_asserted {

--- a/sw/host/tests/chip/spi_device/src/spi_device_tpm_test.rs
+++ b/sw/host/tests/chip/spi_device/src/spi_device_tpm_test.rs
@@ -39,7 +39,7 @@ fn tpm_read_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
 
     /* Wait sync message. */
     let _ = UartConsole::wait_for(&*uart, r"SYNC: Begin TPM Test\r\n", opts.timeout)?;
-    let tpm = tpm::SpiDriver::new(spi, None)?;
+    let tpm = tpm::SpiDriver::new(spi, false)?;
     const SIZE: usize = 10;
 
     for _ in 0..10 {


### PR DESCRIPTION
Adapt TPM driver layer to use advanced transport features, if available.  These features allows asking the backend transport to perform a full TPM register read or write in a single USB roundtrip, including e.g. polling the SPI bus to know when the device is ready for the data transfer.

This change speeds up TPM communication between 2x and 4x when HyperDebug is used to communicate with GSC chips.
