### PR TITLE
[hmac,dv] Write to msg_length when sha_en

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cov.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cov.sv
@@ -103,11 +103,15 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
     msg_len_upper_cross: cross hmac_en, msg_len_upper_cp;
   endgroup : msg_len_cg
 
-  covergroup wr_msg_len_during_sha_en_cg with function sample (logic msg_len_lower,
-                                                               logic msg_len_upper);
+  covergroup wr_msg_len_during_not_idle_cg with function sample (logic msg_len_lower,
+                                                                 logic msg_len_upper);
     msg_len_lower_cp: coverpoint msg_len_lower {bins true = {1'b1};}
     msg_len_upper_cp: coverpoint msg_len_upper {bins true = {1'b1};}
-  endgroup : wr_msg_len_during_sha_en_cg
+  endgroup : wr_msg_len_during_not_idle_cg
+
+  covergroup wr_digest_during_not_idle_cg with function sample (int idx);
+    cp: coverpoint idx {bins idx[] = {[0:15]};}
+  endgroup : wr_digest_during_not_idle_cg
 
   covergroup wr_config_during_hash_cg with function sample (logic wr_config_during_hash);
     cp: coverpoint wr_config_during_hash {bins true = {1'b1};}
@@ -151,21 +155,31 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
 
   // Standard SV/UVM methods
   extern function new(string name, uvm_component parent);
+
+  // // Class specific methods
+  // extern function void sample_digest_during_not_idle(logic [15:0] digest);
 endclass : hmac_env_cov
 
 
 function hmac_env_cov::new(string name, uvm_component parent);
   super.new(name, parent);
-  cfg_cg                      = new();
-  status_cg                   = new();
-  msg_len_cg                  = new();
-  err_code_cg                 = new();
-  wr_msg_len_during_sha_en_cg = new();
-  wr_config_during_hash_cg    = new();
-  wr_key_during_hash_cg       = new();
-  wr_key_during_sha_only_cg   = new();
-  wr_msg_during_hash_cg       = new();
-  trig_rst_during_hash_cg     = new();
-  rd_digest_during_hmac_en_cg = new();
-  save_and_restore_cg         = new();
+  cfg_cg                        = new();
+  status_cg                     = new();
+  msg_len_cg                    = new();
+  err_code_cg                   = new();
+  wr_msg_len_during_not_idle_cg = new();
+  wr_digest_during_not_idle_cg  = new();
+  wr_config_during_hash_cg      = new();
+  wr_key_during_hash_cg         = new();
+  wr_key_during_sha_only_cg     = new();
+  wr_msg_during_hash_cg         = new();
+  trig_rst_during_hash_cg       = new();
+  rd_digest_during_hmac_en_cg   = new();
+  save_and_restore_cg           = new();
 endfunction : new
+
+// function void hmac_env_cov::sample_digest_during_not_idle(int digest_idx);
+//   for (int idx=0; idx<16; idx++) begin
+//     wr_digest_during_not_idle_cg.sample(idx, digest[idx]);
+//   end
+// endfunction : sample_digest_during_not_idle

--- a/hw/ip/hmac/dv/env/hmac_env_cov.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cov.sv
@@ -103,6 +103,12 @@ class hmac_env_cov extends cip_base_env_cov #(.CFG_T(hmac_env_cfg));
     msg_len_upper_cross: cross hmac_en, msg_len_upper_cp;
   endgroup : msg_len_cg
 
+  covergroup wr_msg_len_during_sha_en_cg with function sample (logic msg_len_lower,
+                                                               logic msg_len_upper);
+    msg_len_lower_cp: coverpoint msg_len_lower {bins true = {1'b1};}
+    msg_len_upper_cp: coverpoint msg_len_upper {bins true = {1'b1};}
+  endgroup : wr_msg_len_during_sha_en_cg
+
   covergroup wr_config_during_hash_cg with function sample (logic wr_config_during_hash);
     cp: coverpoint wr_config_during_hash {bins true = {1'b1};}
   endgroup : wr_config_during_hash_cg
@@ -154,6 +160,7 @@ function hmac_env_cov::new(string name, uvm_component parent);
   status_cg                   = new();
   msg_len_cg                  = new();
   err_code_cg                 = new();
+  wr_msg_len_during_sha_en_cg = new();
   wr_config_during_hash_cg    = new();
   wr_key_during_hash_cg       = new();
   wr_key_during_sha_only_cg   = new();

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -326,6 +326,19 @@ task hmac_scoreboard::process_tl_access(tl_seq_item item, tl_channels_e channel,
         "digest_14", "digest_15", "msg_length_upper", "msg_length_lower": begin
           // Predict updated value coming from write iff SHA core is disabled.
           do_predict = !sha_en;
+          // Sample when a message length write is happening while SHA core is enabled and when
+          // the written value is different from the mirrored value, to be sure this is a valid
+          // attempt.
+          if (cfg.en_cov) begin
+            if (sha_en && (csr_name == "msg_length_lower") &&
+                (item.a_data !== `gmv(ral.msg_length_lower))) begin
+                  cov.wr_msg_len_during_sha_en_cg.sample(.msg_len_lower(1), .msg_len_upper(0));
+                end
+            if (sha_en && (csr_name == "msg_length_upper") &&
+                (item.a_data !== `gmv(ral.msg_length_upper))) begin
+              cov.wr_msg_len_during_sha_en_cg.sample(.msg_len_lower(0), .msg_len_upper(1));
+            end
+          end
         end
         default: begin
           `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_smoke_vseq.sv
@@ -109,6 +109,17 @@ task hmac_smoke_vseq::body();
               .key_length(key_length), .intr_fifo_empty_en(intr_fifo_empty_en),
               .intr_hmac_done_en(intr_hmac_done_en), .intr_hmac_err_en(intr_hmac_err_en));
 
+    // Spawn a thread to test register write access when HMAC is not in IDLE after a random delay.
+    // Only do this if not already ongoing from the previous loop.
+    if (!try_wr_ctx_ongoing) begin
+      fork
+        begin
+          cfg.clk_rst_vif.wait_clks($urandom_range(100, 10_000));
+          try_wr_ctx_when_not_idle();
+        end
+      join_none
+    end
+
     // always start off the transaction by first clearing cfg.wipe_secret_triggered flag
     // and update the exp digest val in scb with last digest
     clear_wipe_secret();
@@ -190,22 +201,6 @@ task hmac_smoke_vseq::body();
         trigger_hash_when_active();
         `DV_CHECK_MEMBER_RANDOMIZE_FATAL(msg)
         wr_msg(msg);
-      end
-
-      // Try to write message length registers with a random value to test if ignored when SHA core
-      // is enabled.
-      if (sha_en && $urandom_range(0, 1)) begin
-        bit [2*TL_DW-1:0] rand_vector;
-        // Should be done that way as SV built-in functions are providing 32-bits values and the
-        // message length vector size can evolve.
-        for (int i=0; i<$size(rand_vector); i++) begin
-          rand_vector[i] = $urandom_range(0, 1);
-        end
-        csr_wr_msg_length(rand_vector);
-        // Trigger a read as the SCB will check register values against expected to be sure it
-        // hasn't been updated and will also sample the state for fcov
-        rd_msg_length();
-        `uvm_info(`gfn, $sformatf("attempt to write message length as sha_en=0"), UVM_MEDIUM)
       end
 
       // msg stream in finished, start hash


### PR DESCRIPTION
- this PR is linked to issue #24363
- it aims to test that write access to the message length registers is seemless when SHA core is enabled.
- add also a covergroup to track this from the fcov