### PR TITLE
[sival,bazel] Add SiVal ROM EXT exec env without hyper310 for use in PMOD tests

### DIFF
--- a/sw/device/tests/pmod/BUILD
+++ b/sw/device/tests/pmod/BUILD
@@ -12,19 +12,55 @@ load(
     "silicon_params",
     "verilator_params",
 )
+load("//rules:splice.bzl", "bitstream_splice")
+load(
+    "//rules/opentitan:defs.bzl",
+    "DEFAULT_TEST_FAILURE_MSG",
+    "DEFAULT_TEST_SUCCESS_MSG",
+    "fpga_cw310",
+)
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
+
+# A custom execution environment, which uses the same attributes as the CW310
+# SiVal ROM EXT execution environment, but uses the base universal bitstream
+# & interface for the CW310 as opposed to the hyperdebug variants, due to the
+# PMOD tests requiring the PMOD pins that are not available with hyperdebug.
+fpga_cw310(
+    name = "fpga_cw310_sival_rom_ext_no_hyper",
+    testonly = True,
+    base = "//hw/top_earlgrey:fpga_cw310_sival_rom_ext",
+    # Override the hyperdebug bitstream, interface, and OTP & ROM MMIs.
+    base_bitstream = "//hw/bitstream:bitstream",
+    otp_mmi = "//hw/bitstream:otp_mmi",
+    param = {
+        "interface": "cw310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+        "assemble": "{rom_ext}@0 {firmware}@0x10000",
+    },
+    rom_mmi = "//hw/bitstream:rom_mmi",
+    tags = ["cw310_sival_rom_ext"],
+    visibility = ["//visibility:private"],
+)
 
 opentitan_test(
     name = "spi_host_macronix_flash_test",
     srcs = ["spi_host_macronix_flash_test.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
+        dicts.omit(
+            EARLGREY_TEST_ENVS,
+            # Requires special SiVal ROM EXT environment
+            ["//hw/top_earlgrey:fpga_cw310_sival_rom_ext"],
+        ),
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+            # Custom execution environment must be used for SiVal ROM EXT
+            # to ensure that all the PMOD pins are available.
+            ":fpga_cw310_sival_rom_ext_no_hyper": None,
         },
     ),
     fpga = fpga_params(


### PR DESCRIPTION
Adds a SiVal ROM EXT environment local to the PMOD tests that overrides the `hyper310` bitstream and interface to use the `cw310` versions, so that the relevant pins required for PMOD are accessible during the test, and the test can be run in a ROM EXT environment with the local SiVal changes (e.g. OTP changes). This should work with the existing nightly runner as it uses the same `fpga_cw310_sival_rom_ext` tag, despite being a private exec env.