### PR TITLE
[prim/doc] Add pointer to hardened Keccak implementation in prim_keccak

### DIFF
--- a/hw/ip/prim/doc/prim_keccak.md
+++ b/hw/ip/prim/doc/prim_keccak.md
@@ -2,11 +2,11 @@
 
 # Overview
 
-`prim_keccak` is a single round implementation of the permutation stage in [SHA3 algorithm][fibs-pub-202].
+`prim_keccak` is a single round implementation of the Keccak_p permutation stage in [SHA3 algorithm][fibs-pub-202].
 Keccak primitive module assumes the number of rounds is less than or equal to 12 + 2L.
 It supports all combinations of the data width described in the [spec][fibs-pub-202].
-This implementation is not currently hardened against side-channel or fault injection attacks.
-It implements the Keccak_p function.
+Note that this implementation does not include any countermeasures for security hardening against implementation attacks.
+Please refer to the [`keccak_2share` module](https://github.com/lowRISC/opentitan/blob/master/hw/ip/kmac/rtl/keccak_2share.sv) for the side-channel-hardened implementation used in the [hardened KMAC hardware IP block](../../kmac/README.md).
 
 [fibs-pub-202]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
 

--- a/hw/ip/prim/rtl/prim_keccak.sv
+++ b/hw/ip/prim/rtl/prim_keccak.sv
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// prim_keccak is single round permutation module
+// This module implements a single-round Keccak permutation. It is unhardened. For an
+// implementation with side-channel hardening, refer to the keccak_2share module used in the
+// KMAC hardware IP block.
+
 `include "prim_assert.sv"
 module prim_keccak #(
   parameter int Width = 1600, // b= {25, 50, 100, 200, 400, 800, 1600}


### PR DESCRIPTION
The unhardened prim_keccak primitive is not actually used in the design. It's purpose is serve as an FPV example.