### PR TITLE
[sram_ctrl,dv] Fix readback_err test for write iteration 0

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_readback_err_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_readback_err_vseq.sv
@@ -33,7 +33,7 @@ class sram_ctrl_readback_err_vseq extends sram_ctrl_base_vseq;
     for (int iteration = 0; iteration < iterations; iteration++) begin
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(addr, (addr & sram_addr_mask) < max_offset;)
         if (write) begin
-          do_single_write(.addr(addr), .data(iteration), .mask('1), .blocking(0));
+          do_single_write(.addr(addr), .data(iteration + 1), .mask('1), .blocking(0));
         end else begin
           do_single_read(.addr(addr), .mask('1), .check_rdata(0), .blocking(0), .rdata(rdata));
         end


### PR DESCRIPTION
When injecting a fault into write transaction 0, we previously were writing 0 to memory. However, as the memory seems to be initialized with 0, the readback returned the init value 0. Hence, the readback check was not failing as expected.