### PR TITLE
[hw,pinmux,rtl] Also gate assertions to signals related to strap sampling

### DIFF
--- a/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
+++ b/hw/ip_templates/pinmux/rtl/pinmux.sv.tpl
@@ -655,6 +655,7 @@ module pinmux
 
   `ASSERT_KNOWN(MioKnownO_A, mio_attr_o)
   `ASSERT_KNOWN(DioKnownO_A, dio_attr_o)
+% if enable_strap_sampling:
 
   `ASSERT_KNOWN(LcJtagTckKnown_A, lc_jtag_o.tck)
   `ASSERT_KNOWN(LcJtagTrstKnown_A, lc_jtag_o.trst_n)
@@ -669,6 +670,7 @@ module pinmux
   `ASSERT_KNOWN(DftJtagTmsKnown_A, dft_jtag_o.tms)
 
   `ASSERT_KNOWN(DftStrapsKnown_A, dft_strap_test_o)
+% endif
 
   // running on slow AON clock
   `ASSERT_KNOWN(AonWkupReqKnownO_A, pin_wkup_req_o, clk_aon_i, !rst_aon_ni)

--- a/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
+++ b/hw/top_darjeeling/ip_autogen/pinmux/rtl/pinmux.sv
@@ -480,20 +480,6 @@ module pinmux
   `ASSERT_KNOWN(MioKnownO_A, mio_attr_o)
   `ASSERT_KNOWN(DioKnownO_A, dio_attr_o)
 
-  `ASSERT_KNOWN(LcJtagTckKnown_A, lc_jtag_o.tck)
-  `ASSERT_KNOWN(LcJtagTrstKnown_A, lc_jtag_o.trst_n)
-  `ASSERT_KNOWN(LcJtagTmsKnown_A, lc_jtag_o.tms)
-
-  `ASSERT_KNOWN(RvJtagTckKnown_A, rv_jtag_o.tck)
-  `ASSERT_KNOWN(RvJtagTrstKnown_A, rv_jtag_o.trst_n)
-  `ASSERT_KNOWN(RvJtagTmsKnown_A, rv_jtag_o.tms)
-
-  `ASSERT_KNOWN(DftJtagTckKnown_A, dft_jtag_o.tck)
-  `ASSERT_KNOWN(DftJtagTrstKnown_A, dft_jtag_o.trst_n)
-  `ASSERT_KNOWN(DftJtagTmsKnown_A, dft_jtag_o.tms)
-
-  `ASSERT_KNOWN(DftStrapsKnown_A, dft_strap_test_o)
-
   // running on slow AON clock
   `ASSERT_KNOWN(AonWkupReqKnownO_A, pin_wkup_req_o, clk_aon_i, !rst_aon_ni)
 


### PR DESCRIPTION
These signals are only available when enabling strap sampling. If not, gate the assertions.