### PR TITLE
[pwm] RTL modifications for specification compliance and predictable behavior

### DIFF
--- a/hw/ip/pwm/rtl/pwm_core.sv
+++ b/hw/ip/pwm/rtl/pwm_core.sv
@@ -162,6 +162,7 @@ module pwm_core #(
       .blink_param_x_i  (reg2hw.blink_param[ii].x.q),
       .blink_param_y_i  (reg2hw.blink_param[ii].y.q),
       .phase_ctr_i      (phase_ctr_q),
+      .phase_ctr_next_i (phase_ctr_next),
       .cycle_end_i      (cycle_end),
       .clr_chan_cntr_i  (clr_chan_cntr[ii]),
       .dc_resn_i        (dc_resn),


### PR DESCRIPTION
This PR addresses a number of issues found within the PWM RTL as part of the D3 review process. Since the changes have ended up becoming pretty extensive, the PR is structured as a number of commits. Each of these, except perhaps the final one, should be easy to understand in isolation since it is either (i) small and self-contained or (ii) not a functional change.

Since the last involves significant changes to the blink mode and particularly heartbeat logic it is more involved.
Please see the commit messages for a breakdown of what each commit does.

Issues with the current PWM implementation:

 - phase counter configuration is accepted immediately; software could probably tolerate either immediate or deferred acceptance, but this PR changes the RTL to match the specification/documentation, allowing the configuration to be changed at any point and the phase counting to be disabled at any time. New configuration settings are accepted into the core logic only upon enabling the counter.

 - phase counter is not fully reset when the configuration was changed.

 - channel enable only gates the output on/off and does not start the internal logic from a defined state.

 - heartbeat logic is not reset properly when the configuration was changed, so to achieve synchronized heartbeat signaling (eg. tri-color LED operation) it is necessary first to configure the pwm channels for blinking operation and then quickly set the `htbt_en` bits to ensure that they start at the same time (not at the 5us clock-cycle level, but close enough for LEDs).

 - changing the `pwm_en` or `invert` register impacts the other channels, causing a reset of the blinking logic and a partial reset (loss of predictable timing) of heartbeat logic.

 - the duty cycle within the channel is updated at the end of the pulse cycle without any regard for the phase delay. A given output pulse may thus be formed from two different duty cycles.

 - there is a lot of combinational logic on the output of the PWM block which means that it is likely to suffer from glitches; this could be a problem for any application that is edge-sensitive or relies upon specific timing rather than just the overall average signal level.
