### PR TITLE
[topgen] Support for incoming interrupts

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -15417,6 +15417,7 @@
     }
   ]
   incoming_alert: {}
+  incoming_interrupt: {}
   exported_clks: {}
   wakeups:
   [
@@ -15527,6 +15528,7 @@
       module_name: uart0
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: uart0_rx_watermark
@@ -15535,6 +15537,7 @@
       module_name: uart0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: uart0_tx_done
@@ -15543,6 +15546,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_overflow
@@ -15551,6 +15555,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_frame_err
@@ -15559,6 +15564,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_break_err
@@ -15567,6 +15573,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_timeout
@@ -15575,6 +15582,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_parity_err
@@ -15583,6 +15591,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_tx_empty
@@ -15591,6 +15600,7 @@
       module_name: uart0
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: gpio_gpio
@@ -15599,6 +15609,7 @@
       module_name: gpio
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_upload_cmdfifo_not_empty
@@ -15607,6 +15618,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_upload_payload_not_empty
@@ -15615,6 +15627,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_upload_payload_overflow
@@ -15623,6 +15636,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_readbuf_watermark
@@ -15631,6 +15645,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_readbuf_flip
@@ -15639,6 +15654,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_tpm_header_not_empty
@@ -15647,6 +15663,7 @@
       module_name: spi_device
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_tpm_rdfifo_cmd_end
@@ -15655,6 +15672,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_tpm_rdfifo_drop
@@ -15663,6 +15681,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_fmt_threshold
@@ -15671,6 +15690,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_rx_threshold
@@ -15679,6 +15699,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_acq_threshold
@@ -15687,6 +15708,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_rx_overflow
@@ -15695,6 +15717,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_controller_halt
@@ -15703,6 +15726,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_scl_interference
@@ -15711,6 +15735,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_sda_interference
@@ -15719,6 +15744,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_stretch_timeout
@@ -15727,6 +15753,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_sda_unstable
@@ -15735,6 +15762,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_cmd_complete
@@ -15743,6 +15771,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_tx_stretch
@@ -15751,6 +15780,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_tx_threshold
@@ -15759,6 +15789,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_acq_stretch
@@ -15767,6 +15798,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_unexp_stop
@@ -15775,6 +15807,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_host_timeout
@@ -15783,6 +15816,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: rv_timer_timer_expired_hart0_timer0
@@ -15791,6 +15825,7 @@
       module_name: rv_timer
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: otp_ctrl_otp_operation_done
@@ -15799,6 +15834,7 @@
       module_name: otp_ctrl
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: otp_ctrl_otp_error
@@ -15807,6 +15843,7 @@
       module_name: otp_ctrl
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: alert_handler_classa
@@ -15815,6 +15852,7 @@
       module_name: alert_handler
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: alert_handler_classb
@@ -15823,6 +15861,7 @@
       module_name: alert_handler
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: alert_handler_classc
@@ -15831,6 +15870,7 @@
       module_name: alert_handler
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: alert_handler_classd
@@ -15839,6 +15879,7 @@
       module_name: alert_handler
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_host0_error
@@ -15847,6 +15888,7 @@
       module_name: spi_host0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_host0_spi_event
@@ -15855,6 +15897,7 @@
       module_name: spi_host0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: pwrmgr_aon_wakeup
@@ -15863,6 +15906,7 @@
       module_name: pwrmgr_aon
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: aon_timer_aon_wkup_timer_expired
@@ -15871,6 +15915,7 @@
       module_name: aon_timer_aon
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: aon_timer_aon_wdog_timer_bark
@@ -15879,6 +15924,7 @@
       module_name: aon_timer_aon
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: sensor_ctrl_io_status_change
@@ -15887,6 +15933,7 @@
       module_name: sensor_ctrl
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: sensor_ctrl_init_status_change
@@ -15895,6 +15942,7 @@
       module_name: sensor_ctrl
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: soc_proxy_external
@@ -15903,6 +15951,7 @@
       module_name: soc_proxy
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: hmac_hmac_done
@@ -15911,6 +15960,7 @@
       module_name: hmac
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: hmac_fifo_empty
@@ -15919,6 +15969,7 @@
       module_name: hmac
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: hmac_hmac_err
@@ -15927,6 +15978,7 @@
       module_name: hmac
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: kmac_kmac_done
@@ -15935,6 +15987,7 @@
       module_name: kmac
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: kmac_fifo_empty
@@ -15943,6 +15996,7 @@
       module_name: kmac
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: kmac_kmac_err
@@ -15951,6 +16005,7 @@
       module_name: kmac
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: otbn_done
@@ -15959,6 +16014,7 @@
       module_name: otbn
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: keymgr_dpe_op_done
@@ -15967,6 +16023,7 @@
       module_name: keymgr_dpe
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: csrng_cs_cmd_req_done
@@ -15975,6 +16032,7 @@
       module_name: csrng
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: csrng_cs_entropy_req
@@ -15983,6 +16041,7 @@
       module_name: csrng
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: csrng_cs_hw_inst_exc
@@ -15991,6 +16050,7 @@
       module_name: csrng
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: csrng_cs_fatal_err
@@ -15999,6 +16059,7 @@
       module_name: csrng
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: edn0_edn_cmd_req_done
@@ -16007,6 +16068,7 @@
       module_name: edn0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: edn0_edn_fatal_err
@@ -16015,6 +16077,7 @@
       module_name: edn0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: edn1_edn_cmd_req_done
@@ -16023,6 +16086,7 @@
       module_name: edn1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: edn1_edn_fatal_err
@@ -16031,6 +16095,7 @@
       module_name: edn1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: dma_dma_done
@@ -16039,6 +16104,7 @@
       module_name: dma
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: dma_dma_chunk_done
@@ -16047,6 +16113,7 @@
       module_name: dma
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: dma_dma_error
@@ -16055,6 +16122,7 @@
       module_name: dma
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: mbx0_mbx_ready
@@ -16063,6 +16131,7 @@
       module_name: mbx0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx0_mbx_abort
@@ -16071,6 +16140,7 @@
       module_name: mbx0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx0_mbx_error
@@ -16079,6 +16149,7 @@
       module_name: mbx0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx1_mbx_ready
@@ -16087,6 +16158,7 @@
       module_name: mbx1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx1_mbx_abort
@@ -16095,6 +16167,7 @@
       module_name: mbx1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx1_mbx_error
@@ -16103,6 +16176,7 @@
       module_name: mbx1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx2_mbx_ready
@@ -16111,6 +16185,7 @@
       module_name: mbx2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx2_mbx_abort
@@ -16119,6 +16194,7 @@
       module_name: mbx2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx2_mbx_error
@@ -16127,6 +16203,7 @@
       module_name: mbx2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx3_mbx_ready
@@ -16135,6 +16212,7 @@
       module_name: mbx3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx3_mbx_abort
@@ -16143,6 +16221,7 @@
       module_name: mbx3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx3_mbx_error
@@ -16151,6 +16230,7 @@
       module_name: mbx3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx4_mbx_ready
@@ -16159,6 +16239,7 @@
       module_name: mbx4
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx4_mbx_abort
@@ -16167,6 +16248,7 @@
       module_name: mbx4
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx4_mbx_error
@@ -16175,6 +16257,7 @@
       module_name: mbx4
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx5_mbx_ready
@@ -16183,6 +16266,7 @@
       module_name: mbx5
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx5_mbx_abort
@@ -16191,6 +16275,7 @@
       module_name: mbx5
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx5_mbx_error
@@ -16199,6 +16284,7 @@
       module_name: mbx5
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx6_mbx_ready
@@ -16207,6 +16293,7 @@
       module_name: mbx6
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx6_mbx_abort
@@ -16215,6 +16302,7 @@
       module_name: mbx6
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx6_mbx_error
@@ -16223,6 +16311,7 @@
       module_name: mbx6
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_jtag_mbx_ready
@@ -16231,6 +16320,7 @@
       module_name: mbx_jtag
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_jtag_mbx_abort
@@ -16239,6 +16329,7 @@
       module_name: mbx_jtag
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_jtag_mbx_error
@@ -16247,6 +16338,7 @@
       module_name: mbx_jtag
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_pcie0_mbx_ready
@@ -16255,6 +16347,7 @@
       module_name: mbx_pcie0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_pcie0_mbx_abort
@@ -16263,6 +16356,7 @@
       module_name: mbx_pcie0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_pcie0_mbx_error
@@ -16271,6 +16365,7 @@
       module_name: mbx_pcie0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_pcie1_mbx_ready
@@ -16279,6 +16374,7 @@
       module_name: mbx_pcie1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_pcie1_mbx_abort
@@ -16287,6 +16383,7 @@
       module_name: mbx_pcie1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: mbx_pcie1_mbx_error
@@ -16295,6 +16392,7 @@
       module_name: mbx_pcie1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
   ]
   alert_module:

