### PR TITLE
[manuf] Clean up device ID confirmation message

### DIFF
--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -5,6 +5,7 @@
 
 import struct
 from dataclasses import dataclass
+from typing import Optional
 
 import util
 from sku_config import SkuConfig
@@ -92,7 +93,8 @@ class DeviceId():
         sku_id: A 32-bit string indicating the SKU the chip was provisioned for.
     """
 
-    def __init__(self, sku_config: SkuConfig, din: DeviceIdentificationNumber):
+    def __init__(self, sku_config: SkuConfig,
+                 din: Optional[DeviceIdentificationNumber]):
         # Save string keys for easier printing.
         self._product = sku_config.product
         self._si_creator = sku_config.si_creator
@@ -116,9 +118,13 @@ class DeviceId():
         # - Wafer Y coord.
         self.din = din
 
+        din_as_int = 0
+        if self.din is not None:
+            din_as_int = self.din.to_int()
+
         # Build base unique ID.
         self._base_uid = util.bytes_to_int(
-            struct.pack("<IQI", self._hw_origin, self.din.to_int(), 0))
+            struct.pack("<IQI", self._hw_origin, din_as_int, 0))
 
         # Build SKU specific field.
         self.package_id = sku_config.package_id
@@ -204,12 +210,15 @@ class DeviceId():
             util.format_hex(self.si_creator_id, width=4), self._si_creator))
         print("Product ID:        {} ({})".format(
             util.format_hex(self.product_id, width=4), self._product))
-        print("DIN Year:          {}".format(self.din.year))
-        print("DIN Week:          {}".format(self.din.week))
-        print("DIN Lot:           {}".format(self.din.lot))
-        print("DIN Wafer:         {}".format(self.din.wafer))
-        print("DIN Wafer X Coord: {}".format(self.din.wafer_x_coord))
-        print("DIN Wafer Y Coord: {}".format(self.din.wafer_y_coord))
+        if self.din is not None:
+            print("DIN Year:          {}".format(self.din.year))
+            print("DIN Week:          {}".format(self.din.week))
+            print("DIN Lot:           {}".format(self.din.lot))
+            print("DIN Wafer:         {}".format(self.din.wafer))
+            print("DIN Wafer X Coord: {}".format(self.din.wafer_x_coord))
+            print("DIN Wafer Y Coord: {}".format(self.din.wafer_y_coord))
+        else:
+            print("DIN:               <unset>")
         print("Reserved:          {}".format(hex(0)))
         print("SKU ID:            {} ({})".format(
             util.format_hex(self.sku_id),

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import hjson
 
 import db
-from device_id import DeviceId, DeviceIdentificationNumber
+from device_id import DeviceId
 from ot_dut import OtDut
 from sku_config import SkuConfig
 from util import confirm, parse_hexstring_to_int
@@ -140,16 +140,9 @@ def main(args_in):
         sku_config_args = hjson.load(fp)
     sku_config = SkuConfig(**sku_config_args)
 
-    # Create a (unique) device identification number and device ID.
-    # TODO: update this by extracting data from the device during CP.
-    din = DeviceIdentificationNumber(
-        year=0,
-        week=0,
-        lot=0,
-        wafer=0,
-        wafer_x_coord=0,
-        wafer_y_coord=0,
-    )
+    # The device identification number is determined during CP by extracting data
+    # from the device.
+    din = None
     device_id = DeviceId(sku_config, din)
 
     # TODO: Setup remote and/or local DV connections.

--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -163,18 +163,19 @@ def main(args_in):
                 fpga=args.fpga,
                 require_confirmation=not args.non_interactive)
     dut.run_cp()
-    if not args.cp_only:
-        dut.run_ft()
-
-        db_path = Path(args.db_path)
-        db_handle = db.DB(db.DBConfig(db_path=db_path))
-        db.DeviceRecord.create_table(db_handle)
-
-        device_record = db.DeviceRecord.from_dut(dut)
-        device_record.upsert(db_handle)
-        logging.info(f"Added DeviceRecord to database: {device_record}")
-    else:
+    if args.cp_only:
         logging.info("FT skipped since --cp-only was provided")
+        return
+
+    dut.run_ft()
+
+    db_path = Path(args.db_path)
+    db_handle = db.DB(db.DBConfig(db_path=db_path))
+    db.DeviceRecord.create_table(db_handle)
+
+    device_record = db.DeviceRecord.from_dut(dut)
+    device_record.upsert(db_handle)
+    logging.info(f"Added DeviceRecord to database: {device_record}")
 
 
 if __name__ == "__main__":

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -148,7 +148,7 @@ class OtDut():
             chip_probe_data = self._extract_json_data("CHIP_PROBE_DATA",
                                                       stdout_logfile)
             if "cp_device_id" not in chip_probe_data:
-                logging.error("cp_device_id found in CHIP_PROBE_DATA.")
+                logging.error("cp_device_id not found in CHIP_PROBE_DATA.")
                 confirm()
 
             logging.info(
@@ -156,6 +156,7 @@ class OtDut():
             cp_device_id = self.device_id.from_hexstr(
                 chip_probe_data["cp_device_id"])
             self.device_id.update_base_id(cp_device_id)
+            self.device_id.pretty_print()
 
             self._make_log_dir()
             shutil.move(stdout_logfile, f"{self.log_dir}/cp_out.log.txt")


### PR DESCRIPTION
This PR tweaks the DIN handling in the device ID to create a `None` default and makes the CP confirmation message clearer. I also tossed in a few other small fixes/cleanups while I was in there. 

@timothytrippel LMK if this looks like what you had in mind!