### PR TITLE
fix for gpio_stress_all with rnd reset

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -716,22 +716,19 @@ class cip_base_vseq #(
   // override this task from {block}_common_vseq if needed
   virtual task rand_reset_eor_clean_up();
   endtask
-
   // Run the given sequence together with a TL errors vseq. Suddenly inject a reset after at most
   // reset_delay_bound cycles. When we come out of reset, check all CSR values to ensure they are
   // the documented reset values.
   virtual task run_seq_with_rand_reset_vseq(uvm_sequence seq,
                                             int          num_times,
-                                            uint         reset_delay_bound);    
+                                            uint         reset_delay_bound);
     `DV_CHECK_FATAL(seq != null)
     `uvm_info(`gfn, $sformatf("running run_seq_with_rand_reset_vseq for sequence %s",
                                seq.get_full_name()), UVM_MEDIUM)
-
     for (int i = 1; i <= num_times; i++) begin
       bit ongoing_reset;
       bit do_read_and_check_all_csrs;
       bit vseq_done = 1'b0;
-
       `uvm_info(`gfn, $sformatf("running run_seq_with_rand_reset_vseq iteration %0d/%0d",
                                 i, num_times), UVM_LOW)
       // Arbitration: requests at highest priority granted in FIFO order, so that we can predict
@@ -786,9 +783,8 @@ class cip_base_vseq #(
                 do_read_and_check_all_csrs = 1'b1;
                 ongoing_reset = 1'b0;
               end
-            end 
+            end
           join_any
-
           // If vseq_done is false then we have issued a reset (the second process in the fork) but
           // the vseq that we were racing against hasn't noticed the reset and stopped. Killing that
           // process will cause confusing errors (because there will be some sequence that's waiting
@@ -800,7 +796,6 @@ class cip_base_vseq #(
           // understandable way here.
           //if (cfg.can_reset_with_csr_accesses) `DV_CHECK_FATAL(vseq_done)
           wait(vseq_done)
-
           disable fork;
           `uvm_info(`gfn, $sformatf("\nStress w/ reset is done for run %0d/%0d", i, num_times),
                     UVM_LOW)

--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -134,7 +134,7 @@
       swaccess: "ro",
       hwaccess: "hwo",
       tags: [// data_in is ro register, so exclude its readback check
-             "excl:CsrNonInitTests:CsrExclWriteCheck"],
+             "excl:CsrAllTests:CsrExclAll"],
       fields: [
         { bits: "31:0",
           resval: "x"

--- a/hw/ip/gpio/dv/env/gpio_env_cfg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_cfg.sv
@@ -27,6 +27,7 @@ class gpio_env_cfg extends cip_base_env_cfg #(
 
     // only support 1 outstanding TL item
     m_tl_agent_cfg.max_outstanding_req = 1;
+    can_reset_with_csr_accesses = 1;
   endfunction : initialize
 
 endclass

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
@@ -12,7 +12,6 @@ class gpio_base_vseq extends cip_base_vseq #(
   // Delay between consecutive transactions
   rand uint delay;
   bit  do_init_reset = 1;
-
   constraint delay_c {
     delay dist {0 :/ 20, [1:5] :/ 40, [6:15] :/ 30, [20:25] :/ 10};
   }

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
@@ -12,7 +12,7 @@ class gpio_base_vseq extends cip_base_vseq #(
   // Delay between consecutive transactions
   rand uint delay;
   bit  do_init_reset = 1;
-
+  
   constraint delay_c {
     delay dist {0 :/ 20, [1:5] :/ 40, [6:15] :/ 30, [20:25] :/ 10};
   }

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_base_vseq.sv
@@ -12,7 +12,7 @@ class gpio_base_vseq extends cip_base_vseq #(
   // Delay between consecutive transactions
   rand uint delay;
   bit  do_init_reset = 1;
-  
+
   constraint delay_c {
     delay dist {0 :/ 20, [1:5] :/ 40, [6:15] :/ 30, [20:25] :/ 10};
   }

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
@@ -27,7 +27,7 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
       // Insert some random delay
       cfg.clk_rst_vif.wait_clks(delay);
 
-      
+
 
       randcase
         // drive new gpio data in
@@ -41,12 +41,12 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
           // drive gpio_vif after setting all output enables to 0's
 
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break;          
+          if (!cfg.clk_rst_vif.rst_n) break;
           drive_gpio_in(gpio_i);
           cfg.clk_rst_vif.wait_clks(1);
-          
+
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break; 
+          if (!cfg.clk_rst_vif.rst_n) break;
 
           // read data_in register
           csr_rd(.ptr(ral.data_in), .value(data_in));
@@ -55,16 +55,16 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
         1: begin : write_new_value_gpio_data_reg
           `uvm_info(`gfn, $sformatf("Transaction-%0d: program a random gpio register", tr_num),
                     UVM_HIGH)
-          
+
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break;           
+          if (!cfg.clk_rst_vif.rst_n) break;
           // First, stop driving gpio_i
           undrive_gpio_in();
           // Randomize csr value
           `DV_CHECK_STD_RANDOMIZE_FATAL(csr_val)
 
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break;  
+          if (!cfg.clk_rst_vif.rst_n) break;
 
           randcase
             1: begin
@@ -76,7 +76,7 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
               cfg.clk_rst_vif.wait_clks(1);
 
               //Skip if a reset is on going...
-              if (!cfg.clk_rst_vif.rst_n) break; 
+              if (!cfg.clk_rst_vif.rst_n) break;
               // DATA_IN register is RO, but writing random value to it
               // should have no impact on gpio functionality
               csr_wr(.ptr(ral.data_in), .value(csr_val));
@@ -94,7 +94,7 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
           `uvm_info(`gfn, $sformatf("Transaction-%0d: read random register)", tr_num), UVM_LOW)
 
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break;  
+          if (!cfg.clk_rst_vif.rst_n) break;
 
           randcase
             1: csr_rd(.ptr(ral.data_in         ), .value(csr_val));

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
@@ -22,7 +22,7 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
 
       `DV_CHECK_RANDOMIZE_FATAL(this)
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
       // Insert some random delay
       cfg.clk_rst_vif.wait_clks(delay);
@@ -40,12 +40,12 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           // drive gpio_vif after setting all output enables to 0's
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           drive_gpio_in(gpio_i);
           cfg.clk_rst_vif.wait_clks(1);
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
 
           // read data_in register
@@ -56,26 +56,26 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
           `uvm_info(`gfn, $sformatf("Transaction-%0d: program a random gpio register", tr_num),
                     UVM_HIGH)
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           // First, stop driving gpio_i
           undrive_gpio_in();
           // Randomize csr value
           `DV_CHECK_STD_RANDOMIZE_FATAL(csr_val)
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
 
           randcase
             1: begin
 
-              //Skip if a reset is on going...
+              //Skip if a reset is ongoing...
               if (!cfg.clk_rst_vif.rst_n) break;
               // Add single clock cycle delay to avoid update and predict at
               // the same time due to weak pull-up after undrive_gpio_in()
               cfg.clk_rst_vif.wait_clks(1);
 
-              //Skip if a reset is on going...
+              //Skip if a reset is ongoing...
               if (!cfg.clk_rst_vif.rst_n) break;
               // DATA_IN register is RO, but writing random value to it
               // should have no impact on gpio functionality
@@ -93,7 +93,7 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
         1: begin : read_any_gpio_data_reg
           `uvm_info(`gfn, $sformatf("Transaction-%0d: read random register)", tr_num), UVM_LOW)
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
 
           randcase

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_dout_din_regs_random_rw_vseq.sv
@@ -21,12 +21,17 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
       logic [TL_DW-1:0] csr_val;
 
       `DV_CHECK_RANDOMIZE_FATAL(this)
+
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
       // Insert some random delay
       cfg.clk_rst_vif.wait_clks(delay);
 
+      
+
       randcase
         // drive new gpio data in
-        1: begin
+        1: begin : drive_thread_data_in
           // gpio input to drive
           bit [NUM_GPIOS-1:0] gpio_i;
           bit [TL_DW-1:0] data_in;
@@ -34,25 +39,44 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
                     UVM_HIGH)
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           // drive gpio_vif after setting all output enables to 0's
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;          
           drive_gpio_in(gpio_i);
           cfg.clk_rst_vif.wait_clks(1);
+          
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break; 
+
           // read data_in register
           csr_rd(.ptr(ral.data_in), .value(data_in));
         end
         // write new value to any one of gpio data registers
-        1: begin
+        1: begin : write_new_value_gpio_data_reg
           `uvm_info(`gfn, $sformatf("Transaction-%0d: program a random gpio register", tr_num),
                     UVM_HIGH)
