### PR TITLE
[sival] Fix rv_dm_jtag bazel entries

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -305,10 +305,11 @@
       stage: V2
       si_stage: SV3
       tests: []
-      bazel: ["//sw/device/tests:rv_dm_jtag_test_unlocked1",
-              "//sw/device/tests:rv_dm_jtag_dev_rv_dm_default_enabled",
-              "//sw/device/tests:rv_dm_jtag_dev_rv_dm_delayed_enabled",
-              "//sw/device/tests:rv_dm_jtag_rma"],
+      bazel: [
+        "//sw/device/tests:rv_dm_jtag_test_unlocked1",
+        "//sw/device/tests:rv_dm_jtag_dev",
+        "//sw/device/tests:rv_dm_jtag_rma",
+      ],
       lc_states: ["DEV"]
       host_support: true
       features: [


### PR DESCRIPTION
This Bazel test is parametrised by its LC state, not the RV_DM states like other tests (e.g. `rv_dm_mem_`).