### PR TITLE
[prim,ipgen] Fix up some hierarchies of fusesoc cores

### DIFF
--- a/hw/ip/prim/prim_mubi.core
+++ b/hw/ip/prim/prim_mubi.core
@@ -16,8 +16,8 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:buf
       - lowrisc:prim:flop
+      - lowrisc:prim:mubi_pkg
     files:
-      - rtl/prim_mubi_pkg.sv
       - rtl/prim_mubi4_sender.sv
       - rtl/prim_mubi4_sync.sv
       - rtl/prim_mubi4_dec.sv

--- a/hw/ip/prim/prim_mubi_pkg.core
+++ b/hw/ip/prim/prim_mubi_pkg.core
@@ -8,21 +8,14 @@ CAPI=2:
 #
 #    util/design/gen-mubi.py
 #
-name: "lowrisc:prim:mubi:0.1"
+name: "lowrisc:prim:mubi_pkg:0.1"
 description: "Multibit types and functions"
 filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:buf
-      - lowrisc:prim:flop
-      - lowrisc:prim:mubi_pkg
     files:
-% for n in range(1, n_max_nibbles+1):
-      - rtl/prim_mubi${4*n}_sender.sv
-      - rtl/prim_mubi${4*n}_sync.sv
-      - rtl/prim_mubi${4*n}_dec.sv
-% endfor
+      - rtl/prim_mubi_pkg.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
@@ -50,14 +43,3 @@ targets:
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
-
-  lint:
-    <<: *default_target
-    default_tool: verilator
-    parameters:
-      - SYNTHESIS=true
-    tools:
-      verilator:
-        mode: lint-only
-        verilator_options:
-          - "-Wall"

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -8,7 +8,7 @@ description: "prim"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:tlul
+      - lowrisc:tlul:headers
       - lowrisc:prim:ram_1p
       - "fileset_partner  ? (partner:systems:ast_pkg)"
       - "!fileset_partner ? (lowrisc:systems:ast_pkg)"

--- a/hw/ip/tlul/headers.core
+++ b/hw/ip/tlul/headers.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:secded
-      - lowrisc:prim:mubi
+      - lowrisc:prim:mubi_pkg
     files:
       - rtl/tlul_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip_templates/clkmgr/clkmgr_reg.core.tpl
+++ b/hw/ip_templates/clkmgr/clkmgr_reg.core.tpl
@@ -10,6 +10,8 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:ip:tlul
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/clkmgr_reg_pkg.sv

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_prim_reg_top.core
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_prim_reg_top.core
@@ -8,6 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip_interfaces:flash_ctrl_pkg
+      - lowrisc:prim:subreg
     files:
       - rtl/flash_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/ip_templates/flash_ctrl/flash_ctrl_reg.core.tpl
+++ b/hw/ip_templates/flash_ctrl/flash_ctrl_reg.core.tpl
@@ -10,6 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/flash_ctrl_reg_pkg.sv

--- a/hw/ip_templates/pinmux/pinmux_reg.core.tpl
+++ b/hw/ip_templates/pinmux/pinmux_reg.core.tpl
@@ -10,6 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/pinmux_reg_pkg.sv

--- a/hw/ip_templates/pwrmgr/pwrmgr.core.tpl
+++ b/hw/ip_templates/pwrmgr/pwrmgr.core.tpl
@@ -12,6 +12,7 @@ filesets:
     depend:
       - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg:0.1")}
       - ${instance_vlnv("lowrisc:ip:pwrmgr_reg:0.1")}
+      - lowrisc:ip:rom_ctrl_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:pwrmgr_component
     file_type: systemVerilogSource

--- a/hw/ip_templates/pwrmgr/pwrmgr_pkg.core.tpl
+++ b/hw/ip_templates/pwrmgr/pwrmgr_pkg.core.tpl
@@ -9,12 +9,12 @@ virtual:
 
 filesets:
   files_rtl:
-    depend:
-      - ${instance_vlnv("lowrisc:ip:pwrmgr_reg")}
   % if wait_for_external_reset:
+    depend:
       - lowrisc:ip:rom_ctrl_pkg
   % endif
     files:
+      - rtl/pwrmgr_reg_pkg.sv
       - rtl/pwrmgr_pkg.sv
     file_type: systemVerilogSource
 

