### PR TITLE
[hw,entropy_src,rtl] Move RNG_BUS_WIDTH from entropy_src to top_pkg

### DIFF
--- a/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent_pkg.sv
+++ b/hw/dv/sv/entropy_src_xht_agent/entropy_src_xht_agent_pkg.sv
@@ -9,6 +9,10 @@ package entropy_src_xht_agent_pkg;
   import dv_lib_pkg::*;
   import entropy_src_pkg::*;
 
+  // TODO(#25760): Make the RNG BUS WIDTH parameter overwritable from the outside to allow
+  // testing other configs than the Earlgrey config
+  parameter uint RNG_BUS_WIDTH = 4;
+
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -23,6 +23,10 @@ package entropy_src_env_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // TODO(#25760): Make the RNG BUS WIDTH parameter overwritable from the outside to allow
+  // testing other configs than the Earlgrey config
+  parameter uint              RNG_BUS_WIDTH = 4;
+
   // parameters
   parameter bit [TL_DW-1:0]   INCR_ENTROPY_LO    = 32'h76543210;
   parameter bit [TL_DW-1:0]   INCR_ENTROPY_HI    = 32'hfedcba98;

--- a/hw/ip/entropy_src/entropy_src_pkg.core
+++ b/hw/ip/entropy_src/entropy_src_pkg.core
@@ -7,6 +7,8 @@ description: "entropy_src_pkg"
 
 filesets:
   files_rtl:
+    depend:
+     - lowrisc:constants:top_pkg
     files:
       - rtl/entropy_src_pkg.sv
     file_type: systemVerilogSource

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -3128,7 +3128,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic [63:0] rng_valid_bit_cnt_d, rng_valid_bit_cnt_q;
   assign rng_valid_bit_cnt_d = entropy_src_rng_i.rng_valid && es_enable_fo[5] &&
                                es_delayed_enable_q ?
-                               rng_valid_bit_cnt_q + RNG_BUS_WIDTH :
+                               rng_valid_bit_cnt_q + top_pkg::RNG_BUS_WIDTH :
                                rng_valid_bit_cnt_q;
 
   // Count number of bits pushed into esrng FIFO (RngBusWidth wide).

--- a/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
@@ -9,7 +9,6 @@ package entropy_src_pkg;
   // Entropy Interface
   //-------------------------
 
-  parameter int  RNG_BUS_WIDTH   = 4;
   parameter int  CSRNG_BUS_WIDTH = 384;
   parameter int  FIPS_BUS_WIDTH  = 1;
   parameter int  FIPS_CSRNG_BUS_WIDTH = FIPS_BUS_WIDTH + CSRNG_BUS_WIDTH;
@@ -51,7 +50,7 @@ package entropy_src_pkg;
 
   typedef struct packed {
     logic rng_valid;
-    logic [RNG_BUS_WIDTH-1:0] rng_b;
+    logic [top_pkg::RNG_BUS_WIDTH-1:0] rng_b;
   } entropy_src_rng_rsp_t;
 
   parameter entropy_src_rng_req_t ENTROPY_SRC_RNG_REQ_DEFAULT = '{default: '0};
@@ -59,7 +58,7 @@ package entropy_src_pkg;
 
   // external health test i/f
   typedef struct packed {
-    logic [RNG_BUS_WIDTH-1:0] entropy_bit;
+    logic [top_pkg::RNG_BUS_WIDTH-1:0] entropy_bit;
     logic entropy_bit_valid;
     logic rng_bit_en;
     logic [1:0] rng_bit_sel;

--- a/hw/top_darjeeling/rtl/top_pkg.sv
+++ b/hw/top_darjeeling/rtl/top_pkg.sv
@@ -13,6 +13,10 @@ localparam int TL_DUW=14;   // d_user
 localparam int TL_DBW=(TL_DW>>3);
 localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
 
+// Datapath width from the entropy source IP to the actual source of randomness.
+// This parameter is top-specific and depends on the actully used source of randomness.
+parameter int RNG_BUS_WIDTH = 16;
+
 // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
 // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR
 // PRODUCTION DEVICES.

--- a/hw/top_earlgrey/rtl/top_pkg.sv
+++ b/hw/top_earlgrey/rtl/top_pkg.sv
@@ -14,6 +14,10 @@ localparam int TL_DUW=14;   // d_user
 localparam int TL_DBW=(TL_DW>>3);
 localparam int TL_SZW=$clog2($clog2(TL_DBW)+1);
 
+// Datapath width from the entropy source IP to the actual source of randomness.
+// This parameter is top-specific and depends on the actully used source of randomness.
+parameter int RNG_BUS_WIDTH = 4;
+
 // NOTE THAT THIS IS A FEATURE FOR TEST CHIPS ONLY TO MITIGATE
 // THE RISK OF A BROKEN OTP MACRO. THIS WILL BE DISABLED FOR
 // PRODUCTION DEVICES.


### PR DESCRIPTION
This allows Tops to configure that parameter for their needs. Depending on the used source of of randomness, the bus width to that IP might be different.