### PR TITLE
[manuf] Fix missing test tags for FT FPGA tests

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -417,7 +417,7 @@ filegroup(
             tags = [
                 "lc_test_locked0",
                 "manuf",
-            ] + ["manual"] if config.get("offline", False) else [],
+            ] + (["manual"] if config.get("offline", False) else []),
             test_cmd = _FT_PROVISIONING_CMD_ARGS,
             test_harness = _FT_PROVISIONING_HARNESS.format(sku),
         ),


### PR DESCRIPTION
Commit fd9ba9d261e23647cca2285248014526dab8f4b1 dropped some test coverage, since the conditional unintentionally removes the default test tags if it evaluates to False.

This commit fixes the issue and should fix the "Verify FPGA jobs" CI workflow.