### PR TITLE
[hw,pwrmgr_common_pkg,rtl] Move common interface definitions out of ipgen

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -153,11 +153,11 @@
       package: "lc_ctrl_pkg",
     },
 
-    { struct:  "pwr_cpu",
+    { struct:  "cpu_pwrmgr",
       type:    "uni",
       name:    "pwrmgr",
       act:     "req",
-      package: "pwrmgr_pkg",
+      package: "rv_core_ibex_pkg",
     },
 
     { struct:  "logic",

--- a/hw/ip/rv_core_ibex/doc/interfaces.md
+++ b/hw/ip/rv_core_ibex/doc/interfaces.md
@@ -28,7 +28,7 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 | crash_dump     | rv_core_ibex_pkg::cpu_crash_dump | uni     | req   |       1 |               |
 | lc_cpu_en      | lc_ctrl_pkg::lc_tx               | uni     | rcv   |       1 |               |
 | pwrmgr_cpu_en  | lc_ctrl_pkg::lc_tx               | uni     | rcv   |       1 |               |
-| pwrmgr         | pwrmgr_pkg::pwr_cpu              | uni     | req   |       1 |               |
+| pwrmgr         | rv_core_ibex_pkg::cpu_pwrmgr     | uni     | req   |       1 |               |
 | nmi_wdog       | logic                            | uni     | rcv   |       1 |               |
 | edn            | edn_pkg::edn                     | req_rsp | req   |       1 |               |
 | icache_otp_key | otp_ctrl_pkg::sram_otp_key       | req_rsp | req   |       1 |               |
@@ -100,7 +100,7 @@ Signal               | Direction        | Type                                  
 `cfg_tl_d_o `        | `output`         | `tlul_pkg::tl_d2h_t`                   | Outgoing configuration bus response.
 `lc_cpu_en_i`        | `input`          | `lc_ctrl_pkg::lc_tx_t`                 | CPU enable signal from life cycle controller.
 `pwrmgr_cpu_en_i`    | `input`          | `lc_ctrl_pkg::lc_tx_t`                 | CPU enable signal from power manager.
-`pwrmgr_o`           | `output`         | `pwrmgr_pkg::pwr_cpu_t`                | Low-power CPU status to power manager.
+`pwrmgr_o`           | `output`         | `pwrmgr_pkg::cpu_pwrmgr_t`             | Low-power CPU status to power manager.
 `edn_i`              | `input`          | `edn_pkg::edn_rsp_t`                   | Incoming entropy response from entropy distribution network.
 `edn_o`              | `output`         | `edn_pkg::edn_req_t`                   | Outgoing entropy request to entropy distribution network.
 `icache_otp_key_i`   | `input`          | `otp_ctrl_pkg::sram_otp_key_rsp_t`     | Incoming scrambling key response from OTP to icache.

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -90,7 +90,7 @@ module rv_core_ibex
   // CPU Control Signals
   input lc_ctrl_pkg::lc_tx_t lc_cpu_en_i,
   input lc_ctrl_pkg::lc_tx_t pwrmgr_cpu_en_i,
-  output pwrmgr_pkg::pwr_cpu_t pwrmgr_o,
+  output cpu_pwrmgr_t pwrmgr_o,
 
   // dft bypass
   input scan_rst_ni,

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
@@ -21,4 +21,14 @@ package rv_core_ibex_pkg;
     ibex_pkg::crash_dump_t current;
   } cpu_crash_dump_t;
 
+  // processor to pwrmgr
+  typedef struct packed {
+    logic core_sleeping;
+  } cpu_pwrmgr_t;
+
+  // default value (for dangling ports)
+  parameter cpu_pwrmgr_t CPU_PWRMGR_DEFAULT = '{
+    core_sleeping: 1'b0
+  };
+
 endpackage // rv_core_ibex_pkg

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -10,7 +10,6 @@ filesets:
       - lowrisc:ibex:ibex_top
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:ip_interfaces:pwrmgr_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul
       - lowrisc:ip_interfaces:alert_handler_reg

--- a/hw/ip_templates/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip_templates/pwrmgr/data/pwrmgr.hjson.tpl
@@ -206,11 +206,11 @@
       package: "prim_esc_pkg",
     },
 