+          
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;           
           // First, stop driving gpio_i
           undrive_gpio_in();
           // Randomize csr value
           `DV_CHECK_STD_RANDOMIZE_FATAL(csr_val)
 
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;  
+
           randcase
             1: begin
+
+              //Skip if a reset is on going...
+              if (!cfg.clk_rst_vif.rst_n) break;
               // Add single clock cycle delay to avoid update and predict at
               // the same time due to weak pull-up after undrive_gpio_in()
               cfg.clk_rst_vif.wait_clks(1);
+
+              //Skip if a reset is on going...
+              if (!cfg.clk_rst_vif.rst_n) break; 
               // DATA_IN register is RO, but writing random value to it
               // should have no impact on gpio functionality
               csr_wr(.ptr(ral.data_in), .value(csr_val));
@@ -66,8 +90,12 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
           endcase
         end
         // read any one of the gpio data registers
-        1: begin
-          `uvm_info(`gfn, $sformatf("Transaction-%0d: read random register)", tr_num), UVM_HIGH)
+        1: begin : read_any_gpio_data_reg
+          `uvm_info(`gfn, $sformatf("Transaction-%0d: read random register)", tr_num), UVM_LOW)
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;  
+
           randcase
             1: csr_rd(.ptr(ral.data_in         ), .value(csr_val));
             1: csr_rd(.ptr(ral.direct_out      ), .value(csr_val));
@@ -77,10 +105,10 @@ class gpio_dout_din_regs_random_rw_vseq extends gpio_base_vseq;
             1: csr_rd(.ptr(ral.masked_out_upper), .value(csr_val));
             1: csr_rd(.ptr(ral.masked_oe_upper ), .value(csr_val));
           endcase
-          `uvm_info(`gfn, $sformatf("reg read data = 0x%0h [%0b]", csr_val, csr_val), UVM_HIGH)
+          `uvm_info(`gfn, $sformatf("reg read data = 0x%0h [%0b]", csr_val, csr_val), UVM_LOW)
         end
       endcase
-      `uvm_info(`gfn, $sformatf("End of Transaction-%0d", tr_num), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("End of Transaction-%0d", tr_num), UVM_LOW)
 
     end // end for
 

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_intr_rand_pgm_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_intr_rand_pgm_vseq.sv
@@ -24,7 +24,7 @@ class gpio_intr_rand_pgm_vseq extends gpio_base_vseq;
       string msg_id = {`gfn, $sformatf(" Transaction-%0d", tr_num)};
 
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
       cfg.clk_rst_vif.wait_clks(delay);
@@ -39,17 +39,17 @@ class gpio_intr_rand_pgm_vseq extends gpio_base_vseq;
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           `uvm_info(msg_id, "drive random value on gpio_i", UVM_HIGH)
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
 
           // drive gpio_vif after setting all output enables to 0's
           drive_gpio_in(gpio_i);
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           cfg.clk_rst_vif.wait_clks(1);
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           // read data_in register
           csr_rd(.ptr(ral.data_in), .value(data_in));
@@ -58,7 +58,7 @@ class gpio_intr_rand_pgm_vseq extends gpio_base_vseq;
         1: begin : write_rand_gpio_intr_reg
           `uvm_info(msg_id, "program interrupt register(s) to random value(s)", UVM_HIGH)
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
 
           if ($urandom_range(0, 1)) begin
@@ -96,7 +96,7 @@ class gpio_intr_rand_pgm_vseq extends gpio_base_vseq;
       begin
         bit [TL_DW-1:0] reg_rd_data;
 
-        //Skip if a reset is on going...
+        //Skip if a reset is ongoing...
         if (!cfg.clk_rst_vif.rst_n) break;
         `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
         cfg.clk_rst_vif.wait_clks(delay);

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_intr_rand_pgm_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_intr_rand_pgm_vseq.sv
@@ -23,26 +23,43 @@ class gpio_intr_rand_pgm_vseq extends gpio_base_vseq;
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
       string msg_id = {`gfn, $sformatf(" Transaction-%0d", tr_num)};
 
+
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
       cfg.clk_rst_vif.wait_clks(delay);
 
+      
       randcase
         // drive new gpio data in
-        1: begin
+        1: begin : drive_gpio_data_in
           // gpio input to drive
           bit [NUM_GPIOS-1:0] gpio_i;
           bit [NUM_GPIOS-1:0] data_in;
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           `uvm_info(msg_id, "drive random value on gpio_i", UVM_HIGH)
+          
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;
+          
           // drive gpio_vif after setting all output enables to 0's
           drive_gpio_in(gpio_i);
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break; 
           cfg.clk_rst_vif.wait_clks(1);
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break; 
           // read data_in register
           csr_rd(.ptr(ral.data_in), .value(data_in));
         end
         // write random value(s) to gpio interrupt register(s)
-        1: begin
+        1: begin : write_rand_gpio_intr_reg
           `uvm_info(msg_id, "program interrupt register(s) to random value(s)", UVM_HIGH)
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;
 
           if ($urandom_range(0, 1)) begin
             `DV_CHECK_RANDOMIZE_FATAL(ral.intr_enable)
@@ -78,6 +95,9 @@ class gpio_intr_rand_pgm_vseq extends gpio_base_vseq;
       // Read interrupt state register value
       begin
         bit [TL_DW-1:0] reg_rd_data;
+
+        //Skip if a reset is on going...
+        if (!cfg.clk_rst_vif.rst_n) break;
         `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
         cfg.clk_rst_vif.wait_clks(delay);
         // read intr_state register

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_intr_rand_pgm_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_intr_rand_pgm_vseq.sv
@@ -29,7 +29,7 @@ class gpio_intr_rand_pgm_vseq extends gpio_base_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
       cfg.clk_rst_vif.wait_clks(delay);
 
-      
+
       randcase
         // drive new gpio data in
         1: begin : drive_gpio_data_in
@@ -38,19 +38,19 @@ class gpio_intr_rand_pgm_vseq extends gpio_base_vseq;
           bit [NUM_GPIOS-1:0] data_in;
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           `uvm_info(msg_id, "drive random value on gpio_i", UVM_HIGH)
-          
+
           //Skip if a reset is on going...
           if (!cfg.clk_rst_vif.rst_n) break;
-          
+
           // drive gpio_vif after setting all output enables to 0's
           drive_gpio_in(gpio_i);
 
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break; 
+          if (!cfg.clk_rst_vif.rst_n) break;
           cfg.clk_rst_vif.wait_clks(1);
 
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break; 
+          if (!cfg.clk_rst_vif.rst_n) break;
           // read data_in register
           csr_rd(.ptr(ral.data_in), .value(data_in));
         end

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_rand_intr_trigger_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_rand_intr_trigger_vseq.sv
@@ -27,10 +27,14 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
       string msg_id = {`gfn, $sformatf(" Transaction-%0d", tr_num)};
 
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
       cfg.clk_rst_vif.wait_clks(delay);
       `uvm_info(msg_id, $sformatf("delay = %0d", delay), UVM_HIGH)
 
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
       // Step-1 Program interrupt registers
       pgm_intr_regs();
 
@@ -48,7 +52,11 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
               bit [TL_DW-1:0] data_in;
               int delay_before_gpio_change;
               `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
-              `uvm_info(msg_id, $sformatf("Driving new gpio value 0x%0h", gpio_i), UVM_HIGH)
+
+              //Skip if a reset is on going...
+              if (!cfg.clk_rst_vif.rst_n) break;
+
+              `uvm_info(msg_id, $sformatf("Driving new gpio value 0x%0h", gpio_i), UVM_LOW)
               cfg.gpio_vif.drive(gpio_i);
               `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(delay_before_gpio_change,
                                                  delay_before_gpio_change inside {[1:5]};)
@@ -61,9 +69,16 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
               uint rd_period;
               bit [TL_DW-1:0] reg_rd_data;
               `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rd_period, rd_period inside {[2:20]};)
+
+              //Skip if a reset is on going...
+              if (!cfg.clk_rst_vif.rst_n) break;
+
               cfg.clk_rst_vif.wait_clks(rd_period);
               `uvm_info(msg_id, $sformatf("Reading intr_state after %0d more clock cycles",
                                           rd_period), UVM_HIGH)
+
+              //Skip if a reset is on going...
+              if (!cfg.clk_rst_vif.rst_n) break;
               randcase
                 1: begin
                   csr_rd(.ptr(ral.data_in), .value(reg_rd_data));
@@ -72,6 +87,10 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
                   csr_rd(.ptr(ral.intr_state), .value(reg_rd_data));
                 end
               endcase
+
+              //Skip if a reset is on going...
+              if (!cfg.clk_rst_vif.rst_n) break;
+
               // Randomly clear random set of interrupt state register bits
               if ($urandom_range(0, 1)) begin
                 `DV_CHECK_RANDOMIZE_FATAL(ral.intr_state)
@@ -84,7 +103,6 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
           end
         join
       end
-
       `uvm_info(msg_id, "End of Transaction", UVM_HIGH)
 
     end // end for

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_rand_intr_trigger_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_rand_intr_trigger_vseq.sv
@@ -27,13 +27,13 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
       string msg_id = {`gfn, $sformatf(" Transaction-%0d", tr_num)};
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
       cfg.clk_rst_vif.wait_clks(delay);
       `uvm_info(msg_id, $sformatf("delay = %0d", delay), UVM_HIGH)
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
       // Step-1 Program interrupt registers
       pgm_intr_regs();
@@ -53,7 +53,7 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
               int delay_before_gpio_change;
               `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
 
