### PR TITLE
[pwm,dv] Lots of tidy-ups in the scoreboard and monitor

### DIFF
--- a/hw/dv/sv/pwm_monitor/pwm_item.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_item.sv
@@ -4,7 +4,6 @@
 
 class pwm_item extends uvm_sequence_item;
 
-  int monitor_id    = 0; // for debugging purpose only
   int period        = 0; // clks in a beat
   int duty_cycle    = 0; // high vs low cnt
   int active_cnt    = 0; // number of clocks pwm was high
@@ -19,7 +18,6 @@ class pwm_item extends uvm_sequence_item;
     `uvm_field_int(inactive_cnt, UVM_DEFAULT)
     `uvm_field_int(phase, UVM_DEFAULT)
     `uvm_field_int(invert, UVM_DEFAULT)
-    `uvm_field_int(monitor_id, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -27,7 +25,6 @@ class pwm_item extends uvm_sequence_item;
     function string convert2string();
       string txt ="";
       txt = "\n------| PWM ITEM |------";
-      txt = { txt, $sformatf("\n Item from monitor %d", monitor_id) };
       txt = { txt, $sformatf("\n Period %d clocks", period) };
       txt = { txt, $sformatf("\n Duty cycle %0d pct ", duty_cycle) };
       txt = { txt, $sformatf("\n inverted %0b", invert) };

--- a/hw/dv/sv/pwm_monitor/pwm_item.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_item.sv
@@ -3,41 +3,47 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class pwm_item extends uvm_sequence_item;
-
-  int period        = 0; // clks in a beat
-  int duty_cycle    = 0; // high vs low cnt
-  int active_cnt    = 0; // number of clocks pwm was high
-  int inactive_cnt  = 0; // number of clocks pwm was low
-  int phase         = 0; // what clock cnt did the pulse start
-  bit invert        = 0; // (1)active low (0) active high
+  int unsigned active_cnt    = 0; // number of clocks pwm was high
+  int unsigned inactive_cnt  = 0; // number of clocks pwm was low
+  int unsigned phase         = 0; // what clock cnt did the pulse start
+  bit invert                 = 0; // (1)active low (0) active high
 
   `uvm_object_utils_begin(pwm_item)
-    `uvm_field_int(period, UVM_DEFAULT)
-    `uvm_field_int(duty_cycle, UVM_DEFAULT)
     `uvm_field_int(active_cnt, UVM_DEFAULT)
     `uvm_field_int(inactive_cnt, UVM_DEFAULT)
     `uvm_field_int(phase, UVM_DEFAULT)
     `uvm_field_int(invert, UVM_DEFAULT)
   `uvm_object_utils_end
 
-  `uvm_object_new
+  extern function new (string name="");
+  extern function string convert2string();
 
-    function string convert2string();
-      string txt ="";
-      txt = "\n------| PWM ITEM |------";
-      txt = { txt, $sformatf("\n Period %d clocks", period) };
-      txt = { txt, $sformatf("\n Duty cycle %0d pct ", duty_cycle) };
-      txt = { txt, $sformatf("\n inverted %0b", invert) };
-      txt = { txt, $sformatf("\n # of active cycles %d", active_cnt) };
-      txt = { txt, $sformatf("\n # of inactive cycles %d", inactive_cnt) };
-      txt = { txt, $sformatf("\n phase cnt %d", phase) };
-      return txt;
-    endfunction : convert2string
+  // Return the total time taken by the item (active and inactive cycles)
+  extern function int unsigned get_period();
 
-  function int get_duty_cycle();
-    real dc = 0;
-    dc = (invert) ? (real'(inactive_cnt) / real'(period) * 100)
-                  : (real'(active_cnt) / real'(period) * 100);
-    return dc;
-  endfunction : get_duty_cycle
+  // Return the duty cycle as a rounded percentage
+  extern function int unsigned get_duty_cycle();
 endclass
+
+function pwm_item::new (string name="");
+  super.new(name);
+endfunction
+
+function string pwm_item::convert2string();
+  string txt ="";
+  txt = "\n------| PWM ITEM |------";
+  txt = { txt, $sformatf("\n inverted %0b", invert) };
+  txt = { txt, $sformatf("\n # of active cycles %d", active_cnt) };
+  txt = { txt, $sformatf("\n # of inactive cycles %d", inactive_cnt) };
+  txt = { txt, $sformatf("\n phase cnt %d", phase) };
+  return txt;
+endfunction
+
+function int unsigned pwm_item::get_period();
+  return active_cnt + inactive_cnt;
+endfunction
+
+function int pwm_item::get_duty_cycle();
+  int high_cnt = invert ? inactive_cnt : active_cnt;
+  return real'(high_cnt) / real'(get_period()) * 100;
+endfunction

--- a/hw/dv/sv/pwm_monitor/pwm_monitor.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_monitor.sv
@@ -90,12 +90,10 @@ task pwm_monitor::collect_transaction();
     item.invert       = cfg.invert;
     item.active_cnt   = active_cycles;
     item.inactive_cnt = inactive_cycles;
-    item.period       = inactive_cycles + active_cycles;
-    item.duty_cycle   = item.get_duty_cycle();
 
     // Each PWM pulse cycle is divided into 2^DC_RESN+1 beats, per beat the 16-bit
     // phase counter increments by 2^(16-DC_RESN-1)(modulo 65536)
-    phase_count = ((item.period / (2 ** (cfg.resolution + 1))) *
+    phase_count = ((item.get_period() / (2 ** (cfg.resolution + 1))) *
                    (2 ** (16 - (cfg.resolution - 1))));
     item.phase = (phase_count % 65536);
     analysis_port.write(item);

--- a/hw/dv/sv/pwm_monitor/pwm_monitor.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_monitor.sv
@@ -88,7 +88,6 @@ task pwm_monitor::collect_transaction();
     uint phase_count;
     pwm_item item = pwm_item::type_id::create("item");
     item.invert       = cfg.invert;
-    item.monitor_id   = cfg.monitor_id;
     item.active_cnt   = active_cycles;
     item.inactive_cnt = inactive_cycles;
     item.period       = inactive_cycles + active_cycles;

--- a/hw/dv/sv/pwm_monitor/pwm_monitor.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_monitor.sv
@@ -11,8 +11,15 @@ class pwm_monitor extends dv_base_monitor #(
   extern function new(string name = "", uvm_component parent = null);
   extern function void build_phase(uvm_phase phase);
 
-  // collect transactions forever - already forked in dv_base_monitor::run_phase
+  // Return true if we are currently in the active phase (the first half) of a transaction.
+  extern function bit is_active();
+
+  // Collect transactions forever whenever rst_n is high and cfg.active is true.
   extern protected task collect_trans();
+
+  // Collect a single transaction. This is called in a loop by collect_trans and is safe to kill at
+  // any time.
+  extern protected task collect_transaction();
 
   extern task monitor_ready_to_end();
 endclass
@@ -35,46 +42,64 @@ function void pwm_monitor::build_phase(uvm_phase phase);
   end
 endfunction
 
+function bit pwm_monitor::is_active();
+  // The active phase is the first part of the transaction. If invert is false, pwm is true for that
+  // time.
+  return cfg.vif.cb.pwm == !cfg.invert;
+endfunction
+
 task pwm_monitor::collect_trans();
-  uint count_cycles, active_cycles;
-  logic pwm_prev = 0;
-
-  wait(cfg.vif.rst_n);
   forever begin
-    if (!cfg.active) begin
-      wait (cfg.active);
-      count_cycles = 0;
-      active_cycles = 0;
-    end
+    wait(cfg.vif.rst_n && cfg.active);
+    fork begin : isolation_fork
+      fork
+        wait(!(cfg.vif.rst_n && cfg.active));
+        forever collect_transaction();
+      join_any
+      disable fork;
+    end join
+  end
+endtask
 
+task pwm_monitor::collect_transaction();
+  uint active_cycles = 0, inactive_cycles = 0;
+
+  // Wait until the pwm signal is the 'active' value (marking the start of the first phase of the
+  // transaction).
+  while (!is_active()) @(cfg.vif.cb);
+
+  // Measure the amount of time we are active measure how many cycles we were active.
+  while (is_active()) begin
+    active_cycles++;
     @(cfg.vif.cb);
-    count_cycles++;
-    if (cfg.vif.cb.pwm != pwm_prev) begin
-      `uvm_info(`gfn, $sformatf("Detected edge: %0b->%0b at %0d cycles (from last edge)",
-                                pwm_prev, cfg.vif.cb.pwm, count_cycles), UVM_HIGH)
-      pwm_prev = cfg.vif.cb.pwm;
-      if (cfg.vif.cb.pwm == cfg.invert) begin
-        // We got to the first (active) half duty cycle point. Save the count and restart.
-        active_cycles = count_cycles;
-      end else begin
-        uint phase_count;
-        pwm_item item = pwm_item::type_id::create("item");
-        item.invert       = cfg.invert;
-        item.monitor_id   = cfg.monitor_id;
-        item.active_cnt   = active_cycles;
-        item.inactive_cnt = count_cycles;
-        item.period       = count_cycles + active_cycles;
-        item.duty_cycle   = item.get_duty_cycle();
+  end
 
-        // Each PWM pulse cycle is divided into 2^DC_RESN+1 beats, per beat the 16-bit
-        // phase counter increments by 2^(16-DC_RESN-1)(modulo 65536)
-        phase_count = ((item.period / (2 ** (cfg.resolution + 1))) *
-                       (2 ** (16 - (cfg.resolution - 1))));
-        item.phase = (phase_count % 65536);
-        analysis_port.write(item);
-      end
-      count_cycles = 0;
-    end
+  // Finally, wait until the pwm signal becomes the 'active' value again, incrementing
+  // inactive_cycles to measure how many cycles we were inactive.
+  while (!is_active()) begin
+    inactive_cycles++;
+    @(cfg.vif.cb);
+  end
+
+  // At this point, we've just finished the first cycle of the active phase of the next transaction,
+  // which will be counted correctly if we start collect_transaction again before any more time
+  // elapses. Report the transaction that we have measured through the analysis port.
+  begin
+    uint phase_count;
+    pwm_item item = pwm_item::type_id::create("item");
+    item.invert       = cfg.invert;
+    item.monitor_id   = cfg.monitor_id;
+    item.active_cnt   = active_cycles;
+    item.inactive_cnt = inactive_cycles;
+    item.period       = inactive_cycles + active_cycles;
+    item.duty_cycle   = item.get_duty_cycle();
+
+    // Each PWM pulse cycle is divided into 2^DC_RESN+1 beats, per beat the 16-bit
+    // phase counter increments by 2^(16-DC_RESN-1)(modulo 65536)
+    phase_count = ((item.period / (2 ** (cfg.resolution + 1))) *
+                   (2 ** (16 - (cfg.resolution - 1))));
+    item.phase = (phase_count % 65536);
+    analysis_port.write(item);
   end
 endtask
 

--- a/hw/dv/sv/pwm_monitor/pwm_monitor_cfg.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_monitor_cfg.sv
@@ -4,7 +4,6 @@
 
 class pwm_monitor_cfg  extends dv_base_agent_cfg;
 
-  int monitor_id = 0;
   bit en_monitor = 1'b1; // enable monitor
   bit invert     = 1'b0; // 0: active high,  1: active low
   bit active     = 1'b0; // 1: collect items 0: ignore

--- a/hw/ip/pwm/dv/env/pwm_env_cfg.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_cfg.sv
@@ -36,7 +36,6 @@ function void pwm_env_cfg::initialize(bit [31:0] csr_base_addr = '1);
     m_pwm_monitor_cfg[i] = pwm_monitor_cfg::type_id::create($sformatf("m_pwm_monitor%0d_cfg", i));
     m_pwm_monitor_cfg[i].if_mode = Device;
     m_pwm_monitor_cfg[i].is_active = 0;
-    m_pwm_monitor_cfg[i].monitor_id = i;
   end
 
   // only support 1 outstanding TL items in tlul_adapter

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -299,7 +299,7 @@ task pwm_scoreboard::compare_trans(int channel);
     if (compare_item.active_cnt == 0 || compare_item.inactive_cnt == 0) continue;
 
     // Finally, we only check items if the period is what we're expecting.
-    if (input_item.period != compare_item.period) continue;
+    if (input_item.get_period() != compare_item.get_period()) continue;
 
     `uvm_info(`gfn,
               $sformatf("\n PWM :: Channel = [%0d] EXPECTED CONTENT \n %s",
@@ -483,10 +483,8 @@ task pwm_scoreboard::generate_exp_item(ref pwm_item                     item,
   phase_count = (period / (2**(channel_cfg.DcResn + 1)) * (2**(16 - (channel_cfg.DcResn - 1))));
 
   item.invert          = invert[channel];
-  item.period          = period;
   item.active_cnt      = high_cycles;
   item.inactive_cnt    = low_cycles;
-  item.duty_cycle      = item.get_duty_cycle();
   item.phase           = (phase_count % 65536);
 
 endtask

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -262,6 +262,7 @@ task pwm_scoreboard::compare_trans(int channel);
   pwm_item input_item   = new($sformatf("input_item_%0d", channel));
   string txt            = "";
   int    p = 0;
+  bit    chatty = (channel == 2);
 
   forever begin
     // as this DUT signals needs to be evaluated over time they are only evaluated when the channel
@@ -270,6 +271,13 @@ task pwm_scoreboard::compare_trans(int channel);
 
     item_fifo[channel].get(input_item);
     generate_exp_item(compare_item, channel);
+
+    if (chatty) begin
+    `uvm_info(`gfn,
+              $sformatf("\n PWM :: Channel = [%0d] DUT CONTENT \n %s",
+                        channel, input_item.sprint()),
+              UVM_LOW)
+    end
 
     // The very first item will be when the monitor detects the first active edge and will have no
     // information. Wait for the first expected item.
@@ -474,7 +482,6 @@ task pwm_scoreboard::generate_exp_item(ref pwm_item                     item,
   // increments by 2^(16-DC_RESN-1)(modulo 65536)
   phase_count = (period / (2**(channel_cfg.DcResn + 1)) * (2**(16 - (channel_cfg.DcResn - 1))));
 
-  item.monitor_id      = channel;
   item.invert          = invert[channel];
   item.period          = period;
   item.active_cnt      = high_cycles;

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -268,39 +268,41 @@ task pwm_scoreboard::compare_trans(int channel);
     // is off. this way it is known what the first and last item are as they might deviate from the
     // settings due to rounding and termination.
 
-    // The very first item will be when the monitor detects the first active edge
-    // it will have no information
-    // wait for the first expected item
-    if((ignore_start_pulse[channel] == 2 ) || ( ignore_start_pulse[channel] == 1 )) begin
-      item_fifo[channel].get(input_item);
-      generate_exp_item(compare_item, channel);
-    end else begin
-      item_fifo[channel].get(input_item);
-      generate_exp_item(compare_item, channel);
-      // After the state has switched to different state, settings will change
-      // Comparison ignored till two pulses
-      if(!((ignore_state_change[channel] == 2 ) || (ignore_state_change[channel] == 1 ))) begin
-        // ignore items when resolution would round the duty cycle to 0 or 100
-        if((compare_item.active_cnt != 0) && (compare_item.inactive_cnt != 0)
-           && (input_item.period == compare_item.period)) begin
-          if(!input_item.compare(compare_item)) begin
-            `uvm_error(`gfn, $sformatf("\n PWM :: Channel = [%0d] did not MATCH", channel))
-            `uvm_info(`gfn, $sformatf("\n PWM :: Channel = [%0d] EXPECTED CONTENT \n %s",
-                                      channel, compare_item.sprint()),UVM_HIGH)
-            `uvm_info(`gfn, $sformatf("\n PWM :: Channel = [%0d] DUT CONTENT \n %s",
-                                      channel, input_item.sprint()),UVM_HIGH)
-          end else begin
-            `uvm_info(`gfn, $sformatf("\n PWM :: Channel = [%0d] MATCHED", channel),UVM_HIGH)
-            `uvm_info(`gfn, $sformatf("\n PWM :: Channel = [%0d] EXPECTED CONTENT \n %s",
-                                      channel, compare_item.sprint()),UVM_HIGH)
-            `uvm_info(`gfn, $sformatf("\n PWM :: Channel = [%0d] DUT CONTENT \n %s",
-                                      channel, input_item.sprint()),UVM_HIGH)
-          end
-        end
-      end
-      ignore_state_change[channel] -= 1 ;
+    item_fifo[channel].get(input_item);
+    generate_exp_item(compare_item, channel);
+
+    // The very first item will be when the monitor detects the first active edge and will have no
+    // information. Wait for the first expected item.
+    `DV_CHECK_FATAL(ignore_start_pulse[channel] <= 2)
+    if (ignore_start_pulse[channel]) begin
+      ignore_start_pulse[channel]--;
+      continue;
     end
-    ignore_start_pulse[channel] -= 1 ;
+
+    // After the state has switched to different state, settings will change. Comparison ignored for
+    // the first SettleTime pulses
+    `DV_CHECK_FATAL(ignore_state_change[channel] <= SettleTime)
+    if (ignore_state_change[channel]) begin
+      ignore_state_change[channel]--;
+      continue;
+    end
+
+    // ignore items when resolution would round the duty cycle to 0 or 100
+    if (compare_item.active_cnt == 0 || compare_item.inactive_cnt == 0) continue;
+
+    // Finally, we only check items if the period is what we're expecting.
+    if (input_item.period != compare_item.period) continue;
+
+    `uvm_info(`gfn,
+              $sformatf("\n PWM :: Channel = [%0d] EXPECTED CONTENT \n %s",
+                        channel, compare_item.sprint()),
+              UVM_HIGH)
+    `uvm_info(`gfn,
+              $sformatf("\n PWM :: Channel = [%0d] DUT CONTENT \n %s",
+                        channel, input_item.sprint()),
+              UVM_HIGH)
+
+    `DV_CHECK(input_item.compare(compare_item), $sformatf("Mismatch on channel %0d", channel))
   end
 endtask : compare_trans
 

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -25,7 +25,6 @@ class pwm_scoreboard extends cip_base_scoreboard #(.CFG_T(pwm_env_cfg),
   cfg_reg_t                  channel_cfg              = '0;
 
   bit [PWM_NUM_CHANNELS-1:0] channel_en               = '0;
-  bit [PWM_NUM_CHANNELS-1:0] prev_channel_en          = '0;
   bit [PWM_NUM_CHANNELS-1:0] invert                   = '0;
 
   param_reg_t                channel_param[PWM_NUM_CHANNELS];
@@ -152,7 +151,6 @@ task pwm_scoreboard::process_tl_access(tl_seq_item   item,
           end
         end
         `uvm_info(`gfn, $sformatf("Setting channel enables %s ", txt), UVM_HIGH)
-        prev_channel_en = channel_en;
       end
 
       "cfg": begin

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -22,7 +22,6 @@ class pwm_scoreboard extends cip_base_scoreboard #(.CFG_T(pwm_env_cfg),
   // This gives checker two pulses buffer to sync to DUT pwm_o pulse accurately.
   localparam int SettleTime = 2;
 
-  bit                        regwen                   =  0;
   cfg_reg_t                  channel_cfg              = '0;
 
   bit [PWM_NUM_CHANNELS-1:0] channel_en               = '0;
@@ -133,8 +132,7 @@ task pwm_scoreboard::process_tl_access(tl_seq_item   item,
     // for read, update predication at address phase and compare at data phase
     case (csr.get_name())
       "regwen": begin
-        regwen = item.a_data[0];
-        `uvm_info(`gfn, $sformatf("Register Write en: %0b", regwen), UVM_HIGH)
+        `uvm_info(`gfn, $sformatf("Register Write en: %0b", item.a_data[0]), UVM_HIGH)
       end
 
       "pwm_en": begin

--- a/hw/ip/pwm/dv/tb.sv
+++ b/hw/ip/pwm/dv/tb.sv
@@ -52,7 +52,7 @@ module tb;
   `ASSERT(PwmEnTiedHigh_A, cio_pwm_en == '1, clk, rst_n)
 
   for (genvar n = 0; n < PWM_NUM_CHANNELS; n++) begin: gen_pwm_if_conn
-    pwm_if pwm_if(.clk(clk), .rst_n(rst_n), .pwm(cio_pwm[n]));
+    pwm_if pwm_if(.clk(clk_core), .rst_n(rst_core_n), .pwm(cio_pwm[n]));
 
     initial begin
       uvm_config_db#(virtual pwm_if)::set(null, $sformatf("*.env.m_pwm_monitor%0d*", n), "vif",


### PR DESCRIPTION
I've spent some time looking at the scoreboard and monitor (because of a failing test) and there were lots of places they could be tidied up. This PR contains those tidy-ups (and is not really intended to change behaviour).

There *is* one known behaviour change, which comes from a8ee8ca ("Use the correct clock for pwm_if instances"). Local tests don't show this affecting very much, but it probably makes more sense if the interface uses the clock that drives its data signal.