### PR TITLE
[bazel] Update bazelisk to 1.24.1

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -20,10 +20,10 @@ cd "$(dirname "$0")"
 : "${BINDIR:=.bin}"
 : "${BAZEL_BIN:=$(which bazel 2>/dev/null)}"
 
-readonly release="v1.11.0"
+readonly release="v1.24.1"
 declare -A hashes=(
     # sha256sums for v1.11.0.  Update this if you update the release.
-    [linux-amd64]="231ec5ca8115e94c75a1f4fbada1a062b48822ca04f21f26e4cb1cd8973cd458"
+    [linux-amd64]="0aee09c71828b0012750cb9b689ce3575da8e230f265bf8d6dcd454eee6ea842"
 )
 
 declare -A architectures=(

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -121,6 +121,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
   pushd "${BAZEL_AIRGAPPED_DIR}/empty_workspace"
     touch MODULE.bazel
     touch WORKSPACE
+    cp "${REPO_TOP}/.bazelversion" .
     bazel sync --repository_cache="${BAZEL_AIRGAPPED_DIR}/${BAZEL_CACHEDIR}"
   popd
   rm -rf "${BAZEL_AIRGAPPED_DIR}/empty_workspace"


### PR DESCRIPTION
This will fix master CI.

Required for bzlmod support. Older versions do not recognise `MODULE.bazel` as the root of the repo when searching for `.bazelversion`.