-              //Skip if a reset is on going...
+              //Skip if a reset is ongoing...
               if (!cfg.clk_rst_vif.rst_n) break;
 
               `uvm_info(msg_id, $sformatf("Driving new gpio value 0x%0h", gpio_i), UVM_LOW)
@@ -70,14 +70,14 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
               bit [TL_DW-1:0] reg_rd_data;
               `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rd_period, rd_period inside {[2:20]};)
 
-              //Skip if a reset is on going...
+              //Skip if a reset is ongoing...
               if (!cfg.clk_rst_vif.rst_n) break;
 
               cfg.clk_rst_vif.wait_clks(rd_period);
               `uvm_info(msg_id, $sformatf("Reading intr_state after %0d more clock cycles",
                                           rd_period), UVM_HIGH)
 
-              //Skip if a reset is on going...
+              //Skip if a reset is ongoing...
               if (!cfg.clk_rst_vif.rst_n) break;
               randcase
                 1: begin
@@ -88,7 +88,7 @@ class gpio_rand_intr_trigger_vseq extends gpio_base_vseq;
                 end
               endcase
 
-              //Skip if a reset is on going...
+              //Skip if a reset is ongoing...
               if (!cfg.clk_rst_vif.rst_n) break;
 
               // Randomly clear random set of interrupt state register bits

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
@@ -45,16 +45,16 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
           // drive gpio_vif after setting all output enables to 0's
 
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break;          
+          if (!cfg.clk_rst_vif.rst_n) break;
 
           drive_gpio_in(gpio_i);
 
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break; 
+          if (!cfg.clk_rst_vif.rst_n) break;
           cfg.clk_rst_vif.wait_clks(1);
-          
+
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break; 
+          if (!cfg.clk_rst_vif.rst_n) break;
           // read data_in register
           csr_rd(.ptr(ral.data_in), .value(data_in));
         end
@@ -64,7 +64,7 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
                                     tr_num), UVM_LOW)
 
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break;                           
+          if (!cfg.clk_rst_vif.rst_n) break;
           // First, stop driving gpio_i
           undrive_gpio_in();
 

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
@@ -25,9 +25,11 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
   endtask: dut_init
 
   task body();
-    `uvm_info(`gfn, $sformatf("num_trans = %0d", num_trans), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("num_trans = %0d", num_trans), UVM_LOW)
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
 
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       cfg.clk_rst_vif.wait_clks(delay);
 
@@ -38,20 +40,36 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
           bit [NUM_GPIOS-1:0] gpio_i;
           bit [NUM_GPIOS-1:0] data_in;
           `uvm_info(`gfn, $sformatf("Transaction-%0d: drive random value to gpio_i", tr_num),
-                    UVM_HIGH)
+                    UVM_LOW)
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           // drive gpio_vif after setting all output enables to 0's
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;          
+
           drive_gpio_in(gpio_i);
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break; 
           cfg.clk_rst_vif.wait_clks(1);
+          
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break; 
           // read data_in register
           csr_rd(.ptr(ral.data_in), .value(data_in));
         end
         // write new value(s) to gpio out related register(s)
         1: begin
           `uvm_info(`gfn, $sformatf("Transaction-%0d: program register(s) to random value(s)",
-                                    tr_num), UVM_HIGH)
+                                    tr_num), UVM_LOW)
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;                           
           // First, stop driving gpio_i
           undrive_gpio_in();
+
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;
 
           if ($urandom_range(0, 1)) begin
             `DV_CHECK_RANDOMIZE_FATAL(ral.direct_out)
@@ -84,7 +102,7 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
           end
         end
       endcase
-      `uvm_info(`gfn, $sformatf("End of Transaction-%0d", tr_num), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("End of Transaction-%0d", tr_num), UVM_LOW)
 
     end // end for
 

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_dout_din_vseq.sv
@@ -28,7 +28,7 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
     `uvm_info(`gfn, $sformatf("num_trans = %0d", num_trans), UVM_LOW)
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       cfg.clk_rst_vif.wait_clks(delay);
@@ -44,16 +44,16 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           // drive gpio_vif after setting all output enables to 0's
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
 
           drive_gpio_in(gpio_i);
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           cfg.clk_rst_vif.wait_clks(1);
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           // read data_in register
           csr_rd(.ptr(ral.data_in), .value(data_in));
@@ -63,12 +63,12 @@ class gpio_random_dout_din_vseq extends gpio_base_vseq;
           `uvm_info(`gfn, $sformatf("Transaction-%0d: program register(s) to random value(s)",
                                     tr_num), UVM_LOW)
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           // First, stop driving gpio_i
           undrive_gpio_in();
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
 
           if ($urandom_range(0, 1)) begin

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
@@ -14,7 +14,7 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
   `uvm_object_new
 
   task body();
-    
+
     // gpio pins_if pins_o value to drive
     bit [NUM_GPIOS-1:0] gpio_i;
     // gpio pins_if pins_oe value to drive
@@ -37,7 +37,7 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
       //Skip if a reset is on going...
       if (!cfg.clk_rst_vif.rst_n) return;
       cfg.clk_rst_vif.wait_clks(delay);
-      
+
       randcase
         // drive new gpio data in
         1: begin
@@ -48,9 +48,9 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
           if (!cfg.clk_rst_vif.rst_n) break;
           // drive gpio_vif after setting all output enables to 0's
           drive_gpio_in(gpio_i);
-          
+
           //Skip if a reset is on going...
-          if (!cfg.clk_rst_vif.rst_n) break; 
+          if (!cfg.clk_rst_vif.rst_n) break;
           // Wait for one clock cycle for us to read data_in reg reliably
           cfg.clk_rst_vif.wait_clks(1);
         end

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
@@ -14,12 +14,15 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
   `uvm_object_new
 
   task body();
