### PR TITLE
[ci] Remove ROM e2e test cases from earlgrey_1.0.0

### DIFF
--- a/ci/fpga-job.yml
+++ b/ci/fpga-job.yml
@@ -81,6 +81,10 @@ jobs:
         //... @manufacturer_test_hooks//...
       # Run FPGA tests.
       if [ -s "${{ parameters.target_pattern_file }}" ]; then
+        # Disable ROM e2e test cases. These are not needed in this branch as we
+        # have sufficient coverage from //sw/device/silicon_creator/... unittests
+        # and functests.
+        echo "-//sw/device/silicon_creator/rom/e2e/..." >> "${{ parameters.target_pattern_file }}"
         ci/scripts/run-fpga-tests.sh "${{ parameters.interface }}" "${{ parameters.target_pattern_file }}" || { res=$?; echo "To reproduce failures locally, follow the instructions at https://opentitan.org/book/doc/getting_started/setup_fpga.html#reproducing-fpga-ci-failures-locally"; exit "${res}"; }
       else
         echo "No tests to run after filtering"

--- a/ci/verify-fpga-jobs.yml
+++ b/ci/verify-fpga-jobs.yml
@@ -40,7 +40,12 @@ jobs:
       # - then sort by the target name
       # - then keep all duplicated lines
       pattern_files=$(find $(Pipeline.Workspace)/verify_fpga_jobs -name target_pattern_file.txt)
-      awk '{ print(gensub(/.*\/(.+)\/target_pattern_file.txt/, "\\1", "g", FILENAME) " " $0) }' $pattern_files | sort -k2 | uniq -D -f1 > duplicates.txt
+      # Filter -//sw/device/silicon_creator/rom/e2e/... occurrences as these
+      # are tests patterns that are harcoded across all FPGA jobs to skip
+      # the ROM E2E tests in CI. See ci/fpga-job.yml for more details.
+      awk '!/-\/\/sw\/device\/silicon_creator\/rom\/e2e\/.../ {
+              print(gensub(/.*\/(.+)\/target_pattern_file.txt/, "\\1", "g", FILENAME) " " $0)
+          }' $pattern_files | sort -k2 | uniq -D -f1 > duplicates.txt
       if [ -s duplicates.txt ]; then
         echo "The following tests ran in two or more jobs:"
         cat duplicates.txt


### PR DESCRIPTION
Note: Do not merge this change directly into the `master` or any branches with active hardware or ROM development.

This change disables ROM e2e cases from CI as the branch does not support RTL or ROM changes.

Coverage for software under //sw/device/silicon_created/... is achieved by:

- unittests
- functests
- rom_ext e2e