### PR TITLE
[prim_fifo_sync,fpv+rtl] Add checks for the full_o output

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
@@ -29,6 +29,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -47,6 +48,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -65,6 +67,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -83,6 +86,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -101,6 +105,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -123,6 +128,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -141,6 +147,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -159,6 +166,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -177,6 +185,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -195,6 +204,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -213,6 +223,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 

--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_tb.sv
@@ -31,6 +31,7 @@ module prim_fifo_sync_tb #(
   output              rvalid_o[NumDuts],
   input               rready_i[NumDuts],
   output [Width-1:0]  rdata_o [NumDuts],
+  output              full_o  [NumDuts],
   output [DepthW-1:0] depth_o [NumDuts]
 );
 
@@ -55,6 +56,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[0]),
     .rready_i(rready_i[0]),
     .rdata_o(rdata_o[0]),
+    .full_o(full_o[0]),
     .depth_o(depth_o[0][0])
   );
 
@@ -72,6 +74,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[1]),
     .rready_i(rready_i[1]),
     .rdata_o(rdata_o[1]),
+    .full_o(full_o[1]),
     .depth_o(depth_o[1][2:0])
   );
 
@@ -89,6 +92,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[2]),
     .rready_i(rready_i[2]),
     .rdata_o(rdata_o[2]),
+    .full_o(full_o[2]),
     .depth_o(depth_o[2][3:0])
   );
 
@@ -106,6 +110,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[3]),
     .rready_i(rready_i[3]),
     .rdata_o(rdata_o[3]),
+    .full_o(full_o[3]),
     .depth_o(depth_o[3][3:0])
   );
 
@@ -123,6 +128,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[4]),
     .rready_i(rready_i[4]),
     .rdata_o(rdata_o[4]),
+    .full_o(full_o[4]),
     .depth_o(depth_o[4][4:0])
   );
 
@@ -145,6 +151,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[5]),
     .rready_i(rready_i[5]),
     .rdata_o(rdata_o[5]),
+    .full_o(full_o[5]),
     .depth_o(depth_o[5][0])
   );
 
@@ -162,6 +169,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[6]),
     .rready_i(rready_i[6]),
     .rdata_o(rdata_o[6]),
+    .full_o(full_o[6]),
     .depth_o(depth_o[6][0])
   );
 
@@ -179,6 +187,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[7]),
     .rready_i(rready_i[7]),
     .rdata_o(rdata_o[7]),
+    .full_o(full_o[7]),
     .depth_o(depth_o[7][2:0])
   );
 
@@ -196,6 +205,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[8]),
     .rready_i(rready_i[8]),
     .rdata_o(rdata_o[8]),
+    .full_o(full_o[8]),
     .depth_o(depth_o[8][3:0])
   );
 
@@ -213,6 +223,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[9]),
     .rready_i(rready_i[9]),
     .rdata_o(rdata_o[9]),
+    .full_o(full_o[9]),
     .depth_o(depth_o[9][3:0])
   );
 
@@ -230,6 +241,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[10]),
     .rready_i(rready_i[10]),
     .rdata_o(rdata_o[10]),
+    .full_o(full_o[10]),
     .depth_o(depth_o[10][4:0])
   );
 

--- a/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
@@ -16,15 +16,16 @@ module prim_fifo_sync_assert_fpv #(
   localparam int unsigned DepthWNorm = $clog2(Depth+1),
   localparam int unsigned DepthW = (DepthWNorm == 0) ? 1 : DepthWNorm
 ) (
-  input  clk_i,
-  input  rst_ni,
-  input  clr_i,
-  input  wvalid_i,
-  input  wready_o,
-  input [Width-1:0] wdata_i,
-  input  rvalid_o,
-  input  rready_i,
-  input [Width-1:0] rdata_o,
+  input              clk_i,
+  input              rst_ni,
+  input              clr_i,
+  input              wvalid_i,
+  input              wready_o,
+  input [Width-1:0]  wdata_i,
+  input              rvalid_o,
+  input              rready_i,
+  input [Width-1:0]  rdata_o,
+  input              full_o,
   input [DepthW-1:0] depth_o
 );
 
@@ -135,6 +136,9 @@ module prim_fifo_sync_assert_fpv #(
   ////////////////////////
   // Forward Assertions //
   ////////////////////////
+
+  // The full_o port should be high iff the depth is maximal.
+  `ASSERT(FullIffFullDepth_A, (depth_o == Depth) <-> (full_o))
 
   // assert depth of FIFO
   `ASSERT(Depth_A, depth_o <= Depth)

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -46,7 +46,7 @@ module prim_fifo_sync #(
 
     // host facing
     assign wready_o = rready_i;
-    assign full_o = rready_i;
+    assign full_o = 1'b1;
 
     // this avoids lint warnings
     logic unused_clr;


### PR DESCRIPTION
When working on #25461, I noticed that we didn't have any assertions about the behaviour of the `full_o` output port. This PR adds those assertions in the second commit, and makes them true (in a trivial way) in the first.