### PR TITLE
[rom_ctrl,dv] Override timeouts more cleanly in rom_ctrl_base_vseq

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -25,7 +25,7 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
                           input bit [TL_AW-1:0]  addr,
                           input bit              write,
                           inout bit [TL_DW-1:0]  data,
-                          input uint             tl_access_timeout_ns = cfg.tl_access_timeout_ns,
+                          input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
                           input bit [TL_DBW-1:0] mask = '1,
                           input bit              check_rsp = 1'b1,
                           input bit              exp_err_rsp = 1'b0,
@@ -38,23 +38,23 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
                           input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone);
 
   extern virtual task tl_access_w_abort(
-                           input bit [TL_AW-1:0]  addr,
-                           input bit              write,
-                           inout bit [TL_DW-1:0]  data,
-                           output bit             completed,
-                           output bit             saw_err,
-                           input uint             tl_access_timeout_ns = cfg.tl_access_timeout_ns,
-                           input bit [TL_DBW-1:0] mask = '1,
-                           input bit              check_rsp = 1'b1,
-                           input bit              exp_err_rsp = 1'b0,
-                           input bit [TL_DW-1:0]  exp_data = 0,
-                           input bit [TL_DW-1:0]  compare_mask = '1,
-                           input bit              check_exp_data = 1'b0,
-                           input bit              blocking = csr_utils_pkg::default_csr_blocking,
-                           input mubi4_t          instr_type = MuBi4False,
-                           tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
-                           input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone,
-                           input int              req_abort_pct = 0);
+                          input bit [TL_AW-1:0]  addr,
+                          input bit              write,
+                          inout bit [TL_DW-1:0]  data,
+                          output bit             completed,
+                          output bit             saw_err,
+                          input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
+                          input bit [TL_DBW-1:0] mask = '1,
+                          input bit              check_rsp = 1'b1,
+                          input bit              exp_err_rsp = 1'b0,
+                          input bit [TL_DW-1:0]  exp_data = 0,
+                          input bit [TL_DW-1:0]  compare_mask = '1,
+                          input bit              check_exp_data = 1'b0,
+                          input bit              blocking = csr_utils_pkg::default_csr_blocking,
+                          input mubi4_t          instr_type = MuBi4False,
+                          tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
+                          input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone,
+                          input int              req_abort_pct = 0);
 
   extern function void set_kmac_digest(bit [DIGEST_SIZE-1:0] value);
   extern function void configure_kmac_digest(bit as_expected);
