### PR TITLE
[bazel] Capture output of updatemem to make it less verbose

### DIFF
--- a/rules/scripts/BUILD
+++ b/rules/scripts/BUILD
@@ -38,3 +38,8 @@ sh_binary(
     name = "modid_check",
     srcs = ["modid_check.sh"],
 )
+
+sh_binary(
+    name = "run_and_capture",
+    srcs = ["run_and_capture.sh"],
+)

--- a/rules/scripts/run_and_capture.sh
+++ b/rules/scripts/run_and_capture.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Run the program and redirect the stdout and stderr to given files
+"$@" >"$RUN_CAPTURE_STDOUT" 2>"$RUN_CAPTURE_STDERR"
+res=$?
+if [ $res -ne 0 ]; then
+    cat "$RUN_CAPTURE_STDERR" >&2
+    echo "see stdout in $RUN_CAPTURE_STDOUT" >&2
+    echo "see stderr in $RUN_CAPTURE_STDERR" >&2
+fi
+exit $res


### PR DESCRIPTION
updatemem likes to print a lot of things which makes the CI output less readable for no particular benefit. This commit introduces a bash script that runs updatmem and captures the output. If an error occurs, it will print the path to the output and error logs. Those files are also added to the output groups of the bitstream_splice rules so that they can be queried if needed.