### PR TITLE
[hmac,dv] Add new test to cover FSM transitions

### DIFF
--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -150,6 +150,14 @@
       stage: V3
       tests: ["hmac_smoke"]
     }
+    {
+      name: stress_reset
+      desc: '''Run multiple hmac_long_msg sequences with random on-the-fly reset to ensure that all
+            FSM transitions are exercised.
+            '''
+      stage: V3
+      tests: ["hmac_stress_reset"]
+    }
   ]
 
   covergroups: [

--- a/hw/ip/hmac/dv/env/hmac_env.core
+++ b/hw/ip/hmac/dv/env/hmac_env.core
@@ -29,6 +29,7 @@ filesets:
       - seq_lib/hmac_datapath_stress_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_test_vectors_hmac_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_long_msg_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_stress_reset_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_test_vectors_sha_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_burst_wr_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_error_vseq.sv: {is_include_file: true}

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_reset_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_reset_vseq.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence generates random resets but when HMAC is doing some operations and mostly
+// with long messages.
+class hmac_stress_reset_vseq extends hmac_base_vseq;
+  `uvm_object_utils(hmac_stress_reset_vseq)
+
+  // Standard SV/UVM methods
+  extern function new(string name="");
+  extern task body();
+endclass : hmac_stress_reset_vseq
+
+
+function hmac_stress_reset_vseq::new(string name="");
+  super.new(name);
+endfunction : new
+
+
+task hmac_stress_reset_vseq::body();
+  for (int i = 1; i <= num_trans; i++) begin
+    run_seq_with_rand_reset_vseq(create_seq_by_name("hmac_long_msg_vseq"), 1, 100);
+  end
+endtask : body

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
@@ -5,6 +5,7 @@
 `include "hmac_base_vseq.sv"
 `include "hmac_smoke_vseq.sv"
 `include "hmac_long_msg_vseq.sv"
+`include "hmac_stress_reset_vseq.sv"
 `include "hmac_test_vectors_sha_vseq.sv"
 `include "hmac_test_vectors_hmac_vseq.sv"
 `include "hmac_back_pressure_vseq.sv"

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -64,6 +64,11 @@
     }
 
     {
+      name: hmac_stress_reset
+      uvm_test_seq: hmac_stress_reset_vseq
+    }
+
+    {
       name: hmac_back_pressure
       uvm_test_seq: hmac_back_pressure_vseq
       run_opts: ["+zero_delays=1"]


### PR DESCRIPTION
- New sequence to try to cover all the FSM transitions with random resets along with long message test.