### PR TITLE
[fpga] Add ability to issue POR to self via SW

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw340.sv
@@ -866,17 +866,19 @@ module chip_earlgrey_cw340 #(
   assign ext_clk = '0;
   assign pad2ast = '0;
 
-  logic clk_main, clk_io, clk_usb_48mhz, clk_aon, rst_n;
+  logic clk_main, clk_io, clk_usb_48mhz, clk_aon, rst_n, srst_n;
   clkgen_xil_ultrascale # (
     .AddClkBuf(0)
   ) clkgen (
     .clk_i(manual_in_io_clk),
     .rst_ni(manual_in_por_n),
+    .srst_ni(srst_n),
     .clk_main_o(clk_main),
     .clk_io_o(clk_io),
     .clk_48MHz_o(clk_usb_48mhz),
     .clk_aon_o(clk_aon),
-    .rst_no(rst_n)
+    .rst_no(rst_n),
+    .fpga_eos_o(fpga_eos)
   );
 
   logic [31:0] fpga_info;
@@ -1027,13 +1029,85 @@ module chip_earlgrey_cw340 #(
   // PLL for FPGA //
   //////////////////
 
+  // Internally-generated POR from debug sources.
+  logic fpga_internal_por_n;
+
   assign manual_attr_io_clk = '0;
   assign manual_out_io_clk = 1'b0;
   assign manual_oe_io_clk = 1'b0;
   assign manual_attr_por_n = '0;
   assign manual_out_por_n = 1'b0;
   assign manual_oe_por_n = 1'b0;
+  assign srst_n = fpga_internal_por_n;
 