--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -118,6 +118,10 @@ module top_${top["name"]} #(
   % endfor
 
 % endif
+  % for irq_group, irqs in top['incoming_interrupt'].items():
+  // Incoming interrupt of group ${irq_group}
+  input logic [${len(irqs)-1}:0] incoming_interrupt_${irq_group}_i,
+  % endfor
 
   // All externally supplied clocks
   % for clk in top['clocks'].typed_clocks().ast_clks:
@@ -607,7 +611,14 @@ slice = f"{lo+w-1}:{lo}"
   // interrupt assignments
 <% base = interrupt_num %>\
   assign intr_vector = {
+  % for irq_group, irqs in reversed(top['incoming_interrupt'].items()):
+  <% base -= len(irqs) %>\
+    incoming_interrupt_${irq_group}_i, // IDs [${base} +: ${len(irqs)}]
+  % endfor
   % for intr in top["interrupt"][::-1]:
+    % if intr['incoming']:
+<% continue %>\
+    % endif
 <% base -= intr["width"] %>\
       intr_${intr["name"]}, // IDs [${base} +: ${intr['width']}]
   % endfor

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -14310,6 +14310,7 @@
     }
   ]
   incoming_alert: {}
+  incoming_interrupt: {}
   exported_clks: {}
   wakeups:
   [
@@ -14425,6 +14426,7 @@
       module_name: uart0
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: uart0_rx_watermark
@@ -14433,6 +14435,7 @@
       module_name: uart0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: uart0_tx_done
@@ -14441,6 +14444,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_overflow
@@ -14449,6 +14453,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_frame_err
@@ -14457,6 +14462,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_break_err
@@ -14465,6 +14471,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_timeout
@@ -14473,6 +14480,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_rx_parity_err
@@ -14481,6 +14489,7 @@
       module_name: uart0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart0_tx_empty
@@ -14489,6 +14498,7 @@
       module_name: uart0
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: uart1_tx_watermark
@@ -14497,6 +14507,7 @@
       module_name: uart1
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: uart1_rx_watermark
@@ -14505,6 +14516,7 @@
       module_name: uart1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: uart1_tx_done
@@ -14513,6 +14525,7 @@
       module_name: uart1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart1_rx_overflow
@@ -14521,6 +14534,7 @@
       module_name: uart1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart1_rx_frame_err
@@ -14529,6 +14543,7 @@
       module_name: uart1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart1_rx_break_err
@@ -14537,6 +14552,7 @@
       module_name: uart1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart1_rx_timeout
@@ -14545,6 +14561,7 @@
       module_name: uart1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart1_rx_parity_err
@@ -14553,6 +14570,7 @@
       module_name: uart1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart1_tx_empty
@@ -14561,6 +14579,7 @@
       module_name: uart1
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: uart2_tx_watermark
@@ -14569,6 +14588,7 @@
       module_name: uart2
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: uart2_rx_watermark
@@ -14577,6 +14597,7 @@
       module_name: uart2
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: uart2_tx_done
@@ -14585,6 +14606,7 @@
       module_name: uart2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart2_rx_overflow
@@ -14593,6 +14615,7 @@
       module_name: uart2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart2_rx_frame_err
@@ -14601,6 +14624,7 @@
       module_name: uart2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart2_rx_break_err
@@ -14609,6 +14633,7 @@
       module_name: uart2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart2_rx_timeout
@@ -14617,6 +14642,7 @@
       module_name: uart2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart2_rx_parity_err
@@ -14625,6 +14651,7 @@
       module_name: uart2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart2_tx_empty
@@ -14633,6 +14660,7 @@
       module_name: uart2
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: uart3_tx_watermark
@@ -14641,6 +14669,7 @@
       module_name: uart3
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: uart3_rx_watermark
@@ -14649,6 +14678,7 @@
       module_name: uart3
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: uart3_tx_done
@@ -14657,6 +14687,7 @@
       module_name: uart3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart3_rx_overflow
@@ -14665,6 +14696,7 @@
       module_name: uart3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart3_rx_frame_err
@@ -14673,6 +14705,7 @@
       module_name: uart3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart3_rx_break_err
@@ -14681,6 +14714,7 @@
       module_name: uart3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart3_rx_timeout
@@ -14689,6 +14723,7 @@
       module_name: uart3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart3_rx_parity_err
@@ -14697,6 +14732,7 @@
       module_name: uart3
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: uart3_tx_empty
@@ -14705,6 +14741,7 @@
       module_name: uart3
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: gpio_gpio
@@ -14713,6 +14750,7 @@
       module_name: gpio
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_upload_cmdfifo_not_empty
@@ -14721,6 +14759,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_upload_payload_not_empty
@@ -14729,6 +14768,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_upload_payload_overflow
@@ -14737,6 +14777,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_readbuf_watermark
@@ -14745,6 +14786,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_readbuf_flip
@@ -14753,6 +14795,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_tpm_header_not_empty
@@ -14761,6 +14804,7 @@
       module_name: spi_device
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_tpm_rdfifo_cmd_end
@@ -14769,6 +14813,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_device_tpm_rdfifo_drop
@@ -14777,6 +14822,7 @@
       module_name: spi_device
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_fmt_threshold
@@ -14785,6 +14831,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_rx_threshold
@@ -14793,6 +14840,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_acq_threshold
@@ -14801,6 +14849,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_rx_overflow
@@ -14809,6 +14858,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_controller_halt
@@ -14817,6 +14867,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_scl_interference
@@ -14825,6 +14876,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_sda_interference
@@ -14833,6 +14885,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_stretch_timeout
@@ -14841,6 +14894,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_sda_unstable
@@ -14849,6 +14903,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_cmd_complete
@@ -14857,6 +14912,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_tx_stretch
@@ -14865,6 +14921,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_tx_threshold
@@ -14873,6 +14930,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_acq_stretch
@@ -14881,6 +14939,7 @@
       module_name: i2c0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_unexp_stop
@@ -14889,6 +14948,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c0_host_timeout
@@ -14897,6 +14957,7 @@
       module_name: i2c0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_fmt_threshold
@@ -14905,6 +14966,7 @@
       module_name: i2c1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_rx_threshold
@@ -14913,6 +14975,7 @@
       module_name: i2c1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_acq_threshold
@@ -14921,6 +14984,7 @@
       module_name: i2c1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_rx_overflow
@@ -14929,6 +14993,7 @@
       module_name: i2c1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_controller_halt
@@ -14937,6 +15002,7 @@
       module_name: i2c1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_scl_interference
@@ -14945,6 +15011,7 @@
       module_name: i2c1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_sda_interference
@@ -14953,6 +15020,7 @@
       module_name: i2c1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_stretch_timeout
@@ -14961,6 +15029,7 @@
       module_name: i2c1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_sda_unstable
@@ -14969,6 +15038,7 @@
       module_name: i2c1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_cmd_complete
@@ -14977,6 +15047,7 @@
       module_name: i2c1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_tx_stretch
@@ -14985,6 +15056,7 @@
       module_name: i2c1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_tx_threshold
@@ -14993,6 +15065,7 @@
       module_name: i2c1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_acq_stretch
@@ -15001,6 +15074,7 @@
       module_name: i2c1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_unexp_stop
@@ -15009,6 +15083,7 @@
       module_name: i2c1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c1_host_timeout
@@ -15017,6 +15092,7 @@
       module_name: i2c1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_fmt_threshold
@@ -15025,6 +15101,7 @@
       module_name: i2c2
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_rx_threshold
@@ -15033,6 +15110,7 @@
       module_name: i2c2
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_acq_threshold
@@ -15041,6 +15119,7 @@
       module_name: i2c2
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_rx_overflow
@@ -15049,6 +15128,7 @@
       module_name: i2c2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_controller_halt
@@ -15057,6 +15137,7 @@
       module_name: i2c2
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_scl_interference
@@ -15065,6 +15146,7 @@
       module_name: i2c2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_sda_interference
@@ -15073,6 +15155,7 @@
       module_name: i2c2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_stretch_timeout
@@ -15081,6 +15164,7 @@
       module_name: i2c2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_sda_unstable
@@ -15089,6 +15173,7 @@
       module_name: i2c2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_cmd_complete
@@ -15097,6 +15182,7 @@
       module_name: i2c2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_tx_stretch
@@ -15105,6 +15191,7 @@
       module_name: i2c2
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_tx_threshold
@@ -15113,6 +15200,7 @@
       module_name: i2c2
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_acq_stretch
@@ -15121,6 +15209,7 @@
       module_name: i2c2
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_unexp_stop
@@ -15129,6 +15218,7 @@
       module_name: i2c2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: i2c2_host_timeout
@@ -15137,6 +15227,7 @@
       module_name: i2c2
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: pattgen_done_ch0
@@ -15145,6 +15236,7 @@
       module_name: pattgen
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: pattgen_done_ch1
@@ -15153,6 +15245,7 @@
       module_name: pattgen
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: rv_timer_timer_expired_hart0_timer0
@@ -15161,6 +15254,7 @@
       module_name: rv_timer
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: otp_ctrl_otp_operation_done
@@ -15169,6 +15263,7 @@
       module_name: otp_ctrl
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: otp_ctrl_otp_error
@@ -15177,6 +15272,7 @@
       module_name: otp_ctrl
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: alert_handler_classa
@@ -15185,6 +15281,7 @@
       module_name: alert_handler
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: alert_handler_classb
@@ -15193,6 +15290,7 @@
       module_name: alert_handler
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: alert_handler_classc
@@ -15201,6 +15299,7 @@
       module_name: alert_handler
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: alert_handler_classd
@@ -15209,6 +15308,7 @@
       module_name: alert_handler
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_host0_error
@@ -15217,6 +15317,7 @@
       module_name: spi_host0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_host0_spi_event
@@ -15225,6 +15326,7 @@
       module_name: spi_host0
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: spi_host1_error
@@ -15233,6 +15335,7 @@
       module_name: spi_host1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: spi_host1_spi_event
@@ -15241,6 +15344,7 @@
       module_name: spi_host1
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_pkt_received
@@ -15249,6 +15353,7 @@
       module_name: usbdev
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_pkt_sent
@@ -15257,6 +15362,7 @@
       module_name: usbdev
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_disconnected
@@ -15265,6 +15371,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_host_lost
@@ -15273,6 +15380,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_link_reset
@@ -15281,6 +15389,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_link_suspend
@@ -15289,6 +15398,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_link_resume
@@ -15297,6 +15407,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_av_out_empty
@@ -15305,6 +15416,7 @@
       module_name: usbdev
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_rx_full
@@ -15313,6 +15425,7 @@
       module_name: usbdev
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_av_overflow
@@ -15321,6 +15434,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_link_in_err
@@ -15329,6 +15443,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_rx_crc_err
@@ -15337,6 +15452,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_rx_pid_err
@@ -15345,6 +15461,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_rx_bitstuff_err
@@ -15353,6 +15470,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_frame
@@ -15361,6 +15479,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_powered
@@ -15369,6 +15488,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_link_out_err
@@ -15377,6 +15497,7 @@
       module_name: usbdev
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: usbdev_av_setup_empty
@@ -15385,6 +15506,7 @@
       module_name: usbdev
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: pwrmgr_aon_wakeup
@@ -15393,6 +15515,7 @@
       module_name: pwrmgr_aon
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: sysrst_ctrl_aon_event_detected
@@ -15401,6 +15524,7 @@
       module_name: sysrst_ctrl_aon
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: adc_ctrl_aon_match_pending
@@ -15409,6 +15533,7 @@
       module_name: adc_ctrl_aon
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: aon_timer_aon_wkup_timer_expired
@@ -15417,6 +15542,7 @@
       module_name: aon_timer_aon
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: aon_timer_aon_wdog_timer_bark
@@ -15425,6 +15551,7 @@
       module_name: aon_timer_aon
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: sensor_ctrl_aon_io_status_change
@@ -15433,6 +15560,7 @@
       module_name: sensor_ctrl_aon
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: sensor_ctrl_aon_init_status_change
@@ -15441,6 +15569,7 @@
       module_name: sensor_ctrl_aon
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: flash_ctrl_prog_empty
@@ -15449,6 +15578,7 @@
       module_name: flash_ctrl
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: flash_ctrl_prog_lvl
@@ -15457,6 +15587,7 @@
       module_name: flash_ctrl
       intr_type: IntrType.Status
       default_val: true
+      incoming: false
     }
     {
       name: flash_ctrl_rd_full
@@ -15465,6 +15596,7 @@
       module_name: flash_ctrl
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: flash_ctrl_rd_lvl
@@ -15473,6 +15605,7 @@
       module_name: flash_ctrl
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: flash_ctrl_op_done
@@ -15481,6 +15614,7 @@
       module_name: flash_ctrl
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: flash_ctrl_corr_err
@@ -15489,6 +15623,7 @@
       module_name: flash_ctrl
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: hmac_hmac_done
@@ -15497,6 +15632,7 @@
       module_name: hmac
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: hmac_fifo_empty
@@ -15505,6 +15641,7 @@
       module_name: hmac
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: hmac_hmac_err
@@ -15513,6 +15650,7 @@
       module_name: hmac
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: kmac_kmac_done
@@ -15521,6 +15659,7 @@
       module_name: kmac
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: kmac_fifo_empty
@@ -15529,6 +15668,7 @@
       module_name: kmac
       intr_type: IntrType.Status
       default_val: false
+      incoming: false
     }
     {
       name: kmac_kmac_err
@@ -15537,6 +15677,7 @@
       module_name: kmac
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: otbn_done
@@ -15545,6 +15686,7 @@
       module_name: otbn
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: keymgr_op_done
@@ -15553,6 +15695,7 @@
       module_name: keymgr
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: csrng_cs_cmd_req_done
@@ -15561,6 +15704,7 @@
       module_name: csrng
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: csrng_cs_entropy_req
@@ -15569,6 +15713,7 @@
       module_name: csrng
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: csrng_cs_hw_inst_exc
@@ -15577,6 +15722,7 @@
       module_name: csrng
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: csrng_cs_fatal_err
@@ -15585,6 +15731,7 @@
       module_name: csrng
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: entropy_src_es_entropy_valid
@@ -15593,6 +15740,7 @@
       module_name: entropy_src
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: entropy_src_es_health_test_failed
@@ -15601,6 +15749,7 @@
       module_name: entropy_src
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: entropy_src_es_observe_fifo_ready
@@ -15609,6 +15758,7 @@
       module_name: entropy_src
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: entropy_src_es_fatal_err
@@ -15617,6 +15767,7 @@
       module_name: entropy_src
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: edn0_edn_cmd_req_done
@@ -15625,6 +15776,7 @@
       module_name: edn0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: edn0_edn_fatal_err
@@ -15633,6 +15785,7 @@
       module_name: edn0
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: edn1_edn_cmd_req_done
@@ -15641,6 +15794,7 @@
       module_name: edn1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
     {
       name: edn1_edn_fatal_err
@@ -15649,6 +15803,7 @@
       module_name: edn1
       intr_type: IntrType.Event
       default_val: false
+      incoming: false
     }
   ]
   alert_module:

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -116,6 +116,10 @@ module top_${top["name"]} #(
   % endfor
 
 % endif
