### PR TITLE
[gpio] Introduce reset on flip-flops

### DIFF
--- a/hw/ip/gpio/rtl/gpio.sv
+++ b/hw/ip/gpio/rtl/gpio.sv
@@ -153,9 +153,14 @@ module gpio
     end
   end
 
+  // Previous values of input pins; used to detect rising/falling edges for interrupt generation.
   logic [31:0] data_in_q;
-  always_ff @(posedge clk_i) begin
-    data_in_q <= data_in_d;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      data_in_q <= 32'b0;
+    end else begin
+      data_in_q <= data_in_d;
+    end
   end
 
   logic [31:0] event_intr_rise, event_intr_fall, event_intr_actlow, event_intr_acthigh;


### PR DESCRIPTION
There has apparently never been any reset logic on the 'data_in_q' flip-flops which hold the previous state of the optionally-filtered, optionally-synchronized input pins.

This is very unlikely to be of any consequence but may be worth tidying up to help with backend flows.

In practice there's not even any risk of generating spurious interrupts because the reset will have cleared the enable bits on those registers at the same time that it clears the 'data_in_d' signals produced by the 'prim_filter_ctr' modules.

Background: I had started exploring GPIO w.r.t. the D3/V3 effort; I notice that the block is already marked as D3 and I wouldn't want to compromise that, so I'll leave it to others whether they wish to include this or just close the PR.