### PR TITLE
[dv] Add GUI debug mode for Riviera

### DIFF
--- a/hw/dv/tools/dvsim/riviera.hjson
+++ b/hw/dv/tools/dvsim/riviera.hjson
@@ -70,6 +70,13 @@
       run_opts: []
     }
     {
+      name: riviera_gui_debug
+      // TODO: Add options to setup Riviera gui debug environment and features (as in xcelium.hjson)
+      is_sim_mode: 1
+      build_opts: []
+      run_opts: []
+    }
+    {
       name: riviera_waves
       is_sim_mode: 1
     }


### PR DESCRIPTION
Hi,
I added a missing riviera_gui_debug mode required after f88269d2658dcf0d9c75b7a507d0bda160751c47 update.
This is an initial version allowing running tests with dvsim.py script.