### PR TITLE
[reggen] Describe REGWEN properly for multi-registers

### DIFF
--- a/hw/ip/dma/doc/registers.md
+++ b/hw/ip/dma/doc/registers.md
@@ -682,6 +682,7 @@ Bus selection bit where the clearing command should be performed."
 Destination address for interrupt source clearing write.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Instances
 
@@ -714,6 +715,7 @@ Destination address for interrupt source clearing write.
 Write value for interrupt clearing write.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Instances
 

--- a/hw/ip/keymgr/doc/registers.md
+++ b/hw/ip/keymgr/doc/registers.md
@@ -336,6 +336,7 @@ This binding value is not considered secret, however its integrity is very impor
 The software binding is locked by software and unlocked by hardware upon a successful advance operation.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`SW_BINDING_REGWEN`](#sw_binding_regwen)
 
 ### Instances
 
@@ -369,6 +370,7 @@ This binding value is not considered secret, however its integrity is very impor
 The software binding is locked by software and unlocked by hardware upon a successful advance operation.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`SW_BINDING_REGWEN`](#sw_binding_regwen)
 
 ### Instances
 
@@ -398,6 +400,7 @@ The software binding is locked by software and unlocked by hardware upon a succe
 Salt value used as part of output generation
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Instances
 
@@ -427,6 +430,7 @@ Salt value used as part of output generation
 Version used as part of output generation
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Instances
 

--- a/hw/ip/kmac/doc/registers.md
+++ b/hw/ip/kmac/doc/registers.md
@@ -585,6 +585,7 @@ Current KMAC supports up to 512 bit secret key. It is the sw
 responsibility to keep upper bits of the secret key to 0.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Instances
 
@@ -633,6 +634,7 @@ Current KMAC supports up to 512 bit secret key. It is the sw
 responsibility to keep upper bits of the secret key to 0.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Instances
 
@@ -723,6 +725,7 @@ If the engine computes the hash, it discards any attempts to update the secret k
 and report an error.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Instances
 

--- a/hw/ip/lc_ctrl/doc/registers.md
+++ b/hw/ip/lc_ctrl/doc/registers.md
@@ -283,6 +283,7 @@ In order to have exclusive access to this register, SW must first claim the asso
 hardware mutex via [`CLAIM_TRANSITION_IF.`](#claim_transition_if)
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`TRANSITION_REGWEN`](#transition_regwen)
 
 ### Instances
 

--- a/hw/ip/otp_ctrl/doc/registers.md
+++ b/hw/ip/otp_ctrl/doc/registers.md
@@ -306,6 +306,7 @@ Hardware automatically determines the access granule (32bit or 64bit) based on w
 partition is being written to.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`DIRECT_ACCESS_REGWEN`](#direct_access_regwen)
 
 ### Instances
 

--- a/hw/ip/pwm/doc/registers.md
+++ b/hw/ip/pwm/doc/registers.md
@@ -151,6 +151,7 @@ Invert the PWM output for each channel
 Basic PWM Channel Parameters
 - Reset default: `0x0`
 - Reset mask: `0xc000ffff`
+- Register enable: [`REGWEN`](#regwen)
 
 ### Instances
 
@@ -204,6 +205,7 @@ Phase delay of the PWM leading edge, in units of 2^(-16) PWM
 Controls the duty_cycle of each channel.
 - Reset default: `0x7fff7fff`
 - Reset mask: `0xffffffff`
+- Register enable: [`REGWEN`](#regwen)
 
 ### Instances
 
@@ -246,6 +248,7 @@ The initial duty cycle for PWM output, in units
 Hardware controlled blink/heartbeat parameters.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`REGWEN`](#regwen)
 
 ### Instances
 

--- a/hw/ip/rv_core_ibex/doc/registers.md
+++ b/hw/ip/rv_core_ibex/doc/registers.md
@@ -125,6 +125,7 @@ Ibus address controls write enable.  Once set to 0, it can longer be configured 
 Enable Ibus address matching
 - Reset default: `0x0`
 - Reset mask: `0x1`
+- Register enable: [`IBUS_REGWEN`](#ibus_regwen)
 
 ### Instances
 
@@ -163,6 +164,7 @@ Enable Ibus address matching
   If the user were to translate the 0x8001-th 64KB block, the value programmed would be 0x8001_7FFF.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`IBUS_REGWEN`](#ibus_regwen)
 
 ### Instances
 
@@ -190,6 +192,7 @@ Enable Ibus address matching
   address bits that select which 64KB to be translated.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`IBUS_REGWEN`](#ibus_regwen)
 
 ### Instances
 
@@ -246,6 +249,7 @@ Ibus address controls write enable.  Once set to 0, it can longer be configured 
 Enable dbus address matching
 - Reset default: `0x0`
 - Reset mask: `0x1`
+- Register enable: [`DBUS_REGWEN`](#dbus_regwen)
 
 ### Instances
 
@@ -270,6 +274,7 @@ Enable dbus address matching
 See [`IBUS_ADDR_MATCHING_0`](#ibus_addr_matching_0) for detailed description.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`DBUS_REGWEN`](#dbus_regwen)
 
 ### Instances
 
@@ -293,6 +298,7 @@ See [`IBUS_ADDR_MATCHING_0`](#ibus_addr_matching_0) for detailed description.
 See [`IBUS_REMAP_ADDR_0`](#ibus_remap_addr_0) for a detailed description.
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`DBUS_REGWEN`](#dbus_regwen)
 
 ### Instances
 

--- a/hw/ip/sysrst_ctrl/doc/registers.md
+++ b/hw/ip/sysrst_ctrl/doc/registers.md
@@ -501,6 +501,7 @@ If no keys are configured for the pre-condition, the pre-condition always evalua
 The debounce timing is defined via [`KEY_INTR_DEBOUNCE_CTL`](#key_intr_debounce_ctl) whereas the pre-condition pressed timing is defined via [`COM_PRE_DET_CTL.`](#com_pre_det_ctl)
 - Reset default: `0x0`
 - Reset mask: `0x1f`
+- Register enable: [`REGWEN`](#regwen)
 
 ### Instances
 
@@ -532,6 +533,7 @@ To define the duration that the combo pre-condition should be pressed
 0-60s, each step is 5us(200KHz clock)
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`REGWEN`](#regwen)
 
 ### Instances
 
@@ -569,6 +571,7 @@ If no keys are configured for the combo, the combo detection is disabled.
 The debounce timing is defined via [`KEY_INTR_DEBOUNCE_CTL`](#key_intr_debounce_ctl) whereas the key-pressed timing is defined via [`COM_DET_CTL.`](#com_det_ctl)
 - Reset default: `0x0`
 - Reset mask: `0x1f`
+- Register enable: [`REGWEN`](#regwen)
 
 ### Instances
 
@@ -600,6 +603,7 @@ To define the duration that the combo should be pressed
 0-60s, each step is 5us(200KHz clock)
 - Reset default: `0x0`
 - Reset mask: `0xffffffff`
+- Register enable: [`REGWEN`](#regwen)
 
 ### Instances
 
@@ -629,6 +633,7 @@ To define the actions once the combo is detected
 [3]: rst_req (to OpenTitan reset manager)
 - Reset default: `0x0`
 - Reset mask: `0xf`
+- Register enable: [`REGWEN`](#regwen)
 
 ### Instances
 

--- a/hw/top_darjeeling/ip_autogen/pinmux/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/pinmux/doc/registers.md
@@ -556,6 +556,7 @@ Register write enable for MIO peripheral input selects.
 For each peripheral input, this selects the muxable pad input.
 - Reset default: `0x0`
 - Reset mask: `0xf`
+- Register enable: [`MIO_PERIPH_INSEL_REGWEN`](#mio_periph_insel_regwen)
 
 ### Instances
 
@@ -616,6 +617,7 @@ Register write enable for MIO output selects.
 For each muxable pad, this selects the peripheral output.
 - Reset default: `0x2`
 - Reset mask: `0x7`
+- Register enable: [`MIO_OUTSEL_REGWEN`](#mio_outsel_regwen)
 
 ### Instances
 
@@ -687,6 +689,7 @@ all attributes.
 The muxed pad that is used for TAP strap 0 has a different reset value, with `pull_en` set to 1.
 - Reset default: `0x0`
 - Reset mask: `0xf300ff`
+- Register enable: [`MIO_PAD_ATTR_REGWEN`](#mio_pad_attr_regwen)
 
 ### Instances
 
@@ -866,6 +869,7 @@ This register has WARL behavior since not each pad type may support
 all attributes.
 - Reset default: `0x0`
 - Reset mask: `0xf300ff`
+- Register enable: [`DIO_PAD_ATTR_REGWEN`](#dio_pad_attr_regwen)
 
 ### Instances
 
@@ -1071,6 +1075,7 @@ Register write enable for MIO sleep value configuration.
 Enables the sleep mode of the corresponding muxed pad.
 - Reset default: `0x0`
 - Reset mask: `0x1`
+- Register enable: [`MIO_PAD_SLEEP_REGWEN`](#mio_pad_sleep_regwen)
 
 ### Instances
 
@@ -1115,6 +1120,7 @@ the corresponding [`MIO_PAD_SLEEP_EN`](#mio_pad_sleep_en) bit should be set to 0
 Defines sleep behavior of the corresponding muxed pad.
 - Reset default: `0x2`
 - Reset mask: `0x3`
+- Register enable: [`MIO_PAD_SLEEP_REGWEN`](#mio_pad_sleep_regwen)
 
 ### Instances
 
@@ -1374,6 +1380,7 @@ Register write enable for DIO sleep value configuration.
 Enables the sleep mode of the corresponding dedicated pad.
 - Reset default: `0x0`
 - Reset mask: `0x1`
+- Register enable: [`DIO_PAD_SLEEP_REGWEN`](#dio_pad_sleep_regwen)
 
 ### Instances
 
@@ -1479,6 +1486,7 @@ the corresponding [`DIO_PAD_SLEEP_EN`](#dio_pad_sleep_en) bit should be set to 0
 Defines sleep behavior of the corresponding dedicated pad.
 - Reset default: `0x2`
 - Reset mask: `0x3`
+- Register enable: [`DIO_PAD_SLEEP_REGWEN`](#dio_pad_sleep_regwen)
 
 ### Instances
 
@@ -1618,6 +1626,7 @@ The first write access always completes immediately.
 However, read/write accesses following a write will block until that write has completed.
 - Reset default: `0x0`
 - Reset mask: `0x1`
+- Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
 
@@ -1654,6 +1663,7 @@ Note that the wkup detector should be disabled by setting [`WKUP_DETECTOR_EN_0`]
 The reason for that is that the pulse width counter is NOT cleared upon a mode change while the detector is enabled.
 - Reset default: `0x0`
 - Reset mask: `0x1f`
+- Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
 
@@ -1711,6 +1721,7 @@ The first write access always completes immediately.
 However, read/write accesses following a write will block until that write has completed.
 - Reset default: `0x0`
 - Reset mask: `0xff`
+- Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
 
@@ -1742,6 +1753,7 @@ Pad selects for pad wakeup condition detectors.
 This register is NOT synced to the AON domain since the muxing mechanism is implemented in the same way as the pinmux muxing matrix.
 - Reset default: `0x0`
 - Reset mask: `0x3f`
+- Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
 

--- a/hw/top_darjeeling/ip_autogen/rstmgr/doc/registers.md
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/doc/registers.md
@@ -272,6 +272,7 @@ When a particular bit value is 0, the corresponding module is held in reset.
 When a particular bit value is 1, the corresponding module is not held in reset.
 - Reset default: `0x1`
 - Reset mask: `0x1`
+- Register enable: [`SW_RST_REGWEN`](#sw_rst_regwen)
 
 ### Instances
 

--- a/hw/top_earlgrey/ip/sensor_ctrl/doc/registers.md
+++ b/hw/top_earlgrey/ip/sensor_ctrl/doc/registers.md
@@ -155,6 +155,7 @@ Alert trigger test
 Each multibit value enables a corresponding alert.
 - Reset default: `0x6`
 - Reset mask: `0xf`
+- Register enable: [`CFG_REGWEN`](#cfg_regwen)
 
 ### Instances
 
@@ -424,6 +425,7 @@ The mapping of registers to pads is as follows (only supported for targets that 
 - MANUAL_PAD_ATTR_3: FLASH_TEST_MODE1
 - Reset default: `0x0`
 - Reset mask: `0x8c`
+- Register enable: [`MANUAL_PAD_ATTR_REGWEN`](#manual_pad_attr_regwen)
 
 ### Instances
 

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/doc/registers.md
@@ -485,6 +485,7 @@ Region register write enable.  Once set to 0, it can longer be configured to 1
 Memory property configuration for data partition
 - Reset default: `0x9999999`
 - Reset mask: `0xfffffff`
+- Register enable: [`REGION_CFG_REGWEN`](#region_cfg_regwen)
 
 ### Instances
 
@@ -521,6 +522,7 @@ Memory property configuration for data partition
 Memory base and size configuration for data partition
 - Reset default: `0x0`
 - Reset mask: `0x7ffff`
+- Register enable: [`REGION_CFG_REGWEN`](#region_cfg_regwen)
 
 ### Instances
 
@@ -616,6 +618,7 @@ Info0 page write enable.  Once set to 0, it can longer be configured to 1
   Unlike data partition, each page is individually configured.
 - Reset default: `0x9999999`
 - Reset mask: `0xfffffff`
+- Register enable: [`BANK0_INFO0_REGWEN`](#bank0_info0_regwen)
 
 ### Instances
 
@@ -687,6 +690,7 @@ Info1 page write enable.  Once set to 0, it can longer be configured to 1
   Unlike data partition, each page is individually configured.
 - Reset default: `0x9999999`
 - Reset mask: `0xfffffff`
+- Register enable: [`BANK0_INFO1_REGWEN`](#bank0_info1_regwen)
 
 ### Instances
 
@@ -750,6 +754,7 @@ Info2 page write enable.  Once set to 0, it can longer be configured to 1
   Unlike data partition, each page is individually configured.
 - Reset default: `0x9999999`
 - Reset mask: `0xfffffff`
+- Register enable: [`BANK0_INFO2_REGWEN`](#bank0_info2_regwen)
 
 ### Instances
 
@@ -822,6 +827,7 @@ Info0 page write enable.  Once set to 0, it can longer be configured to 1
   Unlike data partition, each page is individually configured.
 - Reset default: `0x9999999`
 - Reset mask: `0xfffffff`
+- Register enable: [`BANK1_INFO0_REGWEN`](#bank1_info0_regwen)
 
 ### Instances
 
@@ -893,6 +899,7 @@ Info1 page write enable.  Once set to 0, it can longer be configured to 1
   Unlike data partition, each page is individually configured.
 - Reset default: `0x9999999`
 - Reset mask: `0xfffffff`
+- Register enable: [`BANK1_INFO1_REGWEN`](#bank1_info1_regwen)
 
 ### Instances
 
@@ -956,6 +963,7 @@ Info2 page write enable.  Once set to 0, it can longer be configured to 1
   Unlike data partition, each page is individually configured.
 - Reset default: `0x9999999`
 - Reset mask: `0xfffffff`
+- Register enable: [`BANK1_INFO2_REGWEN`](#bank1_info2_regwen)
 
 ### Instances
 

--- a/hw/top_earlgrey/ip_autogen/pinmux/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/pinmux/doc/registers.md
@@ -674,6 +674,7 @@ Register write enable for MIO peripheral input selects.
 For each peripheral input, this selects the muxable pad input.
 - Reset default: `0x0`
 - Reset mask: `0x3f`
+- Register enable: [`MIO_PERIPH_INSEL_REGWEN`](#mio_periph_insel_regwen)
 
 ### Instances
 
@@ -822,6 +823,7 @@ Register write enable for MIO output selects.
 For each muxable pad, this selects the peripheral output.
 - Reset default: `0x2`
 - Reset mask: `0x7f`
+- Register enable: [`MIO_OUTSEL_REGWEN`](#mio_outsel_regwen)
 
 ### Instances
 
@@ -963,6 +965,7 @@ all attributes.
 The muxed pad that is used for TAP strap 0 has a different reset value, with `pull_en` set to 1.
 - Reset default: `0x0`
 - Reset mask: `0xf300ff`
+- Register enable: [`MIO_PAD_ATTR_REGWEN`](#mio_pad_attr_regwen)
 
 ### Instances
 
@@ -1120,6 +1123,7 @@ This register has WARL behavior since not each pad type may support
 all attributes.
 - Reset default: `0x0`
 - Reset mask: `0xf300ff`
+- Register enable: [`DIO_PAD_ATTR_REGWEN`](#dio_pad_attr_regwen)
 
 ### Instances
 
@@ -1353,6 +1357,7 @@ Register write enable for MIO sleep value configuration.
 Enables the sleep mode of the corresponding muxed pad.
 - Reset default: `0x0`
 - Reset mask: `0x1`
+- Register enable: [`MIO_PAD_SLEEP_REGWEN`](#mio_pad_sleep_regwen)
 
 ### Instances
 
@@ -1432,6 +1437,7 @@ the corresponding [`MIO_PAD_SLEEP_EN`](#mio_pad_sleep_en) bit should be set to 0
 Defines sleep behavior of the corresponding muxed pad.
 - Reset default: `0x2`
 - Reset mask: `0x3`
+- Register enable: [`MIO_PAD_SLEEP_REGWEN`](#mio_pad_sleep_regwen)
 
 ### Instances
 
@@ -1582,6 +1588,7 @@ Register write enable for DIO sleep value configuration.
 Enables the sleep mode of the corresponding dedicated pad.
 - Reset default: `0x0`
 - Reset mask: `0x1`
+- Register enable: [`DIO_PAD_SLEEP_REGWEN`](#dio_pad_sleep_regwen)
 
 ### Instances
 
@@ -1630,6 +1637,7 @@ the corresponding [`DIO_PAD_SLEEP_EN`](#dio_pad_sleep_en) bit should be set to 0
 Defines sleep behavior of the corresponding dedicated pad.
 - Reset default: `0x2`
 - Reset mask: `0x3`
+- Register enable: [`DIO_PAD_SLEEP_REGWEN`](#dio_pad_sleep_regwen)
 
 ### Instances
 
@@ -1712,6 +1720,7 @@ The first write access always completes immediately.
 However, read/write accesses following a write will block until that write has completed.
 - Reset default: `0x0`
 - Reset mask: `0x1`
+- Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
 
@@ -1748,6 +1757,7 @@ Note that the wkup detector should be disabled by setting [`WKUP_DETECTOR_EN_0`]
 The reason for that is that the pulse width counter is NOT cleared upon a mode change while the detector is enabled.
 - Reset default: `0x0`
 - Reset mask: `0x1f`
+- Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
 
@@ -1805,6 +1815,7 @@ The first write access always completes immediately.
 However, read/write accesses following a write will block until that write has completed.
 - Reset default: `0x0`
 - Reset mask: `0xff`
+- Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
 
@@ -1836,6 +1847,7 @@ Pad selects for pad wakeup condition detectors.
 This register is NOT synced to the AON domain since the muxing mechanism is implemented in the same way as the pinmux muxing matrix.
 - Reset default: `0x0`
 - Reset mask: `0x3f`
+- Register enable: [`WKUP_DETECTOR_REGWEN`](#wkup_detector_regwen)
 
 ### Instances
 

--- a/hw/top_earlgrey/ip_autogen/rstmgr/doc/registers.md
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/doc/registers.md
@@ -287,6 +287,7 @@ When a particular bit value is 0, the corresponding module is held in reset.
 When a particular bit value is 1, the corresponding module is not held in reset.
 - Reset default: `0x1`
 - Reset mask: `0x1`
+- Register enable: [`SW_RST_REGWEN`](#sw_rst_regwen)
 
 ### Instances
 

--- a/util/reggen/gen_md.py
+++ b/util/reggen/gen_md.py
@@ -128,6 +128,30 @@ def multireg_is_compact(mreg: MultiRegister, width: int) -> bool:
     return mreg.compact and (mreg.reg.fields[0].bits.msb + 1) <= width // 2
 
 
+def describe_reg_hdr(output: TextIO, reg: Register, with_offset: bool) -> None:
+    '''Write a header for the register description.
+
+    If with_offset is True, this includes the offset of the register. (Set it
+    to False if printing a MultiRegister)
+    '''
+    regwen_str = ""
+    if reg.regwen is not None:
+        regwen_url = "#" + reg.regwen.lower()
+        regwen_str = list_item("Register enable: " +
+                               url(mono(reg.regwen), regwen_url))
+
+    offset_str = (list_item("Offset: " + mono(f"{reg.offset:#x}"))
+                  if with_offset else "")
+    output.write(
+        title(reg.name, 2) +
+        regref_to_link(reg.desc) +
+        "\n" +
+        offset_str +
+        list_item("Reset default: " + mono(f"{reg.resval:#x}")) +
+        list_item("Reset mask: " + mono(f"{reg.resmask:#x}")) +
+        regwen_str)
+
+
 def gen_md_multiregister(output: TextIO, mreg: MultiRegister, comp: str, width: int) -> None:
     # Check whether this is a compacted multireg, in which case we cannot use
     # the general definition of the first register as an example for all other instances.
@@ -140,13 +164,7 @@ def gen_md_multiregister(output: TextIO, mreg: MultiRegister, comp: str, width: 
     reg_def = mreg.reg
 
     # Information
-    output.write(
-        title(reg_def.name, 2) +
-        regref_to_link(reg_def.desc) +
-        "\n" +
-        list_item("Reset default: " + mono(f"{reg_def.resval:#x}")) +
-        list_item("Reset mask: " + mono(f"{reg_def.resmask:#x}"))
-    )
+    describe_reg_hdr(output, reg_def, False)
 
     # Instances
     output.write("\n" + title("Instances", 3))
@@ -166,18 +184,7 @@ def gen_md_multiregister(output: TextIO, mreg: MultiRegister, comp: str, width: 
 
 
 def gen_md_register(output: TextIO, reg: Register, comp: str, width: int) -> None:
-    output.write(
-        title(reg.name, 2) +
-        regref_to_link(reg.desc) +
-        "\n" +
-        list_item("Offset: " + mono(f"{reg.offset:#x}")) +
-        list_item("Reset default: " + mono(f"{reg.resval:#x}")) +
-        list_item("Reset mask: " + mono(f"{reg.resmask:#x}"))
-    )
-    if reg.regwen is not None:
-        output.write(
-            list_item("Register enable: " + url(mono(reg.regwen), "#" + reg.regwen.lower()))
-        )
+    describe_reg_hdr(output, reg, True)
 
     # Fields
     output.write("\n" + title("Fields", 3))


### PR DESCRIPTION
The Markdown documentation generator from b1e7742d911 accidentally missed it for multi-registers.

Most of this commit is auto-generated. The only hand-rolled bit is the change to util/reggen/gen_md.py

Fixes #25688.