### PR TITLE
[opentitantool] Convenience for external programs

### DIFF
--- a/sw/host/opentitanlib/src/app/spi.rs
+++ b/sw/host/opentitanlib/src/app/spi.rs
@@ -205,6 +205,13 @@ impl Target for LogicalSpiWrapper {
         self.physical_wrapper.underlying_target.set_voltage(voltage)
     }
 
+    fn get_flashrom_programmer(&self) -> Result<String> {
+        self.apply_settings_to_underlying()?;
+        self.physical_wrapper
+            .underlying_target
+            .get_flashrom_programmer()
+    }
+
     fn run_transaction(&self, transaction: &mut [spi::Transfer]) -> Result<()> {
         self.apply_settings_to_underlying()?;
         self.physical_wrapper

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 use super::{eeprom, gpio};
 use crate::app::TransportWrapper;
 use crate::impl_serializable_error;
+use crate::transport::TransportError;
 use crate::util::voltage::Voltage;
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize)]
@@ -200,6 +201,12 @@ pub trait Target {
 
     fn set_voltage(&self, _voltage: Voltage) -> Result<()> {
         Err(SpiError::InvalidOption("This target does not support set_voltage".to_string()).into())
+    }
+
+    /// Returns `"raiden_debug_spi:serial=XXX"` or similar string usable for passing via `-p`
+    /// argument to `flashrom`, in order for it to connect to this SPI port instance.
+    fn get_flashrom_programmer(&self) -> Result<String> {
+        Err(TransportError::UnsupportedOperation.into())
     }
 
     /// Runs a SPI transaction composed from the slice of [`Transfer`] objects.  Will assert the

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -72,6 +72,12 @@ pub trait Uart {
         Ok(())
     }
 
+    /// Returns `"/dev/ttyUSBn"` or similar OS device path usable by external programs for
+    /// directly accessing the serial port.
+    fn get_device_path(&self) -> Result<String> {
+        Err(TransportError::UnsupportedOperation.into())
+    }
+
     /// Reads UART receive data into `buf`, returning the number of bytes read.
     /// This function _may_ block.
     fn read(&self, buf: &mut [u8]) -> Result<usize>;

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -366,6 +366,10 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_voltage(*voltage)?;
                         Ok(Response::Spi(SpiResponse::SetVoltage))
                     }
