### PR TITLE
[ci] Create GitHub groups in log outputs for FPGA tests

### DIFF
--- a/ci/scripts/BUILD
+++ b/ci/scripts/BUILD
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+sh_binary(
+    name = "run_test",
+    srcs = ["run_test.sh"],
+)

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -47,6 +47,7 @@ trap './bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface=${fpga}
 ./bazelisk.sh run //sw/host/opentitantool -- --rcfile= --interface="$fpga" fpga get-sam3x-fw-version || true
 
 ./bazelisk.sh test \
+    --run_under=//ci/scripts:run_test \
     --define DISABLE_VERILATOR_BUILD=true \
     --nokeep_going \
     --test_timeout_filters=short,moderate \

--- a/ci/scripts/run_test.sh
+++ b/ci/scripts/run_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Print a special GitHub command to create a group in the log's output:
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+#
+# Test variables are documented here:
+# https://bazel.build/reference/test-encyclopedia
+if [ -z "$TEST_RUN_NUMBER" ]; then
+    RUN_NR=""
+else
+    RUN_NR="(Run $TEST_RUN_NUMBER)"
+fi
+
+function cleanup {
+    echo "::endgroup::"
+}
+
+echo "::group::$TEST_TARGET $RUN_NR"
+# NOTE Even if the command fails, we still want to continue to print
+# the endgroup command.
+trap cleanup SIGINT SIGTERM EXIT
+"$@"


### PR DESCRIPTION
The log are quite long and GitHub provides a feature where the output group can split lines into groups. This is achieved by using the --run_under command of bazel test. This allows to run a script that then invokes the test runner. This only thing this script does is print the grouping commands.