### PR TITLE
[rom_ext,dice] build ROM_EXT with DICE CWT cert format support

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -138,7 +138,7 @@ fpga_cw310(
         "assemble": "{rom_ext}@0 {firmware}@0x10000",
     },
     rom = "//sw/device/silicon_creator/rom:mask_rom",
-    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
 )
 
 fpga_cw310(
@@ -191,7 +191,7 @@ fpga_cw310(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{rom_ext}@0 {firmware}@0x10000",
     },
-    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
 )
 
 # FPGA configuration used to emulate silicon targets. This rule can be used by
@@ -229,7 +229,7 @@ fpga_cw310(
         "//sw/device/lib/arch:fpga_cw310",
     ],
     otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_prod_manuf_personalized",
-    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
     tags = ["cw310_sival_rom_ext"],
 )
 
@@ -345,7 +345,7 @@ fpga_cw340(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{rom_ext}@0 {firmware}@0x10000",
     },
-    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
 )
 
 # FPGA configuration used to emulate silicon targets. This rule can be used by
@@ -383,7 +383,7 @@ fpga_cw340(
         "//sw/device/lib/arch:fpga_cw340",
     ],
     otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_prod_manuf_personalized",
-    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+    rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
     tags = ["cw340_sival_rom_ext"],
 )
 
