### PR TITLE
Cherry-pick to master: [rom_ext_e2e] More ownership transfer tests

### DIFF
--- a/sw/device/silicon_creator/lib/ownership/keys/dummy/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/dummy/BUILD
@@ -10,6 +10,11 @@ filegroup(
 )
 
 filegroup(
+    name = "owner_key_pub",
+    srcs = ["owner_ecdsa_p256.pub.der"],
+)
+
+filegroup(
     name = "activate_key",
     srcs = ["activate_ecdsa_p256.der"],
 )

--- a/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
+++ b/sw/device/silicon_creator/lib/ownership/keys/fake/BUILD
@@ -42,6 +42,11 @@ filegroup(
 )
 
 filegroup(
+    name = "owner_key_pub",
+    srcs = ["owner_ecdsa_p256.pub.der"],
+)
+
+filegroup(
     name = "activate_key",
     srcs = ["activate_ecdsa_p256.der"],
 )
@@ -49,4 +54,14 @@ filegroup(
 filegroup(
     name = "unlock_key",
     srcs = ["unlock_ecdsa_p256.der"],
+)
+
+filegroup(
+    name = "app_prod",
+    srcs = ["app_prod_key_rsa_3072_exp_f4.der"],
+)
+
+filegroup(
+    name = "app_prod_pub",
+    srcs = ["app_prod_key_rsa_3072_exp_f4.pub.der"],
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -7,30 +7,27 @@ load(
     "fpga_params",
     "opentitan_test",
 )
+load(
+    "//sw/device/silicon_creator/rom_ext/e2e/ownership:defs.bzl",
+    "ownership_transfer_test",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-opentitan_test(
-    name = "ownership_transfer_test",
-    srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
-    exec_env = {
-        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
-    },
+# TODO(#24462): The tests in this file are marked `changes_otp = True`,
+# but they don't change OTP.  They modify the ownership INFO pages,
+# so we need to clear the bitstream after the test, which is what the
+# `changes_otp` parameter actually does.
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_transfer_any_test
+ownership_transfer_test(
+    name = "transfer_any_test",
     fpga = fpga_params(
-        # This test doesn't change OTP, but it modifies the ownership INFO
-        # pages, so we need to clear the bitstream after the test, which is
-        # what the `changes_otp` parameter actually does.
         changes_otp = True,
-        data = [
-            "//sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key",
-            "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub",
-            "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key",
-            "//sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key",
-            "//sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key",
-        ],
         test_cmd = """
             --clear-bitstream
             --bootstrap={firmware}
+            --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
@@ -48,4 +45,206 @@ opentitan_test(
         "//sw/device/silicon_creator/lib:boot_log",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
     ],
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_unlock_test
+ownership_transfer_test(
+    name = "bad_unlock_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Any
+            # NOTE: We use the wrong unlock key to test that the unlock operation fails.
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+            --expected-error=OwnershipInvalidSignature
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_activate_test
+ownership_transfer_test(
+    name = "bad_activate_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Any
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            # NOTE: We use the wrong activate key to test that the activate operation fails.
+            --activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+            --expected-error=OwnershipInvalidSignature
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_owner_block_test
+ownership_transfer_test(
+    name = "bad_owner_block_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Any
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+            --corrupt-owner-block-signature=true
+            --dual-owner-boot-check=false
+            --expected-error=OwnershipInvalidInfoPage
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_app_key_test
+ownership_transfer_test(
+    name = "bad_app_key_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Any
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            # NOTE: We use the wrong app key (fake instead of dummy) to test that we cannot boot
+            # the test program after completing the transfer.
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_pub)
+            --expected-error=OwnershipKeyNotFound
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_transfer_endorsed_test
+ownership_transfer_test(
+    name = "transfer_endorsed_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Endorsed
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-owner-key-pub=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_pub)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_endorsee_test
+ownership_transfer_test(
+    name = "bad_endorsee_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Endorsed
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            # NOTE: We use the wrong next-owner-public-key to test that endorsee is rejected and the activate operation fails.
+            --next-owner-key-pub=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key_pub)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+            --dual-owner-boot-check=false
+            --expected-error=OwnershipInvalidInfoPage
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_locked_update_test
+ownership_transfer_test(
+    name = "locked_update_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Update
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            # NOTE: We rotate the `fake` test owner's application key to the dummy key to test that
+            #       we can execute code with the new key.
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_locked_update_test
+# Part 1: Ensure a LockedUpdate with a new owner key is rejected.
+ownership_transfer_test(
+    name = "bad_locked_update_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Update
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            # NOTE: We use the wrong owner key to test that the activate operation fails.
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_pub)
+            --dual-owner-boot-check=false
+            --expected-error=OwnershipInvalidInfoPage
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
+    rsa_key = {
+        "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod": "app_prod",
+    },
+)
+
+# rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_locked_update_test
+# Part 2: Ensure a LockedUpdate denies execution to anything signed with new app keys.
+ownership_transfer_test(
+    name = "bad_locked_update_no_exec_test",
+    fpga = fpga_params(
+        changes_otp = True,
+        test_cmd = """
+            --clear-bitstream
+            --bootstrap={firmware}
+            --unlock-mode=Update
+            --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
+            --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
+
+            # NOTE: We use the wrong owner key and the dummy app key (which the ownership_transfer_test rule
+            #       uses for signing) to check that owner code execution is denied in the intermediate
+            #       dual-owner state.
+            --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
+            --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub)
+            --expected-error=OwnershipKeyNotFound
+        """,
+        test_harness = "//sw/host/tests/ownership:transfer_test",
+    ),
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "//rules/opentitan:defs.bzl",
+    "opentitan_test",
+)
+
+def ownership_transfer_test(
+        name,
+        srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
+        exec_env = {
+            "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        },
+        rsa_key = {
+            "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod": "app_prod",
+        },
+        data = [
+            "//sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key",
+            "//sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_pub",
+            "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key",
+            "//sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key_pub",
+            "//sw/device/silicon_creator/lib/ownership/keys/dummy:unlock_key",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake:activate_key",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake:owner_key",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake:owner_key_pub",
+            "//sw/device/silicon_creator/lib/ownership/keys/fake:app_prod_pub",
+        ],
+        deps = [
+            "//sw/device/lib/base:status",
+            "//sw/device/lib/testing/test_framework:ottf_main",
+            "//sw/device/silicon_creator/lib:boot_log",
+            "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        ],
+        **kwargs):
+    opentitan_test(
+        name = name,
+        srcs = srcs,
+        exec_env = exec_env,
+        rsa_key = rsa_key,
+        data = data,
+        deps = deps,
+        **kwargs
+    )

--- a/sw/host/opentitanlib/src/chip/rom_error.rs
+++ b/sw/host/opentitanlib/src/chip/rom_error.rs
@@ -3,5 +3,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::with_unknown;
+use std::error::Error;
 
 include!(env!("rom_error_enum"));
+
+impl Error for RomError {}
+
+impl From<RomError> for Result<(), RomError> {
+    fn from(error: RomError) -> Self {
+        if error == RomError::Ok {
+            Ok(())
+        } else {
+            Err(error)
+        }
+    }
+}
+
+impl From<RomError> for Result<(), anyhow::Error> {
+    fn from(error: RomError) -> Self {
+        if error == RomError::Ok {
+            Ok(())
+        } else {
+            Err(error.into())
+        }
+    }
+}

--- a/sw/host/tests/ownership/BUILD
+++ b/sw/host/tests/ownership/BUILD
@@ -29,5 +29,6 @@ rust_binary(
         "@crate_index//:clap",
         "@crate_index//:humantime",
         "@crate_index//:log",
+        "@crate_index//:regex",
     ],
 )

--- a/sw/host/tests/ownership/transfer_test.rs
+++ b/sw/host/tests/ownership/transfer_test.rs
@@ -3,12 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::bool_assert_comparison)]
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Parser;
+use regex::Regex;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
 
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::chip::boot_svc::UnlockMode;
+use opentitanlib::chip::rom_error::RomError;
 use opentitanlib::rescue::serial::RescueSerial;
 use opentitanlib::test_utils::init::InitializeTest;
 use opentitanlib::uart::console::UartConsole;
@@ -23,62 +27,134 @@ struct Opts {
     timeout: Duration,
     #[arg(long, help = "Unlock private key (ECDSA P256)")]
     unlock_key: PathBuf,
+    #[arg(long, help = "Activate private key (ECDSA P256)")]
+    activate_key: Option<PathBuf>,
     #[arg(long, help = "Next Owner private key (ECDSA P256)")]
     next_owner_key: PathBuf,
+    #[arg(long, help = "Next Owner public key (ECDSA P256)")]
+    next_owner_key_pub: Option<PathBuf>,
     #[arg(long, help = "Next Owner activate private key (ECDSA P256)")]
     next_activate_key: PathBuf,
     #[arg(long, help = "Next Owner unlock private key (ECDSA P256)")]
     next_unlock_key: PathBuf,
     #[arg(long, help = "Next Owner's application public key (RSA3K)")]
     next_application_key: PathBuf,
+
+    #[arg(long, default_value_t = false, action = clap::ArgAction::Set, help = "Corrupt owner block signature")]
+    corrupt_owner_block_signature: bool,
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set, help = "Check the firmware boot in dual-owner mode")]
+    dual_owner_boot_check: bool,
+
+    #[arg(long, default_value = "Any", help = "Mode of the unlock operation")]
+    unlock_mode: UnlockMode,
+    #[arg(long, help = "Expected error condition")]
+    expected_error: Option<String>,
 }
 
-fn main() -> Result<()> {
-    let opts = Opts::parse();
-    opts.init.init_logging();
-
-    let transport = opts.init.init_target()?;
+fn transfer_test(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
     let uart = transport.uart("console")?;
     let rescue = RescueSerial::new(Rc::clone(&uart));
 
-    let data = transfer_lib::get_boot_log(&transport, &rescue)?;
-    transfer_lib::ownership_unlock_any(&transport, &rescue, data.rom_ext_nonce, &opts.unlock_key)?;
+    log::info!("###### Get Boot Log (1/2) ######");
+    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+    log::info!("###### Ownership Unlock ######");
+    transfer_lib::ownership_unlock(
+        transport,
+        &rescue,
+        opts.unlock_mode,
+        data.rom_ext_nonce,
+        &opts.unlock_key,
+        if opts.unlock_mode == UnlockMode::Endorsed {
+            opts.next_owner_key_pub.as_deref()
+        } else {
+            None
+        },
+    )?;
 
+    log::info!("###### Upload Owner Block ######");
     transfer_lib::create_owner(
-        &transport,
+        transport,
         &rescue,
         &opts.next_owner_key,
         &opts.next_activate_key,
         &opts.next_unlock_key,
         &opts.next_application_key,
+        opts.corrupt_owner_block_signature,
     )?;
 
-    // At this point, the device should be unlocked and should have accepted the owner
-    // configuration.  Owner code should run and report the state as `UANY`.
-    transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
-    let capture = UartConsole::wait_for(
-        &*uart,
-        r"(?msR)ownership_state = UANY$.*ownership_transfers = (\d+)$.*PASS!$",
-        opts.timeout,
-    )?;
-    let transfers0 = capture[1].parse::<u32>()?;
+    let mut transfers0 = 0;
+    if opts.dual_owner_boot_check {
+        log::info!("###### Boot in Dual-Owner Mode ######");
+        // At this point, the device should be unlocked and should have accepted the owner
+        // configuration.  Owner code should run and report the ownership state.
+        transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
+        let capture = UartConsole::wait_for(
+            &*uart,
+            r"(?msR)ownership_state = (\w+)$.*ownership_transfers = (\d+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
+            opts.timeout,
+        )?;
+        if capture[0].starts_with("BFV") {
+            return RomError(u32::from_str_radix(&capture[3], 16)?).into();
+        }
+        match opts.unlock_mode {
+            UnlockMode::Any => assert_eq!(capture[1], "UANY"),
+            UnlockMode::Endorsed => assert_eq!(capture[1], "UEND"),
+            UnlockMode::Update => assert_eq!(capture[1], "LUPD"),
+            _ => return Err(anyhow!("Unexpected ownership state: {}", capture[1])),
+        }
+        transfers0 = capture[2].parse::<u32>()?;
+    }
 
-    let data = transfer_lib::get_boot_log(&transport, &rescue)?;
+    log::info!("###### Get Boot Log (2/2) ######");
+    let data = transfer_lib::get_boot_log(transport, &rescue)?;
+
+    log::info!("###### Ownership Activate Block ######");
     transfer_lib::ownership_activate(
-        &transport,
+        transport,
         &rescue,
         data.rom_ext_nonce,
-        &opts.next_activate_key,
+        opts.activate_key
+            .as_deref()
+            .unwrap_or(&opts.next_activate_key),
     )?;
 
+    log::info!("###### Boot After Transfer Complete ######");
     // After the activate command, the device should report the ownership state as `OWND`.
     transport.reset_target(Duration::from_millis(50), /*clear_uart=*/ true)?;
     let capture = UartConsole::wait_for(
         &*uart,
-        r"(?msR)ownership_state = OWND$.*ownership_transfers = (\d+)$.*PASS!$",
+        r"(?msR)ownership_state = (\w+)$.*ownership_transfers = (\d+)$.*PASS!$|BFV:([0-9A-Fa-f]{8})$",
         opts.timeout,
     )?;
-    let transfers1 = capture[1].parse::<u32>()?;
+    if capture[0].starts_with("BFV") {
+        return RomError(u32::from_str_radix(&capture[3], 16)?).into();
+    }
+    assert_eq!(capture[1], "OWND");
+    let transfers1 = capture[2].parse::<u32>()?;
     assert_eq!(transfers0 + 1, transfers1);
     Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+    let transport = opts.init.init_target()?;
+
+    let result = transfer_test(&opts, &transport);
+    if let Some(error) = &opts.expected_error {
+        match result {
+            Ok(_) => Err(anyhow!("Ok when expecting {error:?}")),
+            Err(e) => {
+                let re = Regex::new(error).expect("regex");
+                if re.is_match(&e.to_string()) {
+                    log::info!("Got expected error code: {e}");
+                    Ok(())
+                } else {
+                    Err(anyhow!("Expected {error:?} but got {e}"))
+                }
+            }
+        }
+    } else {
+        result
+    }
 }


### PR DESCRIPTION
This is  a manual cherry-pick of #24479 to master.

The tests added by this change are all simple variations on the ownership transfer test added in #24419.  They involve verifying the different modes and error conditions (e.g. using the wrong key).

Adds the following tests:
- `bad_unlock_test`; Fixes #24466
- `bad_activate_test`; Fixes #24467
- `bad_owner_block_test`; Fixes #24468
- `bad_app_key_test`; Fixes #24469
- `transfer_endorsed_test`; Fixes #24470
- `bad_endorsee_test`; Fixes #24471
- `locked_update_test`; Fixes #24472
- `bad_locked_update_test` & `bad_locked_update_no_exec_test`; Fixes #24473

Signed-off-by: Chris Frantz <cfrantz@google.com>
(cherry picked from commit 4d520bd7efa5399f54cafe756bcc08e58d20b23e)