### PR TITLE
[imm_rom_ext] Add immutable ROM_EXT ePMP reconfiguration

### DIFF
--- a/sw/device/silicon_creator/imm_rom_ext/BUILD
+++ b/sw/device/silicon_creator/imm_rom_ext/BUILD
@@ -14,6 +14,7 @@ cc_library(
     srcs = ["imm_rom_ext.c"],
     hdrs = ["imm_rom_ext.h"],
     deps = [
+        ":imm_rom_ext_epmp",
         "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
@@ -31,6 +32,22 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:uart",
         "//sw/device/silicon_creator/lib/ownership:ownership_key",
         "//sw/device/silicon_creator/rom_ext:rom_ext_manifest",
+    ],
+)
+
+cc_library(
+    name = "imm_rom_ext_epmp",
+    srcs = ["imm_rom_ext_epmp.c"],
+    hdrs = ["imm_rom_ext_epmp.h"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:csr",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:epmp_state",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:manifest",
+        "//sw/device/silicon_creator/lib/drivers:epmp",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],
 )
 

--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/imm_rom_ext/imm_rom_ext_epmp.h"
 #include "sw/device/silicon_creator/lib/base/boot_measurements.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/cert/dice_chain.h"
@@ -31,6 +32,8 @@ static rom_error_t imm_rom_ext_start(void) {
 
   // Initialize Immutable ROM EXT.
   sec_mmio_next_stage_init();
+  HARDENED_RETURN_IF_ERROR(imm_rom_ext_epmp_reconfigure());
+
   // Configure UART0 as stdout.
   pinmux_init_uart0_tx();
   uart_init(kUartNCOValue);
@@ -51,6 +54,9 @@ static rom_error_t imm_rom_ext_start(void) {
 
   // Write the DICE certs to flash if they have been updated.
   HARDENED_RETURN_IF_ERROR(dice_chain_flush_flash());
+
+  // Make mutable part executable.
+  HARDENED_RETURN_IF_ERROR(imm_rom_ext_epmp_mutable_rx(rom_ext));
 
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext_epmp.c
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext_epmp.c
@@ -1,0 +1,115 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/imm_rom_ext/imm_rom_ext_epmp.h"
+
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/epmp.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/epmp_state.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+// Address populated by the linker.
+extern char _rom_ext_immutable_start[];
+extern char _rom_ext_immutable_end[];
+extern char _text_end[];
+extern char _stack_start[];  // Lowest stack address.
+
+static const epmp_region_t kMmioRegion = {
+    .start = TOP_EARLGREY_MMIO_BASE_ADDR,
+    .end = TOP_EARLGREY_MMIO_BASE_ADDR + TOP_EARLGREY_MMIO_SIZE_BYTES,
+};
+
+static const epmp_region_t kFlashRegion = {
+    .start = TOP_EARLGREY_EFLASH_BASE_ADDR,
+    .end = TOP_EARLGREY_EFLASH_BASE_ADDR + TOP_EARLGREY_EFLASH_SIZE_BYTES,
+};
+
+static const epmp_region_t kRvDmRegion = {
+    .start = TOP_EARLGREY_RV_DM_MEM_BASE_ADDR,
+    .end = TOP_EARLGREY_RV_DM_MEM_BASE_ADDR + TOP_EARLGREY_RV_DM_MEM_SIZE_BYTES,
+};
+
+static const epmp_region_t kStackGuard = {.start = (uintptr_t)_stack_start,
+                                          .end = (uintptr_t)_stack_start + 4};
+
+static const epmp_region_t kImmTextRegion = {
+    .start = (uintptr_t)_rom_ext_immutable_start,
+    .end = (uintptr_t)_text_end,
+};
+
+rom_error_t imm_rom_ext_epmp_reconfigure(void) {
+  lifecycle_state_t lc_state = lifecycle_state_get();
+
+  // ePMP region 15 gives read/write access to RAM.
+  // Leave it unchanged.
+
+  // Reconfigure the ePMP MMIO region to be NAPOT region 14, thus freeing
+  // up an ePMP entry for use elsewhere.
+  epmp_set_napot(14, kMmioRegion, kEpmpPermLockedReadWrite);
+
+  // ePMP region 11 protects the stack from overflow.
+  // This stack guard was in ePMP region 14.
+  epmp_set_napot(11, kStackGuard, kEpmpPermLockedNoAccess);
+
+  // ePMP region 12 allows RvDM access.
+  // This RvDM region was in ePMP region 13.
+  if (lc_state == kLcStateProd || lc_state == kLcStateProdEnd) {
+    // No RvDM access in Prod states, so we can clear the entry.
+    epmp_clear(12);
+  } else {
+    epmp_set_napot(12, kRvDmRegion, kEpmpPermLockedReadWriteExecute);
+  }
+
+  // ePMP region 13 gives read access to all of flash for both M and U modes.
+  // This flash region was in ePMP region 5.
+  epmp_set_napot(13, kFlashRegion, kEpmpPermLockedReadOnly);
+
+  // Move the ROM_EXT virtual region from entry 6 to 10.
+  uint32_t virtual_napot;
+  CSR_READ(CSR_REG_PMPADDR6, &virtual_napot);
+  epmp_clear(10);
+  if (virtual_napot) {
+    epmp_set_napot(10, epmp_decode_napot(virtual_napot),
+                   kEpmpPermLockedReadOnly);
+  }
+
+  // Clear mutable ROM_EXT entries (8 & 9).
+  epmp_clear(9);
+  epmp_clear(8);
+
+  // Immutable ROM_EXT TOR (6 & 7).
+  epmp_set_tor(6, kImmTextRegion, kEpmpPermLockedReadExecute);
+
+  // Clear entries from 5 ~ 3.
+  epmp_clear(5);
+  epmp_clear(4);
+  epmp_clear(3);
+
+  // 3 ~ 0 are ROM ePMP entries.
+  // Leave them unchanged.
+
+  HARDENED_RETURN_IF_ERROR(epmp_state_check());
+
+  return kErrorOk;
+}
+
+rom_error_t imm_rom_ext_epmp_mutable_rx(const manifest_t *manifest) {
+  // Immutable ROM_EXT TOR (8 & 9).
+  epmp_region_t mutable_code_region = manifest_code_region_get(manifest);
+
+  // Manifest code_region includes immutable data segment. Move the start
+  // address to exclude.
+  mutable_code_region.start = (uintptr_t)_rom_ext_immutable_end;
+
+  epmp_set_tor(8, mutable_code_region, kEpmpPermLockedReadExecute);
+
+  HARDENED_RETURN_IF_ERROR(epmp_state_check());
+
+  return kErrorOk;
+}

--- a/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext_epmp.h
+++ b/sw/device/silicon_creator/imm_rom_ext/imm_rom_ext_epmp.h
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_EPMP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_EPMP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+
+/**
+ * Reconfigure ePMP entries to lower priority.
+ *
+ * ePMP will be reconfigured to:
+ *    0: ROM      ----- ----
+ *    1: ROM        TOR LX-R
+ *    2: ROM      NAPOT L--R
+ *    3: -------  ----- ----
+ *    4: -------  ----- ----
+ *    5: -------  ----- ----
+ *    6: IM_EXT   ----- ----
+ *    7: IM_EXT     TOR LX-R
+ *    8:[MU_EXT   ----- ----]
+ *    9:[MU_EXT     TOR LX-R]
+ *   10: VIRTUAL  NAPOT L--R
+ *   11: STACK      NA4 L---
+ *   12: RvDM     NAPOT LXWR
+ *   13: FLASH    NAPOT L--R
+ *   14: MMIO     NAPOT L-WR
+ *   15: RAM      NAPOT L-WR
+ *
+ * Mutable ROM_EXT segment (8 & 9) won't be configured by this function.
+ * `imm_rom_ext_epmp_mutable_rx` will configure them when we are ready to
+ * jump back to ROM.
+ *
+ * Entries 6~12 can be recycled in Owner SW stage.
+ *
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t imm_rom_ext_epmp_reconfigure(void);
+
+/**
+ * Configure the Mutable ROM_EXT text segment with read-execute permissions.
+ *
+ *    8: MU_EXT   ----- ----
+ *    9: MU_EXT     TOR LX-R
+ *
+ * Note: When address translation is enabled, the manifest argument should
+ * point to the one in the virtual space.
+ *
+ * @param manifest Pointer to the rom_ext manifest.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+rom_error_t imm_rom_ext_epmp_mutable_rx(const manifest_t *manifest);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_IMM_ROM_EXT_IMM_ROM_EXT_EPMP_H_

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -893,3 +893,13 @@ cc_library(
         "//sw/device/silicon_creator/lib:epmp_state",
     ],
 )
+
+cc_test(
+    name = "epmp_unittest",
+    srcs = ["epmp_unittest.cc"],
+    deps = [
+        ":epmp",
+        "//sw/device/silicon_creator/testing:rom_test",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/sw/device/silicon_creator/lib/drivers/epmp.h
+++ b/sw/device/silicon_creator/lib/drivers/epmp.h
@@ -44,6 +44,31 @@ extern "C" {
 void epmp_clear(uint8_t entry);
 
 /**
+ * Clear the lock bit in all ePMP entries.
+ */
+void epmp_clear_lock_bits(void);
+
+/**
+ * Encode a start/end address pair to NAPOT address.
+ *
+ * The region start must have an alignment consistend with the region size.  The
+ * region size must be a power of two.  If either of these conditions is not
+ * met, this function will fault.
+ *
+ * @param region The address region to configure.
+ * @return The encoded NAPOT address.
+ */
+uint32_t epmp_encode_napot(epmp_region_t region);
+
+/**
+ * Decode a NAPOT address back to start/end address pair.
+ *
+ * @param pmpaddr The encoded NAPOT address.
+ * @return region The decoded start/end address pair.
+ */
+epmp_region_t epmp_decode_napot(uint32_t pmpaddr);
+
+/**
  * Configures an ePMP entry for a NAPOT or NA4 region.
  *
  * The region start must have an alignment consistend with the region size.  The

--- a/sw/device/silicon_creator/lib/drivers/epmp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/epmp_unittest.cc
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/epmp.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/testing/rom_test.h"
+
+namespace epmp_unittest {
+namespace {
+
+struct NapotCase {
+  /**
+   * Start / end of the NAPOT region.
+   */
+  uint32_t start;
+  uint32_t end;
+  /**
+   * Encoded NAPOT address.
+   */
+  uint32_t encoded;
+};
+
+class NapotTest : public rom_test::RomTest,
+                  public testing::WithParamInterface<NapotCase> {};
+
+TEST_P(NapotTest, Codec) {
+  epmp_region_t region = {
+      .start = (uintptr_t)GetParam().start,
+      .end = (uintptr_t)GetParam().end,
+  };
+  EXPECT_EQ(epmp_encode_napot(region), GetParam().encoded);
+
+  epmp_region_t decoded = epmp_decode_napot(GetParam().encoded);
+  EXPECT_EQ(decoded.start, GetParam().start);
+  EXPECT_EQ(decoded.end, GetParam().end);
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases, NapotTest,
+                         testing::Values(
+                             NapotCase{
+                                 .start = 0b1000010100100100101010100000,
+                                 .end = 0b1000010100100100101011000000,
+                                 .encoded = 0b10000101001001001010101011,
+                             },
+                             NapotCase{
+                                 .start = 0b101000001101000011100000000000,
+                                 .end = 0b101000001101000011100100000000,
+                                 .encoded = 0b1010000011010000111000011111,
+                             },
+                             NapotCase{
+                                 .start = 0b10111111111111111111111111111000,
+                                 .end = 0b11000000000000000000000000000000,
+                                 .encoded = 0b101111111111111111111111111110,
+                             },
+                             NapotCase{
+                                 .start = 0b00000000000000000000000000000000,
+                                 .end = 0b10000000000000000000000000000000,
+                                 .encoded = 0b001111111111111111111111111111,
+                             }));
+
+}  // namespace
+}  // namespace epmp_unittest


