### PR TITLE
[sram_ctrl,dv] Add post apply reset delay

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -30,6 +30,12 @@ class sram_ctrl_base_vseq #(
   // enabled at the beginning of the test.
   bit init_w_readback = 1'b0;
 
+  // The extra cycles to wait after reset before starting any test, required
+  // to ensure that the tl_agent is properly emptied.
+  // TODO(lowRISC/opentitan#25757): Make sure that the tl_agent pipeline is emptied.
+  // Then, waiting these cycles is not required anymore.
+  int post_apply_reset_cycles = 1;
+
   constraint readback_en_c {
     soft readback_en inside {MuBi4True, MuBi4False};
   }
@@ -113,6 +119,11 @@ class sram_ctrl_base_vseq #(
     super.apply_resets_concurrently(cfg.otp_clk_rst_vif.clk_period_ps);
     cfg.otp_clk_rst_vif.drive_rst_pin(1);
     cfg.exec_vif.init();
+  endtask
+
+  task post_apply_reset(string reset_kind = "HARD");
+    super.post_apply_reset(reset_kind);
+    cfg.clk_rst_vif.wait_clks(post_apply_reset_cycles);
   endtask
 
   virtual task dut_shutdown();


### PR DESCRIPTION
After resetting, we should wait a bit before starting the new test to make sure that the tl_agent message queue really is emptied. If we are not doing this, we might see the following error:

```
./util/dvsim/dvsim.py hw/ip/sram_ctrl/dv/sram_ctrl_main_sim_cfg.hjson \
  -i sram_ctrl_passthru_mem_tl_intg_err -t vcs --fixed-seed \
  41020402185315011969996404882728929238760707320232330314609988937493640571488

UVM_ERROR @ 2116319532 ps: uvm_test_top.env.m_tl_agent_sram_ctrl_regs_reg_block
sequencer [uvm_test_top.env.m_tl_agent_sram_ctrl_regs_reg_block.sequencer] get_
next_item/try_next_item called twice without item_done or get in between
```