+    
     // gpio pins_if pins_o value to drive
     bit [NUM_GPIOS-1:0] gpio_i;
     // gpio pins_if pins_oe value to drive
     bit [NUM_GPIOS-1:0] gpio_i_oen;
     `uvm_info(`gfn, $sformatf("num_trans = %0d", num_trans), UVM_HIGH)
 
+    //Skip if a reset is on going...
+    if (!cfg.clk_rst_vif.rst_n) return;
     // Wait for minimum 1 clock cycle initially to avoid reading of data_in
     // immediately as the first iteration after reset, while data_in prediction
     // is still being processed
@@ -31,31 +34,42 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_reg_op, num_reg_op inside {[25:50]};)
 
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
       cfg.clk_rst_vif.wait_clks(delay);
+      
       randcase
         // drive new gpio data in
         1: begin
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
-          `uvm_info(msg_id, $sformatf("drive random value 0x%0h on gpio_i", gpio_i), UVM_HIGH)
+          `uvm_info(msg_id, $sformatf("drive random value 0x%0h on gpio_i", gpio_i), UVM_LOW)
 
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;
           // drive gpio_vif after setting all output enables to 0's
           drive_gpio_in(gpio_i);
+          
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break; 
           // Wait for one clock cycle for us to read data_in reg reliably
           cfg.clk_rst_vif.wait_clks(1);
         end
         // long reg write
         1: begin
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;
           undrive_gpio_in();
           repeat (num_reg_op) gpio_reg_wr();
         end
         // long reg read
         1: begin
