### PR TITLE
[rv_core_ibex] Update Ibex to allow all accesses to Debug Module in debug mode

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -399,6 +399,22 @@
       expose:  "true"
     },
 
+    { name:    "DmBaseAddr"
+      type:    "int unsigned"
+      default: "437321728" //"32'h1A110000"
+      desc:    "Base address of Debug Module"
+      local:   "false"
+      expose:  "true"
+    }
+
+    { name:    "DmAddrMask"
+      type:    "int unsigned"
+      default: "4095" //"32'h00000FFF"
+      desc:    "Adress mask of Debug Module"
+      local:   "false"
+      expose:  "true"
+    }
+
     { name:    "DmHaltAddr"
       type:    "int unsigned"
       default: "437323776" //"32'h1A110800"

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -19,7 +19,7 @@
   hw_checklist:       "../doc/checklist",
   sw_checklist:       "/sw/device/lib/dif/dif_rv_core_ibex",
   dv_doc:             "../doc/dv",
-  version:            "2.0.0",
+  version:            "2.1.0",
   life_stage:         "L1",
   design_stage:       "D2S",
   verification_stage: "V2S",

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -36,6 +36,8 @@ module rv_core_ibex
   parameter bit                     SecureIbex       = 1'b1,
   parameter ibex_pkg::lfsr_seed_t   RndCnstLfsrSeed  = ibex_pkg::RndCnstLfsrSeedDefault,
   parameter ibex_pkg::lfsr_perm_t   RndCnstLfsrPerm  = ibex_pkg::RndCnstLfsrPermDefault,
+  parameter int unsigned            DmBaseAddr       = 32'h1A110000,
+  parameter int unsigned            DmAddrMask       = 32'h00000FFF,
   parameter int unsigned            DmHaltAddr       = 32'h1A110800,
   parameter int unsigned            DmExceptionAddr  = 32'h1A110808,
   parameter bit                     PipeLine         = 1'b0,
@@ -409,6 +411,8 @@ module rv_core_ibex
     .RndCnstLfsrPerm             ( RndCnstLfsrPerm          ),
     .RndCnstIbexKey              ( RndCnstIbexKeyDefault    ),
     .RndCnstIbexNonce            ( RndCnstIbexNonceDefault  ),
+    .DmBaseAddr                  ( DmBaseAddr               ),
+    .DmAddrMask                  ( DmAddrMask               ),
     .DmHaltAddr                  ( DmHaltAddr               ),
     .DmExceptionAddr             ( DmExceptionAddr          )
   ) u_core (

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -8580,6 +8580,8 @@
         DbgTriggerEn: "1"
         DbgHwBreakNum: "4"
         SecureIbex: "1"
+        DmBaseAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM
+        DmAddrMask: tl_main_pkg::ADDR_MASK_RV_DM__MEM
         DmHaltAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]
         DmExceptionAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]
         PipeLine: "0"
@@ -8887,6 +8889,24 @@
           local: "false"
           expose: "true"
           name_top: RvCoreIbexSecureIbex
+        }
+        {
+          name: DmBaseAddr
+          desc: Base address of Debug Module
+          type: int unsigned
+          default: tl_main_pkg::ADDR_SPACE_RV_DM__MEM
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexDmBaseAddr
+        }
+        {
+          name: DmAddrMask
+          desc: Adress mask of Debug Module
+          type: int unsigned
+          default: tl_main_pkg::ADDR_MASK_RV_DM__MEM
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexDmAddrMask
         }
         {
           name: DmHaltAddr

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -998,6 +998,8 @@
                    DbgTriggerEn: "1",
                    DbgHwBreakNum: "4",
                    SecureIbex: "1",
+                   DmBaseAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM",
+                   DmAddrMask: "tl_main_pkg::ADDR_MASK_RV_DM__MEM",
                    DmHaltAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]",
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]",
                    PipeLine: "0",

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -134,6 +134,8 @@ module top_darjeeling #(
   parameter bit RvCoreIbexDbgTriggerEn = 1,
   parameter int RvCoreIbexDbgHwBreakNum = 4,
   parameter bit RvCoreIbexSecureIbex = 1,
