### PR TITLE
[darjeeling] Regenerate Darjeeling after tooling changes

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -17205,6 +17205,7 @@
       lpg_idx: 11
     }
   ]
+  unmanaged_resets: {}
   exported_rsts: {}
   alert_lpgs:
   [
@@ -17226,6 +17227,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -17250,6 +17252,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: spi_device
@@ -17274,6 +17277,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: i2c0
@@ -17296,6 +17300,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_timers
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -17319,6 +17324,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_secure
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -17343,6 +17349,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: spi_host0
@@ -17369,6 +17376,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_powerup
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: por_io_div4
@@ -17395,6 +17403,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_powerup
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -17417,6 +17426,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_timers
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -17441,6 +17451,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_infra
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -17464,6 +17475,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_secure
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -17488,6 +17500,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_infra
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -17512,6 +17525,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_io_div4_infra
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc_io_div4
@@ -17536,6 +17550,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_infra
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: sys
@@ -17559,6 +17574,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_secure
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -17583,6 +17599,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_aes
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -17607,6 +17624,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_hmac
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -17631,6 +17649,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_kmac
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc
@@ -17655,6 +17674,7 @@
       }
       clock_connection: clkmgr_aon_clocks.clk_main_otbn
       unmanaged_clock: false
+      unmanaged_reset: false
       reset_connection:
       {
         name: lc

--- a/hw/top_darjeeling/templates/chiplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/chiplevel.sv.tpl
@@ -922,6 +922,7 @@ module chip_${top["name"]}_${target["name"]} #(
     .wdata_o     (sram_wdata),
     .wmask_o     (sram_wmask),
     .intg_error_o(),
+    .user_rsvd_o (),
     .rdata_i     (sram_rdata),
     .rvalid_i    (sram_rvalid),
     .rerror_i    ('0),


### PR DESCRIPTION
Some tooling changes on the generated files are not yet reflected such as external alerts on so on. Re-generate it as a separate PR to avoid having that diff on a new feature PR.