+  % for irq_group, irqs in top['incoming_interrupt'].items():
+  // Incoming interrupt of group ${irq_group}
+  input logic [${len(irqs)-1}:0] incoming_interrupt_${irq_group}_i,
+  % endfor
 
   // All externally supplied clocks
   % for clk in top['clocks'].typed_clocks().ast_clks:
@@ -648,7 +652,14 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
   // interrupt assignments
 <% base = interrupt_num %>\
   assign intr_vector = {
+  % for irq_group, irqs in reversed(top['incoming_interrupt'].items()):
+  <% base -= len(irqs) %>\
+    incoming_interrupt_${irq_group}_i, // IDs [${base} +: ${len(irqs)}]
+  % endfor
   % for intr in top["interrupt"][::-1]:
+    % if intr['incoming']:
+<% continue %>\
+    % endif
 <% base -= intr["width"] %>\
       intr_${intr["name"]}, // IDs [${base} +: ${intr['width']}]
   % endfor

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1045,6 +1045,8 @@ def main():
         # that to the alert handler's module definition.
         if 'incoming_alert' not in topcfg:
             topcfg['incoming_alert'] = {}
+        if 'incoming_interrupt' not in topcfg:
+            topcfg['incoming_interrupt'] = OrderedDict()
 
         for m in topcfg['module']:
             if m['type'] == 'alert_handler':
@@ -1054,6 +1056,12 @@ def main():
                         mapping = hjson.load(falert)
                         for alert_group, alerts in mapping.items():
                             topcfg['incoming_alert'][alert_group] = alerts
+            elif m['type'] == 'rv_plic':
+                for irq_mappings_path in m.get('incoming_interrupt', []):
+                    with open(Path(args.topcfg).parent / irq_mappings_path, "r") as firq:
+                        irq_mapping = hjson.load(firq)
+                        for irq_group, irqs in irq_mapping.items():
+                            topcfg['incoming_interrupt'][irq_group] = irqs
     except ValueError:
         raise SystemExit(sys.exc_info()[1])
 

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -995,7 +995,9 @@ class TopGen:
         # When we generate the `interrupts` enum, the only info we have about
         # the source is the module name. We'll use `source_name_map` to map a
         # short module name to the full name object used for the enum constant.
-        source_name_map = {}
+        source_name_map = {
+            'unknown': unknown_source
+        }
 
         for name in self.top["interrupt_module"]:
 
@@ -1019,7 +1021,8 @@ class TopGen:
                     irq_id = interrupts.add_constant(name,
                                                      docstring="{} {}".format(
                                                          intr["name"], i))
-                    source_name = source_name_map[intr["module_name"]]
+                    source_name_key = 'unknown' if intr['incoming'] else intr['module_name']
+                    source_name = source_name_map[source_name_key]
                     plic_mapping.add_entry(irq_id, source_name)
                     self.device_irqs[intr["module_name"]].append(intr["name"] +
                                                                  str(i))

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -977,7 +977,16 @@ def amend_interrupt(top: OrderedDict, name_to_block: Dict[str, IpBlock]):
                                                    module=m.lower())
             qual["intr_type"] = signal.intr_type
             qual["default_val"] = signal.default_val
