### PR TITLE
[ci] fix dependabot config and expand to Cargo and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,8 @@ updates:
       # Updates are scheduled at the beginning of the work week.
       interval: "weekly"
       day: "monday"
-      time: "02:00"
-      # US Pacific Time
-      timezone: "America/Los_Angeles"
+      time: "10:00"
+      timezone: "Etc/UTC"
     commit-message:
       prefix: "[dependabot]"
     # Ignore packages fetched from GitHub URLs.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,27 @@ updates:
       - dependency-name: "*chipwhisperer*"
     reviewers:
       - "lowRISC/ot-python-reviewers"
+
+  - package-ecosystem: "cargo"
+    directory: "/third_party/rust"
+    schedule:
+      # Updates are scheduled at the beginning of the work week.
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Etc/UTC"
+    commit-message:
+      prefix: "[dependabot]"
+    reviewers:
+      - "lowRISC/ot-rust-reviewers"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Updates are scheduled at the beginning of the work week.
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Etc/UTC"
+    commit-message:
+      prefix: "[dependabot]"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,10 @@ updates:
       timezone: "America/Los_Angeles"
     commit-message:
       prefix: "[dependabot]"
-      reviewers:
-        - "lowRISC/ot-python-reviewers"
     # Ignore packages fetched from GitHub URLs.
     ignore:
       - dependency-name: "*fusesoc*"
       - dependency-name: "*edalize*"
       - dependency-name: "*chipwhisperer*"
     reviewers:
-      - "timothytrippel"
+      - "lowRISC/ot-python-reviewers"


### PR DESCRIPTION
The additional `reviewers` field is preventing dependabot from running. Fix it, and also expand the scanned dependencies to Rust crates and GitHub Actions.