### PR TITLE
[dd, prim_reg_cdc] simplifying condition to help with CCOV

### DIFF
--- a/hw/ip/prim/rtl/prim_reg_cdc.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc.sv
@@ -121,9 +121,9 @@ module prim_reg_cdc #(
   // be copied back.
   logic dst_to_src;
   if (DstWrReq) begin : gen_wr_req
-    assign dst_to_src = src_busy_q && src_ack || src_update && !busy;
+    assign dst_to_src = src_ack || (src_update && !busy);
   end else begin : gen_passthru
-    assign dst_to_src = src_busy_q && src_ack;
+    assign dst_to_src = src_ack;
 
     logic unused_dst_wr;
     assign unused_dst_wr = src_update ^ busy;


### PR DESCRIPTION
prim_reg_cdc has a conditional coverage hole in the condition: `src_busy_q && src_ack` since src_ack is only 1 if `src_busy_q`. this is also ensured via the assertion `SrcAckBusyChk_A`