### PR TITLE
[manuf] Revert CP flow to use UART console rather than SPI

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_cp_provision.c
+++ b/sw/device/silicon_creator/manuf/base/sram_cp_provision.c
@@ -28,9 +28,7 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otp_ctrl_regs.h"  // Generated.
 
-OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
-                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
-                        .console.test_may_clobber = false, );
+OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
 
 static dif_otp_ctrl_t otp_ctrl;
 static dif_pinmux_t pinmux;

--- a/sw/host/provisioning/cp/src/main.rs
+++ b/sw/host/provisioning/cp/src/main.rs
@@ -9,7 +9,6 @@ use clap::Parser;
 use zerocopy::AsBytes;
 
 use cp_lib::{reset_and_lock, run_sram_cp_provision, CpResponse, ManufCpProvisioningDataInput};
-use opentitanlib::console::spi::SpiConsoleDevice;
 use opentitanlib::dif::lc_ctrl::DifLcCtrlState;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::lc::read_lc_state;
@@ -31,18 +30,12 @@ struct Opts {
     /// Console receive timeout.
     #[arg(long, value_parser = humantime::parse_duration, default_value = "600s")]
     timeout: Duration,
-
-    /// Name of the SPI interface to connect to the OTTF console.
-    #[arg(long, default_value = "BOOTSTRAP")]
-    console_spi: String,
 }
 
 fn main() -> Result<()> {
     let opts = Opts::parse();
     opts.init.init_logging();
     let transport = opts.init.init_target()?;
-    let spi = transport.spi(&opts.console_spi)?;
-    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
 
     let provisioning_data = ManufCpProvisioningData {
         wafer_auth_secret: hex_string_to_u32_arrayvec::<8>(
@@ -83,7 +76,6 @@ fn main() -> Result<()> {
                 opts.init.bootstrap.options.reset_delay,
                 &opts.sram_program,
                 &provisioning_data,
-                &spi_console_device,
                 &mut response,
                 opts.timeout,
             )?;

--- a/sw/host/provisioning/cp_lib/src/lib.rs
+++ b/sw/host/provisioning/cp_lib/src/lib.rs
@@ -9,7 +9,6 @@ use clap::Args;
 use serde::Serialize;
 
 use opentitanlib::app::TransportWrapper;
-use opentitanlib::console::spi::SpiConsoleDevice;
 use opentitanlib::dif::lc_ctrl::{DifLcCtrlState, DifLcCtrlToken, LcCtrlReg};
 use opentitanlib::io::jtag::{JtagParams, JtagTap};
 use opentitanlib::test_utils::lc_transition::trigger_lc_transition;
@@ -100,7 +99,6 @@ pub fn run_sram_cp_provision(
     reset_delay: Duration,
     sram_program: &SramProgramParams,
     data_in: &ManufCpProvisioningData,
-    spi_console: &SpiConsoleDevice,
     response: &mut CpResponse,
     timeout: Duration,
 ) -> Result<()> {
@@ -112,6 +110,8 @@ pub fn run_sram_cp_provision(
     // Reset and halt the CPU to ensure we are in a known state, and clear out any ROM messages
     // printed over the console.
     jtag.reset(/*run=*/ false)?;
+    let uart = transport.uart("console")?;
+    uart.clear_rx_buffer()?;
 
     // Load and execute the SRAM program that contains the provisioning code.
     let result = sram_program.load_and_execute(&mut *jtag, ExecutionMode::Jump)?;
@@ -120,28 +120,24 @@ pub fn run_sram_cp_provision(
         _ => panic!("SRAM program load/execution failed: {:?}.", result),
     }
 
-    // Wait for test to start running.
-    let _ = UartConsole::wait_for(
-        spi_console,
-        r"Waiting for CP provisioning data ...",
-        timeout,
-    )?;
+    // Get UART, set flow control, and wait for test to start running.
+    uart.set_flow_control(true)?;
+    let _ = UartConsole::wait_for(&*uart, r"Waiting for CP provisioning data ...", timeout)?;
 
     // Inject provisioning data into the device.
-    data_in.send(spi_console)?;
+    data_in.send(&*uart)?;
 
     // Wait to receive CP device ID, and encode in big-endian in response.
-    let _ = UartConsole::wait_for(spi_console, r"Exporting CP device ID ...", timeout)?;
-    response.cp_device_id = ManufCpProvisioningDataOut::recv(spi_console, timeout, true)?
+    let _ = UartConsole::wait_for(&*uart, r"Exporting CP device ID ...", timeout)?;
+    response.cp_device_id = ManufCpProvisioningDataOut::recv(&*uart, timeout, true)?
         .cp_device_id
         .iter()
         .rev()
         .map(|v| format!("{v:08X}"))
         .collect::<Vec<String>>()
         .join("");
-
     // Wait for provisioning operations to complete.
-    let _ = UartConsole::wait_for(spi_console, r"CP provisioning done.", timeout)?;
+    let _ = UartConsole::wait_for(&*uart, r"CP provisioning done.", timeout)?;
 
     jtag.disconnect()?;
     transport.pin_strapping("PINMUX_TAP_RISCV")?.remove()?;


### PR DESCRIPTION
This is a partial revert of commit
63c6b630dc57c9da5f9946a9669ba0bc42213d11.

cc @milesdai @timothytrippel @benjbender