### PR TITLE
[rom_ctrl, dv] Assertion coverage collection for tlul_adapter_sram

### DIFF
--- a/hw/ip/rom_ctrl/dv/cov/cover_reg_top.cfg
+++ b/hw/ip/rom_ctrl/dv/cov/cover_reg_top.cfg
@@ -2,9 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Collect coverage for tlul_adapter_sram to resolve coverage hole for intg_err.
-+tree tb.dut.u_tl_adapter_rom
-
 begin line+cond+fsm+branch
-  +moduletree tlul_adapter_sram
+  +tree tb.dut.u_tl_adapter_rom
+end
+
+begin assert
+  +tree tb.dut.u_tl_adapter_rom
+  -tree tb.dut.u_tl_adapter_rom.u_reqfifo
+  -tree tb.dut.u_tl_adapter_rom.u_rspfifo
+  -tree tb.dut.u_tl_adapter_rom.u_sramreqfifo
 end


### PR DESCRIPTION
We are not required to collect assertion coverage for prim_fifo_sync instantiated in tlul_adapter_sram. Commit 0372c1f removed the assert coverage for these modules but still got assertion coverage holes reported by VCS.