### PR TITLE
[ci] Move CW305 bitstream build to machine without license

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
   # Build CW305 variant of the English Breakfast toplevel design using Vivado
   chip_englishbreakfast_cw305:
     name: CW305's Bitstream
-    runs-on: ubuntu-22.04-bitstream
+    runs-on: ubuntu-22.04-vivado
     needs: quick_lint
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The CW305 uses an Artix-7 FPGA which does not require an enterprise Vivado license to synthesise for. We limit the number of machines on the `-bitstream` label to match our number of licenses, however CW305s are taking up these spots unnecessarily.

This commit moves them to the `-vivado` machines which have access to Vivado Standard edition only.