### PR TITLE
[sival] Add support for downstream execution envs.

### DIFF
--- a/rules/opentitan/defs.bzl
+++ b/rules/opentitan/defs.bzl
@@ -50,6 +50,10 @@ load(
     "@lowrisc_opentitan//rules/opentitan:ci.bzl",
     "ci_orchestrator",
 )
+load(
+    "@provisioning_exts//:cfg.bzl",
+    "EXT_EXEC_ENV_SILICON_ROM_EXT",
+)
 load("@bazel_skylib//lib:sets.bzl", "sets")
 
 # The following definition is used to clear the key set in the signing
@@ -101,7 +105,7 @@ EARLGREY_TEST_ENVS = {
 # The default set of test environments for Earlgrey.
 EARLGREY_SILICON_OWNER_ROM_EXT_ENVS = {
     "//hw/top_earlgrey:silicon_owner_sival_rom_ext": None,
-}
+} | EXT_EXEC_ENV_SILICON_ROM_EXT
 
 # All CW340 test environments for Earlgrey.
 EARLGREY_CW340_TEST_ENVS = {

--- a/sw/device/silicon_creator/manuf/extensions/README.md
+++ b/sw/device/silicon_creator/manuf/extensions/README.md
@@ -2,6 +2,7 @@
 
 Provisioning an Earlgrey chip requires executing code on devivce during two core
 phases:
+
 1. Chip Probe (CP): when the wafer is still intact, and
 2. Final Test (FT): when each chip has been packaged and loaded into a socket.
 For the most part, the CP process is the same across all Earlgrey chips,
@@ -31,6 +32,12 @@ repo called `@provisioning_exts`.
 
 To define additional OTP configurations downstream, one must add OTP targets
 to the `EXT_EARLGREY_OTP_CFGS` and `EXT_EARLGREY_SKUS` dictionaries in their
+downstream `@provisioning_exts` Bazel repo.
+
+## Execution Environments
+
+To define additional execution environments downstream, add `exec_env`
+compatible entries to the `EXT_EXEC_ENV_SILICON_ROM_EXT` dictionary in the
 downstream `@provisioning_exts` Bazel repo.
 
 ## Personalization Firmware

--- a/sw/device/silicon_creator/manuf/extensions/cfg.bzl
+++ b/sw/device/silicon_creator/manuf/extensions/cfg.bzl
@@ -26,3 +26,11 @@ EXT_EARLGREY_SKUS = {
 }
 
 EXT_SIGNED_PERSO_BINS = []
+
+# This enables downstream integrators to define external Earlgrey execution
+# environments. See the upstream Silicon Owner execution environments defined
+# in the `EARLGREY_SILICON_OWNER_ROM_EXT_ENVS` dictionary in
+# `rules/opentitan/defs.bzl` for more details.
+EXT_EXEC_ENV_SILICON_ROM_EXT = {
+    # "@provisioning_ex/bazel/target/exec_env:exec_env_name": None,
+}


### PR DESCRIPTION
This change adds the ability to run silicon validaton targets on downstream product configurations of Earl Grey, leveraging the @provisioning_ext local repo extensions.