### PR TITLE
[sival] Enable `fpga_cw310_sival_rom_ext` exec env on cryptotests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,7 +64,7 @@ jobs:
                                                     | grep -v examples \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
-          ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test --build_tests_only --test_tag_filters=-skip_in_nightly_ci --target_pattern_file="$bazel_tests"
 
       - name: Run tests after ROM_EXT boot stage
         if: success() || failure()
@@ -75,7 +75,7 @@ jobs:
                                                     | grep -v examples \
                                                     | grep -v penetrationtests \
                                                     > "$bazel_tests"
-          ./bazelisk.sh test --build_tests_only --target_pattern_file="$bazel_tests"
+          ./bazelisk.sh test --build_tests_only --test_tag_filters=-skip_in_nightly_ci --target_pattern_file="$bazel_tests"
 
       - name: Publish bazel test results
         if: success() || failure()

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -20,6 +20,7 @@ AES_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "aes_kat",
+    skip_in_nightly_ci = True,
     test_args = AES_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/aes_nist_kat:harness",
     test_vectors = AES_TESTVECTOR_TARGETS,
@@ -67,6 +68,7 @@ ECDSA_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "ecdsa_kat",
+    skip_in_nightly_ci = True,
     test_args = ECDSA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/ecdsa_kat:harness",
     test_vectors = ECDSA_TESTVECTOR_TARGETS,
@@ -112,6 +114,7 @@ SHA256_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha256_kat",
+    skip_in_nightly_ci = True,
     test_args = SHA256_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA256_TESTVECTOR_TARGETS,
@@ -134,6 +137,7 @@ SHA384_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha384_kat",
+    skip_in_nightly_ci = True,
     test_args = SHA384_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA384_TESTVECTOR_TARGETS,
@@ -156,6 +160,7 @@ SHA512_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha512_kat",
+    skip_in_nightly_ci = True,
     test_args = SHA512_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA512_TESTVECTOR_TARGETS,
@@ -200,6 +205,7 @@ SHA3_256_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha3_256_kat",
+    skip_in_nightly_ci = True,
     test_args = SHA3_256_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA3_256_TESTVECTOR_TARGETS,
@@ -222,6 +228,7 @@ SHA3_384_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha3_384_kat",
+    skip_in_nightly_ci = True,
     test_args = SHA3_384_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA3_384_TESTVECTOR_TARGETS,
@@ -244,6 +251,7 @@ SHA3_512_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha3_512_kat",
+    skip_in_nightly_ci = True,
     test_args = SHA3_512_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA3_512_TESTVECTOR_TARGETS,
@@ -267,6 +275,7 @@ SHAKE128_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "shake128_kat",
+    skip_in_nightly_ci = True,
     test_args = SHAKE128_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHAKE128_TESTVECTOR_TARGETS,
@@ -290,6 +299,7 @@ SHAKE256_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "shake256_kat",
+    skip_in_nightly_ci = True,
     test_args = SHAKE256_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHAKE256_TESTVECTOR_TARGETS,
@@ -323,6 +333,7 @@ DRBG_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "drbg_kat",
+    skip_in_nightly_ci = True,
     test_args = DRBG_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/drbg_kat:harness",
     test_vectors = DRBG_TESTVECTOR_TARGETS,
@@ -340,6 +351,7 @@ HMAC_SHA256_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "hmac_sha256_kat",
+    skip_in_nightly_ci = True,
     test_args = HMAC_SHA256_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
     test_vectors = HMAC_SHA256_TESTVECTOR_TARGETS,
@@ -357,6 +369,7 @@ HMAC_SHA384_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "hmac_sha384_kat",
+    skip_in_nightly_ci = True,
     test_args = HMAC_SHA384_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
     test_vectors = HMAC_SHA384_TESTVECTOR_TARGETS,
@@ -374,6 +387,7 @@ HMAC_SHA512_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "hmac_sha512_kat",
+    skip_in_nightly_ci = True,
     test_args = HMAC_SHA512_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
     test_vectors = HMAC_SHA512_TESTVECTOR_TARGETS,
