### PR TITLE
[sival] Import OTBN testplan for Earl Grey

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -51,6 +51,7 @@
     "hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson",
     "hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson"
     "hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson",
+    "hw/top_earlgrey/data/ip/chip_otbn_testplan.hjson",
   ]
 
   testpoints: [


### PR DESCRIPTION
OTBN tests are required for Earl Grey's silicon validation, so they should be imported by Earl Grey's testplan.