### PR TITLE
[multitop] Add better support for linker scripts (templating)

### DIFF
--- a/hw/top/defs.bzl
+++ b/hw/top/defs.bzl
@@ -52,3 +52,40 @@ def opentitan_require_ip(ip):
     )
     """
     return opentitan_if_ip(ip, [], ["@platforms//:incompatible"])
+
+def opentitan_select_top(values, default):
+    """
+    Select a value based on the top. If not top matches, a default
+    value is returned. The values must be a dictionary where each key
+    is either a string, or an array of string.
+
+    Example:
+    alias(
+      name = "my_alias",
+      actual = opentitan_select_top({
+        "earlgrey": "//something:earlgrey",
+        ["english_breakfast", "darjeeling"]: "//something:else",
+      }, "//something:error")
+    )
+    """
+    branches = {}
+    for (tops, value) in values.items():
+        if type(tops) == "string":
+            tops = [tops]
+        for top in tops:
+            branches["//hw/top:is_{}".format(top)] = value
+    branches["//conditions:default"] = default
+    return select(branches)
+
+def opentitan_require_top(top):
+    """
+    Return a value that can be used with `target_compatible_with` to
+    express that this target only works on the requested top.
+
+    Example:
+    cc_library(
+      name = "my_library",
+      target_compatible_with = opentitan_require_top("darjeeling"),
+    )
+    """
+    return opentitan_select_top({top: []}, ["@platforms//:incompatible"])

--- a/rules/linker.bzl
+++ b/rules/linker.bzl
@@ -5,7 +5,23 @@
 """Rules for declaring linker scripts and linker script fragments."""
 
 def _ld_library_impl(ctx):
-    files = []
+    substitutions = {
+        key: ctx.expand_location(subst)
+        for (key, subst) in ctx.attr.substitutions.items()
+    }
+
+    def get_file(f):
+        if ctx.attr.substitutions == {}:
+            return f
+        fout = ctx.actions.declare_file(ctx.label.name + "_" + f.basename)
+        ctx.actions.expand_template(
+            template = f,
+            output = fout,
+            substitutions = substitutions,
+        )
+        return fout
+
+    files = [get_file(f) for f in ctx.files.includes]
     user_link_flags = []
 
     # Disable non-volatile scratch region and counters if building for english
@@ -20,20 +36,21 @@ def _ld_library_impl(ctx):
             "-Wl,-nmagic",
         ]
 
-    if ctx.files.includes:
-        files += ctx.files.includes
-        user_link_flags += [
-            "-Wl,-L,{}".format(include.dirname)
-            for include in ctx.files.includes
-        ]
+    user_link_flags += [
+        "-Wl,-L,{}".format(include.dirname)
+        for include in files
+    ]
 
     if ctx.file.script:
-        files += ctx.files.script
+        files.append(get_file(ctx.file.script))
         user_link_flags += [
-            "-Wl,-T,{}".format(ctx.file.script.path),
+            "-Wl,-T,{}".format(files[-1].path),
         ]
 
     return [
+        DefaultInfo(
+            files = depset(files),
+        ),
         cc_common.merge_cc_infos(
             direct_cc_infos = [CcInfo(
                 linking_context = cc_common.create_linking_context(
@@ -64,6 +81,10 @@ ld_library = rule(
     alignment for segments and not to include the headers in the first segment
     (this is the -nmagic option of GNU ld). See https://reviews.llvm.org/D61201
     for more details.
+
+    If the substitution dictionary is not empty, the content of the file will
+    be expanded using bazel's `actions.expand_template`. If some substitutions
+    refer to label not present in `deps`, they need to be added to `subst_deps`.
     """,
     attrs = {
         "script": attr.label(allow_single_file = True),
@@ -78,5 +99,7 @@ ld_library = rule(
         "non_page_aligned_segments": attr.bool(
             default = False,
         ),
+        "substitutions": attr.string_dict(),
+        "subst_deps": attr.label_list(),
     },
 )

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -84,6 +84,7 @@ cc_library(
 
 OTTF_REGION_ALIAS = opentitan_select_top(
     {
+        "darjeeling": {"@@OTTF_REGION_ALIAS@@": "ctn"},
     },
     # Default configuration:
     {"@@OTTF_REGION_ALIAS@@": "eflash"},

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -13,6 +13,7 @@ load(
     "verilator_params",
 )
 load("//rules:linker.bzl", "ld_library")
+load("//hw/top:defs.bzl", "opentitan_select_top")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 package(default_visibility = ["//visibility:public"])
@@ -81,9 +82,17 @@ cc_library(
     ],
 )
 
+OTTF_REGION_ALIAS = opentitan_select_top(
+    {
+    },
+    # Default configuration:
+    {"@@OTTF_REGION_ALIAS@@": "eflash"},
+)
+
 ld_library(
     name = "ottf_ld_common",
     includes = ["ottf_common.ld"],
+    substitutions = OTTF_REGION_ALIAS,
     deps = [
         "//sw/device:info_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",
@@ -91,56 +100,80 @@ ld_library(
 )
 
 ld_library(
+    name = "ottf_ld_region_alias",
+    includes = ["ottf_region_alias.ld"],
+    substitutions = OTTF_REGION_ALIAS,
+)
+
+COMMON_LINKER_SUBST = {
+    "@@TOP_MEMORY_LD@@": "$(location //hw/top:top_ld)",
+    "@@OTTF_LD_ALIAS@@": "$(location :ottf_ld_region_alias)",
+    "@@OTTF_LD_COMMON@@": "$(location :ottf_ld_common)",
+}
+
+ld_library(
     name = "ottf_ld_silicon_creator_slot_a",
     script = "ottf_silicon_creator_a.ld",
+    substitutions = COMMON_LINKER_SUBST,
     deps = [
         ":ottf_ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        ":ottf_ld_region_alias",
+        "//hw/top:top_ld",
     ],
 )
 
 ld_library(
     name = "ottf_ld_silicon_creator_slot_b",
     script = "ottf_silicon_creator_b.ld",
+    substitutions = COMMON_LINKER_SUBST,
     deps = [
         ":ottf_ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        ":ottf_ld_region_alias",
+        "//hw/top:top_ld",
     ],
 )
 
 ld_library(
     name = "ottf_ld_silicon_creator_slot_virtual",
     script = "ottf_silicon_creator_virtual.ld",
+    substitutions = COMMON_LINKER_SUBST | OTTF_REGION_ALIAS,
     deps = [
         ":ottf_ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        ":ottf_ld_region_alias",
+        "//hw/top:top_ld",
     ],
 )
 
 ld_library(
     name = "ottf_ld_silicon_owner_slot_a",
     script = "ottf_silicon_owner_a.ld",
+    substitutions = COMMON_LINKER_SUBST,
     deps = [
         ":ottf_ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        ":ottf_ld_region_alias",
+        "//hw/top:top_ld",
     ],
 )
 
 ld_library(
     name = "ottf_ld_silicon_owner_slot_b",
     script = "ottf_silicon_owner_b.ld",
+    substitutions = COMMON_LINKER_SUBST,
     deps = [
         ":ottf_ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        ":ottf_ld_region_alias",
+        "//hw/top:top_ld",
     ],
 )
 
 ld_library(
     name = "ottf_ld_silicon_owner_slot_virtual",
     script = "ottf_silicon_owner_virtual.ld",
+    substitutions = COMMON_LINKER_SUBST | OTTF_REGION_ALIAS,
     deps = [
         ":ottf_ld_common",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        ":ottf_ld_region_alias",
+        "//hw/top:top_ld",
     ],
 )
 

--- a/sw/device/lib/testing/test_framework/ottf_common.ld
+++ b/sw/device/lib/testing/test_framework/ottf_common.ld
@@ -53,9 +53,9 @@ _manifest_entry_point = _ottf_start - _ottf_start_address;
  * the flash region.  Otherwise, the value kHardenedBoolTrue (0x739) is
  * selected.
  */
-_manifest_address_translation = (_text_start >= ORIGIN(eflash) &&
-                                 _text_start < (ORIGIN(eflash)
-                                              + LENGTH(eflash))) ? 0x1d4 : 0x739;
+_manifest_address_translation = (_text_start >= ORIGIN(@@OTTF_REGION_ALIAS@@) &&
+                                 _text_start < (ORIGIN(@@OTTF_REGION_ALIAS@@)
+                                              + LENGTH(@@OTTF_REGION_ALIAS@@))) ? 0x1d4 : 0x739;
 
 PHDRS {
   static_critical_segment PT_LOAD;

--- a/sw/device/lib/testing/test_framework/ottf_region_alias.ld
+++ b/sw/device/lib/testing/test_framework/ottf_region_alias.ld
@@ -1,0 +1,5 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+REGION_ALIAS("ottf_flash", @@OTTF_REGION_ALIAS@@)

--- a/sw/device/lib/testing/test_framework/ottf_silicon_creator_a.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_creator_a.ld
@@ -10,15 +10,14 @@
  * This linker script generates a binary to run rom.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE @@TOP_MEMORY_LD@@
+INCLUDE @@OTTF_LD_ALIAS@@
 
 /**
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the Silicon Creator boot stage in slot A.
  */
-_ottf_size = LENGTH(eflash) / 2;
-_ottf_start_address = ORIGIN(eflash);
+_ottf_size = LENGTH(ottf_flash) / 2;
+_ottf_start_address = ORIGIN(ottf_flash);
 
-REGION_ALIAS("ottf_flash", eflash);
-
-INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld
+INCLUDE @@OTTF_LD_COMMON@@

--- a/sw/device/lib/testing/test_framework/ottf_silicon_creator_b.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_creator_b.ld
@@ -10,15 +10,14 @@
  * This linker script generates a binary to run rom.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE @@TOP_MEMORY_LD@@
+INCLUDE @@OTTF_LD_ALIAS@@
 
 /**
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the Silicon Creator boot stage in slot B.
  */
-_ottf_size = LENGTH(eflash) / 2;
-_ottf_start_address = ORIGIN(eflash) + _ottf_size;
+_ottf_size = LENGTH(ottf_flash) / 2;
+_ottf_start_address = ORIGIN(ottf_flash) + _ottf_size;
 
-REGION_ALIAS("ottf_flash", eflash);
-
-INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld
+INCLUDE @@OTTF_LD_COMMON@@

--- a/sw/device/lib/testing/test_framework/ottf_silicon_creator_virtual.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_creator_virtual.ld
@@ -10,15 +10,15 @@
  * This linker script generates a binary to run rom.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE @@TOP_MEMORY_LD@@
 
 /**
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the Silicon Creator boot stage in the virtual slot.
  */
-_ottf_start_address = ORIGIN(rom_ext_virtual);
-_ottf_size = LENGTH(rom_ext_virtual);
+_ottf_start_address = ORIGIN(@@OTTF_REGION_ALIAS@@);
+_ottf_size = LENGTH(@@OTTF_REGION_ALIAS@@);
 
 REGION_ALIAS("ottf_flash", rom_ext_virtual);
 
-INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld
+INCLUDE @@OTTF_LD_COMMON@@

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_a.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_a.ld
@@ -10,16 +10,15 @@
  * This linker script generates a binary to run BL0 tests.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE @@TOP_MEMORY_LD@@
+INCLUDE @@OTTF_LD_ALIAS@@
 
 /**
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the BL0 boot stage in slot A.
  */
 /* TODO(#9045): Move ROM_EXT size to a common location. */
-_ottf_size = (LENGTH(eflash) / 2) - 0x10000;
-_ottf_start_address = ORIGIN(eflash) + 0x10000;
+_ottf_size = (LENGTH(ottf_flash) / 2) - 0x10000;
+_ottf_start_address = ORIGIN(ottf_flash) + 0x10000;
 
-REGION_ALIAS("ottf_flash", eflash);
-
-INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld
+INCLUDE @@OTTF_LD_COMMON@@

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_b.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_b.ld
@@ -10,16 +10,15 @@
  * This linker script generates a binary to run BL0 tests.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE @@TOP_MEMORY_LD@@
+INCLUDE @@OTTF_LD_ALIAS@@
 
 /**
  * Symbols to be used in the setup of the address translation for the OTTF run
  * at the BL0 boot stage in slot B.
  */
 /* TODO(#9045): Move ROM_EXT size to a common location. */
-_ottf_size = (LENGTH(eflash) / 2) - 0x10000;
-_ottf_start_address = ORIGIN(eflash) + (LENGTH(eflash) / 2) + 0x10000;
+_ottf_size = (LENGTH(ottf_flash) / 2) - 0x10000;
+_ottf_start_address = ORIGIN(ottf_flash) + (LENGTH(ottf_flash) / 2) + 0x10000;
 
-REGION_ALIAS("ottf_flash", eflash);
-
-INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld
+INCLUDE @@OTTF_LD_COMMON@@

--- a/sw/device/lib/testing/test_framework/ottf_silicon_owner_virtual.ld
+++ b/sw/device/lib/testing/test_framework/ottf_silicon_owner_virtual.ld
@@ -10,7 +10,7 @@
  * This linker script generates a binary to run BL0 tests.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE @@TOP_MEMORY_LD@@
 
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
@@ -18,9 +18,9 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
 /* TODO(#9045): Move BL0 size to a common location. */
 _ottf_size = LENGTH(owner_virtual) - 64K;
 _ottf_start_address = ORIGIN(owner_virtual) + 64K;
-ASSERT((_ottf_size <= (LENGTH(eflash) / 2)),
+ASSERT((_ottf_size <= (LENGTH(@@OTTF_REGION_ALIAS@@) / 2)),
   "Error: BL0 flash is bigger than slot.");
 
 REGION_ALIAS("ottf_flash", owner_virtual);
 
-INCLUDE sw/device/lib/testing/test_framework/ottf_common.ld
+INCLUDE @@OTTF_LD_COMMON@@

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//hw/top:defs.bzl", "opentitan_if_ip", "opentitan_select_top")
 load(
     "//rules/opentitan:defs.bzl",
     "OPENTITAN_CPU",
@@ -18,8 +19,19 @@ package(default_visibility = ["//visibility:public"])
 ld_library(
     name = "linker_script",
     script = "test_rom.ld",
+    substitutions = {
+        "@@TOP_MEMORY_LD@@": "$(location //hw/top:top_ld)",
+    } | opentitan_select_top(
+        {
+        },
+        # Default configuration:
+        {
+            "@@TEST_ROM_REGION@@": "rom",
+            "@@TEST_CODE_REGION@@": "eflash",
+        },
+    ),
     deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+        "//hw/top:top_ld",
         "//sw/device:info_sections",
         "//sw/device/silicon_creator/lib/base:static_critical_sections",
     ],

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -23,6 +23,10 @@ ld_library(
         "@@TOP_MEMORY_LD@@": "$(location //hw/top:top_ld)",
     } | opentitan_select_top(
         {
+            "darjeeling": {
+                "@@TEST_ROM_REGION@@": "rom0",
+                "@@TEST_CODE_REGION@@": "ctn",
+            },
         },
         # Default configuration:
         {

--- a/sw/device/lib/testing/test_rom/test_rom.ld
+++ b/sw/device/lib/testing/test_rom/test_rom.ld
@@ -15,24 +15,26 @@ OUTPUT_ARCH(riscv)
  */
 __DYNAMIC = 0;
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+INCLUDE @@TOP_MEMORY_LD@@
+
+REGION_ALIAS("test_rom", @@TEST_ROM_REGION@@)
 
 /**
  * The boot address, which indicates the location of the initial interrupt
  * vector.
  */
-_boot_address = ORIGIN(rom);
+_boot_address = ORIGIN(test_rom);
 
 /**
  * Symbols to be used in the setup of the address translation for ROM_EXT.
  */
 _rom_ext_virtual_start_address = ORIGIN(rom_ext_virtual);
 _rom_ext_virtual_size = LENGTH(rom_ext_virtual);
-ASSERT((_rom_ext_virtual_size <= (LENGTH(eflash) / 2)),
+ASSERT((_rom_ext_virtual_size <= (LENGTH(@@TEST_CODE_REGION@@) / 2)),
   "Error: rom ext flash is bigger than slot.");
 
 _rom_digest_size = 32;
-_chip_info_start = ORIGIN(rom) + LENGTH(rom) - _rom_digest_size - _chip_info_size;
+_chip_info_start = ORIGIN(test_rom) + LENGTH(test_rom) - _rom_digest_size - _chip_info_size;
 
 /* DV Log offset (has to be different to other boot stages). */
 _dv_log_offset = 0x0;
@@ -57,14 +59,14 @@ SECTIONS {
    */
   .vectors _boot_address : ALIGN(4) {
     KEEP(*(.vectors))
-  } > rom
+  } > test_rom
 
   /**
    * C runtime (CRT) section, containing program initialization code.
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-  } > rom
+  } > test_rom
 
   /**
    * Standard text section, containing program code.
@@ -72,7 +74,7 @@ SECTIONS {
   .text : ALIGN(4) {
     *(.text)
     *(.text.*)
-  } > rom
+  } > test_rom
 
   /**
    * Read-only data section, containing all large compile-time constants, like
@@ -85,7 +87,7 @@ SECTIONS {
     *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
-  } > rom
+  } > test_rom
 
   /**
    * Critical static data that is accessible by both the ROM and the ROM
@@ -128,14 +130,14 @@ SECTIONS {
     /* This puts it in ram_main at runtime (for the VMA), but puts the section
      * into rom for load time (for the LMA). This is why `_data_init_*` uses
      * `LOADADDR`. */
-  } > ram_main AT> rom
+  } > ram_main AT> test_rom
 
   /**
    * Immutable chip_info data, containing build-time-recorded information.
    */
   .chip_info _chip_info_start : ALIGN(4) {
     KEEP(*(.chip_info))
-  } > rom
+  } > test_rom
 
   /**
    * Standard BSS section. This will be zeroed at runtime by the CRT.


### PR DESCRIPTION
Linker files are not preprocessed, which makes it hard to support several tops. In particular, including different files based on the top, or using a different region is very difficult. We currently have a semi-hack where we automatically include the directory of any `include`-ed file but it still requires that files have the same name which is not always the case.
    
The `ld_library` rule is modified to take a new substitution dictionary as input which is subject to location expansion. This allows for example to do in the linker script:
```
INCLUDE @@MYFILE@@
```
and then in the BUILD file:
```
ld_library(
  ...,
  substitutions = {
    "@@MYFILE@@": "$(location //path/to/my/file)",
  },
)
```
The rest of the commits add some substitutions for the ottf and test_rom, plus a final commit specifically for darjeeling.

Review commit by commit, skip the first which is a squashed version of #25580