### PR TITLE
[sram_ctrl,dv] Disable intg. checks for FI test

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_mubi_enc_err_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_mubi_enc_err_vseq.sv
@@ -124,6 +124,8 @@ class sram_ctrl_mubi_enc_err_vseq extends sram_ctrl_base_vseq;
     // Turn off tlul_adapter_sram assertions as we are messing around with some
     // signals that would trigger an assertion.
     $assertoff(0, "tb.dut.u_tlul_adapter_sram");
+    // As we injecting faults into prim_ram, disable TL-UL integrity checks.
+    cfg.m_tl_agent_cfgs[cfg.sram_ral_name].check_tl_errs = 0;
 
     // Request memory init.
     req_mem_init();


### PR DESCRIPTION
Occasionally, some TLUL integrity checks fired for the sram_ctrl_mubi_enc_err. This is expected as this test is a fault injection error test. Disable the according check to let the test pass.