### PR TITLE
[dif] Fix dif_<ip>_irq_get_type to handle bad arguments

### DIFF
--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
@@ -72,8 +72,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_adc_ctrl_irq_get_type(const dif_adc_ctrl_t *adc_ctrl,
                                        dif_adc_ctrl_irq_t irq,
                                        dif_irq_type_t *type) {
-  if (adc_ctrl == NULL || type == NULL ||
-      irq == kDifAdcCtrlIrqMatchPending + 1) {
+  if (adc_ctrl == NULL || type == NULL || irq < 0 ||
+      irq > kDifAdcCtrlIrqMatchPending) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
@@ -61,8 +61,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_alert_handler_irq_get_type(
     const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
     dif_irq_type_t *type) {
-  if (alert_handler == NULL || type == NULL ||
-      irq == kDifAlertHandlerIrqClassd + 1) {
+  if (alert_handler == NULL || type == NULL || irq < 0 ||
+      irq > kDifAlertHandlerIrqClassd) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
@@ -84,8 +84,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_aon_timer_irq_get_type(const dif_aon_timer_t *aon_timer,
                                         dif_aon_timer_irq_t irq,
                                         dif_irq_type_t *type) {
-  if (aon_timer == NULL || type == NULL ||
-      irq == kDifAonTimerIrqWdogTimerBark + 1) {
+  if (aon_timer == NULL || type == NULL || irq < 0 ||
+      irq > kDifAonTimerIrqWdogTimerBark) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.c
@@ -84,7 +84,8 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_csrng_irq_get_type(const dif_csrng_t *csrng,
                                     dif_csrng_irq_t irq, dif_irq_type_t *type) {
-  if (csrng == NULL || type == NULL || irq == kDifCsrngIrqCsFatalErr + 1) {
+  if (csrng == NULL || type == NULL || irq < 0 ||
+      irq > kDifCsrngIrqCsFatalErr) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_dma_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_dma_autogen.c
@@ -76,7 +76,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_dma_irq_get_type(const dif_dma_t *dma, dif_dma_irq_t irq,
                                   dif_irq_type_t *type) {
-  if (dma == NULL || type == NULL || irq == kDifDmaIrqDmaError + 1) {
+  if (dma == NULL || type == NULL || irq < 0 || irq > kDifDmaIrqDmaError) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.c
@@ -75,7 +75,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_edn_irq_get_type(const dif_edn_t *edn, dif_edn_irq_t irq,
                                   dif_irq_type_t *type) {
-  if (edn == NULL || type == NULL || irq == kDifEdnIrqEdnFatalErr + 1) {
+  if (edn == NULL || type == NULL || irq < 0 || irq > kDifEdnIrqEdnFatalErr) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
@@ -87,8 +87,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_irq_get_type(const dif_entropy_src_t *entropy_src,
                                           dif_entropy_src_irq_t irq,
                                           dif_irq_type_t *type) {
-  if (entropy_src == NULL || type == NULL ||
-      irq == kDifEntropySrcIrqEsFatalErr + 1) {
+  if (entropy_src == NULL || type == NULL || irq < 0 ||
+      irq > kDifEntropySrcIrqEsFatalErr) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
@@ -100,8 +100,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_flash_ctrl_irq_get_type(const dif_flash_ctrl_t *flash_ctrl,
                                          dif_flash_ctrl_irq_t irq,
                                          dif_irq_type_t *type) {
-  if (flash_ctrl == NULL || type == NULL ||
-      irq == kDifFlashCtrlIrqCorrErr + 1) {
+  if (flash_ctrl == NULL || type == NULL || irq < 0 ||
+      irq > kDifFlashCtrlIrqCorrErr) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.c
@@ -169,7 +169,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_gpio_irq_get_type(const dif_gpio_t *gpio, dif_gpio_irq_t irq,
                                    dif_irq_type_t *type) {
-  if (gpio == NULL || type == NULL || irq == kDifGpioIrqGpio31 + 1) {
+  if (gpio == NULL || type == NULL || irq < 0 || irq > kDifGpioIrqGpio31) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.c
@@ -77,7 +77,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_irq_get_type(const dif_hmac_t *hmac, dif_hmac_irq_t irq,
                                    dif_irq_type_t *type) {
-  if (hmac == NULL || type == NULL || irq == kDifHmacIrqHmacErr + 1) {
+  if (hmac == NULL || type == NULL || irq < 0 || irq > kDifHmacIrqHmacErr) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.c
@@ -113,7 +113,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_i2c_irq_get_type(const dif_i2c_t *i2c, dif_i2c_irq_t irq,
                                   dif_irq_type_t *type) {
-  if (i2c == NULL || type == NULL || irq == kDifI2cIrqHostTimeout + 1) {
+  if (i2c == NULL || type == NULL || irq < 0 || irq > kDifI2cIrqHostTimeout) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
@@ -73,7 +73,7 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_keymgr_irq_get_type(const dif_keymgr_t *keymgr,
                                      dif_keymgr_irq_t irq,
                                      dif_irq_type_t *type) {
-  if (keymgr == NULL || type == NULL || irq == kDifKeymgrIrqOpDone + 1) {
+  if (keymgr == NULL || type == NULL || irq < 0 || irq > kDifKeymgrIrqOpDone) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_keymgr_dpe_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_keymgr_dpe_autogen.c
@@ -75,7 +75,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_keymgr_dpe_irq_get_type(const dif_keymgr_dpe_t *keymgr_dpe,
                                          dif_keymgr_dpe_irq_t irq,
                                          dif_irq_type_t *type) {
-  if (keymgr_dpe == NULL || type == NULL || irq == kDifKeymgrDpeIrqOpDone + 1) {
+  if (keymgr_dpe == NULL || type == NULL || irq < 0 ||
+      irq > kDifKeymgrDpeIrqOpDone) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.c
@@ -80,7 +80,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_kmac_irq_get_type(const dif_kmac_t *kmac, dif_kmac_irq_t irq,
                                    dif_irq_type_t *type) {
-  if (kmac == NULL || type == NULL || irq == kDifKmacIrqKmacErr + 1) {
+  if (kmac == NULL || type == NULL || irq < 0 || irq > kDifKmacIrqKmacErr) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_mbx_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_mbx_autogen.c
@@ -79,7 +79,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_mbx_irq_get_type(const dif_mbx_t *mbx, dif_mbx_irq_t irq,
                                   dif_irq_type_t *type) {
-  if (mbx == NULL || type == NULL || irq == kDifMbxIrqMbxError + 1) {
+  if (mbx == NULL || type == NULL || irq < 0 || irq > kDifMbxIrqMbxError) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.c
@@ -72,7 +72,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_irq_get_type(const dif_otbn_t *otbn, dif_otbn_irq_t irq,
                                    dif_irq_type_t *type) {
-  if (otbn == NULL || type == NULL || irq == kDifOtbnIrqDone + 1) {
+  if (otbn == NULL || type == NULL || irq < 0 || irq > kDifOtbnIrqDone) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
@@ -88,7 +88,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_otp_ctrl_irq_get_type(const dif_otp_ctrl_t *otp_ctrl,
                                        dif_otp_ctrl_irq_t irq,
                                        dif_irq_type_t *type) {
-  if (otp_ctrl == NULL || type == NULL || irq == kDifOtpCtrlIrqOtpError + 1) {
+  if (otp_ctrl == NULL || type == NULL || irq < 0 ||
+      irq > kDifOtpCtrlIrqOtpError) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen.c
@@ -74,7 +74,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_pattgen_irq_get_type(const dif_pattgen_t *pattgen,
                                       dif_pattgen_irq_t irq,
                                       dif_irq_type_t *type) {
-  if (pattgen == NULL || type == NULL || irq == kDifPattgenIrqDoneCh1 + 1) {
+  if (pattgen == NULL || type == NULL || irq < 0 ||
+      irq > kDifPattgenIrqDoneCh1) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
@@ -70,7 +70,7 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_pwrmgr_irq_get_type(const dif_pwrmgr_t *pwrmgr,
                                      dif_pwrmgr_irq_t irq,
                                      dif_irq_type_t *type) {
-  if (pwrmgr == NULL || type == NULL || irq == kDifPwrmgrIrqWakeup + 1) {
+  if (pwrmgr == NULL || type == NULL || irq < 0 || irq > kDifPwrmgrIrqWakeup) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
@@ -122,8 +122,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_timer_irq_get_type(const dif_rv_timer_t *rv_timer,
                                        dif_rv_timer_irq_t irq,
                                        dif_irq_type_t *type) {
-  if (rv_timer == NULL || type == NULL ||
-      irq == kDifRvTimerIrqTimerExpiredHart0Timer0 + 1) {
+  if (rv_timer == NULL || type == NULL || irq < 0 ||
+      irq > kDifRvTimerIrqTimerExpiredHart0Timer0) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen.c
@@ -79,8 +79,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_sensor_ctrl_irq_get_type(const dif_sensor_ctrl_t *sensor_ctrl,
                                           dif_sensor_ctrl_irq_t irq,
                                           dif_irq_type_t *type) {
-  if (sensor_ctrl == NULL || type == NULL ||
-      irq == kDifSensorCtrlIrqInitStatusChange + 1) {
+  if (sensor_ctrl == NULL || type == NULL || irq < 0 ||
+      irq > kDifSensorCtrlIrqInitStatusChange) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
@@ -94,8 +94,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_device_irq_get_type(const dif_spi_device_t *spi_device,
                                          dif_spi_device_irq_t irq,
                                          dif_irq_type_t *type) {
-  if (spi_device == NULL || type == NULL ||
-      irq == kDifSpiDeviceIrqTpmRdfifoDrop + 1) {
+  if (spi_device == NULL || type == NULL || irq < 0 ||
+      irq > kDifSpiDeviceIrqTpmRdfifoDrop) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
@@ -76,7 +76,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_host_irq_get_type(const dif_spi_host_t *spi_host,
                                        dif_spi_host_irq_t irq,
                                        dif_irq_type_t *type) {
-  if (spi_host == NULL || type == NULL || irq == kDifSpiHostIrqSpiEvent + 1) {
+  if (spi_host == NULL || type == NULL || irq < 0 ||
+      irq > kDifSpiHostIrqSpiEvent) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c
@@ -72,8 +72,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_sysrst_ctrl_irq_get_type(const dif_sysrst_ctrl_t *sysrst_ctrl,
                                           dif_sysrst_ctrl_irq_t irq,
                                           dif_irq_type_t *type) {
-  if (sysrst_ctrl == NULL || type == NULL ||
-      irq == kDifSysrstCtrlIrqEventDetected + 1) {
+  if (sysrst_ctrl == NULL || type == NULL || irq < 0 ||
+      irq > kDifSysrstCtrlIrqEventDetected) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.c
@@ -95,7 +95,7 @@ static dif_irq_type_t irq_types[] = {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_uart_irq_get_type(const dif_uart_t *uart, dif_uart_irq_t irq,
                                    dif_irq_type_t *type) {
-  if (uart == NULL || type == NULL || irq == kDifUartIrqTxEmpty + 1) {
+  if (uart == NULL || type == NULL || irq < 0 || irq > kDifUartIrqTxEmpty) {
     return kDifBadArg;
   }
 

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
@@ -125,7 +125,8 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_usbdev_irq_get_type(const dif_usbdev_t *usbdev,
                                      dif_usbdev_irq_t irq,
                                      dif_irq_type_t *type) {
-  if (usbdev == NULL || type == NULL || irq == kDifUsbdevIrqAvSetupEmpty + 1) {
+  if (usbdev == NULL || type == NULL || irq < 0 ||
+      irq > kDifUsbdevIrqAvSetupEmpty) {
     return kDifBadArg;
   }
 

--- a/util/make_new_dif/templates/dif_autogen.c.tpl
+++ b/util/make_new_dif/templates/dif_autogen.c.tpl
@@ -204,11 +204,13 @@ dif_result_t dif_${ip.name_snake}_init(
     % if ip.irqs[-1].width == 1:
       if (${ip.name_snake} == NULL ||
           type == NULL ||
-          irq == kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel} + 1) {
+          irq < 0 ||
+          irq > kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}) {
     % else:
       if (${ip.name_snake} == NULL ||
           type == NULL ||
-          irq == kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}${ip.irqs[-1].width - 1} + 1) {
+          irq < 0 ||
+          irq > kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}${ip.irqs[-1].width - 1}) {
     % endif
       return kDifBadArg;
     }


### PR DESCRIPTION
The functino performs an incorrect check on the irq number. In particular, this number could be negative or above max_irq+1. If this happens, the function will perform an out-of-bound array access.

One particular instance where this could happen is in the isr testutils where it can be called with an incorrect argument.