### PR TITLE
[corefiles] Remove IBEX_CUSTOM_PMP_RESET_VALUES parameter

### DIFF
--- a/hw/top_darjeeling/chip_darjeeling_asic.core
+++ b/hw/top_darjeeling/chip_darjeeling_asic.core
@@ -44,10 +44,6 @@ parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-  IBEX_CUSTOM_PMP_RESET_VALUES:
-    datatype: bool
-    default: true
-    paramtype: vlogdefine
 
 targets:
   default: &default_target

--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -44,10 +44,6 @@ parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-  IBEX_CUSTOM_PMP_RESET_VALUES:
-    datatype: bool
-    default: true
-    paramtype: vlogdefine
 
 targets:
   default: &default_target
@@ -57,8 +53,6 @@ targets:
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
     toplevel: chip_earlgrey_asic
-    parameters:
-      - IBEX_CUSTOM_PMP_RESET_VALUES
 
   lint:
     <<: *default_target

--- a/hw/top_earlgrey/chip_earlgrey_cw310.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310.core
@@ -70,10 +70,6 @@ parameters:
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
-  IBEX_CUSTOM_PMP_RESET_VALUES:
-    datatype: bool
-    default: true
-    paramtype: vlogdefine
 
 targets:
   default: &default_target
@@ -82,7 +78,6 @@ targets:
       - files_ascentlint_waiver
     toplevel: chip_earlgrey_cw310
     parameters:
-      - IBEX_CUSTOM_PMP_RESET_VALUES
       - AST_BYPASS_CLK=true
 
   synth:
@@ -96,7 +91,6 @@ targets:
       - BootRomInitFile
       - OtpCtrlMemInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-      - IBEX_CUSTOM_PMP_RESET_VALUES
       - AST_BYPASS_CLK=true
     tools:
       vivado:

--- a/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310_hyperdebug.core
@@ -72,10 +72,6 @@ parameters:
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
-  IBEX_CUSTOM_PMP_RESET_VALUES:
-    datatype: bool
-    default: true
-    paramtype: vlogdefine
 
 targets:
   default: &default_target
@@ -84,7 +80,6 @@ targets:
       - files_ascentlint_waiver
     toplevel: chip_earlgrey_cw310
     parameters:
-      - IBEX_CUSTOM_PMP_RESET_VALUES
       - AST_BYPASS_CLK=true
 
   synth:
@@ -98,7 +93,6 @@ targets:
       - BootRomInitFile
       - OtpCtrlMemInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-      - IBEX_CUSTOM_PMP_RESET_VALUES
       - AST_BYPASS_CLK=true
     tools:
       vivado:

--- a/hw/top_earlgrey/chip_earlgrey_cw340.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw340.core
@@ -67,10 +67,6 @@ parameters:
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
-  IBEX_CUSTOM_PMP_RESET_VALUES:
-    datatype: bool
-    default: true
-    paramtype: vlogdefine
 
 targets:
   default: &default_target
@@ -79,7 +75,6 @@ targets:
       - files_ascentlint_waiver
     toplevel: chip_earlgrey_cw340
     parameters:
-      - IBEX_CUSTOM_PMP_RESET_VALUES
       - AST_BYPASS_CLK=true
 
   synth:
@@ -93,7 +88,6 @@ targets:
       - BootRomInitFile
       - OtpCtrlMemInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx_ultrascale
-      - IBEX_CUSTOM_PMP_RESET_VALUES
       - AST_BYPASS_CLK=true
     tools:
       vivado:

--- a/hw/top_earlgrey/chip_earlgrey_verilator.core
+++ b/hw/top_earlgrey/chip_earlgrey_verilator.core
@@ -21,17 +21,12 @@ parameters:
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
-  IBEX_CUSTOM_PMP_RESET_VALUES:
-    datatype: bool
-    default: true
-    paramtype: vlogdefine
 
 targets:
   default: &default_target
     filesets:
       - files_sim_verilator
     parameters:
-      - IBEX_CUSTOM_PMP_RESET_VALUES
       - AST_BYPASS_CLK=true
     toplevel: chip_earlgrey_verilator
 

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -97,10 +97,6 @@ parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-  IBEX_CUSTOM_PMP_RESET_VALUES:
-    datatype: bool
-    default: true
-    paramtype: vlogdefine
 
 targets:
   default: &default_target
@@ -110,8 +106,6 @@ targets:
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl_generic
     toplevel: top_earlgrey
-    parameters:
-      - IBEX_CUSTOM_PMP_RESET_VALUES
 
   sim:
     default_tool: icarus

--- a/hw/top_englishbreakfast/chip_englishbreakfast_cw305.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_cw305.core
@@ -51,10 +51,6 @@ parameters:
   AST_BYPASS_CLK:
     datatype: bool
     paramtype: vlogdefine
-  IBEX_CUSTOM_PMP_RESET_VALUES:
-    datatype: bool
-    default: true
-    paramtype: vlogdefine
 
 targets:
   default: &default_target
@@ -73,7 +69,6 @@ targets:
       - BootRomInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
       - AST_BYPASS_CLK=true
-      - IBEX_CUSTOM_PMP_RESET_VALUES
     tools:
       vivado:
         part: "xc7a100tftg256-2" # CW305 Board


### PR DESCRIPTION
This define is superseeded by passing the PMP reset values using parameters to the core.