### PR TITLE
[darjeeling] Feed I2C RAM config to toplevel interface

### DIFF
--- a/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
+++ b/hw/top_darjeeling/data/autogen/top_darjeeling.gen.hjson
@@ -906,6 +906,10 @@
           act: rcv
           width: 1
           inst_name: i2c0
+          default: ""
+          external: true
+          top_signame: i2c_ram_1p_cfg
+          conn_type: false
           index: -1
         }
         {
@@ -10284,6 +10288,7 @@
       ast.lc_hw_debug_en: ""
       ast.obs_ctrl: obs_ctrl
       ast.rom_cfg: rom_cfg
+      i2c0.ram_cfg: i2c_ram_1p_cfg
       i2c0.ram_cfg_rsp: i2c_ram_1p_cfg_rsp
       sram_ctrl_ret_aon.cfg: sram_ctrl_ret_aon_ram_1p_cfg
       sram_ctrl_ret_aon.cfg_rsp: sram_ctrl_ret_aon_ram_1p_cfg_rsp
@@ -18650,6 +18655,10 @@
         act: rcv
         width: 1
         inst_name: i2c0
+        default: ""
+        external: true
+        top_signame: i2c_ram_1p_cfg
+        conn_type: false
         index: -1
       }
       {
@@ -24839,6 +24848,18 @@
         conn_type: true
         index: -1
         netname: ast_rom_cfg
+      }
+      {
+        package: prim_ram_1p_pkg
+        struct: ram_1p_cfg
+        signame: i2c_ram_1p_cfg_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: i2c_ram_1p_cfg
       }
       {
         package: prim_ram_1p_pkg

--- a/hw/top_darjeeling/data/top_darjeeling.hjson
+++ b/hw/top_darjeeling/data/top_darjeeling.hjson
@@ -1285,6 +1285,7 @@
         'ast.lc_hw_debug_en'                   : '',
         'ast.obs_ctrl'                         : 'obs_ctrl',
         'ast.rom_cfg'                          : 'rom_cfg',
+        'i2c0.ram_cfg'                         : 'i2c_ram_1p_cfg',
         'i2c0.ram_cfg_rsp'                     : 'i2c_ram_1p_cfg_rsp',
         'sram_ctrl_ret_aon.cfg'                : 'sram_ctrl_ret_aon_ram_1p_cfg',
         'sram_ctrl_ret_aon.cfg_rsp'            : 'sram_ctrl_ret_aon_ram_1p_cfg_rsp',

--- a/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
+++ b/hw/top_darjeeling/rtl/autogen/top_darjeeling.sv
@@ -170,6 +170,7 @@ module top_darjeeling #(
   output lc_ctrl_pkg::lc_tx_t       ast_lc_hw_debug_en_o,
   input  ast_pkg::ast_obs_ctrl_t       obs_ctrl_i,
   input  prim_rom_pkg::rom_cfg_t       rom_cfg_i,
+  input  prim_ram_1p_pkg::ram_1p_cfg_t       i2c_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t       i2c_ram_1p_cfg_rsp_o,
   input  prim_ram_1p_pkg::ram_1p_cfg_t [SramCtrlRetAonNumRamInst-1:0] sram_ctrl_ret_aon_ram_1p_cfg_i,
   output prim_ram_1p_pkg::ram_1p_cfg_rsp_t [SramCtrlRetAonNumRamInst-1:0] sram_ctrl_ret_aon_ram_1p_cfg_rsp_o,
@@ -1118,7 +1119,7 @@ module top_darjeeling #(
       .alert_rx_i  ( alert_rx[3:3] ),
 
       // Inter-module signals
-      .ram_cfg_i(prim_ram_1p_pkg::RAM_1P_CFG_DEFAULT),
+      .ram_cfg_i(i2c_ram_1p_cfg_i),
       .ram_cfg_rsp_o(i2c_ram_1p_cfg_rsp_o),
       .lsio_trigger_o(i2c0_lsio_trigger),
       .tl_i(i2c0_tl_req),


### PR DESCRIPTION
For completion, also include the I2C ram config interface to the top-level interface of darjeeling.