### PR TITLE
[chip,dv] Fix $plusarg string

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -23,7 +23,7 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
 
   virtual task body();
     string csr_test_type;
-    void'($value$plusargs("+csr_%0s", csr_test_type));
+    void'($value$plusargs("csr_%0s", csr_test_type));
     // sio are driven X when csb is inactive, but these pins can be configured as wakeup cause,
     // assign a known value to avoid X propagation in case that `PINMUX.WKUP_CAUSE` is programmed.
     cfg.chip_vif.spi_host_if.sio_out = $urandom;


### PR DESCRIPTION
Incorrect inclusion of "+" at the start of the plusarg name string in a `$value$plusargs` call.