### PR TITLE
[prim_generic] Depend on the tech ram_pkg within the tech lib

### DIFF
--- a/hw/ip/prim_generic/prim_generic_ram_1p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_1p.core
@@ -9,7 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:ram_1p_pkg
+      - lowrisc:prim_generic:ram_1p_pkg
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_ram_1p.sv

--- a/hw/ip/prim_generic/prim_generic_ram_1r1w.core
+++ b/hw/ip/prim_generic/prim_generic_ram_1r1w.core
@@ -9,7 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:ram_2p_pkg
+      - lowrisc:prim_generic:ram_2p_pkg
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_ram_1r1w.sv

--- a/hw/ip/prim_generic/prim_generic_ram_2p.core
+++ b/hw/ip/prim_generic/prim_generic_ram_2p.core
@@ -9,7 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:ram_2p_pkg
+      - lowrisc:prim_generic:ram_2p_pkg
       - lowrisc:prim:util_memload
     files:
       - rtl/prim_generic_ram_2p.sv

--- a/hw/ip/prim_xilinx/prim_xilinx_ram_1p.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_ram_1p.core
@@ -9,7 +9,6 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
-      - lowrisc:prim:ram_1p_pkg
       # Note that prim_xilinx_pkg is a virtual core that the top should provide.
       # It maps parameters to instructions for how to split memories into
       # logical groups of bits. See prim_xilinx_default_pkg for an example.


### PR DESCRIPTION
For generic usages, i.e.g, when using a ram_pkg in spi_device or in i2c, we rely on the fusesoc resolving skills. Once the virtual cors PR is merged, this gets explicitly set in the top-level core file.