### PR TITLE
[orchestrator] add config fields for perso_bin and otp

### DIFF
--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@//rules:signing.bzl", "offline_presigning_artifacts", "offline_signature_attach")
+load(
+    "@provisioning_exts//:cfg.bzl",
+    "EXT_SIGNED_PERSO_BINS",
+)
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules:manifest.bzl", "manifest")
@@ -380,9 +384,8 @@ filegroup(
            [
                ":ft_fw_bundle_{}".format(sku)
                for sku in EARLGREY_SKUS.keys()
-           ] + [
-        "//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival",
-    ],
+           ] + ["//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival"] +
+           EXT_SIGNED_PERSO_BINS,
 )
 
 [

--- a/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
+++ b/sw/device/silicon_creator/manuf/base/provisioning_inputs.bzl
@@ -16,6 +16,8 @@ EARLGREY_OTP_CFGS = {
     "emulation": "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_consts",
 } | EXT_EARLGREY_OTP_CFGS
 
+EXT_SIGNED_PERSO_BINS = []
+
 # A dictionary of SKU configurations that will be used to generate FT
 # personalization binaries that configure OTP and flash info pages as defined
 # in these bazel targets.
@@ -24,7 +26,7 @@ EARLGREY_SKUS = {
     "emulation": {
         "otp": "emulation",
         "ca_config": "//sw/device/silicon_creator/manuf/keys/fake:ca_config.json",
-        "ca_data": "//sw/device/silicon_creator/manuf/keys/fake:ca_data",
+        "ca_data": "@//sw/device/silicon_creator/manuf/keys/fake:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
@@ -32,13 +34,13 @@ EARLGREY_SKUS = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
         "ecdsa_key": {},
-        "orchestrator_cfg": "//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
+        "orchestrator_cfg": "@//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
     },
     # OTP Config: Emulation; DICE Certs: CWT; Additional Certs: None
     "emulation_dice_cwt": {
         "otp": "emulation",
         "ca_config": "//sw/device/silicon_creator/manuf/keys/fake:ca_config.json",
-        "ca_data": "//sw/device/silicon_creator/manuf/keys/fake:ca_data",
+        "ca_data": "@//sw/device/silicon_creator/manuf/keys/fake:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice_cwt"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
@@ -46,13 +48,13 @@ EARLGREY_SKUS = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_cwt_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
         "ecdsa_key": {},
-        "orchestrator_cfg": "//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
+        "orchestrator_cfg": "@//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
     },
     # OTP Config: Emulation; DICE Certs: X.509; Additional Certs: TPM EK
     "emulation_tpm": {
         "otp": "emulation",
         "ca_config": "//sw/device/silicon_creator/manuf/keys/fake:ca_config.json",
-        "ca_data": "//sw/device/silicon_creator/manuf/keys/fake:ca_data",
+        "ca_data": "@//sw/device/silicon_creator/manuf/keys/fake:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": [
@@ -63,12 +65,12 @@ EARLGREY_SKUS = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_b",
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
         "ecdsa_key": {},
-        "orchestrator_cfg": "//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
+        "orchestrator_cfg": "@//sw/host/provisioning/orchestrator/configs/skus:emulation.hjson",
     },
     "sival": {
         "otp": "sival",
         "ca_config": "//sw/device/silicon_creator/manuf/keys/sival:ca_config.json",
-        "ca_data": "//sw/device/silicon_creator/manuf/keys/sival:ca_data",
+        "ca_data": "@//sw/device/silicon_creator/manuf/keys/sival:ca_data",
         "dice_libs": ["//sw/device/silicon_creator/lib/cert:dice"],
         "host_ext_libs": ["@provisioning_exts//:default_ft_ext_lib"],
         "device_ext_libs": ["@provisioning_exts//:default_perso_fw_ext"],
@@ -79,7 +81,7 @@ EARLGREY_SKUS = {
         "owner_fw": "//sw/device/silicon_owner/bare_metal:bare_metal_slot_b",
         "ecdsa_key": {"//hw/ip/otp_ctrl/data/earlgrey_skus/sival/keys:keyset": "sv00-earlgrey-a1-root-ecdsa-prod-0"},
         "perso_bin": "//sw/device/silicon_creator/manuf/base/binaries:ft_personalize_sival",
-        "orchestrator_cfg": "//sw/host/provisioning/orchestrator/configs/skus:sival.hjson",
+        "orchestrator_cfg": "@//sw/host/provisioning/orchestrator/configs/skus:sival.hjson",
         "offline": True,
     },
 } | EXT_EARLGREY_SKUS

--- a/sw/device/silicon_creator/manuf/extensions/cfg.bzl
+++ b/sw/device/silicon_creator/manuf/extensions/cfg.bzl
@@ -24,3 +24,5 @@ EXT_EARLGREY_SKUS = {
     #    "device_ext_libs": [<which device hooks extension libraries to use>]
     # }
 }
+
+EXT_SIGNED_PERSO_BINS = []

--- a/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/emulation.hjson
@@ -8,6 +8,8 @@
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",
+  otp: "emulation",
+  perso_bin: "sw/device/silicon_creator/manuf/base/ft_personalize_{sku}_{target}.prod_key_0.prod_key_0.signed.bin",
   dice_ca: {
     certificate: "sw/device/silicon_creator/manuf/keys/fake/dice_ca.pem",
     key: "sw/device/silicon_creator/manuf/keys/fake/sk.pkcs8.der",

--- a/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
+++ b/sw/host/provisioning/orchestrator/configs/skus/sival.hjson
@@ -8,6 +8,8 @@
   si_creator: "nuvoton",
   package: "npcr10",
   target_lc_state: "prod",
+  otp: "sival",
+  perso_bin: "sw/device/silicon_creator/manuf/base/binaries/ft_personalize_{sku}_{target}.signed.bin",
   dice_ca: {
     certificate: "sw/device/silicon_creator/manuf/keys/sival/dice_ca.pem",
     key: "sv00-earlgrey-a1-ca-dice-0",

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -33,9 +33,7 @@ _ZERO_256BIT_HEXSTR = "0x" + "_".join(["00000000"] * 8)
 # CP & FT Device Firmware
 _BASE_DEV_DIR           = "sw/device/silicon_creator/manuf/base"  # noqa: E221
 _CP_DEVICE_ELF          = "{base_dir}/sram_cp_provision_{target}.elf"  # noqa: E221
-_FT_INDIVID_DEVICE_ELF  = "{base_dir}/sram_ft_individualize_{sku}_{target}.elf"  # noqa: E221
-_FT_PERSO_EMULATION_BIN = "{base_dir}/ft_personalize_{sku}_{target}.prod_key_0.prod_key_0.signed.bin"  # noqa: E221, E501
-_FT_PERSO_SKU_BIN       = "{base_dir}/binaries/ft_personalize_{sku}_{target}.signed.bin"  # noqa: E221, E501
+_FT_INDIVID_DEVICE_ELF  = "{base_dir}/sram_ft_individualize_{otp}_{target}.elf"  # noqa: E221
 _FT_FW_BUNDLE_BIN       = "{base_dir}/ft_fw_bundle_{sku}_{target}.img"  # noqa: E221
 # CP & FT Host Binaries
 _CP_HOST_BIN = "sw/host/provisioning/cp/cp"
@@ -176,9 +174,7 @@ class OtDut():
         individ_elf = _FT_INDIVID_DEVICE_ELF
         # Emulation perso bins are signed online with fake keys, and therefore
         # have different file naming patterns than production SKUs.
-        perso_bin = _FT_PERSO_EMULATION_BIN
-        if self.sku_config.name != "emulation":
-            perso_bin = _FT_PERSO_SKU_BIN
+        perso_bin = self.sku_config.perso_bin
         fw_bundle_bin = _FT_FW_BUNDLE_BIN
         if self.fpga:
             # Set host flags and device binaries for FPGA DUT.
@@ -189,7 +185,7 @@ class OtDut():
                                            openocd_cfg=_OPENOCD_ADAPTER_CONFIG)
             individ_elf = individ_elf.format(
                 base_dir=self._base_dev_dir(),
-                sku=self.sku_config.name,
+                otp=self.sku_config.otp,
                 target=f"fpga_{self.fpga}_rom_with_fake_keys")
             perso_bin = perso_bin.format(
                 base_dir=self._base_dev_dir(),
@@ -206,7 +202,7 @@ class OtDut():
                                            openocd_cfg=_OPENOCD_ADAPTER_CONFIG)
             host_flags += " --disable-dft-on-reset"
             individ_elf = individ_elf.format(base_dir=self._base_dev_dir(),
-                                             sku=self.sku_config.name,
+                                             otp=self.sku_config.otp,
                                              target="silicon_creator")
             perso_bin = perso_bin.format(base_dir=self._base_dev_dir(),
                                          sku=self.sku_config.name,

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -23,6 +23,8 @@ class SkuConfig:
     si_creator: str  # valid: any SiliconCreator that exists in product database
     package: str  # valid: any package that exists in package database
     target_lc_state: str  # valid: must be in ["dev", "prod", "prod_end"]
+    otp: str  # valid: any string
+    perso_bin: str  # valid: any string
     dice_ca: Optional[OrderedDict]  # valid: see CaConfig
     ext_ca: Optional[OrderedDict]  # valid: see CaConfig
     token_encrypt_key: str
@@ -91,6 +93,8 @@ class SkuConfig:
                                si_creator=si_creator,
                                package=package,
                                target_lc_state="dev",
+                               otp="",
+                               perso_bin="",
                                dice_ca=OrderedDict(),
                                ext_ca=OrderedDict(),
                                token_encrypt_key="")


### PR DESCRIPTION
Additional config fields make it easier to specify various paths for downstream perso bins. Addionally, individualization ELF paths should be based on OTP names not SKU names.