+                    SpiRequest::GetFlashromArgs => {
+                        let programmer = instance.get_flashrom_programmer()?;
+                        Ok(Response::Spi(SpiResponse::GetFlashromArgs { programmer }))
+                    }
                     SpiRequest::RunTransaction { transaction: reqs } => {
                         // Construct proper response to each transfer in request.
                         let mut resps: Vec<SpiTransferResponse> = reqs

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -269,6 +269,10 @@ impl<'a> TransportCommandHandler<'a> {
                         instance.set_parity(*parity)?;
                         Ok(Response::Uart(UartResponse::SetParity))
                     }
+                    UartRequest::GetDevicePath => {
+                        let path = instance.get_device_path()?;
+                        Ok(Response::Uart(UartResponse::GetDevicePath { path }))
+                    }
                     UartRequest::Read {
                         timeout_millis,
                         len,

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -183,6 +183,7 @@ pub enum UartRequest {
         rate: u32,
     },
     SetParity(Parity),
+    GetDevicePath,
     Read {
         timeout_millis: Option<u32>,
         len: u32,
@@ -199,6 +200,7 @@ pub enum UartResponse {
     GetBaudrate { rate: u32 },
     SetBaudrate,
     SetParity,
+    GetDevicePath { path: String },
     Read { data: Vec<u8> },
     Write,
     SupportsNonblockingRead { has_support: bool },

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -246,6 +246,7 @@ pub enum SpiRequest {
     SetVoltage {
         voltage: Voltage,
     },
+    GetFlashromArgs,
     RunTransaction {
         transaction: Vec<SpiTransferRequest>,
     },
@@ -281,6 +282,9 @@ pub enum SpiResponse {
         sizes: MaxSizes,
     },
     SetVoltage,
+    GetFlashromArgs {
+        programmer: String,
+    },
     RunTransaction {
         transaction: Vec<SpiTransferResponse>,
     },

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -18,6 +18,7 @@ use crate::util;
 
 /// Implementation of the `Uart` trait on top of a serial device, such as `/dev/ttyUSB0`.
 pub struct SerialPortUart {
+    port_name: String,
     flow_control: Cell<FlowControl>,
     port: RefCell<TTYPort>,
     rxbuf: RefCell<VecDeque<u8>>,
@@ -38,6 +39,7 @@ impl SerialPortUart {
             .map_err(|e| UartError::OpenError(e.to_string()))?;
         flock_serial(&port, port_name)?;
         Ok(SerialPortUart {
+            port_name: port_name.to_string(),
             flow_control: Cell::new(FlowControl::None),
             port: RefCell::new(port),
             rxbuf: RefCell::default(),
@@ -51,6 +53,7 @@ impl SerialPortUart {
             .map_err(|e| UartError::OpenError(e.to_string()))?;
         flock_serial(&port, port_name)?;
         Ok(SerialPortUart {
+            port_name: port_name.to_string(),
             flow_control: Cell::new(FlowControl::None),
             port: RefCell::new(port),
             rxbuf: RefCell::default(),
@@ -134,6 +137,10 @@ impl Uart for SerialPortUart {
             true => FlowControl::Resume,
         });
         Ok(())
+    }
+
+    fn get_device_path(&self) -> Result<String> {
+        Ok(self.port_name.clone())
     }
 
     /// Reads UART receive data into `buf`, returning the number of bytes read.

--- a/sw/host/opentitanlib/src/transport/dediprog/spi.rs
+++ b/sw/host/opentitanlib/src/transport/dediprog/spi.rs
@@ -379,6 +379,27 @@ impl Target for DediprogSpi {
         inner.set_voltage()
     }
 
+    fn get_flashrom_programmer(&self) -> Result<String> {
+        let inner = self.inner.borrow();
+        let voltage = match inner.voltage {
+            super::Voltage::V0 => "0V",
+            super::Voltage::V1p8 => "1.8V",
+            super::Voltage::V2p5 => "2.5V",
+            super::Voltage::V3p5 => "3.5V",
+        };
+        let spispeed = match inner.spi_clock {
+            ClockSpeed::Clk24Mhz => "24M",
+            ClockSpeed::Clk12Mhz => "12M",
+            ClockSpeed::Clk8Mhz => "8M",
+            ClockSpeed::Clk3Mhz => "3M",
+            ClockSpeed::Clk2p18Mhz => "2.18M",
+            ClockSpeed::Clk1p5Mhz => "1.5M",
+            ClockSpeed::Clk750Khz => "750k",
+            ClockSpeed::Clk375Khz => "375k",
+        };
+        Ok(format!("dediprog:voltage={voltage},spispeed={spispeed}"))
+    }
+
     /// Dediprog has limited support for "plain" SPI transactions.  It can only hold the CS
     /// asserted across a write then optional read, both of at most 16 bytes.
     fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -714,6 +714,14 @@ impl Target for HyperdebugSpiTarget {
         Ok(self.max_sizes)
     }
 
+    fn get_flashrom_programmer(&self) -> Result<String> {
+        Ok(format!(
+            "raiden_debug_spi:serial={},target={}",
+            self.inner.usb_device.borrow().get_serial_number(),
+            self.target_idx
+        ))
+    }
+
     fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {
         let mut idx: usize = 0;
         self.select_my_spi_bus()?;

--- a/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
@@ -93,6 +93,10 @@ impl Uart for HyperdebugUart {
         self.serial_port.set_flow_control(flow_control)
     }
 
+    fn get_device_path(&self) -> Result<String> {
+        self.serial_port.get_device_path()
+    }
+
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
         self.serial_port.read(buf)
     }

--- a/sw/host/opentitanlib/src/transport/proxy/spi.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/spi.rs
@@ -147,6 +147,13 @@ impl Target for ProxySpi {
         }
     }
 
+    fn get_flashrom_programmer(&self) -> Result<String> {
+        match self.execute_command(SpiRequest::GetFlashromArgs)? {
+            SpiResponse::GetFlashromArgs { programmer } => Ok(programmer),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {
         let mut req: Vec<SpiTransferRequest> = Vec::new();
         for transfer in transaction.iter() {

--- a/sw/host/opentitanlib/src/transport/proxy/uart.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/uart.rs
@@ -87,6 +87,13 @@ impl Uart for ProxyUart {
         }
     }
 
+    fn get_device_path(&self) -> Result<String> {
+        match self.execute_command(UartRequest::GetDevicePath)? {
+            UartResponse::GetDevicePath { path } => Ok(path),
+            _ => bail!(ProxyError::UnexpectedReply()),
+        }
+    }
+
     /// Reads UART receive data into `buf`, returning the number of bytes read.
     /// This function _may_ block.
     fn read(&self, buf: &mut [u8]) -> Result<usize> {

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -35,6 +35,7 @@ rust_binary(
         "src/command/status_cmd.rs",
         "src/command/tpm.rs",
         "src/command/transport.rs",
+        "src/command/uart.rs",
         "src/command/update_usr_access.rs",
         "src/command/version.rs",
         "src/command/xmodem.rs",

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -26,6 +26,7 @@ pub mod spx;
 pub mod status_cmd;
 pub mod tpm;
 pub mod transport;
+pub mod uart;
 pub mod update_usr_access;
 pub mod version;
 pub mod xmodem;

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -416,6 +416,31 @@ impl CommandDispatch for SpiRawTransceive {
     }
 }
 
+/// Produces output useful for separate invocation of `flashrom` connecting to a particular SPI
+/// bus alias.
+#[derive(Debug, Args)]
+pub struct SpiFlashromArgs {}
+
+#[derive(Debug, serde::Serialize)]
+pub struct SpiFlashromArgsResponse {
+    programmer: String,
+}
+
+impl CommandDispatch for SpiFlashromArgs {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        transport.capabilities()?.request(Capability::SPI).ok()?;
+        let context = context.downcast_ref::<SpiCommand>().unwrap();
+        let spi_bus = context.params.create(transport, "BOOTSTRAP")?;
+        Ok(Some(Box::new(SpiFlashromArgsResponse {
+            programmer: spi_bus.get_flashrom_programmer()?,
+        })))
+    }
+}
+
 /// Commands for interacting with a SPI EEPROM.
 #[derive(Debug, Subcommand, CommandDispatch)]
 pub enum InternalSpiCommand {
@@ -429,6 +454,7 @@ pub enum InternalSpiCommand {
     RawWriteRead(SpiRawWriteRead),
     RawTransceive(SpiRawTransceive),
     Tpm(SpiTpm),
+    FlashromArgs(SpiFlashromArgs),
 }
 
 #[derive(Debug, Args)]

--- a/sw/host/opentitantool/src/command/uart.rs
+++ b/sw/host/opentitantool/src/command/uart.rs
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::{Args, Subcommand};
+use serde_annotate::Annotate;
+use std::any::Any;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::uart::UartParams;
+
+/// Outputs `"/dev/ttyUSBn"` or similar OS device path usable by external programs for directly
+/// accessing the given serial port of the debugger.
+#[derive(Debug, Args)]
+pub struct UartOsDevice {}
+
+#[derive(Debug, serde::Serialize)]
+pub struct UartOsDeviceResponse {
+    path: String,
+}
+
+impl CommandDispatch for UartOsDevice {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        let context = context.downcast_ref::<UartCommand>().unwrap();
+        let uart = context.params.create(transport)?;
+        Ok(Some(Box::new(UartOsDeviceResponse {
+            path: uart.get_device_path()?,
+        })))
+    }
+}
+
+/// Commands for interacting with a UART.
+#[derive(Debug, Subcommand, CommandDispatch)]
+pub enum InternalUartCommand {
+    OsDevice(UartOsDevice),
+}
+
+#[derive(Debug, Args)]
+pub struct UartCommand {
+    #[command(flatten)]
+    params: UartParams,
+
+    #[command(subcommand)]
+    command: InternalUartCommand,
+}
+
+impl CommandDispatch for UartCommand {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Annotate>>> {
+        // None of the UART commands care about the prior context, but they do
+        // care about the `UartParams` parameter in the current node.
+        self.command.run(self, transport)
+    }
+}

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -60,6 +60,7 @@ enum RootCommandHierarchy {
     Spx(command::spx::Spx),
     #[command(subcommand)]
     Transport(command::transport::TransportCommand),
+    Uart(command::uart::UartCommand),
     Version(command::version::Version),
     #[command(subcommand)]
     Status(command::status_cmd::StatusCommand),


### PR DESCRIPTION
Add two new commands to `opentitantool`: `spi flashrom-arg` and `uart os-device`, which can be used for heling external programs access HyperDebug (or some other backend devices) without going through `opentitanlib`, while still using the `usb-serial` and port aliases from our configuration files to identify the debugger and port.

```
$ opentitantool --conf ... --usb-serial 2042355F3236 spi --bus=BOOTSTRAP flashrom-args
{
  programmer: "raiden_debug_spi:serial=2042355F3236,target=2"
}
$ opentitantool --conf ... --usb-serial 2042355F3236 uart --uart=EC os-device
{
  path: "/dev/ttyUSB6"
}
```
