### PR TITLE
[rom_ext] Remove AST patch functionality.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -114,7 +114,6 @@ cc_library(
     srcs = ["ast.c"],
     hdrs = ["ast.h"],
     deps = [
-        ":flash_ctrl",
         ":lifecycle",
         ":otp",
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",

--- a/sw/device/silicon_creator/lib/drivers/ast.c
+++ b/sw/device/silicon_creator/lib/drivers/ast.c
@@ -8,7 +8,6 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/multibits.h"
-#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 
 #include "ast_regs.h"
@@ -24,27 +23,6 @@ const uint32_t kAstCheckPollCpuCycles = 10000;
 enum {
   kBaseSensorCtrl = TOP_EARLGREY_SENSOR_CTRL_AON_BASE_ADDR,
   kBaseAst = TOP_EARLGREY_AST_BASE_ADDR,
-
-  /**
-   * AST Calibration Data Size - Bank 0, Page 0
-   *
-   * Number of AST calibration words that will be stored in flash / OTP.
-   *
-   * Must match `kFlashInfoAstCalibrationDataSizeIn32BitWords` in
-   * //sw/device/silicon_creator/manuf/lib/flash_info_fields.h.
-   */
-  kAstCalibrationDataSizeIn32BitWords =
-      (AST_REGAL_REG_OFFSET + sizeof(uint32_t)) / sizeof(uint32_t),
-
-  /**
-   * The starting offset of the AST calibration data within the
-   * `kFlashCtrlInfoPageFactoryId` info flash page.
-   *
-   * Must be compatible to the `kFlashInfoFieldAstCalibrationData` byte offset
-   * in //sw/device/silicon_creator/manuf/lib/flash_info_fields.c.
-   */
-  kAstCalibrationDataInfoFlashByteOffset =
-      OTP_CTRL_PARAM_DEVICE_ID_SIZE + OTP_CTRL_PARAM_MANUF_STATE_SIZE,
 };
 
 rom_error_t ast_check(lifecycle_state_t lc_state) {
@@ -120,57 +98,4 @@ hardened_bool_t ast_init_done(void) {
     return kHardenedBoolFalse;
   }
   return res;
-}
-
-/**
- * Loads AST patch from kFlashCtrlInfoPageFactoryId page.
- *
- * The `ast_data` offset must be equivalent to the one used in
- * //sw/device/silicon_creator/manuf/lib/ast_program.c.
- *
- * The info flash configuration must also be the same used to program the page,
- * otherwise the data read will be garbled.
- *
- * @param[out] ast_data Pointer to the buffer used to store the data read.
- *
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-static rom_error_t load_ast_config_from_flash(uint32_t *ast_data) {
-  flash_ctrl_info_perms_set(&kFlashCtrlInfoPageFactoryId,
-                            (flash_ctrl_perms_t){
-                                .read = kMultiBitBool4True,
-                                .write = kMultiBitBool4False,
-                                .erase = kMultiBitBool4False,
-                            });
-  flash_ctrl_info_cfg_set(&kFlashCtrlInfoPageFactoryId,
-                          (flash_ctrl_cfg_t){
-                              .scrambling = kMultiBitBool4False,
-                              .ecc = kMultiBitBool4True,
-                              .he = kMultiBitBool4False,
-                          });
-  return flash_ctrl_info_read(&kFlashCtrlInfoPageFactoryId,
-                              kAstCalibrationDataInfoFlashByteOffset,
-                              kAstCalibrationDataSizeIn32BitWords, ast_data);
-}
-
-rom_error_t ast_patch(lifecycle_state_t lc_state) {
-  uint32_t ast_data[kAstCalibrationDataSizeIn32BitWords];
-  HARDENED_RETURN_IF_ERROR(load_ast_config_from_flash(ast_data));
-
-  // Skip patching logic if either of the first two words don't seem to be
-  // configured.
-  if (ast_data[0] == 0 || ast_data[0] == UINT32_MAX) {
-    return ast_check(lc_state);
-  }
-
-  if (ast_data[1] == 0 || ast_data[1] == UINT32_MAX) {
-    return ast_check(lc_state);
-  }
-
-  for (size_t i = 0; i < kAstCalibrationDataSizeIn32BitWords; ++i) {
-    abs_mmio_write32(kBaseAst + i * sizeof(uint32_t), ast_data[i]);
-  }
-
-  return ast_check(lc_state);
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -317,9 +317,6 @@ static rom_error_t rom_ext_init(boot_data_t *boot_data) {
 
   // TODO: Verify ePMP expectations from ROM.
 
-  // Conditionally patch AST and check that it is in the expected state.
-  HARDENED_RETURN_IF_ERROR(ast_patch(lc_state));
-
   // Check that the retention RAM is initialized.
   // TODO(lowrisc#22387): Check if return-if-error here is a potential
   // boot-loop.


### PR DESCRIPTION
The original implementation was intended to be used during early silicon integration. Since then, the provisioning infrastructure and info flash memory map has changed and this funcitonality is no longer compatible.