### PR TITLE
[rtl, aon_timer] Reset core.prescale_count on wkup_ctrl write

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -158,6 +158,7 @@
         { bits: "12:1",
           name: "prescaler",
           desc: "Pre-scaler value for wakeup timer count",
+          hwqe: "true",
         }
       ],
     },

--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -146,7 +146,10 @@
   regwidth: "32",
   registers: [
     { name: "WKUP_CTRL",
-      desc: "Wakeup Timer Control register",
+      desc: '''
+            Wakeup Timer Control register.
+            Each write to the register resets the internal prescaler count
+            '''
       swaccess: "rw",
       hwaccess: "hro",
       async: "clk_aon_i",

--- a/hw/ip/aon_timer/doc/registers.md
+++ b/hw/ip/aon_timer/doc/registers.md
@@ -6,7 +6,7 @@
 | Name                                            | Offset   |   Length | Description                                    |
 |:------------------------------------------------|:---------|---------:|:-----------------------------------------------|
 | aon_timer.[`ALERT_TEST`](#alert_test)           | 0x0      |        4 | Alert Test Register                            |
-| aon_timer.[`WKUP_CTRL`](#wkup_ctrl)             | 0x4      |        4 | Wakeup Timer Control register                  |
+| aon_timer.[`WKUP_CTRL`](#wkup_ctrl)             | 0x4      |        4 | Wakeup Timer Control register.                 |
 | aon_timer.[`WKUP_THOLD_HI`](#wkup_thold_hi)     | 0x8      |        4 | Wakeup Timer Threshold Register (bits 63 - 32) |
 | aon_timer.[`WKUP_THOLD_LO`](#wkup_thold_lo)     | 0xc      |        4 | Wakeup Timer Threshold Register (bits 31 - 0)  |
 | aon_timer.[`WKUP_COUNT_HI`](#wkup_count_hi)     | 0x10     |        4 | Wakeup Timer Count Register (bits 63 - 32)     |
@@ -38,7 +38,8 @@ Alert Test Register
 |   0    |   wo   |   0x0   | fatal_fault | Write 1 to trigger one alert event of this kind. |
 
 ## WKUP_CTRL
-Wakeup Timer Control register
+Wakeup Timer Control register.
+Each write to the register resets the internal prescaler count
 - Offset: `0x4`
 - Reset default: `0x0`
 - Reset mask: `0x1fff`

--- a/hw/ip/aon_timer/rtl/aon_timer_core.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_core.sv
@@ -45,6 +45,8 @@ module aon_timer_core import aon_timer_reg_pkg::*; (
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
     if (!rst_aon_ni) begin
       prescale_count_q <= 12'h000;
+    end else if (reg2hw_i.wkup_ctrl.prescaler.qe) begin
+      prescale_count_q <= 12'h000;
     end else if (prescale_en) begin
       prescale_count_q <= prescale_count_d;
     end

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -24,6 +24,7 @@ package aon_timer_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [11:0] q;
+      logic        qe;
     } prescaler;
     struct packed {
       logic        q;
@@ -124,8 +125,8 @@ package aon_timer_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    aon_timer_reg2hw_alert_test_reg_t alert_test; // [247:246]
-    aon_timer_reg2hw_wkup_ctrl_reg_t wkup_ctrl; // [245:233]
+    aon_timer_reg2hw_alert_test_reg_t alert_test; // [248:247]
+    aon_timer_reg2hw_wkup_ctrl_reg_t wkup_ctrl; // [246:233]
     aon_timer_reg2hw_wkup_thold_hi_reg_t wkup_thold_hi; // [232:201]
     aon_timer_reg2hw_wkup_thold_lo_reg_t wkup_thold_lo; // [200:169]
     aon_timer_reg2hw_wkup_count_hi_reg_t wkup_count_hi; // [168:137]

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -598,6 +598,17 @@ module aon_timer_reg_top (
 
 
   // R[wkup_ctrl]: V(False)
+  logic wkup_ctrl_qe;
+  logic [1:0] wkup_ctrl_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_wkup_ctrl0_qe (
+    .clk_i(clk_aon_i),
+    .rst_ni(rst_aon_ni),
+    .d_i(&wkup_ctrl_flds_we),
+    .q_o(wkup_ctrl_qe)
+  );
   //   F[enable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -617,7 +628,7 @@ module aon_timer_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_ctrl_flds_we[0]),
     .q      (reg2hw.wkup_ctrl.enable.q),
     .ds     (),
 
@@ -644,13 +655,14 @@ module aon_timer_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wkup_ctrl_flds_we[1]),
     .q      (reg2hw.wkup_ctrl.prescaler.q),
     .ds     (),
 
     // to register interface (read)
     .qs     (aon_wkup_ctrl_prescaler_qs_int)
   );
+  assign reg2hw.wkup_ctrl.prescaler.qe = wkup_ctrl_qe;
 
 
   // R[wkup_thold_hi]: V(False)


### PR DESCRIPTION
The AON timer core has an internal counter `prescale_count_q` which is not reset upon each write to wkup_ctrl.
This causes issues if the WKUP timer is re-configured to a lower prescaler value than it was before, and the `prescale_count_q` variable is greater than the new prescaler value, forcing the `prescale_count_q` counter to overflow itself causing a non-spec compliant behavior.

In order to mitigate the above, the internal `prescale_count_q` is reset after wkup_ctrl write. Thus, the aon timer is forced to count from scratch the new intended prescaler value.

Docs PR is #25904 