### PR TITLE
RFC: Initial ROM vendor hooks implementation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -160,6 +160,12 @@ use_repo(
     "secure_manufacturer_test_hooks",
 )
 
+bazel_dep(name = "rom_hooks", version = "")
+local_path_override(
+    module_name = "rom_hooks",
+    path = "./sw/device/silicon_creator/rom/hooks",
+)
+
 register_toolchains("//rules/opentitan:localtools")
 
 register_toolchains("//toolchain:cc_toolchain_opentitan")

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -260,6 +260,20 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "rom_state",
+    srcs = ["rom_state.c"],
+    hdrs = ["rom_state.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:shutdown",
+    ],
+    alwayslink = True,
+)
+
 opentitan_test(
     name = "rom_epmp_test",
     srcs = [

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -90,6 +90,7 @@ cc_library(
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:macros",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:shutdown",
     ],
 )
 
@@ -134,6 +135,7 @@ cc_library(
         ":boot_policy_ptrs",
         ":bootstrap",
         ":rom_epmp",
+        ":rom_state",
         ":sigverify_keys_ecdsa_p256",
         ":sigverify_keys_spx",
         ":sigverify_otp_keys",
@@ -176,6 +178,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:uart",
         "//sw/device/silicon_creator/lib/drivers:watchdog",
         "//sw/device/silicon_creator/lib/sigverify",
+        "@rom_hooks",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -271,6 +271,7 @@ cc_library(
     deps = [
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib:cfi",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:shutdown",
     ],

--- a/sw/device/silicon_creator/rom/doc/rom_customization.md
+++ b/sw/device/silicon_creator/rom/doc/rom_customization.md
@@ -1,0 +1,101 @@
+---
+Document: RFC
+Title: ROM Vendor Customizations
+Status: Approved by TC on 2025-02-06
+Authors:
+  - Samuel Ortiz <sameo@opentitan.org>
+Reviewers:
+  - "@jadephilipoom"
+  - "@engdoreis"
+---
+
+# RFC: ROM Vendor Customizations
+
+## Problem Statement
+
+Currently, OpenTitan mask ROM implementations lack customization options for silicon creators and vendors. While discrete OpenTitan ROMs can be directly built upon the [upstream implementation](https://github.com/lowRISC/opentitan/tree/master/sw/device/silicon_creator/rom), the same isn't true for integrated OpenTitan top ROMs.
+
+Integrated OpenTitan ROMs configure, initialize, and interact with external subsystems specific to the platform. These interactions often vary between vendors and platform variants. A single, fixed ROM implementation prevents downstream silicon creators and vendors from directly utilizing the upstream code, forcing them to fork the project and maintain custom versions internally.
+
+## Requirements
+
+To enable direct vendor contribution and consumption of OpenTitan upstream ROM implementations, the project architecture and source code for ROMs must meet the following requirements:
+
+1. Vendor customization: OpenTitan ROM code should allow silicon creators and vendors to customize the upstream ROM execution flow with vendor-specific initialization and configuration sequences.
+2. Controlled customization points: OpenTitan ROMs should be customizable at specific, predefined execution points. Vendors can only modify ROM behavior at these designated points.
+3. Support for closed-source customization: The OpenTitan ROM build infrastructure should support linking ROM images with externally stored, vendor-specific customization code, allowing vendors to keep their customizations private.
+4. Attestation: Silicon creators and vendors should provide endorsed reference values for their customized OpenTitan ROMs, including the ROM version and its associated hash. Out-of-band verifiers can then compare these values with the ROM's generated attestation reports.
+5. Default functionality: By default, OpenTitan ROMs should function without any vendor-specific customizations.
+
+## Proposed Approach
+
+At a high level, the proposed solution involves implementing an OpenTitan ROM as a state machine. Each state in this state machine is semantically defined by the upstream ROM code and represents a customizable execution step.
+
+As the ROM progresses through its state machine, it executes the current state and then transitions to the next one. A state execution consists of the following three sequential steps:
+
+1. Pre-run Hook: Executed before the primary ROM state function.
+2. ROM State Run: The core execution of the ROM state.
+3. Post-run Hook: Executed after the primary ROM state function.
+
+By structuring the ROM as a state machine with these hooks, vendors can customize the ROM's behavior at specific points without modifying the upstream ROM code.
+
+```
+           Initial
+          ┌ROM State───┐
+          │ ┌────────┐ │
+          │ │Pre-run │ │
+          │ ├────────┤ │
+          │ │  Run   │ │
+          │ ├────────┤ │
+          │ │Post-run│ │
+          │ └────────┘ │
+          └──────┬─────┘
+ ROM   ┌─────────┴─────────┐  ROM
+┌State─▽─────┐      ┌──────▽──State
+│ ┌────────┐ │      │ ┌────────┐ │
+│ │Pre-run │ │      │ │Pre-run │ │
+│ ├────────┤ │      │ ├────────┤ │
+│ │  Run   │ │      │ │  Run   │ │
+│ ├────────┤ │      │ ├────────┤ │
+│ │Post-run│ │      │ │Post-run│ │
+│ └────────┘ │      │ └────────┘ │
+└────────────┘      └──────┬─────┘
+                           │  ROM
+                    ┌──────▽──State
+                    │ ┌────────┐ │
+                    │ │Pre-run │ │
+                    │ ├────────┤ │
+                    │ │  Run   │ │
+                    │ ├────────┤ │
+                    │ │Post-run│ │
+                    │ └────────┘ │
+                    └────────────┘
+```
+
+With this proposal, vendors can customize an OpenTitan ROM by providing custom implementations for the pre-run and post-run hooks of any ROM state. By default, these hooks are empty.
+
+The main ROM state implementation, the run callback, is executed in step 2. All ROM state run callbacks are defined by the upstream ROM implementation and are not customizable.
+
+Crucially, only the run callback determines the next state in the ROM state machine. Pre-run and post-run hooks cannot override these transitions, preventing vendors from directly modifying the ROM's execution flow.
+
+In essence, this proposal enables vendors to customize the execution of individual ROM states, but it strictly controls the overall ROM execution flow.
+
+### ROM states
+
+Each OpenTitan ROM defines a set of execution states and associates each state with a specific ROM state run callback. A ROM state run callback takes an opaque pointer argument (which is shared with the state hooks) and returns the next state in the sequence.
+
+To enable effective vendor customization, ROM states should be clearly defined and map to specific functional steps in the ROM's execution flow. For instance, `kRomStateBootstrap` is a well-defined state, while `kRomStateStep3` is too generic.
+
+The more precisely a ROM state is defined, the easier it is for vendors to understand and customize its behavior.
+
+### ROM state hooks
+
+Pre-run and post-run ROM state hooks are executed by the ROM state machine before and after each state run callback, respectively. They share state with the state run callbacks through an opaque pointer argument.
+
+Unlike the state run callback, ROM state hooks cannot determine the next state in the ROM state machine. Vendors can customize specific ROM state execution steps through these hooks by providing custom implementations in an external repository.
+
+Similar to the existing manufacturing and test hook customization framework, custom ROM state hooks can be included in a ROM image by specifying the path to the vendor hook implementations in an environment variable passed to the ROM build system:
+
+``` bash
+ROM_HOOKS_DIR=/PATH/TO/LOCAL/ROM/HOOKS ./bazelisk.sh build //sw/device/silicon_creator/rom:mask_rom
+```

--- a/sw/device/silicon_creator/rom/hooks/BUILD.bazel
+++ b/sw/device/silicon_creator/rom/hooks/BUILD.bazel
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "rom_hooks",
+    srcs = ["default_rom_hooks.c"],
+    deps = ["@@//sw/device/silicon_creator/rom:rom_state"],
+    alwayslink = True,
+)

--- a/sw/device/silicon_creator/rom/hooks/MODULE.bazel
+++ b/sw/device/silicon_creator/rom/hooks/MODULE.bazel
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+module(name = "rom_hooks")
+
+# Default, no-op ROM hooks for the OpenTitan ROM.
+#
+# See this repository's README.md and BUILD.bazel files to understand how to
+# write rules for custom ROM hooks.

--- a/sw/device/silicon_creator/rom/hooks/README.md
+++ b/sw/device/silicon_creator/rom/hooks/README.md
@@ -1,0 +1,103 @@
+# Silicon Creator ROM Hooks
+
+## Overview
+
+The OpenTitan ROM defines pre-run and post-run hooks for any defined ROM state.
+
+When transitioning to a ROM state, the ROM state machine first executes the pre-run hook.
+
+The state's run callback is called only if the pre-run hook does not return an error.
+Finally, the post-run hook runs upon successful termination of the ROM state's run callback:
+
+```
+│                      │
+│   ┌──────────────┐   │
+│   │Post-run Hook │   │
+│   └───────┬──────┘   │
+└───────────┼──────────┘
+            │
+            │
+┌───────────┼──────────┐
+│ ROM       │          │
+│ State     │          │
+│   ┌───────▼──────┐   │
+│   │ Pre-run Hook │   │
+│   └───────┬──────┘   │
+│           │          │
+│           │          │
+│   ┌───────▽──────┐   │
+│   │ Run Callback │   │
+│   └───────┬──────┘   │
+│           │          │
+│           │          │
+│   ┌───────▽──────┐   │
+│   │Post-run Hook │   │
+│   └───────┬──────┘   │
+└───────────┼──────────┘
+            │
+            │
+┌───────────┼──────────┐
+│   ┌───────▼──────┐   │
+│   │ Pre-run Hook │   │
+│   └──────────────┘   │
+│                      │
+
+```
+
+The transition from one ROM state to the next one is defined by the current ROM state's run callback:
+
+``` c
+rom_error_t rom_state_run_cb(void *arg, rom_state_t *next_state);
+```
+
+By default, the pre-run and post-run hooks do nothing. However, they provide a mechanism for silicon creators to override them with external implementations (e.g. with closed-source, vendor-specific initialization sequences).
+
+Each ROM state pre-run and post-run hooks are defined as weak symbols using a pre-defined naming scheme.
+
+For example the hooks prototypes for a ROM state named `kRomStateInit` would be:
+
+``` c
+OT_WARN_UNUSED_RESULT rom_error_t rom_state_pre_kRomStateInit(void *arg);
+OT_WARN_UNUSED_RESULT rom_error_t rom_state_post_kRomStateInit(void *arg);
+```
+
+The ROM state API provides `C` macros that simplify the process of binding hook implementations to their corresponding states. Using these macros, the above implementation example would be replaced with the more maintainable form below:
+
+``` c
+OT_WARN_UNUSED_RESULT rom_error_t my_rom_init_pre_hook(void *arg) {
+  ...
+  return kErrorOk;
+}
+// The `kRomStateInit` pre-run hook is `my_rom_init_pre_hook`.
+ROM_STATE_PRE_HOOK(kRomStateInit, my_rom_init_pre_hook);
+
+OT_WARN_UNUSED_RESULT rom_error_t my_rom_init_post_hook(void *arg) {
+  ...
+  return kErrorOk;
+}
+// The `kRomStateInit` post-run hook is `my_rom_init_post_hook`.
+ROM_STATE_POST_HOOK(kRomStateInit, my_rom_init_post_hook);
+```
+
+## ROM State Hooks Implementation
+
+Downstream silicon creators can override the default pre-run and post-run hooks from an external, possibly closed-source repository.
+
+A downstream ROM hooks repository should follow the layout defined in this example.
+
+In particular, the repository must include:
+
+- A `MODULE.bazel` file that defines a `rom_hooks` module: `module(name = "rom_hooks")`.
+- A `BUILD.bazel` file that defines a `rom_hooks` `cc_library` target.
+- A C file implementing the desired ROM state hooks overrides.
+  Hooks implementations must follow the prototype defined in `rom_state.h`.
+  Binding a hook to a ROM state pre-run or post-run step is done through respectively the `ROM_STATE_PRE_HOOK` and `ROM_STATE_POST_HOOK` macros.
+  See `dummy_rom_hooks.c` in this folder for a simple example.
+
+To link an OpenTitan ROM image with external hooks override, use `bazel --override_module` to specify the local path of the hooks repository.
+
+For example:
+
+``` bash
+./bazelisk.sh test --override_module=rom_hooks=<path/to/ROM_hooks> --test_output=streamed --cache_test_results=no //sw/device/silicon_creator/rom/e2e:rom_e2e_smoke_sim_verilator
+```

--- a/sw/device/silicon_creator/rom/hooks/default_rom_hooks.c
+++ b/sw/device/silicon_creator/rom/hooks/default_rom_hooks.c
@@ -1,0 +1,8 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Default, no-op ROM hooks for the OpenTitan ROM.
+//
+// See this repository's README.md and BUILD.bazel files to understand how to
+// provide and use custom ROM hooks.

--- a/sw/device/silicon_creator/rom/hooks/dummy_rom_hooks.c
+++ b/sw/device/silicon_creator/rom/hooks/dummy_rom_hooks.c
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/rom_state.h"
+
+/**
+ * A dummy pre-run hook for the `kRomStateInit` ROM state.
+ *
+ * This is an example on how Silicon Creators should define a ROM state hook.
+ */
+OT_WARN_UNUSED_RESULT rom_error_t dummy_rom_init_pre_hook(void *arg) {
+  return kErrorOk;
+}
+ROM_STATE_PRE_HOOK(kRomStateInit, dummy_rom_init_pre_hook);

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -852,6 +852,6 @@ rom_state_boot_rom_ext(void *arg, uint32_t *next_state) {
 
 void rom_main(void) {
   CFI_FUNC_COUNTER_INIT(rom_counters, kCfiRomMain);
-  shutdown_finalize(
-      rom_state_fsm_walk(rom_states, kRomStateCnt, kRomStateInit));
+  shutdown_finalize(rom_state_fsm_walk(rom_states, kRomStateCnt, kRomStateInit,
+                                       rom_states_cfi));
 }

--- a/sw/device/silicon_creator/rom/rom.c
+++ b/sw/device/silicon_creator/rom/rom.c
@@ -47,6 +47,7 @@
 #include "sw/device/silicon_creator/rom/boot_policy_ptrs.h"
 #include "sw/device/silicon_creator/rom/bootstrap.h"
 #include "sw/device/silicon_creator/rom/rom_epmp.h"
+#include "sw/device/silicon_creator/rom/rom_state.h"
 #include "sw/device/silicon_creator/rom/sigverify_keys_ecdsa_p256.h"
 #include "sw/device/silicon_creator/rom/sigverify_keys_spx.h"
 #include "sw/device/silicon_creator/rom/sigverify_otp_keys.h"
@@ -757,26 +758,100 @@ static rom_error_t rom_try_boot(void) {
   return kErrorRomBootFailed;
 }
 
-void rom_main(void) {
+/*
+ * The bootstrap request is the `kRomStateBootstrapCheck` and
+ * `kRomStateBootstrap` ROM states argument. It must be undefined before
+ * entering the `kRomStateBootstrapCheck` state as only the
+ * `kRomStateBootstrapCheck` run callback or hooks should set it to either
+ * `kHardenedBoolFalse` or `kHardenedBoolTrue`.
+ */
+static hardened_bool_t bootstrap_request = 0;
+
+enum {
+  kRomStateCnt = 4,
+};
+
+/**
+ * Table of ROM states.
+ *
+ * Encoding generated with:
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 4 -n 16 \
+ *     -s 519644925 --language=c
+ */
+// clang-format off
+#define ROM_STATES(X)                                                               \
+  X(kRomStateInit,           0x5616, rom_state_init, NULL)                          \
+  X(kRomStateBootstrapCheck, 0x0a92, rom_state_bootstrap_check, &bootstrap_request) \
+  X(kRomStateBootstrap,      0xd0a0, rom_state_bootstrap, &bootstrap_request)       \
+  X(kRomStateBootRomExt,     0xed14, rom_state_boot_rom_ext, NULL)
+// clang-format on
+
+ROM_STATE_INIT_TABLE(rom_states, kRomStateCnt, ROM_STATES);
+
+static OT_WARN_UNUSED_RESULT rom_error_t rom_state_init(void *arg,
+                                                        uint32_t *next_state) {
   CFI_FUNC_COUNTER_INIT(rom_counters, kCfiRomMain);
 
   CFI_FUNC_COUNTER_PREPCALL(rom_counters, kCfiRomMain, 1, kCfiRomInit);
-  SHUTDOWN_IF_ERROR(rom_init());
+  HARDENED_RETURN_IF_ERROR(rom_init());
   CFI_FUNC_COUNTER_INCREMENT(rom_counters, kCfiRomMain, 3);
-  CFI_FUNC_COUNTER_CHECK(rom_counters, kCfiRomInit, 3);
 
+  *next_state = kRomStateBootstrapCheck;
+
+  return kErrorOk;
+}
+
+static OT_WARN_UNUSED_RESULT rom_error_t
+rom_state_bootstrap_check(void *arg, uint32_t *next_state) {
   if (launder32(waking_from_low_power) != kHardenedBoolTrue) {
     HARDENED_CHECK_EQ(waking_from_low_power, kHardenedBoolFalse);
-    hardened_bool_t bootstrap_req = bootstrap_requested();
-    if (launder32(bootstrap_req) == kHardenedBoolTrue) {
-      HARDENED_CHECK_EQ(bootstrap_req, kHardenedBoolTrue);
-      rom_bootstrap_message();
-      watchdog_disable();
-      shutdown_finalize(bootstrap());
+
+    hardened_bool_t *bootstrap_req = (hardened_bool_t *)arg;
+
+    if (launder32(*bootstrap_req) == 0) {
+      // The pre_ hook has not set the bootstrap request flag, it has to be
+      // checked and set to True or False
+      HARDENED_CHECK_EQ(*bootstrap_req, 0);
+      *bootstrap_req = bootstrap_requested();
+    }
+
+    // The bootstrap request flag must now be True or False.
+    if (launder32(*bootstrap_req) == kHardenedBoolTrue) {
+      HARDENED_CHECK_EQ(*bootstrap_req, kHardenedBoolTrue);
+      *next_state = kRomStateBootstrap;
+      return kErrorOk;
     }
   }
 
+  // We are not bootstrapping, aiming for ROM ext.
+  *next_state = kRomStateBootRomExt;
+  return kErrorOk;
+}
+
+static OT_WARN_UNUSED_RESULT rom_error_t
+rom_state_bootstrap(void *arg, uint32_t *next_state) {
+  hardened_bool_t *bootstrap_req = (hardened_bool_t *)arg;
+
+  if (launder32(*bootstrap_req) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(*bootstrap_req, kHardenedBoolTrue);
+    rom_bootstrap_message();
+    watchdog_disable();
+    // `bootstrap` will not return unless there is an error.
+    HARDENED_RETURN_IF_ERROR(bootstrap());
+  }
+
+  return kErrorRomBootFailed;
+}
+
+static OT_WARN_UNUSED_RESULT rom_error_t
+rom_state_boot_rom_ext(void *arg, uint32_t *next_state) {
   // `rom_try_boot` will not return unless there is an error.
   CFI_FUNC_COUNTER_PREPCALL(rom_counters, kCfiRomMain, 4, kCfiRomTryBoot);
-  shutdown_finalize(rom_try_boot());
+  return rom_try_boot();
+}
+
+void rom_main(void) {
+  CFI_FUNC_COUNTER_INIT(rom_counters, kCfiRomMain);
+  shutdown_finalize(
+      rom_state_fsm_walk(rom_states, kRomStateCnt, kRomStateInit));
 }

--- a/sw/device/silicon_creator/rom/rom.h
+++ b/sw/device/silicon_creator/rom/rom.h
@@ -7,9 +7,23 @@
 
 #include <stdnoreturn.h>
 
+#include "sw/device/silicon_creator/lib/error.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
+
+/**
+ * ROM states run callbacks.
+ */
+static OT_WARN_UNUSED_RESULT rom_error_t rom_state_init(void *arg,
+                                                        uint32_t *next_state);
+static OT_WARN_UNUSED_RESULT rom_error_t
+rom_state_bootstrap_check(void *arg, uint32_t *next_state);
+static OT_WARN_UNUSED_RESULT rom_error_t
+rom_state_bootstrap(void *arg, uint32_t *next_state);
+static OT_WARN_UNUSED_RESULT rom_error_t
+rom_state_boot_rom_ext(void *arg, uint32_t *next_state);
 
 /**
  * The first C function executed by the ROM (defined in `rom.c`)

--- a/sw/device/silicon_creator/rom/rom_state.c
+++ b/sw/device/silicon_creator/rom/rom_state.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/silicon_creator/rom/rom_state.h"
 
+#include "sw/device/silicon_creator/lib/cfi.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 
 static OT_WARN_UNUSED_RESULT rom_error_t rom_state_get_state_cb(
@@ -26,9 +27,30 @@ static OT_WARN_UNUSED_RESULT rom_error_t rom_state_get_state_cb(
   return kErrorRomBootFailed;
 }
 
+// clang-format off
+#define CFI_ROM_STATE_INIT(cfi_table_, state_cb_)                     \
+  do {                                                                \
+    const rom_state_cfi_t *state_cfi = &state_cb_->cfi;               \
+    const rom_state_t state = state_cb_->state;                       \
+    cfi_func_counter_init(cfi_table_, state_cfi->state_index, state); \
+  } while(0)
+
+#define CFI_ROM_STATE_PREP_CB(cfi_table_, state_cb_, cb_step_, counter_) \
+  do {                                                                   \
+    const rom_state_cfi_t *state_cfi = &state_cb_->cfi;                  \
+    const rom_state_t state = state_cb_->state;                          \
+    cfi_func_counter_increment(cfi_table_, state_cfi->state_index,       \
+                               counter_ + 1, state);                     \
+    cfi_func_counter_prepcall(cfi_table_, state_cfi->state_index,        \
+                              counter_ + 2,                              \
+                              state_cfi->cb_step_ ## _index, state,      \
+                              cfi_step_to_count(state, counter_ + 3));   \
+  } while(0)
+// clang-format on
+
 OT_WARN_UNUSED_RESULT rom_error_t rom_state_fsm_walk(
     const rom_state_cb_t state_callbacks[], const size_t state_callbacks_cnt,
-    const rom_state_t init_state) {
+    const rom_state_t init_state, uint32_t state_cfi_table[]) {
   rom_state_t next_state = init_state;
 
   while (true) {
@@ -39,15 +61,21 @@ OT_WARN_UNUSED_RESULT rom_error_t rom_state_fsm_walk(
         rom_state_get_state_cb(state_callbacks, state_callbacks_cnt,
                                current_state, &current_state_cb));
 
+    // Initialize CFI counters.
+    CFI_ROM_STATE_INIT(state_cfi_table, current_state_cb);
+
     // Pre run hook.
+    CFI_ROM_STATE_PREP_CB(state_cfi_table, current_state_cb, pre_run, 0);
     HARDENED_RETURN_IF_ERROR(current_state_cb->pre_run(current_state_cb->arg));
 
     // State run callback.
+    CFI_ROM_STATE_PREP_CB(state_cfi_table, current_state_cb, run, 3);
     HARDENED_RETURN_IF_ERROR(
         current_state_cb->run(current_state_cb->arg, &next_state));
     HARDENED_CHECK_NE(current_state, next_state);
 
     // Post run hooks.
+    CFI_ROM_STATE_PREP_CB(state_cfi_table, current_state_cb, post_run, 6);
     HARDENED_RETURN_IF_ERROR(current_state_cb->post_run(current_state_cb->arg));
   }
 }

--- a/sw/device/silicon_creator/rom/rom_state.c
+++ b/sw/device/silicon_creator/rom/rom_state.c
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom/rom_state.h"
+
+#include "sw/device/silicon_creator/lib/shutdown.h"
+
+static OT_WARN_UNUSED_RESULT rom_error_t rom_state_get_state_cb(
+    const rom_state_cb_t state_callbacks[], const size_t state_callbacks_cnt,
+    const rom_state_t state, const rom_state_cb_t **state_cb) {
+  // TODO Start from a random index
+  for (size_t idx = 0; idx < state_callbacks_cnt; idx++) {
+    if (launder32(state_callbacks[idx].state) != state) {
+      continue;
+    }
+
+    HARDENED_CHECK_EQ(state_callbacks[idx].state, state);
+
+    *state_cb = &state_callbacks[idx];
+    HARDENED_CHECK_EQ(*state_cb, &state_callbacks[idx]);
+
+    return kErrorOk;
+  }
+
+  return kErrorRomBootFailed;
+}
+
+OT_WARN_UNUSED_RESULT rom_error_t rom_state_fsm_walk(
+    const rom_state_cb_t state_callbacks[], const size_t state_callbacks_cnt,
+    const rom_state_t init_state) {
+  rom_state_t next_state = init_state;
+
+  while (true) {
+    rom_state_t current_state = next_state;
+    const rom_state_cb_t *current_state_cb = NULL;
+
+    HARDENED_RETURN_IF_ERROR(
+        rom_state_get_state_cb(state_callbacks, state_callbacks_cnt,
+                               current_state, &current_state_cb));
+
+    // Pre run hook.
+    HARDENED_RETURN_IF_ERROR(current_state_cb->pre_run(current_state_cb->arg));
+
+    // State run callback.
+    HARDENED_RETURN_IF_ERROR(
+        current_state_cb->run(current_state_cb->arg, &next_state));
+    HARDENED_CHECK_NE(current_state, next_state);
+
+    // Post run hooks.
+    HARDENED_RETURN_IF_ERROR(current_state_cb->post_run(current_state_cb->arg));
+  }
+}

--- a/sw/device/silicon_creator/rom/rom_state.h
+++ b/sw/device/silicon_creator/rom/rom_state.h
@@ -66,10 +66,30 @@ typedef OT_WARN_UNUSED_RESULT rom_error_t
 rom_state_run_cb(void *arg, rom_state_t *next_state);
 
 /**
+ * A ROM state Control Flow Integrity (CFI) set of counters indexes.
+ * Four CFI counters per ROM state are maintained in a single ROM state CFI
+ * array, as defined and intialized by the ROM_STATE_CFI_TABLE_ENTRIES_ macro.
+ * This structure keeps track of those four ROM state indexes in that table.
+ * The ROM state CFI counter, indexed by the `state_index` field in this
+ * structure, gets incremented as the ROM state machine goes through the three
+ * steps in the ROM state sequence and calls the pre_run, run and post_run
+ * functions.
+ * The pre_run, run and post_run CFI counters are initialized by the ROM state
+ * machine, before calling their associated functions.
+ */
+typedef struct rom_state_cfi {
+  size_t state_index;    // The overall ROM state index into the CFI table.
+  size_t pre_run_index;  // The pre_run hook CFI index
+  size_t post_run_index;
+  size_t run_index;
+} rom_state_cfi_t;
+
+/**
  * A ROM state callback
  */
 typedef struct rom_state_cb {
   rom_state_t state;
+  rom_state_cfi_t cfi;
   void *arg;
   rom_state_hook_cb *pre_run;
   rom_state_hook_cb *post_run;
@@ -94,10 +114,26 @@ typedef struct rom_state_cb {
   ROM_STATE_POST_HOOK_WEAK_(state_)
 
 #define ROM_STATE_VALUES_(state_, value_, run_, run_arg) state_ = value_,
+#define ROM_STATE_CFI_INDEXES_(state_, value_, run_, run_arg) \
+  state_##_cfi_index,                                         \
+  state_##_pre_run_cfi_index,                                 \
+  state_##_run_cfi_index,                                     \
+  state_##_post_run_cfi_index,
+
+#define ROM_STATE_CFI_ENTRIES_(state_, value_, run_, run_arg)   \
+  {                                                             \
+      .state_index =  state_##_cfi_index,                       \
+      .pre_run_index =  state_##_pre_run_cfi_index,             \
+      .post_run_index =  state_##_post_run_cfi_index,           \
+      .run_index =  state_##_run_cfi_index,                     \
+  }
+
+#define ROM_STATE_CFI_TABLE_ENTRIES_(state_, value_, run_, run_arg_) 0, 0, 0, 0,
 
 #define ROM_STATE_TABLE_ENTRIES_(state_, value_, run_, run_arg_)        \
   {                                                                     \
       .state = state_,                                                  \
+      .cfi = ROM_STATE_CFI_ENTRIES_(state_, value_, run_, run_arg_),    \
       .pre_run = rom_state_pre_##state_,                                \
       .post_run = rom_state_post_##state_,                              \
       .run = run_,                                                      \
@@ -136,6 +172,7 @@ typedef struct rom_state_cb {
  * - For each ROM state, its callback, its pre-run and post-run,
  *   weakly-defined and overridable hooks, and its argument.
  * - The ROM states array.
+ * - The ROM states CFI indexes.
  *
  * @param table_name_ The ROM states array name. This will be defined as a
  *                    static, constant array of `rom_state_cb_t` entries.
@@ -149,7 +186,9 @@ typedef struct rom_state_cb {
  */
 #define ROM_STATE_INIT_TABLE(table_name_, table_cnt_, TABLE_)   \
   enum { TABLE_(ROM_STATE_VALUES_) };                           \
+  enum { TABLE_(ROM_STATE_CFI_INDEXES_) };                      \
   TABLE_(ROM_STATE_CALLBACKS_)                                  \
+  uint32_t table_name_##_cfi[] = {TABLE_(ROM_STATE_CFI_TABLE_ENTRIES_)}; \
   static const rom_state_cb_t table_name_[table_cnt_] = {TABLE_(ROM_STATE_TABLE_ENTRIES_) }
 // clang-format on
 
@@ -169,7 +208,7 @@ typedef struct rom_state_cb {
  */
 OT_WARN_UNUSED_RESULT rom_error_t rom_state_fsm_walk(
     const rom_state_cb_t states_callbacks[], const size_t state_callbacks_cnt,
-    const rom_state_t init_state);
+    const rom_state_t init_state, uint32_t state_cfi_table[]);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/rom/rom_state.h
+++ b/sw/device/silicon_creator/rom/rom_state.h
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_ROM_STATE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_ROM_STATE_H_
+
+#include <stdint.h>
+#include <stdnoreturn.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * The ROM state API allows for declaring ROM states and their associated
+ * callbacks. A ROM state callback defines which new state the ROM should
+ * transition to if the current state executes successfully. The
+ * `rom_state_fsm()` function walks through the ROM defines states, runs
+ * the current state callback and transitions to the next state.
+ *
+ * Silicon creators can customize a ROM state execution flow through pre-run
+ * post-run callback hooks. Pre-run hooks are unconditionally called before a
+ * state callback is executed and can modify the state argument. Post-run hooks
+ * run only after the state callback successfully completed, and can also modify
+ * the state associated argument. The ROM transitions to the next state defined
+ * by the current state callback, if and only if the post-run hook returns
+ * without errors.
+ *
+ * By default, the pre-run and post-run hooks are weakly defined symbols that do
+ * nothing. They can be overriden by silicon creators, through an external
+ * repository. See the corresponding documentation and example in
+ * `sw/device/silicon_creator/rom/hooks/`
+ */
+
+/**
+ * A ROM state.
+ */
+typedef uint32_t rom_state_t;
+
+/**
+ * A ROM state hook.
+ * ROM state hooks are called prior and after the state run callback.
+ * They can be overridden by silicon creator implementation, through an external
+ * repository.
+ *
+ * @param arg The ROM state argument.
+ */
+typedef OT_WARN_UNUSED_RESULT rom_error_t rom_state_hook_cb(void *arg);
+
+/**
+ * A ROM state run callback.
+ * This is the main callback for a ROM state. It can not be overridden by
+ * silicon creator hooks, unlike ROM state hooks.
+ *
+ * @param arg The ROM state callback and hooks argument. This pointer is shared
+ *            between a state run callback and hooks, and will typically point
+ *            to a static structure or variable.
+ * @param[out] next_state The next state the ROM should transition to.
+ */
+typedef OT_WARN_UNUSED_RESULT rom_error_t
+rom_state_run_cb(void *arg, rom_state_t *next_state);
+
+/**
+ * A ROM state callback
+ */
+typedef struct rom_state_cb {
+  rom_state_t state;
+  void *arg;
+  rom_state_hook_cb *pre_run;
+  rom_state_hook_cb *post_run;
+  rom_state_run_cb *run;
+} rom_state_cb_t;
+
+// clang-format off
+#define ROM_STATE_PRE_HOOK_WEAK_(state_)             \
+  OT_WEAK OT_WARN_UNUSED_RESULT                      \
+  rom_error_t rom_state_pre_##state_(void *arg) {    \
+    return kErrorOk;                                 \
+  }
+
+#define ROM_STATE_POST_HOOK_WEAK_(state_)           \
+  OT_WEAK OT_WARN_UNUSED_RESULT                     \
+  rom_error_t rom_state_post_##state_(void *arg) {  \
+    return kErrorOk;                                \
+  }
+
+#define ROM_STATE_CALLBACKS_(state_, value_, run_, run_arg_)     \
+  ROM_STATE_PRE_HOOK_WEAK_(state_)                               \
+  ROM_STATE_POST_HOOK_WEAK_(state_)
+
+#define ROM_STATE_VALUES_(state_, value_, run_, run_arg) state_ = value_,
+
+#define ROM_STATE_TABLE_ENTRIES_(state_, value_, run_, run_arg_)        \
+  {                                                                     \
+      .state = state_,                                                  \
+      .pre_run = rom_state_pre_##state_,                                \
+      .post_run = rom_state_post_##state_,                              \
+      .run = run_,                                                      \
+      .arg = run_arg_,                                                  \
+  },
+
+/**
+ * Binds a hook implementation to a ROM state, in order for it to be run
+ * before the state's run callback.
+ *
+ * This macro overrides the default, empty pre-run hook for a given state.
+ */
+#define ROM_STATE_PRE_HOOK(state_, hook_)           \
+  OT_WARN_UNUSED_RESULT                             \
+  rom_error_t rom_state_pre_##state_(void *arg) {   \
+    return hook_(arg);                              \
+  }
+
+/**
+ * Binds a hook implementation to a ROM state, in order for it to be run
+ * after the state's run callback.
+ *
+ * This macro overrides the default, empty post-run hook for a given state.
+ */
+#define ROM_STATE_POST_HOOK(state_, hook_)          \
+  OT_WARN_UNUSED_RESULT                             \
+  rom_error_t rom_state_post_##state_(void *arg) {  \
+    return hook_(arg);                              \
+  }
+
+/**
+ * The ROM states table.
+ *
+ * This macro declares and defines:
+ * - All ROM state values as an enum.
+ * - For each ROM state, its callback, its pre-run and post-run,
+ *   weakly-defined and overridable hooks, and its argument.
+ * - The ROM states array.
+ *
+ * @param table_name_ The ROM states array name. This will be defined as a
+ *                    static, constant array of `rom_state_cb_t` entries.
+ * @param table_cnt_ The exact number of entries in the states array.
+ * @param TABLE_ The ROM state table definition. `TABLE_` is C macro that
+ *               takes another macro as its argument. The macro passed to
+ *               `TABLE_` takes 4 arguments in order to create a ROM state
+ *               tuple: one identifier, one value, one run callback and one
+ *               argument to pass to the callback. The created tuple is used to
+ *               define and declare a ROM state related structure or variable.
+ */
+#define ROM_STATE_INIT_TABLE(table_name_, table_cnt_, TABLE_)   \
+  enum { TABLE_(ROM_STATE_VALUES_) };                           \
+  TABLE_(ROM_STATE_CALLBACKS_)                                  \
+  static const rom_state_cb_t table_name_[table_cnt_] = {TABLE_(ROM_STATE_TABLE_ENTRIES_) }
+// clang-format on
+
+/**
+ * The ROM state machine walker.
+ *
+ * ROM implementations call this function with the initial ROM state, and it
+ * walk through the ROM states defined in @states_callback.
+ * When transitioning to a ROM state, this function will first call the pre-run
+ * hook for the state, then the state run callback and finally the post-run
+ * hook. If any one of these three call returns an error, `rom_state_fsm`
+ * returns and propagates the error.
+ *
+ * @param states_callbacks The array of all ROM states callbacks.
+ * @param states_callbacks_cnt The number of entries in states_callbacks.
+ * @param init_state The initial state of the ROM.
+ */
+OT_WARN_UNUSED_RESULT rom_error_t rom_state_fsm_walk(
+    const rom_state_cb_t states_callbacks[], const size_t state_callbacks_cnt,
+    const rom_state_t init_state);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_ROM_STATE_H_


### PR DESCRIPTION
This PR implements an initial framework for allowing vendors to customize OpenTitan ROMs with external , potentially closed-source hooks. See #25633 for more details on the problem statement and the proposed solution. 

This pull request is made of six commits:

1. `[sw,silicon_creator,rom] Add a ROM state API` is the main ROM vendor hooks implementation. It provides a set of C macros for defining ROM states and binding them with a run callback implementation. It also provides a simple API for walking through all defined states.
2. `[sw,silicon_creator,rom] Add dummy ROM state hooks` expands the `hooks_setup` bazel rules for supporting external ROM hooks repository. It also provides a dummy example of such a repository, with basic documentation on how to replicate that setup to actually implement custom ROM hooks
3. `[sw,silicon_creator,rom] Convert the OpenTitan ROM to the ROM state API` is really just a PoC as it converts the existing Earlgrey ROM to this new framework. In this commit, the ROM state definitions are wrapper around the existing high level functions of the Earlgrey ROM. A real conversion would split those functions into more granular ones and map those to a finer ROM state machine. This is not done in this commit to keep it as little intrusive as possible, mostly for readability purposes.
4. `[sw,silicon_creator,cfi] Provide more flexible CFI APIs` and `[sw,silicon_creator,rom_state] Inject software control flow integrity` show how CFI counters could be transparently injected into the ROM state machine, providing control flow checks as part of the state machine walk.
5. `[sw,silicon_creator,rom,doc] [RFC] ROM vendor customizations` is the RFC document linked to this PR. The problem statement, requirements and proposed approach are described there. As it gets reviewed and hopefully approved, we could consider converting it into a ROM specification document.

Fixes #25633