### PR TITLE
[hw,darjeeling,rtl] Separate the RAM cfg ports

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -748,7 +748,9 @@
           width: 1
           inst_name: spi_device
           default: ""
-          top_signame: ast_spi_ram_2p_cfg
+          external: true
+          top_signame: spi_device_ram_2p_cfg_sys2spi
+          conn_type: false
           index: -1
         }
         {
@@ -774,7 +776,9 @@
           width: 1
           inst_name: spi_device
           default: ""
-          top_signame: ast_spi_ram_2p_cfg
+          external: true
+          top_signame: spi_device_ram_2p_cfg_spi2sys
+          conn_type: false
           index: -1
         }
         {
@@ -4137,7 +4141,9 @@
           }
           default: "'0"
           inst_name: sram_ctrl_ret_aon
-          top_signame: ast_ram_1p_cfg
+          external: true
+          top_signame: sram_ctrl_ret_aon_ram_1p_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -5449,7 +5455,9 @@
           width: 1
           inst_name: otbn
           default: ""
-          top_signame: ast_ram_1p_cfg
+          external: true
+          top_signame: otbn_imem_ram_1p_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -5461,7 +5469,9 @@
           width: 1
           inst_name: otbn
           default: ""
-          top_signame: ast_ram_1p_cfg
+          external: true
+          top_signame: otbn_dmem_ram_1p_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -6373,7 +6383,9 @@
           }
           default: "'0"
           inst_name: sram_ctrl_main
-          top_signame: ast_ram_1p_cfg
+          external: true
+          top_signame: sram_ctrl_main_ram_1p_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -6642,7 +6654,9 @@
           }
           default: "'0"
           inst_name: sram_ctrl_mbox
-          top_signame: ast_ram_1p_cfg
+          external: true
+          top_signame: sram_ctrl_mbox_ram_1p_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -9215,7 +9229,9 @@
           width: 1
           inst_name: rv_core_ibex
           default: ""
-          top_signame: ast_ram_1p_cfg
+          external: true
+          top_signame: rv_core_ibex_icache_tag_ram_1p_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -9251,7 +9267,9 @@
           width: 1
           inst_name: rv_core_ibex
           default: ""
