### PR TITLE
[doc,pattgen] Documentation refinements

### DIFF
--- a/hw/ip/pattgen/doc/programmers_guide.md
+++ b/hw/ip/pattgen/doc/programmers_guide.md
@@ -11,7 +11,7 @@ To configure a single channel:
 For either channel, a zero in the polarity bit indicates that the channel clock line (`pcl`) should start low, and the channel data line `pda` transitions on every falling edge of `pcl`.
 A one in the polarity bit inverts the `pcl` clock so that it starts high and `pda` transitions on the rising edge.
 The following waveform illustrates the effect of the `POLARITY` bit.
-Here both channels are configured for simultaneous pattern generation, but the two channels are configured for opposite polarity.
+Here both channels are configured for simultaneous pattern generation, but the two channels are configured for opposite polarities.
 ```wavejson
 {signal: [
   {name: 'CTRL.ENABLE_CH0', wave: 'lh......'},
@@ -25,18 +25,18 @@ Here both channels are configured for simultaneous pattern generation, but the t
   head: {text: 'Effect of the Polarity Registers',tick:0}}
 ```
 
-3. Program the length of seed pattern using the length field, [`SIZE.LEN_CH0`](registers.md#size).
+3. Program the length of the seed pattern using the length field, [`SIZE.LEN_CH0`](registers.md#size).
 Note that since the allowed seed length ranges from 1-64, the value of this field should be one less than the pattern length.
-For example, to generate an 16-bit pattern, a value of 15 should be written to the field [`SIZE.LEN_CH0`](registers.md#size).
+For example, to generate a 16-bit pattern, a value of 15 should be written to the field [`SIZE.LEN_CH0`](registers.md#size).
 1. Program the seed pattern (between 1 and 64 bits in length) using the multi-register [`DATA_CH0_0`](registers.md#data_ch0) and [`DATA_CH0_1`](registers.md#data_ch0).
-The first 32 bits to be transmitted, are programmed in the lower half of the multi-register (i.e. [`DATA_CH0_0`](registers.md#data_ch0)), and the latter 32 bits are programmed in the upper half of the multi-register (i.e. [`DATA_CH0_1`](registers.md#data_ch0)).
+The first 32 bits to be transmitted are programmed into the lower half of the multi-register (i.e. [`DATA_CH0_0`](registers.md#data_ch0)), and the latter 32 bits are programmed into the upper half of the multi-register (i.e. [`DATA_CH0_1`](registers.md#data_ch0)).
 1. Program the clock divider ratio using the register [`PREDIV_CH0.CLK_RATIO`](registers.md#prediv_ch0).
 The resulting clock frequency will be slower than the input I/O clock by a ratio of 2&times;(CLK_RATIO+1):
 $$f_{pclx}=\frac{f_\textrm{I/O clk}}{2(\textrm{CLK\_RATIO}+1)}$$
 1. Program the desired number of pattern repetitions using the repetition field [`SIZE.REPS_CH0`](registers.md#size).
 Note that since the allowed number of pattern repetitions ranges from 1-1024, the value of this field should be one less than the desired repetition count.
-For example, to repeat a pattern 30, a value of 29 should written to the field [`SIZE.REPS_CH0`](registers.md#size).
-1. Finally to start the pattern, set the [`CTRL.ENABLE_CH0`](registers.md#ctrl).
+For example, to send a pattern 30 times, a value of 29 should be written into the field [`SIZE.REPS_CH0`](registers.md#size).
+1. Finally, to start the pattern set the [`CTRL.ENABLE_CH0`](registers.md#ctrl).
 To start both channel patterns at the same time, configure both channels then simultaneously assert both the [`CTRL.ENABLE_CH0`](registers.md#ctrl) and [`CTRL.ENABLE_CH1`](registers.md#ctrl) bits in the same register access.
 
 ## Using the *inactive level* feature


### PR DESCRIPTION
Update the design details, and particularly the signal names, to match the implementation better. This should aid in reading and understanding the RTL. Include the `inactive_level_pcl|pda signals` which were previously omitted from the design details. Assorted linguistic corrections and refinements.