### PR TITLE
[SiVal] Map more manufacture tests to the testplans 

### DIFF
--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -307,7 +307,7 @@
       otp_mutate: true
       lc_states: ["DEV", "PROD", "PROD_END"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/silicon_creator/manuf/lib:individualize_functest"]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -257,7 +257,7 @@
       otp_mutate: true
       lc_states: ["TEST_UNLOCKED"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/silicon_creator/manuf/lib:individualize_sw_cfg_functest"]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
+++ b/sw/device/silicon_creator/manuf/data/manuf_testplan.hjson
@@ -222,7 +222,7 @@
       otp_mutate: true
       lc_states: ["TEST_UNLOCKED"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/silicon_creator/manuf/base:ft_provision_sival"]
     }
 
     {
@@ -392,7 +392,7 @@
       otp_mutate: true
       lc_states: ["DEV", "PROD", "PROD_END"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/silicon_creator/manuf/base:ft_provision_sival"]
     }
 
     {
@@ -416,7 +416,7 @@
       otp_mutate: false
       lc_states: ["DEV", "PROD", "PROD_END"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/silicon_creator/manuf/base:ft_provision_sival"]
     }
 
     {
@@ -446,7 +446,7 @@
       otp_mutate: false
       lc_states: ["DEV", "PROD", "PROD_END"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/silicon_creator/manuf/base:ft_provision_sival"]
     }
 
     {
@@ -468,7 +468,7 @@
       otp_mutate: true
       lc_states: ["DEV", "PROD", "PROD_END"]
       tests: []
-      bazel: []
+      bazel: ["//sw/device/silicon_creator/manuf/base:ft_provision_sival"]
     }
 
     {

--- a/sw/device/silicon_creator/manuf/lib/BUILD
+++ b/sw/device/silicon_creator/manuf/lib/BUILD
@@ -207,6 +207,7 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:fpga_hyper310_rom_with_fake_keys": None,
         "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+        "//hw/top_earlgrey:fpga_cw340_sival": None,
     },
     fpga = fpga_params(
         changes_otp = True,


### PR DESCRIPTION
Map the remaining manufacture testes based on the test scope.

@moidx Can you please review if these links are correct and advise in case it's not?