### PR TITLE
[prim_fifo_sync,fpv] Add checks for the full_o output

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
@@ -29,6 +29,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -47,6 +48,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -65,6 +67,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -83,6 +86,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -101,6 +105,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -123,6 +128,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -141,6 +147,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -159,6 +166,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -177,6 +185,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -195,6 +204,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 
@@ -213,6 +223,7 @@ module prim_fifo_sync_bind_fpv;
     .rvalid_o,
     .rready_i,
     .rdata_o,
+    .full_o,
     .depth_o
   );
 

--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_bind_fpv.sv
@@ -30,7 +30,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_nopass7 prim_fifo_sync_assert_fpv #(
@@ -49,7 +50,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_nopass8 prim_fifo_sync_assert_fpv #(
@@ -68,7 +70,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_nopass15 prim_fifo_sync_assert_fpv #(
@@ -87,7 +90,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_nopass16 prim_fifo_sync_assert_fpv #(
@@ -106,7 +110,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   ////////////////
@@ -129,7 +134,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_pass1 prim_fifo_sync_assert_fpv #(
@@ -148,7 +154,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_pass7 prim_fifo_sync_assert_fpv #(
@@ -167,7 +174,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_pass8 prim_fifo_sync_assert_fpv #(
@@ -186,7 +194,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_pass15 prim_fifo_sync_assert_fpv #(
@@ -205,7 +214,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
   bind i_pass16 prim_fifo_sync_assert_fpv #(
@@ -224,7 +234,8 @@ module prim_fifo_sync_bind_fpv;
     .rready_i,
     .rdata_o,
     .full_o,
-    .depth_o
+    .depth_o,
+    .err_o
   );
 
 endmodule : prim_fifo_sync_bind_fpv

--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_tb.sv
@@ -31,6 +31,7 @@ module prim_fifo_sync_tb #(
   output              rvalid_o[NumDuts],
   input               rready_i[NumDuts],
   output [Width-1:0]  rdata_o [NumDuts],
+  output              full_o  [NumDuts],
   output [DepthW-1:0] depth_o [NumDuts]
 );
 
@@ -55,6 +56,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[0]),
     .rready_i(rready_i[0]),
     .rdata_o(rdata_o[0]),
+    .full_o(full_o[0]),
     .depth_o(depth_o[0][0])
   );
 
@@ -72,6 +74,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[1]),
     .rready_i(rready_i[1]),
     .rdata_o(rdata_o[1]),
+    .full_o(full_o[1]),
     .depth_o(depth_o[1][2:0])
   );
 
@@ -89,6 +92,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[2]),
     .rready_i(rready_i[2]),
     .rdata_o(rdata_o[2]),
+    .full_o(full_o[2]),
     .depth_o(depth_o[2][3:0])
   );
 
@@ -106,6 +110,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[3]),
     .rready_i(rready_i[3]),
     .rdata_o(rdata_o[3]),
+    .full_o(full_o[3]),
     .depth_o(depth_o[3][3:0])
   );
 
@@ -123,6 +128,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[4]),
     .rready_i(rready_i[4]),
     .rdata_o(rdata_o[4]),
+    .full_o(full_o[4]),
     .depth_o(depth_o[4][4:0])
   );
 
@@ -145,6 +151,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[5]),
     .rready_i(rready_i[5]),
     .rdata_o(rdata_o[5]),
+    .full_o(full_o[5]),
     .depth_o(depth_o[5][0])
   );
 
@@ -162,6 +169,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[6]),
     .rready_i(rready_i[6]),
     .rdata_o(rdata_o[6]),
+    .full_o(full_o[6]),
     .depth_o(depth_o[6][0])
   );
 
@@ -179,6 +187,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[7]),
     .rready_i(rready_i[7]),
     .rdata_o(rdata_o[7]),
+    .full_o(full_o[7]),
     .depth_o(depth_o[7][2:0])
   );
 
@@ -196,6 +205,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[8]),
     .rready_i(rready_i[8]),
     .rdata_o(rdata_o[8]),
+    .full_o(full_o[8]),
     .depth_o(depth_o[8][3:0])
   );
 
@@ -213,6 +223,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[9]),
     .rready_i(rready_i[9]),
     .rdata_o(rdata_o[9]),
+    .full_o(full_o[9]),
     .depth_o(depth_o[9][3:0])
   );
 
@@ -230,6 +241,7 @@ module prim_fifo_sync_tb #(
     .rvalid_o(rvalid_o[10]),
     .rready_i(rready_i[10]),
     .rdata_o(rdata_o[10]),
+    .full_o(full_o[10]),
     .depth_o(depth_o[10][4:0])
   );
 

--- a/hw/ip/prim/fpv/tb/prim_fifo_sync_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_fifo_sync_tb.sv
@@ -32,7 +32,8 @@ module prim_fifo_sync_tb #(
   input               rready_i[NumDuts],
   output [Width-1:0]  rdata_o [NumDuts],
   output              full_o  [NumDuts],
-  output [DepthW-1:0] depth_o [NumDuts]
+  output [DepthW-1:0] depth_o [NumDuts],
+  output              err_o   [NumDuts]
 );
 
   // need to instantiate by hand since bind statements inside
@@ -57,7 +58,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[0]),
     .rdata_o(rdata_o[0]),
     .full_o(full_o[0]),
-    .depth_o(depth_o[0][0])
+    .depth_o(depth_o[0][0]),
+    .err_o(err_o[0])
   );
 
   prim_fifo_sync #(
@@ -75,7 +77,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[1]),
     .rdata_o(rdata_o[1]),
     .full_o(full_o[1]),
-    .depth_o(depth_o[1][2:0])
+    .depth_o(depth_o[1][2:0]),
+    .err_o(err_o[1])
   );
 
   prim_fifo_sync #(