@@ -170,20 +170,24 @@ endfunction
 // The ROM takes a while to be read and otherwise some tests may timeout when using
 // default timeout.
 task rom_ctrl_base_vseq::tl_access(
-                              input bit [TL_AW-1:0]  addr,
-                              input bit              write,
-                              inout bit [TL_DW-1:0]  data,
-                              input uint             tl_access_timeout_ns,
-                              input bit [TL_DBW-1:0] mask = '1,
-                              input bit              check_rsp = 1'b1,
-                              input bit              exp_err_rsp = 1'b0,
-                              input bit [TL_DW-1:0]  exp_data = 0,
-                              input bit [TL_DW-1:0]  compare_mask = '1,
-                              input bit              check_exp_data = 1'b0,
-                              input bit              blocking,
-                              input mubi4_t          instr_type = MuBi4False,
-                              tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
-                              input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone);
+                          input bit [TL_AW-1:0]  addr,
+                          input bit              write,
+                          inout bit [TL_DW-1:0]  data,
+                          input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
+                          input bit [TL_DBW-1:0] mask = '1,
+                          input bit              check_rsp = 1'b1,
+                          input bit              exp_err_rsp = 1'b0,
+                          input bit [TL_DW-1:0]  exp_data = 0,
+                          input bit [TL_DW-1:0]  compare_mask = '1,
+                          input bit              check_exp_data = 1'b0,
+                          input bit              blocking,
+                          input mubi4_t          instr_type = MuBi4False,
+                          tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
+                          input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone);
+
+  if (tl_access_timeout_ns < cfg.tl_access_timeout_ns) begin
+    tl_access_timeout_ns = cfg.tl_access_timeout_ns;
+  end
 
   super.tl_access(.addr(addr), .write(write), .data(data),
                   .tl_access_timeout_ns(tl_access_timeout_ns),
@@ -198,24 +202,27 @@ endtask
 // The ROM takes a while to be read and otherwise some tests may timeout when using
 // default timeout.
 task rom_ctrl_base_vseq::tl_access_w_abort(
-                              input bit [TL_AW-1:0]  addr,
-                              input bit              write,
-                              inout bit [TL_DW-1:0]  data,
-                              output bit             completed,
-                              output bit             saw_err,
-                              input uint             tl_access_timeout_ns,
-                              input bit [TL_DBW-1:0] mask = '1,
-                              input bit              check_rsp = 1'b1,
-                              input bit              exp_err_rsp = 1'b0,
-                              input bit [TL_DW-1:0]  exp_data = 0,
-                              input bit [TL_DW-1:0]  compare_mask = '1,
-                              input bit              check_exp_data = 1'b0,
-                              input bit              blocking,
-                              input mubi4_t          instr_type = MuBi4False,
-                              tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
-                              input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone,
-                              input int              req_abort_pct = 0);
+                          input bit [TL_AW-1:0]  addr,
+                          input bit              write,
+                          inout bit [TL_DW-1:0]  data,
+                          output bit             completed,
+                          output bit             saw_err,
+                          input uint             tl_access_timeout_ns = default_spinwait_timeout_ns,
+                          input bit [TL_DBW-1:0] mask = '1,
+                          input bit              check_rsp = 1'b1,
+                          input bit              exp_err_rsp = 1'b0,
+                          input bit [TL_DW-1:0]  exp_data = 0,
+                          input bit [TL_DW-1:0]  compare_mask = '1,
+                          input bit              check_exp_data = 1'b0,
+                          input bit              blocking,
+                          input mubi4_t          instr_type = MuBi4False,
+                          tl_sequencer           tl_sequencer_h = p_sequencer.tl_sequencer_h,
+                          input tl_intg_err_e    tl_intg_err_type = TlIntgErrNone,
+                          input int              req_abort_pct = 0);
 
+  if (tl_access_timeout_ns < cfg.tl_access_timeout_ns) begin
+    tl_access_timeout_ns = cfg.tl_access_timeout_ns;
+  end
 
   super.tl_access_w_abort(.addr(addr), .write(write), .data(data), .completed(completed),
                           .saw_err(saw_err), .tl_access_timeout_ns(tl_access_timeout_ns),


### PR DESCRIPTION
This behaviour will work more predictably and will also avoid warnings from VCS. I think that warning is saying that the behaviour with the previous code will depend on what the compiler knows about the type of a vseq. We can do a bit better in a trivial way, so let's do that instead.

Without this change, the warnings look like:

```
  Warning-[MDVMO] Multiple default values in method override
  ../src/lowrisc_dv_rom_ctrl_env_0.1/seq_lib/rom_ctrl_base_vseq.sv, 126
  rom_ctrl_env_pkg, "rom_ctrl_env_pkg_rom_ctrl_base_vseq_11_0::tl_access"
    The class method argument 'tl_access_timeout_ns' has different default
    values specified at the base
    ("../src/lowrisc_dv_cip_lib_0/seq_lib/cip_base_vseq.sv", 178) and the
    current definition.
    VCS resolves default arguments of functions at compile time so the current
    one will be used regardless of virtual override.

  Warning-[MDVMO] Multiple default values in method override
  ../src/lowrisc_dv_rom_ctrl_env_0.1/seq_lib/rom_ctrl_base_vseq.sv, 156
  rom_ctrl_env_pkg, "rom_ctrl_env_pkg_rom_ctrl_base_vseq_11_0::tl_access_w_abort"
    The class method argument 'tl_access_timeout_ns' has different default
    values specified at the base
    ("../src/lowrisc_dv_cip_lib_0/seq_lib/cip_base_vseq.sv", 204) and the
    current definition.
    VCS resolves default arguments of functions at compile time so the current
    one will be used regardless of virtual override.
```

(@antmarzam: Does this match what you'd expect?)