-          top_signame: ast_ram_1p_cfg
+          external: true
+          top_signame: rv_core_ibex_icache_data_ram_1p_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -9574,38 +9592,6 @@
           conn_type: true
         }
         {
-          struct: ram_1p_cfg
-          package: prim_ram_1p_pkg
-          type: uni
-          name: ram_1p_cfg
-          act: rcv
-          inst_name: ast
-          width: 1
-          default: ""
-          end_idx: -1
-          top_type: broadcast
-          top_signame: ast_ram_1p_cfg
-          index: -1
-          external: true
-          conn_type: true
-        }
-        {
-          struct: ram_2p_cfg
-          package: prim_ram_2p_pkg
-          type: uni
-          name: spi_ram_2p_cfg
-          act: rcv
-          inst_name: ast
-          width: 1
-          default: ""
-          end_idx: -1
-          top_type: broadcast
-          top_signame: ast_spi_ram_2p_cfg
-          index: -1
-          external: true
-          conn_type: true
-        }
-        {
           struct: rom_cfg
           package: prim_rom_pkg
           type: uni
@@ -9647,21 +9633,6 @@
       ast.obs_ctrl:
       [
         otp_ctrl.obs_ctrl
-      ]
-      ast.ram_1p_cfg:
-      [
-        otbn.ram_cfg_imem
-        otbn.ram_cfg_dmem
-        sram_ctrl_main.cfg
-        sram_ctrl_ret_aon.cfg
-        sram_ctrl_mbox.cfg
-        rv_core_ibex.ram_cfg_icache_tag
-        rv_core_ibex.ram_cfg_icache_data
-      ]
-      ast.spi_ram_2p_cfg:
-      [
-        spi_device.ram_cfg_sys2spi
-        spi_device.ram_cfg_spi2sys
       ]
       ast.rom_cfg:
       [
@@ -10297,19 +10268,26 @@
       ast.lc_dft_en: ""
       ast.lc_hw_debug_en: ""
       ast.obs_ctrl: obs_ctrl
-      ast.ram_1p_cfg: ram_1p_cfg
-      ast.spi_ram_2p_cfg: spi_ram_2p_cfg
       ast.rom_cfg: rom_cfg
       i2c0.ram_cfg_rsp: i2c_ram_1p_cfg_rsp
+      sram_ctrl_ret_aon.cfg: sram_ctrl_ret_aon_ram_1p_cfg
       sram_ctrl_ret_aon.cfg_rsp: sram_ctrl_ret_aon_ram_1p_cfg_rsp
+      sram_ctrl_main.cfg: sram_ctrl_main_ram_1p_cfg
       sram_ctrl_main.cfg_rsp: sram_ctrl_main_ram_1p_cfg_rsp
+      sram_ctrl_mbox.cfg: sram_ctrl_mbox_ram_1p_cfg
       sram_ctrl_mbox.cfg_rsp: sram_ctrl_mbox_ram_1p_cfg_rsp
+      otbn.ram_cfg_imem: otbn_imem_ram_1p_cfg
       otbn.ram_cfg_rsp_imem: otbn_imem_ram_1p_cfg_rsp
+      otbn.ram_cfg_dmem: otbn_dmem_ram_1p_cfg
       otbn.ram_cfg_rsp_dmem: otbn_dmem_ram_1p_cfg_rsp
+      rv_core_ibex.ram_cfg_icache_tag: rv_core_ibex_icache_tag_ram_1p_cfg
       rv_core_ibex.ram_cfg_rsp_icache_tag: rv_core_ibex_icache_tag_ram_1p_cfg_rsp
+      rv_core_ibex.ram_cfg_icache_data: rv_core_ibex_icache_data_ram_1p_cfg
       rv_core_ibex.ram_cfg_rsp_icache_data: rv_core_ibex_icache_data_ram_1p_cfg_rsp
+      spi_device.ram_cfg_sys2spi: spi_device_ram_2p_cfg_sys2spi
       spi_device.ram_cfg_rsp_sys2spi: spi_device_ram_2p_cfg_rsp_sys2spi
       spi_device.ram_cfg_rsp_spi2sys: spi_device_ram_2p_cfg_rsp_spi2sys
+      spi_device.ram_cfg_spi2sys: spi_device_ram_2p_cfg_spi2sys
       pwrmgr_aon.boot_status: pwrmgr_boot_status
       clkmgr_aon.jitter_en: clk_main_jitter_en
       clkmgr_aon.io_clk_byp_req: io_clk_byp_req
@@ -18553,7 +18531,9 @@
         width: 1
         inst_name: spi_device
         default: ""
-        top_signame: ast_spi_ram_2p_cfg
+        external: true
+        top_signame: spi_device_ram_2p_cfg_sys2spi
+        conn_type: false
         index: -1
       }
       {
@@ -18579,7 +18559,9 @@
         width: 1
         inst_name: spi_device
         default: ""
-        top_signame: ast_spi_ram_2p_cfg
+        external: true
+        top_signame: spi_device_ram_2p_cfg_spi2sys
+        conn_type: false
         index: -1
       }
       {
@@ -20706,7 +20688,9 @@
         }
         default: "'0"
         inst_name: sram_ctrl_ret_aon
-        top_signame: ast_ram_1p_cfg
+        external: true
+        top_signame: sram_ctrl_ret_aon_ram_1p_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -21356,7 +21340,9 @@
         width: 1
         inst_name: otbn
         default: ""
-        top_signame: ast_ram_1p_cfg
+        external: true
+        top_signame: otbn_imem_ram_1p_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -21368,7 +21354,9 @@
         width: 1
         inst_name: otbn
         default: ""
-        top_signame: ast_ram_1p_cfg
+        external: true
+        top_signame: otbn_dmem_ram_1p_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -21821,7 +21809,9 @@
         }
         default: "'0"
         inst_name: sram_ctrl_main
-        top_signame: ast_ram_1p_cfg
+        external: true
+        top_signame: sram_ctrl_main_ram_1p_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -21941,7 +21931,9 @@
         }
         default: "'0"
         inst_name: sram_ctrl_mbox