@@ -413,6 +427,7 @@ SPHINCSPLUS_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sphincsplus_kat",
+    skip_in_nightly_ci = True,
     test_args = SPHINCSPLUS_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/sphincsplus_kat:harness",
     test_vectors = SPHINCSPLUS_TESTVECTOR_TARGETS,

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -19,9 +19,31 @@ load(
 # - silicon
 CRYPTOTEST_EXEC_ENVS = {
     "//hw/top_earlgrey:fpga_cw310_test_rom": None,
+    "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
     "//hw/top_earlgrey:fpga_cw340_test_rom": "fpga_cw340",
     "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon",
 }
+
+FIRMWARE_DEPS = [
+    "//sw/device/tests/crypto/cryptotest/firmware:aes",
+    "//sw/device/tests/crypto/cryptotest/firmware:drbg",
+    "//sw/device/tests/crypto/cryptotest/firmware:ecdh",
+    "//sw/device/tests/crypto/cryptotest/firmware:ecdsa",
+    "//sw/device/tests/crypto/cryptotest/firmware:hash",
+    "//sw/device/tests/crypto/cryptotest/firmware:hmac",
+    "//sw/device/tests/crypto/cryptotest/firmware:kmac",
+    "//sw/device/tests/crypto/cryptotest/firmware:sphincsplus",
+    "//sw/device/lib/base:csr",
+    "//sw/device/lib/base:status",
+    "//sw/device/lib/crypto/drivers:entropy",
+    "//sw/device/lib/testing/test_framework:check",
+    "//sw/device/lib/testing/test_framework:ottf_main",
+    "//sw/device/lib/testing/test_framework:ujson_ottf",
+    "//sw/device/lib/ujson",
+
+    # Include all JSON commands.
+    "//sw/device/tests/crypto/cryptotest/json:commands",
+]
 
 def cryptotest(name, test_vectors, test_args, test_harness, skip_in_nightly_ci = False):
     """A macro for defining a CryptoTest test case.
@@ -36,9 +58,9 @@ def cryptotest(name, test_vectors, test_args, test_harness, skip_in_nightly_ci =
     tags = ["skip_in_nightly_ci"] if skip_in_nightly_ci else []
     opentitan_test(
         name = name,
+        srcs = ["//sw/device/tests/crypto/cryptotest/firmware:firmware.c"],
         fpga = fpga_params(
             timeout = "long",
-            binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
             data = test_vectors,
             tags = tags,
             test_cmd = """
@@ -48,7 +70,6 @@ def cryptotest(name, test_vectors, test_args, test_harness, skip_in_nightly_ci =
         ),
         fpga_cw340 = fpga_params(
             timeout = "long",
-            binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw340_test_rom": "firmware"},
             tags = tags,
             data = test_vectors,
             test_cmd = """
@@ -59,7 +80,6 @@ def cryptotest(name, test_vectors, test_args, test_harness, skip_in_nightly_ci =
         exec_env = CRYPTOTEST_EXEC_ENVS,
         silicon = silicon_params(
             timeout = "eternal",
-            binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
             tags = tags,
             data = test_vectors,
             test_cmd = """
@@ -67,4 +87,5 @@ def cryptotest(name, test_vectors, test_args, test_harness, skip_in_nightly_ci =
             """ + test_args,
             test_harness = test_harness,
         ),
+        deps = FIRMWARE_DEPS,
     )

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -23,7 +23,7 @@ CRYPTOTEST_EXEC_ENVS = {
     "//hw/top_earlgrey:silicon_owner_sival_rom_ext": "silicon",
 }
 
-def cryptotest(name, test_vectors, test_args, test_harness):
+def cryptotest(name, test_vectors, test_args, test_harness, skip_in_nightly_ci = False):
     """A macro for defining a CryptoTest test case.
 
     Args:
@@ -31,13 +31,16 @@ def cryptotest(name, test_vectors, test_args, test_harness):
         test_vectors: the test vectors to use.
         test_args: additional arguments to pass to the test.
         test_harness: the test harness to use.
+        skip_in_nightly_ci: indicate if the test should be run in the nightly CI.
     """
+    tags = ["skip_in_nightly_ci"] if skip_in_nightly_ci else []
     opentitan_test(
         name = name,
         fpga = fpga_params(
             timeout = "long",
             binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw310_test_rom": "firmware"},
             data = test_vectors,
+            tags = tags,
             test_cmd = """
                 --bootstrap={firmware}
             """ + test_args,
@@ -46,6 +49,7 @@ def cryptotest(name, test_vectors, test_args, test_harness):
         fpga_cw340 = fpga_params(
             timeout = "long",
             binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_fpga_cw340_test_rom": "firmware"},
+            tags = tags,
             data = test_vectors,
             test_cmd = """
                 --bootstrap={firmware}
@@ -56,6 +60,7 @@ def cryptotest(name, test_vectors, test_args, test_harness):
         silicon = silicon_params(
             timeout = "eternal",
             binaries = {"//sw/device/tests/crypto/cryptotest/firmware:firmware_silicon_owner_sival_rom_ext": "firmware"},
+            tags = tags,
             data = test_vectors,
             test_cmd = """
                 --bootstrap={firmware}

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -178,22 +178,17 @@ FIRMWARE_DEPS = [
     "//sw/device/tests/crypto/cryptotest/json:commands",
 ]
 
-[
-    opentitan_binary(
-        name = "firmware_{}".format(exec_env),
-        testonly = True,
-        srcs = [":firmware.c"],
-        exec_env = [
-            "//hw/top_earlgrey:{}".format(exec_env),
-        ],
-        deps = FIRMWARE_DEPS,
-    )
-    for exec_env in [
-        "fpga_cw310_test_rom",
-        "fpga_cw340_test_rom",
-        "silicon_owner_sival_rom_ext",
-    ]
-]
+opentitan_binary(
+    name = "firmware",
+    testonly = True,
+    srcs = [":firmware.c"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw340",
+        "//hw/top_earlgrey:silicon_owner_sival_rom_ext",
+    ],
+    deps = FIRMWARE_DEPS,
+)
 
 opentitan_test(
     name = "chip_pen_test",


### PR DESCRIPTION
This PR adds the `fpga_cw310_sival_rom_ext` execution environment to the cryptotests.

This will cause the nightly CI runs to pick up these tests; however, because some of these tests are very slow (i.e. > 30 min), this PR also adds a `skip_in_nightly_ci` bazel tag that allows excluding certain tests.

Currently, only three of the KAT tests repeatably run in under 5 minutes (HMAC-SHA256 is a bit close), so the rest of the tests are being excluded at the moment.

```console
//sw/device/tests/crypto/cryptotest:cshake_kat_fpga_cw310_sival_rom_ext (cached) PASSED in 21.6s
//sw/device/tests/crypto/cryptotest:kmac_kat_fpga_cw310_sival_rom_ext (cached) PASSED in 146.3s
//sw/device/tests/crypto/cryptotest:ecdh_kat_fpga_cw310_sival_rom_ext    PASSED in 248.5s
//sw/device/tests/crypto/cryptotest:hmac_sha256_kat_fpga_cw310_sival_rom_ext PASSED in 237.2s
```