### PR TITLE
[rom_ctrl,dv] Fix how we splat fifo contents in common vseq

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -150,13 +150,15 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
       wait_while_reading_low();
     end
 
-    // Zero the contents of the rom_ctrl sram request fifos if we're about to do fault injection on
-    // their counters. This avoids a problem where we generate a spurious request when the FIFO was
-    // actually empty and lots of signals in the design become X. This will let the fifos error
-    // signal stuck at X. Zeroing the backing memory avoids that problem.
-    splat_fifo_storage("tb.dut.u_tl_adapter_rom.u_reqfifo", 2);
-    splat_fifo_storage("tb.dut.u_tl_adapter_rom.u_sramreqfifo", 2);
-
+    // If do_apply_reset is true then super.dut_init just applied a reset and the rom_ctrl sram
+    // request fifos will be empty. We might be about to do fault injection on those fifos' counters
+    // which will generate spurious requests. But we don't want the request data to be X (because it
+    // will cause the fifos' error signals to get stuck at X). Write some arbitrary rubbish to the
+    // contents.
+    if (do_apply_reset) begin
+      splat_fifo_storage("tb.dut.u_tl_adapter_rom.u_reqfifo", 2);
+      splat_fifo_storage("tb.dut.u_tl_adapter_rom.u_sramreqfifo", 2);
+    end
   endtask
 
   // This task is defined in cip_base_vseq. It tries to run some TL accesses and injects integrity


### PR DESCRIPTION
This code was added by cc0abbfe3e3 and I think it was assuming that we only ever run this after reset (when the FIFO will be empty). It turns out that this isn't quite true and there is a window where we can write rubbish to the FIFO when it isn't empty, causing a sporadic failure in rom_ctrl_stress_all_with_rand_reset.