### PR TITLE
[rv_core_ibex,rtl] Parametrize alert_handler dependencies

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -217,6 +217,22 @@
       randtype:  "data"
     },
 
+    { name:    "NEscalationSeverities"
+      type:    "int unsigned"
+      default: "4"
+      desc:    "Number of escalation severities"
+      local:   "true"
+      expose:  "true"
+    },
+
+    { name:    "WidthPingCounter"
+      type:    "int unsigned"
+      default: "16"
+      desc:    "Width of the ping counter"
+      local:   "true"
+      expose:  "true"
+    },
+
     { name:    "PMPEnable"
       type:    "bit"
       default: "1'b0"

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -42,7 +42,9 @@ module rv_core_ibex
   parameter logic [ibex_pkg::SCRAMBLE_KEY_W-1:0] RndCnstIbexKeyDefault =
       ibex_pkg::RndCnstIbexKeyDefault,
   parameter logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0] RndCnstIbexNonceDefault =
-      ibex_pkg::RndCnstIbexNonceDefault
+      ibex_pkg::RndCnstIbexNonceDefault,
+  parameter int unsigned            NEscalationSeverities = 4,
+  parameter int unsigned            WidthPingCounter = 16
 ) (
   // Clock and Reset
   input  logic        clk_i,
@@ -231,8 +233,8 @@ module rv_core_ibex
   // protocol into single ended signal.
   logic esc_irq_nm;
   prim_esc_receiver #(
-    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
-    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+    .N_ESC_SEV   (NEscalationSeverities),
+    .PING_CNT_DW (WidthPingCounter)
   ) u_prim_esc_receiver (
     .clk_i     ( clk_esc_i  ),
     .rst_ni    ( rst_esc_ni ),

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -13,7 +13,6 @@ filesets:
       - lowrisc:ip_interfaces:pwrmgr_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul
-      - lowrisc:ip_interfaces:alert_handler_reg
       - lowrisc:prim:all
       - lowrisc:prim:clock_gating
       - lowrisc:prim:edn_req

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -8277,6 +8277,8 @@
         DmHaltAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]
         DmExceptionAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]
         PipeLine: "0"
+        NEscalationSeverities: alert_handler_reg_pkg::N_ESC_SEV
+        WidthPingCounter: alert_handler_reg_pkg::PING_CNT_DW
       }
       clock_srcs:
       {
@@ -8370,6 +8372,24 @@
           name_top: RndCnstRvCoreIbexIbexNonceDefault
           default: 0x5279fcbcd2bd2c13
           randwidth: 64
+        }
+        {
+          name: NEscalationSeverities
+          desc: Number of escalation severities
+          type: int unsigned
+          default: alert_handler_reg_pkg::N_ESC_SEV
+          local: "true"
+          expose: "true"
+          name_top: RvCoreIbexNEscalationSeverities
+        }
+        {
+          name: WidthPingCounter
+          desc: Width of the ping counter
+          type: int unsigned
+          default: alert_handler_reg_pkg::PING_CNT_DW
+          local: "true"
+          expose: "true"
+          name_top: RvCoreIbexWidthPingCounter
         }
         {
           name: PMPEnable

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -963,7 +963,9 @@
                    SecureIbex: "1",
                    DmHaltAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]",
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]",
-                   PipeLine: "0"
+                   PipeLine: "0",
+                   NEscalationSeverities: "alert_handler_reg_pkg::N_ESC_SEV",
+                   WidthPingCounter: "alert_handler_reg_pkg::PING_CNT_DW"
                   },
       clock_srcs: {
         clk_i: "main",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -231,6 +231,9 @@ module top_earlgrey #(
   import top_earlgrey_rnd_cnst_pkg::*;
 
   // Local Parameters
+  // local parameters for rv_core_ibex
+  localparam int unsigned RvCoreIbexNEscalationSeverities = alert_handler_reg_pkg::N_ESC_SEV;
+  localparam int unsigned RvCoreIbexWidthPingCounter = alert_handler_reg_pkg::PING_CNT_DW;
 
   // Signals
   logic [56:0] mio_p2d;
@@ -2634,6 +2637,8 @@ module top_earlgrey #(
     .RndCnstLfsrPerm(RndCnstRvCoreIbexLfsrPerm),
     .RndCnstIbexKeyDefault(RndCnstRvCoreIbexIbexKeyDefault),
     .RndCnstIbexNonceDefault(RndCnstRvCoreIbexIbexNonceDefault),
+    .NEscalationSeverities(RvCoreIbexNEscalationSeverities),
+    .WidthPingCounter(RvCoreIbexWidthPingCounter),
     .PMPEnable(RvCoreIbexPMPEnable),
     .PMPGranularity(RvCoreIbexPMPGranularity),
     .PMPNumRegions(RvCoreIbexPMPNumRegions),


### PR DESCRIPTION
Not all tops with an Ibex have an alert handler and its package. This PR removes the dependency of the alert handler from Ibex by parametrizing those values. The top-level then connects the alert handler definitions to those parameters.