### PR TITLE
[sival] Enable CW340 exec. environment for ECC tests

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2599,14 +2599,14 @@ opentitan_test(
     name = "otbn_mem_scramble_test",
     srcs = ["otbn_mem_scramble_test.c"],
     exec_env = dicts.add(
-        EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:silicon_creator": None,
+            "//hw/top_earlgrey:sim_dv": None,
+            "//hw/top_earlgrey:sim_verilator": None,
         },
     ),
-    # TODO(#12486) [bazel] targets in sw/device/tests failing on cw310 and verilator when built by bazel
-    fpga = fpga_params(tags = ["broken"]),
     verilator = verilator_params(timeout = "long"),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6603,6 +6603,7 @@ opentitan_test(
     name = "sram_ctrl_scrambled_access_test",
     srcs = ["sram_ctrl_scrambled_access_test.c"],
     exec_env = dicts.add(
+        EARLGREY_CW340_TEST_ENVS,
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),

--- a/sw/device/tests/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_scrambled_access_test.c
@@ -267,16 +267,17 @@ static void check_sram_data(scramble_test_frame *mem_frame) {
 
   // Decide whether to perform ECC error count checks after memory is scrambled.
   //
-  // This is not done on FPGAs because the interrupt handler that counts them
-  // does not currently trigger on our FPGA platforms.
-  // See #20119 for more details.
+  // This is not done on CW305/CW310 FPGAs because interrupts for ECC errors are
+  // only triggered when the SecureIbex parameter is enabled. This parameter is
+  // disabled for these boards due to resource constraints. On CW340 and the
+  // other targets, this parameter is enabled.
   bool check_ecc_errors = false;
   switch (kDeviceType) {
     case kDeviceFpgaCw305:
     case kDeviceFpgaCw310:
-    case kDeviceFpgaCw340:
       check_ecc_errors = false;
       break;
+    case kDeviceFpgaCw340:
     case kDeviceSilicon:
     case kDeviceSimDV:
     case kDeviceSimVerilator:


### PR DESCRIPTION
With PR https://github.com/lowRISC/opentitan/pull/25146, now, tests that rely on the SecureIbex parameter can now be executed on CW340. This PR consists of two commits enabling the CW340 exec. environment for such tests.