### PR TITLE
[rtl, aon_timer] Simpler condition to aid coverage closure

### DIFF
--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -198,8 +198,12 @@ module aon_timer import aon_timer_reg_pkg::*;
   );
 
   // Registers to interrupt
-  assign intr_test_qe           = reg2hw.intr_test.wkup_timer_expired.qe |
-                                  reg2hw.intr_test.wdog_timer_bark.qe;
+  assign intr_test_qe           = reg2hw.intr_test.wkup_timer_expired.qe;
+  // All the fields of a register have the same value for their qe signals, so we just pick one
+  // of them. This assertion checks that we don't miss writes if the register top changes."
+  `ASSERT(IntrTestFieldsQeMatch_A,
+          reg2hw.intr_test.wkup_timer_expired.qe == reg2hw.intr_test.wdog_timer_bark.qe)
+
   assign intr_test_q [AON_WKUP] = reg2hw.intr_test.wkup_timer_expired.q;
   assign intr_state_q[AON_WKUP] = reg2hw.intr_state.wkup_timer_expired.q;
   assign intr_test_q [AON_WDOG] = reg2hw.intr_test.wdog_timer_bark.q;


### PR DESCRIPTION
The condition originally looked like:
```
 assign intr_test_qe           = reg2hw.intr_test.wkup_timer_expired.qe |
                                 reg2hw.intr_test.wdog_timer_bark
```
Which causes a conditional coverage hole due to both Qe signals being connected to the same signal in aon_timer_reg_top. In order to avoid waving the hole, the RTL has been ammended, and an assertion has been added to ensure things work as expected in case the RTL (register top) changes in the future