### PR TITLE
[bazel] Improve build determinism

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,6 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "googletest", version = "1.14.0.bcr.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.14")
-bazel_dep(name = "rules_foreign_cc", version = "0.9.0")
 bazel_dep(name = "rules_fuzzing", version = "0.5.2")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 
@@ -34,6 +33,8 @@ git_override(
 include("//third_party/rust:rust.MODULE.bazel")
 
 include("//third_party/python:python.MODULE.bazel")
+
+include("//third_party/foreign_cc:foreign_cc.MODULE.bazel")
 
 # Repository rules:
 bitstreams_repo = use_repo_rule("//rules:bitstreams.bzl", "bitstreams_repo")

--- a/rules/otp.bzl
+++ b/rules/otp.bzl
@@ -40,6 +40,7 @@ load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//rules:const.bzl", "CONST", "hex")
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
+load("//rules:stamp.bzl", "stamp_attr", "stamping_enabled")
 
 def get_otp_images():
     """Returns a list of (otp_name, img_target) tuples.
@@ -231,6 +232,8 @@ def _otp_image(ctx):
     args = ctx.actions.args()
     if not ctx.attr.verbose:
         args.add("--quiet")
+    if stamping_enabled(ctx):
+        args.add("--stamp")
     args.add("--lc-state-def", ctx.file.lc_state_def)
     args.add("--mmap-def", ctx.file.mmap_def)
     if ctx.attr.img_seed:
@@ -302,7 +305,7 @@ otp_image = rule(
             executable = True,
             cfg = "exec",
         ),
-    },
+    } | stamp_attr(-1, "//rules:stamp_flag"),
 )
 
 def _otp_image_consts_impl(ctx):
@@ -310,6 +313,8 @@ def _otp_image_consts_impl(ctx):
     args = ctx.actions.args()
     if not ctx.attr.verbose:
         args.add("--quiet")
+    if stamping_enabled(ctx):
+        args.add("--stamp")
     args.add("--lc-state-def", ctx.file.lc_state_def)
     args.add("--mmap-def", ctx.file.mmap_def)
     args.add("--img-seed", ctx.attr.img_seed[BuildSettingInfo].value)
@@ -381,7 +386,7 @@ otp_image_consts = rule(
             executable = True,
             cfg = "exec",
         ),
-    },
+    } | stamp_attr(-1, "//rules:stamp_flag"),
 )
 
 # The following overlays are used to generate a generic OTP image with fake

--- a/third_party/foreign_cc/BUILD
+++ b/third_party/foreign_cc/BUILD
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/foreign_cc/foreign_cc.MODULE.bazel
+++ b/third_party/foreign_cc/foreign_cc.MODULE.bazel
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Dependencies:
+bazel_dep(name = "rules_foreign_cc", version = "0.9.0")
+
+# Overrides and patches:
+single_version_override(
+    module_name = "rules_foreign_cc",
+    patches = [
+        # Patch to remove all build log file output when using rules_foreign_cc
+        # toolchains to ensure deterministic Bazel builds. See upstream issue:
+        # https://github.com/bazel-contrib/rules_foreign_cc/issues/1313
+        "//third_party/foreign_cc/patches:rules_foreign_cc.remove_log_output.patch",
+    ],
+    version = "0.9.0",
+)

--- a/third_party/foreign_cc/patches/BUILD
+++ b/third_party/foreign_cc/patches/BUILD
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/foreign_cc/patches/rules_foreign_cc.remove_log_output.patch
+++ b/third_party/foreign_cc/patches/rules_foreign_cc.remove_log_output.patch
@@ -1,0 +1,13 @@
+diff --git foreign_cc/private/framework.bzl foreign_cc/private/framework.bzl
+index c84c217..f43da2c 100644
+--- foreign_cc/private/framework.bzl
++++ foreign_cc/private/framework.bzl
+@@ -561,7 +561,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, build_script_file =
+     cleanup_on_success_function = create_function(
+         ctx,
+         "cleanup_on_success",
+-        "rm -rf $BUILD_TMPDIR $EXT_BUILD_DEPS",
++        "rm -rf $BUILD_TMPDIR $EXT_BUILD_DEPS && echo > $BUILD_LOG",
+     )
+     cleanup_on_failure_function = create_function(
+         ctx,

--- a/util/design/gen-otp-img.py
+++ b/util/design/gen-otp-img.py
@@ -79,6 +79,12 @@ def main():
                         '-q',
                         action='store_true',
                         help='''Don't print out progress messages.''')
+    parser.add_argument('-stamp',
+                        action='store_true',
+                        help='''
+                        Add a comment 'Generated on [Date] with [Command]' to
+                        generated output files.
+                        ''')
     parser.add_argument('--seed',
                         type=int,
                         metavar='<seed>',
@@ -249,10 +255,12 @@ def main():
                 a = a.resolve() if isinstance(a, Path) else a
                 argstr += ' \\\n//   --' + argname + ' ' + str(a) + ''
 
-    dt = datetime.datetime.now(datetime.timezone.utc)
-    dtstr = dt.strftime("%a, %d %b %Y %H:%M:%S %Z")
-    file_header = '// Generated on {} with\n// $ gen-otp-img.py {}\n//\n'.format(
-        dtstr, argstr)
+    file_header = '//\n'
+    if args.stamp:
+        dt = datetime.datetime.now(datetime.timezone.utc)
+        dtstr = dt.strftime("%a, %d %b %Y %H:%M:%S %Z")
+        file_header = '// Generated on {} with\n// $ gen-otp-img.py {}\n//\n'.format(
+            dtstr, argstr)
 
     if args.c_out:
         log.info(f'Generating C file: {args.c_out}')

--- a/util/design/lib/OtpMemImg.py
+++ b/util/design/lib/OtpMemImg.py
@@ -145,7 +145,7 @@ def _to_memfile_with_ecc(data, annotation, config,
         # count ECC bits. In a comment, we also include any annotations
         # associated with the word.
         line = '@{:06x} {} // {}'.format(i_word, word_hex,
-                                         ', '.join(word_annotations))
+                                         ', '.join(sorted(word_annotations)))
         mem_lines.append(line)
 
     log.info('Done.')


### PR DESCRIPTION
This PR includes three commits, which, in addition to the crate updates from e7868c7c892b7ef459b1aceb90433ddbea0f53bb in #25795, should help improve the determinism of our builds and as such should improve the cache hit rate for Bazel builds, reducing build times. See more details in the commit messages.