--- a/hw/ip_templates/pwrmgr/pwrmgr_reg.core.tpl
+++ b/hw/ip_templates/pwrmgr/pwrmgr_reg.core.tpl
@@ -10,11 +10,11 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:tlul:headers
       - lowrisc:ip:tlul
+      - ${instance_vlnv("lowrisc:ip:pwrmgr_pkg")}
       - lowrisc:prim:subreg
+      - lowrisc:tlul:headers
     files:
-      - rtl/pwrmgr_reg_pkg.sv
       - rtl/pwrmgr_reg_top.sv
     file_type: systemVerilogSource
 

--- a/hw/ip_templates/rstmgr/rstmgr_reg.core.tpl
+++ b/hw/ip_templates/rstmgr/rstmgr_reg.core.tpl
@@ -10,6 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/rstmgr_reg_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/clkmgr/clkmgr_reg.core
+++ b/hw/top_darjeeling/ip_autogen/clkmgr/clkmgr_reg.core
@@ -10,6 +10,8 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:ip:tlul
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/clkmgr_reg_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/pinmux/pinmux_reg.core
+++ b/hw/top_darjeeling/ip_autogen/pinmux/pinmux_reg.core
@@ -10,6 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/pinmux_reg_pkg.sv

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr.core
@@ -12,6 +12,7 @@ filesets:
     depend:
       - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg:0.1
       - lowrisc:opentitan:top_darjeeling_pwrmgr_reg:0.1
+      - lowrisc:ip:rom_ctrl_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:pwrmgr_component
     file_type: systemVerilogSource

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_pkg.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_pkg.core
@@ -10,9 +10,9 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:opentitan:top_darjeeling_pwrmgr_reg
       - lowrisc:ip:rom_ctrl_pkg
     files:
+      - rtl/pwrmgr_reg_pkg.sv
       - rtl/pwrmgr_pkg.sv
     file_type: systemVerilogSource
 

--- a/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_reg.core
+++ b/hw/top_darjeeling/ip_autogen/pwrmgr/pwrmgr_reg.core
@@ -10,11 +10,11 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:tlul:headers
       - lowrisc:ip:tlul
+      - lowrisc:opentitan:top_darjeeling_pwrmgr_pkg
       - lowrisc:prim:subreg
+      - lowrisc:tlul:headers
     files:
-      - rtl/pwrmgr_reg_pkg.sv
       - rtl/pwrmgr_reg_top.sv
     file_type: systemVerilogSource
 

--- a/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr_reg.core
+++ b/hw/top_darjeeling/ip_autogen/rstmgr/rstmgr_reg.core
@@ -10,6 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/rstmgr_reg_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr_reg.core
+++ b/hw/top_earlgrey/ip_autogen/clkmgr/clkmgr_reg.core
@@ -10,6 +10,8 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:ip:tlul
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/clkmgr_reg_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_prim_reg_top.core
@@ -8,6 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip_interfaces:flash_ctrl_pkg
+      - lowrisc:prim:subreg
     files:
       - rtl/flash_ctrl_prim_reg_top.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_reg.core
+++ b/hw/top_earlgrey/ip_autogen/flash_ctrl/flash_ctrl_reg.core
@@ -10,6 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/flash_ctrl_reg_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/pinmux/pinmux_reg.core
+++ b/hw/top_earlgrey/ip_autogen/pinmux/pinmux_reg.core
@@ -10,6 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/pinmux_reg_pkg.sv

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr.core
@@ -12,6 +12,7 @@ filesets:
     depend:
       - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg:0.1
       - lowrisc:opentitan:top_earlgrey_pwrmgr_reg:0.1
+      - lowrisc:ip:rom_ctrl_pkg
       - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:pwrmgr_component
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_pkg.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_pkg.core
@@ -9,9 +9,8 @@ virtual:
 
 filesets:
   files_rtl:
-    depend:
-      - lowrisc:opentitan:top_earlgrey_pwrmgr_reg
     files:
+      - rtl/pwrmgr_reg_pkg.sv
       - rtl/pwrmgr_pkg.sv
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_reg.core
+++ b/hw/top_earlgrey/ip_autogen/pwrmgr/pwrmgr_reg.core
@@ -10,11 +10,11 @@ virtual:
 filesets:
   files_rtl:
     depend:
-      - lowrisc:tlul:headers
       - lowrisc:ip:tlul