+            qual['incoming'] = False
             top["interrupt"].append(qual)
+
+    for irqs in top['incoming_interrupt'].values():
+        for irq in irqs:
+            # Qualify name with module name
+            irq['name'] = f"{irq['module_name']}_{irq['name']}"
+            irq['incoming'] = True
+            irq['width'] = 1
+            top["interrupt"].append(irq)
 
 
 def ensure_alert_modules(top: OrderedDict, name_to_block: Dict[str, IpBlock]):

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -63,6 +63,7 @@ top_optional = {
     'datawidth': ['pn', "default data width"],
     'exported_clks': ['g', 'clock signal routing rules'],
     'host': ['g', 'list of host-only components in the system'],
+    'incoming_interrupt': ['g', 'Parsed incoming interrupts (generated)'],
     'incoming_alert': ['g', 'Parsed incoming alerts (generated)'],
     'inter_module': ['g', 'define the signal connections between the modules'],
     'interrupt': ['lnw', 'interrupts (generated)'],
@@ -212,7 +213,8 @@ module_optional = {
     'generate_dif': ['pb', 'optional bool to indicate if a DIF should be generated for that '
                            'module'],
     'outgoing_alert': ['s', 'optional string to indicate alerts are routed externally to the named '
-                            'group']
+                            'group'],
+    'incoming_interrupt': ['g', 'Parsed incoming interrupts (generated)'],
 }
 
 module_added = {


### PR DESCRIPTION
This PR adds support for incoming interrupts. The approach is analog to incoming alerts. You define an HJSON, which is included in the PLIC instantiation in the top-level HJSON. Out of this, the tooling creates incoming interrupt inputs and routes them to the collective interrupt vector. The number of interrupts is extended with the number of external interrupts. Regarding SW collateral, the external interrupts are included in all mappings. They map to an unknown device, which is reasonable, as the interrupt is coming from external.