### PR TITLE
[ci] allow publish-bazel-test-results to publish to buckets and include hostname

### DIFF
--- a/.github/actions/publish-bazel-test-results/action.yml
+++ b/.github/actions/publish-bazel-test-results/action.yml
@@ -30,6 +30,11 @@ runs:
           echo '<?xml version="1.0" encoding="UTF-8"?><testsuites/>' >> "${{ inputs.merged-results }}"
         fi
 
+    - name: Add hostname to testsuites
+      shell: bash
+      run: |
+        xmlstarlet ed --inplace -i '/testsuites/testsuite' -t attr -n hostname -v "${{ runner.name }}" "${{ inputs.merged-results }}"
+
     - name: Upload report as artifact
       if: inputs.artifact-name != ''
       uses: actions/upload-artifact@v4

--- a/.github/actions/publish-bazel-test-results/action.yml
+++ b/.github/actions/publish-bazel-test-results/action.yml
@@ -12,6 +12,9 @@ inputs:
   artifact-name:
     description: Name of uploaded artifact. Leave empty to skip upload.
     default: ''
+  bucket-destination:
+    description: GCP bucket destination to upload report to.
+    default: ''
 
 runs:
   using: composite
@@ -35,6 +38,15 @@ runs:
         path: ${{ inputs.merged-results }}
         # In case this is from a re-run
         overwrite: true
+
+    - uses: google-github-actions/setup-gcloud@v2
+      if: inputs.bucket-destination != ''
+
+    - name: Upload report to Google Cloud
+      if: inputs.bucket-destination != ''
+      shell: bash
+      run: |
+        gcloud storage cp "${{ inputs.merged-results }}" "gs://${{ inputs.bucket-destination }}"
 
     - name: Publish job summary
       uses: mikepenz/action-junit-report@ec3a351c13e080dc4fa94c49ab7ad5bf778a9668 # v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,8 +27,7 @@ jobs:
     runs-on: [ubuntu-22.04-fpga, cw310]
 
     env:
-      GS_PATH: gs://opentitan-test-results
-      BAZEL_TEST_RESULTS: test_results.xml
+      GS_PATH: opentitan-test-results
 
     steps:
       - uses: actions/checkout@v4
@@ -77,14 +76,19 @@ jobs:
                                                     > "$bazel_tests"
           ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"
 
-      - name: Publish bazel test results
-        if: success() || failure()
+      - name: Compute bucket destination
+        id: bucket_destination
+        if: ${{ !cancelled() }}
         run: |
-          # Bazel produce one xml for each test. So we merge them together.
-          find -L bazel-out -name "test.xml" | xargs merge-junit -o "$BAZEL_TEST_RESULTS"
+          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ inputs.branch || 'earlgrey_1.0.0'}}/$(date +%Y-%m-%d-%H%M%S)_test_results.xml
+          echo "BUCKET_PATH=$BUCKET_PATH" >> $GITHUB_OUTPUT
 
-          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ inputs.branch || 'earlgrey_1.0.0'}}/$(date +%Y-%m-%d-%H%M%S)_${BAZEL_TEST_RESULTS}
-          gcloud storage cp $BAZEL_TEST_RESULTS "$BUCKET_PATH"
+      - name: Publish Bazel test results
+        uses: ./.github/actions/publish-bazel-test-results
+        if: ${{ !cancelled() }}
+        with:
+          artifact-name: fpga_cw310_sival_nightly-test-results
+          bucket-destination: ${{ steps.bucket_destination.outputs.BUCKET_PATH }}
 
   rom_e2e:
     name: ROM E2E Tests

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -47,6 +47,7 @@ python3-urllib3
 python3-wheel
 srecord
 tree
+xmlstarlet
 xsltproc
 zlib1g-dev
 xz-utils


### PR DESCRIPTION
The GCP bucket upload behaviour is opt-in and currently only used in nightly flow.

To track FPGA being used hostname is added to the JUnit XML.