### PR TITLE
[hmac, rtl] Do not skip padding after a hash stop command

### DIFF
--- a/hw/ip/prim/rtl/prim_sha2_pad.sv
+++ b/hw/ip/prim/rtl/prim_sha2_pad.sv
@@ -337,8 +337,13 @@ module prim_sha2_pad import prim_sha2_pkg::*;
       end
     endcase
 
-    if (!sha_en_i)    st_d = StIdle;
-    else if (hash_go) st_d = StFifoReceive;
+    if (!sha_en_i) begin
+      st_d = StIdle;
+    // We do not allow the cancellation of an ongoing padding operation, i.e., reverting back to the
+    // `StFifoReceive` state while being in the states `StPad80`, `StPad00`, `StLenHi` or `StLenLo`.
+    end else if (hash_go && (st_q inside {StIdle, StFifoReceive})) begin
+      st_d = StFifoReceive;
+    end
   end
 
   // tx_count


### PR DESCRIPTION
This commit removes some conditional FSM states transition that were deemed undesirable in `prim_sha2_pad`, see #23936. It made it possible to cancel an ongoing padding operation, which is disallowed by the HMAC module. As a side-effect, the removal plugs some existing FSM transition coverage holes in `prim_sha2_pad` whose manual exclusions can be removed as well.

This change makes it impossible to transition into the `StFifoReceive` state from either `StPad80`, `StPad00`, `StLenHi` or `StLenLo` by asserting the `hash_go` signal.