### PR TITLE
[bazel] Clean up `exec_env_filegroup`

### DIFF
--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -510,12 +510,21 @@ def _exec_env_filegroup(ctx):
         fail("The set of files and exec_envs must be matched: files =", fset.keys(), ", exec_env =", eset.keys())
 
     result = []
+    default_files = []
     for k in files.keys():
         provider = exec_env[k][ExecEnvInfo].provider
         f = files[k].files.to_list()
         if len(f) != 1:
             fail("files[{}] must supply exactly one file".format(k))
+
+        # Return the exec_env's provider so this rule can be consumed by
+        # opentitan_test rules.
         result.append(provider(default = f[0], kind = ctx.attr.kind))
+        default_files.append(f[0])
+
+    # Also return a DefaultInfo provider so this rule can be consumed by other
+    # filegroup or packaging rules.
+    result.append(DefaultInfo(files = depset(default_files)))
     return result
 
 exec_env_filegroup = rule(

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -381,7 +381,7 @@ filegroup(
                ":ft_fw_bundle_{}".format(sku)
                for sku in EARLGREY_SKUS.keys()
            ] + [
-        "//sw/device/silicon_creator/manuf/base/binaries:perso_bins",
+        "//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival",
     ],
 )
 

--- a/sw/device/silicon_creator/manuf/base/binaries/BUILD
+++ b/sw/device/silicon_creator/manuf/base/binaries/BUILD
@@ -6,15 +6,6 @@ load("//rules/opentitan:cc.bzl", "exec_env_filegroup")
 
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
-    name = "perso_bins",
-    srcs = [
-        "ft_personalize_sival_fpga_cw340_rom_with_fake_keys.signed.bin",
-        "ft_personalize_sival_fpga_hyper310_rom_with_fake_keys.signed.bin",
-        "ft_personalize_sival_silicon_creator.signed.bin",
-    ],
-)
-
 exec_env_filegroup(
     name = "ft_personalize_sival",
     testonly = True,


### PR DESCRIPTION
1. Make exec_env_filegroup return a DefaultInfo provider so it may be consumed by other filegroup/packaging rules.
2. Remove `perso_bins` filegroup in favor of `ft_personalize_sival`.