### PR TITLE
[top] Enable Darjeeling in the hw Makefile

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -46,7 +46,7 @@ IPS ?= aes           \
        uart          \
        usbdev
 
-TOPS ?= top_earlgrey
+TOPS ?= top_darjeeling top_earlgrey
 
 USE_BUFFER ?= 0
 

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -8387,6 +8387,8 @@
         DmHaltAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]
         DmExceptionAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]
         PipeLine: "0"
+        NEscalationSeverities: alert_handler_reg_pkg::N_ESC_SEV
+        WidthPingCounter: alert_handler_reg_pkg::PING_CNT_DW
       }
       clock_srcs:
       {
@@ -8485,7 +8487,7 @@
           name: NEscalationSeverities
           desc: Number of escalation severities
           type: int unsigned
-          default: "4"
+          default: alert_handler_reg_pkg::N_ESC_SEV
           local: "true"
           expose: "true"
           name_top: RvCoreIbexNEscalationSeverities
@@ -8494,7 +8496,7 @@
           name: WidthPingCounter
           desc: Width of the ping counter
           type: int unsigned
-          default: "16"
+          default: alert_handler_reg_pkg::PING_CNT_DW
           local: "true"
           expose: "true"
           name_top: RvCoreIbexWidthPingCounter

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -985,7 +985,7 @@
                    SecureIbex: "1",
                    DmHaltAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]",
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]",
-                   PipeLine: "0"
+                   PipeLine: "0",
                    NEscalationSeverities: "alert_handler_reg_pkg::N_ESC_SEV",
                    WidthPingCounter: "alert_handler_reg_pkg::PING_CNT_DW"
                   },

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -277,8 +277,8 @@ module top_darjeeling #(
   // local parameters for lc_ctrl
   localparam int LcCtrlNumRmaAckSigs = 1;
   // local parameters for rv_core_ibex
-  localparam int unsigned RvCoreIbexNEscalationSeverities = 4;
-  localparam int unsigned RvCoreIbexWidthPingCounter = 16;
+  localparam int unsigned RvCoreIbexNEscalationSeverities = alert_handler_reg_pkg::N_ESC_SEV;
+  localparam int unsigned RvCoreIbexWidthPingCounter = alert_handler_reg_pkg::PING_CNT_DW;
 
   // Signals
   logic [3:0] mio_p2d;


### PR DESCRIPTION
Because the Darjeeling target would modify some auto-generated tests, that are not yet in multitop-sw, the Makefile target must be placeed before Earlgrey, which writes back the correct tests