### PR TITLE
[SiVal] Enable spi_host_tpm test for SiVal  nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,6 +86,70 @@ jobs:
           BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ inputs.branch || 'earlgrey_1.0.0'}}/$(date +%Y-%m-%d-%H%M%S)_${BAZEL_TEST_RESULTS}
           gcloud storage cp $BAZEL_TEST_RESULTS "$BUCKET_PATH"
 
+  fpga_cw340_sival_nightly:
+    name: FPGA CW340 SiVal tests
+    runs-on: [ubuntu-22.04-fpga, cw340]
+
+    env:
+      GS_PATH: gs://opentitan-test-results
+      BAZEL_TEST_RESULTS: test_results.xml
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for the bitstream cache to work.
+          ref: ${{ inputs.branch || 'earlgrey_1.0.0' }} # Schedule only work on the default branch, but we want to run on a different branch.
+
+      - name: Install dependencies
+        uses: ./.github/actions/prepare-env
+        with:
+          service_account_json: '${{ secrets.BAZEL_CACHE_CREDS }}'
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Update hyperdebug
+        # We run the update command twice to workaround an issue with udev on the container.
+        # Where rusb cannot dynamically update its device list in CI (udev is not completely
+        # functional). If the device is in normal mode, the first thing that opentitantool
+        # does is to switch it to DFU mode and wait until it reconnects. This reconnection is
+        # never detected. But if we run the tool another time, the device list is queried again
+        # and opentitantool can finish the update. The device will now reboot in normal mode
+        # and work for the hyperdebug job.
+        run: |
+          ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware \
+          || ./bazelisk.sh run //sw/host/opentitantool -- --interface=hyperdebug_dfu transport update-firmware
+
+      - name: Run tests after ROM boot stage
+        if: success() || failure()
+        run: |
+          module load xilinx/vivado
+          bazel_tests="$(mktemp)"
+          ./bazelisk.sh query 'attr("tags", "[\[ ]cw340_sival[,\]]", tests(//sw/device/...))' \
+                                                    | grep -v examples \
+                                                    | grep -v penetrationtests \
+                                                    > "$bazel_tests"
+          ./bazelisk.sh test --build_tests_only --test_tag_filters=-skip_in_nightly_ci --target_pattern_file="$bazel_tests"
+
+      - name: Run tests after ROM_EXT boot stage
+        if: success() || failure()
+        run: |
+          module load xilinx/vivado
+          bazel_tests="$(mktemp)"
+          ./bazelisk.sh query 'attr("tags", "[\[ ]cw340_sival_rom_ext[,\]]", tests(//sw/device/...))' \
+                                                    | grep -v examples \
+                                                    | grep -v penetrationtests \
+                                                    > "$bazel_tests"
+          ./bazelisk.sh test --build_tests_only --test_tag_filters=-skip_in_nightly_ci --target_pattern_file="$bazel_tests"
+
+      - name: Publish bazel test results
+        if: success() || failure()
+        run: |
+          # Bazel produce one xml for each test. So we merge them together.
+          find -L bazel-out -name "test.xml" | xargs merge-junit -o "$BAZEL_TEST_RESULTS"
+
+          BUCKET_PATH=$GS_PATH/job/${{ github.job }}/branch/${{ inputs.branch || 'earlgrey_1.0.0'}}/$(date +%Y-%m-%d-%H%M%S)_${BAZEL_TEST_RESULTS}
+          gcloud storage cp $BAZEL_TEST_RESULTS "$BUCKET_PATH"
+
   rom_e2e:
     name: ROM E2E Tests
     runs-on: [ubuntu-22.04-fpga, cw310]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -3575,8 +3575,13 @@ opentitan_test(
     name = "spi_device_tpm_tx_rx_test",
     srcs = ["spi_device_tpm_tx_rx_test.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+        },
     ),
     fpga = fpga_params(
         # This test requires the spi full duplex on the hyperdebug board.

--- a/sw/host/opentitanlib/src/app/config/hyperdebug_cw340.json
+++ b/sw/host/opentitanlib/src/app/config/hyperdebug_cw340.json
@@ -7,6 +7,82 @@
       "mode": "OpenDrain",
       "pull_mode": "PullUp",
       "alias_of": "CN10_29"
+    },
+    {
+      "name": "SPI_DEV_SCK",
+      "mode": "Alternate",
+      "alias_of": "CN10_24"
+    },
+    {
+      "name": "SPI_DEV_D0",
+      "mode": "Alternate",
+      "alias_of": "CN10_23"
+    },
+    {
+      "name": "SPI_DEV_D1",
+      "mode": "Alternate",
+      "alias_of": "CN10_10"
+    },
+    {
+      "name": "SPI_DEV_SCK",
+      "mode": "Alternate",
+      "alias_of": "CN10_24"
+    },
+    {
+      "name": "SPI_TPM_SCK",
+      "mode": "Input",
+      "alias_of": "CN7_15"
+    },
+    {
+      "name": "SPI_TPM_MOSI",
+      "mode": "Input",
+      "alias_of": "CN7_14"
+    },
+    {
+      "name": "SPI_TPM_MISO",
+      "mode": "Input",
+      "alias_of": "CN7_12"
+    },
+    {
+      "name": "SPI_TPM_CSB",
+      "mode": "Alternate",
+      "pull_mode": "PullUp",
+      "alias_of": "IOA7"
+    }
+  ],
+  "strappings": [
+    {
+      "name": "SPI_TPM",
+      "pins": [
+        {
+          "name": "SPI_DEV_SCK",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_DEV_D0",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_DEV_D1",
+          "mode": "Input"
+        },
+        {
+          "name": "SPI_TPM_SCK",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI_TPM_MOSI",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI_TPM_MISO",
+          "mode": "Alternate"
+        },
+        {
+          "name": "SPI_TPM_CSB",
+          "mode": "PushPull"
+        }
+      ]
     }
   ],
   "spi": [


### PR DESCRIPTION
This PR move the tpm test to run on the CW340 and create a job to run all the SiVal cw340 tests.