### PR TITLE
[SiVal] Map manufacture tests to the testplans

### DIFF
--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -59,6 +59,13 @@
       otp_mutate: true
       lc_states: ["TEST_UNLOCKED", "DEV", "PROD", "PROD_END", "RMA"]
       tests: []
+      bazel: [
+        "sw/device/silicon_creator/manuf/tests:manuf_scrap_functest_test_unlocked0"
+        "sw/device/silicon_creator/manuf/tests:manuf_scrap_functest_dev"
+        "sw/device/silicon_creator/manuf/tests:manuf_scrap_functest_prod"
+        "sw/device/silicon_creator/manuf/tests:manuf_scrap_functest_prod_end"
+        "sw/device/silicon_creator/manuf/tests:manuf_scrap_functest_rma"
+      ]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -530,7 +530,7 @@
       otp_mutate: false
       lc_states: ["TEST_UNLOCKED"]
       tests: []
-      bazel: []
+      bazel: ["sw/device/silicon_creator/manuf/tests:manuf_sram_program_crc_test_unlocked0_functest"]
     }
   ]
 }

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -140,7 +140,7 @@
       otp_mutate: false
       lc_states: ["TEST_UNLOCKED"]
       tests: []
-      bazel: []
+      bazel: ["sw/device/silicon_creator/manuf/tests:manuf_cp_device_info_flash_wr_test_unlocked0_to_prod_functest"]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -181,7 +181,7 @@
       otp_mutate: true
       lc_states: ["TEST_UNLOCKED"]
       tests: []
-      bazel: []
+      bazel: ["sw/device/silicon_creator/manuf/tests:manuf_cp_test_lock_functest"]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -32,7 +32,7 @@
       otp_mutate: true
       lc_states: ["RAW"]
       tests: []
-      bazel: []
+      bazel: ["sw/device/silicon_creator/manuf/tests:manuf_cp_unlock_raw_functest"]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -82,7 +82,7 @@
       otp_mutate: false
       lc_states: ["TEST_UNLOCKED"]
       tests: []
-      bazel: []
+      bazel: ["sw/device/silicon_creator/manuf/tests:manuf_cp_yield_test_functest_test_unlocked0"]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -109,7 +109,7 @@
       otp_mutate: false
       lc_states: ["TEST_UNLOCKED"]
       tests: []
-      bazel: []
+      bazel: ["sw/device/silicon_creator/manuf/tests:manuf_cp_ast_test_execution_test_unlocked0_functest"]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -225,6 +225,7 @@ cc_library(
         name = "manuf_sram_program_crc_{}_functest".format(lc_state.lower()),
         srcs = ["sram_empty_functest.c"],
         exec_env = {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:silicon_creator": None,
         },

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -394,6 +394,7 @@ opentitan_binary(
         name = "manuf_cp_ast_test_execution_{}_functest".format(lc_state.lower()),
         srcs = ["idle_functest.c"],
         exec_env = {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
         fpga = fpga_params(

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -311,6 +311,7 @@ opentitan_binary(
             CONST.LCV.PROD,
         ),
         exec_env = {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
         fpga = fpga_params(

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -73,6 +73,7 @@ _MANUF_TEST_LOCKED_KEY = None
         srcs = ["empty_functest.c"],
         ecdsa_key = _MANUF_TEST_LOCKED_KEY if (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS else ecdsa_key_for_lc_state(ECDSA_SPX_KEY_STRUCTS, lc_val),
         exec_env = {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
         fpga = fpga_params(

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -113,6 +113,7 @@ opentitan_test(
     name = "manuf_cp_unlock_raw_functest",
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw340_sival": None,
         "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
     fpga = fpga_params(

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -433,6 +433,7 @@ opentitan_test(
     name = "manuf_cp_test_lock_functest",
     srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
     exec_env = {
+        "//hw/top_earlgrey:fpga_cw340_sival": None,
         "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
     },
     fpga = fpga_params(

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -174,6 +174,7 @@ opentitan_test(
         name = "manuf_cp_yield_test_functest_{}".format(lc_state.lower()),
         srcs = ["//sw/device/silicon_creator/rom/e2e:empty_test.c"],
         exec_env = {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
             "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         },
         fpga = fpga_params(


### PR DESCRIPTION
These are the most obvious links based on the name.
Adding the CW340 exec_env will make these tests to be executed in the SiVal nightly job.
The remaining manufacture tests will be linked in a separated PR.