### PR TITLE
[entropy_src/rtl] Fix reg reference and default value for stubbed impl

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -209,8 +209,7 @@ module entropy_src
       stub_hw2reg.fw_ov_rd_data.d = stub_lfsr_value[31:0];
       stub_hw2reg.entropy_data.d = stub_lfsr_value[31:0];
       stub_hw2reg.debug_status.main_sm_idle.d = 1'b1;
-      // need to move this to package so that it can be referenced
-      stub_hw2reg.debug_status.main_sm_state.d = 8'b01110110;
+      stub_hw2reg.main_sm_state.d = entropy_src_main_sm_pkg::Idle;
 
       stub_hw2reg.intr_state.es_entropy_valid.de = stub_es_valid;
       stub_hw2reg.intr_state.es_entropy_valid.d = 1'b1;


### PR DESCRIPTION
We currently don't use the stubbing anywhere in the codebase but some lint tools tend to flag issues despite the corresponding parameter being disabled.

This resolves lowRISC/OpenTitan#24231.