+          //Skip if a reset is on going...
+          if (!cfg.clk_rst_vif.rst_n) break;
           repeat (num_reg_op) gpio_reg_rd();
         end
       endcase
 
     end // end for
-
   endtask : body
 
   // Task: gpio_reg_wr

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_random_long_reg_writes_reg_reads_vseq.sv
@@ -21,7 +21,7 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
     bit [NUM_GPIOS-1:0] gpio_i_oen;
     `uvm_info(`gfn, $sformatf("num_trans = %0d", num_trans), UVM_HIGH)
 
-    //Skip if a reset is on going...
+    //Skip if a reset is ongoing...
     if (!cfg.clk_rst_vif.rst_n) return;
     // Wait for minimum 1 clock cycle initially to avoid reading of data_in
     // immediately as the first iteration after reset, while data_in prediction
@@ -34,7 +34,7 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(delay)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_reg_op, num_reg_op inside {[25:50]};)
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
       cfg.clk_rst_vif.wait_clks(delay);
 
@@ -44,26 +44,26 @@ class gpio_random_long_reg_writes_reg_reads_vseq extends gpio_base_vseq;
           `DV_CHECK_STD_RANDOMIZE_FATAL(gpio_i)
           `uvm_info(msg_id, $sformatf("drive random value 0x%0h on gpio_i", gpio_i), UVM_LOW)
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           // drive gpio_vif after setting all output enables to 0's
           drive_gpio_in(gpio_i);
 
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           // Wait for one clock cycle for us to read data_in reg reliably
           cfg.clk_rst_vif.wait_clks(1);
         end
         // long reg write
         1: begin
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           undrive_gpio_in();
           repeat (num_reg_op) gpio_reg_wr();
         end
         // long reg read
         1: begin
