### PR TITLE
[opentitantool] Include updated firmware for HyperDebug

### DIFF
--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20240621_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "649a8cd6d183bc3fb286ea5895c752cfec3aa29b9990f44bb9e7621c0414c7de",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20241206_01/hyperdebug-firmware.tar.gz"],
+        sha256 = "13612708d0d71e340babff07d14d67cd9d51f2eb3c370757c3aa905aeab13d1b",
         build_file = "@lowrisc_opentitan//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
This update includes several improvements:

* New SPI/I2C features to perform TPM operations in a single USB roundtrip.

* Vastly improve efficiency of UART data forwarded via USB.

* Fix to bit-banging, which could previously incorrectly complain about "ongoing operation", if the most recent bit-banging had ended less than one clock-tick ago.  (This clock could be arbitrarily slow.  The problem showed up when bit-banging simulated key presses with a 20ms clock, and the next operation was attempted initiated less than 20ms after the previous one had applied its last sample.)

* ADC calibration did not entirely adhere to STM32 timing requirements, resulting in occasional crash during "reinit" (transport init).

Relevant CLs:
87399ae831 board/hyperdebug: Reduce USB fragmentation in CMSIS-DAP
261e3ec718 chip/stm32: L4/L5 UART driver makes use of RX timeout
ab72b9eaf8 chip/stm32: USB stream driver delays outbound USB packet until flush
19e0f86cd3 chip/stm32: Remove unused fields
3006f5bffb common: Introduce buffered mode and queue_flush()
46b9a8797e board/hyperdebug: Implement tailored logic for TPM I2C devices
5cbea1dba5 board/hyperdebug: Implement tailored logic for TPM SPI devices
8115337458 board/hyperdebug: Route all SPI requests through board code
d2a6c10ad5 board/hyperdebug: Support bit-banging in quick succession
7760f99e7d board/hyperdebug: ADC calibration robustness
513b83b195 chip/stm32: Correct ADC initialization timing
3024d3eb68 chip/stm32: Larger console UART buffer for STM32L5