### PR TITLE
[bazel] Add `rules_rust` `extra_rustc_toolchain_dirs` patch

### DIFF
--- a/third_party/rust/patches/rules_rust.extra_rustc_toolchain_dirs.patch
+++ b/third_party/rust/patches/rules_rust.extra_rustc_toolchain_dirs.patch
@@ -1,0 +1,129 @@
+commit 7723e38b176e6ce5b46e04c13f479cb801aeec6c
+Author: Tim Trippel <ttrippel@google.com>
+Date:   Wed Sep 13 09:56:21 2023 -0700
+
+    Add build setting to enable specifying other tool locations
+    
+    On some systems, the CC toolchain discovered by bazel uses a different
+    path for the linker than where the linker (that is specified by the
+    `-fuse-ld=` flag) actually lives on the system.
+    
+    The issue stems from rules_rust deciding to pass `-fuse-ld=lld` a link arg,
+    rather than just using what was detected by the CC toolchain. This results
+    in the linker not being found, as reported by
+    https://github.com/lowRISC/opentitan/issues/12448
+    
+    This is a workaround that enables telling rules_rust where other linker
+    directories might be on your system. It is used by passing
+    `--@rules_rust//:extra_rustc_toolchain_dirs=/path/to/somewhere/else` to
+    `bazel ...` invocations.
+    
+    Signed-off-by: Tim Trippel <ttrippel@google.com>
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -10,6 +10,7 @@ load(
+     "extra_exec_rustc_flags",
+     "extra_rustc_flag",
+     "extra_rustc_flags",
++    "extra_rustc_toolchain_dirs",
+     "no_std",
+     "per_crate_rustc_flag",
+     "rustc_output_diagnostics",
+@@ -94,6 +95,15 @@ per_crate_rustc_flag(
+     visibility = ["//visibility:public"],
+ )
+ 
++# This setting is to enable passing additional `-B` options to the CC toolchain driver binary to
++# aid in locating toolchain directories on systems where not all toolchain tools are installed in
++# the same system location.
++extra_rustc_toolchain_dirs(
++    name = "extra_rustc_toolchain_dirs",
++    build_setting_default = "",
++    visibility = ["//visibility:public"],
++)
++
+ # This setting is used by the clippy rules. See https://bazelbuild.github.io/rules_rust/rust_clippy.html
+ label_flag(
+     name = "clippy.toml",
+diff --git a/rust/defs.bzl b/rust/defs.bzl
+--- rust/defs.bzl
++++ rust/defs.bzl
+@@ -49,6 +49,7 @@ load(
+     _extra_exec_rustc_flags = "extra_exec_rustc_flags",
+     _extra_rustc_flag = "extra_rustc_flag",
+     _extra_rustc_flags = "extra_rustc_flags",
++    _extra_rustc_toolchain_dirs = "extra_rustc_toolchain_dirs",
+     _no_std = "no_std",
+     _per_crate_rustc_flag = "per_crate_rustc_flag",
+     _rustc_output_diagnostics = "rustc_output_diagnostics",
+@@ -133,6 +134,9 @@ extra_rustc_flag = _extra_rustc_flag
+ extra_rustc_flags = _extra_rustc_flags
+ # See @rules_rust//rust/private:rustc.bzl for a complete description.
+ 
++extra_rustc_toolchain_dirs = _extra_rustc_toolchain_dirs
++# See @rules_rust//rust/private:rustc.bzl for a complete description.
++
+ extra_exec_rustc_flag = _extra_exec_rustc_flag
+ # See @rules_rust//rust/private:rustc.bzl for a complete description.
+ 
+diff --git a/rust/private/rust.bzl b/rust/private/rust.bzl
+--- rust/private/rust.bzl
++++ rust/private/rust.bzl
+@@ -527,6 +527,9 @@ RUSTC_ATTRS = {
+     "_extra_rustc_flags": attr.label(
+         default = Label("//:extra_rustc_flags"),
+     ),
++    "_extra_rustc_toolchain_dirs": attr.label(
++        default = Label("//:extra_rustc_toolchain_dirs"),
++    ),
+     "_is_proc_macro_dep": attr.label(
+         default = Label("//rust/private:is_proc_macro_dep"),
+     ),
+diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
+--- rust/private/rustc.bzl
++++ rust/private/rustc.bzl
+@@ -78,6 +78,11 @@ PerCrateRustcFlagsInfo = provider(
+     fields = {"per_crate_rustc_flags": "List[string] Extra flags to pass to rustc in non-exec configuration"},
+ )
+ 
++ExtraRustcToolchainDirsInfo = provider(
++    doc = "Pass each value as an additional `-B` flag to rustc invocations. Enables use of linkers placed in different directories on the system.",
++    fields = {"extra_rustc_toolchain_dirs": "List[string] Extra `-B` flags to pass to rustc."},
++)
++
+ IsProcMacroDepInfo = provider(
+     doc = "Records if this is a transitive dependency of a proc-macro.",
+     fields = {"is_proc_macro_dep": "Boolean"},
+@@ -455,6 +460,10 @@ def get_linker_and_args(ctx, attr, crate_type, cc_toolchain, feature_configurati
+         action_name = action_name,
+         variables = link_variables,
+     )
++
++    # Make sure linker is locateable.
++    if hasattr(ctx.attr, "_extra_rustc_toolchain_dirs"):
++        link_args = link_args + ctx.attr._extra_rustc_toolchain_dirs[ExtraRustcToolchainDirsInfo].extra_rustc_toolchain_dirs
+     link_env = cc_common.get_environment_variables(
+         feature_configuration = feature_configuration,
+         action_name = action_name,
+@@ -2242,6 +2251,19 @@ per_crate_rustc_flag = rule(
+     build_setting = config.string(flag = True, allow_multiple = True),
+ )
+ 
++def _extra_rustc_toolchain_dirs_impl(ctx):
++    return ExtraRustcToolchainDirsInfo(extra_rustc_toolchain_dirs = ["-B" + f for f in ctx.build_setting_value if f != ""])
++
++extra_rustc_toolchain_dirs = rule(
++    doc = (
++        "Add additional `-B` rustc toolchain flags to specificy where CC toolchain executables are located on the system by" +
++        "using the command line switch `--@rules_rust//:extra_rustc_toolchain_dirs`. " +
++        "Multiple uses are accumulated."
++    ),
++    implementation = _extra_rustc_toolchain_dirs_impl,
++    build_setting = config.string(flag = True, allow_multiple = True),
++)
++
+ def _no_std_impl(ctx):
+     value = str(ctx.attr._no_std[BuildSettingInfo].value)
+     if is_exec_configuration(ctx):

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -97,7 +97,10 @@ def rust_repos(rules_rust = None, serde_annotate = None):
         local = rules_rust,
         integrity = "sha256-3QBrdyIdWeTRQSB8DnrfEbH7YNFEC4/KA7+SVheTKmA=",
         urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.49.3/rules_rust-v0.49.3.tar.gz"],
-        patches = ["//third_party/rust/patches:rules_rust.bindgen_static_lib.patch"],
+        patches = [
+            "//third_party/rust/patches:rules_rust.bindgen_static_lib.patch",
+            "//third_party/rust/patches:rules_rust.extra_rustc_toolchain_dirs.patch",
+        ],
     )
 
     http_archive_or_local(


### PR DESCRIPTION
From the original commit:

Add build setting to enable specifying other tool locations

On some systems, the CC toolchain discovered by bazel uses a different path for the linker than where the linker (that is specified by the `-fuse-ld=` flag) actually lives on the system.

The issue stems from rules_rust deciding to pass `-fuse-ld=lld` a link arg, rather than just using what was detected by the CC toolchain. This results in the linker not being found, as reported by
https://github.com/lowRISC/opentitan/issues/12448

This is a workaround that enables telling rules_rust where other linker directories might be on your system. It is used by passing `--@rules_rust//:extra_rustc_toolchain_dirs=/path/to/somewhere/else` to `bazel ...` invocations.