### PR TITLE
[bazel] Correct `bazel_skylib` version in `MODULE.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@
 
 module(name = "lowrisc_opentitan")
 
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
 include("//third_party/rust:rust.MODULE.bazel")
 


### PR DESCRIPTION
Due to semantic version resolution, we're actually getting `bazel_skylib` version 1.7.1 due to a dependency asking for it.

Update the version listed in `MODULE.bazel` to match so the warning is supressed.