### PR TITLE
[dv/dpi] tcpserver single connection and retry select on EINTR

### DIFF
--- a/hw/dv/dpi/common/tcp_server/tcp_server.c
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.c
@@ -183,7 +183,6 @@ static int client_tryaccept(struct tcp_server_ctx *ctx) {
   int rv;
 
   assert(ctx->sfd > 0);
-  assert(ctx->cfd == 0);
 
   int cfd = accept(ctx->sfd, NULL, NULL);
 
@@ -194,6 +193,14 @@ static int client_tryaccept(struct tcp_server_ctx *ctx) {
   if (cfd == -1) {
     fprintf(stderr, "%s: Unable to accept incoming connection: %s (%d)\n",
             ctx->display_name, strerror(errno), errno);
+    return -1;
+  }
+
+  if (ctx->cfd > 0) {
+    // Enforce a single concurrent connection. Accept and close any
+    // new connection attempt when there's already a client.
+    fprintf(stderr, "%s: Rejecting additional connection\n", ctx->display_name);
+    close(cfd);
     return -1;
   }
 

--- a/hw/dv/dpi/common/tcp_server/tcp_server.c
+++ b/hw/dv/dpi/common/tcp_server/tcp_server.c
@@ -329,9 +329,6 @@ static void *server_create(void *ctx_void) {
     goto err_cleanup_return;
   }
 
-  // Initialise timeout
-  timeout.tv_sec = 0;
-
   // Initialise fd_set
 
   // Start waiting for connection / data
@@ -349,13 +346,20 @@ static void *server_create(void *ctx_void) {
     // max fd num
     int mfd = (ctx->cfd > ctx->sfd) ? ctx->cfd : ctx->sfd;
 
-    // Set timeout - 50us gives good performance
+    // Set timeout - 50us gives good performance; do it every time
+    // since select can trash it.
+    timeout.tv_sec = 0;
     timeout.tv_usec = 50;
 
     // Wait for socket activity or timeout
     rv = select(mfd + 1, &read_fds, NULL, NULL, &timeout);
 
     if (rv < 0) {
+      if (errno == EINTR) {
+        // On interrupt we want to retry
+        continue;
+      }
+
       printf("%s: Socket read failed, port: %d\n", ctx->display_name,
              ctx->listen_port);
       tcp_server_client_close(ctx);


### PR DESCRIPTION
This is pull over from https://github.com/lowRISC/opentitan/pull/23889 to `master`:

Two small patches to the tcp_server code, used by other transactors such as jtagdpi and dmidpi. These improve the usability of the transactors in a shared, remote environment such as an emulator.

Without this change, an interrupted select() call is treated as a connection error and the client is dropped. This makes connections very unstable.