### PR TITLE
[sival, spi] Add missing argument for passthru test harness on silicon

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -4981,6 +4981,7 @@ opentitan_test(
     silicon = silicon_params(
         test_cmd = """
             --bootstrap="{firmware}"
+            "{firmware:elf}"
         """,
         test_harness = "//sw/host/tests/chip/spi_device:spi_passthru",
     ),


### PR DESCRIPTION
This PR fixes spi_passthru_test on silicon. 