### PR TITLE
[provisioning] enable reentrant provisioning flow

### DIFF
--- a/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
+++ b/sw/device/silicon_creator/manuf/base/sram_ft_individualize.c
@@ -56,7 +56,7 @@ static status_t peripheral_handles_init(void) {
  * Print data stored in flash info page 0 to console for manual verification
  * purposes during silicon bring-up.
  */
-static status_t read_and_print_flash_info_0_data(void) {
+static status_t read_and_print_flash_and_ast_data(void) {
   uint32_t byte_address = 0;
   TRY(flash_ctrl_testutils_info_region_setup_properties(
       &flash_ctrl_state, kFlashInfoFieldCpDeviceId.page,
@@ -71,22 +71,22 @@ static status_t read_and_print_flash_info_0_data(void) {
     LOG_INFO("0x%08x", cp_device_id[i]);
   }
 
-  LOG_INFO("AST Calibration Values:");
+  LOG_INFO("AST Calibration Values (in flash):");
   TRY(manuf_flash_info_field_read(
       &flash_ctrl_state, kFlashInfoFieldAstCalibrationData, ast_cfg_data,
       kFlashInfoAstCalibrationDataSizeIn32BitWords));
   for (size_t i = 0; i < kFlashInfoAstCalibrationDataSizeIn32BitWords; ++i) {
-    LOG_INFO("0x%08x", ast_cfg_data[i]);
+    LOG_INFO("Word %d = 0x%08x", i, ast_cfg_data[i]);
+  }
+
+  LOG_INFO("AST Calibration Values (in CSRs):");
+  for (size_t i = 0; i < kFlashInfoAstCalibrationDataSizeIn32BitWords; ++i) {
+    LOG_INFO(
+        "Word %d = 0x%08x", i,
+        abs_mmio_read32(TOP_EARLGREY_AST_BASE_ADDR + i * sizeof(uint32_t)));
   }
 
   return OK_STATUS();
-}
-
-static void manually_init_ast(uint32_t *data) {
-  for (size_t i = 0; i < kFlashInfoAstCalibrationDataSizeIn32BitWords; ++i) {
-    abs_mmio_write32(TOP_EARLGREY_AST_BASE_ADDR + i * sizeof(uint32_t),
-                     data[i]);
-  }
 }
 
 /**
@@ -102,10 +102,10 @@ static status_t provision(ujson_t *uj) {
   TRY(manuf_individualize_device_hw_cfg(&flash_ctrl_state, &otp_ctrl,
                                         kFlashInfoPage0Permissions,
                                         in_data.device_id));
-  TRY(manuf_individualize_device_creator_sw_cfg(&otp_ctrl, &flash_ctrl_state));
-  TRY(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
   TRY(manuf_individualize_device_rot_creator_auth_codesign(&otp_ctrl));
   TRY(manuf_individualize_device_rot_creator_auth_state(&otp_ctrl));
+  TRY(manuf_individualize_device_owner_sw_cfg(&otp_ctrl));
+  TRY(manuf_individualize_device_creator_sw_cfg(&otp_ctrl, &flash_ctrl_state));
   LOG_INFO("FT SRAM provisioning done.");
   return OK_STATUS();
 }
@@ -116,10 +116,9 @@ bool test_main(void) {
   ottf_console_init();
   ujson_t uj = ujson_ottf_console();
 
-  // Read and log flash data to console (for manual verification purposes),
-  // manually init AST, and perform provisioning operations.
-  CHECK_STATUS_OK(read_and_print_flash_info_0_data());
-  manually_init_ast(ast_cfg_data);
+  // Read and log flash and AST data to console (for manual verification
+  // purposes), and perform provisioning operations.
+  CHECK_STATUS_OK(read_and_print_flash_and_ast_data());
   CHECK_STATUS_OK(provision(&uj));
 
   // Halt the CPU here to enable JTAG to perform an LC transition to mission

--- a/sw/host/opentitanlib/src/test_utils/lc.rs
+++ b/sw/host/opentitanlib/src/test_utils/lc.rs
@@ -5,6 +5,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
+use arrayvec::ArrayVec;
 
 use crate::app::TransportWrapper;
 use crate::dif::lc_ctrl::{DifLcCtrlState, LcCtrlReg, LcCtrlStatus};
@@ -34,4 +35,40 @@ pub fn read_lc_state(
     transport.pin_strapping("PINMUX_TAP_LC")?.remove()?;
     transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
     DifLcCtrlState::from_redundant_encoding(raw_lc_state)
+}
+
+pub fn read_device_id(
+    transport: &TransportWrapper,
+    jtag_params: &JtagParams,
+    reset_delay: Duration,
+) -> Result<ArrayVec<u32, 8>> {
+    transport.pin_strapping("PINMUX_TAP_LC")?.apply()?;
+
+    // Apply bootstrap pin to be able to connect to JTAG when ROM execution is
+    // enabled.
+    transport.pin_strapping("ROM_BOOTSTRAP")?.apply()?;
+    transport.reset_target(reset_delay, true)?;
+    let mut jtag = jtag_params.create(transport)?.connect(JtagTap::LcTap)?;
+    // We must wait for the lc_ctrl to initialize before the LC state is exposed.
+    wait_for_status(
+        &mut *jtag,
+        Duration::from_secs(1),
+        LcCtrlStatus::INITIALIZED,
+    )?;
+
+    let mut device_id = ArrayVec::<u32, 8>::new();
+    device_id.push(jtag.read_lc_ctrl_reg(&LcCtrlReg::DeviceId0)?);
+    device_id.push(jtag.read_lc_ctrl_reg(&LcCtrlReg::DeviceId1)?);
+    device_id.push(jtag.read_lc_ctrl_reg(&LcCtrlReg::DeviceId2)?);
+    device_id.push(jtag.read_lc_ctrl_reg(&LcCtrlReg::DeviceId3)?);
+    device_id.push(jtag.read_lc_ctrl_reg(&LcCtrlReg::DeviceId4)?);
+    device_id.push(jtag.read_lc_ctrl_reg(&LcCtrlReg::DeviceId5)?);
+    device_id.push(jtag.read_lc_ctrl_reg(&LcCtrlReg::DeviceId6)?);
+    device_id.push(jtag.read_lc_ctrl_reg(&LcCtrlReg::DeviceId7)?);
+
+    jtag.disconnect()?;
+    transport.pin_strapping("PINMUX_TAP_LC")?.remove()?;
+    transport.pin_strapping("ROM_BOOTSTRAP")?.remove()?;
+
+    Ok(device_id)
 }

--- a/sw/host/provisioning/ft/src/main.rs
+++ b/sw/host/provisioning/ft/src/main.rs
@@ -23,7 +23,7 @@ use opentitanlib::backend;
 use opentitanlib::console::spi::SpiConsoleDevice;
 use opentitanlib::dif::lc_ctrl::DifLcCtrlState;
 use opentitanlib::test_utils::init::InitializeTest;
-use opentitanlib::test_utils::lc::read_lc_state;
+use opentitanlib::test_utils::lc::{read_device_id, read_lc_state};
 use opentitanlib::test_utils::load_sram_program::SramProgramParams;
 use ujson_lib::provisioning_data::{ManufCertgenInputs, ManufFtIndividualizeData};
 use util_lib::{
@@ -250,6 +250,7 @@ fn main() -> Result<()> {
         | DifLcCtrlState::TestUnlocked5
         | DifLcCtrlState::TestUnlocked6
         | DifLcCtrlState::TestUnlocked7 => {
+            // Run FT individualize.
             response.lc_state.individualize = Some(response.lc_state.unlocked);
             let t0 = Instant::now();
             run_sram_ft_individualize(
@@ -262,6 +263,8 @@ fn main() -> Result<()> {
                 &spi_console_device,
             )?;
             response.stats.log_elapsed_time("ft-individualize", t0);
+
+            // Perform test exit.
             let t0 = Instant::now();
             test_exit(
                 &transport,
@@ -303,6 +306,22 @@ fn main() -> Result<()> {
     } else {
         serde_json::to_string(&response)?
     };
+
+    // Extract final device ID.
+    let mut final_device_id = read_device_id(
+        &transport,
+        &opts.init.jtag_params,
+        opts.init.bootstrap.options.reset_delay,
+    )?;
+
+    // Convert final device ID to a big-endian string.
+    final_device_id.reverse();
+    response.device_id = final_device_id
+        .iter()
+        .map(|v| format!("{v:08X}"))
+        .collect::<Vec<String>>()
+        .join("");
+
     println!("PROVISIONING_DATA: {doc}");
 
     Ok(())

--- a/sw/host/provisioning/orchestrator/src/device_id.py
+++ b/sw/host/provisioning/orchestrator/src/device_id.py
@@ -142,28 +142,26 @@ class DeviceId():
         # Build full device ID.
         self.device_id = (self.sku_specific << 128) | self._base_uid
 
-    def update_base_id(self, other: "DeviceId") -> None:
-        """Updates the base unique ID with another DeviceId object.
+    def update_din(self, other: "DeviceIdentificationNumber") -> None:
+        """Updates the DIN component of the device ID with another DIN object.
 
-        Updates the base_id with another DeviceId object's base_id as well as
-        the HW origin, SiliconCreator ID, and Product ID.
+        Updates the DeviceIdentificationNumber (DIN) component of the device ID.
 
         Args:
-            other: The other DeviceId object to update with.
+            other: The other DeviceIdentificationNumber object to update with.
         """
-        self.si_creator_id = other.si_creator_id
-        self.product_id = other.product_id
-        self._hw_origin = other._hw_origin
+        self.din = other
 
-        self.din = other.din
-        self._base_uid = other._base_uid
+        # Build base unique ID.
+        self._base_uid = util.bytes_to_int(
+            struct.pack("<IQI", self._hw_origin, self.din.to_int(), 0))
         self.device_id = (self.sku_specific << 128) | self._base_uid
 
     @staticmethod
     def from_hexstr(hexstr: str) -> "DeviceId":
         """Creates a DeviceId object from a hex string."""
-        cp_device_id = util.parse_hexstring_to_int(hexstr)
-        return DeviceId.from_int(cp_device_id)
+        device_id_int = util.parse_hexstring_to_int(hexstr)
+        return DeviceId.from_int(device_id_int)
 
     @staticmethod
     def from_int(device_id: int) -> "DeviceId":

--- a/sw/host/provisioning/orchestrator/src/ot_dut.py
+++ b/sw/host/provisioning/orchestrator/src/ot_dut.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 
 import hjson
 
-from device_id import DeviceId
+from device_id import DeviceId, DeviceIdentificationNumber
 from sku_config import SkuConfig
 from util import confirm, format_hex, run
 
@@ -143,17 +143,25 @@ class OtDut():
                 logging.warning(f"CP failed with exit code: {res.returncode}.")
                 confirm()
 
+            # Extract CP device ID.
             chip_probe_data = self._extract_json_data("CHIP_PROBE_DATA",
                                                       stdout_logfile)
+            din_from_device = None
             if "cp_device_id" not in chip_probe_data:
                 logging.error("cp_device_id not found in CHIP_PROBE_DATA.")
                 confirm()
-
+            else:
+                if chip_probe_data["cp_device_id"] == "":
+                    logging.warning(
+                        "cp_device_id empty; setting default of all zeros.")
+                    din_from_device = DeviceIdentificationNumber(0)
+                else:
+                    din_from_device = DeviceIdentificationNumber.from_int(
+                        (int(chip_probe_data["cp_device_id"], 16) >> 32) &
+                        0xFFFFFFFFFFFFFFFF)
             logging.info(
                 f"Updating device ID to: {chip_probe_data['cp_device_id']}")
-            cp_device_id = self.device_id.from_hexstr(
-                chip_probe_data["cp_device_id"])
-            self.device_id.update_base_id(cp_device_id)
+            self.device_id.update_din(din_from_device)
             self.device_id.pretty_print()
 
             self._make_log_dir()
@@ -259,4 +267,8 @@ class OtDut():
 
             self.ft_data = self._extract_json_data("PROVISIONING_DATA",
                                                    stdout_logfile)
+
+            # TODO: check device ID from device matches one constructed on host.
+            self.device_id = DeviceId.from_hexstr(self.ft_data["device_id"])
+
             logging.info("FT completed successfully.")

--- a/sw/host/provisioning/orchestrator/tests/device_id_test.py
+++ b/sw/host/provisioning/orchestrator/tests/device_id_test.py
@@ -157,10 +157,8 @@ class TestDeviceId(unittest.TestCase):
                                          wafer_y_coord=100)
         expected = DeviceId(sku_config=self.sku_config, din=din)
         hexstr = expected.to_hexstr()
-        cp_device_id = DeviceId.from_hexstr(hexstr)
-
-        self.device_id.update_base_id(cp_device_id)
-        self.assertEqual(expected.to_int(), self.device_id.to_int())
+        actual = DeviceId.from_hexstr(hexstr)
+        self.assertEqual(expected.to_int(), actual.to_int())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The CP device ID is extracted from flash during CP and passed to FT. If the CP step is skipped, e.g., if the device is already in test_locked*, then host will not know what the CP device ID is.

This updates the provisioning flow to extract the CP device ID from flash again during FT and pass it back to the host, making the flow reentrant.

Note, this depends on #25608; only review the last two commits. 