### PR TITLE
[dv/dpi] add an active port to jtagdpi

### DIFF
--- a/hw/dv/dpi/jtagdpi/jtagdpi.c
+++ b/hw/dv/dpi/jtagdpi/jtagdpi.c
@@ -176,14 +176,12 @@ void jtagdpi_close(void *ctx_void) {
 void jtagdpi_tick(void *ctx_void, svBit *tck, svBit *tms, svBit *tdi,
                   svBit *trst_n, svBit *srst_n, const svBit tdo) {
   struct jtagdpi_ctx *ctx = (struct jtagdpi_ctx *)ctx_void;
-
-  ctx->tdo = tdo;
-
-  // TODO: Evaluate moving this functionality into a separate thread
-  if (ctx) {
-    update_jtag_signals(ctx);
+  if (!ctx) {
+    return;
   }
 
+  ctx->tdo = tdo;
+  update_jtag_signals(ctx);
   *tdi = ctx->tdi;
   *tms = ctx->tms;
   *tck = ctx->tck;

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
@@ -118,6 +118,7 @@ module chip_sim_tb (
   // jtagdpi u_jtagdpi (
   //   .clk_i,
   //   .rst_ni,
+  //   .active      (1'b1),
 
   //   .jtag_tck    (cio_jtag_tck),
   //   .jtag_tms    (cio_jtag_tms),

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -275,6 +275,7 @@ module chip_englishbreakfast_verilator (
   // jtagdpi u_jtagdpi (
   //   .clk_i,
   //   .rst_ni,
+  //   .active      (1'b1),
 
   //   .jtag_tck    (cio_jtag_tck),
   //   .jtag_tms    (cio_jtag_tms),


### PR DESCRIPTION
To avoid starting up a server when not needed, and spending time making the jtagdpi_tick call unnecessarily, an "active" input port is added. This is similar to what's done in gpiodpi already.