+  parameter int unsigned RvCoreIbexDmBaseAddr = tl_main_pkg::ADDR_SPACE_RV_DM__MEM,
+  parameter int unsigned RvCoreIbexDmAddrMask = tl_main_pkg::ADDR_MASK_RV_DM__MEM,
   parameter int unsigned RvCoreIbexDmHaltAddr =
       tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0],
   parameter int unsigned RvCoreIbexDmExceptionAddr =
@@ -2489,6 +2491,8 @@ module top_darjeeling #(
     .DbgTriggerEn(RvCoreIbexDbgTriggerEn),
     .DbgHwBreakNum(RvCoreIbexDbgHwBreakNum),
     .SecureIbex(RvCoreIbexSecureIbex),
+    .DmBaseAddr(RvCoreIbexDmBaseAddr),
+    .DmAddrMask(RvCoreIbexDmAddrMask),
     .DmHaltAddr(RvCoreIbexDmHaltAddr),
     .DmExceptionAddr(RvCoreIbexDmExceptionAddr),
     .PipeLine(RvCoreIbexPipeLine)

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -8294,6 +8294,8 @@
         DbgTriggerEn: "1"
         DbgHwBreakNum: "4"
         SecureIbex: "1"
+        DmBaseAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM
+        DmAddrMask: tl_main_pkg::ADDR_MASK_RV_DM__MEM
         DmHaltAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]
         DmExceptionAddr: tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]
         PipeLine: "0"
@@ -8601,6 +8603,24 @@
           local: "false"
           expose: "true"
           name_top: RvCoreIbexSecureIbex
+        }
+        {
+          name: DmBaseAddr
+          desc: Base address of Debug Module
+          type: int unsigned
+          default: tl_main_pkg::ADDR_SPACE_RV_DM__MEM
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexDmBaseAddr
+        }
+        {
+          name: DmAddrMask
+          desc: Adress mask of Debug Module
+          type: int unsigned
+          default: tl_main_pkg::ADDR_MASK_RV_DM__MEM
+          local: "false"
+          expose: "true"
+          name_top: RvCoreIbexDmAddrMask
         }
         {
           name: DmHaltAddr

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -961,6 +961,8 @@
                    DbgTriggerEn: "1",
                    DbgHwBreakNum: "4",
                    SecureIbex: "1",
+                   DmBaseAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM",
+                   DmAddrMask: "tl_main_pkg::ADDR_MASK_RV_DM__MEM",
                    DmHaltAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0]",
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::ExceptionAddress[31:0]",
                    PipeLine: "0",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -130,6 +130,8 @@ module top_earlgrey #(
   parameter bit RvCoreIbexDbgTriggerEn = 1,
   parameter int RvCoreIbexDbgHwBreakNum = 4,
   parameter bit RvCoreIbexSecureIbex = 1,
+  parameter int unsigned RvCoreIbexDmBaseAddr = tl_main_pkg::ADDR_SPACE_RV_DM__MEM,
+  parameter int unsigned RvCoreIbexDmAddrMask = tl_main_pkg::ADDR_MASK_RV_DM__MEM,
   parameter int unsigned RvCoreIbexDmHaltAddr =
       tl_main_pkg::ADDR_SPACE_RV_DM__MEM + dm::HaltAddress[31:0],
   parameter int unsigned RvCoreIbexDmExceptionAddr =
@@ -2664,6 +2666,8 @@ module top_earlgrey #(
     .DbgTriggerEn(RvCoreIbexDbgTriggerEn),
     .DbgHwBreakNum(RvCoreIbexDbgHwBreakNum),
     .SecureIbex(RvCoreIbexSecureIbex),
+    .DmBaseAddr(RvCoreIbexDmBaseAddr),
+    .DmAddrMask(RvCoreIbexDmAddrMask),
     .DmHaltAddr(RvCoreIbexDmHaltAddr),
     .DmExceptionAddr(RvCoreIbexDmExceptionAddr),
     .PipeLine(RvCoreIbexPipeLine)

--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 667fd20d2ede51caececccbcbda3652074424ce2
+    rev: a05d4d825c6dd1452d46edaaa43680249fcfa001
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/02_user/integration.rst
+++ b/hw/vendor/lowrisc_ibex/doc/02_user/integration.rst
@@ -108,6 +108,8 @@ Instantiation Template
       .RndCnstLfsrSeed  ( ibex_pkg::RndCnstLfsrSeedDefault ),
       .RndCnstLfsrPerm  ( ibex_pkg::RndCnstLfsrPermDefault ),
       .DbgTriggerEn     ( 0                                ),