-    { struct:  "pwr_cpu",
+    { struct:  "cpu_pwrmgr",
       type:    "uni",
       name:    "pwr_cpu",
       act:     "rcv",
-      package: "pwrmgr_pkg",
+      package: "rv_core_ibex_pkg",
     },
 
     { struct:  "logic",

--- a/hw/ip_templates/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip_templates/pwrmgr/dv/env/pwrmgr_if.sv
@@ -36,7 +36,7 @@ interface pwrmgr_if (
   pwrmgr_pkg::pwr_flash_t                                      pwr_flash;
 
   pwrmgr_pkg::pwrmgr_cpu_t                                     cpu_i;
-  pwrmgr_pkg::pwr_cpu_t                                        pwr_cpu;
+  rv_core_ibex_pkg::cpu_pwrmgr_t                               pwr_cpu;
 
   lc_ctrl_pkg::lc_tx_t                                         fetch_en;
   lc_ctrl_pkg::lc_tx_t                                         lc_hw_debug_en;
@@ -192,7 +192,7 @@ interface pwrmgr_if (
     pwr_otp_rsp = '{default: '0};
     pwr_lc_rsp = '{default: '0};
     pwr_flash = '{default: '0};
-    pwr_cpu = pwrmgr_pkg::PWR_CPU_DEFAULT;
+    pwr_cpu = rv_core_ibex_pkg::CPU_PWRMGR_DEFAULT;
     wakeups_i = pwrmgr_pkg::WAKEUPS_DEFAULT;
     rstreqs_i = pwrmgr_pkg::RSTREQS_DEFAULT;
     sw_rst_req_i = prim_mubi_pkg::MuBi4False;

--- a/hw/ip_templates/pwrmgr/pwrmgr.core.tpl
+++ b/hw/ip_templates/pwrmgr/pwrmgr.core.tpl
@@ -12,6 +12,7 @@ filesets:
     depend:
       - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg:0.1")}
       - ${instance_vlnv("lowrisc:ip:pwrmgr_reg:0.1")}
+      - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:pwrmgr_component
     file_type: systemVerilogSource
 

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr.sv.tpl
@@ -56,7 +56,7 @@ module pwrmgr
   input  pwr_flash_t pwr_flash_i,
 
   // processor interface
-  input  pwr_cpu_t pwr_cpu_i,
+  input  rv_core_ibex_pkg::cpu_pwrmgr_t pwr_cpu_i,
   // SEC_CM: LC_CTRL.INTERSIG.MUBI
   output lc_ctrl_pkg::lc_tx_t fetch_en_o,
   input  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,

--- a/hw/ip_templates/pwrmgr/rtl/pwrmgr_pkg.sv.tpl
+++ b/hw/ip_templates/pwrmgr/rtl/pwrmgr_pkg.sv.tpl
@@ -145,11 +145,6 @@ package pwrmgr_pkg;
     flash_idle: 1'b1
   };
 
-  // processor to pwrmgr
-  typedef struct packed {
-    logic core_sleeping;
-  } pwr_cpu_t;
-
   // cpu reset requests and status
   typedef struct packed {
     logic ndmreset_req;
@@ -172,11 +167,6 @@ package pwrmgr_pkg;
   // default value for pwrmgr_ast_rsp_t (for dangling ports)
   parameter pwrmgr_cpu_t PWRMGR_CPU_DEFAULT = '{
     ndmreset_req: '0
-  };
-
-  // default value (for dangling ports)
-  parameter pwr_cpu_t PWR_CPU_DEFAULT = '{
-    core_sleeping: 1'b0
   };
 
   // default value (for dangling ports)

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -2403,8 +2403,8 @@
         }
         {
           name: pwr_cpu
-          struct: pwr_cpu
-          package: pwrmgr_pkg
+          struct: cpu_pwrmgr
+          package: rv_core_ibex_pkg
           type: uni
           act: rcv
           width: 1
@@ -8849,8 +8849,8 @@
         }
         {
           name: pwrmgr
-          struct: pwr_cpu
-          package: pwrmgr_pkg
+          struct: cpu_pwrmgr
+          package: rv_core_ibex_pkg
           type: uni
           act: req
           width: 1
@@ -15386,6 +15386,7 @@
       }
     }
   ]
+  incoming_alert: {}
   exported_clks: {}
   wakeups:
   [
@@ -16311,6 +16312,7 @@
     mbx_pcie1
     rv_core_ibex
   ]
