### PR TITLE
[hw,spi_host,rtl] Make NumCS an exposed  parameter

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -67,6 +67,8 @@
       desc: "The number of active-low chip select (cs_n) lines to create.",
       type: "int",
       default: "1"
+      local: "true",
+      expose: "true",
     },
     { name: "TxDepth",
       desc: "The size of the Tx FIFO (in words)",

--- a/hw/ip/spi_host/dv/env/spi_host_env_cfg_pkg.core
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cfg_pkg.core
@@ -1,0 +1,16 @@
+CAPI=2:
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:spi_host_env_cfg_pkg:0.1"
+description: "SPI_HOST DV UVM environment"
+filesets:
+  files_dv:
+    files:
+      - spi_host_env_cfg_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/spi_host/dv/env/spi_host_env_cfg_pkg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cfg_pkg.sv
@@ -1,0 +1,8 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package spi_host_env_cfg_pkg;
+  // parameters
+  parameter integer unsigned SPI_HOST_NUM_CS = 1;
+endpackage : spi_host_env_cfg_pkg

--- a/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
@@ -15,9 +15,12 @@ package spi_host_env_pkg;
   import dv_base_reg_pkg::*;
   import spi_host_reg_pkg::*;
   import spi_host_ral_pkg::*;
+  import spi_host_env_cfg_pkg::*;
+
+  // Re-export SPI_HOST_NUM_CS from spi_host_env_cfg_pkg to make it available in DV
+  export spi_host_env_cfg_pkg::SPI_HOST_NUM_CS;
 
   // parameters
-  parameter uint SPI_HOST_NUM_CS         = spi_host_reg_pkg::NumCS;
   parameter uint SPI_HOST_TX_DEPTH       = spi_host_reg_pkg::TxDepth;
   parameter uint SPI_HOST_RX_DEPTH       = spi_host_reg_pkg::RxDepth;
   parameter uint SPI_HOST_CMD_DEPTH      = spi_host_reg_pkg::CmdDepth;

--- a/hw/ip/spi_host/dv/sva/spi_host_bind.sv
+++ b/hw/ip/spi_host/dv/sva/spi_host_bind.sv
@@ -20,7 +20,9 @@ module spi_host_bind;
     .d2h    (tl_o)
   );
 
