### PR TITLE
[dv,pattgen] Adjust pattern data distribution

### DIFF
--- a/hw/ip/pattgen/dv/env/pattgen_seq_cfg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_seq_cfg.sv
@@ -36,8 +36,10 @@ class pattgen_seq_cfg extends uvm_object;
   // for error_vseq
   bit  error_injected_enb            = 1'b0;
   uint error_injected_pct            = 10;  // in percentage
-  uint data_top_pct                  = 10;
-  uint data_bottom_pct               = 80;
-  uint data_middle_pct               = 10;
+
+  // pattern data distribution (in percentages)
+  uint data_top_pct                  = 10; // all-high half-pattern
+  uint data_bottom_pct               = 10; // all-low half-pattern
+  uint data_middle_pct               = 80; // everything else
 
 endclass : pattgen_seq_cfg


### PR DESCRIPTION
Adjust the probabilities of the pattgen pattern data randomisation to reduce the chance of an all-zero half-pattern from 80% to 10%, and correspondingly increase the chance of a mixed half-pattern from 10% to 80%.

This should better exercise the block.