### PR TITLE
[aes/rtl] Avoid double import of aes_pkg inside aes_wrap.sv

### DIFF
--- a/hw/ip/aes/rtl/aes_wrap.sv
+++ b/hw/ip/aes/rtl/aes_wrap.sv
@@ -32,7 +32,6 @@ module aes_wrap
   localparam logic SIDELOAD = 1'b1;
   localparam aes_mode_e AES_MODE = AES_ECB;
 
-  import aes_pkg::*;
   import aes_reg_pkg::*;
   import tlul_pkg::*;
 


### PR DESCRIPTION
The aes_pkg is already imported in the port declaration.

We don't use the aes_wrap.sv file (it's sole purpose is/was to enable simulation-based FI experiments), some lint tools flag this.