### PR TITLE
[topgen] Support for unmanaged external resets

### DIFF
--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -8,6 +8,7 @@ import topgen.lib as lib
 from reggen.params import Parameter
 from topgen.clocks import Clocks
 from topgen.resets import Resets
+from topgen.merge import is_unmanaged_reset
 
 num_mio_inputs = top['pinmux']['io_counts']['muxed']['inouts'] + \
                  top['pinmux']['io_counts']['muxed']['inputs']
@@ -127,6 +128,14 @@ module top_${top["name"]} #(
     % for clk in top['unmanaged_clocks']._asdict().values():
   input                        clk_${clk.name}_i,
   input prim_mubi_pkg::mubi4_t cg_${clk.name}_i,
+    % endfor
+  % endif
+  % if len(top['unmanaged_resets']._asdict().values()) > 0:
+
+  // Unmanaged external resets
+    % for rst in top['unmanaged_resets']._asdict().values():
+  input                        ${rst.signal_name},
+  input prim_mubi_pkg::mubi4_t ${rst.rst_en_signal_name},
     % endfor
   % endif
 
@@ -387,7 +396,7 @@ for rst in output_rsts:
     cg_en = 'cg_' + lpg['clock_connection'].split('clk_')[-1]
   else:
     cg_en = top['clocks'].hier_paths['lpg'] + lpg['clock_connection'].split('.clk_')[-1]
-  rst_en = lib.get_reset_lpg_path(top, lpg['reset_connection'])
+  rst_en = lib.get_reset_lpg_path(top, lpg['reset_connection'], False, None, lpg['unmanaged_reset'])
   known_clocks[cg_en] = 0
   known_resets[rst_en] = 0
 %>\
@@ -542,10 +551,16 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
       .${k} (${v}),
     % endfor
     % for port, reset in m["reset_connections"].items():
-      % if lib.is_shadowed_port(block, port):
-      .${lib.shadow_name(port)} (${lib.get_reset_path(top, reset, True)}),
-      % endif:
-      .${port} (${lib.get_reset_path(top, reset)})${"," if not loop.last else ""}
+<%
+      is_shadowed_port = lib.is_shadowed_port(block, port)
+      unmanaged_reset = is_unmanaged_reset(top, reset['name'])
+      reset_port = lib.get_reset_path(top, reset, False, unmanaged_reset)
+      shadowed_port = lib.get_reset_path(top, reset, True, unmanaged_reset)
+%>\
+    % if is_shadowed_port:
+      .${lib.shadow_name(port)} (${shadowed_port}),
+    % endif
+      .${port} (${reset_port})${"," if not loop.last else ""}
     % endfor
   );
 % endfor

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -16253,6 +16253,7 @@
       lpg_idx: 17
     }
   ]
+  unmanaged_resets: {}
   exported_rsts: {}
   alert_lpgs:
   [
@@ -16275,6 +16276,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16300,6 +16302,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: spi_device
@@ -16325,6 +16328,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: i2c0
@@ -16350,6 +16354,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: i2c1
@@ -16375,6 +16380,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: i2c2
@@ -16397,6 +16403,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_timers
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16420,6 +16427,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_secure
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16445,6 +16453,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: spi_host0
@@ -16470,6 +16479,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div2_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: spi_host1
@@ -16495,6 +16505,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_usb_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: usb
@@ -16521,6 +16532,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_powerup
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: por_io_div4
@@ -16547,6 +16559,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_powerup
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16570,6 +16583,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_secure
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16595,6 +16609,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16617,6 +16632,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_timers
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16642,6 +16658,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_infra
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16667,6 +16684,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_infra
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -16692,6 +16710,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_infra
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -16717,6 +16736,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_infra
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: sys
@@ -16740,6 +16760,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_secure
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -16764,6 +16785,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_aes
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -16788,6 +16810,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_hmac
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -16812,6 +16835,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_kmac
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -16836,6 +16860,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_otbn
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -106,6 +106,13 @@
     ],
   },
 
+  // List of unmanaged external resets
+  //
+  // These should be listed as dictionaries that just give their names, in this form:
+  //
+  //    { name: "my_external_reset" }
+  // unmanaged_resets: []
+
   // This is the reset data structure of the design.
   // The hier path refers to the reset reference path (struct / port)
   //   - The top/ext desgination follows the same scheme as inter-module

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -115,6 +115,11 @@
     ],
   },
 
