### PR TITLE
[ci] Update Bazelisk version in dev container to v1.24.1

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -20,9 +20,10 @@ cd "$(dirname "$0")"
 : "${BINDIR:=.bin}"
 : "${BAZEL_BIN:=$(which bazel 2>/dev/null)}"
 
+# Bazelisk (not Bazel) release. Keep this in sync with `util/container/Dockerfile`.
 readonly release="v1.24.1"
 declare -A hashes=(
-    # sha256sums for v1.11.0.  Update this if you update the release.
+    # sha256sums for v1.24.1.  Update this if you update the release.
     [linux-amd64]="0aee09c71828b0012750cb9b689ce3575da8e230f265bf8d6dcd454eee6ea842"
 )
 

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -11,7 +11,7 @@ ARG VERIBLE_VERSION=v0.0-3622-g07b310a3
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20220210-1
 # This should match the version in bazelish.sh.
-ARG BAZELISK_VERSION=v1.11.0
+ARG BAZELISK_VERSION=v1.24.1
 # This should match the version in ci/install-package-dependencies.sh
 ARG GCC_VERSION=9
 # This should match the version of the lowRISC RISC-V toolchain.


### PR DESCRIPTION
This container pre-downloads Bazelisk for some reason, and the version does not match what we're downloading in `bazelisk.sh`.

This old version is broken. Updating will fix the website build.