### PR TITLE
[regtool] Add inline veriblelint waivers for line-length rule in ral_pkg

### DIFF
--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -601,10 +601,10 @@ reg_field_name, field)">\
         assert 0
 %>\
       ${reg_inst}.add_hdl_path_slice(
-          "${shadowed_reg_path}.committed_reg.q",
+          "${shadowed_reg_path}.committed_reg.q", // verilog_lint: waive line-length
           ${field.bits.lsb}, ${field.bits.width()}, 0, "BkdrRegPathRtl");
       ${reg_inst}.add_hdl_path_slice(
-          "${shadowed_reg_path}.shadow_reg.q",
+          "${shadowed_reg_path}.shadow_reg.q", // verilog_lint: waive line-length
           ${field.bits.lsb}, ${field.bits.width()}, 0, "BkdrRegPathRtlShadow");
     % endfor
   % endif


### PR DESCRIPTION
The ral_pkg files are all auto-generated and depending on the name and exact instantiation of shadow registers (potentially `hwext`), may contain pretty long path names. To avoid veriblelint flagging warnings about this (it feels silly as the files are auto-generated anyway), this commit adds a suitable inline waiver specifically for shadow registers paths.