### PR TITLE
[hw,prim_rom,rtl] Add reset input to prim_rom

### DIFF
--- a/hw/ip/prim/lint/prim_rom_adv.waiver
+++ b/hw/ip/prim/lint/prim_rom_adv.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_rom_adv
+
+waive -rules {RESET_USE} -location {prim_rom_adv.sv} -regexp {rst_ni' is connected to 'prim_rom' port 'rst_ni', and used as an asynchronous reset or set at prim_rom_adv.sv} \
+      -comment "rst_ni is the asynchronous reset of prim_rom. It's unused in the generic implementation, but other implementations may use it (e.g., for BIST or DFT purposes)."

--- a/hw/ip/prim/prim_rom_adv.core
+++ b/hw/ip/prim/prim_rom_adv.core
@@ -14,7 +14,17 @@ filesets:
       - rtl/prim_rom_adv.sv
     file_type: systemVerilogSource
 
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+      - lowrisc:lint:comportable
+    files:
+      - lint/prim_rom_adv.waiver
+    file_type: waiver
+
 targets:
   default:
     filesets:
+      - tool_ascentlint  ? (files_ascentlint_waiver)
       - files_rtl

--- a/hw/ip/prim/rtl/prim_rom_adv.sv
+++ b/hw/ip/prim/rtl/prim_rom_adv.sv
@@ -30,6 +30,7 @@ module prim_rom_adv import prim_rom_pkg::*; #(
     .MemInitFile(MemInitFile)
   ) u_prim_rom (
     .clk_i,
+    .rst_ni,
     .req_i,
     .addr_i,
     .rdata_o,

--- a/hw/ip/prim_generic/rtl/prim_generic_rom.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_rom.sv
@@ -12,14 +12,15 @@ module prim_generic_rom import prim_rom_pkg::*; #(
   localparam int Aw          = $clog2(Depth)
 ) (
   input  logic             clk_i,
+  input  logic             rst_ni,
   input  logic             req_i,
   input  logic [Aw-1:0]    addr_i,
   output logic [Width-1:0] rdata_o,
   input rom_cfg_t          cfg_i
 );
 
-  logic unused_cfg;
-  assign unused_cfg = ^cfg_i;
+  logic unused_signals;
+  assign unused_signals = ^{cfg_i, rst_ni};
 
   logic [Width-1:0] mem [Depth];
 


### PR DESCRIPTION
Tech specifc ROM macros might have a reset input. Add them to the prim.