### PR TITLE
[sival, keymgr] Fix failing key manager sival tests

### DIFF
--- a/sw/device/tests/keymgr_key_derivation_test.c
+++ b/sw/device/tests/keymgr_key_derivation_test.c
@@ -55,7 +55,7 @@ bool test_main(void) {
   sideload_params.dest = kDifKeymgrVersionedKeyDestAes;
   CHECK_STATUS_OK(
       keymgr_testutils_generate_versioned_key(&keymgr, sideload_params));
-  LOG_INFO("Keymgr generated HW output for Aes at %sState", state_name);
+  LOG_INFO("Keymgr generated HW output for Aes at %s State", state_name);
 
   sideload_params.dest = kDifKeymgrVersionedKeyDestOtbn;
   CHECK_STATUS_OK(


### PR DESCRIPTION
This PR is composed of two commits fixing two bugs in the keymgr derivation tests:

1. Fix [chip_sw_keymgr_key_derivation](https://github.com/lowRISC/opentitan/commit/fdda4294ec6a7084880d613128d0edb258b0dee7): `chip_sw_keymgr_key_derivation_vseq` provides backdoor support required in the `chip_sw_keymgr_key_derivation` software test. However, the test would trigger an assertion failure when run in DV. The cause of this is a missing space character in the log message that is used as a checkpoint in the sequence.
2. Fix [chip_sw_keymgr_derive_{sealing,attestation}](https://github.com/lowRISC/opentitan/commit/b93e9d1d354605f4bf3b635c5436bf5e51b41afc): The `chip_sw_keymgr_derive_{sealing,attestation}` test would fail on FPGAs with masking disabled due to faulty logic that checks whether derived keymgr outputs differ between states by not taking into account that the second output share is always 0 when masking is disabled. This commit resolves this issue by flagging two outputs as different if and only if they differ in at least one share instead of requiring
both shares to be different which was the cause of the failure.