### PR TITLE
[opentitantool] HyperDebug firmware fix

### DIFF
--- a/third_party/hyperdebug/repos.bzl
+++ b/third_party/hyperdebug/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def hyperdebug_repos():
     http_archive(
         name = "hyperdebug_firmware",
-        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20241206_01/hyperdebug-firmware.tar.gz"],
-        sha256 = "13612708d0d71e340babff07d14d67cd9d51f2eb3c370757c3aa905aeab13d1b",
+        urls = ["https://github.com/lowRISC/hyperdebug-firmware/releases/download/20241211_02/hyperdebug-firmware.tar.gz"],
+        sha256 = "8b72dfe4ecb6a2258228e62c2246c5beffe8339d440a592c483534fa3f54d679",
         build_file = "@lowrisc_opentitan//third_party/hyperdebug:BUILD",
     )


### PR DESCRIPTION
A single bugfix to recently introduced feature to optionally have SPI or I2C TPM operations recognize Google's "TPM ready" signal.

a3d721e81c board/hyperdebug: Corrections to TPM "GSC ready" logic