### PR DESCRIPTION
The immutable ROM_EXT data segment is also covered in ROM_EXT code region due to ROM limitation,
This PR let immutable ROM_EXT reconfigure ePMP first to remove executable permission on the data segment.

### Jumping from IMM_ROM_EXT -> ROM / mutable ROM_EXT

We propose to use the following new ePMP layout before jumping to the mutable ROM_EXT:
```
 *    0: ROM      ----- ----
 *    1: ROM        TOR LX-R
 *    2: ROM      NAPOT L--R
 *    3: -------  ----- ----
 *    4: -------  ----- ----
 *    5: -------  ----- ----
 *    6: IM_EXT   ----- ----
 *    7: IM_EXT     TOR LX-R
 *    8: MU_EXT   ----- ----
 *    9: MU_EXT     TOR LX-R
 *   10: VIRTUAL  NAPOT L--R
 *   11: STACK      NA4 L---
 *   12: RvDM     NAPOT LXWR
 *   13: FLASH    NAPOT L--R
 *   14: MMIO     NAPOT L-WR
 *   15: RAM      NAPOT L-WR
```

MU_EXT stands for mutable part of rom_ext text segment, and IM_EXT is the immutable part.

Slot 10 will be empty if address translation is not enabled, and stack guard
is added back to slot 11. 

