### PR TITLE
[dv,pwm] Synchronize to monitor pulses when blink state changes

### DIFF
--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -144,12 +144,11 @@ task pwm_scoreboard::process_tl_access(tl_seq_item   item,
             blink_cnt[ii] = blink[ii].X;
             blink_state[ii] = CycleA;
             int_dc[ii] = duty_cycle[ii].A;
-
-            // Alas we presently must ignore the first couple of items because the PWM output is
-            // enabled with an arbitrary phase relationship to the shared phase counter.
-            ignore_state_change[ii] = SettleTime;
           end
-          txt = $sformatf("\n Channel[%0d] : %0b", ii, channel_en[ii]);
+          // Alas we presently must ignore the first couple of items because the PWM configuration
+          // is set up with an arbitrary phase relationship to the shared phase counter.
+          ignore_state_change[ii] = SettleTime;
+          txt = $sformatf("\n Channel[%d] : %0b", ii, channel_en[ii]);
         end
         `uvm_info(`gfn, $sformatf("Setting channel enables %s ", txt), UVM_HIGH)
       end

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
@@ -64,15 +64,17 @@ endfunction
 
 task pwm_perf_vseq::body();
   set_ch_enables(32'h0);
-  rand_pwm_cfg_reg();
 
   for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
     set_duty_cycle(i, .A(rand_dc), .B(rand_dc));
     set_blink(i, .X(rand_blink), .Y(rand_blink));
     set_param(i, pwm_param[i]);
   end
-
   set_ch_invert(rand_invert);
+
+  // Start the phase counter.
+  rand_pwm_cfg_reg();
+  // Enable the channels.
   set_ch_enables(rand_chan);
 
   monitor_dut_outputs(low_power, NUM_CYCLES);


### PR DESCRIPTION
The changes in this PR better accommodate the uncertainty at the start of the DUT operation by increasing the initial SettleTime value (necessary for a very small number of seeds; one in 1500 observed to requires 4 pulse cycles, when the phase counter is changing most rapidly), and improves the robustness of the verification by detecting the end of the first blink phase (BLINK_PARAM.X + 1 pulse cycles) and synchronizing the DV to the monitor/DUT output at that point.

Once synchronized, no further discrepancy between observed pulse cycles and expectations is tolerated, until a further configuration change occurs.

With the changes in this PR 1500 seeds (-i all -rx 5) have been observed to pass successfully.