### PR TITLE
[hmac,rtl] Use fifo_full instead of fifo_wready

### DIFF
--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -531,7 +531,6 @@ module hmac
   assign reg_fifo_wentry.data = conv_endian32(reg_fifo_wdata, 1'b1); // always convert
   assign reg_fifo_wentry.mask = {reg_fifo_wmask[0],  reg_fifo_wmask[8],
                                  reg_fifo_wmask[16], reg_fifo_wmask[24]};
-  assign fifo_full   = ~fifo_wready;
   assign fifo_empty  = ~fifo_rvalid;
   assign fifo_wvalid = (hmac_fifo_wsel && fifo_wready) ? hmac_fifo_wvalid : reg_fifo_wvalid;
 
@@ -570,7 +569,7 @@ module hmac
     .wdata_i (fifo_wdata),
 
     .depth_o (fifo_depth),
-    .full_o  (),
+    .full_o  (fifo_full),
 
     .rvalid_o(fifo_rvalid),
     .rready_i(fifo_rready),


### PR DESCRIPTION
- The usage of ~fifo_wready to assess fifo_full state was leading to have `fifo_full_seen_d` set high during a reset. This fifo_full output from the block prim_fifo_sync has been added later and is the correct signal to use.
- Fortunately this is not a bug as `fifo_full_seen_d` signal is only used by `fifo_empty_gate` which is also depending on `msg_allowed`. In order to see `fifo_empty_gate` going low, we should have both `msg_allowed` and `fifo_full_seen_d` set to 1. But `fifo_full_seen_d` is going low when `msg_allowed` is going high. As `msg_allowed` is going high when `hash_start | hash_continue` is detected, but `fifo_full_seen_d` will go low when `reg_hash_start` or `reg_hash_continue` will be detected. See the screenshot to understand better.
- But using the proper signal and driving `fifo_full_seen_d` properly is better.

![image](https://github.com/user-attachments/assets/e26ea19f-ff53-4b62-a04f-2a7f6127ba70)
