### PR TITLE
[rom_ctrl, dv] Removed the option of assert coverage collection

### DIFF
--- a/hw/ip/rom_ctrl/dv/cov/cover_reg_top.cfg
+++ b/hw/ip/rom_ctrl/dv/cov/cover_reg_top.cfg
@@ -5,6 +5,6 @@
 // Collect coverage for tlul_adapter_sram to resolve coverage hole for intg_err.
 +tree tb.dut.u_tl_adapter_rom
 
-begin line+cond+fsm+branch+assert
+begin line+cond+fsm+branch
   +moduletree tlul_adapter_sram
 end


### PR DESCRIPTION
tlul_adapter_sram contains fifos (prim_fifo_sync) and we are'nt required to collect assertion coverage. This will reduce the percentage of assert coverage being uncovered for the adapter.