### PR TITLE
[hmac,dv] Allow reset w/o CSR accesses complete

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -44,4 +44,7 @@ function void hmac_env_cfg::initialize(bit [TL_AW-1:0] csr_base_addr = '1);
 
   // only support 1 outstanding TL items in tlul_adapter
   m_tl_agent_cfg.max_outstanding_req = 1;
+
+  // Used to allow reset operations without waiting for CSR accesses to complete
+  can_reset_with_csr_accesses = 1;
 endfunction : initialize

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -279,13 +279,17 @@ endfunction : clear_wipe_secret
 task hmac_base_vseq::csr_rd_digest(output bit [TL_DW-1:0] digest[16]);
   foreach (digest[i]) begin
     csr_rd(.ptr(ral.digest[i]), .value(digest[i]));
+    if (cfg.under_reset) break;   // Skip if a reset is ongoing...
     `uvm_info(`gfn, $sformatf("digest[%0d]=32'h%08x", i, digest[i]), UVM_MEDIUM)
   end
 endtask : csr_rd_digest
 
 // Write digest value
 task hmac_base_vseq::csr_wr_digest(bit [TL_DW-1:0] digest[16]);
-  foreach (digest[i]) csr_wr(.ptr(ral.digest[i]), .value(digest[i]));
+  foreach (digest[i]) begin
+    csr_wr(.ptr(ral.digest[i]), .value(digest[i]));
+    if (cfg.under_reset) break;   // Skip if a reset is ongoing...
+  end
 endtask : csr_wr_digest
 
 // Read digest size and update mirrored value
@@ -306,6 +310,7 @@ task hmac_base_vseq::wr_key(bit [TL_DW-1:0] key[]);
   foreach (key[i]) begin
     ral.key[i].set(key[i]);
     csr_update(.csr(ral.key[i]));
+    if (cfg.under_reset) break;   // Skip if a reset is ongoing...
     `uvm_info(`gfn, $sformatf("key[%0d] = 0x%0h", i, key[i]), UVM_HIGH)
   end
 endtask : wr_key