-          //Skip if a reset is on going...
+          //Skip if a reset is ongoing...
           if (!cfg.clk_rst_vif.rst_n) break;
           repeat (num_reg_op) gpio_reg_rd();
         end

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_smoke_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_smoke_vseq.sv
@@ -29,12 +29,18 @@ class gpio_smoke_vseq extends gpio_base_vseq;
   task body();
     // test gpio inputs
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
-    `uvm_info(`gfn, $sformatf("No. of transactions (gpio_i) = %0d", num_trans), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("No. of transactions (gpio_i) = %0d", num_trans), UVM_LOW)
+
+    
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
       bit [TL_DW-1:0] csr_rd_val;
       string msg_id = {`gfn, $sformatf(" Transaction-%0d: ", tr_num)};
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_i)
-      `uvm_info(msg_id, $sformatf("gpio_i = %0h", gpio_i), UVM_HIGH)
+      `uvm_info(msg_id, $sformatf("gpio_i = %0h", gpio_i), UVM_LOW)
+      
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
+      
       cfg.gpio_vif.drive(gpio_i);
 `ifdef GPIO_ASYNC_ON
       // If the CDC synchronizer prims are instantiated, it takes 2-3 cycles longer for inputs
@@ -44,34 +50,55 @@ class gpio_smoke_vseq extends gpio_base_vseq;
       // Wait at least one clock cycle
       `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(delay, delay >= 1;)
 `endif
+      
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
       cfg.clk_rst_vif.wait_clks(delay);
+      
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return; 
       // Reading data_in will trigger a check inside scoreboard
       csr_rd(.ptr(ral.data_in), .value(csr_rd_val));
       `uvm_info(msg_id, {$sformatf("reading data_in after %0d clock cycles ", delay),
-                         $sformatf("csr_rd_val = %0h", csr_rd_val)}, UVM_HIGH)
+                         $sformatf("csr_rd_val = %0h", csr_rd_val)}, UVM_LOW)
     end
 
     // test gpio outputs
     cfg.gpio_vif.drive_en('0);
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
-    `uvm_info(`gfn, $sformatf("No. of transactions (gpio_o) = %0d", num_trans), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("No. of transactions (gpio_o) = %0d", num_trans), UVM_LOW)
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
       logic [NUM_GPIOS-1:0] exp_gpio_o;
       logic [NUM_GPIOS-1:0] obs_gpio_o;
       string msg_id = {`gfn, $sformatf(" Transaction-%0d: ", tr_num)};
 
+
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
+
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_o)
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_oe)
       `uvm_info(msg_id, $sformatf("writing direct_out = 0x%0h [%0b] direct_oe = 0x%0h [%0b]",
-                                  gpio_o, gpio_o, gpio_oe, gpio_oe), UVM_HIGH)
+                                  gpio_o, gpio_o, gpio_oe, gpio_oe), UVM_LOW)
       ral.direct_out.set(gpio_o);
       ral.direct_oe.set(gpio_oe);
+
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return;
+
       csr_update(.csr(ral.direct_out));
+
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return; 
+
       csr_update(.csr(ral.direct_oe));
       // Wait at least one clock cycle
       `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(delay, delay >= 1;)
