### PR TITLE
[cherry-pick] manually cherry-pick of a commit from #25195 to `master` branch

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -322,6 +322,7 @@ manifest(d = {
             "//sw/device/lib/testing/test_framework:ujson_ottf",
             "//sw/device/silicon_creator/lib:attestation",
             "//sw/device/silicon_creator/lib:otbn_boot_services",
+            "//sw/device/silicon_creator/lib/base:chip",
             "//sw/device/silicon_creator/lib/base:util",
             "//sw/device/silicon_creator/lib/cert",
             "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",

--- a/sw/device/silicon_creator/manuf/base/ft_personalize.c
+++ b/sw/device/silicon_creator/manuf/base/ft_personalize.c
@@ -20,6 +20,7 @@
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/silicon_creator/lib/attestation.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
+#include "sw/device/silicon_creator/lib/base/chip.h"
 #include "sw/device/silicon_creator/lib/base/util.h"
 #include "sw/device/silicon_creator/lib/cert/cdi_0.h"  // Generated.
 #include "sw/device/silicon_creator/lib/cert/cdi_1.h"  // Generated.
@@ -176,12 +177,10 @@ static const manifest_t *rom_ext_manifest_b_get(void) {
 extern const uint32_t kCreatorSwCfgManufStateValue;
 
 /*
- * Check if the `manuf_state_creator` field in the ROM_EXT manifest (slot b)
- * matches the expected value that will be provisioned into the OTP.
+ * Check if the `identifier` field in slot_b is a ROM_EXT.
  */
-static status_t check_manuf_state_creator_binding(void) {
-  TRY_CHECK(rom_ext_manifest_b_get()->usage_constraints.manuf_state_creator ==
-            kCreatorSwCfgManufStateValue);
+static status_t check_next_slot_bootable(void) {
+  TRY_CHECK(rom_ext_manifest_b_get()->identifier == CHIP_ROM_EXT_IDENTIFIER);
   return OK_STATUS();
 }
 
@@ -777,7 +776,7 @@ static status_t check_otp_measurement_post_lock(hmac_digest_t *measurement,
 static status_t finalize_otp_partitions(void) {
   // TODO(#21554): Complete the provisioning of the root keys and key policies.
 
-  TRY(check_manuf_state_creator_binding());
+  TRY(check_next_slot_bootable());
 
   // Complete the provisioning of OTP OwnerSwCfg partition.
   if (!status_ok(manuf_individualize_device_owner_sw_cfg_check(&otp_ctrl))) {

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -24,16 +24,15 @@ LINK_ORDER = [
 manifest(d = {
     "name": "manifest_sival",
     "identifier": hex(CONST.ROM_EXT),
-    "manuf_state_creator": hex(CONST.MANUF_STATE.PERSONALIZED),
     "version_major": ROM_EXT_VERSION.MAJOR,
     "version_minor": ROM_EXT_VERSION.MINOR,
     "security_version": ROM_EXT_VERSION.SECURITY,
     "visibility": ["//visibility:private"],
 })
 
-# To test that the fake-signed SiVAL ROM_EXT can boot, you need a bitstream
-# with the OTP word CREATOR_SW_CCFG_MANUF_STATE set to `PERSONALIZED` (as above
-# in the manifest definition).  You can manually create such a bitstream with:
+# To test that the prod-signed SiVAL ROM_EXT boots on the FPGA, you need a bitstream
+# with the sival keys pre-programmed into OTP.
+# You can manually create such a bitstream with:
 #
 # bazel build //hw/bitstream/universal:splice --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_cw310_sival
 opentitan_binary(


### PR DESCRIPTION
The ROM_EXT does not need to be bound to `manuf_state_creator`.  That OTP configuration is exclusively for use by the personalization stage and should not affect the ROM_EXT.

Signed-off-by: Chris Frantz <cfrantz@google.com>
(cherry picked from commit 86f0f5b0fa212800e57f6a143a1e532d17cffde8)