@@ -93,7 +96,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[2]),
     .rdata_o(rdata_o[2]),
     .full_o(full_o[2]),
-    .depth_o(depth_o[2][3:0])
+    .depth_o(depth_o[2][3:0]),
+    .err_o(err_o[2])
   );
 
   prim_fifo_sync #(
@@ -111,7 +115,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[3]),
     .rdata_o(rdata_o[3]),
     .full_o(full_o[3]),
-    .depth_o(depth_o[3][3:0])
+    .depth_o(depth_o[3][3:0]),
+    .err_o(err_o[3])
   );
 
   prim_fifo_sync #(
@@ -129,7 +134,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[4]),
     .rdata_o(rdata_o[4]),
     .full_o(full_o[4]),
-    .depth_o(depth_o[4][4:0])
+    .depth_o(depth_o[4][4:0]),
+    .err_o(err_o[4])
   );
 
   ////////////////
@@ -152,7 +158,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[5]),
     .rdata_o(rdata_o[5]),
     .full_o(full_o[5]),
-    .depth_o(depth_o[5][0])
+    .depth_o(depth_o[5][0]),
+    .err_o(err_o[5])
   );
 
   prim_fifo_sync #(
@@ -170,7 +177,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[6]),
     .rdata_o(rdata_o[6]),
     .full_o(full_o[6]),
-    .depth_o(depth_o[6][0])
+    .depth_o(depth_o[6][0]),
+    .err_o(err_o[6])
   );
 
   prim_fifo_sync #(
@@ -188,7 +196,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[7]),
     .rdata_o(rdata_o[7]),
     .full_o(full_o[7]),
-    .depth_o(depth_o[7][2:0])
+    .depth_o(depth_o[7][2:0]),
+    .err_o(err_o[7])
   );
 
   prim_fifo_sync #(
@@ -206,7 +215,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[8]),
     .rdata_o(rdata_o[8]),
     .full_o(full_o[8]),
-    .depth_o(depth_o[8][3:0])
+    .depth_o(depth_o[8][3:0]),
+    .err_o(err_o[8])
   );
 
   prim_fifo_sync #(
@@ -224,7 +234,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[9]),
     .rdata_o(rdata_o[9]),
     .full_o(full_o[9]),
-    .depth_o(depth_o[9][3:0])
+    .depth_o(depth_o[9][3:0]),
+    .err_o(err_o[9])
   );
 
   prim_fifo_sync #(
@@ -242,7 +253,8 @@ module prim_fifo_sync_tb #(
     .rready_i(rready_i[10]),
     .rdata_o(rdata_o[10]),
     .full_o(full_o[10]),
-    .depth_o(depth_o[10][4:0])
+    .depth_o(depth_o[10][4:0]),
+    .err_o(err_o[10])
   );
 
 endmodule : prim_fifo_sync_tb

--- a/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
@@ -16,15 +16,16 @@ module prim_fifo_sync_assert_fpv #(
   localparam int unsigned DepthWNorm = $clog2(Depth+1),
   localparam int unsigned DepthW = (DepthWNorm == 0) ? 1 : DepthWNorm
 ) (
-  input  clk_i,
-  input  rst_ni,
-  input  clr_i,
-  input  wvalid_i,
-  input  wready_o,
-  input [Width-1:0] wdata_i,
-  input  rvalid_o,
-  input  rready_i,
-  input [Width-1:0] rdata_o,
+  input              clk_i,
+  input              rst_ni,
+  input              clr_i,
+  input              wvalid_i,
+  input              wready_o,
+  input [Width-1:0]  wdata_i,
+  input              rvalid_o,
+  input              rready_i,
+  input [Width-1:0]  rdata_o,
+  input              full_o,
   input [DepthW-1:0] depth_o
 );
 
@@ -135,6 +136,9 @@ module prim_fifo_sync_assert_fpv #(
   ////////////////////////
   // Forward Assertions //
   ////////////////////////
+
+  // The full_o port should be high iff the depth is maximal.
+  `ASSERT(FullIffFullDepth_A, (depth_o == Depth) <-> (full_o))
 
   // assert depth of FIFO
   `ASSERT(Depth_A, depth_o <= Depth)

--- a/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_fifo_sync_assert_fpv.sv
@@ -26,7 +26,8 @@ module prim_fifo_sync_assert_fpv #(
   input              rready_i,
   input [Width-1:0]  rdata_o,
   input              full_o,
-  input [DepthW-1:0] depth_o
+  input [DepthW-1:0] depth_o,
+  input              err_o
 );
 
   /////////////////
@@ -220,5 +221,9 @@ module prim_fifo_sync_assert_fpv #(
   `ASSERT(WreadyNoSpaceBkwd_A, 1 |=> !wready_o -> depth_o == Depth)
   // elements ready to be read
   `ASSERT(RvalidNoElemskBkwd_A, !rvalid_o |-> depth_o == 0)
+
+  // The err_o signal should never go high. This isn't supposed to be triggerable without fault
+  // injection (which isn't modelled in FPV so the output should be constant zero).
+  `ASSERT(NoErrSignal_A, !err_o)
 
 endmodule : prim_fifo_sync_assert_fpv

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -46,7 +46,7 @@ module prim_fifo_sync #(
 
     // host facing
     assign wready_o = rready_i;
-    assign full_o = rready_i;
+    assign full_o = 1'b1;
 
     // this avoids lint warnings
     logic unused_clr;


### PR DESCRIPTION
This output doesn't really do anything in the FPV world (because it detects error injection which we don't model), but wiring it up in a trivial way avoids a warning in Jasper.

To avoid merge conflicts, this PR builds on #25464, which contains the first two commits. The only commit that is unique to this PR is the last commit.