### PR TITLE
[aes,dv] Add a cast for the byte type return of getc() function to string variable assignment

### DIFF
--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -503,7 +503,7 @@ class aes_base_vseq extends cip_base_vseq #(
 
   // the index of multi-reg is at the last char of the name
   virtual function int get_multireg_idx(string name);
-    string s = name.getc(name.len - 1);
+    string s = string'(name.getc(name.len - 1));
     return s.atoi();
   endfunction
 


### PR DESCRIPTION
From SV LRM:

```
6.16.3 Getc()
function byte getc(int i);
— str.getc(i) returns the ASCII code of the ith character in str.
— If i < 0 or i >= str.len(), then str.getc(i) returns 0.
```
Thus the type cast should be used to assign it to string variable.