### PR TITLE
[kmac, sival] Add sival exec environment to kmac_app_rom_test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2309,6 +2309,8 @@ _KMAC_APP_ROM_LIST = [
     ("//sw/device/lib/testing/test_rom:test_rom_sim_verilator_hashfile", "sim_verilator"),
     ("//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_hashfile", "fpga_cw310_test_rom"),
     ("//sw/device/silicon_creator/rom:mask_rom_fpga_cw310_hashfile", "fpga_cw310_rom_with_fake_keys"),
+    ("//sw/device/silicon_creator/rom:mask_rom_fpga_cw310_hashfile", "fpga_cw310_sival"),
+    ("//sw/device/silicon_creator/rom:mask_rom_fpga_cw340_hashfile", "fpga_cw340_sival"),
     ("//sw/device/lib/testing/test_rom:test_rom_sim_dv_hashfile", "sim_dv"),
 ]
 


### PR DESCRIPTION
This commit adds the CW310 and CW340 SiVal execution environments to the kmac_app_rom_test.