### PR TITLE
[rom_ext] Mark static critical version as used

### DIFF
--- a/sw/device/silicon_creator/lib/base/static_critical_version.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_version.c
@@ -14,4 +14,4 @@
  * populated by the ROM before the jump to ROM_EXT.
  */
 OT_SET_BSS_SECTION(".static_critical.version",
-                   uint32_t static_critical_version;)
+                   OT_USED uint32_t static_critical_version;)


### PR DESCRIPTION
The previous PR (#25596) missed this file.

Marking it as used prevents optimizations such as LTO from stripping the value.

We'll be ready to enable LTO on ROM_EXT with this PR and https://github.com/lowRISC/crt/pull/40.