+  outgoing_alert_module: {}
   alert:
   [
     {
@@ -17205,6 +17207,7 @@
       lpg_idx: 11
     }
   ]
+  outgoing_alert: {}
   unmanaged_resets: {}
   exported_rsts: {}
   alert_lpgs:
@@ -17682,6 +17685,7 @@
       }
     }
   ]
+  outgoing_alert_lpgs: {}
   inter_signal:
   {
     signals:
@@ -18879,8 +18883,8 @@
       }
       {
         name: pwr_cpu
-        struct: pwr_cpu
-        package: pwrmgr_pkg
+        struct: cpu_pwrmgr
+        package: rv_core_ibex_pkg
         type: uni
         act: rcv
         width: 1
@@ -22356,8 +22360,8 @@
       }
       {
         name: pwrmgr
-        struct: pwr_cpu
-        package: pwrmgr_pkg
+        struct: cpu_pwrmgr
+        package: rv_core_ibex_pkg
         type: uni
         act: req
         width: 1
@@ -25470,15 +25474,15 @@
         default: rv_core_ibex_pkg::CPU_CRASH_DUMP_DEFAULT
       }
       {
-        package: pwrmgr_pkg
-        struct: pwr_cpu
+        package: rv_core_ibex_pkg
+        struct: cpu_pwrmgr
         signame: rv_core_ibex_pwrmgr
         width: 1
         type: uni
         end_idx: -1
         act: req
         suffix: ""
-        default: pwrmgr_pkg::PWR_CPU_DEFAULT
+        default: rv_core_ibex_pkg::CPU_PWRMGR_DEFAULT
       }
       {
         package: spi_device_pkg

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/data/pwrmgr.hjson
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/data/pwrmgr.hjson
@@ -217,11 +217,11 @@
       package: "prim_esc_pkg",
     },
 
