### PR TITLE
[rom_ext] Enable Oz to reduce firmware size

### DIFF
--- a/rules/rv.bzl
+++ b/rules/rv.bzl
@@ -19,10 +19,11 @@ PER_DEVICE_DEPS = {
 }
 
 def _opentitan_transition_impl(settings, attr):
+    features = settings["//command_line_option:features"] + attr.extra_bazel_features
     return {
         "//command_line_option:platforms": attr.platform,
         "//command_line_option:copt": settings["//command_line_option:copt"],
-        "//command_line_option:features": settings["//command_line_option:features"],
+        "//command_line_option:features": features,
         "//hw/bitstream/universal:rom": "//hw/bitstream/universal:none",
         "//hw/bitstream/universal:otp": "//hw/bitstream/universal:none",
         "//hw/bitstream/universal:env": "//hw/bitstream/universal:none",
@@ -58,6 +59,8 @@ def rv_rule(**kwargs):
     attrs = kwargs.pop("attrs", {})
     if "platform" not in attrs:
         attrs["platform"] = attr.string(default = OPENTITAN_PLATFORM)
+    if "extra_bazel_features" not in attrs:
+        attrs["extra_bazel_features"] = attr.string_list(default = [])
     attrs["_allowlist_function_transition"] = attr.label(
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
     )

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -287,6 +287,10 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
     ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
+    ],
     linker_script = ":ld_slot_a",
     manifest = ":manifest",
     spx_key = {"//sw/device/silicon_creator/rom/keys/fake/spx:prod_key_0_spx": "prod_key_0"},
@@ -310,6 +314,10 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
+    ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
     ],
     linker_script = ":ld_slot_b",
     manifest = ":manifest",
@@ -335,6 +343,10 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_verilator_base",
         "//hw/top_earlgrey:silicon_creator",
     ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
+    ],
     linker_script = ":ld_slot_virtual",
     manifest = ":manifest",
     deps = [
@@ -357,6 +369,10 @@ opentitan_binary(
             "//hw/top_earlgrey:sim_dv_base",
             "//hw/top_earlgrey:sim_verilator_base",
             "//hw/top_earlgrey:silicon_creator",
+        ],
+        extra_bazel_features = [
+            "minsize",
+            "use_lld",
         ],
         linker_script = ":ld_slot_virtual",
         manifest = ":manifest",
@@ -387,6 +403,10 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
     ],
     linker_script = ":ld_slot_a",
     manifest = ":manifest_bad_address_translation",

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -619,19 +619,23 @@ void rom_ext_main(void) {
   shutdown_finalize(error);
 }
 
+OT_USED
 void rom_ext_interrupt_handler(void) { shutdown_finalize(rom_ext_irq_error()); }
 
 // We only need a single handler for all ROM_EXT interrupts, but we want to
 // keep distinct symbols to make writing tests easier.  In the ROM_EXT,
 // alias all interrupt handler symbols to the single handler.
+OT_USED
 OT_ALIAS("rom_ext_interrupt_handler")
 void rom_ext_exception_handler(void);
 
+OT_USED
 OT_ALIAS("rom_ext_interrupt_handler")
 void rom_ext_nmi_handler(void);
 
 // A no-op immutable rom_ext fallback to avoid breaking tests before the
 // proper bazel target is ready.
 // TODO(opentitan#24368): Remove this nop fallback.
+OT_USED
 OT_SECTION(".rom_ext_immutable.fallback")
 void imm_rom_ext_placeholder(void) {}

--- a/sw/device/silicon_creator/rom_ext/sival/BUILD
+++ b/sw/device/silicon_creator/rom_ext/sival/BUILD
@@ -45,6 +45,10 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
     ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
+    ],
     linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_a",
     linkopts = LINK_ORDER,
     manifest = ":manifest_sival",
@@ -67,6 +71,10 @@ opentitan_binary(
         "//hw/top_earlgrey:sim_dv_base",
         "//hw/top_earlgrey:sim_verilator_base",
     ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
+    ],
     linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_b",
     linkopts = LINK_ORDER,
     manifest = ":manifest_sival",
@@ -85,6 +93,10 @@ opentitan_binary(
         "//hw/top_earlgrey:silicon_creator",
         "//hw/top_earlgrey:fpga_cw310",
     ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
+    ],
     linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_a",
     linkopts = LINK_ORDER,
     deps = [
@@ -100,6 +112,10 @@ opentitan_binary(
     exec_env = [
         "//hw/top_earlgrey:silicon_creator",
         "//hw/top_earlgrey:fpga_cw310",
+    ],
+    extra_bazel_features = [
+        "minsize",
+        "use_lld",
     ],
     linker_script = "//sw/device/silicon_creator/rom_ext:ld_slot_b",
     linkopts = LINK_ORDER,

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -7164,6 +7164,10 @@ opentitan_test(
     exec_env = dicts.add(
         EARLGREY_TEST_ENVS,
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw340_sival": None,
+            "//hw/top_earlgrey:fpga_cw340_sival_rom_ext": None,
+        },
     ),
     fpga = fpga_params(
         test_cmd = """


### PR DESCRIPTION
This change enables Oz optimization for rom_ext to reduce code size (43084B -> 41868B).

Since some targets can't be built with LLD, this commit introduces a new attribute, `with_features`, to the `opentitan_binary` rule to allow specifying additional features for the target.

LTO is also ready to be enabled for those targets, but we found no size improvement (41868B off v.s. 41896B on), so we keep it off at the moment.