### PR TITLE
[opentitanlib] set EXEC CSR in sram_ctrl when SRAM program is loaded

### DIFF
--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -157,7 +157,6 @@ opentitan_test(
 )
 
 # This is the same as rom_with_fake_keys_otp_test_unlocked* but with ROM execution disabled.
-# TODO(#21204): Enable configuration of ROT AUTH partitions in CP stage.
 [
     otp_image(
         name = "otp_img_rom_exec_disabled_test_unlocked{}".format(i),
@@ -216,6 +215,28 @@ cc_library(
     ],
 )
 
+# Execution from SRAM is always enabled by default in TEST_UNLOCKED* LC states
+# unless HW_CFG1 OTP partition has the EN_SRAM_IFETCH field set to True. In that
+# case, the EXEC CSR in the sram_ctrl controls SRAM execution enablement.
+# Therefore, we want to test with the HW_CFG1 partition programmed with
+# EN_SRAM_IFETCH set to True.
+[
+    otp_image(
+        name = "otp_img_sram_exec_en_test_unlocked{}".format(i),
+        src = "//hw/ip/otp_ctrl/data:otp_json_test_unlocked{}".format(i),
+        overlays = [
+            "//hw/ip/otp_ctrl/data:otp_json_fixed_secret0",
+            "//hw/ip/otp_ctrl/data:otp_json_creator_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_owner_sw_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_alert_digest_cfg",
+            "//hw/ip/otp_ctrl/data:otp_json_hw_cfg1",
+            "//hw/ip/otp_ctrl/data:otp_json_exec_disabled",
+        ],
+        visibility = ["//visibility:private"],
+    )
+    for i in range(0, 8)
+]
+
 # We are using a bitstream with ROM execution disabled so the contents of flash
 # does not matter but opentitan_test() is unhappy if we don't provide one.
 # Additionally, ROM execution is disabled in the OTP image we use so we do not
@@ -230,7 +251,7 @@ cc_library(
         },
         fpga = fpga_params(
             needs_jtag = True,
-            otp = ":otp_img_rom_exec_disabled_{}".format(lc_state.lower()),
+            otp = ":otp_img_sram_exec_en_{}".format(lc_state.lower()),
             tags = ["manuf"],
             test_cmd = "--elf={firmware}",
             test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",

--- a/sw/host/opentitanlib/bindgen/BUILD
+++ b/sw/host/opentitanlib/bindgen/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 load("@rules_rust//bindgen:bindgen.bzl", "rust_bindgen", "rust_bindgen_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -16,6 +16,7 @@ _ENGLISH_BREAKFAST_DEPS = [
     "//sw/device/lib/dif:lc_ctrl",
     "//sw/device/lib/dif:otp_ctrl",
     "//sw/device/lib/dif:rstmgr",
+    "//sw/device/lib/dif:sram_ctrl",
     "//sw/device/lib/dif:uart",
 ]
 

--- a/sw/host/opentitanlib/bindgen/difs.h
+++ b/sw/host/opentitanlib/bindgen/difs.h
@@ -16,6 +16,7 @@
 #include "lc_ctrl_regs.h"    // Generated.
 #include "otp_ctrl_regs.h"   // Generated.
 #include "rstmgr_regs.h"     // Generated.
+#include "sram_ctrl_regs.h"  // Generated.
 #include "uart_regs.h"       // Generated.
 
 #else


### PR DESCRIPTION
Previously, we were relying on HW_CFG1 partition not being programmed yet for SRAM execution to be enabled in TEST_UNLOCKED* states. However, this limits the re-entrancy of the FT individualize program, where HW_CFG1 is programmed but the individualize program needs to be re-tried again.