### PR TITLE
[rom_ext] Explicitly mark static critical vars as used

### DIFF
--- a/sw/device/info_sections.ld
+++ b/sw/device/info_sections.ld
@@ -38,18 +38,12 @@
 /**
  * The following section contains log fields constructed from the logs using
  * the log_fields_t struct defined in sw/device/lib/runtime/log.h. The size of
- * each log field is fixed - 20 bytes.
+ * each log field is fixed - 20 bytes. To distinguish between the fields of
+ * different ELF files we add an offset to the address. We register that offset
+ * here as a header before the log fields.
  */
-.logs.fields _dv_log_offset (INFO): {
-  /* Force this section to always be emitted. The logs extraction script expects
-   * this section to be present in the ELF file, but the linker will not emit it
-   * if there are no outputs (i.e, the *(.logs.fields) statement) with contents.
-   *
-   * However, almost any assignment will implicitly create even an empty section,
-   * including the very silly . = . (set the program counter to itself).
-   *
-   * See https://sourceware.org/binutils/docs-2.29/ld/Output-Section-Discarding.html. */
-  . = .;
+.logs.fields 0 (INFO): {
+  LONG(_dv_log_offset);
   *(.logs.fields)
 }
 

--- a/sw/device/lib/runtime/log.h
+++ b/sw/device/lib/runtime/log.h
@@ -98,6 +98,8 @@ void base_log_internal_core(const log_fields_t *log, ...);
  */
 void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
 
+extern char _dv_log_offset[];
+
 /**
  * A macro that wraps the `OT_FAIL_IF_64_BIT` macro, providing the name
  * of the LOG macro for better error messages.
@@ -139,7 +141,7 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
       __attribute__((section(".logs.fields")))                   \
       static const log_fields_t kLogFields =                     \
           LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);     \
-      base_log_internal_dv(&kLogFields,                          \
+      base_log_internal_dv((const log_fields_t*)((char*)&kLogFields + (uintptr_t)&_dv_log_offset), \
                            OT_VA_ARGS_COUNT(format, ##__VA_ARGS__), \
                            ##__VA_ARGS__); /* clang-format on */ \
     } else {                                                     \

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -280,33 +280,20 @@ SECTIONS {
    _non_volatile_counter_3_start = _non_volatile_counter_3_end - _non_volatile_counter_size;
 
   /**
-   * Non-volatile scratch area in flash.
-   */
-  .non_volatile_scratch _non_volatile_scratch_start (NOLOAD) : ALIGN(2048) {
-    KEEP(*(.non_volatile_scratch))
-    KEEP(*(.non_volatile_scratch.*))
-    . = ABSOLUTE(_non_volatile_scratch_end);
-  } > ottf_flash
-
-
-  /**
    * Non-volatile counter area in flash.
    *
    * Similar to the `.non_volatile_scratch` section, this section is meant to
    * be used by tests. Because we don't want to write to the same flash word
    * twice, tests that require non-volatile counters can use this section by
    * striking flash words to count up to `_non_volatile_counter_max_count`.
+   *
+   * The sections are ordered by ascending memory address, and thus by
+   * descending volatile counter number. That prevents linker problems.
    */
-  .non_volatile_counter_0 _non_volatile_counter_0_start (NOLOAD) : ALIGN(2048) {
-    KEEP(*(.non_volatile_counter_0))
-    KEEP(*(.non_volatile_counter_0.*))
-    . = ABSOLUTE(_non_volatile_counter_0_end);
-  } > ottf_flash
-
-  .non_volatile_counter_1 _non_volatile_counter_1_start (NOLOAD) : ALIGN(2048) {
-    KEEP(*(.non_volatile_counter_1))
-    KEEP(*(.non_volatile_counter_1.*))
-    . = ABSOLUTE(_non_volatile_counter_1_end);
+  .non_volatile_counter_3 _non_volatile_counter_3_start (NOLOAD) : ALIGN(2048) {
+    KEEP(*(.non_volatile_counter_3))
+    KEEP(*(.non_volatile_counter_3.*))
+    . = ABSOLUTE(_non_volatile_counter_3_end);
   } > ottf_flash
 
   .non_volatile_counter_2 _non_volatile_counter_2_start (NOLOAD) : ALIGN(2048) {
@@ -315,10 +302,27 @@ SECTIONS {
     . = ABSOLUTE(_non_volatile_counter_2_end);
   } > ottf_flash
 
-  .non_volatile_counter_3 _non_volatile_counter_3_start (NOLOAD) : ALIGN(2048) {
-    KEEP(*(.non_volatile_counter_3))
-    KEEP(*(.non_volatile_counter_3.*))
-    . = ABSOLUTE(_non_volatile_counter_3_end);
+  .non_volatile_counter_1 _non_volatile_counter_1_start (NOLOAD) : ALIGN(2048) {
+    KEEP(*(.non_volatile_counter_1))
+    KEEP(*(.non_volatile_counter_1.*))
+    . = ABSOLUTE(_non_volatile_counter_1_end);
+  } > ottf_flash
+
+  .non_volatile_counter_0 _non_volatile_counter_0_start (NOLOAD) : ALIGN(2048) {
+    KEEP(*(.non_volatile_counter_0))
+    KEEP(*(.non_volatile_counter_0.*))
+    . = ABSOLUTE(_non_volatile_counter_0_end);
+  } > ottf_flash
+
+  /**
+   * Non-volatile scratch area in flash.
+   */
+  .non_volatile_scratch _non_volatile_scratch_start (NOLOAD) : ALIGN(2048) {
+    begin_of_non_volatile_scratch = . ;
+    KEEP(*(.non_volatile_scratch))
+    KEEP(*(.non_volatile_scratch.*))
+    . = ABSOLUTE(_non_volatile_scratch_end);
+    end_of_non_volatile_scratch = . ;
   } > ottf_flash
 
   INCLUDE sw/device/info_sections.ld

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -285,7 +285,7 @@ SECTIONS {
   .non_volatile_scratch _non_volatile_scratch_start (NOLOAD) : ALIGN(2048) {
     KEEP(*(.non_volatile_scratch))
     KEEP(*(.non_volatile_scratch.*))
-    . = _non_volatile_scratch_size;
+    . = ABSOLUTE(_non_volatile_scratch_end);
   } > ottf_flash
 
 
@@ -300,25 +300,25 @@ SECTIONS {
   .non_volatile_counter_0 _non_volatile_counter_0_start (NOLOAD) : ALIGN(2048) {
     KEEP(*(.non_volatile_counter_0))
     KEEP(*(.non_volatile_counter_0.*))
-    . = _non_volatile_counter_size;
+    . = ABSOLUTE(_non_volatile_counter_0_end);
   } > ottf_flash
 
   .non_volatile_counter_1 _non_volatile_counter_1_start (NOLOAD) : ALIGN(2048) {
     KEEP(*(.non_volatile_counter_1))
     KEEP(*(.non_volatile_counter_1.*))
-    . = _non_volatile_counter_size;
+    . = ABSOLUTE(_non_volatile_counter_1_end);
   } > ottf_flash
 
   .non_volatile_counter_2 _non_volatile_counter_2_start (NOLOAD) : ALIGN(2048) {
     KEEP(*(.non_volatile_counter_2))
     KEEP(*(.non_volatile_counter_2.*))
-    . = _non_volatile_counter_size;
+    . = ABSOLUTE(_non_volatile_counter_2_end);
   } > ottf_flash
 
   .non_volatile_counter_3 _non_volatile_counter_3_start (NOLOAD) : ALIGN(2048) {
     KEEP(*(.non_volatile_counter_3))
     KEEP(*(.non_volatile_counter_3.*))
-    . = _non_volatile_counter_size;
+    . = ABSOLUTE(_non_volatile_counter_3_end);
   } > ottf_flash
 
   INCLUDE sw/device/info_sections.ld

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -57,15 +57,29 @@ _manifest_address_translation = (_text_start >= ORIGIN(eflash) &&
                                  _text_start < (ORIGIN(eflash)
                                               + LENGTH(eflash))) ? 0x1d4 : 0x739;
 
+PHDRS {
+  static_critical_segment PT_LOAD;
+  manifest_segment PT_LOAD;
+  data_segment PT_LOAD;
+  freertos_segment PT_LOAD;
+  scratch_segment PT_LOAD;
+}
+
 /**
  * NOTE: We have to align each section to word boundaries as our current
  * s19->slm conversion scripts are not able to handle non-word aligned sections.
  */
 SECTIONS {
+  /**
+   * Critical static data that is accessible by both the ROM and the ROM
+   * extension.
+   */
+  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
+
   .manifest _ottf_start_address : {
     KEEP(*(.manifest))
     . = ALIGN(4);
-  } > ottf_flash
+  } > ottf_flash : manifest_segment
 
   /**
    * Immutable ROM_EXT section.
@@ -160,12 +174,6 @@ SECTIONS {
   } > ottf_flash
 
   /**
-   * Critical static data that is accessible by both the ROM and the ROM
-   * extension.
-   */
-  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
-
-  /**
    * Standard mutable data section, at the bottom of RAM. This will be
    * initialized from the .idata section at runtime by the CRT.
    */
@@ -217,7 +225,7 @@ SECTIONS {
      * Using `AT>` means we don't have to keep track of the next free part of
      * flash, as we do in our other linker scripts.
      */
-  } > ram_main AT> ottf_flash
+  } > ram_main AT> ottf_flash :data_segment
 
   /**
    * Standard BSS section. This will be zeroed at runtime by the CRT.
@@ -249,7 +257,7 @@ SECTIONS {
   .freertos.heap (NOLOAD): ALIGN(4) {
     _freertos_heap_start = .;
     *(.freertos.heap)
-  } > ram_main
+  } > ram_main :freertos_segment
 
   /**
    * Non-volatile scratch and counter areas for tests.
@@ -294,7 +302,7 @@ SECTIONS {
     KEEP(*(.non_volatile_counter_3))
     KEEP(*(.non_volatile_counter_3.*))
     . = ABSOLUTE(_non_volatile_counter_3_end);
-  } > ottf_flash
+  } > ottf_flash :scratch_segment
 
   .non_volatile_counter_2 _non_volatile_counter_2_start (NOLOAD) : ALIGN(2048) {
     KEEP(*(.non_volatile_counter_2))

--- a/sw/device/silicon_creator/lib/base/static_critical_boot_measurements.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_boot_measurements.c
@@ -10,4 +10,4 @@
 // This is placed at a fixed location in memory within the .static_critical
 // section. It will be populated by the ROM before the jump to ROM_EXT.
 OT_SET_BSS_SECTION(".static_critical.boot_measurements",
-                   boot_measurements_t boot_measurements;)
+                   OT_USED boot_measurements_t boot_measurements;)

--- a/sw/device/silicon_creator/lib/base/static_critical_epmp_state.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_epmp_state.c
@@ -9,4 +9,5 @@
 //
 // This is placed at a fixed location in memory within the .static_critical
 // section. It will be populated by the ROM before the jump to ROM_EXT.
-OT_SET_BSS_SECTION(".static_critical.epmp_state", epmp_state_t epmp_state;)
+OT_SET_BSS_SECTION(".static_critical.epmp_state",
+                   OT_USED epmp_state_t epmp_state;)

--- a/sw/device/silicon_creator/lib/base/static_critical_sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_sec_mmio.c
@@ -10,4 +10,4 @@
 // This is placed at a fixed location in memory within the .static_critical
 // section. It will be populated by the ROM before the jump to ROM_EXT.
 OT_SET_BSS_SECTION(".static_critical.sec_mmio_ctx",
-                   sec_mmio_ctx_t sec_mmio_ctx;)
+                   OT_USED sec_mmio_ctx_t sec_mmio_ctx;)

--- a/sw/device/silicon_creator/lib/manifest_def.c
+++ b/sw/device/silicon_creator/lib/manifest_def.c
@@ -24,8 +24,7 @@ extern char _manifest_address_translation[];
  * binary by `opentitantool` (overriding the implicitly specified initial value
  * of zero).
  */
-OT_SECTION(".manifest")
-static manifest_t kManifest_ = {
+OT_USED OT_SECTION(".manifest") static manifest_t kManifest_ = {
     .manifest_version =
         (manifest_version_t){
             .minor = kManifestVersionMinor1,

--- a/sw/device/silicon_creator/manuf/lib/sram_program.ld
+++ b/sw/device/silicon_creator/manuf/lib/sram_program.ld
@@ -28,6 +28,10 @@ _dv_log_offset = 0x10000;
 
 ENTRY(sram_start);
 
+PHDRS {
+  sram_segment PT_LOAD;
+}
+
 /* NOTE This linker script assumes non-page-aligned segments because we skip
  * the first _static_critical_size bytes of the SRAM and we do not want the
  * ELF segments to contain the headers as this would overwrite the contents of
@@ -45,13 +49,13 @@ SECTIONS {
      * the RAM to the entry point for VMEM files. */
     KEEP(*(.sram_start))
     . = ALIGN(256);
-  } > ram_main
+  } > ram_main : sram_segment
 
   .vectors : ALIGN (256){
     _text_start = .;
     KEEP(*(.vectors))
     . = ALIGN(4);
-  } > ram_main
+  } > ram_main : sram_segment
 
   .text : ALIGN(4) {
     KEEP(*(.crt))
@@ -59,14 +63,14 @@ SECTIONS {
     KEEP(*(.text.*))
     . = ALIGN(4);
     _text_end = .;
-  } > ram_main
+  } > ram_main : sram_segment
 
   .rodata : ALIGN(4) {
     KEEP(*(.rodata))
     KEEP(*(.rodata.*))
     . = ALIGN(4);
     __rodata_end = .;
-  } > ram_main
+  } > ram_main : sram_segment
 
   .data : ALIGN(4) {
     /* This will get loaded into `gp`, and the linker will use that register for
@@ -89,7 +93,7 @@ SECTIONS {
     KEEP(*(.sdata.*))
     . = ALIGN(4);
     _crc_end = .;
-  } > ram_main
+  } > ram_main : sram_segment
 
   /**
    * Standard BSS section. This will be zeroed at runtime by the CRT.
@@ -109,7 +113,7 @@ SECTIONS {
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _bss_end = .;
-  } > ram_main
+  } > ram_main : sram_segment
 
   INCLUDE sw/device/info_sections.ld
 }

--- a/util/device_sw_utils/extract_sw_logs.py
+++ b/util/device_sw_utils/extract_sw_logs.py
@@ -213,7 +213,6 @@ def extract_sw_logs(elf_file, logs_fields_section):
         # Parse the logs fields section to extract the logs.
         section = elf.get_section_by_name(name=logs_fields_section)
         if section:
-            logs_base_addr = int(section.header['sh_addr'])
             logs_size = int(section.header['sh_size'])
             logs_data = section.data()
         else:
@@ -221,15 +220,18 @@ def extract_sw_logs(elf_file, logs_fields_section):
                 logs_fields_section, elf_file))
             sys.exit(1)
 
+        header_size = 4
+        logs_offset, = struct.unpack('I', logs_data[0:header_size])
+
         # Dump the logs with fields.
         result = ""
-        num_logs = logs_size // LOGS_FIELDS_SIZE
+        num_logs = (logs_size - header_size) // LOGS_FIELDS_SIZE
         for i in range(num_logs):
-            start = i * LOGS_FIELDS_SIZE
+            start = header_size + i * LOGS_FIELDS_SIZE
             end = start + LOGS_FIELDS_SIZE
             severity, file_addr, line, nargs, format_addr = struct.unpack(
                 'IIIII', logs_data[start:end])
-            result += "addr: {}\n".format(hex(logs_base_addr + start)[2:])
+            result += "addr: {}\n".format(hex(logs_offset + start)[2:])
             result += "severity: {}\n".format(severity)
             result += "file: {}\n".format(
                 prune_filename(get_str_at_addr(file_addr, addr_strings)))


### PR DESCRIPTION
This PR cherry-picks several commits for preparing LTO on ROM_EXT to reduce firmware size.

Includes:

https://github.com/lowRISC/opentitan/pull/22008
* d4ba5d405ea015ebd1ddf0905ddfcf658ac254ae
* ef73fd81c24adb0ba3399acbcfd1f7d0497ab6ee
* 6f63d6bae02fbb401affd3c510403756e0f6174c
* 42e5bc0ac897e069391950b53111bcde3f0c7a72

https://github.com/lowRISC/opentitan/pull/22052
* 13c8e1da6726b63a75d18ee247a921a006edf1df
* (2eaf0b347de2482ac8daf2575803fa72f22c4691 is skipped since master already uses a newer CRT)