### PR TITLE
[signing] Implement owner-stage signing

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -433,8 +433,11 @@ silicon(
         "--interface={interface}",
     ],
     design = "earlgrey",
-    # TODO(moidx): Switch to real keys once these have been generated.
-    ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+    ecdsa_key = select({
+        "//signing:test_keys": {"//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_ecdsa": "prod_key_0"},
+        # We choose key zero in the appkey's keyset, which should be app-key-prod-0.
+        "//conditions:default": {"//signing:appkey": "0"},
+    }),
     exec_env = "silicon_owner_sival_rom_ext",
     extract_sw_logs = "//util/device_sw_utils:extract_sw_logs_db",
     flash_scramble_tool = "//util/design:gen-flash-img",
@@ -452,10 +455,9 @@ silicon(
     },
     # The //conditions:default ROM_EXT needs to be updated to use the following
     # target once available:
-    # //sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_prod_slot_a
     rom_ext = select({
         "//signing:test_keys": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_dice_x509_fake_slot_a",
-        "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_dice_x509_fake_slot_a",
+        "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_dice_x509_prod",
     }),
     test_cmd = """
         --exec="transport init"

--- a/rules/signing.bzl
+++ b/rules/signing.bzl
@@ -52,6 +52,11 @@ def key_from_dict(key, attr_name):
         ksi = key[KeySetInfo]
         if ksi.selected_key:
             name = ksi.selected_key
+        elif name.isdigit():
+            # If the nickname is a number, we assume it is the index of the key in
+            # the dictionary.
+            name = int(name)
+            name = ksi.keys.keys()[name]
         return struct(
             label = key,
             file = ksi.keys[name],

--- a/signing/BUILD
+++ b/signing/BUILD
@@ -11,6 +11,14 @@ label_flag(
     build_setting_default = "//signing/tokens:local",
 )
 
+# The appkey selects the keyset used for signing application (post-ROM_EXT)
+# code.  This should match the keys that are in the ownershp configuration
+# deployed into the chip.
+label_flag(
+    name = "appkey",
+    build_setting_default = "//sw/device/silicon_creator/rom_ext/sival/keys:keyset",
+)
+
 config_setting(
     name = "test_keys",
     flag_values = {


### PR DESCRIPTION
Implement signing of owner-stage payloads with owner keys.  By default, we select key zero in the owner's keyset.  The default owner's keyset is the SiVAL owner's keyset.  Both the owner
keyset and the selected key can be chosen with commandline parameters:

```
bazel build //sw/device/tests:aes_smoketest_silicon_owner_sival_rom_ext \
    --//signing:token=//signing/tokens:<owner_token> \
    --//signing:appkey=//sw/device/silicon_creator/rom_ext/sival/keys:keyset \
    --//sw/device/silicon_creator/rom_ext/sival/keys:keyset=sv00-app-key-prod-0
```