-    { struct:  "pwr_cpu",
+    { struct:  "cpu_pwrmgr",
       type:    "uni",
       name:    "pwr_cpu",
       act:     "rcv",
-      package: "pwrmgr_pkg",
+      package: "rv_core_ibex_pkg",
     },
 
     { struct:  "logic",

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/doc/interfaces.md
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/doc/interfaces.md
@@ -10,29 +10,29 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name      | Package::Struct             | Type    | Act   |   Width | Description   |
-|:---------------|:----------------------------|:--------|:------|--------:|:--------------|
-| boot_status    | pwrmgr_pkg::pwr_boot_status | uni     | req   |       1 |               |
-| pwr_ast        | pwrmgr_pkg::pwr_ast         | req_rsp | req   |       1 |               |
-| pwr_rst        | pwrmgr_pkg::pwr_rst         | req_rsp | req   |       1 |               |
-| pwr_clk        | pwrmgr_pkg::pwr_clk         | req_rsp | req   |       1 |               |
-| pwr_otp        | pwrmgr_pkg::pwr_otp         | req_rsp | req   |       1 |               |
-| pwr_lc         | pwrmgr_pkg::pwr_lc          | req_rsp | req   |       1 |               |
-| pwr_flash      | pwrmgr_pkg::pwr_flash       | uni     | rcv   |       1 |               |
-| esc_rst_tx     | prim_esc_pkg::esc_tx        | uni     | rcv   |       1 |               |
-| esc_rst_rx     | prim_esc_pkg::esc_rx        | uni     | req   |       1 |               |
-| pwr_cpu        | pwrmgr_pkg::pwr_cpu         | uni     | rcv   |       1 |               |
-| wakeups        | logic                       | uni     | rcv   |       5 |               |
-| rstreqs        | logic                       | uni     | rcv   |       2 |               |
-| ndmreset_req   | logic                       | uni     | rcv   |       1 |               |
-| strap          | logic                       | uni     | req   |       1 |               |
-| low_power      | logic                       | uni     | req   |       1 |               |
-| rom_ctrl       | rom_ctrl_pkg::pwrmgr_data   | uni     | rcv   |       2 |               |
-| fetch_en       | lc_ctrl_pkg::lc_tx          | uni     | req   |       1 |               |
-| lc_dft_en      | lc_ctrl_pkg::lc_tx          | uni     | rcv   |       1 |               |
-| lc_hw_debug_en | lc_ctrl_pkg::lc_tx          | uni     | rcv   |       1 |               |
-| sw_rst_req     | prim_mubi_pkg::mubi4        | uni     | rcv   |       1 |               |
-| tl             | tlul_pkg::tl                | req_rsp | rsp   |       1 |               |
+| Port Name      | Package::Struct              | Type    | Act   |   Width | Description   |
+|:---------------|:-----------------------------|:--------|:------|--------:|:--------------|
+| boot_status    | pwrmgr_pkg::pwr_boot_status  | uni     | req   |       1 |               |
+| pwr_ast        | pwrmgr_pkg::pwr_ast          | req_rsp | req   |       1 |               |
+| pwr_rst        | pwrmgr_pkg::pwr_rst          | req_rsp | req   |       1 |               |
+| pwr_clk        | pwrmgr_pkg::pwr_clk          | req_rsp | req   |       1 |               |
+| pwr_otp        | pwrmgr_pkg::pwr_otp          | req_rsp | req   |       1 |               |
+| pwr_lc         | pwrmgr_pkg::pwr_lc           | req_rsp | req   |       1 |               |
+| pwr_flash      | pwrmgr_pkg::pwr_flash        | uni     | rcv   |       1 |               |
+| esc_rst_tx     | prim_esc_pkg::esc_tx         | uni     | rcv   |       1 |               |
+| esc_rst_rx     | prim_esc_pkg::esc_rx         | uni     | req   |       1 |               |
+| pwr_cpu        | rv_core_ibex_pkg::cpu_pwrmgr | uni     | rcv   |       1 |               |
+| wakeups        | logic                        | uni     | rcv   |       5 |               |
+| rstreqs        | logic                        | uni     | rcv   |       2 |               |
+| ndmreset_req   | logic                        | uni     | rcv   |       1 |               |
+| strap          | logic                        | uni     | req   |       1 |               |
+| low_power      | logic                        | uni     | req   |       1 |               |
+| rom_ctrl       | rom_ctrl_pkg::pwrmgr_data    | uni     | rcv   |       2 |               |
+| fetch_en       | lc_ctrl_pkg::lc_tx           | uni     | req   |       1 |               |
+| lc_dft_en      | lc_ctrl_pkg::lc_tx           | uni     | rcv   |       1 |               |
+| lc_hw_debug_en | lc_ctrl_pkg::lc_tx           | uni     | rcv   |       1 |               |
+| sw_rst_req     | prim_mubi_pkg::mubi4         | uni     | rcv   |       1 |               |
+| tl             | tlul_pkg::tl                 | req_rsp | rsp   |       1 |               |
 
 ## Interrupts
 

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
@@ -36,7 +36,7 @@ interface pwrmgr_if (
   pwrmgr_pkg::pwr_flash_t                                      pwr_flash;
 
   pwrmgr_pkg::pwrmgr_cpu_t                                     cpu_i;
-  pwrmgr_pkg::pwr_cpu_t                                        pwr_cpu;
+  rv_core_ibex_pkg::cpu_pwrmgr_t                               pwr_cpu;
 
   lc_ctrl_pkg::lc_tx_t                                         fetch_en;
   lc_ctrl_pkg::lc_tx_t                                         lc_hw_debug_en;
@@ -192,7 +192,7 @@ interface pwrmgr_if (
     pwr_otp_rsp = '{default: '0};
     pwr_lc_rsp = '{default: '0};
     pwr_flash = '{default: '0};
-    pwr_cpu = pwrmgr_pkg::PWR_CPU_DEFAULT;
+    pwr_cpu = rv_core_ibex_pkg::CPU_PWRMGR_DEFAULT;
     wakeups_i = pwrmgr_pkg::WAKEUPS_DEFAULT;
     rstreqs_i = pwrmgr_pkg::RSTREQS_DEFAULT;
     sw_rst_req_i = prim_mubi_pkg::MuBi4False;

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr.core
@@ -12,6 +12,7 @@ filesets:
     depend:
       - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg:0.1
       - lowrisc:opentitan:top_darjeeling_pwrmgr_reg:0.1
+      - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:pwrmgr_component
     file_type: systemVerilogSource
 

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -56,7 +56,7 @@ module pwrmgr
   input  pwr_flash_t pwr_flash_i,
 
   // processor interface
-  input  pwr_cpu_t pwr_cpu_i,
+  input  rv_core_ibex_pkg::cpu_pwrmgr_t pwr_cpu_i,
   // SEC_CM: LC_CTRL.INTERSIG.MUBI
   output lc_ctrl_pkg::lc_tx_t fetch_en_o,
   input  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -145,11 +145,6 @@ package pwrmgr_pkg;
     flash_idle: 1'b1
   };
 
