### PR TITLE
[provisioning] make extension CA config optional

### DIFF
--- a/sw/host/provisioning/orchestrator/src/orchestrator.py
+++ b/sw/host/provisioning/orchestrator/src/orchestrator.py
@@ -36,21 +36,24 @@ def get_user_confirmation(
 SKU:      {sku_config.name}
 LC State: {sku_config.target_lc_state}
 
+[OTHER]
+fpga:          {args.fpga}
+> commit hash: {commit_hash}
+
 [DICE CA]
 certificate: {sku_config.dice_ca.certificate}
 key:         {sku_config.dice_ca.key}
 key type:    {sku_config.dice_ca.key_type}
 key ID:      {sku_config.dice_ca.key_id}
+""")
+    if sku_config.ext_ca:
+        print(f"""
 
 [EXTENSION CA]
 certificate: {sku_config.ext_ca.certificate}
 key:         {sku_config.ext_ca.key}
 key type:    {sku_config.ext_ca.key_type}
 key ID:      {sku_config.ext_ca.key_id}
-
-[OTHER]
-fpga:          {args.fpga}
-> commit hash: {commit_hash}
 """)
     if not args.non_interactive:
         confirm()

--- a/sw/host/provisioning/orchestrator/src/sku_config.py
+++ b/sw/host/provisioning/orchestrator/src/sku_config.py
@@ -26,9 +26,9 @@ class SkuConfig:
     target_lc_state: str  # valid: must be in ["dev", "prod", "prod_end"]
     otp: str  # valid: any string
     perso_bin: str  # valid: any string
-    dice_ca: Optional[OrderedDict]  # valid: see CaConfig
-    ext_ca: Optional[OrderedDict]  # valid: see CaConfig
     token_encrypt_key: str
+    dice_ca: Optional[OrderedDict]  # valid: see CaConfig
+    ext_ca: Optional[OrderedDict] = None  # valid: see CaConfig
 
     def __post_init__(self):
         # Load CA configs.


### PR DESCRIPTION
The extension CA was made optional in #25545 in the host benchtop provisioning FT harness. However, it was not propagated to the orchestrator script. This updates the orchestrator script to also make the extension CA optional, as some SKUs do not require extensions.