### PR TITLE
[signing] Support SPX signing with `hsmtool`

### DIFF
--- a/signing/tokens/BUILD
+++ b/signing/tokens/BUILD
@@ -15,9 +15,11 @@ signing_tool(
 
 signing_tool(
     name = "nitrokey",
-    data = ["@sc_hsm//:gen_dir"],
+    data = ["@opensc//:gen_dir"],
     env = {
-        "HSMTOOL_MODULE": "$(location @sc_hsm//:gen_dir)/lib/libsc-hsm-pkcs11.so",
+        "LD_LIBRARY_PATH": "$(location @opensc//:gen_dir)/lib",
+        "HSMTOOL_MODULE": "$(location @opensc//:gen_dir)/lib/opensc-pkcs11.so",
+        "HSMTOOL_SPX_MODULE": "pkcs11-ef",
     },
     location = "token",
     tool = "//sw/host/hsmtool",

--- a/sw/host/sphincsplus/variants.rs
+++ b/sw/host/sphincsplus/variants.rs
@@ -233,11 +233,11 @@ algorithms! {
     #[derive(EnumString, Display, Serialize, Deserialize)]
     #[strum(ascii_case_insensitive)]
     pub enum SphincsPlus {
-        #[serde(rename="SPHINCS+-SHAKE-128s-simple", alias="SHAKE-128s-simple")]
-        #[strum(serialize="SPHINCS+-SHAKE-128s-simple", serialize="SHAKE-128s-simple")]
+        #[serde(rename="SLA-DSA-SHAKE-128s", alias="SPHINCS+-SHAKE-128s-simple", alias="SHAKE-128s-simple")]
+        #[strum(to_string="SLA-DSA-SHAKE-128s", serialize="SPHINCS+-SHAKE-128s-simple", serialize="SHAKE-128s-simple")]
         Shake128sSimple => shake_128s_simple,
-        #[serde(rename="SPHINCS+-SHA2-128s-simple", alias="SHA2-128s-simple")]
-        #[strum(serialize="SPHINCS+-SHA2-128s-simple", serialize="SHA2-128s-simple")]
+        #[serde(rename="SLA-DSA-SHA2-128s", alias="SPHINCS+-SHA2-128s-simple", alias="SHA2-128s-simple")]
+        #[strum(to_string="SLA-DSA-SHA2-128s", serialize="SPHINCS+-SHA2-128s-simple", serialize="SHA2-128s-simple")]
         Sha2128sSimple => sha2_128s_simple,
     }
 }

--- a/third_party/hsm/BUILD.opensc.bazel
+++ b/third_party/hsm/BUILD.opensc.bazel
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "opensc",
+    args = ["-j"],
+    autoreconf = True,
+    autoreconf_options = ["-fi"],
+    configure_in_place = True,
+    configure_options = [
+        # Lie about the completions dir so that "make install" won't get
+        # confused about what is already installed on the host.
+        # This doesn't affect the build, as the installation happens in
+        # a bazel-supplied target directory, but it does prevent make from
+        # seeing the system's `/usr/share/bash-completion/completions`
+        # directory and complaining that it will be unable to install there.
+        "--with-completiondir=xxx-completions",
+    ],
+    lib_source = ":all_srcs",
+    out_shared_libs = [
+        # It would be nice to configure this package to build `opensc-pkcs11.so`
+        # as a shared object that statically links `libopensc`, but I don't see
+        # a way to do that via the configure script.  Users of this library
+        # will have to set LD_LIBRARY_PATH appropriately to see the needed
+        # shared libraries (e.g. `//signing/tokens:nitrokey`).
+        "libopensc.so",
+        "libopensc.so.12",
+        "opensc-pkcs11.so",
+    ],
+)
+
+filegroup(
+    name = "gen_dir",
+    srcs = [":opensc"],
+    output_group = "gen_dir",
+)

--- a/third_party/hsm/repos.bzl
+++ b/third_party/hsm/repos.bzl
@@ -24,6 +24,13 @@ def hsm_repos():
         sha256 = "707fca9df630708e0e59a7d4a8a7a016c56c83a585957f0fd9f806c0762f1944",
     )
     http_archive(
+        name = "opensc",
+        build_file = Label("//third_party/hsm:BUILD.opensc.bazel"),
+        url = "https://github.com/OpenSC/OpenSC/archive/refs/tags/0.26.0.tar.gz",
+        strip_prefix = "OpenSC-0.26.0",
+        sha256 = "c692ac7639fa398f7f07b1070ea5358344000d49d08dcb825296d4cec94c6b1f",
+    )
+    http_archive(
         name = "cloud_kms_hsm",
         build_file = Label("//third_party/hsm:BUILD.cloud_kms_hsm.bazel"),
         url = "https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v1.2/libkmsp11-1.2-linux-amd64.tar.gz",


### PR DESCRIPTION
1. Enhance the signing rules to use the spx signing commands added to hsmtool.
2. Change the PKCS#11 provider from sc-hsm-embedded to opensc.
   - sc-hsm-embedded supports RSA3072 and ECDSA P256 signatures, but does not support CKO_DATA objects.
   - opensc supports ECDSA P256 signatures and CKO_DATA objects, but does not support RSA3072 signatures.

   We no longer use RSA3072 signatures for signing code; we _can_ use
   CKO_DATA objects to hold SPX keys for signing.
3. Use the formal NIST names for SPHINCS+ algorithms when saving or serializing keys.  Accept the older names as aliases.
   - SLA-DSA-SHAKE-128s
   - SLA-DSA-SHA2-128s