### PR TITLE
[hmac, rtl] Resolve lint warnings and TODOs for the V3 signoff

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -550,7 +550,7 @@ module hmac
       end else if ((digest_size == SHA2_384) || (digest_size == SHA2_512)) begin
         // reads out first upper 32 bits then lower 32 bits of each digest word
         index = !hmac_fifo_wdata_sel[0];
-        fifo_wdata = '{data: digest[hmac_fifo_wdata_sel >> 1][32*index+:32], mask: '1};
+        fifo_wdata = '{data: digest[hmac_fifo_wdata_sel[3:1]][32*index+:32], mask: '1};
       end
     end
   end

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -172,7 +172,6 @@ module hmac
         if (digest_on_blk) begin
           // Once the digest is being computed for the complete message block, wait for the hash to
           // complete.
-          // TODO (issue #21710): handle incomplete message size and check against 512 or 1024
           done_state_d = DoneAwaitHashComplete;
         end
       end

--- a/hw/ip/hmac/rtl/hmac_core.sv
+++ b/hw/ip/hmac/rtl/hmac_core.sv
@@ -293,9 +293,9 @@ module hmac_core import prim_sha2_pkg::*; (
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      fifo_wdata_sel_o <= 3'h 0;
+      fifo_wdata_sel_o <= '0;
     end else if (clr_fifo_wdata_sel) begin
-      fifo_wdata_sel_o <= 3'h 0;
+      fifo_wdata_sel_o <= '0;
     end else if (fifo_wsel_o && fifo_wvalid_o) begin
       fifo_wdata_sel_o <= fifo_wdata_sel_o + 1'b1; // increment by 1
     end


### PR DESCRIPTION
This PR contains two commits that

1. resolve two Verilator `WIDTH` warnings.
2. remove an obsolete TODO.