### PR TITLE
[ci] Use alternative mechanisms to avoid github API file limits

### DIFF
--- a/.github/workflows/pr_change_check.yml
+++ b/.github/workflows/pr_change_check.yml
@@ -22,7 +22,9 @@ jobs:
         run: |
           pr_url="https://github.com/${{ github.repository }}/pull/${{ github.event.number }}"
           echo $pr_url
-          gh pr diff $pr_url --name-only > $HOME/changed_files
+          gh pr checkout $pr_url --name-only > $HOME/changed_files
+          BASE_BRANCH=$(gh pr view --json baseRefName --jq .baseRefName)
+          git diff --stat --name-only $BASE_BRANCH > $HOME/changed_files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Due to the file number limit for `gh pr diff`, change to comparing the checkout against the base branch.