### PR TITLE
[rom_ctrl,dv] Correct argument to dut_init in rom_ctrl_base_vseq

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -16,7 +16,7 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
   `uvm_object_new
 
   virtual task dut_init(string reset_kind = "HARD");
-    super.dut_init();
+    super.dut_init(reset_kind);
     // Disable intr test since no interrupts
     do_clear_all_interrupts = 1'b0;
   endtask


### PR DESCRIPTION
Practically speaking, this doesn't really matter (because it only ever gets called with the default value), but it seems worth tidying up.