### PR TITLE
[provisioning] Recognize the old ROM_EXT output

### DIFF
--- a/sw/host/provisioning/ft_lib/src/lib.rs
+++ b/sw/host/provisioning/ft_lib/src/lib.rs
@@ -479,7 +479,10 @@ pub fn check_rom_ext_boot_up(
 ) -> Result<()> {
     transport.reset_target(init.bootstrap.options.reset_delay, true)?;
     let uart_console = transport.uart("console")?;
-    let _ = UartConsole::wait_for(&*uart_console, r"ROM_EXT:.*\r\n", timeout)?;
+    // The ROM_EXT used to print "Starting ROM_EXT 0.1", but we cleaned up the
+    // ROM_EXT output.  It now prints "ROM_EXT:0.1".
+    // The following regex recognizes both forms:
+    let _ = UartConsole::wait_for(&*uart_console, r"ROM_EXT[: ].*\r\n", timeout)?;
 
     // Timeout for waiting for a potential error message indicating invalid UDS certificate.
     // This value is tested on fpga cw340 and could be potentially fine-tuned.


### PR DESCRIPTION
The ROM_EXT used to print "Starting ROM_EXT 0.1", but we cleaned up the ROM_EXT output.  It now prints "ROM_EXT:0.1".  Change the regex to recognize both formats.