### PR TITLE
[sram_ctrl,dv] Increase fatal_error timeout

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -543,7 +543,11 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     case (csr_name)
       // add individual case item for each csr
       "alert_test": begin
-        if (addr_phase_write && item.a_data[0]) set_exp_alert("fatal_error", .is_fatal(0));
+        if (addr_phase_write && item.a_data[0]) begin
+          // Allow up to 10 cycles delay to consider a potential delay introduced
+          // by enabling/disabling the SRAM readback feature during the test.
+          set_exp_alert("fatal_error", .is_fatal(0), .max_delay(10));
+        end
       end
       "exec_regwen": begin
         // do nothing


### PR DESCRIPTION
With the introduction of the SRAM readback mode (c.f., lowRISC/opentitan#23212) memory requests can be delayed. The SRAM DV tests are adapted such that the readback feature can be disabled or enabled anytime during a test.

The sram_ctrl_passthru_mem_tl_intg_err failed occasionally because the integrity alert was expected to arrive without any delay. This commit increases the max_delay parameter for the expected alert to take the readback mode delay as well as a potential enabling or disabling of the feature into account.