+  // List of unmanaged external resets
+  unmanaged_resets: [
+    // { name: "my_ext" }
+  ]
+
   // This is the reset data structure of the design.
   // The hier path refers to the reset reference path (struct / port)
   //   - The top/ext desgination follows the same scheme as inter-module

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -9,7 +9,7 @@ from collections import defaultdict, OrderedDict
 from copy import deepcopy
 from mako.template import Template
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import hjson
 from reggen.ip_block import IpBlock
@@ -586,19 +586,27 @@ def shadow_name(name: str) -> str:
         return 'rst_shadowed_ni'
 
 
-def get_reset_path(top: object, reset: str, shadow_sel: bool = False):
+def get_reset_path(top: object, reset: Union[str, object], shadow_sel: bool = False,
+                   unmanaged_reset: bool = False):
     """Return the appropriate reset path given name
     """
-    return top['resets'].get_path(reset['name'], reset['domain'], shadow_sel)
+    if unmanaged_reset:
+        return top['unmanaged_resets'].get(reset['name']).signal_name
+    else:
+        return top['resets'].get_path(reset['name'], reset['domain'], shadow_sel)
 
 
-def get_reset_lpg_path(top: object, reset: str, shadow_sel: bool = False, domain: bool = None):
+def get_reset_lpg_path(top: object, reset: Union[str, object], shadow_sel: bool = False,
+                       domain: bool = None, unmanaged_reset: bool = False):
     """Return the appropriate LPG reset path given name
     """
-    if domain is not None:
-        return top['resets'].get_lpg_path(reset['name'], domain, shadow_sel)
+    if unmanaged_reset:
+        return top['unmanaged_resets'].get(reset['name']).rst_en_signal_name
     else:
-        return top['resets'].get_lpg_path(reset['name'], reset['domain'], shadow_sel)
+        if domain is not None:
+            return top['resets'].get_lpg_path(reset['name'], domain, shadow_sel)
+        else:
+            return top['resets'].get_lpg_path(reset['name'], reset['domain'], shadow_sel)
 
 
 def get_unused_resets(top):

--- a/util/topgen/resets.py
+++ b/util/topgen/resets.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 from .clocks import Clocks
 
 
@@ -214,3 +214,40 @@ class Resets:
                 return True
 
         return False
+
+
+class UnmanagedReset:
+    '''An unmanaged reset (input to the top-level).'''
+
+    def __init__(self, raw: Dict[str, object]):
+        if 'name' not in raw:
+            raise ValueError('Missing field "name" for unmanaged reset')
+        self.name = str(raw['name'])
+        self.signal_name = f'rst_{self.name}_i'
+        self.rst_en_signal_name = f'rst_en_{self.name}_i'
+
+    def _asdict(self) -> Dict[str, object]:
+        return {
+            'name': self.name,
+            'signal_name': self.signal_name,
+            'rst_en_signal_name': self.rst_en_signal_name
+        }
+
+
+class UnmanagedResets:
+    '''Unmanaged reset connections for the chip.'''
+
+    def __init__(self, raw: List[object]):
+        self.resets = {reset['name']: UnmanagedReset(reset) for reset in raw}
+
+    def _asdict(self) -> Dict[str, object]:
+        return self.resets
+
+    def get(self, name: str) -> object:
+        try:
+            return self.resets[name]
+        except KeyError:
+            raise ValueError(f"No reset defined with name {name}") from None
+
+    def __contains__(self, k: str) -> bool:
+        return k in self.resets


### PR DESCRIPTION
Tops may specify resets that are completely managed externally, i.e., with a dedicated reset manager in the uncore environment of an integrated OpenTitan. Feeding that reset to the internal reset manager is not necessary and just adds complexity in the configuration.

To address this, this PR introduces support for unmanaged external resets, allowing them to operate independently from the internal reset manager. To define an unmanaged reset, simply add an entry to the top-level unmanaged_resets list. Once defined, these resets can be used like any other reset for IP instantiation and crossbar mapping.

Additionally, when routing IP alerts to the alert manager, the alert manager requires a reset status signal to know if the reset for the alert’s IP is currently active. For unmanaged external resets, it's assumed that the top-level external environment already has knowledge of the reset status. Topgen creates a dedicated LPG for every external reset. The reset status signal is routed at top-level and connected to the associated group to the alert manager.