+      
+      //Skip if a reset is on going...
+      if (!cfg.clk_rst_vif.rst_n) return; 
       cfg.clk_rst_vif.wait_clks(delay);
-      `uvm_info(msg_id, $sformatf("waiting for %0d clock cycles", delay), UVM_HIGH)
+      `uvm_info(msg_id, $sformatf("waiting for %0d clock cycles", delay), UVM_LOW)
     end
   endtask : body
 

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_smoke_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_smoke_vseq.sv
@@ -38,8 +38,6 @@ class gpio_smoke_vseq extends gpio_base_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_i)
       `uvm_info(msg_id, $sformatf("gpio_i = %0h", gpio_i), UVM_LOW)
 
-      //Skip if a reset is on going...
-      if (!cfg.clk_rst_vif.rst_n) return;
 
       cfg.gpio_vif.drive(gpio_i);
 `ifdef GPIO_ASYNC_ON
@@ -51,12 +49,10 @@ class gpio_smoke_vseq extends gpio_base_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(delay, delay >= 1;)
 `endif
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
       cfg.clk_rst_vif.wait_clks(delay);
 
-      //Skip if a reset is on going...
-      if (!cfg.clk_rst_vif.rst_n) return;
       // Reading data_in will trigger a check inside scoreboard
       csr_rd(.ptr(ral.data_in), .value(csr_rd_val));
       `uvm_info(msg_id, {$sformatf("reading data_in after %0d clock cycles ", delay),
@@ -73,7 +69,7 @@ class gpio_smoke_vseq extends gpio_base_vseq;
       string msg_id = {`gfn, $sformatf(" Transaction-%0d: ", tr_num)};
 
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
 
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_o)
@@ -83,19 +79,12 @@ class gpio_smoke_vseq extends gpio_base_vseq;
       ral.direct_out.set(gpio_o);
       ral.direct_oe.set(gpio_oe);
 
-      //Skip if a reset is on going...
-      if (!cfg.clk_rst_vif.rst_n) return;
-
       csr_update(.csr(ral.direct_out));
-
-      //Skip if a reset is on going...
-      if (!cfg.clk_rst_vif.rst_n) return;
-
       csr_update(.csr(ral.direct_oe));
       // Wait at least one clock cycle
       `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(delay, delay >= 1;)
 
-      //Skip if a reset is on going...
+      //Skip if a reset is ongoing...
       if (!cfg.clk_rst_vif.rst_n) return;
       cfg.clk_rst_vif.wait_clks(delay);
       `uvm_info(msg_id, $sformatf("waiting for %0d clock cycles", delay), UVM_LOW)

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_smoke_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_smoke_vseq.sv
@@ -31,16 +31,16 @@ class gpio_smoke_vseq extends gpio_base_vseq;
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
     `uvm_info(`gfn, $sformatf("No. of transactions (gpio_i) = %0d", num_trans), UVM_LOW)
 
-    
+
     for (uint tr_num = 0; tr_num < num_trans; tr_num++) begin
       bit [TL_DW-1:0] csr_rd_val;
       string msg_id = {`gfn, $sformatf(" Transaction-%0d: ", tr_num)};
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(gpio_i)
       `uvm_info(msg_id, $sformatf("gpio_i = %0h", gpio_i), UVM_LOW)
-      
+
       //Skip if a reset is on going...
       if (!cfg.clk_rst_vif.rst_n) return;
-      
+
       cfg.gpio_vif.drive(gpio_i);
 `ifdef GPIO_ASYNC_ON
       // If the CDC synchronizer prims are instantiated, it takes 2-3 cycles longer for inputs
@@ -50,13 +50,13 @@ class gpio_smoke_vseq extends gpio_base_vseq;
       // Wait at least one clock cycle
       `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(delay, delay >= 1;)
 `endif
-      
+
       //Skip if a reset is on going...
       if (!cfg.clk_rst_vif.rst_n) return;
       cfg.clk_rst_vif.wait_clks(delay);
-      
+
       //Skip if a reset is on going...
-      if (!cfg.clk_rst_vif.rst_n) return; 
+      if (!cfg.clk_rst_vif.rst_n) return;
       // Reading data_in will trigger a check inside scoreboard
       csr_rd(.ptr(ral.data_in), .value(csr_rd_val));
       `uvm_info(msg_id, {$sformatf("reading data_in after %0d clock cycles ", delay),
@@ -89,14 +89,14 @@ class gpio_smoke_vseq extends gpio_base_vseq;
       csr_update(.csr(ral.direct_out));
 
       //Skip if a reset is on going...
-      if (!cfg.clk_rst_vif.rst_n) return; 
+      if (!cfg.clk_rst_vif.rst_n) return;
 
       csr_update(.csr(ral.direct_oe));
       // Wait at least one clock cycle
       `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(delay, delay >= 1;)
-      
+
       //Skip if a reset is on going...
-      if (!cfg.clk_rst_vif.rst_n) return; 
+      if (!cfg.clk_rst_vif.rst_n) return;
       cfg.clk_rst_vif.wait_clks(delay);
       `uvm_info(msg_id, $sformatf("waiting for %0d clock cycles", delay), UVM_LOW)
     end

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_stress_all_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_stress_all_vseq.sv
@@ -40,8 +40,6 @@ class gpio_stress_all_vseq extends gpio_base_vseq;
 
       `uvm_info(`gfn, $sformatf("End of sequence %0s with seq_idx = %0d", gpio_vseq.get_name(),
           seq_idx), UVM_HIGH)
-
-
     end
   endtask : body
 endclass

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_stress_all_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_stress_all_vseq.sv
@@ -37,8 +37,11 @@ class gpio_stress_all_vseq extends gpio_base_vseq;
                 UVM_HIGH)
 
       gpio_vseq.start(p_sequencer);
+
       `uvm_info(`gfn, $sformatf("End of sequence %0s with seq_idx = %0d", gpio_vseq.get_name(),
           seq_idx), UVM_HIGH)
+
+
     end
   endtask : body
 endclass


### PR DESCRIPTION
Temporally fix for the issue when the reset comes during the stress all sequences. 
For all the stress all sequences was included some check if the reset is triggered. 
A wait(vseq_done) is replacing the check for "sequences been finished" to wait for all the remaining sequences finish, then a csr register reset values check is executed.