### PR TITLE
[hmac,doc] Update for arbitrary key length

### DIFF
--- a/hw/ip/hmac/README.md
+++ b/hw/ip/hmac/README.md
@@ -17,7 +17,7 @@ See that document for integration overview within the broader OpenTitan top leve
 
 - Two modes: SHA-2 | HMAC based on SHA-2
 - Multiple digest sizes supported (for both modes): SHA-2 256/384/512 hashing algorithm
-- Configurable key length 128/256/384/512/1024-bit secret key for HMAC mode
+- Configurable key length up to 1024-bit secret key for HMAC mode
 - Support for context switching (via saving and restoring) across multiple message streams
 - 32 x 32-bit message FIFO buffer
 

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -282,7 +282,13 @@
           desc: '''Key length configuration.
 
                 This is a 6-bit one-hot encoded field to configure the key length for HMAC.
-                The HMAC supports key lengths of 128-bit, 256-bit, 384-bit, 512-bit and 1024-bit, as long as the key length is not greater than the block size: up to 1024-bit for SHA-2 384/512 and up to 512-bit for SHA-2 256.
+
+                The HMAC can be programmed with the following key lengths: 128-bit, 256-bit, 384-bit, 512-bit and 1024-bit.
+                But the HMAC supports any arbitrary key length: the software should configure the HMAC with the next largest supported key length and concatenate zeros to reach the programmed key length.
+                The position of these zeros depends on the endianness, thus on the programmed [`CFG.key_swap`](registers.md#cfg--key_swap).
+                For example, for an 80-bit key, HMAC should be configured with an 128-bit key length, fed with the 80-bit key and with 48 zero-bits.
+
+                Note that the key length cannot be greater than the block size: up to 1024-bit for SHA-2 384/512 and up to 512-bit for SHA-2 256.
                 The value of this register is irrelevant when only SHA-2 (not keyed HMAC) is configured.
                 However, for HMAC mode (`hmac_en == 1`), when HMAC is triggered to start while !!KEY_LENGTH holds `Key_None` or !!KEY_LENGTH holds `Key_1024` for !!DIGEST_SIZE = `SHA2_256`, starting is blocked and an error is signalled to SW.
                 '''

--- a/hw/ip/hmac/doc/registers.md
+++ b/hw/ip/hmac/doc/registers.md
@@ -184,7 +184,13 @@ If the software updates the register while the engine computes the hash, the upd
 Key length configuration.
 
 This is a 6-bit one-hot encoded field to configure the key length for HMAC.
-The HMAC supports key lengths of 128-bit, 256-bit, 384-bit, 512-bit and 1024-bit, as long as the key length is not greater than the block size: up to 1024-bit for SHA-2 384/512 and up to 512-bit for SHA-2 256.
+
+The HMAC can be programmed with the following key lengths: 128-bit, 256-bit, 384-bit, 512-bit and 1024-bit.
+But the HMAC supports any arbitrary key length: the software should configure the HMAC with the next largest supported key length and concatenate zeros to reach the programmed key length.
+The position of these zeros depends on the endianness, thus on the programmed [`CFG.key_swap`](registers.md#cfg--key_swap).
+For example, for an 80-bit key, HMAC should be configured with an 128-bit key length, fed with the 80-bit key and with 48 zero-bits.
+
+Note that the key length cannot be greater than the block size: up to 1024-bit for SHA-2 384/512 and up to 512-bit for SHA-2 256.
 The value of this register is irrelevant when only SHA-2 (not keyed HMAC) is configured.
 However, for HMAC mode (`hmac_en == 1`), when HMAC is triggered to start while [`KEY_LENGTH`](#key_length) holds `Key_None` or [`KEY_LENGTH`](#key_length) holds `Key_1024` for [`DIGEST_SIZE`](#digest_size) = `SHA2_256`, starting is blocked and an error is signalled to SW.
 

--- a/hw/ip/hmac/doc/theory_of_operation.md
+++ b/hw/ip/hmac/doc/theory_of_operation.md
@@ -121,7 +121,9 @@ In the second round, the message length is a fixed 768 bits (512-bit size of out
 
 HMAC supports a secret key of length 128/256/384/512/1024-bit, so long as the key length does not exceed the block size of the configured digest, i.e., for SHA-2 256 a maximum length of 512-bit key is supported.
 The byte order of the key registers is big-endian by default, can be swapped to little endian by setting [`CFG.key_swap`](registers.md#cfg--key_swap) to 1.
-To support any arbitrary key length, the software should configure the HMAC to the next largest supported key length, e.g. for an 80-bit key, HMAC should be configured with an 128-bit key length and fed with the 80-bit key.
+To support any arbitrary key length, the software should configure the HMAC to the next largest supported key length and concatenate zeros to reach the programmed key size.
+The position of these zeros depends on the endianness, thus on the programmed [`CFG.key_swap`](registers.md#cfg--key_swap).
+For example, for an 80-bit key, HMAC should be configured with an 128-bit key length, fed with the 80-bit key and with 48 zero-bits.
 It is also up to the software to shrink the key to the supported key length (up to 512-bit for SHA-2 256 and up to 1024-bit for SHA-2 384/512) using a hash function when setting up the HMAC.
 For example, common key sizes may be 2048-bit or 4096-bit.
 Software is expected to hash these into the supported key length and write the hashed result as the configured key to the HMAC IP.


### PR DESCRIPTION
- The HMAC supports arbitrary key lengths. Add precision on how to use it.