### PR TITLE
[darjeeling] Add missing padring.waiver

### DIFF
--- a/hw/top_darjeeling/lint/padring.waiver
+++ b/hw/top_darjeeling/lint/padring.waiver
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for padring
+
+waive -rules {HIER_BRANCH_NOT_READ HIER_NET_NOT_READ} \
+      -location {padring.sv} \
+      -regexp   {Net 'pok_i.*' in module 'padring'.*is not read from} \
+      -comment "SNS and RTO cells are not read from in the converted LIB/DB model, resulting in these warnings."
+
+waive -rules {HIER_BRANCH_NOT_READ HIER_NET_NOT_READ} \
+      -location {padring.sv} \
+      -regexp   {Connected net '(SNS|RTO)'.*is not read from in module.*} \
+      -comment "Some ports are not read from in the converted LIB/DB model, resulting in these warnings."
+
+waive -rules {HIER_BRANCH_NOT_READ} \
+      -location {padring.sv} \
+      -regexp   {Net 'clk_scan_i' in module 'padring'.*} \
+      -comment "This net is not read from if no scan role is defined for the pads (which is the case in the opensource view)."


### PR DESCRIPTION
This file was missing. Together with that and the FUSESOC_IGNORE move you can lint Darjeeling.