### PR TITLE
[topgen] Use the number of alerts and not alert modules

### DIFF
--- a/util/topgen/templates/toplevel_pkg.sv.tpl
+++ b/util/topgen/templates/toplevel_pkg.sv.tpl
@@ -65,7 +65,7 @@ package top_${top["name"]}_pkg;
 % for alert_group, alert_modules in top["outgoing_alert_module"].items():
   
   // Number of ${alert_group} outgoing alerts
-  parameter int unsigned NOutgoingAlerts${alert_group.capitalize()} = ${len(alert_modules)};
+  parameter int unsigned NOutgoingAlerts${alert_group.capitalize()} = ${len(top['outgoing_alert'][alert_group])};
 
   // Number of LPGs for outgoing alert group ${alert_group}
   parameter int unsigned NOutgoingLpgs${alert_group.capitalize()} = ${len(top["outgoing_alert_lpgs"][alert_group])};


### PR DESCRIPTION
Previously, the number of alert modules was used to determine the number of outgoing alerts. That's wrong. If a device has more than one alert, the number of alert modules and the actual number of alerts diverge.

This PR fixes that and uses the correct number.