-  // processor to pwrmgr
-  typedef struct packed {
-    logic core_sleeping;
-  } pwr_cpu_t;
-
   // cpu reset requests and status
   typedef struct packed {
     logic ndmreset_req;
@@ -170,11 +165,6 @@ package pwrmgr_pkg;
   // default value for pwrmgr_ast_rsp_t (for dangling ports)
   parameter pwrmgr_cpu_t PWRMGR_CPU_DEFAULT = '{
     ndmreset_req: '0
-  };
-
-  // default value (for dangling ports)
-  parameter pwr_cpu_t PWR_CPU_DEFAULT = '{
-    core_sleeping: 1'b0
   };
 
   // default value (for dangling ports)

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -530,7 +530,7 @@ module top_darjeeling #(
   logic       rv_plic_irq;
   logic       rv_dm_debug_req;
   rv_core_ibex_pkg::cpu_crash_dump_t       rv_core_ibex_crash_dump;
-  pwrmgr_pkg::pwr_cpu_t       rv_core_ibex_pwrmgr;
+  rv_core_ibex_pkg::cpu_pwrmgr_t       rv_core_ibex_pwrmgr;
   spi_device_pkg::passthrough_req_t       spi_device_passthrough_req;
   spi_device_pkg::passthrough_rsp_t       spi_device_passthrough_rsp;
   logic       rv_dm_ndmreset_req;
@@ -837,6 +837,7 @@ module top_darjeeling #(
   // otbn_trans_lc_0
   assign lpg_cg_en[18] = clkmgr_aon_cg_en.main_otbn;
   assign lpg_rst_en[18] = rstmgr_aon_rst_en.lc[rstmgr_pkg::Domain0Sel];
+
 
 // tie-off unused connections
 //VCS coverage off

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3276,8 +3276,8 @@
         }
         {
           name: pwr_cpu
-          struct: pwr_cpu
-          package: pwrmgr_pkg
+          struct: cpu_pwrmgr
+          package: rv_core_ibex_pkg
           type: uni
           act: rcv
           width: 1
@@ -8749,8 +8749,8 @@
         }
         {
           name: pwrmgr
-          struct: pwr_cpu
-          package: pwrmgr_pkg
+          struct: cpu_pwrmgr
+          package: rv_core_ibex_pkg
           type: uni
           act: req
           width: 1
@@ -18512,8 +18512,8 @@
       }
       {
         name: pwr_cpu
-        struct: pwr_cpu
-        package: pwrmgr_pkg
+        struct: cpu_pwrmgr
+        package: rv_core_ibex_pkg
         type: uni
         act: rcv
         width: 1
@@ -21401,8 +21401,8 @@
       }
       {
         name: pwrmgr
-        struct: pwr_cpu
-        package: pwrmgr_pkg
+        struct: cpu_pwrmgr
+        package: rv_core_ibex_pkg
         type: uni
         act: req
         width: 1
@@ -23940,15 +23940,15 @@
         default: rv_core_ibex_pkg::CPU_CRASH_DUMP_DEFAULT
       }
       {
-        package: pwrmgr_pkg
-        struct: pwr_cpu
+        package: rv_core_ibex_pkg
+        struct: cpu_pwrmgr
         signame: rv_core_ibex_pwrmgr
         width: 1
         type: uni
         end_idx: -1
         act: req
         suffix: ""
-        default: pwrmgr_pkg::PWR_CPU_DEFAULT
+        default: rv_core_ibex_pkg::CPU_PWRMGR_DEFAULT
       }
       {
         package: spi_device_pkg

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/data/pwrmgr.hjson
@@ -217,11 +217,11 @@
       package: "prim_esc_pkg",
     },
 