+
+  // These pad attributes are controlled through sensor_ctrl.  Update the description of
+  // `MANUAL_PAD_ATTR` in `sensor_ctrl.hjson` when you change or extend the mapping below.
+  // Note that the FPGA doesn't have any of these pads, and we commandeer these signals to
+  // add some intrusive debug functionality to the FPGA, including the ability to trigger
+  // a full POR from software.
+  prim_pad_wrapper_pkg::pad_attr_t [3:0] sensor_ctrl_manual_pad_attr;
+  prim_pad_wrapper_pkg::pad_attr_t       manual_attr_cc1;
+  prim_pad_wrapper_pkg::pad_attr_t       manual_attr_cc2;
+  prim_pad_wrapper_pkg::pad_attr_t       manual_attr_flash_test_mode0;
+  prim_pad_wrapper_pkg::pad_attr_t       manual_attr_flash_test_mode1;
+  assign manual_attr_cc1 = sensor_ctrl_manual_pad_attr[0];
+  assign manual_attr_cc2 = sensor_ctrl_manual_pad_attr[1];
+  assign manual_attr_flash_test_mode0 = sensor_ctrl_manual_pad_attr[2];
+  assign manual_attr_flash_test_mode1 = sensor_ctrl_manual_pad_attr[3];
+
+  logic fpga_harness_rst_n;
+  prim_rst_sync #(
+    .ActiveHigh(1'b1),
+    .SkipScan(1'b1)
+  ) u_fpga_por_sync (
+    .clk_i(clk_aon),
+    .d_i(fpga_eos),
+    .q_o(fpga_harness_rst_n),
+    .scan_rst_ni(1'b1),
+    .scanmode_i('0)
+  );
+
+  logic fpga_por_trigger;
+  prim_edge_detector u_internal_por_detector (
+    .clk_i(clk_aon),
+    .rst_ni(fpga_harness_rst_n),
+    .d_i(manual_attr_flash_test_mode0.pull_en),
+    .q_sync_o(),
+    .q_posedge_pulse_o(fpga_por_trigger),
+    .q_negedge_pulse_o()
+  );
+
+  logic fpga_por_request_n;
+  always_ff @ (posedge clk_aon or negedge fpga_harness_rst_n) begin
+    if (!fpga_harness_rst_n) begin
+      fpga_por_request_n <= 1'b0;
+    end else begin
+      if (fpga_por_trigger) begin
+        fpga_por_request_n <= 1'b0;
+      end else begin
+        fpga_por_request_n <= 1'b1;
+      end
+    end
+  end
+
+  prim_filter_ctr #(
+    .CntWidth(15)    // Target 100 ms @ 200 kHz
+  ) u_internal_por_extender (
+    .clk_i(clk_aon),
+    .rst_ni(fpga_por_request_n),
+    .enable_i(1'b1),
+    .filter_i(1'b1),
+    .thresh_i(15'd20000),
+    .filter_o(fpga_internal_por_n)
+  );
+
+  logic unused_manual_sigs;
+  assign unused_manual_sigs = ^{
+    manual_attr_cc1,
+    manual_attr_cc2,
+    manual_attr_flash_test_mode1
+  };
 
   //////////////////////
   // Top-level design //
@@ -1133,6 +1207,7 @@ module chip_earlgrey_cw340 #(
     // Pad attributes
     .mio_attr_o      ( mio_attr      ),
     .dio_attr_o      ( dio_attr      ),
+    .sensor_ctrl_manual_pad_attr_o( sensor_ctrl_manual_pad_attr),
 
     // Memory attributes
     .ram_1p_cfg_i    ( '0 ),

--- a/hw/top_earlgrey/rtl/clkgen_xil7series.sv
+++ b/hw/top_earlgrey/rtl/clkgen_xil7series.sv
@@ -12,7 +12,8 @@ module clkgen_xil7series # (
   output clk_main_o,
   output clk_48MHz_o,
   output clk_aon_o,
-  output rst_no
+  output rst_no,
+  output fpga_eos_o
 );
   logic locked_pll;
   logic io_clk_buf;
@@ -25,6 +26,21 @@ module clkgen_xil7series # (
   logic clk_48_unbuf;
   logic clk_aon_buf;
   logic clk_aon_unbuf;
+
+  STARTUPE2 u_startup_block (
+    .CFGCLK(),
+    .CFGMCLK(),
+    .EOS(fpga_eos_o),
+    .PREQ(),
+    .CLK(1'b0),
+    .GSR(1'b0),
+    .GTS(1'b0),
+    .KEYCLEARB(1'b1),
+    .PACK(1'b0),
+    .USRCCLKO(1'b0),
+    .USRCCLKTS(1'b0),
+    .USRDONETS(1'b0)
+  );
 
   MMCME2_ADV #(
     .BANDWIDTH            ("OPTIMIZED"),

--- a/hw/top_earlgrey/rtl/clkgen_xil_ultrascale.sv
+++ b/hw/top_earlgrey/rtl/clkgen_xil_ultrascale.sv
@@ -8,11 +8,13 @@ module clkgen_xil_ultrascale # (
 ) (
   input  clk_i,
   input  rst_ni,
+  input  srst_ni,
   output clk_main_o,
   output clk_io_o,
   output clk_48MHz_o,
   output clk_aon_o,
-  output rst_no
+  output rst_no,
+  output fpga_eos_o
 );
   logic locked_pll;
   logic io_clk_buf;
@@ -27,6 +29,21 @@ module clkgen_xil_ultrascale # (
   logic clk_48_unbuf;
   logic clk_aon_buf;
   logic clk_aon_unbuf;
+
+  STARTUPE2 u_startup_block (
+    .CFGCLK(),
+    .CFGMCLK(),
+    .EOS(fpga_eos_o),
+    .PREQ(),
+    .CLK(1'b0),
+    .GSR(1'b0),
+    .GTS(1'b0),
+    .KEYCLEARB(1'b1),
+    .PACK(1'b0),
+    .USRCCLKO(1'b0),
+    .USRCCLKTS(1'b0),
+    .USRDONETS(1'b0)
+  );
 
   MMCME2_ADV #(
     .BANDWIDTH            ("OPTIMIZED"),
@@ -135,5 +152,5 @@ module clkgen_xil_ultrascale # (
   assign clk_aon_o = clk_aon_buf;
 
   // reset
-  assign rst_no = locked_pll & rst_ni;
+  assign rst_no = locked_pll & rst_ni & srst_ni;
 endmodule

--- a/hw/top_earlgrey/templates/chiplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/chiplevel.sv.tpl
@@ -699,6 +699,7 @@ module chip_${top["name"]}_${target["name"]} #(
   assign pad2ast = '0;
 
   logic clk_main, clk_usb_48mhz, clk_aon, rst_n, srst_n;
+  logic fpga_eos;
   clkgen_xil7series # (
     .AddClkBuf(0)
   ) clkgen (
@@ -708,7 +709,8 @@ module chip_${top["name"]}_${target["name"]} #(
     .clk_main_o(clk_main),
     .clk_48MHz_o(clk_usb_48mhz),
     .clk_aon_o(clk_aon),
-    .rst_no(rst_n)
+    .rst_no(rst_n),
+    .fpga_eos_o(fpga_eos)
   );
 
   logic [31:0] fpga_info;
@@ -729,17 +731,19 @@ module chip_${top["name"]}_${target["name"]} #(
   assign ext_clk = '0;
   assign pad2ast = '0;
 
-  logic clk_main, clk_io, clk_usb_48mhz, clk_aon, rst_n;
+  logic clk_main, clk_io, clk_usb_48mhz, clk_aon, rst_n, srst_n;
   clkgen_xil_ultrascale # (
     .AddClkBuf(0)
   ) clkgen (
     .clk_i(manual_in_io_clk),
     .rst_ni(manual_in_por_n),
+    .srst_ni(srst_n),
     .clk_main_o(clk_main),
     .clk_io_o(clk_io),
     .clk_48MHz_o(clk_usb_48mhz),
     .clk_aon_o(clk_aon),
-    .rst_no(rst_n)
+    .rst_no(rst_n),
+    .fpga_eos_o(fpga_eos)
   );
 
   logic [31:0] fpga_info;
@@ -991,16 +995,12 @@ module chip_${top["name"]}_${target["name"]} #(
   // Top-level design //
   //////////////////////
   top_${top["name"]} #(
-% if target["name"] != "asic":
-    .PinmuxAonTargetCfg(PinmuxTargetCfg)
-% else:
     .PinmuxAonTargetCfg(PinmuxTargetCfg),
     .I2c0InputDelayCycles(1),
     .I2c1InputDelayCycles(1),
     .I2c2InputDelayCycles(1),
     .SecAesAllowForcingMasks(1'b1),
     .SecRomCtrlDisableScrambling(SecRomCtrlDisableScrambling)
-% endif
   ) top_${top["name"]} (
     // ast connections
     .por_n_i                      ( por_n                      ),
@@ -1104,6 +1104,9 @@ module chip_${top["name"]}_${target["name"]} #(
   // PLL for FPGA //
   //////////////////
 
+  // Internally-generated POR from debug sources.
+  logic fpga_internal_por_n;
+
   assign manual_attr_io_clk = '0;
   assign manual_out_io_clk = 1'b0;
   assign manual_oe_io_clk = 1'b0;
@@ -1115,7 +1118,9 @@ module chip_${top["name"]}_${target["name"]} #(
   assign manual_out_por_button_n = 1'b0;
   assign manual_oe_por_button_n = 1'b0;
 
-  assign srst_n = manual_in_por_button_n;
+  assign srst_n = manual_in_por_button_n & fpga_internal_por_n;
+  % elif target["name"] == "cw340":
+  assign srst_n = fpga_internal_por_n;
   % endif
 
   % if target["name"] == "cw305":
@@ -1123,6 +1128,74 @@ module chip_${top["name"]}_${target["name"]} #(
   //       exist for this target
   assign otp_obs_o = '0;
   % endif
+
+  // These pad attributes are controlled through sensor_ctrl.  Update the description of
+  // `MANUAL_PAD_ATTR` in `sensor_ctrl.hjson` when you change or extend the mapping below.
+  // Note that the FPGA doesn't have any of these pads, and we commandeer these signals to
+  // add some intrusive debug functionality to the FPGA, including the ability to trigger
+  // a full POR from software.
+  prim_pad_wrapper_pkg::pad_attr_t [3:0] sensor_ctrl_manual_pad_attr;
+  prim_pad_wrapper_pkg::pad_attr_t       manual_attr_cc1;
+  prim_pad_wrapper_pkg::pad_attr_t       manual_attr_cc2;
+  prim_pad_wrapper_pkg::pad_attr_t       manual_attr_flash_test_mode0;
+  prim_pad_wrapper_pkg::pad_attr_t       manual_attr_flash_test_mode1;
+  assign manual_attr_cc1 = sensor_ctrl_manual_pad_attr[0];
+  assign manual_attr_cc2 = sensor_ctrl_manual_pad_attr[1];
+  assign manual_attr_flash_test_mode0 = sensor_ctrl_manual_pad_attr[2];
+  assign manual_attr_flash_test_mode1 = sensor_ctrl_manual_pad_attr[3];
+
+  logic fpga_harness_rst_n;
+  prim_rst_sync #(
+    .ActiveHigh(1'b1),
+    .SkipScan(1'b1)
+  ) u_fpga_por_sync (
+    .clk_i(clk_aon),
+    .d_i(fpga_eos),
+    .q_o(fpga_harness_rst_n),
+    .scan_rst_ni(1'b1),
+    .scanmode_i('0)
+  );
+
+  logic fpga_por_trigger;
+  prim_edge_detector u_internal_por_detector (
+    .clk_i(clk_aon),
+    .rst_ni(fpga_harness_rst_n),
+    .d_i(manual_attr_flash_test_mode0.pull_en),
+    .q_sync_o(),
+    .q_posedge_pulse_o(fpga_por_trigger),
+    .q_negedge_pulse_o()
+  );
+
+  logic fpga_por_request_n;
+  always_ff @ (posedge clk_aon or negedge fpga_harness_rst_n) begin
+    if (!fpga_harness_rst_n) begin
+      fpga_por_request_n <= 1'b0;
+    end else begin
+      if (fpga_por_trigger) begin
+        fpga_por_request_n <= 1'b0;
+      end else begin
+        fpga_por_request_n <= 1'b1;
+      end
+    end
+  end
+
+  prim_filter_ctr #(
+    .CntWidth(15)    // Target 100 ms @ 200 kHz
+  ) u_internal_por_extender (
+    .clk_i(clk_aon),
+    .rst_ni(fpga_por_request_n),
+    .enable_i(1'b1),
+    .filter_i(1'b1),
+    .thresh_i(15'd20000),
+    .filter_o(fpga_internal_por_n)
+  );
+
+  logic unused_manual_sigs;
+  assign unused_manual_sigs = ^{
+    manual_attr_cc1,
+    manual_attr_cc2,
+    manual_attr_flash_test_mode1
+  };
 
   //////////////////////
   // Top-level design //
@@ -1257,6 +1330,7 @@ module chip_${top["name"]}_${target["name"]} #(
     // Pad attributes
     .mio_attr_o      ( mio_attr      ),
     .dio_attr_o      ( dio_attr      ),
+    .sensor_ctrl_manual_pad_attr_o( sensor_ctrl_manual_pad_attr),
 
     // Memory attributes
     .ram_1p_cfg_i    ( '0 ),


### PR DESCRIPTION
Co-opt the pad attributes in sensor_ctrl for FLASH_TEST_MODE0 to enable firmware on the FPGA to reset itself with a POR. The FPGA does not have the FLASH_TEST_MODE0 pad, and the ability to give itself a POR allows us to add firmware to fix up inconsistent starting points for the bitstream vs. a real provisioned chip.

This change is motivated by a need to fix up the flash info pages to reflect the expected chip state when in PROD. It is possible to splice VMEM images as is currently done for OTP and ROM, but calls to updatemem appear to consume an undesirable amount of time.