### PR TITLE
Backport 24735 to earlgrey 1.0.0

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -180,7 +180,7 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["chip_sw_aes_prng_reseed"]
+      tests: []
       bazel: []
     }
     {
@@ -214,7 +214,7 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["chip_sw_aes_force_prng_reseed"]
+      tests: []
       bazel: []
     }
     {

--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -123,7 +123,7 @@
       stage: V2
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["chip_plic_all_irqs"]
+      tests: ["chip_plic_all_irqs_0", "chip_plic_all_irqs_10", "chip_plic_all_irqs_20"]
       bazel: [
         "//sw/device/tests/autogen:plic_all_irqs_test_0",
         "//sw/device/tests/autogen:plic_all_irqs_test_10",

--- a/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_device_testplan.hjson
@@ -79,7 +79,8 @@
         "SPI_DEVICE.HW.LANES",
         "SPI_DEVICE.MODE.PASSTHROUGH.CMD_FILTER",
       ]
-      tests: ["//sw/device/tests:spi_passthru_test"]
+      tests: []
+      bazel: ["//sw/device/tests:spi_passthru_test"]
     }
     {
       name: chip_sw_spi_device_pass_through_collision

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -70,8 +70,8 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["//sw/device/tests:spi_host_config_test"]
-      bazel: []
+      tests: []
+      bazel: ["//sw/device/tests:spi_host_config_test"]
     }
     {
       name: chip_sw_spi_host_events

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -2229,7 +2229,9 @@
     }
     {
       name: xcelium_ci_0
-      tests: ["chip_plic_all_irqs",
+      tests: ["chip_plic_all_irqs_0",
+              "chip_plic_all_irqs_10",
+              "chip_plic_all_irqs_20",
               "chip_sw_kmac_app_rom",
               "chip_sw_rstmgr_sw_rst",
               "chip_sw_hmac_enc",


### PR DESCRIPTION
This is a manual backport of https://github.com/lowRISC/opentitan/pull/24735
