### PR TITLE
[hw,prim_ram_1p,rtl] Add reset input to prim_ram_1p

### DIFF
--- a/hw/dv/sv/sim_sram/sim_sram.sv
+++ b/hw/dv/sv/sim_sram/sim_sram.sv
@@ -93,6 +93,7 @@ module sim_sram #(
       .DataBitsPerMask(WidthBytes)
     ) u_sram (
       .clk_i,
+      .rst_ni,
       .req_i  (sram_req),
       .write_i(sram_we),
       .addr_i (sram_addr),

--- a/hw/ip/prim/lint/prim_ram_1p_adv.waiver
+++ b/hw/ip/prim/lint/prim_ram_1p_adv.waiver
@@ -6,3 +6,6 @@
 
 waive -rules {CONST_FF} -location {prim_ram_1p_adv.sv} -regexp {.*Flip-flop 'wmask_q' is driven by constant ones.*EnableECC=1'h1.*} \
       -comment "This particular instance is ok since we do not use the wmask when ECC is enabled."
+
+waive -rules {RESET_USE} -location {prim_ram_1p_adv.sv} -regexp {rst_ni' is connected to 'prim_ram_1p' port 'rst_ni', and used as an asynchronous reset or set at prim_ram_1p_adv.sv} \
+      -comment "rst_ni is the asynchronous reset of prim_ram_1p_adv. It's unused in the generic implementation, but other implementations may use it."

--- a/hw/ip/prim/rtl/prim_ram_1p_adv.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_adv.sv
@@ -111,6 +111,7 @@ module prim_ram_1p_adv import prim_ram_1p_pkg::*; #(
     .DataBitsPerMask (LocalDataBitsPerMask)
   ) u_mem (
     .clk_i,
+    .rst_ni,
 
     .req_i    (req_q_b),
     .write_i  (write_q_b),

--- a/hw/ip/prim_generic/lint/prim_generic_flash.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_flash.waiver
@@ -7,3 +7,6 @@
 # The prim generic module does not make use of the IO ports
 waive -rules INOUT_AS_IN -location {prim_generic_flash.sv} \
       -regexp {Inout port 'flash_.*_io' has no driver}
+
+waive -rules {RESET_USE} -location {prim_generic_flash_bank.sv} -regexp {rst_ni' is connected to 'prim_ram_1p' port 'rst_ni', and used as an asynchronous reset or set at prim_generic_flash_bank.sv} \
+      -comment "rst_ni is the asynchronous reset of prim_ram_1p_adv. It's unused in the generic implementation, but other implementations may use it."

--- a/hw/ip/prim_generic/lint/prim_generic_ram_1p.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_ram_1p.waiver
@@ -8,5 +8,5 @@ waive -rules ALWAYS_SPEC       -location {prim_generic_ram_1p.sv} -regexp {Edge 
       -comment "Vivado requires here an always instead of always_ff"
 waive -rules HIER_NET_NOT_READ -regexp {Connected net '(addr|wdata)_i' at prim_generic_ram_1p.sv.* is not read from in module 'prim_generic_ram_1p'} \
       -comment "Ascentlint blackboxes very deep RAMs to speed up runtime. This blackboxing causes above lint errors."
-waive -rules IFDEF_CODE -location {prim_generic_ram_1p.sv} -regexp {Assignment to 'unused_cfg' contained within `ifndef} \
+waive -rules IFDEF_CODE -location {prim_generic_ram_1p.sv} -regexp {Assignment to 'unused_signals' contained within `ifndef} \
       -comment "Declaration of signal and assignment to it are in same `ifndef"

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -409,6 +409,7 @@ module prim_generic_flash_bank #(
     .DataBitsPerMask(DataWidth)
   ) u_mem (
     .clk_i,
+    .rst_ni,
     .req_i    (data_mem_req),
     .write_i  (mem_wr),
     .addr_i   (mem_addr),
@@ -434,6 +435,7 @@ module prim_generic_flash_bank #(
       .DataBitsPerMask(DataWidth)
     ) u_info_mem (
       .clk_i,
+      .rst_ni,
       .req_i    (info_mem_req),
       .write_i  (mem_wr),
       .addr_i   (mem_addr[0 +: InfoAddrW]),

--- a/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_ram_1p.sv
@@ -15,6 +15,7 @@ module prim_generic_ram_1p import prim_ram_1p_pkg::*; #(
   localparam int Aw              = $clog2(Depth)  // derived parameter
 ) (
   input  logic             clk_i,
+  input  logic             rst_ni,
 
   input  logic             req_i,
   input  logic             write_i,
@@ -39,8 +40,8 @@ module prim_generic_ram_1p import prim_ram_1p_pkg::*; #(
   // Width must be fully divisible by DataBitsPerMask
   `ASSERT_INIT(DataBitsPerMaskCheck_A, (Width % DataBitsPerMask) == 0)
 
-  logic unused_cfg;
-  assign unused_cfg = ^cfg_i;
+  logic unused_signals;
+  assign unused_signals = ^{cfg_i, rst_ni};
   assign cfg_rsp_o.done = 1'b0;
 
   // Width of internal write mask. Note wmask_i input into the module is always assumed

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_ram_1p.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_ram_1p.sv
@@ -15,6 +15,7 @@ module prim_xilinx_ram_1p import prim_ram_1p_pkg::*; #(
   localparam int Aw              = $clog2(Depth)  // derived parameter
 ) (
   input  logic             clk_i,
+  input  logic             rst_ni,
 
   input  logic             req_i,
   input  logic             write_i,
@@ -41,8 +42,8 @@ module prim_xilinx_ram_1p import prim_ram_1p_pkg::*; #(
     logic wr_en;
     assign wr_en = write_i & wmask_i[0];
 
-    logic unused_cfg_i;
-    assign unused_cfg_i = cfg_i;
+    logic unused_signals;
+    assign unused_signals = ^{rst_ni, cfg_i};
     assign cfg_rsp_o.done = 1'b0;
 
     for (genvar k = 0; k < Width; k = k + PrimMaxWidth) begin : gen_split

--- a/hw/ip/prim_xilinx_ultrascale/rtl/prim_xilinx_ultrascale_ram_1p.sv
+++ b/hw/ip/prim_xilinx_ultrascale/rtl/prim_xilinx_ultrascale_ram_1p.sv
@@ -15,6 +15,7 @@ module prim_xilinx_ultrascale_ram_1p import prim_ram_1p_pkg::*; #(
   localparam int Aw              = $clog2(Depth)  // derived parameter
 ) (
   input  logic             clk_i,
+  input  logic             rst_ni,
 
   input  logic             req_i,
   input  logic             write_i,

--- a/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv
+++ b/hw/vendor/lowrisc_ibex/dv/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv
@@ -19,6 +19,7 @@ module prim_badbit_ram_1p #(
   localparam int Aw              = $clog2(Depth)  // derived parameter
 ) (
   input  logic             clk_i,
+  input  logic             rst_ni,
 
   input  logic             req_i,
   input  logic             write_i,
@@ -37,6 +38,7 @@ module prim_badbit_ram_1p #(
     .MemInitFile    (MemInitFile)
   ) u_mem (
     .clk_i    (clk_i),
+    .rst_ni   (rst_ni),
 
     .cfg_i    ('0),
     .cfg_rsp_o(),

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -693,6 +693,7 @@ module ibex_top import ibex_pkg::*; #(
           .DataBitsPerMask  (TagSizeECC)
         ) tag_bank (
           .clk_i,
+          .rst_ni,
 
           .req_i       (ic_tag_req[way]),
 
@@ -713,6 +714,7 @@ module ibex_top import ibex_pkg::*; #(
           .DataBitsPerMask    (LineSizeECC)
         ) data_bank (
           .clk_i,
+          .rst_ni,
 
           .req_i       (ic_data_req[way]),
 

--- a/hw/vendor/patches/lowrisc_ibex/dv/0003-PATCH-Add-rst-to-prim_ram_1p.patch
+++ b/hw/vendor/patches/lowrisc_ibex/dv/0003-PATCH-Add-rst-to-prim_ram_1p.patch
@@ -1,0 +1,35 @@
+From 3b121fa310582a7961b757fa9f870cff046679c1 Mon Sep 17 00:00:00 2001
+From: Robert Schilling <rschilling@rivosinc.com>
+Date: Mon, 23 Dec 2024 11:15:10 +0100
+Subject: [PATCH 1/1] [PATCH] Add rst to prim_ram_1p
+
+Signed-off-by: Robert Schilling <rschilling@rivosinc.com>
+---
+ uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv b/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv
+index 7fa4678f..fef9e9a1 100644
+--- a/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv
++++ b/uvm/icache/dv/prim_badbit/prim_badbit_ram_1p.sv
+@@ -19,6 +19,7 @@ module prim_badbit_ram_1p #(
+   localparam int Aw              = $clog2(Depth)  // derived parameter
+ ) (
+   input  logic             clk_i,
++  input  logic             rst_ni,
+ 
+   input  logic             req_i,
+   input  logic             write_i,
+@@ -36,7 +37,8 @@ module prim_badbit_ram_1p #(
+     .DataBitsPerMask(DataBitsPerMask),
+     .MemInitFile    (MemInitFile)
+   ) u_mem (
+     .clk_i    (clk_i),
++    .rst_ni   (rst_ni),
+ 
+     .cfg_i    ('0),
+     .cfg_rsp_o(),
+     .req_i    (req_i),
+-- 
+2.47.0
+

--- a/hw/vendor/patches/lowrisc_ibex/rtl/0004-PATCH-Add-rst-to-prim_ram_1p.patch
+++ b/hw/vendor/patches/lowrisc_ibex/rtl/0004-PATCH-Add-rst-to-prim_ram_1p.patch
@@ -1,0 +1,33 @@
+From 805f8c59091632a1416c6cd2e2308c1e6a81752d Mon Sep 17 00:00:00 2001
+From: Robert Schilling <rschilling@rivosinc.com>
+Date: Mon, 23 Dec 2024 11:18:32 +0100
+Subject: [PATCH 1/1] [PATCH] Add rst to prim_ram_1p
+
+Signed-off-by: Robert Schilling <rschilling@rivosinc.com>
+---
+ ibex_top.sv | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/ibex_top.sv b/ibex_top.sv
+index a90fee0e..4974270c 100644
+--- a/ibex_top.sv
++++ b/ibex_top.sv
+@@ -686,6 +686,7 @@ module ibex_top import ibex_pkg::*; #(
+           .DataBitsPerMask  (TagSizeECC)
+         ) tag_bank (
+           .clk_i,
++          .rst_ni,
+ 
+           .req_i       (ic_tag_req[way]),
+ 
+@@ -705,6 +706,7 @@ module ibex_top import ibex_pkg::*; #(
+           .DataBitsPerMask    (LineSizeECC)
+         ) data_bank (
+           .clk_i,
++          .rst_ni,
+ 
+           .req_i       (ic_data_req[way]),
+ 
+-- 
+2.47.0
+


### PR DESCRIPTION
A reset input is reasonable as the underlying macro might need a reset signal for internal flops.