### PR TITLE
[dv] Add ROT_AUTH configuration test.

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -875,6 +875,22 @@
       reseed: 1
     }
     {
+      name: chip_sw_otp_ctrl_rot_auth_config
+      uvm_test_seq: chip_sw_rom_e2e_jtag_inject_vseq
+      sw_images: [
+        "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_test_unlocked0_manuf_empty:4",
+        "//sw/device/tests:otp_ctrl_rot_auth_config_test:5",
+      ]
+      en_run_modes: ["sw_test_mode_mask_rom"]
+      run_opts: [
+        "+sw_test_timeout_ns=160_000_000",
+        "+use_jtag_dmi=1",
+        "+use_otp_image=OtpTypeCustom",
+      ]
+      reseed: 1
+      run_timeout_mins: 240
+    }
+    {
       name: chip_sw_otp_ctrl_ecc_error_vendor_test
       uvm_test_seq: chip_sw_otp_ctrl_vendor_test_ecc_error_vseq
       sw_images: ["//sw/device/tests/sim_dv:otp_ctrl_vendor_test_ecc_error_test:1:new_rules"]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2303,6 +2303,33 @@ opentitan_test(
     ],
 )
 
+opentitan_binary(
+    name = "otp_ctrl_rot_auth_config_test",
+    testonly = True,
+    srcs = ["otp_ctrl_rot_auth_config_test.c"],
+    exec_env = [
+        "//hw/top_earlgrey:sim_dv",
+    ],
+    kind = "ram",
+    linker_script = "//sw/device/examples/sram_program:sram_program_linker_script",
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:macros",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:otp_ctrl_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_test_config",
+        "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/silicon_creator/manuf/lib:individualize",
+        "//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_sival",
+        "//sw/device/silicon_creator/manuf/lib:otp_fields",
+        "//sw/device/silicon_creator/manuf/lib:sram_start",
+    ],
+)
+
 opentitan_test(
     name = "keymgr_sideload_aes_test",
     srcs = ["keymgr_sideload_aes_test.c"],

--- a/sw/device/tests/otp_ctrl_rot_auth_config_test.c
+++ b/sw/device/tests/otp_ctrl_rot_auth_config_test.c
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_test_config.h"
+#include "sw/device/silicon_creator/manuf/lib/individualize.h"
+#include "sw/device/silicon_creator/manuf/lib/individualize_sw_cfg.h"
+#include "sw/device/silicon_creator/manuf/lib/otp_fields.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  static dif_otp_ctrl_t otp_ctrl;
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp_ctrl));
+  CHECK_STATUS_OK(
+      manuf_individualize_device_rot_creator_auth_codesign(&otp_ctrl));
+  CHECK_STATUS_OK(manuf_individualize_device_rot_creator_auth_state(&otp_ctrl));
+  if (kDeviceType == kDeviceSimDV) {
+    test_status_set(kTestStatusPassed);
+  }
+  return true;
+}


### PR DESCRIPTION
This test exercises the ROT AUTH programming sequence performed during FT stages. The ROT AUTH partitions are used to store the ROM (e.g. root keys) of the Earl Grey top level.

Note: This is WIP. I will update the PR once I get test results.