### PR TITLE
[provisioning] add sc-hsm-embedded PKCS11 .so as orchestrator dep

### DIFF
--- a/sw/host/provisioning/orchestrator/README.md
+++ b/sw/host/provisioning/orchestrator/README.md
@@ -63,7 +63,8 @@ export ORCHESTRATOR_ZIP="${ORCHESTRATOR_RUN_DIR}/orchestrator.zip"
 unzip ${ORCHESTRATOR_ZIP} \
   "runfiles/lowrisc_opentitan/*" \
   "runfiles/openocd/*" \
-  "runfiles/provisioning_exts/*"
+  "runfiles/provisioning_exts/*" \
+  "runfiles/sc_hsm/*"
 
 # All external dependencies are mapped under
 # runfiles/lowrisc_opentitan/external.

--- a/sw/host/provisioning/orchestrator/src/BUILD
+++ b/sw/host/provisioning/orchestrator/src/BUILD
@@ -84,6 +84,7 @@ filegroup(
         "//third_party/openocd:jtag_cmsis_dap_adapter_cfg",
         "//third_party/openocd:jtag_olimex_cfg",
         "//third_party/openocd:openocd_bin",
+        "@sc_hsm",
     ],
 )
 


### PR DESCRIPTION
This adds the sc-hsm-embedded PKCS11 shared object, thas is built in this repo to support Nitrokey signing flows, as a dep to the orchestrator ZIP so it can be used in offline provisioning environments.