### PR TITLE
[meridiancdc] Include SDC results in setup checks report

### DIFF
--- a/hw/cdc/tools/meridiancdc/run-cdc.tcl
+++ b/hw/cdc/tools/meridiancdc/run-cdc.tcl
@@ -96,7 +96,7 @@ set REPORT_DIR reports
 file mkdir $REPORT_DIR
 
 # Report setup check results.
-report_policy {ALL} -verbose -output $REPORT_DIR/setup_checks.rpt
+report_policy {ALL} -scenario {sdc env} -verbose -output $REPORT_DIR/setup_checks.rpt
 
 # Run CDC verification.
 verify_cdc


### PR DESCRIPTION
Without the `-scenario` argument, `report_policy` only reports checks for the current scenario, which is the ENV file at this point in the script.  By adding `sdc`, also SDC setup check results get reported.