### PR TITLE
[bazel] resolve conflicting actions in `update_manifest`

### DIFF
--- a/rules/manifest.bzl
+++ b/rules/manifest.bzl
@@ -169,21 +169,22 @@ def manifest(d):
     _manifest(**d)
     return d["name"]
 
-def update_manifest(ctx, manifest, elf, update_manifest_json_tool):
+def update_manifest(ctx, manifest, elf, exec_env):
     """Update the `manuf_state_creator` field in a ROM_EXT manifest.
 
     Args:
         ctx: The rule context.
         manifest: The input JSON manifest file.
         elf: The input ROM_EXT ELF file.
-        update_manifest_json_tool: The path to the `update-manifest-json` tool.
+        exec_env: An ExecEnvInfo provider.
 
     Returns:
         The updated JSON manifest file.
     """
     output_file = ctx.actions.declare_file(
-        "{}.{}.with_manuf_state_creator_updated.json".format(
+        "{}_{}.{}.with_manuf_state_creator_updated.json".format(
             ctx.attr.name,
+            exec_env.exec_env,
             paths.split_extension(manifest.basename)[0],
         ),
     )
@@ -195,6 +196,6 @@ def update_manifest(ctx, manifest, elf, update_manifest_json_tool):
         outputs = [output_file],
         inputs = [manifest, elf],
         arguments = [args],
-        executable = update_manifest_json_tool,
+        executable = exec_env._update_manifest_json,
     )
     return output_file

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -186,7 +186,7 @@ def _build_binary(ctx, exec_env, name, deps, kind):
     rsa_key = get_fallback(ctx, "attr.rsa_key", exec_env)
     spx_key = get_fallback(ctx, "attr.spx_key", exec_env)
     if manifest and ctx.attr.immutable_rom_ext_enabled:
-        manifest = update_manifest(ctx, manifest, elf, exec_env._update_manifest_json)
+        manifest = update_manifest(ctx, manifest, elf, exec_env)
 
     if (manifest or rsa_key) and kind != "ram":
         if not (manifest and (rsa_key or ecdsa_key)):


### PR DESCRIPTION
This PR modifies the output file name of the updated manifest  to include the execution environment name, ensuring unique output file names for each ELF file and resolving the conflicting actions.

The `update_manifest` function was previously using the same output file name for different ELF files, resulting in conflicting actions when multiple environments are set in `exec_env`.