### PR TITLE
[cip,dv] Explicit some fcov flags init val.

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -63,6 +63,10 @@ package cip_base_pkg;
     uvm_mem mems[$];
     reg_block.get_memories(mems);
 
+    has_mem_byte_access_err = 0;
+    has_wo_mem              = 0;
+    has_ro_mem              = 0;
+
     foreach (mems[i]) begin
       dv_base_mem dv_mem;
       `downcast(dv_mem, mems[i], , , msg_id)


### PR DESCRIPTION
~~add the option "goal" to 0 to exclude a coverpoint from the coverage calculation as VCS seems to ignore the weight option to 0 for some reason.~~
explicit has_mem_byte_access_err, has_wo_mem, has_ro_mem values as no default has been set, which can lead to different behaviour with different simulators I guess.
~~related to issue https://github.com/lowRISC/opentitan/issues/23594~~