+      .DmBaseAddr       ( 32'h1A110000                     ),
+      .DmAddrMask       ( 32'h00000FFF                     ),
       .DmHaltAddr       ( 32'h1A110800                     ),
       .DmExceptionAddr  ( 32'h1A110808                     )
   ) u_top (
@@ -223,6 +225,10 @@ Parameters
 |                              |                     |            | generate dummy instructions (only relevant when SecureIbex == 1'b1)   |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+
 | ``DbgTriggerEn``             | bit                 | 0          | Enable debug trigger support (one trigger only)                       |
++------------------------------+---------------------+------------+-----------------------------------------------------------------------+
+| ``DmBaseAddr``               | int                 | 0x1A110000 | Base address of the Debug Module                                      |
++------------------------------+---------------------+------------+-----------------------------------------------------------------------+
+| ``DmAddrMask``               | int                 | 0x1A110000 | Address mask of the Debug Module                                      |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+
 | ``DmHaltAddr``               | int                 | 0x1A110800 | Address to jump to when entering Debug Mode                           |
 +------------------------------+---------------------+------------+-----------------------------------------------------------------------+

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/debug.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/debug.rst
@@ -32,6 +32,10 @@ Parameters
 +---------------------+-----------------------------------------------------------------+
 | Parameter           | Description                                                     |
 +=====================+=================================================================+
+| ``DmBaseAddr``      | Base address of the Debug Module                                |
++---------------------+-----------------------------------------------------------------+
+| ``DmAddrMask``      | Address mask of the Debug Module                                |
++---------------------+-----------------------------------------------------------------+
 | ``DmHaltAddr``      | Address to jump to when entering Debug Mode                     |
 +---------------------+-----------------------------------------------------------------+
 | ``DmExceptionAddr`` | Address to jump to when an exception occurs while in Debug Mode |

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/pmp.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/pmp.rst
@@ -52,3 +52,9 @@ By default all PMP CSRs (include ``mseccfg``) are reset to 0.
 Some applications may want other reset values.
 Default reset values are defined in :file:`ibex_pkg.sv`.
 An implementation can either modify this file or pass custom reset values as a module parameter.
+
+Debug Mode
+----------
+
+In debug mode, the PMP allows all accesses to addresses of the Debug Module, as defined by the `DmBaseAddr` and `DmAddrMask` module parameters.
+This is mandated by the RISC-V Debug Specification (v1.0.0).

--- a/hw/vendor/lowrisc_ibex/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
+++ b/hw/vendor/lowrisc_ibex/dv/riscv_compliance/rtl/ibex_riscv_compliance.sv
@@ -155,6 +155,8 @@ module ibex_riscv_compliance (
       .DbgTriggerEn     (DbgTriggerEn      ),
       .SecureIbex       (SecureIbex        ),
       .ICacheScramble   (ICacheScramble    ),
+      .DmBaseAddr       (32'h00000000      ),
+      .DmAddrMask       (32'h00000003      ),
       .DmHaltAddr       (32'h00000000      ),
       .DmExceptionAddr  (32'h00000000      )
     ) u_top (

--- a/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/core_ibex/tb/core_ibex_tb_top.sv
@@ -84,6 +84,8 @@ module core_ibex_tb_top;
   assign {scramble_key, scramble_nonce} = scrambling_key_if.d_data;
 
   ibex_top_tracing #(
+    .DmBaseAddr       (32'h`BOOT_ADDR       ),
+    .DmAddrMask       (32'h0000_0007        ),
     .DmHaltAddr       (32'h`BOOT_ADDR + 'h0 ),
     .DmExceptionAddr  (32'h`BOOT_ADDR + 'h4 ),
     .PMPEnable        (PMPEnable        ),

--- a/hw/vendor/lowrisc_ibex/dv/verilator/pcount/cpp/ibex_pcounts.cc
+++ b/hw/vendor/lowrisc_ibex/dv/verilator/pcount/cpp/ibex_pcounts.cc
@@ -53,10 +53,9 @@ static bool has_hpm_counter(int index) {
 
 std::string ibex_pcount_string(bool csv) {
   char separator = csv ? ',' : ':';
-  std::string::size_type longest_name_length;
+  std::string::size_type longest_name_length = 0;
 
   if (!csv) {
-    longest_name_length = 0;
     for (int i = 0; i < ibex_counter_names.size(); ++i) {
       if (has_hpm_counter(i)) {
         longest_name_length =

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_controller.sv
@@ -997,6 +997,15 @@ module ibex_controller #(
     // If there's a pending exception req that doesn't need a PC set we must not see one
     `ASSERT(IbexNoPCSetOnSpecialReqIfNotExpected,
       exception_req_pending && !expect_exception_pc_set |-> ~pc_set_o)
+
+    // If entering or exiting debug mode, the pipeline must be flushed. This is because Ibex
+    // currently does not support some of the pipeline stages being in debug mode; either all or
+    // none of the pipeline stages must be in debug mode. As `flush_id_o` only affects the ID/EX
+    // stage but does not prevent a fetched instruction from proceeding to ID/EX the next cycle, the
+    // assertion additionally requires `pc_set_o`, which sets the PC in the IF stage to a new value,
+    // hence preventing a fetched instruction from proceeding to the ID/EX stage in the next cycle.
+    `ASSERT(IbexPipelineFlushOnChangingDebugMode,
+      debug_mode_d != debug_mode_q |-> flush_id_o & pc_set_o)
   `endif
 
   `ifdef RVFI

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_core.sv
@@ -44,6 +44,8 @@ module ibex_core import ibex_pkg::*; #(
   parameter int unsigned            RegFileDataWidth = 32,
   parameter bit                     MemECC           = 1'b0,
   parameter int unsigned            MemDataWidth     = MemECC ? 32 + 7 : 32,
+  parameter int unsigned            DmBaseAddr       = 32'h1A110000,
+  parameter int unsigned            DmAddrMask       = 32'h00000FFF,
   parameter int unsigned            DmHaltAddr       = 32'h1A110800,
   parameter int unsigned            DmExceptionAddr  = 32'h1A110808
 ) (
@@ -1177,6 +1179,8 @@ module ibex_core import ibex_pkg::*; #(
     assign pmp_priv_lvl[PMP_D]  = priv_mode_lsu;
 
     ibex_pmp #(
+      .DmBaseAddr    (DmBaseAddr),
+      .DmAddrMask    (DmAddrMask),
       .PMPGranularity(PMPGranularity),
       .PMPNumChan    (PMPNumChan),
       .PMPNumRegions (PMPNumRegions)
@@ -1185,6 +1189,7 @@ module ibex_core import ibex_pkg::*; #(
       .csr_pmp_cfg_i    (csr_pmp_cfg),
       .csr_pmp_addr_i   (csr_pmp_addr),
       .csr_pmp_mseccfg_i(csr_pmp_mseccfg),
+      .debug_mode_i     (debug_mode),
       .priv_mode_i      (pmp_priv_lvl),
       // Access checking channels
       .pmp_req_addr_i   (pmp_req_addr),

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
@@ -40,6 +40,8 @@ module ibex_lockstep import ibex_pkg::*; #(
   parameter int unsigned            RegFileDataWidth  = 32,
   parameter bit                     MemECC            = 1'b0,
   parameter int unsigned            MemDataWidth      = MemECC ? 32 + 7 : 32,
+  parameter int unsigned            DmBaseAddr        = 32'h1A110000,
+  parameter int unsigned            DmAddrMask        = 32'h00000FFF,
   parameter int unsigned            DmHaltAddr        = 32'h1A110800,
   parameter int unsigned            DmExceptionAddr   = 32'h1A110808
 ) (
@@ -377,6 +379,8 @@ module ibex_lockstep import ibex_pkg::*; #(
     .RegFileDataWidth  ( RegFileDataWidth  ),
     .MemECC            ( MemECC            ),
     .MemDataWidth      ( MemDataWidth      ),
+    .DmBaseAddr        ( DmBaseAddr        ),
+    .DmAddrMask        ( DmAddrMask        ),
     .DmHaltAddr        ( DmHaltAddr        ),
     .DmExceptionAddr   ( DmExceptionAddr   )
   ) u_shadow_core (

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -37,6 +37,8 @@ module ibex_top import ibex_pkg::*; #(
   parameter int unsigned            ICacheScrNumPrinceRoundsHalf = 2,
   parameter lfsr_seed_t             RndCnstLfsrSeed              = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t             RndCnstLfsrPerm              = RndCnstLfsrPermDefault,
+  parameter int unsigned            DmBaseAddr                   = 32'h1A110000,
+  parameter int unsigned            DmAddrMask                   = 32'h00000FFF,
   parameter int unsigned            DmHaltAddr                   = 32'h1A110800,
   parameter int unsigned            DmExceptionAddr              = 32'h1A110808,
   // Default seed and nonce for scrambling
@@ -313,6 +315,8 @@ module ibex_top import ibex_pkg::*; #(
     .RegFileDataWidth (RegFileDataWidth),
     .MemECC           (MemECC),
     .MemDataWidth     (MemDataWidth),
+    .DmBaseAddr       (DmBaseAddr),
+    .DmAddrMask       (DmAddrMask),
     .DmHaltAddr       (DmHaltAddr),
     .DmExceptionAddr  (DmExceptionAddr)
   ) u_ibex_core (
@@ -1016,6 +1020,8 @@ module ibex_top import ibex_pkg::*; #(
       .RegFileECC       (RegFileECC),
       .RegFileDataWidth (RegFileDataWidth),
       .MemECC           (MemECC),
+      .DmBaseAddr       (DmBaseAddr),
+      .DmAddrMask       (DmAddrMask),
       .DmHaltAddr       (DmHaltAddr),
       .DmExceptionAddr  (DmExceptionAddr)
     ) u_ibex_lockstep (
@@ -1119,6 +1125,10 @@ module ibex_top import ibex_pkg::*; #(
                                   icache_alert_major_internal;
   assign alert_major_bus_o      = core_alert_major_bus | lockstep_alert_major_bus;
   assign alert_minor_o          = core_alert_minor | lockstep_alert_minor;
+
+  // Parameter assertions
+  `ASSERT_INIT(DmHaltAddrInRange_A, (DmHaltAddr & ~DmAddrMask) == DmBaseAddr)
+  `ASSERT_INIT(DmExceptionAddrInRange_A, (DmExceptionAddr & ~DmAddrMask) == DmBaseAddr)
 
   // X checks for top-level outputs
   `ASSERT_KNOWN(IbexInstrReqX, instr_req_o)

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top_tracing.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top_tracing.sv
@@ -27,6 +27,8 @@ module ibex_top_tracing import ibex_pkg::*; #(
   parameter bit          ICacheScramble   = 1'b0,
   parameter lfsr_seed_t  RndCnstLfsrSeed  = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t  RndCnstLfsrPerm  = RndCnstLfsrPermDefault,
+  parameter int unsigned DmBaseAddr       = 32'h1A110000,
+  parameter int unsigned DmAddrMask       = 32'h00000FFF,
   parameter int unsigned DmHaltAddr       = 32'h1A110800,
   parameter int unsigned DmExceptionAddr  = 32'h1A110808
 ) (
@@ -184,6 +186,8 @@ module ibex_top_tracing import ibex_pkg::*; #(
     .ICacheScramble   ( ICacheScramble   ),
     .RndCnstLfsrSeed  ( RndCnstLfsrSeed  ),
     .RndCnstLfsrPerm  ( RndCnstLfsrPerm  ),
+    .DmBaseAddr       ( DmBaseAddr       ),
+    .DmAddrMask       ( DmAddrMask       ),
     .DmHaltAddr       ( DmHaltAddr       ),
     .DmExceptionAddr  ( DmExceptionAddr  )
   ) u_ibex_top (


### PR DESCRIPTION
This PR updates Ibex to https://github.com/lowRISC/ibex/commit/a05d4d82 to include a recent RTL change that allows all accesses to the Debug Module in debug mode (https://github.com/lowRISC/ibex/pull/2232), and it bumps the minor version of `rv_core_ibex` to 2.1.0 to reflect the SW-visible backward-compatible change.