### PR TITLE
[rom_ext] Update INFO page lockdown for `earlgrey_a1`

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -731,6 +731,7 @@ static const flash_ctrl_info_page_t *kInfoPagesNoOwnerAccess[] = {
     // Bank 1
     &kFlashCtrlInfoPageBootData0,
     &kFlashCtrlInfoPageBootData1,
+    &kFlashCtrlInfoPageCreatorReserved0,
 };
 
 enum {
@@ -776,6 +777,7 @@ void flash_ctrl_cert_info_page_creator_cfg(
 void flash_ctrl_cert_info_page_owner_restrict(
     const flash_ctrl_info_page_t *info_page) {
   SEC_MMIO_ASSERT_WRITE_INCREMENT(kFlashCtrlSecMmioCertInfoPageOwnerRestrict,
-                                  1);
+                                  2);
   flash_ctrl_info_perms_set(info_page, kCertificateInfoPageOwnerAccess);
+  sec_mmio_write32(info_page->cfg_wen_addr, 0);
 }

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -166,9 +166,9 @@ FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_STRUCT_DECL_);
  */
 enum {
   kFlashCtrlSecMmioCertInfoPageCreatorCfg = 2,
-  kFlashCtrlSecMmioCertInfoPageOwnerRestrict = 1,
+  kFlashCtrlSecMmioCertInfoPageOwnerRestrict = 2,
   kFlashCtrlSecMmioCertInfoPagesOwnerRestrict = 5,
-  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 12,
+  kFlashCtrlSecMmioCreatorInfoPagesLockdown = 14,
   kFlashCtrlSecMmioDataDefaultCfgSet = 1,
   kFlashCtrlSecMmioDataDefaultPermsSet = 1,
   kFlashCtrlSecMmioExecSet = 1,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -682,10 +682,11 @@ INSTANTIATE_TEST_SUITE_P(AllCases, FlashCtrlCfgSetTest,
                              }));
 
 TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
-  std::array<const flash_ctrl_info_page_t *, 6> no_owner_access = {
-      &kFlashCtrlInfoPageFactoryId,   &kFlashCtrlInfoPageCreatorSecret,
-      &kFlashCtrlInfoPageOwnerSecret, &kFlashCtrlInfoPageWaferAuthSecret,
-      &kFlashCtrlInfoPageBootData0,   &kFlashCtrlInfoPageBootData1,
+  std::array<const flash_ctrl_info_page_t *, 7> no_owner_access = {
+      &kFlashCtrlInfoPageFactoryId,        &kFlashCtrlInfoPageCreatorSecret,
+      &kFlashCtrlInfoPageOwnerSecret,      &kFlashCtrlInfoPageWaferAuthSecret,
+      &kFlashCtrlInfoPageBootData0,        &kFlashCtrlInfoPageBootData1,
+      &kFlashCtrlInfoPageCreatorReserved0,
   };
   for (auto page : no_owner_access) {
     auto info_page = InfoPages().at(page);
@@ -737,6 +738,7 @@ TEST_F(FlashCtrlTest, CertInfoOwnerRestrict) {
     auto info_page = InfoPages().at(page);
     EXPECT_SEC_READ32(base_ + info_page.cfg_offset, 0x9666666);
     EXPECT_SEC_WRITE32(base_ + info_page.cfg_offset, 0x9669966);
+    EXPECT_SEC_WRITE32(base_ + info_page.cfg_wen_offset, 0);
   }
 
   flash_ctrl_cert_info_page_owner_restrict(

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -251,12 +251,10 @@ rom_error_t owner_block_flash_apply(const owner_flash_config_t *flash,
 }
 
 static inline hardened_bool_t is_owner_page(const owner_info_page_t *config) {
-  if (config->bank == 0) {
-    if (config->page >= 6 && config->page <= 9) {
-      // Currently, bank0, pages 6-9 (inclusive) are the pages reserved
-      // for the owner's use.
-      return kHardenedBoolTrue;
-    }
+  // On earlgrey_a1, in banks 0 and 1, pages 5-8 (inclusive) are reserved
+  // for the owner.
+  if (config->page >= 5 && config->page <= 8) {
+    return kHardenedBoolTrue;
   }
   return kHardenedBoolFalse;
 }

--- a/sw/device/silicon_creator/lib/ownership/owner_block_unittest.cc
+++ b/sw/device/silicon_creator/lib/ownership/owner_block_unittest.cc
@@ -219,7 +219,7 @@ const owner_flash_info_config_t info_config = {
             {
                 // Disallowed page
                 .bank = 0,
-                .page = 5,
+                .page = 9,
                 .access = FLASH_ACCESS(
                     /*index=*/1,
                     /*read=*/true,


### PR DESCRIPTION
The INFO page layout has changed between the ES and PROD chips.  Update the lockdown and ownership functions relating to INFO configuration. Update the `flash_permission_test` to verify the configuration.