Slot 12 and 13 are also swapped, so that the chip in production LCS has one more contiguous free entry. 

---

### Jumping from ROM_EXT -> Owner SW

Before jumping to Owner SW, all lock bits will be cleared, so all entries can
be reclaimed by Owner SW. Entries 8 ~ 11 ( &12 in prod LCS ) can be safely reconfigure by Owner SW.

```
 *    0: -------  ----- ----
 *    1: -------  ----- ----
 *    2: OWNER    ----- ----
 *    3: OWNER      TOR -X-R
 *    4: OWNER_V  NAPOT ---R
 *    5: -------  ----- ----
 *    6: -------  ----- ----
 *    7: -------  ----- ----
 *    8: MU_EXT   ----- ----
 *    9: MU_EXT     TOR -X-R
 *   10: VIRTUAL  NAPOT ---R
 *   11: STACK      NA4 ----
 *   12: RvDM     NAPOT -XWR
 *   13: FLASH    NAPOT ---R
 *   14: MMIO     NAPOT --WR
 *   15: RAM      NAPOT --WR
```

Owner SW ePMP will be placed at the entries 2, 3 and 4 same as before.

---

When the rom_ext is linked directly to the immutable lib instead of prebuilt immutable section, the IM_EXT region (6 & 7) will covers whole ROM_EXT text section. This is the current behavior since prebuilt section is not ready yet.