### PR TITLE
[sival] Add ibex testplan to top_earlgrey plan

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -50,6 +50,7 @@
     "hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson"
+    "hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson",
   ]
 
   testpoints: [


### PR DESCRIPTION
This testplan was missing from `top_earlgrey`'s imports.