### PR TITLE
Update setup_verilator.md

### DIFF
--- a/doc/getting_started/setup_verilator.md
+++ b/doc/getting_started/setup_verilator.md
@@ -64,6 +64,7 @@ Moreover, Bazel automatically connects to the simulated UART (via `opentitantool
 For example, to run the UART smoke test on Verilator simulated hardware, and see the output in real time, use
 ```console
 cd $REPO_TOP
+touch WORKSPACE
 bazel test --test_output=streamed //sw/device/tests:uart_smoketest_sim_verilator
 ```
 or


### PR DESCRIPTION
touching workspace is required, otherwise the bazel complains for missing workspace file.
Refer https://stackoverflow.com/questions/41791171/bazel-build-for-tensorflow-inception-model