### PR TITLE
[sival] Assign `gpio_pinmux_test` to two points

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -115,7 +115,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
-      bazel: []
+      bazel: ["//sw/device/tests:gpio_pinmux_test"]
     }
     {
       name: chip_padctrl_attributes
@@ -135,7 +135,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
-      bazel: []
+      bazel: ["//sw/device/tests:gpio_pinmux_test"]
     }
     {
       name: chip_sw_sleep_pin_mio_dio_val


### PR DESCRIPTION
This test checks various muxing configurations, plus one attribute (invert), which fulfils most of the testpoints here. More attributes can be added later if necessary.