-  bind spi_host spi_host_data_stable_sva spi_host_data_stable_assert (
+  bind spi_host spi_host_data_stable_sva #(
+    .NumCS(spi_host_env_cfg_pkg::SPI_HOST_NUM_CS)
+  ) spi_host_data_stable_assert (
     .rst_ni,
     .cio_sck_o,
     .cio_csb_o,

--- a/hw/ip/spi_host/dv/sva/spi_host_data_stable_sva.sv
+++ b/hw/ip/spi_host/dv/sva/spi_host_data_stable_sva.sv
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-module spi_host_data_stable_sva (
+module spi_host_data_stable_sva #(
+  parameter int unsigned NumCS = 1
+) (
   input logic                                              rst_ni,
   input logic                                              cio_sck_o,
-  input logic [spi_host_reg_pkg::NumCS-1:0]                cio_csb_o,
+  input logic [NumCS-1:0]                                  cio_csb_o,
   input logic [3:0]                                        cio_sd_i,
   input logic [3:0]                                        cio_sd_en_o,
   input spi_host_reg_pkg::spi_host_reg2hw_configopts_reg_t configopts,

--- a/hw/ip/spi_host/dv/sva/spi_host_sva.core
+++ b/hw/ip/spi_host/dv/sva/spi_host_sva.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:ip:spi_host
+      - lowrisc:dv:spi_host_env_cfg_pkg
     files:
       - spi_host_data_stable_sva.sv
       - spi_host_bind.sv

--- a/hw/ip/spi_host/dv/tb.sv
+++ b/hw/ip/spi_host/dv/tb.sv
@@ -28,8 +28,8 @@ module tb;
   lc_tx_t                       scanmode_i;
   logic                         cio_sck_o;
   logic                         cio_sck_en_o;
-  logic [NumCS-1:0]             cio_csb_o;
-  logic [NumCS-1:0]             cio_csb_en_o;
+  logic [SPI_HOST_NUM_CS-1:0]   cio_csb_o;
+  logic [SPI_HOST_NUM_CS-1:0]   cio_csb_en_o;
   logic [3:0]                   cio_sd_o;
   logic [3:0]                   cio_sd_en_o;
   logic [3:0]                   cio_sd_i;
@@ -49,7 +49,9 @@ module tb;
   `DV_ALERT_IF_CONNECT()
 
   // dut
-  spi_host dut (
+  spi_host # (
+    .NumCS(SPI_HOST_NUM_CS)
+  ) dut (
     .clk_i                (clk),
     .rst_ni               (rst_n),
 
@@ -102,7 +104,7 @@ module tb;
     assign (highz0, pull1) sio[i] = !cio_sd_en_o[i];
     assign si_pulldown[i] = sio[i];
 
-    if (i < NumCS) begin : gen_drive_csb
+    if (i < SPI_HOST_NUM_CS) begin : gen_drive_csb
       assign spi_if.csb[i] = cio_csb_en_o[i] ? cio_csb_o[i] : 1'b1;
     end
   end

--- a/hw/ip/spi_host/rtl/spi_host_cmd_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_cmd_pkg.sv
@@ -7,8 +7,7 @@
 
 package spi_host_cmd_pkg;
 
-  parameter int CSW = prim_util_pkg::vbits(spi_host_reg_pkg::NumCS);
-  parameter int CmdSize = CSW + 56;
+  parameter int CmdSize = 56;
 
   // For decoding the direction register
   typedef enum logic [1:0] {
@@ -45,7 +44,6 @@ package spi_host_cmd_pkg;
   } segment_t;
 
   typedef struct packed {
-    logic [CSW-1:0] csid;
     segment_t segment;
     configopts_t configopts;
   } command_t;

--- a/hw/ip/spi_host/rtl/spi_host_core.sv
+++ b/hw/ip/spi_host/rtl/spi_host_core.sv
@@ -6,12 +6,14 @@
 //
 
 module spi_host_core #(
-  parameter  int NumCS     = 1
+  parameter  int NumCS = 1,
+  localparam int CSW   = prim_util_pkg::vbits(NumCS)
 ) (
   input                             clk_i,
   input                             rst_ni,
 
   input spi_host_cmd_pkg::command_t command_i,
+  input logic [CSW-1:0]             command_csid_i,
   input                             command_valid_i,
   output                            command_ready_o,
   input                             en_i,
@@ -128,6 +130,7 @@ module spi_host_core #(
     .rst_ni,
     .en_i,
     .command_i,
+    .command_csid_i,
     .command_valid_i,
     .command_ready_o,
     .sck_o,

--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -8,16 +8,18 @@
 module spi_host_fsm
   import spi_host_cmd_pkg::*;
 #(
-  parameter  int NumCS = 1
+  parameter  int NumCS = 1,
+  localparam int CSW   = prim_util_pkg::vbits(NumCS)
 ) (
   input                              clk_i,
   input                              rst_ni,
   input                              en_i,
   input  command_t                   command_i,
+  input  logic [CSW-1:0]             command_csid_i,
   input                              command_valid_i,
   output logic                       command_ready_o,
   output logic                       sck_o,
-  output logic [NumCS-1:0]           csb_o,
+  output logic [CSW-1:0]             csb_o,
   output logic [3:0]                 sd_en_o,
   output logic                       last_read_o,
   output logic                       last_write_o,
@@ -128,7 +130,7 @@ module spi_host_fsm
                           (command_i.configopts.clkdiv   != clkdiv_q);
 
   always_comb begin
-    csid      = new_command ? command_i.csid : csid_q;
+    csid      = new_command ? command_csid_i : csid_q;
     cpol      = new_command ? command_i.configopts.cpol : cpol_q;
     cpha      = new_command ? command_i.configopts.cpha : cpha_q;
     full_cyc  = new_command ? command_i.configopts.full_cyc : full_cyc_q;
@@ -209,7 +211,7 @@ module spi_host_fsm
   logic         command_ready_idle_csb_active;
   always_comb begin
     if (command_valid_i) begin
-      if (command_i.csid != csid_q) begin
+      if (command_csid_i != csid_q) begin
         //
         // Do not acknowledge the command now, as it will trigger
         // an update of the internal command and configuration registers.

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -8,7 +8,6 @@ package spi_host_reg_pkg;
 
   // Param list
   parameter logic ByteOrder = 1;
-  parameter int NumCS = 1;
   parameter int TxDepth = 72;
   parameter int RxDepth = 64;
   parameter int CmdDepth = 4;

--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -2250,7 +2250,19 @@
         "0"
       ]
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: NumCS
+          desc: The number of active-low chip select (cs_n) lines to create.
+          type: int
+          default: "1"
+          local: "true"
+          expose: "true"
+          name_top: SpiHost0NumCS
+        }
+      ]
       inter_signal_list:
       [
         {

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -297,6 +297,8 @@ module top_darjeeling #(
   // Local Parameters
   // local parameters for lc_ctrl
   localparam int LcCtrlNumRmaAckSigs = 1;
+  // local parameters for spi_host0
+  localparam int SpiHost0NumCS = 1;
   // local parameters for rv_core_ibex
   localparam int unsigned RvCoreIbexNEscalationSeverities = alert_handler_reg_pkg::N_ESC_SEV;
   localparam int unsigned RvCoreIbexWidthPingCounter = alert_handler_reg_pkg::PING_CNT_DW;
@@ -1316,7 +1318,8 @@ module top_darjeeling #(
       .rst_edn_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   spi_host #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[13:13])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[13:13]),
+    .NumCS(SpiHost0NumCS)
   ) u_spi_host0 (
 
       // Input

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2748,7 +2748,19 @@
         "0"
       ]
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: NumCS
+          desc: The number of active-low chip select (cs_n) lines to create.
+          type: int
+          default: "1"
+          local: "true"
+          expose: "true"
+          name_top: SpiHost0NumCS
+        }
+      ]
       inter_signal_list:
       [
         {
@@ -2825,7 +2837,19 @@
         "0"
       ]
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: NumCS
+          desc: The number of active-low chip select (cs_n) lines to create.
+          type: int
+          default: "1"
+          local: "true"
+          expose: "true"
+          name_top: SpiHost1NumCS
+        }
+      ]
       inter_signal_list:
       [
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -241,6 +241,10 @@ module top_earlgrey #(
   // Local Parameters
   // local parameters for lc_ctrl
   localparam int LcCtrlNumRmaAckSigs = 2;
+  // local parameters for spi_host0
+  localparam int SpiHost0NumCS = 1;
+  // local parameters for spi_host1
+  localparam int SpiHost1NumCS = 1;
   // local parameters for rv_core_ibex
   localparam int unsigned RvCoreIbexNEscalationSeverities = alert_handler_reg_pkg::N_ESC_SEV;
   localparam int unsigned RvCoreIbexWidthPingCounter = alert_handler_reg_pkg::PING_CNT_DW;
@@ -1626,7 +1630,8 @@ module top_earlgrey #(
       .rst_edn_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel])
   );
   spi_host #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[19:19]),
+    .NumCS(SpiHost0NumCS)
   ) u_spi_host0 (
 
       // Input
@@ -1659,7 +1664,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel])
   );
   spi_host #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[20:20])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[20:20]),
+    .NumCS(SpiHost1NumCS)
   ) u_spi_host1 (
 
       // Input


### PR DESCRIPTION
This moves the NumCS param from the reg_top_pkg to an instance level parameter. This allows instances to overwrite the parameter.