### PR TITLE
[crypto] Fix the KMAC-KDF implementation to return the output in shares.

### DIFF
--- a/sw/device/lib/crypto/drivers/kmac.h
+++ b/sw/device/lib/crypto/drivers/kmac.h
@@ -240,8 +240,12 @@ status_t kmac_cshake_256(const uint8_t *message, size_t message_len,
  * pointers must be correctly configured and `len` must match the key length.
  *
  * The caller must ensure that `digest_len` words are allocated at the location
- * pointed to by `digest`. `cust_str_len` must not exceed `kKmacCustStrMaxSize`.
+ * pointed to by `digest`. `cust_str_len` must not exceed
+ * `kKmacCustStrMaxSize`. If `masked_digest` is true, the `digest` buffer must
+ * have enough space for 2x `digest_len` words.
  *
+ * @param key The KMAC key.
+ * @param masked_digest Whether to return the digest in concatenated shares.
  * @param message The input message.
  * @param message_len The input message length in bytes.
  * @param cust_str The customization string.
@@ -251,10 +255,10 @@ status_t kmac_cshake_256(const uint8_t *message, size_t message_len,
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
-status_t kmac_kmac_128(kmac_blinded_key_t *key, const uint8_t *message,
-                       size_t message_len, const unsigned char *cust_str,
-                       size_t cust_str_len, uint32_t *digest,
-                       size_t digest_len);
+status_t kmac_kmac_128(kmac_blinded_key_t *key, hardened_bool_t masked_digest,
+                       const uint8_t *message, size_t message_len,
+                       const unsigned char *cust_str, size_t cust_str_len,
+                       uint32_t *digest, size_t digest_len);
 
 /**
  * Compute KMAC-256 in one-shot.
@@ -269,8 +273,12 @@ status_t kmac_kmac_128(kmac_blinded_key_t *key, const uint8_t *message,
  * pointers must be correctly configured and `len` must match the key length.
  *
  * The caller must ensure that `digest_len` words are allocated at the location
- * pointed to by `digest`. `cust_str_len` must not exceed `kKmacCustStrMaxSize`.
+ * pointed to by `digest`. `cust_str_len` must not exceed
+ * `kKmacCustStrMaxSize`. If `masked_digest` is true, the `digest` buffer must
+ * have enough space for 2x `digest_len` words.
  *
+ * @param key The KMAC key.
+ * @param masked_digest Whether to return the digest in concatenated shares.
  * @param message The input message.
  * @param message_len The input message length in bytes.
  * @param cust_str The customization string.
@@ -280,10 +288,10 @@ status_t kmac_kmac_128(kmac_blinded_key_t *key, const uint8_t *message,
  * @return Error status.
  */
 OT_WARN_UNUSED_RESULT
-status_t kmac_kmac_256(kmac_blinded_key_t *key, const uint8_t *message,
-                       size_t message_len, const unsigned char *cust_str,
-                       size_t cust_str_len, uint32_t *digest,
-                       size_t digest_len);
+status_t kmac_kmac_256(kmac_blinded_key_t *key, hardened_bool_t masked_digest,
+                       const uint8_t *message, size_t message_len,
+                       const unsigned char *cust_str, size_t cust_str_len,
+                       uint32_t *digest, size_t digest_len);
 
 #ifdef __cplusplus
 }

--- a/sw/device/lib/crypto/impl/kdf.c
+++ b/sw/device/lib/crypto/impl/kdf.c
@@ -291,10 +291,10 @@ otcrypto_status_t otcrypto_kdf_kmac(
     }
     // No need to further check key size against security level because
     // `kmac_key_length_check` ensures that the key is at least 128-bit.
-    HARDENED_TRY(kmac_kmac_128(&kmac_key, kdf_context.data, kdf_context.len,
-                               kdf_label.data, kdf_label.len,
-                               keying_material->keyblob,
-                               required_byte_len / sizeof(uint32_t)));
+    HARDENED_TRY(kmac_kmac_128(
+        &kmac_key, /*masked_digest=*/kHardenedBoolTrue, kdf_context.data,
+        kdf_context.len, kdf_label.data, kdf_label.len,
+        keying_material->keyblob, required_byte_len / sizeof(uint32_t)));
   } else if (kmac_mode == kOtcryptoKmacModeKmac256) {
     // Check if `key_mode` of the key derivation key matches `kmac_mode`.
     if (key_derivation_key.config.key_mode != kOtcryptoKeyModeKdfKmac256) {
@@ -305,10 +305,10 @@ otcrypto_status_t otcrypto_kdf_kmac(
     if (key_derivation_key.config.key_length < 256 / 8) {
       return OTCRYPTO_BAD_ARGS;
     }
-    HARDENED_TRY(kmac_kmac_256(&kmac_key, kdf_context.data, kdf_context.len,
-                               kdf_label.data, kdf_label.len,
-                               keying_material->keyblob,
-                               required_byte_len / sizeof(uint32_t)));
+    HARDENED_TRY(kmac_kmac_256(
+        &kmac_key, /*masked_digest=*/kHardenedBoolTrue, kdf_context.data,
+        kdf_context.len, kdf_label.data, kdf_label.len,
+        keying_material->keyblob, required_byte_len / sizeof(uint32_t)));
   } else {
     return OTCRYPTO_BAD_ARGS;
   }

--- a/sw/device/lib/crypto/impl/mac.c
+++ b/sw/device/lib/crypto/impl/mac.c
@@ -279,9 +279,10 @@ otcrypto_status_t otcrypto_kmac(const otcrypto_blinded_key_t *key,
       if (key->config.key_mode != kOtcryptoKeyModeKmac128) {
         return OTCRYPTO_BAD_ARGS;
       }
-      HARDENED_TRY(kmac_kmac_128(&kmac_key, input_message.data,
-                                 input_message.len, customization_string.data,
-                                 customization_string.len, tag.data, tag.len));
+      HARDENED_TRY(kmac_kmac_128(
+          &kmac_key, /*masked_digest=*/kHardenedBoolFalse, input_message.data,
+          input_message.len, customization_string.data,
+          customization_string.len, tag.data, tag.len));
       break;
     case kOtcryptoKmacModeKmac256:
       // Check `key_mode` matches `mac_mode`
@@ -289,9 +290,10 @@ otcrypto_status_t otcrypto_kmac(const otcrypto_blinded_key_t *key,
         return OTCRYPTO_BAD_ARGS;
       }
 
-      HARDENED_TRY(kmac_kmac_256(&kmac_key, input_message.data,
-                                 input_message.len, customization_string.data,
-                                 customization_string.len, tag.data, tag.len));
+      HARDENED_TRY(kmac_kmac_256(
+          &kmac_key, /*masked_digest=*/kHardenedBoolFalse, input_message.data,
+          input_message.len, customization_string.data,
+          customization_string.len, tag.data, tag.len));
       break;
     default:
       return OTCRYPTO_BAD_ARGS;

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -468,6 +468,7 @@ opentitan_test(
         "//sw/device/lib/crypto/drivers:kmac",
         "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:kdf",
+        "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/crypto/impl:mac",
         "//sw/device/lib/testing/test_framework:check",
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/crypto/kdf_set_testvectors.py
+++ b/sw/device/tests/crypto/kdf_set_testvectors.py
@@ -69,7 +69,6 @@ def main() -> int:
         t["key_derivation_key"] = t["key"]
         t["context"] = t["input_msg"]
         t["label"] = t["cust_str"]
-        t["keying_material"] = t["digest"]
 
         if t["security_str"] == 128:
             t["test_operation"] = "kKdfTestOperationKmac128"
@@ -85,8 +84,7 @@ def main() -> int:
         t["keyblob"] += ["0x00000000"] * len(t["keyblob"])
 
         # Derived key material also needs to have word granularity
-        t["km_keyblob"] = str_to_hex_array(t["keying_material"], return_byte_array = False)
-        t["km_keyblob"] += ["0x00000000"] * len(t["km_keyblob"])
+        t["expected_output"] = str_to_hex_array(t["digest"], return_byte_array = False)
 
     args.headerfile.write(Template(args.template.read()).render(tests=testvecs))
     args.headerfile.close()

--- a/sw/device/tests/crypto/kdf_testvectors.h.tpl
+++ b/sw/device/tests/crypto/kdf_testvectors.h.tpl
@@ -30,7 +30,7 @@ typedef struct kdf_test_vector {
   otcrypto_blinded_key_t key_derivation_key;
   otcrypto_const_byte_buf_t label;
   otcrypto_const_byte_buf_t context;
-  otcrypto_blinded_key_t keying_material;
+  otcrypto_word32_buf_t expected_output;
 } kdf_kmac_test_vector_t;
 
 static kdf_kmac_test_vector_t kKdfTestVectors[${len(tests)}] = {
@@ -78,15 +78,11 @@ static kdf_kmac_test_vector_t kKdfTestVectors[${len(tests)}] = {
             .len = 0,
   % endif
         },
-        .keying_material = {
-            .config = {
-                .key_length = ${2 * len(t["km_keyblob"])},
-                .hw_backed = kHardenedBoolFalse,
-            },
-            .keyblob_length = ${4 * len(t["km_keyblob"])},
-            .keyblob = (uint32_t[]){
-      % for i in range(0, len(t["km_keyblob"]), 4):
-                ${', '.join(t["km_keyblob"][i:i + 4])},
+        .expected_output = {
+            .len = ${len(t["expected_output"])},
+            .data = (uint32_t[]){
+      % for i in range(0, len(t["expected_output"]), 4):
+                ${', '.join(t["expected_output"][i:i + 4])},
       % endfor
             },
         },


### PR DESCRIPTION
Previously, the KMAC driver always unmasked the shares of the digest returned by the KMAC block. This is OK for hash functions like SHA-3, but problematic for KMAC-KDF where the output is key material. The implementation also did not modify the second half of the keyblob buffer in KMAC-KDF, which would actually cause correctness issues if those values were not initialized to zero.

This commit refactors the KMAC driver to allow returning the digest in masked form, and adjusts KMAC-KDF to use this new capability.

While I was messing with this code anyway, I also made a small tweak to the way that KMAC-KDF test vectors are formed; the previous setup defined the expected output as a full blinded key struct with most of the fields uninitialized, but this is unnecessary and confusing in my opinion given all we care about is the unmasked value. I changed it to a simple word buffer.