### PR TITLE
[hsmtool] SPX cleanups

### DIFF
--- a/sw/host/hsmtool/src/commands/spx/export.rs
+++ b/sw/host/hsmtool/src/commands/spx/export.rs
@@ -24,8 +24,8 @@ pub struct Export {
 }
 
 impl Export {
-    fn export(&self, acorn: &dyn SpxInterface) -> Result<()> {
-        let key = acorn.get_key_info(&self.label)?;
+    fn export(&self, spx: &dyn SpxInterface) -> Result<()> {
+        let key = spx.get_key_info(&self.label)?;
         let algorithm = SphincsPlus::from_str(&key.algorithm)?;
         let pk = SpxPublicKey::from_bytes(algorithm, &key.public_key)?;
         pk.write_pem_file(&self.filename)?;
@@ -41,9 +41,9 @@ impl Dispatch for Export {
         hsm: &Module,
         _session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
-        let acorn = hsm.acorn.as_deref().ok_or(HsmError::AcornUnavailable)?;
+        let spx = hsm.spx.as_deref().ok_or(HsmError::SpxUnavailable)?;
         let _token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
-        self.export(acorn)?;
+        self.export(spx)?;
         Ok(Box::<BasicResult>::default())
     }
 }

--- a/sw/host/hsmtool/src/commands/spx/generate.rs
+++ b/sw/host/hsmtool/src/commands/spx/generate.rs
@@ -36,7 +36,7 @@ impl Dispatch for Generate {
         hsm: &Module,
         _session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
-        let acorn = hsm.acorn.as_ref().ok_or(HsmError::AcornUnavailable)?;
+        let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 
         #[rustfmt::skip]
@@ -44,7 +44,7 @@ impl Dispatch for Generate {
             if self.overwrite { GenerateFlags::OVERWRITE } else { GenerateFlags::NONE }
             | if self.export.is_some() { GenerateFlags::EXPORT_PRIVATE } else { GenerateFlags::NONE };
 
-        let key = acorn.generate_key(&self.label, &self.algorithm.to_string(), token, flags)?;
+        let key = spx.generate_key(&self.label, &self.algorithm.to_string(), token, flags)?;
 
         if let Some(path) = &self.export {
             let sk = SpxSecretKey::from_bytes(self.algorithm, &key.private_key)?;

--- a/sw/host/hsmtool/src/commands/spx/generate.rs
+++ b/sw/host/hsmtool/src/commands/spx/generate.rs
@@ -53,7 +53,7 @@ impl Dispatch for Generate {
 
         Ok(Box::new(BasicResult {
             success: true,
-            id: AttrData::Str(key.hash.expect("key hash")),
+            id: key.hash.map_or(AttrData::None, AttrData::Str),
             label: AttrData::Str(key.alias),
             value: None,
             error: None,

--- a/sw/host/hsmtool/src/commands/spx/import.rs
+++ b/sw/host/hsmtool/src/commands/spx/import.rs
@@ -48,7 +48,7 @@ impl Dispatch for Import {
         )?;
         Ok(Box::new(BasicResult {
             success: true,
-            id: AttrData::Str(key.hash.expect("key hash")),
+            id: key.hash.map_or(AttrData::None, AttrData::Str),
             label: AttrData::Str(key.alias),
             value: None,
             error: None,

--- a/sw/host/hsmtool/src/commands/spx/import.rs
+++ b/sw/host/hsmtool/src/commands/spx/import.rs
@@ -32,13 +32,13 @@ impl Dispatch for Import {
         hsm: &Module,
         _session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
-        let acorn = hsm.acorn.as_ref().ok_or(HsmError::AcornUnavailable)?;
+        let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 
         let sk = SpxSecretKey::read_pem_file(&self.filename)?;
         let pk = SpxPublicKey::from(&sk);
 
-        let key = acorn.import_keypair(
+        let key = spx.import_keypair(
             &self.label,
             &sk.algorithm().to_string(),
             token,

--- a/sw/host/hsmtool/src/commands/spx/list.rs
+++ b/sw/host/hsmtool/src/commands/spx/list.rs
@@ -36,16 +36,16 @@ impl Dispatch for List {
         hsm: &Module,
         _session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
-        let acorn = hsm.acorn.as_ref().ok_or(HsmError::AcornUnavailable)?;
+        let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let _token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 
         let mut result = Box::new(ListResult {
-            version: acorn.get_version()?,
+            version: spx.get_version()?,
             ..Default::default()
         });
-        let keys = acorn.list_keys()?;
+        let keys = spx.list_keys()?;
         for key in keys {
-            let info = acorn.get_key_info(&key.alias)?;
+            let info = spx.get_key_info(&key.alias)?;
             result.objects.push(Key {
                 id: info.hash,
                 label: key.alias,

--- a/sw/host/hsmtool/src/commands/spx/sign.rs
+++ b/sw/host/hsmtool/src/commands/spx/sign.rs
@@ -43,14 +43,14 @@ impl Dispatch for Sign {
         hsm: &Module,
         _session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
-        let acorn = hsm.acorn.as_ref().ok_or(HsmError::AcornUnavailable)?;
+        let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let _token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 
         let data = helper::read_file(&self.input)?;
         let data = self
             .format
             .spx_prepare(self.domain, &data, self.little_endian)?;
-        let result = acorn.sign(self.label.as_deref(), self.id.as_deref(), &data)?;
+        let result = spx.sign(self.label.as_deref(), self.id.as_deref(), &data)?;
         helper::write_file(&self.output, &result)?;
         Ok(Box::<BasicResult>::default())
     }

--- a/sw/host/hsmtool/src/commands/spx/verify.rs
+++ b/sw/host/hsmtool/src/commands/spx/verify.rs
@@ -42,7 +42,7 @@ impl Dispatch for Verify {
         hsm: &Module,
         _session: Option<&Session>,
     ) -> Result<Box<dyn Annotate>> {
-        let acorn = hsm.acorn.as_ref().ok_or(HsmError::AcornUnavailable)?;
+        let spx = hsm.spx.as_ref().ok_or(HsmError::SpxUnavailable)?;
         let _token = hsm.token.as_deref().ok_or(HsmError::SessionRequired)?;
 
         let data = helper::read_file(&self.input)?;
@@ -50,7 +50,7 @@ impl Dispatch for Verify {
             .format
             .spx_prepare(self.domain, &data, self.little_endian)?;
         let signature = helper::read_file(&self.signature)?;
-        let result = acorn.verify(self.label.as_deref(), self.id.as_deref(), &data, &signature)?;
+        let result = spx.verify(self.label.as_deref(), self.id.as_deref(), &data, &signature)?;
         Ok(Box::new(BasicResult {
             success: result,
             error: if result {

--- a/sw/host/hsmtool/src/error.rs
+++ b/sw/host/hsmtool/src/error.rs
@@ -34,8 +34,8 @@ pub enum HsmError {
     FilePermissionError(u32),
     #[error("DER error: {0}")]
     DerError(String),
-    #[error("This operation requires the acorn library")]
-    AcornUnavailable,
+    #[error("This operation requires an spx module")]
+    SpxUnavailable,
     #[error("Parse error: {0}")]
     ParseError(String),
     #[error("Unknown application: {0}")]

--- a/sw/host/hsmtool/src/module.rs
+++ b/sw/host/hsmtool/src/module.rs
@@ -44,7 +44,7 @@ impl FromStr for SpxModule {
 pub struct Module {
     pub pkcs11: Pkcs11,
     pub session: Option<Rc<Session>>,
-    pub acorn: Option<Box<dyn SpxInterface>>,
+    pub spx: Option<Box<dyn SpxInterface>>,
     pub token: Option<String>,
 }
 
@@ -55,7 +55,7 @@ impl Module {
         Ok(Module {
             pkcs11,
             session: None,
-            acorn: None,
+            spx: None,
             token: None,
         })
     }
@@ -72,7 +72,7 @@ impl Module {
                 SpxEf::new(session) as Box<dyn SpxInterface>
             }
         };
-        self.acorn = Some(module);
+        self.spx = Some(module);
         Ok(())
     }
 


### PR DESCRIPTION
1. It is legal for SPX key entities to be missing a PKCS#11 `id`.
2. Rename the `acorn` field to `spx`, as it represents a generic interface to SPX functions rather than a specific implementation.