### PR TITLE
[rv_dm,sival] Fix `rv_dm_mem_access_delayed_enable`

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -5072,7 +5072,7 @@ test_suite(
 [
     opentitan_test(
         name = "rv_dm_mem_access_{}".format(test_cfg["name"]),
-        srcs = ["example_test_from_flash.c"],
+        srcs = ["rv_dm_delayed_enable.c"],
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_sival": None,
             "//hw/top_earlgrey:fpga_cw340_sival": None,
@@ -5081,14 +5081,24 @@ test_suite(
             timeout = "moderate",
             needs_jtag = True,
             otp = test_cfg["otp"],
+            rv_dm_delayed_en = test_cfg["rv_dm_delayed_en"],
             tags = [
                 "lc_{}".format(test_cfg["lc_state"]),
-            ] + (["broken"] if "delayed_enabled" in test_cfg["name"] else []),
-            test_cmd = " --rom={rom:binary}",
+            ],
+            test_cmd = """
+                --rom={rom:binary}
+                --bootstrap="{firmware}"
+                {rv_dm_delayed_en}
+            """,
             test_harness = "//sw/host/tests/chip/rv_dm:mem_access",
         ),
         deps = [
+            "//sw/device/lib/base:multibits",
+            "//sw/device/lib/dif:lc_ctrl",
+            "//sw/device/lib/dif:rv_dm",
+            "//sw/device/lib/runtime:hart",
             "//sw/device/lib/runtime:log",
+            "//sw/device/lib/testing:lc_ctrl_testutils",
             "//sw/device/lib/testing/test_framework:ottf_main",
         ],
     )

--- a/sw/host/tests/chip/rv_dm/BUILD
+++ b/sw/host/tests/chip/rv_dm/BUILD
@@ -35,6 +35,7 @@ rust_binary(
         "//sw/host/opentitanlib/bindgen",
         "@crate_index//:anyhow",
         "@crate_index//:clap",
+        "@crate_index//:humantime",
         "@crate_index//:log",
         "@crate_index//:rand",
         "@crate_index//:rand_chacha",


### PR DESCRIPTION
The `rv_dm_mem_access` test was not working in the `dev_rv_dm_delayed_enable` test configuration. This is because the test was not written to handle the additional logic required for this configuration.

To fix this, before the host side attempts to connect via JTAG, it waits for a message ("`DEBUG_MODE_ENABLED`") from the device, which will configure the RV DM to enable the late debug feature (debug mode). This should only be available using the OTP image with the late debug feature enabled, in the `delayed_enable` test configuration.

This has been tested to pass consistently on a CW310 by running the following command:
`./bazelisk.sh test -t- --test_output=streamed --build_tests_only --runs_per_test=5 --test_tag_filters=cw310 $(./bazelisk.sh query "tests(//sw/device/tests:rv_dm_mem_access)")`