### PR TITLE
[hmac,dv] Skip msg_length check when reset

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -714,7 +714,13 @@ task hmac_base_vseq::sar_different_context();
           csr_spinwait(.ptr(ral.intr_state.hmac_done), .exp_data(1'b1));
           // Check message length -> TODO (#23562) move to the SCB when removing sar_skip_ctxt
           csr_rd_msg_length(msg_length_rd);
-          `DV_CHECK_EQ(msg_length_rd, msg_length_rand+msg_b.size()*8)
+          // Check if reset hasn't been triggered before doing this check
+          // TODO (#25809) remove this from the seq when reset handled properly
+          if (cfg.under_reset) begin
+            return;
+          end else begin
+            `DV_CHECK_EQ(msg_length_rd, msg_length_rand+msg_b.size()*8)
+          end
         end
   endcase
   // Clear the interrupt.


### PR DESCRIPTION
- when a reset a is happening, the HMAC DV env is not really robust. Some tasks are still ongoing and would require to be killed. A temporary fix has been proposed to skip the msg_length check when a Save and Restore task is ongoing when a reset is triggered. A better approach will be put in place later when a proper reset agent will be used.