### PR TITLE
[hmac,dv] Move IDLE check from vseq to scb

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -88,6 +88,10 @@ task hmac_scoreboard::run_phase(uvm_phase phase);
       fork
         begin : main_thread
           fork
+            begin
+              cfg.clk_rst_vif.wait_clks(1);   // Wait one clk cycle to be sure IDLE state is set
+              check_idle(1'b1);               // Check IDLE after a reset has occured
+            end
             hmac_process_fifo_status();
             hmac_process_fifo_wr();
             hmac_process_fifo_rd();

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -139,7 +139,6 @@ task hmac_base_vseq::dut_init(string reset_kind = "HARD");
   if (do_hmac_init) begin
     hmac_init();
   end
-  `DV_CHECK_EQ(cfg.hmac_vif.is_idle(), 1'b1)
 endtask : dut_init
 
 task hmac_base_vseq::apply_reset(string kind = "HARD");


### PR DESCRIPTION
- this PR should fix this issue https://github.com/lowRISC/opentitan/issues/24690
- Move the IDLE pin check from the base sequence to the SCB as it makes more sense to perform check there.