### PR TITLE
[opentitantool] Rescue erases other slot by default

### DIFF
--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -51,6 +51,13 @@ pub struct Firmware {
         long,
         default_value_t = true,
         action = clap::ArgAction::Set,
+        help = "Render unbootable the slot not being programmed"
+    )]
+    erase_other_slot: bool,
+    #[arg(
+        long,
+        default_value_t = true,
+        action = clap::ArgAction::Set,
         help = "Reset the target to enter rescue mode"
     )]
     reset_target: bool,
@@ -92,6 +99,14 @@ impl CommandDispatch for Firmware {
         }
         rescue.wait()?;
         rescue.update_firmware(self.slot, payload)?;
+        if self.erase_other_slot {
+            // Erase the other slot by programming an empty blob.
+            if self.slot == BootSlot::SlotB {
+                rescue.update_firmware(BootSlot::SlotA, &[])?;
+            } else {
+                rescue.update_firmware(BootSlot::SlotB, &[])?;
+            }
+        }
         if self.rate.is_some() {
             rescue.set_baud(prev_baudrate)?;
         }

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -10,6 +10,7 @@ use std::any::Any;
 use std::fs::File;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::time::Duration;
 
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
@@ -89,16 +90,13 @@ impl CommandDispatch for Firmware {
             prev_baudrate = uart.get_baudrate()?;
             rescue.set_baud(rate)?;
         }
-        if self.wait {
-            rescue.wait()?;
-        }
+        rescue.wait()?;
         rescue.update_firmware(self.slot, payload)?;
         if self.rate.is_some() {
-            if self.wait {
-                rescue.set_baud(prev_baudrate)?;
-            } else {
-                uart.set_baudrate(prev_baudrate)?;
-            }
+            rescue.set_baud(prev_baudrate)?;
+        }
+        if !self.wait {
+            transport.reset_target(Duration::from_millis(50), false)?;
         }
         Ok(None)
     }


### PR DESCRIPTION
Add a default true flag `opentitantool rescue firmware --erase_other_slot true"` This can be used to control whether the content of the slot not being newly programmed should be left in place, or erased.  The latter ensures that the newly "rescued" firmware is the one to boot, and is the default, opposite of the previous behavior.