### PR TITLE
[SiVal, usbdev] Mark sof test as NA for SiVal

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_usbdev_testplan.hjson
@@ -107,7 +107,7 @@
         "USBDEV.CONN.REF_PULSE",
       ]
       stage: V2
-      si_stage: SV3
+      si_stage: NA
       lc_states: ["PROD"]
       tests: []
       bazel: []


### PR DESCRIPTION
The test descriptions mention internal signals that aren't exposed to Software, so, this will be covered by closed source tests in SiVal.