### PR TITLE
[rom_ext] Clean up ROM_EXT prints

### DIFF
--- a/sw/device/silicon_creator/rom/e2e/defs.bzl
+++ b/sw/device/silicon_creator/rom/e2e/defs.bzl
@@ -34,7 +34,7 @@ MSG_TEMPLATE_BFV_LCV = "{}{}\r\n{}{}\r\n(?s:.*){}{}\r\n{}{}\r\n".format(
     "{1}",
 )
 
-MSG_STARTING_ROM_EXT = "Starting ROM_EXT"
+MSG_STARTING_ROM_EXT = "ROM_EXT:[^\r\n]*\r\n"
 
 MSG_PASS = "PASS!"
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -475,7 +475,7 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest,
   RETURN_IF_ERROR(owner_keyring_find_key(&keyring, key_id, &verify_key));
   uint32_t key_alg = keyring.key[verify_key]->key_alg;
 
-  dbg_printf("app_verify: key=%u alg=%C domain=%C\r\n", verify_key, key_alg,
+  dbg_printf("verify: key%u;%C;%C\r\n", verify_key, key_alg,
              keyring.key[verify_key]->key_domain);
 
   memset(boot_measurements.bl0.data, (int)rnd_uint32(),
@@ -740,7 +740,7 @@ rom_error_t dice_chain_attestation_silicon(void) {
     // In both cases, we do nothing, and boot normally, later attestation
     // attempts will fail in a detectable manner.
     HARDENED_CHECK_EQ(dice_chain.cert_valid, kHardenedBoolFalse);
-    dbg_printf("Warning: UDS certificate not valid.\r\n");
+    dbg_printf("error: UDS certificate not valid\r\n");
   } else {
     // Cert is valid, move to the next one.
     HARDENED_CHECK_EQ(dice_chain.cert_valid, kHardenedBoolTrue);
@@ -781,7 +781,7 @@ rom_error_t dice_chain_attestation_creator(
   HARDENED_RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_0", /*name_size=*/6));
   if (launder32(dice_chain.cert_valid) == kHardenedBoolFalse) {
     HARDENED_CHECK_EQ(dice_chain.cert_valid, kHardenedBoolFalse);
-    dbg_printf("CDI_0 certificate not valid. Updating it ...\r\n");
+    dbg_printf("warning: CDI_0 certificate not valid; updating\r\n");
     // Update the cert page buffer.
     size_t updated_cert_size = kScratchCertSizeBytes;
     HARDENED_RETURN_IF_ERROR(
@@ -863,7 +863,7 @@ rom_error_t dice_chain_attestation_owner(
   HARDENED_RETURN_IF_ERROR(dice_chain_load_cert_obj("CDI_1", /*name_size=*/6));
   if (launder32(dice_chain.cert_valid) == kHardenedBoolFalse) {
     HARDENED_CHECK_EQ(dice_chain.cert_valid, kHardenedBoolFalse);
-    dbg_printf("CDI_1 certificate not valid. Updating it ...\r\n");
+    dbg_printf("warning: CDI_1 certificate not valid. updating\r\n");
     // Update the cert page buffer.
     size_t updated_cert_size = kScratchCertSizeBytes;
     HARDENED_RETURN_IF_ERROR(dice_cdi_1_cert_build(
@@ -905,7 +905,7 @@ rom_error_t dice_chain_flush_flash(void) {
         /*offset=*/0,
         /*word_count=*/FLASH_CTRL_PARAM_BYTES_PER_PAGE / sizeof(uint32_t),
         dice_chain.data));
-    dbg_printf("Flushed dice cert page %d\r\n",
+    dbg_printf("info: flushed dice cert page %d\r\n",
                dice_chain.info_page->base_addr);
     dice_chain.data_dirty = kHardenedBoolFalse;
   }
@@ -1051,8 +1051,6 @@ static rom_error_t rom_ext_boot(boot_data_t *boot_data, boot_log_t *boot_log,
   // Lock the flash according to the ownership configuration.
   HARDENED_RETURN_IF_ERROR(
       ownership_flash_lockdown(boot_data, boot_log->bl0_slot, &owner_config));
-
-  dbg_print_epmp();
 
   // Verify expectations before jumping to owner code.
   // TODO: we really want to call rnd_uint32 here to select a random starting
@@ -1281,8 +1279,7 @@ rom_error_t dice_chain_init(void) {
 static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   HARDENED_RETURN_IF_ERROR(rom_ext_init(boot_data));
   const manifest_t *self = rom_ext_manifest();
-  dbg_printf("Starting ROM_EXT %u.%u\r\n", self->version_major,
-             self->version_minor);
+  dbg_printf("ROM_EXT:%u.%u\r\n", self->version_major, self->version_minor);
 
   // Establish our identity.
   HARDENED_RETURN_IF_ERROR(dice_chain_init());
@@ -1310,7 +1307,7 @@ static rom_error_t rom_ext_start(boot_data_t *boot_data, boot_log_t *boot_log) {
   // TODO(cfrantz): evaluate permissible ownership init failure conditions
   // and change this to HARDENED_RETURN_IF_ERROR.
   if (error != kErrorOk) {
-    dbg_printf("ownership_init: %x\r\n", error);
+    dbg_printf("error: ownership_init=%x\r\n", error);
   }
 
   // Configure SRAM execution as the owner requested.

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -496,7 +496,7 @@ pub fn check_rom_ext_boot_up(
 ) -> Result<()> {
     transport.reset_target(init.bootstrap.options.reset_delay, true)?;
     let uart_console = transport.uart("console")?;
-    let _ = UartConsole::wait_for(&*uart_console, r"Starting ROM_EXT.*\r\n", timeout)?;
+    let _ = UartConsole::wait_for(&*uart_console, r"ROM_EXT:.*\r\n", timeout)?;
 
     // Timeout for waiting for a potential error message indicating invalid UDS certificate.
     // This value is tested on fpga cw340 and could be potentially fine-tuned.

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -95,7 +95,7 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         log::info!("###### Pre-transfer Boot Check ######");
         let capture = UartConsole::wait_for(
             &*uart,
-            r"(?msR)Starting.*ownership_state = (\w+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
+            r"(?msR)Running.*ownership_state = (\w+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
             opts.timeout,
         )?;
         if capture[0].starts_with("BFV") {
@@ -146,7 +146,7 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
         let capture = UartConsole::wait_for(
             &*uart,
-            r"(?msR)Starting.*ownership_state = (\w+)$.*ownership_transfers = (\d+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
+            r"(?msR)Running.*ownership_state = (\w+)$.*ownership_transfers = (\d+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
             opts.timeout,
         )?;
         if capture[0].starts_with("BFV") {
@@ -189,7 +189,7 @@ fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
     let capture = UartConsole::wait_for(
         &*uart,
-        r"(?msR)Starting.*ownership_state = (\w+)$.*ownership_transfers = (\d+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
+        r"(?msR)Running.*ownership_state = (\w+)$.*ownership_transfers = (\d+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
         opts.timeout,
     )?;
     if capture[0].starts_with("BFV") {


### PR DESCRIPTION
1. Change the startup banner to just "ROM_EXT:<version>".
2. Prefix all ROM_EXT messages with a subject (e.g. error, info, verify, etc).
3. Eliminate the ePMP printout.
4. Update tests.