### PR TITLE
[rom_ctrl,dv] Pass the .prior argument for some mirror calls

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -138,12 +138,12 @@ endtask
 task rom_ctrl_base_vseq::read_digest_regs();
   uvm_status_e status;
   for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
-    ral.digest[i].mirror(.status(status), .check(UVM_CHECK));
+    ral.digest[i].mirror(.status(status), .check(UVM_CHECK), .prior(100));
     if (!cfg.clk_rst_vif.rst_n) return;
     `DV_CHECK_EQ(status, UVM_IS_OK)
   end
   for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
-    ral.exp_digest[i].mirror(.status(status), .check(UVM_CHECK));
+    ral.exp_digest[i].mirror(.status(status), .check(UVM_CHECK), .prior(100));
     if (!cfg.clk_rst_vif.rst_n) return;
     `DV_CHECK_EQ(status, UVM_IS_OK)
   end


### PR DESCRIPTION
Confusingly, the default priority (-1) seems to mostly work. Unfortunately, this *doesn't* work properly with the rom_ctrl_stress_all_with_rand_reset sequence for some seeds for particular iterations of the stressed sequence.

In this situation, we end up with an item from a call to mirror() from the end of one iteration racing against some other register item from the start of the next one. Because there is more than once item, the sequencer tries to decide which one to grant... and explodes because they have a negative priority.

The error message is rather confusing:

    UVM_FATAL @ 2122662017 ps: uvm_test_top.env.m_tl_agent_rom_ctrl_regs_reg_block.sequencer [SEQDEFPRI] Sequence m_tl_host_base_seq has illegal priority: -1

and the point is that if a sequence item has a priority of -1, this means "look at the priority of the *sequence* as a fall-back". This priority happens to be -1 (because the parent_sequence object didn't have a priority in the first place, and its do_copy function didn't copy that across either).

But it turns out that the correct fix has nothing to do with the sequence itself. That took... a LONG time to debug.