+      - lowrisc:opentitan:top_earlgrey_pwrmgr_pkg
       - lowrisc:prim:subreg
+      - lowrisc:tlul:headers
     files:
-      - rtl/pwrmgr_reg_pkg.sv
       - rtl/pwrmgr_reg_top.sv
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr_reg.core
+++ b/hw/top_earlgrey/ip_autogen/rstmgr/rstmgr_reg.core
@@ -10,6 +10,7 @@ virtual:
 filesets:
   files_rtl:
     depend:
+      - lowrisc:prim:subreg
       - lowrisc:tlul:headers
     files:
       - rtl/rstmgr_reg_pkg.sv

--- a/util/design/data/prim_mubi_pkg.core.tpl
+++ b/util/design/data/prim_mubi_pkg.core.tpl
@@ -8,21 +8,14 @@ CAPI=2:
 #
 #    util/design/gen-mubi.py
 #
-name: "lowrisc:prim:mubi:0.1"
+name: "lowrisc:prim:mubi_pkg:0.1"
 description: "Multibit types and functions"
 filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:buf
-      - lowrisc:prim:flop
-      - lowrisc:prim:mubi_pkg
     files:
-% for n in range(1, n_max_nibbles+1):
-      - rtl/prim_mubi${4*n}_sender.sv
-      - rtl/prim_mubi${4*n}_sync.sv
-      - rtl/prim_mubi${4*n}_dec.sv
-% endfor
+      - rtl/prim_mubi_pkg.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
@@ -50,14 +43,3 @@ targets:
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
-
-  lint:
-    <<: *default_target
-    default_tool: verilator
-    parameters:
-      - SYNTHESIS=true
-    tools:
-      verilator:
-        mode: lint-only
-        verilator_options:
-          - "-Wall"

--- a/util/design/mubi/prim_mubi.py
+++ b/util/design/mubi/prim_mubi.py
@@ -7,6 +7,7 @@ r"""Converts mubi mako templates
 from mako.template import Template  # type: ignore
 
 MUBI_PKG_TPL_PATH = "util/design/data/prim_mubi_pkg.sv.tpl"
+MUBI_PKG_CORE_TPL_PATH = "util/design/data/prim_mubi_pkg.core.tpl"
 MUBI_CORE_TPL_PATH = "util/design/data/prim_mubi.core.tpl"
 MUBI_SENDER_TPL_PATH = "util/design/data/prim_mubi_sender.sv.tpl"
 MUBI_SYNC_TPL_PATH = "util/design/data/prim_mubi_sync.sv.tpl"
@@ -15,6 +16,7 @@ MUBI_SW_TPL_PATH = "util/design/data/multibits.h.tpl"
 MUBI_SW_ASM_TPL_PATH = "util/design/data/multibits_asm.h.tpl"
 
 MUBI_PKG_OUT_PATH = "hw/ip/prim/rtl/prim_mubi_pkg.sv"
+MUBI_PKG_CORE_OUT_PATH = "hw/ip/prim/prim_mubi_pkg.core"
 MUBI_CORE_OUT_PATH = "hw/ip/prim/prim_mubi.core"
 MUBI_SENDER_OUT_PATH = "hw/ip/prim/rtl/prim_mubi{}_sender.sv"
 MUBI_SYNC_OUT_PATH = "hw/ip/prim/rtl/prim_mubi{}_sync.sv"
@@ -60,6 +62,7 @@ def gen() -> None:
 
     tpls = [
         (MUBI_PKG_TPL_PATH, MUBI_PKG_OUT_PATH),
+        (MUBI_PKG_CORE_TPL_PATH, MUBI_PKG_CORE_OUT_PATH),
         (MUBI_CORE_TPL_PATH, MUBI_CORE_OUT_PATH),
         (MUBI_SW_TPL_PATH, MUBI_SW_OUT_PATH),
         (MUBI_SW_ASM_TPL_PATH, MUBI_SW_ASM_OUT_PATH),


### PR DESCRIPTION
Ensure packages with constants are at the leaves of the dependency tree, so other cores may depend on them without creating cycles. Adjust the pwrmgr_reg core to depend on the pwrmgr_pkg core, with pwrmgr_reg_pkg moved to the pwrmgr_pkg core.

Also split the mubi RTL implementations from the package with declarations and standalone utility functions.

In addition, fix up the reg tops for various ipgen'd cores to include a dependency on `prim:subreg`.