### PR TITLE
[sram_ctrl,dv] Increase wait_cycles for rand_reset tests

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -127,9 +127,9 @@ class sram_ctrl_base_vseq #(
   // Increase the number of cycles to wait for no outstanding accesses, since it is hard
   // to sequence all invocations of pre_start, and that can trigger ram init which blocks
   // accesses for a long time. The RAM has 32K words, and it updates one per cycle, so
-  // 50,000 cycles should be okay.
+  // 75,000 cycles should be okay.
   virtual function int wait_cycles_with_no_outstanding_accesses();
-    return 50_000;
+    return 75_000;
   endfunction
 
   // Request a memory init, and  wait for it to complete. This is a problematic task since


### PR DESCRIPTION
In the sram_dv_increase_timeout_reset test, we are waiting to issue a reset when no outstanding TL-UL are in the fly. This wait timed out in some of the tests. Increasing the wait timer lets the test pass.