### PR TITLE
[i2c,dv] Fully remove rx oversample test

### DIFF
--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -227,7 +227,7 @@
               - Read rx data oversampled value and ensure it is same as driven value
             '''
       stage: V2
-      tests: ["i2c_host_rx_oversample"]
+      tests: [/* TODO(#21887) "i2c_host_rx_oversample" */]
     }
     {
       name: i2c_host_mode_toggle

--- a/hw/ip/i2c/dv/i2c_sim_cfg.hjson
+++ b/hw/ip/i2c/dv/i2c_sim_cfg.hjson
@@ -307,7 +307,9 @@
       name : host_sanity
       tests: ["i2c_host_smoke", "i2c_host_override", "i2c_host_perf",
               "i2c_host_fifo_watermark", "i2c_host_fifo_overflow", "i2c_host_fifo_reset_fmt",
-              "i2c_host_rx_oversample",  "i2c_host_stretch_timeout",
+              // TODO(#21887)
+              // "i2c_host_rx_oversample",
+              "i2c_host_stretch_timeout",
               "i2c_host_fifo_fmt_empty", "i2c_host_fifo_reset_rx", "i2c_host_stretch_timeout",
               "i2c_host_fifo_full", "i2c_host_may_nack",
               "i2c_host_error_intr"]


### PR DESCRIPTION
These were showing up as errors because host_sanity and V2 were expecting there to be a i2c_host_rx_oversample test, but this has been commented out pending #21887. This commit just comments those out with the same TODO issue linked.