### PR TITLE
[cryptotest] Switch cryptotests over to the SPI console

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/sigverify_tests/sigverify_cryptotest.c
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_tests/sigverify_cryptotest.c
@@ -18,7 +18,11 @@
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdsa_commands.h"
 
-OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false, );
 
 bool ecdsa_p256_params_set(cryptotest_ecdsa_coordinate_t uj_qx,
                            cryptotest_ecdsa_coordinate_t uj_qy,

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -68,7 +68,6 @@ ECDSA_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "ecdsa_kat",
-    skip_in_nightly_ci = True,
     test_args = ECDSA_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/ecdsa_kat:harness",
     test_vectors = ECDSA_TESTVECTOR_TARGETS,
@@ -114,7 +113,6 @@ SHA256_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha256_kat",
-    skip_in_nightly_ci = True,
     test_args = SHA256_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA256_TESTVECTOR_TARGETS,
@@ -137,7 +135,6 @@ SHA384_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha384_kat",
-    skip_in_nightly_ci = True,
     test_args = SHA384_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA384_TESTVECTOR_TARGETS,
@@ -160,7 +157,6 @@ SHA512_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha512_kat",
-    skip_in_nightly_ci = True,
     test_args = SHA512_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA512_TESTVECTOR_TARGETS,
@@ -205,7 +201,6 @@ SHA3_256_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha3_256_kat",
-    skip_in_nightly_ci = True,
     test_args = SHA3_256_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA3_256_TESTVECTOR_TARGETS,
@@ -228,7 +223,6 @@ SHA3_384_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha3_384_kat",
-    skip_in_nightly_ci = True,
     test_args = SHA3_384_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA3_384_TESTVECTOR_TARGETS,
@@ -251,7 +245,6 @@ SHA3_512_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sha3_512_kat",
-    skip_in_nightly_ci = True,
     test_args = SHA3_512_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hash_kat:harness",
     test_vectors = SHA3_512_TESTVECTOR_TARGETS,
@@ -333,7 +326,6 @@ DRBG_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "drbg_kat",
-    skip_in_nightly_ci = True,
     test_args = DRBG_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/drbg_kat:harness",
     test_vectors = DRBG_TESTVECTOR_TARGETS,
@@ -351,7 +343,6 @@ HMAC_SHA256_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "hmac_sha256_kat",
-    skip_in_nightly_ci = True,
     test_args = HMAC_SHA256_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
     test_vectors = HMAC_SHA256_TESTVECTOR_TARGETS,
@@ -369,7 +360,6 @@ HMAC_SHA384_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "hmac_sha384_kat",
-    skip_in_nightly_ci = True,
     test_args = HMAC_SHA384_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
     test_vectors = HMAC_SHA384_TESTVECTOR_TARGETS,
@@ -387,7 +377,6 @@ HMAC_SHA512_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "hmac_sha512_kat",
-    skip_in_nightly_ci = True,
     test_args = HMAC_SHA512_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/hmac_kat:harness",
     test_vectors = HMAC_SHA512_TESTVECTOR_TARGETS,
@@ -427,7 +416,6 @@ SPHINCSPLUS_TESTVECTOR_ARGS = " ".join([
 
 cryptotest(
     name = "sphincsplus_kat",
-    skip_in_nightly_ci = True,
     test_args = SPHINCSPLUS_TESTVECTOR_ARGS,
     test_harness = "//sw/host/tests/crypto/sphincsplus_kat:harness",
     test_vectors = SPHINCSPLUS_TESTVECTOR_TARGETS,

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -174,6 +174,7 @@ FIRMWARE_DEPS = [
     "//sw/device/lib/testing/test_framework:ottf_main",
     "//sw/device/lib/testing/test_framework:ujson_ottf",
     "//sw/device/lib/ujson",
+    "//hw/top_earlgrey/sw/autogen:top_earlgrey",
 
     # Include all JSON commands.
     "//sw/device/tests/crypto/cryptotest/json:commands",

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -10,6 +10,8 @@
 #include "sw/device/lib/testing/test_framework/ujson_ottf.h"
 #include "sw/device/lib/ujson/ujson.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
 // Include commands
 #include "sw/device/tests/crypto/cryptotest/json/aes_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/commands.h"
@@ -31,7 +33,9 @@
 #include "kmac.h"
 #include "sphincsplus.h"
 
-OTTF_DEFINE_TEST_CONFIG(.enable_uart_flow_control = true);
+OTTF_DEFINE_TEST_CONFIG(.console.type = kOttfConsoleSpiDevice,
+                        .console.base_addr = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+                        .console.test_may_clobber = false, );
 
 status_t process_cmd(ujson_t *uj) {
   while (true) {

--- a/sw/host/tests/crypto/drbg_kat/src/main.rs
+++ b/sw/host/tests/crypto/drbg_kat/src/main.rs
@@ -18,6 +18,7 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use opentitanlib::console::spi::SpiConsoleDevice;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -52,7 +53,7 @@ struct DrbgTestCase {
 fn run_drbg_testcase(
     test_case: &DrbgTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    spi_console: &SpiConsoleDevice,
     fail_counter: &mut u32,
 ) -> Result<()> {
     log::info!(
@@ -60,9 +61,8 @@ fn run_drbg_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
 
-    CryptotestCommand::Drbg.send(&*uart)?;
+    CryptotestCommand::Drbg.send(spi_console)?;
 
     // Convert all inputs to little-endian
     let mut entropy_le = Vec::from(test_case.entropy.as_slice());
@@ -95,10 +95,10 @@ fn run_drbg_testcase(
         additional_input_2_len: addl_2_le.len(),
         output_len: test_case.output.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     // Get output
-    let drbg_output = CryptotestDrbgOutput::recv(&*uart, opts.timeout, false)?;
+    let drbg_output = CryptotestDrbgOutput::recv(spi_console, opts.timeout, false)?;
     // The expected output is in a mixed-endian format (32-bit words
     // are in little-endian order, but the bytes within the words are
     // in big-endian order). Convert the actual output to match this
@@ -127,9 +127,9 @@ fn run_drbg_testcase(
 }
 
 fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;
@@ -141,7 +141,7 @@ fn test_drbg(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for drbg_test in &drbg_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_drbg_testcase(drbg_test, opts, transport, &mut fail_counter)?;
+            run_drbg_testcase(drbg_test, opts, &spi_console_device, &mut fail_counter)?;
         }
     }
     assert_eq!(

--- a/sw/host/tests/crypto/ecdh_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdh_kat/src/main.rs
@@ -21,6 +21,7 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use opentitanlib::console::spi::SpiConsoleDevice;
 use p256::elliptic_curve::scalar::ScalarPrimitive as ScalarPrimitiveP256;
 use p256::U256;
 use p384::elliptic_curve::scalar::ScalarPrimitive as ScalarPrimitiveP384;
@@ -65,7 +66,7 @@ struct EcdhTestCase {
 fn run_ecdh_testcase(
     test_case: &EcdhTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    spi_console: &SpiConsoleDevice,
     fail_counter: &mut usize,
     failures: &mut Vec<usize>,
 ) -> Result<()> {
@@ -74,7 +75,6 @@ fn run_ecdh_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
 
     assert_eq!(test_case.algorithm.as_str(), "ecdh");
     // Change byte slice parameters from big endian to little endian
@@ -82,7 +82,7 @@ fn run_ecdh_testcase(
     let qx = BigUint::from_bytes_be(&test_case.qx).to_bytes_le();
     let qy = BigUint::from_bytes_be(&test_case.qy).to_bytes_le();
 
-    CryptotestCommand::Ecdh.send(&*uart)?;
+    CryptotestCommand::Ecdh.send(spi_console)?;
 
     let (curve, d0, d1) = match test_case.curve.as_str() {
         "p256" => {
@@ -170,7 +170,7 @@ fn run_ecdh_testcase(
         _ => panic!("Invalid ECDH curve name"),
     };
 
-    curve.send(&*uart)?;
+    curve.send(spi_console)?;
 
     // Sizes were checked already, so we can unwrap() transformations
     // to `ArrayVec`s.  We can inline the `ArrayVec` initialization
@@ -182,21 +182,21 @@ fn run_ecdh_testcase(
         d1: ArrayVec::try_from(d1.as_slice()).unwrap(),
         d1_len: d1.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestEcdhCoordinate {
         coordinate: ArrayVec::try_from(qx.as_slice()).unwrap(),
         coordinate_len: qx.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestEcdhCoordinate {
         coordinate: ArrayVec::try_from(qy.as_slice()).unwrap(),
         coordinate_len: qy.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
-    let ecdh_output = CryptotestEcdhDeriveOutput::recv(&*uart, opts.timeout, false)?;
+    let ecdh_output = CryptotestEcdhDeriveOutput::recv(spi_console, opts.timeout, false)?;
     let out_len = ecdh_output.shared_secret_len;
     if out_len > ecdh_output.shared_secret.len() {
         panic!("ECDH returned shared secret was too long for device firmware configuration.");
@@ -219,9 +219,9 @@ fn run_ecdh_testcase(
 }
 
 fn test_ecdh(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0usize;
@@ -234,7 +234,7 @@ fn test_ecdh(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for ecdh_test in &ecdh_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_ecdh_testcase(ecdh_test, opts, transport, &mut fail_counter, &mut failures)?;
+            run_ecdh_testcase(ecdh_test, opts, &spi_console_device, &mut fail_counter, &mut failures)?;
         }
     }
     assert_eq!(

--- a/sw/host/tests/crypto/ecdsa_kat/src/main.rs
+++ b/sw/host/tests/crypto/ecdsa_kat/src/main.rs
@@ -33,6 +33,7 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use opentitanlib::console::spi::SpiConsoleDevice;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -180,7 +181,7 @@ fn p384_verify_signature(
 fn run_ecdsa_testcase(
     test_case: &EcdsaTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    spi_console: &SpiConsoleDevice,
     failures: &mut Vec<String>,
 ) -> Result<()> {
     log::info!(
@@ -188,7 +189,6 @@ fn run_ecdsa_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
     assert_eq!(test_case.algorithm.as_str(), "ecdsa");
     let mut qx: Vec<u8> = BigInt::from_str_radix(&test_case.qx, 16)
         .unwrap()
@@ -398,10 +398,10 @@ fn run_ecdsa_testcase(
     };
 
     // Send everything
-    CryptotestCommand::Ecdsa.send(&*uart)?;
-    operation.send(&*uart)?;
-    hash_alg.send(&*uart)?;
-    curve.send(&*uart)?;
+    CryptotestCommand::Ecdsa.send(spi_console)?;
+    operation.send(spi_console)?;
+    hash_alg.send(spi_console)?;
+    curve.send(spi_console)?;
 
     // Size of `input` is determined at compile-time by type inference
     let mut input = ArrayVec::new();
@@ -417,7 +417,7 @@ fn run_ecdsa_testcase(
         input,
         input_len: msg_len,
     };
-    msg.send(&*uart)?;
+    msg.send(spi_console)?;
 
     CryptotestEcdsaSignature {
         r: ArrayVec::try_from(r.as_slice()).unwrap(),
@@ -425,19 +425,19 @@ fn run_ecdsa_testcase(
         s: ArrayVec::try_from(s.as_slice()).unwrap(),
         s_len: s.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestEcdsaCoordinate {
         coordinate: ArrayVec::try_from(qx.as_slice()).unwrap(),
         coordinate_len: qx.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestEcdsaCoordinate {
         coordinate: ArrayVec::try_from(qy.as_slice()).unwrap(),
         coordinate_len: qy.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestEcdsaPrivateKey {
         d0: ArrayVec::try_from(d0.as_slice()).unwrap(),
@@ -446,10 +446,10 @@ fn run_ecdsa_testcase(
         d1_len: d1.len(),
         unmasked_len: d0.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
     let success = match operation {
         CryptotestEcdsaOperation::Sign => {
-            let mut output_signature = CryptotestEcdsaSignature::recv(&*uart, opts.timeout, false)?;
+            let mut output_signature = CryptotestEcdsaSignature::recv(spi_console, opts.timeout, false)?;
             // Truncate signature values to correct size for curve and convert to big-endian
             output_signature.r.truncate(output_signature.r_len);
             output_signature.s.truncate(output_signature.s_len);
@@ -476,7 +476,7 @@ fn run_ecdsa_testcase(
             }
         }
         CryptotestEcdsaOperation::Verify => {
-            let ecdsa_output = CryptotestEcdsaVerifyOutput::recv(&*uart, opts.timeout, false)?;
+            let ecdsa_output = CryptotestEcdsaVerifyOutput::recv(spi_console, opts.timeout, false)?;
             match ecdsa_output {
                 CryptotestEcdsaVerifyOutput::Success => true,
                 CryptotestEcdsaVerifyOutput::Failure => false,
@@ -509,9 +509,9 @@ fn run_ecdsa_testcase(
 }
 
 fn test_ecdsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut failures = vec![];
@@ -523,7 +523,7 @@ fn test_ecdsa(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for ecdsa_test in &ecdsa_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_ecdsa_testcase(ecdsa_test, opts, transport, &mut failures)?;
+            run_ecdsa_testcase(ecdsa_test, opts, &spi_console_device, &mut failures)?;
         }
     }
     assert_eq!(

--- a/sw/host/tests/crypto/hmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/hmac_kat/src/main.rs
@@ -20,6 +20,7 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use opentitanlib::console::spi::SpiConsoleDevice;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -52,7 +53,7 @@ const HMAC_CMD_MAX_KEY_BYTES: usize = 192;
 fn run_hmac_testcase(
     test_case: &HmacTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    spi_console: &SpiConsoleDevice,
     fail_counter: &mut u32,
 ) -> Result<()> {
     log::info!(
@@ -60,10 +61,8 @@ fn run_hmac_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
-
     assert_eq!(test_case.algorithm.as_str(), "hmac");
-    CryptotestCommand::Hmac.send(&*uart)?;
+    CryptotestCommand::Hmac.send(spi_console)?;
 
     assert!(
         test_case.key.len() <= HMAC_CMD_MAX_KEY_BYTES,
@@ -87,21 +86,21 @@ fn run_hmac_testcase(
         "sha3-512" => CryptotestHmacHashAlg::Sha3_512,
         _ => panic!("Unsupported HMAC hash mode"),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestHmacKey {
         key: ArrayVec::try_from(test_case.key.as_slice()).unwrap(),
         key_len: test_case.key.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestHmacMessage {
         message: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
         message_len: test_case.message.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
-    let hmac_tag = CryptotestHmacTag::recv(&*uart, opts.timeout, false)?;
+    let hmac_tag = CryptotestHmacTag::recv(spi_console, opts.timeout, false)?;
     let success = if test_case.tag.len() > hmac_tag.tag_len {
         // If we got a shorter tag back then the test asks for, we can't accept the tag, even if
         // the beginning bytes match.
@@ -126,9 +125,9 @@ fn run_hmac_testcase(
 }
 
 fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;
@@ -140,7 +139,7 @@ fn test_hmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for hmac_test in &hmac_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_hmac_testcase(hmac_test, opts, transport, &mut fail_counter)?;
+            run_hmac_testcase(hmac_test, opts, &spi_console_device, &mut fail_counter)?;
         }
     }
     assert_eq!(

--- a/sw/host/tests/crypto/kmac_kat/src/main.rs
+++ b/sw/host/tests/crypto/kmac_kat/src/main.rs
@@ -21,6 +21,7 @@ use opentitanlib::execute_test;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
 use opentitanlib::uart::console::UartConsole;
+use opentitanlib::console::spi::SpiConsoleDevice;
 
 #[derive(Debug, Parser)]
 struct Opts {
@@ -57,7 +58,7 @@ const KMAC_CMD_MAX_KEY_BYTES: usize = 64;
 fn run_kmac_testcase(
     test_case: &KmacTestCase,
     opts: &Opts,
-    transport: &TransportWrapper,
+    spi_console: &SpiConsoleDevice,
     fail_counter: &mut u32,
 ) -> Result<()> {
     log::info!(
@@ -65,10 +66,8 @@ fn run_kmac_testcase(
         test_case.vendor,
         test_case.test_case_id
     );
-    let uart = transport.uart("console")?;
-
     assert_eq!(test_case.algorithm.as_str(), "kmac");
-    CryptotestCommand::Kmac.send(&*uart)?;
+    CryptotestCommand::Kmac.send(spi_console)?;
 
     assert!(
         test_case.key.len() <= KMAC_CMD_MAX_KEY_BYTES,
@@ -94,35 +93,35 @@ fn run_kmac_testcase(
         256 => CryptotestKmacMode::Kmac256,
         _ => panic!("Unsupported KMAC mode"),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestKmacRequiredTagLength {
         // Set this to the expected tag length, so we guarantee we perform a fair comparison with
         // the expected value.
         required_tag_length: test_case.tag.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestKmacKey {
         key: ArrayVec::try_from(test_case.key.as_slice()).unwrap(),
         key_len: test_case.key.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestKmacMessage {
         message: ArrayVec::try_from(test_case.message.as_slice()).unwrap(),
         message_len: test_case.message.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
     CryptotestKmacCustomizationString {
         customization_string: ArrayVec::try_from(test_case.customization_string.as_slice())
             .unwrap(),
         customization_string_len: test_case.customization_string.len(),
     }
-    .send(&*uart)?;
+    .send(spi_console)?;
 
-    let kmac_tag = CryptotestKmacTag::recv(&*uart, opts.timeout, false)?;
+    let kmac_tag = CryptotestKmacTag::recv(spi_console, opts.timeout, false)?;
     // Cryptolib could have chosen to return more tag bytes than we asked for. If it did, we can
     // ignore the extra ones.
     let success = test_case.tag[..] == kmac_tag.tag[..test_case.tag.len()];
@@ -141,9 +140,9 @@ fn run_kmac_testcase(
 }
 
 fn test_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
-    let uart = transport.uart("console")?;
-    uart.set_flow_control(true)?;
-    let _ = UartConsole::wait_for(&*uart, r"Running [^\r\n]*", opts.timeout)?;
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running [^\r\n]*", opts.timeout)?;
 
     let mut test_counter = 0u32;
     let mut fail_counter = 0u32;
@@ -155,7 +154,7 @@ fn test_kmac(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
         for kmac_test in &kmac_tests {
             test_counter += 1;
             log::info!("Test counter: {}", test_counter);
-            run_kmac_testcase(kmac_test, opts, transport, &mut fail_counter)?;
+            run_kmac_testcase(kmac_test, opts, &spi_console_device, &mut fail_counter)?;
         }
     }
     assert_eq!(


### PR DESCRIPTION
Switch the cryptotest KAT tests to use the SPI console for increased communication performance. This leads to 5-10x speedups across the cryptotests and makes them feasible to run in CI.

Based on some local testing, re-enabling these tests in CI should add about an extra 20 minutes to the nightly CI. The remaining KAT tests each take about 500-700s each.

```console
//sw/device/tests/crypto/cryptotest:aes_kat_fpga_cw310_sival_rom_ext     PASSED in 536.2s
//sw/device/tests/crypto/cryptotest:cshake_kat_fpga_cw310_sival_rom_ext  PASSED in 3.7s
//sw/device/tests/crypto/cryptotest:drbg_kat_fpga_cw310_sival_rom_ext    PASSED in 36.6s
//sw/device/tests/crypto/cryptotest:ecdh_kat_fpga_cw310_sival_rom_ext    PASSED in 35.8s
//sw/device/tests/crypto/cryptotest:ecdsa_kat_fpga_cw310_sival_rom_ext   PASSED in 139.7s
//sw/device/tests/crypto/cryptotest:hmac_sha256_kat_fpga_cw310_sival_rom_ext PASSED in 28.2s
//sw/device/tests/crypto/cryptotest:hmac_sha384_kat_fpga_cw310_sival_rom_ext PASSED in 34.3s
//sw/device/tests/crypto/cryptotest:hmac_sha512_kat_fpga_cw310_sival_rom_ext PASSED in 40.5s
//sw/device/tests/crypto/cryptotest:kmac_kat_fpga_cw310_sival_rom_ext    PASSED in 27.1s
//sw/device/tests/crypto/cryptotest:sha256_kat_fpga_cw310_sival_rom_ext  PASSED in 65.8s
//sw/device/tests/crypto/cryptotest:sha384_kat_fpga_cw310_sival_rom_ext  PASSED in 152.9s
//sw/device/tests/crypto/cryptotest:sha3_224_kat_fpga_cw310_sival_rom_ext PASSED in 142.6s
//sw/device/tests/crypto/cryptotest:sha3_256_kat_fpga_cw310_sival_rom_ext PASSED in 137.0s
//sw/device/tests/crypto/cryptotest:sha3_384_kat_fpga_cw310_sival_rom_ext PASSED in 114.5s
//sw/device/tests/crypto/cryptotest:sha3_512_kat_fpga_cw310_sival_rom_ext PASSED in 92.4s
//sw/device/tests/crypto/cryptotest:sha512_kat_fpga_cw310_sival_rom_ext  PASSED in 152.9s
//sw/device/tests/crypto/cryptotest:shake128_kat_fpga_cw310_sival_rom_ext PASSED in 677.7s
//sw/device/tests/crypto/cryptotest:shake256_kat_fpga_cw310_sival_rom_ext PASSED in 690.9s
//sw/device/tests/crypto/cryptotest:sphincsplus_kat_fpga_cw310_sival_rom_ext PASSED in 61.6s
```