### PR TITLE
[topgen] Fix LPG Map for incoming alerts

### DIFF
--- a/hw/top_darjeeling/templates/toplevel.sv.tpl
+++ b/hw/top_darjeeling/templates/toplevel.sv.tpl
@@ -9,7 +9,7 @@ import topgen.lib as lib
 from reggen.params import Parameter
 from topgen.clocks import Clocks
 from topgen.resets import Resets
-from topgen.merge import is_unmanaged_reset
+from topgen.merge import is_unmanaged_reset, get_alerts_with_unique_lpg_idx
 
 num_mio_inputs = top['pinmux']['io_counts']['muxed']['inouts'] + \
                  top['pinmux']['io_counts']['muxed']['inputs']
@@ -412,6 +412,13 @@ for rst in output_rsts:
 %>\
   assign lpg_cg_en[${k}] = ${cg_en};
   assign lpg_rst_en[${k}] = ${rst_en};
+% endfor
+% for alert_group, alerts in top['incoming_alert'].items():
+  % for unique_alert_lpg_entry in get_alerts_with_unique_lpg_idx(alerts):
+<% k += 1 %>\
+  assign lpg_cg_en[${k}] = incoming_lpg_cg_en_${alert_group}_i[${unique_alert_lpg_entry["lpg_idx"]}];
+  assign lpg_rst_en[${k}] = incoming_lpg_rst_en_${alert_group}_i[${unique_alert_lpg_entry["lpg_idx"]}];
+  % endfor
 % endfor
 
 % for alert_group, lpgs in top['outgoing_alert_lpgs'].items():

--- a/hw/top_earlgrey/templates/toplevel.sv.tpl
+++ b/hw/top_earlgrey/templates/toplevel.sv.tpl
@@ -9,7 +9,7 @@ import topgen.lib as lib
 from reggen.params import Parameter
 from topgen.clocks import Clocks
 from topgen.resets import Resets
-from topgen.merge import is_unmanaged_reset
+from topgen.merge import is_unmanaged_reset, get_alerts_with_unique_lpg_idx
 
 num_mio_inputs = top['pinmux']['io_counts']['muxed']['inouts'] + \
                  top['pinmux']['io_counts']['muxed']['inputs']
@@ -439,6 +439,13 @@ for rst in output_rsts:
 %>\
   assign lpg_cg_en[${k}] = ${cg_en};
   assign lpg_rst_en[${k}] = ${rst_en};
+% endfor
+% for alert_group, alerts in top['incoming_alert'].items():
+  % for unique_alert_lpg_entry in get_alerts_with_unique_lpg_idx(alerts):
+<% k += 1 %>\
+  assign lpg_cg_en[${k}] = incoming_lpg_cg_en_${alert_group}_i[${unique_alert_lpg_entry["lpg_idx"]}];
+  assign lpg_rst_en[${k}] = incoming_lpg_rst_en_${alert_group}_i[${unique_alert_lpg_entry["lpg_idx"]}];
+  % endfor
 % endfor
 
 % for alert_group, lpgs in top['outgoing_alert_lpgs'].items():

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -217,7 +217,7 @@ def generate_alert_handler(top: Dict[str, object], out_path: Path) -> None:
                 for _ in range(alert["width"]):
                     async_on.append(async_on_format.format(int(alert["async"])))
                     lpg_map.append(lpg_idx_format.format(lpg_prev_offset + int(alert["lpg_idx"])))
-                lpg_prev_offset += max(alert['lpg_idx'] for alert in alerts) + 1
+            lpg_prev_offset += max(alert['lpg_idx'] for alert in alerts) + 1
 
     params = {
         "n_alerts": n_alerts,

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -849,6 +849,17 @@ def amend_resets(top, name_to_block):
     top["resets"] = top_resets
 
 
+def get_alerts_with_unique_lpg_idx(incoming_alerts: List[Dict]):
+    unique_lpgs = set()
+    result = []
+
+    for alert in incoming_alerts:
+        if alert['lpg_idx'] not in unique_lpgs:
+            unique_lpgs.add(alert['lpg_idx'])
+            result.append(alert)
+    return result
+
+
 def create_alert_lpgs(top, name_to_block: Dict[str, IpBlock]):
     '''Loop over modules and determine number of unique LPGs'''
     lpg_dict = {}

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -215,6 +215,8 @@ module_optional = {
                            'module'],
     'outgoing_alert': ['s', 'optional string to indicate alerts are routed externally to the named '
                             'group'],
+    'incoming_alert': ['l', 'optional list of paths to incoming alert configurations for the '
+                            'alert_handler'],
     'incoming_interrupt': ['g', 'Parsed incoming interrupts (generated)'],
 }
 


### PR DESCRIPTION
This PR fixes the rendering of the LPG map in the alert handler for incoming alerts. The LPG's are independent for every incoming alert group where their index is only relative within the alert group. Previously, the LPGs index offset was added after every alert, which is wrong. This only needs to be done after dealing with all alerts of one alert group and when switing to the next alert group. 