### PR TITLE
[hmac] Bump version to 2.0.1

### DIFF
--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -37,7 +37,7 @@
       notes:              "",
     }
     {
-      version:            "2.0.0",
+      version:            "2.0.1",
       life_stage:         "L1",
       design_stage:       "D2S",
       verification_stage: "V2S",


### PR DESCRIPTION
This version bump encompasses the RTL changes with minor functional
impact as part of the D3 sign-off. Since milestone 2.0.0 was taped
out, the purpose of this version bump is to document that what has
been taped out and signed-off for tape out is different.