### PR TITLE
[dv,pwm] Phase relationship test sequence

### DIFF
--- a/hw/ip/pwm/data/pwm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_testplan.hjson
@@ -92,7 +92,7 @@
             Check that the relative phase between pulses matches the setting in the phase_delay field in the PWM_PARAM register.
             '''
         stage: V2
-        tests: ["pwm_rand_output"]
+        tests: ["pwm_phase", "pwm_rand_output"]
     }
     {
       name: lowpower

--- a/hw/ip/pwm/dv/env/pwm_env.core
+++ b/hw/ip/pwm/dv/env/pwm_env.core
@@ -21,6 +21,7 @@ filesets:
       - seq_lib/pwm_vseq_list.sv: {is_include_file: true}
       - seq_lib/pwm_base_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_common_vseq.sv: {is_include_file: true}
+      - seq_lib/pwm_phase_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_rand_output_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_heartbeat_wrap_vseq.sv: {is_include_file: true}

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -144,12 +144,11 @@ task pwm_scoreboard::process_tl_access(tl_seq_item   item,
             blink_cnt[ii] = blink[ii].X;
             blink_state[ii] = CycleA;
             int_dc[ii] = duty_cycle[ii].A;
-
-            // Alas we presently must ignore the first couple of items because the PWM output is
-            // enabled with an arbitrary phase relationship to the shared phase counter.
-            ignore_state_change[ii] = SettleTime;
           end
-          txt = $sformatf("\n Channel[%0d] : %0b", ii, channel_en[ii]);
+          // Alas we presently must ignore the first couple of items because the PWM configuration
+          // is set up with an arbitrary phase relationship to the shared phase counter.
+          ignore_state_change[ii] = SettleTime;
+          txt = $sformatf("\n Channel[%d] : %0b", ii, channel_en[ii]);
         end
         `uvm_info(`gfn, $sformatf("Setting channel enables %s ", txt), UVM_HIGH)
       end

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_perf_vseq.sv
@@ -64,15 +64,17 @@ endfunction
 
 task pwm_perf_vseq::body();
   set_ch_enables(32'h0);
-  rand_pwm_cfg_reg();
 
   for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
     set_duty_cycle(i, .A(rand_dc), .B(rand_dc));
     set_blink(i, .X(rand_blink), .Y(rand_blink));
     set_param(i, pwm_param[i]);
   end
-
   set_ch_invert(rand_invert);
+
+  // Start the phase counter.
+  rand_pwm_cfg_reg();
+  // Enable the channels.
   set_ch_enables(rand_chan);
 
   monitor_dut_outputs(low_power, NUM_CYCLES);

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_phase_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_phase_vseq.sv
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests operation with PWM outputs having a specific phase relationship, starting all channels
+// either synchronously or in a staggered fashion.
+class pwm_phase_vseq extends pwm_rand_output_vseq;
+  `uvm_object_utils(pwm_phase_vseq)
+
+  // Decide whether to start all channels synchronously, as opposed to staggered.
+  rand bit sync_start;
+
+  // Constrain the configuration so that all PWM outputs are enabled and have a defined phase
+  // relationship. The other configuration we allow to be randomized.
+  extern constraint rand_chan_c;
+  extern constraint rand_invert_c;
+  extern constraint pwm_param_c;
+
+  extern function new (string name="");
+  extern virtual task body();
+endclass
+
+// All channels shall be enabled.
+constraint pwm_phase_vseq::rand_chan_c {
+  rand_chan == {PWM_NUM_CHANNELS{1'b1}};
+}
+
+// Higher-numbered channels are the phase inversion of the lower ones.
+constraint pwm_phase_vseq::rand_invert_c {
+  rand_invert == { {(PWM_NUM_CHANNELS/2){1'b1}},    // Complementary signals.
+                   {(PWM_NUM_CHANNELS/2){1'b0}} };  // Base signals.
+}
+
+// We typically have 6 outputs, so set them up as two triples, with the signals in each triple
+// being at 120-degree intervals.
+constraint pwm_phase_vseq::pwm_param_c {
+  foreach (pwm_param[ii]) {
+    pwm_param[ii].BlinkEn == 1'b1;
+    pwm_param[ii].HtbtEn == 1'b0;
+    pwm_param[ii].PhaseDelay == ((ii % 3) << 16) / 3;
+  }
+}
+
+function pwm_phase_vseq::new (string name = "");
+  super.new(name);
+endfunction
+
+// TODO: We should perhaps move some the set up code into a base task which may be overridden
+// without replacing the entire `body`.
+task pwm_phase_vseq::body();
+  // Blink mode parameters to be used for all channels.
+  int unsigned blink_pulses_X = $urandom_range(7,  15);
+  int unsigned blink_pulses_Y = $urandom_range(11, 23);
+  set_ch_enables(32'h0);
+
+  // Set random dc and params for all channels
+  for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
+    set_duty_cycle(i, .A(16'h4000), .B(16'hC000));
+    set_blink(i, .X(blink_pulses_X), .Y(blink_pulses_Y));
+    set_param(i, pwm_param[i]);
+  end
+  set_ch_invert(rand_invert);
+
+  // Start the phase counter.
+  rand_pwm_cfg_reg();
+
+  `uvm_info(`gfn, $sformatf("Starting phased channels at the same time %0d", sync_start),
+            UVM_MEDIUM)
+
+  if (sync_start) begin
+    // Enable all of the channels at the same time; the specification requires synchronized
+    // starting of multiple channels. All duty cycle changes on all channels should occur
+    // simultaneously, except for the delays caused by the phase delays.
+    set_ch_enables(rand_chan);
+  end else begin
+    // Start them in a staggered fashion. Nonetheless they should still have the same phase
+    // relationship, but because they've started at different times, they will not necessarily
+    // modify their duty cycles on the same pulse cycles.
+    uvm_reg_data_t en = rand_chan;
+    uvm_reg_data_t set_en = 0;
+    while (en) begin
+      // Lift the MSB from the chosen set of enables, and set it in the register configuration.
+      set_en |= (en & ~(en - 1));
+      set_ch_enables(set_en);
+      // Proceed to the next enable.
+      en &= ~set_en;
+    end
+  end
+
+  monitor_dut_outputs(low_power, NUM_CYCLES);
+
+  shutdown_dut();
+endtask

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_vseq_list.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_vseq_list.sv
@@ -7,5 +7,6 @@
 `include "pwm_common_vseq.sv"
 `include "pwm_rand_output_vseq.sv"
 `include "pwm_perf_vseq.sv"
+`include "pwm_phase_vseq.sv"
 `include "pwm_heartbeat_wrap_vseq.sv"
 `include "pwm_stress_all_vseq.sv"

--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -101,6 +101,10 @@
       reseed: 10
     }
     {
+      name: pwm_phase
+      uvm_test_seq: pwm_phase_vseq
+    }
+    {
       name: pwm_stress_all
       uvm_test_seq: pwm_stress_all_vseq
       run_opts:["+test_timeout_ns=10_000_000_000"]


### PR DESCRIPTION
This PR introduces a sequence to drive the PWM outputs in a known phase relationship, with three of the signals driven at 120-degree offsets and the second group of three driven as their anti-phase counterparts using the `invert` functionality.

![PWMphase](https://github.com/user-attachments/assets/afde3a6c-41cc-4571-ae28-33256999ee2e)

The above capture shows channels 0-2 being driven with phases of 0,120 and 240, and then channels 3-5 being their respective complements. It shows the point of transition from duty cycle A (1/4) to duty cycle B (3/4) and how the channels switch configuration only at the point at which it is safe to change the duty cycle, given their configured phase delays.

Note: **Only the final commit is relevant,** this is built on PR #25815.