### PR TITLE
[ci] Only run FPGA tests on pull requests.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -421,6 +421,10 @@ jobs:
         gcpKeyFile: "gcpkey.json"
         bucketURI: "gs://opentitan-bitstreams/master"
 
+- job: fpga_jobs_check_run
+  displayName: Check if all FPGA jobs should run
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+
 # CW310 FPGA jobs.
 - template: ci/fpga-job.yml
   parameters:

--- a/ci/fpga-job.yml
+++ b/ci/fpga-job.yml
@@ -43,8 +43,7 @@ jobs:
   dependsOn:
     - ${{ parameters.bitstream }}
     - sw_build
-  #condition: succeeded( ${{ parameters.bitstream }}, 'sw_build' )
-  condition: and(in(dependencies.${{ parameters.bitstream }}.result, 'Succeeded', 'SucceededWithIssues'), succeeded('sw_build'))
+  condition: and(in(dependencies.${{ parameters.bitstream }}.result, 'Succeeded', 'SucceededWithIssues'), succeeded('sw_build'), succeeded('fpga_jobs_check_run'))
   steps:
   - template: ./checkout-template.yml
   - template: ./install-package-dependencies.yml


### PR DESCRIPTION
This is to minimize the load on the CI infrastructure. Post-submit testing should be time bound to no more than a few  minutes on resources with very limited availability. This change takes the drastic measure of not running any FPGA tests, but a reduced test suite for post submit can be added in future (e.g. a `test_suite` with optimized coverage).