### PR TITLE
[dd, prim] Simplyfing condition to ease coverage closure

### DIFF
--- a/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc_arb.sv
@@ -154,7 +154,7 @@ module prim_reg_cdc_arb #(
     always_ff @(posedge clk_dst_i or negedge rst_dst_ni) begin
       if (!rst_dst_ni) begin
         id_q <= SelSwReq;
-      end else if (dst_update_req && dst_update_ack) begin
+      end else if (dst_update_ack) begin
         id_q <= SelSwReq;
       end else if (dst_req && dst_lat_d) begin
         id_q <= SelSwReq;
@@ -164,6 +164,9 @@ module prim_reg_cdc_arb #(
         id_q <= SelHwReq;
       end
     end
+
+    // dst_update_ack should only be sent if there was a dst_update_req.
+    `ASSERT(DstAckReqChk_A, dst_update_ack |-> dst_update_req, clk_dst_i, !rst_dst_ni)
 
     // if a destination update is received when the system is idle and there is no
     // software side request, hw update must be selected.


### PR DESCRIPTION
The acknoledgement can't be set unless the request is set. The condition has been simplified to only check for the acknoledgment.

In addition, the new assertion checks if the ack is set, the request must be set