### PR TITLE
[i2c,dv] Add missing "void" type to a function in i2c_monitor

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_monitor.sv
+++ b/hw/dv/sv/i2c_agent/i2c_monitor.sv
@@ -85,7 +85,7 @@ class i2c_monitor extends dv_base_monitor #(
     reset_state();
   endtask : wait_for_reset_and_drop_item
 
-  virtual function reset_state();
+  virtual function void reset_state();
     num_dut_tran = 0;
     mon_dut_item.clear_all();
   endfunction


### PR DESCRIPTION
The default type (bit) causes VCS to emit a warning about the fact we call the function without looking at the return value. Tell VCS that there isn't one!