### PR TITLE
Add python-is-python3 apt to apt-requirements.txt

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -46,6 +46,7 @@ python3-pip
 python3-setuptools
 python3-urllib3
 python3-wheel
+python-is-python3
 srecord
 tree
 xmlstarlet


### PR DESCRIPTION
It turns out we actually depend on that but it's not installed by default on Ubuntu 22.04 LTS.