### PR TITLE
[ownership] Compute correct flash INFO page addresses

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/BUILD
@@ -120,6 +120,7 @@ cc_library(
     hdrs = ["owner_block.h"],
     deps = [
         ":datatypes",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",

--- a/sw/device/silicon_creator/lib/ownership/owner_block.c
+++ b/sw/device/silicon_creator/lib/ownership/owner_block.c
@@ -15,6 +15,7 @@
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "flash_ctrl_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 // RAM copy of the owner INFO pages from flash.
 owner_block_t owner_page[2];
@@ -272,10 +273,12 @@ rom_error_t owner_block_info_apply(const owner_flash_info_config_t *info) {
           .base_addr = config->bank * FLASH_CTRL_PARAM_BYTES_PER_BANK +
                        config->page * FLASH_CTRL_PARAM_BYTES_PER_PAGE,
           .cfg_wen_addr =
+              TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR +
               config->page * sizeof(uint32_t) +
               (config->bank == 0 ? FLASH_CTRL_BANK0_INFO0_REGWEN_0_REG_OFFSET
                                  : FLASH_CTRL_BANK1_INFO0_REGWEN_0_REG_OFFSET),
-          .cfg_addr = config->page * sizeof(uint32_t) +
+          .cfg_addr = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR +
+                      config->page * sizeof(uint32_t) +
                       (config->bank == 0
                            ? FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_REG_OFFSET
                            : FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_REG_OFFSET),

--- a/sw/host/tests/ownership/flash_permission_test.rs
+++ b/sw/host/tests/ownership/flash_permission_test.rs
@@ -127,7 +127,7 @@ fn flash_info_check(info: &[FlashRegion<'_>], unlocked: bool) -> Result<()> {
             FlashRegion("info", 1, 0, 3, "RD-xx-xx-SC-EC-xx", "LK") // owner config 1
         },
         FlashRegion("info", 1, 0, 4, "uu-uu-uu-uu-uu-uu", "LK"), // creator reserved
-        FlashRegion("info", 1, 0, 5, "xx-xx-xx-xx-xx-xx", "UN"), // owner reserved
+        FlashRegion("info", 1, 0, 5, "RD-WR-ER-xx-xx-HE", "UN"), // owner reserved
         FlashRegion("info", 1, 0, 6, "xx-xx-xx-xx-xx-xx", "UN"), // owner reserved
         FlashRegion("info", 1, 0, 7, "xx-xx-xx-xx-xx-xx", "UN"), // owner reserved
         FlashRegion("info", 1, 0, 8, "xx-xx-xx-xx-xx-xx", "UN"), // owner reserved

--- a/sw/host/tests/ownership/transfer_lib.rs
+++ b/sw/host/tests/ownership/transfer_lib.rs
@@ -13,7 +13,8 @@ use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams}
 use opentitanlib::crypto::ecdsa::{EcdsaPrivateKey, EcdsaPublicKey};
 use opentitanlib::ownership::{
     ApplicationKeyDomain, CommandTag, FlashFlags, KeyMaterial, OwnerApplicationKey, OwnerBlock,
-    OwnerConfigItem, OwnerFlashConfig, OwnerFlashRegion, OwnerRescueConfig, OwnershipKeyAlg,
+    OwnerConfigItem, OwnerFlashConfig, OwnerFlashInfoConfig, OwnerFlashRegion, OwnerInfoPage,
+    OwnerRescueConfig, OwnershipKeyAlg,
 };
 use opentitanlib::rescue::serial::RescueSerial;
 
@@ -238,6 +239,15 @@ where
                     OwnerFlashRegion::new(256, 32, config.rom_ext()),
                     OwnerFlashRegion::new(256 + 32, 192, config.firmware()),
                     OwnerFlashRegion::new(256 + 224, 32, config.filesystem()),
+                ],
+                ..Default::default()
+            }));
+        owner
+            .data
+            .push(OwnerConfigItem::FlashInfoConfig(OwnerFlashInfoConfig {
+                config: vec![
+                    // Bank 1, page 5, filesystem-like configuration.
+                    OwnerInfoPage::new(1, 5, config.filesystem()),
                 ],
                 ..Default::default()
             }));


### PR DESCRIPTION
1. Fix incorrect INFO page `cfg` and `cfg_wen` register calculations.
2. Add an INFO page to the various `with-flash` configurations in the ownership transfer tests.