### PR TITLE
[dv] Fix DVSim after GUI_DEBUG addition

### DIFF
--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -100,7 +100,7 @@ class LocalLauncher(Launcher):
         self.job_runtime_secs = elapsed_time.total_seconds()
         if self.process.poll() is None:
             if (self.timeout_secs and (self.job_runtime_secs > self.timeout_secs) and
-                    not (self.deploy.gui or self.deploy.gui_debug)):
+                    not (self.deploy.gui)):
                 self._kill()
                 timeout_message = 'Job timed out after {} minutes'.format(
                     self.deploy.get_timeout_mins())


### PR DESCRIPTION
- GUI_DEBUG mode addition is creating an issue when tests are going into timeout. Because Deploy.py is managing GUI_DEBUG mode through GUI mode, but in LocalLauncher.py we were trying to access gui_debug attribute which doesn't exists.