### PR TITLE
[chip,dv] Correct a testplan item

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -53,8 +53,8 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["//sw/device/tests:spi_passthru_test"]
-      bazel: []
+      tests: []
+      bazel: ["//sw/device/tests:spi_passthru_test"]
     }
     {
       name: chip_sw_spi_host_configuration


### PR DESCRIPTION
Similar to commit 25b8f54

The testpoint was given a "tests" field that was supposed to be the "bazel" field.