### PR TITLE
[manuf,ci] Add an E2E test of the provisioning orchestrator

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -30,6 +30,7 @@ libftdi1-dev
 libncursesw5
 libpcsclite-dev
 libssl-dev
+libtool
 libudev-dev
 libusb-1.0-0
 lld

--- a/sw/host/provisioning/orchestrator/tests/BUILD
+++ b/sw/host/provisioning/orchestrator/tests/BUILD
@@ -4,6 +4,7 @@
 
 load("@ot_python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
+load("//sw/host/provisioning/orchestrator/tests:transition.bzl", "orchestrator_test_settings_transition")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -30,4 +31,30 @@ py_test(
         "//sw/host/provisioning/orchestrator/src:sku_config",
         "//sw/host/provisioning/orchestrator/src:util",
     ],
+)
+
+# This transition has the same effect as supplying the following flags to bazel test:
+#  --//hw/bitstream/universal:env=//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys
+#  --//hw/bitstream/universal:otp=//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_test_unlocked0_manuf_empty
+orchestrator_test_settings_transition(
+    name = "orchestrator_zip",
+    testonly = True,
+    target = "//sw/host/provisioning/orchestrator/src:orchestrator.zip",
+)
+
+sh_test(
+    name = "e2e_test",
+    srcs = ["e2e.sh"],
+    data = [
+        ":orchestrator_zip",
+        "@rules_python//python:current_py_toolchain",
+    ],
+    env = {
+        "PYTHON": "$(PYTHON3)",
+    },
+    tags = [
+        "hyper310",
+        "manuf",
+    ],
+    toolchains = ["@rules_python//python:current_py_toolchain"],
 )

--- a/sw/host/provisioning/orchestrator/tests/e2e.sh
+++ b/sw/host/provisioning/orchestrator/tests/e2e.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+cp sw/host/provisioning/orchestrator/src/orchestrator.zip $TEST_TMPDIR
+
+ORCHESTRATOR_PATH=$TEST_TMPDIR/orchestrator.zip
+
+unzip $ORCHESTRATOR_PATH \
+  "runfiles/lowrisc_opentitan/*" \
+  "runfiles/openocd/*" \
+  -d $TEST_TMPDIR
+  # TODO: uncomment this line when we add the extensions in
+  # "runfiles/provisioning_exts/*" \
+
+mkdir -p $TEST_TMPDIR/runfiles/lowrisc_opentitan/external
+cp -r $TEST_TMPDIR/runfiles/openocd/ $TEST_TMPDIR/runfiles/lowrisc_opentitan/external/
+
+PROVISIONING_EXT_RUNFILES=$TEST_TMPDIR/runfiles/provisioning_exts
+[ -d "${PROVISION_EXT_RUNFILES}" ] && \
+  ln -fs "${PROVISIONING_EXT_RUNFILES}" \
+    $TEST_TMPDIR/runfiles/lowrisc_opentitan/external/provisioning_exts
+
+# Run tool. The path to the --sku-config parameter is relative to the
+# runfiles-dir.
+$PYTHON ${ORCHESTRATOR_PATH} \
+  --sku-config=sw/host/provisioning/orchestrator/configs/skus/emulation.hjson \
+  --test-unlock-token="0x11111111_11111111_11111111_11111111" \
+  --test-exit-token="0x22222222_22222222_22222222_22222222" \
+  --fpga=hyper310 \
+  --non-interactive \
+  --runfiles-dir=$TEST_TMPDIR/runfiles/lowrisc_opentitan \
+  --db-path=$TEST_TMPDIR/registry.sqlite

--- a/sw/host/provisioning/orchestrator/tests/transition.bzl
+++ b/sw/host/provisioning/orchestrator/tests/transition.bzl
@@ -1,0 +1,38 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+def _orchestrator_settings_impl(settings, attr):
+    return {
+        "//hw/bitstream/universal:otp": "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_test_unlocked0_manuf_empty",
+        "//hw/bitstream/universal:env": "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys",
+    }
+
+_orchestrator_settings = transition(
+    implementation = _orchestrator_settings_impl,
+    inputs = [],
+    outputs = [
+        "//hw/bitstream/universal:otp",
+        "//hw/bitstream/universal:env",
+    ],
+)
+
+def _orchestrator_test_settings_transition_impl(ctx):
+    info = ctx.attr.target[DefaultInfo]
+    return [
+        DefaultInfo(
+            files = info.files,
+            data_runfiles = info.data_runfiles,
+        ),
+    ]
+
+orchestrator_test_settings_transition = rule(
+    implementation = _orchestrator_test_settings_transition_impl,
+    cfg = _orchestrator_settings,
+    attrs = {
+        "target": attr.label(),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
The orchestrator.py script is intended to be deployed and run as a zip file in an offline environment. This CI check performs and e2e test that the zip file executes correctly.