### PR TITLE
Updated bazel target to include silicon test

### DIFF
--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -123,6 +123,7 @@ opentitan_test(
     name = "aes_interrupt_encryption_test",
     srcs = ["aes_interrupt_encryption_test.c"],
     exec_env = dicts.add(
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
         {
             "//hw/top_earlgrey:sim_verilator": None,
             "//hw/top_earlgrey:fpga_cw340_sival": None,


### PR DESCRIPTION
Signed-off-by: Ramesh Prakash <rprakas@google.com>
Updated bazel target to include silicon tests for aes_interrupt_encryption tests