### PR TITLE
[sram_ctrl,dv] Increase sram_ctrl_bijection test timeout

### DIFF
--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -82,6 +82,11 @@
     {
       name: "{name}_bijection"
       uvm_test_seq: sram_ctrl_bijection_vseq
+      // We max. do 25*32768 write and 25*32768 read operations. Each operation
+      // takes roughly 1000ns, resulting in 1638400ns for the read/write
+      // operations. Add some buffer for setting up the test and requesting
+      // new scrambling keys.
+      run_opts: ["+test_timeout_ns=2000000000"]
     }
     {
       name: "{name}_stress_pipeline"


### PR DESCRIPTION
This test is quite long and sometimes the default test timeout was not enough, letting the test fail in regression runs. Hence, this commit doubles the test timeout, letting previously failing tests pass again.