-    { struct:  "pwr_cpu",
+    { struct:  "cpu_pwrmgr",
       type:    "uni",
       name:    "pwr_cpu",
       act:     "rcv",
-      package: "pwrmgr_pkg",
+      package: "rv_core_ibex_pkg",
     },
 
     { struct:  "logic",

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/doc/interfaces.md
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/doc/interfaces.md
@@ -10,28 +10,28 @@ Referring to the [Comportable guideline for peripheral device functionality](htt
 
 ## [Inter-Module Signals](https://opentitan.org/book/doc/contributing/hw/comportability/index.html#inter-signal-handling)
 
-| Port Name      | Package::Struct           | Type    | Act   |   Width | Description   |
-|:---------------|:--------------------------|:--------|:------|--------:|:--------------|
-| pwr_ast        | pwrmgr_pkg::pwr_ast       | req_rsp | req   |       1 |               |
-| pwr_rst        | pwrmgr_pkg::pwr_rst       | req_rsp | req   |       1 |               |
-| pwr_clk        | pwrmgr_pkg::pwr_clk       | req_rsp | req   |       1 |               |
-| pwr_otp        | pwrmgr_pkg::pwr_otp       | req_rsp | req   |       1 |               |
-| pwr_lc         | pwrmgr_pkg::pwr_lc        | req_rsp | req   |       1 |               |
-| pwr_flash      | pwrmgr_pkg::pwr_flash     | uni     | rcv   |       1 |               |
-| esc_rst_tx     | prim_esc_pkg::esc_tx      | uni     | rcv   |       1 |               |
-| esc_rst_rx     | prim_esc_pkg::esc_rx      | uni     | req   |       1 |               |
-| pwr_cpu        | pwrmgr_pkg::pwr_cpu       | uni     | rcv   |       1 |               |
-| wakeups        | logic                     | uni     | rcv   |       6 |               |
-| rstreqs        | logic                     | uni     | rcv   |       2 |               |
-| ndmreset_req   | logic                     | uni     | rcv   |       1 |               |
-| strap          | logic                     | uni     | req   |       1 |               |
-| low_power      | logic                     | uni     | req   |       1 |               |
-| rom_ctrl       | rom_ctrl_pkg::pwrmgr_data | uni     | rcv   |       1 |               |
-| fetch_en       | lc_ctrl_pkg::lc_tx        | uni     | req   |       1 |               |
-| lc_dft_en      | lc_ctrl_pkg::lc_tx        | uni     | rcv   |       1 |               |
-| lc_hw_debug_en | lc_ctrl_pkg::lc_tx        | uni     | rcv   |       1 |               |
-| sw_rst_req     | prim_mubi_pkg::mubi4      | uni     | rcv   |       1 |               |
-| tl             | tlul_pkg::tl              | req_rsp | rsp   |       1 |               |
+| Port Name      | Package::Struct              | Type    | Act   |   Width | Description   |
+|:---------------|:-----------------------------|:--------|:------|--------:|:--------------|
+| pwr_ast        | pwrmgr_pkg::pwr_ast          | req_rsp | req   |       1 |               |
+| pwr_rst        | pwrmgr_pkg::pwr_rst          | req_rsp | req   |       1 |               |
+| pwr_clk        | pwrmgr_pkg::pwr_clk          | req_rsp | req   |       1 |               |
+| pwr_otp        | pwrmgr_pkg::pwr_otp          | req_rsp | req   |       1 |               |
+| pwr_lc         | pwrmgr_pkg::pwr_lc           | req_rsp | req   |       1 |               |
+| pwr_flash      | pwrmgr_pkg::pwr_flash        | uni     | rcv   |       1 |               |
+| esc_rst_tx     | prim_esc_pkg::esc_tx         | uni     | rcv   |       1 |               |
+| esc_rst_rx     | prim_esc_pkg::esc_rx         | uni     | req   |       1 |               |
+| pwr_cpu        | rv_core_ibex_pkg::cpu_pwrmgr | uni     | rcv   |       1 |               |
+| wakeups        | logic                        | uni     | rcv   |       6 |               |
+| rstreqs        | logic                        | uni     | rcv   |       2 |               |
+| ndmreset_req   | logic                        | uni     | rcv   |       1 |               |
+| strap          | logic                        | uni     | req   |       1 |               |
+| low_power      | logic                        | uni     | req   |       1 |               |
+| rom_ctrl       | rom_ctrl_pkg::pwrmgr_data    | uni     | rcv   |       1 |               |
+| fetch_en       | lc_ctrl_pkg::lc_tx           | uni     | req   |       1 |               |
+| lc_dft_en      | lc_ctrl_pkg::lc_tx           | uni     | rcv   |       1 |               |
+| lc_hw_debug_en | lc_ctrl_pkg::lc_tx           | uni     | rcv   |       1 |               |
+| sw_rst_req     | prim_mubi_pkg::mubi4         | uni     | rcv   |       1 |               |
+| tl             | tlul_pkg::tl                 | req_rsp | rsp   |       1 |               |
 
 ## Interrupts
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/dv/env/pwrmgr_if.sv
@@ -36,7 +36,7 @@ interface pwrmgr_if (
   pwrmgr_pkg::pwr_flash_t                                      pwr_flash;
 
   pwrmgr_pkg::pwrmgr_cpu_t                                     cpu_i;
-  pwrmgr_pkg::pwr_cpu_t                                        pwr_cpu;
+  rv_core_ibex_pkg::cpu_pwrmgr_t                               pwr_cpu;
 
   lc_ctrl_pkg::lc_tx_t                                         fetch_en;
   lc_ctrl_pkg::lc_tx_t                                         lc_hw_debug_en;
@@ -192,7 +192,7 @@ interface pwrmgr_if (
     pwr_otp_rsp = '{default: '0};
     pwr_lc_rsp = '{default: '0};
     pwr_flash = '{default: '0};
-    pwr_cpu = pwrmgr_pkg::PWR_CPU_DEFAULT;
+    pwr_cpu = rv_core_ibex_pkg::CPU_PWRMGR_DEFAULT;
     wakeups_i = pwrmgr_pkg::WAKEUPS_DEFAULT;
     rstreqs_i = pwrmgr_pkg::RSTREQS_DEFAULT;
     sw_rst_req_i = prim_mubi_pkg::MuBi4False;

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr.core
@@ -12,6 +12,7 @@ filesets:
     depend:
       - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg:0.1
       - lowrisc:opentitan:top_earlgrey_pwrmgr_reg:0.1
+      - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:pwrmgr_component
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr.sv
@@ -56,7 +56,7 @@ module pwrmgr
   input  pwr_flash_t pwr_flash_i,
 
   // processor interface
-  input  pwr_cpu_t pwr_cpu_i,
+  input  rv_core_ibex_pkg::cpu_pwrmgr_t pwr_cpu_i,
   // SEC_CM: LC_CTRL.INTERSIG.MUBI
   output lc_ctrl_pkg::lc_tx_t fetch_en_o,
   input  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -145,11 +145,6 @@ package pwrmgr_pkg;
     flash_idle: 1'b1
   };
 
-  // processor to pwrmgr
-  typedef struct packed {
-    logic core_sleeping;
-  } pwr_cpu_t;
-
   // cpu reset requests and status
   typedef struct packed {
     logic ndmreset_req;
@@ -160,11 +155,6 @@ package pwrmgr_pkg;
   // default value for pwrmgr_ast_rsp_t (for dangling ports)
   parameter pwrmgr_cpu_t PWRMGR_CPU_DEFAULT = '{
     ndmreset_req: '0
-  };
-
-  // default value (for dangling ports)
-  parameter pwr_cpu_t PWR_CPU_DEFAULT = '{
-    core_sleeping: 1'b0
   };
 
   // default value (for dangling ports)

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -638,7 +638,7 @@ module top_earlgrey #(
   logic       rv_plic_irq;
   logic       rv_dm_debug_req;
   rv_core_ibex_pkg::cpu_crash_dump_t       rv_core_ibex_crash_dump;
-  pwrmgr_pkg::pwr_cpu_t       rv_core_ibex_pwrmgr;
+  rv_core_ibex_pkg::cpu_pwrmgr_t       rv_core_ibex_pwrmgr;
   spi_device_pkg::passthrough_req_t       spi_device_passthrough_req;
   spi_device_pkg::passthrough_rsp_t       spi_device_passthrough_rsp;
   logic       rv_dm_ndmreset_req;


### PR DESCRIPTION
Some IPs depend on the power manager package to define their IO interfaces, for example the rv_core_ibex or flash control. However, some tops do not have a power manager, and therefore also not the ipgen'ed power manager package. This causes a dependency error.

To solve that problem, we put out common type definitions to a common `pwrmgr_common_pkg`, which is not part of ipgen. Thus, also tops that don't have a pwrmgr, can reference these definitions.