-        top_signame: ast_ram_1p_cfg
+        external: true
+        top_signame: sram_ctrl_mbox_ram_1p_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -23353,7 +23345,9 @@
         width: 1
         inst_name: rv_core_ibex
         default: ""
-        top_signame: ast_ram_1p_cfg
+        external: true
+        top_signame: rv_core_ibex_icache_tag_ram_1p_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -23389,7 +23383,9 @@
         width: 1
         inst_name: rv_core_ibex
         default: ""
-        top_signame: ast_ram_1p_cfg
+        external: true
+        top_signame: rv_core_ibex_icache_data_ram_1p_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -24723,38 +24719,6 @@
         conn_type: true
       }
       {
-        struct: ram_1p_cfg
-        package: prim_ram_1p_pkg
-        type: uni
-        name: ram_1p_cfg
-        act: rcv
-        inst_name: ast
-        width: 1
-        default: ""
-        end_idx: -1
-        top_type: broadcast
-        top_signame: ast_ram_1p_cfg
-        index: -1
-        external: true
-        conn_type: true
-      }
-      {
-        struct: ram_2p_cfg
-        package: prim_ram_2p_pkg
-        type: uni
-        name: spi_ram_2p_cfg
-        act: rcv
-        inst_name: ast
-        width: 1
-        default: ""
-        end_idx: -1
-        top_type: broadcast
-        top_signame: ast_spi_ram_2p_cfg
-        index: -1
-        external: true
-        conn_type: true
-      }
-      {
         struct: rom_cfg
         package: prim_rom_pkg
         type: uni
@@ -24850,30 +24814,6 @@
         netname: ast_obs_ctrl
       }
       {
-        package: prim_ram_1p_pkg
-        struct: ram_1p_cfg
-        signame: ram_1p_cfg_i
-        width: 1
-        type: uni
-        default: ""
-        direction: in
-        conn_type: true
-        index: -1
-        netname: ast_ram_1p_cfg
-      }
-      {
-        package: prim_ram_2p_pkg
-        struct: ram_2p_cfg
-        signame: spi_ram_2p_cfg_i
-        width: 1
-        type: uni
-        default: ""
-        direction: in
-        conn_type: true
-        index: -1
-        netname: ast_spi_ram_2p_cfg
-      }
-      {
         package: prim_rom_pkg
         struct: rom_cfg
         signame: rom_cfg_i
@@ -24899,6 +24839,28 @@
       }
       {
         package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: sram_ctrl_ret_aon_ram_1p_cfg_i
+        width:
+        {
+          name: NumRamInst
+          desc: Number of internal RAM instances. Must be the same as ceil(MemSizeRam / InstSize) .
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlRetAonNumRamInst
+        }
+        type: uni
+        default: "'0"
+        direction: in
+        conn_type: false
+        index: -1
+        netname: sram_ctrl_ret_aon_ram_1p_cfg
+      }
+      {
+        package: prim_ram_1p_pkg
         struct: ram_1p_cfg_rsp
         signame: sram_ctrl_ret_aon_ram_1p_cfg_rsp_o
         width:
@@ -24918,6 +24880,28 @@
         conn_type: false
         index: -1
         netname: sram_ctrl_ret_aon_ram_1p_cfg_rsp
+      }
+      {
+        package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: sram_ctrl_main_ram_1p_cfg_i
+        width:
+        {
+          name: NumRamInst
+          desc: Number of internal RAM instances. Must be the same as ceil(MemSizeRam / InstSize) .
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlMainNumRamInst
+        }
+        type: uni
+        default: "'0"
+        direction: in
+        conn_type: false
+        index: -1
+        netname: sram_ctrl_main_ram_1p_cfg
       }
       {
         package: prim_ram_1p_pkg
@@ -24943,6 +24927,28 @@
       }
       {
         package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: sram_ctrl_mbox_ram_1p_cfg_i
+        width:
+        {
+          name: NumRamInst
+          desc: Number of internal RAM instances. Must be the same as ceil(MemSizeRam / InstSize) .
+          param_type: int
+          unpacked_dimensions: null
+          default: 1
+          local: false
+          expose: true
+          name_top: SramCtrlMboxNumRamInst
+        }
+        type: uni
+        default: "'0"
+        direction: in
+        conn_type: false
+        index: -1
+        netname: sram_ctrl_mbox_ram_1p_cfg
+      }
+      {
+        package: prim_ram_1p_pkg
         struct: ram_1p_cfg_rsp
         signame: sram_ctrl_mbox_ram_1p_cfg_rsp_o
         width:
@@ -24965,6 +24971,18 @@
       }
       {
         package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: otbn_imem_ram_1p_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: otbn_imem_ram_1p_cfg
+      }
+      {
+        package: prim_ram_1p_pkg
         struct: ram_1p_cfg_rsp
         signame: otbn_imem_ram_1p_cfg_rsp_o
         width: 1
@@ -24977,6 +24995,18 @@
       }
       {
         package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: otbn_dmem_ram_1p_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: otbn_dmem_ram_1p_cfg
+      }
+      {
+        package: prim_ram_1p_pkg
         struct: ram_1p_cfg_rsp
         signame: otbn_dmem_ram_1p_cfg_rsp_o
         width: 1
@@ -24986,6 +25016,18 @@
         conn_type: false
         index: -1
         netname: otbn_dmem_ram_1p_cfg_rsp
+      }
+      {
+        package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: rv_core_ibex_icache_tag_ram_1p_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: rv_core_ibex_icache_tag_ram_1p_cfg
       }
       {
         package: prim_ram_1p_pkg
@@ -25008,6 +25050,18 @@
         conn_type: false
         index: -1
         netname: rv_core_ibex_icache_tag_ram_1p_cfg_rsp
+      }
+      {
+        package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: rv_core_ibex_icache_data_ram_1p_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: rv_core_ibex_icache_data_ram_1p_cfg
       }
       {
         package: prim_ram_1p_pkg
@@ -25034,6 +25088,18 @@
       {
         package: prim_ram_2p_pkg
         struct: ram_2p_cfg
+        signame: spi_device_ram_2p_cfg_sys2spi_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: spi_device_ram_2p_cfg_sys2spi
+      }
+      {
+        package: prim_ram_2p_pkg
+        struct: ram_2p_cfg
         signame: spi_device_ram_2p_cfg_rsp_sys2spi_o
         width: 1
         type: uni
@@ -25054,6 +25120,18 @@
         conn_type: false
         index: -1
         netname: spi_device_ram_2p_cfg_rsp_spi2sys
+      }
+      {
+        package: prim_ram_2p_pkg
+        struct: ram_2p_cfg
+        signame: spi_device_ram_2p_cfg_spi2sys_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: spi_device_ram_2p_cfg_spi2sys
       }
       {
         package: pwrmgr_pkg
@@ -26136,28 +26214,6 @@
         act: rcv
         suffix: ""
         default: ast_pkg::AST_OBS_CTRL_DEFAULT
-      }
-      {
-        package: prim_ram_1p_pkg
-        struct: ram_1p_cfg
-        signame: ast_ram_1p_cfg
-        width: 1
-        type: uni
-        end_idx: -1
-        act: rcv
-        suffix: ""
-        default: prim_ram_1p_pkg::RAM_1P_CFG_DEFAULT
-      }
-      {
-        package: prim_ram_2p_pkg
-        struct: ram_2p_cfg
-        signame: ast_spi_ram_2p_cfg
-        width: 1
-        type: uni
-        end_idx: -1
-        act: rcv
-        suffix: ""
-        default: prim_ram_2p_pkg::RAM_2P_CFG_DEFAULT
       }
       {
         package: prim_rom_pkg

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -1066,24 +1066,6 @@
           package: "lc_ctrl_pkg",
         },
 
-        { struct:  "ram_1p_cfg",
-          package: "prim_ram_1p_pkg",
-          type:    "uni",
-          name:    "ram_1p_cfg",
-          // The activity direction for a port inter-signal is "opposite" of
-          // what the external module actually needs.
-          act:     "rcv"
-        },
-
-        { struct:  "ram_2p_cfg",
-          package: "prim_ram_2p_pkg",
-          type:    "uni",
-          name:    "spi_ram_2p_cfg",
-          // The activity direction for a port inter-signal is "opposite" of
-          // what the external module actually needs.
-          act:     "rcv"
-        },
-
         { struct:  "rom_cfg",
           package: "prim_rom_pkg",
           type:    "uni",
@@ -1114,15 +1096,6 @@
   inter_module: {
     'connect': {
       'ast.obs_ctrl'            : ['otp_ctrl.obs_ctrl']
-      'ast.ram_1p_cfg'          : ['otbn.ram_cfg_imem',
-                                   'otbn.ram_cfg_dmem',
-                                   'sram_ctrl_main.cfg',
-                                   'sram_ctrl_ret_aon.cfg',
-                                   'sram_ctrl_mbox.cfg',
-                                   'rv_core_ibex.ram_cfg_icache_tag',
-                                   'rv_core_ibex.ram_cfg_icache_data'],
-      'ast.spi_ram_2p_cfg'      : ['spi_device.ram_cfg_sys2spi',
-                                   'spi_device.ram_cfg_spi2sys']
       'ast.rom_cfg'             : ['rom_ctrl0.rom_cfg',
                                    'rom_ctrl1.rom_cfg'],
       'alert_handler.crashdump' : ['rstmgr_aon.alert_dump'],
@@ -1308,19 +1281,26 @@
         'ast.lc_dft_en'                        : '',
         'ast.lc_hw_debug_en'                   : '',
         'ast.obs_ctrl'                         : 'obs_ctrl',
-        'ast.ram_1p_cfg'                       : 'ram_1p_cfg',
-        'ast.spi_ram_2p_cfg'                   : 'spi_ram_2p_cfg',
         'ast.rom_cfg'                          : 'rom_cfg',
         'i2c0.ram_cfg_rsp'                     : 'i2c_ram_1p_cfg_rsp',
+        'sram_ctrl_ret_aon.cfg'                : 'sram_ctrl_ret_aon_ram_1p_cfg',
         'sram_ctrl_ret_aon.cfg_rsp'            : 'sram_ctrl_ret_aon_ram_1p_cfg_rsp',
+        'sram_ctrl_main.cfg'                   : 'sram_ctrl_main_ram_1p_cfg',
         'sram_ctrl_main.cfg_rsp'               : 'sram_ctrl_main_ram_1p_cfg_rsp',
+        'sram_ctrl_mbox.cfg'                   : 'sram_ctrl_mbox_ram_1p_cfg',
         'sram_ctrl_mbox.cfg_rsp'               : 'sram_ctrl_mbox_ram_1p_cfg_rsp',
+        'otbn.ram_cfg_imem'                    : 'otbn_imem_ram_1p_cfg',
         'otbn.ram_cfg_rsp_imem'                : 'otbn_imem_ram_1p_cfg_rsp',
+        'otbn.ram_cfg_dmem'                    : 'otbn_dmem_ram_1p_cfg',
         'otbn.ram_cfg_rsp_dmem'                : 'otbn_dmem_ram_1p_cfg_rsp',
+        'rv_core_ibex.ram_cfg_icache_tag'      : 'rv_core_ibex_icache_tag_ram_1p_cfg',
         'rv_core_ibex.ram_cfg_rsp_icache_tag'  : 'rv_core_ibex_icache_tag_ram_1p_cfg_rsp',
+        'rv_core_ibex.ram_cfg_icache_data'     : 'rv_core_ibex_icache_data_ram_1p_cfg',
         'rv_core_ibex.ram_cfg_rsp_icache_data' : 'rv_core_ibex_icache_data_ram_1p_cfg_rsp',
+        'spi_device.ram_cfg_sys2spi'           : 'spi_device_ram_2p_cfg_sys2spi',
         'spi_device.ram_cfg_rsp_sys2spi'       : 'spi_device_ram_2p_cfg_rsp_sys2spi',
         'spi_device.ram_cfg_rsp_spi2sys'       : 'spi_device_ram_2p_cfg_rsp_spi2sys',
+        'spi_device.ram_cfg_spi2sys'           : 'spi_device_ram_2p_cfg_spi2sys',
         'pwrmgr_aon.boot_status'               : 'pwrmgr_boot_status',
         'clkmgr_aon.jitter_en'                 : 'clk_main_jitter_en',
         'clkmgr_aon.io_clk_byp_req'            : 'io_clk_byp_req',

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -168,19 +168,26 @@ module top_darjeeling #(
   output lc_ctrl_pkg::lc_tx_t       ast_lc_dft_en_o,
   output lc_ctrl_pkg::lc_tx_t       ast_lc_hw_debug_en_o,
   input  ast_pkg::ast_obs_ctrl_t       obs_ctrl_i,
-  input  prim_ram_1p_pkg::ram_1p_cfg_t       ram_1p_cfg_i,
-  input  prim_ram_2p_pkg::ram_2p_cfg_t       spi_ram_2p_cfg_i,
   input  prim_rom_pkg::rom_cfg_t       rom_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t       i2c_ram_1p_cfg_rsp_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t [SramCtrlRetAonNumRamInst-1:0] sram_ctrl_ret_aon_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [SramCtrlRetAonNumRamInst-1:0] sram_ctrl_ret_aon_ram_1p_cfg_rsp_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t [SramCtrlMainNumRamInst-1:0] sram_ctrl_main_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [SramCtrlMainNumRamInst-1:0] sram_ctrl_main_ram_1p_cfg_rsp_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t [SramCtrlMboxNumRamInst-1:0] sram_ctrl_mbox_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [SramCtrlMboxNumRamInst-1:0] sram_ctrl_mbox_ram_1p_cfg_rsp_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t       otbn_imem_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t       otbn_imem_ram_1p_cfg_rsp_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t       otbn_dmem_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t       otbn_dmem_ram_1p_cfg_rsp_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t       rv_core_ibex_icache_tag_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [RvCoreIbexICacheNWays-1:0] rv_core_ibex_icache_tag_ram_1p_cfg_rsp_o,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t       rv_core_ibex_icache_data_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [RvCoreIbexICacheNWays-1:0] rv_core_ibex_icache_data_ram_1p_cfg_rsp_o,
+  input  prim_ram_2p_pkg::ram_2p_cfg_t       spi_device_ram_2p_cfg_sys2spi_i,
   output prim_ram_2p_pkg::ram_2p_cfg_t       spi_device_ram_2p_cfg_rsp_sys2spi_o,
   output prim_ram_2p_pkg::ram_2p_cfg_t       spi_device_ram_2p_cfg_rsp_spi2sys_o,
+  input  prim_ram_2p_pkg::ram_2p_cfg_t       spi_device_ram_2p_cfg_spi2sys_i,
   output pwrmgr_pkg::pwr_boot_status_t       pwrmgr_boot_status_o,
   output prim_mubi_pkg::mubi4_t       clk_main_jitter_en_o,
   output prim_mubi_pkg::mubi4_t       io_clk_byp_req_o,
@@ -492,8 +499,6 @@ module top_darjeeling #(
 
   // define inter-module signals
   ast_pkg::ast_obs_ctrl_t       ast_obs_ctrl;
-  prim_ram_1p_pkg::ram_1p_cfg_t       ast_ram_1p_cfg;
-  prim_ram_2p_pkg::ram_2p_cfg_t       ast_spi_ram_2p_cfg;
   prim_rom_pkg::rom_cfg_t       ast_rom_cfg;
   alert_pkg::alert_crashdump_t       alert_handler_crashdump;
   prim_esc_pkg::esc_rx_t [3:0] alert_handler_esc_rx;
@@ -746,8 +751,6 @@ module top_darjeeling #(
   assign ast_lc_dft_en_o = lc_ctrl_lc_dft_en;
   assign ast_lc_hw_debug_en_o = lc_ctrl_lc_hw_debug_en;
   assign ast_obs_ctrl = obs_ctrl_i;
-  assign ast_ram_1p_cfg = ram_1p_cfg_i;
-  assign ast_spi_ram_2p_cfg = spi_ram_2p_cfg_i;
   assign ast_rom_cfg = rom_cfg_i;
   assign pwrmgr_boot_status_o = pwrmgr_aon_boot_status;
 
@@ -1059,9 +1062,9 @@ module top_darjeeling #(
       .alert_rx_i  ( alert_rx[2:2] ),
 
       // Inter-module signals
-      .ram_cfg_sys2spi_i(ast_spi_ram_2p_cfg),
+      .ram_cfg_sys2spi_i(spi_device_ram_2p_cfg_sys2spi_i),
       .ram_cfg_rsp_sys2spi_o(spi_device_ram_2p_cfg_rsp_sys2spi_o),
-      .ram_cfg_spi2sys_i(ast_spi_ram_2p_cfg),
+      .ram_cfg_spi2sys_i(spi_device_ram_2p_cfg_spi2sys_i),
       .ram_cfg_rsp_spi2sys_o(spi_device_ram_2p_cfg_rsp_spi2sys_o),
       .passthrough_o(spi_device_passthrough_req),
       .passthrough_i(spi_device_passthrough_rsp),
@@ -1673,7 +1676,7 @@ module top_darjeeling #(
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[1]),
       .sram_otp_key_i(otp_ctrl_sram_otp_key_rsp[1]),
-      .cfg_i(ast_ram_1p_cfg),
+      .cfg_i(sram_ctrl_ret_aon_ram_1p_cfg_i),
       .cfg_rsp_o(sram_ctrl_ret_aon_ram_1p_cfg_rsp_o),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .lc_hw_debug_en_i(lc_ctrl_pkg::Off),
@@ -1875,8 +1878,8 @@ module top_darjeeling #(
       .edn_urnd_o(edn0_edn_req[6]),
       .edn_urnd_i(edn0_edn_rsp[6]),
       .idle_o(clkmgr_aon_idle[3]),
-      .ram_cfg_imem_i(ast_ram_1p_cfg),
-      .ram_cfg_dmem_i(ast_ram_1p_cfg),
+      .ram_cfg_imem_i(otbn_imem_ram_1p_cfg_i),
+      .ram_cfg_dmem_i(otbn_dmem_ram_1p_cfg_i),
       .ram_cfg_rsp_imem_o(otbn_imem_ram_1p_cfg_rsp_o),
       .ram_cfg_rsp_dmem_o(otbn_dmem_ram_1p_cfg_rsp_o),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
@@ -2040,7 +2043,7 @@ module top_darjeeling #(
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[0]),
       .sram_otp_key_i(otp_ctrl_sram_otp_key_rsp[0]),
-      .cfg_i(ast_ram_1p_cfg),
+      .cfg_i(sram_ctrl_main_ram_1p_cfg_i),
       .cfg_rsp_o(sram_ctrl_main_ram_1p_cfg_rsp_o),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .lc_hw_debug_en_i(lc_ctrl_lc_hw_debug_en),
@@ -2075,7 +2078,7 @@ module top_darjeeling #(
       // Inter-module signals
       .sram_otp_key_o(otp_ctrl_sram_otp_key_req[2]),
       .sram_otp_key_i(otp_ctrl_sram_otp_key_rsp[2]),
-      .cfg_i(ast_ram_1p_cfg),
+      .cfg_i(sram_ctrl_mbox_ram_1p_cfg_i),
       .cfg_rsp_o(sram_ctrl_mbox_ram_1p_cfg_rsp_o),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .lc_hw_debug_en_i(lc_ctrl_pkg::Off),
@@ -2540,9 +2543,9 @@ module top_darjeeling #(
 
       // Inter-module signals
       .rst_cpu_n_o(),
-      .ram_cfg_icache_tag_i(ast_ram_1p_cfg),
+      .ram_cfg_icache_tag_i(rv_core_ibex_icache_tag_ram_1p_cfg_i),
       .ram_cfg_rsp_icache_tag_o(rv_core_ibex_icache_tag_ram_1p_cfg_rsp_o),
-      .ram_cfg_icache_data_i(ast_ram_1p_cfg),
+      .ram_cfg_icache_data_i(rv_core_ibex_icache_data_ram_1p_cfg_i),
       .ram_cfg_rsp_icache_data_o(rv_core_ibex_icache_data_ram_1p_cfg_rsp_o),
       .hart_id_i(rv_core_ibex_hart_id),
       .boot_addr_i(rv_core_ibex_boot_addr),


### PR DESCRIPTION
This allows to route differnt config parameters to different RAM instances.