@@ -454,8 +454,8 @@ silicon(
     # target once available:
     # //sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_prod_slot_a
     rom_ext = select({
-        "//signing:test_keys": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_slot_a",
-        "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_fake_slot_a",
+        "//signing:test_keys": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_dice_x509_fake_slot_a",
+        "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_dice_x509_fake_slot_a",
     }),
     test_cmd = """
         --exec="transport init"

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -173,6 +173,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/cert:dice_keys",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
+        "@open-dice//:cbor_reader_writer",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/cert/cbor.h
+++ b/sw/device/silicon_creator/lib/cert/cbor.h
@@ -37,6 +37,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_out_init(
   CborOutInit(buf, buf_size, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add a "map" header along with the elements count to a CborOut structure.
  *
@@ -50,6 +51,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_map_init(
   CborWriteMap(num_pairs, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add a "array" header along with the elements count to a CborOut structure.
  *
@@ -63,6 +65,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_array_init(
   CborWriteArray(num_elements, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add a "tstr" to a CborOut structure
  *
@@ -76,6 +79,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_string(
   CborWriteTstr(str, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add a "bstr" to a CborOut structure
  *
@@ -109,6 +113,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_uint(
   CborWriteUint(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add 2 elements, "int" and "uint", to a CborOut structure
  *
@@ -124,6 +129,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_int_uint(
   CborWriteUint(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add 2 elements, "uint" and "int", to a CborOut structure
  *
@@ -139,6 +145,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_int(
   CborWriteInt(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add 2 elements, "int" and "bstr", to a CborOut structure
  *
@@ -156,6 +163,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_int_bytes(
   CborWriteBstr(value_size, value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add 2 elements, "uint" and "tstr", to a CborOut structure
  *
@@ -171,6 +179,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_pair_uint_tstr(
   CborWriteTstr(value, p);
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add 2 elements, "int" and "tstr", to a CborOut structure
  *
@@ -210,6 +219,7 @@ static inline size_t cbor_calc_arg_size(uint64_t value) {
     return 8;
   };
 }
+
 /**
  * Calculate how much space is needed in the header for a "signed interger" type
  * of CBOR argument.
@@ -224,7 +234,6 @@ static inline size_t cbor_calc_int_size(int64_t value) {
   return cbor_calc_arg_size((uint64_t)value);
 }
 
-// Add a bstr/tstr header with size, and rewind the cursor
 /**
  * Add a "bstr" header along with the payload size, and rewind the cursor of
  * CborOut structure.
@@ -241,6 +250,7 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_bstr_header(
   p->cursor -= bstr_size;
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 /**
  * Add a "tstr" header along with the payload size, and rewind the cursor of
  * CborOut structure.
@@ -275,4 +285,5 @@ OT_WARN_UNUSED_RESULT static inline rom_error_t cbor_write_raw_bytes(
   p->cursor += raw_size;
   CBOR_CHECK_OVERFLOWED_AND_RETURN(p);
 }
+
 #endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CERT_CBOR_H_

--- a/sw/device/silicon_creator/lib/cert/dice_cwt.c
+++ b/sw/device/silicon_creator/lib/cert/dice_cwt.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include "include/dice/cbor_reader.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/base/util.h"
 #include "sw/device/silicon_creator/lib/cert/cbor.h"
@@ -25,6 +26,17 @@
 #include "otp_ctrl_regs.h"  // Generated.
 
 const dice_cert_format_t kDiceCertFormat = kDiceCertFormatCWTAndroid;
+
+enum {
+  // Must match the label used for the public key in
+  // `cwt_dice_chain_entry_payload.hjson`.
+  kDiceCwtSubjectPublicKeyLabel = -4670552,
+
+  // Must match the labels used for the public key X/Y coords in
+  // `cwt_cose_key.hjson`.
+  kDiceCwtCoseKeyXCoordLabel = -2,
+  kDiceCwtCoseKeyYCoordLabel = -3,
+};
 
 enum config_desc_labels {
   kSecurityVersionLabel = -70005,
@@ -310,10 +322,140 @@ rom_error_t dice_cdi_1_cert_build(hmac_digest_t *owner_measurement,
   return kErrorOk;
 }
 
+static rom_error_t extract_pubkey_from_cose_key(const uint8_t *obj,
+                                                size_t obj_size,
+                                                const uint32_t **x_coord_p,
+                                                const uint32_t **y_coord_p) {
+  // Initialize CBOR object.
+  struct CborIn cbor_obj;
+  CborInInit(obj, obj_size, &cbor_obj);
+
+  // Find the x/y-coord bstrs.
+  size_t num_pairs = 0;
+  CborReadMap(&cbor_obj, &num_pairs);
+  if (num_pairs == 0) {
+    return kErrorDiceCwtKeyCoordsNotFound;
+  }
+
+  size_t x_coord_size = 0;
+  size_t y_coord_size = 0;
+  *x_coord_p = NULL;
+  *y_coord_p = NULL;
+
+  // Locate public key coords bstrs.
+  int64_t key = 0;
+  for (size_t i = 0; i < num_pairs; ++i) {
+    CborReadInt(&cbor_obj, &key);
+    if (key == kDiceCwtCoseKeyXCoordLabel) {
+      CborReadBstr(&cbor_obj, &x_coord_size, (const uint8_t **)x_coord_p);
+      continue;
+    } else if (key == kDiceCwtCoseKeyYCoordLabel) {
+      CborReadBstr(&cbor_obj, &y_coord_size, (const uint8_t **)y_coord_p);
+      continue;
+    }
+    CborReadSkip(&cbor_obj);
+  }
+
+  // Confirm we found the key.
+  if (x_coord_p == NULL || y_coord_p == NULL) {
+    return kErrorDiceCwtKeyCoordsNotFound;
+  }
+  // Confirm the key is the correct size.
+  if (x_coord_size != kEcdsaP256PublicKeyCoordBytes ||
+      y_coord_size != kEcdsaP256PublicKeyCoordBytes) {
+    return kErrorDiceCwtCoseKeyBadSize;
+  }
+
+  return kErrorOk;
+}
+
+static rom_error_t extract_pubkey_from_cose_sign1_payload(
+    const uint8_t *payload, size_t payload_size, const uint32_t **x_coord_p,
+    const uint32_t **y_coord_p) {
+  // Initialize CBOR object.
+  struct CborIn cbor_obj;
+  CborInInit(payload, payload_size, &cbor_obj);
+
+  // Find the COSE_Key object in the COSE_Sign1 payload.
+  size_t num_payload_pairs = 0;
+  CborReadMap(&cbor_obj, &num_payload_pairs);
+  if (num_payload_pairs == 0) {
+    return kErrorDiceCwtCoseKeyNotFound;
+  }
+
+  int64_t key = 0;
+  size_t cose_key_size = 0;
+  const uint8_t *cose_key_p = NULL;
+  for (size_t i = 0; i < num_payload_pairs; ++i) {
+    CborReadInt(&cbor_obj, &key);
+    if (key == kDiceCwtSubjectPublicKeyLabel) {
+      CborReadBstr(&cbor_obj, &cose_key_size, &cose_key_p);
+      break;
+    }
+    CborReadSkip(&cbor_obj);
+  }
+
+  // Check the COSE_Key object was found in the COSE_Sign1 payload.
+  if (key != kDiceCwtSubjectPublicKeyLabel) {
+    return kErrorDiceCwtCoseKeyNotFound;
+  }
+
+  // Extract the pubkey from the COSE_Key payload.
+  RETURN_IF_ERROR(extract_pubkey_from_cose_key(cose_key_p, cose_key_size,
+                                               x_coord_p, y_coord_p));
+
+  return kErrorOk;
+}
+
 rom_error_t dice_cert_check_valid(const perso_tlv_cert_obj_t *cert_obj,
                                   const hmac_digest_t *pubkey_id,
                                   const ecdsa_p256_public_key_t *pubkey,
                                   hardened_bool_t *cert_valid_output) {
-  // TODO(lowRISC/opentitan:#24281): implement body
+  const uint32_t *x_coord_p = NULL;
+  const uint32_t *y_coord_p = NULL;
+
+  struct CborIn cbor_obj;
+  CborInInit(cert_obj->cert_body_p, cert_obj->cert_body_size, &cbor_obj);
+
+  // Check if CBOR object is array or map. UDS is a COSE_Key which is a map.
+  // CDI_* are COSE_Sign1 objects, which are arrays.
+  size_t num_array_items = 0;
+  CborReadArray(&cbor_obj, &num_array_items);
+  size_t num_map_items = 0;
+  CborReadMap(&cbor_obj, &num_map_items);
+
+  // Extract the public key from the CBOR certificate object.
+  if (num_array_items > 0 && num_map_items == 0) {
+    // Skip first two parent items; subject public key is in the "payload" item
+    // of COSE_Sign1 object, which is encoded as a bstr.
+    CborReadSkip(&cbor_obj);
+    CborReadSkip(&cbor_obj);
+    size_t payload_size = 0;
+    const uint8_t *payload_p = NULL;
+    CborReadBstr(&cbor_obj, &payload_size, &payload_p);
+    RETURN_IF_ERROR(extract_pubkey_from_cose_sign1_payload(
+        payload_p, payload_size, &x_coord_p, &y_coord_p));
+  } else if (num_map_items > 0 && num_array_items == 0) {
+    RETURN_IF_ERROR(extract_pubkey_from_cose_key(cert_obj->cert_body_p,
+                                                 cert_obj->cert_body_size,
+                                                 &x_coord_p, &y_coord_p));
+  } else {
+    return kErrorDiceCwtCoseKeyNotFound;
+  }
+
+  // Compare the public key in the certificate to the public updated key.
+  for (size_t i = 0; i < kEcdsaP256PublicKeyCoordWords; ++i) {
+    if (x_coord_p[i] != pubkey->x[i]) {
+      *cert_valid_output = kHardenedBoolFalse;
+      return kErrorOk;
+    }
+    if (y_coord_p[i] != pubkey->y[i]) {
+      *cert_valid_output = kHardenedBoolFalse;
+      return kErrorOk;
+    }
+  }
+
+  *cert_valid_output = kHardenedBoolTrue;
+
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -55,6 +55,7 @@ enum module_ {
   kModuleCert =            MODULE_CODE('C', 'E'),
   kModuleOwnership =       MODULE_CODE('O', 'W'),
   kModulePersoTlv =        MODULE_CODE('P', 'T'),
+  kModuleDice =            MODULE_CODE('D', 'C'),
   // clang-format on
 };
 
@@ -231,6 +232,11 @@ enum module_ {
   X(kErrorPersoTlvCertObjNotFound,    ERROR_(1, kModulePersoTlv, kNotFound)), \
   X(kErrorPersoTlvCertNameTooLong,    ERROR_(2, kModulePersoTlv, kOutOfRange)), \
   X(kErrorPersoTlvOutputBufTooSmall,  ERROR_(3, kModulePersoTlv, kOutOfRange)), \
+  \
+  X(kErrorDiceInternal,               ERROR_(0, kModuleDice, kInternal)), \
+  X(kErrorDiceCwtCoseKeyNotFound,     ERROR_(1, kModuleDice, kNotFound)), \
+  X(kErrorDiceCwtCoseKeyBadSize,      ERROR_(1, kModuleDice, kInternal)), \
+  X(kErrorDiceCwtKeyCoordsNotFound,   ERROR_(2, kModuleDice, kNotFound)), \
   \
   /* This comment prevent clang from trying to format the macro. */
 

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -27,19 +27,19 @@ EARLGREY_SKUS = {
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
         "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
-        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
     },
     # OTP Config: Emulation; DICE Certs: CWT; Additional Certs: None
-    # TODO(#24281): uncomment when DICE CWT cert flows are fully supported
-    # "emulation_dice_cwt": {
-    #     "otp": "emulation",
-    #     "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
-    #     "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
-    #     "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
-    #     "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b",
-    #     "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
-    # },
+    "emulation_dice_cwt": {
+        "otp": "emulation",
+        "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
+        "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
+        "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
+        "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_cwt_slot_b",
+        "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
+    },
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: TPM EK
     "emulation_tpm": {
         "otp": "emulation",
@@ -50,7 +50,7 @@ EARLGREY_SKUS = {
             "//sw/device/silicon_creator/manuf/base:tpm_perso_fw_ext",
         ],
         "ownership_libs": ["//sw/device/silicon_creator/lib/ownership:test_owner"],
-        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b",
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
     },
     # TODO(cfrantz, ttrippel): Add SIVAL configs when we sign perso and

--- a/sw/device/silicon_creator/rom/e2e/address_translation/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/address_translation/BUILD
@@ -3,16 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load(
-    "//rules/opentitan:defs.bzl",
-    "cw310_params",
-    "fpga_params",
-    "opentitan_test",
-)
-load(
     "//rules:const.bzl",
     "CONST",
-    "hex",
     "hex_digits",
+)
+load(
+    "//rules/opentitan:defs.bzl",
+    "fpga_params",
+    "opentitan_test",
 )
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
@@ -31,7 +29,7 @@ opentitan_test(
     fpga = fpga_params(
         assemble = "{firmware}@{offset}",
         binaries = {
-            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": "firmware",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a": "firmware",
         },
         exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
         exit_success = MSG_STARTING_ROM_EXT,
@@ -47,7 +45,7 @@ opentitan_test(
     fpga = fpga_params(
         assemble = "{firmware}@{offset}",
         binaries = {
-            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": "firmware",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b": "firmware",
         },
         exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
         exit_success = MSG_STARTING_ROM_EXT,
@@ -63,7 +61,7 @@ opentitan_test(
     fpga = fpga_params(
         assemble = "{firmware}@{offset}",
         binaries = {
-            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a": "firmware",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a": "firmware",
         },
         exit_failure = MSG_STARTING_ROM_EXT,
         exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.STORE_ACCESS)),
@@ -79,7 +77,7 @@ opentitan_test(
     fpga = fpga_params(
         assemble = "{firmware}@{offset}",
         binaries = {
-            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b": "firmware",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b": "firmware",
         },
         exit_failure = MSG_STARTING_ROM_EXT,
         exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.STORE_ACCESS)),
@@ -95,7 +93,7 @@ opentitan_test(
     fpga = fpga_params(
         assemble = "{firmware}@{offset}",
         binaries = {
-            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": "firmware",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual": "firmware",
         },
         exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
         exit_success = MSG_STARTING_ROM_EXT,
@@ -111,7 +109,7 @@ opentitan_test(
     fpga = fpga_params(
         assemble = "{firmware}@{offset}",
         binaries = {
-            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual": "firmware",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual": "firmware",
         },
         exit_failure = CONST.SHUTDOWN.PREFIX.BFV,
         exit_success = MSG_STARTING_ROM_EXT,
@@ -127,7 +125,7 @@ opentitan_test(
     fpga = fpga_params(
         assemble = "{firmware}@{offset}",
         binaries = {
-            "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a_bad_address_translation": "firmware",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a_bad_address_translation": "firmware",
         },
         exit_failure = MSG_STARTING_ROM_EXT,
         exit_success = MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.INTERRUPT.ILLEGAL_INSTRUCTION)),

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -9,7 +9,9 @@ load("//rules:manifest.bzl", "manifest")
 load("//rules/opentitan:defs.bzl", "OPENTITAN_CPU", "opentitan_binary")
 load(
     "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VARIATIONS",
     "ROM_EXT_VERSION",
+    "SLOTS",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -155,65 +157,67 @@ cc_test(
     ],
 )
 
-cc_library(
-    name = "rom_ext",
-    srcs = [
-        "rom_ext.c",
-        "rom_ext_start.S",
-    ],
-    hdrs = ["rom_ext.h"],
-    target_compatible_with = [OPENTITAN_CPU],
-    deps = [
-        ":rescue",
-        ":rom_ext_boot_policy",
-        ":rom_ext_boot_policy_ptrs",
-        ":rom_ext_epmp",
-        ":sigverify_keys",
-        "//hw/ip/sram_ctrl/data:sram_ctrl_c_regs",
-        "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
-        "//sw/device/lib/arch:device",
-        "//sw/device/lib/base:csr",
-        "//sw/device/lib/base:macros",
-        "//sw/device/lib/base:stdasm",
-        "//sw/device/lib/crypto/drivers:entropy",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/silicon_creator/lib:attestation",
-        "//sw/device/silicon_creator/lib:boot_data",
-        "//sw/device/silicon_creator/lib:boot_log",
-        "//sw/device/silicon_creator/lib:dbg_print",
-        "//sw/device/silicon_creator/lib:keymgr_binding",
-        "//sw/device/silicon_creator/lib:manifest",
-        "//sw/device/silicon_creator/lib:manifest_def",
-        "//sw/device/silicon_creator/lib:otbn_boot_services",
-        "//sw/device/silicon_creator/lib:shutdown",
-        "//sw/device/silicon_creator/lib/base:chip",
-        "//sw/device/silicon_creator/lib/base:sec_mmio",
-        "//sw/device/silicon_creator/lib/base:static_critical",
-        "//sw/device/silicon_creator/lib/base:util",
-        "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
-        "//sw/device/silicon_creator/lib/cert",
-        "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
-        "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
-        "//sw/device/silicon_creator/lib/cert:dice",
-        "//sw/device/silicon_creator/lib/drivers:ast",
-        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
-        "//sw/device/silicon_creator/lib/drivers:hmac",
-        "//sw/device/silicon_creator/lib/drivers:ibex",
-        "//sw/device/silicon_creator/lib/drivers:keymgr",
-        "//sw/device/silicon_creator/lib/drivers:lifecycle",
-        "//sw/device/silicon_creator/lib/drivers:otp",
-        "//sw/device/silicon_creator/lib/drivers:pinmux",
-        "//sw/device/silicon_creator/lib/drivers:retention_sram",
-        "//sw/device/silicon_creator/lib/drivers:rnd",
-        "//sw/device/silicon_creator/lib/drivers:uart",
-        "//sw/device/silicon_creator/lib/ownership",
-        "//sw/device/silicon_creator/lib/ownership:ownership_activate",
-        "//sw/device/silicon_creator/lib/ownership:ownership_unlock",
-        "//sw/device/silicon_creator/lib/sigverify",
-        "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
-        "//sw/otbn/crypto:boot",
-    ],
-)
+[
+    cc_library(
+        name = "rom_ext_{}".format(variation_name),
+        srcs = [
+            "rom_ext.c",
+            "rom_ext_start.S",
+        ],
+        hdrs = ["rom_ext.h"],
+        target_compatible_with = [OPENTITAN_CPU],
+        deps = [
+            ":rescue",
+            ":rom_ext_boot_policy",
+            ":rom_ext_boot_policy_ptrs",
+            ":rom_ext_epmp",
+            ":sigverify_keys",
+            "//hw/ip/sram_ctrl/data:sram_ctrl_c_regs",
+            "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
+            "//sw/device/lib/arch:device",
+            "//sw/device/lib/base:csr",
+            "//sw/device/lib/base:macros",
+            "//sw/device/lib/base:stdasm",
+            "//sw/device/lib/crypto/drivers:entropy",
+            "//sw/device/lib/runtime:hart",
+            "//sw/device/silicon_creator/lib:attestation",
+            "//sw/device/silicon_creator/lib:boot_data",
+            "//sw/device/silicon_creator/lib:boot_log",
+            "//sw/device/silicon_creator/lib:dbg_print",
+            "//sw/device/silicon_creator/lib:keymgr_binding",
+            "//sw/device/silicon_creator/lib:manifest",
+            "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib:otbn_boot_services",
+            "//sw/device/silicon_creator/lib:shutdown",
+            "//sw/device/silicon_creator/lib/base:chip",
+            "//sw/device/silicon_creator/lib/base:sec_mmio",
+            "//sw/device/silicon_creator/lib/base:static_critical",
+            "//sw/device/silicon_creator/lib/base:util",
+            "//sw/device/silicon_creator/lib/boot_svc:boot_svc_msg",
+            "//sw/device/silicon_creator/lib/cert",
+            "//sw/device/silicon_creator/lib/cert:cdi_0_template_library",
+            "//sw/device/silicon_creator/lib/cert:cdi_1_template_library",
+            "//sw/device/silicon_creator/lib/drivers:ast",
+            "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+            "//sw/device/silicon_creator/lib/drivers:hmac",
+            "//sw/device/silicon_creator/lib/drivers:ibex",
+            "//sw/device/silicon_creator/lib/drivers:keymgr",
+            "//sw/device/silicon_creator/lib/drivers:lifecycle",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+            "//sw/device/silicon_creator/lib/drivers:pinmux",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+            "//sw/device/silicon_creator/lib/drivers:rnd",
+            "//sw/device/silicon_creator/lib/drivers:uart",
+            "//sw/device/silicon_creator/lib/ownership",
+            "//sw/device/silicon_creator/lib/ownership:ownership_activate",
+            "//sw/device/silicon_creator/lib/ownership:ownership_unlock",
+            "//sw/device/silicon_creator/lib/sigverify",
+            "//sw/device/silicon_creator/manuf/base:perso_tlv_data",
+            "//sw/otbn/crypto:boot",
+        ] + variation_deps,
+    )
+    for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
+]
 
 manifest(d = {
     "name": "manifest",
@@ -224,76 +228,33 @@ manifest(d = {
     "security_version": ROM_EXT_VERSION.SECURITY,
 })
 
-opentitan_binary(
-    name = "rom_ext_slot_a",
-    testonly = True,
-    # TODO(#22780): Integrate real keys for A1 flows.
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-        "//hw/top_earlgrey:fpga_cw340",
-        "//hw/top_earlgrey:sim_dv_base",
-        "//hw/top_earlgrey:sim_verilator_base",
-        "//hw/top_earlgrey:silicon_creator",
-    ],
-    linker_script = ":ld_slot_a",
-    manifest = ":manifest",
-    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
-    deps = [
-        ":rom_ext",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-        "//sw/device/silicon_creator/lib/ownership:test_owner",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake",
-    ],
-)
-
-opentitan_binary(
-    name = "rom_ext_slot_b",
-    testonly = True,
-    # TODO(#22780): Integrate real keys for A1 flows.
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-        "//hw/top_earlgrey:fpga_cw340",
-        "//hw/top_earlgrey:sim_dv_base",
-        "//hw/top_earlgrey:sim_verilator_base",
-        "//hw/top_earlgrey:silicon_creator",
-    ],
-    linker_script = ":ld_slot_b",
-    manifest = ":manifest",
-    spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
-    deps = [
-        ":rom_ext",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-        "//sw/device/silicon_creator/lib/ownership:test_owner",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake",
-    ],
-)
-
-opentitan_binary(
-    name = "rom_ext_slot_virtual",
-    testonly = True,
-    # TODO(#22780): Integrate real keys for A1 flows.
-    ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
-    exec_env = [
-        "//hw/top_earlgrey:fpga_cw310",
-        "//hw/top_earlgrey:fpga_cw340",
-        "//hw/top_earlgrey:sim_dv_base",
-        "//hw/top_earlgrey:sim_verilator_base",
-        "//hw/top_earlgrey:silicon_creator",
-    ],
-    linker_script = ":ld_slot_virtual",
-    manifest = ":manifest",
-    deps = [
-        ":rom_ext",
-        "//sw/device/lib/crt",
-        "//sw/device/silicon_creator/lib:manifest_def",
-        "//sw/device/silicon_creator/lib/ownership:test_owner",
-        "//sw/device/silicon_creator/lib/ownership/keys/fake",
-    ],
-)
+[
+    opentitan_binary(
+        name = "rom_ext_{}_slot_{}".format(variation_name, slot),
+        testonly = True,
+        # TODO(#22780): Integrate real keys for A1 flows.
+        ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
+        exec_env = [
+            "//hw/top_earlgrey:fpga_cw310",
+            "//hw/top_earlgrey:fpga_cw340",
+            "//hw/top_earlgrey:sim_dv_base",
+            "//hw/top_earlgrey:sim_verilator_base",
+            "//hw/top_earlgrey:silicon_creator",
+        ],
+        linker_script = ":ld_slot_{}".format(slot),
+        manifest = ":manifest",
+        spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
+        deps = [
+            ":rom_ext_{}".format(variation_name),
+            "//sw/device/lib/crt",
+            "//sw/device/silicon_creator/lib:manifest_def",
+            "//sw/device/silicon_creator/lib/ownership:test_owner",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake",
+        ],
+    )
+    for variation_name, variation_deps in ROM_EXT_VARIATIONS.items()
+    for slot in SLOTS
+]
 
 # This binary is a test-only ROM_EXT that has ownership initialized in
 # the "NewVersion" update mode.  Initializing in this mode makes the
@@ -308,7 +269,7 @@ opentitan_binary(
     linker_script = ":ld_slot_a",
     manifest = ":manifest",
     deps = [
-        ":rom_ext",
+        ":rom_ext_dice_x509",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/lib/ownership:test_owner_update_mode_newversion",
@@ -323,7 +284,7 @@ manifest(d = {
 })
 
 opentitan_binary(
-    name = "rom_ext_slot_a_bad_address_translation",
+    name = "rom_ext_dice_x509_slot_a_bad_address_translation",
     testonly = True,
     ecdsa_key = {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:test_key_0_ecdsa_p256": "test_key_0"},
     exec_env = [
@@ -335,7 +296,7 @@ opentitan_binary(
     linker_script = ":ld_slot_a",
     manifest = ":manifest_bad_address_translation",
     deps = [
-        ":rom_ext",
+        ":rom_ext_dice_x509",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",
         "//sw/device/silicon_creator/lib/ownership:test_owner",

--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -11,6 +11,15 @@ ROM_EXT_VERSION = struct(
     SECURITY = "0",
 )
 
+ROM_EXT_VARIATIONS = {
+    "dice_x509": [
+        "//sw/device/silicon_creator/lib/cert:dice",
+    ],
+    "dice_cwt": [
+        "//sw/device/silicon_creator/lib/cert:dice_cwt",
+    ],
+}
+
 SLOTS = [
     "a",
     "b",

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -7,26 +7,34 @@ load(
     "fpga_params",
     "opentitan_test",
 )
+load(
+    "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VARIATIONS",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-opentitan_test(
-    name = "no_refresh_test",
-    srcs = ["no_refresh_test.c"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
-        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
-    },
-    fpga = fpga_params(
-        exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
-        exit_success = "Rebooted\r\n",
-    ),
-    deps = [
-        "//sw/device/lib/base:status",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing/test_framework:check",
-        "//sw/device/lib/testing/test_framework:ottf_main",
-        "//sw/device/silicon_creator/lib/drivers:retention_sram",
-        "//sw/device/silicon_creator/lib/drivers:rstmgr",
-    ],
-)
+[
+    opentitan_test(
+        name = "no_refresh_{}_test".format(variation),
+        srcs = ["no_refresh_test.c"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+            "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        },
+        fpga = fpga_params(
+            exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
+            exit_success = "Rebooted\r\n",
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
+        ),
+        deps = [
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing/test_framework:check",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+            "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        ],
+    )
+    for variation in ROM_EXT_VARIATIONS.keys()
+]

--- a/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/verified_boot/BUILD
@@ -2,18 +2,15 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:const.bzl", "CONST", "hex")
+load("//rules:manifest.bzl", "manifest")
 load(
     "//rules/opentitan:defs.bzl",
-    "CLEAR_KEY_SET",
     "DEFAULT_TEST_FAILURE_MSG",
     "DEFAULT_TEST_SUCCESS_MSG",
-    "EARLGREY_TEST_ENVS",
-    "cw310_params",
     "fpga_params",
     "opentitan_test",
 )
-load("//rules:const.bzl", "CONST", "hex")
-load("//rules:manifest.bzl", "manifest")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,56 +21,56 @@ filegroup(
 
 _POSITIONS = {
     "owner_slot_a": {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
         "owner_offset": "0x10000",
         "success": "bl0_slot = AA__\r\n",
     },
     "owner_slot_b": {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
         "owner_offset": "0x90000",
         "success": "bl0_slot = __BB\r\n",
     },
     "owner_virtual_a": {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         "owner_offset": "0x10000",
         "success": "bl0_slot = AA__\r\n",
     },
     "owner_virtual_b": {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         "owner_offset": "0x90000",
         "success": "bl0_slot = __BB\r\n",
     },
     "romext_slot_a": {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_a",
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
         "owner_offset": "0x10000",
         "success": "rom_ext_slot = AA__\r\n",
     },
     "romext_slot_b": {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_b",
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
         "romext_offset": "0x80000",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
         "owner_offset": "0x10000",
         "success": "rom_ext_slot = __BB\r\n",
     },
     "romext_virtual_a": {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual",
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
         "romext_offset": "0",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
         "owner_offset": "0x10000",
         "success": "rom_ext_slot = AA__\r\n",
     },
     "romext_virtual_b": {
-        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_slot_virtual",
+        "romext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
         "romext_offset": "0x80000",
         "linker_script": "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
         "owner_offset": "0x10000",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -689,8 +689,11 @@ static rom_error_t dice_chain_push_cert(const char *name, const uint8_t *cert,
 
   // Encode the certificate to the tail buffer.
   size_t cert_page_left = dice_chain_get_tail_size();
+  perso_tlv_object_type_t cert_type =
+      kDiceCertFormat == kDiceCertFormatX509TcbInfo ? kPersoObjectTypeX509Cert
+                                                    : kPersoObjectTypeCwtCert;
   HARDENED_RETURN_IF_ERROR(
-      perso_tlv_cert_obj_build(name, kPersoObjectTypeX509Cert, cert, cert_size,
+      perso_tlv_cert_obj_build(name, cert_type, cert, cert_size,
                                dice_chain_get_tail_buffer(), &cert_page_left));
 
   // Move the offset to the new tail.

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -2,25 +2,19 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
-load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load("//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
+load("//rules/opentitan:defs.bzl", "opentitan_binary")
 load(
     "//sw/device/silicon_creator/rom_ext:defs.bzl",
+    "ROM_EXT_VARIATIONS",
     "ROM_EXT_VERSION",
     "SLOTS",
 )
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
-
-# In order to prevent the linker from prematurely discarding symbols, we
-# need to give the CRT library last.
-LINK_ORDER = [
-    "$(location //sw/device/silicon_creator/rom_ext)",
-    "$(location //sw/device/lib/crt)",
-]
 
 manifest(d = {
     "name": "manifest_sival",
@@ -40,7 +34,7 @@ manifest(d = {
 #   --//hw/bitstream/universal:otp=//hw/ip/otp_ctrl/data/earlgrey_skus/sival:otp_img_prod_manuf_personalized
 [
     opentitan_binary(
-        name = "rom_ext_fake_slot_{}".format(slot),
+        name = "rom_ext_{}_fake_slot_{}".format(variation, slot),
         ecdsa_key = select({
             "//signing:test_keys": {"//sw/device/silicon_creator/rom/keys/fake/ecdsa:prod_key_0_ecdsa_p256": "prod_key_0"},
             "//conditions:default": {"//hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys:keyset": "sv00-earlgrey-a1-root-ecdsa-test-0"},
@@ -51,7 +45,12 @@ manifest(d = {
             "//hw/top_earlgrey:fpga_cw340",
         ],
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
-        linkopts = LINK_ORDER,
+        # In order to prevent the linker from prematurely discarding symbols, we
+        # need to give the CRT library last.
+        linkopts = [
+            "$(location //sw/device/silicon_creator/rom_ext:rom_ext_{})".format(variation),
+            "$(location //sw/device/lib/crt)",
+        ],
         manifest = ":manifest_sival",
         deps = [
             # The sival_owner C library is included only in the "fake" ROM_EXT,
@@ -60,30 +59,35 @@ manifest(d = {
             ":sival_owner",
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
-            "//sw/device/silicon_creator/rom_ext",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(variation),
         ],
     )
+    for variation in ROM_EXT_VARIATIONS.keys()
     for slot in SLOTS
 ]
 
 [
     opentitan_binary(
-        name = "rom_ext_prod_slot_{}".format(slot),
+        name = "rom_ext_{}_prod_slot_{}".format(variation, slot),
         exec_env = [
             "//hw/top_earlgrey:silicon_creator",
             "//hw/top_earlgrey:fpga_cw310",
             "//hw/top_earlgrey:fpga_cw340",
         ],
         linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_{}".format(slot),
-        linkopts = LINK_ORDER,
+        linkopts = [
+            "$(location //sw/device/silicon_creator/rom_ext:rom_ext_{})".format(variation),
+            "$(location //sw/device/lib/crt)",
+        ],
         deps = [
             # The sival_owner C library is excluded from the real ROM_EXT,
             # as chips maintain their ownership configuration in flash.
             "//sw/device/lib/crt",
             "//sw/device/silicon_creator/lib:manifest_def",
-            "//sw/device/silicon_creator/rom_ext",
+            "//sw/device/silicon_creator/rom_ext:rom_ext_{}".format(variation),
         ],
     )
+    for variation in ROM_EXT_VARIATIONS.keys()
     for slot in SLOTS
 ]
 

--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -440,19 +440,21 @@ fn provision_certificates(
 
     // Validate the certificate endorsements with OpenSSL.
     // TODO(lowRISC/opentitan:#24281): Add CWT verifier
-    log::info!("Validating DICE certificate chain with OpenSSL ...");
-    validate_cert_chain(ca_certificate.to_str().unwrap(), &dice_cert_chain)?;
-    log::info!("Success.");
-    log::info!("Validating SKU-specific certificates with OpenSSL ...");
+    if !dice_cert_chain.is_empty() {
+        log::info!("Validating DICE certificate chain with OpenSSL ...");
+        validate_cert_chain(ca_certificate.to_str().unwrap(), &dice_cert_chain)?;
+        log::info!("Success.");
+    }
     if !sku_specific_certs.is_empty() {
+        log::info!("Validating SKU-specific certificates with OpenSSL ...");
         for sku_specific_cert in sku_specific_certs.iter() {
             validate_cert_chain(
                 ca_certificate.to_str().unwrap(),
                 &[sku_specific_cert.clone()],
             )?;
         }
+        log::info!("Success.");
     }
-    log::info!("Success.");
 
     Ok(())
 }


### PR DESCRIPTION
This updates the ROM_EXT build configuration to build multiple ROM_EXTs that support each DICE cert format: X.509 and CWT. Additionally, this updates the `dice_cwt` lib to implement the `dice_cert_check_valid()` function for checking if a DICE CWT is valid or not.