### PR TITLE
[pwm,dv] Don't refer to removed pwm_cov_bind

### DIFF
--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -35,7 +35,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: ["pwm_bind", "pwm_cov_bind", "sec_cm_prim_onehot_check_bind"]
+  sim_tops: ["pwm_bind", "sec_cm_prim_onehot_check_bind"]
 
   // Coverage exclusion
   xcelium_cov_refine_files: ["{proj_root}/hw/ip/pwm/dv/cov/pwm_unr_excl.vRefine"]

--- a/util/verible-format-allowlist.txt
+++ b/util/verible-format-allowlist.txt
@@ -153,8 +153,6 @@ hw/ip/prim_xilinx/rtl/prim_xilinx_flop.sv
 hw/ip/prim_xilinx/rtl/prim_xilinx_flop_en.sv
 hw/ip/prim_xilinx/rtl/prim_xilinx_pad_attr.sv
 hw/ip/prim_xilinx/rtl/prim_xilinx_xor2.sv
-hw/ip/pwm/dv/cov/pwm_cov_bind.sv
-hw/ip/pwm/dv/cov/pwm_cov_if.sv
 hw/ip/pwm/dv/env/pwm_env_cov.sv
 hw/ip/pwm/dv/env/pwm_env_pkg.sv
 hw/ip/pwm/dv/env/pwm_virtual_sequencer.sv


### PR DESCRIPTION
This was removed in f79bf34 and it appears I didn't notice that this broke the build. Oops.