### PR TITLE
[rom_ctrl, rtl] Outstanding request fix

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -154,8 +154,8 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
     // their counters. This avoids a problem where we generate a spurious request when the FIFO was
     // actually empty and lots of signals in the design become X. This will let the fifos error
     // signal stuck at X. Zeroing the backing memory avoids that problem.
-    splat_fifo_storage("tb.dut.u_tl_adapter_rom.u_reqfifo", 2);
-    splat_fifo_storage("tb.dut.u_tl_adapter_rom.u_sramreqfifo", 2);
+    splat_fifo_storage("tb.dut.u_tl_adapter_rom.u_reqfifo", 1);
+    splat_fifo_storage("tb.dut.u_tl_adapter_rom.u_sramreqfifo", 1);
 
   endtask
 

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -175,7 +175,7 @@ module rom_ctrl
   tlul_adapter_sram #(
     .SramAw(RomIndexWidth),
     .SramDw(32),
-    .Outstanding(2),
+    .Outstanding(1),
     .ByteAccess(0),
     .ErrOnWrite(1),
     .CmdIntgCheck(1),


### PR DESCRIPTION
** Fixed the outstanding parameter to 1 in rom_ctrl as only one request
   is accepted by rom_ctrl SRAM.

** Fixed the depth of the fifos from 2 to 1 in rom_ctrl_common_vseq due
   to the reason above.