### PR TITLE
[dv/dpi] jtagdpi supports 2 new plusargs

### DIFF
--- a/hw/dv/dpi/jtagdpi/jtagdpi.c
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.c
@@ -27,7 +27,7 @@ struct jtagdpi_ctx {
 /**
  * Reset the JTAG signals to a "dongle unplugged" state
  */
-static void reset_jtag_signals(struct jtagdpi_ctx *ctx) {
+static void reset_jtag_signals(struct jtagdpi_ctx *ctx, bool assert_srst) {
   assert(ctx);
 
   ctx->tck = 0;
@@ -37,8 +37,8 @@ static void reset_jtag_signals(struct jtagdpi_ctx *ctx) {
   // trst_n is pulled down (reset active) by default
   ctx->trst_n = 0;
 
-  // srst_n is pulled up (reset not active) by default
-  ctx->srst_n = 1;
+  // srst_n default is determined by assert_srst
+  ctx->srst_n = assert_srst ? 0 : 1;
 }
 
 /**
@@ -104,7 +104,8 @@ static void update_jtag_signals(struct jtagdpi_ctx *ctx) {
   }
 }
 
-void *jtagdpi_create(const char *display_name, int listen_port) {
+void *jtagdpi_create(const char *display_name, int listen_port,
+                     int assert_srst) {
   struct jtagdpi_ctx *ctx =
       (struct jtagdpi_ctx *)calloc(1, sizeof(struct jtagdpi_ctx));
   assert(ctx);
@@ -112,7 +113,7 @@ void *jtagdpi_create(const char *display_name, int listen_port) {
   // Create socket
   ctx->sock = tcp_server_create(display_name, listen_port);
 
-  reset_jtag_signals(ctx);
+  reset_jtag_signals(ctx, assert_srst != 0);
 
   printf(
       "\n"

--- a/hw/dv/dpi/jtagdpi/jtagdpi.h
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.h
@@ -22,7 +22,8 @@ struct jtagdpi_ctx;
  * @param listen_port Port to listen on
  * @return an initialized struct jtagdpi_ctx context object
  */
-void *jtagdpi_create(const char *display_name, int listen_port);
+void *jtagdpi_create(const char *display_name, int listen_port,
+                     int assert_srst);
 
 /**
  * Destructor: Close all connections and free all resources

--- a/hw/dv/dpi/jtagdpi/jtagdpi.sv
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.sv
@@ -31,7 +31,13 @@ module jtagdpi #(
   chandle ctx;
 
   initial begin
-    ctx = jtagdpi_create(Name, ListenPort);
+    int port;
+
+    // The listening socket port can be customized at runtime
+    port = ListenPort;
+    void'($value$plusargs("jtagdpi_port=%0d", port));
+
+    ctx = jtagdpi_create(Name, port);
   end
 
   final begin

--- a/hw/dv/dpi/jtagdpi/jtagdpi.sv
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.sv
@@ -18,7 +18,8 @@ module jtagdpi #(
 );
 
   import "DPI-C"
-  function chandle jtagdpi_create(input string name, input int listen_port);
+  function chandle jtagdpi_create(input string name, input int listen_port,
+                                  input int assert_srst);
 
   import "DPI-C"
   function void jtagdpi_tick(input chandle ctx, output bit tck, output bit tms,
@@ -31,13 +32,17 @@ module jtagdpi #(
   chandle ctx;
 
   initial begin
-    int port;
+    int port, assert_srst;
 
     // The listening socket port can be customized at runtime
     port = ListenPort;
     void'($value$plusargs("jtagdpi_port=%0d", port));
 
-    ctx = jtagdpi_create(Name, port);
+    // The functional reset can optionally start out asserted
+    assert_srst = 0;
+    void'($value$plusargs("jtagdpi_assert_srst=%0d", assert_srst));
+
+    ctx = jtagdpi_create(Name, port, assert_srst);
   end
 
   final begin


### PR DESCRIPTION
See the commit log messages, but the functionality is (1) override the `LISTEN_PORT` parameter and (2) assert `srst_n` from start of sim.