@@ -341,6 +346,7 @@ task hmac_base_vseq::wr_msg(bit [7:0] msg[], bit no_sar=0);
         bit [TL_DW-1:0] word;
         `DV_CHECK_FATAL(randomize(wr_addr, wr_mask) with {$countones(wr_mask) <= msg_q.size();})
 
+        if (cfg.under_reset) break;   // Skip if a reset is ongoing...
         foreach (wr_mask[i]) begin
           // wr_mask is a packed array, word_unpacked is unpack, has different index
           if (wr_mask[i]) begin
@@ -396,6 +402,7 @@ task hmac_base_vseq::wr_msg(bit [7:0] msg[], bit no_sar=0);
     end
   join
   sar_window.reset();
+  if (cfg.under_reset) return;   // Skip if a reset is ongoing...
   // ensure all msg fifo are written before trigger hmac_process
   if ($urandom_range(0, 1)) begin
     rd_msg_length();
@@ -426,6 +433,7 @@ task hmac_base_vseq::burst_wr_msg(bit [7:0] msg[], int burst_wr_length);
                     .compare_op(CompareOpLe));
         if (msg_q.size() >= burst_wr_length * 4) begin
           repeat (burst_wr_length) begin
+            if (cfg.under_reset) break;   // Skip if a reset is ongoing...
             for (int i = 0; i < 4; i++) word_unpack[i] = msg_q.pop_front();
             word = {>>byte{word_unpack}};
             `uvm_info(`gfn, $sformatf("wr_addr = %0h, wr_mask = %0h, words = 0x%0h",
@@ -459,10 +467,12 @@ task hmac_base_vseq::burst_wr_msg(bit [7:0] msg[], int burst_wr_length);
         end else begin
           wr_msg(msg_q, 1); // Do not S&R on the last piece as message boundary could be wrong
           msg_q.delete();   // Flush the queue to avoid infinite loop
+          if (cfg.under_reset) break;   // Skip if a reset is ongoing...
         end
         if ($urandom_range(0, 1)) begin
           rd_msg_length();
         end
+        if (cfg.under_reset) break;   // Skip if a reset is ongoing...
         read_status_intr_clr();
       end
       // Keep it alive only if needed
@@ -496,6 +506,7 @@ task hmac_base_vseq::read_status_intr_clr();
   csr_rd(ral.intr_state, rdata);
   csr_wr(.ptr(ral.intr_state), .value(rdata));
 endtask : read_status_intr_clr
+
 // This task is called when sha_en=0 and sequence set hash_start, or streamed in msg.
 // It will check intr_pin, intr_state, and error_code registers.
 // Default check_err is 1, if set to 0, means user is not sure if it is error case or not,
@@ -558,12 +569,15 @@ task hmac_base_vseq::save_and_restore();
   // or 1024 bits SHA-2 384/512)
   sar_window.wait_trigger();
 
-  // Insert random delay to mimic the SW accesses which can take some time because of potential
-  // incoming interrupts. To cover the particular case where the stop command is issued while the
-  // hash has already been processed, this delay should exceed the number clock cycles required
-  // for this operation, which is 64 for SHA2-256 and 80 for SHA2-384/512 with the current RTL.
-  cfg.clk_rst_vif.wait_clks($urandom_range(HMAC_MSG_PROCESS_CYCLES_256-10,
-                                           HMAC_MSG_PROCESS_CYCLES_512+10));
+  // Insert random delay to mimic the SW accesses which can take some time because of
+  // potential incoming interrupts. To cover the particular case where the stop command is
+  // issued while the hash has already been processed, this delay should exceed the number
+  // clock cycles required for this operation, which is 64 for SHA2-256 and 80 for
+  // SHA2-384/512 with the current RTL.
+  cfg.clk_rst_vif.wait_clks_or_rst($urandom_range(HMAC_MSG_PROCESS_CYCLES_256-10,
+                                                  HMAC_MSG_PROCESS_CYCLES_512+10));
+
+  if (cfg.under_reset) return;   // Skip if a reset is ongoing...
 
   randcase
     1:  sar_stop_and_continue();
@@ -584,6 +598,7 @@ task hmac_base_vseq::sar_stop_and_continue();
   save_ctx_ongoing = 1;
   // Wait for hash to be done so the digest is updated.
   csr_spinwait(.ptr(ral.intr_state.hmac_done), .exp_data(1'b1));
+  if (cfg.under_reset) return;   // Skip if a reset is ongoing...
   // Clear the interrupt.
   csr_wr(.ptr(ral.intr_state.hmac_done), .value(1'b1));
   save_ctx_ongoing = 0;
@@ -606,6 +621,7 @@ task hmac_base_vseq::sar_same_context();
   save_ctx_ongoing = 1;
   // Wait for hash to be done so the digest is updated.
   csr_spinwait(.ptr(ral.intr_state.hmac_done), .exp_data(1'b1));
+  if (cfg.under_reset) return;   // Skip if a reset is ongoing...
   // Clear the interrupt.
   csr_wr(.ptr(ral.intr_state.hmac_done), .value(1'b1));
   // Read the digest and save it.
@@ -655,6 +671,7 @@ task hmac_base_vseq::sar_different_context();
   save_ctx_ongoing = 1;
   // Wait for hash to be done so the digest is updated.
   csr_spinwait(.ptr(ral.intr_state.hmac_done), .exp_data(1'b1));
+  if (cfg.under_reset) return;   // Skip if a reset is ongoing...
   // Clear the interrupt.
   csr_wr(.ptr(ral.intr_state.hmac_done), .value(1'b1));
 
@@ -687,6 +704,7 @@ task hmac_base_vseq::sar_different_context();
           trigger_hash();
           // Write complete message for B context
           wr_msg(msg_b, 1);
+          if (cfg.under_reset) return;   // Skip if a reset is ongoing...
           // Start hash
           trigger_process();
           // Wait for hash to be done so the digest is updated.
@@ -707,6 +725,7 @@ task hmac_base_vseq::sar_different_context();
           trigger_hash_continue();
           // Write complete message for B context
           wr_msg(msg_b, 1);
+          if (cfg.under_reset) return;   // Skip if a reset is ongoing...
           // Start hash
           trigger_process();
           // Wait for hash to be done so the digest is updated.


### PR DESCRIPTION
- This PR is a temporary fix to allow the reset to complete without waiting for complete CSR accesses. This is done by setting the flag can_reset_with_csr_accesses to 1 in the env_cfg file. Ideally, this should go away once the a better reset approach will be in place via a reset agent.
- The approach here is to try to exit ASAP from all the tasks to skip the CSR accesses.