### PR TITLE
[dv] Try harder for late randomisation in cip_base_vseq

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -251,6 +251,7 @@ class cip_base_vseq #(
 
     cip_tl_host_single_seq tl_seq;
     `uvm_create_on(tl_seq, tl_sequencer_h)
+    csr_utils_pkg::increment_outstanding_access();
     tl_seq.instr_type = instr_type;
     tl_seq.tl_intg_err_type = tl_intg_err_type;
     if (cfg.zero_delays) begin
@@ -264,7 +265,6 @@ class cip_base_vseq #(
         mask  == local::mask;
         data  == local::data;)
 
-    csr_utils_pkg::increment_outstanding_access();
     fork begin : isolation_fork
       fork
         `uvm_send_pri(tl_seq, 100)

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -12,13 +12,13 @@
     seq_t_ tl_seq;                                                                         \
     `uvm_info(`gfn, {"Running ", `"task_name_`"}, UVM_MEDIUM)                              \
     `uvm_create_on(tl_seq, seqr_t)                                                         \
+    csr_utils_pkg::increment_outstanding_access();                                         \
     if (cfg.zero_delays) begin                                                             \
       tl_seq.min_req_delay = 0;                                                            \
       tl_seq.max_req_delay = 0;                                                            \
     end                                                                                    \
     tl_seq.req_abort_pct = $urandom_range(0, 100);                                         \
     `DV_CHECK_RANDOMIZE_WITH_FATAL(tl_seq, with_c_)                                        \
-    csr_utils_pkg::increment_outstanding_access();                                         \
     `DV_SPINWAIT(`uvm_send_pri(tl_seq, 1),                                                 \
         $sformatf("Timeout: %0s with addr %0h", `"task_name_`", tl_seq.addr), 100_000_000) \
     csr_utils_pkg::decrement_outstanding_access();                                         \

--- a/hw/dv/sv/csr_utils/README.md
+++ b/hw/dv/sv/csr_utils/README.md
@@ -21,11 +21,11 @@ register reading and writing. Directly accessing this variable is discouraged. I
 the following methods are used to control this variable to keep track of non-blocking
 accesses made in the testbench:
 ```systemverilog
-  function automatic void increment_outstanding_access();
+  task automatic increment_outstanding_access();
     outstanding_accesses++;
   endfunction
 
-  function automatic void decrement_outstanding_access();
+  task automatic decrement_outstanding_access();
     outstanding_accesses--;
   endfunction
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_buffered_enable_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_buffered_enable_vseq.sv
@@ -85,6 +85,8 @@ class rv_dm_buffered_enable_vseq extends rv_dm_base_vseq;
       force_enable_at(Rom);
     end
 
+    csr_utils_pkg::increment_outstanding_access();
+
     // We want to send a TL request to fetch WHERETO. If fetching is enabled, this should respond
     // with a JAL to some address (tested by rv_dm_halt_resume_whereto_vseq). If not, we have just
     // forced the TL connection to work so we should manage to perform the TL transaction, but it
@@ -99,7 +101,6 @@ class rv_dm_buffered_enable_vseq extends rv_dm_base_vseq;
     `DV_CHECK_RANDOMIZE_WITH_FATAL(seq,
                                    write == 1'b0; addr == 'h300 + mem_base_addr; mask == 4'hf;)
 
-    csr_utils_pkg::increment_outstanding_access();
     `DV_SPINWAIT(`uvm_send_pri(seq, 100), "Timed out when sending fetch request")
     csr_utils_pkg::decrement_outstanding_access();
 


### PR DESCRIPTION
This builds on the change in #25612. The first commit in this PR makes sure that late randomisation of CSR accesses actually happens late enough (if lots of CSR accesses get enqueued at the same time). The second commit is a slight cleanup, actually *doing* later randomisation for the TL sequences that actually do the CSR reads/writes. I'm not sure *that* will make much difference at the moment, but it seems sensible to be cleaner.