### PR TITLE
[dv, base_reg] Adding a prediction flag to field and mask to reg

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -73,6 +73,21 @@ class dv_base_reg extends uvm_reg;
     `downcast(get_dv_base_reg_block, get_parent())
   endfunction
 
+  function uvm_reg_data_t get_predicted_mask();
+    uvm_reg_data_t mask = 0;
+    dv_base_reg_field fields_q[$];
+    this.get_dv_base_reg_fields(fields_q);
+
+    foreach (fields_q[i]) begin
+      if (fields_q[i].has_prediction) begin
+        for (int j = 0; j < fields_q[i].get_n_bits(); j++)
+          mask[j+fields_q[i].get_lsb_pos()] = 1'b1;
+      end
+    end
+
+    return mask;
+  endfunction
+
   // get_n_bits will return number of all the bits in the csr
   // while this function will return actual number of bits used in reg field
   function uint get_n_used_bits();

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -31,6 +31,9 @@ class dv_base_reg_field extends uvm_reg_field;
   // variable for shadowed coverage, which is only created when this is a shadowed reg
   local dv_base_shadowed_field_cov shadowed_cov;
 
+  // Set to 1 if prediction is intended to be carried out in the cip_base_scoreboard
+  bit has_prediction = 0;
+
   `uvm_object_utils(dv_base_reg_field)
   `uvm_object_new
 


### PR DESCRIPTION
The base scoreboard ignores register reads checks unless the prediction flag is set. The fields that are predicted in a given register can be then accessed via a mask in dv_base_reg